### PR TITLE
feat(block): per-block error boundary + localized reload UI

### DIFF
--- a/.changesets/1779547607-feat-block-per-block-error-boundary-localized-reload-au0o.md
+++ b/.changesets/1779547607-feat-block-per-block-error-boundary-localized-reload-au0o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(block): per-block error boundary + localized reload

--- a/docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md
+++ b/docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md
@@ -1,0 +1,104 @@
+# Retro: Agent-pane cascade → replaceChild → blank-tab content area
+
+**Date:** 2026-05-23
+**Author:** AgentA
+**Severity:** High — user-visible blank tab content with red error text; no in-app recovery
+
+---
+
+## 1. Symptom
+
+After a v0.33.900-line portable launched, a SolidJS reactive cascade in a single
+agent pane triggered a `NotFoundError: The node to be removed is not a child of
+this node` from Solid's reconciler. Only the workspace-level `<ErrorBoundary>`
+caught it, so the ENTIRE tab content area went blank with red error text. The
+status bar and tab bar remained alive, but the user could not recover
+individual panes — they had to close the whole tab and re-open from scratch,
+losing any state in other (perfectly healthy) panes that lived in the same
+tab.
+
+## 2. Why one pane took down the whole tab
+
+The render tree at the time:
+
+```
+WorkspaceRoot
+  <ErrorBoundary fallback={...}>     ← only boundary above per-block roots
+    TabContent
+      Layout
+        BlockNode (agent pane)       ← cascade source
+        BlockNode (terminal pane)
+        BlockNode (browser pane)
+```
+
+When the agent-pane cascade threw, Solid unwound everything up to the nearest
+boundary — which was the workspace's. The boundary's fallback replaced the
+whole subtree, so the layout + every sibling block (which were not broken) all
+disappeared.
+
+The `BlockFrame_Default_Component` (`frontend/app/block/blockframe.tsx`) had
+two narrow `<ErrorBoundary>` instances inside it — one wrapping the title-bar
+`headerElem` and one wrapping the view's child `Suspense`-fallback content
+inside `block.tsx`'s `BlockFull`/`BlockSubBlock`. Both of those caught errors
+inside their own narrow children but NEITHER guarded the BlockFrame's outer
+chrome (the `.block-frame-default` wrapper, agent-color memo, focus-effect
+chain, ConnStatusOverlay, BlockMask) — so a throw originating from any of
+those, OR from a cascading reactive write that cleaned up a hook owner before
+the next dispatch landed, escaped past both and bubbled to the workspace
+boundary.
+
+## 3. The cascade source (covered by separate PRs)
+
+The exact root cause was the cascade-during-dispatch class documented in
+`docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md` and partially fixed in
+PR #878 (soft-dispatch variant for async sites). The remaining work to fully
+prevent the cascade is tracked separately as cascade follow-ups PR-3 + PR-4.
+
+This retro is about the OTHER axis: even after we eliminate the cascade
+source, an unforeseen renderer fault in one pane must not blank the whole tab.
+
+## 4. Follow-ups (cascade-follow-up series)
+
+| # | Follow-up | Status |
+|---|---|---|
+| 1 | Per-block `<ErrorBoundary>` + localized reload UI | **this PR** |
+| 2 | Recover conversation history when a pane reloads (use the recent-sessions cascade restore path) | not started |
+| 3 | Eliminate the cascade source (cleanup-ordering refactor in agent-pane-state-store) | not started |
+| 4 | Single-slot per-pane registration helper (the architectural option from §6.2 of the LIFECYCLE_DISPATCH_LEAK analysis) | not started |
+
+## 5. Design — per-block error boundary
+
+Wrap the `.block-frame-default` body in its own `<ErrorBoundary>`. The fallback:
+
+- Logs the catch via `fe_log_structured` (`level: "error"`, `module: "block-error-boundary"`),
+  with `block_id`, `view_type`, `error_name`, `error_message`, and `error_stack`.
+  This gives every future cascade a server-side trace next to the existing
+  uncaught-error forwarder.
+- Renders a localized panel: red border, error icon, headline, the error
+  message, and a collapsible stack section.
+- Offers two actions:
+  - **Reload pane** — calls Solid's `reset` so the boundary re-mounts the
+    children fresh. Reactive owners are torn down and recreated. Any in-flight
+    reactive state in the broken pane is discarded.
+  - **Close pane** — destroys the block via the existing `nodeModel.onClose`
+    affordance.
+- Reads ONLY from the props the boundary passes in (`blockId`, `viewType`,
+  `error`, `reset`, `onClose`). Does NOT touch the agent-pane-state-store,
+  the document atom, or any reactive primitive that the broken pane was
+  using — that graph may be half-flushed.
+
+## 6. Defense in depth
+
+The existing workspace-level boundary stays put. Two boundaries (per-block +
+workspace) means:
+
+- If the per-block fallback itself somehow throws, the workspace catches.
+- If something inside the workspace layout chrome (not inside a block) throws,
+  the workspace still catches.
+
+We are not relying on the per-block boundary to be flawless — it is the FIRST
+line of defense, the workspace is the safety net.
+
+---
+
+🤖 Authored by AgentA, 2026-05-23. Cascade follow-up 1 of 4.

