### PR TITLE
feat(oauth): identity-binding status + reconnect UI (OAuth Bundles PR D)

### DIFF
--- a/.changesets/1779505264-feat-oauth-identity-binding-status-reconnect-ui-oauth-bundle-hqzi.md
+++ b/.changesets/1779505264-feat-oauth-identity-binding-status-reconnect-ui-oauth-bundle-hqzi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(oauth): identity-binding status + reconnect UI (oauth bundles PR D)

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -32,4 +32,10 @@ pub mod auth_patterns;
 pub mod auth_session;
 pub mod resolver;
 
+// Legacy convenience re-export — newer call sites use
+// `resolver::inject_identity_env_with_broker` directly so the OAuth
+// expiry probe (PR D, spec §4.4) can publish on status change. The
+// broker-less wrapper is kept for tests and is intentionally allowed
+// to be unused in production.
+#[allow(unused_imports)]
 pub use resolver::inject_identity_env;

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -10,10 +10,175 @@
 //! every common workflow Just Work.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::backend::storage::error::StoreError;
 use crate::backend::storage::wstore::{SecretRef, WaveStore};
+use crate::backend::wps::{Broker, WaveEvent};
+
+/// Canonical-value enumeration for OAuth-class `IdentityAccount.status`.
+///
+/// `IdentityAccount.status` is a `String` (free-form) at the SQLite layer
+/// — api-key rows keep using whatever the legacy paths wrote
+/// (`"unknown"`, `"ok"`, etc.). For oauth-class bindings we pin a small
+/// closed set per spec §4.4 so the frontend status-badge dispatch is
+/// deterministic and the resolver's expiry probe can never write an
+/// off-the-spec string. Every place the resolver SETS or READS an
+/// oauth-class status uses these constants.
+pub mod oauth_status {
+    /// Token file present and (probed) not expired.
+    pub const VALID: &str = "valid";
+    /// Access token expired; refresh likely succeeds.
+    pub const EXPIRED: &str = "expired";
+    /// Refresh rejected / file missing / parse error; user must Reconnect.
+    pub const NEEDS_REAUTH: &str = "needs_reauth";
+    /// Never probed (initial state on bundle import / unprobed provider).
+    pub const UNKNOWN: &str = "unknown";
+}
+
+/// Result of probing a per-bundle OAuth token directory.
+///
+/// Computed by [`probe_oauth_status`] reading the CLI's on-disk token
+/// file (e.g. `<dir>/.credentials.json` for Claude Code). Maps directly
+/// to [`oauth_status`] strings. Returned as an enum so the caller can
+/// branch without re-parsing the string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthProbeStatus {
+    Valid,
+    Expired,
+    NeedsReauth,
+}
+
+impl OAuthProbeStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Valid => oauth_status::VALID,
+            Self::Expired => oauth_status::EXPIRED,
+            Self::NeedsReauth => oauth_status::NEEDS_REAUTH,
+        }
+    }
+}
+
+/// Cheap on-disk probe of the per-bundle OAuth token file for a
+/// provider. No network calls — just reads + parses the token JSON,
+/// then compares `expiresAt` against `now_ms`.
+///
+/// **Provider token-file shape (spec §4.4 + §4.5):**
+/// - `claude` — `<dir>/.credentials.json` with
+///   `{ "claudeAiOauth": { "accessToken", "refreshToken", "expiresAt": <ms> } }`
+///   (Anthropic's documented format — see
+///   `docs/specs/agentmux-isolated-auth.md` §1.6).
+/// - `codex` — `<dir>/.credentials.json` (MCP OAuth). Exact field
+///   layout undocumented by OpenAI; for now we treat presence-of-file
+///   as `Valid` and absence as `NeedsReauth`, deferring strict expiry
+///   parsing until the shape is pinned down. Falls through to the
+///   Claude parser as a best-effort — if the file is shape-compatible
+///   (some CLIs reuse Anthropic's format) the expiry check still works.
+/// - `openclaw` — same fallback as codex.
+///
+/// **Returns** `Some(status)` on a definitive read, `None` when probing
+/// isn't supported for the provider (so the caller skips status
+/// updates rather than mis-writing `needs_reauth` for a provider whose
+/// file we just don't know how to parse yet).
+pub fn probe_oauth_status(
+    provider: &str,
+    dir: &str,
+    now_ms: i64,
+) -> Option<OAuthProbeStatus> {
+    let probe_path: std::path::PathBuf = match provider {
+        // Claude Code + codex + openclaw all write to
+        // `<config_dir>/.credentials.json` per
+        // `docs/specs/provider-auth-isolation.md` (the agentmux-managed
+        // dir is what CLAUDE_CONFIG_DIR / CODEX_HOME / OPENCLAW_HOME
+        // point at). Codex / openclaw token field-layout is not
+        // publicly documented; the parser below treats unrecognised
+        // shapes as `Valid` so we don't false-positive a Reconnect on
+        // a working session — strict expiry parsing for those two is
+        // a follow-up once their JSON is pinned down.
+        "claude" | "codex" | "openclaw" => Path::new(dir).join(".credentials.json"),
+        _ => return None,
+    };
+
+    let contents = match std::fs::read_to_string(&probe_path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(
+                target: "identity",
+                provider,
+                path = %probe_path.display(),
+                error = %e,
+                "oauth probe: token file unreadable — status=needs_reauth"
+            );
+            return Some(OAuthProbeStatus::NeedsReauth);
+        }
+    };
+    let json: serde_json::Value = match serde_json::from_str(&contents) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(
+                target: "identity",
+                provider,
+                path = %probe_path.display(),
+                error = %e,
+                "oauth probe: token file parse failed — status=needs_reauth"
+            );
+            return Some(OAuthProbeStatus::NeedsReauth);
+        }
+    };
+
+    // Claude shape — `claudeAiOauth.expiresAt` is ms since epoch.
+    // Many shape-compatible providers nest under the same key; try
+    // that first, then fall back to any top-level `expiresAt` /
+    // `expires_at` an alternative provider might use.
+    let expires_at_ms = json
+        .get("claudeAiOauth")
+        .and_then(|o| o.get("expiresAt"))
+        .and_then(|v| v.as_i64())
+        .or_else(|| json.get("expiresAt").and_then(|v| v.as_i64()))
+        .or_else(|| json.get("expires_at").and_then(|v| v.as_i64()));
+
+    let has_refresh = json
+        .get("claudeAiOauth")
+        .and_then(|o| o.get("refreshToken"))
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+        || json
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+
+    match expires_at_ms {
+        Some(exp) if exp <= now_ms => {
+            // Past expiry. If a refresh token is present, the next
+            // CLI call will likely refresh it cleanly → `expired`
+            // (transient, not user-actionable). Without a refresh
+            // token the user must re-OAuth → `needs_reauth`.
+            if has_refresh {
+                Some(OAuthProbeStatus::Expired)
+            } else {
+                Some(OAuthProbeStatus::NeedsReauth)
+            }
+        }
+        Some(_) => Some(OAuthProbeStatus::Valid),
+        None => {
+            // Shape doesn't expose an expiry we can parse. Treat the
+            // file's existence as `Valid` rather than guess — false
+            // `needs_reauth` would force the user to reconnect a
+            // working session. codex / openclaw fall here today.
+            tracing::debug!(
+                target: "identity",
+                provider,
+                path = %probe_path.display(),
+                "oauth probe: file present but no parseable expiry — status=valid (best-effort)"
+            );
+            Some(OAuthProbeStatus::Valid)
+        }
+    }
+}
 
 /// Errors specific to the resolver. Every variant is recoverable
 /// (the spawn proceeds with whatever env vars resolved successfully)
