### PR TITLE
feat(agent): default-continue from agent session zones — frontend (Option E, PR 2 of 2)

### DIFF
--- a/.changesets/1779585812-feat-agent-default-continue-from-agent-session-zones-fronten-5ota.md
+++ b/.changesets/1779585812-feat-agent-default-continue-from-agent-session-zones-fronten-5ota.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): default-continue from agent session zones (frontend)

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1156,6 +1156,34 @@ class RpcApiType {
         return client.rpcCall("blockfile:write_state", data, opts);
     }
 
+    // command "agent:session:read" [call] — Option E (PR #1007). Reads
+    // `output.state.json` from `agent:<definition_id>:current`.
+    AgentSessionReadCommand(client: RpcClient, data: CommandAgentSessionReadData, opts?: RpcOpts): Promise<AgentSessionReadResult> {
+        return client.rpcCall("agent:session:read", data, opts);
+    }
+
+    // command "agent:session:write_state" [call] — Option E. Writes
+    // `output.state.json` into `agent:<definition_id>:current`.
+    AgentSessionWriteStateCommand(client: RpcClient, data: CommandAgentSessionWriteStateData, opts?: RpcOpts): Promise<AgentSessionWriteStateResult> {
+        return client.rpcCall("agent:session:write_state", data, opts);
+    }
+
+    // command "agent:session:append_output" [call] — Option E.
+    AgentSessionAppendOutputCommand(client: RpcClient, data: CommandAgentSessionAppendOutputData, opts?: RpcOpts): Promise<AgentSessionAppendOutputResult> {
+        return client.rpcCall("agent:session:append_output", data, opts);
+    }
+
+    // command "agent:session:archive" [call] — Option E. Snapshots
+    // `:current` into `:archive:<ts>` then clears `:current`.
+    AgentSessionArchiveCommand(client: RpcClient, data: CommandAgentSessionArchiveData, opts?: RpcOpts): Promise<AgentSessionArchiveResult> {
+        return client.rpcCall("agent:session:archive", data, opts);
+    }
+
+    // command "agent:session:list_archives" [call] — Option E.
+    AgentSessionListArchivesCommand(client: RpcClient, data: CommandAgentSessionListArchivesData, opts?: RpcOpts): Promise<AgentArchiveRow[]> {
+        return client.rpcCall("agent:session:list_archives", data, opts);
+    }
+
     // command "session:digest" [call]
     SessionDigestCommand(client: RpcClient, data: CommandSessionDigestData, opts?: RpcOpts): Promise<SessionDigestResult> {
         return client.rpcCall("session:digest", data, opts);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -6,7 +6,7 @@ import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { atoms, getApi, WOS } from "@/app/store/global";
-import { SignalAtom } from "@/util/util";
+import { createSignalAtom, SignalAtom } from "@/util/util";
 import { AgentViewWrapper } from "./agent-view";
 import { buildAgentPaneIcon } from "./components/AgentPaneIcon";
 import { PROVIDERS, resolveProviderAlias } from "./providers";
@@ -15,6 +15,20 @@ import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
 
 export type OverlayTab = "agent" | "identity";
+
+/**
+ * Compact relative-time label for the title-bar continuation chip.
+ *
+ * Mirrors the wording of `formatRelative` in `RecentSessionsList.tsx`
+ * (same "Xm ago" / "Xh ago" / "Xd ago" buckets) but lives here so the
+ * model file has no UI-only dependency cycle. Exported for unit tests.
+ */
+export function formatContinuationAgo(deltaMs: number): string {
+    if (deltaMs < 60_000) return "just now";
+    if (deltaMs < 3_600_000) return `${Math.floor(deltaMs / 60_000)}m ago`;
+    if (deltaMs < 86_400_000) return `${Math.floor(deltaMs / 3_600_000)}h ago`;
+    return `${Math.floor(deltaMs / 86_400_000)}d ago`;
+}
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -43,6 +57,16 @@ export class AgentViewModel implements ViewModel {
     // `voiceHandle` accessor below delegates to whatever's current —
     // before AgentFooter mounts (or after it unmounts) it's a no-op.
     voiceTargetRef: { current: PaneVoiceHandle | null } = { current: null };
+
+    // Option E (PR #1007 backend, this PR frontend): when this pane
+    // mounted on an agent-anchored session zone (`agent:<defId>:current`)
+    // that already contained a snapshot, this holds the `modts` of that
+    // snapshot — the timestamp the previous owner pane last wrote.
+    // `viewText` projects it into a "· continued from Xm ago" chip in
+    // the pane title bar. Zero means "no continuation" (fresh agent or
+    // currently-active pane wrote it just now). useHistoryPagination
+    // sets this on snapshot restore.
+    continuedFromMsAtom: SignalAtom<number> = createSignalAtom(0);
 
     voiceHandle = (): PaneVoiceHandle => ({
         appendFinal: (text: string) => this.voiceTargetRef.current?.appendFinal(text),
@@ -84,7 +108,25 @@ export class AgentViewModel implements ViewModel {
             if (typeof name === "string" && name.length > 0) return name;
             return "Agent";
         };
-        this.viewText = () => [] as HeaderElem[];
+        this.viewText = (): HeaderElem[] => {
+            // Option E: render a "· continued from Xm ago" chip when
+            // the pane mounted on a non-empty agent session zone whose
+            // last write was more than ~30s ago (i.e. NOT the
+            // currently-active pane's own recent save). Threshold
+            // matches the 30s snapshot interval so the chip never
+            // shows for the live pane's own writes.
+            const continuedFromMs = this.continuedFromMsAtom();
+            if (!continuedFromMs) return [];
+            const now = Date.now();
+            const delta = Math.max(0, now - continuedFromMs);
+            if (delta < 30_000) return []; // brief gap — same pane / hot reload
+            const ago = formatContinuationAgo(delta);
+            return [{
+                elemtype: "text",
+                text: `· continued ${ago}`,
+                className: "agent-pane-continuation-chip",
+            }];
+        };
         this.noPadding = () => true;
         this.setViewName = async (name: string) => {
             if (!name.trim()) return;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -24,7 +24,7 @@ import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-
 import { useAgentStream } from "./useAgentStream";
 import { useActivityLog } from "./hooks/useActivityLog";
 import { useSessionDigest } from "./hooks/useSessionDigest";
-import { useHistoryPagination, SNAPSHOT_FILENAME, SNAPSHOT_SCHEMA_VERSION } from "./hooks/useHistoryPagination";
+import { useHistoryPagination, SNAPSHOT_SCHEMA_VERSION } from "./hooks/useHistoryPagination";
 import { useAgentControllerStatus } from "./hooks/useAgentControllerStatus";
 import { useInSessionSearch } from "./hooks/useInSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
@@ -167,11 +167,25 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // History pagination: dispatches HistoryLoaded into the agent-document-store
     // for the trailing 200 lines on mount + each user-triggered loadOlder.
+    //
+    // Option E (PR #1007 backend, this PR frontend): pass the agent
+    // definition id so the snapshot fast-path reads from the
+    // agent-anchored zone (`agent:<defId>:current`) rather than the
+    // per-block zone. `agentId` here is the AgentDefinition slug/UUID —
+    // a non-empty string is guaranteed at this point by the `Show
+    // when={agentId()}` gate in AgentViewWrapper above.
     const history = useHistoryPagination({
         blockId: model.blockId,
         // PR-4 — see useAgentStream above; same rationale.
         model: paneModel,
         outputFormat,
+        definitionId: agentId,
+        // Option E: snapshot read returns the modts of the previous
+        // owner's last write; project into the model so `viewText`
+        // renders a "· continued Xm ago" title-bar chip when the gap
+        // is >30s. Setter is a no-op if the pane unmounts before
+        // restore.
+        onContinuationModts: (ms) => model.continuedFromMsAtom._set(ms),
         log,
     });
 
@@ -220,9 +234,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 historyOffset: capturedOffset,
                 nodes,
             };
-            await RpcApi.BlockfileWriteStateCommand(TabRpcClient, {
-                block_id: model.blockId,
-                filename: SNAPSHOT_FILENAME,
+            // Option E (PR #1007 backend, this PR frontend): write
+            // the snapshot to the agent-anchored zone
+            // `agent:<defId>:current` so the next pane that opens for
+            // this AgentDefinition picks up where this one left off.
+            // `agentId` is the definition slug/UUID from block meta —
+            // non-empty here by the AgentViewWrapper `Show when=...`
+            // gate above.
+            await RpcApi.AgentSessionWriteStateCommand(TabRpcClient, {
+                definition_id: agentId,
                 content: JSON.stringify(snapshot),
             }, { timeout: 10000 });
         }).catch((e) => {

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -31,8 +31,25 @@ interface AgentCardProps {
      *  true = CLI present in the per-version cache.
      *  false = needs install — render the bottom-right ribbon. */
     installed: boolean | undefined;
-    /** Opens the AgentLaunchModal (or Install modal) for this definition. */
-    onLaunch: (agent: AgentDefinition) => void;
+    /**
+     * Opens the AgentLaunchModal (or Install modal) for this definition.
+     * The synthetic `MouseEvent` is forwarded so the parent can read
+     * modifier keys (Shift/Ctrl/Alt) — used by Option E to force the
+     * launch modal even when the agent has an in-progress session
+     * (default click would auto-continue otherwise).
+     */
+    onLaunch: (agent: AgentDefinition, evt?: MouseEvent | KeyboardEvent) => void;
+    /**
+     * Option E (PR 2 of 2): when true, this card's agent has a
+     * non-empty session zone (`agent:<defId>:current`) — i.e. the
+     * default click will auto-continue rather than open the launch
+     * modal. Renders a small "+ New" secondary button that archives
+     * the current zone and opens the launch modal for a fresh start.
+     */
+    hasCurrentSession?: boolean;
+    /** Option E: invoked when the user clicks the "+ New" affordance.
+     *  Parent archives the current zone then opens the launch modal. */
+    onNewSession?: (agent: AgentDefinition) => void;
     /** When true this card is the picker's default choice (the
      *  most-recently-used agent) — focus it on mount so Enter launches
      *  it and the focus ring marks it as the default. */
@@ -49,16 +66,24 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
         if (props.defaultFocus && !props.disabled) cardEl?.focus();
     });
 
-    const handleCardClick = () => {
-        if (!props.disabled) props.onLaunch(props.agent);
+    const handleCardClick = (e: MouseEvent) => {
+        if (!props.disabled) props.onLaunch(props.agent, e);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
         if (props.disabled) return;
         if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            props.onLaunch(props.agent);
+            props.onLaunch(props.agent, e);
         }
+    };
+
+    const handleNewClick = (e: MouseEvent) => {
+        // Don't bubble up — outer card click would auto-continue and
+        // race the archive RPC we're about to fire.
+        e.stopPropagation();
+        if (props.disabled) return;
+        props.onNewSession?.(props.agent);
     };
 
     return (
@@ -85,6 +110,24 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
                 <span class="agent-card-install-ribbon" aria-hidden="true">
                     Click to install
                 </span>
+            </Show>
+            {/* Option E (PR #1008): "+ New" affordance — visible only
+                when the agent has an in-progress session. Outer card
+                click auto-continues by default; this button archives
+                the current zone and opens the launch modal so the
+                user can start fresh. Hidden during install ribbon
+                state to avoid double-CTA overlap. */}
+            <Show when={props.hasCurrentSession && props.installed !== false && !props.launching}>
+                <button
+                    type="button"
+                    class="agent-card-new-session-btn"
+                    onClick={handleNewClick}
+                    title="Archive current session and start a new one"
+                    aria-label={`Start a new session for ${caption()} (archives the current one)`}
+                    tabIndex={props.disabled ? -1 : 0}
+                >
+                    {"+ New"}
+                </button>
             </Show>
             <Show when={props.launching}>
                 <span class="agent-card-spinner" />

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -1,0 +1,221 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the Option E default-continue UX on `AgentPicker`
+ * (PR #1008 frontend follow-up to PR #1007 backend).
+ *
+ * The agent picker should:
+ *   1. Auto-continue (no modal) when the agent has a non-empty
+ *      session zone (`agent:<defId>:current`).
+ *   2. Open the launch modal when the agent has no session yet.
+ *   3. Force the launch modal regardless of session content when the
+ *      user clicks with Shift/Ctrl/Alt held (escape hatch).
+ *
+ * Spec: SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => {
+    const RpcApi = {
+        ListAgentDefinitionsCommand: vi.fn(),
+        ListRecentSessionsCommand: vi.fn(),
+        ListNamedAgentsCommand: vi.fn(),
+        InstallCheckCommand: vi.fn(),
+        ResolvePrereqsCommand: vi.fn(),
+        AgentSessionReadCommand: vi.fn(),
+        AgentSessionArchiveCommand: vi.fn(),
+    };
+    return { RpcApi };
+});
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/app/tab/tab-modal", () => ({
+    useTabModal: () => ({
+        open: vi.fn(),
+        replace: vi.fn(),
+        close: vi.fn(),
+    }),
+}));
+
+vi.mock("@/util/platformutil", () => ({
+    getPlatform: () => "linux",
+}));
+
+vi.mock("../providers", () => ({
+    getProvider: (id: string) =>
+        id === "claude"
+            ? {
+                  id: "claude",
+                  npmPackage: null, // no install needed
+                  cliCommand: "claude",
+                  systemPrereqs: [],
+              }
+            : undefined,
+}));
+
+vi.mock("./AgentCard", () => ({
+    AgentCard: (props: any) => (
+        <button
+            data-testid={`agent-card-${props.agent.id}`}
+            data-has-session={String(!!props.hasCurrentSession)}
+            data-launching={String(!!props.launching)}
+            onClick={(e) => props.onLaunch(props.agent, e)}
+            onContextMenu={(e) => {
+                // tests use right-click to simulate Shift+click since
+                // jsdom MouseEvent ctor wires shiftKey deterministically
+                e.preventDefault();
+                const fake = new MouseEvent("click", {
+                    shiftKey: true,
+                    bubbles: true,
+                });
+                props.onLaunch(props.agent, fake);
+            }}
+        >
+            {props.agent.name}
+        </button>
+    ),
+}));
+
+vi.mock("./AgentActionBar", () => ({
+    AgentActionBar: () => null,
+}));
+
+vi.mock("./RecentSessionsList", () => ({
+    RecentSessionsList: () => null,
+}));
+
+import { AgentPicker } from "./AgentPicker";
+
+let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+
+const ts = () => 1_700_000_000_000;
+
+const claudeAgent = {
+    id: "agent-claude",
+    slug: "claude",
+    name: "Claude Code",
+    icon: "",
+    provider: "claude",
+    description: "",
+    working_directory: "",
+    shell: "",
+    provider_flags: "",
+    auto_start: 0,
+    restart_on_crash: 0,
+    idle_timeout_minutes: 0,
+    created_at: ts(),
+    agent_type: "host",
+    environment: "local",
+    agent_bus_id: "",
+    is_seeded: 0,
+} as AgentDefinition;
+
+const makeMockModel = () => ({
+    blockId: "blk-1",
+    blockAtom: () => ({ meta: {} }),
+    nodejsError: null as string | null,
+    launchAgentDefinition: vi.fn().mockResolvedValue(undefined),
+});
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ RpcApi } = await import("@/app/store/rpc-api"));
+    vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([claudeAgent]);
+    vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+    vi.mocked(RpcApi.ListNamedAgentsCommand).mockResolvedValue([]);
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("AgentPicker — default-continue UX (Option E)", () => {
+    it("auto-continues without opening the modal when the agent has a current session", async () => {
+        // Agent has a session in its zone.
+        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
+            content: '{"schemaVersion":1,"nodes":[]}',
+            modts: ts(),
+        });
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+
+        // Wait for definitions to load + session probe.
+        await flush();
+        await flush();
+        await flush();
+
+        const card = await screen.findByTestId("agent-card-agent-claude");
+        expect(card.getAttribute("data-has-session")).toBe("true");
+
+        fireEvent.click(card);
+        await flush();
+        await flush();
+
+        // launchAgentDefinition called → no modal.
+        expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1);
+        const [, overrides] = model.launchAgentDefinition.mock.calls[0];
+        // Default-continue does NOT set continueOfInstanceId — the
+        // agent zone is structurally continuous.
+        expect(overrides.continueOfInstanceId).toBeUndefined();
+        expect(overrides.instanceName).toBe("Claude Code");
+    });
+
+    it("opens the launch modal when the agent has no current session", async () => {
+        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
+            content: null,
+            modts: null,
+        });
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+
+        await flush();
+        await flush();
+        await flush();
+
+        const card = await screen.findByTestId("agent-card-agent-claude");
+        expect(card.getAttribute("data-has-session")).toBe("false");
+
+        fireEvent.click(card);
+        await flush();
+        await flush();
+
+        // No auto-continue — would have set launching state via modal.
+        expect(model.launchAgentDefinition).not.toHaveBeenCalled();
+    });
+
+    it("forces the launch modal even with a current session when Shift is held", async () => {
+        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
+            content: '{"schemaVersion":1,"nodes":[]}',
+            modts: ts(),
+        });
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+
+        await flush();
+        await flush();
+        await flush();
+
+        const card = await screen.findByTestId("agent-card-agent-claude");
+        expect(card.getAttribute("data-has-session")).toBe("true");
+
+        // Simulate shift+click via our mock card's contextmenu handler
+        // (the mock invokes onLaunch with a synthetic shiftKey=true
+        // MouseEvent — see vi.mock("./AgentCard") above).
+        fireEvent.contextMenu(card);
+        await flush();
+        await flush();
+
+        // Shift forces the modal path; launchAgentDefinition NOT called
+        // directly (the modal would call it after the user submits).
+        expect(model.launchAgentDefinition).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -434,22 +434,28 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             // and skip every prereq / install / modal step. The session
             // zone is per-definition, so the bindings the previous pane
             // used are still on the AgentDefinition — no picker needed.
