### PR TITLE
build(release): self-verify version-file consistency after task release

### DIFF
--- a/.changesets/1779496732-build-release-self-verify-version-file-consistency-after-tas-dmyj.md
+++ b/.changesets/1779496732-build-release-self-verify-version-file-consistency-after-tas-dmyj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+build(release): self-verify version-file consistency after task release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,22 @@ The release script picks the highest bump type across pending changesets (major 
 
 If you absolutely need to manually bump (e.g. rebuilding tooling locally), `bump patch -m "..." --commit` still works — but **don't push it in a feature PR**.
 
+### Release consistency invariant (reagent gate)
+
+In every commit, these MUST all equal the same version:
+
+- `VERSION_HISTORY.md`'s top `## X.Y.Z` section
+- `package.json.version`
+- `Cargo.toml [workspace.package].version`
+- `Cargo.lock`'s workspace-member versions (e.g. `agentmux-cef`)
+- `package-lock.json`'s root `version`
+
+**reagent: when reviewing any PR that touches `VERSION_HISTORY.md`, `package.json`, or `Cargo.toml`, check this invariant and return `CHANGES_REQUESTED` on a mismatch.** A `chore: release vX.Y.Z` PR whose `VERSION_HISTORY` head ≠ `package.json` version is an automatic block.
+
+This invariant is also enforced deterministically by `scripts/release.sh` (re-reads all five locations after the bump and fails loudly if any disagrees). reagent is the safety net for PRs that don't come from `task release`.
+
+History: `docs/retro/retro-release-version-desync-2026-05-22.md` — PR #964 silently shipped 0.38.0 with `package.json` stranded at 0.37.2 because bump-cli skipped the file and nothing checked.
+
 ---
 
 ## Git Workflow

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,8 +123,57 @@ git rm -q -- "${CHANGESETS[@]}"
 # versions across package.json + package-lock.json. Reagent P1 on #865.
 git add -- "$HISTORY" package-lock.json
 
+# ── Verify the release files agree (retro 2026-05-22 action item) ─────────
+#
+# bump-cli has been known to silently skip a target file (e.g. when the
+# description is too long). When that happens, only some of
+# {package.json, Cargo.toml, lockfiles} get bumped — VERSION_HISTORY still
+# advances — and the release commit ships an inconsistent set. The next
+# `task release` then proposes a regressed version, and reviewers have no
+# automatic signal to refuse it. This guard re-reads every version
+# location on disk and fails loudly if they don't all agree.
+#
+# See docs/retro/retro-release-version-desync-2026-05-22.md.
+INCONSISTENCIES=()
+
+PKG_V="$(node -p "require('./package.json').version" 2>/dev/null || echo '<unreadable>')"
+[[ "$PKG_V" == "$NEW_VERSION" ]] || \
+    INCONSISTENCIES+=("package.json version=$PKG_V")
+
+CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p}' Cargo.toml | head -1)"
+[[ "$CARGO_V" == "$NEW_VERSION" ]] || \
+    INCONSISTENCIES+=("Cargo.toml [workspace.package].version=$CARGO_V")
+
+PL_V="$(node -p "require('./package-lock.json').version" 2>/dev/null || echo '<unreadable>')"
+[[ "$PL_V" == "$NEW_VERSION" ]] || \
+    INCONSISTENCIES+=("package-lock.json version=$PL_V")
+
+CL_V="$(sed -n '/^name = "agentmux-cef"$/{n;s/^version = "\(.*\)"$/\1/p;q}' Cargo.lock)"
+[[ "$CL_V" == "$NEW_VERSION" ]] || \
+    INCONSISTENCIES+=("Cargo.lock agentmux-cef version=$CL_V")
+
+VH_V="$(awk '/^## /{print $2; exit}' "$HISTORY")"
+[[ "$VH_V" == "$NEW_VERSION" ]] || \
+    INCONSISTENCIES+=("VERSION_HISTORY.md top=$VH_V")
+
+if (( ${#INCONSISTENCIES[@]} > 0 )); then
+    echo "" >&2
+    echo "ERROR: release-consistency check failed." >&2
+    echo "Expected every version location to equal '$NEW_VERSION', but found:" >&2
+    for e in "${INCONSISTENCIES[@]}"; do
+        echo "  - $e" >&2
+    done
+    echo "" >&2
+    echo "This usually means bump-cli silently skipped a file. Inspect:" >&2
+    echo "  git diff --staged" >&2
+    echo "Then fix the mismatched files before committing." >&2
+    echo "" >&2
+    echo "See docs/retro/retro-release-version-desync-2026-05-22.md." >&2
+    exit 1
+fi
+
 echo >&2
-echo "Release prepared (NOT committed). Review with: git diff --staged" >&2
+echo "Release prepared (NOT committed) — all 5 version locations agree at $NEW_VERSION. Review with: git diff --staged" >&2
 echo "Then commit and push:" >&2
 echo "  git commit -m 'chore: release v$NEW_VERSION'" >&2
 echo "  git push -u origin <branch>" >&2


### PR DESCRIPTION
## Closes retro action items #1 + #2

`docs/retro/retro-release-version-desync-2026-05-22.md`.

### Deterministic check — `scripts/release.sh`

After bump + VERSION_HISTORY update, re-reads all five version locations and **fails loudly** if any disagree with the new version:

- `package.json`
- `Cargo.toml [workspace.package]`
- `package-lock.json`
- `Cargo.lock` (`agentmux-cef` workspace member)
- `VERSION_HISTORY.md` top heading

Catches the failure mode the retro documents — bump-cli silently skipping a target file, shipping a "release" commit where the changelog advanced but the version files didn't (as happened to #964).

### reagent gate — `CLAUDE.md`

New subsection under **Version Management** documents the invariant and asks reagent to enforce it on any PR that touches `VERSION_HISTORY.md` / `package.json` / `Cargo.toml`. Project context that reagent loads, so the rule is explicit, not incidental.

### Note

`main` currently ships `package.json=0.38.2` with `VERSION_HISTORY` top `0.38.1` — a silent bump that rode through #977's squash. The next `task release` will reconcile it; **this gate would have caught it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)