### PR TITLE
feat(agent-pane): bounded Submitting → Done.errored on timeout (turn-phase PR D)

### DIFF
--- a/.changesets/1779537974-feat-agent-pane-bounded-submit-timeout-bqg8.md
+++ b/.changesets/1779537974-feat-agent-pane-bounded-submit-timeout-bqg8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): bounded submit timeout

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -10,6 +10,7 @@ import {
     isInitReady,
     isWorking,
     STUCK_THRESHOLD_MS,
+    SUBMIT_TIMEOUT_MS,
     TurnPhase,
 } from "./types";
 
@@ -1153,6 +1154,275 @@ describe("agent-pane-state reducer", () => {
         it("INTERRUPT_TIMEOUT_MS is 5000 (sanity)", () => {
             // Pinned so a sneaky bump can't slip in unreviewed.
             expect(INTERRUPT_TIMEOUT_MS).toBe(5_000);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────
+    // PR D — bounded `Submitting → Done.errored`.
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §8 /
+    // issue #728 gap 2. TurnStart promotes the phase to Submitting and
+    // emits `schedule-submit-timeout`; if no stream activity arrives
+    // (no flush, no tool, no token) within SUBMIT_TIMEOUT_MS, the
+    // dispatch layer fires `SubmitTimeoutElapsed` and we force-transition
+    // to Done.errored. The reducer guards against stale ticks by
+    // checking the current phase on receipt.
+    // ─────────────────────────────────────────────────────────────────
+    describe("Bounded submit timeout (PR D)", () => {
+        it("TurnStart emits schedule-submit-timeout with correct deadlineMs", () => {
+            const s0 = ready(100);
+            const r = update(s0, { type: "TurnStart", at: 110 });
+            expect(r.state.turnPhase.kind).toBe("Submitting");
+            // Two events: turn-started, and the submit-timeout schedule.
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({
+                type: "turn-started",
+                at: 110,
+            });
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-submit-timeout",
+                deadlineMs: 110 + SUBMIT_TIMEOUT_MS,
+            });
+        });
+
+        it("Suppressed TurnStart does NOT emit schedule-submit-timeout", () => {
+            // Stream inactive → suppressed; only the suppression event,
+            // no watchdog arming.
+            const start = mk();
+            const r = update(start, { type: "TurnStart", at: 100 });
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "turn-start-suppressed",
+            });
+        });
+
+        it("TurnStart while still loading history does NOT emit schedule-submit-timeout", () => {
+            // Subscribed but not InitReady — invariant 2 suppresses;
+            // watchdog must not arm against a turn that never started.
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const r = update(s0, { type: "TurnStart", at: 110 });
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "turn-start-suppressed",
+                reason: "init still loading",
+            });
+        });
+
+        it("SubmitTimeoutElapsed while Submitting → Done.errored", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const deadline = 110 + SUBMIT_TIMEOUT_MS;
+            const r = update(s1, {
+                type: "SubmitTimeoutElapsed",
+                at: deadline,
+            });
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("errored");
+                expect(r.state.turnPhase.finishedAt).toBe(deadline);
+            }
+            // Legacy fields cleared the same way TurnEnd would clear them.
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state.stopping).toBe(false);
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+            // Animation invariant: isWorking flips false.
+            expect(isWorking(r.state)).toBe(false);
+            // Audit event.
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "submit-timed-out",
+                at: deadline,
+            });
+        });
+
+        it("SubmitTimeoutElapsed clears live tool + tokens that snuck in pre-promotion", () => {
+            // Edge case: the dispatch layer might set legacy currentTool
+            // / turnTokens during Submitting before the phase promotion
+            // path actually runs (e.g. an ill-ordered call site). The
+            // forced-Done.errored path must still scrub the sidecars so
+            // the next turn starts clean.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            // Inject live per-turn sidecars without dispatching the
+            // commands (which would also promote to Streaming via
+            // bumpEvent and defeat the test).
+            const sDirty: AgentPaneState = {
+                ...s1,
+                currentTool: "Read",
+                turnTokens: { input: 42, output: 17 },
+            };
+            const r = update(sDirty, {
+                type: "SubmitTimeoutElapsed",
+                at: 5_000,
+            });
+            expect(r.state.turnPhase.kind).toBe("Done");
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+        });
+
+        it("SubmitTimeoutElapsed while Streaming is a no-op (same ref)", () => {
+            // Realistic race: the first chunk arrived (Submitting →
+            // Streaming via StreamFlushObserved) just before the timer
+            // fired. The reducer must not corrupt the live Streaming
+            // phase.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 120,
+            }).state;
+            expect(s2.turnPhase.kind).toBe("Streaming");
+            const r = update(s2, {
+                type: "SubmitTimeoutElapsed",
+                at: 30_110,
+            });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+        });
+
+        it("SubmitTimeoutElapsed while Interrupting is a no-op (same ref)", () => {
+            // User pressed Stop while still in Submitting (e.g. instant
+            // regret). Phase moved to Interrupting; submit watchdog
+            // should not retroactively classify as errored.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "RequestStop", at: 120 }).state;
+            expect(s2.turnPhase.kind).toBe("Interrupting");
+            const r = update(s2, {
+                type: "SubmitTimeoutElapsed",
+                at: 30_110,
+            });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+        });
+
+        it("SubmitTimeoutElapsed while Idle is a no-op (same ref)", () => {
+            const start = mk();
+            const r = update(start, {
+                type: "SubmitTimeoutElapsed",
+                at: 100,
+            });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("SubmitTimeoutElapsed while Done is a no-op (same ref)", () => {
+            // Graceful TurnEnd already landed → Done.completed.
+            // Late submit watchdog must not overwrite the outcome.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TurnEnd", stats: null }, 200).state;
+            expect(s2.turnPhase.kind).toBe("Done");
+            if (s2.turnPhase.kind === "Done") {
+                expect(s2.turnPhase.outcome).toBe("completed");
+            }
+            const r = update(s2, {
+                type: "SubmitTimeoutElapsed",
+                at: 30_110,
+            });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+            // Outcome preserved.
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("completed");
+            }
+        });
+
+        it("SubmitTimeoutElapsed while Disconnected is a no-op (same ref)", () => {
+            // Stream dropped mid-Submitting → Disconnected.lastKind=
+            // Submitting. The submit watchdog must not corrupt that.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const s2 = update(s1, { type: "StreamUnsubscribe", at: 200 }).state;
+            expect(s2.turnPhase.kind).toBe("Disconnected");
+            const r = update(s2, {
+                type: "SubmitTimeoutElapsed",
+                at: 30_110,
+            });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+        });
+
+        it("Three-paths invariant: bumpEvent, StreamFlushObserved, and timeout all exit Submitting", () => {
+            // Spec §8 — "Three independent paths out of Submitting" — so
+            // the working animation can never hang on Submitting.
+            const buildSubmitting = () => {
+                const a = ready(100);
+                return update(a, { type: "TurnStart", at: 110 }).state;
+            };
+
+            // Path 1: promotion via bumpEvent (a tool starts).
+            const p1 = update(
+                buildSubmitting(),
+                { type: "ToolStart", name: "Read" },
+                130,
+            );
+            expect(p1.state.turnPhase.kind).toBe("Streaming");
+
+            // Path 1b: promotion via bumpEvent (token activity).
+            const p1b = update(
+                buildSubmitting(),
+                { type: "TokensIn", input: 10 },
+                130,
+            );
+            expect(p1b.state.turnPhase.kind).toBe("Streaming");
+
+            // Path 2: promotion via StreamFlushObserved.
+            const p2 = update(buildSubmitting(), {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 130,
+            });
+            expect(p2.state.turnPhase.kind).toBe("Streaming");
+
+            // Path 3: bounded timeout — no stream activity arrived.
+            const p3 = update(buildSubmitting(), {
+                type: "SubmitTimeoutElapsed",
+                at: 110 + SUBMIT_TIMEOUT_MS,
+            });
+            expect(isWorking(p3.state)).toBe(false);
+            expect(p3.state.turnPhase.kind).toBe("Done");
+            if (p3.state.turnPhase.kind === "Done") {
+                expect(p3.state.turnPhase.outcome).toBe("errored");
+            }
+        });
+
+        it("Late TurnEnd after SubmitTimeoutElapsed does NOT overwrite errored (first-done-wins)", () => {
+            // PR C added `alreadyDone` to the TurnEnd arm so a late
+            // graceful ack after a forced Done can't reclassify the
+            // outcome. PR D inherits the same guarantee: timeout fires,
+            // turn lands in Done.errored, a stray backend TurnEnd that
+            // arrives afterwards must preserve "errored", not overwrite
+            // with "completed" or "stopped".
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const deadline = 110 + SUBMIT_TIMEOUT_MS;
+            const s2 = update(s1, {
+                type: "SubmitTimeoutElapsed",
+                at: deadline,
+            }).state;
+            expect(s2.turnPhase.kind).toBe("Done");
+            if (s2.turnPhase.kind === "Done") {
+                expect(s2.turnPhase.outcome).toBe("errored");
+            }
+            // Late backend ack — graceful TurnEnd lands.
+            const r = update(s2, { type: "TurnEnd", stats: null }, deadline + 1_000);
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                // First-done-wins: outcome stays "errored".
+                expect(r.state.turnPhase.outcome).toBe("errored");
+                // finishedAt is also pinned (not bumped to the late ack).
+                expect(r.state.turnPhase.finishedAt).toBe(deadline);
+            }
+        });
+
+        it("SUBMIT_TIMEOUT_MS is 30000 (sanity)", () => {
+            // Pinned so a sneaky bump can't slip in unreviewed.
+            expect(SUBMIT_TIMEOUT_MS).toBe(30_000);
         });
     });
 });

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -31,6 +31,7 @@ import {
     KindBeforeDisconnect,
     ReducerResult,
     STUCK_THRESHOLD_MS,
+    SUBMIT_TIMEOUT_MS,
     TurnOutcome,
     TurnPhase,
 } from "./types";