--- a/frontend/app/block/BlockErrorBoundary.test.tsx
+++ b/frontend/app/block/BlockErrorBoundary.test.tsx
@@ -1,0 +1,239 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the per-block error boundary (cascade follow-up 1 of 4).
+ *
+ * Contract:
+ *   - A renderer throw inside one BlockErrorBoundary renders the localized
+ *     fallback ("This pane crashed" + message + reset button).
+ *   - The throw is forwarded to the host via `fe_log_structured`.
+ *   - Two sibling BlockErrorBoundary instances are independent: a throw in
+ *     one does NOT blank the sibling.
+ *   - The "Reload pane" button calls the SolidJS ErrorBoundary reset
+ *     callback, which re-mounts the children.
+ *
+ * Spec: docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted because vi.mock factories run before module imports.
+const invokeCommandMock = vi.fn(() => Promise.resolve());
+vi.mock("@/app/platform/ipc", () => ({
+    invokeCommand: invokeCommandMock,
+}));
+
+// Suppress SolidJS's own console.error of the caught exception so the
+// vitest log isn't drowned in red. The boundary still catches and the
+// fallback still renders; we just don't want the noise.
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+    invokeCommandMock.mockClear();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    cleanup();
+    consoleErrorSpy.mockRestore();
+});
+
+// Component that throws on first render. Used as the child of the boundary.
+function Boom(props: { message?: string }): never {
+    throw new Error(props.message ?? "boom");
+}
+
+function Healthy(props: { label: string }) {
+    return <div data-testid={`healthy-${props.label}`}>{props.label}</div>;
+}
+
+// Lazy import after the mock is registered.
+async function loadBoundary() {
+    const mod = await import("./BlockErrorBoundary");
+    return mod.BlockErrorBoundary;
+}
+
+describe("BlockErrorBoundary — single-pane fallback", () => {
+    it("renders the fallback when the child throws on mount", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <BlockErrorBoundary blockId="abcdef1234" viewType="agent">
+                <Boom message="kaboom" />
+            </BlockErrorBoundary>
+        ));
+
+        expect(screen.getByTestId("block-error-fallback")).toBeInTheDocument();
+        expect(screen.getByText(/This pane crashed/)).toBeInTheDocument();
+        // The thrown message text appears in the body.
+        expect(screen.getByText(/kaboom/)).toBeInTheDocument();
+        // Reload button is the primary affordance.
+        expect(
+            screen.getByTestId("block-error-fallback-reload"),
+        ).toBeInTheDocument();
+    });
+
+    it("shows the short block id and view type in the fallback meta line", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <BlockErrorBoundary blockId="abcdef1234567890" viewType="browser">
+                <Boom />
+            </BlockErrorBoundary>
+        ));
+
+        // 7-char short id.
+        const fallback = screen.getByTestId("block-error-fallback");
+        expect(fallback.textContent).toContain("abcdef1");
+        expect(fallback.textContent).toContain("browser");
+    });
+
+    it("renders the Close pane button only when onClose is provided", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        const onClose = vi.fn();
+        const { unmount } = render(() => (
+            <BlockErrorBoundary blockId="aaa" viewType="agent" onClose={onClose}>
+                <Boom />
+            </BlockErrorBoundary>
+        ));
+
+        const closeBtn = screen.getByTestId("block-error-fallback-close");
+        expect(closeBtn).toBeInTheDocument();
+        const user = userEvent.setup();
+        await user.click(closeBtn);
+        expect(onClose).toHaveBeenCalledTimes(1);
+        unmount();
+        cleanup();
+
+        // No onClose: no Close button.
+        render(() => (
+            <BlockErrorBoundary blockId="aaa" viewType="agent">
+                <Boom />
+            </BlockErrorBoundary>
+        ));
+        expect(
+            screen.queryByTestId("block-error-fallback-close"),
+        ).toBeNull();
+    });
+
+    it("toggles the stack section when 'Show stack' is clicked", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <BlockErrorBoundary blockId="aaa" viewType="agent">
+                <Boom message="stackable" />
+            </BlockErrorBoundary>
+        ));
+
+        // Initially the stack <pre> isn't in the document.
+        expect(screen.queryByText(/at Boom/)).toBeNull();
+        const toggle = screen.getByRole("button", { name: /Show stack/ });
+        const user = userEvent.setup();
+        await user.click(toggle);
+        // After click, the button text flips; the <pre> renders.
+        expect(
+            screen.getByRole("button", { name: /Hide stack/ }),
+        ).toBeInTheDocument();
+    });
+});
+
+describe("BlockErrorBoundary — logging side effect", () => {
+    it("forwards the catch via fe_log_structured with block_id + view_type + stack", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <BlockErrorBoundary blockId="0123456789abcdef" viewType="agent">
+                <Boom message="logged" />
+            </BlockErrorBoundary>
+        ));
+
+        // SolidJS ErrorBoundary catches synchronously during render, so by
+        // the time the fallback is in the DOM the invokeCommand mock has
+        // already been called.
+        expect(invokeCommandMock).toHaveBeenCalledTimes(1);
+        const [cmd, args] = invokeCommandMock.mock.calls[0]!;
+        expect(cmd).toBe("fe_log_structured");
+        expect(args).toMatchObject({
+            level: "error",
+            module: "block-error-boundary",
+        });
+        expect(args.data).toMatchObject({
+            block_id: "0123456789abcdef",
+            view_type: "agent",
+            error_name: "Error",
+            error_message: "logged",
+        });
+        expect(typeof args.data.error_stack === "string").toBe(true);
+        expect(args.message).toMatch(/block-error-boundary/);
+    });
+
+    it("survives an invokeCommand throw (logging must not break the fallback)", async () => {
+        invokeCommandMock.mockImplementationOnce(() => {
+            throw new Error("ipc-dead");
+        });
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <BlockErrorBoundary blockId="x" viewType="agent">
+                <Boom message="survive" />
+            </BlockErrorBoundary>
+        ));
+        // Fallback still rendered.
+        expect(screen.getByTestId("block-error-fallback")).toBeInTheDocument();
+        expect(screen.getByText(/survive/)).toBeInTheDocument();
+    });
+});
+
+describe("BlockErrorBoundary — sibling isolation", () => {
+    it("a throw in one boundary leaves a sibling boundary's children mounted", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        render(() => (
+            <div>
+                <BlockErrorBoundary blockId="aaaaaaa" viewType="agent">
+                    <Boom message="left-pane-crashed" />
+                </BlockErrorBoundary>
+                <BlockErrorBoundary blockId="bbbbbbb" viewType="term">
+                    <Healthy label="right" />
+                </BlockErrorBoundary>
+            </div>
+        ));
+
+        // The throwing pane's fallback is shown.
+        expect(screen.getByTestId("block-error-fallback")).toBeInTheDocument();
+        expect(screen.getByText(/left-pane-crashed/)).toBeInTheDocument();
+        // The healthy sibling stayed mounted.
+        expect(screen.getByTestId("healthy-right")).toBeInTheDocument();
+        // Only one fallback in the document — the sibling did NOT render
+        // its boundary's fallback.
+        expect(screen.queryAllByTestId("block-error-fallback")).toHaveLength(1);
+    });
+});
+
+describe("BlockErrorBoundary — reset / reload pane", () => {
+    it("clicking 'Reload pane' re-mounts the children and clears the fallback", async () => {
+        const BlockErrorBoundary = await loadBoundary();
+        // First mount throws; after reset, swap to a healthy child.
+        let shouldThrow = true;
+        const Conditional = () => {
+            if (shouldThrow) {
+                throw new Error("first-mount-throw");
+            }
+            return <Healthy label="recovered" />;
+        };
+
+        render(() => (
+            <BlockErrorBoundary blockId="resetid" viewType="agent">
+                <Conditional />
+            </BlockErrorBoundary>
+        ));
+
+        expect(screen.getByTestId("block-error-fallback")).toBeInTheDocument();
+
+        // Flip the gate then click Reload — the boundary's reset re-runs
+        // the children, this time without throwing.
+        shouldThrow = false;
+        const user = userEvent.setup();
+        await user.click(screen.getByTestId("block-error-fallback-reload"));
+
+        // Fallback gone, healthy child mounted.
+        expect(screen.queryByTestId("block-error-fallback")).toBeNull();
+        expect(screen.getByTestId("healthy-recovered")).toBeInTheDocument();
+    });
+});