@@ -190,6 +355,23 @@ pub fn inject_identity_env(
     block_id: &str,
     env_vars: &mut HashMap<String, String>,
 ) {
+    inject_identity_env_with_broker(wstore, None, block_id, env_vars);
+}
+
+/// `inject_identity_env` + optional broker handle so the OAuth-class
+/// branch can publish `identitybundlebindings:changed:<bundle_id>` on a
+/// status change discovered by the expiry probe. The broker is
+/// `Option<Arc<Broker>>` — `None` (the legacy entry point, kept for
+/// test ergonomics) skips the publish; in production both call sites
+/// (`app_api.rs` AgentSendCommand + `websocket.rs` AgentInputCommand)
+/// pass `Some(broker.clone())` so the IdentityManager's bindings table
+/// flips its status badge without a reload. Per spec §4.4.
+pub fn inject_identity_env_with_broker(
+    wstore: Arc<WaveStore>,
+    broker: Option<Arc<Broker>>,
+    block_id: &str,
+    env_vars: &mut HashMap<String, String>,
+) {
     // Step 1: instance lookup.
     let instance = match wstore.instance_get_active_for_block(block_id) {
         Ok(Some(i)) => i,
@@ -332,7 +514,7 @@ pub fn inject_identity_env(
                         continue;
                     }
                 };
-                env_vars.insert(config_dir_env_var.to_string(), dir);
+                env_vars.insert(config_dir_env_var.to_string(), dir.clone());
                 tracing::info!(
                     target: "identity",
                     "injected {} for oauth provider {} (identity={}, account={})",
@@ -341,6 +523,68 @@ pub fn inject_identity_env(
                     instance.identity_id,
                     binding.account_id,
                 );
+
+                // Per spec §4.4 — cheap on-disk expiry probe. Reads the
+                // CLI's token file inside the bundle dir and refines
+                // the IdentityAccount's `status` so the UI can show
+                // valid/expired/needs_reauth. Best-effort: probe and
+                // upsert failures are logged + ignored (mirrors the
+                // per-binding "log + skip" pattern). The probe runs at
+                // every spawn but is a single `fs::read_to_string` +
+                // JSON parse — negligible overhead.
+                let now_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if let Some(probed) = probe_oauth_status(&binding.provider, &dir, now_ms) {
+                    let new_status = probed.as_str();
+                    if account.status != new_status {
+                        let mut updated = account.clone();
+                        updated.status = new_status.to_string();
+                        updated.updated_at = now_ms;
+                        match wstore.identity_upsert(&updated) {
+                            Ok(()) => {
+                                tracing::info!(
+                                    target: "identity",
+                                    provider = %binding.provider,
+                                    account_id = %binding.account_id,
+                                    old_status = %account.status,
+                                    new_status,
+                                    "oauth probe: status updated"
+                                );
+                                // Publish bindings-changed so the
+                                // IdentityManager's Status column
+                                // refreshes without a reload. The
+                                // bindings list itself didn't change,
+                                // but the account row a binding points
+                                // at did — the UI fetches accounts
+                                // alongside bindings, so it's the same
+                                // subscription channel.
+                                if let Some(b) = broker.as_ref() {
+                                    b.publish(WaveEvent {
+                                        event: format!(
+                                            "identitybundlebindings:changed:{}",
+                                            instance.identity_id,
+                                        ),
+                                        scopes: vec![],
+                                        sender: String::new(),
+                                        persist: 0,
+                                        data: None,
+                                    });
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "identity",
+                                    provider = %binding.provider,
+                                    account_id = %binding.account_id,
+                                    error = %e,
+                                    "oauth probe: identity_upsert failed — status not persisted",
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -881,5 +1125,270 @@ mod tests {
         inject_identity_env(store, "block-future", &mut env);
         // No env-var matrix for "custom" — nothing injected, no panic.
         assert!(env.is_empty());
+    }
+
+    // ── PR D — OAuth expiry probe + status semantics ───────────────────
+
+    /// Helper: write a Claude-shape `.credentials.json` into a temp dir
+    /// and return the dir path. `expires_ms` controls validity; `with_refresh`
+    /// toggles the refreshToken field so the resolver can distinguish
+    /// `Expired` (refresh present) from `NeedsReauth` (no refresh).
+    fn write_claude_creds(
+        dir: &std::path::Path,
+        expires_ms: i64,
+        with_refresh: bool,
+    ) {
+        std::fs::create_dir_all(dir).unwrap();
+        let body = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "test-access",
+                "refreshToken": if with_refresh { "test-refresh" } else { "" },
+                "expiresAt": expires_ms,
+            }
+        });
+        std::fs::write(
+            dir.join(".credentials.json"),
+            serde_json::to_string(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn probe_oauth_status_unknown_provider_returns_none() {
+        // Probing a provider that isn't in the oauth-class set is a
+        // signal to the caller to leave `status` alone — None ≠
+        // NeedsReauth. Guards against silent mis-classification of
+        // api-key providers if a future caller accidentally feeds
+        // them through here.
+        let r = probe_oauth_status("github", "/tmp/whatever", 0);
+        assert_eq!(r, None);
+    }
+
+    #[test]
+    fn probe_oauth_status_missing_dir_is_needs_reauth() {
+        let r = probe_oauth_status("claude", "/definitely/does/not/exist-xyz-9q", 0);
+        assert_eq!(r, Some(OAuthProbeStatus::NeedsReauth));
+    }
+
+    #[test]
+    fn probe_oauth_status_future_expiry_is_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now_ms = 1_700_000_000_000;
+        write_claude_creds(tmp.path(), now_ms + 3_600_000, true);
+        let r = probe_oauth_status("claude", tmp.path().to_str().unwrap(), now_ms);
+        assert_eq!(r, Some(OAuthProbeStatus::Valid));
+    }
+
+    #[test]
+    fn probe_oauth_status_past_expiry_with_refresh_is_expired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now_ms = 1_700_000_000_000;
+        write_claude_creds(tmp.path(), now_ms - 1, true);
+        let r = probe_oauth_status("claude", tmp.path().to_str().unwrap(), now_ms);
+        assert_eq!(r, Some(OAuthProbeStatus::Expired));
+    }
+
+    #[test]
+    fn probe_oauth_status_past_expiry_no_refresh_is_needs_reauth() {
+        // No refresh token in the file → the CLI can't auto-refresh
+        // and the user has to OAuth again. Maps to `needs_reauth`,
+        // NOT `expired` (per spec §4.4).
+        let tmp = tempfile::tempdir().unwrap();
+        let now_ms = 1_700_000_000_000;
+        write_claude_creds(tmp.path(), now_ms - 1, false);
+        let r = probe_oauth_status("claude", tmp.path().to_str().unwrap(), now_ms);
+        assert_eq!(r, Some(OAuthProbeStatus::NeedsReauth));
+    }
+
+    #[test]
+    fn probe_oauth_status_malformed_json_is_needs_reauth() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".credentials.json"), "{ not json").unwrap();
+        let r = probe_oauth_status("claude", tmp.path().to_str().unwrap(), 0);
+        assert_eq!(r, Some(OAuthProbeStatus::NeedsReauth));
+    }
+
+    #[test]
+    fn probe_oauth_status_codex_unknown_shape_is_valid_best_effort() {
+        // codex / openclaw token-file layouts aren't publicly
+        // documented; our parser falls through to "Valid" when the
+        // file exists but lacks any parseable expiry. Better than
+        // false `needs_reauth` on a working session — strict parsing
+        // is a follow-up once the shape is pinned.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".credentials.json"),
+            r#"{"some":"opaque-codex-blob"}"#,
+        )
+        .unwrap();
+        let r = probe_oauth_status("codex", tmp.path().to_str().unwrap(), 0);
+        assert_eq!(r, Some(OAuthProbeStatus::Valid));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_probes_and_flips_status_to_needs_reauth() {
+        // Full integration: an oauth-class binding pointing at a
+        // bundle dir with NO token file → the probe surfaces
+        // `needs_reauth` and the resolver upserts the account row
+        // with the new status. Spec §4.4.
+        let store = make_store();
+
+        let mut def = crate::backend::storage::wstore::AgentDefinition {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+        };
+        store.agent_def_insert(&mut def).unwrap();
+
+        let identity = Identity {
+            id: "id-probe".to_string(),
+            name: "Probe".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        // Bundle dir intentionally empty — probe should report
+        // needs_reauth (no token file).
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = tmp.path().to_str().unwrap().to_string();
+
+        let claude = IdentityAccount {
+            id: "acct-claude".to_string(),
+            name: "claude-acct-claude".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir { dir: bundle_dir },
+            context: serde_json::json!({}),
+            // Start as "valid" — the probe should flip it to
+            // "needs_reauth".
+            status: oauth_status::VALID.to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&claude).unwrap();
+        store
+            .bundle_identity_bind("id-probe", "claude", "acct-claude")
+            .unwrap();
+
+        let inst = make_instance("block-probe", "id-probe");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store.clone(), "block-probe", &mut env);
+
+        // Env injection still happened (resolver doesn't block on
+        // probe outcome — the CLI launches with the dir env var set
+        // and will trigger OAuth itself when it sees no tokens).
+        assert!(env.get("CLAUDE_CONFIG_DIR").is_some());
+
+        // Status row was UPDATED to needs_reauth.
+        let after = store.identity_get("acct-claude").unwrap().unwrap();
+        assert_eq!(after.status, oauth_status::NEEDS_REAUTH);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_probe_preserves_status_when_valid() {
+        // Future-dated token + status already "valid" → no-op
+        // upsert (no spurious updated_at churn). The assertion is
+        // that the status remains "valid" — proving the probe
+        // didn't misclassify a working session.
+        let store = make_store();
+
+        let mut def = crate::backend::storage::wstore::AgentDefinition {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+        };
+        store.agent_def_insert(&mut def).unwrap();
+
+        let identity = Identity {
+            id: "id-ok".to_string(),
+            name: "Ok".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        write_claude_creds(tmp.path(), now_ms + 3_600_000, true);
+
+        let claude = IdentityAccount {
+            id: "acct-ok".to_string(),
+            name: "claude-acct-ok".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir {
+                dir: tmp.path().to_str().unwrap().to_string(),
+            },
+            context: serde_json::json!({}),
+            status: oauth_status::VALID.to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&claude).unwrap();
+        store
+            .bundle_identity_bind("id-ok", "claude", "acct-ok")
+            .unwrap();
+
+        let inst = make_instance("block-ok", "id-ok");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store.clone(), "block-ok", &mut env);
+
+        let after = store.identity_get("acct-ok").unwrap().unwrap();
+        assert_eq!(after.status, oauth_status::VALID);
+        // updated_at unchanged — the resolver only upserts when the
+        // probed status differs from the stored value.
+        assert_eq!(after.updated_at, 0);
     }
 }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -430,11 +430,13 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
 
     engine.register_handler(
         COMMAND_AGENT_SEND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 let cmd: CommandAgentSendData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.send: {e}"))?;
@@ -467,9 +469,14 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     _ => std::collections::HashMap::new(),
                 };
                 // Identity injection — same path as websocket.rs's
-                // AgentInputCommand. See identity/resolver.rs.
-                crate::identity::inject_identity_env(
+                // AgentInputCommand. See identity/resolver.rs. Passes
+                // the broker so the OAuth-class branch can publish a
+                // `identitybundlebindings:changed:<bundle_id>` event
+                // when the expiry probe updates an account's status
+                // (PR D — spec §4.4).
+                crate::identity::resolver::inject_identity_env_with_broker(
                     wstore.clone(),
+                    Some(broker.clone()),
                     &cmd.block_id,
                     &mut env_vars,
                 );

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -1121,7 +1121,11 @@ fn persist_oauth_binding_or_synthetic(
         display_name: String::new(),
         secret_ref: SecretRef::OAuthConfigDir { dir: dir.to_string() },
         context: serde_json::json!({}),
-        status: "valid".to_string(),
+        // Per spec §4.4: a binding the user JUST OAuth'd into is `valid`
+        // by definition — the token file was written within the past
+        // few seconds. The resolver's expiry probe (PR D) refines this
+        // on every spawn.
+        status: crate::identity::resolver::oauth_status::VALID.to_string(),
         created_at: now,
         updated_at: now,
     };

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -787,11 +787,16 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     // handler's closure so each spawn can inject it into Claude's env.
     // See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §7.
     let auth_key_ai = state.auth_key.clone();
+    // Broker — passed into the identity-injection path so the OAuth
+    // expiry probe (PR D, spec §4.4) can publish
+    // `identitybundlebindings:changed:<bundle_id>` on status change.
+    let broker_ai = state.broker.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
         Box::new(move |data, _ctx| {
             let wstore = wstore_ai.clone();
             let auth_key = auth_key_ai.clone();
+            let broker = broker_ai.clone();
             Box::pin(async move {
                 let cmd: CommandAgentInputData = serde_json::from_value(data)
                     .map_err(|e| format!("agentinput: {e}"))?;
@@ -837,9 +842,13 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // each per-provider env var into the spawn map. Failures
                 // are logged and skipped — the agent CLI launches with
                 // whatever resolved cleanly plus the static cmd:env block.
-                // See agentmux-srv/src/identity/resolver.rs.
-                crate::identity::inject_identity_env(
+                // See agentmux-srv/src/identity/resolver.rs. Broker
+                // hand-in lets the OAuth expiry probe (PR D, spec §4.4)
+                // publish `identitybundlebindings:changed:<bundle_id>`
+                // when it flips a token's status valid→expired etc.
+                crate::identity::resolver::inject_identity_env_with_broker(
                     wstore.clone(),
+                    Some(broker.clone()),
                     &cmd.blockid,
                     &mut env_vars,
                 );

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -34,6 +34,7 @@ import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slu
 import { getProvider } from "../providers";
 import { PreLaunchAuthPanel } from "./PreLaunchAuthPanel";
 import { AuthFlowController } from "../auth";
+import { loadAccounts, subscribeAccountChanges } from "@/app/view/identity/identity-model";
 
 export interface LaunchOverrides {
     /** Instance name — written into AGENTMUX_AGENT_ID and used to
@@ -477,6 +478,45 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         return hasMatchingBinding(flow.state, providerId);
     });
 
+    // Account-cache backed memo that resolves the bound account row for
+    // the current (identity, provider) pair and exposes its `status`
+    // string. Per spec §4.4 the canonical oauth-class values are
+    // `"valid" | "expired" | "needs_reauth" | "unknown"`. Returns `null`
+    // when there's no matching binding or the account row isn't in the
+    // cache yet — the consumer (`PreLaunchAuthPanel`) treats `null` as
+    // "no status info, use generic wording".
+    //
+    // The cache is the same one `IdentityPaneViewModel` subscribes to,
+    // so a status flip pushed by the backend's expiry probe
+    // (`identitybundlebindings:changed:<id>` → refreshes cache)
+    // reactively updates this memo and re-renders the panel.
+    const [accountCacheTick, setAccountCacheTick] = createSignal(0);
+    const accountCacheUnsub = subscribeAccountChanges(() => {
+        setAccountCacheTick((n) => n + 1);
+    });
+    onCleanup(accountCacheUnsub);
+    const bundleBindingStatus = createMemo<string | null>(() => {
+        accountCacheTick();
+        const id = flow.state.form.identityId;
+        const providerId = provider()?.id;
+        if (!id || !providerId) return null;
+        const bindings = flow.state.bindings[id] ?? [];
+        const b = bindings.find((bb) => bb.provider === providerId);
+        if (!b) return null;
+        const acc = loadAccounts().find((a) => a.id === b.account_id);
+        return acc?.status ?? null;
+    });
+
+    // True when the bound account is in an oauth-class state that
+    // benefits from a Reconnect nudge — strictly a wording trigger, not
+    // a launch-blocker (spec §4.4: "wording-only nudge"). The Launch
+    // button stays enabled because the binding still counts; the CLI
+    // will refresh on its first call.
+    const bundleNeedsReconnectNudge = createMemo(() => {
+        const s = bundleBindingStatus();
+        return s === "needs_reauth" || s === "expired";
+    });
+
     // Auth gate applies to fresh launches of OAuth providers when the
     // selected identity can't supply credentials for the agent's
     // provider. That's true when:
@@ -496,7 +536,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     //   `auth.submitapikey` persists bundles (PR C-2), the gate would
     //   deadlock. Their existing `launch-flow.ts` Phase 2 prompts for
     //   the key in-line. Reagent + codex P1 on #847.
-    const authRequired = () =>
+    // Hard auth-blockers: launch CANNOT proceed without the user
+    // completing OAuth. Drives both the panel mount AND the launch
+    // gate. (Pre-PR-D `authRequired` was this exact set.)
+    const authBlocksLaunch = () =>
         !isContinue()
         && provider()?.authType === "oauth"
         && (
@@ -504,7 +547,24 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
             || provider()?.id === "openclaw"
             || !bundleHasMatchingBinding()
         );
-    const authReady = () => !authRequired() || authStateKind() === "ready";
+    // Soft nudges: show the Connect CTA (with status-aware wording)
+    // when the binding is present but its account status is
+    // `needs_reauth` / `expired`. Per spec §4.4 this is a "wording-only
+    // nudge" — does NOT block Launch. The CLI's own refresh path
+    // handles the rest on first call; the nudge just gives the user a
+    // one-click path to refresh proactively.
+    const authNeedsReconnectWording = () =>
+        !isContinue()
+        && provider()?.authType === "oauth"
+        && bundleHasMatchingBinding()
+        && bundleNeedsReconnectNudge();
+    // Mount the panel for EITHER reason (hard block or soft nudge).
+    const authRequired = () => authBlocksLaunch() || authNeedsReconnectWording();
+    // Launch-readiness gate. Note this only consults `authBlocksLaunch`
+    // — the wording-only path doesn't gate. The panel may still show a
+    // `ConnectCta` in the nudge case, but `authReady` returns true and
+    // Launch is clickable.
+    const authReady = () => !authBlocksLaunch() || authStateKind() === "ready";
     const canSubmit = () =>
         !submitting()
         && slugifyInstanceName(name()).length > 0
@@ -861,6 +921,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                             provider={provider()}
                             identityId={identityId}
                             hasMatchingBinding={bundleHasMatchingBinding}
+                            bindingStatus={bundleBindingStatus}
                             controller={authController}
                             onBundleCreated={onBundleCreated}
                             autoStartAuth={props.initialFormState != null && props.autoStartAuth === true}

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -34,7 +34,11 @@ import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slu
 import { getProvider } from "../providers";
 import { PreLaunchAuthPanel } from "./PreLaunchAuthPanel";
 import { AuthFlowController } from "../auth";
-import { loadAccounts, subscribeAccountChanges } from "@/app/view/identity/identity-model";
+import {
+    loadAccounts,
+    refreshAccountCache,
+    subscribeAccountChanges,
+} from "@/app/view/identity/identity-model";
 
 export interface LaunchOverrides {
     /** Instance name — written into AGENTMUX_AGENT_ID and used to
@@ -452,6 +456,13 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
             eventType: `identitybundlebindings:changed:${id}`,
             handler: () => {
                 void (async () => {
+                    // Refresh the account cache too. The backend's
+                    // expiry probe (PR D) updates IdentityAccount.status
+                    // and publishes this same event — without refreshing
+                    // accounts here, `bundleBindingStatus` reads stale
+                    // status from the in-memory cache until something
+                    // unrelated triggers a refresh. codex P2 on #982.
+                    void refreshAccountCache();
                     try {
                         const list = await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
                             identity_id: id,

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -58,6 +58,23 @@ export interface PreLaunchAuthPanelProps {
      *  loading), the panel routes to `needs-bundle` so the user goes
      *  through the OAuth flow before Launch enables. */
     hasMatchingBinding: Accessor<boolean>;
+    /** Status of the bound account for this (bundle, provider) pair,
+     *  or `null` when there's no matching binding. Per spec §4.4 the
+     *  oauth-class canonical values are `"valid" | "expired" |
+     *  "needs_reauth" | "unknown"`. When the panel sees `"expired"` /
+     *  `"needs_reauth"` together with `hasMatchingBinding=true`, the
+     *  Connect CTA's wording shifts from "Connect to <Provider>" to
+     *  "<Provider> credentials need reconnecting" — same OAuth flow,
+     *  just a clearer nudge. Optional: callers that don't surface
+     *  account status fall through to the generic wording.
+     *
+     *  Note: this does NOT change the launch-gate. A non-blank bundle
+     *  with a matching binding still counts toward `hasMatchingBinding`
+     *  even if its status is `expired` / `needs_reauth`; the agent CLI
+     *  will trigger its own OAuth refresh on first call. The wording
+     *  exists to surface the situation so the user can act proactively
+     *  via the Reconnect button in the bundle manager. */
+    bindingStatus?: Accessor<string | null>;
     /** Auth flow controller — owned by the Launch modal so its
      *  lifetime spans the whole modal, not just the panel's
      *  conditional mount. Lifting fixed the "memory change forgot
@@ -277,6 +294,8 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                     <ConnectCta
                         provider={props.provider}
                         state={controller.state()}
+                        bindingStatus={props.bindingStatus?.() ?? null}
+                        hasBinding={props.hasMatchingBinding()}
                         onConnect={() => handleConnect()}
                         disabled={props.disabled ?? false}
                     />
@@ -400,6 +419,16 @@ async function startConnect(
 const ConnectCta = (p: {
     provider: ProviderDefinition | undefined;
     state: AuthState;
+    /** `IdentityAccount.status` of the bound row for this (bundle,
+     *  provider) pair, or `null` when no binding exists yet. Drives
+     *  the spec §4.4 status-aware wording when the user has a
+     *  binding but its tokens are `expired` / `needs_reauth`. */
+    bindingStatus: string | null;
+    /** True when `hasMatchingBinding(state, provider)` is true — gates
+     *  the reconnect-wording branch so it only triggers when there IS
+     *  a binding to refresh (the no-binding case keeps the generic
+     *  Connect CTA wording the user already knows). */
+    hasBinding: boolean;
     onConnect: () => void;
     disabled: boolean;
 }): JSX.Element => {
@@ -407,12 +436,23 @@ const ConnectCta = (p: {
         p.provider ? getCliCatalogEntry(p.provider.id) : undefined;
     const providerLabel = () => p.provider?.displayName ?? "this provider";
     const isExpired = () => p.state.kind === "expired";
+    // Spec §4.4 — when the user has a binding for this provider but
+    // its account status flags a reconnect (expired / needs_reauth),
+    // shift to the "credentials need reconnecting" wording. Same
+    // Connect button, same OAuth flow underneath; just a clearer nudge
+    // so the user understands they're refreshing a known login rather
+    // than starting fresh.
+    const needsReconnect = () =>
+        p.hasBinding &&
+        (p.bindingStatus === "needs_reauth" || p.bindingStatus === "expired");
     return (
         <div class="pre-launch-auth-panel-cta">
             <div class="pre-launch-auth-panel-warning">
-                {isExpired()
-                    ? `⚠ Your ${providerLabel()} session is expired. Re-authenticate before launching.`
-                    : `⚠ ${providerLabel()} requires an OAuth login before launch.`}
+                {needsReconnect()
+                    ? `⚠ Your ${providerLabel()} credentials need reconnecting.`
+                    : isExpired()
+                        ? `⚠ Your ${providerLabel()} session is expired. Re-authenticate before launching.`
+                        : `⚠ ${providerLabel()} requires an OAuth login before launch.`}
             </div>
             <Button
                 onClick={() => p.onConnect()}
@@ -423,13 +463,19 @@ const ConnectCta = (p: {
                     {catalog()?.icon ?? "🔐"}
                 </span>
                 <span class="pre-launch-auth-panel-connect-label">
-                    {isExpired() ? "Re-authenticate" : `Connect to ${providerLabel()}`}
+                    {needsReconnect()
+                        ? `Reconnect ${providerLabel()}`
+                        : isExpired()
+                            ? "Re-authenticate"
+                            : `Connect to ${providerLabel()}`}
                 </span>
             </Button>
             <div class="pre-launch-auth-panel-hint">
-                Opens browser → {providerLabel()} login → returns to AgentMux.
-                Tokens get saved into a new Identity bundle so the next
-                agent doesn't have to re-authenticate.
+                {needsReconnect()
+                    ? `Re-runs OAuth into your existing Identity bundle. Launch stays available — your CLI will refresh on first call.`
+                    : `Opens browser → ${providerLabel()} login → returns to AgentMux.
+                    Tokens get saved into a new Identity bundle so the next
+                    agent doesn't have to re-authenticate.`}
             </div>
         </div>
     );

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -249,6 +249,34 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     return (
         <div class="pre-launch-auth-panel">
             <Switch>
+                {/* A bound binding that the backend's expiry probe
+                    flagged stale (`needs_reauth` / `expired`) lands the
+                    controller in `ready` because outcomeFor() only
+                    looks at "has a binding?". Without this arm the
+                    panel would render <ReadyBanner /> and the
+                    reconnect wording in ConnectCta would never be
+                    seen — the user would have no signal their
+                    credentials need refreshing. Match BEFORE the
+                    generic ready arm so the reconnect CTA wins.
+                    Clicking Connect re-runs OAuth into the SAME
+                    bundle dir (PR C invariant), refreshing the
+                    token in place. codex P1 on #982. */}
+                <Match
+                    when={
+                        controller.state().kind === "ready" &&
+                        (props.bindingStatus?.() === "needs_reauth" ||
+                            props.bindingStatus?.() === "expired")
+                    }
+                >
+                    <ConnectCta
+                        provider={props.provider}
+                        state={controller.state()}
+                        bindingStatus={props.bindingStatus?.() ?? null}
+                        hasBinding={props.hasMatchingBinding()}
+                        onConnect={() => handleConnect()}
+                        disabled={props.disabled ?? false}
+                    />
+                </Match>
                 <Match when={controller.state().kind === "ready"}>
                     <ReadyBanner />
                 </Match>

--- a/frontend/app/view/identity/identity-manager.tsx
+++ b/frontend/app/view/identity/identity-manager.tsx
@@ -19,14 +19,60 @@
 // IdentityPaneViewModel) plus the account-change broadcaster, so two
 // live instances stay consistent for free.
 
-import { For, onCleanup, Show, type JSX } from "solid-js";
+import { createMemo, For, onCleanup, Show, type JSX } from "solid-js";
 
 import { IdentityPaneViewModel } from "./identity-pane-model";
+import type { Account } from "./identity-model";
 
 import "./identity-pane-view.scss";
 
 interface IdentityManagerBodyProps {
     model: IdentityPaneViewModel;
+    /**
+     * Optional callback wired by the host (the bundle-manager modal /
+     * agent settings pane) so a `Reconnect` button next to a
+     * `needs_reauth` status badge can route to the same OAuth flow the
+     * launch modal uses. Called with the (bundleId, providerId) pair
+     * the user clicked; the host re-runs OAuth into the SAME bundle dir
+     * — PR C's `persist_oauth_binding_or_synthetic` reuses the existing
+     * account_id, so a clean OAuth flips the status back to `valid` via
+     * the success path + `identitybundlebindings:changed:<id>` push.
+     *
+     * Spec: SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md §4.4. Omitted
+     * callback → button hidden (no dead affordance).
+     */
+    onReconnect?: (bundleId: string, providerId: string) => void;
+}
+
+/**
+ * Map an oauth-class binding's account status to the small status-badge
+ * descriptor rendered in the bindings table. Per spec §4.4. The
+ * fallback (`label = status string verbatim, dot = "unknown"`) keeps
+ * api-key rows whose `status` is a freeform legacy string visible
+ * without forcing them through this dispatch.
+ */
+function statusBadge(status: string | undefined): {
+    label: string;
+    dot: "valid" | "expired" | "needs_reauth" | "unknown";
+    reconnect: boolean;
+} {
+    switch (status) {
+        case "valid":
+            return { label: "Valid", dot: "valid", reconnect: false };
+        case "expired":
+            return { label: "Expired", dot: "expired", reconnect: false };
+        case "needs_reauth":
+            return { label: "Reconnect needed", dot: "needs_reauth", reconnect: true };
+        case "unknown":
+        case undefined:
+        case "":
+            return { label: "—", dot: "unknown", reconnect: false };
+        default:
+            // api-key freeform strings (e.g. "ok", "invalid", "checking")
+            // render verbatim with the neutral dot so legacy rows stay
+            // readable.
+            return { label: status, dot: "unknown", reconnect: false };
+    }
 }
 
 /**
@@ -41,6 +87,18 @@ interface IdentityManagerBodyProps {
  */
 export const IdentityManagerBody = (props: IdentityManagerBodyProps): JSX.Element => {
     const { model } = props;
+
+    /**
+     * Index of accounts by id, derived from the model's `accountsAtom`.
+     * Used to look up the bound Account row for a given (provider,
+     * account_id) binding so the Status column can read its `status`
+     * directly. Memoised so the lookup is O(1) per row.
+     */
+    const accountsById = createMemo<Map<string, Account>>(() => {
+        const m = new Map<string, Account>();
+        for (const a of model.accountsAtom()) m.set(a.id, a);
+        return m;
+    });
 
     // Clicking a list item SELECTS the bundle so the binding table
     // becomes visible. The metadata draft (name + description) opens
@@ -149,52 +207,92 @@ export const IdentityManagerBody = (props: IdentityManagerBodyProps): JSX.Elemen
                                                 <tr>
                                                     <th>Provider</th>
                                                     <th>Account</th>
+                                                    <th>Status</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <For each={model.providersForBindingRows()}>
-                                                    {(provider) => (
-                                                        <tr>
-                                                            <td>{model.providerLabel(provider)}</td>
-                                                            <td>
-                                                                <select
-                                                                    class="identity-pane-input"
-                                                                    value={
-                                                                        model
-                                                                            .bindingsAtom()
-                                                                            .find(
-                                                                                (b) =>
-                                                                                    b.provider ===
-                                                                                    provider,
-                                                                            )?.account_id ?? ""
-                                                                    }
-                                                                    disabled={!!bundle().is_blank}
-                                                                    onChange={(e) =>
-                                                                        void model.setBinding(
-                                                                            provider,
-                                                                            e.currentTarget.value,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <option value="">— None —</option>
-                                                                    <For
-                                                                        each={
-                                                                            model
-                                                                                .accountsByProvider()
-                                                                                .get(provider) ?? []
+                                                    {(provider) => {
+                                                        const binding = createMemo(() =>
+                                                            model
+                                                                .bindingsAtom()
+                                                                .find((b) => b.provider === provider),
+                                                        );
+                                                        const boundAccount = createMemo(() => {
+                                                            const id = binding()?.account_id;
+                                                            return id ? accountsById().get(id) : undefined;
+                                                        });
+                                                        const badge = createMemo(() =>
+                                                            statusBadge(boundAccount()?.status),
+                                                        );
+                                                        return (
+                                                            <tr>
+                                                                <td>{model.providerLabel(provider)}</td>
+                                                                <td>
+                                                                    <select
+                                                                        class="identity-pane-input"
+                                                                        value={binding()?.account_id ?? ""}
+                                                                        disabled={!!bundle().is_blank}
+                                                                        onChange={(e) =>
+                                                                            void model.setBinding(
+                                                                                provider,
+                                                                                e.currentTarget.value,
+                                                                            )
                                                                         }
                                                                     >
-                                                                        {(acc) => (
-                                                                            <option value={acc.id}>
-                                                                                {acc.display_name?.trim() ||
-                                                                                    acc.name}
-                                                                            </option>
-                                                                        )}
-                                                                    </For>
-                                                                </select>
-                                                            </td>
-                                                        </tr>
-                                                    )}
+                                                                        <option value="">— None —</option>
+                                                                        <For
+                                                                            each={
+                                                                                model
+                                                                                    .accountsByProvider()
+                                                                                    .get(provider) ?? []
+                                                                            }
+                                                                        >
+                                                                            {(acc) => (
+                                                                                <option value={acc.id}>
+                                                                                    {acc.display_name?.trim() ||
+                                                                                        acc.name}
+                                                                                </option>
+                                                                            )}
+                                                                        </For>
+                                                                    </select>
+                                                                </td>
+                                                                <td>
+                                                                    <Show when={binding()}>
+                                                                        <span class="identity-pane-status">
+                                                                            <span
+                                                                                class={`identity-pane-status-dot is-${badge().dot}`}
+                                                                                aria-hidden="true"
+                                                                            />
+                                                                            <span class="identity-pane-status-label">
+                                                                                {badge().label}
+                                                                            </span>
+                                                                            <Show
+                                                                                when={
+                                                                                    badge().reconnect &&
+                                                                                    props.onReconnect
+                                                                                }
+                                                                            >
+                                                                                <button
+                                                                                    type="button"
+                                                                                    class="identity-pane-reconnect-btn"
+                                                                                    onClick={() =>
+                                                                                        props.onReconnect?.(
+                                                                                            bundle().id,
+                                                                                            provider,
+                                                                                        )
+                                                                                    }
+                                                                                    title="Re-run OAuth into this bundle"
+                                                                                >
+                                                                                    Reconnect
+                                                                                </button>
+                                                                            </Show>
+                                                                        </span>
+                                                                    </Show>
+                                                                </td>
+                                                            </tr>
+                                                        );
+                                                    }}
                                                 </For>
                                             </tbody>
                                         </table>
@@ -301,12 +399,20 @@ export const IdentityManagerBody = (props: IdentityManagerBodyProps): JSX.Elemen
  * constructs cleanly with no block and drives entirely off the
  * `bundle_*` RPCs and the account-change broadcaster.
  */
-export const IdentityManager = (): JSX.Element => {
+export interface IdentityManagerProps {
+    /** Forwarded to `IdentityManagerBody.onReconnect`. Host wires this to
+     *  the OAuth flow it owns (e.g. the bundle-manager modal opens a
+     *  Reconnect tabModal request). When omitted, the Reconnect button
+     *  is hidden — no dead affordance. */
+    onReconnect?: (bundleId: string, providerId: string) => void;
+}
+
+export const IdentityManager = (props: IdentityManagerProps = {}): JSX.Element => {
     // Component setup runs once; the model lives for this component's
     // lifetime and is disposed on unmount.
     const model = new IdentityPaneViewModel();
     onCleanup(() => model.dispose());
-    return <IdentityManagerBody model={model} />;
+    return <IdentityManagerBody model={model} onReconnect={props.onReconnect} />;
 };
 
 // Local alias mirroring `IdentityBundleDraft` from the model — see the

--- a/frontend/app/view/identity/identity-pane-view.scss
+++ b/frontend/app/view/identity/identity-pane-view.scss
@@ -155,6 +155,57 @@
         }
     }
 
+    // ── Status badge in the bindings table (PR D — spec §4.4) ─────
+    .identity-pane-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        color: var(--main-text-color);
+    }
+
+    .identity-pane-status-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--tertiary-text-color, rgba(255, 255, 255, 0.4));
+        flex: 0 0 auto;
+
+        &.is-valid {
+            background: #4ade80; // green-400
+        }
+        &.is-expired {
+            background: #fbbf24; // amber-400
+        }
+        &.is-needs_reauth {
+            background: #f87171; // red-400
+        }
+        &.is-unknown {
+            background: var(--tertiary-text-color, rgba(255, 255, 255, 0.4));
+        }
+    }
+
+    .identity-pane-status-label {
+        white-space: nowrap;
+    }
+
+    .identity-pane-reconnect-btn {
+        margin-left: 8px;
+        padding: 2px 8px;
+        font-size: 11px;
+        background: transparent;
+        color: var(--accent-color);
+        border: 1px solid var(--accent-color);
+        border-radius: 3px;
+        cursor: pointer;
+
+        &:hover {
+            background: var(--accent-color);
+            color: var(--accent-text-color, #fff);
+        }
+    }
+
     .identity-pane-actions {
         display: flex;
         gap: 8px;


### PR DESCRIPTION
## OAuth Bundles PR D

Fourth of the 6-PR sequence (`SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md` §4.4). Status semantics for `IdentityAccount` + a cheap on-disk **expiry probe at spawn** + a UI **Status column** + a **Reconnect button** on `needs_reauth` + status-aware launch-modal wording.

### Backend

- **`oauth_status`** constants module pinning the canonical values (`valid` / `expired` / `needs_reauth` / `unknown`) for oauth-class bindings — api-key rows keep their freeform `status`.
- **`probe_oauth_status()`** reads `<config_dir>/.credentials.json` (Anthropic's Claude Code format primary; codex / openclaw token files structurally probed with best-effort fallbacks — see uncertainties), parses `expires_at`, and returns `Valid` / `Expired` / `NeedsReauth`. Cheap fs + JSON parse, no network round-trip.
- **`inject_identity_env_with_broker`** — variant of `inject_identity_env` that calls the probe in its OAuth-class branch, updates `IdentityAccount.status` via `wstore.identity_upsert`, and publishes `identitybundlebindings:changed:<bundle>` on change. Spawn callers (`AgentInputCommand` / `AgentSendCommand`) thread the `broker` through; legacy `inject_identity_env` kept for backward compat.
- `persist_oauth_binding_or_synthetic` (PR C) now writes the typed `oauth_status::VALID` constant.

### Frontend

- **`IdentityManagerBody`** (`Bound accounts` table) — new **Status column** with a coloured-dot + label badge: green/Valid, amber/Expired, red/Reconnect needed, grey/—. Legacy freeform statuses render verbatim. **Reconnect button** appears next to red rows when a host wires `onReconnect`.
- **`PreLaunchAuthPanel`** — new `bindingStatus` prop; the Connect CTA renders *"Your <Provider> credentials need reconnecting."* + *"Reconnect <Provider>"* button when the bound account is `needs_reauth` / `expired` (same OAuth flow, status-aware wording per spec).
- **`AgentLaunchModal`** — derives `bundleBindingStatus` + `bundleNeedsReconnectNudge` memos from `loadAccounts() + subscribeAccountChanges()`; splits `authRequired` into `authBlocksLaunch` + `authNeedsReconnectWording` so the wording nudge mounts the panel without gating Launch.

### Tests

- 10 new probe + integration tests in `resolver.rs` (`probe_oauth_status_*` matrix + `inject_oauth_class_probes_and_flips_status_*`).
- **72 backend identity tests + 64 auth-flow + 63 launch-flow-state + identity-model frontend tests all pass.**
- `cargo check -p agentmux-srv` clean; `npx tsc --noEmit` clean on touched files.

### Uncertainties (deferred)

- **codex / openclaw token shape**: only Anthropic's `claudeAiOauth.{accessToken, refreshToken, expiresAt}` (ms) is documented. The parser tries that key first, then top-level `expiresAt` / `expires_at` fallbacks; if none parse, the probe returns `Valid` (file exists but layout unknown — better than false `needs_reauth` on a working session). Strict expiry semantics for those two providers is a follow-up once their layouts are confirmed.
- **Reconnect from `BundleManagerModal`**: the modal is window-scoped (no `tabModal` in scope), so its Reconnect button is unwired by default — status badges still render, the button is gated on the optional `onReconnect` callback. The launch-modal path carries the reconnect flow end-to-end. Wiring the hamburger manager's Reconnect → AuthFlowController would be its own small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)