### PR TITLE
fix(agent): high-contrast user-input + startup-injection collapse-on-hover

### DIFF
--- a/.changesets/1779632856-fix-agent-high-contrast-user-input-color-no-soft-wrap-on-typ-9phh.md
+++ b/.changesets/1779632856-fix-agent-high-contrast-user-input-color-no-soft-wrap-on-typ-9phh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): high-contrast user-input color + no soft-wrap on typed messages

--- a/.changesets/1779633028-fix-agent-mark-startup-injection-user-messages-via-stream-pa-23q6.md
+++ b/.changesets/1779633028-fix-agent-mark-startup-injection-user-messages-via-stream-pa-23q6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): mark startup-injection user messages via stream-parser flag

--- a/.changesets/1779633219-fix-agent-usermessageblock-collapses-startup-injection-on-ho-4rm4.md
+++ b/.changesets/1779633219-fix-agent-usermessageblock-collapses-startup-injection-on-ho-4rm4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): UserMessageBlock collapses startup injection on hover, mirrors ToolBlock

--- a/docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md
+++ b/docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md
@@ -1,0 +1,395 @@
+# SPEC: User input visibility + startup-injection collapse
+
+**Date:** 2026-05-24
+**Author:** AgentA
+**Status:** Draft
+
+---
+
+## TL;DR
+
+Two coupled changes to user-message rendering in the agent pane:
+
+1. **User input gets a high-contrast color.** The current `.agent-user-message` styling uses `var(--accent-color)` at 5% opacity for background and a 2px border — barely distinguishable from the surrounding text. Regular user-typed messages should pop. New CSS variable `--user-input-color` (with a strong, theme-aware default), used for a more saturated background tint and a bolder border.
+2. **Startup injection collapses to one line by default.** The frontend's `onReadyFn` sends a long Markdown "session context" payload as the opening turn (per `SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md`). It currently renders as a giant wall of text indistinguishable from a real user message. Render it like a tool block: single-line summary by default, hover-expand, click-to-pin.
+
+Additionally: **regular user input must NEVER word-wrap.** The current `.agent-user-message-content pre` uses `white-space: pre-wrap` — long lines fold. The user's request is explicit: regular input is one-line-per-newline; long lines overflow horizontally (or get a scrollbar), they do not re-flow.
+
+---
+
+## Why now
+
+Today on the latest portable, two visibility complaints surface in the same pane:
+
+- Typed messages blend into the agent's reply stream. A user scrolling back through a long session can't quickly find their own inputs without `Ctrl+F`. The 5% accent tint is invisible on most themes.
+- The startup injection (Markdown like `# Session Context`, `## Identity`, lists of accounts and peer agents — ~3k–8k characters) takes 20+ lines of pane real estate every time the user starts a fresh agent. It's noise after the first second.
+
+Both have the same root: **user-input messages are a single rendering class today**, even though they fall into two distinct semantic buckets — the structured startup payload (a one-shot system prompt the user didn't really "type") and the user's actual typed turns.
+
+---
+
+## Current state of the code
+
+### 1. Render site
+
+`frontend/app/view/agent/virtualization/DocumentRow.tsx:249-261`
+
+```tsx
+<Show when={props.node() && props.node().type === "user_message"}>
+    <div
+        class="agent-user-message"
+        classList={{
+            "agent-user-message--collapsed":
+                props.documentState().collapsedNodes.has(props.node().id),
+        }}
+    >
+        <div class="agent-user-message-content">
+            <pre>{(props.node() as Extract<DocumentNode, { type: "user_message" }>).message}</pre>
+        </div>
+    </div>
+</Show>
+```
+
+The collapse state today is driven by a separate `collapsedNodes` set on the document state — toggled by an external hover-strip button, not by hover-on-the-message-itself. There's no `pinned` concept and no on-element hover signal. The startup payload is auto-collapsed once at document load via this same mechanism, but a click anywhere else expands it permanently.
+
+### 2. SCSS
+
+`frontend/app/view/agent/styles/_document-nodes.scss:598-624`
+
+```scss
+.agent-user-message {
+    padding: 3px var(--space-1);
+    background: color-mix(in srgb, var(--accent-color) 5%, transparent);
+    border-left: 2px solid var(--accent-color);
+    border-radius: 2px;
+
+    .agent-user-message-content {
+        pre {
+            margin: 0;
+            white-space: pre-wrap;       // current — wraps long lines
+            overflow-wrap: anywhere;      // current — breaks long words
+        }
+    }
+
+    &--collapsed .agent-user-message-content pre {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+```
+
+### 3. Startup payload
+
+`frontend/app/view/agent/agent-view.tsx:497-539` (`onReadyFn`) builds a Markdown payload via `buildStartupPayload()` (`frontend/app/view/agent/startup/buildStartupPayload.ts`) and sends it via `handleSendMessage(payload)`. The payload always begins with the literal heading **`# Session Context`** as line 1 (see `buildStartupPayload.ts:46-119`). On the wire it's an ordinary `user_message` event; the stream-parser stores it as `type: "user_message"` with no distinguishing metadata.
+
+### 4. Tool-block hover-expand pattern (reference)
+
+`frontend/app/view/agent/components/ToolBlock.tsx:42-156` + `_document-nodes.scss:96-159`:
+
+- `hovering` signal, `HOVER_ENTER_DELAY_MS = 150`.
+- `pinned` prop (parent-managed) and `onTogglePin` callback.
+- `autoExpanded()` for transient states (running, post-completion hold, pending approval).
+- Combined: `expanded() = pinned || autoExpanded() || hovering()`.
+- CSS classes `collapsed` / `expanded` / `pinned` on the outer div.
+- Collapsed row uses `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` on `.agent-tool-summary`.
+- Pinned state adds `border-left: 2px solid var(--accent-color)`.
+
+This pattern is the model.
+
+---
+
+## Target state
+
+### A. High-contrast user-input color
+
+Add to the theme:
+
+```scss
+:root {
+    /* Strong, saturated tint reserved for user-typed input. Distinct
+     * from --accent-color so that future re-themings of the accent
+     * (button highlights, link color) don't drag the user-input
+     * surface with them. */
+    --user-input-color: #00b4d8;          /* cyan-blue; high contrast on dark + light themes */
+    --user-input-bg: color-mix(in srgb, var(--user-input-color) 14%, transparent);
+    --user-input-border: var(--user-input-color);
+}
+```
+
+Update `.agent-user-message`:
+
+```scss
+.agent-user-message {
+    background: var(--user-input-bg);
+    border-left: 3px solid var(--user-input-border);   /* bumped from 2 → 3 */
+    /* …unchanged: padding, border-radius, user-select */
+}
+```
+
+**Why a dedicated variable.** Re-using `--accent-color` couples typed-input visibility to the link/button accent. They are unrelated UX concerns; the user has explicitly asked for typed input to stand out, while the accent stays subtle on its own surfaces.
+
+**Theme cohabitation.** `#00b4d8` is a perceptually distinct cyan that contrasts both against `--background-primary` (typical dark themes, #1c1c1c-ish) and against light surfaces (>4.5:1 luminance ratio on both). Themes that already define their own accent palette can override `--user-input-color` in their theme block.
+
+### B. Regular user input — NEVER wraps
+
+```scss
+.agent-user-message-content {
+    pre {
+        margin: 0;
+        white-space: pre;                /* CHANGED — no wrap, honor newlines as-is */
+        overflow-x: auto;                /* horizontal scroll for over-wide single lines */
+        overflow-y: hidden;
+    }
+}
+```
+
+Each `\n` in the message renders as its own line; the user controls wrapping by inserting newlines. Lines wider than the pane scroll horizontally. The standard browser-native horizontal scroll bar appears only on overflow.
+
+`overflow-wrap: anywhere` is REMOVED — it was the rule that broke long words like URLs across lines. No word-wrap means the URL is one line and scrolls.
+
+### C. Startup injection collapses on hover-expand
+
+#### C.1 Distinguish startup from typed input
+
+The stream-parser detects a startup message by content heuristic — the payload built by `buildStartupPayload()` always begins with `# Session Context` as the first line. We add a node-level metadata flag:
+
+```ts
+// frontend/app/view/agent/types.ts — UserMessageNode interface
+interface UserMessageNode {
+    type: "user_message";
+    id: string;
+    message: string;
+    timestamp: number;
+    /** True when the message is the auto-generated startup payload
+     * (matches `^# Session Context\b`). Used by DocumentRow to
+     * render with collapse-on-hover behavior. Set by the
+     * stream-parser; never user-mutable. */
+    isStartup?: boolean;
+}
+```
+
+In `stream-parser.ts` `userMessageToNode()`:
+
+```ts
+const isStartup = /^# Session Context\b/.test(event.message);
+return {
+    type: "user_message",
+    id: event.id,
+    message: event.message,
+    timestamp: event.timestamp,
+    isStartup,
+};
+```
+
+**Why content heuristic and not a wire-level flag.** `buildStartupPayload` is a frontend-only construct; the backend has no opinion on which user messages are "startup." A wire-level flag would require either (a) round-tripping the flag through the agent CLI's NDJSON output unchanged, which it doesn't do, or (b) duplicating local state in the frontend. The heuristic is one regex, the literal heading is owned by us in `buildStartupPayload.ts`, and a unit test pins the contract: any future renaming of the heading needs both files updated atomically.
+
+#### C.2 Render with the tool-block hover pattern
+
+Promote the user-message render to a small component (`UserMessageBlock.tsx`) that mirrors `ToolBlock`'s shape:
+
+```tsx
+// frontend/app/view/agent/components/UserMessageBlock.tsx
+
+export const UserMessageBlock = (props: {
+    node: UserMessageNode;
+    pinned: boolean;
+    onTogglePin: () => void;
+}): JSX.Element => {
+    const [hovering, setHovering] = createSignal(false);
+    let enterTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const handleMouseEnter = () => {
+        clearTimeout(enterTimer);
+        enterTimer = setTimeout(() => setHovering(true), 150);
+    };
+    const handleMouseLeave = () => {
+        clearTimeout(enterTimer);
+        setHovering(false);
+    };
+    onCleanup(() => clearTimeout(enterTimer));
+
+    // Startup gets collapse-by-default; regular user input is always
+    // visible and unaffected by hover/pin.
+    const collapsible = () => props.node.isStartup === true;
+    const expanded = () => !collapsible() || props.pinned || hovering();
+
+    return (
+        <div
+            class={clsx("agent-user-message", {
+                "agent-user-message--collapsed": collapsible() && !expanded(),
+                "agent-user-message--expanded": collapsible() && expanded(),
+                "agent-user-message--startup": collapsible(),
+                "agent-user-message--pinned": props.pinned,
+            })}
+            onMouseEnter={collapsible() ? handleMouseEnter : undefined}
+            onMouseLeave={collapsible() ? handleMouseLeave : undefined}
+            onClick={collapsible() ? props.onTogglePin : undefined}
+        >
+            <Show when={collapsible() && !expanded()}>
+                {/* one-line collapsed summary */}
+                <div class="agent-user-message-summary">
+                    <span class="agent-user-message-icon">⓵</span>
+                    <span class="agent-user-message-label">Session context</span>
+                    <span class="agent-user-message-hint">(hover to peek · click to pin)</span>
+                </div>
+            </Show>
+            <Show when={!collapsible() || expanded()}>
+                <div class="agent-user-message-content">
+                    <pre>{props.node.message}</pre>
+                </div>
+            </Show>
+        </div>
+    );
+};
+```
+
+`DocumentRow` becomes a thin call site:
+
+```tsx
+<Show when={props.node().type === "user_message"}>
+    <UserMessageBlock
+        node={props.node() as UserMessageNode}
+        pinned={props.documentState().pinnedNodes.has(props.node().id)}
+        onTogglePin={() => props.dispatch({ type: "ToggleNodePin", id: props.node().id })}
+    />
+</Show>
+```
+
+#### C.3 SCSS additions
+
+```scss
+.agent-user-message {
+    // …high-contrast base from §A…
+
+    // Startup variant — single-line collapsed by default.
+    &--startup {
+        cursor: pointer;
+
+        .agent-user-message-summary {
+            display: flex;
+            align-items: center;
+            gap: var(--space-1);
+            padding: var(--space-0-5) var(--space-1);
+            white-space: nowrap;
+            overflow: hidden;
+            min-width: 0;
+            user-select: none;
+
+            .agent-user-message-icon {
+                color: var(--user-input-color);
+            }
+            .agent-user-message-label {
+                font-weight: 500;
+                color: var(--user-input-color);
+            }
+            .agent-user-message-hint {
+                color: var(--secondary-text-color);
+                font-size: 0.85em;
+                opacity: 0.75;
+            }
+        }
+    }
+
+    &--pinned {
+        // Left border slightly thicker when pinned, mirroring ToolBlock.
+        border-left-width: 4px;
+    }
+
+    // Hover-while-collapsed: temporarily shows expanded content but
+    // keeps the visual hint that this row is collapsible.
+    &--expanded.agent-user-message--startup {
+        background: color-mix(in srgb, var(--user-input-color) 18%, transparent);
+    }
+}
+```
+
+The `--collapsed` rule from the current SCSS (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`) is REPLACED by the explicit `--startup .agent-user-message-summary` block — there's no `pre` content to ellipsis-truncate; the summary is its own first-class element.
+
+### D. Migration of the existing collapsedNodes set
+
+`AgentDocumentView` currently populates `collapsedNodes` for any user message above a size threshold. After this spec lands, the startup payload is the only one that should auto-collapse, and it does so via `isStartup`, not via the size threshold. Two follow-up cleanups:
+
+- `documentState.collapsedNodes` for user messages becomes vestigial. Remove the auto-collapse-on-size logic; let regular user input always render full.
+- Add `documentState.pinnedNodes` (parallel structure) and a `ToggleNodePin` action.
+
+Both ride with the implementation PR — no separate migration step.
+
+---
+
+## Behavior matrix
+
+| State | Regular user input | Startup injection |
+|---|---|---|
+| Default render | Always expanded; pre-line text; horizontal scroll if line too wide | Collapsed: `⓵ Session context (hover to peek · click to pin)` one-line summary |
+| Hover | No change | Expands to full content. 150ms enter-delay (matches ToolBlock). |
+| Click | No-op (selectable text) | Toggles pin. Pinned → stays expanded after mouse leaves. |
+| Word wrap | `white-space: pre` — newlines honored, no soft wrap | Same when expanded (no wrap inside the expanded body either) |
+| Color | `--user-input-color` background tint at 14%, 3px left border | Same as regular when expanded; collapsed summary uses solid `--user-input-color` for icon + label |
+
+---
+
+## Edge cases
+
+- **Startup message that crashes the heuristic.** A user who types `# Session Context` as their first message would get auto-collapsed. Acceptable: pinning is one click, and the user is unlikely to type that exact heading. A follow-up could promote the heuristic to a wire-level marker when/if the cost shows up.
+- **Pre-existing sessions whose startup was already auto-collapsed via `collapsedNodes`.** After the migration, those rows re-render via the new path. They were collapsed before, they collapse now. No data loss; state-key on `node.id`.
+- **Themes that already define `--accent-color`.** Untouched — only the user-message styling stops using `--accent-color`.
+- **Very long single line of typed input** (e.g. a pasted URL). Renders one line, horizontal scroll inside the message's pre. The block doesn't grow vertically. Standard browser textarea behavior translates here.
+- **Selection across multiple user messages.** `user-select: text` stays on the regular variant. The startup variant gets `user-select: none` on the summary row (selection inside the collapsed summary would be confusing and not useful), `text` on the expanded body.
+
+---
+
+## Tests
+
+### L1 — Stream parser
+
+- `userMessageToNode` sets `isStartup: true` when message starts with `# Session Context`.
+- `userMessageToNode` sets `isStartup: false` for any other content (typed user message, agent reply quoted in user content, etc.).
+- Test fixture pins the literal heading so a rename of the heading in `buildStartupPayload.ts` fails this test.
+
+### L2 — UserMessageBlock component
+
+- Regular user input (`isStartup` undefined / false): rendered expanded; no hover/click handlers attached; `pre` content visible.
+- Startup input, no pin, no hover: only the summary row renders; `pre` content absent from the DOM.
+- Startup input, hover-enter after 150ms: full `pre` content renders, summary hidden.
+- Startup input, click on collapsed: `onTogglePin` called.
+- Startup input, pinned: full content visible even after `mouseLeave`.
+
+### L3 — Visual / manual
+
+- Open a fresh agent. The first row is the collapsed `⓵ Session context` summary.
+- Type "hello". The user message renders below, in the high-contrast user-input color.
+- Hover the startup summary. Full session context appears under the cursor.
+- Click the startup summary. It stays expanded; clicking again collapses.
+- Type a very long single line (paste a 200-char URL). The line does not wrap; the message gets a horizontal scrollbar.
+- Switch themes (light / dark / system). User-input color stays high-contrast on both.
+
+---
+
+## Order of delivery
+
+One PR, three commits on `agenta/user-input-visibility`:
+
+1. **CSS-only commit.** Add `--user-input-color` variable, swap `.agent-user-message` to use it, change `pre` to `white-space: pre`, remove `overflow-wrap`. Single SCSS file. Visual regression test or screenshot review.
+2. **Stream-parser + types commit.** Add `isStartup` to `UserMessageNode`, set in `userMessageToNode`, with L1 tests.
+3. **UserMessageBlock component commit.** Extract from `DocumentRow.tsx`, add hover/pin signals, wire pinnedNodes through `documentState`, retire the `collapsedNodes` user-message branch, with L2 tests.
+
+Each commit is independently revertible; the SCSS commit alone delivers the high-contrast win without depending on the rest.
+
+---
+
+## Out of scope
+
+- Agent-reply rendering (no change).
+- Tool-block styling (separate spec — `tool-collapse.md`).
+- Light/dark theme palette overhaul (a separate theming pass; this spec only adds one variable to the existing theme block).
+- Markdown rendering of the startup payload (currently raw `<pre>`; making it a rendered `Markdown` block is a follow-up that doesn't change the collapse behavior).
+- Selectable summary row content (the collapsed summary is a fixed `Session context` label; we don't try to extract a preview from the body).
+
+---
+
+## Related
+
+- `docs/specs/tool-collapse.md` — the source pattern for hover-expand-pin, with the same 150ms enter-delay and the same CSS-class trio (`collapsed` / `expanded` / `pinned`).
+- `docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md` — the contract that defines what the startup payload contains and when it's sent. The collapse target is exactly the message that spec produces.
+- `feedback_agent_pane_tool_display` (user memory) — "Tool blocks ONE LINE by default, expand on hover (instant), click to pin." The same rule, now applied to the startup injection.

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -49,6 +49,16 @@
     --fixed-font: normal 12px / normal "Hack", monospace;
     --accent-color: rgb(65, 159, 224);
     --accent-color-rgb: 65, 159, 224;
+
+    // User-input highlight — distinct from --accent-color so that
+    // re-themings of the accent (button highlights, link color, etc.)
+    // don't drag typed-input visibility with them. Default is a
+    // saturated cyan-blue chosen for >4.5:1 contrast on both dark
+    // and light surfaces. Per-theme overrides land in
+    // `frontend/app/themes/*.scss` if a theme wants its own palette.
+    // See `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+    --user-input-color: #00b4d8;
+
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);
     --markdown-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif,

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -19,7 +19,7 @@
  * `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { createEffect, createSignal, Show, type Accessor, type JSX } from "solid-js";
+import { createSignal, Show, type Accessor, type JSX } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -65,32 +65,13 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
     // scroll state is per-pane-mount, not per-agent-session.
     const viewState = createAgentViewState(props.documentAtom);
 
-    // Auto-collapse large user_messages on first arrival. The startup
-    // session-context payload that `buildStartupPayload` sends is a huge
-    // JSON block that visually dominates the pane; short user turns
-    // (one-line prompts) fit unchanged. Tracked per-node via `seenIds`
-    // so we don't re-collapse after the user has explicitly expanded.
-    const seenUserMessageIds = new Set<string>();
-    createEffect(() => {
-        const doc = viewState.nodes();
-        const toCollapse: string[] = [];
-        for (const n of doc) {
-            if (n.type !== "user_message") continue;
-            if (seenUserMessageIds.has(n.id)) continue;
-            seenUserMessageIds.add(n.id);
-            const msg = (n as { message?: string }).message ?? "";
-            if (msg.length > 200 || msg.includes("\n")) {
-                toCollapse.push(n.id);
-            }
-        }
-        if (toCollapse.length > 0) {
-            setDocumentState((prev) => {
-                const next = new Set(prev.collapsedNodes);
-                for (const id of toCollapse) next.add(id);
-                return { ...prev, collapsedNodes: next };
-            });
-        }
-    });
+    // Auto-collapse-on-size for user messages was retired in PR #1020
+    // — `UserMessageBlock` keys collapse off `node.isStartup` and
+    // `documentState.pinnedNodes`, not `collapsedNodes`. Writing to
+    // `collapsedNodes` here would be dead state from the renderer's
+    // perspective. See
+    // `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`
+    // §D.
 
     // Toggle collapsed state for collapsible nodes (agent messages, sections, user messages).
     const toggleCollapse = (nodeId: string): void => {

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -26,8 +26,6 @@ const baseNode: UserMessageNode = {
     id: "user_0",
     message: "Can you run the tests?",
     timestamp: 0,
-    collapsed: false,
-    summary: "👤 User Message",
 };
 
 const startupNode: UserMessageNode = {
@@ -89,9 +87,41 @@ describe("UserMessageBlock — startup injection", () => {
         const { container } = render(() => (
             <UserMessageBlock node={startupNode} pinned={false} onTogglePin={togglePin} />
         ));
-        const root = container.querySelector(".agent-user-message")!;
-        fireEvent.click(root);
+        const summary = container.querySelector(".agent-user-message-summary")!;
+        fireEvent.click(summary);
         expect(togglePin).toHaveBeenCalledTimes(1);
+    });
+
+    it("click on expanded <pre> body does NOT fire onTogglePin", () => {
+        // Codex P2 on PR #1020 first cut: clicking inside the
+        // expanded body (to place the caret or select text for
+        // copying) must not unpin the row. Click handler is
+        // scoped to the summary, not the outer block.
+        const togglePin = vi.fn();
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={true} onTogglePin={togglePin} />
+        ));
+        const pre = container.querySelector(".agent-user-message-content pre")!;
+        fireEvent.click(pre);
+        expect(togglePin).not.toHaveBeenCalled();
+    });
+
+    it("explicit unpin button on pinned row fires onTogglePin", () => {
+        const togglePin = vi.fn();
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={true} onTogglePin={togglePin} />
+        ));
+        const unpin = container.querySelector(".agent-user-message-unpin");
+        expect(unpin).not.toBeNull();
+        fireEvent.click(unpin!);
+        expect(togglePin).toHaveBeenCalledTimes(1);
+    });
+
+    it("unpin button is absent when not pinned", () => {
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+        ));
+        expect(container.querySelector(".agent-user-message-unpin")).toBeNull();
     });
 
     it("pinned=true renders expanded (full markdown body visible)", () => {

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -117,11 +117,47 @@ describe("UserMessageBlock — startup injection", () => {
         expect(togglePin).toHaveBeenCalledTimes(1);
     });
 
-    it("unpin button is absent when not pinned", () => {
+    it("unpin button is absent when not pinned (pin button takes its place)", () => {
+        // Codex P2 round 3: when the row is expanded but not pinned
+        // (e.g. via hover), the user must still be able to pin from
+        // inside the body. The button slot is shared:
+        //   pinned → ✕ unpin
+        //   !pinned → 📌 pin
+        // Both call onTogglePin.
         const { container } = render(() => (
             <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
         ));
+        // Not pinned + collapsed-by-default → button slot is hidden
+        // because the body itself isn't rendered yet.
+        expect(container.querySelector(".agent-user-message-pin")).toBeNull();
         expect(container.querySelector(".agent-user-message-unpin")).toBeNull();
+    });
+
+    it("pin button is visible during hover-expansion and fires onTogglePin", async () => {
+        // Drives the codex round-3 flow: hover to expand the body,
+        // then click 📌 to pin. Without this affordance, the user
+        // would have to leave + re-enter the collapsed summary
+        // before the 150ms enter-delay restarted — defeating the
+        // "hover to peek · click to pin" hint.
+        vi.useFakeTimers();
+        try {
+            const togglePin = vi.fn();
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={false} onTogglePin={togglePin} />
+            ));
+            const root = container.querySelector(".agent-user-message") as HTMLElement;
+            fireEvent.mouseEnter(root);
+            vi.advanceTimersByTime(200);
+            // Hover-expanded — pin button now present.
+            const pin = container.querySelector(".agent-user-message-pin");
+            expect(pin).not.toBeNull();
+            expect((pin as HTMLElement).getAttribute("aria-label")).toContain("Pin");
+            // Click it.
+            (pin as HTMLButtonElement).click();
+            expect(togglePin).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("pinned=true renders expanded (full markdown body visible)", () => {

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -185,4 +185,31 @@ describe("UserMessageBlock — startup injection", () => {
             vi.useRealTimers();
         }
     });
+
+    it("collapsed summary is a real <button> with aria-expanded", () => {
+        // Codex P2 round 2: the summary must be keyboard-operable.
+        // Rendering as <button> gives Tab focus + Space/Enter
+        // activation for free. aria-expanded mirrors the pin state.
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+        ));
+        const summary = container.querySelector(".agent-user-message-summary");
+        expect(summary).not.toBeNull();
+        expect(summary!.tagName).toBe("BUTTON");
+        expect(summary!.getAttribute("type")).toBe("button");
+        expect(summary!.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("button.click() on the summary fires onTogglePin (Space/Enter contract)", () => {
+        // Native <button> dispatches click on Space/Enter. Driving
+        // .click() directly matches the keyboard-activation path that
+        // jsdom would route through HTMLButtonElement.
+        const togglePin = vi.fn();
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={false} onTogglePin={togglePin} />
+        ));
+        const summary = container.querySelector(".agent-user-message-summary") as HTMLButtonElement;
+        summary.click();
+        expect(togglePin).toHaveBeenCalledTimes(1);
+    });
 });

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -1,0 +1,158 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * UserMessageBlock — render-shape tests for the two variants:
+ *
+ *   - regular user input: always expanded, no hover/pin handlers.
+ *   - startup injection (`isStartup === true`): collapsed by default,
+ *     hover-expand after 150ms, click-to-pin.
+ *
+ * Spec: `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserMessageBlock } from "./UserMessageBlock";
+import type { UserMessageNode } from "../types";
+
+afterEach(() => {
+    cleanup();
+});
+
+const baseNode: UserMessageNode = {
+    type: "user_message",
+    id: "user_0",
+    message: "Can you run the tests?",
+    timestamp: 0,
+    collapsed: false,
+    summary: "👤 User Message",
+};
+
+const startupNode: UserMessageNode = {
+    ...baseNode,
+    id: "user_startup",
+    message: "# Session Context\n\n## Identity\n- Name: AgentA\n",
+    isStartup: true,
+};
+
+describe("UserMessageBlock — regular user input", () => {
+    it("renders expanded with the message body, no summary row", () => {
+        render(() => (
+            <UserMessageBlock node={baseNode} pinned={false} onTogglePin={() => {}} />
+        ));
+        // Body present
+        expect(screen.queryByText("Can you run the tests?")).not.toBeNull();
+        // No collapsed summary row
+        expect(screen.queryByText("Session context")).toBeNull();
+    });
+
+    it("ignores pin prop (regular input is always expanded)", () => {
+        render(() => (
+            <UserMessageBlock node={baseNode} pinned={true} onTogglePin={() => {}} />
+        ));
+        expect(screen.queryByText("Can you run the tests?")).not.toBeNull();
+    });
+
+    it("click on a regular row does NOT call onTogglePin", () => {
+        const togglePin = vi.fn();
+        const { container } = render(() => (
+            <UserMessageBlock node={baseNode} pinned={false} onTogglePin={togglePin} />
+        ));
+        const root = container.querySelector(".agent-user-message")!;
+        fireEvent.click(root);
+        expect(togglePin).not.toHaveBeenCalled();
+    });
+
+    it("applies neither the --startup nor the --collapsed class", () => {
+        const { container } = render(() => (
+            <UserMessageBlock node={baseNode} pinned={false} onTogglePin={() => {}} />
+        ));
+        const root = container.querySelector(".agent-user-message")!;
+        expect(root.classList.contains("agent-user-message--startup")).toBe(false);
+        expect(root.classList.contains("agent-user-message--collapsed")).toBe(false);
+    });
+});
+
+describe("UserMessageBlock — startup injection", () => {
+    it("renders collapsed summary, body absent by default", () => {
+        render(() => (
+            <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+        ));
+        expect(screen.queryByText("Session context")).not.toBeNull();
+        expect(screen.queryByText(/Identity/)).toBeNull();
+    });
+
+    it("click on collapsed summary fires onTogglePin", () => {
+        const togglePin = vi.fn();
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={false} onTogglePin={togglePin} />
+        ));
+        const root = container.querySelector(".agent-user-message")!;
+        fireEvent.click(root);
+        expect(togglePin).toHaveBeenCalledTimes(1);
+    });
+
+    it("pinned=true renders expanded (full markdown body visible)", () => {
+        render(() => (
+            <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
+        ));
+        // Body visible — first identity bullet matches the fixture
+        expect(screen.queryByText(/Identity/)).not.toBeNull();
+        // No collapsed summary row when expanded
+        expect(screen.queryByText("Session context")).toBeNull();
+    });
+
+    it("pinned=true gets the --pinned class on the root", () => {
+        const { container } = render(() => (
+            <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
+        ));
+        const root = container.querySelector(".agent-user-message")!;
+        expect(root.classList.contains("agent-user-message--pinned")).toBe(true);
+        expect(root.classList.contains("agent-user-message--startup")).toBe(true);
+        expect(root.classList.contains("agent-user-message--expanded")).toBe(true);
+    });
+
+    it("hover (mouseenter→delay) expands the body after 150ms", async () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+            ));
+            const root = container.querySelector(".agent-user-message") as HTMLElement;
+            // Pre-hover: collapsed summary present, body absent.
+            expect(screen.queryByText("Session context")).not.toBeNull();
+            expect(screen.queryByText(/Identity/)).toBeNull();
+            fireEvent.mouseEnter(root);
+            // 100ms in — still collapsed (under the 150ms threshold).
+            vi.advanceTimersByTime(100);
+            expect(screen.queryByText(/Identity/)).toBeNull();
+            // Past the threshold — expanded.
+            vi.advanceTimersByTime(60);
+            expect(screen.queryByText(/Identity/)).not.toBeNull();
+            expect(screen.queryByText("Session context")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("mouseleave before the enter-delay cancels the expansion", async () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+            ));
+            const root = container.querySelector(".agent-user-message") as HTMLElement;
+            fireEvent.mouseEnter(root);
+            vi.advanceTimersByTime(100);
+            fireEvent.mouseLeave(root);
+            vi.advanceTimersByTime(200);
+            // Still collapsed — the pending timer was cleared on leave.
+            expect(screen.queryByText(/Identity/)).toBeNull();
+            expect(screen.queryByText("Session context")).not.toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -77,10 +77,17 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
             })}
             onMouseEnter={collapsible() ? handleMouseEnter : undefined}
             onMouseLeave={collapsible() ? handleMouseLeave : undefined}
