### PR TITLE
fix(term): await fonts.ready + NaN guard + post-paint refit to fix jumbled startup

### DIFF
--- a/.changesets/1779694669-fix-term-await-fonts-ready-nan-guard-post-paint-refit-to-fix-361k.md
+++ b/.changesets/1779694669-fix-term-await-fonts-ready-nan-guard-post-paint-refit-to-fix-361k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): await fonts.ready + NaN guard + post-paint refit to fix jumbled startup render

--- a/docs/terminal-jumbled-startup-investigation.md
+++ b/docs/terminal-jumbled-startup-investigation.md
@@ -1,0 +1,78 @@
+# Terminal jumbled on startup — investigation
+
+**Symptom:** When loading a terminal pane (especially when starting Claude Code),
+text is sometimes rendered jumbled — glyphs land in wrong positions, lines wrap
+oddly, box-drawing is broken. Resizing the pane or zooming "clicks" it into
+place. Intermittent: doesn't happen every time.
+
+## Diagnosis
+
+Classic xterm.js startup race. The init sequence in
+`frontend/app/view/term/termwrap.ts` is:
+
+| Step | Line | Action |
+|------|------|--------|
+| 1 | termwrap.ts:187 | `terminal.open(connectElem)` mounts xterm to the DOM |
+| 2 | termwrap.ts:237 → 437 | `customFit()` calls `fitAddon.proposeDimensions()`, which **measures rendered cell width from the DOM** |
+| 3 | termwrap.ts:238 | `sendTermSize()` tells the PTY the cols/rows |
+| 4 | termwrap.ts:239 | `resyncController("init")` spawns the PTY |
+| 5 | — | PTY emits output sized to whatever cols were computed in step 2 |
+
+If the **`Hack` web font specified at term.tsx:174 isn't loaded yet** when step 2
+runs, FitAddon measures using the fallback font's metrics. Result: wrong cell
+width → wrong `cols` → PTY receives a stale size. Ink (which Claude Code uses)
+emits ANSI cursor-positioning sequences computed against the size it was told,
+but those positions don't match where glyphs actually land on screen → jumbled
+text, broken box-drawing, mis-wrapped lines.
+
+The reason resize/zoom "clicks it into place":
+
+- The `ResizeObserver` at term.tsx:191 triggers `handleResize_debounced` →
+  `customFit()`. By then fonts are loaded, dims are correct, `sendTermSize()`
+  issues a SIGWINCH, and Ink redraws against the new size.
+- If on the **WebGL renderer** (term.tsx:185 enables it by default when
+  `term:disablewebgl` is unset), zoom also forces a texture-atlas regeneration —
+  the WebGL atlas built with the fallback font has the wrong glyphs baked in
+  until something invalidates it.
+
+Intermittent because it's a font-load race: cold cache → fonts not ready at
+first fit → jumbled. Warm cache → fonts ready synchronously → fine.
+
+## Evidence — others hit the same pattern
+
+- xterm.js #4338 — `proposeDimensions()` returns `NaN` when DOM/font isn't
+  ready: <https://github.com/xtermjs/xterm.js/issues/4338>
+- xterm.js #4830 — fonts render incorrectly, missing bits of glyphs:
+  <https://github.com/xtermjs/xterm.js/issues/4830>
+- xterm.js #4841 — FitAddon doesn't get full dims on first call; workaround is
+  `resize(cols+1, rows+1)`: <https://github.com/xtermjs/xterm.js/issues/4841>
+- xterm.js #4113 — devicePixelRatio / zoom mismatch causes wrong fit:
+  <https://github.com/xtermjs/xterm.js/issues/4113>
+- Hermes IDE #113 — exact same pattern; calls out that the WebGL renderer
+  doesn't clear stale-cell ghost overlays until something forces a refresh:
+  <https://github.com/hermes-hq/hermes-ide/issues/113>
+- Claude Code #59163 — Ink garbling in VS Code's xterm.js, colors and columns
+  intact but glyphs wrong:
+  <https://github.com/anthropics/claude-code/issues/59163>
+
+## Proposed fix
+
+Three changes in `frontend/app/view/term/termwrap.ts`:
+
+1. **Await fonts before first fit.** Insert `await document.fonts.ready;` (or
+   load the Hack font explicitly via the `FontFace` API) between
+   `terminal.open()` and `customFit()` around line 236, before the existing
+   `customFit()` call at line 237.
+
+2. **Guard NaN in `customFit()`.** At line 438, after `proposeDimensions()`,
+   check `Number.isFinite(dims.cols) && Number.isFinite(dims.rows)`. The
+   existing `if (!dims) return;` does not catch `{cols: NaN, rows: NaN}` because
+   that object is truthy.
+
+3. **One re-fit after first paint.** Schedule a second `customFit()` +
+   `sendTermSize()` inside `requestAnimationFrame` after `init()`, so any
+   remaining layout shift propagates as a SIGWINCH before the PTY produces
+   meaningful output.
+
+Together these eliminate the three known root causes: pre-font-load
+measurement, NaN propagation, and post-mount layout shift.

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -232,14 +232,23 @@ export class TermWrap {
             this.loaded = true;
         }
 
