### PR TITLE
fix(agent-pane): PTY cols follow pane width + bump default to 200

### DIFF
--- a/.changesets/1779525893-fix-agent-pane-pty-cols-follow-pane-width-bump-default-to-20-h8tl.md
+++ b/.changesets/1779525893-fix-agent-pane-pty-cols-follow-pane-width-bump-default-to-20-h8tl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): PTY cols follow pane width + bump default to 200

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -400,11 +400,18 @@ impl Controller for ShellController {
             return Ok(());
         }
 
-        // Real PTY path
+        // Real PTY path.
+        //
+        // Initial cols bumped to 200 (was 80) so the agent-pane live-log
+        // doesn't render hard-wrapped at ~80 chars before the frontend's
+        // dynamic resize lands (see hooks/usePtyWidth.ts and
+        // docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md). The dynamic
+        // resize coalesces over a ~150 ms debounce after mount, so the
+        // PTY uses this default for the very first batch of output.
         let pty_system = native_pty_system();
         let pty_size = PtySize {
             rows: 25,
-            cols: 80,
+            cols: 200,
             pixel_width: 0,
             pixel_height: 0,
         };
@@ -418,7 +425,7 @@ impl Controller for ShellController {
             self.unlock_run();
             format!("failed to open PTY: {e}")
         })?;
-        tracing::info!(block_id = %self.block_id, rows = 25, cols = 80, "PTY opened");
+        tracing::info!(block_id = %self.block_id, rows = 25, cols = 200, "PTY opened");
 
         // Determine shell command
         let cmd_str = Self::get_cmd_str(&block_meta);

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -29,6 +29,7 @@ import { useBookmarks } from "./hooks/useBookmarks";
 import { useScrollToNode } from "./hooks/useScrollToNode";
 import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
 import { useProcessCount } from "./hooks/useProcessCount";
+import { usePtyWidth } from "./hooks/usePtyWidth";
 import { useSubagentEvents } from "./hooks/useSubagentEvents";
 import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useAgentCommands } from "./hooks/useAgentCommands";
@@ -536,6 +537,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // note below where the inline handlers were removed.
 
     let rootRef: HTMLDivElement | undefined;
+
+    // Track pane width → PTY cols so tools running inside the agent CLI
+    // (git, ls, claude, …) wrap their output to match the pane instead of
+    // the hard-coded `cols: 80` the PTY was opened with. ResizeObserver
+    // on the root element; debounced 150 ms; one ControllerInputCommand
+    // per net size change. See docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md.
+    // Caveat: already-captured live-log lines stay at their original wrap.
+    usePtyWidth({
+        blockId: model.blockId,
+        elementRef: () => rootRef,
+        log,
+    });
 
     // Zoom input is handled by the universal framework — `keymodel.ts`
     // intercepts Ctrl+/-/0 and dispatches to `zoomIn/Out/Reset`, and

