### PR TITLE
feat(agent): recent sessions tab in launch modal for reattaching previous conversations

### DIFF
--- a/.changesets/1779548808-feat-agent-recent-sessions-reattach-ux-805n.md
+++ b/.changesets/1779548808-feat-agent-recent-sessions-reattach-ux-805n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): recent sessions reattach UX

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -333,6 +333,12 @@ pub const COMMAND_LIST_NAMED_AGENTS: &str = "listnamedagents";
 /// v8 — soft-delete (hide) a named agent instance from the dropdown.
 /// Row + working directory remain on disk for audit + recovery.
 pub const COMMAND_HIDE_NAMED_AGENT: &str = "hidenamedagent";
+/// Cascade follow-up (2026-05-23) — list recent agent sessions with
+/// conversation previews extracted from the filestore `output.state.json`
+/// snapshot. Powers the AgentPicker's "Recent sessions" surface so a
+/// pane crash that orphans a conversation becomes recoverable from
+/// normal UI. See `docs/recovery/MAKS_CONVERSATION_2026_05_23.md`.
+pub const COMMAND_LIST_RECENT_SESSIONS: &str = "listrecentsessions";
 
 // Agent definition branching
 pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
@@ -1734,6 +1740,62 @@ pub struct NamedAgentRow {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandHideNamedAgentData {
     pub id: String,
+}
+
+/// Request for `listrecentsessions` — powers the AgentPicker's "Recent
+/// sessions" surface (cascade follow-up, 2026-05-23). Optional
+/// `identity_id` filter narrows the results to sessions that used the
+/// given identity bundle (matches `db_agent_instances.identity_id`).
+/// `limit` defaults to 20 (capped at 100); rows are sorted by the
+/// most-recent activity timestamp (filestore `output.state.json` modts
+/// when available, otherwise instance `started_at`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandListRecentSessionsData {
+    #[serde(default)]
+    pub limit: usize,
+    /// When set + non-empty, filter to sessions whose `identity_id`
+    /// matches. `Some("")` is treated the same as `None` (no filter)
+    /// to make the frontend wiring straightforward.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_id: Option<String>,
+}
+
+/// One row of the AgentPicker's "Recent sessions" list. Mirrors
+/// `NamedAgentRow` but adds preview fields read from the per-block
+/// `output.state.json` snapshot in filestore. `node_count == 0` and an
+/// empty `preview` mean the snapshot wasn't readable (the block may
+/// pre-date the persistence flow or have crashed before its first
+/// 30s snapshot) — the row still surfaces so the user can reattach.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentSessionRow {
+    pub instance_id: String,
+    pub instance_name: String,
+    pub definition_id: String,
+    pub definition_name: String,
+    pub provider: String,
+    pub working_directory: String,
+    pub identity_id: String,
+    pub identity_name: String,
+    pub memory_id: String,
+    pub memory_name: String,
+    /// The pane / block whose filestore zone holds the conversation.
+    /// Empty when the instance row exists but no SQLite row resolved
+    /// the block_id (cross-version registry rows). Reattach falls
+    /// back to the working-directory continuation path in that case.
+    pub block_id_hint: String,
+    /// Snapshot of the first user message in the conversation (up to
+    /// 240 chars, newlines collapsed). Empty when the snapshot doesn't
+    /// exist or doesn't contain a user_message node yet.
+    pub preview: String,
+    /// Total `nodes.length` from the snapshot. 0 when unavailable.
+    pub node_count: usize,
+    /// Last activity timestamp (filestore modts when the snapshot
+    /// exists, otherwise `started_at`). Drives the sort order.
+    pub last_active_at: i64,
+    /// Whether `output.state.json` was found in filestore for this
+    /// block. False when the snapshot doesn't exist yet (no preview)
+    /// or the block_id_hint was empty.
+    pub has_snapshot: bool,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -36,6 +36,8 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_NAMED_AGENTS, COMMAND_HIDE_NAMED_AGENT,
     CommandListNamedAgentsData, CommandHideNamedAgentData,
     NamedAgentRow,
+    COMMAND_LIST_RECENT_SESSIONS, CommandListRecentSessionsData,
+    RecentSessionRow,
     COMMAND_FORK_AGENT_DEFINITION,
     CommandListIdentityAccountsData, CommandGetIdentityAccountData,
     CommandDeleteIdentityAccountData,