-        // Wait for web fonts to load before the first fit.
+        // Wait for web fonts to load before the first fit, but with a bounded timeout.
         // proposeDimensions() measures rendered cell width from the DOM; if the configured
         // term font (e.g. Hack) hasn't loaded yet, FitAddon uses fallback metrics and computes
         // wrong cols, the PTY is told the wrong size, and TUIs (Ink/Claude Code) emit cursor
         // sequences that don't line up — visible as jumbled glyphs until the next resize.
-        // document.fonts.ready resolves once all pending FontFaces have either loaded or failed.
+        //
+        // The timeout is essential: document.fonts.ready can hang under certain conditions
+        // (frontend/app-init.ts wraps the app-level wait in a 2s race for the same reason).
+        // Without it, a stalled font load would block sendTermSize()/resyncController("init")
+        // and the pane's PTY would never start. The rAF re-fit below catches the case where
+        // the font lands just after the timeout, so a missed wait isn't fatal.
+        const FIT_FONT_TIMEOUT_MS = 1000;
         try {
-            await document.fonts?.ready;
+            await Promise.race([
+                document.fonts?.ready ?? Promise.resolve(),
+                new Promise<void>((resolve) => setTimeout(resolve, FIT_FONT_TIMEOUT_MS)),
+            ]);
         } catch (_) { /* font API unavailable — fall through with fallback metrics */ }
 
         // NOW fit and tell backend to start/resync the shell controller.

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -232,12 +232,36 @@ export class TermWrap {
             this.loaded = true;
         }
 
+        // Wait for web fonts to load before the first fit.
+        // proposeDimensions() measures rendered cell width from the DOM; if the configured
+        // term font (e.g. Hack) hasn't loaded yet, FitAddon uses fallback metrics and computes
+        // wrong cols, the PTY is told the wrong size, and TUIs (Ink/Claude Code) emit cursor
+        // sequences that don't line up — visible as jumbled glyphs until the next resize.
+        // document.fonts.ready resolves once all pending FontFaces have either loaded or failed.
+        try {
+            await document.fonts?.ready;
+        } catch (_) { /* font API unavailable — fall through with fallback metrics */ }
+
         // NOW fit and tell backend to start/resync the shell controller.
         // At this point we are fully subscribed and ready to receive data.
         this.customFit();
         this.sendTermSize();
         await this.resyncController("init");
         this.hasResized = true;
+
+        // One re-fit after first paint to catch any remaining layout shift (slow CSS,
+        // late style recalculation, font swap that landed after fonts.ready resolved).
+        // If dimensions changed, sendTermSize() issues a SIGWINCH to the PTY so the
+        // controller redraws against the correct size before producing meaningful output.
+        requestAnimationFrame(() => {
+            if (!this.terminal) return;
+            const oldRows = this.terminal.rows;
+            const oldCols = this.terminal.cols;
+            this.customFit();
+            if (oldRows !== this.terminal.rows || oldCols !== this.terminal.cols) {
+                this.sendTermSize();
+            }
+        });
 
         this.runProcessIdleTimeout();
     }
