### PR TITLE
chore: release v0.38.3

### DIFF
--- a/.changesets/1779463287-feat-widgets-responsive-labels-collapse-to-icons-on-narrow-t-y8qk.md
+++ b/.changesets/1779463287-feat-widgets-responsive-labels-collapse-to-icons-on-narrow-t-y8qk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(widgets): responsive labels collapse to icons on narrow title bars; all widgets pinned by default

--- a/.changesets/1779463930-fix-modal-defer-singleton-modal-label-resolution-past-app-bo-nnnf.md
+++ b/.changesets/1779463930-fix-modal-defer-singleton-modal-label-resolution-past-app-bo-nnnf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(modal): defer singleton-modal label resolution past app boot

--- a/.changesets/1779493749-fix-launch-modal-thread-continueofid-through-the-new-bundle--b798.md
+++ b/.changesets/1779493749-fix-launch-modal-thread-continueofid-through-the-new-bundle--b798.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launch-modal): thread continueOfId through the +New bundle round-trip

--- a/.changesets/1779494861-feat-identity-add-secretref-oauthconfigdir-per-bundle-dir-he-gpiu.md
+++ b/.changesets/1779494861-feat-identity-add-secretref-oauthconfigdir-per-bundle-dir-he-gpiu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(identity): add SecretRef::OAuthConfigDir + per-bundle dir helpers (oauth bundles PR A)

--- a/.changesets/1779495415-feat-identity-resolver-provider-class-oauth-config-dir-dispa-aune.md
+++ b/.changesets/1779495415-feat-identity-resolver-provider-class-oauth-config-dir-dispa-aune.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(identity): resolver provider-class + OAuth config-dir dispatch (oauth bundles PR B)

--- a/.changesets/1779496732-build-release-self-verify-version-file-consistency-after-tas-dmyj.md
+++ b/.changesets/1779496732-build-release-self-verify-version-file-consistency-after-tas-dmyj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-build(release): self-verify version-file consistency after task release

--- a/.changesets/1779497458-feat-oauth-bind-oauth-credentials-into-identity-bundles-on-c-3npi.md
+++ b/.changesets/1779497458-feat-oauth-bind-oauth-credentials-into-identity-bundles-on-c-3npi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(oauth): bind OAuth credentials into identity bundles on Connect (oauth bundles PR C)

--- a/.changesets/1779505264-feat-oauth-identity-binding-status-reconnect-ui-oauth-bundle-hqzi.md
+++ b/.changesets/1779505264-feat-oauth-identity-binding-status-reconnect-ui-oauth-bundle-hqzi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(oauth): identity-binding status + reconnect UI (oauth bundles PR D)

--- a/.changesets/1779506966-feat-oauth-seed-default-identity-bundle-from-ambient-claude--78qc.md
+++ b/.changesets/1779506966-feat-oauth-seed-default-identity-bundle-from-ambient-claude--78qc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(oauth): seed Default identity bundle from ambient ~/.claude on startup (oauth bundles PR E)

--- a/.changesets/1779508221-refactor-oauth-drop-openclaw-always-gate-hack-bundle-path-ha-3a0t.md
+++ b/.changesets/1779508221-refactor-oauth-drop-openclaw-always-gate-hack-bundle-path-ha-3a0t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(oauth): drop openclaw always-gate hack; bundle path handles all oauth providers (oauth bundles PR F)

--- a/.changesets/1779525893-fix-agent-pane-pty-cols-follow-pane-width-bump-default-to-20-h8tl.md
+++ b/.changesets/1779525893-fix-agent-pane-pty-cols-follow-pane-width-bump-default-to-20-h8tl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): PTY cols follow pane width + bump default to 200

--- a/.changesets/1779525981-feat-agent-pane-add-turnphase-discriminated-union-turn-phase-qzgz.md
+++ b/.changesets/1779525981-feat-agent-pane-add-turnphase-discriminated-union-turn-phase-qzgz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): add TurnPhase discriminated union (turn-phase PR A dual-write)

--- a/.changesets/1779528517-fix-agent-pane-migrate-throwing-dispatch-sites-capture-uncau-u0sr.md
+++ b/.changesets/1779528517-fix-agent-pane-migrate-throwing-dispatch-sites-capture-uncau-u0sr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): migrate throwing dispatch sites + capture uncaught DOM errors

--- a/.changesets/1779533207-docs-recovery-recovered-maks-conversation-transcript-from-v0-960w.md
+++ b/.changesets/1779533207-docs-recovery-recovered-maks-conversation-transcript-from-v0-960w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(recovery): recovered Maks conversation transcript from v0.38.3 cascade incident

--- a/.changesets/1779533388-fix-tool-block-post-completion-hold-timer-was-cancelled-by-r-wuj2.md
+++ b/.changesets/1779533388-fix-tool-block-post-completion-hold-timer-was-cancelled-by-r-wuj2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tool-block): post-completion hold timer was cancelled by reactive self-loop

--- a/.changesets/1779533583-feat-agent-pane-bounded-interrupt-timeout-bo58.md
+++ b/.changesets/1779533583-feat-agent-pane-bounded-interrupt-timeout-bo58.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): bounded interrupt timeout

