### PR TITLE
feat(picker): hide templates (Phase 2 — Q2 Decision Y)

### DIFF
--- a/.changesets/1779599329-feat-picker-hide-templates-cdxo.md
+++ b/.changesets/1779599329-feat-picker-hide-templates-cdxo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(picker): hide templates

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -164,6 +164,11 @@ pub fn seed_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreError> {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: now,
+            // First seeding always lands templates visible. Phase 2
+            // user_hidden is set by `agent_def_set_hidden` after the
+            // user explicitly hides; new template ids in re-seed are
+            // force-reset to 0 below (see `reseed_if_needed`).
+            user_hidden: 0,
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -336,6 +341,13 @@ fn reseed_if_needed(
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: now,
+            // Newly-added template ids start visible (overwritten below
+            // when the row already exists). Phase 2 of the two-tier
+            // picker spec (Q2 Decision Y) requires NEW template ids
+            // surface once even if a same-named template was previously
+            // hidden — the `else` branch below honours that by lining
+            // up against existing ids only.
+            user_hidden: 0,
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -354,6 +366,12 @@ fn reseed_if_needed(
             agent.restart_on_crash = existing_agent.restart_on_crash;
             agent.created_at = existing_agent.created_at;
             agent.accounts = existing_agent.accounts.clone();
+            // Phase 2: preserve the user's hide preference across a
+            // manifest re-sync for templates that already exist on disk
+            // (the user may have explicitly hidden this one). The
+            // newly-added branch below keeps user_hidden = 0 so a never-
+            // before-seen template id always surfaces at least once.
+            agent.user_hidden = existing_agent.user_hidden;
             wstore.agent_def_update(&mut agent)?;
             updated += 1;
         } else {
@@ -372,4 +390,121 @@ fn reseed_if_needed(
     }
 
     Ok(Some(ReseedReport { created, updated, removed }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::wstore::{AgentDefinition, WaveStore};
+
+    /// Helper to build a manifest in-memory with a fixed set of agents.
+    /// `reseed_if_needed` reads `manifest.agents`; we construct the
+    /// struct directly so the test doesn't have to round-trip JSON.
+    fn manifest_with(ids_and_descriptions: &[(&str, &str)]) -> SeedManifest {
+        SeedManifest {
+            version: 999,
+            agents: ids_and_descriptions
+                .iter()
+                .map(|(id, desc)| SeedAgent {
+                    id: id.to_string(),
+                    name: id.to_string(),
+                    icon: default_icon(),
+                    provider: default_provider(),
+                    agent_type: default_agent_type(),
+                    environment: default_environment(),
+                    description: desc.to_string(),
+                    working_directory: String::new(),
+                    shell: String::new(),
+                    agent_bus_id: String::new(),
+                    auto_start: false,
+                    restart_on_crash: false,
+                    content: SeedContent::default(),
+                    skills: Vec::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn insert_tpl(wstore: &Arc<WaveStore>, id: &str, name: &str, hidden: i64) {
+        let mut def = AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: name.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: "v1 desc".to_string(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 1,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+            user_hidden: hidden,
+        };
+        wstore.agent_def_insert(&mut def).unwrap();
+    }
+
+    #[test]
+    fn reseed_preserves_user_hidden_on_existing_templates() {
+        // The user previously hid `tpl-claude`. A description-only
+        // manifest change triggers a re-seed; the user's hide preference
+        // MUST survive (it's a per-user UI flag, not manifest-managed).
+        let wstore = Arc::new(WaveStore::open_in_memory().unwrap());
+        insert_tpl(&wstore, "tpl-claude", "Claude", 1);
+        // Manifest carries a *different* description so reseed_if_needed
+        // sees a change and runs the upsert path.
+        let manifest = manifest_with(&[("tpl-claude", "v2 desc")]);
+
+        let report = reseed_if_needed(&wstore, &manifest)
+            .expect("reseed succeeds")
+            .expect("reseed runs because description changed");
+        assert_eq!(report.created, 0);
+        assert_eq!(report.updated, 1);
+
+        let after = wstore.agent_def_list().unwrap();
+        let tpl = after.iter().find(|a| a.id == "tpl-claude").unwrap();
+        assert_eq!(tpl.user_hidden, 1, "hide preference must survive reseed");
+        assert_eq!(tpl.description, "v2 desc", "description must update");
+    }
+
+    #[test]
+    fn reseed_resets_user_hidden_on_newly_added_template_id() {
+        // The user previously hid `tpl-claude`. A manifest update
+        // introduces a brand-new id `tpl-codex`. The new id MUST land
+        // with user_hidden = 0 — Phase 2 spec invariant so users always
+        // see new templates at least once.
+        let wstore = Arc::new(WaveStore::open_in_memory().unwrap());
+        insert_tpl(&wstore, "tpl-claude", "Claude", 1);
+        let manifest = manifest_with(&[
+            ("tpl-claude", "v1 desc"), // unchanged — won't fire upsert on its own
+            ("tpl-codex", "Codex CLI"),  // NEW id — forces reseed
+        ]);
+
+        let report = reseed_if_needed(&wstore, &manifest)
+            .expect("reseed succeeds")
+            .expect("reseed runs because tpl-codex is new");
+        assert!(report.created >= 1, "tpl-codex should be inserted");
+
+        let after = wstore.agent_def_list().unwrap();
+        let codex = after
+            .iter()
+            .find(|a| a.id == "tpl-codex")
+            .expect("tpl-codex should now exist");
+        assert_eq!(
+            codex.user_hidden, 0,
+            "newly-added template must start visible (Phase 2 spec invariant)",
+        );
+        // And the previously-hidden one stays hidden.
+        let claude = after.iter().find(|a| a.id == "tpl-claude").unwrap();
+        assert_eq!(claude.user_hidden, 1);
+    }
 }

--- a/agentmux-srv/src/backend/agent_session.rs
+++ b/agentmux-srv/src/backend/agent_session.rs
@@ -823,6 +823,7 @@ pub fn migrate_promote_template_sessions_v1(
             parent_id: template.id.clone(),
             branch_label: String::new(),
             updated_at: now,
+            user_hidden: 0,
         };
         if let Err(e) = wstore.agent_def_insert(&mut new_def) {
             tracing::warn!(
@@ -1320,6 +1321,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
+            user_hidden: 0,
         };
         wstore.agent_def_insert(&mut def).unwrap();
         def
@@ -1498,6 +1500,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
+            user_hidden: 0,
         };
         wstore.agent_def_insert(&mut user_def).unwrap();
         write_session_state(&filestore, &user_def.id, br#"{"nodes":[]}"#).unwrap();

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -351,6 +351,25 @@ pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
 /// launch. Rejects non-template ids + duplicate user-agent names.
 pub const COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE: &str = "agentdefcreatefromtemplate";
 
+/// Two-tier picker (Phase 2 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
+/// Q2 Decision Y). Set the `user_hidden` flag on a seeded template so
+/// it disappears from the default `+ New from template` list. Idempotent;
+/// rejects user-owned (`is_seeded = 0`) definitions — those use
+/// `deleteagent` instead. Manifest re-sync resets `user_hidden = 0` for
+/// any newly-added template id so fresh templates always surface once.
+pub const COMMAND_AGENT_DEF_HIDE: &str = "agentdefhide";
+/// Two-tier picker (Phase 2). Inverse of `agentdefhide` — set
+/// `user_hidden = 0` so a previously-hidden template reappears in the
+/// picker's templates tier. Powers the settings "Hidden templates"
+/// unhide affordance. Same validation as hide.
+pub const COMMAND_AGENT_DEF_UNHIDE: &str = "agentdefunhide";
+/// Two-tier picker (Phase 2). Return only the hidden templates
+/// (`is_seeded = 1 AND user_hidden = 1`). Backs the settings UI's
+/// list of templates the user can unhide. The picker proper never
+/// calls this — it uses `listagents` (which excludes hidden rows
+/// by default).
+pub const COMMAND_AGENT_DEF_LIST_HIDDEN_TEMPLATES: &str = "agentdeflisthiddentemplates";
+
 // Drone pane (v8 — issue #753 Phase 1)
 pub const COMMAND_LIST_DRONES: &str = "listdrones";
 pub const COMMAND_GET_DRONE: &str = "getdrone";
@@ -1306,10 +1325,19 @@ fn is_zero_usize(v: &usize) -> bool {
 /// Absent / `None` = no filter — backward-compatible with callers
 /// that pass `{}` or `null`. Phase 1 of the two-tier picker
 /// (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
+///
+/// `include_hidden` (Phase 2 — Q2 Decision Y): when `false` (default),
+/// templates with `user_hidden = 1` are filtered out. The settings
+/// "Hidden templates" surface passes `true` so it can render rows for
+/// unhiding; the picker proper omits the flag and gets the filtered
+/// default. `include_hidden` only affects templates — user-owned rows
+/// never set `user_hidden`, so the flag is a no-op for them.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommandListAgentDefinitionsData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_seeded: Option<i64>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub include_hidden: bool,
 }
 
 /// Request for `agentdefcreatefromtemplate`. Clones a seeded template
@@ -1345,6 +1373,25 @@ pub struct AgentDefCreateFromTemplateResult {
     /// re-thread these — they flow through to the launch overrides.
     pub identity_id: String,
     pub memory_id: String,
+}
+
+/// Request for `agentdefhide` / `agentdefunhide`. Phase 2 of the
+/// two-tier picker (Q2 Decision Y). The two RPCs share the same shape
+/// — the action is encoded in the command name, not the payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandAgentDefHideData {
+    /// id of a seeded definition (must have `is_seeded = 1`).
+    pub definition_id: String,
+}
+
+/// Response for `agentdefhide` / `agentdefunhide`. `ok = true` when a
+/// row was updated; `false` when the id didn't match any row. (A row
+/// that exists but isn't a template returns an RPC-level error, not
+/// `ok: false` — the caller should never have been able to send that
+/// id from the picker UI.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefHideResult {
+    pub ok: bool,
 }
 
 /// Input for createagent

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -26,7 +26,9 @@ use super::error::StoreError;
 /// `user_version`, so legacy files read 0). Bumped per additive migration:
 ///   v1 — flat schema baseline
 ///   v2 — db_agent_definitions.updated_at
-pub const OBJECT_SCHEMA_VERSION: i64 = 2;
+///   v3 — db_agent_definitions.user_hidden (Phase 2 hide templates,
+///        SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md Q2 Decision Y)
+pub const OBJECT_SCHEMA_VERSION: i64 = 3;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -133,7 +135,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             parent_id            TEXT NOT NULL DEFAULT '',
             branch_label         TEXT NOT NULL DEFAULT '',
             created_at           INTEGER NOT NULL DEFAULT 0,
-            updated_at           INTEGER NOT NULL DEFAULT 0
+            updated_at           INTEGER NOT NULL DEFAULT 0,
+            user_hidden          INTEGER NOT NULL DEFAULT 0
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -302,8 +305,13 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
     //
     // v2: db_agent_definitions.updated_at — last-modified timestamp
     //     (created_at already existed; updates now stamp updated_at).
+    // v3: db_agent_definitions.user_hidden — per-user hide flag for
+    //     templates (Phase 2 of the two-tier picker spec, Q2 Decision Y).
+    //     Defaults to 0 (visible) for all existing rows so a migration
+    //     never silently hides previously-visible templates.
     for stmt in &[
         "ALTER TABLE db_agent_definitions ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_agent_definitions ADD COLUMN user_hidden INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();
@@ -740,6 +748,85 @@ mod tests {
         assert_eq!(
             remaining, 0,
             "FK cascade must survive the forge→agent table rename"
+        );
+    }
+
+    #[test]
+    fn test_user_hidden_column_present_on_fresh_db() {
+        // Schema v3 (Phase 2 hide-templates) adds db_agent_definitions
+        // .user_hidden. A fresh database lands the column via the flat
+        // CREATE statement; an existing-but-stale database lands it via
+        // the additive ALTER below.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_object_schema(&conn).unwrap();
+
+        // Column exists with the documented default — INSERT without
+        // user_hidden must succeed and read back as 0.
+        conn.execute_batch(
+            "INSERT INTO db_agent_definitions (id, name, provider)
+             VALUES ('a-fresh', 'Fresh', 'claude');",
+        )
+        .unwrap();
+        let hidden: i64 = conn
+            .query_row(
+                "SELECT user_hidden FROM db_agent_definitions WHERE id='a-fresh'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hidden, 0);
+    }
+
+    #[test]
+    fn test_user_hidden_column_added_to_existing_db_via_alter() {
+        // Simulate an existing dev database created before Phase 2:
+        // db_agent_definitions exists but lacks the user_hidden column.
+        // run_object_schema must ALTER it in, preserving every existing
+        // row at the default 0. Idempotent on subsequent runs.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(
+            "CREATE TABLE db_agent_definitions (
+                id TEXT PRIMARY KEY, slug TEXT NOT NULL DEFAULT '',
+                name TEXT NOT NULL, icon TEXT NOT NULL DEFAULT '✦',
+                provider TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                working_directory TEXT NOT NULL DEFAULT '',
+                shell TEXT NOT NULL DEFAULT '',
+                provider_flags TEXT NOT NULL DEFAULT '',
+                auto_start INTEGER NOT NULL DEFAULT 0,
+                restart_on_crash INTEGER NOT NULL DEFAULT 0,
+                idle_timeout_minutes INTEGER NOT NULL DEFAULT 0,
+                agent_type TEXT NOT NULL DEFAULT 'standalone',
+                environment TEXT NOT NULL DEFAULT '',
+                agent_bus_id TEXT NOT NULL DEFAULT '',
+                is_seeded INTEGER NOT NULL DEFAULT 0,
+                accounts TEXT NOT NULL DEFAULT '',
+                parent_id TEXT NOT NULL DEFAULT '',
+                branch_label TEXT NOT NULL DEFAULT '',
+                created_at INTEGER NOT NULL DEFAULT 0
+            );
+            INSERT INTO db_agent_definitions (id, name, provider, is_seeded)
+                VALUES ('pre-existing', 'Old Template', 'claude', 1);",
+        )
+        .unwrap();
+
+        run_object_schema(&conn).unwrap();
+        // Idempotent — second pass must not error and must not
+        // re-default existing rows.
+        run_object_schema(&conn).unwrap();
+
+        let hidden: i64 = conn
+            .query_row(
+                "SELECT user_hidden FROM db_agent_definitions WHERE id='pre-existing'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            hidden, 0,
+            "ALTER must default existing rows to 0 (visible), never to 1",
         );
     }
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -504,6 +504,18 @@ pub struct AgentDefinition {
     /// rows written before v2 (until next update).
     #[serde(default)]
     pub updated_at: i64,
+    /// Per-user hide flag for seeded templates. `1` = the user clicked
+    /// "Hide template" on the picker's `+ New from template` tier; the
+    /// row stays on disk (templates are manifest-managed; deletion would
+    /// fight re-seed) but the default `listagents` view filters it out.
+    /// Reset to `0` by the agent-seed re-sync flow for any NEW template
+    /// id newly added to the manifest, so a fresh template surfaces once
+    /// even if a same-named one was previously hidden. Schema v3 (Phase
+    /// 2 of `SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md` — Q2 Decision Y).
+    /// User-owned rows (`is_seeded = 0`) MUST stay at `0` here; their
+    /// removal path is `deleteagent`, not hide.
+    #[serde(default)]
+    pub user_hidden: i64,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -588,7 +600,8 @@ impl WaveStore {
                     d.working_directory, d.shell, d.provider_flags, d.auto_start,
                     d.restart_on_crash, d.idle_timeout_minutes, d.created_at,
                     d.agent_type, d.environment, d.agent_bus_id, d.is_seeded,
-                    d.accounts, d.parent_id, d.branch_label, d.updated_at
+                    d.accounts, d.parent_id, d.branch_label, d.updated_at,
+                    d.user_hidden
              FROM db_agent_definitions d
              LEFT JOIN (
                  SELECT definition_id, MAX(started_at) AS last_used
@@ -620,6 +633,7 @@ impl WaveStore {
                 parent_id: row.get(18)?,
                 branch_label: row.get(19)?,
                 updated_at: row.get(20)?,
+                user_hidden: row.get(21)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -684,9 +698,9 @@ impl WaveStore {
             "INSERT INTO db_agent_definitions (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-             is_seeded, accounts, parent_id, branch_label, updated_at)
+             is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21)",
+                     ?17, ?18, ?19, ?20, ?21, ?22)",
             params![
                 agent.id,
                 agent.slug,
@@ -710,9 +724,52 @@ impl WaveStore {
                 agent.branch_label,
                 // New definitions: updated_at == created_at.
                 agent.created_at,
+                // Phase 2 (hide templates): new rows start visible. The
+                // user only hides via the explicit `agent_def_hide` RPC,
+                // and the agent-seed re-sync forces user_hidden = 0 on
+                // any newly-added template id anyway, so honouring the
+                // caller-supplied value here is safe even when a stray
+                // 1 sneaks through.
+                agent.user_hidden,
             ],
         )?;
         Ok(())
+    }
+
+    /// Set the `user_hidden` flag on a single agent definition. Phase 2
+    /// of the two-tier picker (Q2 Decision Y). Returns:
+    ///   `Ok(true)`  — row updated.
+    ///   `Ok(false)` — no row with that id exists.
+    ///   `Err(...)`  — the row exists but is NOT a seeded template
+    ///                 (`is_seeded != 1`). User-owned definitions go
+    ///                 through `agent_def_delete`, not hide.
+    ///
+    /// Does NOT bump `updated_at`: hide is a per-user view-state flag,
+    /// not a definition-content edit. Keeps `updated_at` faithful to the
+    /// agent's payload (the manifest re-sync compares `description` etc.
+    /// against the canonical row).
+    pub fn agent_def_set_hidden(&self, id: &str, hidden: bool) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let is_seeded: i64 = match conn.query_row(
+            "SELECT is_seeded FROM db_agent_definitions WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        ) {
+            Ok(v) => v,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(false),
+            Err(e) => return Err(StoreError::Sqlite(e)),
+        };
+        if is_seeded != 1 {
+            return Err(StoreError::Other(format!(
+                "agent_def_set_hidden: {id} is not a seeded template (is_seeded={is_seeded}); \
+                 user-owned definitions must use delete/archive paths, not hide"
+            )));
+        }
+        let rows = conn.execute(
+            "UPDATE db_agent_definitions SET user_hidden = ?1 WHERE id = ?2",
+            params![if hidden { 1_i64 } else { 0_i64 }, id],
+        )?;
+        Ok(rows > 0)
     }
 
     /// Update an existing agent definition (all fields except id, created_at, is_seeded).
@@ -2652,6 +2709,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -2714,6 +2772,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -2771,6 +2830,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         }
     }
 

--- a/agentmux-srv/src/identity/migration.rs
+++ b/agentmux-srv/src/identity/migration.rs
@@ -653,6 +653,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -770,6 +771,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -843,6 +845,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
         let inst = crate::backend::storage::wstore::AgentInstance {

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -733,6 +733,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -805,6 +806,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -890,6 +892,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -930,6 +933,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1014,6 +1018,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1093,6 +1098,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1256,6 +1262,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1340,6 +1347,7 @@ mod tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -21,6 +21,11 @@ use crate::backend::rpc_types::{
     COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
     CommandAgentDefCreateFromTemplateData, AgentDefCreateFromTemplateResult,
     CommandListAgentDefinitionsData,
+    // Two-tier picker — Phase 2 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
+    // Q2 Decision Y: hide templates).
+    COMMAND_AGENT_DEF_HIDE, COMMAND_AGENT_DEF_UNHIDE,
+    COMMAND_AGENT_DEF_LIST_HIDDEN_TEMPLATES,
+    CommandAgentDefHideData, AgentDefHideResult,
     CommandCreateAgentDefinitionData, CommandUpdateAgentDefinitionData, CommandDeleteAgentDefinitionData,
     CommandGetAgentContentData, CommandSetAgentContentData, CommandGetAllAgentContentData,
     CommandListAgentSkillsData, CommandCreateAgentSkillData, CommandUpdateAgentSkillData,
@@ -86,6 +91,14 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // The two-tier picker (Phase 1) passes `{ is_seeded: 0 }` for the
     // "My Agents" section and `{ is_seeded: 1 }` for the "Templates"
     // section — see SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
+    //
+    // Phase 2 (Q2 Decision Y — hide templates): templates with
+    // `user_hidden = 1` are filtered out by default. Callers that want
+    // them back (the settings panel's "Hidden templates" surface) pass
+    // `include_hidden: true`. Hide filter applies ONLY to templates —
+    // user-owned definitions are unaffected (their `user_hidden` is
+    // always 0 by backend invariant; `agent_def_set_hidden` rejects
+    // non-template ids).
     let wstore_lfa = state.wstore.clone();
     engine.register_handler(
         COMMAND_LIST_AGENTS,
@@ -100,10 +113,23 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let cmd: CommandListAgentDefinitionsData =
                     serde_json::from_value(data).unwrap_or_default();
                 let agents = wstore.agent_def_list().map_err(|e| format!("listagents: {e}"))?;
-                let filtered: Vec<_> = match cmd.is_seeded {
-                    Some(flag) => agents.into_iter().filter(|a| a.is_seeded == flag).collect(),
-                    None => agents,
-                };
+                let is_seeded_filter = cmd.is_seeded;
+                let include_hidden = cmd.include_hidden;
+                let filtered: Vec<_> = agents
+                    .into_iter()
+                    .filter(|a| match is_seeded_filter {
+                        Some(flag) => a.is_seeded == flag,
+                        None => true,
+                    })
+                    // Default behaviour: drop hidden templates. The
+                    // settings panel opts back in with include_hidden.
+                    // User-owned rows (is_seeded == 0) are never
+                    // hideable; the conditional below is a no-op for
+                    // them.
+                    .filter(|a| {
+                        include_hidden || a.is_seeded != 1 || a.user_hidden == 0
+                    })
+                    .collect();
                 Ok(Some(serde_json::to_value(&filtered).unwrap_or_default()))
             })
         }),
@@ -150,6 +176,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     parent_id: String::new(),
                     branch_label: String::new(),
                     updated_at: now,
+                    user_hidden: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -215,6 +242,12 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // timestamp and writes it back into `agent` below, so
                     // the response body carries the fresh value.
                     updated_at: old.updated_at,
+                    // Preserve user_hidden — updateagent edits the
+                    // definition payload, not the per-user view-state
+                    // flag. Hide/unhide go through their dedicated RPCs
+                    // (`agentdefhide` / `agentdefunhide`). Phase 2 of
+                    // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
+                    user_hidden: old.user_hidden,
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -350,6 +383,10 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     parent_id: template.id.clone(),
                     branch_label: String::new(),
                     updated_at: now,
+                    // New user-owned agent starts visible. Phase 2
+                    // (Q2 Decision Y) — hide applies only to seeded
+                    // templates, never to user-owned agents.
+                    user_hidden: 0,
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -375,6 +412,107 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "agentdefcreatefromtemplate: cloned template into user agent"
                 );
                 Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // agentdefhide → set user_hidden = 1 on a seeded template, so it
+    // disappears from the picker's "+ New from template" tier. Phase 2
+    // (Q2 Decision Y) of SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
+    //
+    // Validation:
+    //  - `definition_id` MUST exist. Missing → returns `{ ok: false }`.
+    //  - The row MUST be a seeded template (`is_seeded = 1`). User-owned
+    //    rows reject with a hard error — they have their own delete path
+    //    and a hide flag on them would be misleading.
+    //
+    // Broadcasts `agents:changed` so the picker refetches and the card
+    // disappears (existing list query already excludes hidden by default).
+    let wstore_hide = state.wstore.clone();
+    let broker_hide = state.broker.clone();
+    engine.register_handler(
+        COMMAND_AGENT_DEF_HIDE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_hide.clone();
+            let broker = broker_hide.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentDefHideData = serde_json::from_value(data)
+                    .map_err(|e| format!("agentdefhide: {e}"))?;
+                let ok = wstore
+                    .agent_def_set_hidden(&cmd.definition_id, true)
+                    .map_err(|e| format!("agentdefhide: {e}"))?;
+                if ok {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "agents:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                    tracing::info!(
+                        definition_id = %cmd.definition_id,
+                        "agentdefhide: hid template"
+                    );
+                }
+                let resp = AgentDefHideResult { ok };
+                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // agentdefunhide → set user_hidden = 0 on a seeded template,
+    // bringing it back into the picker. Same validation + broadcast as
+    // agentdefhide. Phase 2 of the two-tier picker spec.
+    let wstore_unhide = state.wstore.clone();
+    let broker_unhide = state.broker.clone();
+    engine.register_handler(
+        COMMAND_AGENT_DEF_UNHIDE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_unhide.clone();
+            let broker = broker_unhide.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentDefHideData = serde_json::from_value(data)
+                    .map_err(|e| format!("agentdefunhide: {e}"))?;
+                let ok = wstore
+                    .agent_def_set_hidden(&cmd.definition_id, false)
+                    .map_err(|e| format!("agentdefunhide: {e}"))?;
+                if ok {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "agents:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                    tracing::info!(
+                        definition_id = %cmd.definition_id,
+                        "agentdefunhide: unhid template"
+                    );
+                }
+                let resp = AgentDefHideResult { ok };
+                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // agentdeflisthiddentemplates → templates the user has hidden
+    // (is_seeded = 1 AND user_hidden = 1). Used by the settings panel
+    // to render the unhide list. The picker proper never calls this —
+    // it uses `listagents` with the default-filter-out behaviour.
+    let wstore_lh = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_AGENT_DEF_LIST_HIDDEN_TEMPLATES,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore_lh.clone();
+            Box::pin(async move {
+                let agents = wstore
+                    .agent_def_list()
+                    .map_err(|e| format!("agentdeflisthiddentemplates: {e}"))?;
+                let hidden: Vec<_> = agents
+                    .into_iter()
+                    .filter(|a| a.is_seeded == 1 && a.user_hidden == 1)
+                    .collect();
+                Ok(Some(serde_json::to_value(&hidden).unwrap_or_default()))
             })
         }),
     );
@@ -690,6 +828,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     parent_id: String::new(),
                     branch_label: String::new(),
                     updated_at: now,
+                    user_hidden: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -821,6 +960,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         parent_id: String::new(),
                         branch_label: String::new(),
                         updated_at: now,
+                        user_hidden: 0,
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {
@@ -1767,6 +1907,7 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     parent_id: source.id.clone(),
                     branch_label: cmd.branch_label.clone(),
                     updated_at: now,
+                    user_hidden: 0,
                 };
                 wstore
                     .agent_def_insert(&mut fork)
@@ -2578,6 +2719,7 @@ mod recent_sessions_tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 0,
+            user_hidden: 0,
         };
         let mut def_mut = def.clone();
         wstore.agent_def_insert(&mut def_mut).unwrap();