@@ -231,6 +232,23 @@ export function update(
                     ],
                 };
             }
+            // PR D: only schedule the submit watchdog when we actually
+            // CROSS INTO Submitting (not when we're already there — that
+            // would double-arm the timeout). Mirrors the PR C entry
+            // pattern for the interrupt watchdog. In practice TurnStart
+            // is dispatched once per user-send so we expect this branch
+            // ~always, but defence in depth keeps the contract clean for
+            // any future re-entrant caller.
+            const enteringSubmitting = state.turnPhase.kind !== "Submitting";
+            const events: AgentPaneEvent[] = [
+                { type: "turn-started", at: command.at },
+            ];
+            if (enteringSubmitting) {
+                events.push({
+                    type: "schedule-submit-timeout",
+                    deadlineMs: command.at + SUBMIT_TIMEOUT_MS,
+                });
+            }
             return {
                 state: {
                     ...state,
@@ -247,7 +265,7 @@ export function update(
                         pendingContent: "",
                     },
                 },
-                events: [{ type: "turn-started", at: command.at }],
+                events,
             };
         }
 
@@ -461,6 +479,48 @@ export function update(
                     },
                 },
                 events: [{ type: "interrupt-timed-out", at: command.at }],
+            };
+        }
+
+        case "SubmitTimeoutElapsed": {
+            // PR D — bounded `Submitting → Done.errored`.
+            //
+            // The dispatch side schedules a setTimeout when it sees the
+            // `schedule-submit-timeout` event emitted by `TurnStart`. A
+            // shared cancel flag (the JS analogue of `Arc<AtomicBool>`,
+            // same pattern as the PR C interrupt timer) prevents a stale
+            // timer from firing after a graceful promotion to Streaming
+            // (via `StreamFlushObserved` or `bumpEvent` from a tool /
+            // token event). Defence in depth: the reducer ALSO checks
+            // the current phase and treats a late tick as a no-op.
+            //
+            // Three independent paths out of Submitting — promotion via
+            // `StreamFlushObserved`, promotion via `bumpEvent` (tool /
+            // token), and this timeout — so the working animation can
+            // never get stuck on Submitting indefinitely. The first
+            // promotion wins; this timeout fires only if none arrived.
+            // Spec §8 / issue #728 gap 2.
+            if (state.turnPhase.kind !== "Submitting") {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    // Legacy cleanup mirrors the InterruptTimeoutElapsed
+                    // arm — a forced exit from a working state clears
+                    // the boolean consumers (turnActive=false, stopping
+                    // cleared) and per-turn sidecars.
+                    turnActive: false,
+                    stopping: false,
+                    currentTool: null,
+                    turnTokens: null,
+                    turnPhase: {
+                        kind: "Done",
+                        outcome: "errored",
+                        finishedAt: command.at,
+                    },
+                },
+                events: [{ type: "submit-timed-out", at: command.at }],
             };
         }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -261,6 +261,18 @@ export type AgentPaneCommand =
      * (e.g. agent acked first, user already resumed). Spec §8.
      */
     | { type: "InterruptTimeoutElapsed"; at: number }