-            const forceModal = !!(
-                evt && (
-                    ("shiftKey" in evt && evt.shiftKey) ||
-                    ("ctrlKey" in evt && evt.ctrlKey) ||
-                    ("altKey" in evt && evt.altKey) ||
-                    ("metaKey" in evt && (evt as MouseEvent).metaKey)
-                )
-            );
-            if (!forceModal && sessionState()[agent.id] === true) {
-                // Still gate on install: an agent with a current
-                // session can still need the CLI binary installed
-                // (e.g. user wiped per-version cache).
-                if (installState()[agent.id] !== false) {
-                    await autoContinue(agent);
-                    return;
-                }
+            // P2 fix: KeyboardEvent also has metaKey, so the MouseEvent
+            // cast was misleading. Both event types are valid here, so
+            // widen the type narrowly instead of asserting one shape.
+            const modKeyed = (evt && (
+                ("shiftKey" in evt && (evt as MouseEvent | KeyboardEvent).shiftKey) ||
+                ("ctrlKey" in evt && (evt as MouseEvent | KeyboardEvent).ctrlKey) ||
+                ("altKey" in evt && (evt as MouseEvent | KeyboardEvent).altKey) ||
+                ("metaKey" in evt && (evt as MouseEvent | KeyboardEvent).metaKey)
+            )) || false;
+            const forceModal = !!modKeyed;
+            // P1 fix: require installState === true (strict), not !== false.
+            // The probe is async; `undefined` means "probe not done yet" and
+            // must NOT be treated as installed — that would race-launch a
+            // missing-CLI agent past the install flow. Falling through to
+            // the slower path below blocks-on-probe correctly.
+            if (
+                !forceModal
+                && sessionState()[agent.id] === true
+                && installState()[agent.id] === true
+            ) {
+                await autoContinue(agent);
+                return;
             }
 
             let installed = installState()[agent.id];

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -78,6 +78,26 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     //   false     = needs install — card shows the bottom-right ribbon
     const [installState, setInstallState] = createSignal<Record<string, boolean | undefined>>({});
 
+    // Option E (PR 2 of 2): per-agent "has a current session" cache,
+    // keyed by agent.id.
+    //   undefined = not yet probed
+    //   true      = `agent:<defId>:current` has content → default
+    //               click auto-continues; "+ New" button surfaces
+    //   false     = no session yet → default click opens launch modal
+    const [sessionState, setSessionState] = createSignal<Record<string, boolean | undefined>>({});
+
+    const checkHasSession = async (agent: AgentDefinition) => {
+        try {
+            const r = await RpcApi.AgentSessionReadCommand(TabRpcClient, {
+                definition_id: agent.id,
+            });
+            setSessionState((s) => ({ ...s, [agent.id]: !!(r.content && r.content.length > 0) }));
+        } catch {
+            // Non-fatal — treat as no session (default click → modal).
+            setSessionState((s) => ({ ...s, [agent.id]: false }));
+        }
+    };
+
     const checkInstalled = async (agent: AgentDefinition) => {
         const prov = getProvider(agent.provider);
         // Non-npm providers (kimi via pip, system-PATH CLIs) don't go
@@ -329,12 +349,109 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             }));
     };
 