@@ -2831,6 +2973,7 @@ mod recent_sessions_tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
+            user_hidden: 0,
         };
         wstore.agent_def_insert(&mut tpl).unwrap();
 
@@ -2856,6 +2999,7 @@ mod recent_sessions_tests {
             parent_id: String::new(),
             branch_label: String::new(),
             updated_at: 1_700_000_001_000,
+            user_hidden: 0,
         };
         wstore.agent_def_insert(&mut user_a).unwrap();
 
@@ -3043,5 +3187,196 @@ mod recent_sessions_tests {
         )
         .await;
         assert!(err.contains("non-empty"), "wrong error: {err}");
+    }
+
+    // ---- Two-tier picker Phase 2: hide / unhide templates ----
+    //
+    // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md Q2 Decision Y.
+
+    #[tokio::test]
+    async fn hide_template_then_listagents_excludes_it_by_default() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+
+        // Before hide: template is in the default listagents result.
+        let before: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({}),
+        )
+        .await;
+        assert!(before.iter().any(|a| a.id == "tpl-claude"));
+
+        // Hide the template.
+        let resp: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        assert!(resp.ok);
+
+        // After hide: default listagents no longer surfaces it.
+        let after: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({}),
+        )
+        .await;
+        assert!(
+            !after.iter().any(|a| a.id == "tpl-claude"),
+            "hidden template should NOT appear by default",
+        );
+
+        // But user-owned rows (is_seeded=0) still appear — hide only
+        // affects templates.
+        assert!(after.iter().any(|a| a.id == "user-a"));
+
+        // include_hidden = true brings it back (settings panel surface).
+        let included: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({ "include_hidden": true }),
+        )
+        .await;
+        let tpl = included
+            .iter()
+            .find(|a| a.id == "tpl-claude")
+            .expect("hidden template should appear with include_hidden=true");
+        assert_eq!(tpl.user_hidden, 1);
+    }
+
+    #[tokio::test]
+    async fn hide_then_unhide_round_trip() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let _: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        let resp: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_UNHIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        assert!(resp.ok);
+        // Listagents now shows it again, default-filter included.
+        let agents: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({}),
+        )
+        .await;
+        let tpl = agents
+            .iter()
+            .find(|a| a.id == "tpl-claude")
+            .expect("unhidden template should appear");
+        assert_eq!(tpl.user_hidden, 0);
+    }
+
+    #[tokio::test]
+    async fn hide_rejects_user_owned_definition() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        // "user-a" is is_seeded=0 — hide must reject.
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "user-a" }),
+        )
+        .await;
+        assert!(
+            err.contains("not a seeded template"),
+            "wrong error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hide_unknown_id_returns_ok_false() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let resp: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "no-such-id" }),
+        )
+        .await;
+        assert!(!resp.ok);
+    }
+
+    #[tokio::test]
+    async fn list_hidden_templates_returns_only_hidden_templates() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        // Empty initially.
+        let empty: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_LIST_HIDDEN_TEMPLATES,
+            serde_json::json!({}),
+        )
+        .await;
+        assert!(empty.is_empty());
+
+        // Hide one; expect it to surface.
+        let _: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        let hidden: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_LIST_HIDDEN_TEMPLATES,
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].id, "tpl-claude");
+        assert_eq!(hidden[0].is_seeded, 1);
+        assert_eq!(hidden[0].user_hidden, 1);
+    }
+
+    #[tokio::test]
+    async fn listagents_is_seeded_filter_with_include_hidden_combines() {
+        // Templates-only filter + include_hidden = the settings panel's
+        // canonical query if it ever wanted the full template universe.
+        // Without include_hidden + is_seeded=1 the hidden ones drop out.
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+        let _: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        let templates_visible: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({ "is_seeded": 1 }),
+        )
+        .await;
+        assert!(
+            !templates_visible.iter().any(|a| a.id == "tpl-claude"),
+            "hidden template should be excluded from is_seeded=1 default query",
+        );
+        let templates_all: Vec<AgentDefinition> = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_LIST_AGENTS,
+            serde_json::json!({ "is_seeded": 1, "include_hidden": true }),
+        )
+        .await;
+        assert!(templates_all.iter().any(|a| a.id == "tpl-claude"));
     }
 }

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -489,12 +489,56 @@ class RpcApiType {
     // Optional `is_seeded` filter: 1 = templates only, 0 = user-owned
     // only, undefined = no filter (backward-compat: every existing
     // caller passes nothing). Backend treats `null` / `{}` as no-filter.
+    //
+    // Phase 2 (Q2 Decision Y — hide templates): by default the backend
+    // excludes templates with `user_hidden = 1`. Pass `include_hidden:
+    // true` to opt back in — only the settings panel's unhide UI needs
+    // to do this. Hide filter never applies to user-owned rows.
     ListAgentDefinitionsCommand(
         client: RpcClient,
-        data?: { is_seeded?: 0 | 1 },
+        data?: { is_seeded?: 0 | 1; include_hidden?: boolean },
         opts?: RpcOpts,
     ): Promise<AgentDefinition[]> {
         return client.rpcCall("listagents", data ?? {}, opts);
+    }
+
+    // command "agentdefhide" [call]
+    //
+    // Two-tier picker — Phase 2 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
+    // Q2 Decision Y). Set `user_hidden = 1` on a seeded template so it
+    // disappears from the default `+ New from template` tier. Idempotent;
+    // rejects user-owned definitions (they have their own delete path).
+    AgentDefHideCommand(
+        client: RpcClient,
+        data: { definition_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ ok: boolean }> {
+        return client.rpcCall("agentdefhide", data, opts);
+    }
+
+    // command "agentdefunhide" [call]
+    //
+    // Two-tier picker — Phase 2. Inverse of `agentdefhide`. Used by the
+    // settings panel's "Hidden templates" unhide affordance.
+    AgentDefUnhideCommand(
+        client: RpcClient,
+        data: { definition_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ ok: boolean }> {
+        return client.rpcCall("agentdefunhide", data, opts);
+    }
+
+    // command "agentdeflisthiddentemplates" [call]
+    //
+    // Two-tier picker — Phase 2. Return only templates the user has
+    // hidden (`is_seeded = 1 AND user_hidden = 1`). The picker itself
+    // never calls this — it uses `listagents` with the default-filter-
+    // out behaviour; this is for the settings "Hidden templates" list.
+    AgentDefListHiddenTemplatesCommand(
+        client: RpcClient,
+        opts?: RpcOpts,
+    ): Promise<AgentDefinition[]> {
+        return client.rpcCall("agentdeflisthiddentemplates", {}, opts);
     }
 
     // command "agentdefcreatefromtemplate" [call]

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -50,6 +50,13 @@ interface AgentCardProps {
     /** Option E: invoked when the user clicks the "+ New" affordance.
      *  Parent archives the current zone then opens the launch modal. */
     onNewSession?: (agent: AgentDefinition) => void;
+    /**
+     * Phase 2 (Q2 Decision Y — hide templates): right-click handler.
+     * Currently only the templates tier wires this up so the user can
+     * hide a template. My-agent rows leave it undefined and the card
+     * falls back to the browser default context menu.
+     */
+    onContextMenu?: (agent: AgentDefinition, evt: MouseEvent) => void;
     /** When true this card is the picker's default choice (the
      *  most-recently-used agent) — focus it on mount so Enter launches
      *  it and the focus ring marks it as the default. */
@@ -86,6 +93,15 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
         props.onNewSession?.(props.agent);
     };
 
+    const handleContextMenu = (e: MouseEvent) => {
+        // Only intercept if a handler is wired. Otherwise let the
+        // browser show its default menu (useful for "Inspect" in
+        // dev). The handler is responsible for preventDefault.
+        if (props.onContextMenu) {
+            props.onContextMenu(props.agent, e);
+        }
+    };
+
     return (
         <div
             ref={cardEl}
@@ -95,6 +111,7 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
                 "agent-card--needs-install": props.installed === false,
             }}
             onClick={handleCardClick}
+            onContextMenu={handleContextMenu}
             onKeyDown={handleKeyDown}
             role="button"
             tabIndex={props.disabled ? -1 : 0}

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -38,12 +38,28 @@ vi.mock("@/app/store/rpc-api", () => {
             identity_id: "",
             memory_id: "",
         }),
+        // Phase 2 (Q2 Decision Y) — hide templates.
+        AgentDefHideCommand: vi.fn().mockResolvedValue({ ok: true }),
+        AgentDefUnhideCommand: vi.fn().mockResolvedValue({ ok: true }),
+        AgentDefListHiddenTemplatesCommand: vi.fn().mockResolvedValue([]),
         ListIdentityBundlesCommand: vi.fn().mockResolvedValue([]),
         ListMemoriesCommand: vi.fn().mockResolvedValue([]),
     };
     return { RpcApi };
 });
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+// Phase 2: the ContextMenu helper shows a native menu via CEF IPC.
+// In jsdom there's no host bridge; we capture the menu spec the
+// picker requests so tests can fire the "Hide template" item's click
+// handler directly. Defined inline inside the factory so vi.mock's
+// top-of-file hoisting doesn't read `contextMenuShow` before the
+// const declaration runs.
+vi.mock("@/app/store/contextmenu", () => ({
+    ContextMenuModel: {
+        showContextMenu: vi.fn(),
+    },
+}));
 
 vi.mock("@/app/store/wps", () => ({
     waveEventSubscribe: vi.fn(() => () => {}),
@@ -83,11 +99,19 @@ vi.mock("./AgentCard", () => ({
             data-is-template={String(props.agent.is_seeded === 1)}
             data-has-session={String(!!props.hasCurrentSession)}
             data-launching={String(!!props.launching)}
+            data-has-ctx-menu={String(typeof props.onContextMenu === "function")}
             onClick={(e) => props.onLaunch(props.agent, e)}
+            onContextMenu={(e) => {
+                props.onContextMenu?.(props.agent, e);
+            }}
         >
             {props.agent.name}
         </button>
     ),
+}));
+
+vi.mock("./HiddenTemplatesSection", () => ({
+    HiddenTemplatesSection: () => null,
 }));
 
 vi.mock("./AgentActionBar", () => ({
@@ -99,8 +123,10 @@ vi.mock("./MyAgentsList", () => ({
 }));
 
 import { AgentPicker } from "./AgentPicker";
+import { ContextMenuModel } from "@/app/store/contextmenu";
 
 let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+const contextMenuShow = vi.mocked(ContextMenuModel.showContextMenu);
 
 const ts = () => 1_700_000_000_000;
 
@@ -152,6 +178,7 @@ beforeEach(async () => {
     tabModalOpen.mockClear();
     tabModalReplace.mockClear();
     tabModalClose.mockClear();
+    contextMenuShow.mockClear();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
     vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([
         claudeTemplate,
@@ -203,6 +230,80 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         render(() => <AgentPicker model={model as any} />);
         const card = await screen.findByTestId("agent-card-tpl-claude");
         expect(card.getAttribute("data-has-session")).toBe("false");
+    });
+
+    // Phase 2 (Q2 Decision Y — hide templates).
+    it("right-click on a template card opens the Hide context menu", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
+        // The mock card forwards the onContextMenu down so the
+        // picker sees the right-click and asks ContextMenuModel to
+        // render the menu.
+        expect(card.getAttribute("data-has-ctx-menu")).toBe("true");
+        fireEvent.contextMenu(card);
+        await waitFor(() => expect(contextMenuShow).toHaveBeenCalled());
+
+        const [menu, evt] = contextMenuShow.mock.calls[0];
+        expect(Array.isArray(menu)).toBe(true);
+        expect(menu.length).toBe(1);
+        expect(menu[0].label).toContain("Hide template");
+        expect(menu[0].label).toContain("Claude Code");
+        // Sanity: the event we forwarded carries the synthetic MouseEvent
+        // shape ContextMenuModel.showContextMenu expects (clientX/Y reads
+        // on the production CEF path).
+        expect(evt).toBeTruthy();
+    });
+
+    it("Hide menu click fires AgentDefHideCommand with the template id", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
+        fireEvent.contextMenu(card);
+        await waitFor(() => expect(contextMenuShow).toHaveBeenCalled());
+
+        const [menu] = contextMenuShow.mock.calls[0];
+        // Invoke the menu item's click handler directly — this is
+        // what the CEF bridge does after the user picks the row.
+        menu[0].click();
+        await waitFor(() =>
+            expect(RpcApi.AgentDefHideCommand).toHaveBeenCalledTimes(1),
+        );
+        const call = vi.mocked(RpcApi.AgentDefHideCommand).mock.calls[0];
+        expect(call[1]).toEqual({ definition_id: "tpl-claude" });
+    });
+
+    it("templates tier never renders hidden templates (filter happens server-side)", async () => {
+        const model = makeMockModel();
+        // Backend filters out hidden rows by default — simulate by
+        // returning only the visible template.
+        vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([
+            // Hidden template absent — server already excluded it.
+            userAgent,
+        ]);
+        render(() => <AgentPicker model={model as any} />);
+        await waitFor(() => {
+            // No template card renders because no template was
+            // returned by ListAgents.
+            expect(screen.queryByTestId("agent-card-tpl-claude")).toBeNull();
+        });
+    });
+
+    it("user-owned agents never get a Hide context menu (they go to MyAgentsList)", async () => {
+        const model = makeMockModel();
+        // Only user-owned in the templates tier shouldn't happen by
+        // design — the picker partitions on is_seeded === 1. But
+        // assert the negative case: only template cards expose the
+        // ctx-menu handler. (User-owned rows are mocked out via
+        // MyAgentsList.)
+        render(() => <AgentPicker model={model as any} />);
+        await waitFor(() => {
+            expect(screen.queryByTestId("agent-card-tpl-claude")).not.toBeNull();
+        });
+        // user-maks isn't in the templates tier — its card never
+        // renders here, so the contextMenu would have no surface to
+        // attach to.
+        expect(screen.queryByTestId("agent-card-user-maks")).toBeNull();
     });
 
     it("modal onCreatedAndLaunch fires launchAgentDefinition with the picked bindings", async () => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -33,6 +33,7 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { ContextMenuModel } from "@/app/store/contextmenu";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { useTabModal, type LaunchFormStateWire } from "@/app/tab/tab-modal";
 import { getPlatform } from "@/util/platformutil";
@@ -40,6 +41,7 @@ import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
+import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
 import type { LaunchOverrides } from "./AgentLaunchModal";
 import { MyAgentsList } from "./MyAgentsList";
 
@@ -602,6 +604,51 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // `handleTemplateSelect` directly. Don't resurrect a single shared
     // `handleSelect` — fan out per tier (reagent P2 on #1011).
 
+    // Phase 2 (Q2 Decision Y — hide templates): right-click on a
+    // template card opens a context menu with "Hide template". The
+    // card disappears from the picker the next render after the RPC
+    // resolves — `listagents` filters by `user_hidden` server-side,
+    // and `agents:changed` (broadcast by the backend after hide)
+    // refetches the list.
+    //
+    // Only seeded templates get this context menu — user-owned rows
+    // belong to `MyAgentsList`, which has its own affordances and
+    // never funnels through this handler.
+    const handleTemplateContextMenu = (
+        agent: AgentDefinition,
+        evt: MouseEvent,
+    ) => {
+        evt.preventDefault();
+        const caption = agent.name || agent.slug || agent.id;
+        ContextMenuModel.showContextMenu(
+            [
+                {
+                    label: `Hide template "${caption}"`,
+                    click: () => {
+                        void (async () => {
+                            try {
+                                await RpcApi.AgentDefHideCommand(TabRpcClient, {
+                                    definition_id: agent.id,
+                                });
+                            } catch (err) {
+                                // Backend rejects only when the row
+                                // isn't a template — should be
+                                // unreachable from this menu, but log
+                                // to muxlog if it ever fires.
+                                // eslint-disable-next-line no-console
+                                console.warn(
+                                    `agentdefhide failed for ${agent.id}:`,
+                                    err,
+                                );
+                            }
+                        })();
+                    },
+                },
+            ],
+            evt,
+        );
+    };
+
     const busy = () => launching() !== null;
 
     // Phase 1 two-tier picker: partition the agent list into the
@@ -677,6 +724,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                         disabled={busy()}
                                         installed={installState()[agent.id]}
                                         onLaunch={handleTemplateSelect}
+                                        // Phase 2: right-click → Hide
+                                        // template (Q2 Decision Y). Only
+                                        // attached for template cards;
+                                        // my-agent rows live in
+                                        // MyAgentsList and have a
+                                        // different action surface.
+                                        onContextMenu={handleTemplateContextMenu}
                                         // Templates by invariant have
                                         // no session zone — suppress
                                         // the "+ New" pill (no
@@ -688,6 +742,17 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                 )}
                             </For>
                         </div>
+                        {/* Phase 2 (Q2 Decision Y): collapsible
+                            "Hidden templates" section, lazy-loaded so
+                            it doesn't add work when no templates are
+                            hidden. Sits under the templates tier so
+                            hide + unhide live in the same surface
+                            (CLAUDE.md notes that the hamburger
+                            Settings menu just opens settings.json,
+                            so there's no separate settings panel to
+                            host this in). */}
+                        <HiddenTemplatesSection />
+
                         <Show when={nodejsError()}>
                             <div class="agent-nodejs-notice">
                                 <div class="nodejs-notice-icon">

--- a/frontend/app/view/agent/components/HiddenTemplatesSection.test.tsx
+++ b/frontend/app/view/agent/components/HiddenTemplatesSection.test.tsx
@@ -1,0 +1,177 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the Phase 2 (Q2 Decision Y) hidden-templates surface
+ * (`SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`).
+ *
+ * Covers:
+ *  - empty state: section disappears entirely (zero footprint)
+ *  - non-empty: header surfaces with count, click toggles list
+ *  - Unhide button fires AgentDefUnhideCommand and removes the row
+ *    optimistically
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => {
+    const RpcApi = {
+        AgentDefListHiddenTemplatesCommand: vi.fn().mockResolvedValue([]),
+        AgentDefUnhideCommand: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    return { RpcApi };
+});
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn(() => () => {}),
+}));
+vi.mock("@/element/ProviderLogo", () => ({
+    ProviderLogo: (props: any) => (
+        <span data-testid={`provider-logo-${props.provider}`} />
+    ),
+}));
+
+import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
+
+let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+
+const makeTemplate = (over: Partial<AgentDefinition>): AgentDefinition =>
+    ({
+        id: "tpl-x",
+        slug: "x",
+        name: "Template X",
+        icon: "",
+        provider: "claude",
+        description: "",
+        working_directory: "",
+        shell: "",
+        provider_flags: "",
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: 0,
+        agent_type: "host",
+        environment: "local",
+        agent_bus_id: "",
+        is_seeded: 1,
+        user_hidden: 1,
+        ...over,
+    }) as AgentDefinition;
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ RpcApi } = await import("@/app/store/rpc-api"));
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("HiddenTemplatesSection", () => {
+    it("renders nothing when no templates are hidden (zero footprint)", async () => {
+        vi.mocked(RpcApi.AgentDefListHiddenTemplatesCommand).mockResolvedValue([]);
+        render(() => <HiddenTemplatesSection />);
+        // Wait one microtask so the initial load resolves.
+        await Promise.resolve();
+        expect(
+            screen.queryByTestId("agent-hidden-templates-section"),
+        ).toBeNull();
+    });
+
+    it("renders header with count when templates are hidden", async () => {
+        vi.mocked(RpcApi.AgentDefListHiddenTemplatesCommand).mockResolvedValue([
+            makeTemplate({ id: "tpl-claude", name: "Claude Code" }),
+            makeTemplate({ id: "tpl-codex", name: "Codex CLI" }),
+        ]);
+        render(() => <HiddenTemplatesSection />);
+        const toggle = await screen.findByTestId(
+            "agent-hidden-templates-toggle",
+        );
+        expect(toggle.textContent).toContain("Hidden templates");
+        expect(toggle.textContent).toContain("(2)");
+        // Body is collapsed initially.
+        expect(
+            screen.queryByTestId("agent-hidden-templates-list"),
+        ).toBeNull();
+    });
+
+    it("expands on click, lists hidden templates with Unhide buttons", async () => {
+        vi.mocked(RpcApi.AgentDefListHiddenTemplatesCommand).mockResolvedValue([
+            makeTemplate({ id: "tpl-claude", name: "Claude Code" }),
+        ]);
+        render(() => <HiddenTemplatesSection />);
+        const toggle = await screen.findByTestId(
+            "agent-hidden-templates-toggle",
+        );
+        fireEvent.click(toggle);
+        const list = await screen.findByTestId(
+            "agent-hidden-templates-list",
+        );
+        expect(list).not.toBeNull();
+        const row = await screen.findByTestId(
+            "agent-hidden-template-tpl-claude",
+        );
+        expect(row.textContent).toContain("Claude Code");
+        expect(
+            screen.queryByTestId("agent-hidden-template-unhide-tpl-claude"),
+        ).not.toBeNull();
+    });
+
+    it("Unhide button fires AgentDefUnhideCommand and removes row optimistically", async () => {
+        vi.mocked(RpcApi.AgentDefListHiddenTemplatesCommand).mockResolvedValue([
+            makeTemplate({ id: "tpl-claude", name: "Claude Code" }),
+            makeTemplate({ id: "tpl-codex", name: "Codex CLI" }),
+        ]);
+        render(() => <HiddenTemplatesSection />);
+        const toggle = await screen.findByTestId(
+            "agent-hidden-templates-toggle",
+        );
+        fireEvent.click(toggle);
+        const unhide = await screen.findByTestId(
+            "agent-hidden-template-unhide-tpl-claude",
+        );
+        fireEvent.click(unhide);
+        await waitFor(() =>
+            expect(RpcApi.AgentDefUnhideCommand).toHaveBeenCalledTimes(1),
+        );
+        expect(vi.mocked(RpcApi.AgentDefUnhideCommand).mock.calls[0][1]).toEqual({
+            definition_id: "tpl-claude",
+        });
+        // Row vanishes from the DOM (optimistic update).
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId("agent-hidden-template-tpl-claude"),
+            ).toBeNull(),
+        );
+        // The other row stays.
+        expect(
+            screen.queryByTestId("agent-hidden-template-tpl-codex"),
+        ).not.toBeNull();
+    });
+
+    it("collapses automatically when the list empties out", async () => {
+        vi.mocked(RpcApi.AgentDefListHiddenTemplatesCommand).mockResolvedValue([
+            makeTemplate({ id: "tpl-only", name: "Only Hidden" }),
+        ]);
+        render(() => <HiddenTemplatesSection />);
+        const toggle = await screen.findByTestId(
+            "agent-hidden-templates-toggle",
+        );
+        fireEvent.click(toggle);
+        // Section is expanded.
+        await screen.findByTestId("agent-hidden-templates-list");
+        // Unhide the only row.
+        const unhide = await screen.findByTestId(
+            "agent-hidden-template-unhide-tpl-only",
+        );
+        fireEvent.click(unhide);
+        // After the optimistic removal the section unmounts entirely
+        // (zero footprint when empty).
+        await waitFor(() => {
+            expect(
+                screen.queryByTestId("agent-hidden-templates-section"),
+            ).toBeNull();
+        });
+    });
+});

