### PR TITLE
feat(agent-pane): Disconnected state + banner (turn-phase PR F)

### DIFF
--- a/.changesets/1779541345-feat-agent-pane-disconnected-state-banner-xrpw.md
+++ b/.changesets/1779541345-feat-agent-pane-disconnected-state-banner-xrpw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): Disconnected state + banner

--- a/docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md
+++ b/docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md
@@ -1,0 +1,337 @@
+# SPEC — agent-pane turn-phase: discriminated union evolution
+
+**Date:** 2026-05-23
+**Author:** AgentA
+**Status:** Draft
+**Scope:** the agent pane's per-turn lifecycle state in
+`frontend/app/store/agent-pane-state/`, the "working" animation, the
+interrupt path. This spec **builds on** existing work — it is not a
+green-field design.
+**Related (must-read first):**
+`docs/specs/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md` (the audit this
+spec extends), GitHub issue **#728** (the 6 gaps the audit produced),
+`docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md` (where this
+slice sits in the broader reducer stack), `SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md`
+(precedent shape).
+
+---
+
+## 1. Summary
+
+The agent pane is **already reducer-based** — two pure slices
+(`agent-pane-state/`, `agent-document/`) following the established
+`update(state, command) → { state, events }` shape (per the May 12
+audit). This spec proposes one targeted evolution on top of that
+foundation: **replace the orthogonal booleans `turnActive` +
+`stopping` + `streaming.active` with a single `turnPhase:
+TurnPhase` discriminated union** so the legal-state set is exactly
+representable and the "working" animation becomes a pure projection
+of `turnPhase.kind`.
+
+The bug it targets — *"the working animation breaks on interrupt"* —
+is a downstream symptom of the boolean-trio shape: 2³ = 8 storable
+combinations, only ~4 of them legal, multiple sources of truth that
+can drift mid-transition. The discriminated union makes the illegal
+states unrepresentable.
+
+## 2. Where we are today
+
+**Existing module** — `frontend/app/store/agent-pane-state/`
+(May 19 commit; live; passing tests):
+
+- `types.ts` — `AgentPaneState { streaming, sessionStats, currentTool, turnTokens, turnActive, stopping, pending, initPhase, initError, lastEventMs }`. Per-pane atoms with cross-atom invariants.
+- `reducer.ts` — pure `update(state, command) → { state, events }`.
+- `reducer.test.ts` — cross-product transition coverage.
+
+**Existing audit** — `AGENT_PANE_REDUCER_AUDIT_2026_05_12.md` —
+identified 6 gaps. Translated into **issue #728**.
+
+**Issue #728 — open, six tracked gaps:**
+
+| # | Gap | This spec's coverage |
+|---|---|---|
+| 1 | Init phase not covered (`InitState`/`InitQuestion` types exist but no lifecycle) | **Out of scope** — `initPhase: "loading" \| "ready" \| "error"` already in `types.ts`; #728 commands (`InitStart`/`InitReady`/`InitFailed`) close it independently. |
+| 2 | No acceptance timeout — `pending[]` linger if `agent-message-accepted` never arrives | **Naturally fits** in the discriminated union — `Submitting` becomes a bounded state with a timeout transition. See §6.2. |
+| 3 | Stuck-stream recovery watchdog | **Naturally fits** — `Streaming` becomes a bounded state; `StreamStalled` event transitions to a recovery sub-state or terminal. See §6.3. |
+| 4 | `nodeIdSet` rebuilt on remount | **Out of scope** — that's `agent-document/`'s territory. |
+| 5 | `DocumentState` outside reducers | **Out of scope** — also `agent-document/`. |
+| 6 | Hardcoded `TRUNCATE_GRACE_MS` | **Out of scope** — utility refactor; works with either state shape. |
+
+So this spec **owns gaps 2 and 3** if/when we ship it (cleaner shape
+than #728's proposal), is **complementary** to gap 1 (init phase
+stays orthogonal), and is **untouched** by gaps 4/5/6 (different
+slice / utility).
+
+## 3. Motivation
+
+### The working animation breaks on interrupt
+
+User reports the spinner either keeps animating after Stop, or freezes
+mid-frame. The root cause is structural:
+
+- Animation is driven by some derivation of `(turnActive, stopping, streaming.active)`.
+- On Stop click, view sets `stopping = true` immediately. RPC fires `SIGINT`. Backend takes a few hundred ms to acknowledge — during which `turnActive` is still `true` and `streaming.active` may still be `true`.
+- Different parts of the view read different combinations of those three. They drift out of phase during the interrupt window. The spinner is most-prone because it polls a derived value.
+
+There is no single source of truth. With three booleans there are eight storable combinations, only a subset are legal, and there's no compile-time enforcement of which are which.
+
+### The boolean-trio shape lets illegal states exist
+
+| `turnActive` | `stopping` | `streaming.active` | Legal? |
+|:---:|:---:|:---:|---|
+| false | false | false | ✓ Idle |
+| true  | false | false | ✓ Submitting (no chunks yet) |
+| true  | false | true  | ✓ Streaming |
+| true  | true  | true  | ✓ Interrupting mid-stream |
+| true  | true  | false | ✓ Interrupting after stream ended |
+| false | true  | * | **✗ stopping without an active turn** |
+| false | false | true  | **✗ streaming without an active turn** |
+
+Type system can't prevent the illegal rows. Runtime invariants in the
+reducer can — but every new field added compounds.
+
+## 4. Goals / non-goals
+
+**Goals:**
+
+- Replace `turnActive` + `stopping` + `streaming.active` with a single `turnPhase: TurnPhase` discriminated union. Illegal states unrepresentable at compile time.
+- `isWorking(state)` is the only animation driver; it's a pure function of `turnPhase.kind`. Existing direct subscriptions to `controllerstatus` from the spinner go away.
+- Every transition out of "busy" is explicit and bounded. The `Interrupting → Done.Interrupted` transition cannot exceed N ms — closes the "animation never stops" symptom by construction.
+- Close issue **#728 gaps 2 + 3** (acceptance timeout + stuck-stream watchdog) by folding them into Submitting / Streaming state bounds.
+
+**Non-goals:**
+
+- `initPhase` reorganisation — keep it orthogonal to `turnPhase`. #728 gap 1 closes it on its own.
+- `agent-document` changes — separate slice, separate spec needs.
+- Streaming-chunk plumbing — `OutputChunk` is just an event into the reducer; the chunk-decoder pipeline (markdown / tool / decision-prompt) is upstream of this slice.
+- Conversation-level state — multi-turn history, queued user inputs. Out of scope.
+
+## 5. Proposed evolution
+
+```ts
+type TurnPhase =
+    | { kind: "Idle" }
+    | { kind: "Submitting"; submittedAt: number; pendingContent: string }
+    | { kind: "Streaming"; bufferSize: number; toolsActive: number; lastEventMs: number }
+    | { kind: "Interrupting"; reason: InterruptReason; sigintSentAt: number }
+    | { kind: "Done"; outcome: TurnOutcome; finishedAt: number }
+    | { kind: "Disconnected"; lastKind: KindBeforeDisconnect; lastConnectedAt: number; reason: DisconnectReason };
+
+type InterruptReason = "user-stop" | "user-esc" | "submit-timeout" | "stream-stalled";
+type TurnOutcome     = "success" | "error" | "interrupted" | "crashed";
+type KindBeforeDisconnect = "Submitting" | "Streaming" | "Interrupting";
+type DisconnectReason = "stream-unsubscribed" | "transport-error";
+```
+
+> **PR F note (2026-05-23):** the `Disconnected` payload was fleshed out
+> from `{ lastKind, reason: string }` (PR A stub) to
+> `{ lastKind, lastConnectedAt, reason: DisconnectReason }`. `lastKind`
+> stays for the "was streaming / was submitting" banner copy;
+> `lastConnectedAt = command.at` from the `StreamUnsubscribe` arm so the
+> banner can render "disconnected 12s ago"; `reason` tightens to a finite
+> literal union so the dispatcher can attach typed reasons going forward
+> (`transport-error` is reserved — not wired by any caller in PR F).
+> The reducer also expands `TurnEnd`'s `alreadyDone` first-done-wins
+> guard to include `Disconnected` (Option A): a late TurnEnd while the
+> phase is `Disconnected` is a same-ref no-op (the disconnect IS the
+> outcome).
+
+**Field-level changes to `AgentPaneState`:**
+
+| Today | After |
+|---|---|
+| `turnActive: boolean` | *removed* — derive from `turnPhase.kind !== "Idle" && !== "Done" && !== "Disconnected"` if needed for legacy callers |
+| `stopping: boolean` | *removed* — `turnPhase.kind === "Interrupting"` |
+| `streaming: { active, agentId, bufferSize, lastEventTime }` | `streaming: { agentId }` (just identity) — `active` becomes `turnPhase.kind === "Streaming"`; `bufferSize` + `lastEventMs` move into the `Streaming` variant payload. |
+| `currentTool: string \| null` | *unchanged* — orthogonal to the phase; one tool at a time today, but multi-tool future-compatible via `Streaming.toolsActive`. |
+| `initPhase`, `initError` | *unchanged* — separate concern. |
+| `sessionStats`, `turnTokens`, `pending` | *unchanged*. |
+
+**`lastEventMs`** moves into the `Streaming` variant payload — it's
+only meaningful during a stream, and putting it there means the
+"stuck-stream" watchdog (#728 gap 3) reads from a place where the
+value is guaranteed live.
+
+### 5.1 Transitions
+
+| From          | Event                                   | To                  | Side-effect |
+|---|---|---|---|
+| Idle          | `UserSubmitted{content}`                | Submitting          | `SendInputRpc{content}` |
+| Submitting    | `BackendAck` *or* `OutputChunk`         | Streaming           | — |
+| Submitting    | `SubmitTimeoutElapsed` *(gap 2)*        | Done.Error          | — |
+| Submitting    | `UserInterrupted`                       | Interrupting        | `SendSigintRpc` |
+| Streaming     | `OutputChunk`                           | Streaming (updated) | — |
+| Streaming     | `ToolStarted` / `ToolEnded`             | Streaming (counts)  | — |
+| Streaming     | `UserInterrupted`                       | Interrupting        | `SendSigintRpc` |
+| Streaming     | `StreamStalled{idleMs}` *(gap 3)*       | Interrupting        | `SendSigintRpc` (reason = stream-stalled) |
+| Streaming     | `TurnFinished{outcome}`                 | Done.{outcome}      | — |
+| Streaming     | `ControllerStatusChanged{done, exit≠0}` | Done.Crashed        | — |
+| Interrupting  | `TurnFinished{outcome}`                 | Done.Interrupted    | — |
+| Interrupting  | `ControllerStatusChanged{done}`         | Done.Interrupted    | — |
+| Interrupting  | `InterruptTimeoutElapsed`               | Done.Interrupted    | **bounded** force-transition |
+| Done          | `UserSubmitted{content}` / `UserRetried`| Submitting          | `SendInputRpc` |
+| *any non-Done*| `Disconnected{reason}`                  | Disconnected        | — |
+| Disconnected  | `Reconnected`                           | Idle                | — |
+
+### 5.2 Guards (no-ops, idempotent)
+
+- `UserSubmitted` in Submitting / Streaming / Interrupting → no-op (logged). Don't double-send.
+- `UserInterrupted` in Idle / Done / Disconnected → no-op.
+- `UserInterrupted` in Interrupting → no-op. SIGINT already sent.
+- `BackendAck` in any state other than Submitting → no-op.
+- `OutputChunk` in Idle / Done / Disconnected → silently dropped.
+
+## 6. How this closes #728's gaps
+
+### 6.1 Gap 1 (init phase) — unchanged
+
+`initPhase` is orthogonal — implement #728's proposed commands
+(`InitStart` / `InitReady` / `InitFailed`) directly on the existing
+field. No interaction with `turnPhase`.
+
+### 6.2 Gap 2 (acceptance timeout)
+
+In the boolean-trio shape, `pending[]` carried a `localId` and a
+`queuedAt`; #728 proposes a separate `PendingMessageExpired` command.
+
+In the discriminated union, `Submitting` *is* the unaccepted state —
+the timeout is a transition out of it. The reducer emits
+`ScheduleSubmitTimeout { ms: 30_000 }` on entering Submitting; the
+view fires `SubmitTimeoutElapsed` if `BackendAck` / `OutputChunk` /
+`UserInterrupted` don't arrive first. The transition lands in
+`Done.Error` with a typed timeout reason in the outcome payload.
+
+`pending[]` stays a separate field for queued-but-deferred messages
+(e.g. user typed faster than RPC ack), independent of the current
+turn's phase. #728 gap 2's timeout is now covered by the Submitting
+bound; `pending[]` only needs cleanup when its corresponding turn
+reaches Done.
+
+### 6.3 Gap 3 (stuck-stream watchdog)
+
+`Streaming` carries `lastEventMs` in its payload. A `setInterval(5s)`
+in the view fires `StreamWatchdogTick { nowMs }`; the reducer compares
+to the live `Streaming.lastEventMs`. If `nowMs - lastEventMs >= 45_000`
+(spec'd in #728), the reducer transitions to `Interrupting` with
+`reason: "stream-stalled"` and emits `SendSigintRpc`. Tools downstream
+see the same shape as a user-initiated interrupt; UI uses the reason
+to surface "stream stalled — interrupted automatically" instead of
+"you pressed Stop".
+
+### 6.4 Bonus — `Disconnected`
+
+Not in #728. Today there's no state for "PTY/WS lost mid-turn"; the
+pane just stalls. Adding the explicit kind gives the UI a banner
+target and a clean reconnect path. Strictly an addition; doesn't
+collide with anything in #728.
+
+## 7. The animation projection
+
+```ts
+export function isWorking(state: AgentPaneState): boolean {
+    switch (state.turnPhase.kind) {
+        case "Submitting":
+        case "Streaming":
+        case "Interrupting":
+            return true;
+        case "Idle":
+        case "Done":
+        case "Disconnected":
+            return false;
+    }
+}
+```
+
+`agent-pane-state` exports `isWorking` as a selector (sibling of the
+existing `realIdentities` / `canSubmit`-style selectors in other
+slices). Spinner / input-disabled / Stop-visible / Disconnected-banner
+all read derivations of this one source. Removes the direct
+`controllerstatus` subscription from the spinner.
+
+## 8. The bounded `Interrupting → Done.Interrupted` invariant
+
+The reducer emits `ScheduleInterruptTimeout { ms: 3_000 }` on entering
+Interrupting. The view runs `setTimeout`, dispatches
+`InterruptTimeoutElapsed` if no `TurnFinished` /
+`ControllerStatusChanged(done)` arrives first. The transition lands in
+`Done.Interrupted`. **Three independent paths into Done.Interrupted**
+— so the animation can never get stuck in Interrupting.
+
+`SendSigintRpc` is only emitted once (on entry). Subsequent
+`UserInterrupted` while already in Interrupting is a no-op.
+
+## 9. Rollout
+
+### 9.1 Sequencing with #728
+
+Two paths, your call:
+
+**Path A — close #728 first, evolve after.** Implement gaps 1-3 as
+prescribed in the audit (boolean-trio shape + timeout setTimeouts).
+Then take this spec on, refactoring those into the discriminated
+union. Pro: smaller PRs, in-flight architecture not disturbed. Con:
+the timeout + watchdog code gets re-written when the union lands.
+
+**Path B — evolve first, close #728 gaps in the new shape.** Take
+this spec's discriminated union directly; gaps 2 + 3 land naturally
+during the implementation. Gap 1 still done independently on
+`initPhase`. Pro: no rework. Con: a larger single change.
+
+Recommendation: **Path B**. Discriminated-union evolution is the
+shape change; doing gap 2+3 within that change is essentially free.
+Gap 1 is independent; ship it alongside or before.
+
+### 9.2 PRs in Path B
+
+| PR | Scope |
+|---|---|
+| **A** | Add `TurnPhase` type + `turnPhase` field to `AgentPaneState`, dual-write alongside legacy `turnActive` / `stopping` / `streaming.active`. Reducer accepts new + old commands. Tests cover both shapes. |
+| **B** | Migrate the view's spinner, input-disabled, Stop-visible to read `isWorking(state)`. Drop spinner's direct `controllerstatus` subscription. |
+| **C** | Bounded `Interrupting → Done.Interrupted` — `ScheduleInterruptTimeout` event + view's `setTimeout` wiring. Closes the working-animation-breaks-on-interrupt bug. |
+| **D** | Gap 2 — `Submitting` bounded by `SubmitTimeoutElapsed`. |
+| **E** | Gap 3 — `Streaming.lastEventMs` in the variant payload; `StreamWatchdogTick` + `StreamStalled → Interrupting`. |
+| **F** | Disconnected state + banner UI. |
+| **G** | Cleanup — drop the dual-write; remove legacy `turnActive` / `stopping` / `streaming.active` fields. View migrates fully to `turnPhase`. |
+
+### 9.3 #728 gap 1 (init phase) lands independently
+
+`InitStart` / `InitReady` / `InitFailed` commands on the existing
+`initPhase` field. Can ship before, during, or after this sequence —
+no coupling.
+
+## 10. Tests
+
+Extend `frontend/app/store/agent-pane-state/reducer.test.ts`'s
+cross-product. Key invariants the suite must pin:
+
+- **i1**: `isWorking(state)` true ⇔ `state.turnPhase.kind ∈ {Submitting, Streaming, Interrupting}`. No exceptions.
+- **i2**: `UserInterrupted` from any working state always lands in `Interrupting` and emits exactly one `SendSigintRpc`.
+- **i3**: From `Interrupting`, *any* one of `TurnFinished` / `ControllerStatusChanged(done)` / `InterruptTimeoutElapsed` lands in `Done.Interrupted`. Bounded.
+- **i4**: `UserInterrupted` while in `Interrupting` is a no-op — no second `SendSigintRpc`, no state change.
+- **i5**: `Submitting` bounded by `SubmitTimeoutElapsed` (gap 2 invariant).
+- **i6**: `Streaming.lastEventMs` updated on every `OutputChunk` / `ToolStarted` / `ToolEnded`; `StreamWatchdogTick` with `nowMs - lastEventMs >= 45_000` transitions to `Interrupting` (gap 3 invariant).
+- **i7**: Late `OutputChunk` after `Done` / `Disconnected` is silently dropped.
+- **i8**: `Disconnected` preserves `lastKind` so the UI banner can say "was streaming" vs "was idle".
+- **i9**: Illegal-by-construction states aren't representable — TypeScript ensures.
+
+## 11. Open questions
+
+1. **Second-interrupt → SIGKILL?** Today: no-op (i4). User pressing Stop twice probably wants force-kill. Defer to v2 unless UX complaints arise.
+2. **Disconnected granularity** — split backend-gone (sidecar crashed) from network-blip (WS drop)? v1: one state. v2: split.
+3. **`currentTool` vs. `Streaming.toolsActive`** — single string vs. count. Claude Code today is one-tool-at-a-time; the count is forward-compatible. Keep both or pick one? Recommendation: keep both, document `currentTool` as "name of the most recent tool" and `toolsActive` as "number currently running" (matches today's behaviour where they're usually 1/0).
+4. **Phase B's submit timeout — 30 s** (per #728) or shorter? RPC ack should be sub-second normally; 30 s is generous. Tune in PR D.
+
+## 12. Why this is worth doing
+
+The May 12 audit already identified the multi-source-of-truth shape as
+the underlying problem; #728 documents six concrete symptoms. This
+spec is the **shape change** that makes most of them
+unrepresentable-by-construction rather than runtime-checked. The
+interrupt-animation-breaks bug is the most visible one, but it's a
+class — `turnActive + stopping` interactions, `streaming.active`
+diverging from `turnActive`, and so on. A discriminated union
+collapses the class into a single typed enum.
+
+Cost: ~7 PRs (one per row in §9.2), each contained. None destabilise
+the in-flight architecture — the dual-write phase (PR A) keeps the
+existing API intact while the new shape grows alongside.

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -7,6 +7,7 @@ import {
     AgentPaneState,
     initialState,
     INTERRUPT_TIMEOUT_MS,
+    isDisconnected,
     isInitReady,
     isWorking,
     STREAMING_IDLE_TIMEOUT_MS,
@@ -658,7 +659,7 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.turnPhase.kind).toBe("Idle");
         });
 