+    // Option E (PR 2 of 2): when an agent has an in-progress session
+    // zone (`agent:<defId>:current`), a plain click on the card
+    // auto-continues into that session — no launch-modal round-trip.
+    // Modifier keys (Shift / Ctrl / Alt / Cmd) are the escape hatch:
+    // they force the launch modal even when a session exists, so the
+    // user can still pick a different identity / memory / runtime.
+    // The "+ New" button on the card archives the current zone and
+    // routes through `openLaunchModal` for a fresh start.
+    const autoContinue = async (agent: AgentDefinition) => {
+        setLaunching(agent.id);
+        try {
+            // Identity / memory are launch-time picks that aren't
+            // stored on the AgentDefinition itself — they live on the
+            // last NamedAgentRow for this definition. We auto-continue
+            // by reusing the most-recent instance's pair so the spawn
+            // resolves credentials the same way as the previous run.
+            // Empty strings are fine: the backend resolver treats them
+            // as "use ambient credentials" (matches the blank bundle).
+            let identityId = "";
+            let memoryId = "";
+            try {
+                const rows = await RpcApi.ListNamedAgentsCommand(TabRpcClient, {
+                    definition_id: agent.id,
+                }) ?? [];
+                const mostRecent = [...rows].sort(
+                    (a, b) => (b.started_at ?? 0) - (a.started_at ?? 0),
+                )[0];
+                if (mostRecent) {
+                    identityId = mostRecent.identity_id && mostRecent.identity_id !== "blank"
+                        ? mostRecent.identity_id : "";
+                    memoryId = mostRecent.memory_id && mostRecent.memory_id !== "blank"
+                        ? mostRecent.memory_id : "";
+                }
+            } catch {
+                // best-effort — fall through with empty bundles.
+            }
+            await props.model.launchAgentDefinition(agent, {
+                instanceName: agent.name,
+                agentType: (agent.agent_type as "host" | "container") || "host",
+                environment: agent.agent_type === "container" ? "docker" : "local",
+                identityId,
+                memoryId,
+                // No `continueOfInstanceId` — the agent's session
+                // zone IS continuous now (E1, PR #1007). The new pane
+                // reads from `agent:<defId>:current` on mount.
+            });
+            if (props.model.nodejsError) {
+                setNodejsError(props.model.nodejsError);
+                props.model.nodejsError = null;
+            }
+        } finally {
+            setLaunching(null);
+        }
+    };
+
+    const handleNewSession = async (agent: AgentDefinition) => {
+        // Archive the current zone so the next launch starts fresh.
+        // RPC failure is non-fatal — fall through to the launch modal
+        // either way so the user isn't stuck.
+        try {
+            await RpcApi.AgentSessionArchiveCommand(TabRpcClient, {
+                definition_id: agent.id,
+            });
+        } catch {
+            // best-effort
+        }
+        setSessionState((s) => ({ ...s, [agent.id]: false }));
+        openLaunchModal(agent);
+    };
+
     const pendingSelect = new Set<string>();
