### PR TITLE
fix(window): drop hand-link cursor on title-bar widgets + Windows window controls (match tabs)

### DIFF
--- a/.changesets/1779694580-fix-window-drop-hand-link-cursor-on-title-bar-widgets-window-mq99.md
+++ b/.changesets/1779694580-fix-window-drop-hand-link-cursor-on-title-bar-widgets-window-mq99.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): drop hand-link cursor on title-bar widgets + Windows window controls

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -29,7 +29,13 @@
     -webkit-app-region: no-drag;
     display: flex;
     align-items: center;
-    cursor: grab;
+    // Inherit `cursor: default` from `.window-header` (matches tabs —
+    // tab bodies also have no override and inherit the same default
+    // arrow). The previous `cursor: grab` here was visually noisy: it
+    // implied "drag me first" on every hover, even though the primary
+    // interaction is click-to-activate. `cursor: grabbing` is still
+    // applied during the actual drag (`:active`) so the user gets a
+    // real signal while a drag is in progress.
     border-radius: 4px;
     transition: opacity 120ms ease;
     touch-action: none;
@@ -66,7 +72,12 @@
     gap: var(--space-1);
     padding: var(--space-0-5) var(--space-2);
     height: 100%;
-    cursor: pointer;
+    // Inherit `cursor: default` from `.window-header` — matches the
+    // tab and widget-slot cursor discipline. (Was `cursor: pointer`
+    // which implied a web-link hand cursor; the title-bar chrome
+    // shouldn't read as a link.) Dropdown menu items inside
+    // `.action-widget-more-dropdown` keep `cursor: pointer` — they're
+    // a menu list, the link cursor is conventional there.
     border-radius: 4px;
     color: var(--secondary-text-color);
     font-size: 12px;

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -73,7 +73,11 @@
         }
 
         .window-action-btn {
-            cursor: pointer;
+            // Inherit `cursor: default` from `.window-header` — matches
+            // native Windows title-bar behavior (min/max/close buttons
+            // show the standard arrow cursor on hover, not the
+            // hand-link pointer). Also matches tabs + widgets, which
+            // also inherit `default`.
             width: 46px;
             height: 100%;
             padding: 0;


### PR DESCRIPTION
**Tiny CSS-only fix** from user UX feedback.

## Problem

Hover cursors on title-bar chrome elements were inconsistent and wrong:

| Element | Was | Should be |
|---|---|---|
| `.action-widget-slot` (pinned widgets, left side) | `cursor: grab` (open-hand) | `cursor: default` (arrow) — match tabs |
| `.action-widget-more-btn` (More dropdown) | `cursor: pointer` (link hand) | `cursor: default` |
| `.window-action-btn` (Windows min/max/close) | `cursor: pointer` (link hand) | `cursor: default` — native Windows behavior |

Tabs (`.tab` body) have no `cursor` declaration and correctly inherit `cursor: default` from `.window-header` (set in `window-header.win32.scss:37`). User feedback: widgets and window controls should match that — they're not links, and "drag me" isn't the primary interaction.

## Fix

Remove the `cursor` overrides from all three classes so they inherit `default` from the title-bar parent.

Preserved deliberately:
- `.action-widget-slot:active { cursor: grabbing }` — closed-fist cursor while a drag is actually in progress is a real signal, not a hover hint.
- `.action-widget-more-item { cursor: pointer }` (dropdown menu items) — link cursor is conventional for menu lists.

## Test plan

Manual smoke (CSS-only change, no automated coverage to update):
- Hover a widget (terminal/browser/agent) → arrow cursor (was open-hand).
- Hover the "More" overflow chevron → arrow cursor (was link hand).
- Hover min/max/close on Windows → arrow cursor (was link hand).
- Drag a widget → cursor flips to closed-fist while held (unchanged).
- Hover an item in the More dropdown → link hand (unchanged, menus are link-like).

🤖 Generated with [Claude Code](https://claude.com/claude-code)