### PR TITLE
ci: release-consistency gate workflow (retro action item 3 of 4)

### DIFF
--- a/.changesets/1779548942-ci-add-release-consistency-gate-closes-retro-action-item-3-le3c.md
+++ b/.changesets/1779548942-ci-add-release-consistency-gate-closes-retro-action-item-3-le3c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ci: add release-consistency gate (closes retro action item 3)

--- a/.github/workflows/release-consistency.yml
+++ b/.github/workflows/release-consistency.yml
@@ -1,0 +1,48 @@
+name: Release consistency check
+
+# Verify the release-consistency invariant on every PR that touches a
+# version-bearing file. See docs/retro/retro-release-version-desync-2026-05-22.md
+# for the v0.38.0 incident this guard addresses. Three layers of defense:
+#
+#   1. scripts/release.sh runs the same check after `task release` bumps.
+#   2. reagent reviews check the invariant on any PR touching these files.
+#   3. THIS workflow — the deterministic CI gate that can't be reviewed past.
+#
+# The job is fast (no build, no install) and only triggers on PRs that
+# touch a version file, so it doesn't slow down feature PRs.
+
+on:
+  # Only fire when VERSION_HISTORY.md itself is touched — that's the
+  # canonical signal of a release-intent commit, which is when all five
+  # version locations MUST agree. Between releases, `task package`'s
+  # patch bumps move package.json + lockfiles ahead of VERSION_HISTORY
+  # by design (VH is only updated by `task release`), so a full-five
+  # check on every PR would mis-fire on every feature build.
+  #
+  # The script + workflow YAML are also included so changes to the
+  # check itself rerun on the gate.
+  pull_request:
+    paths:
+      - 'VERSION_HISTORY.md'
+      - 'scripts/verify-release-consistency.sh'
+      - '.github/workflows/release-consistency.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'VERSION_HISTORY.md'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run release-consistency check
+        run: bash scripts/verify-release-consistency.sh

--- a/.github/workflows/release-consistency.yml
+++ b/.github/workflows/release-consistency.yml
@@ -19,13 +19,9 @@ on:
   # by design (VH is only updated by `task release`), so a full-five
   # check on every PR would mis-fire on every feature build.
   #
-  # The script + workflow YAML are also included so changes to the
-  # check itself rerun on the gate.
   pull_request:
     paths:
       - 'VERSION_HISTORY.md'
-      - 'scripts/verify-release-consistency.sh'
-      - '.github/workflows/release-consistency.yml'
   push:
     branches:
       - main