+    /**
+     * Submit timeout watchdog fired (caller-scheduled setTimeout — see
+     * `schedule-submit-timeout` event). PR D — bounded
+     * `Submitting → Done.errored` force-transition: if the backend never
+     * acks a TurnStart with a chunk / token / tool event within
+     * `SUBMIT_TIMEOUT_MS`, the pane was previously stuck in Submitting
+     * forever (no `isWorking → false` signal) and the working animation
+     * would never settle. No-op if the phase has already moved off
+     * Submitting (e.g. promotion to Streaming via flush / bumpEvent,
+     * user already stopped, stream dropped). Spec §8 / issue #728 gap 2.
+     */
+    | { type: "SubmitTimeoutElapsed"; at: number }
 
     // ── Pending message queue (composer side) ─────────────────────
     | { type: "PendingMessageQueued"; id: string; text: string; at: number }
@@ -327,6 +339,27 @@ export type AgentPaneEvent =
      * "interrupt timed out — assuming dead" if needed. Spec §8.
      */
     | { type: "interrupt-timed-out"; at: number }
+    /**
+     * Reducer signal: a turn has just entered Submitting. The dispatch
+     * layer is expected to start a setTimeout for `SUBMIT_TIMEOUT_MS`
+     * and fire `SubmitTimeoutElapsed` when it expires — gated by a
+     * shared cancel flag so a graceful promotion to Streaming (via
+     * `StreamFlushObserved` or `bumpEvent` from tool / token activity)
+     * cancels the timer before it fires. `deadlineMs` is
+     * `at + SUBMIT_TIMEOUT_MS` so the caller can compute the remaining
+     * slice deterministically. PR D — spec §8 / issue #728 gap 2.
+     */
+    | {
+          type: "schedule-submit-timeout";
+          deadlineMs: number;
+      }
+    /**
+     * Reducer signal: the bounded `Submitting → Done.{errored}`
+     * force-transition fired because no stream activity arrived within
+     * `SUBMIT_TIMEOUT_MS`. Carries the firing wall-clock for audit.
+     * PR D — spec §8 / issue #728 gap 2.
+     */
+    | { type: "submit-timed-out"; at: number }
     | { type: "pending-queued"; id: string }
     | { type: "pending-accepted"; id: string; wasPresent: boolean }
     | { type: "pending-rejected"; id: string; wasPresent: boolean }
