### PR TITLE
fix(build): break \-hex escape in Maks transcript that crashes tailwind v4

### DIFF
--- a/docs/recovery/MAKS_CONVERSATION_2026_05_23.md
+++ b/docs/recovery/MAKS_CONVERSATION_2026_05_23.md
@@ -21,7 +21,7 @@ Related: `docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md` · spe
 - **Name:** Claude
 - **Slug:** claude
 - **Provider:** Claude Code
-- **Working Directory:** ~/.agentmux\agents\maks-05155
+- **Working Directory:** ~/.agentmux/agents/maks-05155
 - **AgentMux Version:** 0.38.3
 - **Date:** 2026-05-23
 
@@ -170,7 +170,7 @@ Let me pull the latest code and dig into the live-feed history all at once.
 - 🔧 **2026-05-23 07:57:11Z** 🔧 Bash gh repo clone agentmuxai/agentmux /tmp/agentmux-inspect 2>&1 || (cd /tmp/agentmux-inspect && git pull 2>&1) ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:23Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline -30 2>&1 ✓ (collapsed)
 - 🔧 **2026-05-23 08:01:17Z** 🤖 Agent Find live-feed component files ✓ (collapsed)
-- 🔧 **2026-05-23 07:59:31Z** 🔧 Bash Get-ChildItem -Path "C:\tmp\agentmux-inspect" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 20 ✗
+- 🔧 **2026-05-23 07:59:31Z** 🔧 Bash Get-ChildItem -Path "C:/tmp/agentmux-inspect" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 20 ✗
 - 🔧 **2026-05-23 07:59:34Z** 🛠️ PowerShell  ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:35Z** 🛠️ PowerShell  ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:38Z** 🛠️ PowerShell  ✓ (collapsed)
@@ -179,14 +179,14 @@ Let me pull the latest code and dig into the live-feed history all at once.
 - 🔧 **2026-05-23 07:59:41Z** 📁 Glob **/block*.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:41Z** 📁 Glob **/components/**/*.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:43Z** 🔍 Grep hover.*delay|hoverDelay|HoverDelay ✓ (collapsed)
-- 🔧 **2026-05-23 07:59:43Z** 🔍 Grep Running\.\.\. ✓ (collapsed)
+- 🔧 **2026-05-23 07:59:43Z** 🔍 Grep Running/././. ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:44Z** 🔍 Grep collapse|expand|collapsed|expanded ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:45Z** 🔍 Grep Running ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:46Z** 🔍 Grep hover|delay ✓ (collapsed)
-- 🔧 **2026-05-23 07:59:47Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\block\block.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 07:59:47Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\block\blockframe.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 07:59:47Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/block/block.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 07:59:47Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/block/blockframe.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:49Z** 📁 Glob **/agent*/**/*.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 07:59:51Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\agent-view.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 07:59:51Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/agent-view.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:53Z** 🔍 Grep onMouseOver|onMouseOut|hover ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:53Z** 🔍 Grep Running|status.*running ✓ (collapsed)
 - 🔧 **2026-05-23 07:59:55Z** 🔍 Grep onMouseOver|onMouseOut ✓ (collapsed)