--- a/scripts/verify-release-consistency.sh
+++ b/scripts/verify-release-consistency.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Verify the release-consistency invariant from CLAUDE.md:
+#
+#   In every commit, these MUST all equal the same version:
+#     - VERSION_HISTORY.md's top `## X.Y.Z` section
+#     - package.json.version
+#     - Cargo.toml [workspace.package].version
+#     - Cargo.lock's workspace-member versions (e.g. agentmux-cef)
+#     - package-lock.json's root version
+#
+# Exit codes:
+#   0 — all five locations agree
+#   1 — at least one location disagrees (prints the mismatched set)
+#   2 — internal error reading a location
+#
+# Usage:
+#   scripts/verify-release-consistency.sh          # check current working tree
+#   scripts/verify-release-consistency.sh --quiet  # only print on failure
+#
+# This script is invoked by:
+#   - scripts/release.sh as the final gate after `task release`
+#   - .github/workflows/release-consistency.yml on PRs/pushes that touch
+#     VERSION_HISTORY.md (release-intent commits)
+#
+# Why we don't check on every package.json bump: between releases,
+# `task package` patch-bumps package.json + Cargo.toml + lockfiles while
+# VERSION_HISTORY.md stays pinned to the last shipped release — that's the
+# operational design. The five-way agreement is only required when a
+# release-intent commit lands (signaled by VH being touched).
+#
+# History: docs/retro/retro-release-version-desync-2026-05-22.md.
+# v0.38.0 shipped with package.json stranded at 0.37.2 because bump-cli
+# silently skipped the file. The reagent gate caught it on a later PR,
+# the release-script self-verify catches it on `task release`, this
+# CI workflow catches any other path (manual edit, rebase artifact, etc).
+
+set -euo pipefail
+
+QUIET=0
+if [[ "${1:-}" == "--quiet" ]]; then
+    QUIET=1
+fi
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+log() { (( QUIET )) && return; echo "$*"; }
+
+# ── Read every location ───────────────────────────────────────────────
+PKG_V="$(node -p "require('./package.json').version" 2>/dev/null || echo '<unreadable>')"
+CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p}' Cargo.toml | head -1)"
+PL_V="$(node -p "require('./package-lock.json').version" 2>/dev/null || echo '<unreadable>')"
+CL_V="$(sed -n '/^name = "agentmux-cef"$/{n;s/^version = "\(.*\)"$/\1/p;q}' Cargo.lock)"
+VH_V="$(awk '/^## /{print $2; exit}' VERSION_HISTORY.md)"
+
+declare -A LOCATIONS=(
+    [package.json]="$PKG_V"
+    [Cargo.toml]="$CARGO_V"
+    [package-lock.json]="$PL_V"
+    [Cargo.lock]="$CL_V"
+    [VERSION_HISTORY.md]="$VH_V"
+)
+
+# ── Compute the consensus (most-common value) ────────────────────────
+#
+# We compare every location against the modal value. If only one place
+# disagrees, that's the bad file. If they all disagree, the report
+# tells the operator which set they need to reconcile.
+declare -A COUNTS=()
+for loc in "${!LOCATIONS[@]}"; do
+    v="${LOCATIONS[$loc]}"
+    COUNTS[$v]=$((${COUNTS[$v]:-0} + 1))
+done
+
+CONSENSUS=""
+CONSENSUS_COUNT=0
+for v in "${!COUNTS[@]}"; do
+    if (( COUNTS[$v] > CONSENSUS_COUNT )); then
+        CONSENSUS="$v"
+        CONSENSUS_COUNT="${COUNTS[$v]}"
+    fi
+done
+
+# ── Report ───────────────────────────────────────────────────────────
+MISMATCHES=()
+for loc in package.json Cargo.toml package-lock.json Cargo.lock VERSION_HISTORY.md; do
+    v="${LOCATIONS[$loc]}"
+    if [[ "$v" != "$CONSENSUS" ]]; then
+        MISMATCHES+=("$loc: $v (expected $CONSENSUS)")
+    fi
+done
+
+if (( ${#MISMATCHES[@]} == 0 )); then
+    log "Release-consistency OK — all 5 locations agree on version $CONSENSUS."
+    exit 0
+fi
+
+# Print failures even in --quiet mode; this is the actionable signal.
+echo "" >&2
+echo "ERROR: release-consistency check failed." >&2
+echo "Most files report version '$CONSENSUS', but these disagree:" >&2
+for m in "${MISMATCHES[@]}"; do
+    echo "  - $m" >&2
+done
+echo "" >&2
+echo "All five locations must equal the same version. This usually means" >&2
+echo "bump-cli silently skipped a file, or a rebase resurrected a stale" >&2
+echo "version line. Inspect:" >&2
+echo "  git diff HEAD~1 -- package.json Cargo.toml Cargo.lock package-lock.json VERSION_HISTORY.md" >&2
+echo "Then fix the mismatched files." >&2
+echo "" >&2
+echo "See docs/retro/retro-release-version-desync-2026-05-22.md." >&2
+exit 1


### PR DESCRIPTION
Closes action item 3 from `docs/retro/retro-release-version-desync-2026-05-22.md`. Three-layer defense: release.sh self-verify (#980) + reagent invariant (CLAUDE.md) + this CI workflow.

Triggers only on PRs/pushes that touch `VERSION_HISTORY.md` — that's the release-intent signal. Between releases `task package` bumps package.json + lockfiles without VH by design, so a five-way check on every bump would false-fire.

`scripts/verify-release-consistency.sh` is the new shared verify (a future PR can switch `release.sh` to call it; this PR keeps the existing inline check intact to avoid coupling).

Smoke-tested locally — positive + negative + quiet modes all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)