### PR TITLE
refactor(agent-pane): drop legacy turnActive/stopping/streaming.active (turn-phase PR G)

### DIFF
--- a/.changesets/1779543002-refactor-agent-pane-drop-legacy-turnactive-stopping-streamin-8rhg.md
+++ b/.changesets/1779543002-refactor-agent-pane-drop-legacy-turnactive-stopping-streamin-8rhg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agent-pane): drop legacy turnActive/stopping/streaming.active

--- a/frontend/app/store/agent-pane-state-store.test.ts
+++ b/frontend/app/store/agent-pane-state-store.test.ts
@@ -35,8 +35,6 @@ function noopProj(): AgentPaneProjections {
         sessionStats: () => {},
         currentTool: () => {},
         turnTokens: () => {},
-        turnActive: () => {},
-        stopping: () => {},
         pending: () => {},
         initPhase: () => {},
     };
@@ -168,7 +166,7 @@ describe("agent-pane-state-store (cascade contracts)", () => {
             //         → StreamFlushObserved (Submitting → Streaming)
             //         → RequestStop (Streaming → Interrupting)
             //         → TurnEnd (Interrupting → Done.stopped)
-            dispatch("blockD", { type: "InitReady" });
+            dispatch("blockD", { type: "InitReady", at: 100 });
             dispatch("blockD", { type: "StreamSubscribe", at: 100 });
             dispatch("blockD", { type: "TurnStart", at: 110 });
             dispatch("blockD", { type: "StreamFlushObserved", addedCount: 1, at: 120 });

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -32,21 +32,24 @@ import { type CommandSource, recordDispatch } from "./command-source";
  * to a pre-existing per-pane Solid signal in `createAgentAtoms`. Readers
  * keep using the existing accessors; only writes are routed through this
  * store.
+ *
+ * PR G dropped the `turnActive` and `stopping` setters — the legacy
+ * fields they backed are gone. The view binds its "working" animation
+ * to `workingFromPhase(turnPhase)` and its "Stopping…" label to
+ * `turnPhase.kind === "Interrupting"`.
  */
 export interface AgentPaneProjections {
     streaming: (next: StreamingState) => void;
     sessionStats: (next: SessionStats | null) => void;
     currentTool: (next: string | null) => void;
     turnTokens: (next: TurnTokens | null) => void;
-    turnActive: (next: boolean) => void;
-    stopping: (next: boolean) => void;
     pending: (next: PendingMessage[]) => void;
     /** Init phase — drives the "Loading history…" overlay (issue #728 gap 1). */
     initPhase?: (next: InitPhase) => void;
     /**
-     * Turn phase (PR A added the union + dual-write in the reducer; PR B —
-     * this PR — projects it through to the view so the "working" animation
-     * can bind to `isWorking(state)` instead of `turnActive || stopping`).
+     * Single-source-of-truth turn phase. Since PR G this is the only
+     * working/stopping signal the view binds to (via
+     * `workingFromPhase(turnPhase)` and `turnPhase.kind === "Interrupting"`).
      * Optional so existing callers (and the cascade-store test's no-op
      * projection) keep compiling.
      */
@@ -127,8 +130,6 @@ export function dispatch(
     proj("sessionStats", prev.sessionStats, slot.state.sessionStats, slot.proj.sessionStats);
     proj("currentTool", prev.currentTool, slot.state.currentTool, slot.proj.currentTool);
     proj("turnTokens", prev.turnTokens, slot.state.turnTokens, slot.proj.turnTokens);
-    proj("turnActive", prev.turnActive, slot.state.turnActive, slot.proj.turnActive);
-    proj("stopping", prev.stopping, slot.state.stopping, slot.proj.stopping);
     proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
     proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);
     proj("turnPhase", prev.turnPhase, slot.state.turnPhase, slot.proj.turnPhase);

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -29,30 +29,33 @@ const ready = (atMs = 100) => {
 
 describe("agent-pane-state reducer", () => {
     describe("Stream lifecycle", () => {
-        it("StreamSubscribe sets active + lastEventTime", () => {
+        it("StreamSubscribe sets lastEventMs + streaming telemetry", () => {
             const r = update(mk(), { type: "StreamSubscribe", at: 100 });
-            expect(r.state.streaming.active).toBe(true);
+            // PR G: subscribed-ness is `lastEventMs !== null`; the
+            // legacy `streaming.active` boolean was dropped.
+            expect(r.state.lastEventMs).toBe(100);
             expect(r.state.streaming.lastEventTime).toBe(100);
             expect(r.events[0]).toMatchObject({ type: "stream-subscribed", at: 100 });
         });
 
-        it("StreamUnsubscribe clears active and force-clears turnActive", () => {
+        it("StreamUnsubscribe clears subscription and forces working turn into Disconnected", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
-            expect(s1.turnActive).toBe(true);
+            expect(isWorking(s1)).toBe(true);
             const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
-            expect(r.state.streaming.active).toBe(false);
-            expect(r.state.turnActive).toBe(false);
+            expect(r.state.lastEventMs).toBe(null);
+            expect(isWorking(r.state)).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Disconnected");
         });
 
-        it("StreamFlushObserved bumps bufferSize when active", () => {
+        it("StreamFlushObserved bumps bufferSize when subscribed", () => {
             const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
             const r = update(s0, { type: "StreamFlushObserved", addedCount: 3, at: 110 });
             expect(r.state.streaming.bufferSize).toBe(3);
             expect(r.state.streaming.lastEventTime).toBe(110);
         });
 
-        it("StreamFlushObserved is no-op when stream inactive", () => {
+        it("StreamFlushObserved is no-op when stream unsubscribed", () => {
             const start = mk();
             const r = update(start, { type: "StreamFlushObserved", addedCount: 3, at: 110 });
             // Reducer must return SAME reference when no work was done.
@@ -62,23 +65,24 @@ describe("agent-pane-state reducer", () => {
     });
 
     describe("Turn lifecycle invariants", () => {
-        it("TurnStart while stream inactive is suppressed", () => {
+        it("TurnStart while stream unsubscribed is suppressed", () => {
             const start = mk();
             const r = update(start, { type: "TurnStart", at: 100 });
-            expect(r.state.turnActive).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Idle");
             expect(r.state).toBe(start);
             expect(r.events[0]).toMatchObject({ type: "turn-start-suppressed" });
         });
 
-        it("TurnStart while active sets turnActive + clears stale stats", () => {
+        it("TurnStart while subscribed transitions to Submitting + clears stale stats", () => {
             const s0 = ready(100);
             const sWithStats = { ...s0, sessionStats: { input_tokens: 50, output_tokens: 100 } };
             const r = update(sWithStats, { type: "TurnStart", at: 110 });
-            expect(r.state.turnActive).toBe(true);
+            expect(r.state.turnPhase.kind).toBe("Submitting");
+            expect(isWorking(r.state)).toBe(true);
             expect(r.state.sessionStats).toBe(null);
         });
 
-        it("TurnEnd clears tool/tokens/turnActive AND stopping in one shot", () => {
+        it("TurnEnd clears tool/tokens and lands in Done in one shot", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "ToolStart", name: "Read" }).state;
@@ -89,15 +93,18 @@ describe("agent-pane-state reducer", () => {
                 type: "TurnEnd",
                 stats: null,
             });
-            expect(r.state.turnActive).toBe(false);
+            expect(isWorking(r.state)).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Done");
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnTokens).toBe(null);
-            expect(r.state.stopping).toBe(false);
             // Stats merged from live tokens (mergeStats fallback path).
             expect(r.state.sessionStats).toEqual({ input_tokens: 50, output_tokens: 200 });
             expect(r.events[0]).toMatchObject({
                 type: "turn-ended",
                 statsMerged: true,
+                // stoppingCleared still carries the audit signal — true
+                // iff the turn ended while in Interrupting (PR G:
+                // derived from `turnPhase.kind === "Interrupting"`).
                 stoppingCleared: true,
             });
         });
@@ -117,7 +124,7 @@ describe("agent-pane-state reducer", () => {
             });
         });
 
-        it("TurnReset clears turn-scoped state but keeps streaming + pending", () => {
+        it("TurnReset clears turn-scoped state but keeps subscription + pending", () => {
             const s0 = ready(100);
             const s1 = update(s0, {
                 type: "PendingMessageQueued",
@@ -128,10 +135,12 @@ describe("agent-pane-state reducer", () => {
             const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
             const s3 = update(s2, { type: "ToolStart", name: "Edit" }).state;
             const r = update(s3, { type: "TurnReset" });
-            expect(r.state.streaming.active).toBe(true); // preserved
+            // PR G: subscription gate is `lastEventMs !== null` (was
+            // `streaming.active`). Preserved across TurnReset.
+            expect(r.state.lastEventMs).not.toBeNull();
             expect(r.state.pending).toHaveLength(1); // preserved
             expect(r.state.currentTool).toBe(null);
-            expect(r.state.turnActive).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Idle");
         });
     });
 
@@ -163,23 +172,45 @@ describe("agent-pane-state reducer", () => {
     });
 
     describe("Stop flow", () => {
-        it("RequestStop sets stopping", () => {
-            const r = update(mk(), { type: "RequestStop", at: 100 });
-            expect(r.state.stopping).toBe(true);
+        it("RequestStop while working transitions to Interrupting", () => {
+            // PR G: RequestStop is only meaningful while a turn is in
+            // flight. Subscribe + start a turn first, then stop.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const r = update(s1, { type: "RequestStop", at: 120 });
+            expect(r.state.turnPhase.kind).toBe("Interrupting");
         });
 
-        it("StopFailed clears stopping", () => {
-            const s0 = update(mk(), { type: "RequestStop", at: 100 }).state;
-            const r = update(s0, { type: "StopFailed" });
-            expect(r.state.stopping).toBe(false);
+        it("RequestStop while Idle is a state no-op (only emits audit event)", () => {
+            // PR G: legacy `stopping` boolean used to flip true here
+            // even with no turn in flight; that was a latent bug
+            // surface (the stop could not actually be acted on).
+            // Now it's a clean no-op state-wise.
+            const start = mk();
+            const r = update(start, { type: "RequestStop", at: 100 });
+            expect(r.state).toBe(start);
+            expect(r.events[0]).toMatchObject({ type: "stop-requested", at: 100 });
         });
 
-        it("TurnEnd clears stopping (the normal path — no explicit StopApplied needed)", () => {
+        it("StopFailed clears Interrupting → Streaming (when subscribed)", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "RequestStop", at: 120 }).state;
+            expect(s2.turnPhase.kind).toBe("Interrupting");
+            const r = update(s2, { type: "StopFailed" });
+            // Rolls back to Streaming since the stream is still subscribed.
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+        });
+
+        it("TurnEnd transitions Interrupting → Done.stopped (was the legacy 'stopping cleared' path)", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "RequestStop", at: 120 }).state;
             const r = update(s2, { type: "TurnEnd", stats: null });
-            expect(r.state.stopping).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Done");
+            if (r.state.turnPhase.kind === "Done") {
+                expect(r.state.turnPhase.outcome).toBe("stopped");
+            }
         });
     });
 
@@ -352,7 +383,7 @@ describe("agent-pane-state reducer", () => {
             // Subscribed but not InitReady — gap 1 invariant.
             const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
             const r = update(s0, { type: "TurnStart", at: 110 });
-            expect(r.state.turnActive).toBe(false);
+            expect(r.state.turnPhase.kind).toBe("Idle");
             expect(r.events[0]).toMatchObject({
                 type: "turn-start-suppressed",
                 reason: "init still loading",
@@ -367,7 +398,8 @@ describe("agent-pane-state reducer", () => {
             }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
             const r = update(s1, { type: "TurnStart", at: 110 });
-            expect(r.state.turnActive).toBe(true);
+            expect(r.state.turnPhase.kind).toBe("Submitting");
+            expect(isWorking(r.state)).toBe(true);
         });
 
         it("isInitReady selector tracks InitReady only", () => {
@@ -486,31 +518,26 @@ describe("agent-pane-state reducer", () => {
     });
 
     // ─────────────────────────────────────────────────────────────────
-    // PR A — TurnPhase dual-write
+    // TurnPhase transitions — single source of truth (since PR G).
     //
     // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §5.
-    // Every command that mutates legacy {turnActive, stopping,
-    // streaming.active} must also write the corresponding turnPhase
-    // kind. These tests pin the dual-write invariant — legacy + new
-    // fields agree.
+    // PR A introduced dual-write against legacy {turnActive, stopping,
+    // streaming.active}; PR B migrated views; PR G removed the legacy
+    // fields. These tests now pin the phase transitions on their own.
     // ─────────────────────────────────────────────────────────────────
-    describe("TurnPhase dual-write (PR A)", () => {
-        it("initialState starts in turnPhase Idle", () => {
+    describe("TurnPhase transitions", () => {
+        it("initialState starts in turnPhase Idle (and not subscribed)", () => {
             const s = mk();
             expect(s.turnPhase).toEqual({ kind: "Idle" });
-            // Legacy invariant: nothing is "working" yet.
-            expect(s.turnActive).toBe(false);
-            expect(s.stopping).toBe(false);
-            expect(s.streaming.active).toBe(false);
+            expect(isWorking(s)).toBe(false);
+            expect(s.lastEventMs).toBeNull();
         });
 
-        it("TurnStart sets phase to Submitting AND turnActive=true", () => {
+        it("TurnStart sets phase to Submitting", () => {
             const s0 = ready(100);
             const r = update(s0, { type: "TurnStart", at: 110 });
-            // Legacy
-            expect(r.state.turnActive).toBe(true);
-            // New phase
             expect(r.state.turnPhase.kind).toBe("Submitting");
+            expect(isWorking(r.state)).toBe(true);
             if (r.state.turnPhase.kind === "Submitting") {
                 expect(r.state.turnPhase.submittedAt).toBe(110);
                 expect(r.state.turnPhase.pendingContent).toBe("");
@@ -518,11 +545,11 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("Suppressed TurnStart does NOT advance turnPhase", () => {
-            // Stream inactive → suppressed; phase stays Idle.
+            // Stream unsubscribed → suppressed; phase stays Idle.
             const start = mk();
             const r = update(start, { type: "TurnStart", at: 100 });
             expect(r.state.turnPhase.kind).toBe("Idle");
-            expect(r.state.turnActive).toBe(false);
+            expect(isWorking(r.state)).toBe(false);
         });
 
         it("StreamSubscribe after Submitting advances phase to Streaming", () => {
@@ -540,15 +567,15 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.toolsActive).toBe(0);
                 expect(r.state.turnPhase.lastEventMs).toBe(120);
             }
-            // Legacy still consistent.
-            expect(r.state.streaming.active).toBe(true);
-            expect(r.state.turnActive).toBe(true);
+            // Subscription gate (PR G: replaces `streaming.active`).
+            expect(r.state.lastEventMs).toBe(120);
+            expect(isWorking(r.state)).toBe(true);
         });
 
         it("StreamSubscribe from Idle keeps phase Idle (no spontaneous promotion)", () => {
             const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const r = update(s0, { type: "StreamSubscribe", at: 100 });
-            expect(r.state.streaming.active).toBe(true);
+            expect(r.state.lastEventMs).toBe(100);
             expect(r.state.turnPhase.kind).toBe("Idle");
         });
 
@@ -571,14 +598,11 @@ describe("agent-pane-state reducer", () => {
             }
         });
 
-        it("TurnEnd transitions phase to Done.completed AND clears turnActive/stopping", () => {
+        it("TurnEnd transitions phase to Done.completed", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const r = update(s1, { type: "TurnEnd", stats: null }, 200);
-            // Legacy
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
-            // New phase
+            expect(isWorking(r.state)).toBe(false);
             expect(r.state.turnPhase.kind).toBe("Done");
             if (r.state.turnPhase.kind === "Done") {
                 expect(r.state.turnPhase.outcome).toBe("completed");
@@ -586,7 +610,7 @@ describe("agent-pane-state reducer", () => {
             }
         });
 
-        it("TurnEnd while stopping was set produces Done.stopped", () => {
+        it("TurnEnd while in Interrupting produces Done.stopped", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "RequestStop", at: 115 }).state;
@@ -595,27 +619,22 @@ describe("agent-pane-state reducer", () => {
             if (r.state.turnPhase.kind === "Done") {
                 expect(r.state.turnPhase.outcome).toBe("stopped");
             }
-            expect(r.state.stopping).toBe(false);
-            expect(r.state.turnActive).toBe(false);
+            expect(isWorking(r.state)).toBe(false);
         });
 
-        it("TurnReset returns phase to Idle AND clears turnActive/stopping", () => {
+        it("TurnReset returns phase to Idle", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "RequestStop", at: 115 }).state;
             const r = update(s2, { type: "TurnReset" });
             expect(r.state.turnPhase).toEqual({ kind: "Idle" });
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
+            expect(isWorking(r.state)).toBe(false);
         });
 
-        it("RequestStop while working sets phase to Interrupting AND stopping=true", () => {
+        it("RequestStop while working sets phase to Interrupting", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const r = update(s1, { type: "RequestStop", at: 120 });
-            // Legacy
-            expect(r.state.stopping).toBe(true);
-            // New phase
             expect(r.state.turnPhase.kind).toBe("Interrupting");
             if (r.state.turnPhase.kind === "Interrupting") {
                 expect(r.state.turnPhase.reason).toBe("user");
@@ -623,17 +642,20 @@ describe("agent-pane-state reducer", () => {
             }
         });
 
-        it("RequestStop while Idle sets legacy stopping but leaves phase Idle", () => {
-            // Edge case: stop pressed without a turn in flight. The
-            // legacy boolean still flips; the phase is unaffected
-            // (there's no working state to interrupt).
+        it("RequestStop while Idle is a same-ref no-op (PR G)", () => {
+            // PR G removed the legacy `stopping` boolean. The pre-PR-G
+            // behaviour flipped `stopping` true even with no turn in
+            // flight; that was a latent bug surface (the stop could
+            // not actually be acted on). The new behaviour leaves
+            // state untouched and only emits the audit event.
             const start = mk();
             const r = update(start, { type: "RequestStop", at: 100 });
-            expect(r.state.stopping).toBe(true);
+            expect(r.state).toBe(start);
             expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.events[0]).toMatchObject({ type: "stop-requested", at: 100 });
         });
 
-        it("StopFailed while Interrupting rolls back to Streaming AND clears stopping", () => {
+        it("StopFailed while Interrupting rolls back to Streaming (subscribed)", () => {
             // Build up: ready → submit → re-subscribe to Streaming →
             // stop → stop-rpc-fails.
             const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
@@ -644,31 +666,27 @@ describe("agent-pane-state reducer", () => {
             const s4 = update(s3, { type: "RequestStop", at: 130 }).state;
             expect(s4.turnPhase.kind).toBe("Interrupting");
             const r = update(s4, { type: "StopFailed" });
-            // Legacy
-            expect(r.state.stopping).toBe(false);
-            // New phase — rolled back because stream is still active.
+            // Rolled back because stream is still subscribed.
             expect(r.state.turnPhase.kind).toBe("Streaming");
         });
 
-        it("StopFailed when not Interrupting just clears stopping (phase unchanged)", () => {
+        it("StopFailed when not Interrupting is a no-op (phase unchanged)", () => {
+            // PR G: previously cleared the legacy `stopping` flag; now
+            // there's nothing to clear and the phase is unchanged.
             const start = mk();
-            const flagged: AgentPaneState = { ...start, stopping: true };
-            const r = update(flagged, { type: "StopFailed" });
-            expect(r.state.stopping).toBe(false);
-            // Phase was Idle and remains Idle.
+            const r = update(start, { type: "StopFailed" });
             expect(r.state.turnPhase.kind).toBe("Idle");
         });
 
         it("StreamUnsubscribe while working surfaces Disconnected.{lastKind, lastConnectedAt}", () => {
             const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
-            // Phase is Submitting (legacy turnActive=true).
             expect(s1.turnPhase.kind).toBe("Submitting");
             const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
-            // Legacy: stream + turnActive cleared.
-            expect(r.state.streaming.active).toBe(false);
-            expect(r.state.turnActive).toBe(false);
-            // New (PR F): Disconnected with Submitting as the lost kind,
+            // Subscription cleared (PR G: replaces `streaming.active=false`).
+            expect(r.state.lastEventMs).toBeNull();
+            expect(isWorking(r.state)).toBe(false);
+            // Disconnected with Submitting as the lost kind,
             // lastConnectedAt = command.at, and a literal reason.
             expect(r.state.turnPhase.kind).toBe("Disconnected");
             if (r.state.turnPhase.kind === "Disconnected") {
@@ -678,14 +696,10 @@ describe("agent-pane-state reducer", () => {
             }
         });
 
-        it("StreamUnsubscribe while Idle is a same-ref no-op (PR F)", () => {
-            // PR F tightened the contract: an unsubscribe from a non-
-            // working phase (Idle / Done / Disconnected) is idempotent
-            // and returns the same state reference. The pre-PR-F
-            // behaviour also cleared `streaming.active` here, but that
-            // was a side-effect of the dual-write era — the legacy
-            // boolean leaves with PR G and the new no-op shape is the
-            // canonical one. The view does not observe a phantom
+        it("StreamUnsubscribe while Idle is a same-ref no-op", () => {
+            // An unsubscribe from a non-working phase (Idle / Done /
+            // Disconnected) is idempotent and returns the same state
+            // reference. The view does not observe a phantom
             // disconnect (no event emitted).
             const s0 = update(mk(), { type: "InitReady", at: 100 }).state;
             const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
@@ -851,30 +865,28 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.turnPhase.kind).toBe("Idle");
         });
 
-        it("dual-write invariant: legacy.turnActive ↔ phase.kind ∈ working set", () => {
-            // Walk a normal turn and assert the invariant at every step.
-            const s0 = ready(100); // Idle, !turnActive
-            expect(s0.turnActive).toBe(false);
-            expect(workingByLegacy(s0)).toBe(false);
+        it("isWorking tracks the working-phase set across a full turn", () => {
+            // Walk a normal turn and assert isWorking flips at the
+            // right boundaries. PR G: this replaced the "legacy ↔
+            // phase dual-write invariant" test since the legacy
+            // booleans no longer exist.
+            const s0 = ready(100); // Idle
             expect(isWorking(s0)).toBe(false);
 
-            const s1 = update(s0, { type: "TurnStart", at: 110 }).state; // Submitting, turnActive
-            expect(s1.turnActive).toBe(true);
-            expect(workingByLegacy(s1)).toBe(true);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state; // Submitting
+            expect(s1.turnPhase.kind).toBe("Submitting");
             expect(isWorking(s1)).toBe(true);
 
             const s2 = update(s1, { type: "StreamSubscribe", at: 120 }).state; // Streaming
-            expect(s2.turnActive).toBe(true);
+            expect(s2.turnPhase.kind).toBe("Streaming");
             expect(isWorking(s2)).toBe(true);
 
             const s3 = update(s2, { type: "RequestStop", at: 130 }).state; // Interrupting
-            expect(s3.stopping).toBe(true);
+            expect(s3.turnPhase.kind).toBe("Interrupting");
             expect(isWorking(s3)).toBe(true);
 
             const s4 = update(s3, { type: "TurnEnd", stats: null }, 140).state; // Done
-            expect(s4.turnActive).toBe(false);
-            expect(s4.stopping).toBe(false);
-            expect(workingByLegacy(s4)).toBe(false);
+            expect(s4.turnPhase.kind).toBe("Done");
             expect(isWorking(s4)).toBe(false);
         });
     });
@@ -1029,9 +1041,7 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.outcome).toBe("interrupted");
                 expect(r.state.turnPhase.finishedAt).toBe(deadline);
             }
-            // Legacy fields cleared the same way TurnEnd would clear them.
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
+            // Per-turn sidecars cleared the same way TurnEnd does.
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnTokens).toBe(null);
             // Animation invariant: isWorking flips false.
@@ -1236,9 +1246,7 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.outcome).toBe("errored");
                 expect(r.state.turnPhase.finishedAt).toBe(deadline);
             }
-            // Legacy fields cleared the same way TurnEnd would clear them.
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
+            // Per-turn sidecars cleared the same way TurnEnd does.
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnTokens).toBe(null);
             // Animation invariant: isWorking flips false.
@@ -1252,8 +1260,8 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("SubmitTimeoutElapsed clears live tool + tokens that snuck in pre-promotion", () => {
-            // Edge case: the dispatch layer might set legacy currentTool
-            // / turnTokens during Submitting before the phase promotion
+            // Edge case: the dispatch layer might set currentTool /
+            // turnTokens during Submitting before the phase promotion
             // path actually runs (e.g. an ill-ordered call site). The
             // forced-Done.errored path must still scrub the sidecars so
             // the next turn starts clean.
@@ -1617,9 +1625,7 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.outcome).toBe("errored");
                 expect(r.state.turnPhase.finishedAt).toBe(stalledAt);
             }
-            // Legacy fields cleared, same as TurnEnd / interrupt timeout.
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
+            // Per-turn sidecars cleared, same as TurnEnd / interrupt timeout.
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnTokens).toBe(null);
             // Animation invariant: isWorking flips false.
@@ -1800,8 +1806,8 @@ describe("agent-pane-state reducer", () => {
             }).state;
             expect(s3.turnPhase.kind).toBe("Streaming");
             // Tool + tokens so we can verify they're cleared on
-            // disconnect (legacy cleanup mirrors the bounded force-
-            // transition arms — see reducer.ts §StreamUnsubscribe).
+            // disconnect (cleanup mirrors the bounded force-transition
+            // arms — see reducer.ts §StreamUnsubscribe).
             const s4 = update(s3, { type: "ToolStart", name: "Read" }, 210)
                 .state;
             const s5 = update(s4, { type: "TokensIn", input: 42 }, 220)
@@ -1817,10 +1823,10 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.lastConnectedAt).toBe(300);
                 expect(r.state.turnPhase.reason).toBe("stream-unsubscribed");
             }
-            // Legacy cleanup.
-            expect(r.state.streaming.active).toBe(false);
-            expect(r.state.turnActive).toBe(false);
-            expect(r.state.stopping).toBe(false);
+            // Subscription cleared (PR G: `lastEventMs !== null` replaces
+            // the legacy `streaming.active` boolean).
+            expect(r.state.lastEventMs).toBeNull();
+            // Per-turn sidecars cleared.
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnTokens).toBe(null);
             // Animation invariant: isWorking false; isDisconnected true.
@@ -1872,8 +1878,8 @@ describe("agent-pane-state reducer", () => {
                 expect(r.state.turnPhase.lastKind).toBe("Interrupting");
                 expect(r.state.turnPhase.lastConnectedAt).toBe(300);
             }
-            // stopping was set when we entered Interrupting — must clear.
-            expect(r.state.stopping).toBe(false);
+            // Working phase exited (PR G: was previously asserted on the
+            // legacy `stopping` boolean).
             expect(isWorking(r.state)).toBe(false);
             expect(isDisconnected(r.state)).toBe(true);
         });
@@ -1881,7 +1887,7 @@ describe("agent-pane-state reducer", () => {
         it("StreamUnsubscribe while Idle is a same-ref no-op", () => {
             // Already in Idle (no working state to disconnect from).
             // The unsubscribe is non-news; no event, no state churn.
-            const s0 = ready(100); // Idle + streaming.active=true
+            const s0 = ready(100); // Idle + subscribed (lastEventMs set)
             expect(s0.turnPhase.kind).toBe("Idle");
             const r = update(s0, { type: "StreamUnsubscribe", at: 200 });
             expect(r.state).toBe(s0);
@@ -1942,8 +1948,10 @@ describe("agent-pane-state reducer", () => {
             // Now the dispatcher (or the reconnect button) re-subscribes.
             const r = update(s3, { type: "StreamSubscribe", at: 400 });
             expect(r.state.turnPhase.kind).toBe("Idle");
-            // streaming.active true again so a fresh TurnStart can fire.
-            expect(r.state.streaming.active).toBe(true);
+            // Subscribed again (PR G: `lastEventMs !== null` replaces
+            // the legacy `streaming.active === true` check) so a fresh
+            // TurnStart can fire.
+            expect(r.state.lastEventMs).toBe(400);
             // No working state → no watchdog re-arm event. Just the
             // standard `stream-subscribed` event.
             expect(r.events).toHaveLength(1);
@@ -2012,12 +2020,6 @@ describe("agent-pane-state reducer", () => {
     });
 });
 
-/**
- * Convenience: the "working" predicate as derived from the legacy
- * booleans only. Used to pin the dual-write invariant — must agree
- * with `isWorking(state)` (which reads turnPhase). PR G removes this
- * once the legacy fields are gone.
- */
-function workingByLegacy(state: AgentPaneState): boolean {
-    return state.turnActive || state.stopping;
-}
+// `workingByLegacy` was the dual-write invariant helper (turnActive ||
+// stopping) — removed in PR G alongside the legacy fields it read.
+// Use `isWorking(state)` directly.

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -2,25 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Pure reducer for the agent pane's lifecycle/turn/tool/tokens/stopping/
+ * Pure reducer for the agent pane's lifecycle/turn/tool/tokens/
  * pending state. See docs/specs/agent-pane-document-reducer-2026-05-03.md
  * (slice #1 — pattern reference) and frontend-reducer-conventions-2026-05-03.md.
  *
  * Invariants enforced:
- *   1. turnActive cannot be set while streaming inactive (suppressed).
- *   2. turnActive cannot be set while initPhase.kind === "InitPending"
- *      (suppressed). After `InitFailed` we fail open — see the
- *      `TurnStart` arm.
- *   3. stopping clears automatically on TurnEnd / TurnReset.
- *   4. currentTool and turnTokens clear on TurnEnd / TurnReset.
- *   5. pending FIFO; accepting/rejecting/expiring unknown ids is no-op.
- *   6. StreamFlushObserved is a no-op when streaming inactive.
- *   7. StreamWatchdogTick is a no-op when streaming inactive or
+ *   1. A turn cannot enter Submitting (TurnStart) while the stream is
+ *      unsubscribed (suppressed).
+ *   2. A turn cannot enter Submitting while initPhase.kind ===
+ *      "InitPending" (suppressed). After `InitFailed` we fail open —
+ *      see the `TurnStart` arm.
+ *   3. currentTool and turnTokens clear on TurnEnd / TurnReset.
+ *   4. pending FIFO; accepting/rejecting/expiring unknown ids is no-op.
+ *   5. StreamFlushObserved is a no-op when the stream is unsubscribed.
+ *   6. StreamWatchdogTick is a no-op when the stream is unsubscribed or
  *      lastEventMs is null (no events seen yet).
- *   8. Init lifecycle transitions are one-way: InitStart / InitReady /
+ *   7. Init lifecycle transitions are one-way: InitStart / InitReady /
  *      InitFailed are no-ops once the pane has reached a terminal init
  *      state (InitReady / InitFailed). Re-entering pending requires a
  *      fresh pane slot.
+ *
+ * Stream-subscription gate: since PR G the legacy `streaming.active`
+ * boolean is gone. `state.lastEventMs !== null` is the canonical "is
+ * the stream subscribed?" check — both fields always moved in lockstep
+ * (only StreamSubscribe / StreamUnsubscribe ever touched either) so
+ * the substitution is mechanical. The {@link isStreamSubscribed} selector
+ * wraps the check.
  */
 
 import {
@@ -148,7 +155,6 @@ export function update(
                     ...state,
                     streaming: {
                         ...state.streaming,
-                        active: true,
                         lastEventTime: command.at,
                     },
                     lastEventMs: command.at,
@@ -159,9 +165,9 @@ export function update(
         }
 
         case "StreamUnsubscribe": {
-            // Dual-write: if we were working (Submitting/Streaming/
-            // Interrupting), surface a Disconnected phase so the view
-            // can show re-attach UX. Otherwise (Idle / Done / already
+            // If we were working (Submitting/Streaming/Interrupting),
+            // surface a Disconnected phase so the view can show
+            // re-attach UX. Otherwise (Idle / Done / already
             // Disconnected) the unsubscribe is idempotent — return the
             // same state ref so reactive consumers don't see a phantom
             // tick. Spec §6.4 / PR F.
@@ -169,10 +175,9 @@ export function update(
             const wasWorking =
                 k === "Submitting" || k === "Streaming" || k === "Interrupting";
             if (!wasWorking) {
-                // Same-ref no-op for Idle / Done / Disconnected. The
-                // legacy fields are already in the cleared shape there
-                // (no in-flight turn), so there's nothing to scrub. No
-                // event either — the unsubscribe is non-news.
+                // Same-ref no-op for Idle / Done / Disconnected. There
+                // is no in-flight turn so per-turn sidecars are already
+                // cleared. No event either — the unsubscribe is non-news.
                 return { state, events: [] };
             }
             const reason: DisconnectReason = "stream-unsubscribed";
@@ -186,14 +191,12 @@ export function update(
             return {
                 state: {
                     ...state,
-                    streaming: { ...state.streaming, active: false },
-                    // Legacy cleanup mirrors the bounded force-transition
-                    // arms (InterruptTimeoutElapsed / SubmitTimeoutElapsed /
-                    // StreamStalled): a forced exit from a working state
-                    // settles the animation and clears per-turn sidecars
-                    // so the header doesn't show ghost tool / token chips.
-                    turnActive: false,
-                    stopping: false,
+                    // Per-turn sidecar cleanup mirrors the bounded
+                    // force-transition arms (InterruptTimeoutElapsed /
+                    // SubmitTimeoutElapsed / StreamStalled): a forced
+                    // exit from a working state settles the animation
+                    // and clears tool / token chips so the header
+                    // doesn't show ghosts.
                     currentTool: null,
                     turnTokens: null,
                     lastEventMs: null,
@@ -212,7 +215,11 @@ export function update(
         }
 
         case "StreamFlushObserved": {
-            if (!state.streaming.active) {
+            // Gate: only mutate if the stream is currently subscribed.
+            // PR G — previously `state.streaming.active`; the
+            // `lastEventMs !== null` check is exactly equivalent
+            // (both moved in lockstep on subscribe/unsubscribe).
+            if (state.lastEventMs == null) {
                 return { state, events: [] };
             }
             const newBuf = state.streaming.bufferSize + command.addedCount;
@@ -260,8 +267,10 @@ export function update(
         }
 
         case "StreamWatchdogTick": {
-            // No-op when stream inactive or no event has ever been seen.
-            if (!state.streaming.active || state.lastEventMs == null) {
+            // No-op when stream unsubscribed (lastEventMs null also
+            // covers "no event seen yet" — same field since PR G
+            // dropped the redundant `streaming.active` boolean).
+            if (state.lastEventMs == null) {
                 return { state, events: [] };
             }
             const idleSinceMs = command.nowMs - state.lastEventMs;
@@ -281,8 +290,11 @@ export function update(
         }
 
         case "TurnStart": {
-            // Invariant 1: can't start a turn without an active stream.
-            if (!state.streaming.active) {
+            // Invariant 1: can't start a turn without a subscribed
+            // stream. PR G: `state.lastEventMs !== null` replaces the
+            // dropped `state.streaming.active` boolean — both moved
+            // in lockstep so the gate is unchanged.
+            if (state.lastEventMs == null) {
                 return {
                     state,
                     events: [
@@ -328,13 +340,12 @@ export function update(
             return {
                 state: {
                     ...state,
-                    turnActive: true,
                     sessionStats: null, // clear stale stats from prior turn
                     lastEventMs: command.at,
-                    // Dual-write: Submitting until first stream event /
-                    // subscribe transitions us to Streaming. PR A doesn't
-                    // know the pendingContent (TurnStart payload doesn't
-                    // carry it); a later PR can thread that through.
+                    // Submitting until the first stream event /
+                    // subscribe transitions us to Streaming. The
+                    // TurnStart payload doesn't carry pendingContent;
+                    // a later PR can thread that through.
                     turnPhase: {
                         kind: "Submitting",
                         submittedAt: command.at,
@@ -346,7 +357,12 @@ export function update(
         }
 
         case "TurnEnd": {
-            const stoppingWasSet = state.stopping;
+            // PR G: replaces the legacy `state.stopping` boolean. A
+            // stop-in-flight is exactly `turnPhase.kind === "Interrupting"`
+            // since RequestStop is the only command that enters
+            // Interrupting and the same arms that previously cleared
+            // `stopping` are the ones that leave Interrupting.
+            const stoppingWasSet = state.turnPhase.kind === "Interrupting";
             // Merge stats with live turn-tokens (mirrors prior finalizeTurn
             // logic — see PR #549 reagent/codex P1 reference).
             const merged = mergeStats(command.stats, state.turnTokens);
@@ -394,8 +410,6 @@ export function update(
                     sessionStats: merged,
                     currentTool: null,
                     turnTokens: null,
-                    turnActive: false,
-                    stopping: false,
                     turnPhase: {
                         kind: "Done",
                         outcome,
@@ -419,10 +433,9 @@ export function update(
                     sessionStats: null,
                     currentTool: null,
                     turnTokens: null,
-                    turnActive: false,
-                    // stopping is part of turn state — clear it too.
-                    stopping: false,
-                    // Dual-write: TurnReset is a wholesale clear → Idle.
+                    // TurnReset is a wholesale clear → Idle. The
+                    // working/stopping cascade lives entirely on
+                    // turnPhase since PR G.
                     turnPhase: { kind: "Idle" },
                 },
                 events: [{ type: "turn-reset" }],
@@ -494,20 +507,30 @@ export function update(
         }
 
         case "RequestStop": {
-            // Dual-write: if a turn is in flight, surface Interrupting;
-            // otherwise keep the phase as-is (stopping is set but there
-            // is no real working state — the legacy boolean alone is
-            // enough until the view migrates in PR B).
+            // If a turn is in flight, surface Interrupting; otherwise
+            // the stop is a no-op (no working state to interrupt).
+            // PR G removed the legacy `stopping` boolean — there is no
+            // hidden "stop pending" mode outside the working set.
             const k = state.turnPhase.kind;
             const isWorking =
                 k === "Submitting" || k === "Streaming" || k === "Interrupting";
+            if (!isWorking) {
+                // No-op stop — emit `stop-requested` for diagnostic
+                // continuity but leave state untouched. The legacy
+                // boolean used to flip true here even with no turn in
+                // flight; that was a latent bug surface (the stop
+                // could not actually be acted on) and PR G drops it.
+                return {
+                    state,
+                    events: [{ type: "stop-requested", at: command.at }],
+                };
+            }
             // PR C: only schedule the bounded-interrupt watchdog when we
             // actually CROSS INTO Interrupting (not when we're already
             // there — that would double-arm the timeout). Spec §8: SIGINT
             // is only emitted once on entry; the timeout follows the same
             // rule so a second Stop press doesn't reset the deadline.
-            const enteringInterrupting =
-                isWorking && k !== "Interrupting";
+            const enteringInterrupting = k !== "Interrupting";
             // Codex P2 on #991: preserve the original sigintSentAt on a
             // repeated Stop press. The timeout was armed from the FIRST
             // press's deadline; rebuilding the phase with a fresh
@@ -515,9 +538,8 @@ export function update(
             // that doesn't match the active deadline. When we're
             // already Interrupting, reuse the existing phase so the
             // timestamp stays pinned to the original SIGINT.
-            const nextPhase: TurnPhase = !isWorking
-                ? state.turnPhase
-                : k === "Interrupting"
+            const nextPhase: TurnPhase =
+                k === "Interrupting"
                     ? state.turnPhase
                     : {
                           kind: "Interrupting",
@@ -534,31 +556,34 @@ export function update(
                 });
             }
             return {
-                state: { ...state, stopping: true, turnPhase: nextPhase },
+                state: { ...state, turnPhase: nextPhase },
                 events,
             };
         }
 
         case "StopFailed": {
-            // Dual-write: rollback Interrupting → previous working kind
-            // best-effort. We don't track the prior kind on Interrupting,
-            // so use the stream's liveness as the deterministic signal:
-            //   streaming.active  → Streaming (the most common case)
-            //   else              → Idle (no longer in a turn)
+            // Rollback Interrupting → previous working kind best-effort.
+            // We don't track the prior kind on Interrupting, so use
+            // the stream-subscribed gate as the deterministic signal:
+            //   subscribed (lastEventMs !== null) → Streaming (common case)
+            //   else                              → Idle (no longer in a turn)
+            // Non-Interrupting phases are a no-op — there's nothing
+            // to roll back. PR G dropped the legacy `stopping` boolean
+            // that previously also cleared here.
             const k = state.turnPhase.kind;
             const nextPhase: TurnPhase =
                 k === "Interrupting"
-                    ? state.streaming.active
+                    ? state.lastEventMs !== null
                         ? {
                               kind: "Streaming",
                               bufferSize: state.streaming.bufferSize,
                               toolsActive: 0,
-                              lastEventMs: state.lastEventMs ?? nowMs,
+                              lastEventMs: state.lastEventMs,
                           }
                         : { kind: "Idle" }
                     : state.turnPhase;
             return {
-                state: { ...state, stopping: false, turnPhase: nextPhase },
+                state: { ...state, turnPhase: nextPhase },
                 events: [{ type: "stop-failed" }],
             };
         }
@@ -582,11 +607,9 @@ export function update(
             return {
                 state: {
                     ...state,
-                    // Legacy: a forced exit from Interrupting is the
-                    // same shape as a graceful TurnEnd for the boolean
-                    // consumers (turnActive=false, stopping cleared).
-                    turnActive: false,
-                    stopping: false,
+                    // Per-turn sidecars cleared the same way TurnEnd
+                    // does — the working spinner settles and the
+                    // header doesn't show ghost tool/token chips.
                     currentTool: null,
                     turnTokens: null,
                     turnPhase: {
@@ -623,12 +646,9 @@ export function update(
             return {
                 state: {
                     ...state,
-                    // Legacy cleanup mirrors the InterruptTimeoutElapsed
-                    // arm — a forced exit from a working state clears
-                    // the boolean consumers (turnActive=false, stopping
-                    // cleared) and per-turn sidecars.
-                    turnActive: false,
-                    stopping: false,
+                    // Per-turn sidecar cleanup mirrors the
+                    // InterruptTimeoutElapsed arm — a forced exit from
+                    // a working state clears tool / token chips.
                     currentTool: null,
                     turnTokens: null,
                     turnPhase: {
@@ -681,12 +701,9 @@ export function update(
             return {
                 state: {
                     ...state,
-                    // Legacy: a forced exit from Streaming carries the
-                    // same boolean shape as TurnEnd would — animation
-                    // settles, currentTool/turnTokens cleared so the
-                    // header doesn't show ghost tool/token chips.
-                    turnActive: false,
-                    stopping: false,
+                    // Per-turn sidecar cleanup mirrors TurnEnd —
+                    // animation settles, currentTool/turnTokens cleared
+                    // so the header doesn't show ghost tool/token chips.
                     currentTool: null,
                     turnTokens: null,
                     turnPhase: {
@@ -783,18 +800,20 @@ export function update(
 /**
  * Bump `lastEventMs` to "now" only while the stream is subscribed. Used
  * by tool/token transitions which are observable stream activity. Skip
- * the bump when streaming is inactive — those would correspond to stale
- * commands and shouldn't reset the watchdog clock.
+ * the bump when the stream is unsubscribed — those would correspond to
+ * stale commands and shouldn't reset the watchdog clock.
  *
- * PR A dual-write: if the phase is Streaming, also update its
- * `lastEventMs` and apply `toolsDelta` to `toolsActive` (clamped ≥ 0).
+ * PR G: the subscribed gate is now `state.lastEventMs !== null` (was
+ * `state.streaming.active`; they always moved in lockstep). If the
+ * phase is Streaming, also update its `lastEventMs` and apply
+ * `toolsDelta` to `toolsActive` (clamped ≥ 0).
  */
 function bumpEvent(
     state: AgentPaneState,
     nowMs: number,
     toolsDelta: number,
 ): AgentPaneState {
-    if (!state.streaming.active) return state;
+    if (state.lastEventMs == null) return state;
     const next: AgentPaneState = { ...state, lastEventMs: nowMs };
     if (next.turnPhase.kind === "Streaming") {
         next.turnPhase = {

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -6,9 +6,18 @@
  * docs/specs/frontend-reducer-architecture-2026-05-03.md).
  *
  * Bundles the per-pane atoms that have cohesive cross-atom invariants:
- *   streaming, sessionStats, currentTool, turnTokens, turnActive,
- *   stopping, pendingMessages, plus init phase and stream-watchdog fields
- *   added in issue #728.
+ *   streaming, sessionStats, currentTool, turnTokens, pendingMessages,
+ *   plus init phase, turn phase, and stream-watchdog fields added in
+ *   issue #728.
+ *
+ * PR G (turn-phase cleanup): the legacy `turnActive` / `stopping`
+ * booleans and `streaming.active` boolean were dropped — every view
+ * now reads `isWorking(state)` / `state.turnPhase.kind` /
+ * `isDisconnected(state)` instead. The reducer-internal "is the
+ * stream subscribed?" gate (previously `state.streaming.active`)
+ * now uses `state.lastEventMs !== null` — both moved in lockstep
+ * already (only `StreamSubscribe` / `StreamUnsubscribe` ever set
+ * them), so the substitution is mechanical.
  *
  * The agent document (message list) lives in its own slice
  * (`agent-document/`); reducer scope is intentionally separate per the
@@ -42,13 +51,14 @@ export type InitPhase =
     | { kind: "InitFailed"; at: number; reason: string };
 
 // ─────────────────────────────────────────────────────────────────────────
-// TurnPhase discriminated union (PR A — dual-write phase)
+// TurnPhase discriminated union — single source of truth for the turn
+// lifecycle (since PR G).
 //
 // SPEC: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §5.
 // This union replaces the scattered { turnActive, stopping, streaming.active }
-// booleans with a single explicit phase. PR A is ADDITIVE: the legacy
-// booleans stay and the reducer dual-writes both. View migration is PR B;
-// the legacy fields are removed in PR G.
+// booleans that PR A introduced as a dual-write, PR B migrated the view
+// off, and PR G removed entirely. Consumers project via `isWorking` /
+// `isDisconnected` / `state.turnPhase.kind`.
 // ─────────────────────────────────────────────────────────────────────────
 
 /** Why the turn entered Interrupting. */
@@ -91,8 +101,10 @@ export type KindBeforeDisconnect =
 export type DisconnectReason = "stream-unsubscribed" | "transport-error";
 
 /**
- * Single source of truth for the turn lifecycle. PR A introduces this
- * alongside the legacy booleans — both are written by the reducer.
+ * Single source of truth for the turn lifecycle. Since PR G this is the
+ * only place where "is the agent working", "is a stop in flight", and
+ * "did the stream drop" are encoded — the legacy `turnActive` /
+ * `stopping` / `streaming.active` booleans have been removed.
  *
  *   Idle          : no turn in flight.
  *   Submitting    : user pressed send; awaiting `StreamSubscribe` / first
@@ -142,15 +154,20 @@ export type TurnPhase =
 /**
  * The reducer's state. Each field maps 1:1 to a Solid signal that the
  * agent pane projects from. The reducer enforces invariants ACROSS
- * fields (e.g. turnActive can't be true while streaming inactive).
+ * fields (e.g. a turn can't enter Submitting/Streaming while the
+ * stream is unsubscribed — see the `TurnStart` arm).
+ *
+ * PR G cleanup: `turnActive` / `stopping` (top-level) and `active` (on
+ * `streaming`) have all been removed. `state.turnPhase.kind` is the
+ * sole working-state encoding; "is the stream subscribed?" is now
+ * derived from `state.lastEventMs !== null` (cleared atomically with
+ * the stream on `StreamSubscribe` / `StreamUnsubscribe`).
  */
 export interface AgentPaneState {
     streaming: StreamingState;
     sessionStats: SessionStats | null;
     currentTool: string | null;
     turnTokens: TurnTokens | null;
-    turnActive: boolean;
-    stopping: boolean;
     pending: PendingMessage[];
     /**
      * Init phase — `InitPending` until history fetch resolves (or fails).
@@ -160,32 +177,49 @@ export interface AgentPaneState {
     initPhase: InitPhase;
     /**
      * Wall-clock ms of the last observable stream activity (subscribe,
-     * flush, tool, tokens). Drives the stuck-stream watchdog. null
-     * when no stream is active.
+     * flush, tool, tokens). Drives the stuck-stream watchdog.
+     *
+     * Doubles as the "is the stream subscribed?" gate since PR G:
+     * `lastEventMs !== null` ⇔ the pane has seen a `StreamSubscribe`
+     * that no subsequent `StreamUnsubscribe` has cleared. Both fields
+     * always moved in lockstep when the legacy `streaming.active`
+     * boolean existed, so the substitution is exact.
      */
     lastEventMs: number | null;
     /**
-     * PR A (dual-write): the single-source-of-truth turn phase. The
-     * reducer writes BOTH this and the legacy {turnActive, stopping,
-     * streaming.active} fields on every command. Subsequent PRs (B
-     * onward) migrate view code off the legacy booleans onto this
-     * field; PR G removes the booleans.
+     * Single-source-of-truth turn phase. PR A added it with dual-write
+     * against the legacy `turnActive` / `stopping` / `streaming.active`
+     * booleans; PR B migrated every view consumer onto it via
+     * `isWorking(state)` / `isDisconnected(state)` /
+     * `state.turnPhase.kind`; PR G removed the legacy fields.
      */
     turnPhase: TurnPhase;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
-    streaming: { active: false, agentId, bufferSize: 0, lastEventTime: 0 },
+    streaming: { agentId, bufferSize: 0, lastEventTime: 0 },
     sessionStats: null,
     currentTool: null,
     turnTokens: null,
-    turnActive: false,
-    stopping: false,
     pending: [],
     initPhase: { kind: "InitPending" },
     lastEventMs: null,
     turnPhase: { kind: "Idle" },
 });
+
+/**
+ * Selector — `true` iff the pane currently holds a stream subscription
+ * (i.e. between `StreamSubscribe` and the next `StreamUnsubscribe`).
+ *
+ * Since PR G, this replaces the legacy `state.streaming.active`
+ * boolean. The two were always equivalent — both were set by
+ * `StreamSubscribe` and cleared by `StreamUnsubscribe`, and nothing
+ * else touched either. `lastEventMs !== null` is the cheaper
+ * single-field check.
+ */
+export function isStreamSubscribed(state: AgentPaneState): boolean {
+    return state.lastEventMs !== null;
+}
 
 /** Selector — `true` iff the pane has finished its initial history load. */
 export function isInitReady(state: AgentPaneState): boolean {
@@ -198,9 +232,9 @@ export function isInitReady(state: AgentPaneState): boolean {
  * Returns true ⇔ `state.turnPhase.kind ∈ {Submitting, Streaming, Interrupting}`.
  * Idle / Done / Disconnected are all "not working".
  *
- * Spec: SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §7. PR A exports this
- * for downstream consumers; the view migration in PR B will rebind the
- * footer's working indicator to this selector.
+ * Spec: SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §7. Since PR G this
+ * is the only "working" predicate — the legacy `turnActive || stopping`
+ * combination has been removed.
  */
 export function isWorking(state: AgentPaneState): boolean {
     return workingFromPhase(state.turnPhase);
@@ -269,8 +303,8 @@ export type AgentPaneCommand =
     /**
      * Stream produced session_end (or fallback timer fired). Final
      * stats merged with current turn-tokens. Clears currentTool,
-     * turnTokens, turnActive, AND stopping (the latter cascades to
-     * "stop applied" without a separate command).
+     * turnTokens, and transitions the phase to Done (interrupting →
+     * Done.stopped, otherwise Done.completed).
      */
     | { type: "TurnEnd"; stats: SessionStats | null }
     /**

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -115,14 +115,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     onCleanup(() => unregisterAgentDocPane(model.blockId));
 
     // Slice #4 — agent-pane-state slot: bundles streaming/sessionStats/
-    // currentTool/turnTokens/turnActive/stopping/pending atoms behind a
-    // single reducer with cross-atom invariants. Same synchronous-register
-    // rule as the agent-document slot.
+    // currentTool/turnTokens/pending atoms behind a single reducer with
+    // cross-atom invariants. Same synchronous-register rule as the
+    // agent-document slot.
     //
-    // `turnPhase` is the PR A / PR B addition — the reducer dual-writes
-    // it alongside the legacy `turnActive` / `stopping` / `streaming.active`
-    // booleans, and the view (see the AgentStatusLine binding below)
-    // reads it via `isWorking(...)`. PR G drops the legacy fields.
+    // `turnPhase` is the single-source-of-truth working/stopping signal
+    // since PR G — the legacy `turnActive` / `stopping` /
+    // `streaming.active` fields and their projection setters have been
+    // removed. The view binds the working animation to
+    // `workingFromPhase(turnPhase)` and the "Stopping…" label to
+    // `turnPhase.kind === "Interrupting"` (see AgentStatusLine below).
     {
         const a = agentAtoms();
         registerAgentPaneStatePane(model.blockId, agentId, {
@@ -130,8 +132,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             sessionStats: a.sessionStatsAtom[1],
             currentTool: a.currentToolAtom[1],
             turnTokens: a.turnTokensAtom[1],
-            turnActive: a.turnActiveAtom[1],
-            stopping: a.stoppingAtom[1],
             pending: a.pendingMessagesAtom[1],
             initPhase: a.initPhaseAtom[1],
             turnPhase: a.turnPhaseAtom[1],
@@ -400,18 +400,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mutations dispatch through agent-document-store; the reducer there
     // owns dedup against in-flight history loads and the truncate-suppress
     // invariant that prevents the mid-session wipe bug.
-    const stoppingAtom = agentAtoms().stoppingAtom;
     const pendingMessagesAtom = agentAtoms().pendingMessagesAtom;
     useAgentStream({
         blockId: model.blockId,
         outputFormat: outputFormat(),
         documentAtom: agentAtoms().documentAtom,
-        streamingStateAtom: agentAtoms().streamingStateAtom,
-        sessionStatsAtom: agentAtoms().sessionStatsAtom,
-        currentToolAtom: agentAtoms().currentToolAtom,
-        turnTokensAtom: agentAtoms().turnTokensAtom,
-        turnActiveAtom: agentAtoms().turnActiveAtom,
-        stoppingAtom,
+        // turnPhase is the SoT for "is a stop in flight" — replaces the
+        // legacy `stoppingAtom` dropped in PR G. useAgentStream needs
+        // it to detect user-initiated stops and append the
+        // "⏹ Interrupted by user" row when session_end lands.
+        turnPhaseAtom: agentAtoms().turnPhaseAtom,
         pendingMessagesAtom,
         enabled: true,
         // Provider id (lowercase catalog key) attributes completed-turn
@@ -442,7 +440,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // defers this to the next animation frame so the mounted node is
         // included in scrollHeight. See SPEC_AGENT_PANE_FOLLOWUPS item #1.
         onSent: () => scrollToBottomFn?.(),
-        stoppingAtom,
         pendingMessagesAtom,
     });
 
@@ -713,11 +710,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
                 showSendNow={() =>
-                    // PR B: view migrated off legacy `turnActive` —
-                    // "send now" appears whenever the agent is working
+                    // "Send now" appears whenever the agent is working
                     // (Submitting / Streaming / Interrupting) and the
-                    // user has at least one queued message. The reducer
-                    // still dual-writes `turnActiveAtom`; PR G drops it.
+                    // user has at least one queued message. PR G removed
+                    // the legacy `turnActive` boolean — the working set
+                    // is now defined purely by `turnPhase`.
                     workingFromPhase(agentAtoms().turnPhaseAtom[0]()) &&
                     pendingMessagesAtom[0]().length > 0
                 }
@@ -758,13 +755,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 activity log doesn't push it off-screen during long
                 agent output.
 
-                PR B (Turn-phase migration): the "working" animation
-                binding now reads `workingFromPhase(turnPhase)` instead
-                of `turnActive || stopping`. The "Stopping…" label still
-                wins over "Working…" via the dedicated `stopping` prop —
-                that maps to `turnPhase.kind === "Interrupting"` so the
-                view no longer touches the legacy boolean. Reducer keeps
-                dual-writing both until PR G. */}
+                Since PR G the working animation reads
+                `workingFromPhase(turnPhase)` (PR B migration) and the
+                "Stopping…" label binding reads `turnPhase.kind ===
+                "Interrupting"`. The legacy `turnActive` / `stopping`
+                booleans were dropped in PR G — turnPhase is the only
+                source. */}
             <AgentStatusLine
                 loading={
                     status.isLoading()

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -73,13 +73,6 @@ export interface UseAgentCommandsOptions {
      */
     onSent?: () => void;
     /**
-     * Flips true when `stopAgent` fires (user pressed Esc on an empty
-     * composer) and back to false when the subsequent `session_end`
-     * arrives. Drives the "Stopping…" status label and the
-     * "⏹ Interrupted by user" chat row appended by `useAgentStream`.
-     */
-    stoppingAtom?: SignalPair<boolean>;
-    /**
      * Queue of messages sent to the backend but not yet accepted.
      * `sendMessage` appends here (instead of directly to the document)
      * and `useAgentStream` removes entries on `agent-message-accepted`,
@@ -238,14 +231,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
 
         // Init guard (issue #728 gap 1, codex P2 on PR #742). The
-        // reducer's TurnStart handler already suppresses turnActive
-        // while initPhase.kind === "InitPending", but that only stops the
-        // local UI state — without this check, the message still gets
-        // queued into pending AND sent over AgentInputCommand. If the
-        // backend accepts before InitReady fires, the accepted-event
-        // TurnStart is also suppressed, leaving the UI showing no active
-        // turn while the agent IS processing. Bail early here so neither
-        // happens.
+        // reducer's TurnStart handler already suppresses the
+        // Submitting transition while initPhase.kind === "InitPending",
+        // but that only stops the local UI state — without this
+        // check, the message still gets queued into pending AND sent
+        // over AgentInputCommand. If the backend accepts before
+        // InitReady fires, the accepted-event TurnStart is also
+        // suppressed, leaving the UI showing no active turn while the
+        // agent IS processing. Bail early here so neither happens.
         const ps = paneSnapshot(opts.blockId);
         if (ps?.initPhase.kind === "InitPending") {
             opts.log("send", "send blocked: history still loading", "warn");
@@ -346,12 +339,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     };
 
     const stopAgent = (): void => {
-        // Flip stopping → status line renders "Stopping…" immediately.
-        // `useAgentStream` owns the finalization: when `session_end`
-        // arrives it clears stopping + appends the "⏹ Interrupted" row,
-        // and it also runs a fallback timer that does the same cleanup
-        // if `session_end` never arrives (killing a subprocess prevents
-        // the CLI from emitting its own terminating result event).
+        // Transition turnPhase → Interrupting; the status line renders
+        // "Stopping…" immediately (via the turnPhase.kind ===
+        // "Interrupting" binding in agent-view.tsx). `useAgentStream`
+        // owns the finalization: when `session_end` arrives it
+        // dispatches TurnEnd (moving phase to Done.stopped) and
+        // appends the "⏹ Interrupted" row, and it also runs a fallback
+        // timer that does the same cleanup if `session_end` never
+        // arrives (killing a subprocess prevents the CLI from emitting
+        // its own terminating result event).
         // Soft variant — cascade-during-dispatch could dispose the pane
         // before this fires; retro 2026-05-23 (agent-pane cascade →
         // replaceChild quick-win).

--- a/frontend/app/view/agent/state.test.ts
+++ b/frontend/app/view/agent/state.test.ts
@@ -18,19 +18,13 @@ describe("createAgentAtoms", () => {
     test("creates signals with correct default values", () => {
         const [getDoc] = atoms.documentAtom;
         const [getStats] = atoms.sessionStatsAtom;
-        const [getTurnActive] = atoms.turnActiveAtom;
+        const [getPhase] = atoms.turnPhaseAtom;
 
         expect(getDoc()).toEqual([]);
         expect(getStats()).toBeNull();
-        expect(getTurnActive()).toBe(false);
-    });
-
-    test("turnActiveAtom can be toggled", () => {
-        const [getTurnActive, setTurnActive] = atoms.turnActiveAtom;
-        setTurnActive(true);
-        expect(getTurnActive()).toBe(true);
-        setTurnActive(false);
-        expect(getTurnActive()).toBe(false);
+        // PR G: the working signal is `turnPhase` only — Idle by default
+        // (the legacy `turnActiveAtom` was dropped).
+        expect(getPhase().kind).toBe("Idle");
     });
 
     test("documentStateAtom has correct default filter", () => {
@@ -45,20 +39,19 @@ describe("createAgentAtoms", () => {
 
     test("separate instances have independent state", () => {
         const atoms2 = createAgentAtoms("test-block-2");
-        const [, setActive1] = atoms.turnActiveAtom;
-        const [getActive1] = atoms.turnActiveAtom;
-        const [getActive2] = atoms2.turnActiveAtom;
+        const [getPhase1, setPhase1] = atoms.turnPhaseAtom;
+        const [getPhase2] = atoms2.turnPhaseAtom;
 
-        setActive1(true);
-        expect(getActive1()).toBe(true);
-        expect(getActive2()).toBe(false);
+        setPhase1({ kind: "Submitting", submittedAt: 1, pendingContent: "" });
+        expect(getPhase1().kind).toBe("Submitting");
+        expect(getPhase2().kind).toBe("Idle");
     });
 
-    // ── PR B (turn-phase view migration) ────────────────────────────────
-    // Verifies that the view's "working" animation binding can be driven
-    // entirely from `turnPhaseAtom` via the `workingFromPhase` selector —
-    // no read of the legacy `turnActiveAtom` / `stoppingAtom` is required.
-    // The reducer still dual-writes the legacy fields (PR G drops them).
+    // ── Turn-phase view binding ─────────────────────────────────────────
+    // The view's working animation and "Stopping…" label both bind to
+    // `turnPhaseAtom`. Verifies the SoT is wired correctly — these are
+    // the only working/stopping signals after PR G dropped the legacy
+    // `turnActiveAtom` / `stoppingAtom`.
     // Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §7.
     test("turnPhaseAtom defaults to Idle and drives workingFromPhase = false", () => {
         const [getPhase] = atoms.turnPhaseAtom;
@@ -95,11 +88,11 @@ describe("createAgentAtoms", () => {
         expect(workingFromPhase(getPhase())).toBe(false);
     });
 
-    test("Interrupting phase drives the 'Stopping…' label (replaces legacy stoppingAtom read)", () => {
+    test("Interrupting phase drives the 'Stopping…' label", () => {
         const [getPhase, setPhase] = atoms.turnPhaseAtom;
         // The view's `stopping` prop on AgentStatusLine reads
-        // `turnPhaseAtom[0]().kind === "Interrupting"` — no read of the
-        // legacy `stoppingAtom`. Verify the predicate flips correctly.
+        // `turnPhaseAtom[0]().kind === "Interrupting"`. Verify the
+        // predicate flips correctly.
         expect(getPhase().kind === "Interrupting").toBe(false);
 
         setPhase({ kind: "Interrupting", reason: "user", sigintSentAt: 1 });

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -43,20 +43,18 @@ export type SignalPair<T> = [Accessor<T>, Setter<T>];
 export interface AgentAtoms {
     documentAtom: SignalPair<DocumentNode[]>;
     documentStateAtom: SignalPair<DocumentState>;
+    /**
+     * Telemetry sub-object — `bufferSize`, `lastEventTime`, `agentId`.
+     * Write-only from the view layer's perspective (no current
+     * consumer reads it); the reducer maintains it for buffer
+     * accounting + the stuck-stream watchdog. The legacy `active`
+     * boolean was dropped in PR G — "is the stream subscribed?" is
+     * derived from `lastEventMs !== null` on the reducer state.
+     */
     streamingStateAtom: SignalPair<StreamingState>;
     sessionStatsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
-    /** True from the moment the user sends a message until session_end arrives. */
-    turnActiveAtom: SignalPair<boolean>;
-    /**
-     * True from the moment the user presses Esc (stopAgent) until session_end
-     * arrives. Drives the "Stopping…" label on the status line and triggers
-     * an "⏹ Interrupted by user" chat row to be appended when the session
-     * actually ends — so the user gets immediate acknowledgment *and*
-     * confirmation that the interrupt landed.
-     */
-    stoppingAtom: SignalPair<boolean>;
     /**
      * Messages sent by the user that the backend hasn't picked up yet.
      * Rendered in a pending zone between the conversation and the composer.
@@ -74,12 +72,11 @@ export interface AgentAtoms {
      */
     initPhaseAtom: SignalPair<InitPhase>;
     /**
-     * Single-source-of-truth turn phase (PR A introduced TurnPhase + dual-
-     * write in the reducer; PR B — this PR — switched the view's "working"
-     * animation binding to read it via the `isWorking(state)` selector).
-     * The reducer continues to dual-write the legacy `turnActiveAtom` /
-     * `stoppingAtom` / `streamingStateAtom.active` fields; PR G will drop
-     * them once every consumer is migrated.
+     * Single-source-of-truth turn phase. PR A introduced TurnPhase
+     * with dual-write against the legacy `turnActive` / `stopping` /
+     * `streaming.active` fields, PR B migrated the view onto the
+     * `isWorking(state)` / `state.turnPhase.kind` selectors, and
+     * PR G removed the legacy fields entirely.
      *
      * Spec: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §5–§7.
      */
@@ -117,7 +114,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
             },
         }),
         streamingStateAtom: createSignal<StreamingState>({
-            active: false,
             agentId: agentId,
             bufferSize: 0,
             lastEventTime: 0,
@@ -125,11 +121,10 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         sessionStatsAtom: createSignal<SessionStats | null>(null),
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
-        turnActiveAtom: createSignal<boolean>(false),
-        stoppingAtom: createSignal<boolean>(false),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
         // gap1 (#993) reshaped InitPhase from string union to discriminated
-        // union; turnPhase from PR B stays alongside.
+        // union; turnPhase from PR B is now the sole working-state encoding
+        // after PR G removed the legacy `turnActiveAtom` / `stoppingAtom`.
         initPhaseAtom: createSignal<InitPhase>({ kind: "InitPending" }),
         turnPhaseAtom: createSignal<TurnPhase>({ kind: "Idle" }),
     };

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -447,10 +447,15 @@ export interface FilterState {
 }
 
 /**
- * Streaming state
+ * Streaming state — telemetry sub-object on the agent-pane reducer.
+ *
+ * PR G dropped the legacy `active: boolean` field; "is the stream
+ * subscribed?" is now derived from the reducer's `lastEventMs !== null`
+ * (or the {@link isStreamSubscribed} selector). The remaining fields
+ * are write-only telemetry consumed by the reducer for buffer
+ * accounting and the stuck-stream watchdog.
  */
 export interface StreamingState {
-    active: boolean;
     agentId: string | null;
     bufferSize: number; // Number of events buffered
     lastEventTime: number;

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -14,8 +14,9 @@ import { createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser } from "./stream-parser";
-import type { DocumentNode, SessionStats, StreamingState, TurnTokens, UserMessageNode } from "./types";
+import type { DocumentNode, SessionStats, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
 import {
     dispatch as dispatchDoc,
     dispatchIfRegistered as dispatchDocIfRegistered,
@@ -24,6 +25,7 @@ import {
 import {
     dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,
+    snapshot as paneSnapshot,
 } from "@/app/store/agent-pane-state-store";
 
 const OutputFileName = "output";
@@ -40,19 +42,15 @@ interface UseAgentStreamOpts {
     blockId: string;
     outputFormat: string;
     documentAtom: SignalPair<DocumentNode[]>;
-    streamingStateAtom: SignalPair<StreamingState>;
-    sessionStatsAtom: SignalPair<SessionStats | null>;
-    currentToolAtom: SignalPair<string | null>;
-    turnTokensAtom: SignalPair<TurnTokens | null>;
-    turnActiveAtom: SignalPair<boolean>;
     /**
-     * True while a user-initiated stop (Esc → SIGINT) is pending. When
-     * session_end arrives and this is true, the hook appends an
-     * "⏹ Interrupted by user" markdown node so the user has durable
-     * visual confirmation that the stop landed. Always cleared on
-     * session_end regardless of whether the row was appended.
+     * The reducer's turn-phase signal — read by the hook to detect
+     * "was this a user-initiated stop?" at session_end so the
+     * "⏹ Interrupted by user" markdown row can be appended for
+     * durable visual confirmation. Replaces the legacy
+     * `turnActiveAtom` / `stoppingAtom` props dropped in PR G; the
+     * predicate is `turnPhase.kind === "Interrupting"`.
      */
-    stoppingAtom?: SignalPair<boolean>;
+    turnPhaseAtom: SignalPair<TurnPhase>;
     /**
      * Pending queue shared with the composer's `sendMessage` path. On
      * `agent-message-accepted` events, the hook removes the matching
@@ -78,12 +76,7 @@ export function useAgentStream({
     blockId,
     outputFormat,
     documentAtom,
-    streamingStateAtom,
-    sessionStatsAtom,
-    currentToolAtom,
-    turnTokensAtom,
-    turnActiveAtom,
-    stoppingAtom,
+    turnPhaseAtom,
     pendingMessagesAtom,
     enabled,
     provider,
@@ -93,8 +86,13 @@ export function useAgentStream({
     // reducer-routed and why `recordDispatch` is a sufficient tap for
     // session-replay fixtures. See docs/analysis/AGENT_PANE_REDUCER_
     // AUDIT_2026_05_12.md.
-    const [getTurnTokens] = turnTokensAtom;
-    const getStopping = stoppingAtom?.[0];
+    //
+    // PR G: turnTokens is fetched directly from the reducer snapshot
+    // at finalize time (paneSnapshot) instead of being threaded through
+    // a dedicated accessor — fewer props, same content. Similarly, the
+    // user-initiated-stop check reads `turnPhase.kind === "Interrupting"`
+    // from the turnPhaseAtom that the agent-view registered.
+    const [getTurnPhase] = turnPhaseAtom;
 
     // Mutable state that doesn't trigger re-renders
     let lineBuffer = "";
@@ -199,10 +197,10 @@ export function useAgentStream({
          * fallback timer armed when the user presses Esc (killing the
          * subprocess prevents it from emitting its own result event).
          *
-         * If `getStopping()` is true when this runs, the ending was user-
-         * initiated — append a visible "⏹ Interrupted by user" row to
-         * the document so the user has durable confirmation that the
-         * stop landed.
+         * If `turnPhase.kind === "Interrupting"` when this runs, the
+         * ending was user-initiated — append a visible "⏹ Interrupted
+         * by user" row to the document so the user has durable
+         * confirmation that the stop landed.
          */
         const finalizeTurn = (stats: SessionStats | null) => {
             parser.flushPending();
@@ -211,7 +209,11 @@ export function useAgentStream({
             // (since turnTokens is cleared on session_end); without this
             // merge the headline tokens-in-Worked feature shows nothing.
             // Per PR #549 reagent/codex P1.
-            const tokens = getTurnTokens();
+            //
+            // PR G: turn-tokens are read from the reducer snapshot
+            // instead of a dedicated signal accessor — same source of
+            // truth, fewer props threaded into the hook.
+            const tokens = paneSnapshot(blockId)?.turnTokens ?? null;
             // Aggregate the completed turn's tokens into the global
             // session-local token-usage store so the status bar's
             // indicator + breakdown popover stay up to date. Guarded
@@ -220,11 +222,15 @@ export function useAgentStream({
             if (provider && tokens) {
                 recordTurn(provider, tokens);
             }
+            // Detect user-initiated stop via the reducer's turn phase.
+            // PR G: replaces the legacy `stoppingAtom` getter — the
+            // predicate is exactly `turnPhase.kind === "Interrupting"`
+            // since RequestStop is the only command that enters
+            // Interrupting and TurnEnd is the next transition out.
             // The reducer's TurnEnd handler does the cross-atom cleanup
-            // in one shot: merges live tokens into stats, clears tool/
-            // tokens/turnActive, AND clears stopping (the latter cascade
-            // replaces the explicit setStopping(false) below).
-            const wasStopping = getStopping?.() === true;
+            // in one shot: merges live tokens into stats, clears
+            // tool/tokens, and transitions the phase to Done.
+            const wasStopping = getTurnPhase().kind === "Interrupting";
             dispatchPaneIfRegistered(blockId, { type: "TurnEnd", stats });
             if (wasStopping) {
                 const interruptedNode: DocumentNode = {
@@ -245,28 +251,33 @@ export function useAgentStream({
         // emit `session_end` within 1.5s (normal for a killed subprocess
         // — TerminateProcess skips any final output), run the same
         // finalization locally so the UI doesn't hang on "Stopping…".
+        //
+        // PR G: previously gated on `getStopping()` (legacy boolean);
+        // now gated on `turnPhase.kind === "Interrupting"`. Same edge
+        // semantics — the reducer transitions into Interrupting on
+        // RequestStop and out on TurnEnd / disconnect.
         let stopFallbackTimer: number | null = null;
-        if (getStopping) {
-            createEffect(() => {
-                const stopping = getStopping();
-                if (stopFallbackTimer != null) {
-                    clearTimeout(stopFallbackTimer);
+        createEffect(() => {
+            const stopping = getTurnPhase().kind === "Interrupting";
+            if (stopFallbackTimer != null) {
+                clearTimeout(stopFallbackTimer);
+                stopFallbackTimer = null;
+            }
+            if (stopping) {
+                stopFallbackTimer = window.setTimeout(() => {
                     stopFallbackTimer = null;
-                }
-                if (stopping) {
-                    stopFallbackTimer = window.setTimeout(() => {
-                        stopFallbackTimer = null;
-                        if (getStopping()) finalizeTurn(null);
-                    }, 1500);
-                }
-            });
-            onCleanup(() => {
-                if (stopFallbackTimer != null) {
-                    clearTimeout(stopFallbackTimer);
-                    stopFallbackTimer = null;
-                }
-            });
-        }
+                    if (getTurnPhase().kind === "Interrupting") {
+                        finalizeTurn(null);
+                    }
+                }, 1500);
+            }
+        });
+        onCleanup(() => {
+            if (stopFallbackTimer != null) {
+                clearTimeout(stopFallbackTimer);
+                stopFallbackTimer = null;
+            }
+        });
 
         // Subscribe to `agent-message-accepted`: when the backend picks
         // up a queued message, promote the matching entry out of the
@@ -296,12 +307,13 @@ export function useAgentStream({
                         id: messageId,
                     });
                     // A new turn is now running (either the first one,
-                    // which already flipped turnActive via handleSendMessage,
-                    // or one drained from the queue — in that case
-                    // turnActive went false on the *previous* session_end
-                    // and nothing else flips it back, leaving the status
-                    // line stuck on "Worked" with no running animation
-                    // even though the CLI is processing the next message).
+                    // which already entered Submitting via the TurnStart
+                    // in handleSendMessage, or one drained from the
+                    // queue — in that case the previous session_end
+                    // dropped the phase to Done and nothing else flips
+                    // it back, leaving the status line stuck on "Worked"
+                    // with no running animation even though the CLI is
+                    // processing the next message).
                     dispatchPaneIfRegistered(blockId, { type: "TurnStart", at: Date.now() });
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
@@ -373,8 +385,8 @@ export function useAgentStream({
                 translator.reset();
                 parser.reset();
                 nodeIdSet = new Set();
-                // Reducer clears sessionStats/currentTool/turnTokens/
-                // turnActive/stopping in one shot.
+                // Reducer clears sessionStats/currentTool/turnTokens
+                // and transitions turnPhase to Idle in one shot.
                 dispatchPaneIfRegistered(blockId, { type: "TurnReset" });
                 return;
             }
@@ -523,8 +535,9 @@ export function useAgentStream({
             subscription.unsubscribe();
             // Tear down the per-block tool_chunk subscription.
             try { blockChunkUnsub(); } catch { /* ignore */ }
-            // StreamUnsubscribe also force-clears turnActive (so a crash
-            // or exit without session_end doesn't leave "Working…" stuck).
+            // StreamUnsubscribe transitions a working turn into the
+            // Disconnected phase (so a crash or exit without
+            // session_end doesn't leave "Working…" stuck).
             const at = Date.now();
             dispatchPaneIfRegistered(blockId, { type: "StreamUnsubscribe", at });
             dispatchDocIfRegistered(blockId, { type: "SessionEnd", at });


### PR DESCRIPTION
**Final PR in the turn-phase migration series.** Drops the legacy `turnActive` / `stopping` (top-level on `AgentPaneState`) and `active` (on `StreamingState`) booleans that PR A (#987) introduced as a dual-write and PR B (#992) migrated every view consumer off.

## Scope

**Pure cleanup. No user-visible behaviour change.**

Every view and hook now reads:
- `isWorking(state)` / `workingFromPhase(turnPhase)` for the "working" animation gate
- `state.turnPhase.kind === "Interrupting"` for the "Stopping…" label
- `isDisconnected(state)` for the disconnect banner (PR F)

The reducer-internal "is the stream subscribed?" gate (previously `state.streaming.active`) is now `state.lastEventMs !== null` — both fields always moved in lockstep (only `StreamSubscribe` / `StreamUnsubscribe` touched either), so the substitution is mechanical. A new `isStreamSubscribed(state)` selector wraps the check.

## Files touched (12)

- `frontend/app/store/agent-pane-state/types.ts` — drop `turnActive`, `stopping` from `AgentPaneState`; drop `active` from `StreamingState`; add `isStreamSubscribed` selector
- `frontend/app/store/agent-pane-state/reducer.ts` — every arm stops writing the legacy fields; subscription gate switches to `lastEventMs !== null`
- `frontend/app/store/agent-pane-state/reducer.test.ts` — assertions migrated to `isWorking(state)` / `state.turnPhase.kind` / `state.lastEventMs`
- `frontend/app/store/agent-pane-state-store.ts` — drop `turnActive` / `stopping` projection setters
- `frontend/app/store/agent-pane-state-store.test.ts` — drop the now-impossible projection setters from `noopProj()`
- `frontend/app/view/agent/state.ts` — drop `turnActiveAtom`, `stoppingAtom`; reshape `streamingStateAtom` initial value
- `frontend/app/view/agent/state.test.ts` — assertions migrated to `turnPhaseAtom`
- `frontend/app/view/agent/types.ts` — drop `active` from `StreamingState`
- `frontend/app/view/agent/agent-view.tsx` — drop legacy atoms from `registerAgentPaneStatePane` projection bundle and from `useAgentStream` / `useAgentCommands` options; pass `turnPhaseAtom` instead
- `frontend/app/view/agent/useAgentStream.ts` — read user-initiated-stop signal from `turnPhase.kind === "Interrupting"`; read turn-tokens from `paneSnapshot` (fewer threaded props)
- `frontend/app/view/agent/hooks/useAgentCommands.ts` — drop unused `stoppingAtom` option

## Behavioural note: `RequestStop` while Idle is now a no-op

The pre-PR-G behaviour flipped the legacy `stopping` boolean true even with no turn in flight — a latent bug surface (the stop could not actually be acted on, but the legacy boolean misled callers into thinking it had). PR G makes this a same-ref state no-op; only the audit `stop-requested` event still fires for diagnostic continuity. New test pins the contract.

## Tests

- **137/137 pass** in `frontend/app/store/agent-pane-state/` and `frontend/app/view/agent/state.test.ts`
- **270/271 pass** in `frontend/app/view/agent/` (the 1 failure — ACP `oauth` vs `api-key` in `providers/index.test.ts` — is pre-existing on `main`; verified by stashing my changes)
- **885/887 pass** across `frontend/` (both pre-existing failures unrelated to this PR)
- `npx tsc --noEmit` reports no new errors (all remaining errors are pre-existing)

## Final reference counts

In real (non-comment) code after this PR:
- `turnActive` property access: **0**
- `stoppingAtom` reference: **0**
- `streaming.active` property access: **0**

Doc-comment references remain (intentional — PR-G context for future readers).

## Series links

| PR | Goal |
|---|---|
| A #987 | Add `TurnPhase` discriminated union; reducer dual-writes both |
| B #992 | View migration — every view reads `isWorking(state)` |
| C #991 | Bounded `Interrupting → Done.interrupted` |
| D #994 | Bounded `Submitting → Done.errored` |
| E #995 | Bounded `Streaming → Done.errored("stream-stalled")` |
| F #996 | `Disconnected` state + banner |
| gap-1 #993 | `InitPhase` state machine |
| **G (this PR)** | **Drop legacy `turnActive` / `stopping` / `streaming.active`** |

Spec: `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md` §5–§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
