### PR TITLE
fix(test): unstale browser-pane title + ACP openclaw OAuth assertions (2 failing → 0)

### DIFF
--- a/.changesets/1779666314-fix-test-unstale-browser-pane-title-and-acp-openclaw-oauth-a-p9vd.md
+++ b/.changesets/1779666314-fix-test-unstale-browser-pane-title-and-acp-openclaw-oauth-a-p9vd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(test): unstale browser-pane title and ACP openclaw OAuth assertions

--- a/frontend/app/store/browser-pane-state-store.test.ts
+++ b/frontend/app/store/browser-pane-state-store.test.ts
@@ -61,9 +61,14 @@ describe("browser-pane-state-store (slice #9 Phase 4)", () => {
         expect(proj.calls.faviconUrl).toEqual([
             "https://example.com/favicon.ico",
         ]);
-        // Cells that didn't change shouldn't be projected.
+        // Navigate also seeds the title with a hostname-based
+        // placeholder so the header doesn't show the previous
+        // page's title during the load
+        // (SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18). The
+        // real title overrides this when CEF emits TitleChanged.
+        expect(proj.calls.title).toEqual(["example.com"]);
+        // closed didn't change (still false) — not projected.
         expect(proj.calls.closed).toEqual([]);
-        expect(proj.calls.title).toEqual([]);
     });
 
     it("does NOT project cells that didn't change between dispatches", () => {

--- a/frontend/app/view/agent/providers/index.test.ts
+++ b/frontend/app/view/agent/providers/index.test.ts
@@ -8,11 +8,18 @@ import type { ProviderDefinition } from "./index";
 // Providers split into two classes by how they talk to the backend:
 //   - OAuth CLIs (raw stream): claude, codex, gemini — authType "oauth",
 //     outputFormat "raw", no defaultArgs.
-//   - ACP providers:           openclaw, pi — authType "api-key",
-//     outputFormat "acp".
+//   - ACP providers:           openclaw (OAuth via subcommand —
+//     SPEC_OPENCLAW_AGENT_2026_05_17.md §4), pi (api-key). Both
+//     `outputFormat: "acp"`.
 const OAUTH_CLI_IDS = ["claude", "codex", "gemini"] as const;
 const API_KEY_CLI_IDS = ["kimi"] as const;
 const ACP_IDS = ["openclaw", "pi"] as const;
+// ACP sub-partition by auth type. Kept separate from the unified
+// `ACP_IDS` so the "ACP providers use the ACP output format"
+// assertion can stay in one loop while the auth assertions live
+// in their own loops below.
+const ACP_OAUTH_IDS = ["openclaw"] as const;
+const ACP_API_KEY_IDS = ["pi"] as const;
 
 describe("PROVIDERS", () => {
     test("includes the OAuth CLI trio and the ACP providers", () => {
@@ -58,11 +65,29 @@ describe("PROVIDERS", () => {
         }
     });
 
-    test("ACP providers use the ACP output format and api-key auth", () => {
+    test("ACP providers use the ACP output format", () => {
+        // The output-format invariant is uniform across ACP
+        // providers — they all speak ACP regardless of how they
+        // authenticate.
         for (const id of ACP_IDS) {
-            const provider = PROVIDERS[id];
-            expect(provider.outputFormat).toBe("acp");
-            expect(provider.authType).toBe("api-key");
+            expect(PROVIDERS[id].outputFormat).toBe("acp");
+        }
+    });
+
+    test("ACP+OAuth providers use OAuth auth (e.g. openclaw — OAuth via subcommand)", () => {
+        // SPEC_OPENCLAW_AGENT_2026_05_17.md §4: openclaw runs an
+        // OAuth flow via `models auth login --provider …` to
+        // borrow another CLI's credentials (currently OpenAI
+        // Codex), so its `authType` is "oauth" despite being an
+        // ACP provider.
+        for (const id of ACP_OAUTH_IDS) {
+            expect(PROVIDERS[id].authType).toBe("oauth");
+        }
+    });
+
+    test("ACP+api-key providers use api-key auth (e.g. pi)", () => {
+        for (const id of ACP_API_KEY_IDS) {
+            expect(PROVIDERS[id].authType).toBe("api-key");
         }
     });
 });


### PR DESCRIPTION
PR B of three from `docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md`. Follows up #1022 which dropped the worktree-noise from 84 → 2 failures; this PR drops those 2 → 0.

## Real failures, both test-only (production code is correct)

### 1. `browser-pane-state-store.test.ts:66`

Test asserted `proj.calls.title === []` after a `Navigate` dispatch. But `SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18` added a hostname-derived title placeholder so the address bar header doesn't show the previous page's title during the 500ms-3s before CEF emits `TitleChanged`. The reducer's `Navigate` case (`reducer.ts:83-94`) sets `title: deriveTitlePlaceholder(url)` — for `https://example.com` that's `"example.com"`.

Production behavior is intentional and correct; the test's assumption that title wouldn't change on Navigate was a spec behind. Updated to `expect(proj.calls.title).toEqual(["example.com"])` with a spec-pointing comment.

### 2. `providers/index.test.ts:65`

Test iterated `ACP_IDS = ["openclaw", "pi"]` asserting each had `authType === "api-key"`. But `SPEC_OPENCLAW_AGENT_2026_05_17.md §4` shipped `openclaw` with `authType: "oauth"` — OAuth-via-subcommand (`models auth login --provider openai-codex`) to borrow OpenAI Codex's credentials. The blanket "all ACP = api-key" assertion was already false on main.

Split into three targeted assertions:
- ACP providers use the `acp` output format (uniform — both still in one loop).
- ACP+OAuth providers (`openclaw`) use OAuth auth.
- ACP+api-key providers (`pi`) use api-key auth.

Each list is small and explicit so a future provider's auth choice fails one targeted assertion instead of a broad blanket one.

## Result

```
before  Tests 2 failed | 1019 passed
after   Tests 0 failed | 1021 passed
```

## Out of scope (PR C)

The `tsc --noEmit` errors in test files (`toBeInTheDocument` / `toHaveTextContent` not on `Assertion` type — 35+ lines across 5 files) — tests pass at runtime, only the typecheck is dirty. PR C will add `@testing-library/jest-dom` to `tsconfig.json`'s `types` array. Spec §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)