### PR TITLE
chore: release v0.38.1

### DIFF
--- a/.changesets/1779410797-fix-magnify-single-instance-pane-render-fixes-zoom-browser-p-4rem.md
+++ b/.changesets/1779410797-fix-magnify-single-instance-pane-render-fixes-zoom-browser-p-4rem.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(magnify): single-instance pane render — fixes zoom + browser-pane black on restore

--- a/.changesets/1779439094-fix-statusbar-show-dev-badge-in-dev-mode-add-to-instance-pan-dvi5.md
+++ b/.changesets/1779439094-fix-statusbar-show-dev-badge-in-dev-mode-add-to-instance-pan-dvi5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): show DEV badge in dev mode + add to instance panel

--- a/.changesets/1779440490-feat-agent-launch-modal-defaults-to-continue-mode-for-known--kyhz.md
+++ b/.changesets/1779440490-feat-agent-launch-modal-defaults-to-continue-mode-for-known--kyhz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): launch modal defaults to Continue mode for known definitions

--- a/.changesets/1779441556-chore-add-notice-security-acknowledgements-spdx-headers.md
+++ b/.changesets/1779441556-chore-add-notice-security-acknowledgements-spdx-headers.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(legal): add NOTICE, SECURITY.md, ACKNOWLEDGEMENTS.md, README disclaimer, and SPDX headers

--- a/.changesets/1779442913-fix-security-md-shell-integration-name.md
+++ b/.changesets/1779442913-fix-security-md-shell-integration-name.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(security): correct shell integration component name in SECURITY.md scope

--- a/.changesets/1779443302-refactor-bundles-extract-identitymanager-memorymanager-compo-bpcv.md
+++ b/.changesets/1779443302-refactor-bundles-extract-identitymanager-memorymanager-compo-bpcv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(bundles): extract IdentityManager/MemoryManager components

--- a/.changesets/1779443305-feat-agent-oauth-connect-creates-a-named-identity-bundle-fir-pcx7.md
+++ b/.changesets/1779443305-feat-agent-oauth-connect-creates-a-named-identity-bundle-fir-pcx7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): OAuth Connect creates a named Identity bundle first

--- a/.changesets/1779446379-feat-modal-app-wide-singleton-modal-coordination-layer-3nho.md
+++ b/.changesets/1779446379-feat-modal-app-wide-singleton-modal-coordination-layer-3nho.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(modal): app-wide singleton modal coordination layer

--- a/.changesets/1779448275-feat-bundles-identity-memory-manager-modal-hamburger-entry-i2vg.md
+++ b/.changesets/1779448275-feat-bundles-identity-memory-manager-modal-hamburger-entry-i2vg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(bundles): Identity & Memory manager modal + hamburger entry

--- a/.changesets/1779460091-refactor-bundles-demote-agent-settings-identity-memory-tabs--lhry.md
+++ b/.changesets/1779460091-refactor-bundles-demote-agent-settings-identity-memory-tabs--lhry.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(bundles): demote agent-settings Identity/Memory tabs to read-only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.37.2"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.37.2"
+version = "0.38.1"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.37.2"
+version = "0.38.1"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.37.2"
+version = "0.38.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.37.2"
+version = "0.38.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.37.2"
+version = "0.38.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,19 @@
 # AgentMux Version History
 
+## 0.38.1 — 2026-05-22
+
+- fix(magnify): single-instance pane render — fixes zoom + browser-pane black on restore
+- fix(statusbar): show DEV badge in dev mode + add to instance panel
+- feat(agent): launch modal defaults to Continue mode for known definitions
+- chore(legal): add NOTICE, SECURITY.md, ACKNOWLEDGEMENTS.md, README disclaimer, and SPDX headers
+- fix(security): correct shell integration component name in SECURITY.md scope
+- refactor(bundles): extract IdentityManager/MemoryManager components
+- feat(agent): OAuth Connect creates a named Identity bundle first
+- feat(modal): app-wide singleton modal coordination layer
+- feat(bundles): Identity & Memory manager modal + hamburger entry
+- refactor(bundles): demote agent-settings Identity/Memory tabs to read-only
+
+
 ## 0.38.0 — 2026-05-22
 
 - fix(term): remove writeInFlight guard from small-data fast path in scheduleRafWrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.37.2",
+  "version": "0.38.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Release v0.38.1

Consumes the **10 pending changesets** — unified scope-based modal system (5-stage migration), statusbar DEV badge, **bundle management** (Features 1 + 2, 5 PRs), launch-modal Continue mode, plus other agents' fixes. **0.38.0 → 0.38.1.**

### ⚠️ Also corrects a version desync
PR #964's `chore: release v0.38.0` advanced `VERSION_HISTORY.md` to `0.38.0` but **never bumped `package.json` / `Cargo.toml`** — they were stranded at `0.37.2` while the changelog claimed 0.38.0. This PR re-bases the version files to 0.38.0, then `task release` bumped to 0.38.1.

**All version locations now agree at `0.38.1`** — `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, and `VERSION_HISTORY.md` head — verified before commit.

Retro: `docs/retro/retro-release-version-desync-2026-05-22.md`. A reagent gate to catch this class of desync is requested in `a5af/reagent#158`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)