### PR TITLE
feat(agent-pane): view reads isWorking(state) (turn-phase PR B)

### DIFF
--- a/.changesets/1779533699-feat-agent-pane-view-reads-isworking-state-hzuq.md
+++ b/.changesets/1779533699-feat-agent-pane-view-reads-isworking-state-hzuq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): view reads isWorking(state)

--- a/frontend/app/store/agent-pane-state-store.test.ts
+++ b/frontend/app/store/agent-pane-state-store.test.ts
@@ -145,4 +145,47 @@ describe("agent-pane-state-store (cascade contracts)", () => {
             }
         });
     });
+
+    // ── PR B (turn-phase view migration) ────────────────────────────────
+    // PR A added `turnPhase` to the reducer state with dual-write; PR B —
+    // this PR — exposes a projection setter for it so the agent VIEW can
+    // bind its "working" animation to `workingFromPhase(turnPhase)` via
+    // a Solid signal. Verify the setter is invoked with the dual-written
+    // phase value at each lifecycle transition.
+    describe("turnPhase projection (PR B)", () => {
+        it("calls the turnPhase setter with the dual-written phase value", () => {
+            const phaseCalls: { kind: string }[] = [];
+            const proj: AgentPaneProjections = {
+                ...noopProj(),
+                turnPhase: (next) => {
+                    phaseCalls.push({ kind: next.kind });
+                },
+            };
+            registerPane("blockD", "agentA", proj);
+
+            // Sequence: InitReady → StreamSubscribe (Idle stays Idle)
+            //         → TurnStart (Idle → Submitting)
+            //         → StreamFlushObserved (Submitting → Streaming)
+            //         → RequestStop (Streaming → Interrupting)
+            //         → TurnEnd (Interrupting → Done.stopped)
+            dispatch("blockD", { type: "InitReady" });
+            dispatch("blockD", { type: "StreamSubscribe", at: 100 });
+            dispatch("blockD", { type: "TurnStart", at: 110 });
+            dispatch("blockD", { type: "StreamFlushObserved", addedCount: 1, at: 120 });
+            dispatch("blockD", { type: "RequestStop", at: 130 });
+            dispatch("blockD", { type: "TurnEnd", stats: null });
+
+            // Only ACTUAL transitions hit the setter (reducer skips
+            // setter calls when prev === next reference). Subscribing
+            // from Idle keeps phase Idle (no spontaneous promotion), so
+            // there's no setter call there.
+            const kinds = phaseCalls.map((c) => c.kind);
+            expect(kinds).toEqual([
+                "Submitting", // TurnStart
+                "Streaming", // StreamFlushObserved promotes from Submitting
+                "Interrupting", // RequestStop while working
+                "Done", // TurnEnd
+            ]);
+        });
+    });
 });

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -23,6 +23,7 @@ import {
     AgentPaneState,
     type InitPhase,
     initialState,
+    type TurnPhase,
 } from "./agent-pane-state/types";
 import { type CommandSource, recordDispatch } from "./command-source";
 
