### PR TITLE
fix(agent): reattach plumbs prior session id so --resume fires on the first turn

### DIFF
--- a/.changesets/1779613227-fix-agent-pass-prior-session-id-through-reattach-so-spawn-in-fv0o.md
+++ b/.changesets/1779613227-fix-agent-pass-prior-session-id-through-reattach-so-spawn-in-fv0o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): pass prior session id through reattach so spawn includes --resume on the first turn

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -65,6 +65,22 @@ pub struct SubprocessSpawnConfig {
     /// queued → running so the frontend can pair the event with a
     /// pending `PendingMessage`. None means no feedback is emitted.
     pub message_id: Option<String>,
+    /// Session id to hydrate `inner.session_id` with BEFORE the first
+    /// turn — used by the picker "My Agents" reattach path. The
+    /// caller reads this from `block.meta["agent:sessionid"]` which
+    /// the frontend pre-populates from the prior block's session id
+    /// when launching with `continueOfInstanceId`. Without this
+    /// hydration `spawn_turn` would only see the captured session id
+    /// AFTER the first turn — meaning the first turn always launches
+    /// the CLI fresh (no `--resume <sid>`) and starts a new
+    /// conversation that re-injects the startup context.
+    ///
+    /// Empty / `None` means "no prior session" (greenfield launch).
+    /// If `inner.session_id` is already set on the controller (e.g. a
+    /// subsequent turn within the same process lifetime captured it
+    /// from CLI stdout), this field is ignored — the in-memory
+    /// captured id always wins.
+    pub session_id: Option<String>,
 }
 
 /// Inner state protected by mutex.
@@ -230,6 +246,41 @@ impl SubprocessController {
         self.inner.lock().unwrap().session_id.clone()
     }
 
+    /// Hydrate `inner.session_id` from a config-supplied id when the
+    /// controller hasn't captured one of its own yet.
+    ///
+    /// Picker reattach path: a fresh `SubprocessController` is
+    /// registered for the new block, so its `inner.session_id` is
+    /// `None`. The frontend persisted the prior block's session id
+    /// into `agent:sessionid` meta, the websocket / app_api caller
+    /// read it into `SubprocessSpawnConfig::session_id`, and this
+    /// method copies it to inner so the spawn_turn args-builder
+    /// appends `--resume <sid>` on the FIRST turn.
+    ///
+    /// Captured-id-wins: if `inner.session_id` is already `Some`
+    /// (captured from CLI stdout on an earlier turn within this same
+    /// process lifetime), the config value is ignored. The captured
+    /// id reflects what the CLI is actually using; honouring a stale
+    /// config value here would force `--resume` against a wrong id
+    /// and the CLI would start a fresh conversation again. Empty
+    /// `&str` is treated as "no value" so the caller can use it
+    /// unconditionally without filtering.
+    pub(crate) fn hydrate_session_id_from_config(&self, config_sid: Option<&str>) {
+        let Some(sid) = config_sid.filter(|s| !s.is_empty()) else {
+            return;
+        };
+        let mut inner = self.inner.lock().unwrap();
+        if inner.session_id.is_some() {
+            return;
+        }
+        tracing::info!(
+            block_id = %self.block_id,
+            session_id = %sid,
+            "hydrated session_id from config (picker reattach)"
+        );
+        inner.session_id = Some(sid.to_string());
+    }
+
     /// Spawn a single turn of the agent CLI.
     ///
     /// This is the core method — it spawns `claude -p`, writes the user message to stdin,
