### PR TITLE
feat(modal): app-wide singleton modal coordination layer

### DIFF
--- a/.changesets/1779446379-feat-modal-app-wide-singleton-modal-coordination-layer-3nho.md
+++ b/.changesets/1779446379-feat-modal-app-wide-singleton-modal-coordination-layer-3nho.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(modal): app-wide singleton modal coordination layer

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -55,6 +55,7 @@ import {
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
 } from "@/app/store/launcher-event-reducer";
+import { startSingletonCrashRelease } from "@/app/store/singleton-modal";
 
 // Deferred — assigned inside initApp() after window.api is ready.
 // Do NOT call getApi() at module level: this file is statically imported by
@@ -454,6 +455,10 @@ async function initWaveWrap(initOpts: AgentMuxInitOpts) {
         // that global state is wired. Idempotent: subsequent calls
         // (e.g. via reinitWave path) are no-ops.
         startLauncherEventReducer();
+        // Bundle-management PR 3 — wire singleton-modal crash release.
+        // Subscribes to the launcher window-exit signal so a dead
+        // holder's singleton claim is auto-released. Idempotent.
+        startSingletonCrashRelease();
     } catch (e) {
         getApi().sendLog("Error in initWave " + e.message + "\n" + e.stack);
         console.error("Error in initWave", e);

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -24,6 +24,7 @@ import { PerfHud } from "@/perf/hud";
 import { DiagPanel } from "./devtools/diag-panel";
 import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
+import { SingletonDemoBanner } from "./modals/singleton-placeholder-demo";
 
 import "./app.scss";
 
@@ -389,6 +390,12 @@ const AppInner = () => {
                 <AppZoomHandler />
                 <AppFocusHandler />
                 <AppSettingsUpdater />
+                {/* Bundle-management PR 3 — placeholder demo banner for the
+                    app-wide singleton-modal coordination layer. Shows
+                    "open in <Window N> — click to focus" in non-holding
+                    windows; renders nothing otherwise. PR 4 swaps this for
+                    the real bundle-manager banner. */}
+                <SingletonDemoBanner />
                 <Workspace />
                 <CrossWindowDragMonitor />
                 <DragOverlay />

--- a/frontend/app/modals/singleton-placeholder-demo.scss
+++ b/frontend/app/modals/singleton-placeholder-demo.scss
@@ -1,0 +1,30 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Styling for the PR-3 singleton-coordination placeholder demo banner.
+// The banner is the "open elsewhere — click to focus" affordance shown
+// in non-holding windows. PR 4 reuses this class for the real bundle
+// manager's banner.
+
+.singleton-elsewhere-banner {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 12px;
+    border: none;
+    border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    background: var(--accent-color, #58a6ff);
+    color: var(--button-text-color, #fff);
+    font-size: 12px;
+    font-weight: 500;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover {
+        filter: brightness(1.08);
+    }
+
+    &:active {
+        filter: brightness(0.95);
+    }
+}

--- a/frontend/app/modals/singleton-placeholder-demo.tsx
+++ b/frontend/app/modals/singleton-placeholder-demo.tsx
@@ -1,0 +1,206 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Placeholder demo for the singleton-modal coordination layer — PR 3 of
+ * docs/specs/SPEC_BUNDLE_MANAGEMENT_2026_05_22.md.
+ *
+ * This is NOT the real bundle manager (that is PR 4). It is a trivial
+ * surface whose only job is to *exercise and demonstrate* the
+ * coordination layer:
+ *
+ *   - `openSingletonPlaceholderDemo()` — the entry point a menu item /
+ *     button calls. It gates on `acquireSingleton(kind)`:
+ *       • acquired  → opens `SingletonPlaceholderModal` (a normal
+ *         `<Modal scope="window">`); this window now holds the singleton.
+ *       • not acquired → no modal; the caller surface instead shows the
+ *         `SingletonElsewhereBanner` (open-in-<Window N>, click to focus).
+ *   - `SingletonPlaceholderModal` releases the singleton on unmount.
+ *   - `SingletonElsewhereBanner` is the persistent "open elsewhere"
+ *     affordance — wired to `getApi().focusWindow(label)`.
+ *
+ * PR 4 swaps the placeholder for `BundleManagerModal` and the demo
+ * button for the real hamburger "Identity & Memory" entry, keeping this
+ * exact gating shape.
+ */
+
+import { createMemo, createSignal, Show, type Accessor, type JSX } from "solid-js";
+
+import { getApi } from "@/store/global";
+import { openWindowEntriesAtom } from "@/app/store/global";
+import { resolveWindowName } from "@/util/window-title";
+import { Modal } from "@/element/modal";
+import type { ModalCloseProps } from "@/app/store/modalmodel";
+import { openModal } from "@/app/store/modalmodel";
+import {
+    acquireSingleton,
+    releaseSingleton,
+    singletonHolder,
+    SINGLETON_KIND_PLACEHOLDER,
+} from "@/app/store/singleton-modal";
+import "./singleton-placeholder-demo.scss";
+
+/**
+ * Resolve a window *label* to its human display name ("Window N", the
+ * workspace name, or a user-set name). Mirrors InstancePanel's naming so
+ * the banner and the panel agree. Falls back to the raw label if the
+ * label is not (yet) in `openWindowEntriesAtom`.
+ */
+function windowNameForLabel(label: string): string {
+    const entries = openWindowEntriesAtom();
+    const idx = entries.findIndex((e) => e.label === label);
+    if (idx === -1) return label;
+    // The placeholder demo keeps naming minimal — positional "Window N".
+    // PR 4's real manager can read the window's `meta.displayname` /
+    // workspace name through `getObjectValue` if a richer name is wanted.
+    return resolveWindowName({ indexInOpenWindows: idx });
+}
+
+// ── The placeholder modal ──────────────────────────────────────────────
+
+/**
+ * The window-scoped placeholder modal. Rendered ONLY in the window that
+ * holds the singleton. Releases the claim when it closes so other
+ * windows can take it.
+ */
+const SingletonPlaceholderModal = (props: ModalCloseProps): JSX.Element => {
+    const handleClose = () => {
+        releaseSingleton(SINGLETON_KIND_PLACEHOLDER);
+        props.close();
+    };
+
+    return (
+        <Modal open={true} onClose={handleClose} scope="window" size="md">
+            <div class="modal-panel-header">
+                <div class="modal-panel-title">Singleton placeholder</div>
+            </div>
+            <div class="modal-panel-body">
+                <p>
+                    This is the PR-3 placeholder for the app-wide singleton
+                    modal. Exactly one of these can be open across every
+                    AgentMux window.
+                </p>
+                <p>
+                    Try the "Singleton demo" hamburger item in another window
+                    while this is open — it will show a focus banner instead
+                    of opening a second copy.
+                </p>
+            </div>
+            <div class="modal-panel-footer">
+                <button
+                    type="button"
+                    class="modal-btn modal-btn--confirm"
+                    onClick={handleClose}
+                >
+                    Close
+                </button>
+            </div>
+        </Modal>
+    );
+};
+
+SingletonPlaceholderModal.displayName = "SingletonPlaceholderModal";
+
+// ── The "open elsewhere" banner ────────────────────────────────────────
+
+/**
+ * Persistent banner shown in NON-holding windows: "Singleton placeholder
+ * is open in <Window N> — click to focus". Clicking calls `focusWindow`
+ * on the holding window.
+ *
+ * Reactive: `singletonHolder` is a tracked accessor, so this disappears
+ * automatically when the holder releases (or crashes — crash-release
+ * clears the holder via the launcher exit signal).
+ */
+export const SingletonElsewhereBanner = (props: {
+    /** Reactive holder accessor — pass `singletonHolder(kind)`. */
+    holder: Accessor<string | null>;
+    /** Label of THIS window — banner only shows when holder !== this. */
+    myLabel: string | null;
+}): JSX.Element => {
+    const showBanner = createMemo(() => {
+        const h = props.holder();
+        return h != null && h !== props.myLabel;
+    });
+
+    const holderName = createMemo(() => {
+        const h = props.holder();
+        return h ? windowNameForLabel(h) : "";
+    });
+
+    const focusHolder = () => {
+        const h = props.holder();
+        if (!h) return;
+        getApi()
+            .focusWindow(h)
+            .catch((e) => console.error("[singleton-demo] focusWindow failed:", e));
+    };
+
+    return (
+        <Show when={showBanner()}>
+            <button
+                type="button"
+                class="singleton-elsewhere-banner"
+                onClick={focusHolder}
+                title="Bring the holding window to the front"
+            >
+                Singleton placeholder is open in {holderName()} — click to focus
+            </button>
+        </Show>
+    );
+};
+
+SingletonElsewhereBanner.displayName = "SingletonElsewhereBanner";
+
+/**
+ * Self-contained banner for the placeholder demo, mountable directly in
+ * the app shell. Resolves this window's label internally and renders the
+ * "open in <Window N> — click to focus" banner whenever the placeholder
+ * singleton is held by a *different* window. Renders nothing otherwise.
+ *
+ * PR 4 mounts the equivalent for the real bundle manager.
+ */
+export const SingletonDemoBanner = (): JSX.Element => {
+    const [myLabel, setMyLabel] = createSignal<string | null>(null);
+    getApi()
+        .getWindowLabel()
+        .then((l) => setMyLabel(l))
+        .catch(() => setMyLabel("main"));
+
+    return (
+        <SingletonElsewhereBanner
+            holder={singletonHolder(SINGLETON_KIND_PLACEHOLDER)}
+            myLabel={myLabel()}
+        />
+    );
+};
+
+SingletonDemoBanner.displayName = "SingletonDemoBanner";
+
+// ── Entry point ────────────────────────────────────────────────────────
+
+/**
+ * Entry point a menu item / button calls. Gates on the singleton:
+ *  - acquired  → opens the placeholder modal in this window.
+ *  - not acquired → focuses the holding window (the same affordance the
+ *    banner gives) so a click is never a dead end.
+ *
+ * Returns `true` if the modal was opened here, `false` if the singleton
+ * was held elsewhere (caller can rely on the banner for the persistent
+ * affordance).
+ */
+export function openSingletonPlaceholderDemo(): boolean {
+    if (acquireSingleton(SINGLETON_KIND_PLACEHOLDER)) {
+        openModal(SingletonPlaceholderModal);
+        return true;
+    }
+    // Held elsewhere — focus that window directly (banner stays the
+    // persistent surface; this makes the menu click itself useful too).
+    const holder = singletonHolder(SINGLETON_KIND_PLACEHOLDER)();
+    if (holder) {
+        getApi()
+            .focusWindow(holder)
+            .catch((e) => console.error("[singleton-demo] focusWindow failed:", e));
+    }
+    return false;
+}

--- a/frontend/app/store/singleton-modal.test.ts
+++ b/frontend/app/store/singleton-modal.test.ts
@@ -1,0 +1,235 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for the singleton-modal coordination layer (PR 3 of
+// SPEC_BUNDLE_MANAGEMENT_2026_05_22.md). The side-effecting deps
+// (HTTP publish, WPS subscribe, launcher events) are mocked so the
+// pure acquire/release/holder decision logic is verified in isolation.
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createRoot } from "solid-js";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+/** Records every claim published, so tests assert broadcast behaviour. */
+const publishedClaims: Array<Record<string, unknown>> = [];
+
+/** Captured launcher-event subscriber so tests can drive crash-release. */
+let launcherCb: ((evt: { event: string; label?: string }) => void) | null = null;
+
+vi.mock("@/store/global", () => ({
+    getApi: () => ({
+        getWindowLabel: () => Promise.resolve("window-self"),
+        getAuthKey: () => "test-key",
+        focusWindow: () => Promise.resolve(),
+    }),
+}));
+
+vi.mock("@/util/endpoints", () => ({
+    getWebServerEndpoint: () => "http://test",
+}));
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        // No persisted history by default — each test that needs replay
+        // overrides this.
+        EventReadHistoryCommand: vi.fn(() => Promise.resolve([])),
+    },
+}));
+
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+vi.mock("@/app/store/wps", () => ({
+    // waveEventSubscribe is a no-op here — live broadcasts are simulated
+    // directly via __applyClaimForTests.
+    waveEventSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/util/launcher-events", () => ({
+    subscribeLauncherEvent: vi.fn((cb: (evt: { event: string; label?: string }) => void) => {
+        launcherCb = cb;
+        return () => {};
+    }),
+}));
+
+// `fetch` — capture the publish payload, succeed.
+const fetchMock = vi.fn(async (_url: string, init?: { body?: string }) => {
+    if (init?.body) publishedClaims.push(JSON.parse(init.body));
+    return { ok: true, status: 200 } as Response;
+});
+vi.stubGlobal("fetch", fetchMock);
+
+// Import AFTER mocks are registered.
+import {
+    acquireSingleton,
+    releaseSingleton,
+    holdsSingleton,
+    singletonHolder,
+    startSingletonCrashRelease,
+    __resetSingletonForTests,
+    __setMyLabelForTests,
+    __applyClaimForTests,
+} from "./singleton-modal";
+
+/** Read a SolidJS signal outside a reactive root. */
+function read<T>(signal: () => T): T {
+    let val!: T;
+    createRoot((dispose) => {
+        val = signal();
+        dispose();
+    });
+    return val;
+}
+
+const KIND = "test-kind";
+
+beforeEach(() => {
+    __resetSingletonForTests();
+    __setMyLabelForTests("window-self");
+    publishedClaims.length = 0;
+    launcherCb = null;
+    fetchMock.mockClear();
+});
+
+// ── acquire / release ──────────────────────────────────────────────────
+
+describe("acquireSingleton", () => {
+    test("acquires a free singleton and becomes the holder", () => {
+        expect(acquireSingleton(KIND)).toBe(true);
+        expect(read(singletonHolder(KIND))).toBe("window-self");
+        expect(holdsSingleton(KIND)).toBe(true);
+    });
+
+    test("broadcasts a claim with this window as holder", () => {
+        acquireSingleton(KIND);
+        expect(publishedClaims).toHaveLength(1);
+        expect(publishedClaims[0].event).toBe("singleton:claim");
+        expect(publishedClaims[0].persist).toBe(1);
+        const data = publishedClaims[0].data as Record<string, unknown>;
+        expect(data.holder).toBe("window-self");
+        expect(data.kind).toBe(KIND);
+    });
+
+    test("re-acquiring a singleton this window already holds returns true", () => {
+        expect(acquireSingleton(KIND)).toBe(true);
+        expect(acquireSingleton(KIND)).toBe(true);
+        expect(holdsSingleton(KIND)).toBe(true);
+    });
+
+    test("cannot acquire a singleton held by another window", () => {
+        // Simulate a claim broadcast from a different window.
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        expect(acquireSingleton(KIND)).toBe(false);
+        expect(read(singletonHolder(KIND))).toBe("window-other");
+        expect(holdsSingleton(KIND)).toBe(false);
+    });
+
+    test("publishes nothing when acquisition is refused", () => {
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        publishedClaims.length = 0;
+        acquireSingleton(KIND);
+        expect(publishedClaims).toHaveLength(0);
+    });
+});
+
+describe("releaseSingleton", () => {
+    test("the holder can release; holder becomes null", () => {
+        acquireSingleton(KIND);
+        releaseSingleton(KIND);
+        expect(read(singletonHolder(KIND))).toBeNull();
+        expect(holdsSingleton(KIND)).toBe(false);
+    });
+
+    test("release broadcasts a null-holder claim", () => {
+        acquireSingleton(KIND);
+        publishedClaims.length = 0;
+        releaseSingleton(KIND);
+        expect(publishedClaims).toHaveLength(1);
+        const data = publishedClaims[0].data as Record<string, unknown>;
+        expect(data.holder).toBeNull();
+    });
+
+    test("a non-holder release is a no-op (does not steal the claim)", () => {
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        publishedClaims.length = 0;
+        releaseSingleton(KIND);
+        expect(read(singletonHolder(KIND))).toBe("window-other");
+        expect(publishedClaims).toHaveLength(0);
+    });
+
+    test("after release the singleton can be acquired again", () => {
+        acquireSingleton(KIND);
+        releaseSingleton(KIND);
+        expect(acquireSingleton(KIND)).toBe(true);
+    });
+});
+
+// ── observability ──────────────────────────────────────────────────────
+
+describe("singletonHolder", () => {
+    test("starts null for an unknown kind", () => {
+        expect(read(singletonHolder("never-claimed"))).toBeNull();
+    });
+
+    test("reflects an inbound claim broadcast from another window", () => {
+        __applyClaimForTests({ kind: KIND, holder: "window-3", epoch: 5 });
+        expect(read(singletonHolder(KIND))).toBe("window-3");
+    });
+
+    test("a release broadcast clears the holder", () => {
+        __applyClaimForTests({ kind: KIND, holder: "window-3", epoch: 5 });
+        __applyClaimForTests({ kind: KIND, holder: null, epoch: 6 });
+        expect(read(singletonHolder(KIND))).toBeNull();
+    });
+});
+
+// ── crash release ──────────────────────────────────────────────────────
+
+describe("startSingletonCrashRelease", () => {
+    test("releases a holder's claim when its window closes", () => {
+        startSingletonCrashRelease();
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        expect(launcherCb).not.toBeNull();
+
+        // Launcher reports that the holding window exited.
+        launcherCb!({ event: "window_closed", label: "window-other" });
+
+        expect(read(singletonHolder(KIND))).toBeNull();
+        // A release was broadcast on the dead holder's behalf.
+        const releases = publishedClaims.filter(
+            (c) => (c.data as Record<string, unknown>).holder === null,
+        );
+        expect(releases.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("window_instance_released also triggers crash release", () => {
+        startSingletonCrashRelease();
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        launcherCb!({ event: "window_instance_released", label: "window-other" });
+        expect(read(singletonHolder(KIND))).toBeNull();
+    });
+
+    test("a window closing that does NOT hold the singleton leaves it intact", () => {
+        startSingletonCrashRelease();
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        launcherCb!({ event: "window_closed", label: "window-unrelated" });
+        expect(read(singletonHolder(KIND))).toBe("window-other");
+    });
+
+    test("a non-exit launcher event does not release the singleton", () => {
+        startSingletonCrashRelease();
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        launcherCb!({ event: "window_opened", label: "window-other" });
+        expect(read(singletonHolder(KIND))).toBe("window-other");
+    });
+
+    test("is idempotent — a second call does not re-subscribe", async () => {
+        const mod = vi.mocked(
+            (await import("@/util/launcher-events")).subscribeLauncherEvent,
+        );
+        startSingletonCrashRelease();
+        const callsAfterFirst = mod.mock.calls.length;
+        startSingletonCrashRelease();
+        expect(mod.mock.calls.length).toBe(callsAfterFirst);
+    });
+});

--- a/frontend/app/store/singleton-modal.test.ts
+++ b/frontend/app/store/singleton-modal.test.ts
@@ -17,12 +17,17 @@ const publishedClaims: Array<Record<string, unknown>> = [];
 /** Captured launcher-event subscriber so tests can drive crash-release. */
 let launcherCb: ((evt: { event: string; label?: string }) => void) | null = null;
 
+/** Mockable window registry — `isWindowLive` reads this via the
+ *  `@/store/global` mock. `[]` ⇒ registry treated as not-yet-populated. */
+let mockWindowEntries: Array<{ label: string }> = [];
+
 vi.mock("@/store/global", () => ({
     getApi: () => ({
         getWindowLabel: () => Promise.resolve("window-self"),
         getAuthKey: () => "test-key",
         focusWindow: () => Promise.resolve(),
     }),
+    openWindowEntriesAtom: () => mockWindowEntries,
 }));
 
 vi.mock("@/util/endpoints", () => ({
@@ -88,6 +93,7 @@ beforeEach(() => {
     __setMyLabelForTests("window-self");
     publishedClaims.length = 0;
     launcherCb = null;
+    mockWindowEntries = [];
     fetchMock.mockClear();
 });
 
@@ -129,6 +135,29 @@ describe("acquireSingleton", () => {
         publishedClaims.length = 0;
         acquireSingleton(KIND);
         expect(publishedClaims).toHaveLength(0);
+    });
+
+    test("returns false when this window's label is unresolved", () => {
+        // Boot-instant call before getWindowLabel resolves: `true` must
+        // mean "holds it NOW", which can't be honoured without a label.
+        __setMyLabelForTests(null);
+        expect(acquireSingleton(KIND)).toBe(false);
+        expect(publishedClaims).toHaveLength(0);
+    });
+
+    test("refused when the holder is still a live window", () => {
+        __applyClaimForTests({ kind: KIND, holder: "window-other", epoch: 1 });
+        mockWindowEntries = [{ label: "window-self" }, { label: "window-other" }];
+        expect(acquireSingleton(KIND)).toBe(false);
+    });
+
+    test("acquires over a stale holder whose window is no longer live", () => {
+        // A persisted claim from a window that crashed — the launcher
+        // registry no longer lists it, so it must not block forever.
+        __applyClaimForTests({ kind: KIND, holder: "window-dead", epoch: 1 });
+        mockWindowEntries = [{ label: "window-self" }];
+        expect(acquireSingleton(KIND)).toBe(true);
+        expect(read(singletonHolder(KIND))).toBe("window-self");
     });
 });
 

--- a/frontend/app/store/singleton-modal.ts
+++ b/frontend/app/store/singleton-modal.ts
@@ -1,0 +1,399 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Singleton-modal coordination layer — PR 3 of
+ * docs/specs/SPEC_BUNDLE_MANAGEMENT_2026_05_22.md (§3 "Singleton — one
+ * manager across the whole app").
+ *
+ * Problem this solves
+ * -------------------
+ * The unified modal has `pane` / `tab` / `window` scopes — each inerts a
+ * DOM region within ONE renderer. A *singleton* modal needs something the
+ * DOM-inert scopes cannot give: exactly one instance of a modal of kind
+ * `K` across EVERY window of the AgentMux process, where each window is
+ * its own CEF renderer. That is cross-window coordination, not DOM inert.
+ *
+ * Chosen mechanism — WPS-backed shared store (no Rust change)
+ * -----------------------------------------------------------
+ * Every AgentMux process runs exactly one `agentmux-srv`; every window's
+ * renderer holds a WebSocket to it. The srv's WPS broker
+ * (`agentmux-srv/src/backend/wps.rs`) is therefore a *process-wide* event
+ * bus already shared by all windows. We ride it:
+ *
+ *   1. **Registry + broadcast.** A claim is a WPS event of type
+ *      `EVENT_SINGLETON_CLAIM`, scoped `singleton:<kind>`, published with
+ *      `persist: 1`. `persist: 1` means the broker keeps the *latest*
+ *      claim and replays it to any window that subscribes later — so the
+ *      "which window holds kind K" registry is simply the most-recent
+ *      persisted event. No bespoke registry RPC, no Rust change.
+ *   2. **Cross-window delivery.** `waveEventSubscribe` in every window
+ *      receives every claim/release; non-holders react (render a banner).
+ *   3. **Focus action.** The banner's button calls the existing
+ *      `getApi().focusWindow(label)` (same primitive InstancePanel uses).
+ *   4. **Crash release.** A holder that exits cannot publish its own
+ *      release. The launcher already detects window exit and emits
+ *      `window_closed` / `window_instance_released`; those events reach
+ *      every *live* window via the launcher-event bridge. The first live
+ *      window to observe its current holder's label close publishes a
+ *      release on the dead holder's behalf — so no window is ever
+ *      stranded pointing at a dead holder.
+ *
+ * Tradeoff vs. riding the launcher window registry directly: the claim
+ * state is not durably persisted in the launcher's Rust-side registry,
+ * so it lives only as long as the srv process. That is acceptable —
+ * the singleton is meaningful only *within* one running AgentMux
+ * process; if the process dies the claim is moot anyway. The win is
+ * zero Rust/launcher changes: the whole layer is renderer-side over
+ * infrastructure that already exists and is already battle-tested
+ * (the same WPS persist/replay path that backs `tool_chunk` streaming).
+ *
+ * Publish transport
+ * -----------------
+ * The frontend `EventPublishCommand` RPC has no srv handler (the srv
+ * only registers `eventsub` / `eventunsub` / `eventreadhistory`). The
+ * auth-gated HTTP endpoint `POST /agentmux/wps/publish` *does* forward
+ * arbitrary `{event, scopes, persist, data}` to the broker — that is the
+ * publish path `agentmux-bashwrap` uses, and the one we use here.
+ */
+
+import { createSignal, type Accessor } from "solid-js";
+
+import { getApi } from "@/store/global";
+import { getWebServerEndpoint } from "@/util/endpoints";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { subscribeLauncherEvent } from "@/util/launcher-events";
+
+/** WPS event name carrying singleton claim/release broadcasts. */
+export const EVENT_SINGLETON_CLAIM = "singleton:claim";
+
+/**
+ * Kind of singleton modal. Open enum (string) so future singletons add a
+ * value without touching this module. PR 3 ships a placeholder kind for
+ * the demo; PR 4 adds `"bundle-manager"`.
+ */
+export type SingletonKind = string;
+
+/** Placeholder kind used by the PR-3 demo. PR 4 replaces this usage. */
+export const SINGLETON_KIND_PLACEHOLDER: SingletonKind = "placeholder-demo";
+
+/**
+ * Payload of an `EVENT_SINGLETON_CLAIM` WPS event. `data` on the wire.
+ *  - `holder` = window label currently holding the singleton, or `null`
+ *    when released.
+ *  - `epoch` = monotonically-increasing-per-window claim counter; used
+ *    only to break ties when two windows race a claim (higher epoch from
+ *    the same logical moment is irrelevant — see `applyClaim`).
+ */
+interface ClaimPayload {
+    kind: SingletonKind;
+    holder: string | null;
+    epoch: number;
+}
+
+/** Scope string for a kind — keeps each kind's claims isolated. */
+function scopeFor(kind: SingletonKind): string {
+    return `singleton:${kind}`;
+}
+
+// ── Per-kind reactive state ────────────────────────────────────────────
+
+interface KindState {
+    /** Reactive accessor → holder window label, or null. */
+    holder: Accessor<string | null>;
+    setHolder: (v: string | null) => void;
+    /** Local epoch counter for claims this window publishes. */
+    epoch: number;
+    /** True once a WPS subscription + history-replay has been wired. */
+    wired: boolean;
+}
+
+const kinds = new Map<SingletonKind, KindState>();
+
+function kindState(kind: SingletonKind): KindState {
+    let st = kinds.get(kind);
+    if (!st) {
+        const [holder, setHolder] = createSignal<string | null>(null);
+        st = { holder, setHolder, epoch: 0, wired: false };
+        kinds.set(kind, st);
+        ensureWired(kind, st);
+    }
+    return st;
+}
+
+// ── This window's label ────────────────────────────────────────────────
+
+let myLabel: string | null = null;
+let myLabelPromise: Promise<string> | null = null;
+
+/**
+ * Resolve (and cache) this window's launcher label. `getWindowLabel`
+ * reads it synchronously from the URL in practice, but the API is async
+ * — so callers that need it before resolution get the cached value or a
+ * pending promise.
+ */
+function resolveMyLabel(): Promise<string> {
+    if (myLabel != null) return Promise.resolve(myLabel);
+    if (!myLabelPromise) {
+        myLabelPromise = getApi()
+            .getWindowLabel()
+            .then((l) => {
+                myLabel = l;
+                return l;
+            })
+            .catch(() => {
+                // Fall back to "main" — matches the cef-api default.
+                myLabel = "main";
+                return "main";
+            });
+    }
+    return myLabelPromise;
+}
+
+/** Synchronous best-effort label. Null until `resolveMyLabel` settles. */
+function myLabelSync(): string | null {
+    return myLabel;
+}
+
+// Kick off resolution eagerly so `acquireSingleton` (sync) has it ready.
+void resolveMyLabel();
+
+// ── Publish ────────────────────────────────────────────────────────────
+
+/**
+ * Publish a claim/release to the process-wide WPS broker via the
+ * auth-gated HTTP endpoint. `persist: 1` so a window that subscribes
+ * later replays the current holder. Fire-and-forget — the optimistic
+ * local update already happened; a failed publish self-heals on the
+ * next claim or on history-replay.
+ */
+async function publishClaim(payload: ClaimPayload): Promise<void> {
+    const key = getApi()?.getAuthKey?.();
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (key) headers["X-AuthKey"] = key;
+    try {
+        const resp = await fetch(getWebServerEndpoint() + "/agentmux/wps/publish", {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                event: EVENT_SINGLETON_CLAIM,
+                scopes: [scopeFor(payload.kind)],
+                // persist: 1 → broker keeps only the latest claim and
+                // replays it to late subscribers. Exactly the registry
+                // semantics we want: "the current holder".
+                persist: 1,
+                data: payload,
+            }),
+        });
+        if (!resp.ok) {
+            console.error("[singleton] publishClaim failed: HTTP", resp.status);
+        }
+    } catch (e) {
+        console.error("[singleton] publishClaim error:", e);
+    }
+}
+
+// ── Apply an incoming claim ─────────────────────────────────────────────
+
+/**
+ * Apply a claim payload to local reactive state. Idempotent — applying
+ * the same holder twice is a no-op (SolidJS signal equality short-
+ * circuits the re-render). A `null` holder clears the registry.
+ */
+function applyClaim(payload: ClaimPayload): void {
+    const st = kindState(payload.kind);
+    if (st.holder() === payload.holder) return;
+    st.setHolder(payload.holder);
+}
+
+function parsePayload(raw: unknown): ClaimPayload | null {
+    if (raw == null || typeof raw !== "object") return null;
+    const r = raw as Record<string, unknown>;
+    if (typeof r.kind !== "string") return null;
+    const holder = r.holder;
+    if (holder !== null && typeof holder !== "string") return null;
+    const epoch = typeof r.epoch === "number" ? r.epoch : 0;
+    return { kind: r.kind, holder: holder as string | null, epoch };
+}
+
+// ── Wiring: WPS subscription + history replay + crash release ───────────
+
+function ensureWired(kind: SingletonKind, st: KindState): void {
+    if (st.wired) return;
+    st.wired = true;
+
+    // 1. Subscribe to live claim/release broadcasts for this kind.
+    waveEventSubscribe({
+        eventType: EVENT_SINGLETON_CLAIM,
+        scope: scopeFor(kind),
+        handler: (event: WaveEvent) => {
+            const payload = parsePayload(event.data);
+            if (payload && payload.kind === kind) applyClaim(payload);
+        },
+    });
+
+    // 2. Replay the persisted latest claim so a window that opens AFTER
+    //    a holder claimed still learns the current holder. Without this,
+    //    a window started late would think the singleton is free.
+    void RpcApi.EventReadHistoryCommand(TabRpcClient, {
+        event: EVENT_SINGLETON_CLAIM,
+        scope: scopeFor(kind),
+        maxitems: 1,
+    })
+        .then((events) => {
+            if (!events || events.length === 0) return;
+            const payload = parsePayload(events[events.length - 1].data);
+            if (payload && payload.kind === kind) applyClaim(payload);
+        })
+        .catch((e) => console.error("[singleton] history replay failed:", e));
+}
+
+/**
+ * Crash-release wiring. Subscribes ONCE (process-wide, not per-kind) to
+ * the launcher window-exit signal. When the window currently holding ANY
+ * kind exits, this live window publishes a release on its behalf.
+ *
+ * Convergence: every live window runs this handler, so several may
+ * publish the same release concurrently. That is safe — releases are
+ * idempotent (a `null` holder applied twice is a no-op) and `persist: 1`
+ * means the broker just keeps the last one. No coordination needed.
+ *
+ * Idempotent: guarded by `crashReleaseWired`.
+ */
+let crashReleaseWired = false;
+
+export function startSingletonCrashRelease(): void {
+    if (crashReleaseWired) return;
+    crashReleaseWired = true;
+
+    subscribeLauncherEvent((evt) => {
+        const isExit =
+            evt.event === "window_closed" || evt.event === "window_instance_released";
+        if (!isExit) return;
+        const evtLabel = (evt as unknown as { label?: unknown }).label;
+        const closedLabel = typeof evtLabel === "string" ? evtLabel : null;
+        if (!closedLabel) return;
+
+        // For every kind whose holder is the closed window, publish a
+        // release. Skip the kinds this window itself holds — those get a
+        // normal `releaseSingleton` on unmount; and if THIS window is the
+        // one closing, it won't be running this handler much longer
+        // anyway (the live siblings cover it).
+        for (const [kind, st] of kinds) {
+            if (st.holder() === closedLabel) {
+                console.log(
+                    "[singleton] crash-release:",
+                    kind,
+                    "holder",
+                    closedLabel,
+                    "exited",
+                );
+                // Optimistic local clear so this window's banner updates
+                // immediately even before the broadcast round-trips.
+                st.setHolder(null);
+                void publishClaim({ kind, holder: null, epoch: ++st.epoch });
+            }
+        }
+    });
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Reactive accessor → the window label currently holding the singleton
+ * modal of `kind`, or `null` if no window holds it.
+ *
+ * Use in a SolidJS component / memo: it tracks as a dependency, so a
+ * banner re-renders when the holder changes (claim, release, or crash).
+ */
+export function singletonHolder(kind: SingletonKind): Accessor<string | null> {
+    return kindState(kind).holder;
+}
+
+/**
+ * Attempt to acquire the app-wide singleton for `kind` for THIS window.
+ *
+ * Returns `true` if this window now holds it (it was free, or this
+ * window already held it). Returns `false` if another window already
+ * holds it — the caller should then show the focus banner instead of
+ * opening the modal.
+ *
+ * The decision is synchronous against the locally-known holder, then the
+ * claim is broadcast. Two windows racing a genuinely-free singleton is
+ * possible but rare (both must call within the WPS round-trip window);
+ * if it happens, both windows' claims broadcast and last-write-wins —
+ * both windows then converge on the same holder, and the loser's modal
+ * (if it opened) should be closed by observing `singletonHolder`. For
+ * the bundle manager (PR 4) the realistic trigger is a deliberate
+ * hamburger click, so the race is not a practical concern.
+ */
+export function acquireSingleton(kind: SingletonKind): boolean {
+    const st = kindState(kind);
+    const me = myLabelSync();
+    const current = st.holder();
+
+    // Held by another window → cannot acquire.
+    if (current != null && current !== me) return false;
+
+    // Free, or already ours. Claim it.
+    if (me != null) {
+        st.setHolder(me);
+        void publishClaim({ kind, holder: me, epoch: ++st.epoch });
+    } else {
+        // Label not resolved yet (very early boot). Claim once it lands.
+        void resolveMyLabel().then((label) => {
+            // Re-check: another window may have claimed during the await.
+            const now = st.holder();
+            if (now != null && now !== label) return;
+            st.setHolder(label);
+            void publishClaim({ kind, holder: label, epoch: ++st.epoch });
+        });
+    }
+    return true;
+}
+
+/**
+ * Release the singleton for `kind` IF this window holds it. No-op if a
+ * different window holds it (or none does) — a window can only release
+ * its own claim.
+ */
+export function releaseSingleton(kind: SingletonKind): void {
+    const st = kindState(kind);
+    const me = myLabelSync();
+    // Only the holder may release. If we don't know our label yet we
+    // also can't be the holder (acquire would have waited), so bail.
+    if (me == null || st.holder() !== me) return;
+    st.setHolder(null);
+    void publishClaim({ kind, holder: null, epoch: ++st.epoch });
+}
+
+/**
+ * True if THIS window currently holds the singleton for `kind`.
+ * Reactive — safe to call inside a memo.
+ */
+export function holdsSingleton(kind: SingletonKind): boolean {
+    return kindState(kind).holder() === myLabelSync();
+}
+
+// ── Test-only helpers ──────────────────────────────────────────────────
+
+/** Test-only: reset all kind state + wiring guards. Never call in prod. */
+export function __resetSingletonForTests(): void {
+    kinds.clear();
+    crashReleaseWired = false;
+    myLabel = null;
+    myLabelPromise = null;
+}
+
+/** Test-only: force this window's label (bypasses the async resolve). */
+export function __setMyLabelForTests(label: string | null): void {
+    myLabel = label;
+    myLabelPromise = label == null ? null : Promise.resolve(label);
+}
+
+/** Test-only: directly apply an inbound claim payload. */
+export function __applyClaimForTests(payload: ClaimPayload): void {
+    applyClaim(payload);
+}

--- a/frontend/app/store/singleton-modal.ts
+++ b/frontend/app/store/singleton-modal.ts
@@ -374,7 +374,11 @@ export function releaseSingleton(kind: SingletonKind): void {
  * Reactive — safe to call inside a memo.
  */
 export function holdsSingleton(kind: SingletonKind): boolean {
-    return kindState(kind).holder() === myLabelSync();
+    // Guard on a resolved label — with `me` null (early boot) and no
+    // holder, `null === null` would wrongly report this window as the
+    // holder. Nobody holds it ⇒ false.
+    const me = myLabelSync();
+    return me != null && kindState(kind).holder() === me;
 }
 
 // ── Test-only helpers ──────────────────────────────────────────────────

--- a/frontend/app/store/singleton-modal.ts
+++ b/frontend/app/store/singleton-modal.ts
@@ -59,7 +59,7 @@
 
 import { createSignal, type Accessor } from "solid-js";
 
-import { getApi } from "@/store/global";
+import { getApi, openWindowEntriesAtom } from "@/store/global";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -313,44 +313,54 @@ export function singletonHolder(kind: SingletonKind): Accessor<string | null> {
 }
 
 /**
+ * True if `label` is a currently-open window per the launcher's window
+ * registry. Used to reject a stale claim left behind by a crashed
+ * holder — one that exited with no live sibling to publish its
+ * crash-release.
+ */
+function isWindowLive(label: string): boolean {
+    const entries = openWindowEntriesAtom();
+    // Empty registry ⇒ not yet populated. Don't judge a holder dead on
+    // incomplete data — that would wrongly steal a live singleton.
+    if (entries.length === 0) return true;
+    return entries.some((e) => e.label === label);
+}
+
+/**
  * Attempt to acquire the app-wide singleton for `kind` for THIS window.
  *
- * Returns `true` if this window now holds it (it was free, or this
- * window already held it). Returns `false` if another window already
- * holds it — the caller should then show the focus banner instead of
- * opening the modal.
+ * Returns `true` only when this window definitely holds it now — it was
+ * free, held by a crashed/stale window, or already ours. Returns
+ * `false` if another LIVE window holds it, or if this window's label
+ * hasn't resolved yet; the caller then shows the focus banner instead
+ * of opening the modal.
  *
- * The decision is synchronous against the locally-known holder, then the
- * claim is broadcast. Two windows racing a genuinely-free singleton is
- * possible but rare (both must call within the WPS round-trip window);
- * if it happens, both windows' claims broadcast and last-write-wins —
- * both windows then converge on the same holder, and the loser's modal
- * (if it opened) should be closed by observing `singletonHolder`. For
- * the bundle manager (PR 4) the realistic trigger is a deliberate
+ * Two windows racing a genuinely-free singleton is possible but rare
+ * (both must call within the WPS round-trip); last-write-wins and both
+ * converge. For the bundle manager the trigger is a deliberate
  * hamburger click, so the race is not a practical concern.
  */
 export function acquireSingleton(kind: SingletonKind): boolean {
     const st = kindState(kind);
     const me = myLabelSync();
+    // `true` must mean "holds it NOW" — only honourable synchronously,
+    // so a window whose label hasn't resolved cannot acquire. In
+    // practice the label is URL-derived and resolves at module load,
+    // well before any user-triggered acquire; this guards a boot-instant
+    // call only.
+    if (me == null) return false;
+
     const current = st.holder();
-
-    // Held by another window → cannot acquire.
-    if (current != null && current !== me) return false;
-
-    // Free, or already ours. Claim it.
-    if (me != null) {
-        st.setHolder(me);
-        void publishClaim({ kind, holder: me, epoch: ++st.epoch });
-    } else {
-        // Label not resolved yet (very early boot). Claim once it lands.
-        void resolveMyLabel().then((label) => {
-            // Re-check: another window may have claimed during the await.
-            const now = st.holder();
-            if (now != null && now !== label) return;
-            st.setHolder(label);
-            void publishClaim({ kind, holder: label, epoch: ++st.epoch });
-        });
+    // Blocked only by a holder that is BOTH another window AND still
+    // live. A holder that crashed with no live sibling to emit
+    // crash-release leaves a stale persisted claim; a non-live holder is
+    // treated as free so the singleton can never get permanently stuck.
+    if (current != null && current !== me && isWindowLive(current)) {
+        return false;
     }
+
+    st.setHolder(me);
+    void publishClaim({ kind, holder: me, epoch: ++st.epoch });
     return true;
 }
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -10,6 +10,7 @@ import { invokeCommand } from "@/app/platform/ipc";
 import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
+import { openSingletonPlaceholderDemo } from "@/app/modals/singleton-placeholder-demo";
 import { isMacOS } from "@/util/platformutil";
 import { getTabGrabOffset } from "./tab-grab-offset";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
@@ -684,6 +685,17 @@ function TabBar(props: TabBarProps): JSX.Element {
                 icon: "magnifying-glass",
                 shortcut: kbd("⌘P", "Ctrl+P"),
                 onClick: () => openModal(CommandPaletteModal),
+            },
+            {
+                // Bundle-management PR 3 — placeholder demo for the
+                // app-wide singleton-modal coordination layer. Opens the
+                // placeholder modal here if the singleton is free; if it
+                // is held in another window, focuses that window instead
+                // (and that window's banner stays the persistent
+                // affordance). PR 4 replaces this with "Identity & Memory".
+                label: "Singleton demo",
+                icon: "object-group",
+                onClick: () => openSingletonPlaceholderDemo(),
             },
             {
                 label: "DevTools",


### PR DESCRIPTION
## Bundle PR 3 — singleton coordination layer (`SPEC_BUNDLE_MANAGEMENT_2026_05_22` §3)

Infrastructure for an **app-wide singleton modal** — exactly one instance across every window of the AgentMux process. PR 4 composes the real bundle manager on top.

### Mechanism — WPS-backed, zero Rust change
A claim is a `singleton:claim` WPS event published with `persist:1`, so the broker keeps the latest claim and replays it to windows that subscribe later — that *is* the "current holder" registry. `frontend/app/store/singleton-modal.ts`:
- `acquireSingleton(kind)` → bool, `releaseSingleton(kind)`, `singletonHolder(kind)` (reactive accessor), `holdsSingleton(kind)`.
- **Crash release** — `startSingletonCrashRelease()` (wired once in `app-init.ts`) watches launcher window-exit events; if a holder window dies, a live window publishes the release on its behalf (idempotent).
- Race on a genuinely-free claim is documented + acceptable for the deliberate-click use case.
- **17 unit tests**.

### Placeholder demo — temporary scaffolding
PR 3 ships a placeholder modal + a "Singleton demo" hamburger item so the layer is independently exercisable. **PR 4 removes the placeholder** when it wires the real `BundleManagerModal` onto this layer.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)