### PR TITLE
fix(agent): hover-anchored startup body (overlay above/below) — summary stays under cursor

### DIFF
--- a/.changesets/1779640151-fix-agent-hover-expanded-startup-body-uses-absolute-overlay--xr8e.md
+++ b/.changesets/1779640151-fix-agent-hover-expanded-startup-body-uses-absolute-overlay--xr8e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): hover-expanded startup body uses absolute overlay so summary stays under cursor

--- a/docs/sessions/PROGRESS_HOVER_ANCHOR_2026_05_24.md
+++ b/docs/sessions/PROGRESS_HOVER_ANCHOR_2026_05_24.md
@@ -1,0 +1,108 @@
+# Progress — startup-injection hover anchor
+
+**Date:** 2026-05-24
+**Spec:** `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md`
+**Branch:** `agenta/hover-anchor-direction`
+
+---
+
+## Research round (best practices)
+
+Consulted:
+
+- **[Floating UI flip middleware](https://floating-ui.com/docs/computeposition)** — when a popover collides with the viewport, flip to the opposite placement. Standard pattern. The library accepts 12 placement names (`top`, `bottom`, `top-start`, …) and re-computes on the fly. We don't need the library, but the flip *heuristic* is exactly our direction selector.
+- **[Floating UI `useHover` + `safePolygon`](https://floating-ui.com/docs/usehover)** — when the cursor moves from trigger to popover, draw a dynamic polygon between them; popover stays open as long as cursor is inside the polygon. Handles diagonal traversals over gaps.
+- **[Radix UI Popover hover discussion](https://github.com/radix-ui/primitives/issues/2051)** — Radix doesn't ship hover-popover by default; reference for the patterns the community has converged on (mostly: hover-intent timeout + safePolygon).
+- **[MDN mouseleave](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event)** — `mouseleave` is fired when the pointer has exited the element AND ALL OF ITS DESCENDANTS. "Descendants" = DOM tree, not visual containment. Confirmed via [javascript.info](https://javascript.info/mousemove-mouseover-mouseout-mouseenter-mouseleave) and the [odetocode article](https://odetocode.com/blogs/scott/archive/2011/08/18/a-tale-of-backgrounds-absolutes-mouseleave-and-mouseenter.aspx).
+- **[CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning)** — Chrome 125+ ships pure-CSS popover anchoring via `anchor()` and `position-area`. AgentMux's CEF build is recent enough to support it, but the cross-platform story is uncertain; the JS-based getBoundingClientRect path is more portable. Park anchor-positioning as a follow-up cleanup.
+- **[TanStack Virtual layout strategy](https://tanstack.com/virtual/latest/docs/api/virtualizer)** — `shouldAdjustScrollPositionOnItemSizeChange` is the per-row hook that triggers when measured height changes. Overlays as `position: absolute` descendants of a row do NOT change the row's measured height, so the virtualizer doesn't see them — exactly what we want.
+
+### Decision: simplest robust design from the research
+
+The DOM-ancestry semantics of `mouseleave` collapse the problem from "we need a safePolygon" to "we need to ensure the body is a DOM child of the same wrapper the hover signal is on." That's free. We get the floating-UI flip pattern via a 12-line pure function. The pinned-vs-hovered distinction maps directly onto absolute-vs-flow positioning.
+
+We do NOT need:
+
+- `safePolygon` — there's no gap between summary and absolute body anchored at `top: 100%` / `bottom: 100%`.
+- A library — the geometry is `getBoundingClientRect()` + `window.innerHeight`, two reads at expand-time.
+- An animation library — the expansion is instant (no transitions, per `feedback_no_timers_or_delays`).
+- A focus-trap or escape-key handler — pinned in-flow content is normal document content; hover-expanded gets closed by mouseleave naturally.
+
+### Decision: Option B (pin → in-flow) confirmed
+
+Picked Option B (pinned content drops into normal document flow). Rationale ties to research:
+
+- TanStack handles per-row remeasure well; the cost of pin → flow is one remeasure event for the pinned row, then steady state.
+- Mental model: hover = preview overlay (transient), pin = commit to keep this content in the conversation (persistent). Matches how Radix / Floating UI / VSCode peek-vs-pin all work.
+- Overlay-when-pinned (Option A) leaves a floating panel that hovers over neighbors — confusing when scrolling and inconsistent with the rest of the agent pane.
+
+---
+
+## Implementation plan
+
+Three commits on `agenta/hover-anchor-direction`:
+
+1. ✅ Pure function `pickExpandDirection` in a new module with L1 unit tests.
+2. ✅ Wire the function into `UserMessageBlock`. Add `displayMode` signal (`"hidden" | "overlay-above" | "overlay-below" | "flow"`). Add SCSS for the three positioning modes.
+3. ✅ L2 component tests covering the new states.
+
+---
+
+## Progress log
+
+(Updated as implementation proceeds.)
+
+### Step 1 — pure function + L1 tests ✅
+
+Created `frontend/app/view/agent/components/hover-anchor.ts` with `pickExpandDirection(rect, viewportH, bodyEstimate) → "above" | "below"`.
+
+Decision tree:
+1. Body fits below → "below".
+2. Body doesn't fit below but fits above → "above" (the canonical "near bottom of viewport" case).
+3. Body fits in neither → pick the larger side; below on tie.
+
+L1 tests cover 10 cases (`hover-anchor.test.ts`): generic top, generic bottom, exact-middle tie, fits-below-but-above-bigger (must still pick below per step 1), fits-neither-pick-larger, fits-neither-tie, off-top, off-bottom, zero-viewport, zero-body.
+
+All 10 pass.
+
+### Step 2 — component wire-up + SCSS ✅
+
+`UserMessageBlock` rewritten:
+
+- New `expandDirection` signal, defaults to `"below"`. Re-evaluated inside the 150ms enter timer via `pickExpandDirection(rect, window.innerHeight, STARTUP_BODY_ESTIMATE_PX)` where `rect = summaryEl.getBoundingClientRect()`. Direction locked for the duration of the hover; mouseleave clears, next mouseenter re-evaluates.
+- New `bodyMode()` derived: `"hidden" | "overlay" | "flow"`. Drives the body's class binding.
+- Summary is now ALWAYS rendered for collapsible rows (was conditional on `!expanded()` before). Stable ARIA / keyboard surface. Visibility of the BODY is what toggles.
+- Summary hint text reflects pin state: `"(hover to peek · click to pin)"` collapsed; `"(pinned · click ✕ to collapse)"` pinned.
+- `aria-expanded` now mirrors `expanded()` (was just `pinned`).
+
+SCSS additions in `_document-nodes.scss`:
+
+- `.agent-user-message` gets `position: relative` so absolute children anchor here.
+- Three new positioning classes on `.agent-user-message-content`:
+  - `--flow` (default, no override) — normal flow.
+  - `--overlay-below` — `position: absolute; top: 100%; left:0; right:0; z-index: 10; max-height: calc(100vh - 80px); overflow-y: auto;` + subtle background/border/shadow.
+  - `--overlay-above` — same but `bottom: 100%`.
+
+Why `mouseleave` doesn't fire when the cursor crosses summary→absolute body: per the MDN spec, `mouseleave` fires when the pointer has exited the element **and all of its descendants**. The absolute body is still a DOM child of `.agent-user-message`, so cursor traversal across the geometric boundary is a no-op for `mouseleave`. Confirmed via the research links in the section above.
+
+### Step 3 — L2 tests + final sweep ✅
+
+Added in `UserMessageBlock.test.tsx`:
+
+- `describe("body positioning")` — 3 cases: hover-expanded → an overlay class; pinned → `--flow`; regular non-startup → `--flow`.
+- `describe("aria-expanded")` — 3 cases: collapsed=false; pinned=true; hover-expanded=true.
+
+Updated 2 prior tests that assumed the summary unmounts when expanded — it doesn't now (always-mounted for ARIA stability).
+
+Final test counts:
+- `hover-anchor.test.ts`: 10 / 10 pass.
+- `UserMessageBlock.test.tsx`: 22 / 22 pass.
+- 32 / 32 total in this PR's footprint.
+
+Pre-existing failing tests (BlockErrorBoundary + AgentPicker mock-fixture) are unchanged from origin/main.
+
+---
+
+## Status
+
+All three steps complete on `agenta/hover-anchor-direction`. Ready to commit + push + open PR.

--- a/docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md
+++ b/docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md
@@ -1,0 +1,315 @@
+# SPEC: Anchor the startup-injection summary at the cursor during hover-expand
+
+**Date:** 2026-05-24
+**Author:** AgentA
+**Status:** Draft — needs decision on §4.2 (Option A vs B) before implementation.
+**Supersedes for §3 (hover-expand mechanics) parts of:** `SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md` §C.2.
+
+---
+
+## TL;DR
+
+PR #1020 ships the startup-injection collapse-on-hover. In practice, when the user hovers the `⓵ Session context` summary, the row expands downward and pushes nearby content. The user perceives an unexpected layout shift, then their mouse — naturally pursuing what they were aiming at — ends up off the summary, mouseleave fires, the row collapses, and the click-to-pin never lands. The expand → mouse follow → collapse → repeat loop is the bug.
+
+The fix: **the summary stays under the cursor across the expand transition.** The body opens UP or DOWN from the summary depending on viewport-space + cursor position, and the summary's screen-Y stays exactly where the user was already pointing. No jitter, no animation, no scroll-anchor hacks.
+
+---
+
+## 1. What's actually happening today
+
+### 1.1 The current expand mechanics (PR #1020)
+
+The collapsed startup row is a 32px-tall `<button>` (the summary). When `hovering` flips to `true` after the 150ms enter-delay, SolidJS swaps the `<Show>` branches: summary out, body in. The body is rendered inside `.agent-user-message-content` as a normal `<pre>` block, which means it sits in document flow **below** the row's top edge. The row grows from 32px to whatever the body is tall (often 200-400px for the session-context Markdown).
+
+Because the body sits in normal flow, three things shift:
+
+1. **The row itself.** Its measured height jumps from 32px to 200+px.
+2. **Rows below it.** Pushed down by the row's new height.
+3. **The virtualizer.** When the row's measured height changes, TanStack Virtual recomputes the offset map and adjusts scroll-anchor — `estimateUserMessage` is now newline-based (PR #1020 round 5), so the estimate vs measured delta is much smaller, but it isn't zero.
+
+### 1.2 Why the user sees a collapse
+
+The summary's screen-Y position **doesn't change** during the expand — its top edge is still anchored to the row's top edge in normal flow, and the row's top didn't move. So in theory the cursor remains over the summary's hit area.
+
+In practice, two failure modes show up:
+
+- **Mouse drift during the 150ms enter-delay.** The user hovers, sees nothing for 150ms, naturally drifts the cursor a few pixels. When expansion finally fires, the cursor may already be 2-3px below the summary (still inside the row's collapsed 32px box, but on its bottom edge). The expansion replaces the summary's bottom 16px with `<pre>` content (because `<button>` had padding that the `<pre>` doesn't reproduce exactly), the cursor lands on `<pre>` instead of `<button>`, the body has no `onMouseLeave/Enter` reciprocal binding, and mouseleave on the outer block fires the moment the user drifts another pixel.
+- **Layout-shift surprise.** Even when the cursor stays on the summary's hit area, the row's height suddenly tripling pushes the rows below it down by ~200-400px. The user's eye tracks "the thing I was about to click" and instinctively moves the cursor toward where they expect the summary to be — except the summary is exactly where it always was, and they over-correct off it.
+
+Both cancel the hover; mouseleave fires; the row collapses. Click-to-pin requires re-entering the now-collapsed summary, which restarts the 150ms timer.
+
+### 1.3 What `feedback_no_timers_or_delays` rules out
+
+We cannot fix this with a grace window, a debounce on mouseleave, a transition animation, or a setTimeout-based "give the user a moment before collapsing." Per the user's memory, those are exactly the workarounds that get rejected as jitter. The fix has to be **deterministic and geometric**: arrange the DOM so the summary is structurally under the cursor after the expand, full stop.
+
+---
+
+## 2. What the user wants
+
+Quoted verbatim:
+
+> wherever the mouse cursor is the expansion happens (either up or down, depending on if the hover is near the bottom). We need to ensure the cursor always ends up at the line (header during expansion) after expansion.
+
+Two parts:
+
+- **Direction is chosen at expand-time.** Some hovers should expand the body **upward** (body rendered above the summary), some **downward** (body rendered below the summary). The signal is "is there room below, or is this row near the bottom edge of the viewport."
+- **The summary is always under the cursor after expand.** No matter which direction the body grows, the summary's screen-Y matches the cursor's screen-Y immediately after the expand fires.
+
+This is a known pattern — context-menu placement uses the same rule: open in the direction with more space, and anchor the menu trigger at the cursor.
+
+---
+
+## 3. The geometric invariant we need
+
+Define:
+
+- `summary.y` = the summary's screen-Y when mouseEnter fires (a constant for the duration of this hover).
+- `cursor.y` = the cursor's screen-Y at the moment the 150ms timer fires.
+
+The invariant: **after the expand, `summary.y` is unchanged**.
+
+If the body grows DOWN (body rendered below summary in document flow), `summary.y` doesn't change — that's the current behavior, and it's fine. The bug is only the user's mental model surprise.
+
+If the body grows UP (body rendered above summary), `summary.y` *would* change in normal flow — the row's top edge moves up by `body.height`, summary shifts down by `body.height`. To prevent this, the body must NOT participate in normal document flow.
+
+So the implementation has two equivalent shapes:
+
+- **Always downward in flow** (today's behavior), and accept the user's complaint about the surprise.
+- **Body is positioned absolutely** so it can grow in either direction without moving the summary in flow.
+
+The user's request is incompatible with the first shape. So: absolute positioning.
+
+---
+
+## 4. Proposed design
+
+### 4.1 The DOM shape
+
+```html
+<div class="agent-user-message agent-user-message--startup"
+     style="position: relative">
+
+  <!-- ALWAYS in normal flow. Screen-Y never changes during hover.
+       Bounding box stays 32px tall regardless of expand state. -->
+  <button class="agent-user-message-summary">
+    ⓵ Session context  (hover to peek · click to pin)
+  </button>
+
+  <!-- ONLY when hovering or pinned. Absolute-positioned inside
+       .agent-user-message; placement = below or above summary,
+       chosen at expand-time. Carries its own onMouseEnter /
+       onMouseLeave to keep `hovering` true while the cursor is
+       over the body. -->
+  <div class="agent-user-message-content
+              agent-user-message-content--below"
+       style="position: absolute; top: 100%; left: 0; right: 0;
+              z-index: 10;">
+    <pre>{message}</pre>
+    <button class="agent-user-message-pin">📌</button>
+  </div>
+</div>
+```
+
+When the body is `--above` instead of `--below`:
+
+```html
+       style="position: absolute; bottom: 100%; left: 0; right: 0;
+              z-index: 10;"
+```
+
+The summary stays in normal flow at 32px. The body floats above neighboring rows (z-index handles the visual stacking). The row's height in document flow is **always 32px** while the body is shown via hover — neighbors don't reflow, the virtualizer doesn't remeasure.
+
+### 4.2 OPEN QUESTION: pinned state — overlay or in-flow?
+
+This is the one decision that needs your input before I start coding.
+
+**Option A: Pinned = stays absolute (overlay forever).**
+
+- Pinned body floats over the rows below it.
+- Document flow unchanged; the row is still 32px in the document.
+- Virtualizer never sees a height change.
+- Visually: the user has a floating panel anchored to one row.
+
+**Option B: Pinned = drops back into normal flow.**
+
+- When the user clicks 📌, the body switches from `position: absolute` to in-flow rendering below the summary.
+- Row's height in document flow grows to 32 + body.height.
+- Virtualizer remeasures; rows below shift down.
+- Visually: the pinned context "anchors" itself into the document like a real expanded block.
+
+I lean Option B — pinning is a persistence statement, and persistence wants document flow so the user can read past it without floating chrome covering things. But there's a coherent case for A (consistent overlay UX, no virtualizer churn on pin). Specify your preference and the implementation follows.
+
+**Recommendation:** Option B. Pinned = full in-flow render; hover-expanded = absolute overlay.
+
+### 4.3 Direction selection
+
+When the 150ms enter timer fires:
+
+```ts
+const rect = summaryEl.getBoundingClientRect();
+const viewportH = window.innerHeight;
+const bodyEstimate = estimateUnwrappedTextHeight(node.message);
+
+// Space available in each direction.
+const spaceBelow = viewportH - rect.bottom;
+const spaceAbove = rect.top;
+
+// Pick the direction with more room; fall back to below on a tie.
+const direction =
+    spaceBelow >= bodyEstimate || spaceBelow >= spaceAbove
+        ? "below"
+        : "above";
+
+setExpandDirection(direction);
+```
+
+Captured **once per hover cycle**. The direction is locked for the duration of this hover — the body doesn't flip mid-hover. Mouseleave clears it; the next mouseenter re-evaluates.
+
+This is the only place we read `getBoundingClientRect()`, and we do it once. No animation frames, no resize-observer, no scroll listener — the direction is right at expand-time and stays consistent.
+
+### 4.4 Mouse-region continuity across summary ↔ body
+
+The summary's bounding box is 32px. The body's absolute-positioned bounding box sits adjacent to it (above or below). The cursor moves from one to the other.
+
+Today (PR #1020), the outer `.agent-user-message` div has the `onMouseEnter / onMouseLeave`. With the body in normal flow, the outer div's bounding box covers both. With the body absolutely-positioned, **the outer div's bounding box is only the summary** — moving the cursor into the body would fire `mouseleave` on the outer div, and the row would collapse.
+
+The fix: each region (summary, body) owns its own enter/leave, and a derived signal combines them:
+
+```ts
+const [overSummary, setOverSummary] = createSignal(false);
+const [overBody, setOverBody] = createSignal(false);
+const hovering = () => overSummary() || overBody();
+```
+
+Sequence when the cursor crosses from summary to body, with body anchored at `top: 100%` (zero-pixel gap by construction):
+
+1. `summary.mouseleave` fires → `setOverSummary(false)`.
+2. `body.mouseenter` fires → `setOverBody(true)`.
+3. SolidJS batches both into one re-render. `hovering()` = false || true = true. No flicker.
+
+The CSS `top: 100% / bottom: 100%` placement is critical — it guarantees zero gap. With `top: calc(100% + 1px)` the user would catch a 1px gap that fires mouseleave AND no body mouseenter → collapse. The spec lives or dies on this contract; the L2 test pins it.
+
+### 4.5 No jitter, no timers added
+
+This whole design is geometry + already-deterministic SolidJS reactivity. No new `setTimeout`. The existing 150ms enter-delay on the summary stays as-is (it's the only timer in the file). Per `feedback_no_timers_or_delays`.
+
+---
+
+## 5. Edge cases
+
+### 5.1 Body too tall for the viewport
+
+`bodyEstimate > Math.max(spaceAbove, spaceBelow)`. Pick the larger side, cap the body's height at `Math.max(spaceAbove, spaceBelow) - <some margin>`, add `overflow-y: auto`. User scrolls inside the body.
+
+The cap is applied in CSS via `max-height: calc(100vh - <reserved>px)`; no JS measurement needed at render time. Spec value: `max-height: calc(100vh - 80px)` (40px top margin from viewport edge + 40px breathing room).
+
+### 5.2 Window resize mid-hover
+
+When the viewport changes size, the direction we picked at expand-time may now be the wrong one. We do NOT add a resize listener — the body re-positions on next hover anyway. Resize while hovering is an acceptable rare case where the user gets a brief moment of awkward placement; mouseleave/mouseenter resolves it.
+
+### 5.3 Row near the very top of the agent pane
+
+`rect.top` is small (e.g. 20px). Body can't expand upward more than 20px worth. Direction selection falls through to "below" via the `spaceBelow >= spaceAbove` tie-breaker.
+
+### 5.4 Row that's currently scrolled partly off-viewport
+
+The summary's `rect.top` is negative (off-screen at top) or `rect.bottom` is past `viewportH` (off-screen at bottom). Mouseenter shouldn't fire — the cursor isn't physically over the row. The direction calculation has self-consistent fallback behavior (negative space ends up tiny; the other side wins). No special case needed.
+
+### 5.5 Multiple startup rows in the same pane
+
+`buildStartupPayload` is called once per fresh agent. Realistically there's one startup row per pane. But the spec doesn't break with N: each row's body is anchored to its own summary; z-index ordering means later-hovered overlays sit above earlier-pinned ones; no shared state to corrupt.
+
+### 5.6 The body overlaps with another row that is also pinned/hovered
+
+Rare but possible: two pinned rows whose absolute bodies overlap. Use `z-index: 10` consistently; the most-recently-hovered/clicked row wins by mount order. Acceptable.
+
+### 5.7 Pinned body when scrolling
+
+(If Option B chosen, this is moot.) Under Option A, the pinned body stays anchored to the summary via absolute positioning. Scrolling the agent pane scrolls the summary; the body moves with it (same `.agent-user-message` ancestor). No issue.
+
+### 5.8 Pin-then-unpin while still over the body
+
+User clicks 📌 → pinned=true. They keep the cursor on the body. They click ✕ → pinned=false. Body collapses; cursor is now in the empty space the body occupied. Next mousemove either lands somewhere new entirely (and stays collapsed) or moves into the summary (and starts a fresh hover cycle). Both are fine.
+
+### 5.9 Keyboard expansion
+
+The summary is a `<button>` already, so Tab focuses it. Today, pressing Space/Enter calls `onTogglePin` directly (no hover-expansion step). The body renders pinned, in whichever direction Option B says — for keyboard activation, pinned = always in-flow (Option B), so body renders below in document order. Keyboard users skip the hover-direction logic entirely; they get the predictable downward expansion.
+
+### 5.10 Pre-existing tool blocks doing the same
+
+ToolBlock has its own overlay portal (`ToolBlockOverlay`). It does NOT have the cursor-anchor problem because tool blocks already always render their overlay below the trigger via `top: 100%`, and ToolBlock's trigger doesn't change size from "1 line" to "many lines" the way the user message does today. The user message's case is unique — we don't need to also re-spec ToolBlock.
+
+But: the design here generalizes. If a future tool block grows enough to want the up/down choice, the same `getBoundingClientRect()` heuristic drops in.
+
+---
+
+## 6. Tests
+
+### 6.1 L1 — pure unit tests on the direction selector
+
+Pull the direction-selection logic into a free function:
+
+```ts
+export function pickExpandDirection(
+    summaryRect: { top: number; bottom: number },
+    viewportHeight: number,
+    bodyEstimate: number,
+): "above" | "below" { … }
+```
+
+Tests:
+- Plenty of space below → returns "below".
+- Plenty of space above, none below → returns "above".
+- Equal space → returns "below" (tie-breaker).
+- Body larger than both → returns the side with more space.
+- Negative-Y summary (off-screen at top) → returns "below".
+- Past-viewport summary (off-screen at bottom) → returns "above".
+
+### 6.2 L2 — component tests on UserMessageBlock
+
+- Hover-expanded body has class `agent-user-message-content--below` when there's room below.
+- Hover-expanded body has class `agent-user-message-content--above` when crowded at the bottom.
+- Body has `onMouseEnter / onMouseLeave` handlers attached when collapsible.
+- Cursor moves from summary to body keeps `hovering` true (simulate via fireEvent: mouseleave summary → mouseenter body in sequence within one task tick).
+- Cursor leaving the body (without re-entering summary) collapses the row.
+- Pinned state renders body in normal flow (Option B) regardless of direction selection.
+
+### 6.3 L3 — manual
+
+- Open a fresh agent at the top of the pane. Hover the summary. Body opens DOWN. Cursor stays on summary.
+- Scroll the pane down so the summary is near the viewport bottom. Hover. Body opens UP. Cursor stays on summary.
+- Hover for 150ms, then click — pin lands every time (no race with collapse).
+- Move cursor smoothly from summary into body — no flicker, body stays open.
+- Move cursor out of the body — body closes, summary returns to collapsed.
+- Repeat 20×; should be 20/20 successful pin clicks.
+
+---
+
+## 7. Order of delivery
+
+One PR, three commits on `agenta/hover-anchor-direction`:
+
+1. **Extract + L1 test the direction selector.** Pure function, no JSX changes. Tests cover the 6 cases in §6.1.
+2. **Add absolute positioning + body mouse-region binding to UserMessageBlock.** SCSS adds `--below / --above` placement classes. Component adds `overSummary / overBody` signals, combined `hovering()`. Body still in normal flow when pinned (Option B). L2 tests in §6.2.
+3. **Wire the direction selector to the component.** Read `getBoundingClientRect()` inside the existing 150ms timer callback. Set the direction signal. L3 manual verification.
+
+Each commit is independently revertible; commit 1 alone ships nothing user-visible, commits 2+3 together deliver the fix.
+
+---
+
+## 8. Out of scope
+
+- **Animations / transitions on the expand.** Out — adds jitter risk; the geometric pin is the whole spec.
+- **Keyboard-driven direction selection.** Out — keyboard goes straight to pinned/in-flow per §5.9.
+- **Generalizing to other agent-pane block types.** Out — ToolBlock has its own overlay; agent-message / markdown don't collapse on hover.
+- **Mobile / touch.** Out — agent pane is desktop-only today.
+- **Theming the overlay shadow.** A subtle `box-shadow` on `.agent-user-message-content--below / --above` to visually distinguish the floating body from the row chrome — included in commit 2 but only as a default; theme palette overrides come in a follow-up.
+
+---
+
+## 9. Related
+
+- `SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md` — the parent spec. §C.2's render-shape claim ("body renders inline beneath summary") is updated by this doc.
+- `docs/specs/tool-collapse.md` — ToolBlock overlay precedent; same direction-of-overlay pattern but no anchor-at-cursor invariant.
+- `feedback_no_timers_or_delays` — the constraint that rules out grace windows; this spec satisfies it.
+- PR #1020 — ships the version with the bug this spec fixes.

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -309,6 +309,39 @@ describe("UserMessageBlock — startup injection", () => {
             expect(body).not.toBeNull();
             expect(body!.classList.contains("agent-user-message-content--flow")).toBe(true);
         });
+
+        it("hover-expanded body has an inline max-height (per-hover cap)", () => {
+            // Codex P2 round 2: the overlay's max-height is computed
+            // per hover from the chosen-side container space, set
+            // inline. We can't assert a specific px value (jsdom's
+            // getBoundingClientRect returns zeros, plus
+            // window.innerHeight defaults), but we CAN assert that
+            // the style attribute carries a `max-height` rule —
+            // proving the inline path fired.
+            vi.useFakeTimers();
+            try {
+                const { container } = render(() => (
+                    <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+                ));
+                const root = container.querySelector(".agent-user-message") as HTMLElement;
+                fireEvent.mouseEnter(root);
+                vi.advanceTimersByTime(200);
+                const body = container.querySelector(".agent-user-message-content") as HTMLElement;
+                expect(body).not.toBeNull();
+                expect(body.style.maxHeight).toMatch(/^\d+px$/);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("pinned body has no inline max-height (in-flow, no cap)", () => {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
+            ));
+            const body = container.querySelector(".agent-user-message-content") as HTMLElement;
+            expect(body).not.toBeNull();
+            expect(body.style.maxHeight).toBe("");
+        });
     });
 
     describe("aria-expanded", () => {

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -161,13 +161,19 @@ describe("UserMessageBlock — startup injection", () => {
     });
 
     it("pinned=true renders expanded (full markdown body visible)", () => {
+        // Per SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24, the
+        // summary is ALWAYS rendered for collapsible rows (so the
+        // ARIA / keyboard surface is stable across collapsed/
+        // expanded states). The body's visibility is what changes.
+        // Hint copy in the summary toggles to reflect the state.
         render(() => (
             <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
         ));
-        // Body visible — first identity bullet matches the fixture
+        // Body visible — first identity bullet matches the fixture.
         expect(screen.queryByText(/Identity/)).not.toBeNull();
-        // No collapsed summary row when expanded
-        expect(screen.queryByText("Session context")).toBeNull();
+        // Summary still mounted; hint reflects the pinned state.
+        expect(screen.queryByText("Session context")).not.toBeNull();
+        expect(screen.queryByText(/click ✕ to collapse/)).not.toBeNull();
     });
 
     it("pinned=true gets the --pinned class on the root", () => {
@@ -181,23 +187,25 @@ describe("UserMessageBlock — startup injection", () => {
     });
 
     it("hover (mouseenter→delay) expands the body after 150ms", async () => {
+        // The summary is now ALWAYS mounted. Only the BODY's
+        // presence changes across the hover transition.
         vi.useFakeTimers();
         try {
             const { container } = render(() => (
                 <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
             ));
             const root = container.querySelector(".agent-user-message") as HTMLElement;
-            // Pre-hover: collapsed summary present, body absent.
+            // Pre-hover: summary present, body absent.
             expect(screen.queryByText("Session context")).not.toBeNull();
             expect(screen.queryByText(/Identity/)).toBeNull();
             fireEvent.mouseEnter(root);
-            // 100ms in — still collapsed (under the 150ms threshold).
+            // 100ms in — still pre-threshold.
             vi.advanceTimersByTime(100);
             expect(screen.queryByText(/Identity/)).toBeNull();
-            // Past the threshold — expanded.
+            // Past the threshold — body now visible alongside summary.
             vi.advanceTimersByTime(60);
             expect(screen.queryByText(/Identity/)).not.toBeNull();
-            expect(screen.queryByText("Session context")).toBeNull();
+            expect(screen.queryByText("Session context")).not.toBeNull();
         } finally {
             vi.useRealTimers();
         }
@@ -247,5 +255,93 @@ describe("UserMessageBlock — startup injection", () => {
         const summary = container.querySelector(".agent-user-message-summary") as HTMLButtonElement;
         summary.click();
         expect(togglePin).toHaveBeenCalledTimes(1);
+    });
+
+    describe("body positioning (overlay vs flow)", () => {
+        // SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24:
+        // hover-expanded body uses absolute positioning so the
+        // summary's screen-Y is anchored across the transition;
+        // pinned body drops back into normal flow (Option B).
+
+        it("hover-expanded body has an overlay positioning class", async () => {
+            vi.useFakeTimers();
+            try {
+                const { container } = render(() => (
+                    <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+                ));
+                const root = container.querySelector(".agent-user-message") as HTMLElement;
+                // jsdom doesn't really compute getBoundingClientRect
+                // sizes for absolute layouts; with the default
+                // (top=0, bottom=0) the direction picker returns
+                // "below". That's fine for asserting the *class
+                // family*: we want one of the overlay classes, not
+                // the flow class.
+                fireEvent.mouseEnter(root);
+                vi.advanceTimersByTime(200);
+                const body = container.querySelector(".agent-user-message-content");
+                expect(body).not.toBeNull();
+                expect(body!.classList.contains("agent-user-message-content--flow")).toBe(false);
+                const isOverlay =
+                    body!.classList.contains("agent-user-message-content--overlay-below") ||
+                    body!.classList.contains("agent-user-message-content--overlay-above");
+                expect(isOverlay).toBe(true);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("pinned body uses the in-flow positioning class", () => {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
+            ));
+            const body = container.querySelector(".agent-user-message-content");
+            expect(body).not.toBeNull();
+            expect(body!.classList.contains("agent-user-message-content--flow")).toBe(true);
+            expect(body!.classList.contains("agent-user-message-content--overlay-below")).toBe(false);
+            expect(body!.classList.contains("agent-user-message-content--overlay-above")).toBe(false);
+        });
+
+        it("regular (non-startup) body uses the in-flow positioning class", () => {
+            const { container } = render(() => (
+                <UserMessageBlock node={baseNode} pinned={false} onTogglePin={() => {}} />
+            ));
+            const body = container.querySelector(".agent-user-message-content");
+            expect(body).not.toBeNull();
+            expect(body!.classList.contains("agent-user-message-content--flow")).toBe(true);
+        });
+    });
+
+    describe("aria-expanded", () => {
+        it("is false when collapsed (not pinned, not hovering)", () => {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+            ));
+            const summary = container.querySelector(".agent-user-message-summary");
+            expect(summary!.getAttribute("aria-expanded")).toBe("false");
+        });
+
+        it("is true when pinned (persistent expanded state)", () => {
+            const { container } = render(() => (
+                <UserMessageBlock node={startupNode} pinned={true} onTogglePin={() => {}} />
+            ));
+            const summary = container.querySelector(".agent-user-message-summary");
+            expect(summary!.getAttribute("aria-expanded")).toBe("true");
+        });
+
+        it("is true when transiently hover-expanded (mirrors visual state)", () => {
+            vi.useFakeTimers();
+            try {
+                const { container } = render(() => (
+                    <UserMessageBlock node={startupNode} pinned={false} onTogglePin={() => {}} />
+                ));
+                const root = container.querySelector(".agent-user-message") as HTMLElement;
+                fireEvent.mouseEnter(root);
+                vi.advanceTimersByTime(200);
+                const summary = container.querySelector(".agent-user-message-summary");
+                expect(summary!.getAttribute("aria-expanded")).toBe("true");
+            } finally {
+                vi.useRealTimers();
+            }
+        });
     });
 });

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -48,6 +48,7 @@ import { Show, createSignal, onCleanup, type JSX } from "solid-js";
 import type { UserMessageNode } from "../types";
 import {
     findScrollContainerRect,
+    maxOverlayHeight,
     pickExpandDirection,
     type ExpandDirection,
 } from "./hover-anchor";
@@ -78,6 +79,12 @@ const STARTUP_BODY_ESTIMATE_PX = 400;
 export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const [hovering, setHovering] = createSignal(false);
     const [expandDirection, setExpandDirection] = createSignal<ExpandDirection>("below");
+    // Pixel cap on the overlay's height, computed per hover from
+    // the chosen-side container space so the overlay's own
+    // `overflow-y: auto` activates inside the pane bounds even when
+    // the body is taller than either side. `null` means no cap
+    // applied (greenfield or non-overlay render).
+    const [overlayMaxHeight, setOverlayMaxHeight] = createSignal<number | null>(null);
     let enterTimer: ReturnType<typeof setTimeout> | undefined;
     let rootEl: HTMLDivElement | undefined;
 
@@ -102,13 +109,19 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                 if (summaryEl) {
                     const rect = summaryEl.getBoundingClientRect();
                     const container = findScrollContainerRect(summaryEl);
-                    setExpandDirection(
-                        pickExpandDirection(
-                            { top: rect.top, bottom: rect.bottom },
-                            container,
-                            STARTUP_BODY_ESTIMATE_PX,
-                        ),
+                    const summaryV = { top: rect.top, bottom: rect.bottom };
+                    const dir = pickExpandDirection(
+                        summaryV,
+                        container,
+                        STARTUP_BODY_ESTIMATE_PX,
                     );
+                    setExpandDirection(dir);
+                    // Cap the overlay's height to the chosen side's
+                    // container space so its own `overflow-y: auto`
+                    // activates inside the pane (vs the pane
+                    // clipping the overlay and the tail being
+                    // unreachable). Codex P2 round 2 on PR #1021.
+                    setOverlayMaxHeight(maxOverlayHeight(summaryV, container, dir));
                 }
             }
             setHovering(true);
@@ -117,6 +130,10 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const handleMouseLeave = () => {
         clearTimeout(enterTimer);
         setHovering(false);
+        // Clear cap so the next hover recomputes from a fresh
+        // measurement; stale values would matter if the pane has
+        // resized between hovers.
+        setOverlayMaxHeight(null);
     };
     onCleanup(() => clearTimeout(enterTimer));
 
@@ -186,6 +203,11 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                         "agent-user-message-content--overlay-above":
                             bodyMode() === "overlay" && expandDirection() === "above",
                     })}
+                    style={
+                        bodyMode() === "overlay" && overlayMaxHeight() !== null
+                            ? { "max-height": `${overlayMaxHeight()}px` }
+                            : undefined
+                    }
                 >
                     {/* Top-right action button. Two glyphs:
                      *    📌 — pin (hovered, not yet pinned).

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -4,56 +4,104 @@
 /**
  * UserMessageBlock — agent-pane row for user input.
  *
- * Two render shapes, gated by `node.isStartup` (set by the stream
- * parser when the message matches the startup-injection heading):
+ * Render shapes:
  *
- *   - **Regular user input** (`isStartup` false / undefined):
- *     always expanded. `<pre>` content rendered with
- *     `white-space: pre` (no soft wrap; long lines scroll
- *     horizontally inside the bubble). High-contrast cyan-blue
- *     tint via `--user-input-color`.
+ *   - **Regular user input** (`isStartup` false / undefined): always
+ *     expanded inline. `<pre>` content uses `white-space: pre` so
+ *     long lines scroll horizontally inside the bubble. Highest-
+ *     contrast user-input color via `--user-input-color`.
  *
- *   - **Startup injection** (`isStartup === true`): collapsed-by-
- *     default summary row (`⓵ Session context (hover to peek ·
- *     click to pin)`). Hover-expand (150ms enter delay) shows the
- *     full Markdown payload transiently. Clicking the summary
- *     pins the expanded state. Mirrors the ToolBlock pattern in
- *     `docs/specs/tool-collapse.md`.
+ *   - **Startup injection, not pinned, not hovering**: collapsed.
+ *     Only the summary `<button>` renders.
  *
- * Spec: `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
+ *   - **Startup injection, hovering (transient)**: body renders as
+ *     a `position: absolute` overlay anchored to the summary,
+ *     EITHER above (`bottom: 100%`) OR below (`top: 100%`),
+ *     depending on `pickExpandDirection()`. The summary's screen-Y
+ *     never changes — the cursor stays exactly where it was when
+ *     the hover timer fired. See
+ *     `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md`.
  *
- * SolidJS reactivity note: props are accessed via `props.X` (never
- * destructured). Pin toggles mutate `documentState.pinnedNodes`
- * without triggering a parent re-render of the document array —
- * destructuring `pinned` would lose reactivity (cost AgentMux a
- * bug fix in PR #346 on ToolBlock; same shape here).
+ *   - **Startup injection, pinned**: body renders in normal
+ *     document flow below the summary. Persistent commitment to
+ *     the expanded form; the virtualizer remeasures the row to
+ *     its new height (estimated by `estimateUnwrappedTextHeight`
+ *     in `renderers.ts`). Option B from the spec §4.2.
+ *
+ * Why mouseleave doesn't fire when the cursor crosses from
+ * summary into the absolute body: per the MDN spec, `mouseleave`
+ * fires only when the pointer has exited the element AND ALL OF
+ * ITS DESCENDANTS — and "descendants" is the DOM tree, NOT visual
+ * containment. The absolute body is still a DOM child of
+ * `.agent-user-message`, so cursor moves between summary and
+ * body keep `hovering` true with no jitter and no `safePolygon`.
+ *
+ * SolidJS reactivity note: props are accessed via `props.X`
+ * (never destructured). Pin toggles mutate
+ * `documentState.pinnedNodes` without re-triggering the parent's
+ * render of the document array; destructuring would lose the
+ * reactive read (PR #346 ToolBlock fix; same shape here).
  */
 
 import clsx from "clsx";
 import { Show, createSignal, onCleanup, type JSX } from "solid-js";
 import type { UserMessageNode } from "../types";
+import { pickExpandDirection, type ExpandDirection } from "./hover-anchor";
 
 interface UserMessageBlockProps {
     node: UserMessageNode;
     /** User has clicked to pin a startup row open. Has no effect
-     * for regular user input (which is always expanded). */
+     * for regular user input (always expanded). */
     pinned: boolean;
     /** Toggle the pin. Wired by the parent through
      * `documentState.pinnedNodes`. */
     onTogglePin: () => void;
 }
 
-// Matches ToolBlock's 150ms — prevents accidental expansions while
-// the user scrolls past the row.
+// 150ms enter-delay matches ToolBlock — prevents accidental
+// expansions during fast scroll-throughs.
 const HOVER_ENTER_DELAY_MS = 150;
+
+// Conservative estimate of the rendered body height for direction
+// selection. The startup payload is typically 4-12kB of Markdown;
+// at 24px line-height + average line density, ~400px is realistic.
+// The pure-function `pickExpandDirection` handles the "fits-neither"
+// case gracefully if this is wrong; this is just a hint for the
+// flip decision. Over-estimating slightly biases toward "above" in
+// near-bottom rows, which is the desirable conservative direction.
+const STARTUP_BODY_ESTIMATE_PX = 400;
 
 export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const [hovering, setHovering] = createSignal(false);
+    const [expandDirection, setExpandDirection] = createSignal<ExpandDirection>("below");
     let enterTimer: ReturnType<typeof setTimeout> | undefined;
+    let rootEl: HTMLDivElement | undefined;
 
     const handleMouseEnter = () => {
         clearTimeout(enterTimer);
-        enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
+        enterTimer = setTimeout(() => {
+            // Capture the summary's position and the viewport size
+            // ONCE at expand-time. Direction stays fixed for the
+            // duration of this hover (no resize listener, no
+            // re-evaluation — per spec §5.2). Re-evaluated on the
+            // next mouseenter.
+            if (rootEl) {
+                const summaryEl = rootEl.querySelector<HTMLElement>(
+                    ".agent-user-message-summary",
+                );
+                if (summaryEl) {
+                    const rect = summaryEl.getBoundingClientRect();
+                    setExpandDirection(
+                        pickExpandDirection(
+                            { top: rect.top, bottom: rect.bottom },
+                            window.innerHeight,
+                            STARTUP_BODY_ESTIMATE_PX,
+                        ),
+                    );
+                }
+            }
+            setHovering(true);
+        }, HOVER_ENTER_DELAY_MS);
     };
     const handleMouseLeave = () => {
         clearTimeout(enterTimer);
@@ -67,8 +115,23 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const expanded = (): boolean =>
         !collapsible() || props.pinned || hovering();
 
+    /** Render mode for the body — drives DOM positioning + CSS classes:
+     *
+     *   - `flow`    — normal document flow (regular input + pinned startup).
+     *   - `overlay` — `position: absolute`, anchored to summary, direction
+     *                 from `expandDirection()`.
+     *   - `hidden`  — body not rendered.
+     */
+    const bodyMode = (): "flow" | "overlay" | "hidden" => {
+        if (!collapsible()) return "flow";
+        if (props.pinned) return "flow";
+        if (hovering()) return "overlay";
+        return "hidden";
+    };
+
     return (
         <div
+            ref={(el) => (rootEl = el)}
             class={clsx("agent-user-message", {
                 "agent-user-message--startup": collapsible(),
                 "agent-user-message--collapsed": collapsible() && !expanded(),
@@ -78,47 +141,48 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
             onMouseEnter={collapsible() ? handleMouseEnter : undefined}
             onMouseLeave={collapsible() ? handleMouseLeave : undefined}
         >
-            <Show when={collapsible() && !expanded()}>
-                {/* Click-to-pin is bound HERE, on the summary row
-                 *  only. Binding it on the outer block would let
-                 *  clicks inside the expanded <pre> (e.g. placing
-                 *  the caret, selecting text to copy) toggle pin and
-                 *  immediately collapse the message — codex P2
-                 *  round 1 on PR #1020.
-                 *
-                 *  Rendered as a real <button> so keyboard users get
-                 *  Tab focus + Space/Enter activation for free. The
-                 *  default button-chrome is reset in SCSS via the
-                 *  shared `.agent-user-message-summary` rule.
-                 *  Codex P2 round 2 on PR #1020. */}
+            {/* Summary is always present (when collapsible) so the
+             *  ARIA/keyboard surface is stable. We hide it via CSS
+             *  when bodyMode is "flow" + pinned, since the body
+             *  takes over the row's identity in that mode.
+             *
+             *  When in overlay mode, the summary stays visible at
+             *  its normal 32px height — the body floats above or
+             *  below it. */}
+            <Show when={collapsible()}>
                 <button
                     type="button"
                     class="agent-user-message-summary"
                     onClick={props.onTogglePin}
-                    aria-expanded={props.pinned}
+                    aria-expanded={expanded()}
                     aria-label="Session context — click to expand and pin"
                 >
                     <span class="agent-user-message-icon">⓵</span>
                     <span class="agent-user-message-label">Session context</span>
                     <span class="agent-user-message-hint">
-                        (hover to peek · click to pin)
+                        {props.pinned
+                            ? "(pinned · click ✕ to collapse)"
+                            : "(hover to peek · click to pin)"}
                     </span>
                 </button>
             </Show>
-            <Show when={!collapsible() || expanded()}>
-                <div class="agent-user-message-content">
-                    {/* Top-right action button — has two modes:
+            <Show when={bodyMode() !== "hidden"}>
+                <div
+                    class={clsx("agent-user-message-content", {
+                        "agent-user-message-content--flow": bodyMode() === "flow",
+                        "agent-user-message-content--overlay-below":
+                            bodyMode() === "overlay" && expandDirection() === "below",
+                        "agent-user-message-content--overlay-above":
+                            bodyMode() === "overlay" && expandDirection() === "above",
+                    })}
+                >
+                    {/* Top-right action button. Two glyphs:
+                     *    📌 — pin (hovered, not yet pinned).
+                     *    ✕  — unpin (currently pinned).
                      *
-                     *   - Hover-expanded but not pinned: shows 📌
-                     *     so the user can pin without racing the
-                     *     150ms enter-delay. (Codex P2 round 3:
-                     *     "Keep click-to-pin available while
-                     *      startup preview is expanded.")
-                     *   - Pinned: shows ✕ to collapse.
-                     *
-                     * Both call `onTogglePin` — the parent reducer
-                     * flips the boolean and the conditional below
-                     * picks the right glyph for the new state. */}
+                     * stopPropagation so the click doesn't bubble
+                     * to ancestors (no outer handlers today, but
+                     * defensive for future additions). */}
                     <Show when={collapsible()}>
                         <button
                             type="button"
@@ -137,10 +201,6 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                                     : "Pin session context open"
                             }
                             onClick={(e) => {
-                                // Stop propagation so the click doesn't
-                                // bubble to the outer block (where no
-                                // handler is bound today, but future
-                                // outer handlers won't fire either).
                                 e.stopPropagation();
                                 props.onTogglePin();
                             }}

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -46,7 +46,11 @@
 import clsx from "clsx";
 import { Show, createSignal, onCleanup, type JSX } from "solid-js";
 import type { UserMessageNode } from "../types";
-import { pickExpandDirection, type ExpandDirection } from "./hover-anchor";
+import {
+    findScrollContainerRect,
+    pickExpandDirection,
+    type ExpandDirection,
+} from "./hover-anchor";
 
 interface UserMessageBlockProps {
     node: UserMessageNode;
@@ -80,21 +84,28 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const handleMouseEnter = () => {
         clearTimeout(enterTimer);
         enterTimer = setTimeout(() => {
-            // Capture the summary's position and the viewport size
-            // ONCE at expand-time. Direction stays fixed for the
-            // duration of this hover (no resize listener, no
-            // re-evaluation — per spec §5.2). Re-evaluated on the
-            // next mouseenter.
+            // Capture the summary's position and the nearest scroll
+            // container's bounds ONCE at expand-time. Direction
+            // stays fixed for the duration of this hover (no resize
+            // listener, no re-evaluation — per spec §5.2). Next
+            // mouseenter re-evaluates.
+            //
+            // Using the scroll container's rect (not
+            // `window.innerHeight`) is essential when the agent
+            // pane lives in a clipped region — a summary near the
+            // pane's bottom can be far from the window's bottom
+            // (codex P1 round 2 on PR #1021).
             if (rootEl) {
                 const summaryEl = rootEl.querySelector<HTMLElement>(
                     ".agent-user-message-summary",
                 );
                 if (summaryEl) {
                     const rect = summaryEl.getBoundingClientRect();
+                    const container = findScrollContainerRect(summaryEl);
                     setExpandDirection(
                         pickExpandDirection(
                             { top: rect.top, bottom: rect.bottom },
-                            window.innerHeight,
+                            container,
                             STARTUP_BODY_ESTIMATE_PX,
                         ),
                     );

--- a/frontend/app/view/agent/components/hover-anchor.test.ts
+++ b/frontend/app/view/agent/components/hover-anchor.test.ts
@@ -11,72 +11,102 @@ import { describe, expect, it } from "vitest";
 import { pickExpandDirection } from "./hover-anchor";
 
 describe("pickExpandDirection", () => {
-    const viewportH = 1000;
+    // Container occupying the whole viewport (no clipping).
+    const fullViewport = { top: 0, bottom: 1000 };
 
     it("returns 'below' when there's plenty of space below", () => {
-        // Summary near top; 100px below summary, 1000-100=900px below.
+        // Summary near top; 1000-100=900px below.
         const rect = { top: 50, bottom: 100 };
-        expect(pickExpandDirection(rect, viewportH, 400)).toBe("below");
+        expect(pickExpandDirection(rect, fullViewport, 400)).toBe("below");
     });
 
     it("returns 'above' when body doesn't fit below but fits above", () => {
         // Summary near bottom; 1000-950=50px below, 900px above.
         const rect = { top: 900, bottom: 950 };
-        expect(pickExpandDirection(rect, viewportH, 400)).toBe("above");
+        expect(pickExpandDirection(rect, fullViewport, 400)).toBe("above");
     });
 
     it("returns 'below' on tie (equal space, body fits in both)", () => {
-        // Summary in the middle; 475px below, 475px above. Body needs 200.
         const rect = { top: 475, bottom: 525 };
-        expect(pickExpandDirection(rect, viewportH, 200)).toBe("below");
+        expect(pickExpandDirection(rect, fullViewport, 200)).toBe("below");
     });
 
     it("returns 'below' when body fits below — even if above has more space", () => {
-        // Summary lower-middle; below = 1000-700=300, above = 650.
-        // Body = 200, fits below → step 1 picks below despite above
-        // having more room.
         const rect = { top: 650, bottom: 700 };
-        expect(pickExpandDirection(rect, viewportH, 200)).toBe("below");
+        expect(pickExpandDirection(rect, fullViewport, 200)).toBe("below");
     });
 
     it("picks the side with more room when body fits in neither", () => {
-        // Body = 600. Summary near bottom: below = 100, above = 850.
-        // Neither side fits 600, but above has more room.
         const rect = { top: 850, bottom: 900 };
-        expect(pickExpandDirection(rect, viewportH, 600)).toBe("above");
+        expect(pickExpandDirection(rect, fullViewport, 600)).toBe("above");
     });
 
     it("picks the larger side when body fits neither — below wins on tie", () => {
-        // Exact-middle summary, body too tall for either half.
         const rect = { top: 475, bottom: 525 };
-        expect(pickExpandDirection(rect, viewportH, 999)).toBe("below");
+        expect(pickExpandDirection(rect, fullViewport, 999)).toBe("below");
     });
 
-    it("handles a summary scrolled partly off the top of the viewport", () => {
-        // Summary's `top` is negative (off-screen). spaceAbove clamps
-        // to 0; body must go below.
+    it("handles a summary scrolled partly off the top", () => {
         const rect = { top: -20, bottom: 30 };
-        expect(pickExpandDirection(rect, viewportH, 400)).toBe("below");
+        expect(pickExpandDirection(rect, fullViewport, 400)).toBe("below");
     });
 
-    it("handles a summary scrolled past the bottom of the viewport", () => {
-        // Summary's `bottom` exceeds viewportH. spaceBelow clamps to
-        // 0; body must go above (assuming there's room).
+    it("handles a summary scrolled past the bottom", () => {
         const rect = { top: 990, bottom: 1020 };
-        expect(pickExpandDirection(rect, viewportH, 400)).toBe("above");
+        expect(pickExpandDirection(rect, fullViewport, 400)).toBe("above");
     });
 
-    it("handles a zero-height viewport gracefully (degenerate but defined)", () => {
-        // Both spaces are 0; tie → "below".
+    it("handles a zero-height container gracefully", () => {
         const rect = { top: 0, bottom: 0 };
-        expect(pickExpandDirection(rect, 0, 100)).toBe("below");
+        expect(pickExpandDirection(rect, { top: 0, bottom: 0 }, 100)).toBe("below");
     });
 
     it("handles a zero-height body — always picks below (step 1)", () => {
-        // 0 fits in any spaceBelow >= 0.
-        expect(pickExpandDirection({ top: 100, bottom: 200 }, viewportH, 0)).toBe("below");
-        // Even when summary is at the very bottom and spaceBelow is 0,
-        // step 1 still matches (0 <= 0), so "below".
-        expect(pickExpandDirection({ top: 990, bottom: 1000 }, viewportH, 0)).toBe("below");
+        expect(
+            pickExpandDirection({ top: 100, bottom: 200 }, fullViewport, 0),
+        ).toBe("below");
+        expect(
+            pickExpandDirection({ top: 990, bottom: 1000 }, fullViewport, 0),
+        ).toBe("below");
+    });
+
+    // Codex P1 round 2 on PR #1021 — the agent pane is a
+    // scrollable region, not the whole viewport. The container
+    // rect lets us pick the right direction when the pane's
+    // bottom is well above the window's bottom.
+    describe("clipped to a scroll container", () => {
+        // Pane occupies the upper 600px of a 1000px window — e.g.
+        // a split view where the lower 400px is another pane.
+        const upperPane = { top: 0, bottom: 600 };
+
+        it("picks 'above' when the summary is near the pane's bottom even though the window has plenty of room below", () => {
+            // Summary in viewport coords at y=550-580. Window has
+            // 420px below (1000-580), but pane only has 20px below
+            // (600-580). Above the summary inside the pane: 550px.
+            const rect = { top: 550, bottom: 580 };
+            expect(pickExpandDirection(rect, upperPane, 400)).toBe("above");
+        });
+
+        it("picks 'below' when the summary is near the pane's top", () => {
+            const rect = { top: 30, bottom: 60 };
+            expect(pickExpandDirection(rect, upperPane, 400)).toBe("below");
+        });
+
+        it("handles a pane that doesn't start at 0", () => {
+            // Pane occupies y=200 to y=700 (a header offsets it).
+            const middlePane = { top: 200, bottom: 700 };
+            // Summary at y=600-630: 70px below, 400px above inside
+            // the pane. 400-tall body fits above.
+            const rect = { top: 600, bottom: 630 };
+            expect(pickExpandDirection(rect, middlePane, 400)).toBe("above");
+        });
+
+        it("clamps to 0 when the summary is outside the container", () => {
+            // Summary above the pane's top: spaceAbove negative,
+            // clamped to 0. Below has the full pane height.
+            const rect = { top: 150, bottom: 180 };
+            const middlePane = { top: 200, bottom: 700 };
+            expect(pickExpandDirection(rect, middlePane, 300)).toBe("below");
+        });
     });
 });

--- a/frontend/app/view/agent/components/hover-anchor.test.ts
+++ b/frontend/app/view/agent/components/hover-anchor.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { pickExpandDirection } from "./hover-anchor";
+import { maxOverlayHeight, pickExpandDirection } from "./hover-anchor";
 
 describe("pickExpandDirection", () => {
     // Container occupying the whole viewport (no clipping).
@@ -108,5 +108,78 @@ describe("pickExpandDirection", () => {
             const middlePane = { top: 200, bottom: 700 };
             expect(pickExpandDirection(rect, middlePane, 300)).toBe("below");
         });
+    });
+});
+
+describe("maxOverlayHeight", () => {
+    it("'below' returns the container space below the summary, minus margin", () => {
+        // 200px below summary (1000 - 800), minus 4px margin = 196.
+        expect(
+            maxOverlayHeight(
+                { top: 700, bottom: 800 },
+                { top: 0, bottom: 1000 },
+                "below",
+            ),
+        ).toBe(196);
+    });
+
+    it("'above' returns the container space above the summary, minus margin", () => {
+        // 700px above summary (700 - 0), minus 4px margin = 696.
+        expect(
+            maxOverlayHeight(
+                { top: 700, bottom: 800 },
+                { top: 0, bottom: 1000 },
+                "above",
+            ),
+        ).toBe(696);
+    });
+
+    it("respects a non-zero container top (header offset)", () => {
+        // Summary at 600-700, pane is 200-1000. Below = 1000-700-4=296.
+        expect(
+            maxOverlayHeight(
+                { top: 600, bottom: 700 },
+                { top: 200, bottom: 1000 },
+                "below",
+            ),
+        ).toBe(296);
+        // Above = 600-200-4 = 396.
+        expect(
+            maxOverlayHeight(
+                { top: 600, bottom: 700 },
+                { top: 200, bottom: 1000 },
+                "above",
+            ),
+        ).toBe(396);
+    });
+
+    it("clamps to 0 for a degenerate case (summary outside container)", () => {
+        // Summary above pane top — 'above' space is negative → 0.
+        expect(
+            maxOverlayHeight(
+                { top: 50, bottom: 100 },
+                { top: 200, bottom: 1000 },
+                "above",
+            ),
+        ).toBe(0);
+    });
+
+    it("accepts a custom margin", () => {
+        expect(
+            maxOverlayHeight(
+                { top: 0, bottom: 50 },
+                { top: 0, bottom: 1000 },
+                "below",
+                0,
+            ),
+        ).toBe(950);
+        expect(
+            maxOverlayHeight(
+                { top: 0, bottom: 50 },
+                { top: 0, bottom: 1000 },
+                "below",
+                20,
+            ),
+        ).toBe(930);
     });
 });

--- a/frontend/app/view/agent/components/hover-anchor.test.ts
+++ b/frontend/app/view/agent/components/hover-anchor.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * L1 unit tests for the hover-anchor direction picker.
+ *
+ * Spec: `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md` §6.1.
+ */
+
+import { describe, expect, it } from "vitest";
+import { pickExpandDirection } from "./hover-anchor";
+
+describe("pickExpandDirection", () => {
+    const viewportH = 1000;
+
+    it("returns 'below' when there's plenty of space below", () => {
+        // Summary near top; 100px below summary, 1000-100=900px below.
+        const rect = { top: 50, bottom: 100 };
+        expect(pickExpandDirection(rect, viewportH, 400)).toBe("below");
+    });
+
+    it("returns 'above' when body doesn't fit below but fits above", () => {
+        // Summary near bottom; 1000-950=50px below, 900px above.
+        const rect = { top: 900, bottom: 950 };
+        expect(pickExpandDirection(rect, viewportH, 400)).toBe("above");
+    });
+
+    it("returns 'below' on tie (equal space, body fits in both)", () => {
+        // Summary in the middle; 475px below, 475px above. Body needs 200.
+        const rect = { top: 475, bottom: 525 };
+        expect(pickExpandDirection(rect, viewportH, 200)).toBe("below");
+    });
+
+    it("returns 'below' when body fits below — even if above has more space", () => {
+        // Summary lower-middle; below = 1000-700=300, above = 650.
+        // Body = 200, fits below → step 1 picks below despite above
+        // having more room.
+        const rect = { top: 650, bottom: 700 };
+        expect(pickExpandDirection(rect, viewportH, 200)).toBe("below");
+    });
+
+    it("picks the side with more room when body fits in neither", () => {
+        // Body = 600. Summary near bottom: below = 100, above = 850.
+        // Neither side fits 600, but above has more room.
+        const rect = { top: 850, bottom: 900 };
+        expect(pickExpandDirection(rect, viewportH, 600)).toBe("above");
+    });
+
+    it("picks the larger side when body fits neither — below wins on tie", () => {
+        // Exact-middle summary, body too tall for either half.
+        const rect = { top: 475, bottom: 525 };
+        expect(pickExpandDirection(rect, viewportH, 999)).toBe("below");
+    });
+
+    it("handles a summary scrolled partly off the top of the viewport", () => {
+        // Summary's `top` is negative (off-screen). spaceAbove clamps
+        // to 0; body must go below.
+        const rect = { top: -20, bottom: 30 };
+        expect(pickExpandDirection(rect, viewportH, 400)).toBe("below");
+    });
+
+    it("handles a summary scrolled past the bottom of the viewport", () => {
+        // Summary's `bottom` exceeds viewportH. spaceBelow clamps to
+        // 0; body must go above (assuming there's room).
+        const rect = { top: 990, bottom: 1020 };
+        expect(pickExpandDirection(rect, viewportH, 400)).toBe("above");
+    });
+
+    it("handles a zero-height viewport gracefully (degenerate but defined)", () => {
+        // Both spaces are 0; tie → "below".
+        const rect = { top: 0, bottom: 0 };
+        expect(pickExpandDirection(rect, 0, 100)).toBe("below");
+    });
+
+    it("handles a zero-height body — always picks below (step 1)", () => {
+        // 0 fits in any spaceBelow >= 0.
+        expect(pickExpandDirection({ top: 100, bottom: 200 }, viewportH, 0)).toBe("below");
+        // Even when summary is at the very bottom and spaceBelow is 0,
+        // step 1 still matches (0 <= 0), so "below".
+        expect(pickExpandDirection({ top: 990, bottom: 1000 }, viewportH, 0)).toBe("below");
+    });
+});

--- a/frontend/app/view/agent/components/hover-anchor.ts
+++ b/frontend/app/view/agent/components/hover-anchor.ts
@@ -30,49 +30,59 @@
 
 export type ExpandDirection = "above" | "below";
 
-export interface SummaryRect {
-    /** Distance from viewport top to summary's top edge, in px. */
+export interface VerticalRect {
+    /** Distance from viewport top to top edge, in px. */
     readonly top: number;
-    /** Distance from viewport top to summary's bottom edge, in px. */
+    /** Distance from viewport top to bottom edge, in px. */
     readonly bottom: number;
 }
+
+// Backwards-compat alias — public API name from PR #1021 first cut.
+// Both rects use the same shape (top + bottom in viewport coords).
+export type SummaryRect = VerticalRect;
 
 /**
  * Pick the side on which the floating body should render.
  *
  * Decision tree:
- *   1. If body fits below the summary inside the viewport → "below".
- *   2. Else if body fits above the summary inside the viewport → "above".
+ *   1. If body fits below the summary inside the clipping
+ *      container → "below".
+ *   2. Else if body fits above → "above".
  *   3. Else pick whichever side has more room → "below" on a tie.
  *
- * Step 2 catches the "near-bottom" case — the canonical reason the
- * user asked for the direction-flip in the first place. Step 3
- * gracefully handles the (rare) case where the body is taller than
- * either side of the viewport; the body will need a scrollbar
- * regardless, but we pick the side that minimizes the scroll
- * surface.
+ * Step 2 catches the "near-bottom" case — the canonical reason
+ * the user asked for the direction-flip in the first place.
  *
  * The function is pure; pass exact values for unit testing. In
- * production the caller wires `summaryEl.getBoundingClientRect()`,
- * `window.innerHeight`, and the body's estimated height.
+ * production the caller wires `summaryEl.getBoundingClientRect()`
+ * and the nearest scrollable ancestor's rect (or
+ * `{top: 0, bottom: window.innerHeight}` when no scroll
+ * container exists).
+ *
+ * Why the container rect and not `window.innerHeight`: the agent
+ * pane lives inside a scrollable `.agent-document` region. A
+ * summary near the bottom of that pane can still be 200px above
+ * the window's bottom — `window.innerHeight` would think there's
+ * plenty of room and pick `below`, but the overlay would render
+ * clipped or off the bottom of the pane. Codex P1 round 2 on
+ * PR #1021.
  *
  * @param summaryRect  the summary's bounding rect in viewport
- *   coordinates (call sites use `getBoundingClientRect()`).
- * @param viewportHeight  the viewport height in CSS pixels
- *   (`window.innerHeight`).
+ *   coordinates.
+ * @param containerRect  the nearest clipping ancestor's bounding
+ *   rect, also in viewport coordinates. For the document body
+ *   (no clipping), pass `{ top: 0, bottom: window.innerHeight }`.
  * @param bodyEstimate  the estimated rendered height of the body
- *   in CSS pixels. Caller derives this from
- *   `estimateUnwrappedTextHeight` or a constant for the startup
- *   payload. Conservative over-estimates are safe (they just
- *   push toward step 3's tie-break).
+ *   in CSS pixels. Conservative over-estimates are safe (they
+ *   just push toward step 3's tie-break).
  */
 export function pickExpandDirection(
-    summaryRect: SummaryRect,
-    viewportHeight: number,
+    summaryRect: VerticalRect,
+    containerRect: VerticalRect,
     bodyEstimate: number,
 ): ExpandDirection {
-    const spaceBelow = Math.max(0, viewportHeight - summaryRect.bottom);
-    const spaceAbove = Math.max(0, summaryRect.top);
+    const spaceBelow = Math.max(0, containerRect.bottom - summaryRect.bottom);
+    const spaceAbove = Math.max(0, summaryRect.top - containerRect.top);
 
     // Step 1: body fits below — preferred direction.
     if (bodyEstimate <= spaceBelow) {
@@ -86,4 +96,29 @@ export function pickExpandDirection(
     // wins on tie (and on the no-room-anywhere edge case where
     // both `spaceAbove` and `spaceBelow` are 0).
     return spaceBelow >= spaceAbove ? "below" : "above";
+}
+
+/**
+ * Find the nearest scrolling ancestor of `el` (the element whose
+ * computed `overflow-y` is `auto`, `scroll`, or `hidden`). Returns
+ * its viewport-coordinate rect, or a viewport-wide fallback if
+ * no such ancestor exists.
+ *
+ * Used by `UserMessageBlock` to feed `pickExpandDirection` the
+ * right clipping bounds — typically `.agent-document` (the
+ * agent-pane's scroll container).
+ */
+export function findScrollContainerRect(el: HTMLElement): VerticalRect {
+    let current: HTMLElement | null = el.parentElement;
+    while (current && current !== document.body) {
+        const cs = window.getComputedStyle(current);
+        const oy = cs.overflowY;
+        if (oy === "auto" || oy === "scroll" || oy === "hidden") {
+            const r = current.getBoundingClientRect();
+            return { top: r.top, bottom: r.bottom };
+        }
+        current = current.parentElement;
+    }
+    // No scroll container found — overlay can use the whole viewport.
+    return { top: 0, bottom: window.innerHeight };
 }

--- a/frontend/app/view/agent/components/hover-anchor.ts
+++ b/frontend/app/view/agent/components/hover-anchor.ts
@@ -1,0 +1,89 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * hover-anchor — pure function for choosing the expansion direction
+ * of a hover-expanded overlay so that the trigger (summary) stays
+ * under the cursor across the expand transition.
+ *
+ * Used by `UserMessageBlock` for the startup-injection collapse.
+ * The mechanic: at the moment hover fires (after the 150ms enter
+ * delay), the body content is rendered absolutely above OR below
+ * the summary based on viewport space. The summary itself never
+ * moves in document flow — the body floats over neighbors.
+ *
+ * The direction picker considers BOTH:
+ *   1. Whether the body fits below the summary without overflowing
+ *      the viewport.
+ *   2. Whether more space is available above or below the summary.
+ *
+ * Below wins on tie (matches the historical default of dropdowns,
+ * and the keyboard-activated pinned-in-flow path also opens
+ * downward, so the visual model is consistent).
+ *
+ * Spec:
+ * `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md` §4.3.
+ *
+ * No dependency on `window` / DOM — caller passes in viewportHeight
+ * so this stays a pure function and is trivially unit-testable.
+ */
+
+export type ExpandDirection = "above" | "below";
+
+export interface SummaryRect {
+    /** Distance from viewport top to summary's top edge, in px. */
+    readonly top: number;
+    /** Distance from viewport top to summary's bottom edge, in px. */
+    readonly bottom: number;
+}
+
+/**
+ * Pick the side on which the floating body should render.
+ *
+ * Decision tree:
+ *   1. If body fits below the summary inside the viewport → "below".
+ *   2. Else if body fits above the summary inside the viewport → "above".
+ *   3. Else pick whichever side has more room → "below" on a tie.
+ *
+ * Step 2 catches the "near-bottom" case — the canonical reason the
+ * user asked for the direction-flip in the first place. Step 3
+ * gracefully handles the (rare) case where the body is taller than
+ * either side of the viewport; the body will need a scrollbar
+ * regardless, but we pick the side that minimizes the scroll
+ * surface.
+ *
+ * The function is pure; pass exact values for unit testing. In
+ * production the caller wires `summaryEl.getBoundingClientRect()`,
+ * `window.innerHeight`, and the body's estimated height.
+ *
+ * @param summaryRect  the summary's bounding rect in viewport
+ *   coordinates (call sites use `getBoundingClientRect()`).
+ * @param viewportHeight  the viewport height in CSS pixels
+ *   (`window.innerHeight`).
+ * @param bodyEstimate  the estimated rendered height of the body
+ *   in CSS pixels. Caller derives this from
+ *   `estimateUnwrappedTextHeight` or a constant for the startup
+ *   payload. Conservative over-estimates are safe (they just
+ *   push toward step 3's tie-break).
+ */
+export function pickExpandDirection(
+    summaryRect: SummaryRect,
+    viewportHeight: number,
+    bodyEstimate: number,
+): ExpandDirection {
+    const spaceBelow = Math.max(0, viewportHeight - summaryRect.bottom);
+    const spaceAbove = Math.max(0, summaryRect.top);
+
+    // Step 1: body fits below — preferred direction.
+    if (bodyEstimate <= spaceBelow) {
+        return "below";
+    }
+    // Step 2: body doesn't fit below but fits above — flip.
+    if (bodyEstimate <= spaceAbove) {
+        return "above";
+    }
+    // Step 3: doesn't fit either way; pick the larger side. Below
+    // wins on tie (and on the no-room-anywhere edge case where
+    // both `spaceAbove` and `spaceBelow` are 0).
+    return spaceBelow >= spaceAbove ? "below" : "above";
+}

--- a/frontend/app/view/agent/components/hover-anchor.ts
+++ b/frontend/app/view/agent/components/hover-anchor.ts
@@ -122,3 +122,29 @@ export function findScrollContainerRect(el: HTMLElement): VerticalRect {
     // No scroll container found — overlay can use the whole viewport.
     return { top: 0, bottom: window.innerHeight };
 }
+
+/**
+ * The pixel height the overlay should be capped at, given the
+ * chosen direction and the clipping container's bounds. The
+ * caller applies this as an inline `max-height` on the overlay
+ * so that — for the "fits-neither" case — the overlay's own
+ * `overflow-y: auto` activates inside the container's bounds
+ * (instead of the overlay being clipped by the container and
+ * the hidden tail being unreachable). Codex P2 round 2 on
+ * PR #1021.
+ *
+ * `margin` is reserved space at the container edge so the
+ * overlay doesn't sit flush against the pane border. 4px is
+ * enough breathing room without compromising readable area.
+ */
+export function maxOverlayHeight(
+    summaryRect: VerticalRect,
+    containerRect: VerticalRect,
+    direction: ExpandDirection,
+    margin = 4,
+): number {
+    if (direction === "below") {
+        return Math.max(0, containerRect.bottom - summaryRect.bottom - margin);
+    }
+    return Math.max(0, summaryRect.top - containerRect.top - margin);
+}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -672,10 +672,12 @@
             left: 0;
             right: 0;
             z-index: 10;
-            // Cap height to keep the overlay inside the viewport
-            // (with a 40px breathing room at both edges). Body
-            // gets its own scrollbar if it doesn't fit.
-            max-height: calc(100vh - 80px);
+            // max-height is set inline by UserMessageBlock from the
+            // chosen-side container space — keeps `overflow-y: auto`
+            // operating INSIDE the scroll container's bounds rather
+            // than relying on `calc(100vh - …)`, which clipped the
+            // overlay's tail when the agent pane is in a sub-region
+            // of the window (codex P2 round 2 on PR #1021).
             overflow-y: auto;
             // Solid background so the overlay reads as a discrete
             // surface against the rows it covers. Slightly deeper

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -616,6 +616,10 @@
         border-radius: 2px;
         user-select: text;
         cursor: text;
+        // Establish a positioning context for the overlay body
+        // (`agent-user-message-content--overlay-above/below` use
+        // `position: absolute` relative to this).
+        position: relative;
 
         .agent-user-message-content {
             pre {
@@ -627,6 +631,66 @@
                 overflow-x: auto;
                 overflow-y: hidden;
             }
+        }
+
+        // ─── Body render modes (PR for SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24) ─
+        //
+        // Three modes (gated by `bodyMode()` in UserMessageBlock):
+        //
+        //   --flow            — normal document flow. Used for regular
+        //                       (non-startup) user input AND for pinned
+        //                       startup rows. Row's measured height
+        //                       grows to include the body.
+        //
+        //   --overlay-below   — `position: absolute; top: 100%; …`.
+        //                       Body floats below the summary as a
+        //                       transient hover preview. Row's
+        //                       measured height stays at 32px so the
+        //                       virtualizer doesn't see a height
+        //                       change.
+        //
+        //   --overlay-above   — `position: absolute; bottom: 100%; …`.
+        //                       Same as above but anchored to the
+        //                       summary's TOP edge — body grows
+        //                       upward. Picked when the row is near
+        //                       the bottom of the viewport.
+        //
+        // The summary's screen-Y is anchored across the transition.
+        // No layout shift in the document, no jitter — geometry
+        // determines direction, mouseleave on the outer block
+        // doesn't fire when the cursor crosses summary→body because
+        // the absolute body is still a DOM descendant of
+        // `.agent-user-message`. See the doc comment in
+        // UserMessageBlock.tsx and the spec.
+        .agent-user-message-content--flow {
+            // Default — no special positioning. Body participates
+            // in document flow. (This is the regular-input style.)
+        }
+        .agent-user-message-content--overlay-below,
+        .agent-user-message-content--overlay-above {
+            position: absolute;
+            left: 0;
+            right: 0;
+            z-index: 10;
+            // Cap height to keep the overlay inside the viewport
+            // (with a 40px breathing room at both edges). Body
+            // gets its own scrollbar if it doesn't fit.
+            max-height: calc(100vh - 80px);
+            overflow-y: auto;
+            // Solid background so the overlay reads as a discrete
+            // surface against the rows it covers. Slightly deeper
+            // than the inline tint to match the
+            // `&--expanded.agent-user-message--startup` rule below.
+            background: color-mix(in srgb, var(--user-input-color) 18%, var(--block-bg-solid-color, var(--main-bg-color, #1c1c1c)));
+            border: 1px solid color-mix(in srgb, var(--user-input-color) 40%, transparent);
+            border-radius: 4px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        }
+        .agent-user-message-content--overlay-below {
+            top: 100%;
+        }
+        .agent-user-message-content--overlay-above {
+            bottom: 100%;
         }
 
         // ─── Startup-injection variant ────────────────────────────

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -761,9 +761,26 @@
             //   - .agent-user-message-unpin shows ✕ when pinned,
             //     so the user can collapse without hunting.
             // Both share styling.
-            .agent-user-message-content {
+            //
+            // Anchoring (codex P1 round 3 on PR #1021):
+            //   - Overlay variants are `position: absolute` —
+            //     they serve as the containing block for the
+            //     absolute-positioned buttons themselves, no
+            //     explicit `position: relative` needed (and
+            //     applying `relative` here would lose at equal
+            //     specificity to the overlay rule, dropping the
+            //     overlay back into flow and breaking the whole
+            //     anchor design).
+            //   - The flow variant (pinned, or non-startup
+            //     regular input) needs an explicit
+            //     `position: relative` to serve as containing
+            //     block for the buttons. Scoped via the
+            //     `--flow` modifier so it can't accidentally
+            //     override the overlay rules.
+            .agent-user-message-content--flow {
                 position: relative;
-
+            }
+            .agent-user-message-content {
                 .agent-user-message-pin,
                 .agent-user-message-unpin {
                     position: absolute;

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -159,6 +159,30 @@
             width: 100%;
             table-layout: fixed;
         }
+
+        // Elevate the row when it carries a hover-expanded
+        // startup-injection overlay. `contain: layout style`
+        // creates a stacking context per the CSS spec, which
+        // would otherwise trap the overlay's z-index inside the
+        // row — codex P1 round 2 on PR #1021. By elevating the
+        // ROW itself (with `position: relative` + `z-index`),
+        // the whole row stacks above its siblings; the overlay's
+        // inner `z-index: 10` then lifts it within the elevated
+        // row's own stacking context, putting it above the
+        // sibling rows' content too. The `:has()` selector
+        // scopes the elevation precisely to the moment a
+        // transient overlay is showing — no permanent z-index
+        // bump on every row.
+        //
+        // CEF 146+ supports `:has()` (Chromium 105+). Pinned
+        // bodies stay in normal flow (Option B) so they don't
+        // need elevation.
+        &:has(
+            .agent-user-message--expanded.agent-user-message--startup:not(.agent-user-message--pinned)
+        ) {
+            position: relative;
+            z-index: 100;
+        }
     }
 
     // Legacy class — keep for any non-virtualized callers; remove


### PR DESCRIPTION
Implements `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md`. Companion progress log: `docs/sessions/PROGRESS_HOVER_ANCHOR_2026_05_24.md`.

## What

The hover-expansion of `⓵ Session context` was perturbing document layout (32px → ~200-400px), which combined with the user's natural mouse drift during the 150ms enter-delay produced an "expand → mouse drifts off → collapse" loop. PR #1020's spec said body grows inline below summary; in practice it didn't work for users near the bottom of the viewport or who hovered near the summary's bottom edge.

This PR makes the hover-expanded body float as an absolute-positioned overlay anchored to the summary, on the side with more viewport room. The summary's screen-Y is unchanged across the expand. Pinned content drops into normal flow (a deliberate persistence commitment).

## Research round (best practices)

- [Floating UI flip middleware](https://floating-ui.com/docs/computeposition) — the canonical "pick the direction with more room" pattern.
- [Floating UI useHover + safePolygon](https://floating-ui.com/docs/usehover) — for trigger→popover gaps. Not needed here (see below).
- [MDN mouseleave](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event) — confirms `mouseleave` fires when pointer exits element AND ALL DESCENDANTS. "Descendants" = DOM tree, NOT visual containment.
- [TanStack Virtual](https://tanstack.com/virtual/latest/docs/api/virtualizer) — absolute-positioned children don't change the row's measured height; virtualizer doesn't see the overlay.

The MDN insight collapses the design: because the overlay body is a DOM child of `.agent-user-message`, cursor moves between summary and absolute body do NOT fire mouseleave on the outer block. No `safePolygon`, no hover-intent timeout, no grace window. Per `feedback_no_timers_or_delays`.

## How (three independently revertible commits)

| Commit | Files | Effect |
|---|---|---|
| 1 | `hover-anchor.ts` + `.test.ts` | Pure function `pickExpandDirection(rect, viewportH, bodyEstimate) → "above" \| "below"`. 10 L1 tests. |
| 2 | `UserMessageBlock.tsx`, `_document-nodes.scss` | New `expandDirection` signal set inside the 150ms enter timer; `bodyMode()` derived (`hidden` / `overlay` / `flow`); SCSS overlay vs flow positioning. Summary always rendered for stable ARIA. |
| 3 | `UserMessageBlock.test.tsx` | 6 new L2 tests (body positioning class matrix + aria-expanded). 2 prior tests updated for the always-mounted summary. |

All three squashed into one commit on push.

## Pinned vs hovered — Option B chosen

Pin = body drops into normal document flow below the summary (virtualizer remeasures, row grows). Hover = body floats as overlay (no remeasure, row stays 32px in flow). Rationale in spec §4.2.

## Tests

- **L1 — `hover-anchor.test.ts`** (10 tests): plenty-below, near-bottom, exact tie, fits-below-even-when-above-bigger, fits-neither-pick-larger, fits-neither-tie, off-top, off-bottom, zero-viewport, zero-body.
- **L2 — `UserMessageBlock.test.tsx`** (22 tests; 12 prior + 6 new + 4 updated):
  - body positioning: hover-expanded → overlay class; pinned → `--flow`; regular → `--flow`.
  - aria-expanded: false collapsed, true pinned, true hover-expanded.
  - pre-existing: click scopes, hover delay, mouseleave-cancel, pin/unpin buttons, Space/Enter contract.
- **32 / 32 PR-footprint tests pass.** Pre-existing failures on origin/main (BlockErrorBoundary, AgentPicker mock-fixture) are unchanged.

## Manual verification (L3 to run on the portable)

- Open a fresh agent near the top of the pane. Hover `⓵ Session context`. Body opens **below**. Cursor stays on summary.
- Scroll the pane so the summary is near the bottom of the viewport. Hover. Body opens **above**. Cursor stays on summary.
- Move cursor smoothly from summary into body. No flicker, body stays open. Move out — body closes.
- Click summary or 📌 to pin. Body settles into normal flow below summary. Click ✕ to collapse. Repeat ≥10× — pin lands every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)