### PR TITLE
fix(agent-pane): migrate throwing dispatch sites + capture uncaught DOM errors

### DIFF
--- a/.changesets/1779528517-fix-agent-pane-migrate-throwing-dispatch-sites-capture-uncau-u0sr.md
+++ b/.changesets/1779528517-fix-agent-pane-migrate-throwing-dispatch-sites-capture-uncau-u0sr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): migrate throwing dispatch sites + capture uncaught DOM errors

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -28,7 +28,6 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
 import {
-    dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,
     snapshot as paneSnapshot,
 } from "@/app/store/agent-pane-state-store";
@@ -264,7 +263,10 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // the acceptance event promotes it. This is the architecture
         // from AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md (two lists,
         // migration on accept).
-        dispatchPane(
+        // Soft variant — cascade-during-dispatch could dispose the pane
+        // before this fires; retro 2026-05-23 (agent-pane cascade →
+        // replaceChild quick-win).
+        dispatchPaneIfRegistered(
             opts.blockId,
             {
                 type: "PendingMessageQueued",
@@ -350,7 +352,10 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // and it also runs a fallback timer that does the same cleanup
         // if `session_end` never arrives (killing a subprocess prevents
         // the CLI from emitting its own terminating result event).
-        dispatchPane(opts.blockId, { type: "RequestStop", at: Date.now() }, "user");
+        // Soft variant — cascade-during-dispatch could dispose the pane
+        // before this fires; retro 2026-05-23 (agent-pane cascade →
+        // replaceChild quick-win).
+        dispatchPaneIfRegistered(opts.blockId, { type: "RequestStop", at: Date.now() }, "user");
         RpcApi.ControllerInputCommand(TabRpcClient, {
             blockid: opts.blockId,
             signame: "SIGINT",

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -35,10 +35,7 @@ import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { dispatchIfRegistered as dispatchDocIfRegistered } from "@/app/store/agent-document-store";
-import {
-    dispatch as dispatchPane,
-    dispatchIfRegistered as dispatchPaneIfRegistered,
-} from "@/app/store/agent-pane-state-store";
+import { dispatchIfRegistered as dispatchPaneIfRegistered } from "@/app/store/agent-pane-state-store";
 import { parseHistoryLines } from "../parseHistoryLines";
 
 import type { LogFn } from "../types";
@@ -135,7 +132,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
         // fetch, InitReady on success, InitFailed on error. The reducer
         // gates TurnStart on initPhase === "ready" so we don't accept
         // sends while history is still loading.
-        dispatchPane(opts.blockId, { type: "InitStart" });
+        // Soft variant — cascade-during-dispatch could dispose the pane
+        // before this fires; retro 2026-05-23 (agent-pane cascade →
+        // replaceChild quick-win).
+        dispatchPaneIfRegistered(opts.blockId, { type: "InitStart" });
         (async () => {
             // Fast path: try the reducer-state snapshot first. If it exists
             // and the schema version matches, restore wholesale and skip

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -6,6 +6,7 @@
 // then launches the main application (app-init.ts).
 
 import { initLogPipe } from "./log/log-pipe";
+import { initErrorForwarder } from "./log/error-forwarder";
 import { setupCefApi } from "./cef-init";
 import { initApp } from "./app-init";
 import { renderFloatingPaneShell } from "./app/floating-pane/floating-pane-shell";
@@ -15,6 +16,14 @@ import { initPerf } from "@/perf";
 // Pipe all console.log/warn/error to the Rust host log file.
 // Must run before any other code so early messages are captured.
 initLogPipe();
+
+// Capture uncaught errors + unhandled promise rejections and forward
+// them via the same fe_log_structured IPC channel as the console pipe.
+// SolidJS reconciler DOM exceptions (e.g. replaceChild NotFoundError)
+// surface only as window "error" events and would otherwise leave no
+// trace in the host log. Retro 2026-05-23 (agent-pane cascade →
+// replaceChild quick-win).
+initErrorForwarder();
 
 // Phase 0 perf instrumentation: Long Tasks observer + INP/event
 // observer. Must run before any user-interactive code so we never
@@ -161,12 +170,10 @@ async function bootstrap() {
     }
 }
 
-// Capture unhandled errors to backend log
-window.addEventListener("error", (event) => {
-    log("UNCAUGHT-ERROR", event.message, "at", event.filename, "line", String(event.lineno));
-});
-window.addEventListener("unhandledrejection", (event) => {
-    log("UNHANDLED-REJECTION", event.reason?.message ?? String(event.reason));
-});
+// Uncaught error / unhandled promise rejection forwarding is handled
+// by initErrorForwarder() at the top of this file. That path captures
+// stack / name / source and ships via the same fe_log_structured IPC
+// channel as the console pipe, so DOM exceptions from the SolidJS
+// reconciler land in the host log.
 
 bootstrap();

--- a/frontend/log/error-forwarder.ts
+++ b/frontend/log/error-forwarder.ts
@@ -40,7 +40,14 @@ function safeStringify(value: unknown): string {
     if (value === undefined) return "undefined";
     if (typeof value === "string") return value;
     try {
-        return JSON.stringify(value);
+        // Codex P2 on #989: JSON.stringify returns `undefined` (NOT a
+        // string) for certain values without throwing — symbols, plain
+        // functions, and any value whose `.toJSON()` returns undefined.
+        // The previous implementation forwarded that `undefined` to the
+        // host log. Coerce via String() in that case to preserve a
+        // useful diagnostic shape.
+        const out = JSON.stringify(value);
+        return typeof out === "string" ? out : String(value);
     } catch {
         return String(value);
     }

--- a/frontend/log/error-forwarder.ts
+++ b/frontend/log/error-forwarder.ts
@@ -1,0 +1,114 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Uncaught error forwarder: captures `window.error` and
+// `window.unhandledrejection` events and forwards them to the Rust host
+// via the same `fe_log_structured` IPC channel that `log-pipe.ts` uses
+// for monkey-patched console.* calls.
+//
+// Why this exists (retro 2026-05-23 — agent-pane cascade → replaceChild
+// quick-win): DOM exceptions thrown from SolidJS's reconciler (e.g.
+// `NotFoundError: The node to be removed is not a child of this node`)
+// bypass the console pipe entirely — they surface only as window-level
+// "error" events. Without a global handler that forwards them through
+// the same IPC channel, the host log shows no trace of the throw,
+// only the cascade warnings that preceded it.
+//
+// This forwarder is purely a logging side-effect:
+//   - it does NOT call event.preventDefault() (errors still surface in
+//     DevTools and SolidJS ErrorBoundary)
+//   - it does NOT swallow the error
+//   - it is fire-and-forget on the IPC side, so a failing send never
+//     breaks the app
+//
+// Usage: call initErrorForwarder() once at startup, ideally right after
+// initLogPipe() so any errors during the rest of bootstrap are caught.
+
+import { invokeCommand } from "@/app/platform/ipc";
+
+let initialized = false;
+
+interface ForwardedErrorPayload {
+    message: string;
+    stack: string | null;
+    name: string | null;
+    source: string | null;
+}
+
+function safeStringify(value: unknown): string {
+    if (value === null) return "null";
+    if (value === undefined) return "undefined";
+    if (typeof value === "string") return value;
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+function forward(tag: string, payload: ForwardedErrorPayload): void {
+    try {
+        const headline = `${tag} ${payload.name ?? "Error"}: ${payload.message}`;
+        // Fire-and-forget — never let logging break the app
+        invokeCommand("fe_log_structured", {
+            level: "error",
+            module: "uncaught",
+            message: headline,
+            data: {
+                tag,
+                name: payload.name,
+                message: payload.message,
+                stack: payload.stack,
+                source: payload.source,
+            },
+        }).catch(() => {});
+    } catch {
+        // swallow
+    }
+}
+
+function extractErrorFields(err: unknown): {
+    name: string | null;
+    message: string;
+    stack: string | null;
+} {
+    if (err instanceof Error) {
+        return {
+            name: err.name ?? null,
+            message: err.message ?? String(err),
+            stack: err.stack ?? null,
+        };
+    }
+    return {
+        name: null,
+        message: safeStringify(err),
+        stack: null,
+    };
+}
+
+export function initErrorForwarder(): void {
+    if (initialized) return;
+    initialized = true;
+
+    window.addEventListener("error", (event: ErrorEvent) => {
+        const fields = extractErrorFields(event.error);
+        forward("[uncaught-error]", {
+            name: fields.name,
+            // ErrorEvent.message exists even when event.error is null
+            // (e.g. cross-origin script errors).
+            message: fields.message || event.message || "(no message)",
+            stack: fields.stack,
+            source: event.filename || null,
+        });
+    });
+
+    window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+        const fields = extractErrorFields(event.reason);
+        forward("[unhandled-rejection]", {
+            name: fields.name,
+            message: fields.message,
+            stack: fields.stack,
+            source: null,
+        });
+    });
+}

--- a/frontend/log/error-forwarder.ts
+++ b/frontend/log/error-forwarder.ts
@@ -91,11 +91,28 @@ export function initErrorForwarder(): void {
     initialized = true;
 
     window.addEventListener("error", (event: ErrorEvent) => {
+        // Codex P2 on #989: when `event.error` is null/undefined (common
+        // for cross-origin and resource/script errors), the previous
+        // implementation passed `undefined` through `extractErrorFields`
+        // which returned the literal string "undefined" via
+        // `safeStringify(undefined)`. That string is truthy, so the
+        // `fields.message || event.message` chain never reached the
+        // ErrorEvent fallback — the host logged "undefined" instead of
+        // the browser-provided error text. Short-circuit when there is
+        // no Error object: build the payload from ErrorEvent fields
+        // directly.
+        if (event.error == null) {
+            forward("[uncaught-error]", {
+                name: null,
+                message: event.message || "(no message)",
+                stack: null,
+                source: event.filename || null,
+            });
+            return;
+        }
         const fields = extractErrorFields(event.error);
         forward("[uncaught-error]", {
             name: fields.name,
-            // ErrorEvent.message exists even when event.error is null
-            // (e.g. cross-origin script errors).
             message: fields.message || event.message || "(no message)",
             stack: fields.stack,
             source: event.filename || null,


### PR DESCRIPTION
Quick-win for the agent-pane cascade leak class (#878, retro
\`docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md\`).

## What this PR does

1. **Migrates three remaining throwing dispatch sites to the soft variant** —
   the last holdouts after PR #878:
   - \`useAgentCommands.ts:267\` PendingMessageQueued
   - \`useAgentCommands.ts:353\` RequestStop
   - \`useHistoryPagination.ts:138\` InitStart

   All three now use \`dispatchPaneIfRegistered\`. Each site has an inline
   pointer at the 2026-05-23 retro.

2. **Adds a global uncaught-error forwarder** (\`frontend/log/error-forwarder.ts\`)
   that captures \`error\` + \`unhandledrejection\` events and forwards them
   through \`fe_log_structured\` with \`{tag, name, message, stack, source}\`.
   Wired in \`bootstrap.ts\` right after \`initLogPipe()\`. Does NOT call
   \`preventDefault()\` — DevTools / SolidJS \`ErrorBoundary\` still see it.

   Replaces the weaker \`window.addEventListener("error", …)\` listeners that
   were at the bottom of \`bootstrap.ts\` (no stack, no name, concatenated
   message). The new forwarder is strictly stronger.

## Why this matters

The 2026-05-23 incident showed \`CASCADE_DETECTED\` (the PR #878 detection)
firing on \`StreamFlush\` but no \`replaceChild\` line in either log — the
visible host modal had no diagnostic. With this forwarder, the next
incident lands with full stack in the host log.

The dispatch-site migration closes a class of \`dispatch for unregistered
pane\` throws even when the cascade still happens.

## Out of scope (next PRs)

- PR-3: unified per-pane registration (atomic across both stores)
- PR-4: model-level \`dispatchIfAlive\` helper with disposed flag

## Verification

- 0 new TS errors on touched files.
- \`vitest run frontend/app/store + frontend/app/view/agent\`: 588/590 pass.
  Two failures are pre-existing on main (\`browser-pane-state-store.test.ts\`,
  \`providers/index.test.ts\`).
- The 5-test cascade detection suite passes.

Follow-up to retro \`docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)