@@ -368,3 +401,22 @@ export const STUCK_THRESHOLD_MS = 45_000;
  * on live agents.
  */
 export const INTERRUPT_TIMEOUT_MS = 5_000;
+
+/**
+ * Bounded `Submitting → Done.{errored}` window. After `TurnStart` puts a
+ * turn into Submitting, if no stream activity (flush / bumpEvent from
+ * tool / token) lands within this many ms the reducer force-transitions
+ * to Done.errored on receipt of `SubmitTimeoutElapsed`. 30 s is the
+ * generous outer bound for a backend ack — network handshakes, agent
+ * spawn, and the first model token round-trip on a fresh session. Any
+ * longer and the working animation has been pinned past the user's
+ * patience window; PR E's streaming watchdog covers the longer "agent
+ * is thinking" idle case once we're in Streaming.
+ *
+ * PR D — spec §8 / issue #728 gap 2. The dispatcher arms this via the
+ * `schedule-submit-timeout` event emitted when `TurnStart` promotes the
+ * phase into Submitting; the standard cancel-flag pattern (the same
+ * `Arc<AtomicBool>` analogue used for the interrupt timeout) gates a
+ * stale fire against a graceful promotion to Streaming.
+ */
+export const SUBMIT_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
**PR D of the agent-pane turn-phase migration.** Reducer-only — bounded `Submitting → Done.errored` watchdog. Closes the second gap in issue #728 from the reducer side.

## Why