@@ -194,25 +194,25 @@ Let me pull the latest code and dig into the live-feed history all at once.
 - 🔧 **2026-05-23 07:59:58Z** 🔍 Grep onMouseOver|onMouseOut ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:00Z** 📁 Glob **/ToolBlock*.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:00Z** 📁 Glob **/StreamDown*.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:02Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\components\ToolBlock.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:04Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\components\ToolBlockOverlay.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:06Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\components\ToolOverlayLog.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:02Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:04Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/components/ToolBlockOverlay.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:06Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/components/ToolOverlayLog.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:08Z** 📁 Glob **/*.scss ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:09Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\styles\_tool-overlay-portal.scss ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:11Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\styles\_document-nodes.scss ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:09Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/styles/_tool-overlay-portal.scss ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:11Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/styles/_document-nodes.scss ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:13Z** 📁 Glob **/tool-collapse.md ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:14Z** 📁 Glob **/*tool*log*.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:15Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\docs\specs\tool-collapse.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:23Z** 🔧 Bash find "~/.agentmux\agents\maks-05155" -name "*TOOL_BLOCK_LIVE_LOG*" -o -name "*tool*live*" 2>/dev/null | head -20 ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:25Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\docs\specs\SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:33Z** 🔧 Bash find "~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent" -name "types.ts" -o -name "types.tsx" 2>/dev/null ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:37Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\types.ts ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:41Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\types.ts ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:43Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\types.ts ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:15Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/docs/specs/tool-collapse.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:23Z** 🔧 Bash find "~/.agentmux/agents/maks-05155" -name "*TOOL_BLOCK_LIVE_LOG*" -o -name "*tool*live*" 2>/dev/null | head -20 ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:25Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:33Z** 🔧 Bash find "~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent" -name "types.ts" -o -name "types.tsx" 2>/dev/null ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:37Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/types.ts ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:41Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/types.ts ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:43Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/types.ts ✓ (collapsed)
 - 🔧 **2026-05-23 08:00:45Z** 🔍 Grep STATUS_ICONS|STATUS_LABEL ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:46Z** 📖 Read ~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\types.ts ✓ (collapsed)
-- 🔧 **2026-05-23 08:00:54Z** 🔧 Bash grep -n "HOVER_ENTER_DELAY_MS\|HOVER_LEAVE_DELAY_MS" "~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\components\ToolBlock.tsx" ✓ (collapsed)
-- 🔧 **2026-05-23 08:01:02Z** 🔧 Bash grep -n "Running" "~/.agentmux\agents\maks-05155\agentmux\frontend\app\view\agent\components\ToolOverlayLog.tsx" ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:46Z** 📖 Read ~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/types.ts ✓ (collapsed)
+- 🔧 **2026-05-23 08:00:54Z** 🔧 Bash grep -n "HOVER_ENTER_DELAY_MS/|HOVER_LEAVE_DELAY_MS" "~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/components/ToolBlock.tsx" ✓ (collapsed)
+- 🔧 **2026-05-23 08:01:02Z** 🔧 Bash grep -n "Running" "~/.agentmux/agents/maks-05155/agentmux/frontend/app/view/agent/components/ToolOverlayLog.tsx" ✓ (collapsed)
 ### 💭 thinking — 2026-05-23 08:01:18Z — _node_12_
 
 Now let me get the git log output and read the relevant files to understand the current state better.
@@ -221,7 +221,7 @@ Now let me get the git log output and read the relevant files to understand the 
 
 Good, now let me read the actual current code and git history for the hover delay removal.
 
-- 🔧 **2026-05-23 08:01:29Z** 🔧 Bash cat ~/AppData\Local\Temp\claude\C--Users-<redacted-user>--agentmux-agents-maks-05155\d85077b2-8fd6-4397-a164-9311d1457ee5\tasks\b9mr9vy4b.output 2>/dev/null || echo "still running" ✓ (collapsed)
+- 🔧 **2026-05-23 08:01:29Z** 🔧 Bash cat ~/AppData/Local/Temp/claude/C--Users-<redacted-user>--agentmux-agents-maks-05155/d85077b2-8fd6-4397-a164-9311d1457ee5/tasks/b9mr9vy4b.output 2>/dev/null || echo "still running" ✓ (collapsed)
 - 🔧 **2026-05-23 08:03:30Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline -30 ✓ (collapsed)
 - 🔧 **2026-05-23 08:03:30Z** 📖 Read /tmp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✗
 - 🔧 **2026-05-23 08:03:30Z** 📖 Read /tmp/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx ✗
@@ -239,9 +239,9 @@ Now let me check the git history for the hover delay removal and the SCSS for cu
 
 - 🔧 **2026-05-23 08:04:00Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline --all | head -30 ✓ (collapsed)
 - 🔧 **2026-05-23 08:06:01Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline --follow -20 -- frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:06:07Z** 🔧 Bash grep -n "transition\|animation\|collapse\|expand\|height\|overflow" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss | head -60 ✓ (collapsed)
-- 🔧 **2026-05-23 08:06:17Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline --all | grep -i "hover\|delay\|collapse\|expand\|tool.block\|live.feed\|panel\|auto.expand" | head -20 ✓ (collapsed)
-- 🔧 **2026-05-23 08:06:23Z** 🔧 Bash grep -n "agent-tool-block\|agent-tool-panel\|collapsed\|expanded\|transition\|animation" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss | grep -A2 -B2 "tool-block\|tool-panel\|collapsed\|expanded" | head -80 ✓ (collapsed)
+- 🔧 **2026-05-23 08:06:07Z** 🔧 Bash grep -n "transition/|animation/|collapse/|expand/|height/|overflow" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss | head -60 ✓ (collapsed)
+- 🔧 **2026-05-23 08:06:17Z** 🔧 Bash cd /tmp/agentmux-inspect && git log --oneline --all | grep -i "hover/|delay/|collapse/|expand/|tool.block/|live.feed/|panel/|auto.expand" | head -20 ✓ (collapsed)
+- 🔧 **2026-05-23 08:06:23Z** 🔧 Bash grep -n "agent-tool-block/|agent-tool-panel/|collapsed/|expanded/|transition/|animation" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss | grep -A2 -B2 "tool-block/|tool-panel/|collapsed/|expanded" | head -80 ✓ (collapsed)
 - 🔧 **2026-05-23 08:06:32Z** 🔧 Bash cd /tmp/agentmux-inspect && git show 199818cd --stat 2>&1 | head -20 ✓ (collapsed)
 - 🔧 **2026-05-23 08:06:38Z** 🔧 Bash cd /tmp/agentmux-inspect && git show 633b1c3a --stat 2>&1 | head -20 ✓ (collapsed)
 - 🔧 **2026-05-23 08:06:46Z** 🔧 Bash sed -n '60,220p' /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss ✓ (collapsed)
@@ -334,35 +334,35 @@ Now
 - 🔧 **2026-05-23 08:10:04Z** 🔧 Bash ls /tmp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 08:10:26Z** 🔧 Bash realpath /tmp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
 - 🔧 **2026-05-23 08:10:35Z** 🔧 Bash cygpath -w /tmp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx 2>/dev/null || echo "no cygpath" ✓ (collapsed)
-- 🔧 **2026-05-23 08:10:38Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx ✗
-- 🔧 **2026-05-23 08:10:41Z** 📖 Read ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:10:42Z** 📖 Read ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolOverlayLog.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:10:42Z** 📖 Read ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\styles\_document-nodes.scss ✓ (collapsed)
+- 🔧 **2026-05-23 08:10:38Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✗
+- 🔧 **2026-05-23 08:10:41Z** 📖 Read ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:10:42Z** 📖 Read ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:10:42Z** 📖 Read ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:10:45Z — _node_22_
 
 Now
 
-- 🔧 **2026-05-23 08:10:48Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:11:07Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:11:17Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:10:48Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:11:07Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:11:17Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:11:23Z — _node_23_
 
 Now the SCSS:
 
-- 🔧 **2026-05-23 08:11:30Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\styles\_document-nodes.scss ✓ (collapsed)
+- 🔧 **2026-05-23 08:11:30Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:11:34Z — _node_24_
 
 Now "Running..." → "Thinking...":
 
-- 🔧 **2026-05-23 08:11:36Z** 📖 Read ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolOverlayLog.tsx ✓ (collapsed)
-- 🔧 **2026-05-23 08:11:44Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolOverlayLog.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:11:36Z** 📖 Read ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx ✓ (collapsed)
+- 🔧 **2026-05-23 08:11:44Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:11:47Z — _node_25_
 
 Now
 
-- 🔧 **2026-05-23 08:11:56Z** 🔧 Bash code \
-  "~/<tmp>/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx" \
-  "~/<tmp>/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx" \
+- 🔧 **2026-05-23 08:11:56Z** 🔧 Bash code /
+  "~/<tmp>/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx" /
+  "~/<tmp>/agentmux-inspect/frontend/app/view/agent/components/ToolOverlayLog.tsx" /
   "~/<tmp>/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss" 2>&1 ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:11:57Z — _node_26_
 
@@ -417,10 +417,10 @@ The Write tool wrote to `/tmp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POL
 The bash `/tmp` and Windows `AppData/Local/Temp` are different locations. Let me find and rewrite it to the right place.
 
 - 🔧 **2026-05-23 08:13:38Z** 🔧 Bash cygpath -w /tmp/agentmux-inspect/docs/specs/ ✓ (collapsed)
-- 🔧 **2026-05-23 08:13:46Z** 🔧 Bash ls /tmp/agentmux-inspect/docs/specs/ | grep -i "polish\|ux\|2026_05_23" ✓ (collapsed)
+- 🔧 **2026-05-23 08:13:46Z** 🔧 Bash ls /tmp/agentmux-inspect/docs/specs/ | grep -i "polish/|ux/|2026_05_23" ✓ (collapsed)
 ### 💭 thinking — 2026-05-23 08:13:49Z — _node_34_
 
-The Write tool wrote to `/tmp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md` but somehow that file isn't there. The paths are the same (cygpath confirms `/tmp/agentmux-inspect` = `~/AppData\Local\Temp\agentmux-inspect`). But the ls output shows a different set of files - this is a different directory! Looking at both `ls` outputs:
+The Write tool wrote to `/tmp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md` but somehow that file isn't there. The paths are the same (cygpath confirms `/tmp/agentmux-inspect` = `~/AppData/Local/Temp/agentmux-inspect`). But the ls output shows a different set of files - this is a different directory! Looking at both `ls` outputs:
 
 1. First `ls` (using Windows path): shows files like `widget-visibility-rearchitecture.md`, `window-close-process-cleanup.md`, etc.
 
@@ -431,13 +431,13 @@ These are completely different directories, even though the paths should map to 
 
 Looking more carefully at the two file lists, the Windows path shows files like `widget-visibility-rearchitecture.md` and `zoom-architecture.md`, while the bash path shows files starting with `SPEC_WAVE_TO_MUX_` and other names. These are genuinely different sets of files, so either the paths aren't actually equivalent, or something else is going on with how Git Bash maps `/tmp` on Windows.
 
-But I know from the successful ToolBlock.tsx edit that the code changes went to `~/AppData\Local\Temp\agentmux-inspect\frontend\app\view\agent\components\ToolBlock.tsx`, so I should write the spec file to the same Windows path location: `~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md`.
+But I know from the successful ToolBlock.tsx edit that the code changes went to `~/AppData/Local/Temp/agentmux-inspect/frontend/app/view/agent/components/ToolBlock.tsx`, so I should write the spec file to the same Windows path location: `~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md`.
 
 ### 🤖 Maks — 2026-05-23 08:14:01Z — _node_35_
 
 Two different clones ended up in two locations
 
-- 🔧 **2026-05-23 08:14:43Z** 📝 Write ~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:14:43Z** 📝 Write ~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
 - 🔧 **2026-05-23 08:14:54Z** 🔧 Bash code "~/<tmp>/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md" ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:14:58Z — _node_36_
 
@@ -482,17 +482,17 @@ Let me add this to the spec. The fix is straightforward CSS: `overscroll-behavio
 
 Now I'm checking what the current CSS looks like for that element.
 
-- 🔧 **2026-05-23 08:18:32Z** 🔧 Bash grep -n "agent-tool-overlay-log\|overscroll" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss ✗
-- 🔧 **2026-05-23 08:18:41Z** 🔧 Bash grep -rn "agent-tool-overlay-log\|overscroll" "~/<tmp>/agentmux-inspect/frontend/app/view/agent/styles/" ✓ (collapsed)
+- 🔧 **2026-05-23 08:18:32Z** 🔧 Bash grep -n "agent-tool-overlay-log/|overscroll" /tmp/agentmux-inspect/frontend/app/view/agent/styles/_document-nodes.scss ✗
+- 🔧 **2026-05-23 08:18:41Z** 🔧 Bash grep -rn "agent-tool-overlay-log/|overscroll" "~/<tmp>/agentmux-inspect/frontend/app/view/agent/styles/" ✓ (collapsed)
 - 🔧 **2026-05-23 08:18:50Z** 🔧 Bash sed -n '40,65p' "~/<tmp>/agentmux-inspect/frontend/app/view/agent/styles/_tool-overlay-portal.scss" ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:18:53Z — _node_41_
 
 Got it. The fix is one CSS line — `overscroll-behavior: contain` on `.agent-tool-overlay-log`. Now adding Change 5 to the spec.
 
-- 🔧 **2026-05-23 08:18:55Z** 📖 Read ~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:19:11Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:19:24Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
-- 🔧 **2026-05-23 08:19:49Z** ✏️ Edit ~/AppData\Local\Temp\agentmux-inspect\docs\specs\SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:18:55Z** 📖 Read ~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:19:11Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:19:24Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
+- 🔧 **2026-05-23 08:19:49Z** ✏️ Edit ~/AppData/Local/Temp/agentmux-inspect/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md ✓ (collapsed)
 ### 🤖 Maks — 2026-05-23 08:19:50Z — _node_42_
 
 Done. Change 5 added to the spec covering:

--- a/scripts/redact-pii.mjs
+++ b/scripts/redact-pii.mjs
@@ -31,6 +31,25 @@ s = s.replace(/\barea54\b/g, "<redacted-user>");
 s = s.replace(/~\/AppData\/Local\/Temp\//g, "~/<tmp>/");
 s = s.replace(/~[\\]+AppData[\\]+Local[\\]+Temp[\\]+/g, "~/<tmp>/");
 
+// 6) Normalize Windows path separators to forward slash — and CRITICALLY,
+//    break any `\<hex>` sequence that tailwind v4's CSS-escape regex
+//    would interpret as a code point.
+//
+//    Background: tailwind v4 scans .md (and other) files looking for CSS
+//    custom-property usages. Its regex `/\\([\dA-Fa-f]{1,6}…/` greedily
+//    matches a backslash followed by 1-6 hex digits and passes the parse
+//    to `String.fromCodePoint`. A path fragment like
+//    `\d85077b2-8fd6-4397-…` (a UUID after a Windows path separator)
+//    captures `\d85077` → 0xD85077 → invalid code point → THE WHOLE
+//    PRODUCTION BUILD FAILS with "Invalid code point 14176375". Hit on
+//    2026-05-23 — the Maks transcript brought down `task build:frontend`
+//    (and every other agent's build) until this normalization landed.
+//
+//    Fix: replace single backslashes with forward slashes everywhere in
+//    transcript text. Paths stay legible; the CSS-escape pattern is
+//    structurally impossible afterwards.
+s = s.replace(/\\(?!\\)/g, "/");
+
 writeFileSync(file, s);
 const after = s.length;
 console.log(`redacted ${file}: ${before} -> ${after} bytes`);


### PR DESCRIPTION
**P0** — `task build:frontend` is broken on `main` because Maks' recovered conversation transcript contains a Windows path with `\d85077b2-...`. Tailwind v4's CSS-escape scanner reads `\d85077` as a 6-digit codepoint literal, parses it to 0xD85077 = 14176375, calls `String.fromCodePoint`, and crashes.

Fix: normalize single backslashes to forward slashes in transcript text. `scripts/redact-pii.mjs` gains the rule so future transcripts are sanitized at capture. The existing transcript is re-run through the script.

`task build:frontend` verified green after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)