### PR TITLE
fix(launch-modal): thread continueOfId through the +New bundle round-trip

### DIFF
--- a/.changesets/1779493749-fix-launch-modal-thread-continueofid-through-the-new-bundle--b798.md
+++ b/.changesets/1779493749-fix-launch-modal-thread-continueofid-through-the-new-bundle--b798.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launch-modal): thread continueOfId through the +New bundle round-trip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.1"
+version = "0.38.2"
 
 [profile.release]
 strip = true

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -85,6 +85,13 @@ export interface LaunchFormStateWire {
     image: string;
     identityId: string;
     memoryId: string;
+    /** Continuation context — the `continueOfId` from the Continue
+     *  dropdown. `null` = "— New agent —". Threaded through the
+     *  `+ New bundle` round-trip so the re-opened launch modal restores
+     *  Continue mode (otherwise an ambient-creds continuation drops out
+     *  of Continue and the auth gate wrongly re-engages — see
+     *  docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md). */
+    continueOfId: string | null;
 }
 
 export interface LaunchAgentSubmit {

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -104,6 +104,13 @@ export interface LaunchFormState {
     image: string;
     identityId: string;
     memoryId: string;
+    /** Continuation context. `null` = "— New agent —". Round-trip
+     *  preserved alongside the form fields so Continue mode survives
+     *  the `+ New bundle` flow (otherwise an ambient-creds
+     *  continuation drops out of Continue and the auth gate wrongly
+     *  re-engages on return — see
+     *  docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md). */
+    continueOfId: string | null;
 }
 
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
@@ -227,6 +234,11 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         image: image(),
         identityId: identityId(),
         memoryId: memoryId(),
+        // Capture continuation context so the `+ New bundle` round-trip
+        // restores Continue mode on return; without this the launch
+        // modal flips to New and an ambient-creds continuation's auth
+        // gate wrongly re-engages.
+        continueOfId: flow.state.form.continueOfId,
     });
     // The plain `+ New identity` button uses `purpose: "create"`. The
     // OAuth Connect (`needs-bundle`) interposition routes through the
@@ -264,7 +276,14 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         if (!id) return null;
         return (namedAgents() ?? []).find((r) => r.instance_id === id) ?? null;
     });
-    const isContinue = () => continuedRow() != null;
+    // Continuation status is read from the reducer's `form.continueOfId`
+    // (the source of truth) rather than from `continuedRow()` — the
+    // latter depends on `namedAgents()` having loaded, so on round-trip
+    // re-open isContinue() would transiently be false until that
+    // resource lands, flipping the auth gate on for a tick. Reading the
+    // form directly keeps the answer stable from the moment Opened
+    // dispatches with a restored continueOfId.
+    const isContinue = () => flow.state.form.continueOfId !== null;
     // Per-bundle continuation locks come from the slice's selectors.
     // Local memos read flow.state.form so they invalidate when the
     // selection or carry-over identity changes.
@@ -309,10 +328,19 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         if (rows.length === 0) return null;
         return [...rows].sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))[0];
     };
-    const [viewMode, setViewMode] = createSignal<"continue" | "new">("new");
-    // A `+ New bundle` round-trip re-opens the panel with initialFormState
-    // and only ever originates from New mode (the +New buttons are disabled
-    // while continuing) — so skip the auto-decide and keep New.
+    // Initial viewMode honors a restored continuation: if the snapshot
+    // captured a `continueOfId`, the user was in Continue mode when
+    // they left for the `+ New bundle` flow — restore them there. The
+    // previous "+New buttons disabled while continuing → always restore
+    // as New" assumption was false for ambient-creds continuations
+    // (continueLocksIdentity is false when the carried identity is
+    // empty, so the +New button stays enabled even in Continue mode).
+    const [viewMode, setViewMode] = createSignal<"continue" | "new">(
+        props.initialFormState?.continueOfId != null ? "continue" : "new",
+    );
+    // viewModeDecided suppresses the auto-decide effect when we're
+    // restoring from a snapshot — the snapshot's continueOfId decides
+    // it, not the most-recent-instance heuristic.
     let viewModeDecided = props.initialFormState != null;
     createEffect(() => {
         const rows = namedAgents();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## The bug

When the user opens the launch modal in Continue mode (Feature A auto-selects the most-recent instance, e.g. "Maks"), clicks **+ New identity bundle…**, then **cancels** — the modal returns saying *"Connect to Claude Code"*, even though the continued agent already has a working Claude Code OAuth.

## Root cause

The form snapshot type used for the `+ New bundle` round-trip (`LaunchFormStateWire` / `LaunchFormState`) omitted **`continueOfId`**. On return:

- `form.continueOfId` came back `null`
- `isContinue()` flipped `false`
- `authRequired()`'s `!isContinue()` short-circuit was lost
- For an ambient-creds continuation the carried `identityId` is `""` → `authRequired()` → `true` → "Connect to Claude Code"

The "+New buttons disabled while continuing" comment that justified the omission was **false** for ambient-creds continuations — `continueLocksIdentity()` only locks when the continued row carries a real identity bundle, which Maks's doesn't.

## Fix

- Add `continueOfId: string | null` to `LaunchFormStateWire` (`tab-modal.ts`) and `LaunchFormState` (`AgentLaunchModal.tsx`).
- `snapshot()` captures it.
- `isContinue()` reads `form.continueOfId` directly — decoupled from the `namedAgents()` resource load.
- `viewMode` initializes to `"continue"` when the snapshot has a `continueOfId`.
- Stale comment replaced.

Reducer untouched (`LaunchForm` already has the field; `Opened` already merges `initial` into `form`). **63 launch-flow tests pass**; tsc clean for touched files (the 2 pre-existing `toBeInTheDocument` errors in `AgentLaunchModal.integration.test.tsx` are task #36, unrelated).

Diagnosis: `docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)