-            onClick={collapsible() ? props.onTogglePin : undefined}
         >
             <Show when={collapsible() && !expanded()}>
-                <div class="agent-user-message-summary">
+                {/* Click-to-pin is bound HERE, on the summary row only.
+                 *  Binding it on the outer block would let clicks inside
+                 *  the expanded <pre> (e.g. placing the caret, selecting
+                 *  text to copy) toggle pin and immediately collapse the
+                 *  message — codex P2 on PR #1020 first cut. */}
+                <div
+                    class="agent-user-message-summary"
+                    onClick={props.onTogglePin}
+                >
                     <span class="agent-user-message-icon">⓵</span>
                     <span class="agent-user-message-label">Session context</span>
                     <span class="agent-user-message-hint">
@@ -90,6 +97,28 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
             </Show>
             <Show when={!collapsible() || expanded()}>
                 <div class="agent-user-message-content">
+                    {/* For pinned startup rows, expose a small "unpin"
+                     *  affordance in the corner so users can collapse
+                     *  without hunting for the trick. Hidden when not
+                     *  pinned (mouseleave already collapses transient
+                     *  hover-expansions). */}
+                    <Show when={collapsible() && props.pinned}>
+                        <button
+                            type="button"
+                            class="agent-user-message-unpin"
+                            title="Collapse session context"
+                            onClick={(e) => {
+                                // Stop propagation so the click doesn't
+                                // bubble — though no outer handler is
+                                // bound after the codex P2 fix, future
+                                // outer handlers won't fire either.
+                                e.stopPropagation();
+                                props.onTogglePin();
+                            }}
+                        >
+                            ✕
+                        </button>
+                    </Show>
                     <pre>{props.node.message}</pre>
                 </div>
             </Show>

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -79,21 +79,31 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
             onMouseLeave={collapsible() ? handleMouseLeave : undefined}
         >
             <Show when={collapsible() && !expanded()}>
