### PR TITLE
tweak(tool-block): bump post-completion hold from 1s to 5s

### DIFF
--- a/.changesets/1779554462-tweak-tool-block-bump-post-completion-hold-from-1s-to-5s-i9sg.md
+++ b/.changesets/1779554462-tweak-tool-block-bump-post-completion-hold-from-1s-to-5s-i9sg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+tweak(tool-block): bump post-completion hold from 1s to 5s

--- a/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md
+++ b/docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md
@@ -141,12 +141,14 @@ the browser picks up the transition from the new rule and animates.
 
 ---
 
-## Change 3 — 1-second post-completion hold before auto-collapse
+## Change 3 — 5-second post-completion hold before auto-collapse
 
 ### Why
 `autoExpanded()` currently returns `false` the instant `status` changes from
-`running` → `success`. The panel snaps shut with zero reading time. A 1-second
-grace period lets the user see the final output line before the block collapses.
+`running` → `success`. The panel snaps shut with zero reading time. A
+5-second grace period lets the user actually finish reading the final output
+lines before the block collapses. (Initially shipped at 1 s; bumped to 5 s
+after live testing — 1 s was too tight to read more than a single line.)
 
 This only affects the **auto-expand** path (running tools). A user who has
 manually pinned the block is unaffected — `props.pinned` still wins.
@@ -154,16 +156,22 @@ manually pinned the block is unaffected — `props.pinned` still wins.
 ### Implementation — `frontend/app/view/agent/components/ToolBlock.tsx`
 
 ```tsx
-// New signal — stays true for 1s after a running tool completes:
+// New signal — stays true for POST_COMPLETION_HOLD_MS (5 s) after a
+// running tool completes. The hold is gated on a real active→inactive
+// TRANSITION (not status-snapshot) to avoid arming on mount of loaded
+// transcripts. See ToolBlock.tsx for the prevStatus comparator.
+const POST_COMPLETION_HOLD_MS = 5000;
 const [postCompletionHold, setPostCompletionHold] = createSignal(false);
+let prevStatus: string = props.node.status;
+const isActive = (s: string) => s === "running" || s === "pending_approval" || s === "failed";
 createEffect(() => {
     const s = props.node.status;
-    if (s !== "running" && s !== "pending_approval" && s !== "failed") {
-        if (postCompletionHold()) return;
+    if (isActive(prevStatus) && !isActive(s)) {
         setPostCompletionHold(true);
-        const t = setTimeout(() => setPostCompletionHold(false), 1000);
+        const t = setTimeout(() => setPostCompletionHold(false), POST_COMPLETION_HOLD_MS);
         onCleanup(() => clearTimeout(t));
     }
+    prevStatus = s;
 });
 
 // Updated autoExpanded:
@@ -258,7 +266,7 @@ included) since Chrome 63. No fallback needed for the Tauri/Electron target.
 | Cursor skims over a collapsed tool | Instant expand | 150ms delay — no expand on quick pass |
 | Cursor enters and stays | Instant expand | Expands after 150ms |
 | Cursor leaves expanded block | Instant collapse, no animation | 200ms slide-out animation |
-| Running tool finishes | Panel snaps shut immediately | Panel stays open 1s then collapses with animation |
+| Running tool finishes | Panel snaps shut immediately | Panel stays open 5s then collapses with animation |
 | No chunks yet, tool running | "⏳ Running..." | "⏳ Thinking..." |
 | Scroll reaches end of log | Chains to agent pane scroll | Stops at log boundary |
 | User has pinned block | Already works | Unaffected — pin still wins |

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -89,15 +89,19 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     };
     onCleanup(() => clearTimeout(enterTimer));
 
-    // Stays true for 1s after a running tool completes so the user can read
-    // the final output line before the panel collapses.
-    // (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 3)
+    // Stays true for POST_COMPLETION_HOLD_MS after a running tool
+    // completes so the user can read the final output line before the
+    // panel collapses.
+    // (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 3 — bumped from
+    // 1s to 5s on user request after live testing showed 1s was too
+    // tight to actually finish reading the last lines of a Bash/Read.)
+    const POST_COMPLETION_HOLD_MS = 5000;
     const [postCompletionHold, setPostCompletionHold] = createSignal(false);
     // Gate the post-completion hold on a real active → inactive
     // TRANSITION (not on a status-value snapshot). The earlier draft
     // simply checked `s !== "running" && ...` which fired on mount
     // for already-completed tools — loaded transcripts would briefly
-    // auto-expand every completed tool row for 1s on initial render
+    // auto-expand every completed tool row on initial render
     // (codex P1 round 2 on #988).
     //
     // Background on the older self-loop bug (round 1): reading
@@ -116,7 +120,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         const s = props.node.status;
         if (isActive(prevStatus) && !isActive(s)) {
             setPostCompletionHold(true);
-            const t = setTimeout(() => setPostCompletionHold(false), 1000);
+            const t = setTimeout(() => setPostCompletionHold(false), POST_COMPLETION_HOLD_MS);
             onCleanup(() => clearTimeout(t));
         }
         prevStatus = s;


### PR DESCRIPTION
Live-testing the 1 s hold in the v0.38.4 portable showed it was too tight to actually finish reading the last line(s) of a completed tool. Bumped to 5 s.

Also pulls the magic number out to a named `POST_COMPLETION_HOLD_MS = 5000` constant so the next tuning round is a one-liner. Spec doc updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)