### PR TITLE
feat(agent-pane): InitPhase state machine (closes #728 gap 1)

### DIFF
--- a/.changesets/1779534298-feat-agent-pane-initphase-state-machine-z5g7.md
+++ b/.changesets/1779534298-feat-agent-pane-initphase-state-machine-z5g7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): initPhase state machine

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -7,6 +7,7 @@ import {
     AgentPaneState,
     initialState,
     INTERRUPT_TIMEOUT_MS,
+    isInitReady,
     isWorking,
     STUCK_THRESHOLD_MS,
     TurnPhase,
@@ -19,7 +20,7 @@ const mk = () => initialState("test-agent");
  * gate, so subscribing alone no longer permits `TurnStart`.
  */
 const ready = (atMs = 100) => {
-    const s0 = update(mk(), { type: "InitReady" }).state;
+    const s0 = update(mk(), { type: "InitReady", at: atMs }).state;
     return update(s0, { type: "StreamSubscribe", at: atMs }).state;
 };
 
@@ -237,36 +238,114 @@ describe("agent-pane-state reducer", () => {
     });
 
     describe("Init phase (gap 1)", () => {
-        it("starts in 'loading'", () => {
-            expect(mk().initPhase).toBe("loading");
-            expect(mk().initError).toBe(null);
+        it("starts in InitPending", () => {
+            const s = mk();
+            expect(s.initPhase).toEqual({ kind: "InitPending" });
+            expect(isInitReady(s)).toBe(false);
         });
 
-        it("InitReady advances to ready and clears error", () => {
-            const s0 = update(mk(), { type: "InitFailed", reason: "boom" }).state;
-            expect(s0.initPhase).toBe("error");
-            expect(s0.initError).toBe("boom");
-            const r = update(s0, { type: "InitReady" });
-            expect(r.state.initPhase).toBe("ready");
-            expect(r.state.initError).toBe(null);
+        it("InitReady advances InitPending → InitReady with timestamp", () => {
+            const r = update(mk(), { type: "InitReady", at: 500 });
+            expect(r.state.initPhase).toEqual({ kind: "InitReady", at: 500 });
+            expect(isInitReady(r.state)).toBe(true);
             expect(r.events[0]).toMatchObject({ type: "init-ready" });
         });
 
-        it("InitFailed captures reason", () => {
-            const r = update(mk(), { type: "InitFailed", reason: "RPC timeout" });
-            expect(r.state.initPhase).toBe("error");
-            expect(r.state.initError).toBe("RPC timeout");
+        it("InitFailed advances InitPending → InitFailed with timestamp + reason", () => {
+            const r = update(mk(), { type: "InitFailed", at: 750, reason: "RPC timeout" });
+            expect(r.state.initPhase).toEqual({
+                kind: "InitFailed",
+                at: 750,
+                reason: "RPC timeout",
+            });
+            expect(isInitReady(r.state)).toBe(false);
             expect(r.events[0]).toMatchObject({ type: "init-failed", reason: "RPC timeout" });
         });
 
-        it("InitStart while already loading is a no-op (same ref)", () => {
+        it("InitStart in InitPending is a no-op (same ref, no events)", () => {
             const start = mk();
             const r = update(start, { type: "InitStart" });
             expect(r.state).toBe(start);
             expect(r.events).toEqual([]);
         });
 
-        it("TurnStart suppressed while initPhase === 'loading'", () => {
+        it("InitStart after InitReady is a no-op (one-way; same ref)", () => {
+            const readyState = update(mk(), { type: "InitReady", at: 100 }).state;
+            const r = update(readyState, { type: "InitStart" });
+            expect(r.state).toBe(readyState);
+            expect(r.events).toEqual([]);
+        });
+
+        it("InitStart after InitFailed is a no-op (one-way; same ref)", () => {
+            const failed = update(mk(), {
+                type: "InitFailed",
+                at: 100,
+                reason: "boom",
+            }).state;
+            const r = update(failed, { type: "InitStart" });
+            expect(r.state).toBe(failed);
+            expect(r.events).toEqual([]);
+        });
+
+        it("InitReady after InitReady is a no-op (idempotent)", () => {
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const r = update(s0, { type: "InitReady", at: 200 });
+            expect(r.state).toBe(s0);
+            // Original timestamp is preserved — re-firing doesn't bump it.
+            expect(r.state.initPhase).toEqual({ kind: "InitReady", at: 100 });
+            expect(r.events).toEqual([]);
+        });
+
+        it("InitReady after InitFailed is dropped (one-way; same ref)", () => {
+            const failed = update(mk(), {
+                type: "InitFailed",
+                at: 100,
+                reason: "load broke",
+            }).state;
+            const r = update(failed, { type: "InitReady", at: 200 });
+            expect(r.state).toBe(failed);
+            // Stays in InitFailed — reason preserved.
+            expect(r.state.initPhase).toEqual({
+                kind: "InitFailed",
+                at: 100,
+                reason: "load broke",
+            });
+            expect(r.events).toEqual([]);
+        });
+
+        it("InitFailed after InitReady is dropped (one-way; same ref)", () => {
+            const readyState = update(mk(), { type: "InitReady", at: 100 }).state;
+            const r = update(readyState, {
+                type: "InitFailed",
+                at: 200,
+                reason: "late",
+            });
+            expect(r.state).toBe(readyState);
+            expect(r.state.initPhase).toEqual({ kind: "InitReady", at: 100 });
+            expect(r.events).toEqual([]);
+        });
+
+        it("InitFailed after InitFailed is a no-op (preserves first reason + timestamp)", () => {
+            const first = update(mk(), {
+                type: "InitFailed",
+                at: 100,
+                reason: "first failure",
+            }).state;
+            const r = update(first, {
+                type: "InitFailed",
+                at: 200,
+                reason: "second failure",
+            });
+            expect(r.state).toBe(first);
+            expect(r.state.initPhase).toEqual({
+                kind: "InitFailed",
+                at: 100,
+                reason: "first failure",
+            });
+            expect(r.events).toEqual([]);
+        });
+
+        it("TurnStart suppressed while in InitPending", () => {
             // Subscribed but not InitReady — gap 1 invariant.
             const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
             const r = update(s0, { type: "TurnStart", at: 110 });
@@ -277,11 +356,27 @@ describe("agent-pane-state reducer", () => {
             });
         });
 
-        it("TurnStart permitted on init error (fail-open)", () => {
-            const s0 = update(mk(), { type: "InitFailed", reason: "load failed" }).state;
+        it("TurnStart permitted on InitFailed (fail-open)", () => {
+            const s0 = update(mk(), {
+                type: "InitFailed",
+                at: 100,
+                reason: "load failed",
+            }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const r = update(s1, { type: "TurnStart", at: 110 });
             expect(r.state.turnActive).toBe(true);
+        });
+
+        it("isInitReady selector tracks InitReady only", () => {
+            expect(isInitReady(mk())).toBe(false);
+            const failed = update(mk(), {
+                type: "InitFailed",
+                at: 100,
+                reason: "x",
+            }).state;
+            expect(isInitReady(failed)).toBe(false);
+            const readyState = update(mk(), { type: "InitReady", at: 100 }).state;
+            expect(isInitReady(readyState)).toBe(true);
         });
     });
 
@@ -431,7 +526,7 @@ describe("agent-pane-state reducer", () => {
             // Manual sequence: Submitting then a fresh subscribe (e.g.
             // after reconnect). The subscribe should hand off to
             // Streaming.
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             expect(s2.turnPhase.kind).toBe("Submitting");
@@ -448,14 +543,14 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("StreamSubscribe from Idle keeps phase Idle (no spontaneous promotion)", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const r = update(s0, { type: "StreamSubscribe", at: 100 });
             expect(r.state.streaming.active).toBe(true);
             expect(r.state.turnPhase.kind).toBe("Idle");
         });
 
         it("StreamFlushObserved while Streaming mirrors bufferSize + lastEventMs onto phase", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "StreamSubscribe", at: 120 }).state;
@@ -538,7 +633,7 @@ describe("agent-pane-state reducer", () => {
         it("StopFailed while Interrupting rolls back to Streaming AND clears stopping", () => {
             // Build up: ready → submit → re-subscribe to Streaming →
             // stop → stop-rpc-fails.
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "StreamSubscribe", at: 120 }).state;
@@ -579,7 +674,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("StreamUnsubscribe while Idle returns to Idle (no Disconnected)", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             // Phase is still Idle (subscribe alone doesn't promote).
             expect(s1.turnPhase.kind).toBe("Idle");
@@ -593,7 +688,7 @@ describe("agent-pane-state reducer", () => {
             // user message dispatches TurnStart. Submitting → Streaming
             // must promote on the first chunk arrival, NOT depend on a
             // re-subscribe that never fires in practice.
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             // (no second subscribe — that was the synthetic test crutch)
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
@@ -612,7 +707,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("ToolStart while Submitting promotes phase to Streaming with toolsActive=1", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             expect(s2.turnPhase.kind).toBe("Submitting");
@@ -625,7 +720,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TokensIn while Submitting promotes phase to Streaming", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             expect(s2.turnPhase.kind).toBe("Submitting");
@@ -638,7 +733,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("ToolStart while Streaming increments toolsActive on the phase", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "StreamSubscribe", at: 120 }).state;
@@ -663,7 +758,7 @@ describe("agent-pane-state reducer", () => {
 
         it("ToolEnd clamps toolsActive at 0 (never goes negative)", () => {
             // Defensive: out-of-order ToolEnd while toolsActive is 0.
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "StreamSubscribe", at: 120 }).state;
@@ -675,7 +770,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TokensIn / TokensOut while Streaming bump lastEventMs on the phase", () => {
-            const s0 = update(mk(), { type: "InitReady" }).state;
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "StreamSubscribe", at: 120 }).state;
@@ -724,9 +819,12 @@ describe("agent-pane-state reducer", () => {
             // initPhase and turnPhase are orthogonal axes.
             const s0 = update(mk(), { type: "InitStart" }).state;
             expect(s0.turnPhase.kind).toBe("Idle");
-            const s1 = update(s0, { type: "InitReady" }).state;
+            const s1 = update(s0, { type: "InitReady", at: 100 }).state;
             expect(s1.turnPhase.kind).toBe("Idle");
-            const s2 = update(s1, { type: "InitFailed", reason: "boom" }).state;
+            // s1 is already InitReady (terminal); InitFailed becomes a
+            // no-op there. We just need to assert turnPhase stays Idle
+            // either way — the orthogonality assertion still holds.
+            const s2 = update(s1, { type: "InitFailed", at: 200, reason: "boom" }).state;
             expect(s2.turnPhase.kind).toBe("Idle");
         });
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -8,13 +8,19 @@
  *
  * Invariants enforced:
  *   1. turnActive cannot be set while streaming inactive (suppressed).
- *   2. turnActive cannot be set while initPhase !== "ready" (suppressed).
+ *   2. turnActive cannot be set while initPhase.kind === "InitPending"
+ *      (suppressed). After `InitFailed` we fail open — see the
+ *      `TurnStart` arm.
  *   3. stopping clears automatically on TurnEnd / TurnReset.
  *   4. currentTool and turnTokens clear on TurnEnd / TurnReset.
  *   5. pending FIFO; accepting/rejecting/expiring unknown ids is no-op.
  *   6. StreamFlushObserved is a no-op when streaming inactive.
  *   7. StreamWatchdogTick is a no-op when streaming inactive or
  *      lastEventMs is null (no events seen yet).
+ *   8. Init lifecycle transitions are one-way: InitStart / InitReady /
+ *      InitFailed are no-ops once the pane has reached a terminal init
+ *      state (InitReady / InitFailed). Re-entering pending requires a
+ *      fresh pane slot.
  */
 
 import {
@@ -43,24 +49,35 @@ export function update(
     switch (command.type) {
         // ── Init lifecycle (gap 1) ─────────────────────────────────
         case "InitStart": {
-            if (state.initPhase === "loading") return { state, events: [] };
-            return {
-                state: { ...state, initPhase: "loading", initError: null },
-                events: [{ type: "init-started" }],
-            };
+            // Idempotent: only emits when first entering pending. Already
+            // in pending → no-op (same ref). Already terminal → no-op
+            // (we don't reset back from InitReady/InitFailed).
+            return { state, events: [] };
         }
 
         case "InitReady": {
-            if (state.initPhase === "ready") return { state, events: [] };
+            if (state.initPhase.kind !== "InitPending") {
+                // Already terminal — no-op. Out-of-order InitReady after
+                // an earlier InitFailed (or a duplicate InitReady) is
+                // silently dropped to keep transitions one-way.
+                return { state, events: [] };
+            }
             return {
-                state: { ...state, initPhase: "ready", initError: null },
+                state: { ...state, initPhase: { kind: "InitReady", at: command.at } },
                 events: [{ type: "init-ready" }],
             };
         }
 
         case "InitFailed": {
+            if (state.initPhase.kind !== "InitPending") {
+                // Same one-way rule as InitReady — once terminal, stay.
+                return { state, events: [] };
+            }
             return {
-                state: { ...state, initPhase: "error", initError: command.reason },
+                state: {
+                    ...state,
+                    initPhase: { kind: "InitFailed", at: command.at, reason: command.reason },
+                },
                 events: [{ type: "init-failed", reason: command.reason }],
             };
         }
@@ -203,7 +220,7 @@ export function update(
             // After init failure we fail open — the live stream may still
             // work even if history fetch hung, and blocking the user
             // would be worse than silently dropping a stale send.
-            if (state.initPhase === "loading") {
+            if (state.initPhase.kind === "InitPending") {
                 return {
                     state,
                     events: [

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -22,8 +22,24 @@ import type {
     TurnTokens,
 } from "../../view/agent/types";
 
-/** Init lifecycle — covers the "history still loading" gap. */
-export type InitPhase = "loading" | "ready" | "error";
+/**
+ * Init lifecycle — covers the "history still loading" gap (issue #728 gap 1).
+ *
+ * Discriminated union. The pane starts in `InitPending`; the history
+ * load resolves into either `InitReady` (success) or `InitFailed`
+ * (error, with diagnostic reason). Transitions are one-way: once a
+ * pane has reached a terminal state (`InitReady` / `InitFailed`),
+ * `InitStart` is a no-op. Re-mount creates a new pane slot whose state
+ * resets to `InitPending`.
+ *
+ * Each terminal variant carries the wall-clock ms it was entered. The
+ * timestamp is intentionally part of the variant payload (not a
+ * separate field) so a transition is one atomic write.
+ */
+export type InitPhase =
+    | { kind: "InitPending" }
+    | { kind: "InitReady"; at: number }
+    | { kind: "InitFailed"; at: number; reason: string };
 
 // ─────────────────────────────────────────────────────────────────────────
 // TurnPhase discriminated union (PR A — dual-write phase)
@@ -106,10 +122,12 @@ export interface AgentPaneState {
     turnActive: boolean;
     stopping: boolean;
     pending: PendingMessage[];
-    /** Init phase — `loading` until history fetch completes (or fails). */
+    /**
+     * Init phase — `InitPending` until history fetch resolves (or fails).
+     * Discriminated union; failure reason lives in the `InitFailed`
+     * variant's `reason` payload — no separate `initError` field.
+     */
     initPhase: InitPhase;
-    /** Reason captured on InitFailed; null otherwise. */
-    initError: string | null;
     /**
      * Wall-clock ms of the last observable stream activity (subscribe,
      * flush, tool, tokens). Drives the stuck-stream watchdog. null
@@ -134,11 +152,15 @@ export const initialState = (agentId: string): AgentPaneState => ({
     turnActive: false,
     stopping: false,
     pending: [],
-    initPhase: "loading",
-    initError: null,
+    initPhase: { kind: "InitPending" },
     lastEventMs: null,
     turnPhase: { kind: "Idle" },
 });
+
+/** Selector — `true` iff the pane has finished its initial history load. */
+export function isInitReady(state: AgentPaneState): boolean {
+    return state.initPhase.kind === "InitReady";
+}
 
 /**
  * Selector — true while the agent is processing a user request.
@@ -168,12 +190,16 @@ export function workingFromPhase(phase: TurnPhase): boolean {
 
 export type AgentPaneCommand =
     // ── Init lifecycle (gap 1) ─────────────────────────────────────
-    /** Caller signal: history fetch began. */
+    /**
+     * Caller signal: history fetch began. Idempotent — if the pane is
+     * already in any terminal state (`InitReady` / `InitFailed`),
+     * `InitStart` is a no-op (we don't reset back to pending).
+     */
     | { type: "InitStart" }
     /** Caller signal: history fetch resolved successfully. */
-    | { type: "InitReady" }
+    | { type: "InitReady"; at: number }
     /** Caller signal: history fetch failed; reason surfaced for diagnostics. */
-    | { type: "InitFailed"; reason: string }
+    | { type: "InitFailed"; at: number; reason: string }
 
     // ── Stream lifecycle ───────────────────────────────────────────
     /** Hook signal: subscription is up. */
@@ -251,7 +277,6 @@ export type AgentPaneCommand =
     | { type: "PendingMessageExpired"; id: string };
 
 export type AgentPaneEvent =
-    | { type: "init-started" }
     | { type: "init-ready" }
     | { type: "init-failed"; reason: string }
     | { type: "stream-subscribed"; at: number }
@@ -272,7 +297,7 @@ export type AgentPaneEvent =
     | {
           /**
            * Invariant fire: TurnStart while streaming inactive OR
-           * initPhase !== "ready" — dropped.
+           * initPhase.kind === "InitPending" — dropped.
            */
           type: "turn-start-suppressed";
           reason: string;

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -239,15 +239,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
 
         // Init guard (issue #728 gap 1, codex P2 on PR #742). The
         // reducer's TurnStart handler already suppresses turnActive
-        // while initPhase === "loading", but that only stops the local
-        // UI state — without this check, the message still gets queued
-        // into pending AND sent over AgentInputCommand. If the backend
-        // accepts before InitReady fires, the accepted-event TurnStart
-        // is also suppressed, leaving the UI showing no active turn
-        // while the agent IS processing. Bail early here so neither
+        // while initPhase.kind === "InitPending", but that only stops the
+        // local UI state — without this check, the message still gets
+        // queued into pending AND sent over AgentInputCommand. If the
+        // backend accepts before InitReady fires, the accepted-event
+        // TurnStart is also suppressed, leaving the UI showing no active
+        // turn while the agent IS processing. Bail early here so neither
         // happens.
         const ps = paneSnapshot(opts.blockId);
-        if (ps?.initPhase === "loading") {
+        if (ps?.initPhase.kind === "InitPending") {
             opts.log("send", "send blocked: history still loading", "warn");
             return;
         }

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -130,8 +130,8 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
         // Init lifecycle (issue #728 gap 1): dispatch InitStart before the
         // fetch, InitReady on success, InitFailed on error. The reducer
-        // gates TurnStart on initPhase === "ready" so we don't accept
-        // sends while history is still loading.
+        // gates TurnStart on initPhase.kind !== "InitPending" so we don't
+        // accept sends while history is still loading.
         // Soft variant — cascade-during-dispatch could dispose the pane
         // before this fires; retro 2026-05-23 (agent-pane cascade →
         // replaceChild quick-win).
@@ -162,7 +162,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             `restored ${snapshot.nodes.length} nodes from snapshot ` +
                                 `(savedAt=${snapshot.savedAt ?? "unknown"}, loadOlder offset=${offset})`,
                         );
-                        dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
+                        dispatchPaneIfRegistered(opts.blockId, {
+                            type: "InitReady",
+                            at: Date.now(),
+                        });
                         return;
                     }
                     opts.log(
@@ -189,7 +192,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
                 const total = countResp?.count ?? 0;
                 if (total === 0) {
-                    dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
+                    dispatchPaneIfRegistered(opts.blockId, {
+                        type: "InitReady",
+                        at: Date.now(),
+                    });
                     return;
                 }
 
@@ -219,7 +225,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 setHistoryTotal(available);
 
                 opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);
-                dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
+                dispatchPaneIfRegistered(opts.blockId, {
+                    type: "InitReady",
+                    at: Date.now(),
+                });
             } catch (err: any) {
                 if (!mounted) return;
                 // Non-fatal — fresh session or backend not ready yet.
@@ -229,10 +238,14 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 const reason = err?.message ?? String(err);
                 opts.log("history", `could not load history: ${reason}`, "warn");
                 // Surface the failure for diagnostics. The reducer's
-                // TurnStart guard treats `error` as fail-open (only
-                // `loading` blocks sends), so no follow-up InitReady
+                // TurnStart guard treats `InitFailed` as fail-open (only
+                // `InitPending` blocks sends), so no follow-up InitReady
                 // is needed — the user can still send.
-                dispatchPaneIfRegistered(opts.blockId, { type: "InitFailed", reason });
+                dispatchPaneIfRegistered(opts.blockId, {
+                    type: "InitFailed",
+                    at: Date.now(),
+                    reason,
+                });
             }
         })();
     });

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -67,9 +67,10 @@ export interface AgentAtoms {
      */
     pendingMessagesAtom: SignalPair<PendingMessage[]>;
     /**
-     * Init lifecycle — `loading` until the initial history fetch resolves
-     * (or fails). Drives a "Loading history…" hint and gates `TurnStart`.
-     * Issue #728 gap 1.
+     * Init lifecycle — `InitPending` until the initial history fetch
+     * resolves into `InitReady` (success) or `InitFailed` (error).
+     * Drives a "Loading history…" hint and gates `TurnStart`. Issue
+     * #728 gap 1; discriminated-union shape.
      */
     initPhaseAtom: SignalPair<InitPhase>;
     /**
@@ -127,7 +128,9 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         turnActiveAtom: createSignal<boolean>(false),
         stoppingAtom: createSignal<boolean>(false),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
-        initPhaseAtom: createSignal<InitPhase>("loading"),
+        // gap1 (#993) reshaped InitPhase from string union to discriminated
+        // union; turnPhase from PR B stays alongside.
+        initPhaseAtom: createSignal<InitPhase>({ kind: "InitPending" }),
         turnPhaseAtom: createSignal<TurnPhase>({ kind: "Idle" }),
     };
 }


### PR DESCRIPTION
Refactor the agent pane's init lifecycle into a discriminated-union state machine so views and downstream PRs can wait on explicit init phases.

Closes #728 (gap 1). Aligns with the gap-1 section of `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md`, which explicitly keeps init-phase orthogonal to the in-flight TurnPhase PR sequence.

## State shape

`InitPhase` becomes a discriminated union:

```ts
type InitPhase =
    | { kind: "InitPending" }
    | { kind: "InitReady"; at: number }
    | { kind: "InitFailed"; at: number; reason: string };
```

`AgentPaneState.initPhase` defaults to `{ kind: "InitPending" }`. The separate `initError` field is removed — the failure reason now lives inside the `InitFailed` variant payload so a transition is one atomic write.

## Commands

| Command | Payload | Behaviour |
|---|---|---|
| `InitStart` | — | Idempotent no-op in every state (we don't reset terminal back to pending). |
| `InitReady` | `{ at }` | `InitPending` → `InitReady` (one-way). |
| `InitFailed` | `{ at, reason }` | `InitPending` → `InitFailed` (one-way). |

Out-of-order `InitReady` / `InitFailed` after a terminal state are silently dropped — transitions are monotonic. Once a pane reaches `InitReady` or `InitFailed` it stays there; a fresh pane slot is needed to re-enter pending. The now-unreachable `init-started` event is removed.

## Selector

```ts
isInitReady(state) // true iff state.initPhase.kind === "InitReady"
```

## Wiring (minimal — no new dispatch sites)

Just enough to keep existing call sites working with the new shape:

- `useHistoryPagination` dispatches `InitReady` / `InitFailed` with `at: Date.now()` at every existing site (snapshot-restore, NDJSON-empty, NDJSON-loaded, NDJSON-failed).
- `useAgentCommands` replaces `ps?.initPhase === "loading"` with `ps?.initPhase.kind === "InitPending"`.
- `AgentAtoms.initPhaseAtom` initialises to `{ kind: "InitPending" }`.
- Reducer's `TurnStart` guard reads `initPhase.kind === "InitPending"` (fail-open on `InitFailed` is preserved).

No new dispatch sites; no view changes that depend on the new variant payloads — those land in follow-up PRs.

## Tests (11 new)

All in `frontend/app/store/agent-pane-state/reducer.test.ts > "Init phase (gap 1)"`:

1. starts in `InitPending`
2. `InitReady` advances `InitPending → InitReady` with timestamp
3. `InitFailed` advances `InitPending → InitFailed` with timestamp + reason
4. `InitStart` in `InitPending` is a no-op (same ref, no events)
5. `InitStart` after `InitReady` is a no-op (one-way; same ref)
6. `InitStart` after `InitFailed` is a no-op (one-way; same ref)
7. `InitReady` after `InitReady` is a no-op (idempotent; same ref; preserves first timestamp)
8. `InitReady` after `InitFailed` is dropped (one-way; same ref; reason preserved)
9. `InitFailed` after `InitReady` is dropped (one-way; same ref)
10. `InitFailed` after `InitFailed` is a no-op (preserves first reason + timestamp)
11. `TurnStart` suppressed while in `InitPending`
12. `TurnStart` permitted on `InitFailed` (fail-open)
13. `isInitReady` selector tracks `InitReady` only

(Plus updates to PR A's TurnPhase tests to include the new `at` / `reason` fields where they dispatch `InitReady` / `InitFailed`.)

All 73 tests in `frontend/app/store/agent-pane-state/` pass.

## Out of scope (follow-up PRs)

- Wiring the model to dispatch `InitStart` / `InitReady` / `InitFailed` at additional sites.
- Views reading the new `at` / `reason` payloads.
- Touching `turnPhase` or other PRs' surface.

## References

- Issue: #728 (gap 1)
- Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)