### PR TITLE
fix(test): exclude .claude/worktrees from vitest discovery (84 failed → 2 failed)

### DIFF
--- a/.changesets/1779665878-fix-test-exclude-claude-worktrees-from-vitest-discovery-to-d-a23h.md
+++ b/.changesets/1779665878-fix-test-exclude-claude-worktrees-from-vitest-discovery-to-d-a23h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(test): exclude .claude/worktrees from vitest discovery to drop 82 duplicate failures

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,19 @@ export default mergeConfig(
                 "**/node_modules/**",
                 "**/dist/**",
                 "**/infra/cdk/**", // CDK has its own testing setup with aws-cdk-lib
+                // Leftover git worktrees from prior agent sessions
+                // live under `.claude/worktrees/agent-*/`. Each carries
+                // a full clone of the project (including test files),
+                // so without an exclusion vitest discovers and runs
+                // them all — inflating runtime ~6× and showing each
+                // real failure under N duplicate paths.
+                //
+                // `**/.claude/**` is the precise rule for the current
+                // layout; `**/worktrees/**` is a defensive second net
+                // in case the location moves.
+                // Spec: docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md §1.
+                "**/.claude/**",
+                "**/worktrees/**",
             ],
             coverage: {
                 provider: "istanbul",


### PR DESCRIPTION
PR A of three from `docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md`.

## What

`npx vitest run frontend/` reports 84 failed tests. **82 of them are duplicate runs from leftover `.claude/worktrees/agent-*/` directories** — worktrees from prior agent sessions that vitest scans because no exclusion is in place. Only 2 are real failures.

Add `**/.claude/**` and `**/worktrees/**` to the vitest `exclude` list. Two patterns: the first is precise to today's `.claude/worktrees/agent-*/` layout, the second is a defensive net if worktree storage moves later.

## Measured effect

| Metric | Before | After |
|---|---|---|
| Test files failed | 58 | (down — only 2 underlying files) |
| Tests failed | **84** | **2** |
| Tests passed | 18,648 | 1,017 |
| Tests total | 18,732 | 1,019 |
| Runtime | ~165s | ~25s |

The "84 failed" headline was psychologically alarming; the real number was always 2.

## What this PR does NOT fix

The two surviving failures are real and will land in follow-up PRs (per spec §2 + §3):

- `frontend/app/store/browser-pane-state-store.test.ts:66` — stale test assumption (title projected when it shouldn't be, or vice versa).
- `frontend/app/view/agent/providers/index.test.ts:65` — `authType === "api-key"` test expectation; at least one ACP provider has migrated to OAuth.

The separate `tsc --noEmit` errors in test files (`toBeInTheDocument` not on `Assertion` type — 35+ lines) are also a follow-up PR (spec §4). Tests pass at runtime; the typecheck is dirty because `@testing-library/jest-dom` types aren't in `tsconfig.json`.

## Worktree cleanup (separate from this PR)

`.claude/worktrees/` has 21 leftover dirs eating disk space (~half a GB each on a build-laden repo). Recommend running locally:

```
git worktree prune
rm -rf .claude/worktrees/agent-*
```

…but that's not necessary for this PR; the exclusion makes them invisible to vitest regardless.

## Spec

`docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md` §1 (this PR) + §2/§3/§4 (follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)