### PR TITLE
refactor(oauth): drop openclaw always-gate; bundle path handles all oauth providers (OAuth Bundles PR F)

### DIFF
--- a/.changesets/1779508221-refactor-oauth-drop-openclaw-always-gate-hack-bundle-path-ha-3a0t.md
+++ b/.changesets/1779508221-refactor-oauth-drop-openclaw-always-gate-hack-bundle-path-ha-3a0t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(oauth): drop openclaw always-gate hack; bundle path handles all oauth providers (oauth bundles PR F)

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -533,10 +533,6 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // provider. That's true when:
     //
     // - `blank`/empty is selected — ambient creds, OAuth flow runs once.
-    // - OpenClaw provider — until identity bundles include openclaw
-    //   auth profiles, gate ALWAYS (Phase α addition, 2026-05-17).
-    //   Lifts once identity-bundles-include-openclaw lands (planned
-    //   with Phase δ persistence work).
     // - A non-blank bundle without a matching provider binding —
     //   e.g. "+ New" just created an empty "Work" bundle. Reagent +
     //   codex P1 on PR #910 round 3.
@@ -547,15 +543,22 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     //   `auth.submitapikey` persists bundles (PR C-2), the gate would
     //   deadlock. Their existing `launch-flow.ts` Phase 2 prompts for
     //   the key in-line. Reagent + codex P1 on #847.
+    //
     // Hard auth-blockers: launch CANNOT proceed without the user
     // completing OAuth. Drives both the panel mount AND the launch
-    // gate. (Pre-PR-D `authRequired` was this exact set.)
+    // gate.
+    //
+    // (Historical note: PRs A–E of SPEC_OAUTH_IDENTITY_BUNDLES wired
+    //  oauth-class providers — including openclaw — through real
+    //  per-bundle credential dirs, so the previous `provider.id ===
+    //  "openclaw"` always-gate is no longer needed. The standard
+    //  `hasMatchingBinding` path handles every oauth provider.
+    //  PR F cleanup, 2026-05-22.)
     const authBlocksLaunch = () =>
         !isContinue()
         && provider()?.authType === "oauth"
         && (
             identityId() === ""
-            || provider()?.id === "openclaw"
             || !bundleHasMatchingBinding()
         );
     // Soft nudges: show the Connect CTA (with status-aware wording)

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -343,12 +343,12 @@ function outcomeFor(
     providerId: string | undefined,
     hasMatchingBinding: boolean,
 ): SelectionOutcome {
-    // Phase α for openclaw: bundle persistence isn't wired yet, so an
-    // already-selected identity can't be trusted as authenticated. Force
-    // a fresh OAuth on every launch so AgentLaunchModal's openclaw
-    // override actually gates Launch. Lift once Phase δ wires real
-    // bundle storage.
-    if (providerId === "openclaw") return "needs-bundle";
+    // (Historical note: openclaw previously short-circuited to
+    //  `needs-bundle` here as a Phase α stub because identity bundles
+    //  didn't store openclaw auth. PRs A–E of
+    //  SPEC_OAUTH_IDENTITY_BUNDLES gave openclaw real per-bundle
+    //  credential dirs + bindings, so the standard binding-driven
+    //  outcome path handles it now. PR F cleanup, 2026-05-22.)
     if (!identityId) return "needs-bundle";
     // Reagent + codex P1 on PR #910 round 3 — a non-blank bundle
     // without a binding for the agent's provider can't supply creds


### PR DESCRIPTION
## OAuth Bundles PR F — final cleanup

Sixth and last of the OAuth-identity-bundles sequence (`SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md` §6). With PRs A–E shipped, openclaw bindings live in real identity bundles with `SecretRef::OAuthConfigDir`, get resolved into the right config-dir env var at spawn, get probed for status, and get seeded from ambient `~/.openclaw` on startup. The two openclaw "Phase α" overrides that short-circuited the standard binding-driven path are no longer needed.

### Removed

- **`AgentLaunchModal.tsx::authBlocksLaunch`** — the `|| provider().id === "openclaw"` arm that gated Launch ALWAYS for openclaw regardless of binding state. The standard `bundleHasMatchingBinding()` check now handles openclaw the same as claude / codex.
- **`PreLaunchAuthPanel.tsx::outcomeFor`** — the `if (providerId === "openclaw") return "needs-bundle";` short-circuit that forced a fresh OAuth even when an openclaw binding existed. The standard `hasMatchingBinding` path resolves openclaw correctly.

The historical-context comments at the removal sites point at this PR for future readers; the spec's open question on codex/openclaw env var names was already resolved by PR B sourcing them from the canonical CLI registry.

### Tests

- 127 launch-flow + auth tests pass.
- `npx tsc --noEmit` clean on touched files.
- No test referenced the always-gate; openclaw appears only as a generic provider name in the auth-state suite.

---

This closes the 6-PR sequence. Net effect across A–F:

| PR | What it landed |
|---|---|
| **A** (#978) | `SecretRef::OAuthConfigDir` + per-bundle dir layout |
| **B** (#979) | `ProviderClass` + OAuth dispatch in the resolver |
| **C** (#981) | OAuth-success invariant — every Connect lands bound |
| **D** (#982) | Status field + expiry probe + UI + Reconnect |
| **E** (#983) | Default-bundle migration from ambient `~/.claude` |
| **F** (this) | Drop openclaw `gate always` — bundle path is the standard path |

Identity bundles now carry OAuth credentials as filesystem pointers for every oauth-class provider, with status tracking and self-healing back-fill. Maks (and every other ambient-creds user) gets a real bound identity automatically on startup; the launch modal stops needing provider-specific hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)