-        it("StreamUnsubscribe while working surfaces Disconnected.{lastKind}", () => {
+        it("StreamUnsubscribe while working surfaces Disconnected.{lastKind, lastConnectedAt}", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             // Phase is Submitting (legacy turnActive=true).
@@ -667,22 +668,33 @@ describe("agent-pane-state reducer", () => {
             // Legacy: stream + turnActive cleared.
             expect(r.state.streaming.active).toBe(false);
             expect(r.state.turnActive).toBe(false);
-            // New: Disconnected, with Submitting as the lost kind.
+            // New (PR F): Disconnected with Submitting as the lost kind,
+            // lastConnectedAt = command.at, and a literal reason.
             expect(r.state.turnPhase.kind).toBe("Disconnected");
             if (r.state.turnPhase.kind === "Disconnected") {
                 expect(r.state.turnPhase.lastKind).toBe("Submitting");
                 expect(r.state.turnPhase.reason).toBe("stream-unsubscribed");
+                expect(r.state.turnPhase.lastConnectedAt).toBe(200);
             }
         });
 
-        it("StreamUnsubscribe while Idle returns to Idle (no Disconnected)", () => {
+        it("StreamUnsubscribe while Idle is a same-ref no-op (PR F)", () => {
+            // PR F tightened the contract: an unsubscribe from a non-
+            // working phase (Idle / Done / Disconnected) is idempotent
+            // and returns the same state reference. The pre-PR-F
+            // behaviour also cleared `streaming.active` here, but that
+            // was a side-effect of the dual-write era — the legacy
+            // boolean leaves with PR G and the new no-op shape is the
+            // canonical one. The view does not observe a phantom
+            // disconnect (no event emitted).
             const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             // Phase is still Idle (subscribe alone doesn't promote).
             expect(s1.turnPhase.kind).toBe("Idle");
             const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
-            expect(r.state.turnPhase.kind).toBe("Idle");
-            expect(r.state.streaming.active).toBe(false);
+            // Same reference — no spurious tick to reactive consumers.
+            expect(r.state).toBe(s1);
+            expect(r.events).toEqual([]);
         });
 
         it("StreamFlushObserved while Submitting promotes phase to Streaming (codex P1 on #987)", () => {
@@ -904,6 +916,7 @@ describe("agent-pane-state reducer", () => {
                 {
                     kind: "Disconnected",
                     lastKind: "Streaming",
+                    lastConnectedAt: 0,
                     reason: "stream-unsubscribed",
                 },
                 false,
@@ -1758,6 +1771,243 @@ describe("agent-pane-state reducer", () => {
             });
             expect(r.state).toBe(start);
             expect(r.events).toEqual([]);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────
+    // PR F — `Disconnected` phase + banner contract.
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §6.4.
+    // StreamUnsubscribe from a working phase (Submitting / Streaming /
+    // Interrupting) transitions to Disconnected — carrying `lastKind`,
+    // `lastConnectedAt`, and a finite literal `reason`. Non-working
+    // phases (Idle / Done / Disconnected) make StreamUnsubscribe a
+    // same-ref no-op. StreamSubscribe from Disconnected resets to
+    // Idle. A late TurnEnd while Disconnected is preserved (the
+    // disconnect is the authoritative outcome).
+    // ─────────────────────────────────────────────────────────────────
+    describe("Disconnected phase (PR F)", () => {
+        it("StreamUnsubscribe while Streaming → Disconnected; legacy cleared; isWorking=false; emits stream-disconnected", () => {
+            // Reach Streaming via the realistic path (subscribe once,
+            // then TurnStart, then a flush promotes).
+            const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const s3 = update(s2, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 200,
+            }).state;
+            expect(s3.turnPhase.kind).toBe("Streaming");
+            // Tool + tokens so we can verify they're cleared on
+            // disconnect (legacy cleanup mirrors the bounded force-
+            // transition arms — see reducer.ts §StreamUnsubscribe).
+            const s4 = update(s3, { type: "ToolStart", name: "Read" }, 210)
+                .state;
+            const s5 = update(s4, { type: "TokensIn", input: 42 }, 220)
+                .state;
+            expect(s5.currentTool).toBe("Read");
+            expect(s5.turnTokens?.input).toBe(42);
+
+            const r = update(s5, { type: "StreamUnsubscribe", at: 300 });
+            // Phase transitions to Disconnected with lastKind = Streaming.
+            expect(r.state.turnPhase.kind).toBe("Disconnected");
+            if (r.state.turnPhase.kind === "Disconnected") {
+                expect(r.state.turnPhase.lastKind).toBe("Streaming");
+                expect(r.state.turnPhase.lastConnectedAt).toBe(300);
+                expect(r.state.turnPhase.reason).toBe("stream-unsubscribed");
+            }
+            // Legacy cleanup.
+            expect(r.state.streaming.active).toBe(false);
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state.stopping).toBe(false);
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+            // Animation invariant: isWorking false; isDisconnected true.
+            expect(isWorking(r.state)).toBe(false);
+            expect(isDisconnected(r.state)).toBe(true);
+            // Two events: stream-unsubscribed (always) + stream-disconnected.
+            expect(r.events).toHaveLength(2);
+            expect(r.events[0]).toMatchObject({
+                type: "stream-unsubscribed",
+                at: 300,
+            });
+            expect(r.events[1]).toMatchObject({
+                type: "stream-disconnected",
+                at: 300,
+                lastKind: "Streaming",
+                reason: "stream-unsubscribed",
+            });
+        });
+
+        it("StreamUnsubscribe while Submitting → Disconnected.{lastKind=Submitting}", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
+            expect(r.state.turnPhase.kind).toBe("Disconnected");
+            if (r.state.turnPhase.kind === "Disconnected") {
+                expect(r.state.turnPhase.lastKind).toBe("Submitting");
+                expect(r.state.turnPhase.lastConnectedAt).toBe(200);
+                expect(r.state.turnPhase.reason).toBe("stream-unsubscribed");
+            }
+            expect(isDisconnected(r.state)).toBe(true);
+            // stream-disconnected event surfaces the lost kind.
+            expect(r.events[1]).toMatchObject({
+                type: "stream-disconnected",
+                lastKind: "Submitting",
+            });
+        });
+
+        it("StreamUnsubscribe while Interrupting → Disconnected.{lastKind=Interrupting}", () => {
+            // Reach Interrupting via the standard path.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state;
+            const s3 = update(s2, { type: "RequestStop", at: 200 }).state;
+            expect(s3.turnPhase.kind).toBe("Interrupting");
+            const r = update(s3, { type: "StreamUnsubscribe", at: 300 });
+            expect(r.state.turnPhase.kind).toBe("Disconnected");
+            if (r.state.turnPhase.kind === "Disconnected") {
+                expect(r.state.turnPhase.lastKind).toBe("Interrupting");
+                expect(r.state.turnPhase.lastConnectedAt).toBe(300);
+            }
+            // stopping was set when we entered Interrupting — must clear.
+            expect(r.state.stopping).toBe(false);
+            expect(isWorking(r.state)).toBe(false);
+            expect(isDisconnected(r.state)).toBe(true);
+        });
+
+        it("StreamUnsubscribe while Idle is a same-ref no-op", () => {
+            // Already in Idle (no working state to disconnect from).
+            // The unsubscribe is non-news; no event, no state churn.
+            const s0 = ready(100); // Idle + streaming.active=true
+            expect(s0.turnPhase.kind).toBe("Idle");
+            const r = update(s0, { type: "StreamUnsubscribe", at: 200 });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamUnsubscribe while Done is a same-ref no-op", () => {
+            // Graceful TurnEnd landed → Done. A later teardown
+            // (component unmount, etc.) must not corrupt the outcome.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TurnEnd", stats: null }, 200).state;
+            expect(s2.turnPhase.kind).toBe("Done");
+            const r = update(s2, { type: "StreamUnsubscribe", at: 300 });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+            // Outcome preserved.
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("completed");
+            }
+        });
+
+        it("StreamUnsubscribe while Disconnected is a same-ref no-op", () => {
+            // Idempotent: a duplicate unsubscribe (e.g. socket teardown
+            // fires twice during cleanup) must not synthesise a fresh
+            // Disconnected with a newer `lastConnectedAt` — the original
+            // disconnect timestamp is the authoritative one.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "StreamUnsubscribe", at: 200 })
+                .state;
+            expect(s2.turnPhase.kind).toBe("Disconnected");
+            const r = update(s2, { type: "StreamUnsubscribe", at: 300 });
+            expect(r.state).toBe(s2);
+            expect(r.events).toEqual([]);
+            // lastConnectedAt pinned to the original disconnect.
+            if (r.state.turnPhase.kind === "Disconnected") {
+                expect(r.state.turnPhase.lastConnectedAt).toBe(200);
+            }
+        });
+
+        it("StreamSubscribe from Disconnected → Idle (does NOT auto-resume Streaming)", () => {
+            // Spec §6.4: a fresh subscribe after disconnect resets the
+            // working state. The lost turn is gone; the user must press
+            // send again to start a new one (next TurnStart promotes
+            // back to Submitting).
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 200,
+            }).state;
+            expect(s2.turnPhase.kind).toBe("Streaming");
+            const s3 = update(s2, { type: "StreamUnsubscribe", at: 300 })
+                .state;
+            expect(s3.turnPhase.kind).toBe("Disconnected");
+            // Now the dispatcher (or the reconnect button) re-subscribes.
+            const r = update(s3, { type: "StreamSubscribe", at: 400 });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            // streaming.active true again so a fresh TurnStart can fire.
+            expect(r.state.streaming.active).toBe(true);
+            // No working state → no watchdog re-arm event. Just the
+            // standard `stream-subscribed` event.
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "stream-subscribed",
+                at: 400,
+            });
+        });
+
+        it("Late TurnEnd while Disconnected preserves the disconnect (Option A; first-done-wins)", () => {
+            // PR F spec §4 Option A: the disconnect IS the outcome.
+            // A late TurnEnd from the backend (e.g. a final session_end
+            // that was buffered just before the PTY died, then drained
+            // post-mortem) must NOT overwrite Disconnected with Done.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "StreamFlushObserved",
+                addedCount: 1,
+                at: 200,
+            }).state;
+            const s3 = update(s2, { type: "StreamUnsubscribe", at: 300 })
+                .state;
+            expect(s3.turnPhase.kind).toBe("Disconnected");
+            // Late ack arrives.
+            const r = update(
+                s3,
+                {
+                    type: "TurnEnd",
+                    stats: { input_tokens: 5, output_tokens: 10 } as any,
+                },
+                400,
+            );
+            // Same reference — Disconnected preserved entirely.
+            expect(r.state).toBe(s3);
+            expect(r.events).toEqual([]);
+            // Phase + payload intact.
+            expect(r.state.turnPhase.kind).toBe("Disconnected");
+            if (r.state.turnPhase.kind === "Disconnected") {
+                expect(r.state.turnPhase.lastConnectedAt).toBe(300);
+                expect(r.state.turnPhase.lastKind).toBe("Streaming");
+            }
+        });
+
+        it("isDisconnected selector matches the phase kind", () => {
+            // Cross-product sanity — `isDisconnected(state)` is a pure
+            // projection of `turnPhase.kind === "Disconnected"`. Wired
+            // separately from `isWorking` so a single mistaken edit can
+            // be caught.
+            const idle = ready(100);
+            expect(isDisconnected(idle)).toBe(false);
+            const submitting = update(idle, { type: "TurnStart", at: 110 })
+                .state;
+            expect(isDisconnected(submitting)).toBe(false);
+            const disc = update(submitting, {
+                type: "StreamUnsubscribe",
+                at: 200,
+            }).state;
+            expect(isDisconnected(disc)).toBe(true);
+            const done = update(idle, { type: "TurnEnd", stats: null }, 300)
+                .state;
+            // (Done from Idle path: TurnEnd from Idle promotes to Done
+            // via the same arm — see existing tests.)
+            expect(isDisconnected(done)).toBe(false);
         });
     });
 });

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -36,6 +36,7 @@ import {
     TurnOutcome,
     TurnPhase,
 } from "./types";
