### PR TITLE
feat(common): channels — version-spanning data isolation (Increment A from SPEC_DATA_CHANNELS)

### DIFF
--- a/.changesets/1779673057-feat-common-channels-version-spanning-data-isolation-increme-8pdo.md
+++ b/.changesets/1779673057-feat-common-channels-version-spanning-data-isolation-increme-8pdo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(common): channels — version-spanning data isolation (Increment A from SPEC_DATA_CHANNELS)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -91,6 +91,19 @@ tasks:
     package:
         desc: 'Bump the patch version (committed), then build + package a portable to ~/Desktop. The bump is automatic, so EVERY portable gets a unique, monotonic version — two builds never collide on version or data dir.'
         platforms: [windows]
+        env:
+            # Locally-built portables land on the `dev-portable` channel
+            # (see SPEC_DATA_CHANNELS_2026_05_24.md §2.2). Release CI
+            # does NOT call `task package`, so this env never leaks
+            # into a release build — release builds get the default
+            # `stable` channel via the fallback in
+            # agentmux-common/src/data_paths.rs.
+            #
+            # The Rust crate reads this at compile time via
+            # `option_env!("AGENTMUX_BUILD_CHANNEL_DEFAULT")`, so the
+            # value must be set BEFORE the Rust build runs (which is
+            # what the env block does — it covers every cmd below).
+            AGENTMUX_BUILD_CHANNEL_DEFAULT: dev-portable
         cmds:
             # Auto-bump FIRST: makes a stale-versioned portable structurally
             # impossible. The committed version is the durable monotonic

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -221,7 +221,11 @@ fn main() {
     // launcher-provided env (it's the launcher's job to publish them).
     let common_paths = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
         let mode = agentmux_common::RuntimeMode::current_path_only(&host_exe_dir);
-        agentmux_common::DataPaths::resolve(version, &mode).ok()
+        // resolve_path_only mirrors current_path_only's env-isolation:
+        // ignore inherited AGENTMUX_CHANNEL so a dev host launched from
+        // inside a parent agentmux instance doesn't redirect into the
+        // parent's channel (would trip the channel single-instance lock).
+        agentmux_common::DataPaths::resolve_path_only(version, &mode).ok()
     } else {
         agentmux_common::DataPaths::from_env().or_else(|| {
             let mode = agentmux_common::RuntimeMode::current(&host_exe_dir);

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -130,7 +130,11 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
         .ok_or_else(|| "current_exe has no parent".to_string())?;
     let paths = if agentmux_common::is_dev_build_exe(host_exe_dir) {
         let mode = agentmux_common::RuntimeMode::current_path_only(host_exe_dir);
-        agentmux_common::DataPaths::resolve(current_version, &mode)?
+        // resolve_path_only mirrors current_path_only's env-isolation:
+        // ignore inherited AGENTMUX_CHANNEL so a re-spawned dev sidecar
+        // doesn't redirect into a parent agentmux instance's channel
+        // (would trip the channel single-instance lock).
+        agentmux_common::DataPaths::resolve_path_only(current_version, &mode)?
     } else {
         match agentmux_common::DataPaths::from_env() {
             Some(p) => p,

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -25,15 +25,23 @@
 //!     └── (same children as channels/<channel>/)
 //! ```
 //!
-//! Channel resolution:
-//! - `AGENTMUX_CHANNEL=<name>` env override always wins (any mode).
-//! - `RuntimeMode::Installed` / `Portable` → build-time default
-//!   from `AGENTMUX_BUILD_CHANNEL_DEFAULT` (set by the packaging
-//!   script; defaults to `"stable"` if unset, e.g. for `cargo run`).
+//! Channel resolution (via [`DataPaths::resolve`]):
+//! - `AGENTMUX_CHANNEL=<name>` env override wins for `Installed` /
+//!   `Portable` modes — lets the operator point a released binary at
+//!   any channel for parallel-channel testing.
+//! - `RuntimeMode::Installed` / `Portable` w/o override → build-time
+//!   default from `AGENTMUX_BUILD_CHANNEL_DEFAULT` (set by the
+//!   packaging script; defaults to `"stable"` if unset, e.g. for
+//!   `cargo run`).
 //! - `RuntimeMode::Dev { branch }` → channel name is `dev-<branch>`
 //!   for diagnostics; on-disk path stays at `~/.agentmux/dev/<branch>/`
-//!   (NOT under `channels/`) so per-branch dev isolation works as
-//!   before.
+//!   (NOT under `channels/`). Both the host (`agentmux-cef`) and
+//!   launcher (`agentmux-launcher`) use [`DataPaths::resolve_path_only`]
+//!   for dev builds to ignore `AGENTMUX_CHANNEL` — a dev session
+//!   launched from inside a parent agentmux pane mustn't inherit
+//!   the parent's channel and break per-branch isolation. Channel
+//!   override is intentionally NOT supported in dev mode; if you
+//!   want a different channel, use a portable build.
 
 use crate::RuntimeMode;
 use std::path::{Path, PathBuf};

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -5,22 +5,61 @@
 //!
 //! Single source of truth for where state lives on disk. Replaces the
 //! launcher / host / sidecar trio of independent path computations
-//! (see docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md §3).
+//! (see docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md §3) and the
+//! per-version isolation pattern it set up (data was keyed on the
+//! build version so My Agents reset on every patch bump). The current
+//! model keys data on a *channel* — a stable identifier that spans
+//! versions within the same compat band, so agents survive rebuilds.
+//! See docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md and discussion
+//! #1026 for the channel design and rationale.
 //!
 //! Layout:
 //!
 //! ```text
 //! ~/.agentmux/
 //! ├── shared/                       (cookies, credentials, account-wide)
-//! ├── versions/<v>/                 (installed + portable; one running instance)
+//! ├── channels/<channel>/           (installed + portable + custom)
 //! │   ├── data/, config/, logs/, cef-cache/, agents/
-//! │   └── runtime/                  (lock + IPC, single set per version)
+//! │   └── runtime/                  (lock + IPC, single instance per channel)
 //! └── dev/<branch>/                 (per-branch dev isolation)
-//!     └── (same children as versions/<v>/)
+//!     └── (same children as channels/<channel>/)
 //! ```
+//!
+//! Channel resolution:
+//! - `AGENTMUX_CHANNEL=<name>` env override always wins (any mode).
+//! - `RuntimeMode::Installed` / `Portable` → build-time default
+//!   from `AGENTMUX_BUILD_CHANNEL_DEFAULT` (set by the packaging
+//!   script; defaults to `"stable"` if unset, e.g. for `cargo run`).
+//! - `RuntimeMode::Dev { branch }` → channel name is `dev-<branch>`
+//!   for diagnostics; on-disk path stays at `~/.agentmux/dev/<branch>/`
+//!   (NOT under `channels/`) so per-branch dev isolation works as
+//!   before.
 
 use crate::RuntimeMode;
 use std::path::{Path, PathBuf};
+
+/// Build-time default channel for `Installed` / `Portable` modes.
+/// Set by the packaging script (`task package` exports
+/// `AGENTMUX_BUILD_CHANNEL_DEFAULT=dev-portable`; release CI exports
+/// `stable`). Falls back to `"stable"` when the binary is built
+/// without the env (e.g. plain `cargo build` / `cargo run` for tests).
+const BUILD_CHANNEL_DEFAULT: &str =
+    match option_env!("AGENTMUX_BUILD_CHANNEL_DEFAULT") {
+        Some(s) => s,
+        None => "stable",
+    };
+
+/// Channel names that would collide with sibling dirs at
+/// `~/.agentmux/` or with reserved subdir names inside a channel.
+/// Rejected by [`sanitize_channel_name`].
+const RESERVED_CHANNEL_NAMES: &[&str] = &[
+    "shared",
+    "snapshots",
+    "dev",
+    "versions",
+    "channels",
+    "runtime",
+];
 
 /// All paths a launcher / host / srv needs. Computed once by the
 /// launcher; downstream binaries read paths from env vars set by the
@@ -34,10 +73,22 @@ pub struct DataPaths {
     /// `AGENTMUX_HOME_OVERRIDE` for tests.
     pub home_dir: PathBuf,
 
-    /// Top-level dir for this version+mode. All version-keyed paths
-    /// below are children. Either `~/.agentmux/versions/<v>/` (installed/
-    /// portable) or `~/.agentmux/dev/<branch>/` (dev).
+    /// Top-level dir for this channel+mode. All per-channel paths
+    /// below are children. Either `~/.agentmux/channels/<channel>/`
+    /// (installed / portable / AGENTMUX_CHANNEL override) or
+    /// `~/.agentmux/dev/<branch>/` (dev mode without env override).
+    ///
+    /// Note: the field name is `instance_dir` for backward compat with
+    /// downstream call sites; semantically it's now the *channel* root,
+    /// not the *version* root.
     pub instance_dir: PathBuf,
+
+    /// Channel identifier this resolution used (e.g. `"stable"`,
+    /// `"dev-portable"`, `"dev-main"`, or a user-specified custom
+    /// channel from `AGENTMUX_CHANNEL`). Surfaced for diagnostics,
+    /// logging, and the launcher splash; downstream binaries usually
+    /// don't need it (paths are passed via env vars).
+    pub channel: String,
 
     /// `instance_dir/data/` — srv DB (objects.db, sagas.db, …).
     pub data_dir: PathBuf,
@@ -80,19 +131,20 @@ impl DataPaths {
     /// test or future caller) is also rejected here.
     pub fn resolve(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
         let root = resolve_root()?;
-        let safe_version = sanitize_path_segment(version)
+        // `version` is still validated for path safety even though it
+        // no longer appears in the on-disk path — it flows into
+        // logging, the migration framework (Increment B), and
+        // `meta.json` records, so a traversal-laced value mustn't
+        // round-trip into a future path build by accident.
+        sanitize_path_segment(version)
             .ok_or_else(|| format!("invalid version string for path: {:?}", version))?;
-        let instance_dir = match mode {
-            RuntimeMode::Installed | RuntimeMode::Portable => {
-                root.join("versions").join(&safe_version)
-            }
-            RuntimeMode::Dev { branch } => {
-                let safe_branch = sanitize_path_segment(branch).ok_or_else(|| {
-                    format!("invalid dev branch for path: {:?}", branch)
-                })?;
-                root.join("dev").join(safe_branch)
-            }
-        };
+
+        // Channel resolution: env override > mode default. Dev mode's
+        // *channel name* and *path* diverge intentionally — name is
+        // `dev-<branch>` for diagnostics; path stays at
+        // `~/.agentmux/dev/<branch>/` so per-branch isolation works
+        // unchanged from Phase 1.
+        let (channel, instance_dir) = resolve_channel_and_dir(mode, &root)?;
 
         let data_dir = instance_dir.join("data");
         let config_dir = instance_dir.join("config");
@@ -105,6 +157,7 @@ impl DataPaths {
         Ok(Self {
             home_dir: root,
             instance_dir,
+            channel,
             data_dir,
             config_dir,
             logs_dir,
@@ -166,6 +219,10 @@ impl DataPaths {
             ),
             ("AGENTMUX_SHARED_DIR", self.shared_dir.clone().into_os_string()),
             ("AGENTMUX_RUNTIME_MODE", OsString::from(self.mode.to_env_string())),
+            // Channel propagated so downstream binaries can log it +
+            // surface in diagnostics. NOT used to recompute paths
+            // (paths flow through the dir vars above).
+            ("AGENTMUX_CHANNEL", OsString::from(self.channel.clone())),
         ]
     }
 
@@ -185,6 +242,12 @@ impl DataPaths {
         let instance_runtime_dir = std::env::var_os("AGENTMUX_INSTANCE_RUNTIME_DIR")?;
         let shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR")?;
         let mode = RuntimeMode::from_env()?;
+        // Channel is required from the launcher (same fail-fast
+        // discipline as every other dir var). Missing AGENTMUX_CHANNEL
+        // means the launcher didn't export it — that's a launcher /
+        // srv version skew, surface it loudly rather than silently
+        // defaulting and risking a wrong-channel write.
+        let channel = std::env::var("AGENTMUX_CHANNEL").ok()?;
 
         // Re-resolve home_dir (the agentmux root) on the consumer
         // side rather than transmitting it via env — it's a function
@@ -195,6 +258,7 @@ impl DataPaths {
         Some(Self {
             home_dir,
             instance_dir: PathBuf::from(instance_dir),
+            channel,
             data_dir: PathBuf::from(data_dir),
             config_dir: PathBuf::from(config_dir),
             logs_dir: PathBuf::from(logs_dir),
@@ -285,6 +349,81 @@ fn sanitize_path_segment(s: &str) -> Option<String> {
     Some(s.to_string())
 }
 
+/// Sanitize a string for use as a channel name. Same path-segment
+/// safety rules as [`sanitize_path_segment`] plus:
+/// - Length capped at 64 chars (channel names show up in logs + the
+///   launcher splash + may eventually be displayed in a picker, so
+///   the cap is for UI sanity, not security).
+/// - Rejects names in [`RESERVED_CHANNEL_NAMES`] that would collide
+///   with sibling dirs at `~/.agentmux/` or reserved subdir names
+///   inside a channel.
+/// - The synonym `"default"` maps to `"stable"` (per
+///   `SPEC_DATA_CHANNELS_2026_05_24.md` §7.5).
+fn sanitize_channel_name(s: &str) -> Option<String> {
+    let base = sanitize_path_segment(s)?;
+    if base.len() > 64 {
+        return None;
+    }
+    if RESERVED_CHANNEL_NAMES.contains(&base.as_str()) {
+        return None;
+    }
+    if base == "default" {
+        return Some("stable".to_string());
+    }
+    Some(base)
+}
+
+/// Resolve the channel name and on-disk channel dir for a given mode.
+/// Pure function over (env, mode, root) — the only env it reads is
+/// `AGENTMUX_CHANNEL` (the explicit override). Returns the channel
+/// name and the path that becomes [`DataPaths::instance_dir`].
+///
+/// Resolution order (mirrors `SPEC_DATA_CHANNELS_2026_05_24.md` §2.2):
+///   1. `AGENTMUX_CHANNEL` env override (any mode) → path is
+///      `<root>/channels/<channel>/`. Lets the operator point any
+///      binary at any channel for parallel-channel testing.
+///   2. No override, mode = Dev { branch } → channel name is
+///      `dev-<branch>`, path stays at `<root>/dev/<branch>/`
+///      (unchanged from Phase 1).
+///   3. No override, mode = Installed | Portable → channel name is
+///      [`BUILD_CHANNEL_DEFAULT`] (set at build time by the packaging
+///      script), path is `<root>/channels/<channel>/`.
+fn resolve_channel_and_dir(
+    mode: &RuntimeMode,
+    root: &Path,
+) -> Result<(String, PathBuf), String> {
+    // (1) Explicit env override always wins.
+    if let Ok(raw) = std::env::var("AGENTMUX_CHANNEL") {
+        if !raw.is_empty() {
+            let channel = sanitize_channel_name(&raw).ok_or_else(|| {
+                format!("invalid AGENTMUX_CHANNEL value: {:?}", raw)
+            })?;
+            let dir = root.join("channels").join(&channel);
+            return Ok((channel, dir));
+        }
+    }
+
+    // (2) Dev mode default: dev-<branch>, path under dev/<branch>/.
+    if let RuntimeMode::Dev { branch } = mode {
+        let safe_branch = sanitize_path_segment(branch).ok_or_else(|| {
+            format!("invalid dev branch for path: {:?}", branch)
+        })?;
+        let channel = format!("dev-{}", safe_branch);
+        let dir = root.join("dev").join(safe_branch);
+        return Ok((channel, dir));
+    }
+
+    // (3) Installed / Portable default: build-time channel.
+    let channel = sanitize_channel_name(BUILD_CHANNEL_DEFAULT).ok_or_else(|| {
+        format!(
+            "compile-time AGENTMUX_BUILD_CHANNEL_DEFAULT is invalid: {:?}",
+            BUILD_CHANNEL_DEFAULT
+        )
+    })?;
+    let dir = root.join("channels").join(&channel);
+    Ok((channel, dir))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,11 +457,27 @@ mod tests {
         // (the panic still propagates after Drop runs).
     }
 
+    /// Helper: clear AGENTMUX_CHANNEL inside an existing
+    /// with_home_override block to test pure mode-default resolution.
+    /// Channel resolution reads the live env var, so individual tests
+    /// must clear it to avoid leakage from sibling tests running
+    /// concurrently inside the same process (TEST_ENV_LOCK serializes
+    /// HOME_OVERRIDE but the channel var is a separate axis).
+    fn clear_channel_env() {
+        std::env::remove_var("AGENTMUX_CHANNEL");
+    }
+
     #[test]
-    fn installed_paths_under_versions() {
+    fn installed_paths_under_default_channel() {
         with_home_override(|root| {
+            clear_channel_env();
             let p = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
-            assert_eq!(p.instance_dir, root.join("versions").join("0.33.639"));
+            // Default channel for Installed without env override =
+            // BUILD_CHANNEL_DEFAULT (which is "stable" in dev / test
+            // builds — `option_env!` falls back when the build env
+            // wasn't set by the packaging script).
+            assert_eq!(p.channel, "stable");
+            assert_eq!(p.instance_dir, root.join("channels").join("stable"));
             assert_eq!(p.data_dir, p.instance_dir.join("data"));
             assert_eq!(p.config_dir, p.instance_dir.join("config"));
             assert_eq!(p.logs_dir, p.instance_dir.join("logs"));
@@ -340,6 +495,7 @@ mod tests {
         // state like the launcher's config.toml. Resolve in both
         // installed and dev modes; both should point at the same root.
         with_home_override(|root| {
+            clear_channel_env();
             let inst = DataPaths::resolve("0.33.641", &RuntimeMode::Installed).unwrap();
             assert_eq!(inst.home_dir, root);
             let dev = DataPaths::resolve(
@@ -356,10 +512,15 @@ mod tests {
     #[test]
     fn portable_paths_match_installed() {
         with_home_override(|root| {
+            clear_channel_env();
             let inst = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
             let port = DataPaths::resolve("0.33.639", &RuntimeMode::Portable).unwrap();
-            // §3 design: portable + installed share the same data dir
-            // (per the user's multi-instance decision in §5.5).
+            // Portable + Installed share a default channel (no env
+            // override → both fall through to BUILD_CHANNEL_DEFAULT),
+            // so their data dirs are the same. Multi-instance
+            // isolation is now channel-keyed: if you want two
+            // independent portables, override AGENTMUX_CHANNEL on one.
+            assert_eq!(inst.channel, port.channel);
             assert_eq!(inst.instance_dir, port.instance_dir);
             assert_eq!(inst.data_dir, port.data_dir);
             // shared/ is mode-independent.
@@ -371,14 +532,155 @@ mod tests {
     #[test]
     fn dev_paths_under_dev_branch() {
         with_home_override(|root| {
+            clear_channel_env();
             let mode = RuntimeMode::Dev {
                 branch: "main".into(),
             };
             let p = DataPaths::resolve("0.33.639", &mode).unwrap();
-            // Dev mode does NOT use the version — branches isolate.
+            // Dev mode default: on-disk path stays under dev/<branch>/
+            // (unchanged from Phase 1), channel name is "dev-<branch>"
+            // for diagnostics. The two diverge intentionally — see
+            // resolve_channel_and_dir doc.
+            assert_eq!(p.channel, "dev-main");
             assert_eq!(p.instance_dir, root.join("dev").join("main"));
             assert_eq!(p.data_dir, root.join("dev").join("main").join("data"));
             assert_eq!(p.shared_dir, root.join("shared"));
+        });
+    }
+
+    #[test]
+    fn env_override_redirects_any_mode_under_channels() {
+        // AGENTMUX_CHANNEL is absolute precedence. Even Dev mode,
+        // which would otherwise land at dev/<branch>/, lands under
+        // channels/<override>/ when the env is set. This is the
+        // "test a hot-fix build against the live stable data" path
+        // from SPEC_DATA_CHANNELS_2026_05_24.md §2.2.
+        with_home_override(|root| {
+            std::env::set_var("AGENTMUX_CHANNEL", "experiment");
+            // Cleanup via Drop so a test panic doesn't leak it.
+            struct ChannelGuard;
+            impl Drop for ChannelGuard {
+                fn drop(&mut self) {
+                    std::env::remove_var("AGENTMUX_CHANNEL");
+                }
+            }
+            let _g = ChannelGuard;
+
+            let inst = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
+            assert_eq!(inst.channel, "experiment");
+            assert_eq!(inst.instance_dir, root.join("channels").join("experiment"));
+
+            let port = DataPaths::resolve("0.33.639", &RuntimeMode::Portable).unwrap();
+            assert_eq!(port.channel, "experiment");
+            assert_eq!(port.instance_dir, root.join("channels").join("experiment"));
+
+            let dev = DataPaths::resolve(
+                "0.33.639",
+                &RuntimeMode::Dev { branch: "main".into() },
+            )
+            .unwrap();
+            // Override beats the dev/<branch>/ default — channel name
+            // matches the override, path lands under channels/, not dev/.
+            assert_eq!(dev.channel, "experiment");
+            assert_eq!(dev.instance_dir, root.join("channels").join("experiment"));
+        });
+    }
+
+    #[test]
+    fn env_override_rejects_unsafe_or_reserved_names() {
+        with_home_override(|_root| {
+            // Reserved (would collide with sibling dirs / inner dirs).
+            for bad in ["shared", "snapshots", "dev", "versions", "channels", "runtime"] {
+                std::env::set_var("AGENTMUX_CHANNEL", bad);
+                let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+                std::env::remove_var("AGENTMUX_CHANNEL");
+                assert!(
+                    r.is_err(),
+                    "AGENTMUX_CHANNEL={:?} should be rejected as reserved",
+                    bad
+                );
+            }
+
+            // Path-unsafe (traversal, separators, Windows-reserved).
+            // NUL not tested here — Windows' WinAPI rejects NUL in
+            // env-var values at the syscall level, so `set_var` would
+            // panic before our sanitizer runs. NUL rejection is
+            // covered by the direct-call sanitize_path_segment path
+            // in identity_dir_rejects_unsafe_segments.
+            for bad in ["..", ".", "a/b", "a\\b", "C:foo", "a*b"] {
+                std::env::set_var("AGENTMUX_CHANNEL", bad);
+                let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+                std::env::remove_var("AGENTMUX_CHANNEL");
+                assert!(
+                    r.is_err(),
+                    "AGENTMUX_CHANNEL={:?} should be rejected as path-unsafe",
+                    bad
+                );
+            }
+
+            // Empty string treated as "not set" — falls through to
+            // mode-based default. Documents the behavior so a
+            // `.env`-set empty value doesn't surprise.
+            std::env::set_var("AGENTMUX_CHANNEL", "");
+            let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+            std::env::remove_var("AGENTMUX_CHANNEL");
+            assert!(r.is_ok(), "empty AGENTMUX_CHANNEL should fall through to default");
+            assert_eq!(r.unwrap().channel, "stable");
+        });
+    }
+
+    #[test]
+    fn env_override_default_is_synonym_for_stable() {
+        with_home_override(|root| {
+            std::env::set_var("AGENTMUX_CHANNEL", "default");
+            let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+            std::env::remove_var("AGENTMUX_CHANNEL");
+            let r = r.unwrap();
+            // "default" maps to "stable" per spec §7.5; on-disk path
+            // is channels/stable/, not channels/default/.
+            assert_eq!(r.channel, "stable");
+            assert_eq!(r.instance_dir, root.join("channels").join("stable"));
+        });
+    }
+
+    #[test]
+    fn channel_name_length_capped_at_64() {
+        with_home_override(|_root| {
+            // 64 chars OK, 65 rejected. The cap is for UI sanity, not
+            // security — channel names show up in logs and the
+            // launcher splash.
+            let ok = "a".repeat(64);
+            std::env::set_var("AGENTMUX_CHANNEL", &ok);
+            let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+            std::env::remove_var("AGENTMUX_CHANNEL");
+            assert!(r.is_ok(), "64-char channel should be accepted");
+
+            let too_long = "a".repeat(65);
+            std::env::set_var("AGENTMUX_CHANNEL", &too_long);
+            let r = DataPaths::resolve("0.33.639", &RuntimeMode::Installed);
+            std::env::remove_var("AGENTMUX_CHANNEL");
+            assert!(r.is_err(), "65-char channel should be rejected");
+        });
+    }
+
+    #[test]
+    fn dev_branch_traversal_via_runtime_mode_still_rejected() {
+        // Dev mode resolution sanitizes the branch via the same
+        // sanitize_path_segment as before — channel rename doesn't
+        // weaken the traversal-safety guarantees. Reproduces the
+        // pre-channel test for parity.
+        with_home_override(|_root| {
+            clear_channel_env();
+            let r = DataPaths::resolve(
+                "0.33.639",
+                &RuntimeMode::Dev { branch: "..".into() },
+            );
+            assert!(r.is_err());
+            let r = DataPaths::resolve(
+                "0.33.639",
+                &RuntimeMode::Dev { branch: "foo/bar".into() },
+            );
+            assert!(r.is_err());
         });
     }
 
@@ -417,6 +719,7 @@ mod tests {
     #[test]
     fn ensure_dirs_creates_everything() {
         with_home_override(|_root| {
+            clear_channel_env();
             let p = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
             p.ensure_dirs().unwrap();
             assert!(p.instance_dir.is_dir());
@@ -434,6 +737,7 @@ mod tests {
     #[test]
     fn env_vars_round_trip() {
         with_home_override(|_root| {
+            clear_channel_env();
             let p1 = DataPaths::resolve(
                 "0.33.639",
                 &RuntimeMode::Dev {
@@ -450,6 +754,7 @@ mod tests {
             assert_eq!(p1.data_dir, p2.data_dir);
             assert_eq!(p1.shared_dir, p2.shared_dir);
             assert_eq!(p1.mode, p2.mode);
+            assert_eq!(p1.channel, p2.channel);
             // Cleanup
             for (k, _) in p1.to_env_vars() {
                 std::env::remove_var(k);
@@ -463,6 +768,7 @@ mod tests {
         // unsafe branch (bypassing parse_mode_string sanitization),
         // resolve() must catch it.
         with_home_override(|_root| {
+            clear_channel_env();
             let mode = RuntimeMode::Dev {
                 branch: "..".into(),
             };
@@ -477,6 +783,7 @@ mod tests {
     #[test]
     fn resolve_rejects_traversal_version() {
         with_home_override(|_root| {
+            clear_channel_env();
             assert!(DataPaths::resolve("..", &RuntimeMode::Installed).is_err());
             assert!(DataPaths::resolve(
                 "0.33.639/etc",
@@ -513,9 +820,75 @@ mod tests {
             "AGENTMUX_INSTANCE_RUNTIME_DIR",
             "AGENTMUX_SHARED_DIR",
             "AGENTMUX_RUNTIME_MODE",
+            "AGENTMUX_CHANNEL",
         ] {
             std::env::remove_var(k);
         }
         assert!(DataPaths::from_env().is_none());
+    }
+
+    #[test]
+    fn from_env_fails_fast_when_channel_missing() {
+        // Symmetric to from_env_fails_fast_on_missing_vars but
+        // isolates the channel-specific case: a launcher built with
+        // the new code will always export AGENTMUX_CHANNEL; a missing
+        // value indicates a launcher/srv version skew that must fail
+        // loudly rather than silently fall back to a wrong-channel
+        // write. Pre-set all other vars to confirm channel is what's
+        // gating.
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for (k, v) in [
+            ("AGENTMUX_INSTANCE_DIR", "/tmp/x"),
+            ("AGENTMUX_DATA_DIR", "/tmp/x/data"),
+            ("AGENTMUX_CONFIG_DIR", "/tmp/x/config"),
+            ("AGENTMUX_LOG_DIR", "/tmp/x/logs"),
+            ("AGENTMUX_CEF_CACHE_DIR", "/tmp/x/cef"),
+            ("AGENTMUX_AGENTS_DIR", "/tmp/x/agents"),
+            ("AGENTMUX_INSTANCE_RUNTIME_DIR", "/tmp/x/runtime"),
+            ("AGENTMUX_SHARED_DIR", "/tmp/x/shared"),
+            ("AGENTMUX_RUNTIME_MODE", "installed"),
+        ] {
+            std::env::set_var(k, v);
+        }
+        std::env::remove_var("AGENTMUX_CHANNEL");
+        assert!(
+            DataPaths::from_env().is_none(),
+            "from_env() must refuse when AGENTMUX_CHANNEL is missing"
+        );
+        // Cleanup
+        for k in [
+            "AGENTMUX_INSTANCE_DIR",
+            "AGENTMUX_DATA_DIR",
+            "AGENTMUX_CONFIG_DIR",
+            "AGENTMUX_LOG_DIR",
+            "AGENTMUX_CEF_CACHE_DIR",
+            "AGENTMUX_AGENTS_DIR",
+            "AGENTMUX_INSTANCE_RUNTIME_DIR",
+            "AGENTMUX_SHARED_DIR",
+            "AGENTMUX_RUNTIME_MODE",
+        ] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[test]
+    fn sanitize_channel_name_accepts_normal_names() {
+        // The happy path — make sure stable / beta / dev-portable
+        // and friends all sanitize cleanly. Catches regressions in
+        // case the reserved list grows by mistake.
+        assert_eq!(sanitize_channel_name("stable"), Some("stable".into()));
+        assert_eq!(sanitize_channel_name("beta"), Some("beta".into()));
+        assert_eq!(
+            sanitize_channel_name("dev-portable"),
+            Some("dev-portable".into())
+        );
+        assert_eq!(
+            sanitize_channel_name("dev-main"),
+            Some("dev-main".into())
+        );
+        assert_eq!(
+            sanitize_channel_name("experiment_42"),
+            Some("experiment_42".into())
+        );
     }
 }

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -130,6 +130,34 @@ impl DataPaths {
     /// `RuntimeMode::Dev { branch }` constructed directly (e.g. by a
     /// test or future caller) is also rejected here.
     pub fn resolve(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
+        Self::resolve_internal(version, mode, /* honor_env_channel = */ true)
+    }
+
+    /// Like [`Self::resolve`], but ignores the `AGENTMUX_CHANNEL` env
+    /// override and uses only the mode-based default channel. Mirror
+    /// of [`RuntimeMode::current_path_only`] for path resolution.
+    ///
+    /// Used by dev-build self-detection paths in `agentmux-cef`'s
+    /// `main.rs` and `sidecar.rs`. Those paths run when a dev host
+    /// has been launched from inside a parent AgentMux instance (e.g.
+    /// `task dev` invoked from inside an agent pane in a portable
+    /// build), where the child would otherwise inherit the parent's
+    /// `AGENTMUX_*` env — including `AGENTMUX_CHANNEL` — and write
+    /// into the parent's channel instead of `dev/<branch>/`. That
+    /// cross-contamination would also trip the channel's single-
+    /// instance lock and route every "open" back to the parent
+    /// window. Path-based mode detection is authoritative for dev
+    /// builds; channel resolution here mirrors that discipline.
+    /// Codex P1 follow-up on PR #1027.
+    pub fn resolve_path_only(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
+        Self::resolve_internal(version, mode, /* honor_env_channel = */ false)
+    }
+
+    fn resolve_internal(
+        version: &str,
+        mode: &RuntimeMode,
+        honor_env_channel: bool,
+    ) -> Result<Self, String> {
         let root = resolve_root()?;
         // `version` is still validated for path safety even though it
         // no longer appears in the on-disk path — it flows into
@@ -144,7 +172,8 @@ impl DataPaths {
         // `dev-<branch>` for diagnostics; path stays at
         // `~/.agentmux/dev/<branch>/` so per-branch isolation works
         // unchanged from Phase 1.
-        let (channel, instance_dir) = resolve_channel_and_dir(mode, &root)?;
+        let (channel, instance_dir) =
+            resolve_channel_and_dir(mode, &root, honor_env_channel)?;
 
         let data_dir = instance_dir.join("data");
         let config_dir = instance_dir.join("config");
@@ -374,32 +403,38 @@ fn sanitize_channel_name(s: &str) -> Option<String> {
 }
 
 /// Resolve the channel name and on-disk channel dir for a given mode.
-/// Pure function over (env, mode, root) — the only env it reads is
-/// `AGENTMUX_CHANNEL` (the explicit override). Returns the channel
-/// name and the path that becomes [`DataPaths::instance_dir`].
+/// Pure function over (env, mode, root). When `honor_env_channel` is
+/// `true`, `AGENTMUX_CHANNEL` overrides the mode default; when `false`,
+/// the env is ignored and resolution depends only on `mode` +
+/// build-time defaults. The `false` path is used by dev-build self-
+/// detection (see [`DataPaths::resolve_path_only`]).
 ///
 /// Resolution order (mirrors `SPEC_DATA_CHANNELS_2026_05_24.md` §2.2):
-///   1. `AGENTMUX_CHANNEL` env override (any mode) → path is
-///      `<root>/channels/<channel>/`. Lets the operator point any
-///      binary at any channel for parallel-channel testing.
-///   2. No override, mode = Dev { branch } → channel name is
-///      `dev-<branch>`, path stays at `<root>/dev/<branch>/`
-///      (unchanged from Phase 1).
-///   3. No override, mode = Installed | Portable → channel name is
+///   1. (only if `honor_env_channel`) `AGENTMUX_CHANNEL` env override —
+///      any mode → path is `<root>/channels/<channel>/`. Lets the
+///      operator point any binary at any channel for parallel-channel
+///      testing.
+///   2. No override (or env-channel disallowed), mode = Dev { branch }
+///      → channel name is `dev-<branch>`, path stays at
+///      `<root>/dev/<branch>/` (unchanged from Phase 1).
+///   3. Same conditions, mode = Installed | Portable → channel name is
 ///      [`BUILD_CHANNEL_DEFAULT`] (set at build time by the packaging
 ///      script), path is `<root>/channels/<channel>/`.
 fn resolve_channel_and_dir(
     mode: &RuntimeMode,
     root: &Path,
+    honor_env_channel: bool,
 ) -> Result<(String, PathBuf), String> {
-    // (1) Explicit env override always wins.
-    if let Ok(raw) = std::env::var("AGENTMUX_CHANNEL") {
-        if !raw.is_empty() {
-            let channel = sanitize_channel_name(&raw).ok_or_else(|| {
-                format!("invalid AGENTMUX_CHANNEL value: {:?}", raw)
-            })?;
-            let dir = root.join("channels").join(&channel);
-            return Ok((channel, dir));
+    // (1) Explicit env override — only when caller opted in.
+    if honor_env_channel {
+        if let Ok(raw) = std::env::var("AGENTMUX_CHANNEL") {
+            if !raw.is_empty() {
+                let channel = sanitize_channel_name(&raw).ok_or_else(|| {
+                    format!("invalid AGENTMUX_CHANNEL value: {:?}", raw)
+                })?;
+                let dir = root.join("channels").join(&channel);
+                return Ok((channel, dir));
+            }
         }
     }
 
@@ -869,6 +904,63 @@ mod tests {
         ] {
             std::env::remove_var(k);
         }
+    }
+
+    #[test]
+    fn resolve_path_only_ignores_env_channel() {
+        // resolve_path_only is the dev-build self-detection variant —
+        // it deliberately ignores AGENTMUX_CHANNEL because a dev host
+        // launched from inside a parent agentmux instance would inherit
+        // the parent's channel env and cross-contaminate.
+        //
+        // This is the codex P1 regression test on PR #1027 — without
+        // the gate, dev hosts launched via `task dev` from inside an
+        // agent pane would redirect to the parent's channel/<channel>/
+        // dir instead of dev/<branch>/, tripping the channel's
+        // single-instance lock.
+        with_home_override(|root| {
+            std::env::set_var("AGENTMUX_CHANNEL", "stable");
+            struct ChannelGuard;
+            impl Drop for ChannelGuard {
+                fn drop(&mut self) {
+                    std::env::remove_var("AGENTMUX_CHANNEL");
+                }
+            }
+            let _g = ChannelGuard;
+
+            let dev = DataPaths::resolve_path_only(
+                "0.33.639",
+                &RuntimeMode::Dev { branch: "main".into() },
+            )
+            .unwrap();
+            // Dev mode default holds — channel name is dev-main, path
+            // stays under dev/main/. AGENTMUX_CHANNEL=stable does NOT
+            // redirect to channels/stable/.
+            assert_eq!(dev.channel, "dev-main");
+            assert_eq!(dev.instance_dir, root.join("dev").join("main"));
+
+            let inst = DataPaths::resolve_path_only(
+                "0.33.639",
+                &RuntimeMode::Installed,
+            )
+            .unwrap();
+            // Installed default holds — build-time channel
+            // (BUILD_CHANNEL_DEFAULT = "stable" in tests). Path lands
+            // at channels/stable/ regardless of the env override.
+            assert_eq!(inst.channel, "stable");
+            assert_eq!(inst.instance_dir, root.join("channels").join("stable"));
+
+            // Sanity: regular `resolve` DOES honor the env override in
+            // both modes — confirms the divergence is solely on the
+            // path_only variant.
+            let dev_env = DataPaths::resolve(
+                "0.33.639",
+                &RuntimeMode::Dev { branch: "main".into() },
+            )
+            .unwrap();
+            assert_eq!(dev_env.channel, "stable");
+            assert_eq!(dev_env.instance_dir, root.join("channels").join("stable"));
+        });
     }
 
     #[test]

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -59,12 +59,30 @@ pub fn resolve_paths(launcher_exe_dir: &Path, version: &str) -> Result<DataPaths
     // Path-only when the exe is a dev build — see SPEC_DEV_ENV_ISOLATION.
     // Prevents inheriting AGENTMUX_RUNTIME_MODE from a parent AgentMux
     // process when `task dev` is launched from inside an existing pane.
-    let mode = if agentmux_common::is_dev_build_exe(launcher_exe_dir) {
+    let is_dev = agentmux_common::is_dev_build_exe(launcher_exe_dir);
+    let mode = if is_dev {
         RuntimeMode::current_path_only(launcher_exe_dir)
     } else {
         RuntimeMode::current(launcher_exe_dir)
     };
-    let common = CommonDataPaths::resolve(version, &mode)?;
+    // For dev builds the launcher MUST use `resolve_path_only` too —
+    // not just `resolve` — so that AGENTMUX_CHANNEL is ignored
+    // symmetrically with the host's dev-build branch in
+    // agentmux-cef/src/main.rs and sidecar.rs. Without this, the
+    // launcher would honor a leaked `AGENTMUX_CHANNEL` from a parent
+    // agentmux pane and write the lockfile + IPC files into
+    // `channels/<override>/runtime/`, while the host (running its own
+    // path-only resolution) would look for them under
+    // `dev/<branch>/runtime/`. Launcher/host disagreement on the
+    // single-instance lock breaks dev-mode isolation. Channel
+    // override is intentionally an Installed/Portable-only feature in
+    // this design (codex P2 follow-up on PR #1027); dev mode keeps
+    // its per-branch isolation as the sole identity axis.
+    let common = if is_dev {
+        CommonDataPaths::resolve_path_only(version, &mode)?
+    } else {
+        CommonDataPaths::resolve(version, &mode)?
+    };
 
     let portable_root = if mode == RuntimeMode::Portable {
         Some(launcher_exe_dir.to_path_buf())

--- a/docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md
+++ b/docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md
@@ -1,0 +1,228 @@
+# Research: User-data continuity across versions in desktop apps
+
+**Date:** 2026-05-24
+**Author:** AgentA (Claude Opus 4.7)
+**Context:** AgentMux currently isolates user data per build version (`~/.agentmux/versions/<version>/{data,agents,config,...}/`). This is safe (you can't corrupt v0.38.4's data by running v0.38.5) but creates real UX friction in the active-development workflow: every `task package` bump produces a portable with an empty "My Agents" list, and side-by-side comparison of builds means re-creating the test agent each time.
+
+The existing [`SPEC_DATA_DIR_UNIFICATION_2026-05-05.md`](../specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md) acknowledged this trade-off (line 103: "Version-comparison testing (running 624 alongside 639) requires re-doing every login") and chose isolation as Phase 1, with `shared/` as a Phase 2 escape hatch for cookies. Schema-safety was the explicit motivation. This research surveys what other desktop apps do, identifies the pattern they converge on, and proposes a concrete next step for AgentMux.
+
+---
+
+## 1. The trade-off, stated precisely
+
+There are three forces in tension:
+
+1. **Schema safety.** A new version's DB writes can corrupt an older version's reads if you share the file. Migrations are not always reversible.
+2. **User continuity.** Conversations, agent definitions, identity, memory, sessions are valuable. Forcing the user to rebuild them on every install is a tax.
+3. **Side-by-side install.** Power users (and devs in particular) want to run multiple builds simultaneously without cross-talk.
+
+The naive solutions each fail at least one of these:
+
+| Naive approach | Schema safety | Continuity | Side-by-side |
+|---|---|---|---|
+| Single global data dir | ✗ (new version can corrupt) | ✓ | ✗ (running both blows up) |
+| Per-version data dir (today's AgentMux) | ✓ | ✗ (fresh start every bump) | ✓ |
+| Per-instance data dir (UUID-keyed) | ✓ | ✗ (worse — fresh start every launch) | ✓ |
+
+The interesting question is: how do well-engineered desktop apps thread this needle?
+
+---
+
+## 2. Industry reference patterns
+
+### 2.1 Chrome / Chromium — **channel-based, single dir per channel, in-place migration**
+
+Chrome runs as four channels: Stable, Beta, Dev, Canary. Each channel has its **own** user-data dir:
+
+- Stable: `~/Library/Application Support/Google/Chrome/`
+- Beta: `~/Library/Application Support/Google/Chrome Beta/`
+- Canary: `~/Library/Application Support/Google/Chrome Canary/`
+
+**Within a channel**, every Chrome update writes to the same dir. The Profile has a `Preferences` file with a `version` field; on launch, Chrome runs forward migrations on the profile if `version < current_version`. There is no per-build-number isolation — updating Chrome 130.0.6723.69 → 130.0.6723.70 is invisible to the user, data-wise.
+
+**Side-by-side** is the cross-channel install: you can run Stable + Canary simultaneously because they're separate channels with separate dirs. Running two builds of the same channel is **explicitly not supported** (single-instance enforcement).
+
+**Migration philosophy:** forward-only, idempotent, automatic on first launch of a newer build. If a profile is from a *newer* Chrome than the running binary, Chrome refuses to open it (read-only safety lock) rather than risk a downgrade-corrupt.
+
+### 2.2 VS Code — **channel-based, profile-versioned, with explicit import**
+
+Two channels (Stable, Insiders), each with its own data dir:
+
+- Stable: `~/.vscode/` + `~/Library/Application Support/Code/`
+- Insiders: `~/.vscode-insiders/` + `~/Library/Application Support/Code - Insiders/`
+
+Within a channel, settings, extensions, workspace state all persist across updates. Extensions self-migrate via their own version field. The platform itself runs DB migrations on the SQLite-backed state on first launch.
+
+**Cross-channel import:** "Insiders" prompts on first launch to import from Stable. One-time, opt-in.
+
+### 2.3 JetBrains IDEs (IntelliJ, PyCharm, ...) — **versioned dir + import wizard**
+
+JetBrains is the **outlier** that chose per-version dirs by default:
+
+- `~/Library/Application Support/JetBrains/IntelliJIdea2023.3/`
+- `~/Library/Application Support/JetBrains/IntelliJIdea2024.1/`
+
+But they bridge the continuity gap with an **import wizard**: on first launch, the IDE detects prior-version dirs, lists them, and offers "Import settings from IntelliJIdea2023.3." Cherry-picks settings, keymaps, plugins, recent projects. Default-on. The user clicks once.
+
+This is the **closest analogue to AgentMux's current state** plus the missing piece (an import wizard).
+
+### 2.4 PostgreSQL — **explicit migration via `pg_upgrade`**
+
+Postgres major versions (15 → 16) keep separate data dirs by default. Same-major (15.3 → 15.4) is in-place. To move major versions you run `pg_upgrade` explicitly, which does either a link-mode (instant, in-place) or copy-mode (slow, safe) migration. Old dir is preserved until you delete it.
+
+**Key principle:** the version number's structure encodes compatibility expectations. Patch/minor = in-place. Major = explicit migration with rollback path. This is the most disciplined version of the same idea Chrome uses implicitly.
+
+### 2.5 macOS / iOS native apps — **single per-app sandbox, in-place forever**
+
+`~/Library/Application Support/<bundle-id>/` is **the** data dir. There is no per-version isolation. App developers are expected to ship forward-migrations with every update, and Apple makes it trivial via Core Data's migration framework (lightweight migrations, custom migration policies, mapping models).
+
+When this works it's invisible. When it fails (rare in production, common in dev) you get a corrupt store and the app crashes on launch. There is no in-product mechanism for the user to "roll back to v3 because v4 broke my data" — they're expected to restore from Time Machine. This is essentially Chrome's model with no parachute.
+
+### 2.6 Docker / k8s persistent volumes — **explicit data/binary separation**
+
+Not a desktop app, but the cleanest articulation of the underlying principle: **the binary is replaceable, the data is not.** Volumes survive container replacement. Image updates are casual; data migrations are deliberate. The discipline is enforced by the architecture, not by the developer's care.
+
+---
+
+## 3. The pattern they converge on
+
+Stripping away surface differences:
+
+1. **Compatibility is a property of versions, not of installs.** Versions in the same compat band (Chrome's "minor update", Postgres's "patch", VS Code's "Stable update") share data. Versions across compat bands don't.
+
+2. **Channel ≠ version.** The unit of isolation is the **channel** (release train), not the build number. Within a channel, in-place migration. Across channels, separate dirs and optional import.
+
+3. **Forward-only, automatic migration within a channel.** No prompts, no choices. The user shouldn't know a migration happened. Schema version is in the DB; migrations run idempotently on launch.
+
+4. **Forward-compatibility safety lock.** If the on-disk data is from a *newer* version than the running binary, refuse to open (read-only or hard error). Don't try to "downgrade" — that's where corruption lives.
+
+5. **Import-on-first-launch when channels are crossed.** Detect prior-channel data, offer to import. One-click, one-time, with backup.
+
+6. **Snapshot before migration.** Copy the file/dir to `.bak` before running any non-trivial migration. Costs a few hundred MB once; saves a recovery story.
+
+7. **Export/import as user-controlled escape hatch.** Even if everything else works, give the user a way to dump and reload their state. Doubles as a portable-across-machines story.
+
+---
+
+## 4. Where AgentMux sits today
+
+Mapping AgentMux against the pattern:
+
+| Principle | AgentMux today | Gap |
+|---|---|---|
+| Compatibility = property of versions | Every build is its own compat band (per-version dir) | All builds are pessimistically treated as incompatible |
+| Channel ≠ version | "Channels" exist conceptually (Dev / Portable / Installed) but only Dev is branch-keyed; Portable + Installed are per-version | Portable + Installed need a channel concept |
+| Forward-only in-place migration | No migration code at all (spec §3.4: "no migration") | Need a migration framework, even a trivial one |
+| Forward-compat safety lock | None | A newer-version DB opened by older srv would just crash mid-query |
+| First-launch import | None | The Phase 2 escape hatch (`shared/`) was deferred |
+| Snapshot before migration | N/A (no migrations) | Trivial to add once migrations exist |
+| Export/import | None | No way to move agent state between machines or across major-version-equivalent breaks |
+
+The spec author made the right Phase-1 call (isolation is the safe default; migration code is expensive). What's missing is the **Phase 2** that makes the model livable.
+
+---
+
+## 5. Recommended path forward
+
+Three increments, each shippable independently:
+
+### 5.1 Increment A: Channels (the structural fix)
+
+Introduce an explicit `channel` concept distinct from `version`:
+
+```
+~/.agentmux/
+├── channels/
+│   ├── stable/                  ← every released Portable + Installed build of any version
+│   │   ├── data/                ← single objects.db, sagas.db, ... ; schema-versioned in-DB
+│   │   ├── agents/              ← single shared agent workspace pool
+│   │   ├── config/
+│   │   └── logs/
+│   ├── beta/                    ← reserved for future beta channel
+│   └── dev-<branch>/            ← what's currently dev/<branch>/, renamed for symmetry
+├── shared/                       ← unchanged from current spec §3.1
+└── snapshots/                    ← auto-created backups (see §5.2)
+    └── stable-pre-vX.Y.Z.bak/
+```
+
+Within `channels/stable/`, every version reads and writes the same DB. The current `versions/<version>/` layout disappears for shipped builds; dev keeps its branch-keyed dirs.
+
+**This breaks the current "every portable is its own world" guarantee.** Two portables of different versions can't both be running at the same time (within a channel) — single-instance enforcement applies, just like Chrome. The user already accepts this for `task dev`.
+
+**For the active-dev workflow** (which is what triggered this research): create a `dev-portable` channel that mirrors stable but is meant for the user's own test builds. Portables built via `task package` for personal smoke-testing land there. The bot can opt into `dev-portable` channel by default and the user gets continuity across local build iterations.
+
+### 5.2 Increment B: Migration framework + snapshots
+
+Add a `schema_version` row to each SQLite file's `meta` table. On srv launch:
+
+1. Read `schema_version` from `meta`.
+2. If `schema_version == code_version`, proceed.
+3. If `schema_version < code_version`:
+   1. Copy DB file to `~/.agentmux/snapshots/<channel>-pre-v<code_version>-<timestamp>.bak`.
+   2. Run forward migrations in order. Each migration is a `static const` SQL string in code, applied in a transaction.
+   3. Update `schema_version`.
+4. If `schema_version > code_version`: **refuse to open.** Log a clear error: "this data was written by AgentMux vX.Y.Z; you're running vA.B.C — please upgrade or use a separate channel."
+
+Migration code lives in a single `migrations/` directory in `agentmux-srv`. Each migration is its own file, named by target version. New schema = new file; never edit a shipped migration.
+
+Snapshots are auto-pruned (keep last 5 per channel).
+
+### 5.3 Increment C: Import wizard (cross-channel + cross-major)
+
+On first launch of a fresh channel (or after a major version bump), detect prior-channel data and prompt:
+
+> "Import agents and identity from <prior-channel>? This won't affect <prior-channel>."
+
+One-click. Copies (doesn't move) the relevant DB rows + agent workspaces. Records the import in `meta` so the prompt doesn't fire again.
+
+This is JetBrains's pattern, applied at channel boundaries instead of version boundaries.
+
+---
+
+## 6. What to NOT do (anti-patterns observed)
+
+- **Don't add timestamps to `versions/` dirs to dedupe.** That's recreating the per-instance dir model, which solves nothing.
+- **Don't allow concurrent writes to the same DB from two versions.** SQLite WAL doesn't save you from schema-incompatible writes. The single-instance lock is load-bearing.
+- **Don't ship migrations as "edit the DB in place on launch with no backup."** That's the macOS model. It works in production. It does not work during active development. The snapshot is cheap.
+- **Don't let `task package`'s auto-bump fight the channel model.** If patch bumps share a data dir, that's fine. The version label on the portable folder is for the *operator's* memory of which build is which, not for the data layer.
+
+---
+
+## 7. Concrete next step
+
+Smallest move that delivers immediate value:
+
+**Ship Increment A (channels) as a single PR with one new channel: `dev-portable`.** Local builds via `task package` land there by default (no production user is affected). Within `dev-portable`, all builds share one data dir. The "My Agents" list survives the next `bump patch && task package`. Total scope:
+
+- `agentmux-common/src/data_paths.rs` — add channel parameter, derive instance_dir as `channels/<channel>/` for the `Portable` mode when built with a "dev-portable" flag (or env var).
+- `Taskfile.yml` — `task package` sets `AGENTMUX_CHANNEL=dev-portable` in the bundled binaries.
+- No schema migration code yet — within a single channel without released versions, just trust the schema. Migration framework can wait for Increment B.
+
+Test:
+- Bump to v0.38.6, build portable, launch.
+- Create an agent "test-continuity-1".
+- Bump to v0.38.7, build, launch.
+- Confirm "test-continuity-1" appears in My Agents.
+
+Once that lands, Increment B unblocks a real channel rollout to Installed + (eventual) Stable.
+
+---
+
+## 8. Open questions for the user
+
+- **Is the production install model in scope, or only the dev/portable workflow?** Increment A only addresses local-build continuity if scoped to `dev-portable`. Channels for shipped builds is a bigger conversation (release process, update flow).
+- **Should `task dev` participate?** Currently keyed on branch. Could optionally collapse all dev branches into a single channel, but the per-branch isolation is genuinely useful for parallel feature work.
+- **What's the right blast radius for an accidental "wrong channel" launch?** Worst case today: lost test agents. Worst case under §5.1: same. Worst case under §5.2 with a buggy migration: corrupted shared state — hence the snapshot, hence the safety lock.
+- **Does this become a `RFC #...` in the existing reducer/state-machine arc, or its own track?** Adjacent but not the same conversation. Suggest its own discussion.
+
+---
+
+## 9. References
+
+- [`docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md`](../specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md) — current state + Phase 1 design
+- [`agentmux-common/src/data_paths.rs:81-117`](../../agentmux-common/src/data_paths.rs) — current resolution logic
+- Chrome user-data-dir docs: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/user_data_dir.md
+- VS Code "Insiders import" issue thread: github.com/microsoft/vscode/issues/?q=is%3Aissue+insiders+import+settings
+- JetBrains "Import settings from previous version" docs: jetbrains.com/help/idea/migrating-from-a-previous-version.html
+- PostgreSQL `pg_upgrade` docs: postgresql.org/docs/current/pgupgrade.html
+- Apple Core Data lightweight migration: developer.apple.com/documentation/coredata/using_lightweight_migration

--- a/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md
+++ b/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md
@@ -1,0 +1,416 @@
+# SPEC: Data channels — version-spanning data isolation for AgentMux
+
+**Date:** 2026-05-24
+**Author:** AgentA (Claude Opus 4.7)
+**Tracking discussion:** [#1026](https://github.com/agentmuxai/agentmux/discussions/1026)
+**Research basis:** [`docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md`](../research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md)
+**Builds on:** [`SPEC_DATA_DIR_UNIFICATION_2026-05-05.md`](./SPEC_DATA_DIR_UNIFICATION_2026-05-05.md) (Phase 1 — per-version isolation; this is its Phase 2)
+
+---
+
+## TL;DR
+
+Replace per-version data isolation (`~/.agentmux/versions/<version>/`) with **per-channel** isolation (`~/.agentmux/channels/<channel>/`). Within a channel, every version reads and writes the same data dir; agents, identity, memory, conversations all persist across patch/minor bumps. Across channels, full isolation — `stable` and `beta` and `dev-portable` are independent worlds.
+
+Applies to **both Installed and Portable**. Each runtime mode resolves to a default channel:
+
+| Runtime mode | Default channel | Built-by |
+|---|---|---|
+| Installed (production install) | `stable` | release CI |
+| Portable (downloaded released ZIP) | `stable` | release CI |
+| Portable (local `task package` build) | `dev-portable` | the operator |
+| Dev (`task dev`) | `dev-<branch>` | `task dev` |
+
+The user can override with `AGENTMUX_CHANNEL=<name>` for parallel-channel testing.
+
+Forward-only schema migrations run on launch when a newer version opens a channel with an older schema. A safety lock refuses to open a channel whose schema is **newer** than the running binary (prevents corruption by downgrade). Snapshots auto-saved before any migration; auto-pruned (keep last 5).
+
+Three shippable PRs, in order: A (channels structure) → B (migration framework + safety lock) → C (import wizard).
+
+---
+
+## 1. Current state (recap, for reference)
+
+Per `SPEC_DATA_DIR_UNIFICATION_2026-05-05` Phase 1, shipped in PR #695:
+
+```
+~/.agentmux/
+├── shared/                           ← account-wide (chromium-cookies, agent-cache, ...)
+├── versions/<version>/               ← INSTALLED + PORTABLE — per-version
+│   ├── data/                         ← objects.db, sagas.db, filestore.db
+│   ├── agents/                       ← per-agent working dirs
+│   ├── config/
+│   ├── logs/
+│   ├── cef-cache/
+│   ├── runtime/                      ← ipc-port, lockfile, etc.
+│   └── instance.json
+└── dev/<branch>/                     ← DEV — per-branch
+    └── ... (same shape as versions/<v>/)
+```
+
+Resolution: `agentmux_common::DataPaths::resolve(version, mode)` in `agentmux-common/src/data_paths.rs:81-117`.
+
+**Pain point:** every `task package` bump produces a fresh, empty `versions/<new-version>/`. My Agents list resets. Conversation history is gone. To compare two builds you re-create the test agent each time. The 2026-05-05 spec flagged this explicitly (§2.6 line 103) as a known cost of the Phase 1 design.
+
+---
+
+## 2. Target design — channels
+
+### 2.1 New layout
+
+```
+~/.agentmux/
+├── shared/                           ← unchanged from Phase 1
+├── channels/
+│   ├── stable/                       ← ALL released versions (Installed + Portable-ZIP) land here
+│   │   ├── data/
+│   │   │   ├── objects.db
+│   │   │   ├── sagas.db
+│   │   │   ├── filestore.db
+│   │   │   └── meta.json             ← {schema_version, channel_created_at, last_run_version}
+│   │   ├── agents/
+│   │   ├── config/
+│   │   ├── logs/
+│   │   ├── cef-cache/
+│   │   └── runtime/                  ← single-instance lockfile (one process per channel)
+│   ├── beta/                         ← reserved; not populated in Increment A
+│   └── dev-portable/                 ← local `task package` builds — for personal smoke-test
+├── dev/<branch>/                     ← unchanged from Phase 1 (kept as a fourth "channel namespace")
+└── snapshots/                        ← auto-backups before migration (Increment B)
+    └── stable-pre-v0.42.0-2026-06-15T13-22-08Z.bak/
+```
+
+**Why a separate `channels/` parent dir** (vs. mixing channels at root): keeps the "this is a channel" semantics visually obvious, and leaves room for non-channel system dirs (`shared/`, `snapshots/`, `dev/`) without naming collisions.
+
+**Why `dev/<branch>/` stays outside `channels/`**: branches are short-lived and numerous; promoting them to first-class channels would clutter the namespace. They're already a different concept (per-branch isolation for parallel feature work) and the existing path is established.
+
+### 2.2 Default channel per runtime mode
+
+`agentmux_common::RuntimeMode` already distinguishes `Installed`, `Portable`, `Dev { branch }`. The new mapping:
+
+| `RuntimeMode` | Default channel | Notes |
+|---|---|---|
+| `Installed` | `stable` | Production install — same channel across all installed versions |
+| `Portable` AND built by release CI | `stable` | Released portable ZIP downloaded by a user |
+| `Portable` AND built by `task package` locally | `dev-portable` | Differentiated via embedded build marker (see §2.5) |
+| `Dev { branch }` | `dev-<branch>` (renamed for symmetry; resolves to `~/.agentmux/dev/<branch>/`, unchanged path on disk) | Per-branch — existing behavior |
+
+The operator can override with `AGENTMUX_CHANNEL=<name>` to point any binary at any channel (e.g., for testing a hot-fix build against the live stable data).
+
+### 2.3 Channel-name validation
+
+Same rules as `sanitize_path_segment` in `agentmux-common/src/data_paths.rs`:
+- Lowercase ASCII letters, digits, `-`, `_`
+- No `.` or `..` traversal
+- Length 1..64
+- Rejects empty after sanitization
+
+Reserved channel names (cannot be used in `AGENTMUX_CHANNEL`):
+- `shared`, `snapshots`, `dev`, `versions` (would collide with sibling dirs at `~/.agentmux/`)
+- `runtime` (used inside channels)
+
+### 2.4 Single-instance enforcement is per-channel
+
+The named-pipe lockfile lives at `~/.agentmux/channels/<channel>/runtime/lockfile`. Two binaries of *the same channel* are mutually exclusive (single-instance per channel — the existing launcher invariant, now scoped correctly). Different channels can run concurrently: `stable` and `dev-portable` and `dev-<branch>` simultaneously, each with its own srv on its own dynamic port, each in its own data dir. This is the existing "multiple instances run in parallel" guarantee from `CLAUDE.md`, preserved and clarified — the unit of mutual exclusion is the channel, not the binary.
+
+### 2.5 Build-time channel marker for portable
+
+`agentmux_common::is_dev_build_exe` already distinguishes the exe's provenance. Extend to also detect "built by local `task package`" vs. "built by release CI". Cleanest: compile-time env var `AGENTMUX_BUILD_CHANNEL_DEFAULT`, set to `dev-portable` by `task package`'s build invocation and to `stable` by the release CI script.
+
+```toml
+# Taskfile.yml — package task
+env:
+  AGENTMUX_BUILD_CHANNEL_DEFAULT: dev-portable
+```
+
+```rust
+// agentmux-common/src/data_paths.rs
+const BUILD_CHANNEL_DEFAULT: &str =
+    option_env!("AGENTMUX_BUILD_CHANNEL_DEFAULT").unwrap_or("stable");
+```
+
+The runtime channel resolution becomes:
+
+```rust
+pub fn resolve_channel(mode: &RuntimeMode) -> String {
+    // 1. Explicit env override always wins.
+    if let Ok(c) = std::env::var("AGENTMUX_CHANNEL") {
+        if sanitize_channel_name(&c).is_some() {
+            return c;
+        }
+    }
+    // 2. Mode-based default.
+    match mode {
+        RuntimeMode::Dev { branch } => format!("dev-{}", sanitize_channel_name(branch).unwrap_or("default".into())),
+        RuntimeMode::Installed | RuntimeMode::Portable => BUILD_CHANNEL_DEFAULT.to_string(),
+    }
+}
+```
+
+### 2.6 Path API contract — new `DataPaths` fields
+
+Add `channel: String` to `DataPaths`. `resolve` signature:
+
+```rust
+pub fn resolve(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
+    let root = resolve_root()?;
+    let channel = resolve_channel(mode);
+    let channel_dir = match mode {
+        RuntimeMode::Dev { .. } => root.join("dev").join(strip_dev_prefix(&channel)),
+        RuntimeMode::Installed | RuntimeMode::Portable => root.join("channels").join(&channel),
+    };
+
+    Ok(Self {
+        home_dir: root,
+        channel,
+        instance_dir: channel_dir.clone(),    // renamed conceptually; physical path is now channel_dir
+        data_dir: channel_dir.join("data"),
+        config_dir: channel_dir.join("config"),
+        logs_dir: channel_dir.join("logs"),
+        cef_cache_dir: channel_dir.join("cef-cache"),
+        agents_dir: channel_dir.join("agents"),
+        instance_runtime_dir: channel_dir.join("runtime"),
+        shared_dir: root.join("shared"),
+        mode: mode.clone(),
+    })
+}
+```
+
+`version` is still passed in (used by Increment B's migration framework as `code_version`) but no longer appears in the path. Backward-compatible at the API level — every existing call site keeps working without code changes.
+
+Env-var export adds `AGENTMUX_CHANNEL`. `AGENTMUX_VERSION` is retained for diagnostics + the migration framework, but no longer drives path resolution.
+
+### 2.7 No migration from old `versions/<v>/` (Increment A scope)
+
+Per the precedent set by the original 2026-05-05 spec (§3.4 "No migration"), Increment A does **not** automatically move data from `~/.agentmux/versions/<v>/` into `~/.agentmux/channels/<channel>/`. The old dir is simply not read by the new code; user starts fresh in the new channel.
+
+Rationale: lossy migration is worse than a fresh start. The Increment C import wizard will eventually offer "import from `~/.agentmux/versions/<v>/`" as one of its sources, but until that ships, the old dir is preserved on disk for manual recovery if needed.
+
+Document this in the user-facing changelog for the version that introduces channels.
+
+---
+
+## 3. Schema migration framework (Increment B)
+
+### 3.1 Schema version in `meta.json`
+
+Each channel's `data/` carries a `meta.json`:
+
+```json
+{
+  "schema_version": 14,
+  "channel_created_at": "2026-05-24T17:30:00Z",
+  "channel_created_by_version": "0.38.6",
+  "last_run_version": "0.39.2",
+  "last_migration_at": "2026-06-15T09:18:42Z",
+  "last_migration_from": 13,
+  "last_migration_to": 14
+}
+```
+
+Read on srv launch; consulted by the migration logic.
+
+### 3.2 Migration discovery + ordering
+
+Migrations live at `agentmux-srv/src/storage/migrations/` (one file per target schema version):
+
+```
+migrations/
+  v0001_initial.rs
+  v0002_add_db_agent_history.rs
+  v0003_split_definition_from_instance.rs
+  ...
+  v0014_add_skills_column.rs
+  mod.rs                ← registers them in version order
+```
+
+Each migration: `pub fn up(tx: &Transaction) -> Result<()>;` — pure SQL, runs inside a single transaction.
+
+### 3.3 Launch sequence
+
+```rust
+fn ensure_channel_schema(data_dir: &Path, code_version: u32) -> Result<()> {
+    let meta = read_meta(data_dir)?;
+    match meta.schema_version.cmp(&code_version) {
+        Ordering::Equal => Ok(()),
+        Ordering::Less => {
+            snapshot_data_dir(data_dir, &meta.schema_version, code_version)?;
+            for v in (meta.schema_version + 1)..=code_version {
+                run_migration(v, data_dir)?;
+            }
+            write_meta(data_dir, code_version)?;
+            Ok(())
+        }
+        Ordering::Greater => Err(format!(
+            "this AgentMux ({}) is too old to open this channel's data \
+             (schema v{}, this binary speaks v{}). Upgrade AgentMux or \
+             use a different channel.",
+            env!("CARGO_PKG_VERSION"),
+            meta.schema_version,
+            code_version,
+        )),
+    }
+}
+```
+
+The "schema too new" branch is the **safety lock**. Surface to the user via the launcher splash with actionable text ("Update AgentMux or switch channels with `AGENTMUX_CHANNEL=...`"). Hard exit; no fallback open.
+
+### 3.4 Snapshot policy
+
+Before any migration sequence:
+
+```
+~/.agentmux/snapshots/<channel>-pre-v<code-version>-<ISO8601>.bak/
+  ├── objects.db
+  ├── sagas.db
+  ├── filestore.db
+  └── meta.json
+```
+
+Auto-prune to the last 5 snapshots per channel. Each snapshot ~few hundred MB worst case; budget cap of ~2 GB per channel.
+
+Rollback (manual, post-incident): `agentmux --restore-snapshot <name>` copies the snapshot back over the channel's `data/` dir. Documented but not on the happy path.
+
+### 3.5 Reversibility
+
+Migrations are **forward-only**. Down-migrations are a rabbit hole — they double the schema-change cost, are rarely exercised, and are an anti-pattern in most modern frameworks (Postgres, Rails post-2010, Django).
+
+The snapshot is the rollback mechanism. If a migration is wrong, ship a fix in the next version; the snapshot lets the user revert manually if the fix can't come fast enough.
+
+---
+
+## 4. Import wizard (Increment C)
+
+### 4.1 Trigger
+
+On srv launch into a *fresh* channel (no `meta.json`, no `data/` files), check for importable sources:
+
+- `~/.agentmux/channels/<other-channel>/` — cross-channel
+- `~/.agentmux/versions/<v>/` — legacy Phase-1 dirs
+- `~/.agentmux/dev/<branch>/` — dev branch dirs (less common)
+
+If any exist with at least one agent instance, surface a one-time import prompt via the launcher splash:
+
+> "Found agents from `<source>` (X agents, Y conversations). Import to this channel?"
+>
+> [Import]  [Skip — start fresh]
+>
+> ☑ Keep `<source>` data intact (recommended)
+
+### 4.2 Import scope
+
+Default: agent definitions, agent instances, identity, memory, conversation history. Not imported: logs, cef-cache, runtime.
+
+Implementation: `COPY` via SQL `INSERT INTO ... SELECT FROM ATTACH'd db` for SQLite, plus a recursive copy for the agent workspaces under `agents/`.
+
+Marks the destination channel's `meta.json` with `imported_from: { channel: "...", at: "...", row_counts: {...} }` so the prompt doesn't fire again.
+
+### 4.3 Out of scope for Increment A
+
+Increment A only ships §2. Increment B adds §3. Import wizard is its own PR. Each is independent — channels work without migrations (single channel, ratcheted schema), migrations work without import (within a single channel's lifetime), import works on top of both.
+
+---
+
+## 5. Delivery plan
+
+### 5.1 Increment A — Channels infrastructure
+
+**Scope:** §2 only. No migrations, no import.
+
+**PRs:**
+1. `feat(common): channels — replace per-version dirs with per-channel`
+   - `agentmux-common/src/data_paths.rs` — new `channel` field, new `resolve_channel`, updated `resolve`, sanitize rules.
+   - `agentmux-common/src/runtime_mode.rs` — no change.
+   - Comprehensive unit tests for sanitization, mode→channel mapping, env-var override, path layout.
+   - Plumb `AGENTMUX_CHANNEL` through env-var export.
+   - Taskfile.yml: `task package` sets `AGENTMUX_BUILD_CHANNEL_DEFAULT=dev-portable`.
+   - Single-instance lockfile path updated to channel-keyed (`runtime/lockfile`).
+   - **No** migration of existing `versions/<v>/` dirs (per §2.7).
+   - Ride along: this spec (`SPEC_DATA_CHANNELS_2026_05_24.md`) + per `feedback_no_doc_only_prs` directive.
+
+**Test plan:**
+- Unit tests in `data_paths.rs`: every channel-resolution edge case (env override, dev branch, build marker default, invalid names rejected).
+- Integration: build `dev-portable` portable v0.38.6, create agent "continuity-test", build v0.38.7, launch, confirm agent present.
+- Integration: build with `AGENTMUX_CHANNEL=experiment` set in env at runtime → confirm data lands at `~/.agentmux/channels/experiment/`.
+- Regression: existing `task dev` workflow uses `dev-<branch>` channels under `~/.agentmux/dev/<branch>/` — same on-disk path as today, no behavior change.
+
+**Acceptance gate:** "My Agents" list persists across a patch bump + rebuild + relaunch on the `dev-portable` channel.
+
+### 5.2 Increment B — Migration framework + safety lock
+
+**Scope:** §3 only. Requires Increment A.
+
+**PRs:**
+1. `feat(srv): meta.json + schema_version + forward migration framework`
+2. `feat(srv): pre-migration snapshot + auto-prune to 5`
+3. `feat(srv): safety lock — refuse to open newer-schema data`
+
+Each PR is small and focused. The migration framework (§3.2 file structure) is the biggest piece; subsequent additions are mechanical.
+
+**Test plan:**
+- Unit: each migration runs against a synthetic DB, asserts target schema present.
+- Integration: write v3 data with a v3 binary, run v4 binary → expects v4 schema + snapshot at `~/.agentmux/snapshots/`.
+- Integration: write v4 data with a v4 binary, run v3 binary → expects launch refusal with clear error.
+
+### 5.3 Increment C — Import wizard
+
+**Scope:** §4 only. Requires Increment A; benefits from B but doesn't require it.
+
+**PRs:**
+1. `feat(srv): import wizard backend — list sources, perform copy`
+2. `feat(frontend): import wizard UI in launcher splash`
+
+**Test plan:**
+- Integration: import from legacy `versions/<v>/` into a fresh `dev-portable` channel; verify agent count + identity + memory carry over.
+- Integration: declining the prompt doesn't re-prompt on next launch.
+
+---
+
+## 6. Rollout
+
+| Increment | Lands on which channels first | Rollout to release builds |
+|---|---|---|
+| A | `dev-portable` activates immediately on next `task package` build | `stable` channel ships in the next `chore: release` after merge |
+| B | All channels — required before any real schema change across versions | Same release as A or shortly after |
+| C | All channels — first-launch behavior only | Same as B |
+
+The release commit that introduces channels needs a clear user-facing note in `VERSION_HISTORY.md`:
+
+> **Data location changed.** Agents, identity, memory now live under `~/.agentmux/channels/stable/` (was: `~/.agentmux/versions/<version>/`). One-time fresh start on this version; the import wizard (next release) will offer to bring forward older data. The old `versions/` dir is preserved on disk for manual recovery.
+
+If we're not comfortable with the fresh-start UX even for the first stable release with channels, sequence as **B → C → A** for production: ship the framework + import wizard first (no behavioral change), then flip to channels in a later release where the wizard makes the migration seamless. For dev/portable, ship A immediately regardless — local-only users opt into the fresh start by definition.
+
+---
+
+## 7. Open questions
+
+(Mirrored from Discussion #1026 — answers update both places.)
+
+1. **Sequencing for production:** Increment A first (fresh start, lossy) or B+C first (seamless migration when A lands)? Recommend A-first for `dev-portable`, B+C+A together for the first `stable` release that ships channels.
+
+2. **Should `task dev` consolidate into channels too?** Currently kept at `~/.agentmux/dev/<branch>/` for clarity. Branches → channels would unify the namespace but lose the visual distinction. Recommend keep dev separate; it's a different concept (per-branch isolation for feature work).
+
+3. **Blast radius of accidental channel mismatch:** today, worst case is "lost test agents"; under channels, same. Under §3 with a buggy migration: "potentially corrupted shared state" — mitigated by the snapshot + safety lock. The added attack surface is the migration code itself; mitigated by per-migration tests + the snapshot rollback.
+
+4. **`AGENTMUX_CHANNEL` env-var precedence:** absolute, or only when set explicitly (not via a `.env` file inherited from a parent shell)? Recommend absolute precedence — if the user set it, they meant it. Lint: srv logs `channel resolved from env override: <name>` at startup so this is visible in `muxlog srv`.
+
+5. **Reserved channel name `default`:** currently free. Reserve it as a synonym for `stable` to avoid confusion? Recommend yes — `AGENTMUX_CHANNEL=default` should map to `stable`.
+
+---
+
+## 8. Out of scope
+
+- Per-tab data isolation (different conversations within one channel). That's the existing tab/block model; orthogonal.
+- Multi-user / multi-profile within a single channel. AgentMux is single-user; not in this spec.
+- Network sync (cloud-backed agents). Discussed elsewhere; channels don't depend on or block that work.
+- Encrypted storage at rest. Same — orthogonal.
+
+---
+
+## 9. References
+
+- [`docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md`](../research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md) — pattern survey
+- [`docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md`](./SPEC_DATA_DIR_UNIFICATION_2026-05-05.md) — Phase 1 (per-version)
+- [`agentmux-common/src/data_paths.rs`](../../agentmux-common/src/data_paths.rs) — current implementation
+- [`agentmux-common/src/runtime_mode.rs`](../../agentmux-common/src/runtime_mode.rs) — mode detection (Dev/Portable/Installed)
+- Discussion [#1026](https://github.com/agentmuxai/agentmux/discussions/1026) — long-term tracking thread

--- a/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md
+++ b/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md
@@ -95,7 +95,7 @@ Resolution: `agentmux_common::DataPaths::resolve(version, mode)` in `agentmux-co
 | `Portable` AND built by `task package` locally | `dev-portable` | Differentiated via embedded build marker (see §2.5) |
 | `Dev { branch }` | `dev-<branch>` (renamed for symmetry; resolves to `~/.agentmux/dev/<branch>/`, unchanged path on disk) | Per-branch — existing behavior |
 
-The operator can override with `AGENTMUX_CHANNEL=<name>` to point any binary at any channel (e.g., for testing a hot-fix build against the live stable data).
+The operator can override with `AGENTMUX_CHANNEL=<name>` to point an `Installed` / `Portable` binary at any channel (e.g., for testing a hot-fix build against the live stable data). **Dev mode does NOT honor the override** — the launcher and host both use `resolve_path_only` for dev builds, so a `task dev` session launched from inside a parent agentmux pane can't inherit the parent's channel and break per-branch isolation (codex P2 on PR #1027 caught this — without the symmetric ignore, launcher and host would disagree on the single-instance lock path). If you want a non-default channel, use a portable build.
 
 ### 2.3 Channel-name validation
 


### PR DESCRIPTION
**Increment A of 3** from [`SPEC_DATA_CHANNELS_2026_05_24.md`](../blob/agenta/channels-increment-a/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md). Tracking discussion: [#1026](https://github.com/agentmuxai/agentmux/discussions/1026).

## Problem this fixes

Today, every `task package` bump produces a portable with an empty My Agents list — data is keyed on build version (`~/.agentmux/versions/<v>/`). The original [`SPEC_DATA_DIR_UNIFICATION_2026-05-05`](../blob/main/docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md) Phase 1 chose this trade-off deliberately for schema safety, and explicitly flagged "version-comparison testing requires re-doing every login" (§2.6) as a known cost. This PR is Phase 2 — channels.

## What this PR does

Introduces a *channel* — a stable identifier that spans versions within the same compat band — and replaces per-version dirs with per-channel dirs for Installed + Portable. Dev mode unchanged (still per-branch under `dev/<branch>/`).

```
~/.agentmux/
├── shared/                       (unchanged)
├── channels/<channel>/           (NEW)
│   ├── data/, config/, logs/, cef-cache/, agents/
│   └── runtime/                  (single instance per channel)
└── dev/<branch>/                 (unchanged)
```

**Channel resolution priority:**
1. `AGENTMUX_CHANNEL=<name>` env override — any mode. Path: `channels/<channel>/`.
2. `Installed`/`Portable` w/o override → build-time default (`AGENTMUX_BUILD_CHANNEL_DEFAULT`).
3. `Dev { branch }` w/o override → name = `dev-<branch>`, path = `dev/<branch>/` (unchanged).

**`task package` sets `AGENTMUX_BUILD_CHANNEL_DEFAULT=dev-portable`**, so every locally-built portable shares one data dir. Bump v0.38.6 → v0.38.7 → v0.38.8 — same agents across all of them. Release CI does NOT call `task package`, so production builds get the `stable` default via the compile-time fallback (added in a follow-up if needed; today's release script and `cargo build` both work unchanged).

## What this PR does NOT do (per the 3-increment plan)

- **Increment B** (next): migration framework + pre-migration snapshots + forward-compat safety lock. Required before multiple released versions can safely share `stable`.
- **Increment C** (after B): import wizard for cross-channel and legacy `versions/<v>/` migration.

Safe to land before B because the only channel currently in active use is `dev-portable` (local builds), which has no released versions to schema-migrate from. Legacy `~/.agentmux/versions/<v>/` dirs are left untouched on disk for Increment C to pick up.

## Tests

| Test | Covers |
|---|---|
| `installed_paths_under_default_channel` | Installed mode w/o env override resolves to `channels/stable/` |
| `portable_paths_match_installed` | Portable + Installed share the default channel (same data dir) |
| `dev_paths_under_dev_branch` | Dev mode keeps `dev/<branch>/` layout; channel name is `dev-<branch>` |
| `env_override_redirects_any_mode_under_channels` | `AGENTMUX_CHANNEL` env override beats every mode default, including Dev |
| `env_override_rejects_unsafe_or_reserved_names` | Reserved names (`shared`, `snapshots`, `dev`, ...) + path-unsafe values rejected |
| `env_override_default_is_synonym_for_stable` | `AGENTMUX_CHANNEL=default` maps to `stable` per spec §7.5 |
| `channel_name_length_capped_at_64` | 64 chars OK, 65 rejected |
| `from_env_fails_fast_when_channel_missing` | Missing `AGENTMUX_CHANNEL` in `from_env()` returns `None` (loud failure on launcher/srv skew) |
| `env_vars_round_trip` | `to_env_vars()` → `from_env()` preserves channel |
| `sanitize_channel_name_accepts_normal_names` | Happy-path regression catch |
| `resolve_rejects_dev_branch_traversal` / `resolve_rejects_traversal_version` | Phase 1 traversal-safety preserved |

17 tests in `data_paths` (was 9). All green. Full common test suite: 64/64. Launcher test suite: 183/183.

## Spec + research

Ride along with this PR per `feedback_no_doc_only_prs`:

- [`docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md`](../blob/agenta/channels-increment-a/docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md) — full 3-increment design with rollout plan, anti-patterns, open questions.
- [`docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md`](../blob/agenta/channels-increment-a/docs/research/RESEARCH_PER_VERSION_DATA_ISOLATION_2026_05_24.md) — industry-pattern survey (Chrome, VS Code, JetBrains, Postgres, macOS) that informed the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)