@@ -42,6 +43,14 @@ export interface AgentPaneProjections {
     pending: (next: PendingMessage[]) => void;
     /** Init phase — drives the "Loading history…" overlay (issue #728 gap 1). */
     initPhase?: (next: InitPhase) => void;
+    /**
+     * Turn phase (PR A added the union + dual-write in the reducer; PR B —
+     * this PR — projects it through to the view so the "working" animation
+     * can bind to `isWorking(state)` instead of `turnActive || stopping`).
+     * Optional so existing callers (and the cascade-store test's no-op
+     * projection) keep compiling.
+     */
+    turnPhase?: (next: TurnPhase) => void;
 }
 
 interface Slot {
@@ -122,6 +131,7 @@ export function dispatch(
     proj("stopping", prev.stopping, slot.state.stopping, slot.proj.stopping);
     proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
     proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);
+    proj("turnPhase", prev.turnPhase, slot.state.turnPhase, slot.proj.turnPhase);
 
     if (cascadeSetter != null) {
         console.warn(

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -151,7 +151,18 @@ export const initialState = (agentId: string): AgentPaneState => ({
  * footer's working indicator to this selector.
  */
 export function isWorking(state: AgentPaneState): boolean {
-    const k = state.turnPhase.kind;
+    return workingFromPhase(state.turnPhase);
+}
+
+/**
+ * Phase-only variant of {@link isWorking}. The view layer projects
+ * `turnPhase` through a dedicated signal (PR B); call sites that only
+ * have the phase (not the whole state) use this helper. Same predicate.
+ *
+ * Returns true ⇔ `phase.kind ∈ {Submitting, Streaming, Interrupting}`.
+ */
+export function workingFromPhase(phase: TurnPhase): boolean {
+    const k = phase.kind;
     return k === "Submitting" || k === "Streaming" || k === "Interrupting";
 }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -17,6 +17,7 @@ import {
     registerPane as registerAgentPaneStatePane,
     unregisterPane as unregisterAgentPaneStatePane,
 } from "@/app/store/agent-pane-state-store";
+import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
@@ -116,6 +117,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // currentTool/turnTokens/turnActive/stopping/pending atoms behind a
     // single reducer with cross-atom invariants. Same synchronous-register
     // rule as the agent-document slot.
+    //
+    // `turnPhase` is the PR A / PR B addition — the reducer dual-writes
+    // it alongside the legacy `turnActive` / `stopping` / `streaming.active`
+    // booleans, and the view (see the AgentStatusLine binding below)
+    // reads it via `isWorking(...)`. PR G drops the legacy fields.
     {
         const a = agentAtoms();
         registerAgentPaneStatePane(model.blockId, agentId, {
@@ -127,6 +133,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             stopping: a.stoppingAtom[1],
             pending: a.pendingMessagesAtom[1],
             initPhase: a.initPhaseAtom[1],
+            turnPhase: a.turnPhaseAtom[1],
         });
         onCleanup(() => unregisterAgentPaneStatePane(model.blockId));
     }
@@ -705,7 +712,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
                 showSendNow={() =>
-                    agentAtoms().turnActiveAtom[0]() &&
+                    // PR B: view migrated off legacy `turnActive` —
+                    // "send now" appears whenever the agent is working
+                    // (Submitting / Streaming / Interrupting) and the
+                    // user has at least one queued message. The reducer
+                    // still dual-writes `turnActiveAtom`; PR G drops it.
+                    workingFromPhase(agentAtoms().turnPhaseAtom[0]()) &&
                     pendingMessagesAtom[0]().length > 0
                 }
                 onSendImmediately={() => {
@@ -717,10 +729,21 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 doing about the queue above". Used to live inside the
                 composer region right above the input; moved here so the
                 activity log doesn't push it off-screen during long
-                agent output. */}
+                agent output.
+
+                PR B (Turn-phase migration): the "working" animation
+                binding now reads `workingFromPhase(turnPhase)` instead
+                of `turnActive || stopping`. The "Stopping…" label still
+                wins over "Working…" via the dedicated `stopping` prop —
+                that maps to `turnPhase.kind === "Interrupting"` so the
+                view no longer touches the legacy boolean. Reducer keeps
+                dual-writing both until PR G. */}
             <AgentStatusLine
-                loading={status.isLoading() || agentAtoms().turnActiveAtom[0]() || stoppingAtom[0]()}
-                stopping={stoppingAtom[0]()}
+                loading={
+                    status.isLoading()
+                    || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
+                }
+                stopping={agentAtoms().turnPhaseAtom[0]().kind === "Interrupting"}
                 currentTool={agentAtoms().currentToolAtom[0]()}
                 sessionStats={agentAtoms().sessionStatsAtom[0]()}
                 turnTokens={agentAtoms().turnTokensAtom[0]()}

--- a/frontend/app/view/agent/state.test.ts
+++ b/frontend/app/view/agent/state.test.ts
@@ -6,6 +6,7 @@ import {
     createAgentAtoms,
     type AgentAtoms,
 } from "./state";
+import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 
 let atoms: AgentAtoms;
 
@@ -51,5 +52,59 @@ describe("createAgentAtoms", () => {
         setActive1(true);
         expect(getActive1()).toBe(true);
         expect(getActive2()).toBe(false);
+    });
+
+    // ── PR B (turn-phase view migration) ────────────────────────────────
+    // Verifies that the view's "working" animation binding can be driven
+    // entirely from `turnPhaseAtom` via the `workingFromPhase` selector —
+    // no read of the legacy `turnActiveAtom` / `stoppingAtom` is required.
+    // The reducer still dual-writes the legacy fields (PR G drops them).
+    // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §7.
+    test("turnPhaseAtom defaults to Idle and drives workingFromPhase = false", () => {
+        const [getPhase] = atoms.turnPhaseAtom;
+        expect(getPhase().kind).toBe("Idle");
+        expect(workingFromPhase(getPhase())).toBe(false);
+    });
+
+    test("workingFromPhase(turnPhaseAtom) = true for Submitting/Streaming/Interrupting", () => {
+        const [getPhase, setPhase] = atoms.turnPhaseAtom;
+
+        setPhase({ kind: "Submitting", submittedAt: 1, pendingContent: "" });
+        expect(workingFromPhase(getPhase())).toBe(true);
+
+        setPhase({
+            kind: "Streaming",
+            bufferSize: 0,
+            toolsActive: 0,
+            lastEventMs: 1,
+        });
+        expect(workingFromPhase(getPhase())).toBe(true);
+
+        setPhase({ kind: "Interrupting", reason: "user", sigintSentAt: 1 });
+        expect(workingFromPhase(getPhase())).toBe(true);
+
+        setPhase({ kind: "Done", outcome: "completed", finishedAt: 1 });
+        expect(workingFromPhase(getPhase())).toBe(false);
+
+        setPhase({
+            kind: "Disconnected",
+            lastKind: "Streaming",
+            reason: "x",
+        });
+        expect(workingFromPhase(getPhase())).toBe(false);
+    });
+
+    test("Interrupting phase drives the 'Stopping…' label (replaces legacy stoppingAtom read)", () => {
+        const [getPhase, setPhase] = atoms.turnPhaseAtom;
+        // The view's `stopping` prop on AgentStatusLine reads
+        // `turnPhaseAtom[0]().kind === "Interrupting"` — no read of the
+        // legacy `stoppingAtom`. Verify the predicate flips correctly.
+        expect(getPhase().kind === "Interrupting").toBe(false);
+
+        setPhase({ kind: "Interrupting", reason: "user", sigintSentAt: 1 });
+        expect(getPhase().kind === "Interrupting").toBe(true);
+
+        setPhase({ kind: "Done", outcome: "stopped", finishedAt: 2 });
+        expect(getPhase().kind === "Interrupting").toBe(false);
     });
 });

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -30,7 +30,7 @@ import {
     StreamingState,
     TurnTokens,
 } from "./types";
-import type { InitPhase } from "@/app/store/agent-pane-state/types";
+import type { InitPhase, TurnPhase } from "@/app/store/agent-pane-state/types";
 
 /**
  * A signal pair: [getter, setter]
@@ -72,6 +72,17 @@ export interface AgentAtoms {
      * Issue #728 gap 1.
      */
     initPhaseAtom: SignalPair<InitPhase>;
+    /**
+     * Single-source-of-truth turn phase (PR A introduced TurnPhase + dual-
+     * write in the reducer; PR B — this PR — switched the view's "working"
+     * animation binding to read it via the `isWorking(state)` selector).
+     * The reducer continues to dual-write the legacy `turnActiveAtom` /
+     * `stoppingAtom` / `streamingStateAtom.active` fields; PR G will drop
+     * them once every consumer is migrated.
+     *
+     * Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §5–§7.
+     */
+    turnPhaseAtom: SignalPair<TurnPhase>;
 }
 
 /**
@@ -117,5 +128,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         stoppingAtom: createSignal<boolean>(false),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
         initPhaseAtom: createSignal<InitPhase>("loading"),
+        turnPhaseAtom: createSignal<TurnPhase>({ kind: "Idle" }),
     };
 }


### PR DESCRIPTION
## PR B of the agent-pane turn-phase migration

Follow-up to #987 (PR A — TurnPhase discriminated union + `isWorking(state)` selector + dual-write logic).

This PR migrates the agent VIEW layer off the legacy `turnActive` / `stopping` / `streaming.active` boolean reads onto the new single-source-of-truth phase. The reducer continues to dual-write the legacy fields; **PR G will drop them once every consumer is migrated.**

## What this PR does

### View migration
Three view-layer reads in `frontend/app/view/agent/agent-view.tsx` switched off legacy fields:

| Location | Before | After |
| --- | --- | --- |
| `<AgentStatusLine loading={...}>` (the **working animation binding** the user identified as broken) | `status.isLoading() \|\| turnActive \|\| stopping` | `status.isLoading() \|\| workingFromPhase(turnPhase)` |
| `<AgentStatusLine stopping={...}>` (the "Stopping…" label override) | `stoppingAtom[0]()` | `turnPhaseAtom[0]().kind === "Interrupting"` |
| `<PendingMessagesPanel showSendNow={...}>` ("Send now" button visibility) | `turnActiveAtom[0]() && pending.length > 0` | `workingFromPhase(turnPhase) && pending.length > 0` |

### Plumbing
- `AgentAtoms` gains `turnPhaseAtom: SignalPair<TurnPhase>` (defaults to `{ kind: "Idle" }`).
- `AgentPaneProjections` gains an optional `turnPhase` setter; the store calls it on every dispatch alongside the existing legacy setters (`turnActive`, `stopping`, etc.).
- `agent-view.tsx` wires the new projection into the slot registration.
- New `workingFromPhase(phase: TurnPhase): boolean` exported from `agent-pane-state/types.ts`. View code only has the phase signal, not the full reducer state, so this avoids forcing callers to fabricate a `{turnPhase}`-shaped `AgentPaneState`. `isWorking(state)` now delegates to it.

### Tests
- `frontend/app/view/agent/state.test.ts` — three new tests verifying `turnPhaseAtom` defaults to Idle, `workingFromPhase` returns true only for Submitting/Streaming/Interrupting, and the Interrupting-as-stopping-label predicate flips correctly.
- `frontend/app/store/agent-pane-state-store.test.ts` — new "turnPhase projection (PR B)" describe block verifying the projection setter fires with the dual-written phase value at each lifecycle transition (Idle → Submitting → Streaming → Interrupting → Done).

## Test results
```
npx vitest run frontend/app/store/agent-pane-state/                    → 66 passed
npx vitest run frontend/app/view/agent/state.test.ts                   → 8 passed (3 new)
npx vitest run frontend/app/store/agent-pane-state-store.test.ts       → 5 passed (1 new)
npx vitest run frontend/app/view/agent/                                → 267 passed (1 pre-existing failure
                                                                          in providers/index.test.ts — ACP
                                                                          authType, unrelated to this PR;
                                                                          verified failing on main too)
```

`npx tsc --noEmit` produces no new errors on the touched files.

## Out of scope (next PRs)

- PR C: Bounded Interrupting
- PR D: Submitting timeout
- PR E: Streaming watchdog
- **PR G: drop the legacy `turnActive` / `stopping` / `streaming.active` fields** once all consumers are migrated. After PR B, the remaining legacy reads are inside hooks (`useAgentStream.ts` stop-fallback timer, `useAgentCommands.ts` parameter stub) and the reducer's own dual-write — those migrate alongside their owning PRs.

## Spec
See PR A (#987) for the TurnPhase union and dual-write rationale. The spec file `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` is referenced throughout but lives in the PR-A discussion thread; if a docs-PR for it is desired, it can ride with PR C.

## Changeset
`.changesets/1779533699-feat-agent-pane-view-reads-isworking-state-hzuq.md` — `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)