### PR TITLE
feat(widgets): responsive widget labels + all widgets pinned by default

### DIFF
--- a/.changesets/1779463287-feat-widgets-responsive-labels-collapse-to-icons-on-narrow-t-y8qk.md
+++ b/.changesets/1779463287-feat-widgets-responsive-labels-collapse-to-icons-on-narrow-t-y8qk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(widgets): responsive labels collapse to icons on narrow title bars; all widgets pinned by default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ This means:
 
 Widgets are defined in `agentmux-srv/src/config/widgets.json`. These are the **only** widget types — do not invent or reference widgets that don't exist here.
 
-The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`: pinned widgets (`"display:pinned": true`) appear directly in the bar; everything else lives in the **More** dropdown. Both tiers are user-facing.
+The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`: pinned widgets (`"display:pinned": true`) appear directly in the bar; everything else lives in the **More** dropdown. Both tiers are user-facing. By default every surfaced widget is pinned. Their text labels collapse to icon-only automatically when the title bar is too narrow (and the manual `widget:icononly` setting can force icon-only at any width).
 
 | Widget Key | View | Label | Tier |
 |------------|------|-------|------|
@@ -101,10 +101,10 @@ The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`
 | `defwidget@browser` | `browser` | browser | Pinned |
 | `defwidget@terminal` | `term` | terminal | Pinned |
 | `defwidget@sysinfo` | `sysinfo` | sysinfo | Pinned |
-| `defwidget@editor` | `editor` | editor | More dropdown |
-| `defwidget@swarm` | `swarm` | swarm | More dropdown |
-| `defwidget@drone` | `drone` | drone | More dropdown |
-| `defwidget@help` | `help` | help | More dropdown |
+| `defwidget@editor` | `editor` | editor | Pinned |
+| `defwidget@drone` | `drone` | drone | Pinned |
+| `defwidget@help` | `help` | help | Pinned |
+| `defwidget@swarm` | `swarm` | swarm | More dropdown (`display:hidden`) |
 
 ### Not widgets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`
 | `defwidget@editor` | `editor` | editor | Pinned |
 | `defwidget@drone` | `drone` | drone | Pinned |
 | `defwidget@help` | `help` | help | Pinned |
