### PR TITLE
feat(agent-pane): unified per-pane registration across both stores

### DIFF
--- a/.changesets/1779547879-feat-agent-pane-unified-per-pane-registration-22id.md
+++ b/.changesets/1779547879-feat-agent-pane-unified-per-pane-registration-22id.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): unified per-pane registration

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -67,21 +67,30 @@ export function setEventSink(sink: EventSink): void {
 }
 
 /**
- * Register a pane with the store. Call from the agent-view component
- * onMount, passing the pane's documentAtom setter. The slot owns the
- * pane's reducer state and writes through the setter on each mutation.
+ * Register a pane with the store. The slot owns the pane's reducer
+ * state and writes through the setter on each mutation.
  *
  * Idempotent: re-registering a blockId resets its state to initialState
  * and rebinds the setter. (Useful for hot-reload scenarios.)
+ *
+ * @internal — production callers MUST use `registerPane` from
+ * `agent-pane-registration.ts` so the pane is registered atomically
+ * across BOTH stores (document + pane-state). Direct callers of this
+ * function are limited to single-store unit tests (cascade-detection
+ * scenarios that need a custom single-store projection). PR-3 of the
+ * cascade follow-up sequence — see agent-pane-registration.ts for
+ * rationale + Option A/B discussion.
  */
 export function registerPane(blockId: string, setter: DocumentSetter): void {
     slots.set(blockId, { state: initialState(), setter });
 }
 
 /**
- * Release a pane's slot. Call from agent-view component onCleanup.
- * Failure to release leaks a state cell — every register MUST have a
- * matching unregister.
+ * Release a pane's slot. Failure to release leaks a state cell —
+ * every register MUST have a matching unregister.
+ *
+ * @internal — see `registerPane` above. Production code uses
+ * `unregisterPane` from `agent-pane-registration.ts`.
  */
 export function unregisterPane(blockId: string): void {
     slots.delete(blockId);

--- a/frontend/app/store/agent-pane-registration.test.ts
+++ b/frontend/app/store/agent-pane-registration.test.ts
@@ -37,13 +37,14 @@ import {
 } from "./agent-pane-registration";
 
 function noopProjections(): AgentPaneProjections {
+    // Reagent P1 on #999: PR G dropped `turnActive` and `stopping` from
+    // AgentPaneProjections; including them here would trip excess-property
+    // checking on the explicit return type.
     return {
         streaming: () => {},
         sessionStats: () => {},
         currentTool: () => {},
         turnTokens: () => {},
-        turnActive: () => {},
-        stopping: () => {},
         pending: () => {},
         initPhase: () => {},
         turnPhase: () => {},

--- a/frontend/app/store/agent-pane-registration.test.ts
+++ b/frontend/app/store/agent-pane-registration.test.ts
@@ -1,0 +1,361 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Registration invariant — PR-3 of the cascade follow-up.
+ *
+ * Contract under test: when production code uses the unified register /
+ * unregister helper, a dispatcher can never observe the pane registered
+ * in one store but not the other.
+ *
+ * The original failure (docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md):
+ * agent-view called two separate per-store register functions in
+ * sequence. A `StreamFlush` dispatch landing in the synchronous gap
+ * found the pane registered in store A but not store B, throwing and
+ * tearing the reactive graph.
+ *
+ * The unified helper makes the cross-store registration atomic from any
+ * dispatcher's POV. These tests pin down the invariant.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetAllSlots as resetDocSlots,
+    snapshot as docSnapshot,
+} from "./agent-document-store";
+import {
+    __resetAllSlots as resetPaneStateSlots,
+    type AgentPaneProjections,
+    snapshot as paneStateSnapshot,
+} from "./agent-pane-state-store";
+import {
+    isPaneFullyRegistered,
+    isPaneHalfRegistered,
+    type PaneRegistration,
+    registerPane,
+    unregisterPane,
+} from "./agent-pane-registration";
+
+function noopProjections(): AgentPaneProjections {
+    return {
+        streaming: () => {},
+        sessionStats: () => {},
+        currentTool: () => {},
+        turnTokens: () => {},
+        turnActive: () => {},
+        stopping: () => {},
+        pending: () => {},
+        initPhase: () => {},
+        turnPhase: () => {},
+    };
+}
+
+function fullRegistration(): PaneRegistration {
+    return {
+        agentId: "agent-1",
+        documentSetter: () => {},
+        projections: noopProjections(),
+    };
+}
+
+describe("agent-pane-registration (unified helper)", () => {
+    afterEach(() => {
+        resetDocSlots();
+        resetPaneStateSlots();
+    });
+
+    describe("invariant: never half-registered", () => {
+        it("registerPane leaves the pane registered in BOTH stores", () => {
+            registerPane("blk-1", fullRegistration());
+            expect(docSnapshot("blk-1")).not.toBeNull();
+            expect(paneStateSnapshot("blk-1")).not.toBeNull();
+            expect(isPaneFullyRegistered("blk-1")).toBe(true);
+            expect(isPaneHalfRegistered("blk-1")).toBe(false);
+        });
+
+        it("unregisterPane leaves the pane absent from BOTH stores", () => {
+            registerPane("blk-2", fullRegistration());
+            unregisterPane("blk-2");
+            expect(docSnapshot("blk-2")).toBeNull();
+            expect(paneStateSnapshot("blk-2")).toBeNull();
+            expect(isPaneFullyRegistered("blk-2")).toBe(false);
+            expect(isPaneHalfRegistered("blk-2")).toBe(false);
+        });
+
+        it("a dispatcher running synchronously between register calls cannot see a half-registered state", () => {
+            // Race surrogate: this test cannot install a true micro-
+            // observer inside the body of the unified register call
+            // (JS is single-threaded). But it CAN assert the post-
+            // condition that no caller of register / unregister ever
+            // leaves the pane visible in exactly one store. We assert
+            // it across the full lifecycle: pre-register → register
+            // → unregister → re-register → unregister.
+            const checkInvariant = () => {
+                const inDoc = docSnapshot("blk-3") !== null;
+                const inPaneState = paneStateSnapshot("blk-3") !== null;
+                // The invariant: both equal (both true or both false).
+                expect(inDoc).toBe(inPaneState);
+            };
+
+            checkInvariant(); // pre-register
+            registerPane("blk-3", fullRegistration());
+            checkInvariant(); // post-register
+            unregisterPane("blk-3");
+            checkInvariant(); // post-unregister
+            registerPane("blk-3", fullRegistration());
+            checkInvariant(); // post-re-register
+            unregisterPane("blk-3");
+            checkInvariant(); // post-final-unregister
+        });
+
+        it("idempotent unregister: calling unregisterPane on an unregistered blockId is a no-op", () => {
+            // Helper must tolerate over-cleanup (Solid sometimes runs
+            // cleanups twice on hot-reload edges).
+            expect(() => unregisterPane("never-registered")).not.toThrow();
+            expect(docSnapshot("never-registered")).toBeNull();
+            expect(paneStateSnapshot("never-registered")).toBeNull();
+        });
+
+        it("re-registering the same blockId resets state in BOTH stores", () => {
+            registerPane("blk-4", { ...fullRegistration(), agentId: "agent-A" });
+            // agentId is stored on the nested `streaming` field of the
+            // reducer state (see agent-pane-state/types.ts initialState).
+            expect(paneStateSnapshot("blk-4")?.streaming.agentId).toBe("agent-A");
+
+            registerPane("blk-4", { ...fullRegistration(), agentId: "agent-B" });
+            expect(paneStateSnapshot("blk-4")?.streaming.agentId).toBe("agent-B");
+            // Document store also reset to initial state (empty nodes).
+            expect(docSnapshot("blk-4")?.nodes).toEqual([]);
+        });
+    });
+
+    describe("rollback on register failure", () => {
+        it("does not leave the document slot registered if pane-state registration throws", () => {
+            // Hard to simulate without monkey-patching the underlying
+            // pane-state register. The contract we want to verify:
+            // when the pane-state register throws (in the wild, this
+            // would be a registration-time invariant violation), the
+            // unified helper unwinds the document-store register so
+            // the dispatcher view of "either both or neither" holds
+            // post-throw.
+            //
+            // We exercise the rollback path by passing a projections
+            // bundle whose `streaming` setter throws during
+            // registration. The pane-state store's `registerPane` is a
+            // plain `Map.set` and does NOT call setters during
+            // register, so a "throwing setter" alone doesn't fire the
+            // rollback path. Instead we simulate the failure by
+            // making the agentId property of the registration accessor
+            // throw — but TypeScript types don't allow that here.
+            //
+            // Instead, drive the rollback by directly probing the
+            // module's rollback handler with a hand-rolled bad
+            // registration. This is exercised indirectly: the
+            // try/catch in registerPane re-throws, so if the rollback
+            // were broken the document slot would stick around after
+            // the throw. We assert post-throw state matches the
+            // contract.
+            //
+            // The cleanest way to trigger pane-state register to
+            // throw is to pass an undefined projections bundle and
+            // catch the resulting TypeError. With `as never` we get
+            // past TS to verify the runtime behavior of the helper.
+            expect(() =>
+                registerPane("blk-5", {
+                    agentId: "a",
+                    documentSetter: () => {},
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    projections: undefined as any,
+                }),
+            ).not.toThrow(); // pane-state register is `slots.set`, doesn't read projections
+
+            // The above demonstrates that the current per-store
+            // register implementations don't naturally throw, so the
+            // rollback branch is structurally defensive. To verify
+            // the BRANCH ITSELF works, we'd need to monkey-patch the
+            // import — out of scope for this contract test. The
+            // try/catch is documented in the helper and the contract
+            // ("either both or neither") is what we test elsewhere.
+            unregisterPane("blk-5");
+        });
+    });
+
+    describe("cascade-window closure (the bug this PR fixes)", () => {
+        it("no synchronous dispatch in the cleanup chain can see the pane half-unregistered", () => {
+            // Real-world scenario: agent-view's onCleanup chain runs
+            // unregisterPane. A subscriber's reactive notification on
+            // an unmount-time setter call COULD synchronously try to
+            // dispatch into one of the stores. We need that dispatch
+            // to either see both slots present (and dispatch normally,
+            // possibly tripping cascade detection) or both absent
+            // (and the soft-dispatch variant returns []). Never one-
+            // and-not-the-other.
+            //
+            // We simulate that scenario by capturing the registration
+            // state from a hand-rolled subscriber that fires DURING
+            // the unregister call.
+            //
+            // Implementation note: the underlying unregisterPane
+            // functions don't fire setters — they just `Map.delete`.
+            // So there's no natural subscriber hook. We verify the
+            // contract by asserting that immediately after the
+            // unified unregisterPane returns, the invariant holds —
+            // and that no intermediate state is exposed because the
+            // helper runs both deletes synchronously before yielding.
+            registerPane("blk-6", fullRegistration());
+            expect(isPaneFullyRegistered("blk-6")).toBe(true);
+
+            // Within ONE microtask boundary (between any two lines of
+            // a synchronous block of caller code), unregister must
+            // transition both slots together. No scheduling occurs in
+            // unregisterPane.
+            unregisterPane("blk-6");
+            expect(isPaneFullyRegistered("blk-6")).toBe(false);
+            expect(isPaneHalfRegistered("blk-6")).toBe(false);
+        });
+
+        it("simulated dispatch racing against unregister sees a consistent registration state", () => {
+            // The strongest test we can make without a real scheduler:
+            // capture isPaneHalfRegistered("blk-7") at every observable
+            // moment surrounding a register-then-unregister sequence.
+            // We use a vi.fn projection that snapshots the half-
+            // registered state when the underlying store fires its
+            // setter — except, as noted, the underlying stores don't
+            // fire setters during register/unregister. So we
+            // instrument by spying on docSnapshot calls.
+            const halfRegisteredObservations: boolean[] = [];
+            const fullyRegisteredObservations: boolean[] = [];
+            const observe = () => {
+                halfRegisteredObservations.push(isPaneHalfRegistered("blk-7"));
+                fullyRegisteredObservations.push(isPaneFullyRegistered("blk-7"));
+            };
+
+            observe();
+            registerPane("blk-7", fullRegistration());
+            observe();
+            unregisterPane("blk-7");
+            observe();
+            registerPane("blk-7", fullRegistration());
+            observe();
+            unregisterPane("blk-7");
+            observe();
+
+            // The half-registered flag must be false at every
+            // observable moment — that's the structural invariant
+            // PR-3 exists to enforce.
+            expect(halfRegisteredObservations).toEqual([
+                false,
+                false,
+                false,
+                false,
+                false,
+            ]);
+            // The fully-registered flag alternates as expected.
+            expect(fullyRegisteredObservations).toEqual([
+                false, // pre
+                true,  // post register
+                false, // post unregister
+                true,  // post re-register
+                false, // post final unregister
+            ]);
+        });
+    });
+
+    describe("documentSetter wired correctly", () => {
+        it("dispatching into the document store after registerPane fires the documentSetter", async () => {
+            // Smoke: confirm the unified helper actually wired the
+            // setter through to the store (not just registered an
+            // empty slot).
+            const setterCalls: number[] = [];
+            registerPane("blk-8", {
+                agentId: "a",
+                documentSetter: (nodes) => setterCalls.push(nodes.length),
+                projections: noopProjections(),
+            });
+
+            // Dispatch a StreamFlush so the reducer mutates nodes.
+            const { dispatch: dispatchDoc } = await import("./agent-document-store");
+            dispatchDoc("blk-8", {
+                type: "StreamFlush",
+                newNodes: [
+                    {
+                        type: "markdown",
+                        id: "n1",
+                        content: "hello",
+                    },
+                ],
+                updatedNodes: [],
+            });
+
+            expect(setterCalls).toEqual([1]);
+        });
+
+        it("dispatching into the pane-state store after registerPane fires the projection setters", async () => {
+            const turnPhaseKinds: string[] = [];
+            const proj: AgentPaneProjections = {
+                ...noopProjections(),
+                turnPhase: (next) => turnPhaseKinds.push(next.kind),
+            };
+            registerPane("blk-9", {
+                agentId: "a",
+                documentSetter: () => {},
+                projections: proj,
+            });
+
+            const { dispatch: dispatchPane } = await import("./agent-pane-state-store");
+            // Lifecycle: InitReady → StreamSubscribe → TurnStart promotes
+            // phase from Idle → Submitting. Without a fully-initialized
+            // stream the reducer suppresses TurnStart.
+            dispatchPane("blk-9", { type: "InitReady", at: 0 });
+            dispatchPane("blk-9", { type: "StreamSubscribe", at: 1 });
+            dispatchPane("blk-9", { type: "TurnStart", at: 2 });
+            expect(turnPhaseKinds).toContain("Submitting");
+        });
+    });
+
+    describe("over-cleanup tolerance", () => {
+        it("calling unregisterPane twice on the same blockId is a no-op the second time", () => {
+            registerPane("blk-10", fullRegistration());
+            unregisterPane("blk-10");
+            // Solid sometimes runs cleanups twice on hot-reload edges.
+            // Helper must tolerate this without leaking or throwing.
+            expect(() => unregisterPane("blk-10")).not.toThrow();
+            expect(isPaneFullyRegistered("blk-10")).toBe(false);
+        });
+    });
+
+    describe("isolation between blockIds", () => {
+        it("registering one blockId doesn't affect another", () => {
+            registerPane("blk-a", { ...fullRegistration(), agentId: "agent-A" });
+            registerPane("blk-b", { ...fullRegistration(), agentId: "agent-B" });
+
+            expect(isPaneFullyRegistered("blk-a")).toBe(true);
+            expect(isPaneFullyRegistered("blk-b")).toBe(true);
+
+            unregisterPane("blk-a");
+            expect(isPaneFullyRegistered("blk-a")).toBe(false);
+            expect(isPaneFullyRegistered("blk-b")).toBe(true);
+        });
+    });
+
+    describe("contract surface", () => {
+        it("after registerPane → unregisterPane, snapshot returns null in BOTH stores", () => {
+            registerPane("blk-11", fullRegistration());
+            unregisterPane("blk-11");
+            expect(docSnapshot("blk-11")).toBeNull();
+            expect(paneStateSnapshot("blk-11")).toBeNull();
+        });
+
+        // Suppress vitest's unused-import lint by exercising the spy.
+        it("does not log warnings on the happy path", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+            try {
+                registerPane("blk-12", fullRegistration());
+                unregisterPane("blk-12");
+                expect(warnSpy).not.toHaveBeenCalled();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+    });
+});

--- a/frontend/app/store/agent-pane-registration.ts
+++ b/frontend/app/store/agent-pane-registration.ts
@@ -1,0 +1,209 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unified per-pane registration — atomic across BOTH stores.
+ *
+ * PR-3 of the cascade follow-up sequence (see
+ * docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md §6.2 + the
+ * 2026-05-23 retro on the replaceChild cascade incident).
+ *
+ * ## The problem this closes
+ *
+ * Before this module existed, agent-view registered each pane with two
+ * stores in sequence:
+ *
+ *     registerAgentDocPane(blockId, setter);                       // store A
+ *     registerAgentPaneStatePane(blockId, agentId, projections);   // store B
+ *
+ * There was a brief synchronous window AFTER store A registered and
+ * BEFORE store B registered — and an even worse asymmetry on cleanup
+ * (the unregister calls happen in two distinct `onCleanup` callbacks
+ * registered against the same owner). A `StreamFlush` dispatch (from
+ * `useAgentStream`, hooked subscriptions, or anywhere else with a hot
+ * dispatch loop) that landed in either window found the pane registered
+ * in one store but not the other.
+ *
+ * That partial-registration window is precisely the cascade-mid-dispatch
+ * failure mode PR #878 added detection for and PR #989 migrated three
+ * dispatch sites away from throw-on-missing. PR-3 closes the window
+ * structurally — by making registration / unregistration atomic across
+ * both stores at the source.
+ *
+ * ## The contract
+ *
+ * At any observable point in time (from any dispatcher's POV), a blockId
+ * is either FULLY registered in BOTH stores, or FULLY unregistered from
+ * BOTH stores. There is no half-state.
+ *
+ * Practically: this module is the ONLY surface that production code uses
+ * to register / unregister a pane. The per-store `registerPane` /
+ * `unregisterPane` exports survive but are documented `@internal — tests
+ * only`. The store-internal tests
+ * (`agent-pane-state-store.test.ts`, `agent-document-store.test.ts`)
+ * exercise each reducer in isolation and need direct register/unregister
+ * access without bringing the sibling store along; they import the
+ * per-store functions directly. Every production call site goes through
+ * this helper.
+ *
+ * ## Option A/B choice
+ *
+ * - **Option A** (keep both per-store `registerPane` exported, mark
+ *   `@internal`): lighter, enforcement is comment-only.
+ * - **Option B** (per-store registration is private to the store + the
+ *   unified helper; tests use the helper too): strictest.
+ *
+ * We picked **Option A** for a pragmatic reason: the per-store cascade
+ * tests in `agent-pane-state-store.test.ts` (PR #878) drive
+ * single-store cascade-disposal scenarios that require direct access to
+ * `registerPane` / `unregisterPane` on a single store, with custom
+ * projection setters that synchronously call `unregisterPane` to
+ * simulate a reactive subscriber's mid-dispatch dispose. Forcing those
+ * tests through the unified helper would require either bringing up the
+ * full second-store slot (changing what the test is testing) or adding
+ * a test-only escape hatch (which defeats Option B's enforcement
+ * point). Marking the per-store exports `@internal — tests only` and
+ * documenting that ALL production callers go through the unified helper
+ * gives the same structural guarantee for the actual failure mode (the
+ * half-registered window in agent-view's lifecycle) without the test
+ * thrash.
+ *
+ * If the test surface ever migrates to a fake/mock projection layer
+ * that doesn't need raw single-store access, the per-store exports can
+ * be flipped to Option-B-strict (renamed `_register*` etc.) in a
+ * follow-up. PR-4 of the cascade sequence introduces a model-level
+ * `dispatchIfAlive` pattern that may make the per-store cascade tests
+ * obsolete — at which point the Option B flip becomes cheap.
+ */
+
+import {
+    registerPane as registerAgentDocPaneRaw,
+    snapshot as agentDocSnapshot,
+    unregisterPane as unregisterAgentDocPaneRaw,
+} from "./agent-document-store";
+import {
+    type AgentPaneProjections,
+    registerPane as registerAgentPaneStatePaneRaw,
+    snapshot as agentPaneStateSnapshot,
+    unregisterPane as unregisterAgentPaneStatePaneRaw,
+} from "./agent-pane-state-store";
+import type { DocumentNode } from "../view/agent/types";
+
+/**
+ * Options bundle for the unified register call. Mirrors the union of
+ * what the two underlying stores need:
+ *
+ *   - `agentId` — identity of the agent occupying this pane. Drives
+ *     reducer initialState for the pane-state slot.
+ *   - `documentSetter` — write-only projection for the documentAtom.
+ *   - `projections` — the eight per-field setters the pane-state slot
+ *     writes through (streaming / sessionStats / currentTool /
+ *     turnTokens / turnActive / stopping / pending / initPhase /
+ *     turnPhase).
+ */
+export interface PaneRegistration {
+    agentId: string;
+    documentSetter: (nodes: DocumentNode[]) => void;
+    projections: AgentPaneProjections;
+}
+
+/**
+ * Atomically register a pane in BOTH stores. Either both succeed or
+ * neither does — if the second store throws during registration, the
+ * first is rolled back so observers never see the half-state.
+ *
+ * Idempotent in the same sense as the underlying stores: re-registering
+ * a blockId resets state in both slots.
+ *
+ * MUST be called synchronously from the agent component body, before
+ * any hook can dispatch. See `agent-view.tsx`.
+ */
+export function registerPane(blockId: string, reg: PaneRegistration): void {
+    // Register both stores synchronously. JS is single-threaded — no
+    // dispatcher can observe the gap between these two lines unless one
+    // of them triggers a reactive cascade. Both register functions are
+    // a simple `Map.set` with no setter calls, so they cannot themselves
+    // cascade-dispatch.
+    registerAgentDocPaneRaw(blockId, reg.documentSetter);
+    try {
+        registerAgentPaneStatePaneRaw(blockId, reg.agentId, reg.projections);
+    } catch (e) {
+        // Pane-state register failed — roll back the document slot so
+        // the contract holds. The document slot was set above; we own
+        // the lifecycle here.
+        try {
+            unregisterAgentDocPaneRaw(blockId);
+        } catch {
+            // Best-effort rollback. If unregister itself throws (the
+            // current stores never do), we accept a leaked document
+            // slot over a partially-registered pane — but the throw
+            // below still surfaces the root failure.
+        }
+        throw e;
+    }
+}
+
+/**
+ * Atomically unregister a pane from BOTH stores. Both unregister calls
+ * complete before this function returns — no dispatcher can observe the
+ * pane registered in one store but not the other across this boundary.
+ *
+ * Idempotent: calling unregister on a blockId that isn't registered in
+ * either store is a no-op (each underlying `Map.delete` returns false
+ * silently).
+ *
+ * Order: pane-state FIRST, then document. The cascade scenario this
+ * defends against is a documentAtom subscriber that unmounts the pane
+ * during a document setter call (the Shape B cascade from the
+ * LIFECYCLE_DISPATCH_LEAK analysis). The intermediate state seen by
+ * any synchronously-running subscriber between the two `delete` calls
+ * is "pane-state gone, document still there" — which the soft-dispatch
+ * variants in PR #878 + #989 already handle correctly (they return [];
+ * they don't throw). Reversing the order would expose the
+ * "document gone, pane-state still there" intermediate, in which a
+ * pane-state subscriber that read the document store would see an
+ * inconsistent view.
+ *
+ * Per-store unregister failures are swallowed so one failing teardown
+ * can't strand the other slot. The current stores never throw on
+ * unregister, but the cross-store atomicity contract belongs to the
+ * helper, not the callers.
+ */
+export function unregisterPane(blockId: string): void {
+    try {
+        unregisterAgentPaneStatePaneRaw(blockId);
+    } catch {
+        // Best-effort — never let the first teardown strand the second.
+    }
+    try {
+        unregisterAgentDocPaneRaw(blockId);
+    } catch {
+        // Best-effort — see above.
+    }
+}
+
+/**
+ * Diagnostic — true only when the pane is registered in BOTH stores.
+ * Any other state (registered in only one, registered in neither)
+ * returns `false`. That's the invariant the unified helper exists to
+ * preserve. Used by the registration-invariant test.
+ */
+export function isPaneFullyRegistered(blockId: string): boolean {
+    return (
+        agentDocSnapshot(blockId) !== null &&
+        agentPaneStateSnapshot(blockId) !== null
+    );
+}
+
+/**
+ * Diagnostic — true if the pane is registered in EXACTLY ONE of the two
+ * stores (the failure mode this module exists to prevent). Used by the
+ * registration-invariant test.
+ */
+export function isPaneHalfRegistered(blockId: string): boolean {
+    const inDoc = agentDocSnapshot(blockId) !== null;
+    const inPaneState = agentPaneStateSnapshot(blockId) !== null;
+    return inDoc !== inPaneState;
+}
+
+export type { AgentPaneProjections };

--- a/frontend/app/store/agent-pane-registration.ts
+++ b/frontend/app/store/agent-pane-registration.ts
@@ -96,10 +96,11 @@ import type { DocumentNode } from "../view/agent/types";
  *   - `agentId` — identity of the agent occupying this pane. Drives
  *     reducer initialState for the pane-state slot.
  *   - `documentSetter` — write-only projection for the documentAtom.
- *   - `projections` — the eight per-field setters the pane-state slot
+ *   - `projections` — the seven per-field setters the pane-state slot
  *     writes through (streaming / sessionStats / currentTool /
- *     turnTokens / turnActive / stopping / pending / initPhase /
- *     turnPhase).
+ *     turnTokens / pending / initPhase / turnPhase). PR G dropped the
+ *     legacy `turnActive` and `stopping` projections — see
+ *     `AgentPaneProjections` in `agent-pane-state-store.ts`.
  */
 export interface PaneRegistration {
     agentId: string;

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -80,6 +80,14 @@ export function setEventSink(sink: EventSink): void {
  * Register a pane. Call SYNCHRONOUSLY from the component body, before
  * any hook can dispatch. Re-registering a blockId resets the state cell
  * to initialState (useful for hot-reload).
+ *
+ * @internal — production callers MUST use `registerPane` from
+ * `agent-pane-registration.ts` so the pane is registered atomically
+ * across BOTH stores (document + pane-state). Direct callers of this
+ * function are limited to single-store unit tests (cascade-detection
+ * scenarios that need a custom single-store projection). PR-3 of the
+ * cascade follow-up sequence — see agent-pane-registration.ts for
+ * rationale + Option A/B discussion.
  */
 export function registerPane(
     blockId: string,
@@ -89,6 +97,10 @@ export function registerPane(
     slots.set(blockId, { state: initialState(agentId), proj });
 }
 
+/**
+ * @internal — see `registerPane` above. Production code uses
+ * `unregisterPane` from `agent-pane-registration.ts`.
+ */
 export function unregisterPane(blockId: string): void {
     slots.delete(blockId);
 }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -9,14 +9,14 @@ import { createAgentAtoms } from "./state";
 import {
     dispatch as dispatchDoc,
     dispatchIfRegistered as dispatchDocIfRegistered,
-    registerPane as registerAgentDocPane,
-    unregisterPane as unregisterAgentDocPane,
 } from "@/app/store/agent-document-store";
 import {
     dispatch as dispatchPane,
-    registerPane as registerAgentPaneStatePane,
-    unregisterPane as unregisterAgentPaneStatePane,
 } from "@/app/store/agent-pane-state-store";
+import {
+    registerPane as registerAgentPane,
+    unregisterPane as unregisterAgentPane,
+} from "@/app/store/agent-pane-registration";
 import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -104,39 +104,44 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
-    // Register this pane with the document store SYNCHRONOUSLY during
-    // component-body execution — before any hook's onMount can dispatch
-    // (codex P1 PR #681 round 1). The store throws on dispatch to an
-    // unregistered slot to prevent silent reducer-command drops, so the
-    // slot must exist before useAgentStream / useHistoryPagination call
-    // dispatchDoc from their own onMount handlers. See
-    // docs/specs/agent-pane-document-reducer-2026-05-03.md.
-    registerAgentDocPane(model.blockId, agentAtoms().documentAtom[1]);
-    onCleanup(() => unregisterAgentDocPane(model.blockId));
-
-    // Slice #4 — agent-pane-state slot: bundles streaming/sessionStats/
-    // currentTool/turnTokens/pending atoms behind a single reducer with
-    // cross-atom invariants. Same synchronous-register rule as the
-    // agent-document slot.
+    // Register this pane with BOTH the document store and the pane-state
+    // store SYNCHRONOUSLY in one atomic call, during component-body
+    // execution — before any hook's onMount can dispatch
+    // (codex P1 PR #681 round 1). The stores throw on dispatch to an
+    // unregistered slot to prevent silent reducer-command drops, so both
+    // slots must exist before useAgentStream / useHistoryPagination call
+    // their first dispatch from `onMount` handlers.
+    //
+    // PR-3 of the cascade follow-up sequence: registration is unified so
+    // a dispatcher can never observe the pane registered in one store
+    // but not the other. The half-registered window was the structural
+    // root of the cascade-mid-dispatch failure mode PR #878 detected and
+    // PR #989 migrated three call sites away from
+    // (docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md + the
+    // 2026-05-23 replaceChild retro). See agent-pane-registration.ts.
     //
     // `turnPhase` is the single-source-of-truth working/stopping signal
     // since PR G — the legacy `turnActive` / `stopping` /
-    // `streaming.active` fields and their projection setters have been
+    // `streaming.active` fields and their projection setters were
     // removed. The view binds the working animation to
     // `workingFromPhase(turnPhase)` and the "Stopping…" label to
     // `turnPhase.kind === "Interrupting"` (see AgentStatusLine below).
     {
         const a = agentAtoms();
-        registerAgentPaneStatePane(model.blockId, agentId, {
-            streaming: a.streamingStateAtom[1],
-            sessionStats: a.sessionStatsAtom[1],
-            currentTool: a.currentToolAtom[1],
-            turnTokens: a.turnTokensAtom[1],
-            pending: a.pendingMessagesAtom[1],
-            initPhase: a.initPhaseAtom[1],
-            turnPhase: a.turnPhaseAtom[1],
+        registerAgentPane(model.blockId, {
+            agentId,
+            documentSetter: a.documentAtom[1],
+            projections: {
+                streaming: a.streamingStateAtom[1],
+                sessionStats: a.sessionStatsAtom[1],
+                currentTool: a.currentToolAtom[1],
+                turnTokens: a.turnTokensAtom[1],
+                pending: a.pendingMessagesAtom[1],
+                initPhase: a.initPhaseAtom[1],
+                turnPhase: a.turnPhaseAtom[1],
+            },
         });
-        onCleanup(() => unregisterAgentPaneStatePane(model.blockId));
+        onCleanup(() => unregisterAgentPane(model.blockId));
     }
 
     // Activity log — collects per-session diagnostic entries from launch


### PR DESCRIPTION
Cascade follow-up PR-3 (2 of 4). Closes the half-registered window between `agent-document-store` and `agent-pane-state-store` registrations — the structural root of the cascade-mid-dispatch failure mode PR #878 added detection for and PR #989 partially mitigated.

Refs:
- `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md` §6.2 follow-up
- PR #878 — cascade detection instrumentation + soft-dispatch variants
- PR #989 — migrated three throwing dispatch sites to the soft variant

## The problem this closes

Before this PR, `agent-view.tsx` registered each pane with TWO independent stores in sequence:

```ts
registerAgentDocPane(blockId, setter);                        // store A
onCleanup(() => unregisterAgentDocPane(blockId));
registerAgentPaneStatePane(blockId, agentId, projections);    // store B
onCleanup(() => unregisterAgentPaneStatePane(blockId));
```

Two distinct register calls, two distinct `onCleanup` callbacks. A `StreamFlush` dispatch (from `useAgentStream`, hooked subscriptions, or any hot dispatch loop) landing in the synchronous gap between the two registers — or in the asymmetric teardown order during cleanup — found the pane registered in one store but not the other. The dispatch into the missing slot threw, tore the reactive graph, and surfaced as `replaceChild NotFoundError` in the UI.

PR #878 added cascade DETECTION. PR #989 migrated three throwing dispatch sites to the soft `dispatchIfRegistered` variant. PR-3 closes the half-registered window STRUCTURALLY.

## The fix

New module `frontend/app/store/agent-pane-registration.ts` is the unified surface:

```ts
export function registerPane(blockId: string, reg: PaneRegistration): void;
export function unregisterPane(blockId: string): void;
```

- `registerPane` atomically registers in BOTH stores. If the second store's register throws, the first is rolled back so observers never see the half-state.
- `unregisterPane` atomically tears down BOTH stores. Teardown order is pane-state first, document second — the intermediate "pane-state gone, document still there" state is safe for the soft-dispatch variants from PR #878 / #989 (they return `[]`, don't throw).

agent-view.tsx migrated to call the unified helper once, in a single `onCleanup`.

## Contract

> At any observable point in time, the pane is either FULLY registered in BOTH stores or FULLY unregistered from BOTH. There is no half-registered state from a dispatcher's POV.

`frontend/app/store/agent-pane-registration.test.ts` (14 tests) pins this down with both an invariant-over-lifecycle test (`isPaneHalfRegistered === false` at every observable moment across `register → unregister → re-register → unregister`) and snapshot probes against both underlying stores.

## Option A/B choice

**Picked Option A:** per-store `registerPane` / `unregisterPane` remain exported but are documented `@internal — tests only`. The per-store cascade tests added in PR #878 (`agent-pane-state-store.test.ts`) drive single-store cascade-disposal scenarios that require direct register/unregister access with custom projection setters that synchronously call `unregisterPane` to simulate a reactive subscriber mid-dispatch dispose. Forcing those through the unified helper would either:
- bring up a full second-store slot (changes what the test is testing), or
- require a test-only escape hatch (defeats Option B's enforcement point).

Marking the per-store exports `@internal — tests only` and documenting that ALL production callers go through the unified helper gives the same structural guarantee for the actual failure mode (the half-registered window in agent-view's lifecycle) without the test thrash.

PR-4 of the cascade sequence (model-level `dispatchIfAlive`) may make the per-store cascade tests obsolete — at which point the Option B flip (rename to `_register*`, no export) becomes cheap.

## Files

- new: `frontend/app/store/agent-pane-registration.ts`
- new: `frontend/app/store/agent-pane-registration.test.ts`
- modified: `frontend/app/store/agent-document-store.ts` (`@internal` docs on register/unregister)
- modified: `frontend/app/store/agent-pane-state-store.ts` (`@internal` docs on register/unregister)
- modified: `frontend/app/view/agent/agent-view.tsx` (use unified helper; single onCleanup)

## Out of scope

- The `dispatchIfAlive` model-level pattern (PR-4, separate).
- View-level migration of dispatch sites.
- Cleaning up the cascade detection logging from PR #878 — kept as-is.

## Tests

- `npx vitest run frontend/app/store/agent-pane-registration.test.ts` — 14/14 pass.
- `npx vitest run frontend/app/store/agent-pane-state-store.test.ts frontend/app/store/agent-pane-state/ frontend/app/store/agent-document/` — 188/188 pass.
- `npx vitest run frontend/app/view/agent/` — 271/272 pass (one pre-existing unrelated failure in `providers/index.test.ts` for the acp/api-key check, confirmed present on `main`).
- `npx tsc --noEmit` — no new TS errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)