-                {/* Click-to-pin is bound HERE, on the summary row only.
-                 *  Binding it on the outer block would let clicks inside
-                 *  the expanded <pre> (e.g. placing the caret, selecting
-                 *  text to copy) toggle pin and immediately collapse the
-                 *  message — codex P2 on PR #1020 first cut. */}
-                <div
+                {/* Click-to-pin is bound HERE, on the summary row
+                 *  only. Binding it on the outer block would let
+                 *  clicks inside the expanded <pre> (e.g. placing
+                 *  the caret, selecting text to copy) toggle pin and
+                 *  immediately collapse the message — codex P2
+                 *  round 1 on PR #1020.
+                 *
+                 *  Rendered as a real <button> so keyboard users get
+                 *  Tab focus + Space/Enter activation for free. The
+                 *  default button-chrome is reset in SCSS via the
+                 *  shared `.agent-user-message-summary` rule.
+                 *  Codex P2 round 2 on PR #1020. */}
+                <button
+                    type="button"
                     class="agent-user-message-summary"
                     onClick={props.onTogglePin}
+                    aria-expanded={props.pinned}
+                    aria-label="Session context — click to expand and pin"
                 >
                     <span class="agent-user-message-icon">⓵</span>
                     <span class="agent-user-message-label">Session context</span>
                     <span class="agent-user-message-hint">
                         (hover to peek · click to pin)
                     </span>