--- a/.changesets/1779533699-feat-agent-pane-view-reads-isworking-state-hzuq.md
+++ b/.changesets/1779533699-feat-agent-pane-view-reads-isworking-state-hzuq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): view reads isWorking(state)

--- a/.changesets/1779534298-feat-agent-pane-initphase-state-machine-z5g7.md
+++ b/.changesets/1779534298-feat-agent-pane-initphase-state-machine-z5g7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): initPhase state machine

--- a/.changesets/1779535427-feat-tool-block-ux-polish-hover-delay-collapse-animation-pos-acwe.md
+++ b/.changesets/1779535427-feat-tool-block-ux-polish-hover-delay-collapse-animation-pos-acwe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tool-block): UX polish — hover delay, collapse animation, post-completion hold, scroll isolation, a11y inert

--- a/.changesets/1779537974-feat-agent-pane-bounded-submit-timeout-bqg8.md
+++ b/.changesets/1779537974-feat-agent-pane-bounded-submit-timeout-bqg8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): bounded submit timeout

--- a/.changesets/1779538048-feat-agent-pane-bounded-streaming-watchdog-nm1x.md
+++ b/.changesets/1779538048-feat-agent-pane-bounded-streaming-watchdog-nm1x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): bounded streaming watchdog

--- a/.changesets/1779541345-feat-agent-pane-disconnected-state-banner-xrpw.md
+++ b/.changesets/1779541345-feat-agent-pane-disconnected-state-banner-xrpw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): Disconnected state + banner

--- a/.changesets/1779543002-refactor-agent-pane-drop-legacy-turnactive-stopping-streamin-8rhg.md
+++ b/.changesets/1779543002-refactor-agent-pane-drop-legacy-turnactive-stopping-streamin-8rhg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(agent-pane): drop legacy turnActive/stopping/streaming.active

--- a/.changesets/1779547607-feat-block-per-block-error-boundary-localized-reload-au0o.md
+++ b/.changesets/1779547607-feat-block-per-block-error-boundary-localized-reload-au0o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(block): per-block error boundary + localized reload

--- a/.changesets/1779547879-feat-agent-pane-unified-per-pane-registration-22id.md
+++ b/.changesets/1779547879-feat-agent-pane-unified-per-pane-registration-22id.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): unified per-pane registration

--- a/.changesets/1779548808-feat-agent-recent-sessions-reattach-ux-805n.md
+++ b/.changesets/1779548808-feat-agent-recent-sessions-reattach-ux-805n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): recent sessions reattach UX

--- a/.changesets/1779548942-ci-add-release-consistency-gate-closes-retro-action-item-3-le3c.md
+++ b/.changesets/1779548942-ci-add-release-consistency-gate-closes-retro-action-item-3-le3c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci: add release-consistency gate (closes retro action item 3)

--- a/.changesets/1779549929-feat-agent-pane-model-level-dispatchifalive-helper-h6ae.md
+++ b/.changesets/1779549929-feat-agent-pane-model-level-dispatchifalive-helper-h6ae.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): model-level dispatchIfAlive helper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.2"
+version = "0.38.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,37 @@
 # AgentMux Version History
 
+## 0.38.3 — 2026-05-23
+
+- feat(widgets): responsive labels collapse to icons on narrow title bars; all widgets pinned by default
+- fix(modal): defer singleton-modal label resolution past app boot
+- fix(launch-modal): thread continueOfId through the +New bundle round-trip
+- feat(identity): add SecretRef::OAuthConfigDir + per-bundle dir helpers (oauth bundles PR A)
+- feat(identity): resolver provider-class + OAuth config-dir dispatch (oauth bundles PR B)
+- build(release): self-verify version-file consistency after task release
+- feat(oauth): bind OAuth credentials into identity bundles on Connect (oauth bundles PR C)
+- feat(oauth): identity-binding status + reconnect UI (oauth bundles PR D)
+- feat(oauth): seed Default identity bundle from ambient ~/.claude on startup (oauth bundles PR E)
+- refactor(oauth): drop openclaw always-gate hack; bundle path handles all oauth providers (oauth bundles PR F)
+- fix(agent-pane): PTY cols follow pane width + bump default to 200
+- feat(agent-pane): add TurnPhase discriminated union (turn-phase PR A dual-write)
+- fix(agent-pane): migrate throwing dispatch sites + capture uncaught DOM errors
+- docs(recovery): recovered Maks conversation transcript from v0.38.3 cascade incident
+- fix(tool-block): post-completion hold timer was cancelled by reactive self-loop
+- feat(agent-pane): bounded interrupt timeout
+- feat(agent-pane): view reads isWorking(state)
+- feat(agent-pane): initPhase state machine
+- feat(tool-block): UX polish — hover delay, collapse animation, post-completion hold, scroll isolation, a11y inert
+- feat(agent-pane): bounded submit timeout
+- feat(agent-pane): bounded streaming watchdog
+- feat(agent-pane): Disconnected state + banner
+- refactor(agent-pane): drop legacy turnActive/stopping/streaming.active
+- feat(block): per-block error boundary + localized reload
+- feat(agent-pane): unified per-pane registration
+- feat(agent): recent sessions reattach UX
+- ci: add release-consistency gate (closes retro action item 3)
+- feat(agent-pane): model-level dispatchIfAlive helper
+
+
 ## 0.38.1 — 2026-05-22
 
 - fix(magnify): single-instance pane render — fixes zoom + browser-pane black on restore