--- a/frontend/app/view/agent/hooks/usePtyWidth.ts
+++ b/frontend/app/view/agent/hooks/usePtyWidth.ts
@@ -1,0 +1,126 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * usePtyWidth — observe the agent pane's width and push a matching
+ * `cols` value to the backing PTY whenever it changes.
+ *
+ * Background: the agent pane is a custom UI, not an xterm.js terminal,
+ * so the PTY that hosts the agent CLI never sees a resize event from
+ * a `fitAddon`. As a result tools like `git`, `ls`, `claude` wrap
+ * their output at whatever cols the PTY was opened with (80) and
+ * the captured live-log shows hard wraps that don't match the pane.
+ *
+ * The backend (`shell.rs`) already accepts `termsize: { rows, cols }`
+ * on incoming `controllerinput` messages and forwards it to
+ * `master.resize(...)`. This hook supplies the value:
+ *
+ *   1. Attaches a `ResizeObserver` to the supplied container ref.
+ *   2. Converts width-in-pixels to cols using the computed monospace
+ *      cell width (`font-size × ~0.6`).
+ *   3. Debounces by `DEBOUNCE_MS` so a drag-resize emits at most one
+ *      RPC per gesture.
+ *   4. Sends `RpcApi.ControllerInputCommand` with `termsize`.
+ *
+ * Caveat (documented in
+ * `docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md`): lines already
+ * in the live-log buffer stay wrapped at whatever cols was active
+ * when they were captured. Only NEW output reflows.
+ */
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { onCleanup, onMount, type Accessor } from "solid-js";
+
+export interface UsePtyWidthOpts {
+    blockId: string;
+    /** Accessor returning the element whose width drives the PTY cols. */
+    elementRef: Accessor<HTMLElement | undefined>;
+    /** Optional logger; warnings are surfaced through the activity log. */
+    log?: (tag: string, text: string, level?: "info" | "warn" | "error") => void;
+}
+
+/** Approximate monospace cell-width ratio (cell_width ≈ font-size × 0.6). */
+const CELL_WIDTH_RATIO = 0.6;
+/** Coalesce burst resize events (drag) into a single RPC. */
+const DEBOUNCE_MS = 150;
+/** Minimum cols floor — avoids pathological `cols: 0` from very narrow panes. */
+const MIN_COLS = 40;
+/** Default rows; the agent pane is scrollable so the value rarely matters. */
+const DEFAULT_ROWS = 25;
+/** Horizontal padding fudge (px); the pane has small inset around content. */
+const PADDING_X_PX = 16;
+
+function computeCols(widthPx: number, fontSizePx: number): number {
+    const cellWidth = Math.max(1, fontSizePx * CELL_WIDTH_RATIO);
+    const usable = Math.max(0, widthPx - PADDING_X_PX);
+    const raw = Math.floor(usable / cellWidth);
+    return Math.max(MIN_COLS, raw);
+}
+
+function readFontSizePx(el: HTMLElement): number {
+    // computed font-size is always returned in px by getComputedStyle.
+    const cs = getComputedStyle(el);
+    const parsed = parseFloat(cs.fontSize);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    return 13; // matches the SCSS fallback for --termfontsize.
+}
+
+export function usePtyWidth(opts: UsePtyWidthOpts): void {
+    onMount(() => {
+        const el = opts.elementRef();
+        if (!el) return;
+        // `ResizeObserver` is browser-native (Chromium-based host).
+        if (typeof ResizeObserver === "undefined") return;
+
+        let lastCols = -1;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+
+        const send = (cols: number) => {
+            if (cols === lastCols) return;
+            lastCols = cols;
+            RpcApi.ControllerInputCommand(TabRpcClient, {
+                blockid: opts.blockId,
+                termsize: { rows: DEFAULT_ROWS, cols },
+            }).catch((err: unknown) => {
+                opts.log?.(
+                    "pty",
+                    `resize to ${cols} cols failed: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                    "warn",
+                );
+            });
+        };
+
+        const compute = () => {
+            const target = opts.elementRef();
+            if (!target) return;
+            const width = target.clientWidth;
+            if (width <= 0) return;
+            const fontSize = readFontSizePx(target);
+            send(computeCols(width, fontSize));
+        };
+
+        const observer = new ResizeObserver(() => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(compute, DEBOUNCE_MS);
+        });
+        observer.observe(el);
+
+        // Fire once after mount so the agent gets the right cols before
+        // its first tool invocation, not just after the user resizes.
+        // Use the same debounced path so this initial value can be
+        // coalesced with any layout-driven ResizeObserver burst at mount.
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(compute, DEBOUNCE_MS);
+
+        onCleanup(() => {
+            if (timer) clearTimeout(timer);
+            observer.disconnect();
+        });
+    });
+}
+
+// Export internals for unit tests / sanity checks.
+export const __test__ = { computeCols, CELL_WIDTH_RATIO, MIN_COLS, DEBOUNCE_MS };

--- a/frontend/app/view/agent/hooks/usePtyWidth.ts
+++ b/frontend/app/view/agent/hooks/usePtyWidth.ts
@@ -76,21 +76,45 @@ export function usePtyWidth(opts: UsePtyWidthOpts): void {
         let lastCols = -1;
         let timer: ReturnType<typeof setTimeout> | undefined;
 
-        const send = (cols: number) => {
+        // codex P1 on #986: the controller can be unregistered at first
+        // mount (launcher async-spawns it AFTER `startLaunchFlow` runs),
+        // so the initial `controllerinput` send fails with "controller is
+        // not running" and `lastCols` was being set BEFORE the RPC
+        // resolved — meaning we'd never retry the same width and the PTY
+        // stayed at the fallback 200 for the whole session unless the
+        // user manually resized the pane.
+        //
+        // Fix: only mark `lastCols` AFTER the RPC succeeds. Retry up to 2
+        // times on failure with a short backoff so the controller has a
+        // chance to come up. A user-driven resize remains independent —
+        // each new width attempts a fresh send.
+        const send = (cols: number, retriesLeft: number = 2) => {
             if (cols === lastCols) return;
-            lastCols = cols;
             RpcApi.ControllerInputCommand(TabRpcClient, {
                 blockid: opts.blockId,
                 termsize: { rows: DEFAULT_ROWS, cols },
-            }).catch((err: unknown) => {
-                opts.log?.(
-                    "pty",
-                    `resize to ${cols} cols failed: ${
-                        err instanceof Error ? err.message : String(err)
-                    }`,
-                    "warn",
-                );
-            });
+            })
+                .then(() => {
+                    lastCols = cols;
+                })
+                .catch((err: unknown) => {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    if (retriesLeft > 0) {
+                        const delay = (3 - retriesLeft) * 500;
+                        opts.log?.(
+                            "pty",
+                            `resize to ${cols} cols failed: ${msg} (retrying in ${delay}ms)`,
+                            "warn",
+                        );
+                        setTimeout(() => send(cols, retriesLeft - 1), delay);
+                    } else {
+                        opts.log?.(
+                            "pty",
+                            `resize to ${cols} cols failed after 3 attempts: ${msg}`,
+                            "warn",
+                        );
+                    }
+                });
         };
 
         const compute = () => {


### PR DESCRIPTION
## Closes task #59 — diagnosed in `docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md`

The agent pane's PTY was hardcoded to `cols: 80`. Tools the CLI shells out to (`git log`, `ls`, …) inherit the PTY's column count and wrap their output to 80 — embedding real `\n`s into the byte stream the live-log captures. CSS soft-wrap can't undo that; the wraps are in the data.

### What landed

- **`frontend/app/view/agent/hooks/usePtyWidth.ts`** (new) — `ResizeObserver` on the agent-view root, computes `cols = floor((width - 16) / (font-size × 0.6))` clamped to ≥ 40, debounces to 150 ms, sends `ControllerInputCommand({ termsize: { rows, cols } })` on change.
- **`frontend/app/view/agent/agent-view.tsx`** — wires the hook to `rootRef`. First fire happens shortly after mount so the agent sees the real cols before its first tool invocation.
- **`agentmux-srv/src/backend/blockcontroller/shell.rs`** — initial PTY `cols: 80 → 200`. Quick-win floor for the brief window between mount and the first ResizeObserver fire, and a saner default for users still on the static path.

The backend resize handler already existed (`shell.rs:842-852`) — only the wiring was missing.

### Wire format note

Wire field is `termsize` (not `term_size` — that's the Rust struct's snake_case in the source; the TS `CommandBlockInputData` type uses the lowercase form). Agent caught this when grepping for the existing call shape.

### Caveat

**Already-captured lines stay wrapped.** Reflowing historical PTY output would corrupt anything that used the original width for layout (e.g. `git log --graph` ASCII art, aligned tables). Only output produced AFTER the resize matches the new width.

### Verification

- `npx tsc --noEmit` — clean on touched files.
- `cargo check -p agentmux-srv` — clean.
- Smoke test deferred to merge-time (needs `task dev` + a manual pane resize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)