-                </div>
+                </button>
             </Show>
             <Show when={!collapsible() || expanded()}>
                 <div class="agent-user-message-content">

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -107,26 +107,45 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
             </Show>
             <Show when={!collapsible() || expanded()}>
                 <div class="agent-user-message-content">
-                    {/* For pinned startup rows, expose a small "unpin"
-                     *  affordance in the corner so users can collapse
-                     *  without hunting for the trick. Hidden when not
-                     *  pinned (mouseleave already collapses transient
-                     *  hover-expansions). */}
-                    <Show when={collapsible() && props.pinned}>
+                    {/* Top-right action button — has two modes:
+                     *
+                     *   - Hover-expanded but not pinned: shows 📌
+                     *     so the user can pin without racing the
+                     *     150ms enter-delay. (Codex P2 round 3:
+                     *     "Keep click-to-pin available while
+                     *      startup preview is expanded.")
+                     *   - Pinned: shows ✕ to collapse.
+                     *
+                     * Both call `onTogglePin` — the parent reducer
+                     * flips the boolean and the conditional below
+                     * picks the right glyph for the new state. */}
+                    <Show when={collapsible()}>
                         <button
                             type="button"
-                            class="agent-user-message-unpin"
-                            title="Collapse session context"
+                            class={clsx({
+                                "agent-user-message-unpin": props.pinned,
+                                "agent-user-message-pin": !props.pinned,
+                            })}
+                            title={
+                                props.pinned
+                                    ? "Collapse session context"
+                                    : "Pin session context open"
+                            }
+                            aria-label={
+                                props.pinned
+                                    ? "Collapse session context"
+                                    : "Pin session context open"
+                            }
                             onClick={(e) => {
                                 // Stop propagation so the click doesn't
-                                // bubble — though no outer handler is
-                                // bound after the codex P2 fix, future
-                                // outer handlers won't fire either.
+                                // bubble to the outer block (where no
+                                // handler is bound today, but future
+                                // outer handlers won't fire either).
                                 e.stopPropagation();
                                 props.onTogglePin();
                             }}
                         >
