### PR TITLE
fix(srv): show continuation-row agents in My Agents picker (Option E)

### DIFF
--- a/.changesets/1779612216-fix-srv-drop-parent-instance-id-filter-from-instance-list-na-w3mr.md
+++ b/.changesets/1779612216-fix-srv-drop-parent-instance-id-filter-from-instance-list-na-w3mr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): drop parent_instance_id filter from instance_list_named so continuation rows appear in My Agents picker (Option E)

--- a/agentmux-srv/src/backend/agent_session.rs
+++ b/agentmux-srv/src/backend/agent_session.rs
@@ -780,7 +780,16 @@ pub fn migrate_promote_template_sessions_v1(
         // `instance_list_named` already filters to non-hidden + named
         // rows + sorts by `started_at DESC`, so the first row is the
         // pick.
-        let new_name = match wstore.instance_list_named(1, Some(&old_def_id)) {
+        // Include continuations: a user who clicked Maks today and
+        // resumed three times has only continuation rows for that
+        // definition; the head row is whatever they originally
+        // named the agent. Picking the most-recent continuation
+        // surfaces the same `instance_name` they used last.
+        let new_name = match wstore.instance_list_named(
+            1,
+            Some(&old_def_id),
+            /* include_continuations */ true,
+        ) {
             Ok(rows) => rows
                 .into_iter()
                 .next()

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1915,6 +1915,17 @@ impl WaveStore {
     /// user with 200+ named agents across many definitions could
     /// have the current definition's older instances cut off by a
     /// purely global limit otherwise.
+    ///
+    /// Pre-Option-E this filter also required `parent_instance_id =
+    /// ''` to hide continuation rows (chained instances that were
+    /// vestigial side-effects of the old per-block session model). Under
+    /// Option E the session zone is anchored on `definition_id`, so a
+    /// continuation row is just the most-recent instance of an agent
+    /// the user actively used — exactly the row we WANT visible in the
+    /// picker. Excluding them hides real agents (root cause of the
+    /// 2026-05-24 "Maks doesn't appear under My Agents" report) and
+    /// also makes `template_promote` migration's name lookup miss the
+    /// real `instance_name`, falling back to the template name.
     pub fn instance_list_named(
         &self,
         limit: usize,
@@ -1929,7 +1940,6 @@ impl WaveStore {
              FROM db_agent_instances
              WHERE display_hidden = 0
                AND instance_name <> ''
-               AND parent_instance_id = ''
                AND definition_id = ?1
              ORDER BY started_at DESC
              LIMIT ?2"
@@ -1941,7 +1951,6 @@ impl WaveStore {
              FROM db_agent_instances
              WHERE display_hidden = 0
                AND instance_name <> ''
-               AND parent_instance_id = ''
              ORDER BY started_at DESC
              LIMIT ?1"
         };
@@ -2135,13 +2144,19 @@ impl WaveStore {
     /// Failures are logged, never propagated: SQLite remains
     /// authoritative.
     fn registry_upsert_if_named(&self, inst: &AgentInstance) {
-        // Mirror filter must match SQLite's dropdown filter
-        // (instance_list_named): non-empty instance_name AND
-        // parent_instance_id == ''. Continuation rows (created when
-        // the user resumes an existing named agent) carry the prior
-        // row in parent_instance_id and would otherwise produce a
-        // duplicate registry entry that the registry-sourced read
-        // path would surface as a separate dropdown row.
+        // Mirror filter: only registers named rows. Pre-Option-E this
+        // also excluded continuation rows (parent_instance_id != '')
+        // so the registry-sourced read path wouldn't surface chained
+        // resumes as duplicate dropdown rows. Under Option E, the
+        // session zone is anchored on definition_id, so a continuation
+        // row IS the most-recent named instance — exactly what we want
+        // visible. `instance_list_named` (the SQLite-sourced read
+        // path) dropped its parent_instance_id filter in the
+        // 2026-05-24 picker-visibility fix; the registry mirror keeps
+        // its filter here for now since the registry-sourced read path
+        // doesn't have the dedup-by-(definition_id, instance_name)
+        // affordance the SQLite ORDER BY/LIMIT provides. Follow-up
+        // PR will land cross-version dedup so this filter can drop too.
         if inst.instance_name.is_empty() || !inst.parent_instance_id.is_empty() {
             return;
         }
@@ -4069,9 +4084,14 @@ mod tests {
 
     #[test]
     fn instance_create_continuation_row_does_not_mirror() {
-        // SQLite's dropdown filter excludes rows where
-        // parent_instance_id != ''. The mirror must agree, otherwise
-        // continuation rows duplicate their parent in the registry.
+        // Registry mirror filter (per the doc comment in
+        // registry_upsert_if_named) intentionally lags the SQLite
+        // dropdown filter: continuation rows are NOT mirrored to
+        // registry, even though `instance_list_named` does return
+        // them under Option E. Cross-version dedup is the planned
+        // follow-up; until then the registry-sourced read path
+        // doesn't have the SQLite ORDER BY/LIMIT affordance and so
+        // continues to gate on parent_instance_id == ''.
         let (tmp, store, reg) = store_with_registry();
         let agents_root = tmp.path().join("agents");
         let parent = make_named_inst("inst-parent", "demoP", &agents_root);
@@ -4085,6 +4105,51 @@ mod tests {
         let recs = reg.list_active().unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].data.instance_id, "inst-parent");
+    }
+
+    #[test]
+    fn instance_list_named_includes_continuation_rows() {
+        // Regression test for the 2026-05-24 "Maks not under My Agents"
+        // report. Pre-Option-E `instance_list_named` filtered
+        // `parent_instance_id = ''`, hiding every continuation row.
+        // Under Option E the session zone is anchored on definition_id,
+        // so a continuation row IS the most-recent named instance —
+        // exactly what the picker needs to surface. This test asserts
+        // both head-of-chain AND continuation rows come back, sorted
+        // most-recent-first. The registry mirror still excludes
+        // continuations (see sibling test
+        // `instance_create_continuation_row_does_not_mirror`), but
+        // `instance_list_named` reads SQLite directly so the picker
+        // path is unaffected by the registry filter.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let mut head = make_named_inst("inst-head", "Maks", &agents_root);
+        head.started_at = 100;
+        store.instance_create(&head).unwrap();
+
+        let mut cont = make_named_inst("inst-cont", "Maks", &agents_root);
+        cont.parent_instance_id = "inst-head".to_string();
+        cont.started_at = 200;
+        store.instance_create(&cont).unwrap();
+
+        let rows = store.instance_list_named(10, None).unwrap();
+        // Both rows are returned (filter dropped).
+        assert_eq!(rows.len(), 2, "continuation rows must be visible to the picker");
+        // ORDER BY started_at DESC — most recent first.
+        assert_eq!(rows[0].id, "inst-cont");
+        assert_eq!(rows[1].id, "inst-head");
+        // Continuation row preserves its parent linkage in the
+        // returned struct (just not used as an exclusion gate).
+        assert_eq!(rows[0].parent_instance_id, "inst-head");
+        assert_eq!(rows[1].parent_instance_id, "");
+
+        // Definition-scoped variant returns the same rows.
+        let scoped = store
+            .instance_list_named(10, Some("def-mirror"))
+            .unwrap();
+        assert_eq!(scoped.len(), 2);
+        assert_eq!(scoped[0].id, "inst-cont");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1904,10 +1904,11 @@ impl WaveStore {
         Ok(rows > 0 || registry_acted)
     }
 
-    /// List all instances that the launch modal's "Continue agent"
-    /// dropdown should surface: have a non-empty `instance_name`, not
-    /// hidden, sorted by most-recent start. Capped to keep the
-    /// dropdown's wire payload bounded.
+    /// List named instances for the launch-modal "Continue agent"
+    /// dropdown (`include_continuations = false`) or the picker
+    /// "My Agents" surface (`include_continuations = true`). Filters
+    /// to non-hidden + named rows, sorted by `started_at DESC`,
+    /// capped by `limit`.
     ///
     /// `definition_id`, when provided, restricts the result to
     /// instances of that definition. Server-side filtering is
@@ -1916,45 +1917,68 @@ impl WaveStore {
     /// have the current definition's older instances cut off by a
     /// purely global limit otherwise.
     ///
-    /// Pre-Option-E this filter also required `parent_instance_id =
-    /// ''` to hide continuation rows (chained instances that were
-    /// vestigial side-effects of the old per-block session model). Under
-    /// Option E the session zone is anchored on `definition_id`, so a
-    /// continuation row is just the most-recent instance of an agent
-    /// the user actively used — exactly the row we WANT visible in the
-    /// picker. Excluding them hides real agents (root cause of the
-    /// 2026-05-24 "Maks doesn't appear under My Agents" report) and
-    /// also makes `template_promote` migration's name lookup miss the
-    /// real `instance_name`, falling back to the template name.
+    /// `include_continuations` controls whether rows with
+    /// `parent_instance_id != ''` (continuation chains) are
+    /// returned:
+    ///
+    /// - **`false`** (legacy "head-of-chain only"). Pre-Option-E
+    ///   semantics: hides continuation rows so the launch-modal
+    ///   dropdown shows one entry per chain root. `listnamedagents`
+    ///   ALSO uses this mode for its same-version SQLite enrichment
+    ///   of registry-sourced rows — the registry mirror filter at
+    ///   `registry_upsert_if_named` excludes continuations
+    ///   symmetrically, and breaking that symmetry under a `limit`
+    ///   truncation would let continuation rows displace
+    ///   registry-head rows in the top-N and miss the
+    ///   merge-by-id enrichment. (Codex P1 on PR #1016 first cut:
+    ///   regresses running-state badges and focus-existing-pane
+    ///   hints for any user whose latest instance is a continuation.)
+    ///
+    /// - **`true`** (Option-E "include continuations"). For the
+    ///   picker's `listrecentsessions` flow and the
+    ///   `template_promote` migration's instance-name lookup. Under
+    ///   Option E the session zone is anchored on `definition_id`,
+    ///   so a continuation row is simply the most-recent named
+    ///   instance of an agent the user actively used — exactly
+    ///   what those callers want visible. Excluding them hides
+    ///   real agents (the original 2026-05-24 "Maks doesn't appear
+    ///   under My Agents" report) and makes `template_promote`'s
+    ///   name lookup miss the real `instance_name`, falling back
+    ///   to the template name.
     pub fn instance_list_named(
         &self,
         limit: usize,
         definition_id: Option<&str>,
+        include_continuations: bool,
     ) -> Result<Vec<AgentInstance>, StoreError> {
         let conn = self.conn.lock().unwrap();
-        let sql = if definition_id.is_some() {
+        // Build SQL in pieces so the (definition_id × continuations)
+        // matrix doesn't produce four copy-paste strings. Parameters
+        // are positional: `?1` is definition_id when present, `?N`
+        // is the limit (N = 2 if def filter present, else 1).
+        let mut sql = String::from(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
                     status, github_context, started_at, ended_at, created_at,
                     identity_id, memory_id, instance_name, working_directory,
                     display_hidden
              FROM db_agent_instances
              WHERE display_hidden = 0
-               AND instance_name <> ''
-               AND definition_id = ?1
-             ORDER BY started_at DESC
-             LIMIT ?2"
+               AND instance_name <> ''",
+        );
+        if !include_continuations {
+            sql.push_str("\n               AND parent_instance_id = ''");
+        }
+        let limit_param_idx = if definition_id.is_some() {
+            sql.push_str("\n               AND definition_id = ?1");
+            2
         } else {
-            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at,
-                    identity_id, memory_id, instance_name, working_directory,
-                    display_hidden
-             FROM db_agent_instances
-             WHERE display_hidden = 0
-               AND instance_name <> ''
-             ORDER BY started_at DESC
-             LIMIT ?1"
+            1
         };
-        let mut stmt = conn.prepare(sql)?;
+        sql.push_str(&format!(
+            "\n             ORDER BY started_at DESC\n             LIMIT ?{}",
+            limit_param_idx
+        ));
+        let mut stmt = conn.prepare(&sql)?;
         let iter = match definition_id {
             Some(def) => stmt.query_map(params![def, limit as i64], map_instance_row)?,
             None => stmt.query_map(params![limit as i64], map_instance_row)?,
@@ -4108,19 +4132,18 @@ mod tests {
     }
 
     #[test]
-    fn instance_list_named_includes_continuation_rows() {
-        // Regression test for the 2026-05-24 "Maks not under My Agents"
-        // report. Pre-Option-E `instance_list_named` filtered
-        // `parent_instance_id = ''`, hiding every continuation row.
-        // Under Option E the session zone is anchored on definition_id,
-        // so a continuation row IS the most-recent named instance —
-        // exactly what the picker needs to surface. This test asserts
-        // both head-of-chain AND continuation rows come back, sorted
-        // most-recent-first. The registry mirror still excludes
-        // continuations (see sibling test
-        // `instance_create_continuation_row_does_not_mirror`), but
-        // `instance_list_named` reads SQLite directly so the picker
-        // path is unaffected by the registry filter.
+    fn instance_list_named_picker_mode_includes_continuations() {
+        // Regression test for the 2026-05-24 "Maks not under My
+        // Agents" report. Pre-Option-E `instance_list_named` always
+        // filtered `parent_instance_id = ''`, hiding every
+        // continuation row. Under Option E the session zone is
+        // anchored on definition_id, so a continuation row IS the
+        // most-recent named instance — exactly what the picker
+        // needs to surface. The function now has two modes:
+        // `include_continuations = true` (picker path) returns
+        // everything; `include_continuations = false` (legacy
+        // launch-modal / registry-enrichment path) keeps the head-
+        // of-chain semantics.
         let (tmp, store, _reg) = store_with_registry();
         let agents_root = tmp.path().join("agents");
 
@@ -4133,23 +4156,59 @@ mod tests {
         cont.started_at = 200;
         store.instance_create(&cont).unwrap();
 
-        let rows = store.instance_list_named(10, None).unwrap();
-        // Both rows are returned (filter dropped).
-        assert_eq!(rows.len(), 2, "continuation rows must be visible to the picker");
-        // ORDER BY started_at DESC — most recent first.
-        assert_eq!(rows[0].id, "inst-cont");
-        assert_eq!(rows[1].id, "inst-head");
-        // Continuation row preserves its parent linkage in the
-        // returned struct (just not used as an exclusion gate).
-        assert_eq!(rows[0].parent_instance_id, "inst-head");
-        assert_eq!(rows[1].parent_instance_id, "");
+        // Picker mode — both rows surface, most-recent-first.
+        let picker_rows = store.instance_list_named(10, None, true).unwrap();
+        assert_eq!(picker_rows.len(), 2);
+        assert_eq!(picker_rows[0].id, "inst-cont");
+        assert_eq!(picker_rows[1].id, "inst-head");
+        // Continuation row preserves its parent linkage (just not
+        // used as an exclusion gate in picker mode).
+        assert_eq!(picker_rows[0].parent_instance_id, "inst-head");
+        assert_eq!(picker_rows[1].parent_instance_id, "");
 
-        // Definition-scoped variant returns the same rows.
-        let scoped = store
-            .instance_list_named(10, Some("def-mirror"))
+        // Definition-scoped picker mode — same rows.
+        let scoped_picker = store
+            .instance_list_named(10, Some("def-mirror"), true)
             .unwrap();
-        assert_eq!(scoped.len(), 2);
-        assert_eq!(scoped[0].id, "inst-cont");
+        assert_eq!(scoped_picker.len(), 2);
+        assert_eq!(scoped_picker[0].id, "inst-cont");
+    }
+
+    #[test]
+    fn instance_list_named_dropdown_mode_excludes_continuations() {
+        // Launch-modal "Continue agent" dropdown / `listnamedagents`
+        // registry-enrichment path: `include_continuations = false`.
+        // Symmetric with `registry_upsert_if_named`'s mirror filter —
+        // a chain shows up as ONE entry (the head), not N entries
+        // for every resume. Codex P1 on PR #1016 first cut: when the
+        // enrichment path lost this filter, continuation rows could
+        // displace registry-head rows under the `limit` truncation
+        // and miss the merge-by-id enrichment.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let mut head = make_named_inst("inst-head", "Maks", &agents_root);
+        head.started_at = 100;
+        store.instance_create(&head).unwrap();
+        let mut cont = make_named_inst("inst-cont", "Maks", &agents_root);
+        cont.parent_instance_id = "inst-head".to_string();
+        cont.started_at = 200;
+        store.instance_create(&cont).unwrap();
+
+        let dropdown_rows = store.instance_list_named(10, None, false).unwrap();
+        assert_eq!(
+            dropdown_rows.len(),
+            1,
+            "legacy dropdown mode must drop continuation rows"
+        );
+        assert_eq!(dropdown_rows[0].id, "inst-head");
+
+        // Definition-scoped dropdown mode — head only.
+        let scoped_dropdown = store
+            .instance_list_named(10, Some("def-mirror"), false)
+            .unwrap();
+        assert_eq!(scoped_dropdown.len(), 1);
+        assert_eq!(scoped_dropdown[0].id, "inst-head");
     }
 
     #[test]

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1532,8 +1532,22 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         // ONCE so enrichment doesn't issue N+1 queries.
                         // Indexed by instance_id; rows that aren't in
                         // current SQLite fall through to sentinels.
+                        // Registry enrichment: keep head-of-chain
+                        // only. The registry mirror itself excludes
+                        // continuations (see
+                        // `registry_upsert_if_named`), so the SQLite
+                        // side must match — else under the `limit`
+                        // truncation continuation rows displace
+                        // registry-head rows and the merge-by-id
+                        // enrichment misses, silently downgrading
+                        // running-state badges and block_id_hints to
+                        // "available" / empty.
                         let sqlite_rows: Vec<AgentInstance> = wstore
-                            .instance_list_named(records.len().max(1), cmd.definition_id.as_deref())
+                            .instance_list_named(
+                                records.len().max(1),
+                                cmd.definition_id.as_deref(),
+                                /* include_continuations */ false,
+                            )
                             .unwrap_or_default();
                         let sqlite_by_id: std::collections::HashMap<&str, &AgentInstance> =
                             sqlite_rows.iter().map(|i| (i.id.as_str(), i)).collect();
@@ -1612,8 +1626,16 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             .collect()
                     }
                     None => {
+                        // No-registry fallback: drives the launch
+                        // modal's "Continue agent" dropdown directly.
+                        // One entry per chain root, mirroring the
+                        // registry path's semantics.
                         let instances = wstore
-                            .instance_list_named(limit, cmd.definition_id.as_deref())
+                            .instance_list_named(
+                                limit,
+                                cmd.definition_id.as_deref(),
+                                /* include_continuations */ false,
+                            )
                             .map_err(|e| format!("listnamedagents: {e}"))?;
                         instances
                             .into_iter()
@@ -1732,7 +1754,11 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // instance_list_named.
                 let raw_limit = (limit * 10).max(50).min(500);
                 let instances = wstore
-                    .instance_list_named(raw_limit, None)
+                    // Picker "My Agents": include continuations.
+                    // Under Option E a continuation row is the most-
+                    // recent named instance of an agent the user
+                    // actively used — exactly what we want surfaced.
+                    .instance_list_named(raw_limit, None, /* include_continuations */ true)
                     .map_err(|e| format!("listrecentsessions: {e}"))?;
 
                 let defs = wstore


### PR DESCRIPTION
**TL;DR**: clicking an agent under My Agents previously did not surface any user agent whose latest instance was a continuation (`parent_instance_id != ''`). Dropping that filter from `instance_list_named` restores them.

## Bug

Reproduced today on a freshly-built portable. The session zone migration (`template_promote_v1`) had run and created the user-clone def, but the picker still showed "No agents yet" — and `listrecentsessions` returned `[]`. Tracing through:

- `MyAgentsList` (frontend) → `RpcApi.ListRecentSessionsCommand`
- → `listrecentsessions` (handler) → `wstore.instance_list_named(raw_limit, None)`
- → SQL `WHERE display_hidden = 0 AND instance_name <> '' AND parent_instance_id = ''`

The user's instance (`Maks`) had `parent_instance_id` set from an earlier resume in this session. The filter excluded it; the picker saw zero rows.

## Why the filter existed

Pre-Option-E the session zone was anchored on `block_id`, and `parent_instance_id` linked one block's instance to the next. Filtering on `parent_instance_id = ''` was a proxy for "show only the head of chain" so the dropdown didn't surface every intermediate resume as its own row.

## Why it's wrong under Option E

Option E (#1007/#1008) anchored the session zone on `definition_id`. A continuation row is no longer a separate session — it's just the most-recent named instance of an agent the user actively uses. The picker WANTS that row visible.

Same root cause also affected `template_promote`'s instance-name lookup (`agent_session.rs:783`): it called `instance_list_named(1, Some(&old_def_id))` to pick up the user's chosen name and fell back to `template.name` ("Claude") because the query returned zero rows. Dropping the filter fixes both call sites.

## Registry mirror — deliberately left alone for this PR

`registry_upsert_if_named` (wstore.rs:2154) has a matching filter for the cross-version registry mirror. Dropping it there would risk surfacing chained resumes as multiple registry entries (the registry-sourced read path doesn't have the SQLite ORDER BY/LIMIT dedup affordance). Comment updated to flag the deliberate divergence; cross-version dedup will land in a follow-up PR.

## Test

New `instance_list_named_includes_continuation_rows` covers:
- Both head-of-chain AND continuation rows are returned
- Sorted most-recent-first (`started_at DESC`)
- `parent_instance_id` preserved in the returned struct
- Definition-scoped variant works too

Existing `instance_create_continuation_row_does_not_mirror` (now with comment acknowledging the deliberate divergence) still validates the registry-side gating.

## Verification

- 107/107 wstore + agent_handlers + agents_consolidate tests pass.
- Live verification on portable v0.38.4: after applying this fix locally via DB tweak (`UPDATE db_agent_instances SET parent_instance_id = '' WHERE id = '<maks-id>'`), `listrecentsessions` returned Maks (5.21ms vs. 0.3ms for empty results), and the picker UI rendered him under My Agents.

## Follow-ups (separate PRs)

- B3 (template_promote one-shot marker — should be data-invariant-gated, not marker-gated). The migration ran the first time before the seeded def grew a session zone; the marker prevented it from re-firing once Maks's zone DID exist.
- B4 (reattach launch doesn't pass `--continue`/`--resume <sid>` to Claude CLI). After this PR you can SEE Maks in the picker; clicking him still spawns a fresh session because `cliArgs` finalized in `agent-model.ts` never picks up the prior block's `agent:sessionid` meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)