### PR TITLE
refactor(bundles): demote agent-settings Identity/Memory tabs to read-only

### DIFF
--- a/.changesets/1779460091-refactor-bundles-demote-agent-settings-identity-memory-tabs--lhry.md
+++ b/.changesets/1779460091-refactor-bundles-demote-agent-settings-identity-memory-tabs--lhry.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(bundles): demote agent-settings Identity/Memory tabs to read-only

--- a/frontend/app/view/bundle-summary.scss
+++ b/frontend/app/view/bundle-summary.scss
@@ -1,0 +1,48 @@
+// Read-only summary panel for the demoted agent-settings Identity /
+// Memory tabs (PR 5 of SPEC_BUNDLE_MANAGEMENT_2026_05_22.md).
+
+.bundle-summary {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    height: 100%;
+    overflow-y: auto;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+
+    .bundle-summary-inner {
+        max-width: 480px;
+        padding: 32px 24px;
+    }
+
+    .bundle-summary-title {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .bundle-summary-body {
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.7));
+        margin: 0 0 12px;
+    }
+
+    .bundle-summary-hint {
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+    }
+
+    .bundle-summary-btn {
+        margin-top: 4px;
+        padding: 7px 16px;
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+
+        &:hover {
+            filter: brightness(1.1);
+        }
+    }
+}

--- a/frontend/app/view/bundle-summary.tsx
+++ b/frontend/app/view/bundle-summary.tsx
@@ -1,0 +1,68 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// BundleSummaryPanel — the read-only summary surface that the
+// agent-settings Identity / Memory tabs now render (PR 5 of
+// docs/specs/SPEC_BUNDLE_MANAGEMENT_2026_05_22.md, §5 decision 3).
+//
+// Before this PR the `view: "identity"` / `view: "memory"` panes
+// rendered the full-CRUD `IdentityManagerBody` / `MemoryManagerBody`.
+// §4 of the spec consolidated all bundle CRUD into the hamburger
+// "Identity & Memory" manager (`BundleManagerModal`); the per-agent
+// settings tabs are now *consumers*, not editors.
+//
+// This panel is intentionally context-free and CRUD-free: it shows a
+// short pointer explaining that bundles are app-wide data managed in one
+// place, plus a "Manage in Identity & Memory" button that opens the
+// app-wide manager via `openBundleManager()`.
+//
+// Per-agent bundle resolution — DATA GAP: the spec's ideal is to show
+// "this agent uses Identity: X". The launched identity/memory bundle ids
+// live on the `AgentInstance` DB row (`identity_id` / `memory_id`),
+// reachable only from the *agent pane's* block meta (`agentInstanceId`).
+// The `view: "identity"` / `view: "memory"` panes are SEPARATE blocks
+// with no link back to the launching agent, so the per-agent bundle is
+// not resolvable from this surface. The panel therefore degrades to the
+// pointer-only form. See the PR report for detail.
+
+import { type JSX } from "solid-js";
+
+import { openBundleManager } from "@/app/modals/bundle-manager-modal";
+
+import "./bundle-summary.scss";
+
+interface BundleSummaryPanelProps {
+    /** "Identity" | "Memory" — drives the heading + copy. */
+    kind: "Identity" | "Memory";
+}
+
+export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element => {
+    const lowerPlural = props.kind === "Identity" ? "identities" : "memories";
+
+    return (
+        <div class="bundle-summary">
+            <div class="bundle-summary-inner">
+                <h2 class="bundle-summary-title">{props.kind} bundles</h2>
+                <p class="bundle-summary-body">
+                    {props.kind} bundles are app-wide data, shared across every
+                    agent and window. They are now created, edited, and deleted
+                    in one place — the <strong>Identity &amp; Memory</strong>{" "}
+                    manager, opened from the hamburger menu.
+                </p>
+                <p class="bundle-summary-body bundle-summary-hint">
+                    This settings tab no longer manages {lowerPlural}; open the
+                    manager to make changes.
+                </p>
+                <button
+                    type="button"
+                    class="bundle-summary-btn"
+                    onClick={() => openBundleManager()}
+                >
+                    Manage in Identity &amp; Memory
+                </button>
+            </div>
+        </div>
+    );
+};
+
+BundleSummaryPanel.displayName = "BundleSummaryPanel";

--- a/frontend/app/view/identity/identity-pane-view.tsx
+++ b/frontend/app/view/identity/identity-pane-view.tsx
@@ -1,27 +1,29 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Identity pane view — thin wrapper around the context-free
-// <IdentityManagerBody/>.
+// Identity pane view — the agent-settings `view: "identity"` tab.
 //
