### PR TITLE
test(reagent): synthetic release-consistency mismatch — DO NOT MERGE

### DIFF
--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,9 @@
 # AgentMux Version History
 
+## 0.99.0 — 2026-05-23
+
+- test(reagent): synthetic release-consistency mismatch — VERSION_HISTORY advanced to 0.99.0 while package.json / Cargo.toml stay at 0.38.2. This entry exists only to verify a5af/reagent#158 fires `[P0] Release-consistency mismatch` instead of approving the PR. **Do not merge.**
+
 ## 0.38.1 — 2026-05-22
 
 - fix(magnify): single-instance pane render — fixes zoom + browser-pane black on restore


### PR DESCRIPTION
## Purpose — smoke test only

Verifies that the release-consistency check from a5af/reagent#158 (PR #159, **deployed to prod 2026-05-23 07:35 UTC**) fires correctly.

## What this PR does

Advances `VERSION_HISTORY.md` to a fake `## 0.99.0` section while leaving `package.json` and `Cargo.toml` **untouched at 0.38.2** — the textbook release-PR inconsistency the new check is meant to catch.

## Expected reagent behavior

ReAgent should post `[P0] Release-consistency mismatch` for `package.json` and `Cargo.toml` (each still at `0.38.2` vs the changelog's `0.99.0`) and **not** approve the PR.

## Do not merge

This PR will be **closed without merge** once the review has posted, regardless of outcome.

- ReAgent posts P0 mismatch → check is working, close PR.
- ReAgent approves → check is broken; close PR, file a regression issue on a5af/reagent.