@@ -1366,6 +1368,157 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
+    // ---- Recent sessions (cascade follow-up 2026-05-23) ----
+    //
+    // listrecentsessions — joins `db_agent_instances` with the
+    // filestore `output.state.json` snapshot for each instance's
+    // block_id_hint, producing a preview + node count so the
+    // AgentPicker can show actual conversation context instead of just
+    // metadata. Sort key is the snapshot modts (last activity)
+    // descending; rows without a snapshot fall back to the instance
+    // started_at and are de-prioritized. Cap at 20 rows.
+    //
+    // The reattach mechanism is the existing continuation flow:
+    // continueOfInstanceId + workDirOverride (see PR #977). This RPC
+    // is a more discoverable surface for finding sessions to continue
+    // — particularly orphaned ones whose pane crashed.
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+    engine.register_handler(
+        COMMAND_LIST_RECENT_SESSIONS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            Box::pin(async move {
+                let cmd: CommandListRecentSessionsData =
+                    serde_json::from_value(data).unwrap_or_default();
+                let limit = if cmd.limit == 0 {
+                    20
+                } else {
+                    cmd.limit.min(100)
+                };
+                // Pull up to ~10x the requested cap so we can post-
+                // filter by snapshot presence + identity_id without
+                // running out of candidates. 10x is a safety margin
+                // and stays well inside the 200 default of
+                // instance_list_named.
+                let raw_limit = (limit * 10).max(50).min(500);
+                let instances = wstore
+                    .instance_list_named(raw_limit, None)
+                    .map_err(|e| format!("listrecentsessions: {e}"))?;
+
+                let defs = wstore
+                    .agent_def_list()
+                    .map_err(|e| format!("listrecentsessions: defs: {e}"))?;
+                let identities = wstore
+                    .bundle_identity_list()
+                    .map_err(|e| format!("listrecentsessions: identities: {e}"))?;
+                let memories = wstore
+                    .bundle_memory_list()
+                    .map_err(|e| format!("listrecentsessions: memories: {e}"))?;
+
+                let identity_filter = cmd
+                    .identity_id
+                    .as_deref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty());
+
+                // Build rows. Hits filestore once per instance; with
+                // raw_limit ≤ 500 and stat() being a single indexed
+                // SQLite query, the per-call cost is dominated by
+                // the eventual snapshot read for the top-20.
+                let mut rows: Vec<RecentSessionRow> = Vec::with_capacity(instances.len());
+                for inst in instances {
+                    // Identity filter — applied before any filestore
+                    // I/O so the rejected rows don't pay for a stat.
+                    if let Some(filter) = identity_filter {
+                        if inst.identity_id != filter {
+                            continue;
+                        }
+                    }
+                    let def = defs.iter().find(|d| d.id == inst.definition_id);
+                    let identity_name = if inst.identity_id.is_empty() {
+                        "(ambient creds)".to_string()
+                    } else {
+                        identities
+                            .iter()
+                            .find(|i| i.id == inst.identity_id)
+                            .map(|i| i.name.clone())
+                            .unwrap_or_else(|| "(missing identity)".to_string())
+                    };
+                    let memory_name = if inst.memory_id.is_empty() {
+                        "(vanilla CLI)".to_string()
+                    } else {
+                        memories
+                            .iter()
+                            .find(|m| m.id == inst.memory_id)
+                            .map(|m| m.name.clone())
+                            .unwrap_or_else(|| "(missing memory)".to_string())
+                    };
+
+                    // Stat first (cheap) — gives us the modts for
+                    // sorting. Only fetch the full content if the
+                    // snapshot exists.
+                    let (has_snapshot, last_active_at, preview, node_count) =
+                        if inst.block_id.is_empty() {
+                            (false, inst.started_at, String::new(), 0usize)
+                        } else {
+                            match filestore.stat(&inst.block_id, "output.state.json") {
+                                Ok(Some(file)) => {
+                                    let modts = if file.modts > 0 {
+                                        file.modts
+                                    } else {
+                                        inst.started_at
+                                    };
+                                    let (preview, node_count) = read_session_preview(
+                                        &filestore,
+                                        &inst.block_id,
+                                    );
+                                    (true, modts, preview, node_count)
+                                }
+                                _ => (false, inst.started_at, String::new(), 0usize),
+                            }
+                        };
+
+                    rows.push(RecentSessionRow {
+                        instance_id: inst.id,
+                        instance_name: inst.instance_name,
+                        definition_id: inst.definition_id.clone(),
+                        definition_name: def
+                            .map(|d| d.name.clone())
+                            .unwrap_or_else(|| "(missing definition)".to_string()),
+                        provider: def.map(|d| d.provider.clone()).unwrap_or_default(),
+                        working_directory: inst.working_directory,
+                        identity_id: inst.identity_id,
+                        identity_name,
+                        memory_id: inst.memory_id,
+                        memory_name,
+                        block_id_hint: inst.block_id,
+                        preview,
+                        node_count,
+                        last_active_at,
+                        has_snapshot,
+                    });
+                }
+
+                // Sort: rows with a snapshot first (descending by
+                // modts), then no-snapshot rows by started_at desc.
+                // This keeps live conversations at the top while
+                // still surfacing legacy rows.
+                rows.sort_by(|a, b| match (a.has_snapshot, b.has_snapshot) {
+                    (true, true) | (false, false) => {
+                        b.last_active_at.cmp(&a.last_active_at)
+                    }
+                    (true, false) => std::cmp::Ordering::Less,
+                    (false, true) => std::cmp::Ordering::Greater,
+                });
+                rows.truncate(limit);
+
+                Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
+            })
+        }),
+    );
+
     // ---- Definition fork ----
 
     let wstore = state.wstore.clone();