@@ -436,7 +460,11 @@ export class TermWrap {
 
     private customFit() {
         const dims = this.fitAddon.proposeDimensions();
-        if (!dims) return;
+        // proposeDimensions can return {cols: NaN, rows: NaN} when the DOM cell measurement
+        // fails (font not loaded, hidden container, zero pixel dimensions). The truthy check
+        // alone doesn't catch this because the object exists — NaN < N is always false,
+        // so it propagates through to terminal.resize() and corrupts the rendered grid.
+        if (!dims || !Number.isFinite(dims.cols) || !Number.isFinite(dims.rows)) return;
         const core = (this.terminal as any)._core;
         const cellWidth: number = core?._renderService?.dimensions?.css?.cell?.width ?? 0;
         if (cellWidth > 0) {


### PR DESCRIPTION
## Summary

Fixes the intermittent jumbled text on terminal-pane startup (especially with Claude Code / Ink TUIs) that "clicks into place" after a manual resize or Ctrl+Wheel zoom.

Root cause is a font-load race in `TermWrap.init()`:

1. `terminal.open()` mounts xterm.
2. `customFit()` runs immediately and calls `fitAddon.proposeDimensions()`, which measures rendered cell width from the DOM.
3. If `Hack` (or whatever term font) hasn't loaded yet, FitAddon uses fallback metrics → wrong `cols` → `sendTermSize()` tells the PTY the wrong size → Ink emits ANSI cursor sequences that don't line up with where glyphs actually land.

The existing `[startup-perf] initApp (fonts ready): 239.8ms` benchmark already shows there is real time between init start and fonts-ready, so the race is observable on this machine.

Three changes in `frontend/app/view/term/termwrap.ts`:

- **Await fonts before first fit** — `await document.fonts?.ready` between `terminal.open()` and the first `customFit()`.
- **NaN guard in `customFit()`** — `proposeDimensions()` can return `{cols: NaN, rows: NaN}` (xterm.js#4338); the existing `!dims` check doesn't catch it because the object is truthy and NaN propagates into `terminal.resize()` and corrupts the grid.
- **One rAF re-fit after init** — schedules a second `customFit()` + `sendTermSize()` in `requestAnimationFrame` so any remaining layout shift (slow CSS, late font swap) propagates as a SIGWINCH before the PTY produces meaningful output.

Investigation write-up included at `docs/terminal-jumbled-startup-investigation.md`.

Changeset: `patch` (RFC #857 Phase 2 workflow — no version bump in this PR).

## References

- xterm.js [#4338](https://github.com/xtermjs/xterm.js/issues/4338) — FitAddon NaN dimensions
- xterm.js [#4830](https://github.com/xtermjs/xterm.js/issues/4830) — fonts render incorrectly
- xterm.js [#4841](https://github.com/xtermjs/xterm.js/issues/4841) — FitAddon resizes incorrectly
- xterm.js [#4113](https://github.com/xtermjs/xterm.js/issues/4113) — DPR / zoom mismatch
- hermes-ide [#113](https://github.com/hermes-hq/hermes-ide/issues/113) — same pattern + WebGL ghost overlays
- claude-code [#59163](https://github.com/anthropics/claude-code/issues/59163) — Ink garbling in xterm.js

## Test plan

- [x] `npx tsc --noEmit` — no new type errors (pre-existing failures elsewhere are unrelated)
- [x] `task dev` — builds clean, Vite up on :5173, CEF host loads, terminal pane renders without errors
- [ ] Manually open a fresh terminal pane (cold cache) and start Claude Code — should render correctly without needing a resize. Repeat ~10x.
- [ ] Open with `term:disablewebgl=true` to verify the DOM-renderer path also works.
- [ ] Confirm no regression on existing panes resuming from cache (`loadInitialTerminalData` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)