-                            ✕
+                            {props.pinned ? "✕" : "📌"}
                         </button>
                     </Show>
                     <pre>{props.node.message}</pre>

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -1,0 +1,100 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * UserMessageBlock — agent-pane row for user input.
+ *
+ * Two render shapes, gated by `node.isStartup` (set by the stream
+ * parser when the message matches the startup-injection heading):
+ *
+ *   - **Regular user input** (`isStartup` false / undefined):
+ *     always expanded. `<pre>` content rendered with
+ *     `white-space: pre` (no soft wrap; long lines scroll
+ *     horizontally inside the bubble). High-contrast cyan-blue
+ *     tint via `--user-input-color`.
+ *
+ *   - **Startup injection** (`isStartup === true`): collapsed-by-
+ *     default summary row (`⓵ Session context (hover to peek ·
+ *     click to pin)`). Hover-expand (150ms enter delay) shows the
+ *     full Markdown payload transiently. Clicking the summary
+ *     pins the expanded state. Mirrors the ToolBlock pattern in
+ *     `docs/specs/tool-collapse.md`.
+ *
+ * Spec: `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+ *
+ * SolidJS reactivity note: props are accessed via `props.X` (never
+ * destructured). Pin toggles mutate `documentState.pinnedNodes`
+ * without triggering a parent re-render of the document array —
+ * destructuring `pinned` would lose reactivity (cost AgentMux a
+ * bug fix in PR #346 on ToolBlock; same shape here).
+ */
+
+import clsx from "clsx";
+import { Show, createSignal, onCleanup, type JSX } from "solid-js";
+import type { UserMessageNode } from "../types";
+
+interface UserMessageBlockProps {
+    node: UserMessageNode;
+    /** User has clicked to pin a startup row open. Has no effect
+     * for regular user input (which is always expanded). */
+    pinned: boolean;
+    /** Toggle the pin. Wired by the parent through
+     * `documentState.pinnedNodes`. */
+    onTogglePin: () => void;
+}
+
+// Matches ToolBlock's 150ms — prevents accidental expansions while
+// the user scrolls past the row.
+const HOVER_ENTER_DELAY_MS = 150;
+
+export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
+    const [hovering, setHovering] = createSignal(false);
+    let enterTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const handleMouseEnter = () => {
+        clearTimeout(enterTimer);
+        enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
+    };
+    const handleMouseLeave = () => {
+        clearTimeout(enterTimer);
+        setHovering(false);
+    };
+    onCleanup(() => clearTimeout(enterTimer));
+
+    // Only the startup variant is collapsible. Regular input is
+    // always fully visible — hover/pin are no-ops there.
+    const collapsible = (): boolean => props.node.isStartup === true;
+    const expanded = (): boolean =>
+        !collapsible() || props.pinned || hovering();
+
+    return (
+        <div
+            class={clsx("agent-user-message", {
+                "agent-user-message--startup": collapsible(),
+                "agent-user-message--collapsed": collapsible() && !expanded(),
+                "agent-user-message--expanded": collapsible() && expanded(),
+                "agent-user-message--pinned": collapsible() && props.pinned,
+            })}
+            onMouseEnter={collapsible() ? handleMouseEnter : undefined}
+            onMouseLeave={collapsible() ? handleMouseLeave : undefined}
+            onClick={collapsible() ? props.onTogglePin : undefined}
+        >
+            <Show when={collapsible() && !expanded()}>
+                <div class="agent-user-message-summary">
+                    <span class="agent-user-message-icon">⓵</span>
+                    <span class="agent-user-message-label">Session context</span>
+                    <span class="agent-user-message-hint">
+                        (hover to peek · click to pin)
+                    </span>
+                </div>
+            </Show>
+            <Show when={!collapsible() || expanded()}>
+                <div class="agent-user-message-content">
+                    <pre>{props.node.message}</pre>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+UserMessageBlock.displayName = "UserMessageBlock";

--- a/frontend/app/view/agent/stream-parser.test.ts
+++ b/frontend/app/view/agent/stream-parser.test.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, test, expect, beforeEach } from "vitest";
-import { ClaudeCodeStreamParser } from "./stream-parser";
-import type { StreamEvent, MarkdownNode, ToolNode } from "./types";
+import { ClaudeCodeStreamParser, STARTUP_HEADING_RE } from "./stream-parser";
+import { buildStartupPayload } from "./startup/buildStartupPayload";
+import type { StreamEvent, MarkdownNode, ToolNode, UserMessageNode } from "./types";
 
 let parser: ClaudeCodeStreamParser;
 
@@ -314,5 +315,84 @@ describe("reset", () => {
         const node = parser.parseStreamEvent({ type: "text", content: "fresh" });
         expect(node!.id).toBe("node_0");
         expect((node as MarkdownNode).content).toBe("fresh");
+    });
+});
+
+// ── startup-injection detection (SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24) ─
+
+describe("user_message startup-injection detection", () => {
+    test("sets isStartup=true when message starts with '# Session Context'", () => {
+        const node = parser.parseStreamEvent({
+            type: "user_message",
+            message: "# Session Context\n\n## Identity\n- Name: AgentA\n",
+        });
+        expect(node).not.toBeNull();
+        expect(node!.type).toBe("user_message");
+        expect((node as UserMessageNode).isStartup).toBe(true);
+    });
+
+    test("sets isStartup=false for normal typed input", () => {
+        const node = parser.parseStreamEvent({
+            type: "user_message",
+            message: "Can you run the tests?",
+        });
+        expect((node as UserMessageNode).isStartup).toBe(false);
+    });
+
+    test("sets isStartup=false when '# Session Context' is not at the start", () => {
+        // A user replying to an agent's output that quoted the heading
+        // must NOT be misclassified as a startup payload.
+        const node = parser.parseStreamEvent({
+            type: "user_message",
+            message: "I noticed the agent said:\n# Session Context\n— what does that mean?",
+        });
+        expect((node as UserMessageNode).isStartup).toBe(false);
+    });
+
+    test("sets isStartup=false when heading is similar but different", () => {
+        // Word-boundary anchor `\b` after the literal — `# Session Contextual`
+        // is NOT a startup payload.
+        const node = parser.parseStreamEvent({
+            type: "user_message",
+            message: "# Session Contextual notes follow",
+        });
+        expect((node as UserMessageNode).isStartup).toBe(false);
+    });
+
+    test("STARTUP_HEADING_RE pins the literal heading buildStartupPayload emits", () => {
+        // Contract test: any future rename of the heading in
+        // buildStartupPayload.ts must update the regex in
+        // stream-parser.ts in the same commit, or this test fails.
+        const payload = buildStartupPayload({
+            agent: {
+                id: "test-agent",
+                slug: "test",
+                name: "Test",
+                provider: "claude",
+                description: "",
+                icon: "",
+                working_directory: "",
+                provider_flags: "",
+                shell: "",
+                created_at: 0,
+                updated_at: 0,
+                agent_type: "host",
+                environment: "",
+                agent_bus_id: "",
+                accounts: "",
+                is_seeded: 0,
+                parent_id: "",
+                branch_label: "",
+                user_hidden: 0,
+            } as any,
+            providerDisplayName: "Claude",
+            workDir: "/tmp",
+            version: "0.0.0",
+            accounts: [],
+            peerAgents: [],
+            startupContent: null,
+        });
+        expect(payload).not.toBeNull();
+        expect(STARTUP_HEADING_RE.test(payload!)).toBe(true);
     });
 });

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -351,8 +351,6 @@ export class ClaudeCodeStreamParser {
             id: `user_${this.nodeIdCounter++}`,
             message: event.message,
             timestamp: event.timestamp || Date.now(),
-            collapsed: false, // UserMessageBlock owns the collapse state now
-            summary: "👤 User Message",
             isStartup,
         };
     }

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -26,6 +26,20 @@ import {
     UserMessageEvent,
 } from "./types";
 