-    const handleSelect = async (agent: AgentDefinition) => {
+    const handleSelect = async (
+        agent: AgentDefinition,
+        evt?: MouseEvent | KeyboardEvent,
+    ) => {
         if (pendingSelect.has(agent.id)) return;
         pendingSelect.add(agent.id);
         try {
             setNodejsError(null);
+
+            // Option E default-continue: when the agent has a current
+            // session and no modifier key forces the modal, auto-launch
+            // and skip every prereq / install / modal step. The session
+            // zone is per-definition, so the bindings the previous pane
+            // used are still on the AgentDefinition — no picker needed.
+            const forceModal = !!(
+                evt && (
+                    ("shiftKey" in evt && evt.shiftKey) ||
+                    ("ctrlKey" in evt && evt.ctrlKey) ||
+                    ("altKey" in evt && evt.altKey) ||
+                    ("metaKey" in evt && (evt as MouseEvent).metaKey)
+                )
+            );
+            if (!forceModal && sessionState()[agent.id] === true) {
+                // Still gate on install: an agent with a current
+                // session can still need the CLI binary installed
+                // (e.g. user wiped per-version cache).
+                if (installState()[agent.id] !== false) {
+                    await autoContinue(agent);
+                    return;
+                }
+            }
+
             let installed = installState()[agent.id];
 
             // If the bg check hasn't populated state yet (initial render
@@ -451,6 +568,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             if (!(agent.id in installState())) {
                 void checkInstalled(agent);
             }
+            // Option E: probe the session zone for every agent on
+            // first sight so we know whether to default-continue or
+            // open the modal when the user clicks.
+            if (!(agent.id in sessionState())) {
+                void checkHasSession(agent);
+            }
         }
     });
 