--- a/frontend/app/view/agent/components/HiddenTemplatesSection.tsx
+++ b/frontend/app/view/agent/components/HiddenTemplatesSection.tsx
@@ -1,0 +1,182 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * HiddenTemplatesSection — Phase 2 (Q2 Decision Y) of the two-tier
+ * picker (`SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`).
+ *
+ * A collapsible "Hidden templates" section that lives directly under
+ * the picker's templates tier. Lists templates the user has previously
+ * hidden via right-click → "Hide template", and offers an Unhide
+ * button per row to bring them back into the main picker.
+ *
+ * Why this lives in AgentPicker rather than a separate settings
+ * panel: per the project CLAUDE.md note, the hamburger Settings menu
+ * just opens `settings.json` in the user's editor — AgentMux doesn't
+ * have an in-app settings panel that's a natural home for "manage
+ * hidden agent templates". Co-locating hide + unhide on the picker
+ * surface keeps the affordance discoverable: where you hid it is
+ * where you go to bring it back.
+ *
+ * Data source:
+ *  - `AgentDefListHiddenTemplatesCommand` — backend-filtered list of
+ *    rows with `is_seeded = 1 AND user_hidden = 1`.
+ *  - Subscribes to `agents:changed` so hide/unhide elsewhere keeps
+ *    this section's count + list in sync.
+ *
+ * UX:
+ *  - Empty case: section is collapsed AND the header is hidden
+ *    entirely — zero footprint when nothing's hidden, so first-run
+ *    users don't see an empty curiosity.
+ *  - Non-empty: header shows `Hidden templates (N)`, click to expand.
+ *    Each row: icon + name + Unhide button.
+ */
+
+import {
+    createEffect,
+    createMemo,
+    createSignal,
+    For,
+    onCleanup,
+    Show,
+    type JSX,
+} from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { ProviderLogo } from "@/element/ProviderLogo";
+
+export const HiddenTemplatesSection = (): JSX.Element => {
+    const [hidden, setHidden] = createSignal<AgentDefinition[]>([]);
+    const [expanded, setExpanded] = createSignal(false);
+    const [loading, setLoading] = createSignal(false);
+
+    let cancelled = false;
+    const load = async () => {
+        try {
+            setLoading(true);
+            const rows = await RpcApi.AgentDefListHiddenTemplatesCommand(TabRpcClient);
+            if (!cancelled) setHidden(rows ?? []);
+        } catch {
+            // Silent — empty result is the safe fallback. The picker
+            // proper still works without this section.
+            if (!cancelled) setHidden([]);
+        } finally {
+            if (!cancelled) setLoading(false);
+        }
+    };
+
+    // Initial load + re-fetch on every `agents:changed`. The backend
+    // fires that event from both `agentdefhide` and `agentdefunhide`,
+    // so any state change reflects here without a manual refresh.
+    void load();
+    const unsub = waveEventSubscribe({
+        eventType: "agents:changed",
+        handler: () => void load(),
+    });
+    onCleanup(() => {
+        cancelled = true;
+        unsub();
+    });
+
+    // Auto-collapse when the list becomes empty, so the next time the
+    // section becomes non-empty the user sees the header in its
+    // collapsed state (no surprise "Hidden templates" panel
+    // pre-opened).
+    createEffect(() => {
+        if (hidden().length === 0 && expanded()) {
+            setExpanded(false);
+        }
+    });
+
+    const handleUnhide = async (agent: AgentDefinition) => {
+        try {
+            await RpcApi.AgentDefUnhideCommand(TabRpcClient, {
+                definition_id: agent.id,
+            });
+            // The waveEvent refresh will repopulate, but optimistic
+            // local update keeps the click snappy.
+            setHidden((rows) => rows.filter((r) => r.id !== agent.id));
+        } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn(`agentdefunhide failed for ${agent.id}:`, err);
+        }
+    };
+
+    const count = createMemo(() => hidden().length);
+
+    return (
+        <Show when={count() > 0}>
+            <div
+                class="agent-picker-hidden-templates"
+                data-testid="agent-hidden-templates-section"
+            >
+                <button
+                    type="button"
+                    class="agent-picker-hidden-templates-header"
+                    aria-expanded={expanded()}
+                    onClick={() => setExpanded((v) => !v)}
+                    data-testid="agent-hidden-templates-toggle"
+                >
+                    <span class="agent-picker-hidden-templates-caret">
+                        {expanded() ? "▾" : "▸"}
+                    </span>
+                    <span>Hidden templates ({count()})</span>
+                </button>
+                <Show when={expanded()}>
+                    <div
+                        class="agent-picker-hidden-templates-body"
+                        data-testid="agent-hidden-templates-list"
+                    >
+                        <Show
+                            when={!loading()}
+                            fallback={
+                                <div class="agent-picker-hidden-templates-loading">
+                                    Loading…
+                                </div>
+                            }
+                        >
+                            <Show
+                                when={count() > 0}
+                                fallback={
+                                    <div class="agent-picker-hidden-templates-empty">
+                                        No hidden templates.
+                                    </div>
+                                }
+                            >
+                                <For each={hidden()}>
+                                    {(agent) => (
+                                        <div
+                                            class="agent-picker-hidden-template-row"
+                                            data-testid={`agent-hidden-template-${agent.id}`}
+                                        >
+                                            <ProviderLogo
+                                                provider={agent.provider}
+                                                size={20}
+                                                class="agent-picker-hidden-template-icon"
+                                            />
+                                            <span class="agent-picker-hidden-template-name">
+                                                {agent.name}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                class="agent-picker-hidden-template-unhide-btn"
+                                                onClick={() => void handleUnhide(agent)}
+                                                data-testid={`agent-hidden-template-unhide-${agent.id}`}
+                                                aria-label={`Unhide template ${agent.name}`}
+                                            >
+                                                Unhide
+                                            </button>
+                                        </div>
+                                    )}
+                                </For>
+                            </Show>
+                        </Show>
+                    </div>
+                </Show>
+            </div>
+        </Show>
+    );
+};
+
+HiddenTemplatesSection.displayName = "HiddenTemplatesSection";

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -47,6 +47,96 @@
         align-self: center;
     }
 
