### PR TITLE
feat(agent-pane): bounded Streaming → Done.errored on idle watchdog (turn-phase PR E)

### DIFF
--- a/.changesets/1779538048-feat-agent-pane-bounded-streaming-watchdog-nm1x.md
+++ b/.changesets/1779538048-feat-agent-pane-bounded-streaming-watchdog-nm1x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): bounded streaming watchdog

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -9,6 +9,7 @@ import {
     INTERRUPT_TIMEOUT_MS,
     isInitReady,
     isWorking,
+    STREAMING_IDLE_TIMEOUT_MS,
     STUCK_THRESHOLD_MS,
     SUBMIT_TIMEOUT_MS,
     TurnPhase,
@@ -1423,6 +1424,340 @@ describe("agent-pane-state reducer", () => {
         it("SUBMIT_TIMEOUT_MS is 30000 (sanity)", () => {
             // Pinned so a sneaky bump can't slip in unreviewed.
             expect(SUBMIT_TIMEOUT_MS).toBe(30_000);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────
+    // PR E — bounded `Streaming → Done.errored("stream-stalled")`.
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §10.
+    // Stream activity that lands inside Streaming emits a
+    // `schedule-stream-watchdog` event carrying the deadline; the
+    // dispatch layer cancels the prior arm and schedules a fresh
+    // setTimeout that fires `StreamStalled` if no new event refreshes
+    // `lastEventMs` within `STREAMING_IDLE_TIMEOUT_MS`. The reducer
+    // makes the final call: if the phase is still Streaming AND truly
+    // idle on receipt, transition to Done.errored; otherwise no-op.
+    // ─────────────────────────────────────────────────────────────────
+    describe("Bounded streaming watchdog (PR E)", () => {
+        it("STREAMING_IDLE_TIMEOUT_MS is 60000 (sanity)", () => {
+            // Pinned so a sneaky bump can't slip in unreviewed.
+            expect(STREAMING_IDLE_TIMEOUT_MS).toBe(60_000);
+        });
+
+        it("first stream activity from Submitting emits schedule-stream-watchdog", () => {
+            // Realistic flow: subscribe ONCE at mount, then a user
+            // message starts a new turn (Submitting). The first chunk
+            // arrives via StreamFlushObserved → promotes to Streaming.
+            // That promotion must arm the bounded idle watchdog.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            expect(s2.turnPhase.kind).toBe("Submitting");
+            const r = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 3,
+                at: 200,
+            });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            // Two events: the flush itself, then the watchdog schedule.
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({
+                type: "stream-flush-observed",
+                addedCount: 3,
+            });
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 200 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+        });
+
+        it("ToolStart from Submitting promotes to Streaming AND emits schedule-stream-watchdog", () => {
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const r = update(s2, { type: "ToolStart", name: "Read" }, 150);
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({ type: "tool-started" });
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 150 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+        });
+
+        it("TokensIn from Submitting promotes to Streaming AND emits schedule-stream-watchdog", () => {
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const r = update(s2, { type: "TokensIn", input: 50 }, 175);
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events).toHaveLength(2);
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 175 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+        });
+
+        it("subsequent stream activity within Streaming re-emits schedule-stream-watchdog with refreshed deadline", () => {
+            // Idempotent re-arm: every chunk / tool / token / flush
+            // while Streaming must extend the deadline. The dispatcher
+            // cancels the previous timer; the reducer's job is just to
+            // emit the new schedule.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            // Promote to Streaming with first flush.
+            const s3 = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 200,
+            }).state;
+            expect(s3.turnPhase.kind).toBe("Streaming");
+
+            // Second flush — must re-emit with refreshed deadline.
+            const r1 = update(s3, {
+                type: "StreamFlushObserved",
+                addedCount: 2,
+                at: 300,
+            });
+            expect(r1.events).toHaveLength(2);
+            expect(r1.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 300 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+
+            // Tool activity inside Streaming — also re-emits.
+            const s4 = r1.state;
+            const r2 = update(s4, { type: "ToolStart", name: "Bash" }, 400);
+            expect(r2.events).toHaveLength(2);
+            expect(r2.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 400 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+
+            // TokensOut inside Streaming — also re-emits.
+            const s5 = r2.state;
+            const r3 = update(s5, { type: "TokensOut", output: 200 }, 500);
+            expect(r3.events).toHaveLength(2);
+            expect(r3.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 500 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+
+            // ToolEnd inside Streaming — also re-emits (still activity).
+            const s6 = r3.state;
+            const r4 = update(s6, { type: "ToolEnd" }, 600);
+            expect(r4.events).toHaveLength(2);
+            expect(r4.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 600 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+        });
+
+        it("StreamSubscribe from Submitting emits schedule-stream-watchdog", () => {
+            // The hand-off case: subscribe finally lands after submit
+            // (e.g. reconnect mid-turn). Promotes to Streaming and arms.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const r = update(s2, { type: "StreamSubscribe", at: 120 });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({ type: "stream-subscribed" });
+            expect(r.events[1]).toMatchObject({
+                type: "schedule-stream-watchdog",
+                deadlineMs: 120 + STREAMING_IDLE_TIMEOUT_MS,
+            });
+        });
+
+        it("StreamSubscribe from Idle does NOT emit schedule-stream-watchdog", () => {
+            // Subscribe alone (no Submitting) doesn't promote to
+            // Streaming — phase stays Idle — so no watchdog is armed.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const r = update(s0, { type: "StreamSubscribe", at: 100 });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({ type: "stream-subscribed" });
+        });
+
+        it("StreamStalled after STREAMING_IDLE_TIMEOUT_MS → Done.errored stream-stalled", () => {
+            // Build a Streaming phase whose lastEventMs is far enough
+            // in the past that the deadline has elapsed.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const s3 = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 1_000,
+            }).state;
+            expect(s3.turnPhase.kind).toBe("Streaming");
+            if (s3.turnPhase.kind === "Streaming") {
+                expect(s3.turnPhase.lastEventMs).toBe(1_000);
+            }
+            const stalledAt = 1_000 + STREAMING_IDLE_TIMEOUT_MS;
+            const r = update(s3, { type: "StreamStalled", at: stalledAt });
+            // Phase forced to Done.errored.
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("errored");
+                expect(r.state.turnPhase.finishedAt).toBe(stalledAt);
+            }
+            // Legacy fields cleared, same as TurnEnd / interrupt timeout.
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state.stopping).toBe(false);
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+            // Animation invariant: isWorking flips false.
+            expect(isWorking(r.state)).toBe(false);
+            // Audit event.
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "stream-stalled",
+                at: stalledAt,
+            });
+        });
+
+        it("StreamStalled while Streaming but NOT yet stale is a same-ref no-op", () => {
+            // Early callback / race: a fresh event refreshed
+            // `lastEventMs` between the dispatcher seeing the timer pop
+            // and the command landing. The reducer's defence-in-depth
+            // check sees idleMs < STREAMING_IDLE_TIMEOUT_MS and no-ops;
+            // the dispatcher re-arms on the next activity.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const s3 = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 1_000,
+            }).state;
+            expect(s3.turnPhase.kind).toBe("Streaming");
+            // 1ms before the deadline — still within the live window.
+            const earlyAt = 1_000 + STREAMING_IDLE_TIMEOUT_MS - 1;
+            const r = update(s3, { type: "StreamStalled", at: earlyAt });
+            // Same-ref no-op pattern — no mutation, no event.
+            expect(r.state).toBe(s3);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamStalled while Idle is a same-ref no-op", () => {
+            const start = mk();
+            const r = update(start, { type: "StreamStalled", at: 100_000 });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamStalled while Submitting is a same-ref no-op", () => {
+            // The stale timer was from a prior turn that already ended.
+            // The fresh Submitting must not be force-failed.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const r = update(s1, { type: "StreamStalled", at: 999_999 });
+            expect(r.state).toBe(s1);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamStalled while Interrupting is a same-ref no-op", () => {
+            // User pressed Stop and we're awaiting the SIGINT ack —
+            // the interrupt timeout (PR C) owns this state, not the
+            // stream-stalled watchdog.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            const s3 = update(s2, { type: "RequestStop", at: 200 }).state;
+            expect(s3.turnPhase.kind).toBe("Interrupting");
+            const r = update(s3, { type: "StreamStalled", at: 999_999 });
+            expect(r.state).toBe(s3);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamStalled while Done is a same-ref no-op (first-done-wins)", () => {
+            // Graceful TurnEnd landed first. The late stalled tick must
+            // not overwrite the existing outcome.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TurnEnd", stats: null }, 200).state;
+            expect(s2.turnPhase.kind).toBe("Done");
+            if (s2.turnPhase.kind === "Done") {
+                expect(s2.turnPhase.outcome).toBe("completed");
+            }
+            const r = update(s2, { type: "StreamStalled", at: 999_999 });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+            // Outcome preserved.
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("completed");
+            }
+        });
+
+        it("StreamStalled while Disconnected is a same-ref no-op", () => {
+            // Stream dropped mid-turn → Disconnected. The stale watchdog
+            // must not corrupt that state.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamUnsubscribe", at: 200 }).state;
+            expect(s2.turnPhase.kind).toBe("Disconnected");
+            const r = update(s2, { type: "StreamStalled", at: 999_999 });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+        });
+
+        it("First-done-wins: late TurnEnd after StreamStalled does NOT overwrite the errored outcome", () => {
+            // PR C's `TurnEnd` arm already has the `alreadyDone` guard:
+            // when phase is already Done, the outcome is preserved and
+            // only stats merging happens. Exercise that interaction for
+            // the stream-stalled path.
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const s3 = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 1_000,
+            }).state;
+            const stalledAt = 1_000 + STREAMING_IDLE_TIMEOUT_MS;
+            const s4 = update(s3, { type: "StreamStalled", at: stalledAt })
+                .state;
+            expect(s4.turnPhase.kind).toBe("Done");
+            if (s4.turnPhase.kind === "Done") {
+                expect(s4.turnPhase.outcome).toBe("errored");
+                expect(s4.turnPhase.finishedAt).toBe(stalledAt);
+            }
+            // Late ack from the backend (e.g. socket eventually unfroze
+            // and emitted a final session_end). PR C's alreadyDone guard
+            // must keep `errored`, not overwrite to `completed`.
+            const lateAck = stalledAt + 5_000;
+            const r = update(
+                s4,
+                {
+                    type: "TurnEnd",
+                    stats: { input_tokens: 50, output_tokens: 100 } as any,
+                },
+                lateAck,
+            );
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("errored");
+                // finishedAt preserved from the stall, not bumped to lateAck.
+                expect(r.state.turnPhase.finishedAt).toBe(stalledAt);
+            }
+        });
+
+        it("StreamFlushObserved while inactive does NOT emit schedule-stream-watchdog", () => {
+            // Defence: the watchdog must only re-arm when we genuinely
+            // land in Streaming. Inactive-stream flushes are dropped
+            // with no events — including no watchdog.
+            const start = mk();
+            const r = update(start, {
+                type: "StreamFlushObserved",
+                addedCount: 3,
+                at: 110,
+            });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
         });
     });
 });

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -104,9 +104,13 @@ export function update(
         // ── Stream lifecycle ───────────────────────────────────────
         case "StreamSubscribe": {
             // Dual-write: if a turn was Submitting, the subscription is
-            // its expected hand-off to Streaming. Otherwise the phase
-            // stays as-is (subscribing without a pending send isn't
-            // "working"; Idle/Done/Disconnected/Streaming stay put).
+            // its expected hand-off to Streaming. If already Streaming,
+            // the resubscribe IS fresh activity — refresh
+            // `lastEventMs` to `command.at` so the re-armed watchdog
+            // deadline is in the future. (P1 on #995 from reagent +
+            // codex: stale `lastEventMs` could schedule a deadline in
+            // the past, firing `StreamStalled` immediately on a freshly-
+            // resubscribed turn.) Idle/Done/Disconnected stay put.
             const nextPhase: TurnPhase =
                 state.turnPhase.kind === "Submitting"
                     ? {
@@ -115,19 +119,19 @@ export function update(
                           toolsActive: 0,
                           lastEventMs: command.at,
                       }
-                    : state.turnPhase;
+                    : state.turnPhase.kind === "Streaming"
+                        ? {
+                              ...state.turnPhase,
+                              lastEventMs: command.at,
+                          }
+                        : state.turnPhase;
             const events: AgentPaneEvent[] = [
                 { type: "stream-subscribed", at: command.at },
             ];
             // PR E: re-arm the bounded streaming watchdog on every
-            // activity that lands inside Streaming. Submitting →
-            // Streaming above qualifies; if the phase was already
-            // Streaming the resubscribe is also fresh activity (we
-            // leave phase.lastEventMs as-is by design — re-subscribe
-            // doesn't bump the phase clock in PR A, only the legacy
-            // streaming.lastEventTime — but the dispatcher still
-            // re-arms to the existing deadline so a previously stale
-            // timer is replaced).
+            // activity that lands inside Streaming. The refresh of
+            // `lastEventMs` above ensures the new deadline is always
+            // `command.at + STREAMING_IDLE_TIMEOUT_MS`, never in the past.
             const wd = streamWatchdogEvent(nextPhase);
             if (wd) events.push(wd);
             return {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -30,11 +30,29 @@ import {
     INTERRUPT_TIMEOUT_MS,
     KindBeforeDisconnect,
     ReducerResult,
+    STREAMING_IDLE_TIMEOUT_MS,
     STUCK_THRESHOLD_MS,
     SUBMIT_TIMEOUT_MS,
     TurnOutcome,
     TurnPhase,
 } from "./types";
+
+/**
+ * If `phase` is `Streaming`, return the `schedule-stream-watchdog` event
+ * that re-arms the bounded idle-timeout against the latest event time.
+ * The dispatcher cancels any prior arm and reschedules — so this is
+ * called on EVERY stream-activity command that lands inside Streaming.
+ * Spec §10 / PR E.
+ */
+function streamWatchdogEvent(
+    phase: TurnPhase,
+): AgentPaneEvent | null {
+    if (phase.kind !== "Streaming") return null;
+    return {
+        type: "schedule-stream-watchdog",
+        deadlineMs: phase.lastEventMs + STREAMING_IDLE_TIMEOUT_MS,
+    };
+}
 
 export function update(
     state: AgentPaneState,
@@ -98,6 +116,20 @@ export function update(
                           lastEventMs: command.at,
                       }
                     : state.turnPhase;
+            const events: AgentPaneEvent[] = [
+                { type: "stream-subscribed", at: command.at },
+            ];
+            // PR E: re-arm the bounded streaming watchdog on every
+            // activity that lands inside Streaming. Submitting →
+            // Streaming above qualifies; if the phase was already
+            // Streaming the resubscribe is also fresh activity (we
+            // leave phase.lastEventMs as-is by design — re-subscribe
+            // doesn't bump the phase clock in PR A, only the legacy
+            // streaming.lastEventTime — but the dispatcher still
+            // re-arms to the existing deadline so a previously stale
+            // timer is replaced).
+            const wd = streamWatchdogEvent(nextPhase);
+            if (wd) events.push(wd);
             return {
                 state: {
                     ...state,
@@ -109,7 +141,7 @@ export function update(
                     lastEventMs: command.at,
                     turnPhase: nextPhase,
                 },
-                events: [{ type: "stream-subscribed", at: command.at }],
+                events,
             };
         }
 
@@ -166,6 +198,13 @@ export function update(
                               lastEventMs: command.at,
                           }
                         : state.turnPhase;
+            const events: AgentPaneEvent[] = [
+                { type: "stream-flush-observed", addedCount: command.addedCount },
+            ];
+            // PR E: flushes are the primary stream-activity signal; if
+            // we landed inside Streaming, re-arm the idle watchdog.
+            const wd = streamWatchdogEvent(nextPhase);
+            if (wd) events.push(wd);
             return {
                 state: {
                     ...state,
@@ -177,9 +216,7 @@ export function update(
                     lastEventMs: command.at,
                     turnPhase: nextPhase,
                 },
-                events: [
-                    { type: "stream-flush-observed", addedCount: command.addedCount },
-                ],
+                events,
             };
         }
 
@@ -334,35 +371,51 @@ export function update(
                 events: [{ type: "turn-reset" }],
             };
 
-        case "ToolStart":
-            return {
-                state: bumpEvent(
-                    { ...state, currentTool: command.name },
-                    nowMs,
-                    /* toolsDelta */ +1,
-                ),
-                events: [{ type: "tool-started", name: command.name }],
-            };
+        case "ToolStart": {
+            const nextState = bumpEvent(
+                { ...state, currentTool: command.name },
+                nowMs,
+                /* toolsDelta */ +1,
+            );
+            const events: AgentPaneEvent[] = [
+                { type: "tool-started", name: command.name },
+            ];
+            // PR E: re-arm the streaming watchdog when activity lands
+            // inside Streaming (covers both promote-from-Submitting and
+            // tools-active bump within Streaming).
+            const wd = streamWatchdogEvent(nextState.turnPhase);
+            if (wd) events.push(wd);
+            return { state: nextState, events };
+        }
 
-        case "ToolEnd":
-            return {
-                state: bumpEvent(
-                    { ...state, currentTool: null },
-                    nowMs,
-                    /* toolsDelta */ -1,
-                ),
-                events: [{ type: "tool-ended" }],
-            };
+        case "ToolEnd": {
+            const nextState = bumpEvent(
+                { ...state, currentTool: null },
+                nowMs,
+                /* toolsDelta */ -1,
+            );
+            const events: AgentPaneEvent[] = [{ type: "tool-ended" }];
+            const wd = streamWatchdogEvent(nextState.turnPhase);
+            if (wd) events.push(wd);
+            return { state: nextState, events };
+        }
 
         case "TokensIn": {
             const next = {
                 input: command.input,
                 output: state.turnTokens?.output ?? 0,
             };
-            return {
-                state: bumpEvent({ ...state, turnTokens: next }, nowMs, 0),
-                events: [{ type: "tokens-updated", input: command.input, output: null }],
-            };
+            const nextState = bumpEvent(
+                { ...state, turnTokens: next },
+                nowMs,
+                0,
+            );
+            const events: AgentPaneEvent[] = [
+                { type: "tokens-updated", input: command.input, output: null },
+            ];
+            const wd = streamWatchdogEvent(nextState.turnPhase);
+            if (wd) events.push(wd);
+            return { state: nextState, events };
         }
 
         case "TokensOut": {
@@ -370,10 +423,17 @@ export function update(
                 input: state.turnTokens?.input ?? 0,
                 output: command.output,
             };
-            return {
-                state: bumpEvent({ ...state, turnTokens: next }, nowMs, 0),
-                events: [{ type: "tokens-updated", input: null, output: command.output }],
-            };
+            const nextState = bumpEvent(
+                { ...state, turnTokens: next },
+                nowMs,
+                0,
+            );
+            const events: AgentPaneEvent[] = [
+                { type: "tokens-updated", input: null, output: command.output },
+            ];
+            const wd = streamWatchdogEvent(nextState.turnPhase);
+            if (wd) events.push(wd);
+            return { state: nextState, events };
         }
 
         case "RequestStop": {
@@ -521,6 +581,64 @@ export function update(
                     },
                 },
                 events: [{ type: "submit-timed-out", at: command.at }],
+            };
+        }
+
+        case "StreamStalled": {
+            // PR E — bounded `Streaming → Done.errored("stream-stalled")`.
+            //
+            // The dispatcher schedules a setTimeout when it sees the
+            // `schedule-stream-watchdog` event; on every fresh stream
+            // event the reducer re-emits the schedule and the
+            // dispatcher cancels the previous timer (shared cancel
+            // flag — JS analogue of `Arc<AtomicBool>`). When the timer
+            // finally fires, the reducer makes the final decision:
+            //
+            //   - `Streaming` + idle ≥ `STREAMING_IDLE_TIMEOUT_MS` →
+            //     force-transition to `Done.errored`. Legacy fields are
+            //     cleared the same way TurnEnd / interrupt-timeout do.
+            //   - `Streaming` + NOT yet stale (early callback or a
+            //     just-arrived event already refreshed `lastEventMs`)
+            //     → same-ref no-op. The dispatcher re-arms on the next
+            //     activity command — defence in depth against a leaked
+            //     timer firing right after an event landed.
+            //   - any other phase → same-ref no-op. The timer is a
+            //     stale leftover from a prior turn; harmless.
+            //
+            // First-done-wins: if a graceful `TurnEnd` already landed
+            // us in `Done`, the late stalled tick can't reach this arm
+            // (the phase check is `=== "Streaming"`), so the outcome
+            // is preserved. Mirrors the `Interrupting → Done` timeout
+            // pattern from PR C. Spec §10.
+            if (state.turnPhase.kind !== "Streaming") {
+                return { state, events: [] };
+            }
+            const idleMs = command.at - state.turnPhase.lastEventMs;
+            if (idleMs < STREAMING_IDLE_TIMEOUT_MS) {
+                // Early callback / race: real activity refreshed
+                // `lastEventMs` between the dispatcher seeing the timer
+                // pop and the command landing. No-op; the next activity
+                // command will re-arm.
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    // Legacy: a forced exit from Streaming carries the
+                    // same boolean shape as TurnEnd would — animation
+                    // settles, currentTool/turnTokens cleared so the
+                    // header doesn't show ghost tool/token chips.
+                    turnActive: false,
+                    stopping: false,
+                    currentTool: null,
+                    turnTokens: null,
+                    turnPhase: {
+                        kind: "Done",
+                        outcome: "errored",
+                        finishedAt: command.at,
+                    },
+                },
+                events: [{ type: "stream-stalled", at: command.at }],
             };
         }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -273,6 +273,29 @@ export type AgentPaneCommand =
      * user already stopped, stream dropped). Spec §8 / issue #728 gap 2.
      */
     | { type: "SubmitTimeoutElapsed"; at: number }
+    /**
+     * Streaming idle-watchdog fired (caller-scheduled setTimeout — see
+     * `schedule-stream-watchdog` event). PR E: bounded
+     * `Streaming → Done.errored("stream-stalled")` force-transition.
+     *
+     * Today an agent process that stops emitting (LLM stuck, network
+     * silent) but holds the connection open leaves the pane pinned in
+     * `Streaming` forever — `lastEventMs` ages but nothing forces an
+     * exit. This command is the deterministic exit: when the dispatcher
+     * sees the deadline elapse without a new event refreshing it, it
+     * fires `StreamStalled`.
+     *
+     * Behaviour:
+     *   - `Streaming` + idle ≥ `STREAMING_IDLE_TIMEOUT_MS` → Done.errored
+     *     with reason "stream-stalled" (emits `stream-stalled` event).
+     *   - `Streaming` + NOT yet stale (early callback / race vs a fresh
+     *     event refreshing `lastEventMs`) → same-ref no-op; dispatcher
+     *     re-arms on the next activity command.
+     *   - Any other phase → same-ref no-op; the stale timer is harmless.
+     *
+     * Spec: SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §10 (PR E).
+     */
+    | { type: "StreamStalled"; at: number }
 
     // ── Pending message queue (composer side) ─────────────────────
     | { type: "PendingMessageQueued"; id: string; text: string; at: number }
@@ -360,6 +383,34 @@ export type AgentPaneEvent =
      * PR D — spec §8 / issue #728 gap 2.
      */
     | { type: "submit-timed-out"; at: number }
+    /**
+     * Reducer signal (PR E): a turn just LANDED INSIDE `Streaming` via a
+     * stream-activity command (`StreamSubscribe` promoting from
+     * Submitting, `StreamFlushObserved`, or a bumped tool/token
+     * transition). The dispatch layer is expected to:
+     *   1. cancel any previously-armed stream watchdog (shared cancel
+     *      flag — the JS analogue of `Arc<AtomicBool>`), and
+     *   2. start a fresh `setTimeout` that fires `StreamStalled` when
+     *      `deadlineMs` is reached (or skip if a newer arm has since
+     *      replaced it).
+     *
+     * Idempotent re-arm: emitted on EVERY stream activity that lands
+     * inside Streaming, so the deadline always tracks the latest event.
+     * `deadlineMs` is `lastEventMs + STREAMING_IDLE_TIMEOUT_MS` so the
+     * caller can compute the remaining slice deterministically. Spec §10.
+     */
+    | {
+          type: "schedule-stream-watchdog";
+          deadlineMs: number;
+      }
+    /**
+     * Reducer signal (PR E): the bounded `Streaming → Done.{errored,
+     * reason: "stream-stalled"}` force-transition fired because no
+     * observable stream event refreshed `lastEventMs` within
+     * `STREAMING_IDLE_TIMEOUT_MS`. The view can surface this as
+     * "stream stalled — agent unresponsive" if needed. Spec §10.
+     */
+    | { type: "stream-stalled"; at: number }
     | { type: "pending-queued"; id: string }
     | { type: "pending-accepted"; id: string; wasPresent: boolean }
     | { type: "pending-rejected"; id: string; wasPresent: boolean }
@@ -420,3 +471,23 @@ export const INTERRUPT_TIMEOUT_MS = 5_000;
  * stale fire against a graceful promotion to Streaming.
  */
 export const SUBMIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Streaming idle watchdog (PR E). A `Streaming` turn that hasn't seen
+ * any observable stream event (subscribe, flush, tool, tokens) refresh
+ * `lastEventMs` for this many ms is force-transitioned to
+ * `Done.errored("stream-stalled")` on receipt of `StreamStalled`.
+ *
+ * 60 s is generous compared to the typical sub-second flush cadence on
+ * a healthy agent stream but tight enough that a wedged LLM /
+ * silenced socket doesn't keep the working animation pinned forever.
+ *
+ * Intentionally distinct from {@link STUCK_THRESHOLD_MS} (45 s, diagnostic
+ * `stream-stuck` audit event only — does NOT force a transition).
+ * `STUCK_THRESHOLD_MS` fires first so the UI can surface "stream is
+ * idle" before the bounded watchdog gives up. Don't conflate the two.
+ *
+ * Spec: SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §10. Closes #728
+ * gap 3 (bounded streaming, not just diagnostic).
+ */
+export const STREAMING_IDLE_TIMEOUT_MS = 60_000;


### PR DESCRIPTION
## Summary

PR E of the agent-pane turn-phase migration. Adds an **idle watchdog** that bounds the `Streaming` phase: if the agent process stops emitting events (LLM stuck, network silent, socket frozen) but the connection stays open, the state machine now force-transitions to `Done.errored("stream-stalled")` instead of leaving the working animation pinned forever.

Closes #728 gap 3 (bounded streaming, not just diagnostic).

Follow-up to:
- PR A (#987) — TurnPhase dual-write
- PR B (#992) — view reads `isWorking(state)`
- PR C (#991) — bounded `Interrupting → Done.interrupted`

Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` (PR E section, §10).

## What changed

### `types.ts`
- New constant `STREAMING_IDLE_TIMEOUT_MS = 60_000`. Intentionally distinct from `STUCK_THRESHOLD_MS = 45_000` (diagnostic-only `stream-stuck` event; does NOT force a transition).
- New command `StreamStalled { at: number }`.
- New events:
  - `schedule-stream-watchdog { deadlineMs }` — re-arm signal for the dispatcher.
  - `stream-stalled { at }` — audit event for the forced transition.

### `reducer.ts`
- Stream-activity arms (`StreamSubscribe`, `StreamFlushObserved`, `ToolStart`, `ToolEnd`, `TokensIn`, `TokensOut`) now append `schedule-stream-watchdog` whenever the resulting phase is `Streaming`. Idempotent re-arm against the latest `lastEventMs` — the dispatcher cancels the prior timer.
- New `StreamStalled` arm:
  - `Streaming` + `idleMs >= STREAMING_IDLE_TIMEOUT_MS` → `Done.errored`, legacy fields cleared (mirrors the `InterruptTimeoutElapsed` shape from PR C), emit `stream-stalled`.
  - `Streaming` + early callback (idle < threshold) → same-ref no-op; dispatcher re-arms on next activity.
  - Any other phase → same-ref no-op (stale leftover timer is harmless).
- First-done-wins is already handled by PR C's `alreadyDone` guard in `TurnEnd` — a late backend `TurnEnd` ack after `stream-stalled` preserves the errored outcome.

## Tests

16 new tests under **Bounded streaming watchdog (PR E)** in `reducer.test.ts`:

- `STREAMING_IDLE_TIMEOUT_MS is 60000 (sanity)` — pinned constant.
- `first stream activity from Submitting emits schedule-stream-watchdog` — via `StreamFlushObserved`.
- `ToolStart from Submitting promotes to Streaming AND emits schedule-stream-watchdog`.
- `TokensIn from Submitting promotes to Streaming AND emits schedule-stream-watchdog`.
- `subsequent stream activity within Streaming re-emits schedule-stream-watchdog with refreshed deadline` — covers flush / tool-start / tokens-out / tool-end inside Streaming.
- `StreamSubscribe from Submitting emits schedule-stream-watchdog`.
- `StreamSubscribe from Idle does NOT emit schedule-stream-watchdog`.
- `StreamStalled after STREAMING_IDLE_TIMEOUT_MS → Done.errored stream-stalled`.
- `StreamStalled while Streaming but NOT yet stale is a same-ref no-op` — 1ms-before-deadline race.
- `StreamStalled while Idle / Submitting / Interrupting / Done / Disconnected is a same-ref no-op` — five separate tests for all non-Streaming phases.
- `First-done-wins: late TurnEnd after StreamStalled does NOT overwrite the errored outcome`.
- `StreamFlushObserved while inactive does NOT emit schedule-stream-watchdog`.

All 102 tests in `reducer.test.ts` + all in `agent-pane-state-store.test.ts` pass locally. 0 new TS errors.

## Out of scope

- **Dispatcher wiring** (`setTimeout` + cancel flag in `useAgentStream.ts`) — separate follow-up.
- **PR D — Submit timeout** is in flight in parallel and touches the same reducer; this PR's additions are cleanly separable (new command + new constant + new event + isolated arm + ancillary watchdog emits on existing arms).
- **View files** — PR B already migrated to `isWorking(state)`, so the new `Done.errored` outcome flows through without view changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