@@ -1771,4 +1924,510 @@ fn register_v7_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+/// Read the per-block `output.state.json` snapshot from filestore and
+/// extract a `(preview, node_count)` pair for the AgentPicker's
+/// "Recent sessions" list.
+///
+/// The snapshot shape is owned by the frontend (see
+/// `frontend/app/view/agent/agent-view.tsx::writeSnapshotNow`):
+/// `{ schemaVersion, savedAt, highWaterMark, historyOffset, nodes: [DocumentNode...] }`.
+/// We only touch two fields:
+/// - `nodes.length` → `node_count`.
+/// - The first node with `type === "user_message"`, `message` field →
+///   `preview` (trimmed, newlines collapsed, max 240 chars).
+///
+/// On any error (snapshot missing, malformed JSON, no user message),
+/// returns `("", 0)`. Callers treat that the same as "no preview".
+fn read_session_preview(
+    filestore: &crate::backend::storage::filestore::FileStore,
+    block_id: &str,
+) -> (String, usize) {
+    let bytes = match filestore.read_file(block_id, "output.state.json") {
+        Ok(Some(b)) => b,
+        _ => return (String::new(), 0),
+    };
+    // Cap the parse budget — a misbehaving / corrupted snapshot
+    // shouldn't be able to stall this handler. 4MiB is well above the
+    // typical conversation snapshot (Maks's was ~750KiB for 169 nodes)
+    // but bounded enough to fail fast on garbage.
+    if bytes.len() > 4 * 1024 * 1024 {
+        tracing::warn!(
+            block_id = %block_id,
+            size = bytes.len(),
+            "listrecentsessions: snapshot too large; skipping preview"
+        );
+        return (String::new(), 0);
+    }
+    let json: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => return (String::new(), 0),
+    };
+    let nodes = match json.get("nodes").and_then(|v| v.as_array()) {
+        Some(a) => a,
+        None => return (String::new(), 0),
+    };
+    let node_count = nodes.len();
+    // First user_message wins. Skip the bootstrap "Session Context"
+    // prompt when present — it's always the first node and is system
+    // boilerplate the user didn't type; if a subsequent user_message
+    // exists, that's the more useful preview. Heuristic: if the first
+    // user message starts with "# Session Context", scan for the next.
+    let mut preview = String::new();
+    for node in nodes {
+        let ty = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if ty != "user_message" {
+            continue;
+        }
+        let msg = node
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+        if msg.is_empty() {
+            continue;
+        }
+        if preview.is_empty() && msg.starts_with("# Session Context") {
+            // Stash as fallback in case there's no later user_message.
+            preview = collapse_preview(msg);
+            continue;
+        }
+        preview = collapse_preview(msg);
+        break;
+    }
+    (preview, node_count)
+}
+
+/// Collapse newlines + extra whitespace, cap at 240 chars. Output is
+/// safe to render inline in a single-line preview row.
+fn collapse_preview(s: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    let mut buf = String::with_capacity(s.len().min(MAX_CHARS + 4));
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if buf.chars().count() >= MAX_CHARS {
+            buf.push('\u{2026}'); // "…"
+            return buf;
+        }
+        if ch.is_whitespace() {
+            if !prev_space && !buf.is_empty() {
+                buf.push(' ');
+                prev_space = true;
+            }
+        } else {
+            buf.push(ch);
+            prev_space = false;
+        }
+    }
+    buf
+}
+
+#[cfg(test)]
+mod recent_sessions_tests {
+    use super::*;
+    use crate::backend::storage::filestore::FileStore;
+
+    fn fresh_filestore() -> std::sync::Arc<FileStore> {
+        std::sync::Arc::new(FileStore::open_in_memory().unwrap())
+    }
+
+    fn write_snapshot(fs: &FileStore, block_id: &str, body: &str) {
+        // make_file then write_file mirrors the production
+        // BlockfileWriteState handler path.
+        let meta: crate::backend::storage::filestore::FileMeta =
+            std::collections::HashMap::new();
+        let opts = crate::backend::storage::filestore::FileOpts::default();
+        fs.make_file(block_id, "output.state.json", meta, opts)
+            .expect("make_file");
+        fs.write_file(block_id, "output.state.json", body.as_bytes())
+            .expect("write_file");
+    }
+
+    #[test]
+    fn collapse_preview_strips_newlines_and_caps_length() {
+        let s = "hello\n\nworld\n  next   line";
+        assert_eq!(collapse_preview(s), "hello world next line");
+        let long: String = "a".repeat(500);
+        let out = collapse_preview(&long);
+        // 240 chars + ellipsis.
+        assert!(out.ends_with('\u{2026}'));
+        assert!(out.chars().count() <= 241);
+    }
+
+    #[test]
+    fn read_session_preview_missing_returns_zero() {
+        let fs = fresh_filestore();
+        let (preview, count) = read_session_preview(&fs, "no-such-block");
+        assert_eq!(preview, "");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn read_session_preview_extracts_first_user_message_skipping_context() {
+        let fs = fresh_filestore();
+        // Two user messages: first is the boilerplate Session Context;
+        // second is the user's real prompt. Preview should be the real one.
+        let snapshot = serde_json::json!({
+            "schemaVersion": 1,
+            "savedAt": "2026-05-23T08:00:00Z",
+            "highWaterMark": 169,
+            "historyOffset": 0,
+            "nodes": [
+                {
+                    "type": "user_message",
+                    "id": "u0",
+                    "timestamp": 0,
+                    "collapsed": false,
+                    "summary": "👤 User Message",
+                    "message": "# Session Context\nIdentity: Claude\n## Description\nStartup boilerplate"
+                },
+                { "type": "markdown", "id": "m0", "content": "ack" },
+                {
+                    "type": "user_message",
+                    "id": "u1",
+                    "timestamp": 100,
+                    "collapsed": false,
+                    "summary": "👤 User Message",
+                    "message": "check the agentmuxai/agentmux history, get the latest code"
+                }
+            ]
+        });
+        write_snapshot(&fs, "blk-1", &snapshot.to_string());
+        let (preview, count) = read_session_preview(&fs, "blk-1");
+        assert_eq!(count, 3);
+        assert!(preview.starts_with("check the agentmuxai/agentmux"));
+    }
+
+    #[test]
+    fn read_session_preview_falls_back_to_session_context_when_only_one() {
+        let fs = fresh_filestore();
+        let snapshot = serde_json::json!({
+            "schemaVersion": 1,
+            "nodes": [
+                {
+                    "type": "user_message",
+                    "id": "u0",
+                    "message": "# Session Context\nIdentity: Claude\nStartup boilerplate"
+                }
+            ]
+        });
+        write_snapshot(&fs, "blk-2", &snapshot.to_string());
+        let (preview, count) = read_session_preview(&fs, "blk-2");
+        assert_eq!(count, 1);
+        // Newlines collapsed; starts with the boilerplate marker.
+        assert!(preview.starts_with("# Session Context"));
+    }
+
+    #[test]
+    fn read_session_preview_handles_malformed_json() {
+        let fs = fresh_filestore();
+        write_snapshot(&fs, "blk-3", "not valid json {");
+        let (preview, count) = read_session_preview(&fs, "blk-3");
+        assert_eq!(preview, "");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn read_session_preview_handles_no_user_messages() {
+        let fs = fresh_filestore();
+        let snapshot = serde_json::json!({
+            "schemaVersion": 1,
+            "nodes": [
+                { "type": "markdown", "id": "m0", "content": "system note" }
+            ]
+        });
+        write_snapshot(&fs, "blk-4", &snapshot.to_string());
+        let (preview, count) = read_session_preview(&fs, "blk-4");
+        assert_eq!(preview, "");
+        assert_eq!(count, 1);
+    }
+
+    // ── Integration test: full listrecentsessions handler ────────────
+    //
+    // Spins up the same engine + state shape as the production
+    // websocket path so the handler runs end-to-end against an
+    // in-memory wstore + filestore. Asserts the row shape, the
+    // identity filter, the snapshot-first sort, the preview extraction,
+    // and the cross-version "no snapshot" fallback. This is the
+    // backend correctness gate for the AgentPicker's Recent Sessions
+    // surface (cascade follow-up 2026-05-23).
+    use crate::backend::storage::wstore::{
+        AgentDefinition, AgentInstance, Identity, InstanceStatus, Memory, WaveStore,
+    };
+    use crate::backend::rpc::engine::WshRpcEngine;
+    use crate::server::AppState;
+    use std::sync::Arc;
+
+    /// Drive a single RPC round-trip against the in-memory engine,
+    /// asserting success + deserializing the JSON payload into `T`.
+    async fn call_rpc<T: serde::de::DeserializeOwned>(
+        engine: &Arc<WshRpcEngine>,
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<crate::backend::rpc_types::RpcMessage>,
+        command: &str,
+        data: serde_json::Value,
+    ) -> T {
+        let req_id = format!("test-{}", uuid::Uuid::new_v4());
+        let msg = crate::backend::rpc_types::RpcMessage {
+            command: command.to_string(),
+            reqid: req_id.clone(),
+            data: Some(data),
+            ..Default::default()
+        };
+        engine.handle_message(msg);
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler timed out")
+            .expect("output channel closed");
+        assert_eq!(resp.resid, req_id, "unexpected response id");
+        assert!(resp.error.is_empty(), "handler returned error: {}", resp.error);
+        let payload = resp.data.unwrap_or(serde_json::Value::Null);
+        serde_json::from_value(payload).expect("response deserialize")
+    }
+
+    fn build_state_with_seed() -> (
+        AppState,
+        Arc<WshRpcEngine>,
+        tokio::sync::mpsc::UnboundedReceiver<crate::backend::rpc_types::RpcMessage>,
+    ) {
+        let wstore = Arc::new(WaveStore::open_in_memory().unwrap());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let event_bus = Arc::new(crate::backend::eventbus::EventBus::new());
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let reactive_handler = crate::backend::reactive::get_global_handler();
+        let poller = Arc::new(crate::backend::reactive::Poller::new(
+            crate::backend::reactive::PollerConfig {
+                agentmux_url: None,
+                agentmux_token: None,
+                poll_interval_secs: 30,
+            },
+            reactive_handler,
+        ));
+        crate::backend::wcore::ensure_initial_data(&wstore).unwrap();
+        let config_watcher = Arc::new(crate::backend::wconfig::ConfigWatcher::new());
+        let process_tracker = Arc::new(
+            crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
+        );
+        let state = AppState {
+            auth_key: "test".to_string(),
+            version: "test".to_string(),
+            app_path: String::new(),
+            wstore: wstore.clone(),
+            filestore: filestore.clone(),
+            event_bus: event_bus.clone(),
+            broker,
+            reactive_handler,
+            poller,
+            config_watcher,
+            messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
+            http_client: reqwest::Client::new(),
+            local_web_url: String::new(),
+            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
+            history_service: Arc::new(crate::backend::history::HistoryService::new()),
+            lan_discovery: None,
+            process_tracker,
+            srv_state: Arc::new(tokio::sync::Mutex::new(crate::state::State::default())),
+            srv_events_tx: tokio::sync::broadcast::channel::<agentmux_common::ipc::Event>(64).0,
+            saga_id_alloc: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
+            auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
+            install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
+        };
+
+        // Seed: 1 definition, 1 identity bundle, 1 memory bundle.
+        let def = AgentDefinition {
+            id: "def-claude".to_string(),
+            slug: "claude-code".to_string(),
+            name: "Claude Code".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+        };
+        let mut def_mut = def.clone();
+        wstore.agent_def_insert(&mut def_mut).unwrap();
+        let identity = Identity {
+            id: "id-work".to_string(),
+            name: "Work".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        wstore.bundle_identity_upsert(&identity).unwrap();
+        let memory = Memory {
+            id: "mem-notes".to_string(),
+            name: "Notes".to_string(),
+            description: String::new(),
+            is_blank: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: String::new(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        wstore.bundle_memory_upsert(&memory).unwrap();
+
+        // 3 instances:
+        //   - blk-recent: has snapshot, more recent activity
+        //   - blk-older:  has snapshot, older activity
+        //   - blk-none:   no snapshot at all (legacy / pre-persistence row)
+        // All three use the same identity bundle so the filter test
+        // can also exercise it without re-seeding.
+        for (id, block, started) in [
+            ("inst-recent", "blk-recent", 1_700_000_100_000_i64),
+            ("inst-older", "blk-older", 1_700_000_000_000_i64),
+            ("inst-none", "blk-none", 1_700_000_050_000_i64),
+        ] {
+            let inst = AgentInstance {
+                id: id.to_string(),
+                definition_id: "def-claude".to_string(),
+                parent_instance_id: String::new(),
+                block_id: block.to_string(),
+                session_id: String::new(),
+                status: InstanceStatus::Running.as_str().to_string(),
+                github_context: String::new(),
+                started_at: started,
+                ended_at: 0,
+                created_at: started,
+                identity_id: "id-work".to_string(),
+                memory_id: "mem-notes".to_string(),
+                instance_name: format!("name-{id}"),
+                working_directory: format!("/tmp/{id}"),
+                display_hidden: false,
+            };
+            wstore.instance_create(&inst).unwrap();
+        }
+
+        // Snapshots for the two with snapshots.
+        let snap_recent = serde_json::json!({
+            "schemaVersion": 1,
+            "nodes": [
+                {"type": "user_message", "id": "u0",
+                 "message": "# Session Context\nboilerplate"},
+                {"type": "markdown", "id": "m0", "content": "ack"},
+                {"type": "user_message", "id": "u1",
+                 "message": "fix the live-feed hover delay"}
+            ]
+        });
+        write_snapshot(&filestore, "blk-recent", &snap_recent.to_string());
+        let snap_older = serde_json::json!({
+            "schemaVersion": 1,
+            "nodes": [
+                {"type": "user_message", "id": "u0",
+                 "message": "earlier conversation"}
+            ]
+        });
+        write_snapshot(&filestore, "blk-older", &snap_older.to_string());
+
+        let (engine, rx) = WshRpcEngine::new();
+        super::register_agent_handlers(&engine, &state);
+        (state, engine, rx)
+    }
+
+    #[tokio::test]
+    async fn handler_returns_sessions_with_previews_sorted_by_snapshot_first() {
+        let (_state, engine, mut rx) = build_state_with_seed();
+        let rows: Vec<RecentSessionRow> = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_LIST_RECENT_SESSIONS,
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(rows.len(), 3, "all three sessions surfaced");
+
+        // Sort: snapshot-bearing rows first (recent then older), then
+        // the no-snapshot row at the tail.
+        assert_eq!(rows[0].instance_id, "inst-recent");
+        assert!(rows[0].has_snapshot);
+        assert_eq!(rows[0].node_count, 3);
+        assert!(
+            rows[0].preview.starts_with("fix the live-feed"),
+            "preview should be the post-context user message, got {:?}",
+            rows[0].preview
+        );
+
+        assert_eq!(rows[1].instance_id, "inst-older");
+        assert!(rows[1].has_snapshot);
+        assert_eq!(rows[1].node_count, 1);
+        assert_eq!(rows[1].preview, "earlier conversation");
+
+        assert_eq!(rows[2].instance_id, "inst-none");
+        assert!(!rows[2].has_snapshot);
+        assert_eq!(rows[2].node_count, 0);
+        assert_eq!(rows[2].preview, "");
+
+        // Joins: definition + identity + memory names resolved.
+        assert_eq!(rows[0].definition_name, "Claude Code");
+        assert_eq!(rows[0].identity_name, "Work");
+        assert_eq!(rows[0].memory_name, "Notes");
+        assert_eq!(rows[0].block_id_hint, "blk-recent");
+    }
+
+    #[tokio::test]
+    async fn handler_identity_filter_restricts_rows() {
+        let (_state, engine, mut rx) = build_state_with_seed();
+        // Filter to a non-existent identity → empty list.
+        let rows: Vec<RecentSessionRow> = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_LIST_RECENT_SESSIONS,
+            serde_json::json!({ "identity_id": "no-such-bundle" }),
+        )
+        .await;
+        assert_eq!(rows.len(), 0);
+
+        // Filter to the seeded one → all three.
+        let rows: Vec<RecentSessionRow> = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_LIST_RECENT_SESSIONS,
+            serde_json::json!({ "identity_id": "id-work" }),
+        )
+        .await;
+        assert_eq!(rows.len(), 3);
+
+        // Empty-string identity_id is treated as "no filter" so the
+        // frontend can pass `""` without special-casing.
+        let rows: Vec<RecentSessionRow> = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_LIST_RECENT_SESSIONS,
+            serde_json::json!({ "identity_id": "" }),
+        )
+        .await;
+        assert_eq!(rows.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn handler_respects_limit() {
+        let (_state, engine, mut rx) = build_state_with_seed();
+        let rows: Vec<RecentSessionRow> = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_LIST_RECENT_SESSIONS,
+            serde_json::json!({ "limit": 1 }),
+        )
+        .await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].instance_id, "inst-recent");
+    }
 }

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1000,6 +1000,22 @@ class RpcApiType {
         return client.rpcCall("hidenamedagent", data, opts);
     }
 
+    // command "listrecentsessions" [call]
+    // Cascade follow-up (2026-05-23) — powers the AgentPicker's
+    // "Recent sessions" surface. Each row joins an agent-instance
+    // record with the filestore `output.state.json` snapshot for that
+    // block, producing a conversation preview + node count so an
+    // orphaned conversation (e.g. after a renderer crash) becomes
+    // recoverable from normal UI. See docs/recovery/MAKS_CONVERSATION_2026_05_23.md
+    // and PR #977 for the underlying continueOfId reattach plumbing.
+    ListRecentSessionsCommand(
+        client: RpcClient,
+        data: { limit?: number; identity_id?: string },
+        opts?: RpcOpts,
+    ): Promise<RecentSessionRow[]> {
+        return client.rpcCall("listrecentsessions", data, opts);
+    }
+
     // command "forkagentdefinition" [call]
     ForkAgentDefinitionCommand(
         client: RpcClient,

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -21,6 +21,7 @@
 @use "styles/disconnected-banner";
 @use "styles/activity-log";
 @use "styles/picker";
+@use "styles/recent-sessions";
 @use "styles/control-bar";
 @use "styles/connection-status";
 @use "styles/document";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -21,6 +21,7 @@ import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
 import type { LaunchOverrides } from "./AgentLaunchModal";
+import { RecentSessionsList } from "./RecentSessionsList";
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
@@ -201,6 +202,48 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
 
     const openLaunchModal = (agent: AgentDefinition) => {
         tabModal.open(buildLaunchRequest(agent));
+    };
+
+    // Cascade follow-up (2026-05-23) — reattach via Recent Sessions.
+    // We bypass the launch modal entirely (no Identity / Memory picks
+    // to make — the row carries them) and call launchAgentDefinition
+    // directly with the same `continueOfInstanceId + workDirOverride`
+    // shape the modal's Continue dropdown produces. That keeps the
+    // continuation path single-sourced: same backend RPCs, same
+    // CreateAgentInstance lineage, same env injection. If the
+    // definition for this row no longer exists (rare, but possible if
+    // the user deleted it), fall back to the launch modal for the
+    // first matching definition so the user can pick a substitute.
+    // See: RecentSessionsList.tsx file header for the full mechanism
+    // discussion.
+    const handleReattach = async (row: RecentSessionRow) => {
+        const def = agents().find((a) => a.id === row.definition_id);
+        if (!def) {
+            // Definition gone — log + no-op rather than spawn into a
+            // missing definition. The frontend logger forwards to the
+            // sidecar so this shows up in muxlog. Surfacing a toast is
+            // a UX polish follow-up; for the cascade-recovery flow,
+            // not crashing the picker is the priority.
+            // eslint-disable-next-line no-console
+            console.warn(
+                `recent-session reattach: definition ${row.definition_id} not found`,
+            );
+            return;
+        }
+        setLaunching(def.id);
+        try {
+            await props.model.launchAgentDefinition(def, {
+                instanceName: row.instance_name,
+                agentType: (def.agent_type as "host" | "container") || "host",
+                environment: def.agent_type === "container" ? "docker" : "local",
+                identityId: row.identity_id,
+                memoryId: row.memory_id,
+                continueOfInstanceId: row.instance_id,
+                workDirOverride: row.working_directory,
+            });
+        } finally {
+            setLaunching(null);
+        }
     };
 
     // Extracted from the install branch of handleSelect so the
@@ -442,6 +485,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             >
                 <div class="agent-view" style={{ zoom: zoomFactor() }}>
                     <div class="agent-picker">
+                        {/* Cascade follow-up (2026-05-23) — recent
+                            sessions appear ABOVE the agent cards so
+                            users see "continue what you were doing"
+                            before they see "start something new". This
+                            makes orphaned conversations recoverable
+                            from normal UI. Picker is generic (no
+                            identity filter) — the modal-level
+                            Continue dropdown handles per-identity. */}
+                        <RecentSessionsList onReattach={handleReattach} />
                         <div class="agent-picker-list">
                             <For each={agents()}>
                                 {(agent, index) => (

--- a/frontend/app/view/agent/components/RecentSessionsList.test.tsx
+++ b/frontend/app/view/agent/components/RecentSessionsList.test.tsx
@@ -1,0 +1,197 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Render tests for `RecentSessionsList` — the AgentPicker's "Recent
+ * sessions" surface (cascade follow-up 2026-05-23). Covers the three
+ * UX states the parent relies on:
+ *   1. empty (no filter) → generic copy
+ *   2. empty (identity filter) → "for this identity" copy
+ *   3. populated → row count + preview + provider icon + click handler
+ *
+ * Plus a unit test for `formatRelative` to pin the "Xm ago" wording.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    EMPTY_FILTERED,
+    EMPTY_GLOBAL,
+    formatRelative,
+    RecentSessionsList,
+} from "./RecentSessionsList";
+
+vi.mock("@/app/store/rpc-api", () => {
+    const RpcApi = {
+        ListRecentSessionsCommand: vi.fn(),
+    };
+    return { RpcApi };
+});
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+// ProviderLogo just renders something — we don't care what, just that
+// rows mount. The component module imports SVG assets via raw imports
+// which vitest can't resolve without a transformer.
+vi.mock("@/element/ProviderLogo", () => ({
+    ProviderLogo: () => null,
+}));
+
+let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ RpcApi } = await import("@/app/store/rpc-api"));
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+const makeRow = (overrides: Partial<RecentSessionRow> = {}): RecentSessionRow => ({
+    instance_id: "inst-1",
+    instance_name: "Maks",
+    definition_id: "def-claude",
+    definition_name: "Claude Code",
+    provider: "claude",
+    working_directory: "/tmp/maks",
+    identity_id: "id-work",
+    identity_name: "Work",
+    memory_id: "mem-notes",
+    memory_name: "Notes",
+    block_id_hint: "blk-1",
+    preview: "fix the live-feed hover delay",
+    node_count: 12,
+    last_active_at: Date.now() - 60_000,
+    has_snapshot: true,
+    ...overrides,
+});
+
+describe("RecentSessionsList — empty state", () => {
+    it("renders the generic empty copy when no filter is applied", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        render(() => <RecentSessionsList onReattach={() => {}} />);
+        const empty = await screen.findByTestId("agent-recent-sessions-empty");
+        expect(empty).toHaveTextContent(EMPTY_GLOBAL);
+        // No row entries rendered.
+        expect(screen.queryByTestId("agent-recent-sessions-entry")).toBeNull();
+    });
+
+    it("renders the identity-specific empty copy when filtered", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        const [identityId] = createSignal<string>("id-work");
+        render(() => (
+            <RecentSessionsList
+                identityId={identityId}
+                onReattach={() => {}}
+            />
+        ));
+        const empty = await screen.findByTestId("agent-recent-sessions-empty");
+        expect(empty).toHaveTextContent(EMPTY_FILTERED);
+    });
+});
+
+describe("RecentSessionsList — populated", () => {
+    it("renders one row per session with preview + node count", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+            makeRow({ instance_id: "a", instance_name: "Maks", preview: "fix the live-feed" }),
+            makeRow({
+                instance_id: "b",
+                instance_name: "Other",
+                preview: "earlier conversation",
+                node_count: 1,
+            }),
+        ]);
+        render(() => <RecentSessionsList onReattach={() => {}} />);
+        // Wait for resource to settle.
+        const entries = await screen.findAllByTestId("agent-recent-sessions-entry");
+        expect(entries).toHaveLength(2);
+
+        // Previews render verbatim.
+        expect(screen.getByText("fix the live-feed")).toBeInTheDocument();
+        expect(screen.getByText("earlier conversation")).toBeInTheDocument();
+
+        // Node-count pluralization (12 messages vs 1 message).
+        expect(screen.getByText(/12 messages/)).toBeInTheDocument();
+        expect(screen.getByText(/^1 message$/)).toBeInTheDocument();
+    });
+
+    it("renders an italic empty-preview hint when has_snapshot but no user message", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+            makeRow({ preview: "", has_snapshot: true, node_count: 0 }),
+        ]);
+        render(() => <RecentSessionsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-recent-sessions-entry");
+        expect(
+            screen.getByText("(no user message yet)"),
+        ).toBeInTheDocument();
+    });
+
+    it("renders a 'no snapshot' hint when the block has no snapshot file", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+            makeRow({ preview: "", has_snapshot: false, node_count: 0 }),
+        ]);
+        render(() => <RecentSessionsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-recent-sessions-entry");
+        expect(
+            screen.getByText("(no conversation snapshot)"),
+        ).toBeInTheDocument();
+    });
+
+    it("fires onReattach with the row when an entry is clicked", async () => {
+        const onReattach = vi.fn();
+        const row = makeRow({ instance_id: "click-me" });
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([row]);
+        render(() => <RecentSessionsList onReattach={onReattach} />);
+        const entry = await screen.findByTestId("agent-recent-sessions-entry");
+        await userEvent.click(entry);
+        expect(onReattach).toHaveBeenCalledTimes(1);
+        expect(onReattach.mock.calls[0][0].instance_id).toBe("click-me");
+    });
+
+    it("passes identity_id to the RPC when filter is set", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        const [identityId] = createSignal<string>("id-work");
+        render(() => (
+            <RecentSessionsList
+                identityId={identityId}
+                onReattach={() => {}}
+            />
+        ));
+        await screen.findByTestId("agent-recent-sessions-empty");
+        expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ identity_id: "id-work" }),
+        );
+    });
+
+    it("treats null / undefined identityId as no-filter (empty string sent)", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        render(() => <RecentSessionsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-recent-sessions-empty");
+        expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ identity_id: "" }),
+        );
+    });
+});
+
+describe("formatRelative", () => {
+    it("returns 'just now' for sub-minute deltas", () => {
+        expect(formatRelative(1_000_000, 1_000_000 - 30_000)).toBe("just now");
+    });
+    it("returns 'Xm ago' for sub-hour deltas", () => {
+        expect(formatRelative(10_000_000, 10_000_000 - 5 * 60_000)).toBe("5m ago");
+    });
+    it("returns 'Xh ago' for sub-day deltas", () => {
+        expect(formatRelative(100_000_000, 100_000_000 - 3 * 3_600_000)).toBe("3h ago");
+    });
+    it("returns 'Xd ago' for multi-day deltas", () => {
+        expect(formatRelative(1_000_000_000, 1_000_000_000 - 2 * 86_400_000)).toBe("2d ago");
+    });
+    it("returns '' for zero", () => {
+        expect(formatRelative(Date.now(), 0)).toBe("");
+    });
+});