--- a/docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md
+++ b/docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md
@@ -1,0 +1,95 @@
+# Analysis — agent-pane live-log wraps at a fixed ~80 chars
+
+**Date:** 2026-05-23
+**Author:** AgentA
+**Severity:** Low (functional — readability annoyance, no data loss)
+**Area:** `agentmux-srv/src/backend/blockcontroller/shell.rs`, the agent pane's frontend wiring.
+
+---
+
+## Symptom
+
+The agent pane's live-log panel renders captured tool output with hard
+line-wraps at ~80 characters. The wrap point does **not change** when the
+agent pane is resized wider or narrower. Long lines (e.g. `git log
+--oneline` output for commits with long subject lines) break mid-word.
+
+```
+99818cd feat(live-log): PTY-backed tool streaming + auto-expand inline panel (#
+888)
+633b1c3a feat(agent-pane): hover-expand tool blocks + show bash output (#825)
+```
+
+CSS `white-space: pre-wrap` does not help — the `\n` after `(#` is **in
+the captured stream**, not a display-time wrap.
+
+## Root cause
+
+The agent pane's PTY is opened with a **hardcoded column count**:
+
+```rust
+// agentmux-srv/src/backend/blockcontroller/shell.rs:405-410
+let pty_size = PtySize {
+    rows: 25,
+    cols: 80,
+    pixel_width: 0,
+    pixel_height: 0,
+};
+```
+
+The agent CLI (Claude Code) runs inside this PTY. When it shells out to
+tools (`git`, `ls`, etc.), the children inherit the PTY's column count
+via the kernel and `$COLUMNS`. Tools that respect terminal width (most
+CLIs) wrap their output to fit 80 chars — embedding real `\n` characters
+into the byte stream that the live-log subscriber captures.
+
+## Why pane resize does not help
+
+The backend **already supports** PTY resize. `shell.rs:842-852` handles a
+`term_size` field on incoming input messages and calls
+`master.resize(pty_size)`. The standard **terminal pane** uses this via
+xterm.js's `fitAddon` (see CLAUDE.md `termWrap.handleResize()` — "PTY
+gets SIGWINCH and CLI reflows").
+
+But the **agent pane** is a custom UI, not an xterm.js terminal. Its
+render path never observes panel width and never sends a `term_size`
+update. The agent's PTY therefore stays at 80×25 for its entire
+lifetime regardless of how the user sizes the pane.
+
+## Fix path
+
+In the agent pane's container component:
+
+1. `ResizeObserver` on the log-panel element.
+2. Convert pixels → cols using the panel's monospace cell width
+   (`font-size × ~0.6`, or read a CSS variable).
+3. Send `ControllerInputCommand` with `term_size: { rows, cols }`
+   whenever the computed value changes (debounce by ~150 ms).
+
+Backend already accepts this — no Rust changes. CLIs that respect
+`SIGWINCH` / `$COLUMNS` (the majority) will reflow on their next
+invocation.
+
+## Caveat (set expectations)
+
+**Already-captured lines stay wrapped.** Reflowing historical PTY output
+would corrupt anything that used the original width for layout
+(`git log --graph` ASCII art, aligned tables). Only output produced
+AFTER the resize matches the new width. The live-log buffer carries
+content from possibly many widths over the agent's lifetime; that
+history cannot be retroactively re-flowed.
+
+## Quick-win alternative
+
+A one-line bump of the initial `cols: 80` → `cols: 160` (or `200`) in
+`shell.rs:407` drops the wrap frequency dramatically without touching
+the frontend. Tradeoff: very wide tool output (`ls -l` on a directory
+with long names) may look sparser on narrow panes. Pick this if the
+proper dynamic resize is not worth the frontend wiring right now.
+
+## Recommendation
+
+Do the proper dynamic resize. The frontend code is small and contained
+(one ResizeObserver, one debounce, one `ControllerInputCommand` per
+size change), and it brings the agent pane in line with the terminal
+pane's behavior. Schedule as a small follow-up PR.

