### PR TITLE
chore(test): load jest-dom vitest matcher types in tsconfig (29 tsc errors → 0)

### DIFF
--- a/.changesets/1779666876-chore-test-load-testing-library-jest-dom-vitest-types-in-tsc-kt9x.md
+++ b/.changesets/1779666876-chore-test-load-testing-library-jest-dom-vitest-types-in-tsc-kt9x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(test): load @testing-library/jest-dom/vitest types in tsconfig (29 tsc errors → 0)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
             "@/perf/*": ["frontend/perf/*"]
         },
         "lib": ["dom", "dom.iterable", "es6"],
-        "types": ["vite/client"],
+        "types": ["vite/client", "@testing-library/jest-dom/vitest"],
         "allowJs": true,
         "strict": false,
         "noEmit": true


### PR DESCRIPTION
**PR C from [SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md §4](../blob/main/docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md).** PR A (#1022) excluded worktrees; PR B (#1023) fixed the 2 real test failures. This closes out the test-file type errors.

## Problem

`tsc --noEmit` reported **29 errors** of the form

```
frontend/app/.../*.test.tsx: error TS2339:
  Property 'toBeInTheDocument' does not exist on type 'Assertion<HTMLElement>'.
```

across 5 test files (`BlockErrorBoundary.test.tsx`, `AgentDisconnectedBanner.test.tsx`, `AgentLaunchModal.integration.test.tsx`, `AgentPicker.test.tsx`, `MyAgentsList.test.tsx`).

Tests **passed at runtime** — `test/vitest-setup.ts:16` does `import "@testing-library/jest-dom/vitest"` which calls `expect.extend(matchers)` AND triggers the type augmentation `declare module 'vitest' { interface Assertion<T> extends TestingLibraryMatchers<...> {} }`. But tsc never saw the augmentation: the setup file lives outside the `frontend/**/*` include, so the module-declaration block from `node_modules/@testing-library/jest-dom/types/vitest.d.ts` was never pulled into the program.

## Fix

One line — add the vitest subpath to the tsconfig `types` array:

```diff
- "types": ["vite/client"],
+ "types": ["vite/client", "@testing-library/jest-dom/vitest"],
```

This loads the augmentation globally without needing each test file to import the types directly.

## Spec deviation worth flagging

[SPEC §4](../blob/main/docs/specs/SPEC_FRONTEND_TEST_HEALTH_2026_05_24.md#proposed-fix) proposed `"@testing-library/jest-dom"` (the base package entry). That points at `types/index.d.ts` which only references `jest.d.ts` — it augments **Jest's** `Matchers`, not **Vitest's** `Assertion`. Adding it doesn't reduce the error count. The `/vitest` subpath has the right module augmentation and is what's actually needed here.

## Result

| Metric | Before | After |
|---|---|---|
| `tsc --noEmit` errors | 56 | 27 |
| jest-dom matcher errors | 29 | **0** |
| Vitest pass/fail | 1021/1021 ✓ | 1021/1021 ✓ |

## Remaining 27 — out of scope (spec §4 tail)

These are the stragglers the spec flagged as a separate class:

- `BlockErrorBoundary.test.tsx` — 3 non-matcher errors (tuple `[]` index out of bounds, `args` possibly undefined). Real type-safety holes in test code.
- `layoutTree.test.ts` — 7 errors (`LayoutTreeInsertNodeAction` shape mismatch). Stale test, production type tightened.
- `launcher-events.test.ts` — 3 errors (`VersionedEvent` casts to literal). Stale test.
- Production-code errors that pre-date this PR (not test files): `tab-presets.ts`, `BashOutputViewer.tsx`, `termutil.ts`, `nodeRefMap.ts`, `keyutil.ts`, `frontend/test/replay/{loader,replay}.ts`.

Each needs its own investigation; none are unblocked or blocked by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)