--- a/frontend/app/block/BlockErrorBoundary.tsx
+++ b/frontend/app/block/BlockErrorBoundary.tsx
@@ -1,0 +1,159 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-block error boundary — localized fallback UI so one pane's renderer
+// fault cannot blank the whole tab.
+//
+// Retro: docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md.
+//
+// Design contract (cascade-safe):
+//   - The fallback reads ONLY from the props the boundary passes in. It does
+//     NOT subscribe to the broken pane's reactive graph (no agent-pane-state
+//     store reads, no documentAtom, no useAtomValue against per-pane atoms).
+//     The pane that just crashed may have a half-flushed reactive owner; any
+//     subscription into it from the fallback would re-throw.
+//   - The fallback's "Reload pane" action delegates to SolidJS's
+//     `ErrorBoundary` `reset` callback, which re-mounts the children fresh —
+//     i.e., re-runs the component's entire reactive setup. Any half-flushed
+//     state in the broken pane is discarded.
+//   - On catch, we forward a structured payload to the host via the
+//     `fe_log_structured` IPC channel — same channel used by
+//     `frontend/log/log-pipe.ts` and `frontend/log/error-forwarder.ts` — so
+//     the host log shows block_id + view_type + error_name + stack alongside
+//     the existing cascade-detection warnings.
+
+import { invokeCommand } from "@/app/platform/ipc";
+import { ErrorBoundary as SolidErrorBoundary, createSignal, Show } from "solid-js";
+import type { JSX } from "solid-js";
+
+export interface BlockErrorBoundaryProps {
+    /** The block this boundary protects. Logged in the host trace. */
+    blockId: string;
+    /** Optional view type ("agent", "term", "browser", ...) for the host trace. */
+    viewType?: string;
+    /**
+     * Optional close handler. When provided, the fallback renders a "Close
+     * pane" button that destroys the block. Skipped if missing (e.g. in
+     * tests that don't have a layout).
+     */
+    onClose?: () => void;
+    children: JSX.Element;
+}
+
+/** Pure side effect: forward the catch to the host log. */
+function logBoundaryCatch(blockId: string, viewType: string | undefined, err: Error): void {
+    try {
+        const errName = err?.name ?? "Error";
+        const errMessage = err?.message ?? String(err);
+        const errStack = err?.stack ?? null;
+        // Fire-and-forget — never let logging compound the rendering fault.
+        invokeCommand("fe_log_structured", {
+            level: "error",
+            module: "block-error-boundary",
+            message: `[block-error-boundary] ${errName}: ${errMessage} (block=${blockId.substring(0, 7)}, view=${viewType ?? "?"})`,
+            data: {
+                block_id: blockId,
+                view_type: viewType ?? null,
+                error_name: errName,
+                error_message: errMessage,
+                error_stack: errStack,
+            },
+        }).catch(() => {});
+    } catch {
+        // swallow — logging must never break the fallback UI
+    }
+}
+
+/** Fallback UI. Reads ONLY from the props that are passed in. */
+function BlockErrorFallback(props: {
+    blockId: string;
+    viewType?: string;
+    error: Error;
+    reset: () => void;
+    onClose?: () => void;
+}): JSX.Element {
+    const [stackOpen, setStackOpen] = createSignal(false);
+    const errName = () => props.error?.name ?? "Error";
+    const errMessage = () => props.error?.message ?? String(props.error);
+    const errStack = () => props.error?.stack ?? "";
+    const shortId = () => props.blockId.substring(0, 7);
+
+    return (
+        <div class="block-error-fallback" role="alert" data-testid="block-error-fallback">
+            <div class="block-error-fallback-header">
+                <i class="fa-sharp fa-solid fa-triangle-exclamation block-error-fallback-icon" aria-hidden="true" />
+                <div class="block-error-fallback-title">This pane crashed</div>
+            </div>
+            <div class="block-error-fallback-body">
+                <div class="block-error-fallback-message">
+                    <strong>{errName()}:</strong> {errMessage()}
+                </div>
+                <div class="block-error-fallback-meta">
+                    block <code>{shortId()}</code>
+                    <Show when={props.viewType}>
+                        {" · view "}
+                        <code>{props.viewType}</code>
+                    </Show>
+                </div>
+                <Show when={errStack()}>
+                    <button
+                        type="button"
+                        class="block-error-fallback-stack-toggle"
+                        onClick={() => setStackOpen((v) => !v)}
+                        aria-expanded={stackOpen()}
+                    >
+                        {stackOpen() ? "Hide stack" : "Show stack"}
+                    </button>
+                    <Show when={stackOpen()}>
+                        <pre class="block-error-fallback-stack">{errStack()}</pre>
+                    </Show>
+                </Show>
+            </div>
+            <div class="block-error-fallback-footer">
+                <button
+                    type="button"
+                    class="modal-btn"
+                    onClick={() => props.reset()}
+                    data-testid="block-error-fallback-reload"
+                >
+                    Reload pane
+                </button>
+                <Show when={props.onClose}>
+                    <button
+                        type="button"
+                        class="modal-btn"
+                        onClick={() => props.onClose?.()}
+                        data-testid="block-error-fallback-close"
+                    >
+                        Close pane
+                    </button>
+                </Show>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Wrap each block's body so a renderer exception inside one pane only blanks
+ * THAT pane. Other panes in the same tab + the layout chrome stay alive.
+ */
+export function BlockErrorBoundary(props: BlockErrorBoundaryProps): JSX.Element {
+    return (
+        <SolidErrorBoundary
+            fallback={(err: Error, reset: () => void) => {
+                logBoundaryCatch(props.blockId, props.viewType, err);
+                return (
+                    <BlockErrorFallback
+                        blockId={props.blockId}
+                        viewType={props.viewType}
+                        error={err}
+                        reset={reset}
+                        onClose={props.onClose}
+                    />
+                );
+            }}
+        >
+            {props.children}
+        </SolidErrorBoundary>
+    );
+}

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -503,3 +503,101 @@
 
     }
 }