--- a/docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md
+++ b/docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md
@@ -1,0 +1,125 @@
+# Analysis — launch modal drops the continuation across the "+ New identity" round-trip
+
+**Date:** 2026-05-22
+**Author:** AgentA
+**Severity:** High (functional) — a continued agent silently falls out of Continue
+mode and is incorrectly re-prompted to authenticate.
+**Area:** `frontend/app/view/agent/components/AgentLaunchModal.tsx`,
+`frontend/app/store/launch-flow-state.ts` (the `SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19`
+reducer slice).
+
+---
+
+## Symptom (user repro)
+
+1. Open the launch modal for an agent that has past instances. Feature A
+   auto-selects Continue mode with the most-recent instance ("Maks")
+   preselected.
+2. Click **"+ New identity bundle…"**.
+3. **Cancel** the New Identity modal.
+4. Back in the launch modal it now says **"Connect to Claude Code"** —
+   even though the continued agent already has a working Claude Code
+   OAuth login.
+
+Expected: cancelling returns to exactly the prior state — Continue mode,
+"Maks" selected, no auth prompt (a continuation reuses the prior launch's
+credentials).
+
+## Root cause
+
+**`continueOfId` — the field that records "this launch is continuing a
+prior agent" — is not part of the form snapshot that survives the
+"+ New bundle" round-trip.**
+
+The `+ New identity` flow hands off to the New Identity modal and re-opens
+the launch panel from a snapshot of the form. That snapshot type carries
+five fields and **omits `continueOfId`**:
+
+```ts
+// AgentLaunchModal.tsx:101-107
+export interface LaunchFormState {
+    name: string;
+    runtime: "host" | "container";
+    image: string;
+    identityId: string;
+    memoryId: string;
+    // ← no continueOfId
+}
+```
+
+```ts
+// AgentLaunchModal.tsx:224-230 — snapshot() handed to onRequestNewIdentity
+const snapshot = (): LaunchFormState => ({
+    name: name(), runtime: runtime(), image: image(),
+    identityId: identityId(), memoryId: memoryId(),
+    // ← continueOfId() is never captured
+});
+```
+
+So when the panel re-opens with `initialFormState = snapshot`, the
+reducer's `Opened` event restores name/identity/memory but `continueOfId`
+comes back empty.
+
+## Failure chain
+
+| Step | State |
+|---|---|
+| Re-open from snapshot | `continueOfId()` → `""` (not in `LaunchFormState`) |
+| `continuedRow()` (`:262`) | `null` |
+| `isContinue()` (`:267`) | **`false`** |
+| `viewModeDecided` (`:316`) | `true` (`initialFormState != null`) → the Feature-A auto-decide effect (`:317-326`) is **skipped** → `viewMode` stuck at `"new"` |
+| `authRequired()` (`:471-478`) | `!isContinue()` is now `true`, so the gate is no longer short-circuited. The continued agent ("Maks") launched on ambient creds, so the carried `identityId` is `""` → `identityId() === ""` is `true` → **`authRequired()` → `true`** |
+| Result | The `PreLaunchAuthPanel` renders → **"Connect to Claude Code"** |
+
+When "Maks" is genuinely selected in Continue mode, `isContinue()` is
+`true`, which short-circuits `authRequired()` to `false` ("prior launch
+already produced creds", `:466`). Dropping `continueOfId` removes that
+short-circuit.
+
+## Why the existing code did not guard against this
+
+`AgentLaunchModal.tsx:313-315` carries this comment:
+
+> A `+ New bundle` round-trip re-opens the panel with initialFormState
+> and only ever originates from New mode (the +New buttons are disabled
+> while continuing) — so skip the auto-decide and keep New.
+
+That assumption is **false**. The `+ New identity` button is disabled
+while continuing only when `continueLocksIdentity()` is true — which
+requires the continued row to carry a *real* identity bundle. An agent
+continued from an ambient-creds launch (`identity_id` empty/`"blank"`)
+does **not** lock identity, so its `+ New identity` button is enabled —
+and clicking it triggers exactly this round-trip from Continue mode.
+
+## Fix
+
+Thread the continuation through the round-trip:
+
+1. **`LaunchFormState`** — add `continueOfId: string` (`""` = no
+   continuation).
+2. **`snapshot()`** — capture `continueOfId: continueOfId()`.
+3. **`Opened` reducer event** (`launch-flow-state.ts`) — map
+   `initial.continueOfId` into `form.continueOfId`. Restoring the id
+   alone is not enough: `handleContinueSelect` also re-derives the
+   `carry` (name/identity/memory) and the continuation locks — so on
+   re-open, if `initialFormState.continueOfId` is set, re-run the
+   continuation restore once `namedAgents()` has loaded (re-derive the
+   row + carry rather than trusting raw form values).
+4. **`viewMode`** — when `initialFormState?.continueOfId` is non-empty,
+   initialize `viewMode` to `"continue"` (and keep `viewModeDecided`
+   true so the auto-decide doesn't fight it).
+5. Correct the stale comment at `:313-315`.
+
+Scope: `AgentLaunchModal.tsx` + `launch-flow-state.ts`. No backend
+change. The continuation's auth bypass then survives the `+ New`
+round-trip, and the modal returns to Continue mode with "Maks" selected
+and no auth prompt.
+
+## Note — identity bundles vs. ambient creds
+
+The repro also surfaces that "Maks" was launched on **ambient** Claude
+Code creds, not an identity bundle (his named-agent row has no real
+`identity_id`). Binding that OAuth into a managed identity bundle is a
+reasonable, *separate* improvement — but it is not the fix here: even
+with a bound bundle, the round-trip would still drop `continueOfId` and
+misbehave. Fix the round-trip first.

--- a/docs/retro/retro-release-version-desync-2026-05-22.md
+++ b/docs/retro/retro-release-version-desync-2026-05-22.md
@@ -1,0 +1,107 @@
+# RETRO — release changelog / version-file desync (v0.38.0)
+
+**Date:** 2026-05-22
+**Author:** AgentA
+**Severity:** Medium — no data lost; caught before a regressed release shipped, but it blocked the release pipeline and risked publishing a version *below* the changelog's latest entry.
+**Area:** release workflow (`task release`, `scripts/bump-wrapper.sh`, `@a5af/bump-cli`), `VERSION_HISTORY.md`, reagent review gate.
+
+---
+
+## Summary
+
+PR **#964** (`chore: release v0.38.0`, squash commit `791add54`) advanced
+`VERSION_HISTORY.md` to a `## 0.38.0` section and consumed the pending
+changesets — but **never bumped `package.json` / `Cargo.toml`**, which stayed
+at `0.37.2`. The repo's two records of "current version" — the changelog and
+the version files — silently diverged.
+
+It surfaced ~a day later: the *next* `task release` read `package.json`
+(`0.37.2`) and proposed **`0.37.3`** — a release *below* the `0.38.0` already
+recorded as shipped. reagent had reviewed #964 and approved it without
+catching the mismatch.
+
+## Timeline
+
+- **#964 `chore: release v0.38.0`** merges (commit `791add54`). Its diff:
+  ~29 `.changesets/*.md` deletions + the `VERSION_HISTORY.md` `## 0.38.0`
+  section. `package.json` / `Cargo.toml` **unchanged — `0.37.2`** before *and*
+  after the commit (`git show 791add54:package.json` confirms).
+- reagent reviews #964 → **APPROVED**.
+- Later: `task release` for the next release reads `package.json` = `0.37.2`,
+  proposes `0.37.3`. Caught by hand — a release below the changelog head.
+
+## Impact
+
+- `VERSION_HISTORY.md` says `0.38.0` shipped; the version files say `0.37.2`.
+- The next release was blocked: `task release` would regress the version.
+- Build artifacts carry an unreliable version label.
+
+## Root cause
+
+The changeset/changelog workflow (RFC #857) split a release into **multiple
+artifacts that must stay in lockstep**:
+
+- the consumed `.changesets/*.md`
+- the `VERSION_HISTORY.md` section
+- `package.json.version` + `Cargo.toml [workspace.package].version`
+- the lockfiles (`Cargo.lock`, `package-lock.json`)
+
+`task release` produces all of them — but **nothing enforces that they agree**
+once committed. If the version-file bump silently fails — `@a5af/bump-cli` has
+a known silent-fail mode (it skips `Cargo.toml` when a description is too long;
+see the bump-long-description finding) — `task release` *still* reports
+success, *still* appends `VERSION_HISTORY`, *still* consumes the changesets.
+The result is a "release" commit whose **changelog says 0.38.0 while the
+version files never moved**.
+
+Before the changelog workflow there was effectively **one** record of the
+version: the version files, bumped by `bump --commit`. The changelog added a
+**second, independent** record — and added no check that the two agree. That
+is why this class of failure "started once we moved to changelogs."
+
+## Why it wasn't caught
+
+reagent reviewed a PR literally titled `chore: release v0.38.0` and approved it
+without noticing that `VERSION_HISTORY` in that same diff said `0.38.0` while
+`package.json` stayed `0.37.2`. The release-consistency invariant was not part
+of any review checklist or CI gate — it relied entirely on the operator and a
+general-purpose reviewer noticing.
+
+## The invariant
+
+> In every commit, the top version of `VERSION_HISTORY.md` MUST equal
+> `package.json.version`, MUST equal `Cargo.toml [workspace.package].version`,
+> MUST equal the project versions in `Cargo.lock` / `package-lock.json`.
+>
+> A PR that advances one of these without the others is a defect.
+
+## Action items
+
+1. **reagent gate (primary — the explicit ask).** reagent must verify the
+   release-consistency invariant and return `CHANGES_REQUESTED` on a mismatch —
+   especially on any PR that touches `VERSION_HISTORY.md`, `package.json`, or
+   `Cargo.toml`. A `chore: release` PR whose `VERSION_HISTORY` head ≠
+   `package.json` version is an automatic block. Wire it via `CLAUDE.md` (which
+   reagent loads as project context) and/or reagent's own configuration so the
+   check is explicit, not incidental.
+
+2. **`task release` self-verify (deterministic).** After `task release` runs,
+   it must assert `package.json == Cargo.toml == VERSION_HISTORY-head ==
+   lockfiles` and **fail loudly** otherwise. It must not report success on a
+   partial bump. Do not trust `bump-cli`'s own "version = X" report — re-read
+   the files on disk.
+
+3. **CI guard (deterministic backstop).** A CI step on every PR that checks the
+   invariant, independent of the LLM reviewer. An invariant this mechanical
+   should be enforced by a script that *cannot* miss it — a reviewer is the
+   secondary net, not the primary one.
+
+4. **Fix the `bump-cli` silent failure.** A version-bump tool silently skipping
+   a file is the underlying trigger. Make `@a5af/bump-cli` fail loudly when it
+   cannot update a target file, or replace the bump step.
+
+## Remediation of the current desync
+
+`package.json` / `Cargo.toml` / lockfiles will be corrected to `0.38.0`
+(matching `VERSION_HISTORY`'s latest released entry) as the base of the next
+release PR, which then bumps forward normally.

--- a/docs/specs/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md
+++ b/docs/specs/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md
@@ -1,0 +1,227 @@
+# SPEC — OAuth credentials as first-class identity-bundle members
+
+**Date:** 2026-05-22
+**Author:** AgentA
+**Status:** Draft
+**Scope:** `agentmux-srv` identity/resolver + storage, agentmux-cef OAuth flow controller, launch modal.
+**Related:**
+`SPEC_BUNDLE_MANAGEMENT_2026_05_22.md` (bundle CRUD, just shipped),
+`SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` (the OAuth flow),
+`SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md` (the modal reducer),
+`docs/analysis/LAUNCH_MODAL_CONTINUE_LOST_2026_05_22.md` (`continueOfId` bug — orthogonal),
+`reference_data_dir_unification_plan` (the `~/.agentmux/` unification — coordinates with §4.1).
+
+---
+
+## 1. Summary
+
+Make identity bundles the **single home for all agent credentials** — API keys *and* OAuth — by representing OAuth credentials as a **filesystem pointer** (a per-bundle config directory) with **status tracking**, and making "OAuth → bundle-bound" an **invariant** of the OAuth flow.
+
+Closes the long-standing "ambient OAuth" gap that today forces hacks like the openclaw `authRequired` always-gate (`AgentLaunchModal.tsx:474-477`), lets two "identities" silently share one `~/.claude` directory, and causes the launch modal to misclassify continuation-with-ambient-creds as "needs auth" the moment any state hiccup loses `continueOfId`.
+
+## 2. Motivation
+
+**Today** the identity-bundle system handles only **API-key** secrets. `resolver.rs:46-55`:
+
+```rust
+pub fn provider_env_vars(provider: &str) -> Vec<&'static str> {
+    match provider {
+        "github"    => vec!["GITHUB_TOKEN", "GH_TOKEN"],
+        "anthropic" => vec!["ANTHROPIC_API_KEY"],
+        "openai"    => vec!["OPENAI_API_KEY"],
+        "kimi"      => vec!["MOONSHOT_API_KEY"],
+        "aws"       => vec!["AWS_ACCESS_KEY_ID"],
+        _ => Vec::new(),
+    }
+}
+```
+
+Resolution is *one thing*: turn a `SecretRef` into a plaintext string and inject it as an env var. There is no path for OAuth. So **OAuth credentials live ambient** — Claude Code at `~/.claude/.credentials.json`, codex / openclaw at their own paths — and identity bundles for OAuth providers are *labels only*: they provide no actual credential isolation.
+
+### Costs
+
+- Two "identities" both reading `~/.claude` are **not actually distinct** — no multi-identity for OAuth providers.
+- The launch modal hardcodes `provider?.id === "openclaw"` to **always** gate auth (`AgentLaunchModal.tsx:474-477`) because bundles can't carry openclaw auth. The comment explicitly tags this as Phase δ deferred work.
+- Continuation rows with empty `identity_id` fall back to ambient at spawn (`resolver.rs:134-148`) and the launch modal cannot tell *"this user has a working OAuth"* from *"this user has nothing"*.
+- The Maks case: continuation correctly skips the auth gate, but any path that loses `continueOfId` (e.g. the `+New identity` round-trip bug) re-engages it — because the system has no first-class representation of "his OAuth is valid."
+
+### Goal
+
+Every credential — API key or OAuth — is **bound to an identity bundle**. Bundles are the truth; ambient is migration glue, not a parallel system.
+
+## 3. Goals / non-goals
+
+**Goals:**
+
+- Identity bundles carry OAuth credentials, as **pointers** (not stored token blobs).
+- Per-bundle credential **isolation**: each bundle's Claude/codex/openclaw login is genuinely separate.
+- **Status** surfaced on identity (`valid` / `expired` / `needs_reauth` / `unknown`) so users can see and act on credential health.
+- A successful OAuth flow **always** lands bound to a bundle — created on the spot if none was selected. The OAuth invariant.
+- A **clean migration** for existing ambient users — a "Default" identity bundle that points at the existing `~/.claude`, no token movement required.
+- Remove the openclaw `gate always` hack.
+
+**Non-goals:**
+
+- agentmux performing the OAuth refresh dance itself. CLIs (Claude Code, codex, `gh`) refresh their own tokens — agentmux tracks status and offers a **Reconnect** affordance when refresh fails.
+- Encrypted secret storage / AWS Secrets Manager backend integration (separate Phase 3 work, already deferred in `resolver.rs`).
+- Migrating API-key bindings (they already work — out of scope).
+- Cross-machine bundle sync (a different feature).
+- The launch-modal `continueOfId` round-trip bug — fixed independently (see the analysis doc).
+
+## 4. Design
+
+### 4.1 Per-bundle credential directories
+
+Each identity bundle owns a credential root:
+
+```
+~/.agentmux/identities/<bundle-id>/
+    claude/        # CLAUDE_CONFIG_DIR for this bundle
+    codex/         # codex's config dir
+    openclaw/      # openclaw's config dir
+    ...
+```
+
+Agents launched with a given identity bundle spawn with the relevant per-provider config-dir env var pointing into this bundle's tree — e.g. `CLAUDE_CONFIG_DIR=~/.agentmux/identities/<id>/claude/`. The CLI reads/writes its tokens there; refreshes are CLI-local; **nothing leaks between bundles**.
+
+*Layout coordinates with the data-dir unification plan* (`reference_data_dir_unification_plan`) — the `identities/` directory hangs off the same unified `~/.agentmux/` root.
+
+### 4.2 `SecretRef` extension
+
+`resolver.rs` `SecretRef` today:
+
+```rust
+pub enum SecretRef {
+    Env { env_var: String },
+    PlaintextDev { plaintext_dev: String },
+    SecretsManager { sm_path: String, sm_json_path: Option<String> },
+}
+```
+
+Add one variant:
+
+```rust
+SecretRef::OAuthConfigDir { dir: PathBuf },
+```
+
+— a pointer to a directory the agent CLI reads at spawn. **The tokens live in the dir**; agentmux holds only the path. This makes OAuth trivially refresh-safe (the CLI rotates tokens in place; the path is stable).
+
+### 4.3 Provider taxonomy + resolver mode
+
+Today `provider_env_vars` (`resolver.rs:46-55`) maps `provider → env vars`. Replace with a per-provider **classification** that drives the resolution mode:
+
+| Provider     | Class    | Resolution                                              |
+|---|---|---|
+| `github`     | api-key  | inject `GITHUB_TOKEN`, `GH_TOKEN`                       |
+| `anthropic`  | api-key  | inject `ANTHROPIC_API_KEY`                              |
+| `openai`     | api-key  | inject `OPENAI_API_KEY`                                 |
+| `kimi`       | api-key  | inject `MOONSHOT_API_KEY`                               |
+| `aws`        | api-key  | inject `AWS_ACCESS_KEY_ID`                              |
+| `claude`     | oauth    | set `CLAUDE_CONFIG_DIR=<bundle>/claude`                 |
+| `codex`      | oauth    | set the codex equivalent (its config-dir env var)       |
+| `openclaw`   | oauth    | set the openclaw equivalent                             |
+
+`inject_identity_env` (`resolver.rs:115-232`) dispatches by class:
+
+- **api-key** binding → existing path: resolve `SecretRef` → plaintext string → inject env var.
+- **oauth** binding → resolve `SecretRef::OAuthConfigDir` → set the provider's config-dir env var to that path.
+
+The per-binding *failure-is-skipped* semantic is preserved across both modes.
+
+### 4.4 Status semantics
+
+`IdentityAccount.status: String` exists in the schema today, populated as `"unknown"` (`resolver.rs:258`). Define values for **oauth** accounts:
+
+| Value           | Meaning                                                                 |
+|---|---|
+| `valid`         | Token present and (probed) not expired.                                 |
+| `expired`       | Access token expired; refresh likely succeeds. Soft state.              |
+| `needs_reauth`  | Refresh token rejected / missing; user must Reconnect. Hard state.      |
+| `unknown`       | Not yet probed. Initial state on bundle import.                         |
+
+**Update points:**
+
+- On **bind** (initial OAuth success) → `valid`.
+- On **agent spawn** → cheap expiry-read of `bundle/<provider>/credentials.json` updates status (no network round-trip).
+- On user-triggered **Refresh status** → re-probe.
+- On a **failed spawn** where the CLI reports auth error → `needs_reauth`.
+
+**Surfaces:**
+
+- The **Identity & Memory** manager (the hamburger modal from `BundleManagerModal`) shows status per-account with a **Reconnect** button when `needs_reauth`.
+- The launch modal's auth panel — instead of "Connect to Claude Code" out of nowhere — says e.g. *"Claude credentials need reconnecting"* when the bound account's status is `needs_reauth`.
+
+### 4.5 OAuth-success invariant
+
+PR #969 (Feature 1) made OAuth Connect open the New Identity modal first. This spec makes it an **invariant**:
+
+> A successful OAuth flow MUST land bound to an identity bundle. If none is selected when OAuth begins, one is created (user- or auto-named) *before* the OAuth process starts.
+
+Sequence (`AuthFlowController` orchestrates):
+
+1. Bundle selected, or new bundle named + created.
+2. Bundle's `<provider>/` dir allocated under `~/.agentmux/identities/<id>/`.
+3. The provider's CLI process spawned with the config-dir env var pointing at that path.
+4. CLI runs its OAuth dance and writes its own tokens into the bundle dir.
+5. On success, the `db_identity_bindings` row is persisted with the account's `SecretRef::OAuthConfigDir { dir }` and status `valid`.
+6. On failure, the dir is left intact for the user's next attempt; the bundle row stays — the binding does not.
+
+### 4.6 Spawn wiring
+
+`inject_identity_env` is already the call-site for "build the agent's env from its identity." With this spec, **oauth-class bindings** also inject the per-provider config-dir env var. The agent CLI then reads its tokens from the per-bundle dir transparently — no further wiring needed in the agent runtime.
+
+## 5. Migration
+
+### 5.1 The "Default" identity bundle — closes the Maks case for real
+
+On first run under the new resolver — or as a one-shot startup migration:
+
+1. If `~/.claude/.credentials.json` exists *and* no identity bundle has a `claude` binding, create an identity bundle named **"Default"** (or the OS user's display name).
+2. Its `claude` binding stores `SecretRef::OAuthConfigDir { dir: <user-home>/.claude }`.
+3. Status is probed (`valid` / `expired` / `needs_reauth`).
+4. Any `db_agent_instances` row with empty/`"blank"` `identity_id` is back-filled to this Default bundle.
+
+**Result:** Maks's existing OAuth is now bound to a real bundle. No token movement, no fabrication — the pointer genuinely resolves. The launch modal sees a valid bound binding and behaves correctly *with or without* `continueOfId`. Anyone else with an ambient login converts the same way.
+
+### 5.2 codex / openclaw
+
+Same treatment when those providers' config dirs are detected on disk.
+
+### 5.3 Backward compat
+
+Empty `identity_id` continues to be tolerated by the resolver (the existing ambient fallback at `resolver.rs:134-148`, with its warn-log, stays). Migration makes empty rare; not eliminating the fallback is intentional — it's the safety net for any future ambient launch we haven't migrated.
+
+## 6. Removed hacks
+
+- `AgentLaunchModal.tsx:474-477` — drop the `provider?.id === "openclaw"` always-gate. With bundles carrying openclaw auth, the standard `hasMatchingBinding` path handles it.
+- The `"blank"` sentinel sub-checks become rare (migration back-fills most ambient launches).
+- `inject_identity_env`'s warn-log for empty `identity_id` (`resolver.rs:141-147`) keeps firing only for genuinely-unmigrated rows — a useful signal that the migration missed something.
+
+## 7. Rollout
+
+Suggested PR sequence — each PR independently mergeable, each adds value alone:
+
+| PR | Scope |
+|---|---|
+| **A** | Schema: `SecretRef::OAuthConfigDir` variant + storage migration. Per-bundle dir layout (`~/.agentmux/identities/<id>/`) provisioned on bundle create. |
+| **B** | Resolver: provider-class table replaces `provider_env_vars`; `inject_identity_env` learns the oauth-resolution mode (sets `CLAUDE_CONFIG_DIR` etc.). API-key path unchanged. |
+| **C** | OAuth-success invariant: `AuthFlowController` spawns the CLI with the bundle's config dir; auto-create-bundle path on OAuth-without-identity; persists the `OAuthConfigDir` binding on success. |
+| **D** | Status field semantics: cheap expiry-probe + UI surfacing in the Identity & Memory manager (Reconnect button) + launch-modal auth-panel wording. |
+| **E** | Migration: seed Default bundle from `~/.claude`; back-fill empty `identity_id` rows; symmetric handling for codex / openclaw config dirs. |
+| **F** | Cleanup: drop the openclaw always-gate; tighten the launch modal's auth gate to the bound-binding check alone. Update the `Phase δ` comment to "done." |
+
+## 8. Open questions
+
+1. **Codex / openclaw config-dir env vars** — confirm the exact env var names for each CLI. Default to documented values; verify by probe before locking in the matrix.
+2. **Bundle deletion** — should removing an identity bundle wipe its credential dir? Yes (it's a credential rotation event), but with a confirm modal (`BundleManagerModal` already has the framing).
+3. **Multiple OAuth accounts per provider per bundle** — out of scope for this spec (one bundle ⇒ one `<provider>/` dir per provider). If we want "two Claude logins in one bundle" later, the dir layout becomes `<provider>/<account-id>/` — additive change, no schema break.
+4. **Status probing scope** — `valid`/`expired` is read from token expiry on disk. `needs_reauth` requires either a CLI auth-fail signal or a network probe. Defer the network probe; rely on spawn-time CLI feedback initially.
+
+## 9. Why this is worth the spend
+
+The current "API keys in bundles, OAuth ambient" split is a long-standing seam — it forced #969 to land the OAuth-creates-bundle UX without an actual backend representation, it gave the openclaw gate-always hack a permanent home, it made the Maks-case dance subtle and fragile. Closing the seam:
+
+- Removes a class of "the modal forgot I'm authed" bugs (Maks's symptom is *one* of them).
+- Makes the bundle manager (#972) functionally meaningful for OAuth users, not just API-key ones.
+- Aligns with the data-dir unification direction (one tree, one source of truth).
+- Drops the deferral hedge in the launch modal — the codebase stops pointing at "Phase δ" and just *is* the Phase δ.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.2",
+      "version": "0.38.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes **17 pending changesets** from the 2026-05-23 session — see the VERSION_HISTORY.md top entry for the full list.

Major themes:
- **Agent-pane state machine migration (PRs A-G)** — `TurnPhase` discriminated union, view reads `isWorking(state)`, bounded Interrupting / Submitting / Streaming, Disconnected state + banner, legacy `turnActive`/`stopping`/`streaming.active` removed.
- **#728 gaps 1-3 closed** — `InitPhase`, submit timeout, streaming watchdog.
- **Cascade follow-ups** — per-block ErrorBoundary, unified registration, recent sessions reattach, model-level `dispatchIfAlive`.
- **OAuth identity bundles (PRs A-F)** — landed earlier in session, full bundle binding flow.
- **Tool-block UX polish, PTY width, CI release-consistency gate, Maks transcript recovery**.

All 5 version locations verified consistent at `0.38.3` (the new CI gate in `.github/workflows/release-consistency.yml` will fire on this PR since it touches VERSION_HISTORY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)