### PR TITLE
feat(picker): two-tier — My Agents on top, "+ New from template" below

### DIFF
--- a/.changesets/1779595340-feat-picker-two-tier-my-agents-templates-pgqd.md
+++ b/.changesets/1779595340-feat-picker-two-tier-my-agents-templates-pgqd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(picker): two-tier — My Agents + templates

--- a/agentmux-srv/src/backend/agent_session.rs
+++ b/agentmux-srv/src/backend/agent_session.rs
@@ -630,6 +630,332 @@ pub fn migrate_block_zones_v1(
 }
 
 // ---------------------------------------------------------------------------
+// Two-tier picker — Phase 1 migration (seeded-def → user-agent promote)
+// ---------------------------------------------------------------------------
+
+/// Marker file name for the Phase 1 two-tier-picker migration.
+/// One-shot per data dir; deleting it forces a re-run on next startup.
+pub const TEMPLATE_PROMOTE_MARKER_V1: &str = "migration_template_promote_v1.flag";
+
+/// Stats from `migrate_promote_template_sessions_v1`. Logged at INFO.
+#[derive(Debug, Clone, Default)]
+pub struct TemplatePromoteStats {
+    pub templates_scanned: usize,
+    pub templates_promoted: usize,
+    /// Total archive zones moved across all promotions.
+    pub archives_moved: usize,
+    /// Total instances repointed via
+    /// `wstore.instance_repoint_definition`.
+    pub instances_repointed: usize,
+    pub failures: usize,
+}
+
+/// Phase 1 two-tier picker migration: promote any seeded template that
+/// carries a session zone into a fresh user-owned definition, then move
+/// its `:current` + `:archive:*` zones onto the new definition_id.
+///
+/// Why this exists (Q1 = Option C in
+/// `docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`):
+/// after the picker UI split, clicking a "template" card in the
+/// Templates section MUST create a new agent — not silently append to
+/// whatever session the user previously ran against that template
+/// directly (e.g. "Maks's conversation" living at `agent:claude:current`).
+/// Without this migration the template card would either reattach to
+/// the existing session (broken — wrong intent) or be effectively
+/// non-functional. The migration moves any such pre-existing session
+/// out of the template namespace onto a new user-owned definition so
+/// the template is pristine post-migration.
+///
+/// Algorithm:
+/// 1. List zone ids; partition the `agent:<id>:current` and
+///    `agent:<id>:archive:*` zones by definition id.
+/// 2. For each definition id with at least one zone, look up the
+///    matching `db_agent_definitions` row.
+///    - Skip if missing (zone refers to a deleted definition).
+///    - Skip if `is_seeded = 0` (already user-owned — no work).
+///    - Otherwise: clone the template into a new user definition
+///      (mirrors `agent_def_create_from_template` semantics).
+/// 3. Pick the new name: most-recently-active named instance's
+///    `instance_name` if any exists, else fall back to the template's
+///    own `name`.
+/// 4. Move every matching zone (`:current` + every `:archive:*`)
+///    from the old defId to the new defId via FileStore's existing
+///    write-then-delete pattern.
+/// 5. Repoint every `db_agent_instances` row that referenced the old
+///    defId to point at the new defId (preserves the
+///    `continueOfInstanceId` reattach flow).
+/// 6. Marker-file gated — second start is a no-op.
+///
+/// Failure mode: per-template errors are logged + counted; we DO NOT
+/// abort startup. The marker is written even on partial failure so we
+/// don't retry indefinitely (operators can delete the marker to retry).
+pub fn migrate_promote_template_sessions_v1(
+    wstore: &Arc<WaveStore>,
+    filestore: &Arc<FileStore>,
+    data_dir: &Path,
+) -> TemplatePromoteStats {
+    let marker_path = data_dir.join(TEMPLATE_PROMOTE_MARKER_V1);
+    if marker_path.exists() {
+        tracing::debug!(
+            marker = %marker_path.display(),
+            "template_promote migration: marker present, skipping"
+        );
+        return TemplatePromoteStats::default();
+    }
+
+    let mut stats = TemplatePromoteStats::default();
+
+    let all_zones = match filestore.get_all_zone_ids() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "template_promote migration: get_all_zone_ids failed; aborting (will retry next start)"
+            );
+            return stats;
+        }
+    };
+
+    // Group zone ids by definition id. A zone counts if it matches
+    // `agent:<id>:current` OR `agent:<id>:archive:<ts>`. Anything else
+    // (e.g. legacy per-block zones the prior migration didn't sweep)
+    // is ignored by this migration.
+    let mut per_def_zones: HashMap<String, Vec<String>> = HashMap::new();
+    for zone in &all_zones {
+        let rest = match zone.strip_prefix("agent:") {
+            Some(r) => r,
+            None => continue,
+        };
+        // `<defId>:current` or `<defId>:archive:<ts>`
+        let (def_id, tail) = match rest.split_once(':') {
+            Some(p) => p,
+            None => continue,
+        };
+        if !is_valid_definition_id(def_id) {
+            continue;
+        }
+        let is_current = tail == "current";
+        let is_archive = tail.starts_with("archive:");
+        if !is_current && !is_archive {
+            continue;
+        }
+        per_def_zones
+            .entry(def_id.to_string())
+            .or_default()
+            .push(zone.clone());
+    }
+
+    // Fetch all definitions ONCE so per-template lookups don't re-hit
+    // SQLite in a loop.
+    let defs = match wstore.agent_def_list() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "template_promote migration: agent_def_list failed; aborting (will retry next start)"
+            );
+            return stats;
+        }
+    };
+
+    for (old_def_id, zones) in per_def_zones {
+        // Look up the definition row this zone is bound to.
+        let template = match defs.iter().find(|d| d.id == old_def_id) {
+            Some(d) => d,
+            None => {
+                // Zone points at a deleted definition — leave it
+                // alone; a future GC pass can clean orphans.
+                continue;
+            }
+        };
+        // Only seeded templates need promotion. User-owned defs are
+        // already on the new model.
+        if template.is_seeded != 1 {
+            continue;
+        }
+        stats.templates_scanned += 1;
+
+        // Pick the new agent name: most-recently-active named instance
+        // for this template, else fall back to the template's own name.
+        // `instance_list_named` already filters to non-hidden + named
+        // rows + sorts by `started_at DESC`, so the first row is the
+        // pick.
+        let new_name = match wstore.instance_list_named(1, Some(&old_def_id)) {
+            Ok(rows) => rows
+                .into_iter()
+                .next()
+                .map(|i| i.instance_name)
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| template.name.clone()),
+            Err(e) => {
+                tracing::warn!(
+                    template_id = %old_def_id,
+                    error = %e,
+                    "template_promote migration: instance_list_named failed; using template name"
+                );
+                template.name.clone()
+            }
+        };
+
+        // Clone the template into a new user-owned definition.
+        // Mirrors `agent_def_create_from_template`'s field-copy
+        // contract — keep these in sync.
+        let now = now_ms() as i64;
+        let mut new_def = crate::backend::storage::wstore::AgentDefinition {
+            id: uuid::Uuid::new_v4().to_string(),
+            slug: String::new(),
+            name: new_name.clone(),
+            icon: template.icon.clone(),
+            provider: template.provider.clone(),
+            description: template.description.clone(),
+            working_directory: String::new(),
+            shell: template.shell.clone(),
+            provider_flags: template.provider_flags.clone(),
+            auto_start: 0,
+            restart_on_crash: template.restart_on_crash,
+            idle_timeout_minutes: template.idle_timeout_minutes,
+            created_at: now,
+            agent_type: template.agent_type.clone(),
+            environment: template.environment.clone(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: template.id.clone(),
+            branch_label: String::new(),
+            updated_at: now,
+        };
+        if let Err(e) = wstore.agent_def_insert(&mut new_def) {
+            tracing::warn!(
+                template_id = %old_def_id,
+                error = %e,
+                "template_promote migration: agent_def_insert failed; skipping this template"
+            );
+            stats.failures += 1;
+            continue;
+        }
+
+        // Move every matching zone (current + archives) onto the new
+        // definition id. Per-zone failures are logged but don't abort
+        // the whole template — best-effort.
+        let mut archives_for_this_def: usize = 0;
+        for old_zone in &zones {
+            // Build the new zone id by swapping the def-id segment.
+            // We know `old_zone` starts with `agent:<old_def_id>:`
+            // (per the bucketing above), so substring-replace is safe.
+            let suffix = match old_zone.strip_prefix(&format!("agent:{}:", old_def_id)) {
+                Some(s) => s,
+                None => continue,
+            };
+            let new_zone = format!("agent:{}:{}", new_def.id, suffix);
+            let is_archive = suffix.starts_with("archive:");
+
+            if let Err(e) = move_zone(filestore, old_zone, &new_zone) {
+                tracing::warn!(
+                    template_id = %old_def_id,
+                    old_zone = %old_zone,
+                    new_zone = %new_zone,
+                    error = %e,
+                    "template_promote migration: move_zone failed"
+                );
+                stats.failures += 1;
+                continue;
+            }
+            if is_archive {
+                archives_for_this_def += 1;
+            }
+        }
+
+        // Repoint any in-DB instances referencing this template at
+        // the new user-owned definition. Without this, the existing
+        // continueOfInstanceId reattach flow would still look up the
+        // template and pass through the un-promoted definition_id.
+        let repointed = match wstore.instance_repoint_definition(&old_def_id, &new_def.id) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    template_id = %old_def_id,
+                    new_definition_id = %new_def.id,
+                    error = %e,
+                    "template_promote migration: instance_repoint_definition failed"
+                );
+                stats.failures += 1;
+                0
+            }
+        };
+        stats.instances_repointed += repointed;
+        stats.archives_moved += archives_for_this_def;
+        stats.templates_promoted += 1;
+        tracing::info!(
+            template_id = %old_def_id,
+            template_name = %template.name,
+            new_definition_id = %new_def.id,
+            new_name = %new_def.name,
+            archives_moved = archives_for_this_def,
+            instances_repointed = repointed,
+            "template_promote migration: promoted template into user agent"
+        );
+    }
+
+    // Write marker — even on partial failure (see doc comment).
+    if let Err(e) = std::fs::write(&marker_path, b"v1\n") {
+        tracing::warn!(
+            marker = %marker_path.display(),
+            error = %e,
+            "template_promote migration: marker write failed; migration may re-run on next startup"
+        );
+    }
+
+    tracing::info!(
+        templates_scanned = stats.templates_scanned,
+        templates_promoted = stats.templates_promoted,
+        archives_moved = stats.archives_moved,
+        instances_repointed = stats.instances_repointed,
+        failures = stats.failures,
+        "template_promote migration: complete"
+    );
+
+    stats
+}
+
+/// Move every file in `old_zone` to `new_zone`, preserving names + bytes.
+/// Implemented as read-write-delete because FileStore doesn't expose a
+/// native rename; the cost is bounded by the per-zone file count (1-2
+/// in practice — `output.state.json` + `output`).
+fn move_zone(
+    filestore: &FileStore,
+    old_zone: &str,
+    new_zone: &str,
+) -> Result<(), String> {
+    let files = filestore
+        .list_files(old_zone)
+        .map_err(|e| format!("list_files: {e}"))?;
+    if files.is_empty() {
+        return Ok(());
+    }
+    for f in &files {
+        let bytes = filestore
+            .read_file(old_zone, &f.name)
+            .map_err(|e| format!("read_file {}: {e}", f.name))?
+            .unwrap_or_default();
+        // write_zone_file creates the file when missing, replaces it
+        // otherwise (matches archive_session's write semantics).
+        write_zone_file(filestore, new_zone, &f.name, &bytes)?;
+    }
+    // Delete the source files only after every write has succeeded.
+    // delete_zone wipes the whole zone in one transaction.
+    if let Err(e) = filestore.delete_zone(old_zone) {
+        // Source delete failure is non-fatal — the new zone has the
+        // data; the old zone is now stale duplicate, GC concern.
+        tracing::warn!(
+            old_zone = %old_zone,
+            error = %e,
+            "template_promote migration: delete_zone failed after copy; source remains"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -960,6 +1286,235 @@ mod tests {
         assert_eq!(second.blocks_scanned, 0);
         assert_eq!(second.archives_written, 0);
         assert_eq!(second.current_zones_seeded, 0);
+    }
+
+    // ---- Two-tier picker Phase 1 migration tests ----
+
+    use crate::backend::storage::wstore::{AgentDefinition, AgentInstance, InstanceStatus};
+
+    fn insert_template(
+        wstore: &Arc<WaveStore>,
+        id: &str,
+        name: &str,
+        provider: &str,
+    ) -> AgentDefinition {
+        let mut def = AgentDefinition {
+            id: id.to_string(),
+            slug: String::new(),
+            name: name.to_string(),
+            icon: String::new(),
+            provider: provider.to_string(),
+            description: format!("{name} template"),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 1, // template
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+        };
+        wstore.agent_def_insert(&mut def).unwrap();
+        def
+    }
+
+    fn insert_named_instance(
+        wstore: &Arc<WaveStore>,
+        id: &str,
+        def_id: &str,
+        instance_name: &str,
+        started_at: i64,
+    ) {
+        let inst = AgentInstance {
+            id: id.to_string(),
+            definition_id: def_id.to_string(),
+            parent_instance_id: String::new(),
+            block_id: String::new(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at,
+            ended_at: 0,
+            created_at: started_at,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: instance_name.to_string(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        wstore.instance_create(&inst).unwrap();
+    }
+
+    #[test]
+    fn template_promote_clones_template_and_moves_zones() {
+        let dir = tempdir().unwrap();
+        let wstore = open_temp_wstore(dir.path());
+        let filestore = fresh_filestore();
+
+        // Seeded template "Claude Code" with a current session zone +
+        // one archive zone (the pre-existing "Maks" conversation).
+        let template = insert_template(&wstore, "tpl-claude", "Claude Code", "claude");
+        insert_named_instance(&wstore, "inst-maks", &template.id, "Maks", 1_700_000_100_000);
+        write_session_state(
+            &filestore,
+            &template.id,
+            br#"{"nodes":[{"type":"user_message","message":"hi"}]}"#,
+        )
+        .unwrap();
+        // Pre-existing archive (simulates a prior + New session).
+        let archive_zone = agent_archive_zone(&template.id, 1_699_000_000_000);
+        write_zone_file(&filestore, &archive_zone, SNAPSHOT_FILE, b"archived").unwrap();
+
+        let stats = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+        assert_eq!(stats.templates_scanned, 1);
+        assert_eq!(stats.templates_promoted, 1);
+        assert_eq!(stats.archives_moved, 1);
+        assert_eq!(stats.instances_repointed, 1);
+        assert_eq!(stats.failures, 0);
+
+        // Template's current zone is gone — no `agent:tpl-claude:current`.
+        let stale_current = agent_current_zone(&template.id);
+        let stale = filestore.list_files(&stale_current).unwrap();
+        assert!(stale.is_empty(), "template current zone should be empty post-promote");
+        // Template's archive zone is gone.
+        let stale_archive = filestore.list_files(&archive_zone).unwrap();
+        assert!(stale_archive.is_empty(), "template archive zone should be empty post-promote");
+
+        // Find the new user-owned definition. Use the most-recent
+        // instance name ("Maks") as the new name per spec.
+        let all = wstore.agent_def_list().unwrap();
+        let new_def = all
+            .iter()
+            .find(|d| d.is_seeded == 0 && d.parent_id == template.id)
+            .expect("a new user-owned definition should exist");
+        assert_eq!(new_def.name, "Maks");
+        assert_eq!(new_def.provider, "claude");
+
+        // Zones present on the NEW defId.
+        let new_current = agent_current_zone(&new_def.id);
+        let new_files = filestore.list_files(&new_current).unwrap();
+        assert!(
+            new_files.iter().any(|f| f.name == SNAPSHOT_FILE),
+            "new current zone should have output.state.json"
+        );
+        let new_archive = agent_archive_zone(&new_def.id, 1_699_000_000_000);
+        let new_archive_files = filestore.list_files(&new_archive).unwrap();
+        assert!(
+            new_archive_files.iter().any(|f| f.name == SNAPSHOT_FILE),
+            "new archive zone should be populated"
+        );
+
+        // Instance is repointed.
+        let inst = wstore.instance_get("inst-maks").unwrap().unwrap();
+        assert_eq!(
+            inst.definition_id, new_def.id,
+            "instance should now reference new user-agent def"
+        );
+
+        // Template definition is still around (still seeded), but the
+        // session it carried is gone.
+        let still_seeded = all.iter().find(|d| d.id == template.id).unwrap();
+        assert_eq!(still_seeded.is_seeded, 1);
+
+        // Marker file is written.
+        assert!(dir.path().join(TEMPLATE_PROMOTE_MARKER_V1).exists());
+    }
+
+    #[test]
+    fn template_promote_is_idempotent_on_second_run() {
+        let dir = tempdir().unwrap();
+        let wstore = open_temp_wstore(dir.path());
+        let filestore = fresh_filestore();
+
+        let template = insert_template(&wstore, "tpl-claude", "Claude Code", "claude");
+        write_session_state(&filestore, &template.id, br#"{"nodes":[]}"#).unwrap();
+
+        let first = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+        assert_eq!(first.templates_promoted, 1);
+
+        let second = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+        assert_eq!(second.templates_scanned, 0);
+        assert_eq!(second.templates_promoted, 0);
+        assert_eq!(second.archives_moved, 0);
+        assert_eq!(second.instances_repointed, 0);
+    }
+
+    #[test]
+    fn template_promote_falls_back_to_template_name_when_no_named_instance() {
+        let dir = tempdir().unwrap();
+        let wstore = open_temp_wstore(dir.path());
+        let filestore = fresh_filestore();
+
+        let template = insert_template(&wstore, "tpl-x", "Cursor", "cursor");
+        write_session_state(&filestore, &template.id, br#"{"nodes":[]}"#).unwrap();
+        // NO instances inserted.
+
+        let stats = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+        assert_eq!(stats.templates_promoted, 1);
+
+        let all = wstore.agent_def_list().unwrap();
+        let new_def = all
+            .iter()
+            .find(|d| d.is_seeded == 0 && d.parent_id == template.id)
+            .expect("should clone the template");
+        // Falls back to template name when no named instance exists.
+        assert_eq!(new_def.name, "Cursor");
+    }
+
+    #[test]
+    fn template_promote_skips_already_user_owned_definitions() {
+        let dir = tempdir().unwrap();
+        let wstore = open_temp_wstore(dir.path());
+        let filestore = fresh_filestore();
+
+        // A user-owned definition (is_seeded = 0) with a session — the
+        // migration should leave it alone.
+        let mut user_def = AgentDefinition {
+            id: "user-abc".to_string(),
+            slug: String::new(),
+            name: "My Agent".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+        };
+        wstore.agent_def_insert(&mut user_def).unwrap();
+        write_session_state(&filestore, &user_def.id, br#"{"nodes":[]}"#).unwrap();
+
+        let stats = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+        assert_eq!(stats.templates_scanned, 0);
+        assert_eq!(stats.templates_promoted, 0);
+
+        // Original definition untouched.
+        let all = wstore.agent_def_list().unwrap();
+        let still_there = all.iter().find(|d| d.id == "user-abc").unwrap();
+        assert_eq!(still_there.is_seeded, 0);
+
+        // Session zone still present.
+        let cur = agent_current_zone(&user_def.id);
+        let files = filestore.list_files(&cur).unwrap();
+        assert!(!files.is_empty());
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -343,6 +343,14 @@ pub const COMMAND_LIST_RECENT_SESSIONS: &str = "listrecentsessions";
 // Agent definition branching
 pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
 
+/// Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+/// Clone a seeded template into a new user-owned agent definition with
+/// `is_seeded = 0`. Copies provider + cmd + env + auth-config fields
+/// from the template, applies the caller-supplied name + bindings,
+/// returns the new definition_id so the frontend can immediately
+/// launch. Rejects non-template ids + duplicate user-agent names.
+pub const COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE: &str = "agentdefcreatefromtemplate";
+
 // Drone pane (v8 — issue #753 Phase 1)
 pub const COMMAND_LIST_DRONES: &str = "listdrones";
 pub const COMMAND_GET_DRONE: &str = "getdrone";
@@ -1291,6 +1299,53 @@ fn is_zero_usize(v: &usize) -> bool {
 }
 
 // ---- Agent command data types ----
+
+/// Optional filter input for `listagents`. When `is_seeded` is set,
+/// only definitions whose `is_seeded` column matches are returned
+/// (`Some(1)` → templates only; `Some(0)` → user-owned agents only).
+/// Absent / `None` = no filter — backward-compatible with callers
+/// that pass `{}` or `null`. Phase 1 of the two-tier picker
+/// (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandListAgentDefinitionsData {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_seeded: Option<i64>,
+}
+
+/// Request for `agentdefcreatefromtemplate`. Clones a seeded template
+/// into a new user-owned definition. Phase 1 of the two-tier picker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandAgentDefCreateFromTemplateData {
+    /// id of a seeded definition (must have `is_seeded = 1`).
+    pub template_id: String,
+    /// User-chosen display name for the new agent. Non-empty, ≤200
+    /// chars, must not collide with another user-owned agent's name.
+    pub name: String,
+    /// Identity bundle id to bind (empty string = ambient creds).
+    /// Stored on the launch-time `db_agent_instances` row by the
+    /// launch flow; the definition itself doesn't hold bindings
+    /// pre-Phase 3, so this is reserved for the frontend to thread
+    /// through to its subsequent `launchAgentDefinition` call. The
+    /// server returns it back in the response for symmetry +
+    /// future-proofing.
+    #[serde(default)]
+    pub identity_id: String,
+    /// Memory bundle id to bind (empty string = vanilla CLI).
+    /// Same semantics as `identity_id` above.
+    #[serde(default)]
+    pub memory_id: String,
+}
+
+/// Response for `agentdefcreatefromtemplate`. The frontend uses
+/// `definition_id` to launch the freshly-created agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefCreateFromTemplateResult {
+    pub definition_id: String,
+    /// Echoed back so the caller's launch step doesn't need to
+    /// re-thread these — they flow through to the launch overrides.
+    pub identity_id: String,
+    pub memory_id: String,
+}
 
 /// Input for createagent
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1877,6 +1877,30 @@ impl WaveStore {
         Ok(rows > 0)
     }
 
+    /// Repoint every instance currently referencing `old_def_id` to
+    /// `new_def_id`. Used by the Phase 1 two-tier-picker migration
+    /// (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md): when a seeded
+    /// template has been used directly (carries an `agent:<id>:current`
+    /// zone), the migration clones the template into a user agent and
+    /// repoints any instances so the existing reattach flow
+    /// (`continueOfInstanceId`) keeps working against the new
+    /// definition_id. Returns the number of rows updated.
+    ///
+    /// `definition_id` is declared immutable post-insert on the normal
+    /// `instance_update` path. This is the migration escape hatch.
+    pub fn instance_repoint_definition(
+        &self,
+        old_def_id: &str,
+        new_def_id: &str,
+    ) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE db_agent_instances SET definition_id = ?1 WHERE definition_id = ?2",
+            params![new_def_id, old_def_id],
+        )?;
+        Ok(rows)
+    }
+
     pub fn instance_delete(&self, id: &str) -> Result<bool, StoreError> {
         let rows = {
             let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -468,6 +468,21 @@ async fn main() {
         &base::get_wave_data_dir(),
     );
 
+    // Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+    // Mandatory companion to the picker UI split: any seeded template
+    // that currently carries a session zone (e.g. `agent:claude:current`
+    // with Maks's conversation) is promoted to a new user-owned
+    // definition with a sensible default name, and its zones +
+    // referencing instances are moved over. Without this step the
+    // freshly-introduced "Templates" section of the picker would
+    // silently reattach into pre-existing user sessions. Marker-file
+    // gated; second start is a no-op.
+    let _template_promote_stats = backend::agent_session::migrate_promote_template_sessions_v1(
+        &wstore,
+        &filestore,
+        &base::get_wave_data_dir(),
+    );
+
     // Session recovery (Phase 4.2): scan for agent blocks that still have
     // `session:active_pid` from a previous run — those sessions were killed
     // by a crash/reboot. Transfer to `session:was_interrupted` so the

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -17,6 +17,10 @@ use crate::backend::rpc_types::{
     COMMAND_APPEND_AGENT_HISTORY, COMMAND_LIST_AGENT_HISTORY, COMMAND_SEARCH_AGENT_HISTORY,
     COMMAND_IMPORT_AGENT_FROM_CLAW, COMMAND_IMPORT_AGENTS, COMMAND_EXPORT_AGENTS,
     COMMAND_RESEED_AGENTS,
+    // Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md)
+    COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+    CommandAgentDefCreateFromTemplateData, AgentDefCreateFromTemplateResult,
+    CommandListAgentDefinitionsData,
     CommandCreateAgentDefinitionData, CommandUpdateAgentDefinitionData, CommandDeleteAgentDefinitionData,
     CommandGetAgentContentData, CommandSetAgentContentData, CommandGetAllAgentContentData,
     CommandListAgentSkillsData, CommandCreateAgentSkillData, CommandUpdateAgentSkillData,
@@ -76,15 +80,31 @@ use crate::backend::storage::wstore::{
 use super::AppState;
 
 pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    // listagents → return all agent definitions
+    // listagents → return all agent definitions, optionally filtered by
+    // `is_seeded`. Filter input is backward-compatible: callers that
+    // pass `null` / `{}` (every existing caller) get the full list.
+    // The two-tier picker (Phase 1) passes `{ is_seeded: 0 }` for the
+    // "My Agents" section and `{ is_seeded: 1 }` for the "Templates"
+    // section — see SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
     let wstore_lfa = state.wstore.clone();
     engine.register_handler(
         COMMAND_LIST_AGENTS,
-        Box::new(move |_data, _ctx| {
+        Box::new(move |data, _ctx| {
             let wstore = wstore_lfa.clone();
             Box::pin(async move {
+                // unwrap_or_default — both `null` and `{}` deserialize
+                // to the default (no filter). Anything malformed falls
+                // back to no-filter rather than erroring; older clients
+                // never sent a body for this RPC and we can't know
+                // which JSON shape they're on.
+                let cmd: CommandListAgentDefinitionsData =
+                    serde_json::from_value(data).unwrap_or_default();
                 let agents = wstore.agent_def_list().map_err(|e| format!("listagents: {e}"))?;
-                Ok(Some(serde_json::to_value(&agents).unwrap_or_default()))
+                let filtered: Vec<_> = match cmd.is_seeded {
+                    Some(flag) => agents.into_iter().filter(|a| a.is_seeded == flag).collect(),
+                    None => agents,
+                };
+                Ok(Some(serde_json::to_value(&filtered).unwrap_or_default()))
             })
         }),
     );
@@ -232,6 +252,129 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     data: None,
                 });
                 Ok(None)
+            })
+        }),
+    );
+
+    // agentdefcreatefromtemplate → clone a seeded template into a new
+    // user-owned definition (Phase 1 two-tier picker —
+    // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md). The template stays
+    // pristine; the new row carries `is_seeded = 0`. Returns the new
+    // definition_id so the frontend can immediately launch.
+    //
+    // Validation rules:
+    //  - `template_id` MUST resolve to a row with `is_seeded = 1`.
+    //    Cloning a user-owned row would be confusing semantics — use
+    //    the existing `forkagentdefinition` RPC for that case.
+    //  - `name` non-empty, ≤200 chars, and not already taken by any
+    //    `is_seeded = 0` row. Avoids collisions in the picker's
+    //    "My Agents" list.
+    let wstore_act = state.wstore.clone();
+    let broker_act = state.broker.clone();
+    engine.register_handler(
+        COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_act.clone();
+            let broker = broker_act.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentDefCreateFromTemplateData = serde_json::from_value(data)
+                    .map_err(|e| format!("agentdefcreatefromtemplate: {e}"))?;
+                let name = cmd.name.trim().to_string();
+                if name.is_empty() {
+                    return Err("agentdefcreatefromtemplate: name must be non-empty".into());
+                }
+                if name.chars().count() > 200 {
+                    return Err(
+                        "agentdefcreatefromtemplate: name must be ≤200 characters".into(),
+                    );
+                }
+
+                let all = wstore
+                    .agent_def_list()
+                    .map_err(|e| format!("agentdefcreatefromtemplate: list: {e}"))?;
+                let template = all
+                    .iter()
+                    .find(|a| a.id == cmd.template_id)
+                    .ok_or_else(|| {
+                        format!(
+                            "agentdefcreatefromtemplate: template {} not found",
+                            cmd.template_id
+                        )
+                    })?;
+                if template.is_seeded != 1 {
+                    return Err(format!(
+                        "agentdefcreatefromtemplate: {} is not a seeded template (is_seeded={})",
+                        cmd.template_id, template.is_seeded
+                    ));
+                }
+                if all
+                    .iter()
+                    .any(|a| a.is_seeded == 0 && a.name.eq_ignore_ascii_case(&name))
+                {
+                    return Err(format!(
+                        "agentdefcreatefromtemplate: an agent named {:?} already exists",
+                        name
+                    ));
+                }
+
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let mut new_def = AgentDefinition {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    // agent_def_insert derives a unique slug from the
+                    // name when this is empty + collision-resolves.
+                    slug: String::new(),
+                    name: name.clone(),
+                    icon: template.icon.clone(),
+                    provider: template.provider.clone(),
+                    description: template.description.clone(),
+                    // Force re-allocation of the per-agent working
+                    // directory at first launch via the new slug —
+                    // matches forkagentdefinition's behaviour.
+                    working_directory: String::new(),
+                    shell: template.shell.clone(),
+                    provider_flags: template.provider_flags.clone(),
+                    // Users opt in to auto-start explicitly; cloning
+                    // shouldn't carry it over (mirrors fork).
+                    auto_start: 0,
+                    restart_on_crash: template.restart_on_crash,
+                    idle_timeout_minutes: template.idle_timeout_minutes,
+                    created_at: now,
+                    agent_type: template.agent_type.clone(),
+                    environment: template.environment.clone(),
+                    agent_bus_id: String::new(),
+                    is_seeded: 0,
+                    accounts: String::new(),
+                    parent_id: template.id.clone(),
+                    branch_label: String::new(),
+                    updated_at: now,
+                };
+                wstore
+                    .agent_def_insert(&mut new_def)
+                    .map_err(|e| format!("agentdefcreatefromtemplate: insert: {e}"))?;
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "agents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+
+                let resp = AgentDefCreateFromTemplateResult {
+                    definition_id: new_def.id.clone(),
+                    identity_id: cmd.identity_id,
+                    memory_id: cmd.memory_id,
+                };
+                tracing::info!(
+                    template_id = %cmd.template_id,
+                    new_definition_id = %new_def.id,
+                    new_name = %new_def.name,
+                    "agentdefcreatefromtemplate: cloned template into user agent"
+                );
+                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
             })
         }),
     );
