### PR TITLE
chore(modal): drop modal-v2 references from comments — canonical modal is the only version

### DIFF
--- a/.changesets/1779697463-chore-modal-drop-modal-v2-references-from-comments-canonical-28es.md
+++ b/.changesets/1779697463-chore-modal-drop-modal-v2-references-from-comments-canonical-28es.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(modal): drop modal-v2 references from comments — canonical modal is the only version

--- a/frontend/app/element/modal.scss
+++ b/frontend/app/element/modal.scss
@@ -1,18 +1,21 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Modal — the unified, scope-based modal primitive (Stage 1 of
-// SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21). Ports modal-v2.scss's rules and
-// adds: scope-specific positioning (tab/pane backdrops are absolute
-// within their mount node, not fixed full-window) and the cancel-nudge
-// keyframes (spec §9).
+// Modal — the canonical dialog primitive (paired with `modal.tsx`).
+//
+// Scope-aware positioning: window-scope renders a fixed full-window
+// overlay; tab/pane scope render absolute-positioned backdrops inside
+// their mount node so the lock visually covers only the scope, not the
+// whole window. Cancel-nudge keyframes (used when
+// `closeOnBackdropClick={false}` and the backdrop is clicked) live
+// alongside. Design rationale: SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21.md.
 //
 // Consumes design tokens from `theme.scss` (SPEC_DESIGN_SYSTEM_2026_04_23).
 
 @use "../mixins.scss";
 
 .modal-root {
-    // Window scope: a fixed full-window overlay (identical to modal-v2).
+    // Window scope: a fixed full-window overlay.
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);

--- a/frontend/app/element/modal.tsx
+++ b/frontend/app/element/modal.tsx
@@ -2,39 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Modal — the unified, scope-based modal primitive.
+ * Modal — the canonical dialog primitive.
  *
- * Stage 1 of SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21. This is `modal-v2`
- * evolved to add a first-class `scope` axis: what the modal *locks* —
- * the window, a tab, or a single pane. Mount point, backdrop extent,
- * `inert` boundary, scroll lock and the modal stack are all consequences
- * of that scope.
+ * One modal system for the whole app. The `scope` prop selects what
+ * region the modal *locks* — the window, a tab, or a single pane.
+ * Mount point, backdrop extent, `inert` boundary, scroll lock, and
+ * the modal stack are all consequences of that scope.
  *
- * `modal-v2.{tsx,scss}` is intentionally left untouched — the two systems
- * co-exist until later stages migrate every caller (spec §11).
- *
- * Scope model (spec §3):
+ * Scope model:
  * - `window` — Portal into the originating window's `document.body`.
  *   Inert = the body's element children; backdrop covers the full
- *   window. Identical to modal-v2 today.
+ *   window.
  * - `tab`   — mounts into the active tab's content root, supplied by a
  *   `TabModalScope` context. Inert = that tab's content; the tab bar +
  *   other tabs stay live. Falls back to `window` (with a console.warn)
  *   when no provider is present.
  * - `pane`  — mounts into a pane root supplied by a `PaneModalScope`
- *   context. Inert = that pane only. Built per spec §12.2 even though no
- *   caller uses it yet.
+ *   context. Inert = that pane only. The infrastructure is wired even
+ *   though no in-tree caller uses it yet — pane-scoped modals (e.g. a
+ *   launch flow that should only lock its own agent pane) plug in by
+ *   adding a `<PaneModalScope.Provider>` at the pane root and passing
+ *   `scope="pane"`.
  *
- * Ported verbatim from modal-v2 (spec §8): focus trap via sentinel
- * spans, focus save/restore, ARIA labelling + the title-id context,
- * the pane-overlay clip, `prefers-reduced-motion` handling.
+ * Features:
+ * - Focus trap via sentinel spans, focus save/restore on close.
+ * - ARIA labelling — auto-generated title id shared between the
+ *   dialog root and a nested `ModalHeader` via `ModalTitleIdContext`.
+ * - Pane-overlay clip — registers the modal's rect with the backend
+ *   so native browser-pane HWNDs paint transparent under the modal
+ *   (`SPEC_MODAL_PANE_CLIP_2026_04_24.md`).
+ * - `prefers-reduced-motion` honored — entrance/exit animations
+ *   suppressed when set.
+ * - `closeOnBackdropClick={false}` nudges the panel's
+ *   `[data-modal-dismiss]` control instead of silently swallowing
+ *   the click.
  *
- * Redesigned around `scope`: mount resolution (§7), scope-relative
- * inert + scroll lock (§5), the scope-aware stack (§6).
- *
- * New in §9: `closeOnBackdropClick={false}` no longer silently swallows
- * a backdrop click — it nudges the panel's `[data-modal-dismiss]`
- * control instead.
+ * History (relevant when reading older PRs / specs): this file is the
+ * descendant of two prior implementations — `modal.tsx` (v1, single
+ * Portal into `document.body`) and `modal-v2.tsx` (added the chrome
+ * slot system + paint gate). Both are gone; the surviving file is the
+ * canonical one. Older specs reference "modal-v2"; treat that as a
+ * pointer to this file. Design rationale for the scope axis lives in
+ * `SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21.md`.
  *
  * Consumes design tokens from `theme.scss`:
  *   --z-modal, --shadow-modal, --shadow-focus-ring, --radius-lg,
@@ -69,7 +78,7 @@ export type ModalScope = "window" | "tab" | "pane";
 // nested `ModalHeader` so `aria-labelledby` on the dialog root resolves to
 // the heading `ModalHeader` actually renders. Without it the two sides
 // generate independent ids via `createUniqueId()` and never match,
-// breaking the labelling contract. (Ported verbatim from modal-v2.)
+// breaking the labelling contract.
 
 const ModalTitleIdContext = createContext<string | undefined>(undefined);
 
@@ -103,17 +112,17 @@ export const PaneModalScope = createContext<ModalScopeMount | undefined>(undefin
 // where the modal is. Rendered inside <Show> so registration is bound
 // to the modal's open/close lifecycle, not its component instance.
 // Full rationale: docs/specs/SPEC_MODAL_PANE_CLIP_2026_04_24.md.
-// Ported verbatim from modal-v2's ModalPaneOverlayClip (spec §8).
 
 const ModalPaneOverlayClip: Component<{ getEl: Accessor<HTMLElement | null | undefined> }> = (p) => {
     usePaneOverlay(p.getEl);
     return null;
 };
 
-// ── Modal stack (spec §6) ────────────────────────────────────────────────────
-// Module-level so every Modal instance shares it. Unlike modal-v2's flat
-// z-order stack, each entry records the modal's `scope` and `lockEl` so
-// ESC / backdrop can reason about scope containment.
+// ── Modal stack (SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21 §6) ──────────────────
+// Module-level so every Modal instance shares it. Each entry records the
+// modal's `scope` and `lockEl` so ESC / backdrop dispatch can reason about
+// scope containment (e.g. a pane modal stacked inside a window modal stays
+// dismissable on its own ESC; window modal stays untouched).
 //
 // The "reachable topmost" is the highest-stacked modal NOT contained
 // within a higher modal's lock region. Modals whose lock regions don't
@@ -168,16 +177,16 @@ function isReachable(self: StackEntry): boolean {
     return true;
 }
 
-// ── Per-region scroll + inert lock (spec §5) ────────────────────────────────
-// modal-v2 inerts the whole document body unconditionally. The unified
-// system inerts only the *lock region's* element children that aren't a
-// modal root, and scroll-locks only that region.
+// ── Per-region scroll + inert lock (SPEC_UNIFIED_MODAL_SYSTEM §5) ─────────
+// Inert only the *lock region's* element children that aren't a modal
+// root, and scroll-lock only that region. Window-scope locks the
+// document body (every other element goes inert); tab-scope locks
+// just that tab's content; pane-scope locks just that pane.
 //
 // Reference-counted, keyed per lock-region element (a WeakMap keyed by
 // the region node) — so stacked modals sharing a region release the lock
 // only when the last one closes, while modals in disjoint regions never
-// interfere. The window-scope region is `document.body`, so window-modal
-// stacking behaves exactly as modal-v2's per-document lock did.
+// interfere.
 
 interface RegionLockState {
     openCount: number;
@@ -195,8 +204,8 @@ const supportsInert = typeof HTMLElement !== "undefined" && "inert" in HTMLEleme
  *
  * Inert is applied to `region`'s direct element children that are not a
  * `modal-root` and not already inert. For window scope `region` is the
- * document body — identical to modal-v2. For tab/pane scope only that
- * region's children are inerted, leaving the rest of the page live.
+ * document body. For tab/pane scope only that region's children are
+ * inerted, leaving the rest of the page live.
  */
 function acquireRegionLock(region: HTMLElement): void {
     const existing = regionLocks.get(region);
@@ -260,7 +269,7 @@ function lastFocusable(root: HTMLElement): HTMLElement | null {
  * Resolve the document the modal should mount into. Uses the currently
  * focused element's `ownerDocument` so a modal opened from a click in
  * the N-th CEF window mounts into that window's DOM, not the main
- * window's. (Ported verbatim from modal-v2 — used for `window` scope.)
+ * window's. Used for `window` scope.
  */
 function resolveMountDocument(): Document {
     const active = typeof document !== "undefined" ? document.activeElement : null;

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Command-palette specific styles. Outer chrome (backdrop, z-index,
-// scroll lock, inert) is provided by modal-v2; this file only styles
-// the panel sizing + inner search row + result list.
+// scroll lock, inert) is provided by the canonical `<Modal>`; this
+// file only styles the panel sizing + inner search row + result list.
 
-// Override modal-v2's default panel width for the palette. Applied
-// via the `panelClass="command-palette-panel"` prop passed to Modal.
+// Override the default panel width for the palette. Applied via the
+// `panelClass="command-palette-panel"` prop passed to Modal.
 .modal-panel.command-palette-panel {
     width: 560px;
     max-width: 92vw;

--- a/frontend/app/modals/command-palette.tsx
+++ b/frontend/app/modals/command-palette.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Command palette modal — opened via Ctrl+P, lists all registered commands.
-// Migrated to the shared `element/modal-v2` primitive; the palette's
-// specific chrome (search row + scroll list) lives in the panel body.
+// Uses the canonical `element/modal` primitive; the palette's specific
+// chrome (search row + scroll list) lives in the panel body.
 
 import { commandRegistry, type CommandEntry } from "@/app/store/command-registry";
 import type { ModalCloseProps } from "@/app/store/modalmodel";
@@ -78,7 +78,7 @@ const CommandPaletteModal = (props: ModalCloseProps): JSX.Element => {
     }
 
     // Arrow keys + Enter are palette-specific navigation. ESC and
-    // backdrop close are handled by modal-v2 → `onClose`.
+    // backdrop close are handled by `<Modal>` → `onClose`.
     function handleKeyDown(e: KeyboardEvent) {
         if (e.key === "ArrowDown") {
             e.preventDefault();

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -64,7 +64,7 @@ const UserInputModal = (props: UserInputRequest & ModalCloseProps) => {
     };
 
     const handleKeyDown = (waveEvent: WaveKeyboardEvent): boolean => {
-        // Enter submits; ESC is handled by modal-v2's closeOnEscape
+        // Enter submits; ESC is handled by `<Modal>`'s closeOnEscape
         // which calls our onClose → handleSendErrResponse.
         if (keyutil.checkKeyPressed(waveEvent, "Enter")) {
             handleSubmit();

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -43,7 +43,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
 
     // Airspace cut so the popover paints over any browser pane HWND that
     // the status bar overlaps. Same primitive as TokenBreakdownPopover,
-    // MoreDropdown, modal-v2.
+    // MoreDropdown, and `<Modal>`.
     usePaneOverlay(() => rootRef);
 
     const about = createMemo(() => {

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -7,8 +7,8 @@
  * grand total row, and a destructive-gated "Reset counter" action.
  *
  * Calls `usePaneOverlay` so the popover renders cleanly over any
- * browser pane HWND (same airspace pattern as MoreDropdown and
- * modal-v2). Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.2.
+ * browser pane HWND (same airspace pattern as MoreDropdown and the
+ * canonical `<Modal>`). Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.2.
  */
 
 import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
@@ -52,7 +52,7 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
     let rootRef: HTMLDivElement | undefined;
 
     // Airspace cut so the popover shows through any browser pane HWND
-    // that the status bar overlaps. Same primitive used by modal-v2
+    // that the status bar overlaps. Same primitive used by `<Modal>`
     // (PR #544) and MoreDropdown.
     usePaneOverlay(() => rootRef);
 

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -66,7 +66,7 @@
     font-size: 12px;
     zoom: var(--zoomfactor);
     // Above the status bar and above browser panes — sits in the same
-    // stacking tier as modal-v2's overlays. pane-overlay.ts clips the
+    // stacking tier as the modal overlays. pane-overlay.ts clips the
     // pane HWND beneath this rect so the DOM content paints on top.
     z-index: var(--zindex-modal-wrapper);
     display: flex;

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -17,7 +17,7 @@
  * affordances, NamedAgents resource). For a template-create the
  * minimum surface is name + bindings; mixing it into the launch modal
  * would push its complexity onto a flow that doesn't need it. The
- * existing modal-v2 panel styles (`modal-panel-*`) and shared bundle
+ * canonical modal panel styles (`modal-panel-*`) and shared bundle
  * styles (`agent-new-bundle-modal-*`) are reused so this fits the
  * universal modal system per `feedback_use_universal_modal_system`.
  */

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -57,7 +57,7 @@ const SCOPE_HINT: Record<DecisionOutcome["scope"], string> = {
 const SCOPE_ORDER: DecisionOutcome["scope"][] = ["once", "session", "project", "global"];
 
 // Tiny child that calls usePaneOverlay against the panel root ref.
-// Same pattern as modal-v2's `ModalPaneOverlayClip` — mounted only
+// Same pattern as `<Modal>`'s `ModalPaneOverlayClip` — mounted only
 // when the panel is visible, so `onMount` runs while `rootRef` is
 // already attached to the live DOM element. Calling usePaneOverlay
 // from the outer component would register undefined on first mount

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Shared styles for AgentNewIdentityModalPanel and
-// AgentNewMemoryModalPanel. Modal-v2 chrome lives in modal-v2.scss;
-// this file styles the form bodies only.
+// AgentNewMemoryModalPanel. Canonical modal chrome lives in
+// `frontend/app/element/modal.scss`; this file styles the form
+// bodies only.
 
 .agent-new-bundle-modal-body {
     display: flex;

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -1,8 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Modal-panel chrome lives in modal-v2.scss; this file only styles
-// the prereq list body. SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+// Modal-panel chrome lives in `frontend/app/element/modal.scss`;
+// this file only styles the prereq list body.
+// SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
 
 .agent-prereq-modal-body {
     display: flex;

--- a/frontend/app/view/agent/styles/_import-modal-body.scss
+++ b/frontend/app/view/agent/styles/_import-modal-body.scss
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Import Preview Modal — shows catalog entries being imported.
-// Top-level (rendered through modal-v2 portal).
+// Rendered through the canonical `<Modal>` (window scope, portals
+// to `document.body`).
 // ── Import Preview Modal ─────────────────────────────────────────────────────
-// Inner content styles for the Modal v2-rendered import preview. Kept
-// at top level because modal-v2 portals to `document.body`, so
-// selectors nested inside `.agent-view` never match (caught by reagent
-// on PR #513).
+// Inner content styles for the import-preview panel. Kept at top
+// level because window-scope modals portal to `document.body`, so
+// selectors nested inside `.agent-view` never match (caught by
+// reagent on PR #513).
 
 .agent-import-count {
     font-size: 12px;

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // AgentInstallModal — install-specific bits only. The outer modal
-// chrome (header/body/footer/title/description) lives in
-// `frontend/app/element/modal-v2.scss` and is shared across all
-// tab-modal panels.
+// chrome (header/body/footer/title/description) lives in the canonical
+// `frontend/app/element/modal.scss` and is shared across every modal
+// panel in the app.
 
 .agent-install-modal-body {
     display: flex;

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -3,7 +3,7 @@
 
 // AgentLaunchModal — opens when user clicks a definition card.
 // Collects instance name + host/container runtime.
-// Top-level (rendered through modal-v2 portal).
+// Rendered through the canonical `<Modal>` (today via TabModalLayer).
 // ── AgentLaunchModal ─────────────────────────────────────────────────────────
 // Modal that opens when the user clicks a definition card in the
 // picker. Collects instance name + host/container runtime. See

--- a/frontend/app/view/browser/components/BrowserAuthModal.scss
+++ b/frontend/app/view/browser/components/BrowserAuthModal.scss
@@ -1,8 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// BrowserAuthModal — modal-panel chrome lives in modal-v2.scss; this
-// file only styles the form body. SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+// BrowserAuthModal — modal-panel chrome lives in the canonical
+// `frontend/app/element/modal.scss`; this file only styles the form
+// body. SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
 
 .browser-auth-modal-body {
     display: flex;


### PR DESCRIPTION
**Comment cleanup only — no behavior change.**

## Problem

The modal system consolidation is **done in code** — `modal-v2.{tsx,scss}` were deleted, `modal.{tsx,scss}` is the single canonical primitive, every active import resolves to `@/element/modal`. But the source **comments** throughout the codebase still referred to "modal-v2" everywhere, implying a co-existing v2 file readers might look for. They couldn't — it's gone. The comments lied.

User feedback called this out explicitly: the modal work was supposed to remove versioning, just call it canonical modals.

## Fix

Sweep across 16 files; every comment now refers to `<Modal>`, "the canonical modal", or the actual canonical path (`frontend/app/element/modal.{tsx,scss}`).

| File | Was | Now |
|---|---|---|
| `frontend/app/element/modal.tsx` | Top-doc led with "Stage 1 of SPEC_UNIFIED_MODAL_SYSTEM", described `modal-v2` as "intentionally left untouched" | Top-doc leads with "canonical dialog primitive"; describes scope axis directly; "Ported verbatim from modal-v2" asides removed |
| `frontend/app/element/modal.scss` | "Ports modal-v2.scss's rules" | "the canonical dialog primitive (paired with `modal.tsx`)" |
| `frontend/app/modals/command-palette.{tsx,scss}` | "Migrated to the shared `element/modal-v2` primitive"; "modal-v2's closeOnEscape" | "the canonical `<Modal>` primitive"; "`<Modal>`'s closeOnEscape" |
| `frontend/app/modals/userinputmodal.tsx` | "ESC handled by modal-v2's closeOnEscape" | "ESC handled by `<Modal>`'s closeOnEscape" |
| `frontend/app/statusbar/{InstancePanel,TokenBreakdownPopover}.tsx` + `_token-usage.scss` | "Same primitive as ... modal-v2" | "Same primitive as ... `<Modal>`" |
| `frontend/app/view/agent/components/{AgentCreateFromTemplateModal,AgentDecisionPanel,AgentNewBundleModal.scss,AgentPrereqModal.scss}` | various "modal-v2" mentions | "canonical modal" / `modal.scss` |
| `frontend/app/view/agent/styles/{_import-modal-body,_launch-modal-body,_install-modal}.scss` | "rendered through modal-v2 portal" | "rendered through the canonical `<Modal>`" |
| `frontend/app/view/browser/components/BrowserAuthModal.scss` | "modal-v2.scss" | canonical `modal.scss` path |

## Kept (intentional)

The `modal.tsx` top-doc-comment **History** paragraph still names `modal.tsx` (v1) and `modal-v2.tsx` (v2) as gone files. That paragraph exists specifically to help readers navigating older PRs / specs map "modal-v2" references to the current file — removing it would orphan that historical context. Two intentional mentions, none in active code paths.

## What this PR does NOT do

- Code refactor — none. Imports, exports, runtime behavior unchanged.
- Spec changes — the unified-modal spec doesn't mention modal-v2 except in history sections; no edits needed.
- Tests — no tests assert on comment text.

## Companion PR

A follow-up PR in `agentmuxai/agentmux-docs` updates `internals/modal-system.md` (currently titled "Modal system (modal-v2)" and describes the now-deleted two-path mental model) to reflect the canonical scope-based system. That's separate because it's a different repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)