+
+// ── Per-block error boundary fallback ───────────────────────────────────────
+// Localized "this pane crashed" panel that replaces ONLY the broken pane's
+// body. Other panes in the tab + the layout chrome stay alive.
+// See: docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md.
+.block-error-fallback {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: auto;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    border: 1px solid var(--error-color);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    gap: var(--space-3);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+
+    .block-error-fallback-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .block-error-fallback-icon {
+        color: var(--error-color);
+        font-size: var(--text-lg);
+    }
+
+    .block-error-fallback-title {
+        font-size: var(--text-md);
+        font-weight: var(--font-weight-bold);
+        color: var(--error-color);
+    }
+
+    .block-error-fallback-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        min-height: 0;
+    }
+
+    .block-error-fallback-message {
+        word-break: break-word;
+        white-space: pre-wrap;
+    }
+
+    .block-error-fallback-meta {
+        color: var(--secondary-text-color);
+        font-size: var(--text-xs);
+
+        code {
+            font-family: var(--fixed-font);
+            font-size: inherit;
+            background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+            padding: 1px 4px;
+            border-radius: var(--radius-sm);
+        }
+    }
+
+    .block-error-fallback-stack-toggle {
+        align-self: flex-start;
+        background: transparent;
+        border: 1px solid var(--border-color);
+        color: var(--secondary-text-color);
+        font-size: var(--text-xs);
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+
+        &:hover {
+            color: var(--main-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+        }
+    }
+
+    .block-error-fallback-stack {
+        margin: 0;
+        max-height: 220px;
+        overflow: auto;
+        font-family: var(--fixed-font);
+        font-size: var(--text-xs);
+        background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+        padding: var(--space-2);
+        border-radius: var(--radius-sm);
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+    .block-error-fallback-footer {
+        display: flex;
+        gap: var(--space-2);
+        margin-top: auto;
+    }
+}

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -38,6 +38,7 @@ import clsx from "clsx";
 import type { JSX } from "solid-js";
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, Suspense } from "solid-js";
 import "./block.scss";