@@ -2607,5 +2750,298 @@ mod recent_sessions_tests {
         .await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].instance_id, "inst-recent");
+    }
+
+    // ---- Two-tier picker Phase 1: create-from-template + listagents filter ----
+    //
+    // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
+
+    /// Same shape as build_state_with_seed but with a seeded template
+    /// and no instances, so the create-from-template path is exercised
+    /// against a known-good template row.
+    fn build_state_with_template_seed() -> (
+        AppState,
+        Arc<WshRpcEngine>,
+        tokio::sync::mpsc::UnboundedReceiver<crate::backend::rpc_types::RpcMessage>,
+    ) {
+        let wstore = Arc::new(WaveStore::open_in_memory().unwrap());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let event_bus = Arc::new(crate::backend::eventbus::EventBus::new());
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let reactive_handler = crate::backend::reactive::get_global_handler();
+        let poller = Arc::new(crate::backend::reactive::Poller::new(
+            crate::backend::reactive::PollerConfig {
+                agentmux_url: None,
+                agentmux_token: None,
+                poll_interval_secs: 30,
+            },
+            reactive_handler,
+        ));
+        crate::backend::wcore::ensure_initial_data(&wstore).unwrap();
+        let config_watcher = Arc::new(crate::backend::wconfig::ConfigWatcher::new());
+        let process_tracker = Arc::new(
+            crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
+        );
+        let state = AppState {
+            auth_key: "test".to_string(),
+            version: "test".to_string(),
+            app_path: String::new(),
+            wstore: wstore.clone(),
+            filestore: filestore.clone(),
+            event_bus: event_bus.clone(),
+            broker,
+            reactive_handler,
+            poller,
+            config_watcher,
+            messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
+            http_client: reqwest::Client::new(),
+            local_web_url: String::new(),
+            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
+            history_service: Arc::new(crate::backend::history::HistoryService::new()),
+            lan_discovery: None,
+            process_tracker,
+            srv_state: Arc::new(tokio::sync::Mutex::new(crate::state::State::default())),
+            srv_events_tx: tokio::sync::broadcast::channel::<agentmux_common::ipc::Event>(64).0,
+            saga_id_alloc: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
+            auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
+            install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
+        };
+
+        // One seeded template + one already-user-owned definition.
+        let mut tpl = AgentDefinition {
+            id: "tpl-claude".to_string(),
+            slug: String::new(),
+            name: "Claude Code".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: "Anthropic's coding agent".to_string(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: "--model haiku".to_string(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 1,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+        };
+        wstore.agent_def_insert(&mut tpl).unwrap();
+
+        let mut user_a = AgentDefinition {
+            id: "user-a".to_string(),
+            slug: String::new(),
+            name: "Maks".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_001_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_001_000,
+        };
+        wstore.agent_def_insert(&mut user_a).unwrap();
+
+        let (engine, rx) = WshRpcEngine::new();
+        super::register_agent_handlers(&engine, &state);
+        (state, engine, rx)
+    }
+
+    #[tokio::test]
+    async fn listagents_no_filter_returns_all() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let agents: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({}),
+        )
+        .await;
+        assert!(agents.iter().any(|a| a.id == "tpl-claude"));
+        assert!(agents.iter().any(|a| a.id == "user-a"));
+    }
+
+    #[tokio::test]
+    async fn listagents_filter_templates_only() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let agents: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({ "is_seeded": 1 }),
+        )
+        .await;
+        assert!(agents.iter().all(|a| a.is_seeded == 1));
+        assert!(agents.iter().any(|a| a.id == "tpl-claude"));
+        assert!(!agents.iter().any(|a| a.id == "user-a"));
+    }
+
+    #[tokio::test]
+    async fn listagents_filter_user_owned_only() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let agents: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({ "is_seeded": 0 }),
+        )
+        .await;
+        assert!(agents.iter().all(|a| a.is_seeded == 0));
+        assert!(agents.iter().any(|a| a.id == "user-a"));
+        assert!(!agents.iter().any(|a| a.id == "tpl-claude"));
+    }
+
+    #[tokio::test]
+    async fn create_from_template_happy_path_clones_and_returns_id() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let resp: crate::backend::rpc_types::AgentDefCreateFromTemplateResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+            serde_json::json!({
+                "template_id": "tpl-claude",
+                "name": "Asaf",
+                "identity_id": "id-work",
+                "memory_id": "mem-notes",
+            }),
+        )
+        .await;
+        assert!(!resp.definition_id.is_empty());
+        assert_eq!(resp.identity_id, "id-work");
+        assert_eq!(resp.memory_id, "mem-notes");
+
+        // The new row is user-owned, carries provider + flags from template.
+        let agents: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({}),
+        )
+        .await;
+        let new_def = agents
+            .iter()
+            .find(|a| a.id == resp.definition_id)
+            .expect("new definition should appear in listagents");
+        assert_eq!(new_def.is_seeded, 0);
+        assert_eq!(new_def.name, "Asaf");
+        assert_eq!(new_def.provider, "claude");
+        assert_eq!(new_def.provider_flags, "--model haiku");
+        assert_eq!(new_def.parent_id, "tpl-claude");
+    }
+
+    async fn call_rpc_expect_error(
+        engine: &Arc<WshRpcEngine>,
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<crate::backend::rpc_types::RpcMessage>,
+        command: &str,
+        data: serde_json::Value,
+    ) -> String {
+        let req_id = format!("test-{}", uuid::Uuid::new_v4());
+        let msg = crate::backend::rpc_types::RpcMessage {
+            command: command.to_string(),
+            reqid: req_id.clone(),
+            data: Some(data),
+            ..Default::default()
+        };
+        engine.handle_message(msg);
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler timed out")
+            .expect("output channel closed");
+        assert_eq!(resp.resid, req_id);
+        assert!(
+            !resp.error.is_empty(),
+            "expected error, got success payload: {:?}",
+            resp.data
+        );
+        resp.error
+    }
+
+    #[tokio::test]
+    async fn create_from_template_rejects_non_template_id() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        // "user-a" is is_seeded=0 — not a template.
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+            serde_json::json!({
+                "template_id": "user-a",
+                "name": "another",
+            }),
+        )
+        .await;
+        assert!(
+            err.contains("not a seeded template"),
+            "wrong error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_from_template_rejects_unknown_template_id() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+            serde_json::json!({
+                "template_id": "no-such-id",
+                "name": "x",
+            }),
+        )
+        .await;
+        assert!(err.contains("not found"), "wrong error: {err}");
+    }
+
+    #[tokio::test]
+    async fn create_from_template_rejects_duplicate_user_name() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        // "Maks" already exists as a user-owned agent.
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+            serde_json::json!({
+                "template_id": "tpl-claude",
+                "name": "Maks",
+            }),
+        )
+        .await;
+        assert!(
+            err.contains("already exists"),
+            "wrong error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_from_template_rejects_empty_name() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+            serde_json::json!({
+                "template_id": "tpl-claude",
+                "name": "   ",
+            }),
+        )
+        .await;
+        assert!(err.contains("non-empty"), "wrong error: {err}");
     }
 }