+import type { DisconnectReason } from "./types";
 
 /**
  * If `phase` is `Streaming`, return the `schedule-stream-watchdog` event
@@ -110,7 +111,13 @@ export function update(
             // deadline is in the future. (P1 on #995 from reagent +
             // codex: stale `lastEventMs` could schedule a deadline in
             // the past, firing `StreamStalled` immediately on a freshly-
-            // resubscribed turn.) Idle/Done/Disconnected stay put.
+            // resubscribed turn.)
+            //
+            // PR F: a subscribe from `Disconnected` clears the
+            // disconnect — we land in `Idle` (not back in the working
+            // set; the lost turn is gone, the next `TurnStart` promotes
+            // to Submitting). Done stays Done (terminal). Idle stays
+            // Idle (no-op).
             const nextPhase: TurnPhase =
                 state.turnPhase.kind === "Submitting"
                     ? {
@@ -124,7 +131,9 @@ export function update(
                               ...state.turnPhase,
                               lastEventMs: command.at,
                           }
-                        : state.turnPhase;
+                        : state.turnPhase.kind === "Disconnected"
+                            ? { kind: "Idle" }
+                            : state.turnPhase;
             const events: AgentPaneEvent[] = [
                 { type: "stream-subscribed", at: command.at },
             ];
@@ -152,27 +161,53 @@ export function update(
         case "StreamUnsubscribe": {
             // Dual-write: if we were working (Submitting/Streaming/
             // Interrupting), surface a Disconnected phase so the view
-            // can show re-attach UX. Otherwise → Idle.
+            // can show re-attach UX. Otherwise (Idle / Done / already
+            // Disconnected) the unsubscribe is idempotent — return the
+            // same state ref so reactive consumers don't see a phantom
+            // tick. Spec §6.4 / PR F.
             const k = state.turnPhase.kind;
             const wasWorking =
                 k === "Submitting" || k === "Streaming" || k === "Interrupting";
-            const nextPhase: TurnPhase = wasWorking
-                ? {
-                      kind: "Disconnected",
-                      lastKind: k as KindBeforeDisconnect,
-                      reason: "stream-unsubscribed",
-                  }
-                : { kind: "Idle" };
+            if (!wasWorking) {
+                // Same-ref no-op for Idle / Done / Disconnected. The
+                // legacy fields are already in the cleared shape there
+                // (no in-flight turn), so there's nothing to scrub. No
+                // event either — the unsubscribe is non-news.
+                return { state, events: [] };
+            }
+            const reason: DisconnectReason = "stream-unsubscribed";
+            const lastKind = k as KindBeforeDisconnect;
+            const nextPhase: TurnPhase = {
+                kind: "Disconnected",
+                lastKind,
+                lastConnectedAt: command.at,
+                reason,
+            };
             return {
                 state: {
                     ...state,
                     streaming: { ...state.streaming, active: false },
-                    // Defensive: subscription gone → no turn can be active.
+                    // Legacy cleanup mirrors the bounded force-transition
+                    // arms (InterruptTimeoutElapsed / SubmitTimeoutElapsed /
+                    // StreamStalled): a forced exit from a working state
+                    // settles the animation and clears per-turn sidecars
+                    // so the header doesn't show ghost tool / token chips.
                     turnActive: false,
+                    stopping: false,
+                    currentTool: null,
+                    turnTokens: null,
                     lastEventMs: null,
                     turnPhase: nextPhase,
                 },
-                events: [{ type: "stream-unsubscribed", at: command.at }],
+                events: [
+                    { type: "stream-unsubscribed", at: command.at },
+                    {
+                        type: "stream-disconnected",
+                        at: command.at,
+                        lastKind,
+                        reason,
+                    },
+                ],
             };
         }
 
@@ -323,17 +358,35 @@ export function update(
             // First-done-wins: if we're already in `Done`, preserve the
             // existing outcome and only refresh the stats sidecar. The
             // late ack is confirmatory, not authoritative.
-            const alreadyDone = state.turnPhase.kind === "Done";
+            //
+            // PR F extends the guard to `Disconnected` as well — Option A
+            // from the PR F spec: a late TurnEnd that arrives after the
+            // stream has already torn down (e.g. backend pushed a final
+            // session_end into a buffer right before the PTY died, then
+            // the buffered ack drains) must NOT overwrite the disconnect
+            // with a synthetic Done. The disconnect is the authoritative
+            // outcome; the late ack is informational. Same-ref no-op
+            // preserves both the phase and the cleared legacy fields.
+            if (state.turnPhase.kind === "Disconnected") {
+                return { state, events: [] };
+            }
             // Dual-write outcome: stop-in-flight → "stopped"; otherwise
             // "completed". "interrupted" / "errored" are reserved for
-            // future-PR commands (StreamStalled, Disconnected, etc.).
-            const outcome: TurnOutcome = alreadyDone
-                ? state.turnPhase.outcome
+            // bounded force-transition arms (InterruptTimeoutElapsed,
+            // SubmitTimeoutElapsed, StreamStalled).
+            //
+            // TS narrowing: read the phase via a local so the
+            // `.kind === "Done"` ternary below narrows `outcome` /
+            // `finishedAt` accesses (a `const alreadyDone = …` boolean
+            // wouldn't carry the narrow into the ternary branches).
+            const phase = state.turnPhase;
+            const outcome: TurnOutcome = phase.kind === "Done"
+                ? phase.outcome
                 : stoppingWasSet
                     ? "stopped"
                     : "completed";
-            const finishedAt = alreadyDone
-                ? state.turnPhase.finishedAt
+            const finishedAt = phase.kind === "Done"
+                ? phase.finishedAt
                 : nowMs;
             return {
                 state: {

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -76,6 +76,21 @@ export type KindBeforeDisconnect =
     | "Interrupting";
 
 /**
+ * Why the stream dropped while a turn was in-flight (PR F).
+ *
+ *   stream-unsubscribed : the dispatch layer / hook fired a clean
+ *                         `StreamUnsubscribe` (component unmount, PTY
+ *                         exited, etc.) — the local end tore down.
+ *   transport-error     : reserved for an in-flight transport failure
+ *                         surface; the dispatcher decides which reason
+ *                         to attach. Not yet wired by any caller — the
+ *                         union is part of PR F's API contract so the
+ *                         dispatcher can adopt it without a follow-up
+ *                         type churn.
+ */
+export type DisconnectReason = "stream-unsubscribed" | "transport-error";
+
+/**
  * Single source of truth for the turn lifecycle. PR A introduces this
  * alongside the legacy booleans — both are written by the reducer.
  *
@@ -104,9 +119,24 @@ export type TurnPhase =
       }
     | { kind: "Done"; outcome: TurnOutcome; finishedAt: number }
     | {
+          /**
+           * Stream dropped while a turn was in flight. PR F fleshes out
+           * the variant payload:
+           *   - `lastKind`     : the working-kind we lost (so the UI can
+           *                      say "was streaming" vs "was submitting").
+           *                      Carried since PR A.
+           *   - `lastConnectedAt` : wall-clock ms at which the disconnect
+           *                      command was processed (= `command.at`
+           *                      from `StreamUnsubscribe`). Drives a
+           *                      "disconnected 5s ago" age label and
+           *                      keeps the variant audit-friendly.
+           *   - `reason`       : a finite literal union (was `string` in
+           *                      PR A) — see {@link DisconnectReason}.
+           */
           kind: "Disconnected";
           lastKind: KindBeforeDisconnect;