+import { BlockErrorBoundary } from "./BlockErrorBoundary";
 import { BlockFrame } from "./blockframe";
 import { blockViewToIcon, blockViewToName } from "./blockutil";
 
@@ -318,12 +319,25 @@ function Block(props: BlockProps): JSX.Element {
 
     const ready = createMemo(() => !loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel() != null);
 
+    // Per-block ErrorBoundary: a renderer fault in this pane only blanks
+    // THIS pane, not the whole tab. See retro
+    // docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md.
+    // The fallback reads only from props passed in (blockId, viewType,
+    // error, reset, onClose) — never touches the broken pane's reactive
+    // graph, which may be half-flushed.
+    const viewTypeStr = createMemo(() => blockData()?.meta?.view);
     return (
         <Show when={ready()}>
-            {props.preview
-                ? <BlockPreview nodeModel={props.nodeModel} viewModel={viewModel()} preview={props.preview} />
-                : <BlockFull nodeModel={props.nodeModel} viewModel={viewModel()} preview={props.preview} />
-            }
+            <BlockErrorBoundary
+                blockId={props.nodeModel.blockId}
+                viewType={viewTypeStr()}
+                onClose={props.nodeModel.onClose}
+            >
+                {props.preview
+                    ? <BlockPreview nodeModel={props.nodeModel} viewModel={viewModel()} preview={props.preview} />
+                    : <BlockFull nodeModel={props.nodeModel} viewModel={viewModel()} preview={props.preview} />
+                }
+            </BlockErrorBoundary>
         </Show>
     );
 }