+    // Two-tier picker (Phase 2 — Q2 Decision Y: hide templates).
+    // Collapsible "Hidden templates (N)" surface that lives directly
+    // under the templates tier, hidden entirely when no templates are
+    // hidden (zero footprint by default).
+    .agent-picker-hidden-templates {
+        max-width: 520px;
+        width: 100%;
+        align-self: center;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        margin-top: var(--space-2);
+    }
+
+    .agent-picker-hidden-templates-header {
+        all: unset;
+        cursor: pointer;
+        font-size: var(--text-sm, 0.875rem);
+        font-weight: 600;
+        color: color-mix(in srgb, var(--main-text-color) 60%, transparent);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-1) 0;
+
+        &:hover,
+        &:focus-visible {
+            color: var(--main-text-color);
+        }
+    }
+
+    .agent-picker-hidden-templates-caret {
+        display: inline-block;
+        width: 1ch;
+        font-size: 0.85em;
+    }
+
+    .agent-picker-hidden-templates-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        padding-left: var(--space-3);
+    }
+
+    .agent-picker-hidden-templates-empty,
+    .agent-picker-hidden-templates-loading {
+        font-size: var(--text-sm, 0.875rem);
+        color: var(--secondary-text-color);
+        padding: var(--space-2) 0;
+    }
+
+    .agent-picker-hidden-template-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-2) var(--space-3);
+        border-radius: 4px;
+        background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+        }
+    }
+
+    .agent-picker-hidden-template-name {
+        flex: 1;
+        font-size: var(--text-sm, 0.875rem);
+        color: var(--main-text-color);
+    }
+
+    .agent-picker-hidden-template-unhide-btn {
+        all: unset;
+        cursor: pointer;
+        padding: 4px 10px;
+        border-radius: 4px;
+        font-size: var(--text-xs, 0.75rem);
+        font-weight: 500;
+        color: var(--accent-color);
+        border: 1px solid var(--accent-color);
+        background: transparent;
+        transition: background 0.15s;
+
+        &:hover,
+        &:focus-visible {
+            background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+        }
+    }
+
     .agent-card {
         position: relative;                // anchor for absolutely-positioned actions
         display: flex;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -251,6 +251,14 @@ declare global {
          * before v2.
          */
         updated_at?: number;
+        /**
+         * Per-user hide flag for seeded templates (0 = visible, 1 = hidden).
+         * Schema v3. Set via AgentDefHideCommand / AgentDefUnhideCommand
+         * — Phase 2 of SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
+         * `listagents` excludes hidden templates by default; only the
+         * settings unhide UI passes `include_hidden: true` to see them.
+         */
+        user_hidden?: number;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 2 of the two-tier agent picker per
[`docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`](../blob/main/docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md)
(Q2 Decision Y: "hide, not delete"). Users can right-click any
template in the `+ New from template` tier to hide it; hidden
templates remain on disk and can be unhidden from a collapsible
"Hidden templates (N)" section under the templates tier.

Follow-up to #1011 (Phase 1, merged on main). Phase 3 (full
`db_agents` consolidation per
`SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md`) is still pending.

## Why hide, not delete

Seeded templates are manifest-managed; user-deleted templates would
just reappear on the next seed. Hide is a per-user UI preference that
survives manifest updates. New template ids auto-reset
`user_hidden = 0` so users always see fresh templates at least once.

## Backend (`agentmux-srv`)

- **Schema migration v3** in `agentmux-srv/src/backend/storage/migrations.rs`:
  `db_agent_definitions.user_hidden INTEGER NOT NULL DEFAULT 0`,
  added to the flat `CREATE` batch + an idempotent `ALTER` for
  existing dev databases. `OBJECT_SCHEMA_VERSION` bumped 2 → 3.
- **Three new RPCs** in `agentmux-srv/src/server/agent_handlers.rs`:
  - `agentdefhide { definition_id } → { ok: bool }`
  - `agentdefunhide { definition_id } → { ok: bool }`
  - `agentdeflisthiddentemplates → [AgentDefinition]`

  Hide / unhide reject user-owned rows (`is_seeded != 1`) with a hard
  error; missing ids return `{ ok: false }`.
- **`listagents` filter** gains `include_hidden: bool` (defaults
  `false`). The picker proper gets hidden rows filtered out; the
  settings unhide UI passes `include_hidden: true`. Backward-
  compatible — every existing caller omits the flag.
- **Manifest re-sync** (`agent_seed.rs::reseed_if_needed`):
  preserves the user's hide preference for templates that already
  exist on disk; **newly-added template ids land with
  `user_hidden = 0`** so a fresh template surfaces once even if a
  same-named one was previously hidden (spec invariant).
- `agent_def_set_hidden` does **not** bump `updated_at` — hide is
  per-user view state, not a definition-content edit, so the
  manifest re-sync diff stays faithful.

## Frontend (`frontend/app/view/agent/`)

- **Context menu** on template cards (`AgentPicker.tsx`): right-click
  opens a CEF menu via `ContextMenuModel.showContextMenu` with
  "Hide template '<name>'"; click fires `AgentDefHideCommand`. Card
  disappears on the next `agents:changed` broadcast.
- **`AgentCard`**: new optional `onContextMenu` prop. Falls back to
  the browser default menu when undefined (user-owned rows in
  `MyAgentsList` don't wire it — they have their own action surface).
- **`HiddenTemplatesSection.tsx`**: new collapsible "Hidden templates
  (N)" section directly under the templates tier. Renders **nothing**
  when no templates are hidden (zero footprint). Each row: icon +
  name + Unhide button. Lives in the picker, not a separate settings
  panel, because per the project `CLAUDE.md` the hamburger Settings
  menu just opens `settings.json` in the user's editor — co-locating
  hide + unhide on the picker surface keeps the affordance
  discoverable.
- Type + RPC plumbing: `AgentDefinition.user_hidden?: number` in
  `gotypes.d.ts`; `AgentDefHideCommand` / `AgentDefUnhideCommand` /
  `AgentDefListHiddenTemplatesCommand` in `rpc-api.ts`;
  `listagents` gains `include_hidden?: boolean`.
- SCSS for the new section + rows + unhide button in `_picker.scss`.

## Tests

| Suite | Notes |
| --- | --- |
| `migrations.rs` | Column lands on fresh DB; idempotent `ALTER` preserves rows at `user_hidden = 0`. |
| `agent_seed.rs` | Re-seed preserves `user_hidden` on existing templates; newly-added template ids reset to `0`. |
| `agent_handlers.rs` | Hide/unhide round-trip; default `listagents` excludes hidden; `include_hidden + is_seeded` combine; hide rejects user-owned; unknown id → `{ ok: false }`; `list_hidden_templates` returns only hidden templates. |
| `AgentPicker.test.tsx` | Right-click opens context menu; menu click fires `AgentDefHideCommand`; templates tier excludes hidden (server-side filter); user-owned rows never get the context menu. |
| `HiddenTemplatesSection.test.tsx` | Empty-state zero footprint; header count + toggle; Unhide fires `AgentDefUnhideCommand` + optimistic row removal; auto-collapse when list empties. |

### Gates (all green except a pre-existing test on `main`)

- `cargo test -p agentmux-srv --bin agentmux-srv` → **1142 passed**,
  0 failed, 1 ignored.
- `npx vitest run frontend/app/view/agent/ frontend/app/window/` →
  **305 passed**, 1 failed. The single failure
  (`PROVIDERS > ACP providers use the ACP output format and api-key
  auth`) is **pre-existing on main**; unrelated to this PR.
- `task build:frontend` → green.
- `npx tsc --noEmit` on touched files → 0 new errors (the single
  `toHaveTextContent` matcher error in `AgentPicker.test.tsx` is the
  same pre-existing pattern present on main, just on a different
  line).

## Out of scope

- Phase 3: full `db_agents` consolidation.
- Hiding user-owned agents (`is_seeded = 0`) — they have their own
  archive/delete flows; hide is template-only by design.
- Per-user multi-tenancy (single-user assumption holds).
- Bulk hide/unhide UI.

## Spec reference

- `docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md` (already on
  main from Phase 1 — see #1011 for the full picker rationale).
  Phase 2 implements §"Q2: Can a user delete a seeded template? —
  **Decision: Option Y (hide, not delete)**" verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)