### PR TITLE
feat(network): LAN discovery toggle in HostPopover + Warden widget spec

### DIFF
--- a/.changesets/1779699173-feat-add-lan-discovery-toggle-to-hostpopover.md
+++ b/.changesets/1779699173-feat-add-lan-discovery-toggle-to-hostpopover.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(network): add LAN discovery toggle to HostPopover with live daemon start/stop

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -226,3 +226,92 @@ impl Drop for LanDiscovery {
         }
     }
 }
+
+/// Controller for live start/stop of `LanDiscovery` in response to setting changes.
+///
+/// Owns the daemon slot plus the start arguments, so toggling
+/// `network:lan_discovery` from the UI (or from an external edit of
+/// `settings.json`) can start or stop the daemon without restarting the
+/// process.
+///
+/// Spec: specs/lan-discovery-toggle.md
+pub struct LanDiscoveryController {
+    slot: Arc<RwLock<Option<Arc<LanDiscovery>>>>,
+    instance_id: String,
+    hostname: String,
+    version: String,
+    port: u16,
+    event_bus: Arc<EventBus>,
+}
+
+impl LanDiscoveryController {
+    pub fn new(
+        instance_id: String,
+        hostname: String,
+        version: String,
+        port: u16,
+        event_bus: Arc<EventBus>,
+    ) -> Self {
+        Self {
+            slot: Arc::new(RwLock::new(None)),
+            instance_id,
+            hostname,
+            version,
+            port,
+            event_bus,
+        }
+    }
+
+    /// Idempotent: starts the daemon when `enabled` and not running, stops it
+    /// when `!enabled` and running. Re-entrant safe.
+    pub fn apply(&self, enabled: bool) {
+        let is_running = self.slot.read().is_some();
+        match (enabled, is_running) {
+            (true, false) => {
+                match LanDiscovery::start(
+                    self.instance_id.clone(),
+                    self.hostname.clone(),
+                    self.version.clone(),
+                    self.port,
+                    self.event_bus.clone(),
+                ) {
+                    Ok(d) => {
+                        *self.slot.write() = Some(d);
+                        tracing::info!("LAN discovery enabled via setting");
+                    }
+                    Err(e) => {
+                        tracing::warn!("LAN discovery start failed: {e}");
+                        // Surface to the UI so the user sees why the toggle
+                        // didn't take effect (e.g. Windows Firewall blocked).
+                        self.event_bus.broadcast_event(&WSEventType {
+                            eventtype: "laninstances:error".to_string(),
+                            oref: String::new(),
+                            data: Some(json!({ "error": e })),
+                        });
+                    }
+                }
+            }
+            (false, true) => {
+                *self.slot.write() = None;
+                // Drop impl on LanDiscovery handles mDNS unregister + shutdown.
+                tracing::info!("LAN discovery disabled via setting");
+                self.event_bus.broadcast_event(&WSEventType {
+                    eventtype: "laninstances".to_string(),
+                    oref: String::new(),
+                    data: Some(json!([])),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    /// Read the current peer list. Returns empty when the daemon is not
+    /// running (discovery disabled or start failed).
+    pub fn get_instances(&self) -> Vec<LanInstance> {
+        self.slot
+            .read()
+            .as_ref()
+            .map(|d| d.get_instances())
+            .unwrap_or_default()
+    }
+}

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -264,8 +264,16 @@ impl LanDiscoveryController {
 
     /// Idempotent: starts the daemon when `enabled` and not running, stops it
     /// when `!enabled` and running. Re-entrant safe.
+    ///
+    /// Holds the slot's write lock for the entire check-and-modify transaction
+    /// to avoid a TOCTOU race between the `is_running` read and the slot
+    /// mutation. `apply()` is called from toggle clicks and setting writes —
+    /// low frequency — so briefly blocking concurrent peer-list reads is
+    /// acceptable. `LanDiscovery::start()` and `Drop` are both fast (mDNS
+    /// daemon construction + service register/unregister are local socket ops).
     pub fn apply(&self, enabled: bool) {
-        let is_running = self.slot.read().is_some();
+        let mut slot = self.slot.write();
+        let is_running = slot.is_some();
         match (enabled, is_running) {
             (true, false) => {
                 match LanDiscovery::start(
@@ -276,7 +284,7 @@ impl LanDiscoveryController {
                     self.event_bus.clone(),
                 ) {
                     Ok(d) => {
-                        *self.slot.write() = Some(d);
+                        *slot = Some(d);
                         tracing::info!("LAN discovery enabled via setting");
                     }
                     Err(e) => {
@@ -295,7 +303,7 @@ impl LanDiscoveryController {
                 }
             }
             (false, true) => {
-                *self.slot.write() = None;
+                *slot = None;
                 // Drop impl on LanDiscovery handles mDNS unregister + shutdown.
                 tracing::info!("LAN discovery disabled via setting");
                 self.event_bus.broadcast_event(&WSEventType {

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -283,10 +283,13 @@ impl LanDiscoveryController {
                         tracing::warn!("LAN discovery start failed: {e}");
                         // Surface to the UI so the user sees why the toggle
                         // didn't take effect (e.g. Windows Firewall blocked).
+                        // `e` is already a String, but `.to_string()` is the
+                        // documented contract for the wire payload (frontend
+                        // reads `event.data.error` as a string).
                         self.event_bus.broadcast_event(&WSEventType {
                             eventtype: "laninstances:error".to_string(),
                             oref: String::new(),
-                            data: Some(json!({ "error": e })),
+                            data: Some(json!({ "error": e.to_string() })),
                         });
                     }
                 }

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -213,17 +213,34 @@ impl LanDiscovery {
     pub fn peer_count(&self) -> usize {
         self.instances.read().len()
     }
+
+    /// Stop the mDNS daemon — synchronously closes the daemon socket
+    /// (UDP:5353), causing the `browse_receiver` to return Err and the
+    /// event-loop thread spawned by `start()` to exit.
+    ///
+    /// Required for live-disable to actually stop discovery: the event-loop
+    /// thread holds its own `Arc<Self>` clone, so simply dropping the
+    /// controller's Arc never reaches refcount zero and `Drop` does not
+    /// run. Callers must invoke `shutdown()` before clearing their Arc.
+    /// Idempotent — safe to call from both the explicit path and `Drop`.
+    pub fn shutdown(&self) {
+        if let Err(e) = self.daemon.unregister(&self.service_fullname) {
+            // Likely already unregistered; do not warn loudly.
+            tracing::debug!("mDNS unregister returned: {e}");
+        }
+        if let Err(e) = self.daemon.shutdown() {
+            tracing::debug!("mDNS daemon shutdown returned: {e}");
+        }
+    }
 }
 
 impl Drop for LanDiscovery {
     fn drop(&mut self) {
-        // Gracefully unregister from mDNS
-        if let Err(e) = self.daemon.unregister(&self.service_fullname) {
-            tracing::warn!("mDNS unregister failed: {e}");
-        }
-        if let Err(e) = self.daemon.shutdown() {
-            tracing::warn!("mDNS daemon shutdown failed: {e}");
-        }
+        // Fallback path. Under normal live-toggle flow the controller calls
+        // `shutdown()` explicitly; this only fires for process exit, when
+        // the event-loop thread has already terminated and the final Arc
+        // is being released.
+        self.shutdown();
     }
 }
 
@@ -303,8 +320,19 @@ impl LanDiscoveryController {
                 }
             }
             (false, true) => {
+                // Explicitly shut down before dropping our Arc. The
+                // spawn_blocking event-loop thread holds an `Arc<LanDiscovery>`
+                // clone (see `start()` line ~94), so dropping the slot's Arc
+                // alone does not reach refcount zero — `Drop` would never run
+                // and the daemon would keep advertising/browsing. `shutdown()`
+                // closes the mDNS socket synchronously, the receiver returns
+                // Err, the event-loop exits, and the spawned thread releases
+                // its Arc. `Drop`'s subsequent call to `shutdown()` is a
+                // no-op (idempotent).
+                if let Some(d) = slot.as_ref() {
+                    d.shutdown();
+                }
                 *slot = None;
-                // Drop impl on LanDiscovery handles mDNS unregister + shutdown.
                 tracing::info!("LAN discovery disabled via setting");
                 self.event_bus.broadcast_event(&WSEventType {
                     eventtype: "laninstances".to_string(),

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -657,27 +657,20 @@ async fn main() {
 
     // LAN discovery via mDNS — opt-in to avoid Windows Firewall prompt.
     // mDNS binds 0.0.0.0:5353 UDP which triggers the firewall dialog.
-    // Only start if explicitly enabled in settings.
-    let lan_discovery_enabled = config_watcher.get_settings().network_lan_discovery;
+    // The setting defaults to false; users opt in via the HostPopover toggle
+    // (or by editing settings.json). The controller supports live start/stop
+    // so flipping the setting does not require an app restart.
+    // See specs/lan-discovery-toggle.md.
     let hostname = whoami::fallible::hostname().unwrap_or_else(|_| "unknown".to_string());
-    let lan_discovery = if lan_discovery_enabled {
-        match backend::lan_discovery::LanDiscovery::start(
-            config.instance_id.clone(),
-            hostname,
-            version.clone(),
-            web_addr.port(),
-            event_bus.clone(),
-        ) {
-            Ok(d) => Some(d),
-            Err(e) => {
-                tracing::warn!("LAN discovery unavailable: {e}");
-                None
-            }
-        }
-    } else {
-        tracing::info!("LAN discovery disabled (enable via network:lan_discovery setting)");
-        None
-    };
+    let lan_discovery = Arc::new(backend::lan_discovery::LanDiscoveryController::new(
+        config.instance_id.clone(),
+        hostname,
+        version.clone(),
+        web_addr.port(),
+        event_bus.clone(),
+    ));
+    // Honor the current setting at boot — starts the daemon if enabled.
+    lan_discovery.apply(config_watcher.get_settings().network_lan_discovery);
 
     // Clean up stale cross-instance agent registry entries (entries older than 4h).
     backend::reactive::registry::cleanup_stale(

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -33,7 +33,7 @@ use serde_json::json;
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::backend::eventbus::EventBus;
-use crate::backend::lan_discovery::LanDiscovery;
+use crate::backend::lan_discovery::LanDiscoveryController;
 use crate::backend::messagebus::MessageBus;
 use crate::backend::reactive::{Poller, ReactiveHandler};
 use crate::backend::storage::filestore::FileStore;
@@ -66,7 +66,11 @@ pub struct AppState {
     /// provides kill-tree on pane close / host exit.
     /// See `backend::process_tracker` + `agentmux-ai/AGENT_SPAWNED_PROCESSES_SPEC.md`.
     pub process_tracker: Arc<crate::backend::process_tracker::registry::AgentProcessRegistry>,
-    pub lan_discovery: Option<Arc<LanDiscovery>>,
+    /// Live controller for mDNS-based LAN/host peer discovery. The controller
+    /// owns a swappable daemon slot so the `network:lan_discovery` setting can
+    /// be toggled at runtime without restarting the process.
+    /// See `specs/lan-discovery-toggle.md`.
+    pub lan_discovery: Arc<LanDiscoveryController>,
     /// Local HTTP URL of this instance (e.g. "http://127.0.0.1:PORT").
     /// Used for cross-instance inject forwarding and file registry entries.
     pub local_web_url: String,
@@ -292,12 +296,7 @@ async fn handle_diag_sagas(State(state): State<AppState>) -> Json<serde_json::Va
 }
 
 async fn handle_lan_instances(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let instances = state
-        .lan_discovery
-        .as_ref()
-        .map(|d| d.get_instances())
-        .unwrap_or_default();
-    Json(json!(instances))
+    Json(json!(state.lan_discovery.get_instances()))
 }
 
 async fn stub_501() -> impl IntoResponse {

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -48,9 +48,15 @@ pub(crate) fn test_state() -> AppState {
         messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
         http_client: reqwest::Client::new(),
         local_web_url: String::new(),
-        subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
+        subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone())),
         history_service: Arc::new(crate::backend::history::HistoryService::new()),
-        lan_discovery: None,
+        lan_discovery: Arc::new(crate::backend::lan_discovery::LanDiscoveryController::new(
+            "test-instance".to_string(),
+            "test-host".to_string(),
+            "0.28.20".to_string(),
+            0,
+            event_bus.clone(),
+        )),
         process_tracker,
         // Phase E.2c.2 — workspace RPC dispatches through reducer.
         // Tests get fresh state + a dummy broadcast bus.

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1169,11 +1169,13 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     // The fs watcher's subsequent reload is a no-op (settings already up to date).
     let config_watcher_setconfig = state.config_watcher.clone();
     let event_bus_setconfig = state.event_bus.clone();
+    let lan_discovery_setconfig = state.lan_discovery.clone();
     engine.register_handler(
         COMMAND_SET_CONFIG,
         Box::new(move |data, _ctx| {
             let cw = config_watcher_setconfig.clone();
             let eb = event_bus_setconfig.clone();
+            let lan = lan_discovery_setconfig.clone();
             Box::pin(async move {
                 let new_keys: serde_json::Map<String, serde_json::Value> =
                     serde_json::from_value(data).map_err(|e| format!("setconfig: {e}"))?;
@@ -1184,9 +1186,16 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
                 // 2. Update in-memory config immediately
                 let merged_settings = crate::backend::config_watcher_fs::merge_settings_into_current(&cw, new_keys);
+                let lan_enabled = merged_settings.network_lan_discovery;
                 cw.update_settings(merged_settings);
 
-                // 3. Broadcast updated config now — no waiting for fs watcher
+                // 3. Live-toggle LAN discovery if the key changed. `apply` is
+                //    idempotent so it's safe to call unconditionally — when the
+                //    daemon is already in the requested state, this is a no-op.
+                //    See specs/lan-discovery-toggle.md.
+                lan.apply(lan_enabled);
+
+                // 4. Broadcast updated config now — no waiting for fs watcher
                 let config = cw.get_full_config();
                 if let Ok(config_val) = serde_json::to_value(config.as_ref()) {
                     let event = crate::backend::eventbus::WSEventType {

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -1,8 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getApi, lanInstancesAtom, settingsAtom } from "@/store/global";
+import { getApi, lanInstancesAtom, lanDiscoveryErrorAtom, setLanDiscoveryErrorAtom, settingsAtom } from "@/store/global";
 import { invokeCommand } from "@/app/platform/ipc";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 
 type HostInfo = {
@@ -31,6 +33,24 @@ const HostPopover = (): JSX.Element => {
     const lanInstances = lanInstancesAtom;
     const lanCount = () => lanInstances().length;
     const lanDiscoveryEnabled = () => !!settingsAtom()?.["network:lan_discovery"];
+    const lanDiscoveryError = lanDiscoveryErrorAtom;
+
+    // Toggle the network:lan_discovery setting. The backend's setconfig handler
+    // calls LanDiscoveryController.apply, which starts/stops the mDNS daemon
+    // live — no restart. On Windows, the first enable triggers the firewall
+    // prompt; if the user clicks Block, a "laninstances:error" event flows back
+    // and surfaces in the panel.
+    // Spec: specs/lan-discovery-toggle.md
+    const handleLanToggle = async (enabled: boolean) => {
+        // Optimistic clear of any prior error; backend will resend if it still
+        // can't start the daemon.
+        setLanDiscoveryErrorAtom(null);
+        try {
+            await RpcApi.SetConfigCommand(TabRpcClient, { "network:lan_discovery": enabled } as any);
+        } catch (e) {
+            setLanDiscoveryErrorAtom(`Failed to update setting: ${e}`);
+        }
+    };
 
     const handleClick = async () => {
         if (popoverOpen()) {
@@ -113,38 +133,60 @@ const HostPopover = (): JSX.Element => {
                                 </span>
                             </div>
 
-                            {/* Network */}
+                            {/* Network — LAN discovery toggle.
+                                Spec: specs/lan-discovery-toggle.md */}
                             <div class="status-bar-popover-divider" />
-                            <Show when={lanCount() > 0}>
-                                <div class="status-bar-popover-row">
-                                    <span style={{ color: "var(--accent-color)" }}>{"◆"}</span>
-                                    <span>{lanCount()} instance{lanCount() !== 1 ? "s" : ""} on LAN</span>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">LAN discovery</span>
+                                <label
+                                    class="status-bar-toggle"
+                                    data-tip={lanDiscoveryEnabled() ? "Disable" : "Enable (may prompt Windows Firewall)"}
+                                    style={{ "margin-left": "auto" }}
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={lanDiscoveryEnabled()}
+                                        onChange={(e) =>
+                                            void handleLanToggle((e.target as HTMLInputElement).checked)
+                                        }
+                                    />
+                                </label>
+                            </div>
+                            <Show when={lanDiscoveryError()}>
+                                <div
+                                    class="status-bar-popover-row"
+                                    style={{
+                                        "padding-left": "12px",
+                                        "font-size": "0.85em",
+                                        color: "var(--warning-color, #d97706)",
+                                    }}
+                                >
+                                    <span>⚠ {lanDiscoveryError()}</span>
+                                </div>
+                            </Show>
+                            <Show when={lanDiscoveryEnabled() && lanCount() > 0}>
+                                <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
+                                    <span style={{ color: "var(--accent-color)" }}>◆</span>
+                                    <span>{lanCount()} peer{lanCount() !== 1 ? "s" : ""}</span>
                                 </div>
                                 <For each={lanInstances()}>
                                     {(inst: LanInstance) => (
-                                        <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
+                                        <div class="status-bar-popover-row" style={{ "padding-left": "20px" }}>
                                             <span style={{ opacity: "0.7" }}>{inst.hostname || inst.instance_id}</span>
                                             <span class="status-bar-popover-mono" style={{ opacity: "0.5" }}>v{inst.version}</span>
                                         </div>
                                     )}
                                 </For>
-                                <div class="status-bar-popover-divider" />
                             </Show>
-                            <Show when={lanCount() === 0 && lanDiscoveryEnabled()}>
-                                <div class="status-bar-popover-row" style={{ opacity: "0.5" }}>
-                                    <span>No LAN peers found</span>
+                            <Show when={lanDiscoveryEnabled() && lanCount() === 0 && !lanDiscoveryError()}>
+                                <div
+                                    class="status-bar-popover-row"
+                                    style={{ "padding-left": "12px", opacity: "0.5", "font-size": "0.85em" }}
+                                >
+                                    <span>Searching for peers…</span>
                                 </div>
-                                <div class="status-bar-popover-divider" />
                             </Show>
-                            <Show when={lanCount() === 0 && !lanDiscoveryEnabled()}>
-                                <div class="status-bar-popover-row" style={{ opacity: "0.5" }}>
-                                    <span>LAN discovery disabled</span>
-                                </div>
-                                <div class="status-bar-popover-row" style={{ opacity: "0.4", "font-size": "0.85em" }}>
-                                    <span>Enable via "network:lan_discovery": true</span>
-                                </div>
-                                <div class="status-bar-popover-divider" />
-                            </Show>
+                            <div class="status-bar-popover-divider" />
 
                             {/* Ports */}
                             <div class="status-bar-popover-row">

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -301,6 +301,48 @@
         margin: 5px 0;
         opacity: 0.4;
     }
+
+    /* Toggle switch used in the LAN discovery row.
+       Spec: specs/lan-discovery-toggle.md */
+    .status-bar-toggle {
+        display: inline-flex;
+        align-items: center;
+        cursor: pointer;
+        user-select: none;
+
+        input[type="checkbox"] {
+            appearance: none;
+            -webkit-appearance: none;
+            width: 28px;
+            height: 14px;
+            background: var(--border-color);
+            border-radius: 7px;
+            position: relative;
+            cursor: pointer;
+            transition: background 120ms ease;
+            margin: 0;
+
+            &::before {
+                content: "";
+                position: absolute;
+                top: 1px;
+                left: 1px;
+                width: 12px;
+                height: 12px;
+                background: var(--main-bg-color, #fff);
+                border-radius: 50%;
+                transition: transform 120ms ease;
+            }
+
+            &:checked {
+                background: var(--accent-color);
+
+                &::before {
+                    transform: translateX(14px);
+                }
+            }
+        }
+    }
 }
 
 .status-bar-popover.host-popover {

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -134,6 +134,9 @@ export const [isTermMultiInput, setIsTermMultiInput] = createSignal(false);
 export const [windowInstanceNumAtom, setWindowInstanceNumAtom] = createSignal(0);
 export const [windowCountAtom, setWindowCountAtom] = createSignal(1);
 export const [lanInstancesAtom, setLanInstancesAtom] = createSignal<LanInstance[]>([]);
+// Last error message from the LAN discovery daemon (e.g. firewall block).
+// Cleared on successful enable. See specs/lan-discovery-toggle.md.
+export const [lanDiscoveryErrorAtom, setLanDiscoveryErrorAtom] = createSignal<string | null>(null);
 
 // List of all open AgentMux window labels in this process. Updated by
 // app-init's window-instances-changed listener whenever a window opens
@@ -284,6 +287,15 @@ export function initGlobalEventSubs(initOpts: AgentMuxInitOpts) {
             handler: (event) => {
                 const instances: LanInstance[] = event.data ?? [];
                 setLanInstancesAtom(instances);
+                // A successful broadcast clears any prior error state.
+                setLanDiscoveryErrorAtom(null);
+            },
+        },
+        {
+            eventType: "laninstances:error",
+            handler: (event) => {
+                const errMsg = event.data?.error ?? "unknown error";
+                setLanDiscoveryErrorAtom(String(errMsg));
             },
         },
     );

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -171,6 +171,10 @@
         },
         "conn:wshenabled": {
           "type": "boolean"
+        },
+        "network:lan_discovery": {
+          "type": "boolean",
+          "description": "Enable mDNS-based discovery of other AgentMux instances on the same host and LAN. Defaults to false to avoid the Windows Firewall prompt; toggle from the HostPopover panel. See specs/lan-discovery-toggle.md."
         }
       },
       "additionalProperties": false,

--- a/specs/SPEC_GOVERNANCE_WIDGET_2026-05-25.md
+++ b/specs/SPEC_GOVERNANCE_WIDGET_2026-05-25.md
@@ -1,0 +1,442 @@
+# Spec: Governance Widget
+
+**Branch:** `agenty/governance-widget`
+**Status:** Draft — design / discovery
+**Date:** 2026-05-25
+**Author:** AgentY
+**Depends on:** `specs/lan-awareness-and-embedded-jekt-api.md` (Phases 1–2)
+
+---
+
+## TL;DR
+
+A **Governance** widget (More-dropdown tier) that monitors and controls every AgentMux
+instance reachable from this host — across three trust layers: **Host**, **LAN**, and
+**Internet**. The widget renders the same 3-layer fabric that the jekt cascade already
+uses (tiers 1-2 / tier 3 / tier 4) and exposes per-layer controls: identity, policy,
+audit, kill-switch, quotas.
+
+**Sequencing:** networking first. The widget design is unblocked, but LAN-layer
+features have no substrate until `lan-awareness-and-embedded-jekt-api.md` Phase 1
+(mDNS discovery) and Phase 2 (embedded MCP server) ship. We can build the widget shell
++ Host layer in parallel with networking work and light up LAN/Internet as their
+substrates arrive.
+
+---
+
+## Why a Governance widget — and why now
+
+AgentMux is moving from "one process talking to a cloud relay" to a **mesh of
+instances** (host process + LAN peers + opt-in cloud relay). With more agents in more
+places, the operator needs a single place to:
+
+- See **who** is running (which agents, on which instance, with which identity)
+- See **what** they are doing (jekt activity, message bus traffic, tool calls)
+- Decide **who can talk to whom** (cross-instance and cross-layer policy)
+- Hit **stop** on a runaway agent, an entire instance, or a whole layer
+- Keep an **audit trail** that is immutable and reviewable
+
+Today these capabilities are scattered (settings.json, swarm widget, logs, AgentBus
+console) or absent (no LAN policy because LAN doesn't exist yet). The Governance widget
+consolidates them on the same conceptual surface the jekt cascade already uses, so
+operators learn one mental model.
+
+---
+
+## The 3-layer governance model
+
+| Layer | Trust | Substrate | Jekt tier | Reachability | Auth |
+|------|------|-----------|----------|--------------|------|
+| **L1 — Host** | Trusted | This `agentmuxsrv-rs` process: PTYs, ReactiveHandler, MessageBus | Tiers 1–2 | < 1 ms, same process | `X-AuthKey` (existing) |
+| **L2 — LAN** | Semi-trusted | mDNS-discovered peers on `_agentmux._tcp.local` | Tier 3 | 1–10 ms over LAN HTTP | Shared LAN key (proposed) |
+| **L3 — Internet** | Untrusted | AgentBus cloud relay (`agentbus.asaf.cc`) | Tier 4 | 100 ms – 15 s | `AGENTBUS_TOKEN` |
+
+The trust gradient is deliberate: defaults tighten as you move outward. A host-local
+jekt is allowed by default; a LAN jekt requires the LAN to be enrolled; an
+internet/cloud jekt requires explicit opt-in token. The widget renders this gradient
+literally — three stacked panels, each with its own toggles, lists, and audit feed.
+
+---
+
+## Networking first? (the question the user asked)
+
+**Yes — networking first, widget design in parallel.**
+
+Concretely:
+
+1. **`lan-awareness-and-embedded-jekt-api.md` Phase 1 (mDNS discovery)** is a hard
+   prerequisite for the L2 panel. Without `LanDiscovery` + `GET /api/lan-instances`,
+   the widget has no peers to list and no way to address them.
+2. **Phase 2 (embedded MCP server)** is the prerequisite for cross-instance policy
+   propagation — once peers expose a uniform MCP/HTTP surface, the widget can push
+   governance state (allowlists, quotas, kill flags) to peers.
+3. **Phase 3 (LAN forwarding)** is when L2 control actions actually take effect
+   end-to-end.
+
+Build order:
+
+```
+Networking:   [Phase 1: mDNS] → [Phase 2: MCP/SSE] → [Phase 3: LAN forward] → [Phase 4: cloud fallback]
+Governance:   [Shell + L1]    → [L2 read-only]    → [L2 control]           → [L3 read/control]
+```
+
+The widget shell, L1 (Host) monitoring, and L1 controls (kill-agent, pause-instance)
+can ship as soon as we agree on the design — they do not need LAN. L2 and L3 light up
+behind their networking counterparts.
+
+---
+
+## Governance: best-practices research
+
+Distilled from CNCF (Kubernetes RBAC, NetworkPolicy, OPA), zero-trust networking,
+capability-based security, and existing AI-agent control planes (LangSmith, AgentOps,
+Anthropic admin console).
+
+Principles we adopt:
+
+1. **Defense in depth across layers.** Each layer enforces its own policy. A LAN-layer
+   deny is not bypassable by an Internet-layer allow.
+2. **Capabilities, not roles.** Each agent gets an explicit capability set
+   (`can.jekt.lan`, `can.send.cloud`, `can.exec.tool:bash`). Roles are syntactic sugar
+   over capability bundles.
+3. **Policy as data.** Governance state lives in a versioned, signable document
+   (`governance.json` under the config dir) — not embedded in code. Hot-reloadable
+   like `settings.json`.
+4. **Audit is append-only.** Every action that crosses a layer boundary writes an
+   event to `~/.agentmux/audit/YYYY-MM-DD.jsonl`. Never mutated, only rotated.
+5. **Kill switches at every boundary.** Per agent, per instance, per layer. The
+   widget's primary affordance is a big stop button at each scope.
+6. **Quotas before kills.** Soft controls (rate limits, token budgets, message
+   ceilings) run first; kills are the escape hatch.
+7. **Human-in-the-loop for sensitive ops.** A configurable allowlist of
+   tool-calls/jekts that require approval — surfaced as a notification with
+   `approve / deny / always` actions.
+8. **Identity provenance.** Every agent advertises (a) who spawned it, (b) the
+   capability bundle at spawn time, (c) the parent instance's signature. Surfaced as
+   the first column in every agent list.
+9. **Drift detection.** When a peer's advertised capability set differs from what we
+   expect (e.g., LAN peer claims `can.exec.tool:rm`), surface as a warning chip.
+10. **Closed by default at boundary 3.** Internet-layer governance starts denying
+    everything except an explicit allowlist. Network effects must be earned per agent.
+
+What we deliberately don't do (yet): full OPA/Rego integration, mTLS between
+instances, distributed consensus on policy. These are listed in Future Work.
+
+---
+
+## Widget design
+
+### Placement
+
+`defwidget@governance` — **More dropdown** tier (alongside `swarm`, `drone`). Pinning
+can be enabled later if usage justifies. Icon: `shield-halved` or `gavel`. Label:
+`governance`.
+
+### Surface
+
+A single pane, three vertically-stacked, collapsible sections — one per layer. Each
+section has identical structure so the operator learns one row:
+
+```
+┌─ Governance ──────────────────────────────────────────── [⏻ kill all]
+│
+│ ▼ HOST                              ● 3 agents · 0 alerts   [⏸ pause] [⏻]
+│   ┌──────────────────────────────────────────────────────────────────┐
+│   │ agent     identity        caps                  jekts/min  state │
+│   │ ──────────────────────────────────────────────────────────────── │
+│   │ agent1    user:asaf  ✓    jekt.host,send.host       12      active│
+│   │ agent2    user:asaf  ✓    jekt.host,send.host        4      idle  │
+│   │ forge1    user:asaf  ✓    jekt.host                  0      ready │
+│   └──────────────────────────────────────────────────────────────────┘
+│   policy: [allow host jekt ✓]  [require approval for tool:bash ✗]
+│   audit:  last 5 events ▸
+│
+│ ▼ LAN                                ◆ 2 peers · 1 alert    [⏸ pause] [⏻]
+│   ┌──────────────────────────────────────────────────────────────────┐
+│   │ peer        host         version   agents  caps          state   │
+│   │ ──────────────────────────────────────────────────────────────── │
+│   │ ◆ desk-mac  agentx-asaf  0.38.4    2       jekt.lan ✓    healthy │
+│   │ ◆ pi-lab    pi-builder   0.38.2    1       jekt.lan ⚠    drift   │
+│   └──────────────────────────────────────────────────────────────────┘
+│   policy: [LAN enrolled ✓]  [shared key set ✓]  [allow inbound jekt ✓]
+│   audit:  last 5 events ▸
+│
+│ ▼ INTERNET                           ☁ AgentBus · disabled  [enable…]
+│   AgentBus relay is not configured. Enable to allow cross-network
+│   jekt/send via agentbus.asaf.cc. Closed by default.
+│   [Set AGENTBUS_TOKEN] [Configure allowlist]
+│
+└──────────────────────────────────────────────────────────────────────
+```
+
+### Affordances per layer
+
+| Action | L1 Host | L2 LAN | L3 Internet |
+|--------|---------|--------|-------------|
+| List agents/peers | ✓ | ✓ | ✓ (via AgentBus list) |
+| Show identity provenance | ✓ | ✓ | ✓ |
+| Show capability set | ✓ | ✓ | ✓ |
+| Live jekt/msg counters | ✓ | ✓ | ✓ |
+| Pause inbound | ✓ | ✓ | ✓ |
+| Kill (force-stop agent / drop peer / disable layer) | ✓ | ✓ | ✓ |
+| Edit policy | ✓ | ✓ | ✓ |
+| Stream audit events | ✓ | ✓ | ✓ |
+| Approval queue | ✓ | ✓ | ✓ |
+
+Each row is right-click-actionable: `View jekt history`, `Revoke capability`,
+`Quarantine`, `Open settings`.
+
+### Top-level controls
+
+- `⏻ kill all` — emergency stop. Drops all inbound across all layers, pauses every
+  agent's PTY, writes a `kill-all` event to audit. Re-enable is manual.
+- Per-layer `⏸ pause` — stop accepting new jekts/messages at that layer; existing
+  in-flight finish.
+- Per-layer `⏻` — full layer disable (no inbound or outbound).
+
+---
+
+## Architecture
+
+### Frontend
+
+- View key: `governance`. Registered like `swarm` (block-rendered, not a special-case
+  like `settings`/`devtools`).
+- Atoms in `frontend/state/governance.ts`:
+  - `governanceLayersAtom` → `{ host, lan, internet }` summaries
+  - `governancePolicyAtom` → live mirror of `governance.json`
+  - `governanceAuditTailAtom` → last 50 audit events per layer (ring buffer)
+- New RPCs:
+  - `GetGovernanceSnapshot` → one-shot read of all three layers
+  - `SetGovernancePolicy` → write to `governance.json` (validated, signed)
+  - `GovernanceAction` → `{ scope, target, action }` e.g. `kill agent1`,
+    `pause-layer lan`
+  - `SubscribeGovernanceEvents` → WS topic streaming audit events
+- Reuses existing components: `BlockTable`, `Chip`, `PolicyToggle` (new, small).
+
+### Backend (agentmuxsrv-rs)
+
+New module: `agentmuxsrv-rs/src/backend/governance/`
+
+```
+governance/
+├── mod.rs              // facade
+├── policy.rs           // GovernancePolicy struct, load/save/validate
+├── enforcer.rs         // hooks into ReactiveHandler, MessageBus, LanDiscovery
+├── audit.rs            // append-only JSONL writer + WS broadcaster
+└── snapshot.rs         // GetGovernanceSnapshot assembly
+```
+
+Integration points (read-only at first; enforce in Phase 2):
+
+| Call site | Purpose |
+|----------|---------|
+| `ReactiveHandler::inject_block` | Consult `enforcer::allow_jekt(agent, scope)` before PTY write |
+| `MessageBus::send` | Consult `enforcer::allow_send(from, to, layer)` |
+| `LanDiscovery` peer-discovered hook | Tag peer with `pending|enrolled|quarantined`, fire `lan.peer.discovered` audit |
+| `agentbus_client::*` (cloud fallback) | Consult `enforcer::allow_cloud(agent)` |
+| Any `kill_all` invocation | Write audit, broadcast `governance.kill_all` event |
+
+### Policy file: `~/.agentmux/config/governance.json`
+
+```jsonc
+{
+  "version": 1,
+  "host": {
+    "default": "allow",
+    "agents": {
+      "agent1": { "caps": ["jekt.host", "send.host", "tool:*"] },
+      "forge1": { "caps": ["jekt.host"] }
+    },
+    "approval_required": ["tool:bash", "tool:rm"]
+  },
+  "lan": {
+    "enabled": false,
+    "shared_key": null,
+    "allow_inbound": false,
+    "allow_outbound": true,
+    "trusted_peers": []
+  },
+  "internet": {
+    "enabled": false,
+    "agentbus_token_env": "AGENTBUS_TOKEN",
+    "outbound_allowlist": [],
+    "inbound_allowlist": []
+  },
+  "quotas": {
+    "jekt_per_minute": { "host": 600, "lan": 120, "internet": 30 }
+  },
+  "audit": {
+    "retain_days": 30,
+    "dir": "~/.agentmux/audit"
+  }
+}
+```
+
+Schema lives at `schema/governance.json` (strict, `additionalProperties: false`,
+loaded by `wconfig.rs`'s `ConfigWatcher`).
+
+### Audit log
+
+`~/.agentmux/audit/YYYY-MM-DD.jsonl`. One JSON object per line:
+
+```jsonc
+{ "ts": "2026-05-25T20:14:03Z",
+  "layer": "lan",
+  "kind": "jekt.allowed",
+  "from": { "instance": "desk-mac", "agent": "agent3" },
+  "to":   { "instance": "this",     "agent": "agent1" },
+  "policy_rule": "lan.allow_inbound",
+  "request_id": "..." }
+```
+
+Append-only at the API level (writes go through `audit::Writer`, which never
+truncates and never rewrites). Rotation is by date file; retention is `audit.retain_days`.
+
+---
+
+## Implementation phases
+
+### Phase 0 — Spec acceptance (this doc)
+Review, refine, merge to `specs/`. Decide naming (`Governance` vs `Govern`) and
+icon.
+
+### Phase 1 — Shell + L1 read-only
+Depends on: nothing.
+
+- Register `defwidget@governance` in `widgets.json`
+- Wire `GetGovernanceSnapshot` RPC returning Host layer only
+- Render shell with three sections; LAN/Internet sections stubbed as "requires
+  networking (PR #lan-discovery)"
+- Stream Host audit events
+- No enforcement yet — observation only
+
+### Phase 2 — L1 controls + policy file
+Depends on: Phase 1.
+
+- `governance.json` schema + watcher
+- `SetGovernancePolicy` RPC
+- `enforcer::allow_*` hooks in ReactiveHandler / MessageBus (Host layer)
+- `GovernanceAction` RPC: `kill agent`, `pause host`, `kill all`
+- Approval queue for `approval_required` capabilities — surfaced as a desktop
+  notification + in-widget toast
+
+### Phase 3 — L2 read-only
+Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 1 (mDNS).
+
+- LAN section lists discovered peers from `LanDiscovery`
+- Per-peer drift detection (version, declared caps, last-seen)
+- Per-peer audit (peer discovered, peer lost, peer drift)
+- No control of remote peers yet
+
+### Phase 4 — L2 control
+Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 2 (embedded MCP) +
+Phase 3 (LAN forward).
+
+- Shared LAN key — enrollment ceremony (operator copies a key between instances)
+- Inbound jekt/send enforcement at the LAN boundary
+- Quarantine peer (drop all inbound from peer + don't forward to peer)
+- Policy push: when this instance updates `governance.lan.*`, broadcast to
+  enrolled peers (each peer applies it locally — no distributed consensus, just
+  best-effort fan-out with version vectors)
+
+### Phase 5 — L3 (Internet) read + control
+Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 4 (cloud fallback).
+
+- Enable/disable cloud relay from widget
+- Outbound allowlist per agent
+- Inbound allowlist (who can reach my agents from cloud)
+- Token management surface (read from env, never display, only set/clear)
+
+### Phase 6 — Polish
+- Per-row history drawer
+- Quota tuning UI
+- Export audit log as CSV
+- Right-click menu actions
+
+---
+
+## Open questions
+
+1. **Widget vs first-class panel?** Governance is operator-grade and might warrant
+   pinned status (always visible chip in widget bar showing aggregate state).
+   Recommendation: ship in More dropdown first; promote based on usage.
+2. **LAN enrollment UX.** mDNS discovers peers automatically, but enrollment (sharing
+   a key) needs a flow. Options: QR code on host, copy/paste key, optimistic
+   trust-on-first-use. TOFU is the lowest-friction path for dev; explicit key is
+   better for shared/office LANs.
+3. **Where does the policy author edit?** Two paths: in-widget toggle UI (limited)
+   or `governance.json` in external editor (full). Both should work; the toggle UI
+   covers the 80% case.
+4. **Capability syntax.** `tool:bash` vs `tool.bash` vs `bash`. Pick one and stick
+   with it — Kubernetes uses `verb:noun:resource`, MCP uses `tool.name`. Recommend
+   matching MCP for consistency (`tool.bash`).
+5. **Audit privacy.** Audit events may contain prompts. Default to redacting
+   message bodies; allow opt-in full logging per agent for debugging.
+6. **Quota enforcement granularity.** Per-minute is easy; per-agent-session may
+   matter more. Start with per-minute global + per-layer; add per-agent later.
+7. **Relationship to `swarm` widget.** Both touch agent control, but Swarm is
+   workflow (task queues, lifecycle); Governance is policy (who can do what).
+   Keep separate; cross-link in the UI ("Swarm tasks for agent1 →").
+8. **Reagent / CI integration.** Should auto-approve/auto-kill rules be expressible
+   here, or stay in reagent? Lean: governance describes the boundary; reagent
+   describes review behavior. Separate concerns.
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase 1 — `defwidget@governance` appears in More dropdown
+- [ ] Phase 1 — Widget renders three layer sections, Host populated, LAN/Internet
+      stubbed with informative message
+- [ ] Phase 1 — Host section lists every agent with identity, caps, jekt/min rate,
+      state
+- [ ] Phase 1 — Audit events stream live for Host actions
+- [ ] Phase 2 — `governance.json` validates against schema, hot-reloads on save
+- [ ] Phase 2 — Kill-agent action stops PTY and writes audit event
+- [ ] Phase 2 — Approval-required capability surfaces a notification with
+      approve/deny/always
+- [ ] Phase 2 — `⏻ kill all` halts every agent within 500 ms
+- [ ] Phase 3 — LAN peers appear with drift indicators when mDNS is up
+- [ ] Phase 4 — Quarantined peer cannot deliver inbound jekt, audit shows
+      `lan.jekt.denied`
+- [ ] Phase 5 — Internet layer toggle on/off works; cloud fallback respects
+      allowlists
+- [ ] Audit log retained per `audit.retain_days`, rotated daily
+
+---
+
+## Out of scope (future work)
+
+- OPA/Rego policy language (current syntax is sufficient for v1)
+- mTLS between instances (shared LAN key is the v1 model)
+- Distributed consensus on policy (best-effort fan-out is fine for v1)
+- Cross-org federation (a different problem; AgentBus is the model for now)
+- A standalone "governance API" for external tools (could come later via MCP
+  resource exposure)
+
+---
+
+## Key files (to be created)
+
+| File | Role |
+|------|------|
+| `agentmuxsrv-rs/src/backend/governance/mod.rs` | Module facade |
+| `agentmuxsrv-rs/src/backend/governance/policy.rs` | `GovernancePolicy` + load/save |
+| `agentmuxsrv-rs/src/backend/governance/enforcer.rs` | Allow/deny hooks |
+| `agentmuxsrv-rs/src/backend/governance/audit.rs` | Append-only JSONL writer |
+| `agentmuxsrv-rs/src/server/governance.rs` | HTTP/WS endpoints |
+| `agentmuxsrv-rs/src/config/widgets.json` | Add `defwidget@governance` |
+| `schema/governance.json` | JSON Schema for `governance.json` |
+| `frontend/app/widget/governance/` | React view + atoms |
+| `frontend/state/governance.ts` | Atoms + RPC bindings |
+
+## References
+
+- `specs/lan-awareness-and-embedded-jekt-api.md` — 3-tier jekt cascade + LAN mDNS
+- `specs/swarm-orchestration.md` — adjacent control plane (workflow, not policy)
+- `specs/SPEC_SETTINGS_WIDGET.md` — widget bar conventions
+- `specs/local-messagebus-architecture.md` — what we're governing on the inside
+- CNCF: Kubernetes RBAC, NetworkPolicy
+- OWASP zero-trust networking guidance
+- MCP capability model (tool naming convention)

--- a/specs/SPEC_WARDEN_WIDGET_2026-05-25.md
+++ b/specs/SPEC_WARDEN_WIDGET_2026-05-25.md
@@ -1,6 +1,6 @@
-# Spec: Governance Widget
+# Spec: Warden Widget
 
-**Branch:** `agenty/governance-widget`
+**Branch:** `agenty/governance-widget-spec`
 **Status:** Draft — design / discovery
 **Date:** 2026-05-25
 **Author:** AgentY
@@ -8,13 +8,23 @@
 
 ---
 
+## Name
+
+**Warden** — one who watches over an institution. Authority + observation,
+matches the monitor-and-control role across boundaries (Host / LAN / Internet).
+Fits the existing single-word, evocative widget vocabulary (`swarm`, `drone`,
+`forge`) without bureaucratic baggage. The *concept* it implements is still
+called "governance" in this doc — the widget is just the surface.
+
+---
+
 ## TL;DR
 
-A **Governance** widget (More-dropdown tier) that monitors and controls every AgentMux
-instance reachable from this host — across three trust layers: **Host**, **LAN**, and
-**Internet**. The widget renders the same 3-layer fabric that the jekt cascade already
-uses (tiers 1-2 / tier 3 / tier 4) and exposes per-layer controls: identity, policy,
-audit, kill-switch, quotas.
+The **Warden** widget monitors and controls every AgentMux instance reachable
+from this host — across three trust layers: **Host**, **LAN**, and **Internet**.
+It renders the same 3-layer fabric that the jekt cascade already uses (tiers 1-2
+/ tier 3 / tier 4) and exposes per-layer controls: identity, policy, audit,
+kill-switch, quotas.
 
 **Sequencing:** networking first. The widget design is unblocked, but LAN-layer
 features have no substrate until `lan-awareness-and-embedded-jekt-api.md` Phase 1
@@ -24,7 +34,7 @@ substrates arrive.
 
 ---
 
-## Why a Governance widget — and why now
+## Why a Warden — and why now
 
 AgentMux is moving from "one process talking to a cloud relay" to a **mesh of
 instances** (host process + LAN peers + opt-in cloud relay). With more agents in more
@@ -37,7 +47,7 @@ places, the operator needs a single place to:
 - Keep an **audit trail** that is immutable and reviewable
 
 Today these capabilities are scattered (settings.json, swarm widget, logs, AgentBus
-console) or absent (no LAN policy because LAN doesn't exist yet). The Governance widget
+console) or absent (no LAN policy because LAN doesn't exist yet). The Warden
 consolidates them on the same conceptual surface the jekt cascade already uses, so
 operators learn one mental model.
 
@@ -77,7 +87,7 @@ Build order:
 
 ```
 Networking:   [Phase 1: mDNS] → [Phase 2: MCP/SSE] → [Phase 3: LAN forward] → [Phase 4: cloud fallback]
-Governance:   [Shell + L1]    → [L2 read-only]    → [L2 control]           → [L3 read/control]
+Warden:       [Shell + L1]    → [L2 read-only]    → [L2 control]           → [L3 read/control]
 ```
 
 The widget shell, L1 (Host) monitoring, and L1 controls (kill-agent, pause-instance)
@@ -86,7 +96,7 @@ behind their networking counterparts.
 
 ---
 
-## Governance: best-practices research
+## Best-practices research
 
 Distilled from CNCF (Kubernetes RBAC, NetworkPolicy, OPA), zero-trust networking,
 capability-based security, and existing AI-agent control planes (LangSmith, AgentOps,
@@ -128,9 +138,9 @@ instances, distributed consensus on policy. These are listed in Future Work.
 
 ### Placement
 
-`defwidget@governance` — **More dropdown** tier (alongside `swarm`, `drone`). Pinning
-can be enabled later if usage justifies. Icon: `shield-halved` or `gavel`. Label:
-`governance`.
+`defwidget@warden` — **Pinned** tier (per `CLAUDE.md`'s "every surfaced widget
+is pinned" default; collapses to icon-only on narrow title bars). Icon:
+`shield-halved` or `gavel`. Label: `warden`.
 
 ### Surface
 
@@ -138,7 +148,7 @@ A single pane, three vertically-stacked, collapsible sections — one per layer.
 section has identical structure so the operator learns one row:
 
 ```
-┌─ Governance ──────────────────────────────────────────── [⏻ kill all]
+┌─ Warden ────────────────────────────────────────────────── [⏻ kill all]
 │
 │ ▼ HOST                              ● 3 agents · 0 alerts   [⏸ pause] [⏻]
 │   ┌──────────────────────────────────────────────────────────────────┐
@@ -298,13 +308,13 @@ truncates and never rewrites). Rotation is by date file; retention is `audit.ret
 ## Implementation phases
 
 ### Phase 0 — Spec acceptance (this doc)
-Review, refine, merge to `specs/`. Decide naming (`Governance` vs `Govern`) and
-icon.
+Review, refine, merge to `specs/`. Naming decided (Warden); icon selection
+still open (`shield-halved` vs `gavel`).
 
 ### Phase 1 — Shell + L1 read-only
 Depends on: nothing.
 
-- Register `defwidget@governance` in `widgets.json`
+- Register `defwidget@warden` in `widgets.json`
 - Wire `GetGovernanceSnapshot` RPC returning Host layer only
 - Render shell with three sections; LAN/Internet sections stubbed as "requires
   networking (PR #lan-discovery)"
@@ -358,9 +368,9 @@ Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 4 (cloud fallback).
 
 ## Open questions
 
-1. **Widget vs first-class panel?** Governance is operator-grade and might warrant
-   pinned status (always visible chip in widget bar showing aggregate state).
-   Recommendation: ship in More dropdown first; promote based on usage.
+1. **Widget vs first-class panel?** ~~Pinned status~~ now resolved — per
+   `CLAUDE.md`'s "every surfaced widget is pinned" default, Warden ships
+   pinned from the start.
 2. **LAN enrollment UX.** mDNS discovers peers automatically, but enrollment (sharing
    a key) needs a flow. Options: QR code on host, copy/paste key, optimistic
    trust-on-first-use. TOFU is the lowest-friction path for dev; explicit key is
@@ -376,17 +386,17 @@ Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 4 (cloud fallback).
 6. **Quota enforcement granularity.** Per-minute is easy; per-agent-session may
    matter more. Start with per-minute global + per-layer; add per-agent later.
 7. **Relationship to `swarm` widget.** Both touch agent control, but Swarm is
-   workflow (task queues, lifecycle); Governance is policy (who can do what).
+   workflow (task queues, lifecycle); Warden is policy (who can do what).
    Keep separate; cross-link in the UI ("Swarm tasks for agent1 →").
 8. **Reagent / CI integration.** Should auto-approve/auto-kill rules be expressible
-   here, or stay in reagent? Lean: governance describes the boundary; reagent
+   here, or stay in reagent? Lean: Warden describes the boundary; reagent
    describes review behavior. Separate concerns.
 
 ---
 
 ## Acceptance criteria
 
-- [ ] Phase 1 — `defwidget@governance` appears in More dropdown
+- [ ] Phase 1 — `defwidget@warden` appears in More dropdown
 - [ ] Phase 1 — Widget renders three layer sections, Host populated, LAN/Internet
       stubbed with informative message
 - [ ] Phase 1 — Host section lists every agent with identity, caps, jekt/min rate,
@@ -426,7 +436,7 @@ Depends on: `lan-awareness-and-embedded-jekt-api.md` Phase 4 (cloud fallback).
 | `agentmuxsrv-rs/src/backend/governance/enforcer.rs` | Allow/deny hooks |
 | `agentmuxsrv-rs/src/backend/governance/audit.rs` | Append-only JSONL writer |
 | `agentmuxsrv-rs/src/server/governance.rs` | HTTP/WS endpoints |
-| `agentmuxsrv-rs/src/config/widgets.json` | Add `defwidget@governance` |
+| `agentmuxsrv-rs/src/config/widgets.json` | Add `defwidget@warden` |
 | `schema/governance.json` | JSON Schema for `governance.json` |
 | `frontend/app/widget/governance/` | React view + atoms |
 | `frontend/state/governance.ts` | Atoms + RPC bindings |

--- a/specs/lan-discovery-toggle.md
+++ b/specs/lan-discovery-toggle.md
@@ -1,0 +1,330 @@
+# Spec: LAN Discovery Toggle (HostPopover)
+
+**Branch:** `agenty/governance-widget-spec`
+**Status:** Draft — design
+**Date:** 2026-05-25
+**Author:** AgentY
+**Related:** `specs/lan-awareness-and-embedded-jekt-api.md`, `specs/windows-firewall-fix.md`, `specs/hostname-popover.md`, `specs/SPEC_GOVERNANCE_WIDGET_2026-05-25.md`
+
+---
+
+## TL;DR
+
+Add a **toggle switch** to the **HostPopover** (bottom-right status bar, the hostname
+chip). The toggle controls the existing `network:lan_discovery` setting and
+**starts/stops the mDNS daemon live** — no restart. The setting **stays opt-in**
+(`false` by default) so Windows users don't get a surprise firewall prompt on
+launch. Discovery becomes a discoverable, one-click affordance instead of a
+hidden settings.json key.
+
+---
+
+## Why
+
+Today the feature is gated behind a settings.json edit:
+
+- Setting: `network:lan_discovery: bool` — default `false`
+  (`agentmux-srv/src/backend/wconfig/types.rs:206-207`)
+- The HostPopover already detects the disabled state and shows the literal text
+  `Enable via "network:lan_discovery": true`
+  (`frontend/app/statusbar/HostPopover.tsx:144`)
+- mDNS daemon is started **once at boot** (`agentmux-srv/src/main.rs:601-620`).
+  Changing the setting requires a restart today.
+
+This is bad for two reasons:
+
+1. **Discoverability.** Operators see "LAN discovery disabled" and a string they
+   have to copy into a JSON file. Most never bother.
+2. **The opt-in *reason* (firewall) is invisible.** Users don't know why it's
+   off, only that it is.
+
+Why we keep it opt-in (and don't just flip the default):
+
+> `specs/windows-firewall-fix.md:117-118` — "Disable mDNS LAN discovery by default
+> → firewall popup gone. One config flag, zero risk, the feature already handles
+> failure gracefully."
+
+mDNS binds `0.0.0.0:5353 UDP`, which Windows Firewall intercepts. Flipping the
+default to `true` would resurrect the popup on every fresh Windows install. A
+UI toggle is the right middle ground: the user **initiates** the opt-in, so the
+firewall popup is the **expected consequence**, not a surprise.
+
+---
+
+## Where it lives
+
+The HostPopover is the rightmost item in the status bar (`frontend/app/statusbar/StatusBar.tsx:61-65`).
+Clicking the hostname opens a popover that already has a **Network** section
+between Instance/Host info and Ports.
+
+Current "disabled" state (HostPopover.tsx lines 139-147):
+
+```
+LAN discovery disabled
+Enable via "network:lan_discovery": true
+```
+
+This is exactly where the toggle goes — same lines, real control instead of
+literal text.
+
+---
+
+## UX
+
+### Disabled state (default)
+
+```
+┌─ desk-mac.local ─────────────────────────────┐
+│ OS    Windows 11                             │
+│ IP    192.168.1.42                           │
+│ ───────────────────────────────────────────  │
+│ Instance  a3f9-...                           │
+│ Host      cef                                │
+│ PID       18432                              │
+│ Data      C:\Users\asaf\.agentmux            │
+│ ───────────────────────────────────────────  │
+│ LAN discovery       [ off ⚪ ]               │
+│ Discover other AgentMux instances via mDNS.  │
+│ May prompt Windows Firewall on first enable. │
+│ ───────────────────────────────────────────  │
+│ IPC       64321                              │
+│ Backend   64322                              │
+│ ...                                          │
+└──────────────────────────────────────────────┘
+```
+
+### Enabled state, no peers yet
+
+```
+│ LAN discovery       [ on  🟢 ]               │
+│ No peers found yet                           │
+```
+
+### Enabled state, peers discovered
+
+```
+│ LAN discovery       [ on  🟢 ]               │
+│ ◆ 2 instances on LAN                         │
+│   pi-lab          v0.38.2                    │
+│   asaf-laptop     v0.38.4                    │
+```
+
+### After a fresh enable (first-time UX on Windows)
+
+The firewall prompt fires *immediately* when the daemon starts. Since the user
+just clicked the toggle, the prompt is intelligible: "AgentMux wants to access
+the network → Allow / Block." No mystery.
+
+If they **Block**, mDNS fails. We already handle that gracefully (`main.rs:613-615`
+`tracing::warn!("LAN discovery unavailable: {e}")`). The toggle UI should
+detect daemon-failure and surface it:
+
+```
+│ LAN discovery       [ on  🟢 ]               │
+│ ⚠ Blocked — check firewall settings          │
+```
+
+---
+
+## Behavior
+
+### Toggle semantics
+
+| User action | Setting write | Backend action |
+|------------|---------------|----------------|
+| OFF → ON | `set("network:lan_discovery", true)` | Start `LanDiscovery` daemon |
+| ON → OFF | `set("network:lan_discovery", false)` | Stop daemon, drop peer list |
+
+### Live daemon lifecycle (no restart required)
+
+This is the non-trivial part. Today, the daemon is constructed in `main.rs` and
+moved into `AppState.lan_discovery: Option<Arc<LanDiscovery>>` once at boot.
+
+**Change:** wrap the daemon slot in something that can be swapped at runtime,
+and subscribe to setting changes:
+
+```rust
+// AppState (agentmux-srv/src/server/mod.rs:69)
+pub lan_discovery: Arc<RwLock<Option<Arc<LanDiscovery>>>>,
+```
+
+ConfigWatcher already exists for hot-reload. Add a hook:
+
+```rust
+// When network:lan_discovery flips:
+config_watcher.on_change("network:lan_discovery", |new_val: bool, ctx| {
+    let mut slot = ctx.app_state.lan_discovery.write();
+    if new_val && slot.is_none() {
+        // OFF → ON
+        match LanDiscovery::start(ctx.instance_id.clone(),
+                                  ctx.hostname.clone(),
+                                  ctx.version.clone(),
+                                  ctx.port,
+                                  ctx.event_bus.clone()) {
+            Ok(d) => *slot = Some(d),
+            Err(e) => {
+                tracing::warn!("LAN discovery start failed: {e}");
+                ctx.event_bus.broadcast_event(&WSEventType {
+                    eventtype: "laninstances:error".to_string(),
+                    oref: String::new(),
+                    data: Some(json!({"error": e.to_string()})),
+                });
+            }
+        }
+    } else if !new_val && slot.is_some() {
+        // ON → OFF
+        *slot = None;  // Drop impl unregisters mDNS + shuts down daemon
+        // Broadcast empty list so frontend clears peers
+        ctx.event_bus.broadcast_event(&WSEventType {
+            eventtype: "laninstances".to_string(),
+            oref: String::new(),
+            data: Some(json!([])),
+        });
+    }
+});
+```
+
+The `Drop` impl on `LanDiscovery` (lines 218-228) already handles graceful
+unregister + shutdown. Re-creating is a clean re-run of `start()`.
+
+### Boot semantics (unchanged from spec's existing description)
+
+Boot still reads `network:lan_discovery` and starts the daemon if `true`. The
+only addition is the hot-reload hook. If the setting is missing from
+`settings.json`, default stays `false` (no behavior change).
+
+---
+
+## Implementation
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `frontend/app/statusbar/HostPopover.tsx` | Add toggle component to disabled-state block; keep peer list rendering for enabled-state |
+| `frontend/app/statusbar/StatusBar.scss` (or `_instance-panel.scss`) | Toggle styles (small switch, matches existing status-bar-item visuals) |
+| `frontend/app/store/global.ts` | Add `setLanDiscoveryEnabled(enabled: boolean)` helper (writes via SetConfigCommand) |
+| `agentmux-srv/src/server/mod.rs` | `AppState.lan_discovery: Arc<RwLock<Option<Arc<LanDiscovery>>>>` |
+| `agentmux-srv/src/server/mod.rs` | `handle_lan_instances` reads through the RwLock |
+| `agentmux-srv/src/main.rs` | Move initial start into a shared function; wire ConfigWatcher hook |
+| `agentmux-srv/src/backend/wconfig/config_watcher_fs.rs` (or wherever the watcher dispatches) | Add `network:lan_discovery` change hook |
+| `schema/settings.json` | Add missing `network:lan_discovery` entry (also fixes a current schema gap) |
+
+No new dependencies. `mdns-sd` is already in `Cargo.toml`. Setting write API
+(`SetConfigCommand`) already exists.
+
+### Frontend toggle component
+
+Small SolidJS component. No new library — reuse plain checkbox styled as a
+switch (matches the codebase's minimal-UI norm; existing styling lives in
+`_instance-panel.scss`).
+
+```tsx
+const LanDiscoveryToggle = (): JSX.Element => {
+    const enabled = () => !!settingsAtom()?.["network:lan_discovery"];
+    const handleToggle = async (e: Event) => {
+        const next = (e.target as HTMLInputElement).checked;
+        await invokeCommand("set_config", { "network:lan_discovery": next });
+    };
+    return (
+        <label class="status-bar-toggle">
+            <span class="status-bar-popover-label">LAN discovery</span>
+            <input type="checkbox" checked={enabled()} onChange={handleToggle} />
+        </label>
+    );
+};
+```
+
+`invokeCommand("set_config", {...})` is the existing path used elsewhere
+(e.g., `frontend/app/store/rpc-api.ts:396` `SetConfigCommand`).
+
+### State sync
+
+`settingsAtom` already mirrors the backend settings (via `wave:setsettings`
+events from ConfigWatcher). Toggle reads from `settingsAtom`, writes via RPC,
+and `settingsAtom` re-syncs on the WS broadcast. No new state plumbing.
+
+---
+
+## Edge cases
+
+1. **Firewall blocked.** Daemon `start()` fails. Backend broadcasts
+   `laninstances:error` with the error message. Frontend renders an inline
+   warning under the toggle. Setting stays `true` so the user can retry without
+   re-toggling.
+2. **Toggle clicked rapidly.** Setting writes are atomic. Daemon
+   start/stop are serialized by the `RwLock` on the slot. Worst case: one extra
+   start/stop cycle.
+3. **Setting edited externally** (someone edits `settings.json` while AgentMux
+   is running). ConfigWatcher already fires; the same hook handles it. UI
+   reflects the change automatically because `settingsAtom` is updated.
+4. **Multi-instance on same host.** Two AgentMux processes on the same Windows
+   box: the first to enable triggers the firewall once. The second uses the
+   same allowed rule. Both discover each other via loopback mDNS (mdns-sd
+   advertises on all interfaces including localhost).
+5. **Setting absent vs. `false`.** Same behavior — discovery off. UI shows
+   toggle off in both cases.
+6. **Network change** (Wi-Fi switch). mdns-sd handles interface changes
+   internally; no special UI behavior needed.
+
+---
+
+## Why not other approaches
+
+| Approach | Why not |
+|----------|---------|
+| Flip default to `true` | Reverses `windows-firewall-fix.md`. Surprises Windows users with firewall popup on every fresh install. |
+| First-run nudge modal | Heavyweight for a one-line setting. Modal fatigue. Also harder to revisit later. |
+| Settings widget only | Already exists (`/settings`), but it just opens `settings.json` in an external editor. Not in-app, not discoverable, not one-click. |
+| New top-level network widget | Premature — once governance widget lands, this lives there too. For now, HostPopover is the right scope. |
+
+---
+
+## Future work / open questions
+
+1. **Governance widget integration.** Once `SPEC_GOVERNANCE_WIDGET_2026-05-25.md`
+   ships, the Governance widget's L2 section will also expose this toggle.
+   HostPopover's toggle remains as a quick-access affordance; Governance is the
+   deep-dive surface. Both write the same setting.
+2. **Per-interface enable.** A future enhancement could let the user pick which
+   network interface mDNS advertises on (e.g., enable on Wi-Fi but not on a VPN
+   tunnel). Out of scope here.
+3. **Same-host vs LAN split.** Loopback-only mDNS for same-host discovery
+   (no firewall trigger) plus opt-in LAN — discussed in the governance spec.
+   Bigger change, separate PR.
+4. **Visual indicator of firewall-pending state.** On Windows, after the user
+   toggles ON, the daemon `start()` may succeed at bind but actual mDNS traffic
+   may still be blocked pending the user's firewall decision. We can't easily
+   detect this. v1 just trusts `start()`'s return value.
+
+---
+
+## Test plan
+
+- [ ] Default settings: HostPopover shows toggle in OFF state
+- [ ] Click toggle ON: setting persists in `settings.json`, daemon starts, no
+      app restart
+- [ ] Within ~5s, peer instance on same host shows in the popover peer list
+- [ ] Click toggle OFF: daemon stops, peer list clears within ~1s
+- [ ] On Windows, first-time ON triggers firewall prompt; clicking Allow lets
+      mDNS proceed
+- [ ] On Windows, first-time ON + Block surfaces "Blocked — check firewall
+      settings" in the popover
+- [ ] Edit `settings.json` externally to flip the value: UI updates without
+      manual refresh
+- [ ] Cargo check / cargo build pass with `Arc<RwLock<Option<Arc<LanDiscovery>>>>`
+      lifetime changes
+- [ ] Existing `/api/lan-instances` endpoint still returns correct list
+
+---
+
+## Acceptance criteria
+
+- [ ] Toggle visible in HostPopover's Network section, regardless of enabled
+      state
+- [ ] Toggle persists state across app restarts
+- [ ] No app restart required to apply the change
+- [ ] Default behavior unchanged on fresh install (opt-in)
+- [ ] `schema/settings.json` includes `network:lan_discovery`
+- [ ] Failure modes (firewall blocked, daemon start error) are visible in the
+      popover, not silent

--- a/specs/lan-discovery-toggle.md
+++ b/specs/lan-discovery-toggle.md
@@ -4,7 +4,7 @@
 **Status:** Draft — design
 **Date:** 2026-05-25
 **Author:** AgentY
-**Related:** `specs/lan-awareness-and-embedded-jekt-api.md`, `specs/windows-firewall-fix.md`, `specs/hostname-popover.md`, `specs/SPEC_GOVERNANCE_WIDGET_2026-05-25.md`
+**Related:** `specs/lan-awareness-and-embedded-jekt-api.md`, `specs/windows-firewall-fix.md`, `specs/hostname-popover.md`, `specs/SPEC_WARDEN_WIDGET_2026-05-25.md`
 
 ---
 
@@ -224,7 +224,7 @@ const LanDiscoveryToggle = (): JSX.Element => {
     const enabled = () => !!settingsAtom()?.["network:lan_discovery"];
     const handleToggle = async (e: Event) => {
         const next = (e.target as HTMLInputElement).checked;
-        await invokeCommand("set_config", { "network:lan_discovery": next });
+        await RpcApi.SetConfigCommand(TabRpcClient, { "network:lan_discovery": next } as any);
     };
     return (
         <label class="status-bar-toggle">
@@ -235,8 +235,11 @@ const LanDiscoveryToggle = (): JSX.Element => {
 };
 ```
 
-`invokeCommand("set_config", {...})` is the existing path used elsewhere
-(e.g., `frontend/app/store/rpc-api.ts:396` `SetConfigCommand`).
+`RpcApi.SetConfigCommand(TabRpcClient, {...})` is the established settings-write
+path used elsewhere (e.g. `frontend/app/menu/base-menus.ts:71`,
+`frontend/app/window/action-widgets.tsx:85`,
+`frontend/app/tab/tabbar.tsx:614`). It wraps the `setconfig` RPC defined in
+`frontend/app/store/rpc-api.ts:396`.
 
 ### State sync
 
@@ -276,15 +279,15 @@ and `settingsAtom` re-syncs on the WS broadcast. No new state plumbing.
 | Flip default to `true` | Reverses `windows-firewall-fix.md`. Surprises Windows users with firewall popup on every fresh install. |
 | First-run nudge modal | Heavyweight for a one-line setting. Modal fatigue. Also harder to revisit later. |
 | Settings widget only | Already exists (`/settings`), but it just opens `settings.json` in an external editor. Not in-app, not discoverable, not one-click. |
-| New top-level network widget | Premature — once governance widget lands, this lives there too. For now, HostPopover is the right scope. |
+| New top-level network widget | Premature — once the Warden widget lands, this lives there too. For now, HostPopover is the right scope. |
 
 ---
 
 ## Future work / open questions
 
-1. **Governance widget integration.** Once `SPEC_GOVERNANCE_WIDGET_2026-05-25.md`
-   ships, the Governance widget's L2 section will also expose this toggle.
-   HostPopover's toggle remains as a quick-access affordance; Governance is the
+1. **Warden integration.** Once `SPEC_WARDEN_WIDGET_2026-05-25.md`
+   ships, the Warden's L2 section will also expose this toggle.
+   HostPopover's toggle remains as a quick-access affordance; the Warden is the
    deep-dive surface. Both write the same setting.
 2. **Per-interface enable.** A future enhancement could let the user pick which
    network interface mDNS advertises on (e.g., enable on Wi-Fi but not on a VPN


### PR DESCRIPTION
> **What this PR ships:** Operator-facing toggle that turns LAN discovery on/off live from the status bar, without restart. Plus the broader **Warden** widget design spec it's the first step of.
>
> **Shape-level discussion:** #1033 (Warden Widget RFC)

## Summary

Two specs and one focused implementation:

1. **`specs/SPEC_WARDEN_WIDGET_2026-05-25.md`** — design for the Warden, a 3-layer (Host / LAN / Internet) operator surface that maps 1:1 onto the existing jekt cascade. Not implemented in this PR — opens the design conversation. Renamed from "Governance Widget" — Warden fits the existing widget vocabulary (swarm, drone, forge) without bureaucratic baggage.

2. **`specs/lan-discovery-toggle.md`** — design for the first operator-facing piece: turn mDNS LAN discovery on/off from the HostPopover.

3. **Implementation of #2** — see below.

## Why

The mDNS LAN discovery substrate already shipped (gated behind `network:lan_discovery` setting, off by default per `windows-firewall-fix.md`). Today, enabling it means editing `settings.json` and restarting. Today's popover literally says:

> Enable via `"network:lan_discovery": true`

This PR replaces that string with a real toggle, and makes flipping the setting take effect immediately — no restart.

**The default stays off** — we don't reverse `windows-firewall-fix.md`. The toggle simply makes the opt-in discoverable. Because the user *initiates* the enable, the Windows Firewall prompt becomes the expected consequence of clicking the toggle, not a surprise on app launch.

## Implementation

Backend:
- New `LanDiscoveryController` (`agentmux-srv/src/backend/lan_discovery.rs`) — wraps the mDNS daemon in a swappable slot. `apply(enabled)` is idempotent: starts the daemon if enabled & not running, stops it if disabled & running. On start failure (e.g. firewall blocked), broadcasts `laninstances:error` for the UI to surface.
- `AppState.lan_discovery` is now `Arc<LanDiscoveryController>` (previously `Option<Arc<LanDiscovery>>`).
- `main.rs` constructs the controller on boot and calls `apply` with the current setting, preserving boot semantics.
- The setconfig WS handler captures the controller in its closure and calls `apply(merged_settings.network_lan_discovery)` after every settings update. Idempotent so no special-casing needed.

Frontend:
- `HostPopover.tsx` — toggle component in the Network section. Calls `RpcApi.SetConfigCommand({"network:lan_discovery": next})`. Shows "Searching for peers…" when on with no peers, "⚠ {error}" when daemon failed to start.
- `global.ts` — new `lanDiscoveryErrorAtom`, subscribed to `laninstances:error` event.
- `StatusBar.scss` — small toggle-switch styling.

Schema:
- `schema/settings.json` gains the missing `network:lan_discovery` entry (this was a pre-existing schema gap unrelated to this PR — fixing it here is opportunistic).

## Review feedback addressed

- **P0 release-consistency mismatch** — resolved by rebase onto current main (0.38.3 across VERSION_HISTORY, package.json, Cargo.toml).
- **P1 `lan_discovery.rs:285`** — broadcast payload now uses `e.to_string()` to make the string-on-the-wire contract explicit (frontend reads `event.data.error` as a string).
- **P1 `HostPopover.tsx:53`** — the impl was correct (`RpcApi.SetConfigCommand(TabRpcClient, ...)` matches `base-menus.ts:71`, `action-widgets.tsx:85`, `tabbar.tsx:614`). The toggle spec snippet was the one with the bug; the spec is now updated to match the established pattern.

## Out of scope (documented in spec § Edge cases)

External edits to `settings.json` still require a restart to live-toggle the daemon. Threading the controller through `spawn_settings_watcher` was deferred to keep the diff focused. The toggle UI is the primary path; external edits are the rare case.

## Verification

- `cargo check -p agentmux-srv` — passes
- `npx tsc --noEmit` — passes for all files this PR touches (pre-existing TS errors in unrelated files persist)

## Manual smoke test

1. Run two instances of AgentMux on the same host (or one host + one LAN peer)
2. Open the HostPopover (bottom-right hostname chip) on both
3. Click the **LAN discovery** toggle to ON
   - On Windows first-time: firewall prompt appears — Allow
4. Within ~5s, each instance should see the other in the popover under "◆ N peers"
5. Toggle OFF: peer list clears within ~1s, daemon stops
6. Verify `~/.agentmux/config/settings.json` reflects the toggle state