@@ -353,9 +367,16 @@ function SubBlock(props: SubBlockProps): JSX.Element {
         viewModel()?.dispose?.();
     });
 
+    const viewTypeStr = createMemo(() => blockData()?.meta?.view);
     return (
         <Show when={!loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel()}>
-            <BlockSubBlock nodeModel={props.nodeModel} viewModel={viewModel()} />
+            <BlockErrorBoundary
+                blockId={props.nodeModel.blockId}
+                viewType={viewTypeStr()}
+                onClose={props.nodeModel.onClose}
+            >
+                <BlockSubBlock nodeModel={props.nodeModel} viewModel={viewModel()} />
+            </BlockErrorBoundary>
         </Show>
     );
 }


### PR DESCRIPTION
## Summary

Wrap each block (pane) in its own SolidJS `<ErrorBoundary>` so a renderer exception in one pane only blanks THAT pane. Other panes in the same tab + the layout chrome stay alive.

**Cascade follow-up 1 of 4.** See retro: `docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md`.

## Background

On 2026-05-23, a SolidJS reactive cascade in a single agent pane took out the ENTIRE tab content area because the only error boundary that caught it was at the workspace level. After F5, the user saw status bar + tab bar but a blank content region with red error text — couldn't recover the pane individually. They had to close the tab.

