### PR TITLE
fix(modal): defer singleton-modal label resolution past app boot

### DIFF
--- a/.changesets/1779463930-fix-modal-defer-singleton-modal-label-resolution-past-app-bo-nnnf.md
+++ b/.changesets/1779463930-fix-modal-defer-singleton-modal-label-resolution-past-app-bo-nnnf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(modal): defer singleton-modal label resolution past app boot

--- a/frontend/app/store/singleton-modal.ts
+++ b/frontend/app/store/singleton-modal.ts
@@ -225,6 +225,14 @@ function ensureWired(kind: SingletonKind, st: KindState): void {
     if (st.wired) return;
     st.wired = true;
 
+    // Resolve this window's label here too. A kind is first wired when a
+    // component reads `singletonHolder`/`acquireSingleton` — which only
+    // happens once the app shell has rendered, so `window.api` is ready.
+    // This is the retry path: if the `startSingletonCrashRelease`
+    // kick-off ran before the API bridge existed (and bailed), this
+    // recovers the label so `acquireSingleton` is not a permanent no-op.
+    void resolveMyLabel();
+
     // 1. Subscribe to live claim/release broadcasts for this kind.
     waveEventSubscribe({
         eventType: EVENT_SINGLETON_CLAIM,

--- a/frontend/app/store/singleton-modal.ts
+++ b/frontend/app/store/singleton-modal.ts
@@ -135,7 +135,13 @@ let myLabelPromise: Promise<string> | null = null;
 function resolveMyLabel(): Promise<string> {
     if (myLabel != null) return Promise.resolve(myLabel);
     if (!myLabelPromise) {
-        myLabelPromise = getApi()
+        const api = getApi();
+        // `window.api` may not exist yet at very early boot. Calling
+        // through a missing bridge throws synchronously — which would
+        // crash app init. Bail without caching so a later call (the
+        // post-init kick-off in `startSingletonCrashRelease`) retries.
+        if (api == null) return Promise.resolve("main");
+        myLabelPromise = api
             .getWindowLabel()
             .then((l) => {
                 myLabel = l;
@@ -154,9 +160,6 @@ function resolveMyLabel(): Promise<string> {
 function myLabelSync(): string | null {
     return myLabel;
 }
-
-// Kick off resolution eagerly so `acquireSingleton` (sync) has it ready.
-void resolveMyLabel();
 
 // ── Publish ────────────────────────────────────────────────────────────
 
@@ -265,6 +268,12 @@ let crashReleaseWired = false;
 export function startSingletonCrashRelease(): void {
     if (crashReleaseWired) return;
     crashReleaseWired = true;
+
+    // Kick off this window's label resolution here. `app-init` calls
+    // this once `window.api` exists, so resolving from here (not at
+    // module-eval) keeps `getApi()` safe; `myLabelSync()` is then ready
+    // well before any user-triggered acquire.
+    void resolveMyLabel();
 
     subscribeLauncherEvent((evt) => {
         const isExit =


### PR DESCRIPTION
## Boot crash — v0.38.2 portable hung on the loading screen

`frontend/app/store/singleton-modal.ts` ran `void resolveMyLabel()` at **module-eval time**. `resolveMyLabel()` calls `getApi().getWindowLabel()` — but at module-eval the CEF API bridge (`window.api`) isn't set up yet, so `getApi()` returns `undefined` and `.getWindowLabel()` throws an **uncaught `TypeError`**, stalling app init.

```
[getApi] called before window.api exists
Uncaught TypeError: Cannot read properties of undefined (reading 'getWindowLabel')
```

Shipped silently in v0.38.2: tsc can't see runtime-timing, the singleton unit tests mock `getApi`, and no build was smoke-tested with the singleton layer before the portable.

### Fix
- Move the label kick-off out of module-eval into `startSingletonCrashRelease()` — which `app-init` calls *after* `window.api` exists.
- `resolveMyLabel` now guards `getApi() == null` and bails without caching, so it can never throw synchronously (a later post-init call retries).

`tsc` clean; 20/20 singleton tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)