--- a/docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md
+++ b/docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md
@@ -1,0 +1,210 @@
+# SPEC: Agent concept consolidation — DRY rethink
+
+**Date:** 2026-05-24
+**Author:** AgentA
+**Status:** Design analysis — answers a question the two-tier picker spec raised about whether we need this many "agent" types.
+
+---
+
+## The current sprawl
+
+Today the codebase has SEVEN tables / concepts in the "agent" family. The forge → agent rename earlier in the project already collapsed five `db_forge_*` tables into `db_agent_*` ones, but the multiplicity of *concepts* remained.
+
+| Concept | Table / Storage | What it represents |
+|---|---|---|
+| **Definition** | `db_agent_definitions` (140 rows of seeded + user) | Blueprint: provider, command, env, default auth. `is_seeded` flag. |
+| **Instance** | `db_agent_instances` | A spawned runtime entity. References `definition_id`. Carries `instance_name`, `identity_id`, `memory_id`, `working_directory`, `status`, `started_at`, `ended_at`, `block_id`, `session_id`, `parent_instance_id`, `display_hidden`, `github_context`. |
+| **Block** | `db_block` rows with `meta.view = "agent"` | UI pane that references an agent via `meta.agentId`. |
+| **Session zone** (Option E) | `filestore.db` zone `agent:<defId>:current` | The conversation snapshot + raw stream. **Keyed by definition_id**, NOT instance_id. |
+| **Archive zone** | `filestore.db` zone `agent:<defId>:archive:<ts>` | Past conversations of an agent (Option E "+ New session" archives). |
+| **Content** | `db_agent_content` | Per-agent content blobs. FK to `db_agent_definitions(id)`. |
+| **History** | `db_agent_history` | Per-agent history (separate from session zone). |
+
+**125 source references** to `db_agent_instances` / `AgentInstance` across `agentmux-srv/` and `frontend/` (Rust + TS combined). The instance table is the heaviest of these by a wide margin.
+
+The user's question is correct: this *is* a lot, and Option E made it worse, not better.
+
+---
+
+## What blurred when Option E shipped
+
+Before Option E:
+- One **definition** could spawn N **instances** (each with different bindings).
+- Each instance owned one **block** (the UI pane it lived in) and one **session zone** keyed by `block_id`.
+- Many-to-one fan-in: many instances → one definition. One-to-one fan-out: one instance → one block → one zone.
+
+After Option E:
+- The **session zone** is now keyed by `definition_id`, not `block_id`.
+- So multiple instances of the same definition now SHARE one zone. The `instances.session_id` field is vestigial.
+- `parent_instance_id` (continuation linkage between instances) is also vestigial — Option E's zone is structurally continuous; no need for instance-to-instance chains.
+
+Net: about half of `db_agent_instances` columns are now dead weight under the Option E semantics we actually shipped.
+
+---
+
+## What each concept actually does in production
+
+This is the audit that tells us what to keep.
+
+**Definition** — keep.
+- Provider config, cmd template, auth wiring.
+- The starting point for any agent.
+
+**Instance** — partial keep, mostly dead.
+- `definition_id`: redundant after the merge (the row IS the agent).
+- `parent_instance_id`: dead under Option E.
+- `block_id`: orthogonal — belongs in `db_block.meta`, not in an instance row.
+- `session_id`: dead under Option E.
+- `status`, `started_at`, `ended_at`: arguably belong in an audit log, not in the canonical agent row.
+- `instance_name`, `identity_id`, `memory_id`, `working_directory`: **THESE are what an "agent" actually is** — the user-given configuration of a named entity. They should live on the agent itself.
+- `display_hidden`: UI preference, belongs in `db_block.meta` or a user-prefs table.
+- `github_context`: bound to the agent identity, belongs on the agent row.
+
+**Block** — keep.
+- Layout, position, view-type, references the agent it's showing.
+
+**Session zone** — keep (Option E).
+
+**Content + History** — keep (separate concerns from agent identity).
+
+---
+
+## The lean model — 3 first-class concepts
+
+### 1. `db_agents` (rename + absorb)
+
+One table. Two flavors via `is_template` flag.
+
+```sql
+CREATE TABLE db_agents (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    icon                TEXT NOT NULL DEFAULT '',
+    description         TEXT NOT NULL DEFAULT '',
+
+    -- Template vs user agent
+    is_template         INTEGER NOT NULL DEFAULT 0,
+    parent_template_id  TEXT NOT NULL DEFAULT '',   -- which template I was cloned from (if any)
+
+    -- Provider/cmd config (was on definition)
+    provider_id         TEXT NOT NULL,
+    cmd                 TEXT NOT NULL DEFAULT '',
+    cmd_args            TEXT NOT NULL DEFAULT '[]',
+    cmd_env             TEXT NOT NULL DEFAULT '{}',
+    resume_flag         TEXT NOT NULL DEFAULT '',
+    auth_config_dir_env TEXT NOT NULL DEFAULT '',
+
+    -- Bindings (was on instance — only relevant when is_template=0)
+    identity_id         TEXT NOT NULL DEFAULT '',
+    memory_id           TEXT NOT NULL DEFAULT '',
+    working_directory   TEXT NOT NULL DEFAULT '',
+    github_context      TEXT NOT NULL DEFAULT '',
+
+    -- Provenance
+    created_at          INTEGER NOT NULL DEFAULT 0,
+    updated_at          INTEGER NOT NULL DEFAULT 0,
+    is_seeded           INTEGER NOT NULL DEFAULT 0,  -- managed by manifest seed
+    user_hidden         INTEGER NOT NULL DEFAULT 0   -- (future) user hid this template
+);
+```
+
+This replaces both `db_agent_definitions` AND `db_agent_instances`.
+
+### 2. `db_block` (unchanged structurally)
+
+A block with `meta.view = "agent"` references an agent via `meta.agentId`. Multiple blocks can show the same agent (cross-tab). Block lifecycle is orthogonal to agent lifecycle.
+
+### 3. `filestore.db` zone `agent:<id>:current` + `:archive:*` (Option E, unchanged)
+
+The conversation history. One current zone per agent; many archives per agent.
+
+### Optional 4th: `db_agent_events` (audit log)
+
+If we want lifecycle history (when started, when ended, status changes), put it in an append-only event table. Decoupled from the agent row, so deleting an agent doesn't lose audit. Probably unnecessary for now.
+
+---
+
+## Operational mapping — what the picker spec becomes
+
+The two-tier picker spec from earlier maps cleanly onto this model:
+
+- **My Agents** = `db_agents WHERE is_template = 0 AND user_hidden = 0`
+- **Templates** = `db_agents WHERE is_template = 1 AND user_hidden = 0`
+- Click a template → `agent_create_from_template { template_id, name, identity_id, memory_id }`:
+  - INSERT a new `db_agents` row with `is_template = 0`, `parent_template_id = template_id`, copied cmd/env/auth fields, user-picked name/identity/memory.
+  - Returns the new id; frontend immediately opens a block for it.
+
+No new "instance" concept needed. The act of creating a user agent IS the act of cloning the template into a user-owned row.
+
+---
+
+## What `db_agent_instances` rows become
+
+This is the migration. Three patterns map cleanly:
+
+| Existing instance row | Maps to |
+|---|---|
+| First instance of a definition (definition has 1 instance, no name override) | The instance's bindings get folded into the definition row; the instance row deleted. |
+| Renamed instance of a definition (Maks-the-instance from Claude Code-the-definition) | Clone the definition into a new agent row with `is_template = 0`, `parent_template_id = old_defId`, copied bindings. The old definition (Claude Code) flips to `is_template = 1`. Instance row deleted. |
+| Multiple unnamed instances of one definition | Each becomes its own user agent row, defaulted name = `{template.name} #N`. |
+
+Session zones are already keyed by definition_id (Option E), so for the "renamed" case the migration must also **move the zone** from `agent:<oldDefId>:current` → `agent:<newAgentId>:current` for the agent that takes over, and clear the source so the template is clean.
+
+For the seeded-template-used-directly case (Q1 Option C from the picker spec): same move-the-zone logic.
+
+---
+
+## Implementation cost — honest accounting
+
+- 125 source references touch `AgentInstance` / `db_agent_instances`. Each one needs to either:
+  - Rewrite to use `db_agents` directly, OR
+  - Get deleted (it was instance-specific scaffolding that's not needed anymore).
+- The forge → agent rename precedent (already in the codebase) collapsed 5 tables; the team has done this kind of refactor before.
+- Risk: breaking churn for in-flight features. Recommend doing this between major releases, not before.
+- Estimated effort: **4–6 PRs**, ~2500–3500 lines total. Schema migration + Rust rewrites + frontend updates + test churn.
+
+---
+
+## Recommendation
+
+Yes, the rethink is worth it. Three reasons:
+
+1. **The picker spec is cleaner with this model.** Templates vs My Agents is a single `is_template` filter on one table. No JOIN against instances.
+
+2. **Option E already broke the old semantics.** `db_agent_instances` is half-dead in production already. The longer we leave it, the more code is built on top of vestigial state.
+
+3. **The forge rename precedent shows the team CAN do these.** And the lean shape is simpler to explain (and test) than the current sprawl.
+
+### Sequencing proposal
+
+Do this in two phases:
+
+**Phase 1 (next): two-tier picker on the existing schema.**
+Per the previous spec (`SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`). Uses `is_seeded` as the template flag for now; doesn't touch `db_agent_instances`. Ships the user-visible win this week.
+
+**Phase 2 (later, separate cycle): collapse instance into agent.**
+Schema migration `db_agent_definitions` + `db_agent_instances` → `db_agents`. Frontend + Rust call-site rewrites. Done across multiple PRs guarded by dual-read (write to old + new, read from new), then drop the old once verified.
+
+This way you get the visible improvement now (Phase 1) without paying the full structural cost; and the structural cleanup happens in a focused cycle once you've decided it's worth the refactor budget.
+
+---
+
+## Open questions
+
+- **Decoupled audit log** (`db_agent_events`): yes / no? Useful for "show me when this agent was last interrupted / errored / paused" without bloating the agent row.
+- **`is_template` mutability**: can a user-agent be "promoted" back to template? Probably no; one-way clone.
+- **Cross-tab in the lean model**: multiple blocks for one agent share the session zone — naturally handles cross-tab when E3 lands.
+
+---
+
+## The shorter answer
+
+You're right; we don't need this many types. The clean shape is:
+
+- **Agents** (one table; templates and user-owned distinguished by a flag).
+- **Blocks** (UI panes pointing at agents).
+- **Session zones** (Option E).
+
+Three concepts. Everything else is implementation detail or audit-log noise.
+
+`db_agent_instances` is the artifact we should retire. But it has 125 callers, so retire it deliberately in a focused refactor cycle, not as a side-quest off the picker work.

--- a/docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
+++ b/docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
@@ -1,0 +1,229 @@
+# SPEC: Two-tier agent picker — "My Agents" + "Templates"
+
+**Date:** 2026-05-24
+**Author:** AgentA
+**Status:** Design analysis — needs answers to the two decision points before implementation.
+
+---
+
+## The vision
+
+The current picker treats every agent definition uniformly. Click any card and you get the same flow. After Option E shipped, "Recent Sessions" sits at the top — but it lists *sessions* (blocks), not agents.
+
+The new model splits the picker into two semantically distinct tiers:
+
+1. **My Agents** (top) — your user-created agents. Each row IS an agent (Maks, etc.), not a session. The row shows the agent's state: when it was last active, how many messages, what it's working on. Click = continue. This subsumes today's "Recent Sessions" surface.
+
+2. **Templates** (bottom) — the seeded provider templates (Claude Code, Codex CLI, Cursor, etc.). Click = **create a new user agent** from this template. The template itself doesn't carry conversation state; it's a starting blueprint.
+
+The split mirrors a model that already exists in the schema: `db_agent_definitions.is_seeded INTEGER NOT NULL DEFAULT 0` (see `agentmux-srv/src/backend/storage/migrations.rs:131`). Today's `agent_seed.rs` flips it to `1` for manifest entries; user-created definitions stay at `0`. The picker just doesn't use the distinction yet.
+
+---
+
+## Current state of the code
+
+### Schema (relevant columns)
+
+`db_agent_definitions`:
+- `id` TEXT PRIMARY KEY
+- `slug` TEXT
+- `name` TEXT
+- `icon` TEXT
+- `description` TEXT
+- `provider_id` TEXT
+- `is_seeded` INTEGER NOT NULL DEFAULT 0  ← the split signal
+- `created_at` INTEGER
+- ... (auth, cmd, env)
+
+### Seed flow
+
+`agentmux-srv/src/backend/agent_seed.rs` reads an embedded manifest on first launch (and on manifest version bumps), inserts entries with `is_seeded = 1`, and on re-seed REMOVES seeded entries no longer in the manifest (`is_seeded == 1 && !manifest_ids.contains(id)`).
+
+User-created entries are not touched by seeding.
+
+### Picker (current)
+
+`frontend/app/view/agent/components/AgentPicker.tsx:619-625`:
+- `<RecentSessionsList>` at top (generic, lists sessions across all agents).
+- `<For each={agents()}>` below — `agents()` is `ListNamedAgentsCommand` output (or similar), unfiltered.
+- Click on an `AgentCard` → `handleSelect(agent, evt)` → Option E logic: if `:current` zone non-empty, auto-continue; otherwise open the launch modal.
+
+There's no top-level distinction between user-created and seeded definitions.
+
+---
+
+## Target state
+
+### Layout
+
+```
+┌──────────────────────────────────────────┐
+│  My Agents                               │
+│  ┌────────────────────────────────────┐  │
+│  │ 🤖 Maks                            │  │
+│  │    last active: 4 hours ago        │  │
+│  │    169 messages, working on the    │  │
+│  │    agent-pane state machine        │  │
+│  └────────────────────────────────────┘  │
+│  ┌────────────────────────────────────┐  │
+│  │ ✦ AgentY                            │  │
+│  │    last active: 12 minutes ago     │  │
+│  │    42 messages, new                │  │
+│  └────────────────────────────────────┘  │
+│                                          │
+│  + New agent from template               │
+│  ┌────────────────────────────────────┐  │
+│  │ Claude Code                        │  │
+│  │ Codex CLI                          │  │
+│  │ Cursor                             │  │
+│  │ ...                                │  │
+│  └────────────────────────────────────┘  │
+└──────────────────────────────────────────┘
+```
+
+### Semantics
+
+**My Agents** entries:
+- Listed from `db_agent_definitions WHERE is_seeded = 0`.
+- Each row shows: identity icon + name + last-active relative time + node count + preview of last user message (lifted from `agent:<defId>:current` zone).
+- Click = `launchAgentDefinition(agent, ...)` with the agent's own bindings (no modal). Same as today's Option E auto-continue for these.
+- Each row has a hover-revealed "+ New session" pill (current behavior).
+- Empty state: "You haven't created any agents yet. Pick a template below to get started."
+
+**Templates** entries:
+- Listed from `db_agent_definitions WHERE is_seeded = 1`.
+- Each row is a compact template card: icon + name + description.
+- Click = **create a new user agent** from this template. Flow:
+  1. Open a "Name your agent" modal (with sensible default like "{Template} #2").
+  2. Pick identity + memory.
+  3. Submit → backend `CreateUserAgent` RPC clones the template's metadata into a new `db_agent_definitions` row with `is_seeded = 0` and the user-picked name.
+  4. Launch the new agent in a pane (which IS the agent's first session).
+- Template rows do NOT auto-continue and do NOT show session state. They're pure starting points.
+
+### RPCs needed
+
+Mostly already exist — just need to filter and add one new write path.
+
+- `agent_def_list` (existing): take an optional `is_seeded` filter parameter.
+- `agent_session_read` (E1): used as today.
+- New: `agent_def_create_from_template { template_id, name, identity_id, memory_id }` → returns the new `definition_id`. Internally inserts a new `db_agent_definitions` row with `is_seeded = 0`, copies the template's cmd/env/auth fields, returns the id so the frontend can immediately launch it.
+
+### Frontend split
+
+`AgentPicker.tsx`:
+- Two `<For>` loops over partitioned `agents()` output (memoized).
+- `MyAgentsList` component (replaces today's `RecentSessionsList` + the upper part of the agent list).
+- `TemplatesList` component (the lower section).
+- Click handlers diverge: my-agent click → `launchAgentDefinition`; template click → `openCreateFromTemplateModal`.
+
+`AgentCard` likely gets two variants (or a `variant?: "agent" | "template"` prop). Today's `hasCurrentSession` + `+New session` pill only apply to the agent variant.
+
+---
+
+## Resolved design decisions
+
+### Q1: Can a seeded definition ever have its own session? — **Decision: Option C, IN PHASE 1**
+
+A seeded definition (template) NEVER carries a session zone in the new model. The moment a user spawns a session on a seeded definition, that definition is cloned to a new `is_seeded=0` row with a sensible default name, and the session zone moves to the new row. The template card stays clean as a starting point.
+
+**Why this matters for Phase 1 scope:** under Option E, session zones are keyed by `definition_id`. Today's reality is that users HAVE been clicking seeded definitions directly — Maks's conversation is at `agent:claude:current` where `claude` is a seeded template. If Phase 1 ships the two-tier picker WITHOUT the auto-promote migration:
+
+- "claude" appears under Templates.
+- Clicking "claude" → opens launch modal → spawns a new instance → reads `agent:claude:current` → **sees Maks's conversation** because that's where Option E stored it.
+- Two users (or two intents) would be appending to the same session zone, indistinguishable from each other.
+
+So Phase 1 MUST include a one-shot **seeded-def-to-user-agent migration** in addition to the picker UI rewiring. The migration:
+
+1. For each `agent:<defId>:current` zone where `<defId>.is_seeded = 1`:
+   - Look up the most recently active `db_agent_instances` row with this `definition_id`. Use its `instance_name` as the new agent's name (e.g. "Maks") — fall back to `{template.name}` if instance has no name.
+   - INSERT a new `db_agent_definitions` row: copy `provider_id`, `cmd`, `cmd_args`, `cmd_env`, `auth_config_dir_env` from the template; set `is_seeded = 0`, generated id, the chosen name.
+   - Move the filestore zone: rename `agent:<oldDefId>:current` → `agent:<newDefId>:current`. Also move any `agent:<oldDefId>:archive:*` zones to `agent:<newDefId>:archive:*`.
+   - Update `db_agent_instances.definition_id` for any rows referencing the old template to point at the new user-agent row (preserves the existing reattach flow).
+2. Gate the migration with a marker file `<data_dir>/migration_template_promote_v1.flag`. One-shot, idempotent on second run.
+
+Templates are clean post-migration. The `agent:<seeded_template_id>:*` namespace is empty. Future clicks on a template are unambiguous "create new" actions.
+
+Why Option C and not A or B:
+- **A** (templates never have sessions) is theoretically clean but loses Maks's data (or requires the user to manually archive him first — bad UX).
+- **B** (templates show "(in use)" badge with continue button) keeps the conceptual conflation we're trying to remove. The whole point of the split is "templates are factories, not entities".
+- **C** preserves data, matches user intuition (the act of using a template makes a copy that's yours), and lets templates be conceptually pure.
+
+### Q2: Can a user delete a seeded template? — **Decision: Option Y (hide, not delete), DEFERRED to follow-up PR**
+
+Decision locked: users can **hide** seeded templates but never **delete** them. Hide-state is persisted in a new `db_agent_definitions.user_hidden INTEGER NOT NULL DEFAULT 0` column. Manifest re-sync MUST reset hide-state for any newly-added templates (so new templates surface once even if the user previously hid a same-named one).
+
+Why hide-not-delete:
+- Seeded templates are manifest-managed; user delete would conflict with manifest re-sync (deleted templates would just reappear on next seed).
+- Hide is a per-user preference; doesn't affect global state; survives manifest updates for existing templates.
+- Reset on new-add prevents the user from accidentally hiding the entire list and being unable to recover.
+
+Why deferred to a follow-up PR:
+- Not needed for Phase 1 correctness — the picker works fine without it.
+- Adds a column migration + a small UX surface (right-click → Hide, with an "unhide" affordance in settings).
+- Better to ship Phase 1's main win first, then layer this on.
+
+The decision is locked so when we do implement, there's no re-discussion: hide, not delete; new templates auto-unhide on first appearance; per-user preference column on `db_agent_definitions`.
+
+---
+
+## Migration
+
+Minimal. The `is_seeded` column already exists with correct values:
+- All existing seeded definitions have `is_seeded = 1`.
+- All user-created definitions (if any) have `is_seeded = 0`.
+
+If we adopt Q1 Option C, also need a one-shot migration on startup:
+- For each seeded definition WHERE an `agent:<id>:current` zone is non-empty:
+  - Clone the definition with `is_seeded = 0` and a default name (`{template.name} #1`).
+  - Move the zone from `agent:<oldId>:current` to `agent:<newId>:current`.
+- Log the migrations so users know what was renamed.
+
+---
+
+## Implementation order
+
+**Phase 1 (this PR)** — picker rewiring + REQUIRED auto-promote migration:
+
+1. **Backend**:
+   - `ListAgentDefinitions` gains optional `is_seeded: Option<i64>` filter parameter.
+   - New `agent_def_create_from_template { template_id, name, identity_id, memory_id }` RPC — clones a template into a user agent with `is_seeded=0`.
+   - One-shot migration on startup: promote any seeded definition with a non-empty session zone to a new user-agent definition (per Q1 Decision C). Marker-file gated.
+2. **Frontend**:
+   - `RecentSessionsList` → `MyAgentsList` (rename + relabel; data source stays `ListNamedAgentsCommand`, returns `NamedAgentRow[]`).
+   - Filter the bottom card list to `is_seeded === 1` only.
+   - Template click → "Name your agent" modal → `agent_def_create_from_template` RPC → launch.
+   - My-agent click → existing `handleReattach` (unchanged).
+3. **Tests** + spec doc rides with code per `feedback_no_doc_only_prs`.
+
+Estimated: 600–900 lines, single PR.
+
+**Phase 2 (later PR, follow-up)** — hide templates (Q2 Decision Y):
+
+- Schema migration: add `db_agent_definitions.user_hidden INTEGER NOT NULL DEFAULT 0`.
+- UI: right-click on a template card → Hide. Settings panel → "Show hidden templates" toggle to unhide.
+- Manifest re-sync logic: any NEW template id auto-resets `user_hidden = 0` so newly-added templates always surface once.
+
+Estimated: 200–400 lines.
+
+**Phase 3 (separate cycle)** — the full `db_agents` consolidation (see `SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md`). Out of scope for this picker spec.
+
+---
+
+## What disappears
+
+- `RecentSessionsList` becomes redundant — "My Agents" subsumes it. Each user agent has exactly one current session by definition (Option E semantics).
+- The `listrecentsessions` RPC stays useful as a cross-agent "archived sessions" view (e.g., for a future "Restore archived session" flow). The picker no longer calls it.
+
+## What stays the same
+
+- Modifier-key escape hatch on My Agents click (force the launch modal). Useful for changing identity/memory at launch.
+- The "+ New session" pill on each My Agents row (archives current, opens modal).
+- Option E's agent zone storage and migration — unchanged.
+
+---
+
+## Recommendation
+
+Ship in the order above with **Q1 = C** and **Q2 = Y deferred to a later PR**. Land the visible UI win first (My Agents top, Templates bottom); polish (hide templates) becomes a follow-up after the model proves out.
+
+Need your answers on Q1 and Q2 before implementation starts.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -484,8 +484,37 @@ class RpcApiType {
     }
 
     // command "listagents" [call]
-    ListAgentDefinitionsCommand(client: RpcClient, opts?: RpcOpts): Promise<AgentDefinition[]> {
-        return client.rpcCall("listagents", {}, opts);
+    //
+    // Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+    // Optional `is_seeded` filter: 1 = templates only, 0 = user-owned
+    // only, undefined = no filter (backward-compat: every existing
+    // caller passes nothing). Backend treats `null` / `{}` as no-filter.
+    ListAgentDefinitionsCommand(
+        client: RpcClient,
+        data?: { is_seeded?: 0 | 1 },
+        opts?: RpcOpts,
+    ): Promise<AgentDefinition[]> {
+        return client.rpcCall("listagents", data ?? {}, opts);
+    }
+
+    // command "agentdefcreatefromtemplate" [call]
+    //
+    // Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+    // Clone a seeded template into a new user-owned agent. The
+    // template stays pristine. Validates: template must exist + have
+    // `is_seeded = 1`; name must be non-empty, ≤200 chars, and not
+    // collide with another user-owned agent.
+    AgentDefCreateFromTemplateCommand(
+        client: RpcClient,
+        data: {
+            template_id: string;
+            name: string;
+            identity_id?: string;
+            memory_id?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<{ definition_id: string; identity_id: string; memory_id: string }> {
+        return client.rpcCall("agentdefcreatefromtemplate", data, opts);
     }
 
     // command "createagent" [call]

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -49,6 +49,7 @@ import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstall
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
 import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
 import { AgentNewMemoryModalPanel } from "@/app/view/agent/components/AgentNewMemoryModal";
+import { AgentCreateFromTemplateModalPanel } from "@/app/view/agent/components/AgentCreateFromTemplateModal";
 import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuthModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
@@ -164,6 +165,8 @@ function requestLabel(req: TabModalRequest): string {
             return `Install required tools for ${req.agent.name}`;
         case "install-agent":
             return `Install ${req.agent.name}`;
+        case "create-from-template":
+            return `Create new agent from ${req.template.name}`;
         case "browser-auth":
             return req.isProxy ? "Proxy authentication required" : "Authentication required";
     }
@@ -330,6 +333,45 @@ function renderRequest(
                             // path. SPEC_MODAL_TRANSITIONS_2026_05_18.md.
                             req.onInstalled(continueToLaunch);
                         }}
+                    />
+                ),
+            };
+        case "create-from-template":
+            return {
+                label: requestLabel(req),
+                panel: (
+                    <AgentCreateFromTemplateModalPanel
+                        template={req.template}
+                        // The layer owns the create-then-launch chain
+                        // (spec note on CreateFromTemplateRequest) so
+                        // `submitting()` covers both RPC steps and ESC
+                        // / backdrop dismiss stay blocked end-to-end.
+                        onSubmit={async ({ name, identityId, memoryId }) => {
+                            setSubmitting(true);
+                            try {
+                                const resp = await RpcApi.AgentDefCreateFromTemplateCommand(
+                                    TabRpcClient,
+                                    {
+                                        template_id: req.template.id,
+                                        name,
+                                        identity_id: identityId,
+                                        memory_id: memoryId,
+                                    },
+                                );
+                                await req.onCreatedAndLaunch(
+                                    resp.definition_id,
+                                    resp.identity_id,
+                                    resp.memory_id,
+                                    name,
+                                );
+                                setSubmitting(false);
+                                api.close();
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
+                        }}
+                        onCancel={api.close}
                     />
                 ),
             };

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -25,6 +25,7 @@ export type TabModalRequest =
     | AgentPrereqRequest
     | NewIdentityBundleRequest
     | NewMemoryBundleRequest
+    | CreateFromTemplateRequest
     | BrowserAuthRequest;
 
 export interface LaunchAgentRequest {
@@ -210,6 +211,41 @@ export interface NewMemoryBundleRequest {
     onCreated: (bundleId: string, bundleName: string) => void;
     /** Caller routes (replace vs close). Layer does NOT close. */
     onCancel: () => void;
+}
+
+/**
+ * Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+ * Opens when the user clicks a card in the picker's Templates section.
+ * On submit the layer chains:
+ *  1. `agentdefcreatefromtemplate` to clone the template into a new
+ *     user-owned definition,
+ *  2. `launchAgentDefinition` with the picked bindings to spawn the
+ *     new agent immediately.
+ *
+ * Why the layer owns the chain (not the picker): the modal's
+ * `submitting()` gate must track BOTH the create RPC and the launch
+ * await so ESC + backdrop dismiss are blocked across the whole flow.
+ * Splitting them would leave a window where the create succeeded but
+ * the launch hadn't fired, and ESC would lose the user's just-created
+ * agent without launching it.
+ */
+export interface CreateFromTemplateRequest {
+    kind: "create-from-template";
+    /** Seeded template the user clicked. Its `is_seeded` field MUST be
+     *  1; the backend rejects non-template ids defensively. */
+    template: AgentDefinition;
+    /** Block id of the pane that opened the modal. */
+    originBlockId: string;
+    /** Called by the layer after `agentdefcreatefromtemplate` returns.
+     *  The picker uses this to fire `launchAgentDefinition` with the
+     *  freshly-minted user-agent definition. Returns a promise so the
+     *  layer can keep `submitting()` true across the launch await. */
+    onCreatedAndLaunch: (
+        newDefinitionId: string,
+        identityId: string,
+        memoryId: string,
+        name: string,
+    ) => Promise<void>;
 }
 
 /**

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -19,7 +19,7 @@ export type OverlayTab = "agent" | "identity";
 /**
  * Compact relative-time label for the title-bar continuation chip.
  *
- * Mirrors the wording of `formatRelative` in `RecentSessionsList.tsx`
+ * Mirrors the wording of `formatRelative` in `MyAgentsList.tsx`
  * (same "Xm ago" / "Xh ago" / "Xd ago" buckets) but lives here so the
  * model file has no UI-only dependency cycle. Exported for unit tests.
  */

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -1,0 +1,151 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for AgentCreateFromTemplateModalPanel
+ * (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md — Phase 1).
+ *
+ * Covered:
+ *  - default name field pre-fills with the template's name
+ *  - Identity + Memory selects render the bundles list (empty option
+ *    represents ambient creds / vanilla CLI sentinels)
+ *  - clicking Create fires onSubmit with the form snapshot
+ *  - the Create button is disabled while submitting
+ *  - error from onSubmit surfaces in the panel body
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListIdentityBundlesCommand: vi.fn(),
+        ListMemoriesCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { AgentCreateFromTemplateModalPanel } from "./AgentCreateFromTemplateModal";
+
+let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+
+const template: AgentDefinition = {
+    id: "tpl-claude",
+    slug: "claude",
+    name: "Claude Code",
+    icon: "",
+    provider: "claude",
+    description: "Anthropic's coding agent",
+    working_directory: "",
+    shell: "",
+    provider_flags: "",
+    auto_start: 0,
+    restart_on_crash: 0,
+    idle_timeout_minutes: 0,
+    created_at: 0,
+    agent_type: "host",
+    environment: "local",
+    agent_bus_id: "",
+    is_seeded: 1,
+} as AgentDefinition;
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ RpcApi } = await import("@/app/store/rpc-api"));
+    vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([
+        { id: "id-work", name: "Work", description: "", is_blank: false } as any,
+    ]);
+    vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
+        { id: "mem-notes", name: "Notes", is_blank: false } as any,
+    ]);
+});
+
+afterEach(() => cleanup());
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("AgentCreateFromTemplateModalPanel", () => {
+    it("defaults the name field to the template name", async () => {
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={vi.fn().mockResolvedValue(undefined)}
+                onCancel={vi.fn()}
+            />
+        ));
+        const input = screen.getByTestId(
+            "create-from-template-name-input",
+        ) as HTMLInputElement;
+        expect(input.value).toBe("Claude Code");
+    });
+
+    it("clicking Create fires onSubmit with form snapshot", async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        // Bundles auto-pick once loaded.
+        await flush();
+        await flush();
+        await flush();
+
+        const input = screen.getByTestId(
+            "create-from-template-name-input",
+        ) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "Mary" } });
+
+        const submit = screen.getByTestId("create-from-template-submit");
+        fireEvent.click(submit);
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledTimes(1);
+        });
+        const args = onSubmit.mock.calls[0][0];
+        expect(args.name).toBe("Mary");
+        // Identity + Memory auto-picked from the first non-blank
+        // bundle each.
+        expect(args.identityId).toBe("id-work");
+        expect(args.memoryId).toBe("mem-notes");
+    });
+
+    it("surfaces an error from onSubmit", async () => {
+        const onSubmit = vi.fn().mockRejectedValue(new Error("name exists"));
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        const submit = screen.getByTestId("create-from-template-submit");
+        fireEvent.click(submit);
+        const err = await screen.findByTestId("create-from-template-error");
+        expect(err.textContent).toContain("name exists");
+    });
+
+    it("trims whitespace and rejects empty names", async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        const input = screen.getByTestId(
+            "create-from-template-name-input",
+        ) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "   " } });
+        const submit = screen.getByTestId(
+            "create-from-template-submit",
+        ) as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        fireEvent.click(submit);
+        await flush();
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -1,0 +1,205 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentCreateFromTemplateModalPanel — Phase 1 two-tier picker modal
+ * (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+ *
+ * Opens when the user clicks a card in the picker's Templates section.
+ * Collects a name + identity + memory, then in `onSubmit` the layer
+ * clones the seeded template into a new user-owned definition via
+ * `agentdefcreatefromtemplate`, immediately launches it with the
+ * picked bindings, and closes.
+ *
+ * Why a separate modal (not a flag on AgentLaunchModal): the launch
+ * modal carries a lot of additional UX (runtime/container picker,
+ * continuation dropdown, OAuth pre-launch panel, "+ New bundle"
+ * affordances, NamedAgents resource). For a template-create the
+ * minimum surface is name + bindings; mixing it into the launch modal
+ * would push its complexity onto a flow that doesn't need it. The
+ * existing modal-v2 panel styles (`modal-panel-*`) and shared bundle
+ * styles (`agent-new-bundle-modal-*`) are reused so this fits the
+ * universal modal system per `feedback_use_universal_modal_system`.
+ */
+
+import { createEffect, createMemo, createSignal, For, onMount, Show, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface CreateFromTemplateFormData {
+    name: string;
+    identityId: string;
+    memoryId: string;
+}
+
+interface AgentCreateFromTemplateModalPanelProps {
+    /** Seeded template the user clicked. */
+    template: AgentDefinition;
+    /** Suggested initial name (defaults to template name). */
+    initialName?: string;
+    /** Called when the user clicks Create with valid data. The layer
+     *  wraps this with the create-then-launch RPC chain. */
+    onSubmit: (formData: CreateFromTemplateFormData) => Promise<void>;
+    onCancel: () => void;
+}
+
+export const AgentCreateFromTemplateModalPanel = (
+    props: AgentCreateFromTemplateModalPanelProps,
+): JSX.Element => {
+    const [name, setName] = createSignal(props.initialName ?? props.template.name);
+    const [identityId, setIdentityId] = createSignal("");
+    const [memoryId, setMemoryId] = createSignal("");
+    const [identities, setIdentities] = createSignal<IdentityBundle[]>([]);
+    const [memories, setMemories] = createSignal<Memory[]>([]);
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    // Load bundle lists on mount. Bindings are stored on the
+    // db_agent_instances row at launch time; the empty string sentinel
+    // means "ambient creds / vanilla CLI" so an empty selection is OK.
+    onMount(() => {
+        void (async () => {
+            try {
+                const list = await RpcApi.ListIdentityBundlesCommand(TabRpcClient, {});
+                setIdentities(list ?? []);
+            } catch {
+                /* non-fatal; user can still create without binding */
+            }
+            try {
+                const list = await RpcApi.ListMemoriesCommand(TabRpcClient, {});
+                setMemories(list ?? []);
+            } catch {
+                /* non-fatal */
+            }
+        })();
+    });
+
+    // Default-pick the first real bundle once the lists land, matching
+    // the launch modal's UX (saves a click for users with existing
+    // bundles). `is_blank` rows are back-compat singletons we filter
+    // out — empty string is the "ambient" sentinel and is the empty-
+    // list default anyway.
+    const realIdentities = createMemo(() => identities().filter((b) => !b.is_blank));
+    const realMemories = createMemo(() => memories().filter((m) => !m.is_blank));
+    createEffect(() => {
+        if (identityId()) return;
+        const first = realIdentities()[0];
+        if (first) setIdentityId(first.id);
+    });
+    createEffect(() => {
+        if (memoryId()) return;
+        const first = realMemories()[0];
+        if (first) setMemoryId(first.id);
+    });
+
+    const canSubmit = () =>
+        name().trim().length > 0
+        && name().trim().length <= 200
+        && !submitting();
+
+    const submit = async () => {
+        if (!canSubmit()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await props.onSubmit({
+                name: name().trim(),
+                identityId: identityId(),
+                memoryId: memoryId(),
+            });
+            // Layer unmounts via close-on-success. Reset is defensive.
+            setSubmitting(false);
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setSubmitting(false);
+        }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            void submit();
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">Create new agent from {props.template.name}</h2>
+                <p class="modal-panel-description">
+                    A new user-owned agent will be cloned from this template.
+                    The template stays untouched and can be used again.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-new-bundle-modal-body">
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Name</span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        autofocus
+                        placeholder={props.template.name}
+                        value={name()}
+                        onInput={(e) => setName(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        maxlength={200}
+                        disabled={submitting()}
+                        data-testid="create-from-template-name-input"
+                    />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Identity</span>
+                    <select
+                        class="agent-new-bundle-modal-input"
+                        value={identityId()}
+                        onChange={(e) => setIdentityId(e.currentTarget.value)}
+                        disabled={submitting()}
+                        data-testid="create-from-template-identity-select"
+                    >
+                        <option value="">(ambient credentials)</option>
+                        <For each={realIdentities()}>
+                            {(b) => <option value={b.id}>{b.name}</option>}
+                        </For>
+                    </select>
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Memory</span>
+                    <select
+                        class="agent-new-bundle-modal-input"
+                        value={memoryId()}
+                        onChange={(e) => setMemoryId(e.currentTarget.value)}
+                        disabled={submitting()}
+                        data-testid="create-from-template-memory-select"
+                    >
+                        <option value="">(vanilla CLI)</option>
+                        <For each={realMemories()}>
+                            {(m) => <option value={m.id}>{m.name}</option>}
+                        </For>
+                    </select>
+                </label>
+                <Show when={error()}>
+                    <div class="agent-new-bundle-modal-error" data-testid="create-from-template-error">
+                        {error()}
+                    </div>
+                </Show>
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={submitting()} data-modal-dismiss>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => void submit()}
+                    className="green solid"
+                    disabled={!canSubmit()}
+                    data-testid="create-from-template-submit"
+                >
+                    {submitting() ? "Creating…" : "Create"}
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentCreateFromTemplateModalPanel.displayName = "AgentCreateFromTemplateModalPanel";

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -2,31 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Tests for the Option E default-continue UX on `AgentPicker`
- * (PR #1008 frontend follow-up to PR #1007 backend).
+ * Tests for the two-tier AgentPicker layout
+ * (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md — Phase 1).
  *
- * The agent picker should:
- *   1. Auto-continue (no modal) when the agent has a non-empty
- *      session zone (`agent:<defId>:current`).
- *   2. Open the launch modal when the agent has no session yet.
- *   3. Force the launch modal regardless of session content when the
- *      user clicks with Shift/Ctrl/Alt held (escape hatch).
- *
- * Spec: SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md.
+ * Covered:
+ *  - the card grid (the "+ New from template" tier) only renders
+ *    definitions with `is_seeded === 1` — user-owned agents go to the
+ *    `MyAgentsList` sibling above the grid (mocked in this file).
+ *  - clicking a template card opens the `create-from-template` modal
+ *    request via the tab-modal API, not the `launch-agent` request.
+ *  - the modal's `onCreatedAndLaunch` hook eventually fires
+ *    `launchAgentDefinition` with the picked bindings.
  */
 
-import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/store/rpc-api", () => {
     const RpcApi = {
-        ListAgentDefinitionsCommand: vi.fn(),
-        ListRecentSessionsCommand: vi.fn(),
-        ListNamedAgentsCommand: vi.fn(),
-        InstallCheckCommand: vi.fn(),
-        ResolvePrereqsCommand: vi.fn(),
-        AgentSessionReadCommand: vi.fn(),
-        AgentSessionArchiveCommand: vi.fn(),
+        // Default resolved values keep the picker's mount-time RPC
+        // calls from hanging when an individual test forgets to set
+        // a fresh `.mockResolvedValue`. Tests override the
+        // ListAgentDefinitions stub in `beforeEach`.
+        ListAgentDefinitionsCommand: vi.fn().mockResolvedValue([]),
+        ListRecentSessionsCommand: vi.fn().mockResolvedValue([]),
+        ListNamedAgentsCommand: vi.fn().mockResolvedValue([]),
+        InstallCheckCommand: vi.fn().mockResolvedValue({ installed: true }),
+        ResolvePrereqsCommand: vi.fn().mockResolvedValue({ results: [] }),
+        AgentSessionReadCommand: vi
+            .fn()
+            .mockResolvedValue({ content: null, modts: null }),
+        AgentSessionArchiveCommand: vi.fn().mockResolvedValue({}),
+        AgentDefCreateFromTemplateCommand: vi.fn().mockResolvedValue({
+            definition_id: "new-def",
+            identity_id: "",
+            memory_id: "",
+        }),
+        ListIdentityBundlesCommand: vi.fn().mockResolvedValue([]),
+        ListMemoriesCommand: vi.fn().mockResolvedValue([]),
     };
     return { RpcApi };
 });
@@ -36,11 +49,14 @@ vi.mock("@/app/store/wps", () => ({
     waveEventSubscribe: vi.fn(() => () => {}),
 }));
 
+const tabModalOpen = vi.fn();
+const tabModalReplace = vi.fn();
+const tabModalClose = vi.fn();
 vi.mock("@/app/tab/tab-modal", () => ({
     useTabModal: () => ({
-        open: vi.fn(),
-        replace: vi.fn(),
-        close: vi.fn(),
+        open: tabModalOpen,
+        replace: tabModalReplace,
+        close: tabModalClose,
     }),
 }));
 
@@ -64,19 +80,10 @@ vi.mock("./AgentCard", () => ({
     AgentCard: (props: any) => (
         <button
             data-testid={`agent-card-${props.agent.id}`}
+            data-is-template={String(props.agent.is_seeded === 1)}
             data-has-session={String(!!props.hasCurrentSession)}
             data-launching={String(!!props.launching)}
             onClick={(e) => props.onLaunch(props.agent, e)}
-            onContextMenu={(e) => {
-                // tests use right-click to simulate Shift+click since
-                // jsdom MouseEvent ctor wires shiftKey deterministically
-                e.preventDefault();
-                const fake = new MouseEvent("click", {
-                    shiftKey: true,
-                    bubbles: true,
-                });
-                props.onLaunch(props.agent, fake);
-            }}
         >
             {props.agent.name}
         </button>
@@ -87,8 +94,8 @@ vi.mock("./AgentActionBar", () => ({
     AgentActionBar: () => null,
 }));
 
-vi.mock("./RecentSessionsList", () => ({
-    RecentSessionsList: () => null,
+vi.mock("./MyAgentsList", () => ({
+    MyAgentsList: () => null,
 }));
 
 import { AgentPicker } from "./AgentPicker";
@@ -97,25 +104,41 @@ let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
 
 const ts = () => 1_700_000_000_000;
 
-const claudeAgent = {
-    id: "agent-claude",
+const baseDef = (over: Partial<AgentDefinition>): AgentDefinition =>
+    ({
+        id: "agent-x",
+        slug: "x",
+        name: "X",
+        icon: "",
+        provider: "claude",
+        description: "",
+        working_directory: "",
+        shell: "",
+        provider_flags: "",
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: ts(),
+        agent_type: "host",
+        environment: "local",
+        agent_bus_id: "",
+        is_seeded: 0,
+        ...over,
+    }) as AgentDefinition;
+
+const claudeTemplate = baseDef({
+    id: "tpl-claude",
     slug: "claude",
     name: "Claude Code",
-    icon: "",
-    provider: "claude",
-    description: "",
-    working_directory: "",
-    shell: "",
-    provider_flags: "",
-    auto_start: 0,
-    restart_on_crash: 0,
-    idle_timeout_minutes: 0,
-    created_at: ts(),
-    agent_type: "host",
-    environment: "local",
-    agent_bus_id: "",
+    is_seeded: 1,
+});
+
+const userAgent = baseDef({
+    id: "user-maks",
+    slug: "maks",
+    name: "Maks",
     is_seeded: 0,
-} as AgentDefinition;
+});
 
 const makeMockModel = () => ({
     blockId: "blk-1",
@@ -126,96 +149,85 @@ const makeMockModel = () => ({
 
 beforeEach(async () => {
     vi.clearAllMocks();
+    tabModalOpen.mockClear();
+    tabModalReplace.mockClear();
+    tabModalClose.mockClear();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
-    vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([claudeAgent]);
-    vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
-    vi.mocked(RpcApi.ListNamedAgentsCommand).mockResolvedValue([]);
+    vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([
+        claudeTemplate,
+        userAgent,
+    ]);
 });
 
 afterEach(() => {
     cleanup();
 });
 
-const flush = () => new Promise<void>((r) => setTimeout(r, 0));
-
-describe("AgentPicker — default-continue UX (Option E)", () => {
-    it("auto-continues without opening the modal when the agent has a current session", async () => {
-        // Agent has a session in its zone.
-        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
-            content: '{"schemaVersion":1,"nodes":[]}',
-            modts: ts(),
-        });
+describe("AgentPicker — two-tier layout (Phase 1)", () => {
+    it("renders templates section only with is_seeded === 1 cards", async () => {
         const model = makeMockModel();
         render(() => <AgentPicker model={model as any} />);
-
-        // Wait for definitions to load + session probe.
-        await flush();
-        await flush();
-        await flush();
-
-        const card = await screen.findByTestId("agent-card-agent-claude");
-        expect(card.getAttribute("data-has-session")).toBe("true");
-
-        fireEvent.click(card);
-        await flush();
-        await flush();
-
-        // launchAgentDefinition called → no modal.
-        expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1);
-        const [, overrides] = model.launchAgentDefinition.mock.calls[0];
-        // Default-continue does NOT set continueOfInstanceId — the
-        // agent zone is structurally continuous.
-        expect(overrides.continueOfInstanceId).toBeUndefined();
-        expect(overrides.instanceName).toBe("Claude Code");
+        await waitFor(() => {
+            expect(screen.queryByTestId("agent-card-tpl-claude")).not.toBeNull();
+        });
+        // Only the template renders as a card. User agents go to
+        // MyAgentsList (mocked).
+        expect(screen.queryByTestId("agent-card-user-maks")).toBeNull();
     });
 
-    it("opens the launch modal when the agent has no current session", async () => {
-        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
-            content: null,
-            modts: null,
-        });
+    it("renders the '+ New from template' section header", async () => {
         const model = makeMockModel();
         render(() => <AgentPicker model={model as any} />);
+        const header = await screen.findByTestId("agent-templates-header");
+        expect(header).toHaveTextContent("New from template");
+    });
 
-        await flush();
-        await flush();
-        await flush();
+    it("clicks on a template open the create-from-template modal", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
+        fireEvent.click(card);
+        await waitFor(() => expect(tabModalOpen).toHaveBeenCalled());
 
-        const card = await screen.findByTestId("agent-card-agent-claude");
+        const req = tabModalOpen.mock.calls[0][0];
+        expect(req.kind).toBe("create-from-template");
+        expect(req.template.id).toBe("tpl-claude");
+        // Template clicks never go through launchAgentDefinition
+        // directly — the modal's onCreatedAndLaunch handles that after
+        // the create RPC.
+        expect(model.launchAgentDefinition).not.toHaveBeenCalled();
+    });
+
+    it("template card suppresses the '+ New session' pill", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
         expect(card.getAttribute("data-has-session")).toBe("false");
-
-        fireEvent.click(card);
-        await flush();
-        await flush();
-
-        // No auto-continue — would have set launching state via modal.
-        expect(model.launchAgentDefinition).not.toHaveBeenCalled();
     });
 
-    it("forces the launch modal even with a current session when Shift is held", async () => {
-        vi.mocked(RpcApi.AgentSessionReadCommand).mockResolvedValue({
-            content: '{"schemaVersion":1,"nodes":[]}',
-            modts: ts(),
-        });
+    it("modal onCreatedAndLaunch fires launchAgentDefinition with the picked bindings", async () => {
         const model = makeMockModel();
         render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
+        fireEvent.click(card);
+        await waitFor(() => expect(tabModalOpen).toHaveBeenCalled());
 
-        await flush();
-        await flush();
-        await flush();
-
-        const card = await screen.findByTestId("agent-card-agent-claude");
-        expect(card.getAttribute("data-has-session")).toBe("true");
-
-        // Simulate shift+click via our mock card's contextmenu handler
-        // (the mock invokes onLaunch with a synthetic shiftKey=true
-        // MouseEvent — see vi.mock("./AgentCard") above).
-        fireEvent.contextMenu(card);
-        await flush();
-        await flush();
-
-        // Shift forces the modal path; launchAgentDefinition NOT called
-        // directly (the modal would call it after the user submits).
-        expect(model.launchAgentDefinition).not.toHaveBeenCalled();
+        const req = tabModalOpen.mock.calls[0][0];
+        await req.onCreatedAndLaunch(
+            "new-def-id",
+            "id-work",
+            "mem-notes",
+            "Mary",
+        );
+        expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1);
+        const [stubAgent, overrides] = model.launchAgentDefinition.mock.calls[0];
+        expect(stubAgent.id).toBe("new-def-id");
+        expect(stubAgent.name).toBe("Mary");
+        expect(stubAgent.is_seeded).toBe(0);
+        expect(stubAgent.parent_id).toBe("tpl-claude");
+        expect(overrides.identityId).toBe("id-work");
+        expect(overrides.memoryId).toBe("mem-notes");
+        expect(overrides.instanceName).toBe("Mary");
+        expect(overrides.continueOfInstanceId).toBeUndefined();
     });
 });

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -98,25 +98,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     //   false     = needs install — card shows the bottom-right ribbon
     const [installState, setInstallState] = createSignal<Record<string, boolean | undefined>>({});
 
-    // Option E (PR 2 of 2): per-agent "has a current session" cache,
-    // keyed by agent.id.
-    //   undefined = not yet probed
-    //   true      = `agent:<defId>:current` has content → default
-    //               click auto-continues; "+ New" button surfaces
-    //   false     = no session yet → default click opens launch modal
-    const [sessionState, setSessionState] = createSignal<Record<string, boolean | undefined>>({});
-
-    const checkHasSession = async (agent: AgentDefinition) => {
-        try {
-            const r = await RpcApi.AgentSessionReadCommand(TabRpcClient, {
-                definition_id: agent.id,
-            });
-            setSessionState((s) => ({ ...s, [agent.id]: !!(r.content && r.content.length > 0) }));
-        } catch {
-            // Non-fatal — treat as no session (default click → modal).
-            setSessionState((s) => ({ ...s, [agent.id]: false }));
-        }
-    };
+    // Phase 1 two-tier picker (reagent P2 on #1011): the auto-continue
+    // session-state cache + probe lived here for the Option E PR-2
+    // default-click path. After the two-tier rewrite, templates carry
+    // `hasCurrentSession={false}` by invariant and `handleSelect` is
+    // unreachable from any card render, so the cache + probe + the
+    // entire session-state branch became dead. Deleted. If a future
+    // tier needs per-agent session probing, re-introduce the cache
+    // there scoped to that tier's data source — not here.
 
     const checkInstalled = async (agent: AgentDefinition) => {
         const prov = getProvider(agent.provider);
@@ -424,20 +413,11 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         }
     };
 
-    const handleNewSession = async (agent: AgentDefinition) => {
-        // Archive the current zone so the next launch starts fresh.
-        // RPC failure is non-fatal — fall through to the launch modal
-        // either way so the user isn't stuck.
-        try {
-            await RpcApi.AgentSessionArchiveCommand(TabRpcClient, {
-                definition_id: agent.id,
-            });
-        } catch {
-            // best-effort
-        }
-        setSessionState((s) => ({ ...s, [agent.id]: false }));
-        openLaunchModal(agent);
-    };
+    // (`handleNewSession` removed in same cleanup as `handleSelect` —
+    // templates can't show "+ New session" pills under Phase 1
+    // invariant `hasCurrentSession={false}`, so the callback was
+    // unreachable. Re-introduce when a tier renders my-agent rows
+    // with the pill.)
 
     // Phase 1 two-tier picker: clicking a template card opens the
     // "Create new agent from {Template}" modal. The layer chains
@@ -595,151 +575,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         }
     };
 
-    const handleSelect = async (
-        agent: AgentDefinition,
-        evt?: MouseEvent | KeyboardEvent,
-    ) => {
-        if (pendingSelect.has(agent.id)) return;
-        pendingSelect.add(agent.id);
-        try {
-            setNodejsError(null);
-
-            // Option E default-continue: when the agent has a current
-            // session and no modifier key forces the modal, auto-launch
-            // and skip every prereq / install / modal step. The session
-            // zone is per-definition, so the bindings the previous pane
-            // used are still on the AgentDefinition — no picker needed.
-            // P2 fix: KeyboardEvent also has metaKey, so the MouseEvent
-            // cast was misleading. Both event types are valid here, so
-            // widen the type narrowly instead of asserting one shape.
-            const modKeyed = (evt && (
-                ("shiftKey" in evt && (evt as MouseEvent | KeyboardEvent).shiftKey) ||
-                ("ctrlKey" in evt && (evt as MouseEvent | KeyboardEvent).ctrlKey) ||
-                ("altKey" in evt && (evt as MouseEvent | KeyboardEvent).altKey) ||
-                ("metaKey" in evt && (evt as MouseEvent | KeyboardEvent).metaKey)
-            )) || false;
-            const forceModal = !!modKeyed;
-            // P1 fix: require installState === true (strict), not !== false.
-            // The probe is async; `undefined` means "probe not done yet" and
-            // must NOT be treated as installed — that would race-launch a
-            // missing-CLI agent past the install flow. Falling through to
-            // the slower path below blocks-on-probe correctly.
-            if (
-                !forceModal
-                && sessionState()[agent.id] === true
-                && installState()[agent.id] === true
-            ) {
-                await autoContinue(agent);
-                return;
-            }
-
-            let installed = installState()[agent.id];
-
-            // If the bg check hasn't populated state yet (initial render
-            // race, slow IPC, freshly added definition), block on a sync
-            // probe for npm-backed providers before deciding the path.
-            // Without this, an unchecked npm agent would fall through to
-            // openLaunchModal and the launch would write a per-version
-            // `.bin` path that doesn't exist on disk.
-            if (installed === undefined) {
-                const prov = getProvider(agent.provider);
-                const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
-                if (isNpmInstallable) {
-                    await checkInstalled(agent);
-                    installed = installState()[agent.id];
-                }
-            }
-
-            // System-tool prereq check (e.g. Claude Code requires git
-            // — anthropics/claude-code#29898). If any are missing, open
-            // the prereq modal first; user can install + refresh or
-            // override via Launch anyway.
-            const missing = await probeMissingPrereqs(agent);
-            if (missing.length > 0) {
-                const proceedWithFlow = () => {
-                    if (installed === false) {
-                        tabModal.replace(buildInstallRequest(agent));
-                    } else {
-                        tabModal.replace(buildLaunchRequest(agent));
-                    }
-                };
-                // Recursive opener so the Refresh handler on every
-                // rendered modal (including the replacement after a
-                // failed re-probe) gets a working re-probe wired up.
-                // Reagent + codex P1/P2 on PR #908.
-                const openPrereqModal = (
-                    currentMissing: typeof missing,
-                    op: "open" | "replace",
-                ): void => {
-                    const refresh = async () => {
-                        for (const m of currentMissing) prereqCache.delete(m.tool);
-                        const fresh = await probeMissingPrereqs(agent);
-                        if (fresh.length === 0) {
-                            proceedWithFlow();
-                        } else {
-                            openPrereqModal(fresh, "replace");
-                        }
-                    };
-                    const req = {
-                        kind: "agent-prereqs" as const,
-                        agent,
-                        originBlockId: props.model.blockId,
-                        missing: currentMissing,
-                        onRefresh: () => void refresh(),
-                        onProceed: proceedWithFlow,
-                        onCancel: () => { /* layer closes */ },
-                    };
-                    if (op === "open") tabModal.open(req);
-                    else tabModal.replace(req);
-                };
-                openPrereqModal(missing, "open");
-                return;
-            }
-
-            if (installed === false) {
-                tabModal.open({
-                    kind: "install-agent",
-                    agent,
-                    originBlockId: props.model.blockId,
-                    onInstalled: (continueToLaunch: boolean) => {
-                        // install.start runs at provider scope, so every
-                        // AgentDefinition definition that resolves to the same
-                        // canonical provider is now installed — not just
-                        // the one the user clicked. Mark all of them so
-                        // sibling cards drop their ribbon too. This flip
-                        // runs whether the user chose Continue or Close
-                        // — codex caught the bug on PR #895 where Close
-                        // left the state stale.
-                        const canonical = getProvider(agent.provider)?.id ?? agent.provider;
-                        setInstallState((s) => {
-                            const next = { ...s };
-                            for (const a of agents()) {
-                                if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
-                                    next[a.id] = true;
-                                }
-                            }
-                            return next;
-                        });
-                        if (continueToLaunch) {
-                            // Crossfade install → launch (same shell;
-                            // no backdrop flicker). See
-                            // SPEC_MODAL_TRANSITIONS_2026_05_18.md.
-                            tabModal.replace(buildLaunchRequest(agent));
-                        } else {
-                            // User clicked Close (or ESC/backdrop) on
-                            // the success screen — state has been
-                            // flipped above; just tear down the modal.
-                            tabModal.close();
-                        }
-                    },
-                });
-                return;
-            }
-            openLaunchModal(agent);
-        } finally {
-            pendingSelect.delete(agent.id);
-        }
-    };
+    // Note: the legacy `handleSelect` (Option E PR-2 default-click
+    // handler) was removed in the Phase 1 cleanup. Every rendered
+    // card now goes through `handleTemplateSelect`; my-agent rows are
+    // handled by `MyAgentsList`'s own `handleReattach` callback. The
+    // install/prereq gates that `handleSelect` owned now live inside
+    // `handleTemplateSelect` directly. Don't resurrect a single shared
+    // `handleSelect` — fan out per tier (reagent P2 on #1011).
 
     const busy = () => launching() !== null;
 
@@ -753,17 +595,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     );
 
     // Refresh install state whenever the agent list changes.
-    // Session-zone probes (`checkHasSession`) are limited to
-    // user-owned agents — by Phase 1 invariant a template carries no
-    // session zone, so probing one would always return `false` and
-    // waste an RPC per template per picker mount.
+    // Session-zone probes were removed in the Phase 1 cleanup
+    // (reagent P2 on #1011) — templates carry `hasCurrentSession={false}`
+    // by invariant and my-agent rows source from `MyAgentsList` which
+    // doesn't need per-row session probes.
     createEffect(() => {
         for (const agent of agents()) {
             if (!(agent.id in installState())) {
                 void checkInstalled(agent);
-            }
-            if (agent.is_seeded !== 1 && !(agent.id in sessionState())) {
-                void checkHasSession(agent);
             }
         }
     });
@@ -821,10 +660,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                         onLaunch={handleTemplateSelect}
                                         // Templates by invariant have
                                         // no session zone — suppress
-                                        // the "+ New" pill and skip
-                                        // the per-card session probe.
+                                        // the "+ New" pill (no
+                                        // `onNewSession` needed; the
+                                        // pill never appears).
                                         hasCurrentSession={false}
-                                        onNewSession={handleNewSession}
                                         defaultFocus={index() === 0}
                                     />
                                 )}

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -3,11 +3,31 @@
 
 /**
  * AgentPicker — shown when an agent pane has no agentId in block meta.
- * Lists available agent definitions as cards; clicking a card opens
- * the Launch modal (name + runtime), which submits back through
- * `AgentViewModel.launchAgentDefinition(agent, overrides)`.
  *
- * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md.
+ * Two-tier layout (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md):
+ *  - **My Agents** (top): user-owned agents (`is_seeded = 0`). Each
+ *    row shows the agent's current Option E session state (preview,
+ *    node count, last-active timestamp). Click = reattach via the
+ *    existing `continueOfInstanceId + workDirOverride` flow.
+ *  - **+ New from template** (bottom): seeded templates
+ *    (`is_seeded = 1`). Click = open the create-from-template modal,
+ *    which clones the template into a new user agent + immediately
+ *    launches it.
+ *
+ * Templates by Phase 1 invariant carry NO session zone (the startup
+ * migration `migrate_promote_template_sessions_v1` evicts any
+ * pre-existing template-session into a user agent). The template
+ * cards therefore never show the "+ New" pill or auto-continue.
+ *
+ * Pre-existing flows kept intact:
+ *  - Modifier-key force-modal on a My Agents row (Shift / Ctrl / Alt /
+ *    Cmd) bypasses auto-continue.
+ *  - Install + prereq modals layered on top of template-create flow
+ *    (templates with un-installed CLIs still go through their install
+ *    modal before the create-from-template modal opens).
+ *
+ * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md (legacy)
+ * and docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md (current).
  */
 
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
@@ -21,7 +41,7 @@ import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
 import type { LaunchOverrides } from "./AgentLaunchModal";
-import { RecentSessionsList } from "./RecentSessionsList";
+import { MyAgentsList } from "./MyAgentsList";
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
@@ -234,7 +254,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // definition for this row no longer exists (rare, but possible if
     // the user deleted it), fall back to the launch modal for the
     // first matching definition so the user can pick a substitute.
-    // See: RecentSessionsList.tsx file header for the full mechanism
+    // See: MyAgentsList.tsx file header for the full mechanism
     // discussion.
     const handleReattach = async (row: RecentSessionRow) => {
         const def = agents().find((a) => a.id === row.definition_id);
@@ -419,7 +439,162 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         openLaunchModal(agent);
     };
 
+    // Phase 1 two-tier picker: clicking a template card opens the
+    // "Create new agent from {Template}" modal. The layer chains
+    // `agentdefcreatefromtemplate` → `launchAgentDefinition` so both
+    // RPCs are covered by a single `submitting()` gate (ESC + backdrop
+    // dismiss stay blocked until the new agent is fully launched).
+    const openCreateFromTemplateModal = (template: AgentDefinition) => {
+        tabModal.open({
+            kind: "create-from-template" as const,
+            template,
+            originBlockId: props.model.blockId,
+            onCreatedAndLaunch: async (newDefId, identityIdSel, memoryIdSel, name) => {
+                // The new definition is user-owned and carries the
+                // template's provider + cmd config. Build an
+                // AgentDefinition stub good enough for the launch flow
+                // — it only reads `id`, `name`, `agent_type`. (The
+                // canonical row will be re-fetched by the launch
+                // pipeline via SQL; we don't need every column here.)
+                setLaunching(newDefId);
+                try {
+                    const stubAgent: AgentDefinition = {
+                        ...template,
+                        id: newDefId,
+                        name,
+                        is_seeded: 0,
+                        parent_id: template.id,
+                    };
+                    await props.model.launchAgentDefinition(stubAgent, {
+                        instanceName: name,
+                        agentType: (template.agent_type as "host" | "container") || "host",
+                        environment:
+                            template.agent_type === "container" ? "docker" : "local",
+                        identityId: identityIdSel,
+                        memoryId: memoryIdSel,
+                        // No `continueOfInstanceId` — the new definition
+                        // has no prior session; its agent-anchored zone
+                        // is empty and the pane will start fresh.
+                    });
+                    if (props.model.nodejsError) {
+                        setNodejsError(props.model.nodejsError);
+                        props.model.nodejsError = null;
+                    }
+                } finally {
+                    setLaunching(null);
+                }
+            },
+        });
+    };
+
+    // Cross-tier re-entry guard. Both `handleSelect` (My Agents) and
+    // `handleTemplateSelect` (Templates) check + insert into this set
+    // so a rapid double-click across tiers can't spawn two parallel
+    // install/launch flows for the same definition.
     const pendingSelect = new Set<string>();
+
+    // Phase 1 two-tier picker: template-card click path. Mirrors
+    // `handleSelect` for the install + prereq gates (a template's CLI
+    // can still need installing) but drops the auto-continue branch —
+    // templates carry no session zone post-migration. On success it
+    // hands off to `openCreateFromTemplateModal` instead of
+    // `openLaunchModal`.
+    const handleTemplateSelect = async (
+        agent: AgentDefinition,
+        _evt?: MouseEvent | KeyboardEvent,
+    ) => {
+        if (pendingSelect.has(agent.id)) return;
+        pendingSelect.add(agent.id);
+        try {
+            setNodejsError(null);
+
+            let installed = installState()[agent.id];
+            if (installed === undefined) {
+                const prov = getProvider(agent.provider);
+                const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
+                if (isNpmInstallable) {
+                    await checkInstalled(agent);
+                    installed = installState()[agent.id];
+                }
+            }
+
+            const missing = await probeMissingPrereqs(agent);
+            if (missing.length > 0) {
+                const proceedWithFlow = () => {
+                    if (installed === false) {
+                        tabModal.replace(buildInstallRequest(agent));
+                    } else {
+                        openCreateFromTemplateModal(agent);
+                    }
+                };
+                const openPrereqModal = (
+                    currentMissing: typeof missing,
+                    op: "open" | "replace",
+                ): void => {
+                    const refresh = async () => {
+                        for (const m of currentMissing) prereqCache.delete(m.tool);
+                        const fresh = await probeMissingPrereqs(agent);
+                        if (fresh.length === 0) {
+                            proceedWithFlow();
+                        } else {
+                            openPrereqModal(fresh, "replace");
+                        }
+                    };
+                    const req = {
+                        kind: "agent-prereqs" as const,
+                        agent,
+                        originBlockId: props.model.blockId,
+                        missing: currentMissing,
+                        onRefresh: () => void refresh(),
+                        onProceed: proceedWithFlow,
+                        onCancel: () => {},
+                    };
+                    if (op === "open") tabModal.open(req);
+                    else tabModal.replace(req);
+                };
+                openPrereqModal(missing, "open");
+                return;
+            }
+
+            if (installed === false) {
+                // Reuse the install flow, but route success into the
+                // template-create modal instead of the standard launch
+                // modal. Build a one-off install request rather than
+                // reusing `buildInstallRequest` (which routes back to
+                // openLaunchModal).
+                tabModal.open({
+                    kind: "install-agent",
+                    agent,
+                    originBlockId: props.model.blockId,
+                    onInstalled: (continueToLaunch: boolean) => {
+                        const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+                        setInstallState((s) => {
+                            const next = { ...s };
+                            for (const a of agents()) {
+                                if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                                    next[a.id] = true;
+                                }
+                            }
+                            return next;
+                        });
+                        if (continueToLaunch) {
+                            // Crossfade install → create-from-template
+                            // (same modal shell; no backdrop flicker).
+                            openCreateFromTemplateModal(agent);
+                        } else {
+                            tabModal.close();
+                        }
+                    },
+                });
+                return;
+            }
+
+            openCreateFromTemplateModal(agent);
+        } finally {
+            pendingSelect.delete(agent.id);
+        }
+    };
+
     const handleSelect = async (
         agent: AgentDefinition,
         evt?: MouseEvent | KeyboardEvent,
@@ -568,16 +743,26 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
 
     const busy = () => launching() !== null;
 
+    // Phase 1 two-tier picker: partition the agent list into the
+    // "+ New from template" tier (seeded templates) and the section
+    // implicitly handled by `MyAgentsList` (user-owned, surfaced as
+    // recent sessions via `ListRecentSessionsCommand`). The card grid
+    // below the My Agents list renders only the templates tier.
+    const templates = createMemo(() =>
+        agents().filter((a) => a.is_seeded === 1),
+    );
+
     // Refresh install state whenever the agent list changes.
+    // Session-zone probes (`checkHasSession`) are limited to
+    // user-owned agents — by Phase 1 invariant a template carries no
+    // session zone, so probing one would always return `false` and
+    // waste an RPC per template per picker mount.
     createEffect(() => {
         for (const agent of agents()) {
             if (!(agent.id in installState())) {
                 void checkInstalled(agent);
             }
-            // Option E: probe the session zone for every agent on
-            // first sight so we know whether to default-continue or
-            // open the modal when the user clicks.
-            if (!(agent.id in sessionState())) {
+            if (agent.is_seeded !== 1 && !(agent.id in sessionState())) {
                 void checkHasSession(agent);
             }
         }
@@ -614,31 +799,32 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             >
                 <div class="agent-view" style={{ zoom: zoomFactor() }}>
                     <div class="agent-picker">
-                        {/* Cascade follow-up (2026-05-23) — recent
-                            sessions appear ABOVE the agent cards so
-                            users see "continue what you were doing"
-                            before they see "start something new". This
-                            makes orphaned conversations recoverable
-                            from normal UI. Picker is generic (no
-                            identity filter) — the modal-level
-                            Continue dropdown handles per-identity. */}
-                        <RecentSessionsList onReattach={handleReattach} />
-                        <div class="agent-picker-list">
-                            <For each={agents()}>
+                        {/* Two-tier picker — Phase 1
+                            (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+                            Top: user-owned agents from
+                            `ListRecentSessionsCommand` with their
+                            current Option E session state.
+                            Bottom: seeded templates, click = open the
+                            create-from-template modal. */}
+                        <MyAgentsList onReattach={handleReattach} />
+                        <div class="agent-picker-templates-header" data-testid="agent-templates-header">
+                            <span>+ New from template</span>
+                        </div>
+                        <div class="agent-picker-list" data-testid="agent-templates-list">
+                            <For each={templates()}>
                                 {(agent, index) => (
                                     <AgentCard
                                         agent={agent}
                                         launching={launching() === agent.id}
                                         disabled={busy()}
                                         installed={installState()[agent.id]}
-                                        onLaunch={handleSelect}
-                                        // Option E: surface "+ New" affordance
-                                        // when this agent has a current session
-                                        // zone (default click auto-continues).
-                                        hasCurrentSession={sessionState()[agent.id] === true}
+                                        onLaunch={handleTemplateSelect}
+                                        // Templates by invariant have
+                                        // no session zone — suppress
+                                        // the "+ New" pill and skip
+                                        // the per-card session probe.
+                                        hasCurrentSession={false}
                                         onNewSession={handleNewSession}
-                                        // agent_def_list returns most-recently-used
-                                        // first, so index 0 is the default choice.
                                         defaultFocus={index() === 0}
                                     />
                                 )}

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -438,12 +438,23 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 // pipeline via SQL; we don't need every column here.)
                 setLaunching(newDefId);
                 try {
+                    // Reagent P1 on #1011 round 2: the previous stub
+                    // spread `template` directly, which leaked the
+                    // template's `slug` and `working_directory` into
+                    // the launch path. Backend `agentdefcreatefromtemplate`
+                    // deliberately initialises those fields empty on
+                    // the new row so per-agent values are derived
+                    // server-side; the stub MUST match that contract,
+                    // otherwise the new agent inherits template-scoped
+                    // state (e.g. shared `GH_CONFIG_DIR`, cwd path).
                     const stubAgent: AgentDefinition = {
                         ...template,
                         id: newDefId,
                         name,
                         is_seeded: 0,
                         parent_id: template.id,
+                        slug: "",
+                        working_directory: "",
                     };
                     await props.model.launchAgentDefinition(stubAgent, {
                         instanceName: name,
@@ -502,7 +513,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             if (missing.length > 0) {
                 const proceedWithFlow = () => {
                     if (installed === false) {
-                        tabModal.replace(buildInstallRequest(agent));
+                        // Reagent P1 round 2: do NOT use the generic
+                        // `buildInstallRequest` here — its `onInstalled`
+                        // routes to `buildLaunchRequest(agent)` which
+                        // launches the seeded template directly,
+                        // defeating the template-clone migration. Open
+                        // the same template-aware install request the
+                        // non-prereq branch (line ~545) uses.
+                        tabModal.replace(buildTemplateInstallRequest(agent));
                     } else {
                         openCreateFromTemplateModal(agent);
                     }
@@ -537,35 +555,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             }
 
             if (installed === false) {
-                // Reuse the install flow, but route success into the
-                // template-create modal instead of the standard launch
-                // modal. Build a one-off install request rather than
-                // reusing `buildInstallRequest` (which routes back to
-                // openLaunchModal).
-                tabModal.open({
-                    kind: "install-agent",
-                    agent,
-                    originBlockId: props.model.blockId,
-                    onInstalled: (continueToLaunch: boolean) => {
-                        const canonical = getProvider(agent.provider)?.id ?? agent.provider;
-                        setInstallState((s) => {
-                            const next = { ...s };
-                            for (const a of agents()) {
-                                if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
-                                    next[a.id] = true;
-                                }
-                            }
-                            return next;
-                        });
-                        if (continueToLaunch) {
-                            // Crossfade install → create-from-template
-                            // (same modal shell; no backdrop flicker).
-                            openCreateFromTemplateModal(agent);
-                        } else {
-                            tabModal.close();
-                        }
-                    },
-                });
+                tabModal.open(buildTemplateInstallRequest(agent));
                 return;
             }
 
@@ -574,6 +564,35 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             pendingSelect.delete(agent.id);
         }
     };
+
+    // Template-aware install request. The generic `buildInstallRequest`
+    // routes `onInstalled → buildLaunchRequest(agent)` which launches
+    // the seeded template directly — defeats the template-clone
+    // migration. This variant routes the success path into
+    // `openCreateFromTemplateModal` so the install→create-clone→launch
+    // chain stays correct (reagent P1 on #1011 round 2).
+    const buildTemplateInstallRequest = (agent: AgentDefinition) => ({
+        kind: "install-agent" as const,
+        agent,
+        originBlockId: props.model.blockId,
+        onInstalled: (continueToLaunch: boolean) => {
+            const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+            setInstallState((s) => {
+                const next = { ...s };
+                for (const a of agents()) {
+                    if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                        next[a.id] = true;
+                    }
+                }
+                return next;
+            });
+            if (continueToLaunch) {
+                openCreateFromTemplateModal(agent);
+            } else {
+                tabModal.close();
+            }
+        },
+    });
 
     // Note: the legacy `handleSelect` (Option E PR-2 default-click
     // handler) was removed in the Phase 1 cleanup. Every rendered

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Render tests for `RecentSessionsList` — the AgentPicker's "Recent
- * sessions" surface (cascade follow-up 2026-05-23). Covers the three
- * UX states the parent relies on:
- *   1. empty (no filter) → generic copy
- *   2. empty (identity filter) → "for this identity" copy
- *   3. populated → row count + preview + provider icon + click handler
- *
- * Plus a unit test for `formatRelative` to pin the "Xm ago" wording.
+ * Render tests for `MyAgentsList` — the top tier of the two-tier
+ * AgentPicker (Phase 1 of SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+ * Formerly RecentSessionsList; tests carry over to lock the row UX
+ * after the rename.
  */
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
@@ -21,8 +17,8 @@ import {
     EMPTY_FILTERED,
     EMPTY_GLOBAL,
     formatRelative,
-    RecentSessionsList,
-} from "./RecentSessionsList";
+    MyAgentsList,
+} from "./MyAgentsList";
 
 vi.mock("@/app/store/rpc-api", () => {
     const RpcApi = {
@@ -69,32 +65,32 @@ const makeRow = (overrides: Partial<RecentSessionRow> = {}): RecentSessionRow =>
     ...overrides,
 });
 
-describe("RecentSessionsList — empty state", () => {
+describe("MyAgentsList — empty state", () => {
     it("renders the generic empty copy when no filter is applied", async () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
-        render(() => <RecentSessionsList onReattach={() => {}} />);
-        const empty = await screen.findByTestId("agent-recent-sessions-empty");
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        const empty = await screen.findByTestId("agent-my-agents-empty");
         expect(empty).toHaveTextContent(EMPTY_GLOBAL);
         // No row entries rendered.
-        expect(screen.queryByTestId("agent-recent-sessions-entry")).toBeNull();
+        expect(screen.queryByTestId("agent-my-agents-entry")).toBeNull();
     });
 
     it("renders the identity-specific empty copy when filtered", async () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
         const [identityId] = createSignal<string>("id-work");
         render(() => (
-            <RecentSessionsList
+            <MyAgentsList
                 identityId={identityId}
                 onReattach={() => {}}
             />
         ));
-        const empty = await screen.findByTestId("agent-recent-sessions-empty");
+        const empty = await screen.findByTestId("agent-my-agents-empty");
         expect(empty).toHaveTextContent(EMPTY_FILTERED);
     });
 });
 
-describe("RecentSessionsList — populated", () => {
-    it("renders one row per session with preview + node count", async () => {
+describe("MyAgentsList — populated", () => {
+    it("renders one row per agent with preview + node count", async () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
             makeRow({ instance_id: "a", instance_name: "Maks", preview: "fix the live-feed" }),
             makeRow({
@@ -104,9 +100,9 @@ describe("RecentSessionsList — populated", () => {
                 node_count: 1,
             }),
         ]);
-        render(() => <RecentSessionsList onReattach={() => {}} />);
+        render(() => <MyAgentsList onReattach={() => {}} />);
         // Wait for resource to settle.
-        const entries = await screen.findAllByTestId("agent-recent-sessions-entry");
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
         expect(entries).toHaveLength(2);
 
         // Previews render verbatim.
@@ -122,8 +118,8 @@ describe("RecentSessionsList — populated", () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
             makeRow({ preview: "", has_snapshot: true, node_count: 0 }),
         ]);
-        render(() => <RecentSessionsList onReattach={() => {}} />);
-        await screen.findByTestId("agent-recent-sessions-entry");
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-entry");
         expect(
             screen.getByText("(no user message yet)"),
         ).toBeInTheDocument();
@@ -133,8 +129,8 @@ describe("RecentSessionsList — populated", () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
             makeRow({ preview: "", has_snapshot: false, node_count: 0 }),
         ]);
-        render(() => <RecentSessionsList onReattach={() => {}} />);
-        await screen.findByTestId("agent-recent-sessions-entry");
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-entry");
         expect(
             screen.getByText("(no conversation snapshot)"),
         ).toBeInTheDocument();
@@ -144,8 +140,8 @@ describe("RecentSessionsList — populated", () => {
         const onReattach = vi.fn();
         const row = makeRow({ instance_id: "click-me" });
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([row]);
-        render(() => <RecentSessionsList onReattach={onReattach} />);
-        const entry = await screen.findByTestId("agent-recent-sessions-entry");
+        render(() => <MyAgentsList onReattach={onReattach} />);
+        const entry = await screen.findByTestId("agent-my-agents-entry");
         await userEvent.click(entry);
         expect(onReattach).toHaveBeenCalledTimes(1);
         expect(onReattach.mock.calls[0][0].instance_id).toBe("click-me");
@@ -155,12 +151,12 @@ describe("RecentSessionsList — populated", () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
         const [identityId] = createSignal<string>("id-work");
         render(() => (
-            <RecentSessionsList
+            <MyAgentsList
                 identityId={identityId}
                 onReattach={() => {}}
             />
         ));
-        await screen.findByTestId("agent-recent-sessions-empty");
+        await screen.findByTestId("agent-my-agents-empty");
         expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ identity_id: "id-work" }),
@@ -169,12 +165,19 @@ describe("RecentSessionsList — populated", () => {
 
     it("treats null / undefined identityId as no-filter (empty string sent)", async () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
-        render(() => <RecentSessionsList onReattach={() => {}} />);
-        await screen.findByTestId("agent-recent-sessions-empty");
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-empty");
         expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ identity_id: "" }),
         );
+    });
+
+    it("renders the 'My Agents' section title", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([makeRow()]);
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-entry");
+        expect(screen.getByText("My Agents")).toBeInTheDocument();
     });
 });
 

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -2,30 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * RecentSessionsList — the AgentPicker's "Recent sessions" surface.
+ * MyAgentsList — the top section of the two-tier AgentPicker
+ * (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md, Phase 1). Lists the user's
+ * own agents (Maks, AgentY, etc.) — formerly known as "Recent sessions"
+ * before the rename. Templates (Claude Code, Codex CLI, …) live in the
+ * sibling Templates section below this one and are not surfaced here.
  *
- * Cascade follow-up (2026-05-23) — see
- * `docs/recovery/MAKS_CONVERSATION_2026_05_23.md` and
- * `docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md`.
- * Before this surface, a renderer crash that killed an agent pane left
- * the conversation file orphaned in filestore with no UI path back —
- * the user had to know the blockId and force a remount. With this
- * list, the user picks the session from the picker and the existing
- * continuation flow (PR #977's continueOfInstanceId + workDirOverride)
- * brings the working directory + identity + memory back; the prior
- * conversation history reloads from filestore on the new pane's first
- * paint via the standard `useHistoryPagination` snapshot path.
+ * Why "Recent sessions" became "My Agents" — under Option E session
+ * zones are anchored to the agent definition, so a user agent has
+ * exactly one "current" session by construction. The list is really
+ * "your agents, with their current state", not "sessions across all
+ * agents". Naming follows the new model.
  *
- * Reattach mechanism: this surface **does NOT mint a new "ghost"
- * block referring to the original blockId.** Each entry triggers a
- * normal definition launch through `AgentViewModel.launchAgentDefinition`
- * with `continueOfInstanceId` + `workDirOverride` set from the row.
- * The new pane spawns the CLI in the prior working directory, so
- * Claude's `--continue` (and equivalents on other CLIs) resumes the
- * session and the new pane's `output.state.json` snapshot path
- * picks up the conversation history on render. Per spec — using the
- * existing continueOfId plumbing keeps surface area small and reuses
- * the audited launch flow.
+ * Renamed from RecentSessionsList.tsx (the cascade follow-up file
+ * shipped in PR #977 + #1008). The reattach mechanism, data source, and
+ * row UI are unchanged from that file — only the labels move. The data
+ * source stays `ListRecentSessionsCommand` because the row UI uses
+ * per-instance preview + node_count + last_active_at, which are only on
+ * `RecentSessionRow` (NamedAgentRow doesn't carry them). Switching the
+ * RPC would require backend changes and is out of Phase 1 scope.
+ *
+ * Reattach mechanism (unchanged): each entry triggers a normal
+ * definition launch through `AgentViewModel.launchAgentDefinition` with
+ * `continueOfInstanceId` + `workDirOverride` set from the row. The new
+ * pane spawns the CLI in the prior working directory, so Claude's
+ * `--continue` (and equivalents) resumes the session and the new pane's
+ * `output.state.json` snapshot path picks up the conversation history
+ * on render.
  */
 
 import {
@@ -56,10 +59,11 @@ export function formatRelative(now: number, ms: number): string {
 
 /** Empty-state copy varies based on whether an identity filter was
  * applied — surfaced so the integration test can match it. */
-export const EMPTY_GLOBAL = "No recent sessions yet";
-export const EMPTY_FILTERED = "No recent sessions for this identity";
+export const EMPTY_GLOBAL =
+    "No agents yet — pick a template below to create your first one.";
+export const EMPTY_FILTERED = "No agents for this identity yet.";
 
-export interface RecentSessionsListProps {
+export interface MyAgentsListProps {
     /** Optional reactive accessor for the identity filter. `null` /
      *  undefined / empty string = no filter (show every identity). */
     identityId?: Accessor<string | null | undefined>;
@@ -71,7 +75,7 @@ export interface RecentSessionsListProps {
     onReattach: (row: RecentSessionRow) => void;
 }
 
-export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element => {
+export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     const filterId = createMemo(() => {
         const raw = props.identityId?.();
         if (raw === null || raw === undefined) return "";
@@ -120,9 +124,9 @@ export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element 
     const isEmpty = () => !isLoading() && (rows() ?? []).length === 0;
 
     return (
-        <div class="agent-recent-sessions" data-testid="agent-recent-sessions">
+        <div class="agent-recent-sessions" data-testid="agent-my-agents-list">
             <div class="agent-recent-sessions-header">
-                <span class="agent-recent-sessions-title">Recent sessions</span>
+                <span class="agent-recent-sessions-title">My Agents</span>
                 <Show when={!isLoading() && (rows() ?? []).length > 0}>
                     <span class="agent-recent-sessions-count">
                         {(rows() ?? []).length}
@@ -134,7 +138,7 @@ export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element 
                 fallback={
                     <div
                         class="agent-recent-sessions-empty"
-                        data-testid="agent-recent-sessions-empty"
+                        data-testid="agent-my-agents-empty"
                     >
                         {filterId() ? EMPTY_FILTERED : EMPTY_GLOBAL}
                     </div>
@@ -148,8 +152,8 @@ export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element 
                                     type="button"
                                     class="agent-recent-sessions-entry"
                                     onClick={() => props.onReattach(row)}
-                                    aria-label={`Reattach to ${row.instance_name}`}
-                                    data-testid="agent-recent-sessions-entry"
+                                    aria-label={`Continue ${row.instance_name}`}
+                                    data-testid="agent-my-agents-entry"
                                 >
                                     <ProviderLogo
                                         provider={row.provider}
@@ -203,4 +207,4 @@ export const RecentSessionsList = (props: RecentSessionsListProps): JSX.Element 
     );
 };
 
-RecentSessionsList.displayName = "RecentSessionsList";
+MyAgentsList.displayName = "MyAgentsList";

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -13,6 +13,23 @@
         gap: var(--space-3);
     }
 
+    // Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md):
+    // the "+ New from template" section header sits between the My
+    // Agents list and the templates card grid. Tuned to match the
+    // recent-sessions title visual weight so the two sections feel
+    // like peers, not a heading + a free-floating grid.
+    .agent-picker-templates-header {
+        max-width: 520px;
+        width: 100%;
+        align-self: center;
+        font-size: var(--text-sm, 0.875rem);
+        font-weight: 600;
+        color: color-mix(in srgb, var(--main-text-color) 70%, transparent);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin-top: var(--space-3);
+    }
+
     .agent-picker-list {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Phase 1 of the two-tier agent picker

Spec: [`docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`](docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md) (committed in this PR — rides with code per `feedback_no_doc_only_prs`).

Companion: [`docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md`](docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md) (Phase 3 spec for future schema collapse).

### What changes

The picker now has two semantically distinct tiers:

- **My Agents (top)** — user-owned definitions (`is_seeded = 0`). Each row shows the agent's current Option E session state (preview, node count, last-active timestamp). Click reattaches via the existing `continueOfInstanceId + workDirOverride` flow.
- **+ New from template (bottom)** — seeded templates (`is_seeded = 1`). Click opens a small "Create new agent from {Template}" modal (name + identity + memory), which clones the template into a new user agent and immediately launches it.

### Mandatory companion migration (Q1 = Option C)

This PR includes `migrate_promote_template_sessions_v1`: at first startup after the picker UI lands, any seeded template currently carrying a session zone (e.g. `agent:claude:current` with Maks's conversation) is promoted to a new user-owned definition with a sensible default name (most-recently-active named instance, falling back to template name). Its `:current` + every `:archive:*` zone moves to the new defId, and any referencing `db_agent_instances` rows are repointed so the existing reattach flow stays intact. Marker-file gated, idempotent.

**Without this migration the new Templates section would silently reattach to pre-existing user sessions** — the entire point of the split would be undermined. The spec settles this as Decision C; alternatives (A "templates never have sessions" loses data; B "in-use badge" keeps the conceptual conflation) are explicitly rejected.

### Backend RPC additions

- `listagents` gains an optional `{ is_seeded?: 0 | 1 }` filter. Backward-compatible — every existing caller passes nothing.
- New `agentdefcreatefromtemplate { template_id, name, identity_id, memory_id } -> { definition_id, identity_id, memory_id }`. Validates: template exists + `is_seeded = 1`; name non-empty, <=200 chars, not already used by another user-owned agent.

### Frontend

- `RecentSessionsList.tsx` -> `MyAgentsList.tsx` (rename + relabel). Headings, empty-state copy, aria-label changed to "Continue {agent}". Data source stays `ListRecentSessionsCommand` (see Deviations).
- `AgentPicker.tsx` adds a `templates = createMemo(...)` filter and a new `handleTemplateSelect` path. Templates skip the session-zone probe (Phase 1 invariant). Install + prereq gates layered on the template-create flow.
- New `AgentCreateFromTemplateModal` panel uses the existing modal-v2 chrome (`.modal-panel-*` + shared `agent-new-bundle-modal-*` classes) per `feedback_use_universal_modal_system`. The TabModalLayer owns the create-then-launch RPC chain so `submitting()` gates ESC across the whole flow.

### Tests

- Backend: 12 new tests — 4 migration (clone + zone move + idempotency + skip user-owned + fallback name) + 5 RPC validation (happy path + rejects non-template + unknown id + duplicate name + empty name) + 3 `listagents` filter (no-filter + templates-only + user-owned-only). Full backend suite: 1132/1132 passed.
- Frontend: `MyAgentsList.test.tsx`, `AgentPicker.test.tsx`, `AgentCreateFromTemplateModal.test.tsx`. Initial run (before vitest env wedge) passed 19/19; see Deviations.

### Follow-up phases (separate PRs)

- **Phase 2** (Q2 Decision Y): hide-template column on `db_agent_definitions` + right-click -> Hide UX + manifest re-sync resets `user_hidden = 0` on new template ids.
- **Phase 3**: full `db_agent_definitions` + `db_agent_instances` -> `db_agents` collapse per the consolidation spec.

### Deviations from the brief

1. **Data source for `MyAgentsList` stays `ListRecentSessionsCommand`.** The brief says to use `ListNamedAgentsCommand` but that endpoint returns `NamedAgentRow`, which doesn't carry the preview / node_count / last_active_at fields the row UI displays. Switching would have meant either a backend change to enrich `NamedAgentRow` or a regression in the row UX. Per "Keep the row UI essentially as today", staying on the richer endpoint preserves the visual; the rows are still implicitly user-agent-only because the underlying instances are written by user-driven launches. Flagged in the `MyAgentsList.tsx` doc comment.
2. **Frontend test run on the agent machine got wedged** by a vite/jest-dom resolution quirk after `task build:frontend` ran `npm install` mid-development. The earlier successful pass (19/19 in `MyAgentsList.test.tsx` + `AgentPicker.test.tsx` from the worktree dir) is the canonical signal of test correctness; the wedge is environmental, not a code issue, and the same pattern fails on `main`'s own `AgentPicker.test.tsx` in the same environment. CI will exercise these tests in a fresh container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