Prior analysis: `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md` (PR #878 fixed the dispatch-after-cleanup half of the cascade class; this PR adds the defensive boundary so an unforeseen renderer fault never blanks the whole tab again).

## User-visible recovery flow

When a pane's renderer throws (mount, update, anything):

1. The crashed pane's body is replaced with a localized panel: red border, warning icon, "This pane crashed" headline, the error message, and a collapsible stack section.
2. The pane header, sibling panes, layout chrome, tab bar, and status bar **stay alive**.
3. User clicks **Reload pane** → SolidJS `reset` re-mounts the children fresh; reactive owners torn down and recreated. If the crash was transient, the pane recovers.
4. Or user clicks **Close pane** → existing `nodeModel.onClose` destroys the block.

## Logging

Every catch forwards a structured payload via `fe_log_structured` (the same IPC channel `frontend/log/log-pipe.ts` and `frontend/log/error-forwarder.ts` use):

```
level: "error"
module: "block-error-boundary"
data: { block_id, view_type, error_name, error_message, error_stack }
```

This is the "next incident lands with a stack trace" insurance — the host log now correlates cascade-detection warnings with the exact pane that lost its render tree.

## Cascade-safety contract

The fallback UI **reads only from props** (`blockId`, `viewType`, `error`, `reset`, `onClose`). It deliberately does NOT subscribe to:
- the agent-pane-state-store
- the agent-document-store
- any per-pane atom

The broken pane's reactive graph may be half-flushed at catch time; any subscription into it from the fallback would re-throw.

Logging is fire-and-forget — an `invokeCommand` throw cannot break the fallback (covered by a regression test).

## Defense in depth

The existing workspace-level `<ErrorBoundary>` stays put. Two boundaries (per-block + workspace) means:
- If the per-block fallback itself somehow throws, the workspace catches.
- If something inside the workspace layout chrome (not inside a block) throws, the workspace still catches.

## Out of scope

- Fixing the cascade source itself (PR-3 + PR-4)
- Recovering conversation history when the pane reloads (PR-2 "recent sessions" cascade restore)

## Tests

`frontend/app/block/BlockErrorBoundary.test.tsx` (8 cases):
- fallback renders on first-render throw
- short block id + view type in the meta line
- Close button conditional on `onClose` prop
- stack section toggle (Show stack ↔ Hide stack)
- `fe_log_structured` payload shape (block_id, view_type, error_name, error_message, error_stack)
- logging-failure resilience (invokeCommand throws → fallback still renders)
- **sibling isolation** — throwing pane + healthy pane in one render, only the throwing pane shows the fallback; the healthy sibling stays mounted
- Reload pane re-mounts the children (gate flip + click reset)

```
✓ frontend/app/block/BlockErrorBoundary.test.tsx (8 tests)
✓ frontend/app/block/autotitle.test.ts (35 tests)
```

Existing `frontend/app/view/agent/` tests: 271 pass, 1 pre-existing unrelated failure (`providers/index.test.ts` — oauth vs api-key, exists on main).

## Files touched

- `frontend/app/block/BlockErrorBoundary.tsx` (new) — boundary + fallback UI
- `frontend/app/block/BlockErrorBoundary.test.tsx` (new) — 8 test cases
- `frontend/app/block/block.tsx` — wrap `Block` and `SubBlock` render in `BlockErrorBoundary`
- `frontend/app/block/block.scss` — `.block-error-fallback*` styles (uses existing theme tokens, no new modal classes)
- `docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md` (new) — the retro this PR addresses
- `.changesets/...` (new) — patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)