@@ -254,6 +305,11 @@ impl SubprocessController {
         // drain-from-queue path (in process_waiter) emits the same
         // event just before calling spawn_turn recursively.
         self.emit_message_accepted(&config);
+
+        // Hydrate inner.session_id from the config-supplied id if the
+        // controller hasn't captured one yet. See
+        // `hydrate_session_id_from_config` for the full rationale.
+        self.hydrate_session_id_from_config(config.session_id.as_deref());
 
         // Build CLI args, appending resume flag + session_id if we have one and the provider supports it
         let mut args = config.cli_args.clone();
@@ -929,6 +985,7 @@ mod tests {
             resume_flag: String::new(),
             session_id_field: "session_id".to_string(),
             message_id: None,
+            session_id: None,
         };
 
         let result = ctrl.spawn_turn(config);
@@ -943,5 +1000,122 @@ mod tests {
 
         // Release lock
         ctrl.run_lock.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn hydrate_session_id_populates_inner_when_none() {
+        // Regression test for the 2026-05-24 "clicking My Agents
+        // re-inserts the startup context" report. A fresh
+        // SubprocessController is created for the reattached block;
+        // its inner.session_id starts as None. The picker reattach
+        // flow persists the prior block's session id into
+        // `agent:sessionid` meta, the caller plumbs it into
+        // `SubprocessSpawnConfig::session_id`, and spawn_turn calls
+        // `hydrate_session_id_from_config` before building args.
+        // After hydration, the existing args-builder appends
+        // `--resume <sid>` on this very first turn — no
+        // re-injected startup context.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-reattach".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(ctrl.inner.lock().unwrap().session_id.is_none());
+
+        ctrl.hydrate_session_id_from_config(Some("prior-sid-from-meta"));
+        assert_eq!(
+            ctrl.inner.lock().unwrap().session_id.as_deref(),
+            Some("prior-sid-from-meta")
+        );
+    }
+
+    #[test]
+    fn hydrate_session_id_keeps_captured_over_config_value() {
+        // Captured-id-wins invariant: once a turn has captured a
+        // session id from CLI stdout, hydration on a subsequent turn
+        // must NOT overwrite it with a stale config value. The
+        // captured id reflects what the CLI is actually using;
+        // forcing --resume against a different value would start a
+        // NEW conversation again.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-resume".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        ctrl.inner.lock().unwrap().session_id = Some("captured-sid".to_string());
+
+        ctrl.hydrate_session_id_from_config(Some("stale-config-sid"));
+        assert_eq!(
+            ctrl.inner.lock().unwrap().session_id.as_deref(),
+            Some("captured-sid")
+        );
+    }
+
+    #[test]
+    fn hydrate_session_id_ignores_empty_and_none() {
+        // Greenfield launches pass `None` (or `Some("")` if the
+        // caller didn't filter) — hydration must be a no-op in
+        // either case so inner.session_id stays None until the CLI
+        // captures its own.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-greenfield".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        ctrl.hydrate_session_id_from_config(None);
+        assert!(ctrl.inner.lock().unwrap().session_id.is_none());
+
+        ctrl.hydrate_session_id_from_config(Some(""));
+        assert!(ctrl.inner.lock().unwrap().session_id.is_none());
+    }
+
+    #[test]
+    fn spawn_turn_preserves_session_id_in_queued_config() {
+        // When the controller is busy, spawn_turn queues the config
+        // for the drain-from-queue path. The hydration ONLY runs on
+        // the direct-spawn path (after try_lock_run), so the queued
+        // config must carry session_id through unchanged for the
+        // drain path's recursive call to see it.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-queued".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        ctrl.run_lock.store(true, Ordering::SeqCst);
+
+        let config = SubprocessSpawnConfig {
+            cli_command: "claude".to_string(),
+            cli_args: vec!["-p".to_string()],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            message: "hi".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id_field: "session_id".to_string(),
+            message_id: None,
+            session_id: Some("prior-sid".to_string()),
+        };
+        let _ = ctrl.spawn_turn(config);
+
+        let inner = ctrl.inner.lock().unwrap();
+        assert_eq!(inner.pending_messages.len(), 1);
+        assert_eq!(
+            inner.pending_messages[0].session_id.as_deref(),
+            Some("prior-sid"),
+        );
+        // Hydration didn't run yet — direct-spawn path was bypassed
+        // by the busy lock; the drain will hydrate when it dequeues.
+        assert!(inner.session_id.is_none());
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -76,10 +76,14 @@ pub struct SubprocessSpawnConfig {
     /// conversation that re-injects the startup context.
     ///
     /// Empty / `None` means "no prior session" (greenfield launch).
-    /// If `inner.session_id` is already set on the controller (e.g. a
-    /// subsequent turn within the same process lifetime captured it
-    /// from CLI stdout), this field is ignored — the in-memory
-    /// captured id always wins.
+    ///
+    /// Best-effort, not authoritative: if the hydrated id is stale,
+    /// the CLI's stdout-emitted session id always overwrites it at
+    /// capture time (see `spawn_turn`'s stdout-reader block). The
+    /// reattach turn passes the (possibly stale) hydrated id via
+    /// `--resume`; the CLI either accepts it or starts a new
+    /// session and emits its own id, which then becomes the in-
+    /// memory authority for every subsequent turn.
     pub session_id: Option<String>,
 }
 
@@ -246,8 +250,48 @@ impl SubprocessController {
         self.inner.lock().unwrap().session_id.clone()
     }
 
+    /// Record an authoritative session id captured from the CLI's
+    /// stdout init/`thread.started` event. The CLI is the source of
+    /// truth for which session is live, so this ALWAYS overwrites
+    /// any prior value of `inner.session_id` — including values
+    /// previously hydrated from config on a picker reattach (which
+    /// may be stale by the time the CLI speaks).
+    ///
+    /// Free-function form (taking `&Arc<Mutex<…Inner>>` instead of
+    /// `&self`) so the spawn_turn stdout-reader tokio task can call
+    /// it without holding an `Arc<Self>` reference. The
+    /// `&SubprocessController` method below just delegates.
+    ///
+    /// Returns `true` when the value changed (caller should
+    /// broadcast the meta update + persist to block meta). Returns
+    /// `false` when the new id matches the current one — common
+    /// when the CLI emits the same `session_id` on every NDJSON
+    /// frame within a single turn.
+    pub(crate) fn record_captured_session_id_inner(
+        inner: &Mutex<SubprocessControllerInner>,
+        sid: &str,
+    ) -> bool {
+        if sid.is_empty() {
+            return false;
+        }
+        let mut guard = inner.lock().unwrap();
+        let differs = guard.session_id.as_deref() != Some(sid);
+        if differs {
+            guard.session_id = Some(sid.to_string());
+        }
+        differs
+    }
+
+    /// `&self` convenience wrapper around
+    /// `record_captured_session_id_inner` — used by tests that
+    /// already hold a `SubprocessController`.
+    #[cfg(test)]
+    pub(crate) fn record_captured_session_id(&self, sid: &str) -> bool {
+        Self::record_captured_session_id_inner(&self.inner, sid)
+    }
+
     /// Hydrate `inner.session_id` from a config-supplied id when the
-    /// controller hasn't captured one of its own yet.
+    /// controller hasn't seen a value yet.
     ///
     /// Picker reattach path: a fresh `SubprocessController` is
     /// registered for the new block, so its `inner.session_id` is
@@ -257,14 +301,24 @@ impl SubprocessController {
     /// method copies it to inner so the spawn_turn args-builder
     /// appends `--resume <sid>` on the FIRST turn.
     ///
-    /// Captured-id-wins: if `inner.session_id` is already `Some`
-    /// (captured from CLI stdout on an earlier turn within this same
-    /// process lifetime), the config value is ignored. The captured
-    /// id reflects what the CLI is actually using; honouring a stale
-    /// config value here would force `--resume` against a wrong id
-    /// and the CLI would start a fresh conversation again. Empty
-    /// `&str` is treated as "no value" so the caller can use it
-    /// unconditionally without filtering.
+    /// **Hydration is best-effort, not authoritative.** If
+    /// `inner.session_id` is already `Some` we no-op (don't overwrite
+    /// a value already in place — could be a captured-from-stdout
+    /// id from an earlier turn, or a prior hydration on the same
+    /// reattach). Critically, the **CLI's stdout-emitted session id
+    /// is authoritative** and overwrites any prior value at capture
+    /// time (see the stdout-reader block in `spawn_turn`). So if the
+    /// hydrated value is stale, the FIRST turn passes the stale id
+    /// via `--resume` (likely accepted as a no-op or rejected with a
+    /// "no such session" error from the CLI), the CLI then emits its
+    /// own session id in the init event, and `inner.session_id` is
+    /// overwritten with that authoritative value for subsequent
+    /// turns. Without the capture overwrite, a stale hydrated id
+    /// would be re-used forever — that was the bug codex flagged on
+    /// PR #1018 first cut.
+    ///
+    /// Empty `&str` is treated as "no value" so the caller can use
+    /// it unconditionally without filtering.
     pub(crate) fn hydrate_session_id_from_config(&self, config_sid: Option<&str>) {
         let Some(sid) = config_sid.filter(|s| !s.is_empty()) else {
             return;
@@ -538,19 +592,25 @@ impl SubprocessController {
                         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
                             if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {
                                 let sid_string = sid.to_string();
-                                // Only capture once (first occurrence in the output)
-                                let already_captured = inner_read.lock().unwrap().session_id.is_some();
-                                if !already_captured {
+                                // Authoritative CLI capture —
+                                // overwrites any prior value
+                                // (including stale hydrated ids
+                                // from picker reattach). De-dups
+                                // when the same id repeats across
+                                // turns. See
+                                // `record_captured_session_id_inner`
+                                // for the unit-tested form.
+                                let changed = SubprocessController::record_captured_session_id_inner(
+                                    &inner_read,
+                                    &sid_string,
+                                );
+                                if changed {
                                     tracing::info!(
                                         block_id = %block_id_read,
                                         field = %session_id_field,
                                         session_id = %sid_string,
                                         "captured session id"
                                     );
-                                    {
-                                        let mut inner = inner_read.lock().unwrap();
-                                        inner.session_id = Some(sid_string.clone());
-                                    }
 
                                     // Persist session_id to block metadata
                                     if let Some(ref store) = wstore_read {
@@ -1033,13 +1093,14 @@ mod tests {
     }
 
     #[test]
-    fn hydrate_session_id_keeps_captured_over_config_value() {
-        // Captured-id-wins invariant: once a turn has captured a
-        // session id from CLI stdout, hydration on a subsequent turn
-        // must NOT overwrite it with a stale config value. The
-        // captured id reflects what the CLI is actually using;
-        // forcing --resume against a different value would start a
-        // NEW conversation again.
+    fn hydrate_session_id_is_noop_when_value_already_present() {
+        // Hydration is best-effort, not authoritative — it only
+        // sets `inner.session_id` when None. The reason isn't
+        // captured-id-wins (that's enforced at CAPTURE time below);
+        // it's just to avoid re-hydrating on every spawn_turn call
+        // within a controller lifetime. A stale value here is fine
+        // because the next CLI emit at `record_captured_session_id_inner`
+        // will overwrite.
         let ctrl = SubprocessController::new(
             "tab-1".to_string(),
             "block-resume".to_string(),
@@ -1050,11 +1111,83 @@ mod tests {
         );
         ctrl.inner.lock().unwrap().session_id = Some("captured-sid".to_string());
 
-        ctrl.hydrate_session_id_from_config(Some("stale-config-sid"));
+        ctrl.hydrate_session_id_from_config(Some("different-config-sid"));
         assert_eq!(
             ctrl.inner.lock().unwrap().session_id.as_deref(),
-            Some("captured-sid")
+            Some("captured-sid"),
+            "hydration must not overwrite an existing value"
         );
+    }
+
+    #[test]
+    fn record_captured_overwrites_hydrated_value() {
+        // The CLI is authoritative for session id once it speaks.
+        // Codex P1 on PR #1018 first cut: my original
+        // `if !already_captured` guard in the stdout reader meant
+        // that a hydrated (possibly stale) session id would lock
+        // out every subsequent CLI-emitted value, so a wrong
+        // `--resume <stale>` would be passed forever. The fix
+        // (`record_captured_session_id_inner`) always overwrites
+        // and returns whether the value changed.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-overwrite".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        ctrl.hydrate_session_id_from_config(Some("stale-hydrated-sid"));
+        assert_eq!(
+            ctrl.session_id().as_deref(),
+            Some("stale-hydrated-sid")
+        );
+
+        let changed = ctrl.record_captured_session_id("authoritative-sid");
+        assert!(changed, "value differs from hydrated; must report changed");
+        assert_eq!(
+            ctrl.session_id().as_deref(),
+            Some("authoritative-sid"),
+            "CLI-emitted id must overwrite hydrated value"
+        );
+    }
+
+    #[test]
+    fn record_captured_dedups_same_value() {
+        // Real CLI streams emit `session_id` on every NDJSON frame,
+        // not just the first. The dedup is a perf knob (skips the
+        // meta-update broadcast on repeats), not a correctness
+        // gate — captured-id is still authoritative on first emit.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-dedup".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(ctrl.record_captured_session_id("sid-1"));
+        assert!(!ctrl.record_captured_session_id("sid-1"),
+            "second call with same value must return false (no broadcast)");
+        assert_eq!(ctrl.session_id().as_deref(), Some("sid-1"));
+    }
+
+    #[test]
+    fn record_captured_ignores_empty() {
+        // Defensive: empty string from a malformed CLI emit must
+        // not clear a valid prior value.
+        let ctrl = SubprocessController::new(
+            "tab-1".to_string(),
+            "block-empty".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        ctrl.record_captured_session_id("real-sid");
+        assert!(!ctrl.record_captured_session_id(""),
+            "empty CLI emit must be ignored");
+        assert_eq!(ctrl.session_id().as_deref(), Some("real-sid"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1897,6 +1897,17 @@ pub struct RecentSessionRow {
     /// the block_id (cross-version registry rows). Reattach falls
     /// back to the working-directory continuation path in that case.
     pub block_id_hint: String,
+    /// The CLI-emitted session id (`session_id` for Claude/Gemini,
+    /// `thread_id` for Codex) captured during the prior run. Empty
+    /// when the row predates the capture, the CLI didn't emit a
+    /// session id, or the instance was created via a path that
+    /// doesn't go through the spawn that captures it. Used by the
+    /// picker reattach flow to populate `agent:sessionid` on the new
+    /// block's meta so the spawned subprocess gets a real
+    /// `--resume <sid>` on the FIRST turn instead of starting a
+    /// fresh conversation that re-injects the startup context.
+    #[serde(default)]
+    pub session_id: String,
     /// Snapshot of the first user message in the conversation (up to
     /// 240 chars, newlines collapsed). Empty when the snapshot doesn't
     /// exist or doesn't contain a user_message node yet.

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1822,6 +1822,12 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         memory_id: inst.memory_id,
                         memory_name,
                         block_id_hint: inst.block_id,
+                        // Surface the CLI-captured session id so the
+                        // picker reattach can `--resume <sid>` on the
+                        // FIRST turn of the new block. Without this
+                        // the new subprocess starts a fresh session
+                        // and the CLI re-injects the startup context.
+                        session_id: inst.session_id,
                         preview,
                         node_count,
                         last_active_at,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -506,6 +506,13 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     let resume_flag = obj::meta_get_string(
                         &block.meta, "agent:resume_flag", "--resume",
                     );
+                    // Picker reattach (parallel of the websocket-path
+                    // logic): hydrate the persisted session id from
+                    // block meta so spawn_turn appends --resume <sid>
+                    // on the FIRST turn after reattach.
+                    let persisted_session_id = obj::meta_get_string(
+                        &block.meta, "agent:sessionid", "",
+                    );
                     let config = blockcontroller::subprocess::SubprocessSpawnConfig {
                         cli_command,
                         cli_args,
@@ -515,6 +522,11 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         resume_flag,
                         session_id_field,
                         message_id: None,
+                        session_id: if persisted_session_id.is_empty() {
+                            None
+                        } else {
+                            Some(persisted_session_id)
+                        },
                     };
                     subprocess_ctrl.spawn_turn(config)?;
                 } else {

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -774,6 +774,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     resume_flag: "--resume".to_string(),
                     session_id_field: "session_id".to_string(),
                     message_id: None,
+                    // Direct-spawn legacy command — caller doesn't
+                    // carry a reattach context. Greenfield session id
+                    // is None; spawn_turn captures it from CLI stdout
+                    // on the first turn as before.
+                    session_id: None,
                 };
                 subprocess_ctrl.spawn_turn(config)?;
                 Ok(None)
@@ -926,6 +931,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     let resume_flag = crate::backend::obj::meta_get_string(
                         &block.meta, "agent:resume_flag", "--resume",
                     );
+                    // Picker reattach: the frontend writes the prior
+                    // block's session id here when launching with
+                    // `continueOfInstanceId`. spawn_turn hydrates its
+                    // inner.session_id from this on the first turn so
+                    // --resume <sid> lands on the very first launch.
+                    let persisted_session_id = crate::backend::obj::meta_get_string(
+                        &block.meta, "agent:sessionid", "",
+                    );
                     let config = blockcontroller::subprocess::SubprocessSpawnConfig {
                         cli_command,
                         cli_args,
@@ -935,6 +948,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         resume_flag,
                         session_id_field,
                         message_id: cmd.message_id,
+                        session_id: if persisted_session_id.is_empty() {
+                            None
+                        } else {
+                            Some(persisted_session_id)
+                        },
                     };
                     subprocess_ctrl.spawn_turn(config)?;
                 } else {

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -487,15 +487,32 @@ export class AgentViewModel implements ViewModel {
             // Store CLI config in block metadata using the (possibly
             // collision-resolved) finalWorkDir.
             //
-            // Two-tier picker reattach (2026-05-24): when launching
-            // with `continueSessionId` we pre-seed `agent:sessionid`
-            // here so the backend's spawn_turn hydrates
-            // `inner.session_id` and includes `--resume <sid>` on
-            // the FIRST turn (otherwise the CLI starts a brand-new
-            // conversation and re-injects the startup context). The
-            // captured-id-wins invariant in the controller ensures
-            // any session id the CLI later emits on stdout overrides
-            // this seeded value on subsequent turns.
+            // Two-tier picker reattach (2026-05-24): the new block's
+            // `agent:sessionid` MUST mirror the launch intent
+            // exactly. SetMetaCommand merges meta (it doesn't
+            // replace), so an empty/omitted key on a REUSED block
+            // would leave any prior block's `agent:sessionid` in
+            // place — and the backend would then append
+            // `--resume <stale>` on a greenfield launch, resuming
+            // the wrong conversation (codex P1 round 2 on PR
+            // #1018).
+            //
+            // Set the key UNCONDITIONALLY:
+            //   - continueSessionId non-empty → set to that id;
+            //     spawn_turn hydrates inner.session_id and appends
+            //     `--resume <sid>` on the FIRST turn.
+            //   - continueSessionId empty (greenfield) → set to ""
+            //     to clear any stale residue. The backend
+            //     (`meta_get_string` with default "") already
+            //     treats "" as "no value" and sets
+            //     SubprocessSpawnConfig::session_id = None, so no
+            //     resume flag is appended.
+            //
+            // The captured-id-wins invariant in the controller
+            // ensures any session id the CLI later emits on stdout
+            // overrides whatever value lands here on subsequent
+            // turns.
+            const continueSid = overrides?.continueSessionId?.trim() ?? "";
             const meta: Record<string, unknown> = {
                 agentId: agent.id,
                 agentProvider: agent.provider,
@@ -510,11 +527,8 @@ export class AgentViewModel implements ViewModel {
                 "cmd:env": envVars,
                 "agent:resume_flag": provider.resumeFlag ?? "",
                 "agent:session_id_field": provider.sessionIdField,
+                "agent:sessionid": continueSid,
             };
-            const continueSid = overrides?.continueSessionId?.trim() ?? "";
-            if (continueSid) {
-                meta["agent:sessionid"] = continueSid;
-            }
             await RpcApi.SetMetaCommand(TabRpcClient, {
                 oref,
                 meta,

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -486,23 +486,38 @@ export class AgentViewModel implements ViewModel {
 
             // Store CLI config in block metadata using the (possibly
             // collision-resolved) finalWorkDir.
+            //
+            // Two-tier picker reattach (2026-05-24): when launching
+            // with `continueSessionId` we pre-seed `agent:sessionid`
+            // here so the backend's spawn_turn hydrates
+            // `inner.session_id` and includes `--resume <sid>` on
+            // the FIRST turn (otherwise the CLI starts a brand-new
+            // conversation and re-injects the startup context). The
+            // captured-id-wins invariant in the controller ensures
+            // any session id the CLI later emits on stdout overrides
+            // this seeded value on subsequent turns.
+            const meta: Record<string, unknown> = {
+                agentId: agent.id,
+                agentProvider: agent.provider,
+                agentOutputFormat: provider.styledOutputFormat,
+                agentName: instanceName,
+                agentIcon: agent.icon,
+                agentMode: overrides?.agentType ?? agent.agent_type ?? "host",
+                controller: isPersistent ? "persistent" : "subprocess",
+                cmd: cliBin,
+                "cmd:args": cliArgs,
+                "cmd:cwd": finalWorkDir,
+                "cmd:env": envVars,
+                "agent:resume_flag": provider.resumeFlag ?? "",
+                "agent:session_id_field": provider.sessionIdField,
+            };
+            const continueSid = overrides?.continueSessionId?.trim() ?? "";
+            if (continueSid) {
+                meta["agent:sessionid"] = continueSid;
+            }
             await RpcApi.SetMetaCommand(TabRpcClient, {
                 oref,
-                meta: {
-                    agentId: agent.id,
-                    agentProvider: agent.provider,
-                    agentOutputFormat: provider.styledOutputFormat,
-                    agentName: instanceName,
-                    agentIcon: agent.icon,
-                    agentMode: overrides?.agentType ?? agent.agent_type ?? "host",
-                    controller: isPersistent ? "persistent" : "subprocess",
-                    cmd: cliBin,
-                    "cmd:args": cliArgs,
-                    "cmd:cwd": finalWorkDir,
-                    "cmd:env": envVars,
-                    "agent:resume_flag": provider.resumeFlag ?? "",
-                    "agent:session_id_field": provider.sessionIdField,
-                },
+                meta,
             });
 
             // Create SubprocessController (no-op start — waits for first message)

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -65,6 +65,13 @@ export interface LaunchOverrides {
      *  `allocate_agent_workdir`. Reuses the prior agent's files,
      *  configs, and conversation context. */
     workDirOverride?: string;
+    /** Two-tier picker (2026-05-24) — CLI-emitted session id of the
+     *  prior instance. When non-empty, written to the new block's
+     *  `agent:sessionid` meta so the spawned subprocess can pass
+     *  `--resume <sid>` on its FIRST turn. Without this the
+     *  reattached pane starts a fresh CLI session and re-injects the
+     *  startup context. */
+    continueSessionId?: string;
 }
 
 interface AgentLaunchModalPanelProps {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -271,6 +271,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
+                // Carry the CLI-emitted session id forward so the new
+                // block's spawn sees `--resume <sid>` on the FIRST
+                // turn — otherwise the CLI starts a fresh session
+                // and re-injects the startup context (the 2026-05-24
+                // "click Maks → startup context replayed" report).
+                continueSessionId: row.session_id ?? "",
             });
         } finally {
             setLaunching(null);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -518,6 +518,14 @@ declare global {
         memory_id: string;
         memory_name: string;
         block_id_hint: string;
+        /**
+         * CLI-emitted session id captured during the prior run. Empty
+         * when the row predates the capture or the CLI didn't emit a
+         * session id. Used by the picker reattach to populate
+         * `agent:sessionid` on the new block's meta so the spawned
+         * subprocess gets a real `--resume <sid>` on the FIRST turn.
+         */
+        session_id?: string;
         preview: string;
         node_count: number;
         last_active_at: number;


### PR DESCRIPTION
**TL;DR**: clicking an existing agent under "My Agents" spawned a fresh CLI session and re-injected the startup context, even though `agent:resume_flag` was set in block meta. Root cause: the resume flag is conditionally added in `spawn_turn` only when `inner.session_id` is populated — and a freshly-spawned `SubprocessController` for the reattached block has `None` there until AFTER the first turn's stdout is consumed. This PR threads the prior block's CLI-emitted session id through the launch flow end to end, so the first turn already has it.

## Observed bug

Today on portable v0.38.4, after #1016 + #1017 made Maks visible under My Agents, clicking him spawned `claude` with these args:

```
-p --output-format stream-json --verbose --include-partial-messages
--dangerously-skip-permissions --model sonnet --effort medium
```

No `--resume`. Claude logged in its thinking pane: *"The user hasn't sent a message yet — this appears to be the start of a session."*

## Why

`subprocess.rs::spawn_turn` lines 258–268 (pre-fix):

```rust
let mut args = config.cli_args.clone();
{
    let inner = self.inner.lock().unwrap();
    if let Some(ref sid) = inner.session_id {
        if !config.resume_flag.is_empty() {
            args.push(config.resume_flag.clone());
            args.push(sid.clone());
        }
    }
}
```

`inner.session_id` is populated from CLI stdout at line 496. On a brand-new controller for a reattached block, it's `None` on turn 1 → no `--resume <sid>` appended → fresh session.

## Fix

Thread the session id end to end:

**Backend**
- `RecentSessionRow` adds `session_id: String` (from `db_agent_instances.session_id` which the spawn path already persists).
- `SubprocessSpawnConfig` adds `session_id: Option<String>`.
- New `SubprocessController::hydrate_session_id_from_config(Option<&str>)` — copies value to `inner.session_id` IFF currently `None`. **Captured-id-wins**: a CLI-emitted id captured on a prior turn always wins over a (potentially stale) config value, so the CLI's view of its own session is authoritative once it speaks.
- `spawn_turn` calls the helper before building args, so the existing resume-flag block fires on the first turn.
- `websocket.rs` + `app_api.rs` (both `SubprocessSpawnConfig` builders) read `agent:sessionid` from block meta and populate the new field.

**Frontend**
- `LaunchOverrides` adds `continueSessionId?: string`.
- `AgentPicker.handleReattach` passes `row.session_id` from the picker row.
- `agent-model.ts::launchAgentDefinition` writes it to `agent:sessionid` meta when non-empty. (Greenfield launches omit the key so a later captured value isn't shadowed.)
- `gotypes.d.ts` synced.

## Tests

Four new unit tests on the helper:

- `hydrate_session_id_populates_inner_when_none` — fresh controller, hydration writes through.
- `hydrate_session_id_keeps_captured_over_config_value` — captured-id-wins invariant.
- `hydrate_session_id_ignores_empty_and_none` — greenfield path.
- `spawn_turn_preserves_session_id_in_queued_config` — busy-lock queue path forwards the value to the drain.

Plus the original `test_subprocess_controller_concurrent_spawn_blocked` updated to set the new field.

**1164 backend tests pass.** Frontend pre-existing failures (BlockErrorBoundary + AgentPicker mock-fixture) are unchanged on this branch.

## Stack context

Closes the 3-PR series from the 2026-05-24 "Maks not under My Agents" investigation:

- #1016 — drop `parent_instance_id = ''` filter from `instance_list_named` (picker visibility)
- #1017 — make `template_promote` migration self-idempotent (no marker gate)
- **THIS** — reattach plumbs session id forward (resume on first turn)

After this PR ships, clicking Maks under My Agents spawns `claude -p … --resume <prior-sid>`, the CLI resumes the actual conversation, and the startup context is NOT re-injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)