-| `defwidget@swarm` | `swarm` | swarm | More dropdown (`display:hidden`) |
+| `defwidget@swarm` | `swarm` | swarm | Pinned |
 
 ### Not widgets
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -19,7 +19,7 @@
     },
     "defwidget@swarm": {
         "display:order": 4,
-        "display:hidden": true,
+        "display:pinned": true,
         "icon": "bee",
         "color": "#f59e0b",
         "label": "swarm",

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -45,6 +45,7 @@
     },
     "defwidget@editor": {
         "display:order": 3,
+        "display:pinned": true,
         "icon": "file-code",
         "label": "editor",
         "description": "Code editor with syntax highlighting",
@@ -80,6 +81,7 @@
     },
     "defwidget@drone": {
         "display:order": 9,
+        "display:pinned": true,
         "icon": "diagram-project",
         "color": "#06b6d4",
         "label": "drone",
@@ -92,6 +94,7 @@
     },
     "defwidget@help": {
         "display:order": 7,
+        "display:pinned": true,
         "icon": "circle-question",
         "label": "help",
         "description": "Help and documentation",

--- a/docs/investigations/INVESTIGATION_WIDGET_LABEL_RESPONSIVE_2026_05_22.md
+++ b/docs/investigations/INVESTIGATION_WIDGET_LABEL_RESPONSIVE_2026_05_22.md
@@ -1,0 +1,184 @@
+# Investigation: Responsive Widget Labels in the Action Widget Bar
+
+**Date:** 2026-05-22
+**Owner:** AgentY
+**Branch:** `agenty/refine-tab-appearance`
+**Status:** Analysis — implementation pending one open decision
+
+---
+
+## 1. Goal
+
+The widget text labels in the action widget bar should **show or hide automatically
+based on available width**: when the title bar is too narrow to fit the labeled
+widgets, the labels collapse so only the icons remain.
+
+Today this is a manual, all-or-nothing toggle with no width-awareness.
+
+---
+
+## 2. Current Implementation
+
+### Layout
+
+The widget bar (`ActionWidgets`) sits on the right of the window header, inside
+`SystemStatus`:
+
+```
+.window-header
+   ├── WindowDrag .left
+   ├── TabBar              (flex: 1 1 auto — grows/shrinks)
+   └── SystemStatus
+         ├── ActionWidgets       ← the widget bar
+         └── WindowActionButtons (min / max / close)
+```
+
+Files:
+- `frontend/app/window/action-widgets.tsx` — widget bar component
+- `frontend/app/window/action-widgets.scss` — widget bar styles
+- `frontend/app/window/system-status.tsx` — host container
+- `frontend/app/window/window-header.tsx` — title bar root
+
+### Label gating
+
+Each widget renders an icon and a label. The label is gated by one boolean:
+
+```tsx
+// action-widgets.tsx:213
+const iconOnly = () => settings()["widget:icononly"] ?? true;
+
+// action-widgets.tsx:120 — inside ActionWidget
+<Show when={!iconOnly() && !isBlank(widget.label)}>
+    <div class="text-xs whitespace-nowrap">{widget.label}</div>
+</Show>
+```
+
+The same flag also gates the "more" button's label (`action-widgets.tsx:428`).
+
+`widget:icononly` is a user setting toggled via right-click on the bar →
+"Icon Only" checkbox (`handleBarContextMenu`, `action-widgets.tsx:342`).
+
+### Key observations
+
+- **Default is `true`** — labels are hidden out of the box. Labels only appear
+  if the user explicitly turns the setting off.
+- **No width-responsiveness exists.** Nothing observes the window-header or
+  window width. Labels are purely a static user preference.
+- Labels are **conditionally rendered** (`<Show>`), not always-in-DOM-then-
+  CSS-hidden. A pure-CSS container-query approach would require restructuring
+  this to always render the label and hide it via CSS.
+
+---
+
+## 3. Approach — Overflow Detection (decided)
+
+Two approaches were considered:
+
+| Approach | How | Verdict |
+|---|---|---|
+| **Width threshold** | `ResizeObserver` on `.window-header`; force icon-only below a fixed pixel width. | Rejected — the threshold is a magic number that needs re-tuning whenever widgets are pinned/unpinned. |
+| **Overflow detection** | Measure whether the labeled widgets actually fit the available space; drop labels only when they would overflow. | **Chosen** — self-tuning, no magic constant, adapts to the current set of pinned widgets. |
+
+### Layout finding — the widget bar genuinely compresses
+
+The window header is a flex row:
+
+| Child | Flex | Behavior |
+|---|---|---|
+| `.window-drag .left` | `flex-shrink: 0` | fixed 2px |
+| `.tab-bar` | `flex: 1 1 auto`, `min-width: 0` | grows/shrinks, clips tabs |
+| `.system-status` | `flex: 0 1 auto` (default) | **shrinkable** |
+
+`.system-status` → `.action-widgets` are both shrinkable (`flex-shrink: 1`).
+So when the window narrows, the widget bar **is** compressed below its natural
+width — `scrollWidth > clientWidth` becomes true on `.action-widgets`. Overflow
+on the widget bar itself is therefore directly observable; we do not need to
+reach into the tab bar's DOM.
+
+### Mechanics
+
+1. A **hidden measuring mirror** of the widget bar is rendered off-screen,
+   always in the *labeled* state. Its width is the labeled natural width and
+   does not depend on what the visible bar is currently rendering.
+2. A `ResizeObserver` tracks the visible bar's available `clientWidth`.
+3. `tooNarrow` = `labeledNaturalWidth > availableWidth`.
+4. The visible bar renders icon-only whenever `tooNarrow` is true.
+
+Using a mirror (rather than measuring the live bar) means the decision is
+computed from an invariant width — collapsing the visible bar cannot change
+the mirror's measurement, so there is **no collapse→expand oscillation** and no
+hysteresis fudge factor is needed. The mirror re-measures automatically when
+the pinned widget set changes (`ResizeObserver` fires on its own resize).
+
+The frontend has no existing `ResizeObserver` usage — this is the first.
+
+---
+
+## 4. Resolved Decisions
+
+### 4.1 Keep `widget:icononly`, default it to `false`
+
+The manual setting **stays**. It keeps one job: let a user force icon-only
+*even on a wide screen* where labels would otherwise fit. The new behavior is
+additive:
+
+```
+effectiveIconOnly = manualSetting || tooNarrow
+```
+
+- Manual "Icon Only" ON  → always icon-only.
+- Manual "Icon Only" OFF → labels show when they fit, auto-collapse when narrow.
+
+**Default flips from `true` → `false`.** Labels now show by default (when there
+is room); `widget:icononly` only needs to be set when a user explicitly wants
+the always-compact look.
+
+### 4.2 Show all widgets in the bar by default
+
+Today the default pinned set is derived from `display:pinned` in
+`widgets.json` — only 4 of 8 widgets (`agent`, `browser`, `terminal`,
+`sysinfo`); the other 4 (`editor`, `swarm`, `drone`, `help`) default into the
+"More" dropdown.
+
+**New default: all widgets are pinned/shown in the bar.** The "More" dropdown
+becomes empty by default and only populates if a user unpins a widget.
+
+This pairs naturally with §4.1's responsive labels: with 8 widgets the bar is
+wider, but labels auto-collapse to icons when the window is narrow, so the
+fuller default bar stays usable at any width.
+
+Implementation: set `display:pinned: true` on every entry in
+`agentmux-srv/src/config/widgets.json` (the data-driven path — `getPinnedKeys`
+already derives the default set from that flag). The widget table in the
+repo's `CLAUDE.md` must be updated to match (all rows become "Pinned").
+
+---
+
+## 5. Implementation Plan
+
+1. Flip the `widget:icononly` default: `?? true` → `?? false`
+   (`action-widgets.tsx:213`).
+2. Set `display:pinned: true` on all entries in `widgets.json` so all widgets
+   show by default (§4.2).
+3. Render a hidden, always-labeled measuring mirror of the widget bar; capture
+   its width as `labeledNaturalWidth`.
+4. Add a `ResizeObserver` on the visible `.action-widgets` to track
+   `availableWidth`; derive `tooNarrow = labeledNaturalWidth > availableWidth`.
+5. Add `effectiveIconOnly = iconOnly() || tooNarrow()` and replace the raw
+   `iconOnly()` usage at `action-widgets.tsx:120` and `:428`. The
+   `handleBarContextMenu` checkbox stays bound to the raw `iconOnly()` setting.
+6. Update the widget table in the repo `CLAUDE.md` (all rows → "Pinned").
+7. Verify in `task dev`: shrink the window — labels drop before the bar
+   overflows and reappear when widened, with no flicker at the boundary;
+   confirm all 8 widgets show on a fresh config.
+
+---
+
+## 6. Files to Touch
+
+| File | Change |
+|---|---|
+| `frontend/app/window/action-widgets.tsx` | Default flip, mirror, `ResizeObserver`, `tooNarrow`, `effectiveIconOnly` |
+| `frontend/app/window/action-widgets.scss` | Off-screen mirror styling |
+| `agentmux-srv/src/config/widgets.json` | `display:pinned: true` on all widgets |
+| `CLAUDE.md` (repo root) | Widget table — all rows become "Pinned" |

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -12,6 +12,19 @@
     user-select: none;
 }
 