-          reason: string;
+          lastConnectedAt: number;
+          reason: DisconnectReason;
       };
 
 /**
@@ -186,6 +216,18 @@ export function isWorking(state: AgentPaneState): boolean {
 export function workingFromPhase(phase: TurnPhase): boolean {
     const k = phase.kind;
     return k === "Submitting" || k === "Streaming" || k === "Interrupting";
+}
+
+/**
+ * Selector — `true` iff the pane is in the `Disconnected` phase. PR F:
+ * drives the {@link AgentDisconnectedBanner} visibility, replacing any
+ * ad-hoc "streaming.active === false but turn was active" checks. Pure
+ * projection of `turnPhase.kind` — same SoT as `isWorking`.
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §6.4.
+ */
+export function isDisconnected(state: AgentPaneState): boolean {
+    return state.turnPhase.kind === "Disconnected";
 }
 
 export type AgentPaneCommand =
@@ -316,6 +358,20 @@ export type AgentPaneEvent =
     | { type: "init-failed"; reason: string }
     | { type: "stream-subscribed"; at: number }
     | { type: "stream-unsubscribed"; at: number }
+    /**
+     * PR F: the stream tore down while a turn was in flight
+     * (Submitting / Streaming / Interrupting). Surfaced alongside the
+     * generic `stream-unsubscribed` so the view can drive a dedicated
+     * "Disconnected — reconnecting…" banner without re-deriving from
+     * `turnPhase.kind`. Emitted ONLY on the working-set → Disconnected
+     * transition; idle-state unsubscribes do not emit it.
+     */
+    | {
+          type: "stream-disconnected";
+          at: number;
+          lastKind: KindBeforeDisconnect;
+          reason: DisconnectReason;
+      }
     | { type: "stream-flush-observed"; addedCount: number }
     | {
           /**

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -18,6 +18,7 @@
 @use "styles/bookmarks";
 @use "styles/search";
 @use "styles/session-digest";
+@use "styles/disconnected-banner";
 @use "styles/activity-log";
 @use "styles/picker";
 @use "styles/control-bar";

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -37,6 +37,7 @@ import { useAgentCommands } from "./hooks/useAgentCommands";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { ActivityLogPanel } from "./components/ActivityLogPanel";
 import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
+import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter, AgentStatusLine } from "./components/AgentFooter";
 import { PendingMessagesPanel } from "./components/PendingMessagesPanel";
@@ -722,6 +723,32 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 }
                 onSendImmediately={() => {
                     commands.stopAgent();
+                }}
+            />
+
+            {/* PR F — Disconnected banner. Visible when the stream
+                tore down while a turn was in flight (kind=Disconnected).
+                Sits above the status line so the working spinner (which
+                is already suppressed because `isWorking(Disconnected) =
+                false`) doesn't overlay the disconnect message. The
+                Reconnect button re-subscribes; the reducer's
+                `StreamSubscribe` arm clears the phase to Idle. Spec
+                docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md
+                §6.4. */}
+            <AgentDisconnectedBanner
+                phase={agentAtoms().turnPhaseAtom[0]}
+                onReconnect={() => {
+                    // Standard stream-reconnect path: dispatch
+                    // `StreamSubscribe` against the live pane. If the
+                    // backend has auto-reconnected between render and
+                    // click, the second subscribe is harmless — the
+                    // reducer's Disconnected→Idle transition is the
+                    // same regardless of who calls it.
+                    dispatchPane(
+                        model.blockId,
+                        { type: "StreamSubscribe", at: Date.now() },
+                        "user",
+                    );
                 }}
             />
 