-// The full list / create / edit / delete / bindings UI was extracted
-// into `identity-manager.tsx` (PR 2 of
-// SPEC_BUNDLE_MANAGEMENT_2026_05_22.md) so the same surface can render
-// both here (the `view: "identity"` settings pane) and inside the
-// window-scoped bundle manager modal. This file exists only so the
-// BlockRegistry barrel has a `viewComponent` taking the pane's
-// ViewModel; it renders the shared body verbatim, so the settings pane
-// is byte-for-byte unchanged.
+// PR 5 of SPEC_BUNDLE_MANAGEMENT_2026_05_22.md (§5 decision 3) DEMOTED
+// this tab from full CRUD to a read-only summary. Full Identity-bundle
+// management now lives in exactly one place: the hamburger "Identity &
+// Memory" manager (`BundleManagerModal`).
+//
+// This file no longer renders `IdentityManagerBody` — it renders the
+// context-free, CRUD-free `<BundleSummaryPanel/>`, which points the user
+// at the app-wide manager. The `IdentityPaneViewModel` is still the
+// registered `viewComponent` ViewModel (BlockRegistry needs one), and
+// the context-free `IdentityManager` (used by the hamburger modal) is
+// untouched — only this agent-settings wrapper changed.
 
 import { type JSX } from "solid-js";
 
-import { IdentityManagerBody } from "./identity-manager";
+import { BundleSummaryPanel } from "@/app/view/bundle-summary";
 import type { IdentityPaneViewModel } from "./identity-pane-model";
 
 interface IdentityPaneViewProps {
     model: IdentityPaneViewModel;
 }
 
-export const IdentityPaneView = (props: IdentityPaneViewProps): JSX.Element => {
-    return <IdentityManagerBody model={props.model} />;
+export const IdentityPaneView = (_props: IdentityPaneViewProps): JSX.Element => {
+    return <BundleSummaryPanel kind="Identity" />;
 };

--- a/frontend/app/view/memory/memory-view.tsx
+++ b/frontend/app/view/memory/memory-view.tsx
@@ -1,26 +1,29 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Memory pane view — thin wrapper around the context-free
-// <MemoryManagerBody/>.
+// Memory pane view — the agent-settings `view: "memory"` tab.
 //
-// The full list / create / edit / delete UI was extracted into
-// `memory-manager.tsx` (PR 2 of SPEC_BUNDLE_MANAGEMENT_2026_05_22.md)
-// so the same surface can render both here (the `view: "memory"`
-// settings pane) and inside the window-scoped bundle manager modal.
-// This file exists only so the BlockRegistry barrel has a
-// `viewComponent` taking the pane's ViewModel; it renders the shared
-// body verbatim, so the settings pane is byte-for-byte unchanged.
+// PR 5 of SPEC_BUNDLE_MANAGEMENT_2026_05_22.md (§5 decision 3) DEMOTED
+// this tab from full CRUD to a read-only summary. Full Memory-bundle
+// management now lives in exactly one place: the hamburger "Identity &
+// Memory" manager (`BundleManagerModal`).
+//
+// This file no longer renders `MemoryManagerBody` — it renders the
+// context-free, CRUD-free `<BundleSummaryPanel/>`, which points the user
+// at the app-wide manager. The `MemoryViewModel` is still the registered
+// `viewComponent` ViewModel (BlockRegistry needs one), and the
+// context-free `MemoryManager` (used by the hamburger modal) is
+// untouched — only this agent-settings wrapper changed.
 
 import { type JSX } from "solid-js";
 
-import { MemoryManagerBody } from "./memory-manager";
+import { BundleSummaryPanel } from "@/app/view/bundle-summary";
 import type { MemoryViewModel } from "./memory-model";
 
 interface MemoryViewProps {
     model: MemoryViewModel;
 }
 
-export const MemoryView = (props: MemoryViewProps): JSX.Element => {
-    return <MemoryManagerBody model={props.model} />;
+export const MemoryView = (_props: MemoryViewProps): JSX.Element => {
+    return <BundleSummaryPanel kind="Memory" />;
 };


### PR DESCRIPTION
## Bundle PR 5 — `SPEC_BUNDLE_MANAGEMENT_2026_05_22` §5 decision 3

Now that the hamburger **"Identity & Memory"** manager (#972) is the one CRUD home, the per-agent cog → Identity/Memory settings tabs should not duplicate full bundle CRUD.

### What changed
- New `BundleSummaryPanel` (`frontend/app/view/bundle-summary.tsx`) — a read-only panel: explains bundles are app-wide data managed in one place, plus a **"Manage in Identity & Memory"** button → `openBundleManager()`.
- `identity-pane-view.tsx` / `memory-view.tsx` now render `<BundleSummaryPanel/>` instead of the full-CRUD `IdentityManagerBody` / `MemoryManagerBody`.
- The context-free `IdentityManager` / `MemoryManager` and `BundleManagerModal` are untouched.

### Data gap (documented)
The spec's ideal — "this agent uses Identity: *X*" — needs the launched bundle ids, which live on the `AgentInstance` row reachable only from the *agent pane's* block (`agentInstanceId`). The `view: "identity"` / `view: "memory"` panes are **separate blocks** with no link to the launching agent, so the per-agent bundle isn't resolvable here. Per the spec's fallback, this PR demotes to the **pointer-only** form; surfacing "uses *X*" would need new plumbing (propagating `agentInstanceId` into the settings-tab block) — a follow-up.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)