### PR TITLE
fix(agent): failed tool panels collapse after the 5s post-completion hold like successes

### DIFF
--- a/.changesets/1779631619-fix-agent-failed-tool-panels-collapse-after-the-5s-post-comp-gisc.md
+++ b/.changesets/1779631619-fix-agent-failed-tool-panels-collapse-after-the-5s-post-comp-gisc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): failed tool panels collapse after the 5s post-completion hold like successes

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -114,8 +114,16 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // `props.node.status`, and gate on a transition by comparing
     // against `prevStatus` captured outside the reactive scope.
     let prevStatus: string = props.node.status;
+    // ACTIVE states are the ones that keep the panel auto-expanded
+    // continuously. Terminal states (success, failed) trigger the
+    // 5s post-completion hold once, then collapse. Failed used to
+    // be in the active set (kept open forever) — removed per user
+    // feedback that failed panels cluttered the pane; the ✗ icon
+    // and red border-left already signal failure at a glance, and
+    // hover-to-peek covers the rare case where the user wants to
+    // re-read the output later.
     const isActive = (s: string): boolean =>
-        s === "running" || s === "pending_approval" || s === "failed";
+        s === "running" || s === "pending_approval";
     createEffect(() => {
         const s = props.node.status;
         if (isActive(prevStatus) && !isActive(s)) {
@@ -126,21 +134,21 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         prevStatus = s;
     });
 
-    // Auto-expand while the tool is actively running (or awaiting approval,
-    // or in a terminal-failure state where the user almost certainly wants
-    // to see the output). Pin still wins as an explicit override (so the
-    // user can keep a completed tool expanded). Hover keeps working as a
-    // peek affordance for collapsed (completed-success) tools.
+    // Auto-expand while the tool is actively running (or awaiting
+    // approval). Terminal states (success OR failure) get the 5s
+    // post-completion hold then collapse. Pin still wins as an
+    // explicit override (so the user can keep a completed tool
+    // expanded). Hover keeps working as a peek affordance for
+    // collapsed (completed) tools — successes and failures alike.
     //
-    // Per SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4.2 — Phase B. This
-    // hybrid is the minimal change that delivers the visibility win
-    // without introducing `userExpandState` (the three-state map). A
-    // follow-up phase can add click-to-collapse-mid-run if needed; for
-    // now, click on a running tool is a no-op visually because it's
-    // already expanded.
+    // Per SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4.2 — Phase B.
+    // The 2026-05-24 user feedback removed `failed` from the
+    // always-expanded set; failed-collapses-after-5s mirrors the
+    // success path, and the ✗ icon + red border-left at the
+    // collapsed row continue to flag the failure.
     const autoExpanded = (): boolean => {
         const s = props.node.status;
-        return s === "running" || s === "pending_approval" || s === "failed"
+        return s === "running" || s === "pending_approval"
             || postCompletionHold();
     };
     const expanded = () => props.pinned || autoExpanded() || hovering();

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -262,7 +262,14 @@ export class ClaudeCodeStreamParser {
             status: event.status,
             duration: event.duration,
             result: event.result,
-            collapsed: event.status === "success", // Collapse successes, expand failures
+            // Collapse on EVERY terminal state (success or failure).
+            // The ✗ icon + red border-left in ToolBlock signal
+            // failure at a glance; the user's feedback was that
+            // failed-tool panels staying open forever cluttered the
+            // pane. They get the same 5s post-completion hold as
+            // successes — long enough to read the last lines, then
+            // collapse to the single-line ✗ row with hover-to-peek.
+            collapsed: true,
             summary,
         };
     }


### PR DESCRIPTION
**TL;DR**: failed Bash / Read / Grep panels were staying open forever. They should fold to the single-line ✗ row after the same 5s post-completion hold that successes get. Three sites were force-expanding failures; this PR fixes all three.

## User report

> "i notice failed commands log doesn't collapse after a couple seconds, they stay open"

## Why failures stay open

Three forced-expand sites:

1. **`stream-parser.ts:265`** — `collapsed: event.status === "success"`. Failures arrived with `collapsed: false`.
2. **`ToolBlock.tsx`'s `isActive` predicate** treated `failed` as a continuing active state, so failures never crossed the active→inactive transition that triggers the 5s post-completion hold + collapse.
3. **`ToolBlock.tsx`'s `autoExpanded`** returned true while `status === "failed"`. Even if the hold had elapsed, the panel would still be forced open.

## Fix

Collapse on EVERY terminal state (success OR failure). The existing 5s hold (`POST_COMPLETION_HOLD_MS`, bumped from 1s to 5s in #944) gives time to read the last output line before the panel folds. Per `feedback_no_timers_or_delays`, no new setTimeout — reuses the deterministic active→inactive transition already in place.

## Discoverability of failures preserved

Per `docs/specs/tool-collapse.md`:

- Collapsed row: `✗ <ToolName>` with red `border-left: 2px solid var(--error-color)`.
- Hover-to-peek still expands collapsed failures (instant).
- Pin (click) still keeps any tool expanded indefinitely.

## Tests

- All 504 frontend stream-parser tests pass.
- No prior test asserted `failed-stays-open` behavior (searched: only finds the auth-state `status: "failed"` references, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)