+/**
+ * Detects the auto-generated startup payload by its literal first
+ * heading. `buildStartupPayload` emits `# Session Context` on the
+ * first line — this regex pins that contract. Updating the heading
+ * there without updating this regex will break the startup
+ * collapse-on-hover render. The L1 test on
+ * `ClaudeCodeStreamParser.userMessageToNode` asserts both
+ * positive and negative cases.
+ *
+ * Spec:
+ * `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+ */
+export const STARTUP_HEADING_RE = /^# Session Context\b/;
+
 export class ClaudeCodeStreamParser {
     private buffer: string = "";
     private nodeIdCounter: number = 0;
@@ -316,16 +330,30 @@ export class ClaudeCodeStreamParser {
     }
 
     /**
-     * Convert user message event to user message node
+     * Convert user message event to user message node.
+     *
+     * Detects the auto-generated startup payload by the literal
+     * `# Session Context` heading that `buildStartupPayload` emits
+     * as line 1. The flag drives `UserMessageBlock` to render
+     * collapsed-by-default with hover-expand + click-to-pin
+     * (mirrors the ToolBlock pattern). Heuristic is one regex
+     * matched against the heading; any future rename in
+     * `buildStartupPayload.ts` needs to update both atomically —
+     * pinned by the L1 test on this method.
+     *
+     * Spec:
+     * `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
      */
     private userMessageToNode(event: UserMessageEvent): DocumentNode {
+        const isStartup = STARTUP_HEADING_RE.test(event.message);
         return {
             type: "user_message",
             id: `user_${this.nodeIdCounter++}`,
             message: event.message,
             timestamp: event.timestamp || Date.now(),
-            collapsed: false, // Always show user messages
+            collapsed: false, // UserMessageBlock owns the collapse state now
             summary: "👤 User Message",
+            isStartup,
         };
     }
 

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -633,10 +633,9 @@
         // Long Markdown payload the frontend sends as the opening
         // turn (see SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md). It
         // shouldn't dominate the pane. Collapsed-by-default with
-        // hover-expand + click-to-pin.
+        // hover-expand + click-to-pin (on the summary row only —
+        // see UserMessageBlock for the rationale).
         &--startup {
-            cursor: pointer;
-
             .agent-user-message-summary {
                 display: flex;
                 align-items: center;
@@ -646,6 +645,7 @@
                 overflow: hidden;
                 min-width: 0;
                 user-select: none;
+                cursor: pointer;
 
                 .agent-user-message-icon {
                     color: var(--user-input-color);
@@ -662,6 +662,32 @@
                     opacity: 0.75;
                     overflow: hidden;
                     text-overflow: ellipsis;
+                }
+            }
+
+            // Unpin button only appears when the startup row is
+            // pinned open. Top-right corner of the content area.
+            .agent-user-message-content {
+                position: relative;
+
+                .agent-user-message-unpin {
+                    position: absolute;
+                    top: var(--space-0-5);
+                    right: var(--space-0-5);
+                    background: transparent;
+                    border: none;
+                    color: var(--user-input-color);
+                    font-size: 0.9em;
+                    line-height: 1;
+                    padding: 2px 6px;
+                    border-radius: 3px;
+                    cursor: pointer;
+                    opacity: 0.6;
+
+                    &:hover {
+                        opacity: 1;
+                        background: color-mix(in srgb, var(--user-input-color) 15%, transparent);
+                    }
                 }
             }
         }

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -637,6 +637,19 @@
         // see UserMessageBlock for the rationale).
         &--startup {
             .agent-user-message-summary {
+                // Rendered as a <button> for keyboard accessibility
+                // (Tab + Space/Enter). Reset the default button
+                // chrome so it lines up visually with the block-
+                // bubble shell — color/background come from the
+                // surrounding `--user-input-color` rules.
+                appearance: none;
+                background: transparent;
+                border: 0;
+                font: inherit;
+                color: inherit;
+                text-align: left;
+                width: 100%;
+
                 display: flex;
                 align-items: center;
                 gap: var(--space-1);
@@ -646,6 +659,13 @@
                 min-width: 0;
                 user-select: none;
                 cursor: pointer;
+
+                &:focus-visible {
+                    // Visible focus ring for keyboard users — matches
+                    // the accent treatment used elsewhere for focus.
+                    outline: 2px solid var(--user-input-color);
+                    outline-offset: 1px;
+                }
 
                 .agent-user-message-icon {
                     color: var(--user-input-color);

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -685,11 +685,20 @@
                 }
             }
 
-            // Unpin button only appears when the startup row is
-            // pinned open. Top-right corner of the content area.
+            // Top-right action button on the expanded body.
+            //   - .agent-user-message-pin   shows 📌 when the row
+            //     is hover-expanded but not pinned, so the user
+            //     can pin from inside the body (codex P2 round 3
+            //     on PR #1020 — without it, the only "pin"
+            //     affordance was on the summary button that's
+            //     no longer present once hover-expansion kicks in).
+            //   - .agent-user-message-unpin shows ✕ when pinned,
+            //     so the user can collapse without hunting.
+            // Both share styling.
             .agent-user-message-content {
                 position: relative;
 
+                .agent-user-message-pin,
                 .agent-user-message-unpin {
                     position: absolute;
                     top: var(--space-0-5);
@@ -707,6 +716,11 @@
                     &:hover {
                         opacity: 1;
                         background: color-mix(in srgb, var(--user-input-color) 15%, transparent);
+                    }
+                    &:focus-visible {
+                        outline: 2px solid var(--user-input-color);
+                        outline-offset: 1px;
+                        opacity: 1;
                     }
                 }
             }

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -596,10 +596,23 @@
     }
 
     // === User Message ===
+    // High-contrast user-input styling per
+    // `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+    // Uses --user-input-color (distinct from --accent-color) so typed
+    // input pops independently of the accent re-theming surface.
+    //
+    // Regular user input NEVER soft-wraps — newlines are honored
+    // verbatim and long lines scroll horizontally inside the message.
+    // The user controls wrapping by inserting their own \n.
+    //
+    // The startup-injection variant (`--startup`) gets a single-line
+    // summary that expands on hover and pins on click — mirroring
+    // the ToolBlock pattern in `tool-collapse.md`. See
+    // `components/UserMessageBlock.tsx` for the JSX side.
     .agent-user-message {
         padding: 3px var(--space-1);
-        background: color-mix(in srgb, var(--accent-color) 5%, transparent);
-        border-left: 2px solid var(--accent-color);
+        background: color-mix(in srgb, var(--user-input-color) 14%, transparent);
+        border-left: 3px solid var(--user-input-color);
         border-radius: 2px;
         user-select: text;
         cursor: text;
@@ -607,19 +620,62 @@
         .agent-user-message-content {
             pre {
                 margin: 0;
-                white-space: pre-wrap;
-                overflow-wrap: anywhere;
+                // pre = honor newlines, no soft-wrap. Long lines
+                // scroll horizontally inside the bubble; word-break
+                // rules removed so URLs / paths stay intact.
+                white-space: pre;
+                overflow-x: auto;
+                overflow-y: hidden;
             }
         }
 
-        // Collapsed state: show only the first line (ellipsis-truncated).
-        // Driven by AgentDocumentView auto-collapse for large user messages
-        // like the startup session-context payload. The hover strip's expand
-        // button toggles this off.
-        &--collapsed .agent-user-message-content pre {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
+        // ─── Startup-injection variant ────────────────────────────
+        // Long Markdown payload the frontend sends as the opening
+        // turn (see SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md). It
+        // shouldn't dominate the pane. Collapsed-by-default with
+        // hover-expand + click-to-pin.
+        &--startup {
+            cursor: pointer;
+
+            .agent-user-message-summary {
+                display: flex;
+                align-items: center;
+                gap: var(--space-1);
+                padding: var(--space-0-5) var(--space-1);
+                white-space: nowrap;
+                overflow: hidden;
+                min-width: 0;
+                user-select: none;
+
+                .agent-user-message-icon {
+                    color: var(--user-input-color);
+                    flex-shrink: 0;
+                }
+                .agent-user-message-label {
+                    font-weight: 500;
+                    color: var(--user-input-color);
+                    flex-shrink: 0;
+                }
+                .agent-user-message-hint {
+                    color: var(--secondary-text-color);
+                    font-size: 0.85em;
+                    opacity: 0.75;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
+        }
+
+        // Hover-while-collapsed (startup expanded transiently) gets
+        // a slightly deeper background so the user knows this is a
+        // hover-preview, not a permanent expansion.
+        &--expanded.agent-user-message--startup {
+            background: color-mix(in srgb, var(--user-input-color) 18%, transparent);
+        }
+
+        // Pinned state — thicker left border mirrors ToolBlock.pinned.
+        &--pinned {
+            border-left-width: 4px;
         }
     }
 

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -245,6 +245,20 @@ export interface UserMessageNode {
     timestamp: number;
     collapsed: boolean;
     summary: string; // "👤 User Message"
+    /** True when this row is the auto-generated startup context
+     * payload (see `buildStartupPayload.ts` + onReadyFn in
+     * `agent-view.tsx`). The renderer surfaces these
+     * collapsed-by-default with hover-expand + click-to-pin,
+     * mirroring the ToolBlock pattern — they otherwise dominate
+     * the pane on every fresh agent launch.
+     *
+     * Detected by stream-parser via the literal `# Session Context`
+     * heading the builder emits. Frontend-only marker; never
+     * round-trips through the agent CLI.
+     *
+     * Spec:
+     * `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`. */
+    isStartup?: boolean;
 }
 
 /**

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -236,15 +236,20 @@ export interface AgentMessageNode {
 }
 
 /**
- * User message to agent
+ * User message to agent.
+ *
+ * `collapsed` + `summary` fields were retired in PR #1020 — the
+ * renderer (`UserMessageBlock`) keys its render shape off
+ * `isStartup` + `documentState.pinnedNodes`, not per-node mutable
+ * state. The agent-message variant still carries `collapsed` /
+ * `summary` because its toggle UI lives on the document-level
+ * `collapsedNodes` set; user messages have their own pin model.
  */
 export interface UserMessageNode {
     type: "user_message";
     id: string;
     message: string;
     timestamp: number;
-    collapsed: boolean;
-    summary: string; // "👤 User Message"
     /** True when this row is the auto-generated startup context
      * payload (see `buildStartupPayload.ts` + onReadyFn in
      * `agent-view.tsx`). The renderer surfaces these

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -13,7 +13,7 @@ import { base64ToArray } from "@/util/util";
 import { createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
-import { ClaudeCodeStreamParser } from "./stream-parser";
+import { ClaudeCodeStreamParser, STARTUP_HEADING_RE } from "./stream-parser";
 import type { DocumentNode, SessionStats, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
 import type { TurnPhase } from "@/app/store/agent-pane-state/types";
@@ -326,14 +326,21 @@ export function useAgentStream({
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
                     // node ties back to the pending entry 1:1.
+                    // The optimistic-acceptance path goes through the
+                    // same `handleSendMessage` pipeline as the startup
+                    // injection (see agent-view.tsx `onReadyFn`). Apply
+                    // the same heuristic here as in the stream-parser
+                    // so the startup payload is flagged on first
+                    // render — otherwise UserMessageBlock would render
+                    // it as a regular user message (the full Markdown
+                    // wall, not the collapsed summary).
+                    // Codex P1 round 2 on PR #1020.
                     const node: UserMessageNode = {
                         type: "user_message",
                         id: pending.id,
                         message: pending.text,
                         timestamp: Date.now(),
-                        // No `isStartup` — locally-dispatched pending
-                        // messages are typed user input, never the
-                        // auto-generated startup payload.
+                        isStartup: STARTUP_HEADING_RE.test(pending.text),
                     };
                     if (!nodeIdSet.has(node.id)) {
                         nodeIdSet.add(node.id);

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -331,8 +331,9 @@ export function useAgentStream({
                         id: pending.id,
                         message: pending.text,
                         timestamp: Date.now(),
-                        collapsed: false,
-                        summary: "",
+                        // No `isStartup` — locally-dispatched pending
+                        // messages are typed user input, never the
+                        // auto-generated startup payload.
                     };
                     if (!nodeIdSet.has(node.id)) {
                         nodeIdSet.add(node.id);

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -21,7 +21,8 @@ import { MarkdownBlock } from "../components/MarkdownBlock";
 import { NodeHoverStrip } from "../components/NodeHoverStrip";
 import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
 import { ToolBlock } from "../components/ToolBlock";
-import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import { UserMessageBlock } from "../components/UserMessageBlock";
+import type { DocumentNode, DocumentState, SubagentLinkNode, UserMessageNode } from "../types";
 import { markRowMount } from "./perf-probe";
 
 export interface DocumentRowProps {
@@ -247,17 +248,11 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                 />
             </Show>
             <Show when={props.node() && props.node().type === "user_message"}>
-                <div
-                    class="agent-user-message"
-                    classList={{
-                        "agent-user-message--collapsed":
-                            props.documentState().collapsedNodes.has(props.node().id),
-                    }}
-                >
-                    <div class="agent-user-message-content">
-                        <pre>{(props.node() as Extract<DocumentNode, { type: "user_message" }>).message}</pre>
-                    </div>
-                </div>
+                <UserMessageBlock
+                    node={props.node() as UserMessageNode}
+                    pinned={props.documentState().pinnedNodes.has(props.node().id)}
+                    onTogglePin={() => props.onTogglePin(props.node().id)}
+                />
             </Show>
             <Show when={props.node() && props.node().type === "subagent_link"}>
                 <SubagentLinkBlock

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -55,10 +55,16 @@ export interface DocumentRowProps {
     dataIndex?: number;
 }
 
+// Kinds whose hover-strip surfaces an Expand/Collapse control.
+// `user_message` was here until PR #1020 — UserMessageBlock now owns
+// its own collapse state (via `isStartup` + `documentState.pinnedNodes`,
+// not `collapsedNodes`), so a hover-strip toggle here would have been a
+// no-op control writing dead state. Toggling pin from the strip would
+// also be confusing for normal typed input (which is never collapsible
+// to begin with). Codex P2 on PR #1020.
 const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
     "tool",
     "agent_message",
-    "user_message",
     "section",
 ]);
 

--- a/frontend/app/view/agent/virtualization/renderers.test.ts
+++ b/frontend/app/view/agent/virtualization/renderers.test.ts
@@ -18,6 +18,7 @@ import {
     estimateSection,
     estimateSubagentLink,
     estimateTextHeight,
+    estimateUnwrappedTextHeight,
     estimateTool,
     estimateUserMessage,
     STREAMING_CAPABLE,
@@ -60,6 +61,37 @@ describe("estimateTextHeight", () => {
 
     it("respects custom chars/lineHeight params", () => {
         expect(estimateTextHeight("a".repeat(40), 20, 30)).toBe(60); // 2 lines × 30 = 60
+    });
+});
+
+describe("estimateUnwrappedTextHeight", () => {
+    it("returns the minimum height for empty content", () => {
+        expect(estimateUnwrappedTextHeight("")).toBe(32);
+    });
+
+    it("estimates one line for any content without newlines (no soft wrap)", () => {
+        // Codex P2 round 4: a 300-char URL on one line must NOT be
+        // estimated as 4 wrapped lines like estimateTextHeight would.
+        expect(estimateUnwrappedTextHeight("short")).toBe(32);
+        expect(estimateUnwrappedTextHeight("a".repeat(80))).toBe(32);
+        expect(estimateUnwrappedTextHeight("a".repeat(300))).toBe(32);
+        expect(estimateUnwrappedTextHeight("https://example.com/very/long/path/" + "x".repeat(500))).toBe(32);
+    });
+
+    it("counts explicit newlines", () => {
+        expect(estimateUnwrappedTextHeight("line1\nline2")).toBe(48); // 2 lines × 24
+        expect(estimateUnwrappedTextHeight("a\nb\nc")).toBe(72); // 3 lines × 24
+    });
+
+    it("ignores per-line character count entirely", () => {
+        // Long-line + multiline: counted by newlines only.
+        const longLines = "a".repeat(500) + "\n" + "b".repeat(500);
+        expect(estimateUnwrappedTextHeight(longLines)).toBe(48); // exactly 2 lines
+    });
+
+    it("caps at the max estimate", () => {
+        const manyLines = "x\n".repeat(100); // 101 lines × 24 = 2424
+        expect(estimateUnwrappedTextHeight(manyLines)).toBe(320);
     });
 });
 
@@ -122,8 +154,29 @@ describe("per-kind estimators", () => {
             type: "user_message", id: "um1", message: "hi", timestamp: 0,
         };
 
-        it("uses text-height estimate for a regular user message", () => {
+        it("uses unwrapped (newline-based) estimate for a regular user message", () => {
             expect(estimateUserMessage(node, baseDocState())).toBe(32); // short → MIN
+        });
+
+        it("does NOT inflate height for long single-line input (no soft wrap)", () => {
+            // Codex P2 round 4: user input has white-space: pre,
+            // long lines scroll horizontally. The estimator must
+            // not over-allocate vertical space for them.
+            const longUrl: UserMessageNode = {
+                ...node,
+                id: "um-url",
+                message: "https://example.com/" + "x".repeat(500),
+            };
+            expect(estimateUserMessage(longUrl, baseDocState())).toBe(32); // 1 visual line
+        });
+
+        it("scales with explicit newline count", () => {
+            const multiline: UserMessageNode = {
+                ...node,
+                id: "um-multi",
+                message: "a\nb\nc",
+            };
+            expect(estimateUserMessage(multiline, baseDocState())).toBe(72); // 3 × 24
         });
 
         it("returns the collapsed-summary size for an unpinned startup row", () => {

--- a/frontend/app/view/agent/virtualization/renderers.test.ts
+++ b/frontend/app/view/agent/virtualization/renderers.test.ts
@@ -120,16 +120,39 @@ describe("per-kind estimators", () => {
     describe("estimateUserMessage", () => {
         const node: UserMessageNode = {
             type: "user_message", id: "um1", message: "hi", timestamp: 0,
-            collapsed: false, summary: "User",
         };
 
-        it("uses text-height estimate when not collapsed", () => {
+        it("uses text-height estimate for a regular user message", () => {
             expect(estimateUserMessage(node, baseDocState())).toBe(32); // short → MIN
         });
 
-        it("returns the collapsed size when in collapsedNodes", () => {
+        it("returns the collapsed-summary size for an unpinned startup row", () => {
+            // Post-SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24:
+            // user messages collapse on isStartup + pinnedNodes, NOT on
+            // collapsedNodes (renderer ignores collapsedNodes for
+            // user_message). Mirror estimateTool.
+            const startup: UserMessageNode = { ...node, id: "um-start", isStartup: true };
+            expect(estimateUserMessage(startup, baseDocState())).toBe(32); // collapsed
+        });
+
+        it("returns the full text-height estimate for a pinned startup row", () => {
+            const startup: UserMessageNode = { ...node, id: "um-pin", isStartup: true };
+            const state = baseDocState();
+            state.pinnedNodes.add("um-pin");
+            // "hi" is still short → min height, but the path is different
+            // (the function takes the not-collapsed branch). The
+            // assertion below pins the expected behavior; a longer
+            // multi-line startup would yield a bigger number via
+            // estimateTextHeight.
+            expect(estimateUserMessage(startup, state)).toBe(32);
+        });
+
+        it("ignores collapsedNodes for user_message (no longer wired)", () => {
             const state = baseDocState();
             state.collapsedNodes.add("um1");
+            // Regular user message, collapsedNodes set but not pinned —
+            // estimate is still the text-height fall-through, not the
+            // collapsed-summary height.
             expect(estimateUserMessage(node, state)).toBe(32);
         });
     });
@@ -164,7 +187,6 @@ describe("estimateNode dispatch", () => {
         };
         const um: UserMessageNode = {
             type: "user_message", id: "um", message: "hi", timestamp: 0,
-            collapsed: false, summary: "S",
         };
         const sl: SubagentLinkNode = {
             type: "subagent_link", id: "sl", subagentId: "x", slug: "y",

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -81,6 +81,35 @@ export function estimateTextHeight(
     return Math.min(Math.max(lines * lineHeight, TEXT_MIN_HEIGHT_PX), TEXT_MAX_ESTIMATE_PX);
 }
 
+/**
+ * Height estimate for unwrapped content — rows that render with
+ * `white-space: pre` and horizontal scroll on overflow (no soft
+ * wrap). One visual line per explicit `\n`; long single lines do
+ * NOT bloat the estimate.
+ *
+ * Used by `estimateUserMessage` since PR #1020 — user input
+ * switched to `white-space: pre` in
+ * `_document-nodes.scss`, so the char-count heuristic in
+ * `estimateTextHeight` would over-allocate for long URLs / paths
+ * (300-char URL → 4 estimated lines vs 1 actual line) and cause
+ * blank gaps / scroll jumps in the virtualized list until
+ * measureElement caught up. Codex P2 round 4 on PR #1020.
+ */
+export function estimateUnwrappedTextHeight(
+    content: string,
+    lineHeight = TEXT_LINE_HEIGHT_PX,
+): number {
+    if (!content) return TEXT_MIN_HEIGHT_PX;
+    // Each `\n` introduces a new visual line; content with no
+    // newlines is exactly 1 visual line.
+    let newlines = 0;
+    for (let i = 0; i < content.length; i++) {
+        if (content.charCodeAt(i) === 10 /* '\n' */) newlines++;
+    }
+    const lines = newlines + 1;
+    return Math.min(Math.max(lines * lineHeight, TEXT_MIN_HEIGHT_PX), TEXT_MAX_ESTIMATE_PX);
+}
+
 // Per-kind constants — tuned empirically. Phase 3 perf-probe HUD
 // flags any kind whose p50 actual diverges > 30% from estimate.
 const TOOL_COLLAPSED_PX = 32;
@@ -118,13 +147,15 @@ export function estimateUserMessage(node: UserMessageNode, state: DocumentState)
     // user messages collapse on `isStartup` + `pinnedNodes`, NOT
     // `collapsedNodes` (which is unused for user_message nodes
     // post-PR-#1020). Mirror the rule in `estimateTool`: startup
-    // payload is the one-line summary unless pinned; regular user
-    // input is its full text height (no soft-wrap means line count
-    // ≈ newline count).
+    // payload is the one-line summary unless pinned.
     if (node.isStartup && !state.pinnedNodes.has(node.id)) {
         return COLLAPSED_MESSAGE_PX;
     }
-    return estimateTextHeight(node.message);
+    // Use newline-count estimation — user_message <pre> is
+    // `white-space: pre` (no soft wrap), so line count comes
+    // from explicit `\n`. Char-count heuristic from
+    // `estimateTextHeight` would over-estimate long single lines.
+    return estimateUnwrappedTextHeight(node.message);
 }
 
 export function estimateSubagentLink(_node: SubagentLinkNode): number {

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -114,7 +114,16 @@ export function estimateAgentMessage(node: AgentMessageNode, state: DocumentStat
 }
 
 export function estimateUserMessage(node: UserMessageNode, state: DocumentState): number {
-    if (state.collapsedNodes.has(node.id)) return COLLAPSED_MESSAGE_PX;
+    // Per SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md,
+    // user messages collapse on `isStartup` + `pinnedNodes`, NOT
+    // `collapsedNodes` (which is unused for user_message nodes
+    // post-PR-#1020). Mirror the rule in `estimateTool`: startup
+    // payload is the one-line summary unless pinned; regular user
+    // input is its full text height (no soft-wrap means line count
+    // ≈ newline count).
+    if (node.isStartup && !state.pinnedNodes.has(node.id)) {
+        return COLLAPSED_MESSAGE_PX;
+    }
     return estimateTextHeight(node.message);
 }
 


### PR DESCRIPTION
Implements `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md` (spec landed alongside the implementation per `feedback_no_doc_only_prs`).

## What

1. **High-contrast user-input color.** New `--user-input-color: #00b4d8` theme variable (separate from `--accent-color`), used by `.agent-user-message`: 14% tint background + 3px left border. Typed input now visibly pops out of the agent reply stream.
2. **Regular input never soft-wraps.** `<pre>` content switches from `white-space: pre-wrap; overflow-wrap: anywhere;` to `white-space: pre; overflow-x: auto;` — newlines honored verbatim, long lines (URLs, paths) scroll horizontally inside the bubble.
3. **Startup injection collapses like tools.** The Markdown payload from `buildStartupPayload` (sent by `agent-view.tsx onReadyFn`) renders as a single-line summary `⓵ Session context (hover to peek · click to pin)`. Hover-enter delay 150ms (matches ToolBlock), click toggles pin via the existing `documentState.pinnedNodes` infrastructure.

## How

Three commits, each independently revertible:

| Commit | Files | Effect |
|---|---|---|
| `cc7180f4` | `theme.scss`, `_document-nodes.scss` | High-contrast color + no-wrap rule + startup-variant SCSS scaffold |
| `ae4fc980` | `types.ts`, `stream-parser.ts`, `stream-parser.test.ts` | `isStartup` flag set when message matches `/^# Session Context\b/`; 5 L1 tests + a contract test against `buildStartupPayload` |
| `19a59ac1` | `UserMessageBlock.tsx` (+test), `DocumentRow.tsx`, spec | Component swap, 10 L2 tests |

## Why heuristic and not a wire-level marker

The startup payload is a frontend-only construct — backend has no opinion on what's "startup", and the wire-level event has no metadata field for it. Round-tripping a flag through the agent CLI's NDJSON would require backend changes for a frontend-only concern. The literal heading `# Session Context` is owned by `buildStartupPayload.ts`; a contract test in `stream-parser.test.ts` calls the real builder and asserts the regex matches, so any future rename of the heading fails the test atomically with the source change. Discussed in spec §C.1.

## Tests

- 10 new L2 tests on `UserMessageBlock` (render shapes, hover-enter delay, mouseleave-cancel, click-to-pin, pin-class).
- 5 new L1 tests on `stream-parser.userMessageToNode` (positive, negative, mid-message-not-detected, similar-but-different heading, contract with `buildStartupPayload`).
- 357 renderer tests + 509 stream-parser tests pass.

## Verification

- Open agent pane, type a message → bubble in saturated cyan with 3px left border.
- Paste a 200-char URL → one line, horizontal scrollbar inside the bubble (no line break).
- Open a fresh agent → first row is the collapsed `⓵ Session context` summary instead of 20 lines of Markdown.
- Hover the summary → expands after ~150ms.
- Click the summary → stays expanded; click again collapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)