--- a/frontend/app/view/agent/components/AgentDisconnectedBanner.test.tsx
+++ b/frontend/app/view/agent/components/AgentDisconnectedBanner.test.tsx
@@ -1,0 +1,102 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Banner-visibility tests for AgentDisconnectedBanner (PR F of the
+ * turn-phase migration). The banner must:
+ *   - render iff `phase().kind === "Disconnected"`
+ *   - surface `lastKind` + a relative age on the message line
+ *   - fire `onReconnect` when the Reconnect button is clicked
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §6.4.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentDisconnectedBanner } from "./AgentDisconnectedBanner";
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
+
+afterEach(() => {
+    // @solidjs/testing-library doesn't auto-cleanup by default. Each
+    // `render` mounts into a fresh container, but the previous
+    // container is left in the DOM — `screen.queryBy*` searches the
+    // whole document body so multiple renders within one file
+    // accumulate. Explicit cleanup keeps tests independent.
+    cleanup();
+});
+
+describe("AgentDisconnectedBanner", () => {
+    it("renders nothing when phase.kind !== 'Disconnected'", () => {
+        const [phase] = createSignal<TurnPhase>({ kind: "Idle" });
+        render(() => (
+            <AgentDisconnectedBanner phase={phase} onReconnect={() => {}} />
+        ));
+        expect(screen.queryByText(/Disconnected from stream/)).toBeNull();
+        expect(screen.queryByRole("button", { name: /Reconnect/ })).toBeNull();
+    });
+
+    it("renders the banner + Reconnect button when phase.kind === 'Disconnected'", () => {
+        const [phase] = createSignal<TurnPhase>({
+            kind: "Disconnected",
+            lastKind: "Streaming",
+            lastConnectedAt: Date.now(),
+            reason: "stream-unsubscribed",
+        });
+        render(() => (
+            <AgentDisconnectedBanner phase={phase} onReconnect={() => {}} />
+        ));
+        expect(
+            screen.getByText(/Disconnected from stream/),
+        ).toBeInTheDocument();
+        // The detail line mentions the lost kind, lowercased.
+        expect(screen.getByText(/was streaming/i)).toBeInTheDocument();
+        // Manual reconnect affordance present.
+        expect(
+            screen.getByRole("button", { name: /Reconnect/ }),
+        ).toBeInTheDocument();
+    });
+
+    it("invokes onReconnect when the Reconnect button is clicked", async () => {
+        const onReconnect = vi.fn();
+        const [phase] = createSignal<TurnPhase>({
+            kind: "Disconnected",
+            lastKind: "Submitting",
+            lastConnectedAt: Date.now(),
+            reason: "stream-unsubscribed",
+        });
+        render(() => (
+            <AgentDisconnectedBanner phase={phase} onReconnect={onReconnect} />
+        ));
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("button", { name: /Reconnect/ }));
+        expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("toggles visibility when the phase signal flips", () => {
+        const [phase, setPhase] = createSignal<TurnPhase>({ kind: "Idle" });
+        render(() => (
+            <AgentDisconnectedBanner phase={phase} onReconnect={() => {}} />
+        ));
+        // Initially absent.
+        expect(screen.queryByText(/Disconnected from stream/)).toBeNull();
+
+        // Flip to Disconnected — banner appears.
+        setPhase({
+            kind: "Disconnected",
+            lastKind: "Interrupting",
+            lastConnectedAt: Date.now(),
+            reason: "stream-unsubscribed",
+        });
+        expect(
+            screen.getByText(/Disconnected from stream/),
+        ).toBeInTheDocument();
+
+        // Flip back to Idle (e.g. user pressed Reconnect, dispatcher
+        // landed StreamSubscribe → Idle). Banner disappears.
+        setPhase({ kind: "Idle" });
+        expect(screen.queryByText(/Disconnected from stream/)).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/AgentDisconnectedBanner.tsx
+++ b/frontend/app/view/agent/components/AgentDisconnectedBanner.tsx
@@ -1,0 +1,95 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentDisconnectedBanner — surfaces the agent-pane `Disconnected`
+ * phase (PR F of the turn-phase migration). The banner appears
+ * whenever `turnPhase.kind === "Disconnected"` and offers a manual
+ * "Reconnect" button that re-subscribes to the stream. The reducer
+ * resets the phase to `Idle` on `StreamSubscribe` — see
+ * `frontend/app/store/agent-pane-state/reducer.ts` §StreamSubscribe.
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §6.4.
+ *
+ * The pane is NOT in the "working" set while Disconnected
+ * (`isWorking(state) === false` — verified by
+ * `frontend/app/store/agent-pane-state/reducer.test.ts` PR F suite),
+ * so the working-spinner animation is already suppressed. The banner
+ * is the only disconnect-aware UI surface PR F introduces; the rest
+ * of the view ignores the phase except through the existing
+ * `isWorking` projection.
+ */
+
+import { Show, type Accessor, type JSX } from "solid-js";
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
+
+interface AgentDisconnectedBannerProps {
+    /** Live phase accessor — banner only renders when kind=Disconnected. */
+    phase: Accessor<TurnPhase>;
+    /**
+     * Manual-reconnect handler. The view passes the standard
+     * stream-resubscribe path here (see `agent-view.tsx` wiring).
+     * The reducer's `StreamSubscribe` arm clears the disconnect.
+     * No-op-safe if the system auto-reconnects between render and
+     * click — the second subscribe still lands in Idle.
+     */
+    onReconnect: () => void;
+}
+
+function formatLastConnectedAge(lastConnectedAt: number): string {
+    const ageMs = Date.now() - lastConnectedAt;
+    if (ageMs < 1_000) return "just now";
+    const seconds = Math.floor(ageMs / 1_000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ago`;
+}
+
+export const AgentDisconnectedBanner = (
+    props: AgentDisconnectedBannerProps,
+): JSX.Element => {
+    return (
+        <Show when={props.phase().kind === "Disconnected"}>
+            {(() => {
+                const p = props.phase();
+                if (p.kind !== "Disconnected") return null;
+                return (
+                    <div
+                        class="agent-disconnected-banner"
+                        role="status"
+                        aria-live="polite"
+                    >
+                        <span
+                            class="agent-disconnected-banner-icon"
+                            aria-hidden="true"
+                        >
+                            {"⚠"}
+                        </span>
+                        <span class="agent-disconnected-banner-message">
+                            <span class="agent-disconnected-banner-title">
+                                Disconnected from stream
+                            </span>
+                            <span class="agent-disconnected-banner-detail">
+                                {" · "}was {p.lastKind.toLowerCase()}
+                                {", "}
+                                {formatLastConnectedAge(p.lastConnectedAt)}
+                            </span>
+                        </span>
+                        <button
+                            type="button"
+                            class="agent-disconnected-banner-action"
+                            onClick={props.onReconnect}
+                            title="Reconnect to the agent stream"
+                        >
+                            Reconnect
+                        </button>
+                    </div>
+                );
+            })()}
+        </Show>
+    );
+};
+
+AgentDisconnectedBanner.displayName = "AgentDisconnectedBanner";

--- a/frontend/app/view/agent/state.test.ts
+++ b/frontend/app/view/agent/state.test.ts
@@ -89,7 +89,8 @@ describe("createAgentAtoms", () => {
         setPhase({
             kind: "Disconnected",
             lastKind: "Streaming",
-            reason: "x",
+            lastConnectedAt: 1,
+            reason: "stream-unsubscribed",
         });
         expect(workingFromPhase(getPhase())).toBe(false);
     });

--- a/frontend/app/view/agent/styles/_disconnected-banner.scss
+++ b/frontend/app/view/agent/styles/_disconnected-banner.scss
@@ -1,0 +1,76 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Disconnected banner (PR F of the turn-phase migration). Shown when
+// `turnPhase.kind === "Disconnected"` — i.e. the stream tore down while
+// a turn was in flight (Submitting / Streaming / Interrupting). Wrapped
+// in .agent-view so the cascade chain matches the pre-split file
+// (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
+.agent-view {
+    .agent-disconnected-banner {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1-5);
+        margin: var(--space-1) 0 var(--space-0-5);
+        padding: var(--space-1) var(--space-2);
+        background: color-mix(in srgb, var(--error-color) 12%, transparent);
+        border: 1px solid color-mix(in srgb, var(--error-color) 50%, transparent);
+        border-radius: 4px;
+        font-size: 12px;
+        flex-shrink: 0;
+        color: var(--main-text-color);
+    }
+
+    .agent-disconnected-banner-icon {
+        color: var(--error-color);
+        font-size: 14px;
+        line-height: 1;
+        flex-shrink: 0;
+    }
+
+    .agent-disconnected-banner-message {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0;
+    }
+
+    .agent-disconnected-banner-title {
+        font-weight: 600;
+        color: var(--main-text-color);
+    }
+
+    .agent-disconnected-banner-detail {
+        font-weight: normal;
+        opacity: 0.75;
+        font-size: 11px;
+    }
+
+    .agent-disconnected-banner-action {
+        background: none;
+        border: 1px solid color-mix(in srgb, var(--error-color) 50%, transparent);
+        cursor: pointer;
+        padding: var(--space-0-5) var(--space-1-5);
+        color: var(--error-color);
+        font-size: 11px;
+        line-height: 1.4;
+        border-radius: 3px;
+        transition: background 0.1s, color 0.1s;
+        flex-shrink: 0;
+
+        &:hover:not(:disabled) {
+            background: color-mix(in srgb, var(--error-color) 20%, transparent);
+        }
+
+        &:active:not(:disabled) {
+            background: color-mix(in srgb, var(--error-color) 30%, transparent);
+        }
+
+        &:disabled {
+            cursor: default;
+            opacity: 0.4;
+        }
+    }
+}


### PR DESCRIPTION
PR F of the turn-phase migration. Builds on the merged upstream PRs:
- PR A #987 — TurnPhase discriminated union (dual-write)
- PR B #992 — view reads `isWorking(state)`
- PR C #991 — bounded `Interrupting → Done.interrupted`
- PR D #994 — bounded `Submitting → Done.errored`
- PR E #995 — bounded `Streaming → Done.errored("stream-stalled")`
- Gap 1 #993 — `InitPhase` state machine

Only PR G (cleanup of legacy `turnActive` / `stopping` / `streaming.active`) remains after this.

Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §6.4 (committed in this PR).

## Reducer changes

- **`StreamUnsubscribe`** from a working phase (Submitting / Streaming / Interrupting) → `Disconnected { lastKind, lastConnectedAt, reason: "stream-unsubscribed" }`. Legacy fields cleared (`turnActive=false`, `stopping=false`, `currentTool=null`, `turnTokens=null`) the same way the bounded force-transition arms do. Emits both `stream-unsubscribed` (existing) and a new `stream-disconnected` event.
- **`StreamUnsubscribe`** from Idle / Done / Disconnected → **same-ref no-op** (idempotent). Was a partial state mutation pre-PR-F; the cleared-shape was indistinguishable from the input so the no-op is the canonical form. The one existing test that relied on the partial-mutation behaviour (`StreamUnsubscribe while Idle returns to Idle (no Disconnected)`) is updated to assert the new same-ref shape.
- **`StreamSubscribe`** from Disconnected → **Idle** (not back to the working set; a fresh send via `TurnStart` promotes to Submitting).
- **`TurnEnd`**'s first-done-wins `alreadyDone` guard extended to include `Disconnected` (**Option A** from the PR F spec): a late backend ack arriving while disconnected preserves the disconnect — the disconnect IS the authoritative outcome.

## Type changes

- `Disconnected` payload extended with `lastConnectedAt: number` (= `command.at` from `StreamUnsubscribe`).
- `reason` tightened from `string` to a finite literal union `DisconnectReason = "stream-unsubscribed" | "transport-error"`. `transport-error` is reserved for a future dispatcher surface; no caller wires it in PR F (out of scope per the task spec — "real transport-error detection is the dispatcher's responsibility").
- New selector `isDisconnected(state: AgentPaneState): boolean` exported alongside `isWorking` / `workingFromPhase`.
- New event variant `{ type: "stream-disconnected"; at; lastKind; reason }`.

## View changes

- New `AgentDisconnectedBanner` component (SolidJS). Visible iff `phase.kind === "Disconnected"`. Surfaces:
  - Title: "Disconnected from stream"
  - Detail: "was streaming, 12s ago" (lowercased `lastKind` + relative age computed from `lastConnectedAt`)
  - **Reconnect** button — dispatches `StreamSubscribe`; the reducer's Disconnected→Idle transition clears the banner. No-op-safe if the system auto-reconnects between render and click (second subscribe still lands in Idle).
- Wired into `agent-view.tsx` between `PendingMessagesPanel` and `AgentStatusLine`. The pane does NOT show the working spinner while Disconnected — `isWorking(Disconnected) === false` already (PR A).
- New SCSS module `_disconnected-banner.scss` using `var(--error-color)` for the visual treatment (color-mixed background + border).

## Tests

**Reducer** (`frontend/app/store/agent-pane-state/reducer.test.ts`, new `"Disconnected phase (PR F)"` describe block):

- `StreamUnsubscribe while Streaming → Disconnected; legacy cleared; isWorking=false; emits stream-disconnected`
- `StreamUnsubscribe while Submitting → Disconnected.{lastKind=Submitting}`
- `StreamUnsubscribe while Interrupting → Disconnected.{lastKind=Interrupting}` (also verifies `stopping` clears)
- `StreamUnsubscribe while Idle → same-ref no-op`
- `StreamUnsubscribe while Done → same-ref no-op` (outcome preserved)
- `StreamUnsubscribe while Disconnected → same-ref no-op` (lastConnectedAt pinned to original disconnect)
- `StreamSubscribe from Disconnected → Idle` (does NOT auto-resume Streaming)
- `Late TurnEnd while Disconnected preserves the disconnect (Option A)` — same-ref no-op
- `isDisconnected selector matches the phase kind`

**View** (`frontend/app/view/agent/components/AgentDisconnectedBanner.test.tsx`, new file):

- `renders nothing when phase.kind !== 'Disconnected'`
- `renders the banner + Reconnect button when phase.kind === 'Disconnected'`
- `invokes onReconnect when the Reconnect button is clicked`
- `toggles visibility when the phase signal flips`

Updated existing assertions in `reducer.test.ts` and `state.test.ts` to include the new `lastConnectedAt` field on Disconnected literal payloads. The matrix test in `isWorking selector` already covered `Disconnected → false`; updated to pass the new shape.

Pre-PR-F total: 113 reducer tests. PR F adds 9 new tests + 4 view tests + 1 banner-suite cleanup helper = **135 total passing tests** across the touched test files.

## Test before push

```
$ npx vitest run frontend/app/store/agent-pane-state/ \
                 frontend/app/view/agent/components/AgentDisconnectedBanner.test.tsx \
                 frontend/app/view/agent/state.test.ts
Test Files  3 passed (3)
     Tests  135 passed (135)
```

`npx tsc --noEmit` on touched non-test files (`reducer.ts`, `types.ts`, `AgentDisconnectedBanner.tsx`, `agent-view.tsx`) reports zero new errors. Pre-existing errors in unrelated files (layout/tests, providers/index.test.ts, BashOutputViewer, etc.) are untouched.

## Out of scope

- Real transport-error detection (dispatcher's responsibility — the reason-union is the type-side reservation only).
- PR G's cleanup of legacy fields. PR F does NOT remove `turnActive` / `stopping` / `streaming.active` reads.

## Files

- `frontend/app/store/agent-pane-state/types.ts` — `DisconnectReason`, fleshed-out `Disconnected` payload, `isDisconnected` selector, `stream-disconnected` event.
- `frontend/app/store/agent-pane-state/reducer.ts` — `StreamUnsubscribe` / `StreamSubscribe` / `TurnEnd` arm changes.
- `frontend/app/store/agent-pane-state/reducer.test.ts` — new PR F describe block + matrix update + same-ref no-op update.
- `frontend/app/view/agent/components/AgentDisconnectedBanner.tsx` — new component.
- `frontend/app/view/agent/components/AgentDisconnectedBanner.test.tsx` — new banner tests.
- `frontend/app/view/agent/styles/_disconnected-banner.scss` — new SCSS module.
- `frontend/app/view/agent/agent-view.scss` — imports the new SCSS module.
- `frontend/app/view/agent/agent-view.tsx` — wires the banner in + Reconnect handler.
- `frontend/app/view/agent/state.test.ts` — payload literal update.
- `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` — spec committed (was untracked locally) + PR F note documenting the payload extension and the late-TurnEnd Option A choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)