+// Hidden measuring mirror — see action-widgets.tsx. Always rendered in the
+// labeled state; its width is the labeled natural width used to decide when
+// the visible bar must collapse to icons. Absolutely positioned so it never
+// affects the real bar's layout; invisible and inert.
+.action-widgets--measure {
+    position: absolute;
+    top: 0;
+    left: 0;
+    visibility: hidden;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
 .action-widget-slot {
     -webkit-app-region: no-drag;
     display: flex;

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -20,7 +20,7 @@ import { atoms, createBlock, getApi } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { invokeCommand } from "@/app/platform/ipc";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
-import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import "./action-widgets.scss";
 
@@ -210,9 +210,24 @@ const ActionWidgets = (): JSX.Element => {
     const fullConfig = atoms.fullConfigAtom;
     const settings = (): Record<string, any> => fullConfig()?.settings ?? {};
     const wmap = (): Record<string, WidgetConfigType> => fullConfig()?.widgets ?? {};
-    const iconOnly = (): boolean => settings()["widget:icononly"] ?? true;
+    const iconOnly = (): boolean => settings()["widget:icononly"] ?? false;
     const pinnedWidgets = () => getPinnedWidgets(settings(), wmap());
     const moreWidgets = () => getMoreWidgets(settings(), wmap());
+
+    // ── Responsive labels ─────────────────────────────────────────────────────
+    // Labels collapse to icons when the title bar is too narrow to fit the
+    // labeled bar while leaving the tab bar a usable strip. `tooNarrow` is
+    // derived from a hidden always-labeled mirror (rendered below), so the
+    // decision never depends on the visible bar's own collapsed state — there
+    // is no measure→collapse→re-expand oscillation.
+    const [tooNarrow, setTooNarrow] = createSignal(false);
+    const effectiveIconOnly = (): boolean => iconOnly() || tooNarrow();
+    let mirrorRef: HTMLDivElement | undefined;
+
+    // Header width always reserved for the tab bar before widget labels are
+    // dropped. The collapse point still auto-tracks the widget count via the
+    // mirror's measured width; this only floors the tab bar's share.
+    const MIN_TAB_WIDTH = 120;
 
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
@@ -252,6 +267,28 @@ const ActionWidgets = (): JSX.Element => {
     let draggingKeyRef: string | null = null;
     let dropIndexRef: number | null = null;
     let dragStartRef: { x: number; y: number; key: string } | null = null;
+
+    // Re-evaluate `tooNarrow` whenever the window header resizes or the mirror's
+    // labeled width changes (e.g. a widget is pinned/unpinned).
+    onMount(() => {
+        const header = containerRef?.closest(".window-header") as HTMLElement | null;
+        if (!header || !mirrorRef) return;
+        const buttons = containerRef?.parentElement?.querySelector(
+            ".window-action-buttons"
+        ) as HTMLElement | null;
+        const measure = () => {
+            const labeledW = mirrorRef?.offsetWidth ?? 0;
+            const headerW = header.clientWidth;
+            if (labeledW === 0 || headerW === 0) return;
+            const buttonsW = buttons?.offsetWidth ?? 0;
+            setTooNarrow(labeledW + buttonsW + MIN_TAB_WIDTH > headerW);
+        };
+        const ro = new ResizeObserver(measure);
+        ro.observe(header);
+        ro.observe(mirrorRef);
+        measure();
+        onCleanup(() => ro.disconnect());
+    });
 
     const handlePointerDown = (key: string, e: PointerEvent) => {
         dragStartRef = { x: e.clientX, y: e.clientY, key };
@@ -406,7 +443,7 @@ const ActionWidgets = (): JSX.Element => {
                             >
                                 <ActionWidget
                                     widget={widget}
-                                    iconOnly={iconOnly()}
+                                    iconOnly={effectiveIconOnly()}
                                     onContextMenu={(e) => handlePinnedContextMenu(e, key)}
                                 />
                             </div>
@@ -425,12 +462,32 @@ const ActionWidgets = (): JSX.Element => {
                         onClick={openMore}
                     >
                         <i class="fa-solid fa-ellipsis" />
-                        <Show when={!iconOnly()}>
+                        <Show when={!effectiveIconOnly()}>
                             <span class="action-widget-more-label">more</span>
                         </Show>
                         <i
                             class={`fa-solid ${moreOpen() ? "fa-chevron-up" : "fa-chevron-down"} action-widget-more-chevron`}
                         />
+                    </div>
+                </Show>
+            </div>
+
+            {/* Hidden always-labeled mirror. Measured to decide whether the
+                labeled bar fits; absolutely positioned so it never affects the
+                visible bar's layout, and inert (invisible, no pointer events). */}
+            <div ref={mirrorRef} class="action-widgets action-widgets--measure" aria-hidden="true">
+                <For each={pinnedWidgets()}>
+                    {({ widget }) => (
+                        <div class="action-widget-slot">
+                            <ActionWidget widget={widget} iconOnly={false} />
+                        </div>
+                    )}
+                </For>
+                <Show when={moreWidgets().length > 0}>
+                    <div class="action-widget-more-btn">
+                        <i class="fa-solid fa-ellipsis" />
+                        <span class="action-widget-more-label">more</span>
+                        <i class="fa-solid fa-chevron-down action-widget-more-chevron" />
                     </div>
                 </Show>
             </div>


### PR DESCRIPTION
## Summary

The action widget bar's text labels now **show or hide automatically based on the title bar width** — they collapse to icon-only when the title bar is too narrow and expand again when there is room.

- **Responsive labels.** `effectiveIconOnly = widget:icononly || tooNarrow`. `tooNarrow` is derived from a hidden, always-labeled **measuring mirror**, so the decision is computed from an invariant width — there is no measure→collapse→re-expand oscillation and no hard-coded window-width breakpoint.
- **`widget:icononly` kept, default flipped `true` → `false`.** The manual setting still lets a user force icon-only at any width; labels now show by default when they fit.
- **All widgets pinned by default.** `editor`, `drone`, and `help` gain `display:pinned: true` (joining `agent`, `browser`, `terminal`, `sysinfo`). The More dropdown starts empty.

## Notes / decisions

- `MIN_TAB_WIDTH` (120px) is the only constant — it floors how much header space is reserved for the tab bar before labels are sacrificed. The collapse point still auto-tracks the widget count via the mirror's measured width, so it stays correct if widgets are pinned/unpinned.
- **`swarm` is now also pinned + surfaced** — per follow-up discussion, the `display:hidden` flag was removed so the bar shows all 8 widgets by default. swarm was hidden as a relic from when top-level swarm widgets duplicated agent-pane functionality; the modern multi-agent orchestration view is fine to surface like any other widget.
- First use of `ResizeObserver` in the frontend.
- Design rationale is captured in `docs/investigations/INVESTIGATION_WIDGET_LABEL_RESPONSIVE_2026_05_22.md`.

## Test plan

- [ ] `task dev` — widget labels visible on a wide window
- [ ] Narrow the window — labels collapse to icons before the bar overflows; widen — labels return; no flicker at the boundary
- [ ] Fresh config shows all 8 widgets pinned in the bar; More dropdown empty
- [ ] Right-click bar → "Icon Only" still forces icon-only on a wide window
- [ ] Pin/unpin a widget — collapse threshold adjusts accordingly