--- a/frontend/app/view/agent/components/RecentSessionsList.tsx
+++ b/frontend/app/view/agent/components/RecentSessionsList.tsx
@@ -1,0 +1,206 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * RecentSessionsList — the AgentPicker's "Recent sessions" surface.
+ *
+ * Cascade follow-up (2026-05-23) — see
+ * `docs/recovery/MAKS_CONVERSATION_2026_05_23.md` and
+ * `docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md`.
+ * Before this surface, a renderer crash that killed an agent pane left
+ * the conversation file orphaned in filestore with no UI path back —
+ * the user had to know the blockId and force a remount. With this
+ * list, the user picks the session from the picker and the existing
+ * continuation flow (PR #977's continueOfInstanceId + workDirOverride)
+ * brings the working directory + identity + memory back; the prior
+ * conversation history reloads from filestore on the new pane's first
+ * paint via the standard `useHistoryPagination` snapshot path.
+ *
+ * Reattach mechanism: this surface **does NOT mint a new "ghost"
+ * block referring to the original blockId.** Each entry triggers a
+ * normal definition launch through `AgentViewModel.launchAgentDefinition`
+ * with `continueOfInstanceId` + `workDirOverride` set from the row.
+ * The new pane spawns the CLI in the prior working directory, so
+ * Claude's `--continue` (and equivalents on other CLIs) resumes the
+ * session and the new pane's `output.state.json` snapshot path
+ * picks up the conversation history on render. Per spec — using the
+ * existing continueOfId plumbing keeps surface area small and reuses
+ * the audited launch flow.
+ */
+
+import {
+    createMemo,
+    createResource,
+    createSignal,
+    For,
+    onCleanup,
+    Show,
+    type Accessor,
+    type JSX,
+} from "solid-js";
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { ProviderLogo } from "@/element/ProviderLogo";
+
+/** ms epoch → human-readable relative timestamp. Centralized here +
+ * exported so unit tests can pin its boundary behavior. */
+export function formatRelative(now: number, ms: number): string {
+    if (!ms) return "";
+    const delta = Math.max(0, now - ms);
+    if (delta < 60_000) return "just now";
+    if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+    if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+    return `${Math.floor(delta / 86_400_000)}d ago`;
+}
+
+/** Empty-state copy varies based on whether an identity filter was
+ * applied — surfaced so the integration test can match it. */
+export const EMPTY_GLOBAL = "No recent sessions yet";
+export const EMPTY_FILTERED = "No recent sessions for this identity";
+
+export interface RecentSessionsListProps {
+    /** Optional reactive accessor for the identity filter. `null` /
+     *  undefined / empty string = no filter (show every identity). */
+    identityId?: Accessor<string | null | undefined>;
+    /** Visible cap. Backend caps at 100; default is 20. */
+    limit?: number;
+    /** Called when the user clicks an entry. The parent (AgentPicker)
+     *  hands this to `AgentViewModel.launchAgentDefinition` with the
+     *  continuation overrides — see "Reattach mechanism" above. */
+    onReattach: (row: RecentSessionRow) => void;
+}
+
+export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element => {
+    const filterId = createMemo(() => {
+        const raw = props.identityId?.();
+        if (raw === null || raw === undefined) return "";
+        return String(raw).trim();
+    });
+
+    const [rows, { refetch }] = createResource<RecentSessionRow[], string>(
+        // Key the resource on the filter so changes refetch.
+        filterId,
+        async (id) => {
+            try {
+                return await RpcApi.ListRecentSessionsCommand(TabRpcClient, {
+                    limit: props.limit ?? 20,
+                    // Backend treats "" as "no filter" — see
+                    // CommandListRecentSessionsData docs.
+                    identity_id: id,
+                });
+            } catch {
+                return [];
+            }
+        },
+    );
+
+    // Re-poll on visibility regain so a session that just ended in
+    // another pane shows up at the top without the user having to
+    // re-open the picker. createEffect runs after first render too,
+    // so the initial subscribe doesn't double-fetch.
+    const onVisible = () => {
+        if (document.visibilityState === "visible") void refetch();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    onCleanup(() => document.removeEventListener("visibilitychange", onVisible));
+
+    // The Date.now() snapshot updates every minute so "5m ago" rolls
+    // forward without the user having to re-render. createSignal ticks
+    // are cheaper than re-running the createResource.
+    const [now, setNow] = createSignal(Date.now());
+    const tick = setInterval(() => setNow(Date.now()), 60_000);
+    onCleanup(() => clearInterval(tick));
+
+    // Surfacing rules:
+    // - rows undefined → still loading (skeleton hint)
+    // - rows []        → empty state (filter-aware copy)
+    // - rows non-empty → list
+    const isLoading = () => rows() === undefined;
+    const isEmpty = () => !isLoading() && (rows() ?? []).length === 0;
+
+    return (
+        <div class="agent-recent-sessions" data-testid="agent-recent-sessions">
+            <div class="agent-recent-sessions-header">
+                <span class="agent-recent-sessions-title">Recent sessions</span>
+                <Show when={!isLoading() && (rows() ?? []).length > 0}>
+                    <span class="agent-recent-sessions-count">
+                        {(rows() ?? []).length}
+                    </span>
+                </Show>
+            </div>
+            <Show
+                when={!isEmpty()}
+                fallback={
+                    <div
+                        class="agent-recent-sessions-empty"
+                        data-testid="agent-recent-sessions-empty"
+                    >
+                        {filterId() ? EMPTY_FILTERED : EMPTY_GLOBAL}
+                    </div>
+                }
+            >
+                <ul class="agent-recent-sessions-list">
+                    <For each={rows() ?? []}>
+                        {(row) => (
+                            <li class="agent-recent-sessions-row">
+                                <button
+                                    type="button"
+                                    class="agent-recent-sessions-entry"
+                                    onClick={() => props.onReattach(row)}
+                                    aria-label={`Reattach to ${row.instance_name}`}
+                                    data-testid="agent-recent-sessions-entry"
+                                >
+                                    <ProviderLogo
+                                        provider={row.provider}
+                                        size={24}
+                                        class="agent-recent-sessions-icon"
+                                    />
+                                    <span class="agent-recent-sessions-body">
+                                        <span class="agent-recent-sessions-line1">
+                                            <span class="agent-recent-sessions-name">
+                                                {row.instance_name || row.definition_name}
+                                            </span>
+                                            <span class="agent-recent-sessions-meta">
+                                                {row.identity_name || "(ambient creds)"}
+                                            </span>
+                                        </span>
+                                        <Show
+                                            when={row.preview}
+                                            fallback={
+                                                <span class="agent-recent-sessions-preview agent-recent-sessions-preview--empty">
+                                                    {row.has_snapshot
+                                                        ? "(no user message yet)"
+                                                        : "(no conversation snapshot)"}
+                                                </span>
+                                            }
+                                        >
+                                            <span class="agent-recent-sessions-preview">
+                                                {row.preview}
+                                            </span>
+                                        </Show>
+                                        <span class="agent-recent-sessions-line3">
+                                            <Show when={row.node_count > 0}>
+                                                <span class="agent-recent-sessions-nodes">
+                                                    {row.node_count} message
+                                                    {row.node_count === 1 ? "" : "s"}
+                                                </span>
+                                            </Show>
+                                            <Show when={row.last_active_at > 0}>
+                                                <span class="agent-recent-sessions-when">
+                                                    {formatRelative(now(), row.last_active_at)}
+                                                </span>
+                                            </Show>
+                                        </span>
+                                    </span>
+                                </button>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </Show>
+        </div>
+    );
+};
+
+RecentSessionsList.displayName = "RecentSessionsList";

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -1,0 +1,164 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// AgentPicker "Recent sessions" surface (cascade follow-up 2026-05-23).
+// Sits ABOVE the agent-card list inside `.agent-picker`. Visually
+// secondary to the "+New" tiles (the cards) — same width cap, lighter
+// border, smaller type, but actionable rows that match the card hover
+// affordance so users learn one interaction model.
+.agent-view {
+    .agent-recent-sessions {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        max-width: 520px;
+        width: 100%;
+        align-self: center;
+        // Hard cap so the list doesn't swallow the picker when the
+        // user has 20 active sessions. Internal scroll instead.
+        max-height: 40vh;
+        overflow: hidden;
+    }
+
+    .agent-recent-sessions-header {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-1);
+        padding: 0 2px;
+    }
+
+    .agent-recent-sessions-title {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color);
+    }
+
+    .agent-recent-sessions-count {
+        font-size: 11px;
+        color: color-mix(in srgb, var(--secondary-text-color) 60%, transparent);
+        font-variant-numeric: tabular-nums;
+    }
+
+    .agent-recent-sessions-empty {
+        font-size: 12px;
+        color: color-mix(in srgb, var(--secondary-text-color) 75%, transparent);
+        padding: var(--space-2) var(--space-3);
+        border: 1px dashed var(--border-color);
+        border-radius: 6px;
+        background: transparent;
+        text-align: center;
+        font-style: italic;
+    }
+
+    .agent-recent-sessions-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        overflow-y: auto;
+        // Scroll containment so wheeling inside the list doesn't
+        // spill into the picker-list below once we hit the boundary.
+        overscroll-behavior: contain;
+    }
+
+    .agent-recent-sessions-row {
+        margin: 0;
+    }
+
+    .agent-recent-sessions-entry {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-2);
+        padding: var(--space-2) 10px;
+        width: 100%;
+        border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+        background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+        border-radius: 5px;
+        cursor: pointer;
+        text-align: left;
+        color: var(--main-text-color);
+        font-family: inherit;
+        transition: all 0.15s;
+
+        &:hover {
+            border-color: var(--accent-color);
+            background: color-mix(in srgb, var(--accent-color) 6%, transparent);
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--accent-color);
+            outline-offset: 1px;
+        }
+    }
+
+    .agent-recent-sessions-icon {
+        flex-shrink: 0;
+        margin-top: 2px;
+    }
+
+    .agent-recent-sessions-body {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .agent-recent-sessions-line1 {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        min-width: 0;
+    }
+
+    .agent-recent-sessions-name {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--main-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex-shrink: 0;
+        max-width: 60%;
+    }
+
+    .agent-recent-sessions-meta {
+        font-size: 11px;
+        color: color-mix(in srgb, var(--secondary-text-color) 85%, transparent);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .agent-recent-sessions-preview {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-style: normal;
+    }
+
+    .agent-recent-sessions-preview--empty {
+        color: color-mix(in srgb, var(--secondary-text-color) 55%, transparent);
+        font-style: italic;
+    }
+
+    .agent-recent-sessions-line3 {
+        display: flex;
+        gap: var(--space-2);
+        font-size: 10px;
+        color: color-mix(in srgb, var(--secondary-text-color) 70%, transparent);
+        font-variant-numeric: tabular-nums;
+    }
+
+    .agent-recent-sessions-nodes {
+        // Numeric "12 messages" stays inline with timestamp.
+    }
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -492,6 +492,30 @@ declare global {
         block_id_hint: string;
     };
 
+    /** Cascade follow-up (2026-05-23) — one row of the AgentPicker's
+     * "Recent sessions" list. Mirrors NamedAgentRow + adds a preview
+     * (first user message text) and node count read from the filestore
+     * `output.state.json` snapshot. has_snapshot: false means the
+     * pane never wrote a snapshot (legacy / pre-persistence row); the
+     * row still surfaces so the user can reattach. */
+    type RecentSessionRow = {
+        instance_id: string;
+        instance_name: string;
+        definition_id: string;
+        definition_name: string;
+        provider: string;
+        working_directory: string;
+        identity_id: string;
+        identity_name: string;
+        memory_id: string;
+        memory_name: string;
+        block_id_hint: string;
+        preview: string;
+        node_count: number;
+        last_active_at: number;
+        has_snapshot: boolean;
+    };
+
     // AgentContent
     type AgentContent = {
         agent_id: string;


### PR DESCRIPTION
Cascade follow-up **4 of 4** — see retro
[`docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md`](docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md)
and the recovered transcript at
[`docs/recovery/MAKS_CONVERSATION_2026_05_23.md`](docs/recovery/MAKS_CONVERSATION_2026_05_23.md).

Previous cascade follow-ups:
- PR #977 — `continueOfId` round-trip through the +New bundle flow (foundation we extend)

## The problem

On 2026-05-23 a renderer cascade ate the agent pane mid-session. The
conversation file (`output.state.json`) was still in `filestore.db`
under the original `blockId`, but the only way to recover it would
have been to know the blockId and force a remount on the original
pane. There was no UI path. The user lost their working context.

## User flow

1. User opens an agent pane. AgentPicker renders the list of
   definitions.
2. **NEW:** ABOVE the agent cards, a "Recent sessions" list shows up
   to 20 entries — each one is a clickable row with:
   - provider icon + instance name + identity name
   - first-user-message preview (newline-collapsed, ≤240 chars,
     skipping bootstrap "Session Context" boilerplate when a later
     message exists)
   - "X messages • Ym ago"
3. Clicking a row launches a new pane that reattaches to the prior
   working directory + identity + memory; the conversation history
   reloads from `filestore.db` on first paint via the existing
   `useHistoryPagination` snapshot fast-path.
4. Empty state branches by identity filter — picker is generic
   (no filter), but the component supports filtered surfacing for any
   future per-identity caller.

## Reattach mechanism

Using the existing `continueOfInstanceId + workDirOverride` flow that
PR #977 wired through the launch modal — same backend RPCs, same
`CreateAgentInstance` lineage, same env injection. The new pane
spawns the CLI in the prior working directory; Claude's `--continue`
(et al.) resumes the session; the new pane's `output.state.json`
loads on first paint.

**This is NOT a "ghost block" remount of the original `blockId`.**
Each entry produces a new block tied to the prior conversation via
the continuation chain. The original `block_id_hint` is preserved on
the row for diagnostics + future "reattach by blockId" hamburger
debug paths (out of scope here).

## What lands

### Backend (`agentmux-srv`)
- New `listrecentsessions` RPC (`agent_handlers.rs`):
  - Joins `db_agent_instances` with the per-block `output.state.json`
    snapshot in filestore.
  - Sort: snapshot-bearing rows first (descending by file modts),
    then no-snapshot rows by `started_at`. Cap 20 (max 100).
  - Optional `identity_id` filter (`""` = no filter, frontend-friendly).
- New `RecentSessionRow` adds `preview`, `node_count`,
  `last_active_at`, `has_snapshot` to `NamedAgentRow`'s shape.
- 9 new tests — 5 unit tests for the snapshot parser + 3 integration
  tests for the full handler round-trip (sort, identity filter, limit)
  plus a `collapse_preview` boundary test. Tests pass alongside the
  existing 1093 (full suite: **1102 passed, 0 failed**).

### Frontend (`frontend/app/view/agent`)
- New `RecentSessionsList` component lands in `AgentPicker` ABOVE
  the agent cards. Uses **existing modal-v2 design tokens** —
  no new modal pattern, no new class prefix beyond
  `.agent-recent-sessions-*` which sits inside `.agent-view`.
- `RpcApi.ListRecentSessionsCommand` + `RecentSessionRow` global type.
- `_recent-sessions.scss` with `overscroll-behavior: contain` so the
  list doesn't spill into the picker-list at its scroll boundary.
- 60s tick refreshes relative timestamps without re-fetching.
- `visibilitychange` listener re-polls when the pane returns to
  foreground so a session that just ended elsewhere bubbles up.
- **13 new render tests** — empty (filter-aware), populated, preview
  variants (no-snapshot vs no-user-message-yet), click → onReattach,
  identity_id pass-through, formatRelative boundaries.

## Test results

- Backend: `cargo test -p agentmux-srv --bin agentmux-srv` →
  **1102 passed, 0 failed, 1 ignored** (9 new).
- Frontend touched files:
  `npx vitest run frontend/app/view/agent/components/{AgentLaunchModal.integration,AgentDisconnectedBanner,RecentSessionsList}.test.tsx`
  → **18 passed, 0 failed** (13 new).
- One pre-existing test failure in `providers/index.test.ts`
  (`PROVIDERS.openclaw.authType` expectation drift) — unchanged by
  this PR; reproduced on `origin/main` after stashing my changes.

## Out of scope (per spec)

- Per-conversation search.
- Reattach-by-blockId hamburger debug action — the launch-modal
  surface is enough for users; a debug action would be separate.
- Background pruning of old sessions.

## Identity

AgentA. Per the global rules at `~/.claude/CLAUDE.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)