Today, a turn enters `Submitting` via `TurnStart` and depends entirely on the backend acking with a chunk / `TokensIn` / `TokensOut` / `ToolStart` event to promote to `Streaming` (via `StreamFlushObserved` or `bumpEvent`). If the backend never responds — network drop, agent crash before any output, RPC hang post-send — the pane stays in `Submitting` forever. There is no `isWorking → false` signal, so the working animation runs forever.

## What

Mirror PR C's bounded-state pattern. New contract:

- **`SUBMIT_TIMEOUT_MS = 30_000`** constant exported from `types.ts` alongside `INTERRUPT_TIMEOUT_MS`. 30 s is the outer bound for a healthy backend ack — handshake, agent spawn, and the first model token round-trip.
- **`SubmitTimeoutElapsed { at: number }`** added to `AgentPaneCommand` union.
- **`schedule-submit-timeout { deadlineMs: number }`** added to `AgentPaneEvent` union, emitted by `TurnStart` whenever the phase crosses INTO `Submitting`.
- **`submit-timed-out { at: number }`** audit event emitted when the bounded transition fires.
- **`TurnStart` arm**: emits `schedule-submit-timeout` only on entry — does not re-arm if the phase is already `Submitting` (mirrors PR C's entry-only rule for the interrupt watchdog).
- **`SubmitTimeoutElapsed` arm**:
  - If `state.turnPhase.kind === "Submitting"`: force-transition to `Done.errored` with `finishedAt = command.at`, plus the standard legacy cleanup (`turnActive=false`, `stopping=false`, `currentTool=null`, `turnTokens=null`). Emits `submit-timed-out`.
  - Else (`Streaming`, `Interrupting`, `Done`, `Disconnected`, `Idle`): no-op (same-ref).

The promotion arms (`bumpEvent`, `StreamFlushObserved`) implicitly cancel the timeout via the dispatch-side cancel-flag pattern — the reducer doesn't need to know about that; the timeout's own arm checks the current phase.

Three independent paths out of `Submitting` are now pinned:
1. promotion via `bumpEvent` (`ToolStart` / `TokensIn` / `TokensOut`)
2. promotion via `StreamFlushObserved`
3. bounded timeout via `SubmitTimeoutElapsed`

**First-done-wins** preserved: a late graceful `TurnEnd` arriving after `SubmitTimeoutElapsed` already forced `Done.errored` inherits PR C's `alreadyDone` guard and does NOT overwrite `errored` (also pinned by test).

## Tests

13 new tests, mirrors PR C structure:

- `TurnStart emits schedule-submit-timeout` with `deadlineMs = at + SUBMIT_TIMEOUT_MS`
- Suppressed `TurnStart` (stream inactive / init still loading) does NOT schedule
- `SubmitTimeoutElapsed while Submitting → Done.errored` with full legacy cleanup, `isWorking → false`
- Live tool + tokens injected during `Submitting` are scrubbed by the forced transition
- `SubmitTimeoutElapsed while Streaming / Interrupting / Idle / Done / Disconnected` — no-op (same ref)
- Three-paths invariant: bumpEvent (`ToolStart` + `TokensIn`), `StreamFlushObserved`, and `SubmitTimeoutElapsed` all exit `Submitting`
- Late `TurnEnd` after `SubmitTimeoutElapsed` preserves `"errored"` (first-done-wins)
- `SUBMIT_TIMEOUT_MS === 30_000` pinned

`npx vitest run frontend/app/store/agent-pane-state/` — **99/99 passing**. 0 new TS errors.

## Out of scope

- **Dispatcher wiring**: the actual `setTimeout` + cancel-flag in `useAgentStream.ts` / model layer — separate follow-up. This PR exposes the reducer contract only.
- **PR E (Streaming watchdog)**: orthogonal phase, separate command (will land alongside this PR in parallel). PR E touches the same reducer but its arm is independent; merge surface is restricted to the import list + arm position.
- **View / `frontend/app/view/agent/`** changes — none here.

## Refs

- Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §8
- PR A: #987 (TurnPhase discriminated union, dual-write)
- PR B: #992 (view reads `isWorking(state)`)
- PR C: #991 (bounded `Interrupting → Done.interrupted`)
- Init: #993 (InitPhase state machine, gap 1)
- Closes #728 gap 2 (submit-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
