### PR TITLE
feat(identity): SecretRef::OAuthConfigDir + per-bundle dir layout (OAuth Bundles PR A)

### DIFF
--- a/.changesets/1779494861-feat-identity-add-secretref-oauthconfigdir-per-bundle-dir-he-gpiu.md
+++ b/.changesets/1779494861-feat-identity-add-secretref-oauthconfigdir-per-bundle-dir-he-gpiu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(identity): add SecretRef::OAuthConfigDir + per-bundle dir helpers (oauth bundles PR A)

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -205,6 +205,25 @@ impl DataPaths {
             mode,
         })
     }
+
+    /// `~/.agentmux/shared/identities/` — root for per-bundle OAuth
+    /// credential directories. Lives under `shared_dir` so it's
+    /// account-wide and version-independent: upgrading agentmux does
+    /// not move a user's bundle credentials. Per
+    /// `SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md` §4.1.
+    pub fn identities_dir(&self) -> PathBuf {
+        self.shared_dir.join("identities")
+    }
+
+    /// `~/.agentmux/shared/identities/<bundle_id>/` — a specific
+    /// bundle's credential root. Per-provider subdirectories (e.g.
+    /// `claude/`, `codex/`) hang off this when the bundle gains an
+    /// OAuth binding (PR C). The directory is created lazily by the
+    /// bundle / OAuth flow that needs it — `ensure_dirs()` does not
+    /// pre-create it.
+    pub fn identity_dir(&self, bundle_id: &str) -> PathBuf {
+        self.identities_dir().join(bundle_id)
+    }
 }
 
 /// `~/.agentmux/` root, or the test override via

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -853,7 +853,7 @@ mod tests {
             None,
             None,
         );
-        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()));
+        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("AgentInputCommand"));
     }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1126,6 +1126,21 @@ pub enum SecretRef {
     PlaintextDev {
         plaintext_dev: String,
     },
+    /// **OAuth credentials stored as a filesystem pointer.** The CLI
+    /// (Claude Code, codex, openclaw, …) reads its OAuth tokens from
+    /// this directory at spawn time — agentmux only holds the path,
+    /// never the tokens themselves. Token refresh is the CLI's job;
+    /// the path stays stable across refreshes. Used by oauth-class
+    /// providers; the resolver (PR B) dispatches to a config-dir
+    /// env-var injection mode rather than the api-key env-var path.
+    /// See `docs/specs/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md`.
+    OAuthConfigDir {
+        /// Absolute path to the per-bundle, per-provider config
+        /// directory — e.g. `~/.agentmux/shared/identities/<id>/claude/`,
+        /// or the legacy `~/.claude/` for the Default migration bundle
+        /// (PR E).
+        dir: String,
+    },
 }
 
 /// An identity account (reusable credential, linked to agents via the

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -32,6 +32,16 @@ pub enum ResolverError {
     #[error("PlaintextDev secrets are disabled in release builds")]
     PlaintextDevDisabledInRelease,
 
+    /// `OAuthConfigDir` is a filesystem pointer, not a secret string —
+    /// `resolve_secret` cannot turn it into a credential value because
+    /// the credential lives in a CLI-managed token file inside the dir.
+    /// Oauth-class providers must be routed through the config-dir
+    /// injection path that PR B adds to `inject_identity_env`. Seeing
+    /// this error from `resolve_secret` means the caller forgot to
+    /// dispatch by provider class first.
+    #[error("OAuthConfigDir is a config-dir pointer, not a resolvable secret — routed via the oauth-class injection path, not resolve_secret")]
+    OAuthConfigDirNotASecret,
+
     #[error("storage error: {0}")]
     Storage(#[from] StoreError),
 }
@@ -85,6 +95,15 @@ pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolverError> {
             }
         }
         SecretRef::SecretsManager { .. } => Err(ResolverError::SecretsManagerUnsupported),
+        SecretRef::OAuthConfigDir { dir } => {
+            // Read but ignored — the resolver doesn't consume the
+            // pointer; PR B's oauth-class dispatch in
+            // `inject_identity_env` reads `dir` and sets the
+            // provider's config-dir env var directly, bypassing
+            // `resolve_secret` entirely.
+            let _ = dir;
+            Err(ResolverError::OAuthConfigDirNotASecret)
+        }
     }
 }
 
@@ -323,6 +342,21 @@ mod tests {
             sm_json_path: None,
         });
         assert!(matches!(res, Err(ResolverError::SecretsManagerUnsupported)));
+    }
+
+    #[test]
+    fn resolve_oauth_config_dir_is_not_a_secret() {
+        // OAuthConfigDir is a pointer to a CLI-managed token directory,
+        // not a resolvable secret string. PR B's oauth-class dispatch
+        // in `inject_identity_env` reads `dir` and sets the provider's
+        // config-dir env var directly, bypassing `resolve_secret`. The
+        // error here is a guard against a caller forgetting that
+        // dispatch — pre-PR-B nothing produces this variant, but the
+        // arm has to exist for the match to be exhaustive.
+        let res = resolve_secret(&SecretRef::OAuthConfigDir {
+            dir: "/path/to/bundle/claude".to_string(),
+        });
+        assert!(matches!(res, Err(ResolverError::OAuthConfigDirNotASecret)));
     }
 
     #[test]


### PR DESCRIPTION
## OAuth Bundles PR A

First of the 6-PR sequence in `docs/specs/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md`. **Schema-only** — sets up the type infrastructure that PRs B-F build on. Behavior unchanged.

### Changes

- **`wstore.rs`** — `SecretRef::OAuthConfigDir { dir: String }` variant (spec §4.2). Serializes via the existing `backend` tag (`"oauth_config_dir"`). Same column, no DB migration.
- **`data_paths.rs`** — `DataPaths::identities_dir()` + `identity_dir(bundle_id)` helpers rooting at `~/.agentmux/shared/identities/<id>/` (spec §4.1). Under `shared_dir`, so account-wide and version-independent. Lazy provisioning (PR C / E allocate on demand).
- **`resolver.rs`** — `OAuthConfigDir` arm in `resolve_secret` returns `ResolverError::OAuthConfigDirNotASecret`. The variant is a pointer, not a secret string — PR B routes oauth-class bindings around `resolve_secret` via a new config-dir injection mode; this error is a guard if a caller forgets that dispatch.

### Tests

- New: `resolve_oauth_config_dir_is_not_a_secret`.
- Existing 9 resolver + 9 `data_paths` tests still pass.

### Incidental — closes task #36

`backend/blockcontroller/subprocess.rs:856` was calling `send_input(..)` with one argument but the signature takes two. The error was blocking the entire test-binary compile (and the whole `cargo test -p agentmux-srv` run). Added `, None` — trivial fix, unblocks the test suite for every PR in this sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)