### PR TITLE
feat(tool-block): hover delay, collapse animation, post-completion hold, scroll isolation

### DIFF
--- a/.changesets/1779533388-fix-tool-block-post-completion-hold-timer-was-cancelled-by-r-wuj2.md
+++ b/.changesets/1779533388-fix-tool-block-post-completion-hold-timer-was-cancelled-by-r-wuj2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tool-block): post-completion hold timer was cancelled by reactive self-loop

--- a/.changesets/1779535427-feat-tool-block-ux-polish-hover-delay-collapse-animation-pos-acwe.md
+++ b/.changesets/1779535427-feat-tool-block-ux-polish-hover-delay-collapse-animation-pos-acwe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tool-block): UX polish — hover delay, collapse animation, post-completion hold, scroll isolation, a11y inert

--- a/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md
+++ b/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md
@@ -1,0 +1,264 @@
+# SPEC: Tool Block UX Polish — Hover Delay, Collapse Animation, Post-Completion Hold, Thinking Label, Scroll Isolation
+
+**Date:** 2026-05-23  
+**Status:** Ready for implementation  
+**Files touched:** `ToolBlock.tsx`, `ToolOverlayLog.tsx`, `_document-nodes.scss`, `_tool-overlay-portal.scss`
+
+---
+
+## Background
+
+When the portal overlay was replaced with the inline panel
+(`SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md`, PR #888), three UX
+regressions were introduced alongside one label that never got updated:
+
+1. The **150 ms hover enter delay** was removed (comment at `ToolBlock.tsx:65–72`
+   explains the rationale — inline panel removes "dead space" — but the delay
+   also prevents accidental expansions while scrolling past tools).
+2. The **panel collapse is instant** — no exit animation, making the pane feel
+   abrupt when a running tool finishes and the block snaps shut.
+3. The **post-completion collapse is also instant** — the panel disappears the
+   moment `status` flips from `running` → `success`, giving the user no time
+   to read the final output.
+4. The **"Running..." placeholder text** was never updated to reflect that Claude
+   is thinking, not executing a shell command.
+5. The **log panel has no scroll isolation** — when the user scrolls to the top
+   or bottom of the log, the wheel event propagates to the agent pane and scrolls
+   the entire conversation, even though the cursor is still over the log.
+
+This spec addresses all five.
+
+---
+
+## Change 1 — Restore the 150 ms hover enter delay
+
+### Why
+Scrolling through a long agent response causes the cursor to briefly enter
+tool-block rows. Without a debounce, every such row expands and collapses in
+rapid succession, creating visual noise. The 150 ms gate prevents this.
+Leave is instant (no grace window needed — the inline panel is inside the
+same `.agent-tool-block` bounding box, so `mouseleave` only fires when the
+cursor genuinely exits the whole block).
+
+### Implementation — `frontend/app/view/agent/components/ToolBlock.tsx`
+
+```tsx
+// Before (lines 76–78):
+const [hovering, setHovering] = createSignal(false);
+const handleMouseEnter = () => setHovering(true);
+const handleMouseLeave = () => setHovering(false);
+
+// After:
+const HOVER_ENTER_DELAY_MS = 150;
+
+const [hovering, setHovering] = createSignal(false);
+let enterTimer: ReturnType<typeof setTimeout> | undefined;
+
+const handleMouseEnter = () => {
+    enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
+};
+const handleMouseLeave = () => {
+    clearTimeout(enterTimer);
+    setHovering(false);
+};
+onCleanup(() => clearTimeout(enterTimer));
+```
+
+Also add `onCleanup` to the import line:
+```tsx
+// Before:
+import { Show, createSignal, type JSX } from "solid-js";
+
+// After:
+import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js";
+```
+
+---
+
+## Change 2 — Animate collapse, instant open
+
+### Why
+The panel should feel like it's sliding shut (200 ms ease-out) so the user
+can track what happened, but it should open **instantly** (after the hover
+delay) so there is no sluggishness when intentionally expanding.
+
+### Approach
+Replace the `<Show when={expanded()}>` gate with an always-rendered div whose
+visibility is CSS-driven. This avoids a SolidJS exit-animation workaround
+(SolidJS has no built-in leave transition) and keeps the implementation simple.
+
+The panel is hidden via `max-height: 0` + `overflow: hidden` when the block
+has the `--hidden` modifier class. The transition fires on collapse only.
+
+### Implementation — `frontend/app/view/agent/components/ToolBlock.tsx`
+
+```tsx
+// Before:
+<Show when={expanded()}>
+    <div class="agent-tool-panel" ...>
+        <ToolBlockOverlay ... />
+    </div>
+</Show>
+
+// After — always rendered, visibility via CSS modifier:
+<div
+    class={clsx("agent-tool-panel", { "agent-tool-panel--hidden": !expanded() })}
+    onClick={(e) => e.stopPropagation()}
+    onMouseEnter={handleMouseEnter}
+    onMouseLeave={handleMouseLeave}
+>
+    <ToolBlockOverlay ... />
+</div>
+```
+
+### Implementation — `frontend/app/view/agent/styles/_document-nodes.scss`
+
+```scss
+.agent-tool-panel {
+    // ... existing properties ...
+    overflow: hidden; // required for max-height collapse to clip content
+
+    // No transition here — open is instant (after the hover delay).
+    // The --hidden modifier carries the collapse transition so it only
+    // fires on the way out.
+    &--hidden {
+        max-height: 0 !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        opacity: 0;
+        transition: max-height 200ms ease-out, opacity 150ms ease-out,
+                    padding 200ms ease-out, margin 200ms ease-out;
+    }
+}
+```
+
+**Why "instant open" works:** The `transition` property only exists on the
+`&--hidden` modifier. When the class is removed (expand), the browser sees no
+transition rule and snaps open immediately. When the class is added (collapse),
+the browser picks up the transition from the new rule and animates.
+
+---
+
+## Change 3 — 1-second post-completion hold before auto-collapse
+
+### Why
+`autoExpanded()` currently returns `false` the instant `status` changes from
+`running` → `success`. The panel snaps shut with zero reading time. A 1-second
+grace period lets the user see the final output line before the block collapses.
+
+This only affects the **auto-expand** path (running tools). A user who has
+manually pinned the block is unaffected — `props.pinned` still wins.
+
+### Implementation — `frontend/app/view/agent/components/ToolBlock.tsx`
+
+```tsx
+// New signal — stays true for 1s after a running tool completes:
+const [postCompletionHold, setPostCompletionHold] = createSignal(false);
+createEffect(() => {
+    const s = props.node.status;
+    if (s !== "running" && s !== "pending_approval" && s !== "failed") {
+        if (postCompletionHold()) return;
+        setPostCompletionHold(true);
+        const t = setTimeout(() => setPostCompletionHold(false), 1000);
+        onCleanup(() => clearTimeout(t));
+    }
+});
+
+// Updated autoExpanded:
+const autoExpanded = (): boolean => {
+    const s = props.node.status;
+    return s === "running" || s === "pending_approval" || s === "failed"
+        || postCompletionHold();
+};
+```
+
+---
+
+## Change 4 — "Running..." → "Thinking..."
+
+### Why
+The tool blocks represent Claude's reasoning steps. "Thinking..." better
+matches the mental model than "Running...", which implies a shell process.
+
+### Implementation — `frontend/app/view/agent/components/ToolOverlayLog.tsx`
+
+```tsx
+// Before (line 177):
+<span class="agent-tool-spinner">⏳</span> Running...
+
+// After:
+<span class="agent-tool-spinner">⏳</span> Thinking...
+```
+
+---
+
+---
+
+## Change 5 — Scroll isolation on the log panel
+
+### Why
+Browsers implement **scroll chaining** by default: when a scrollable element
+hits its top or bottom boundary, the remaining wheel delta propagates to the
+nearest scrollable ancestor. For the tool log panel this means scrolling to
+the end of a long output then continuing to scroll moves the entire agent
+conversation — the user loses their place in the transcript while their cursor
+is still over the log. It's unexpected and disorienting.
+
+### Fix
+`overscroll-behavior: contain` on `.agent-tool-overlay-log` tells the browser
+to absorb the wheel event at this element's boundary and not chain it upward.
+One CSS property, no JS.
+
+### Implementation — `frontend/app/view/agent/styles/_tool-overlay-portal.scss`
+
+```scss
+// Before (line 45):
+.agent-tool-overlay-log {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
+    ...
+}
+
+// After — add one line:
+.agent-tool-overlay-log {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain; // prevent scroll chaining to agent pane
+    padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
+    ...
+}
+```
+
+### Browser support
+`overscroll-behavior` is supported in all Chromium-based browsers (Electron
+included) since Chrome 63. No fallback needed for the Tauri/Electron target.
+
+---
+
+## Summary of file changes
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/components/ToolBlock.tsx` | Re-add 150ms hover enter delay; post-completion hold signal + effect; replace `<Show>` panel with always-rendered + CSS modifier class |
+| `frontend/app/view/agent/components/ToolOverlayLog.tsx` | `"Running..."` → `"Thinking..."` |
+| `frontend/app/view/agent/styles/_document-nodes.scss` | `overflow: hidden` on panel; `&--hidden` modifier with 200ms collapse transition |
+| `frontend/app/view/agent/styles/_tool-overlay-portal.scss` | `overscroll-behavior: contain` on `.agent-tool-overlay-log` |
+
+---
+
+## Behaviour matrix after this spec
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Cursor skims over a collapsed tool | Instant expand | 150ms delay — no expand on quick pass |
+| Cursor enters and stays | Instant expand | Expands after 150ms |
+| Cursor leaves expanded block | Instant collapse, no animation | 200ms slide-out animation |
+| Running tool finishes | Panel snaps shut immediately | Panel stays open 1s then collapses with animation |
+| No chunks yet, tool running | "⏳ Running..." | "⏳ Thinking..." |
+| Scroll reaches end of log | Chains to agent pane scroll | Stops at log boundary |
+| User has pinned block | Already works | Unaffected — pin still wins |

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -73,7 +73,14 @@ const HOVER_ENTER_DELAY_MS = 150;
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     const [hovering, setHovering] = createSignal(false);
     let enterTimer: ReturnType<typeof setTimeout> | undefined;
+    // Codex P1 on #988: both the block container AND the inline panel
+    // bind these handlers. A fast cursor traversal (container → panel)
+    // fires enter twice without an intervening leave; without clearing
+    // the previous timer, multiple stale timeouts accumulate and
+    // `handleMouseLeave` only clears the most recent. Clearing at the
+    // top of enter makes the timer a single-active-armed value.
     const handleMouseEnter = () => {
+        clearTimeout(enterTimer);
         enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
     };
     const handleMouseLeave = () => {

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -34,7 +34,7 @@
  */
 
 import clsx from "clsx";
-import { Show, createSignal, type JSX } from "solid-js";
+import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js";
 import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { ToolBlockOverlay } from "./ToolBlockOverlay";
@@ -62,20 +62,39 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
     denied: "⊘",
 };
 
-// Hover is instant under the inline-panel layout. The portal overlay
-// needed 150ms enter / 300ms leave because it floated outside the
-// row's hover boundary — the user had to "travel" through dead space
-// to reach the overlay content. With the inline panel
-// (SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md), both the summary row
-// and the panel sit inside the same .agent-tool-block element, so
-// mouseleave only fires when the cursor truly exits the whole block.
-// No dead space, no grace window. See feedback_no_timers_or_delays.md.
+// 150ms enter delay prevents accidental expansions while scrolling past
+// tool rows. Leave is instant — the inline panel is inside the same
+// .agent-tool-block bounding box, so mouseleave only fires when the cursor
+// truly exits the whole block. No dead space, no grace window needed on leave.
+// (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 1)
+
+const HOVER_ENTER_DELAY_MS = 150;
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
-    // Hover-expand state. Instant on enter, instant on leave.
     const [hovering, setHovering] = createSignal(false);
-    const handleMouseEnter = () => setHovering(true);
-    const handleMouseLeave = () => setHovering(false);
+    let enterTimer: ReturnType<typeof setTimeout> | undefined;
+    const handleMouseEnter = () => {
+        enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
+    };
+    const handleMouseLeave = () => {
+        clearTimeout(enterTimer);
+        setHovering(false);
+    };
+    onCleanup(() => clearTimeout(enterTimer));
+
+    // Stays true for 1s after a running tool completes so the user can read
+    // the final output line before the panel collapses.
+    // (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 3)
+    const [postCompletionHold, setPostCompletionHold] = createSignal(false);
+    createEffect(() => {
+        const s = props.node.status;
+        if (s !== "running" && s !== "pending_approval" && s !== "failed") {
+            if (postCompletionHold()) return;
+            setPostCompletionHold(true);
+            const t = setTimeout(() => setPostCompletionHold(false), 1000);
+            onCleanup(() => clearTimeout(t));
+        }
+    });
 
     // Auto-expand while the tool is actively running (or awaiting approval,
     // or in a terminal-failure state where the user almost certainly wants
@@ -91,7 +110,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // already expanded.
     const autoExpanded = (): boolean => {
         const s = props.node.status;
-        return s === "running" || s === "pending_approval" || s === "failed";
+        return s === "running" || s === "pending_approval" || s === "failed"
+            || postCompletionHold();
     };
     const expanded = () => props.pinned || autoExpanded() || hovering();
 
@@ -156,27 +176,23 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
             </div>
             {/* Phase A: inline panel — replaces the Portal-to-document.body
                 positioning hack. The panel renders in normal document
-                flow underneath the summary row, so its lifecycle is
-                tied to the tool's `expanded()` state (and, in Phase B,
-                to the tool's running status). Mouse enter/leave on the
-                panel keeps the hover state alive so the user can
-                interact with the content. See
-                docs/specs/SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4. */}
-            <Show when={expanded()}>
-                <div
-                    class="agent-tool-panel"
-                    onClick={(e) => e.stopPropagation()}
-                    onMouseEnter={handleMouseEnter}
-                    onMouseLeave={handleMouseLeave}
-                >
-                    <ToolBlockOverlay
-                        node={props.node}
-                        isBookmarked={props.isBookmarked}
-                        onBookmark={props.onBookmark}
-                        onOpenInPane={props.onOpenInPane}
-                    />
-                </div>
-            </Show>
+                flow underneath the summary row. Always in DOM so CSS can
+                animate the collapse transition; visibility is controlled by
+                the agent-tool-panel--hidden modifier class.
+                (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 2) */}
+            <div
+                class={clsx("agent-tool-panel", { "agent-tool-panel--hidden": !expanded() })}
+                onClick={(e) => e.stopPropagation()}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
+                <ToolBlockOverlay
+                    node={props.node}
+                    isBookmarked={props.isBookmarked}
+                    onBookmark={props.onBookmark}
+                    onOpenInPane={props.onOpenInPane}
+                />
+            </div>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -86,10 +86,24 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // the final output line before the panel collapses.
     // (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 3)
     const [postCompletionHold, setPostCompletionHold] = createSignal(false);
+    // Reagent + codex P1 on #988: the prior implementation read
+    // `postCompletionHold()` inside this effect AND wrote to it, which
+    // made the effect a subscriber of its own write. The synchronous
+    // re-run disposed the previous owner — running the just-registered
+    // `onCleanup(() => clearTimeout(t))` BEFORE the 1s timer could fire.
+    // Net effect: the panel stayed auto-expanded forever after the first
+    // completion, the OPPOSITE of the intended 1s-hold-then-collapse.
+    //
+    // Fix: drop the early-exit read. The effect now tracks ONLY
+    // `props.node.status` as its trigger. Each transition into a
+    // non-active state arms a hold; if status flips back to running
+    // before the timer fires, the next effect run's onCleanup cancels
+    // the in-flight timer (intended behaviour). `postCompletionHold`
+    // is read only by `autoExpanded` — this effect no longer subscribes
+    // to its own writes.
     createEffect(() => {
         const s = props.node.status;
         if (s !== "running" && s !== "pending_approval" && s !== "failed") {
-            if (postCompletionHold()) return;
             setPostCompletionHold(true);
             const t = setTimeout(() => setPostCompletionHold(false), 1000);
             onCleanup(() => clearTimeout(t));
@@ -182,6 +196,15 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 2) */}
             <div
                 class={clsx("agent-tool-panel", { "agent-tool-panel--hidden": !expanded() })}
+                // Codex P2 on #988: with the always-rendered markup, the
+                // collapsed panel was visually hidden via max-height /
+                // opacity but still in the focusable + a11y tree, so
+                // keyboard users could tab into action buttons that
+                // aren't visible. `inert` removes the entire subtree
+                // from focus + accessibility while collapsed (Chrome 102+,
+                // supported in the bundled CEF runtime).
+                inert={!expanded()}
+                aria-hidden={!expanded()}
                 onClick={(e) => e.stopPropagation()}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -86,28 +86,33 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // the final output line before the panel collapses.
     // (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 3)
     const [postCompletionHold, setPostCompletionHold] = createSignal(false);
-    // Reagent + codex P1 on #988: the prior implementation read
-    // `postCompletionHold()` inside this effect AND wrote to it, which
-    // made the effect a subscriber of its own write. The synchronous
-    // re-run disposed the previous owner — running the just-registered
-    // `onCleanup(() => clearTimeout(t))` BEFORE the 1s timer could fire.
-    // Net effect: the panel stayed auto-expanded forever after the first
-    // completion, the OPPOSITE of the intended 1s-hold-then-collapse.
+    // Gate the post-completion hold on a real active → inactive
+    // TRANSITION (not on a status-value snapshot). The earlier draft
+    // simply checked `s !== "running" && ...` which fired on mount
+    // for already-completed tools — loaded transcripts would briefly
+    // auto-expand every completed tool row for 1s on initial render
+    // (codex P1 round 2 on #988).
     //
-    // Fix: drop the early-exit read. The effect now tracks ONLY
-    // `props.node.status` as its trigger. Each transition into a
-    // non-active state arms a hold; if status flips back to running
-    // before the timer fires, the next effect run's onCleanup cancels
-    // the in-flight timer (intended behaviour). `postCompletionHold`
-    // is read only by `autoExpanded` — this effect no longer subscribes
-    // to its own writes.
+    // Background on the older self-loop bug (round 1): reading
+    // `postCompletionHold()` inside the same effect that wrote to it
+    // made the effect a subscriber of its own write; the synchronous
+    // re-run disposed the previous owner and ran the just-registered
+    // `onCleanup(() => clearTimeout(t))` BEFORE the timer could fire,
+    // leaving the panel auto-expanded forever after the first
+    // completion. Both bugs are fixed here: track only
+    // `props.node.status`, and gate on a transition by comparing
+    // against `prevStatus` captured outside the reactive scope.
+    let prevStatus: string = props.node.status;
+    const isActive = (s: string): boolean =>
+        s === "running" || s === "pending_approval" || s === "failed";
     createEffect(() => {
         const s = props.node.status;
-        if (s !== "running" && s !== "pending_approval" && s !== "failed") {
+        if (isActive(prevStatus) && !isActive(s)) {
             setPostCompletionHold(true);
             const t = setTimeout(() => setPostCompletionHold(false), 1000);
             onCleanup(() => clearTimeout(t));
         }
+        prevStatus = s;
     });
 
     // Auto-expand while the tool is actively running (or awaiting approval,

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -174,7 +174,7 @@ function ToolOverlayResult(props: { node: ToolNode }): JSX.Element {
             when={props.node.status !== "running"}
             fallback={
                 <div class="agent-tool-loading">
-                    <span class="agent-tool-spinner">⏳</span> Running...
+                    <span class="agent-tool-spinner">⏳</span> Thinking...
                 </div>
             }
         >

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -190,8 +190,23 @@
             padding: 6px 8px;
             max-height: 50vh;
             min-height: 0;
+            overflow: hidden;
             font-family: var(--fixed-font, monospace);
             font-size: 12px;
+            // No transition here — open is instant (after the hover delay).
+            // The --hidden modifier carries the collapse transition so it only
+            // fires on the way out. (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 2)
+
+            &--hidden {
+                max-height: 0 !important;
+                padding-top: 0 !important;
+                padding-bottom: 0 !important;
+                margin-top: 0 !important;
+                margin-bottom: 0 !important;
+                opacity: 0;
+                transition: max-height 200ms ease-out, opacity 150ms ease-out,
+                            padding 200ms ease-out, margin 200ms ease-out;
+            }
         }
 
         .agent-tool-loading {

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -46,6 +46,7 @@
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
+    overscroll-behavior: contain;
     padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
 
     .agent-tool-log-line {


### PR DESCRIPTION
## Summary

Five UX polish changes to the tool block live-feed panel (spec: `docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md`):

- **Hover enter delay (150ms)** — prevents accidental panel expansion while scrolling past tool rows; leave remains instant since the inline panel shares the same bounding box
- **Collapse animation** — panel slides out over 200ms ease-out; open is instant (transition rule only lives on the `--hidden` modifier, so removing the class snaps open with no delay)
- **Post-completion hold (1s)** — panel stays open 1 second after a running tool finishes before auto-collapsing, giving the user time to read the final output line
- **"Thinking..." label** — replaces "Running..." placeholder; better reflects that Claude is reasoning, not executing a shell process
- **Scroll isolation** — `overscroll-behavior: contain` on `.agent-tool-overlay-log` stops scroll chaining to the agent pane when the log reaches its top/bottom boundary

## Files changed

| File | Change |
|------|--------|
| `frontend/app/view/agent/components/ToolBlock.tsx` | Hover delay, post-completion hold, always-rendered panel with CSS modifier |
| `frontend/app/view/agent/components/ToolOverlayLog.tsx` | "Running..." → "Thinking..." |
| `frontend/app/view/agent/styles/_document-nodes.scss` | `overflow: hidden` + `&--hidden` collapse transition |
| `frontend/app/view/agent/styles/_tool-overlay-portal.scss` | `overscroll-behavior: contain` |
| `docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md` | Spec |

## Test plan

- [ ] Scroll quickly through a long agent response — tool panels should not flash open
- [ ] Hover over a collapsed tool and hold — panel expands after ~150ms
- [ ] Move cursor off an expanded panel — panel slides out over ~200ms
- [ ] Watch a running tool complete — panel stays open ~1s then collapses with animation
- [ ] No chunks yet on a running tool — placeholder reads "Thinking..."
- [ ] Scroll to the bottom of a long log — wheel stops at log boundary, agent pane does not scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)