### PR TITLE
feat(agent-pane): bounded Interrupting → Done.Interrupted (turn-phase PR C)

### DIFF
--- a/.changesets/1779533583-feat-agent-pane-bounded-interrupt-timeout-bo58.md
+++ b/.changesets/1779533583-feat-agent-pane-bounded-interrupt-timeout-bo58.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): bounded interrupt timeout

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -6,6 +6,7 @@ import { update } from "./reducer";
 import {
     AgentPaneState,
     initialState,
+    INTERRUPT_TIMEOUT_MS,
     isWorking,
     STUCK_THRESHOLD_MS,
     TurnPhase,
@@ -814,6 +815,247 @@ describe("agent-pane-state reducer", () => {
                 expect(isWorking(stateWith(phase))).toBe(expected);
             });
         }
+    });
+
+    // ─────────────────────────────────────────────────────────────────
+    // PR C — bounded `Interrupting → Done.interrupted`.
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §8.
+    // RequestStop while a turn is in flight schedules an interrupt
+    // timeout (via the `schedule-interrupt-timeout` event); if no
+    // graceful ack arrives, the dispatch layer fires
+    // `InterruptTimeoutElapsed` and we force-transition to
+    // Done.interrupted. The reducer guards against stale ticks by
+    // checking the current phase on receipt.
+    // ─────────────────────────────────────────────────────────────────
+    describe("Bounded interrupt (PR C)", () => {
+        it("RequestStop while Streaming emits schedule-interrupt-timeout", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            expect(s2.turnPhase.kind).toBe("Streaming");
+            const r = update(s2, { type: "RequestStop", at: 200 });
+            expect(r.state.turnPhase.kind).toBe("Interrupting");
+            // Two events: stop-requested, and the timeout schedule.
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({
+                type: "stop-requested",
+                at: 200,
+            });
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-interrupt-timeout",
+                deadlineMs: 200 + INTERRUPT_TIMEOUT_MS,
+            });
+        });
+
+        it("RequestStop while Submitting also schedules the timeout", () => {
+            // Phase enters Submitting before any chunk arrives. Stop
+            // pressed here must still be bounded — same code path.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const r = update(s1, { type: "RequestStop", at: 150 });
+            expect(r.state.turnPhase.kind).toBe("Interrupting");
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-interrupt-timeout",
+                deadlineMs: 150 + INTERRUPT_TIMEOUT_MS,
+            });
+        });
+
+        it("RequestStop while already Interrupting does NOT re-schedule", () => {
+            // A second Stop press must not double-arm the timeout
+            // (spec §8: SIGINT only emitted once on entry, timeout
+            // follows the same rule so the deadline isn't reset).
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            const s3 = update(s2, { type: "RequestStop", at: 200 }).state;
+            expect(s3.turnPhase.kind).toBe("Interrupting");
+            const r = update(s3, { type: "RequestStop", at: 250 });
+            expect(r.state.turnPhase.kind).toBe("Interrupting");
+            // Only the stop-requested event — no second schedule.
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({ type: "stop-requested" });
+        });
+
+        it("RequestStop while Idle does NOT schedule the timeout", () => {
+            // Stop pressed without a turn in flight: legacy boolean
+            // flips but no Interrupting phase, so no watchdog.
+            const start = mk();
+            const r = update(start, { type: "RequestStop", at: 100 });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({ type: "stop-requested" });
+        });
+
+        it("RequestStop while Done does NOT schedule the timeout", () => {
+            // After TurnEnd lands the phase in Done; a late Stop press
+            // mustn't start a watchdog over an already-finished turn.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TurnEnd", stats: null }, 200).state;
+            expect(s2.turnPhase.kind).toBe("Done");
+            const r = update(s2, { type: "RequestStop", at: 250 });
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({ type: "stop-requested" });
+        });
+
+        it("InterruptTimeoutElapsed while Interrupting → Done.interrupted", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            const s3 = update(s2, { type: "RequestStop", at: 200 }).state;
+            expect(s3.turnPhase.kind).toBe("Interrupting");
+            const deadline = 200 + INTERRUPT_TIMEOUT_MS;
+            const r = update(s3, {
+                type: "InterruptTimeoutElapsed",
+                at: deadline,
+            });
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("interrupted");
+                expect(r.state.turnPhase.finishedAt).toBe(deadline);
+            }
+            // Legacy fields cleared the same way TurnEnd would clear them.
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state.stopping).toBe(false);
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+            // Animation invariant: isWorking flips false.
+            expect(isWorking(r.state)).toBe(false);
+            // Audit event.
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "interrupt-timed-out",
+                at: deadline,
+            });
+        });
+
+        it("InterruptTimeoutElapsed while Streaming is a no-op (agent acked first)", () => {
+            // Realistic race: user pressed Stop, agent ack landed first
+            // (TurnEnd → Done), then the user submitted again and we're
+            // back in Streaming. The stale setTimeout finally fires —
+            // it must not move us off Streaming.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            expect(s2.turnPhase.kind).toBe("Streaming");
+            const r = update(s2, {
+                type: "InterruptTimeoutElapsed",
+                at: 500,
+            });
+            // Reducer must return the SAME reference (no-op pattern).
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+        });
+
+        it("InterruptTimeoutElapsed while Submitting is a no-op", () => {
+            // Even more stale: phase rolled back to Submitting (e.g. a
+            // fresh turn started before the timer fired).
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const r = update(s1, {
+                type: "InterruptTimeoutElapsed",
+                at: 500,
+            });
+            expect(r.state).toBe(s1);
+            expect(r.events).toEqual([]);
+        });
+
+        it("InterruptTimeoutElapsed while Idle is a no-op", () => {
+            const start = mk();
+            const r = update(start, {
+                type: "InterruptTimeoutElapsed",
+                at: 100,
+            });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("InterruptTimeoutElapsed while Done is a no-op (graceful ack already landed)", () => {
+            // The agent acked the SIGINT and we landed in Done.stopped
+            // before the timer fired. The late tick must not overwrite
+            // the outcome.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "RequestStop", at: 200 }).state;
+            expect(s2.turnPhase.kind).toBe("Interrupting");
+            const s3 = update(s2, { type: "TurnEnd", stats: null }, 300).state;
+            expect(s3.turnPhase.kind).toBe("Done");
+            if (s3.turnPhase.kind === "Done") {
+                expect(s3.turnPhase.outcome).toBe("stopped");
+            }
+            const r = update(s3, {
+                type: "InterruptTimeoutElapsed",
+                at: 500,
+            });
+            expect(r.state).toBe(s3);
+            expect(r.events).toEqual([]);
+            // Outcome preserved.
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("stopped");
+            }
+        });
+
+        it("InterruptTimeoutElapsed while Disconnected is a no-op", () => {
+            // Stream dropped after stop was requested → Disconnected.
+            // The timeout that was armed must not corrupt that state.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "RequestStop", at: 200 }).state;
+            const s3 = update(s2, { type: "StreamUnsubscribe", at: 300 }).state;
+            expect(s3.turnPhase.kind).toBe("Disconnected");
+            const r = update(s3, {
+                type: "InterruptTimeoutElapsed",
+                at: 500,
+            });
+            expect(r.state).toBe(s3);
+            expect(r.events).toEqual([]);
+        });
+
+        it("Three-paths invariant: TurnEnd, StreamUnsubscribe, and timeout all exit Interrupting", () => {
+            // Spec §8: "Three independent paths into Done.Interrupted" —
+            // the working animation can never get stuck.
+            const buildInterrupting = () => {
+                const a = ready(100);
+                const b = update(a, { type: "TurnStart", at: 110 }).state;
+                const c = update(b, { type: "StreamSubscribe", at: 120 }).state;
+                return update(c, { type: "RequestStop", at: 200 }).state;
+            };
+
+            // Path 1: graceful TurnEnd.
+            const p1 = update(buildInterrupting(), {
+                type: "TurnEnd",
+                stats: null,
+            }, 300);
+            expect(isWorking(p1.state)).toBe(false);
+            expect(p1.state.turnPhase.kind).toBe("Done");
+
+            // Path 2: stream torn down → Disconnected (also not working).
+            const p2 = update(buildInterrupting(), {
+                type: "StreamUnsubscribe",
+                at: 300,
+            });
+            expect(isWorking(p2.state)).toBe(false);
+            expect(p2.state.turnPhase.kind).toBe("Disconnected");
+
+            // Path 3: bounded timeout.
+            const p3 = update(buildInterrupting(), {
+                type: "InterruptTimeoutElapsed",
+                at: 200 + INTERRUPT_TIMEOUT_MS,
+            });
+            expect(isWorking(p3.state)).toBe(false);
+            expect(p3.state.turnPhase.kind).toBe("Done");
+            if (p3.state.turnPhase.kind === "Done") {
+                expect(p3.state.turnPhase.outcome).toBe("interrupted");
+            }
+        });
+
+        it("INTERRUPT_TIMEOUT_MS is 5000 (sanity)", () => {
+            // Pinned so a sneaky bump can't slip in unreviewed.
+            expect(INTERRUPT_TIMEOUT_MS).toBe(5_000);
+        });
     });
 });
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -340,13 +340,22 @@ export function update(
             // rule so a second Stop press doesn't reset the deadline.
             const enteringInterrupting =
                 isWorking && k !== "Interrupting";
-            const nextPhase: TurnPhase = isWorking
-                ? {
-                      kind: "Interrupting",
-                      reason: "user",
-                      sigintSentAt: command.at,
-                  }
-                : state.turnPhase;
+            // Codex P2 on #991: preserve the original sigintSentAt on a
+            // repeated Stop press. The timeout was armed from the FIRST
+            // press's deadline; rebuilding the phase with a fresh
+            // `command.at` here makes consumers see a `sigintSentAt`
+            // that doesn't match the active deadline. When we're
+            // already Interrupting, reuse the existing phase so the
+            // timestamp stays pinned to the original SIGINT.
+            const nextPhase: TurnPhase = !isWorking
+                ? state.turnPhase
+                : k === "Interrupting"
+                    ? state.turnPhase
+                    : {
+                          kind: "Interrupting",
+                          reason: "user",
+                          sigintSentAt: command.at,
+                      };
             const events: AgentPaneEvent[] = [
                 { type: "stop-requested", at: command.at },
             ];

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -19,7 +19,9 @@
 
 import {
     AgentPaneCommand,
+    AgentPaneEvent,
     AgentPaneState,
+    INTERRUPT_TIMEOUT_MS,
     KindBeforeDisconnect,
     ReducerResult,
     STUCK_THRESHOLD_MS,
@@ -331,6 +333,13 @@ export function update(
             const k = state.turnPhase.kind;
             const isWorking =
                 k === "Submitting" || k === "Streaming" || k === "Interrupting";
+            // PR C: only schedule the bounded-interrupt watchdog when we
+            // actually CROSS INTO Interrupting (not when we're already
+            // there — that would double-arm the timeout). Spec §8: SIGINT
+            // is only emitted once on entry; the timeout follows the same
+            // rule so a second Stop press doesn't reset the deadline.
+            const enteringInterrupting =
+                isWorking && k !== "Interrupting";
             const nextPhase: TurnPhase = isWorking
                 ? {
                       kind: "Interrupting",
@@ -338,9 +347,18 @@ export function update(
                       sigintSentAt: command.at,
                   }
                 : state.turnPhase;
+            const events: AgentPaneEvent[] = [
+                { type: "stop-requested", at: command.at },
+            ];
+            if (enteringInterrupting) {
+                events.push({
+                    type: "schedule-interrupt-timeout",
+                    deadlineMs: command.at + INTERRUPT_TIMEOUT_MS,
+                });
+            }
             return {
                 state: { ...state, stopping: true, turnPhase: nextPhase },
-                events: [{ type: "stop-requested", at: command.at }],
+                events,
             };
         }
 
@@ -365,6 +383,42 @@ export function update(
             return {
                 state: { ...state, stopping: false, turnPhase: nextPhase },
                 events: [{ type: "stop-failed" }],
+            };
+        }
+
+        case "InterruptTimeoutElapsed": {
+            // PR C — bounded `Interrupting → Done.interrupted`.
+            //
+            // The dispatch side schedules a setTimeout when it sees the
+            // `schedule-interrupt-timeout` event. A shared cancel flag
+            // (the JS analogue of `Arc<AtomicBool>`) prevents a stale
+            // timer from firing after a graceful TurnEnd / unsubscribe
+            // already moved us off Interrupting — but defence in depth:
+            // the reducer ALSO checks the current phase and treats a
+            // late tick as a no-op. Three independent paths into
+            // Done.interrupted (TurnEnd, StreamUnsubscribe → Disconnected,
+            // and this timeout) — so the working animation can never
+            // hang on Interrupting indefinitely. Spec §8.
+            if (state.turnPhase.kind !== "Interrupting") {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    // Legacy: a forced exit from Interrupting is the
+                    // same shape as a graceful TurnEnd for the boolean
+                    // consumers (turnActive=false, stopping cleared).
+                    turnActive: false,
+                    stopping: false,
+                    currentTool: null,
+                    turnTokens: null,
+                    turnPhase: {
+                        kind: "Done",
+                        outcome: "interrupted",
+                        finishedAt: command.at,
+                    },
+                },
+                events: [{ type: "interrupt-timed-out", at: command.at }],
             };
         }
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -239,10 +239,26 @@ export function update(
             // Merge stats with live turn-tokens (mirrors prior finalizeTurn
             // logic — see PR #549 reagent/codex P1 reference).
             const merged = mergeStats(command.stats, state.turnTokens);
+            // Codex P1 on #991: when an `InterruptTimeoutElapsed` has
+            // already forced us to `Done.interrupted` (clearing `stopping`
+            // in the process), a late backend `TurnEnd` ack would see
+            // `stoppingWasSet === false` and classify the outcome as
+            // "completed", overwriting the forced interrupted state.
+            // First-done-wins: if we're already in `Done`, preserve the
+            // existing outcome and only refresh the stats sidecar. The
+            // late ack is confirmatory, not authoritative.
+            const alreadyDone = state.turnPhase.kind === "Done";
             // Dual-write outcome: stop-in-flight → "stopped"; otherwise
             // "completed". "interrupted" / "errored" are reserved for
             // future-PR commands (StreamStalled, Disconnected, etc.).
-            const outcome: TurnOutcome = stoppingWasSet ? "stopped" : "completed";
+            const outcome: TurnOutcome = alreadyDone
+                ? state.turnPhase.outcome
+                : stoppingWasSet
+                    ? "stopped"
+                    : "completed";
+            const finishedAt = alreadyDone
+                ? state.turnPhase.finishedAt
+                : nowMs;
             return {
                 state: {
                     ...state,
@@ -254,7 +270,7 @@ export function update(
                     turnPhase: {
                         kind: "Done",
                         outcome,
-                        finishedAt: nowMs,
+                        finishedAt,
                     },
                 },
                 events: [

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -214,6 +214,16 @@ export type AgentPaneCommand =
     | { type: "RequestStop"; at: number }
     /** Stop RPC failed — bail on the stopping state. */
     | { type: "StopFailed" }
+    /**
+     * Interrupt timeout watchdog fired (caller-scheduled setTimeout — see
+     * `ScheduleInterruptTimeout` event). Bounded `Interrupting → Done`
+     * force-transition: if the agent never acks the SIGINT (backend died,
+     * stream dropped, etc.) the pane was previously stuck in Interrupting
+     * forever and the working animation would never settle. This command
+     * is a no-op if the phase has already moved off Interrupting
+     * (e.g. agent acked first, user already resumed). Spec §8.
+     */
+    | { type: "InterruptTimeoutElapsed"; at: number }
 
     // ── Pending message queue (composer side) ─────────────────────
     | { type: "PendingMessageQueued"; id: string; text: string; at: number }
@@ -261,6 +271,26 @@ export type AgentPaneEvent =
     | { type: "tokens-updated"; input: number | null; output: number | null }
     | { type: "stop-requested"; at: number }
     | { type: "stop-failed" }
+    /**
+     * Reducer signal: a turn has just entered Interrupting. The
+     * dispatch layer (view / saga) is expected to start a setTimeout
+     * for `INTERRUPT_TIMEOUT_MS` and fire `InterruptTimeoutElapsed`
+     * when it expires — gated by a shared cancel flag (analogous to
+     * `Arc<AtomicBool>`) so a later `RequestStop` doesn't double-fire.
+     * `deadlineMs` is `at + INTERRUPT_TIMEOUT_MS` so the caller can
+     * compute the remaining slice deterministically. Spec §8.
+     */
+    | {
+          type: "schedule-interrupt-timeout";
+          deadlineMs: number;
+      }
+    /**
+     * Reducer signal: the bounded `Interrupting → Done.{interrupted}`
+     * force-transition fired because no graceful ack arrived within
+     * `INTERRUPT_TIMEOUT_MS`. The view can surface this as
+     * "interrupt timed out — assuming dead" if needed. Spec §8.
+     */
+    | { type: "interrupt-timed-out"; at: number }
     | { type: "pending-queued"; id: string }
     | { type: "pending-accepted"; id: string; wasPresent: boolean }
     | { type: "pending-rejected"; id: string; wasPresent: boolean }
@@ -286,3 +316,19 @@ export interface ReducerResult {
  * positives. Issue #728 gap 3.
  */
 export const STUCK_THRESHOLD_MS = 45_000;
+
+/**
+ * Bounded `Interrupting → Done.{interrupted}` window. After `RequestStop`
+ * fires SIGINT, if neither `TurnEnd` nor `StreamUnsubscribe` lands within
+ * this many ms the reducer force-transitions to Done.interrupted on
+ * receipt of `InterruptTimeoutElapsed`. 5 s is generous compared to the
+ * typical sub-second SIGINT-ack on a healthy agent but tight enough that
+ * a dead agent doesn't keep the working animation pinned forever.
+ *
+ * Spec: SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §8 — the spec doc
+ * suggests 3_000 but the implementation lands at 5_000 to leave more
+ * headroom for slow Windows PTY teardowns and remote agents on flaky
+ * networks. Tune in a follow-up if telemetry shows the watchdog firing
+ * on live agents.
+ */
+export const INTERRUPT_TIMEOUT_MS = 5_000;


### PR DESCRIPTION
Adds a bounded watchdog on the Interrupting phase so the working animation can never get stuck after Stop is pressed. Follow-up to #987 (turn-phase PR A — TurnPhase dual-write).

## Problem

Today, hitting Stop sets `stopping = true` and transitions the phase to `Interrupting`. The reducer waits for the agent to ack (`TurnEnd` or `StreamUnsubscribe`). If the agent dies, the backend hangs, or the network drops the ack — **the ack never arrives, the pane sits in `Interrupting` forever, and the spinner never settles**. There was no upper bound on how long that wait could last.

## Fix — bounded `Interrupting → Done.interrupted`

Spec: [`docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §8](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md).

Three-paths invariant: `TurnEnd`, `StreamUnsubscribe` (→ `Disconnected`), and now `InterruptTimeoutElapsed` all exit `Interrupting`. The animation cannot get pinned.

### Command shape (reducer side — this PR)

- New command: `{ type: "InterruptTimeoutElapsed"; at: number }` — handler force-transitions `Interrupting → Done.{outcome=interrupted}` and clears the legacy `stopping` / `turnActive` / `currentTool` / `turnTokens` fields. A late tick (phase already moved off `Interrupting`) is a same-reference no-op.
- New event: `{ type: "schedule-interrupt-timeout"; deadlineMs: number }` — emitted by the `RequestStop` arm when (and only when) the phase newly crosses INTO `Interrupting`. A second Stop press while already `Interrupting` does NOT re-emit the schedule (same rule as SIGINT itself: one-shot on entry; the deadline is not reset).
- New event: `{ type: "interrupt-timed-out"; at: number }` — audit signal when the bounded transition fires.
- New constant: `INTERRUPT_TIMEOUT_MS = 5_000`. Spec doc suggests 3 s; shipped 5 s for headroom on slow Windows PTY teardowns / remote agents on flaky networks. Tune in a follow-up if telemetry shows false-positive firings on healthy agents.

### Reducer transitions

| From | Command | To | Why |
|---|---|---|---|
| `Submitting` / `Streaming` | `RequestStop` | `Interrupting` + `schedule-interrupt-timeout` event | First Stop press arms the watchdog |
| `Interrupting` | `RequestStop` | `Interrupting` (no event) | One-shot — don't double-arm |
| `Interrupting` | `InterruptTimeoutElapsed` | `Done.interrupted` | Bounded force-exit |
| `Streaming` / `Submitting` / `Idle` / `Done` / `Disconnected` | `InterruptTimeoutElapsed` | (no-op, same ref) | Late tick — phase already moved off Interrupting |

## Dispatch-side wiring (NOT in this PR)

The event handler that listens for `schedule-interrupt-timeout` and fires `InterruptTimeoutElapsed` lives outside the reducer (likely `useAgentStream.ts` or a saga). **PR B owns view files and is in flight in parallel — this PR is reducer-only.** The dispatcher work will land in a follow-up PR (or alongside PR B's view migration).

The pattern is the JS analogue of `Arc<AtomicBool>`: a shared `{ cancelled: boolean }` ref that the *next* `RequestStop → Interrupting` event flips (cancelling any prior in-flight timer), plus a `setTimeout(INTERRUPT_TIMEOUT_MS)` that checks the ref before dispatching `InterruptTimeoutElapsed`. The reducer ALSO guards against stale ticks by phase-check (defence in depth) — so even a buggy dispatch can't corrupt state.

The event-name and payload shape are pinned by the schedule-event tests so the dispatch side has a stable contract.

## Tests (13 new)

`frontend/app/store/agent-pane-state/reducer.test.ts` — new `describe("Bounded interrupt (PR C)")` block:

1. `RequestStop` while `Streaming` emits `schedule-interrupt-timeout`.
2. `RequestStop` while `Submitting` also schedules the timeout.
3. `RequestStop` while already `Interrupting` does NOT re-schedule.
4. `RequestStop` while `Idle` does NOT schedule.
5. `RequestStop` while `Done` does NOT schedule.
6. `InterruptTimeoutElapsed` while `Interrupting` → `Done.interrupted` (clears legacy fields, `isWorking` flips false).
7. `InterruptTimeoutElapsed` while `Streaming` is a same-reference no-op.
8. `InterruptTimeoutElapsed` while `Submitting` is a same-reference no-op.
9. `InterruptTimeoutElapsed` while `Idle` is a same-reference no-op.
10. `InterruptTimeoutElapsed` while `Done` is a no-op (outcome preserved).
11. `InterruptTimeoutElapsed` while `Disconnected` is a no-op.
12. Three-paths invariant: `TurnEnd`, `StreamUnsubscribe`, and timeout all exit `Interrupting`.
13. `INTERRUPT_TIMEOUT_MS` pinned at 5000.

All 79 tests pass (66 pre-existing + 13 new). Zero new TS errors on touched files.

```
npx vitest run frontend/app/store/agent-pane-state/
# 1 file, 79 tests, all passing
```

## Out of scope

- **PR B (view)** — view files (spinner / input-disabled / Stop-visible) untouched per the spec's separation.
- **PR D (`SubmitTimeoutElapsed`)** — same pattern, different phase. Different PR.
- **Dispatcher wiring** — see "Dispatch-side wiring" above.

## Spec & references

- Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §8
- PR A (TurnPhase dual-write — merged): #987
- Long-term reducer-stack tracking discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