@@ -503,6 +626,11 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                         disabled={busy()}
                                         installed={installState()[agent.id]}
                                         onLaunch={handleSelect}
+                                        // Option E: surface "+ New" affordance
+                                        // when this agent has a current session
+                                        // zone (default click auto-continues).
+                                        hasCurrentSession={sessionState()[agent.id] === true}
+                                        onNewSession={handleNewSession}
                                         // agent_def_list returns most-recently-used
                                         // first, so index 0 is the default choice.
                                         defaultFocus={index() === 0}

--- a/frontend/app/view/agent/hooks/useHistoryPagination.test.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.test.ts
@@ -1,0 +1,190 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for `useHistoryPagination` covering the Option E
+ * agent-anchored snapshot fast-path (PR #1007 backend, this PR
+ * frontend).
+ *
+ * The hook reads the persisted-session snapshot from the agent zone
+ * `agent:<defId>:current` when `opts.definitionId` is set, falling
+ * back to the per-block NDJSON ring-buffer replay when the read
+ * returns no content (or when no `definitionId` is passed).
+ *
+ * Spec: SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md.
+ */
+
+import { createRoot, type Owner } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => {
+    const RpcApi = {
+        AgentSessionReadCommand: vi.fn(),
+        BlockfileLineCountCommand: vi.fn(),
+        BlockfileReadRangeCommand: vi.fn(),
+        BlockfileReadStateCommand: vi.fn(),
+    };
+    return { RpcApi };
+});
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+
+import { useHistoryPagination } from "./useHistoryPagination";
+import type { AgentPaneModel } from "@/app/store/agent-pane-model";
+
+const makeMockModel = (): AgentPaneModel & {
+    paneEvents: any[];
+    docEvents: any[];
+} => {
+    const paneEvents: any[] = [];
+    const docEvents: any[] = [];
+    const m: any = {
+        blockId: "blk-1",
+        disposed: false,
+        dispatchPane: (cmd: any) => {
+            paneEvents.push(cmd);
+            return [];
+        },
+        dispatchDoc: (cmd: any) => {
+            docEvents.push(cmd);
+            return [];
+        },
+        paneEvents,
+        docEvents,
+    };
+    return m as AgentPaneModel & { paneEvents: any[]; docEvents: any[] };
+};
+
+let dispose: (() => void) | null = null;
+
+const flushMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ RpcApi } = await import("@/app/store/rpc-api"));
+});
+
+afterEach(() => {
+    if (dispose) {
+        dispose();
+        dispose = null;
+    }
+});
+
+describe("useHistoryPagination — Option E agent-anchored snapshot read", () => {
+    it("reads from agent:session:read when definitionId is set and restores nodes", async () => {
+        const snapshot = {
+            schemaVersion: 1,
+            savedAt: "2026-05-23T00:00:00Z",
+            highWaterMark: 5,
+            historyOffset: 0,
+            nodes: [
+                { id: "n1", type: "user_message", text: "hello" },
+                { id: "n2", type: "assistant_message", text: "hi" },
+            ],
+        };
+        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
+            content: JSON.stringify(snapshot),
+            modts: Date.now() - 3_600_000, // 1h ago
+        });
+
+        const model = makeMockModel();
+        const onContinuationModts = vi.fn();
+
+        createRoot((d) => {
+            dispose = d;
+            useHistoryPagination({
+                blockId: "blk-1",
+                model,
+                outputFormat: () => "claude-stream-json",
+                definitionId: "def-claude",
+                onContinuationModts,
+                log: () => {},
+            });
+        });
+
+        // Two microtasks: onMount + async snapshot fetch.
+        await flushMicrotasks();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(RpcApi.AgentSessionReadCommand).toHaveBeenCalledWith(
+            {},
+            { definition_id: "def-claude" },
+            { timeout: 5000 },
+        );
+
+        // The state-resp from the per-block zone should NOT be invoked
+        // when the agent-zone read succeeded.
+        expect(RpcApi.BlockfileReadStateCommand).not.toHaveBeenCalled();
+
+        // HistoryRestored dispatched with snapshot nodes.
+        const restored = model.docEvents.find((e) => e.type === "HistoryRestored");
+        expect(restored).toBeTruthy();
+        expect(restored.nodes).toEqual(snapshot.nodes);
+        expect(restored.fromSnapshot).toBe(true);
+
+        // InitReady fired.
+        expect(model.paneEvents.some((e) => e.type === "InitReady")).toBe(true);
+
+        // modts surfaced for the continuation chip.
+        expect(onContinuationModts).toHaveBeenCalledTimes(1);
+        expect(onContinuationModts.mock.calls[0][0]).toBeGreaterThan(0);
+    });
+
+    it("falls through to NDJSON replay when AgentSessionRead returns no content", async () => {
+        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
+            content: null,
+            modts: null,
+        });
+        vi.mocked(RpcApi.BlockfileLineCountCommand).mockResolvedValue({ count: 0 });
+
+        const model = makeMockModel();
+        createRoot((d) => {
+            dispose = d;
+            useHistoryPagination({
+                blockId: "blk-1",
+                model,
+                outputFormat: () => "claude-stream-json",
+                definitionId: "def-claude",
+                log: () => {},
+            });
+        });
+
+        await flushMicrotasks();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(RpcApi.AgentSessionReadCommand).toHaveBeenCalled();
+        // No snapshot → falls through to line-count probe.
+        expect(RpcApi.BlockfileLineCountCommand).toHaveBeenCalled();
+        // No HistoryRestored — only InitReady (total=0 early-exit).
+        expect(model.docEvents.find((e) => e.type === "HistoryRestored")).toBeFalsy();
+        expect(model.paneEvents.some((e) => e.type === "InitReady")).toBe(true);
+    });
+
+    it("skips the snapshot fast-path entirely when definitionId is unset", async () => {
+        vi.mocked(RpcApi.BlockfileLineCountCommand).mockResolvedValue({ count: 0 });
+
+        const model = makeMockModel();
+        createRoot((d) => {
+            dispose = d;
+            useHistoryPagination({
+                blockId: "blk-1",
+                model,
+                outputFormat: () => "claude-stream-json",
+                // no definitionId
+                log: () => {},
+            });
+        });
+
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        // AgentSessionRead must NOT be called when the caller didn't
+        // provide a definitionId — falls straight to NDJSON.
+        expect(RpcApi.AgentSessionReadCommand).not.toHaveBeenCalled();
+        expect(RpcApi.BlockfileLineCountCommand).toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -59,6 +59,23 @@ export interface UseHistoryPaginationOptions {
      * loads asynchronously).
      */
     outputFormat: Accessor<string>;
+    /**
+     * Option E (PR #1007 backend / this PR frontend): agent definition
+     * id, used to read the snapshot from the agent-anchored session
+     * zone `agent:<definitionId>:current` instead of the per-block
+     * `<blockId>/output.state.json`. When unset (legacy callers, picker
+     * screen), the snapshot fast-path is skipped and the hook falls
+     * straight through to the NDJSON ring-buffer replay.
+     */
+    definitionId?: string;
+    /**
+     * Option E: called with the `modts` (Unix ms) returned by
+     * `agent:session:read` when the pane successfully restores from a
+     * pre-existing snapshot. The view model projects this into the
+     * "· continued Xm ago" chip in the title bar. Called with 0 when
+     * the read returned no snapshot (fresh agent).
+     */
+    onContinuationModts?: (modts: number) => void;
     log: LogFn;
 }
 
@@ -150,10 +167,20 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
             // and the schema version matches, restore wholesale and skip
             // the lossy 200-line NDJSON replay. Spec
             // docs/specs/SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md §4.4.
+            //
+            // Option E (PR #1007 backend, this PR frontend): when a
+            // `definitionId` is available, read from the agent-anchored
+            // session zone (`agent:<defId>:current`) so continuation is
+            // structural — any new pane for the same agent definition
+            // picks up where the last one left off. When the caller
+            // didn't pass `definitionId` (legacy / picker), skip the
+            // fast path and fall straight through to the NDJSON replay.
             try {
-                const stateResp = await RpcApi.BlockfileReadStateCommand(TabRpcClient, {
-                    block_id: opts.blockId,
-                    filename: SNAPSHOT_FILENAME,
+                if (!opts.definitionId) {
+                    throw new Error("no definitionId — fall through to NDJSON");
+                }
+                const stateResp = await RpcApi.AgentSessionReadCommand(TabRpcClient, {
+                    definition_id: opts.definitionId,
                 }, { timeout: 5000 });
                 if (!mounted) return;
                 if (stateResp.content) {
@@ -166,6 +193,13 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             : 0;
                         setHistoryOffset(offset);
                         setHistoryTotal(typeof snapshot.highWaterMark === "number" ? snapshot.highWaterMark : snapshot.nodes.length);
+                        // Option E: surface the snapshot's modts so the
+                        // view model can render the "· continued from
+                        // Xm ago" chip in the title bar. The chip
+                        // suppresses itself when the gap is <30s (same
+                        // pane's own fresh write).
+                        const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
+                        opts.onContinuationModts?.(modts);
                         opts.log(
                             "history",
                             `restored ${snapshot.nodes.length} nodes from snapshot ` +

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -175,10 +175,12 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
             // picks up where the last one left off. When the caller
             // didn't pass `definitionId` (legacy / picker), skip the
             // fast path and fall straight through to the NDJSON replay.
-            try {
-                if (!opts.definitionId) {
-                    throw new Error("no definitionId — fall through to NDJSON");
-                }
+            // P2 fix on #1008 reagent: prior version threw an exception
+            // purely for control flow into the catch arm — clean code
+            // path but emitted a stack on every legacy mount. Use an
+            // explicit early-skip instead.
+            if (opts.definitionId) {
+              try {
                 const stateResp = await RpcApi.AgentSessionReadCommand(TabRpcClient, {
                     definition_id: opts.definitionId,
                 }, { timeout: 5000 });
@@ -217,7 +219,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         "warn",
                     );
                 }
-            } catch (err: any) {
+              } catch (err: any) {
                 // Most common: snapshot doesn't exist yet — silent fall-through.
                 // Anything else logs but still falls through to NDJSON.
                 const reason = err?.message ?? String(err);
@@ -225,7 +227,8 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                     opts.log("history", `snapshot read failed: ${reason}; falling back to NDJSON replay`, "warn");
                 }
                 if (!mounted) return;
-            }
+              }
+            }  // end if (opts.definitionId)
             try {
                 const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
                     block_id: opts.blockId,

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -109,6 +109,44 @@
             transform: scale(1.06);
         }
 
+        // Option E (PR #1008): "+ New" affordance — visible only when
+        // the agent has a current session and the default click would
+        // auto-continue. Anchored bottom-right (where the install
+        // ribbon would otherwise sit). Subtle by default; reveal on
+        // card hover so the primary "Continue" affordance reads as
+        // the dominant action.
+        .agent-card-new-session-btn {
+            position: absolute;
+            right: var(--space-1);
+            bottom: var(--space-1);
+            padding: 2px 8px;
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: var(--secondary-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+            border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+            border-radius: 3px;
+            cursor: pointer;
+            opacity: 0;
+            transition: opacity 0.12s ease-out, background 0.12s, color 0.12s, border-color 0.12s;
+            pointer-events: none;
+            z-index: 1;
+            user-select: none;
+        }
+
+        &:hover .agent-card-new-session-btn,
+        &:focus-within .agent-card-new-session-btn {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .agent-card-new-session-btn:hover {
+            color: var(--main-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 12%, transparent);
+            border-color: var(--accent-color);
+        }
+
         &.agent-card--needs-install {
             // Subtle accent on the card border to reinforce the
             // ribbon's "needs action" signal.

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2021,6 +2021,74 @@ declare global {
         bytes_written: number;
     };
 
+    // wshrpc.CommandAgentSessionReadData — Option E (agent-anchored
+    // session zones). Reads `output.state.json` from
+    // `agent:<definition_id>:current`.
+    type CommandAgentSessionReadData = {
+        definition_id: string;
+    };
+
+    // wshrpc.AgentSessionReadResult — `content === null` (or undefined)
+    // means no zone / snapshot exists for this definition (fresh
+    // agent), NOT an error.
+    type AgentSessionReadResult = {
+        content?: string | null;
+        modts?: number | null;
+    };
+
+    // wshrpc.CommandAgentSessionWriteStateData — writes
+    // `output.state.json` into `agent:<definition_id>:current`
+    // (creates the zone if missing).
+    type CommandAgentSessionWriteStateData = {
+        definition_id: string;
+        content: string;
+    };
+
+    // wshrpc.AgentSessionWriteStateResult
+    type AgentSessionWriteStateResult = {
+        bytes_written: number;
+    };
+
+    // wshrpc.CommandAgentSessionAppendOutputData — appends a single
+    // NDJSON line to `output` in `agent:<definition_id>:current`.
+    type CommandAgentSessionAppendOutputData = {
+        definition_id: string;
+        line: string;
+    };
+
+    // wshrpc.AgentSessionAppendOutputResult
+    type AgentSessionAppendOutputResult = {
+        bytes_written: number;
+    };
+
+    // wshrpc.CommandAgentSessionArchiveData — snapshots
+    // `agent:<defId>:current` into `agent:<defId>:archive:<now_ms>`
+    // then clears the current zone.
+    type CommandAgentSessionArchiveData = {
+        definition_id: string;
+    };
+
+    // wshrpc.AgentSessionArchiveResult — empty `archive_zoneid` when
+    // nothing was archived (current zone was empty).
+    type AgentSessionArchiveResult = {
+        archive_zoneid: string;
+        archived_at_ms: number;
+    };
+
+    // wshrpc.CommandAgentSessionListArchivesData
+    type CommandAgentSessionListArchivesData = {
+        definition_id: string;
+        limit?: number;
+    };
+
+    // wshrpc.AgentArchiveRow — one row of the agent's archive list.
+    type AgentArchiveRow = {
+        archive_zoneid: string;
+        archived_at_ms: number;
+        preview: string;
+        node_count: number;
+    };
+
     // wshrpc.CommandSessionDigestData
     type CommandSessionDigestData = {
         block_id: string;


### PR DESCRIPTION
**Spec:** [SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md](https://github.com/agentmuxai/agentmux/blob/agenta/spec-continuation-session-persistence/docs/specs/SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md)

**Follows up:** #1007 (Option E backend — agent-anchored session zones)

Option E PR 2 of 2 — frontend. Wires the agent-anchored session zones from #1007 into the document-history fast path and adds a default-continue interaction on the agent picker.

## What changed

### Snapshot read/write switched from per-block to per-agent zone
- `useHistoryPagination` now reads the document snapshot from `agent:<defId>:current` via the new `agent:session:read` RPC (with a fallthrough to the per-block NDJSON replay when the agent zone is empty — covers fresh agents and the picker screen).
- `agent-view.tsx`'s 30 s snapshot writer + on-close save now write to the same agent zone via `agent:session:write_state`.
- Net effect: opening a new pane for an agent that previously had one running picks up the conversation automatically — no manual reattach required.

### Default-continue UX on the agent picker
`AgentPicker.handleSelect` now probes `agent:session:read` for each card on mount. The click contract is:

| State | Plain click | Shift / Ctrl / Alt / Cmd click |
|---|---|---|
| Agent has a `:current` session | **Auto-continue** (no modal, reuses most-recent NamedAgentRow's identity/memory binding) | Forces the launch modal — pick a different identity/memory/runtime |
| Agent has no session | Opens launch modal | Opens launch modal |

The auto-continue path doesn't set `continueOfInstanceId` — the agent zone is structurally continuous now, so the new pane just reads from `agent:<defId>:current` on mount.

### "+ New" affordance
Cards with a current session show a hover-revealed `+ New` button (bottom-right, where the install ribbon would otherwise sit). Click archives the current zone via `agent:session:archive`, then opens the launch modal so the user can start fresh without losing the prior conversation (it lives at `agent:<defId>:archive:<ts>` and will appear in the recent-sessions list).

### Pane title continuation chip
`viewText` renders `· continued Xm ago` when the snapshot's `modts` (returned by `agent:session:read`) indicates a >30 s gap from now — so the active pane's own writes never trigger the chip.

### RPC bindings
`AgentSessionRead` / `WriteState` / `AppendOutput` / `Archive` / `ListArchives` wrappers added to `frontend/app/store/rpc-api.ts` + `frontend/types/gotypes.d.ts`.

## Tests

- `useHistoryPagination.test.ts` — 3 tests covering the agent-zone read path, NDJSON fallback when content is null, and the `definitionId`-unset skip behavior.
- `AgentPicker.test.tsx` — 3 tests covering auto-continue when a session exists, modal open when none, and Shift forcing the modal regardless of session content.

All 6 new tests pass. Full agent + store suite: 736 passed / 2 pre-existing failures unrelated to this PR (`browser-pane-state-store`, `providers/index.test.ts` — both fail on a clean `main` checkout too).

`task build:frontend` succeeds (no tailwind regression).

## Out of scope

- **E3 cross-tab live sync.** Two panes of the same agent reading and writing the same zone concurrently — concurrent-write races, conflict resolution, and live event fan-out across panes is the next follow-up.
- **Old per-block-zone GC.** `<blockId>/output.state.json` files from before E1's migration stay in place; cleanup is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)