### PR TITLE
diag(cef): instrument browser-pane auth callback + load-error entry points

### DIFF
--- a/.changesets/1779716363-diag-cef-instrument-on-auth-credentials-on-load-error-entry--lr3h.md
+++ b/.changesets/1779716363-diag-cef-instrument-on-auth-credentials-on-load-error-entry--lr3h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(cef): instrument on_auth_credentials + on_load_error entry points (browser-pane auth diagnosis)

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1128,6 +1128,31 @@ impl AgentMuxHandler {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
         let error_code_raw = sys::cef_errorcode_t::from(error_code);
+
+        // [DIAG] Unconditional entry log — captures every load error
+        // BEFORE the ERR_ABORTED filter, sub-frame filter, or fallback-
+        // page render. Pair with `[browser-pane-auth][ENTRY]` to
+        // diagnose the auth-modal-doesn't-appear path: if we see a
+        // load-error here with no preceding auth-credentials entry,
+        // CEF skipped the auth flow entirely.
+        let failed_url_dbg = failed_url.map(CefString::to_string).unwrap_or_default();
+        let error_text_dbg = error_text.map(CefString::to_string).unwrap_or_default();
+        // `as_ref()` + auto-deref on `&&mut Frame` — relies only on
+        // `is_main(&self)` resolving through normal method-call deref,
+        // not on `Deref` for the `Option::as_deref()` blanket impl.
+        let is_main_frame = match frame.as_ref() {
+            Some(f) => f.is_main() == 1,
+            None => false,
+        };
+        tracing::info!(
+            "[load-error][ENTRY] url={:?} error={:?} ({}) is_main_frame={} aborted={}",
+            failed_url_dbg,
+            error_text_dbg,
+            error_code_raw as i32,
+            is_main_frame,
+            error_code_raw == sys::cef_errorcode_t::ERR_ABORTED,
+        );
+
         if error_code_raw == sys::cef_errorcode_t::ERR_ABORTED {
             return;
         }
@@ -1450,6 +1475,35 @@ impl AgentMuxHandler {
         _scheme: Option<&CefString>,
         callback: Option<&mut AuthCallback>,
     ) -> ::std::os::raw::c_int {
+        // [DIAG] Top-of-function entry log — fires unconditionally before
+        // every early-return so we can confirm whether CEF is invoking
+        // the callback at all for a given URL. The reagent-merged
+        // browser-pane auth flow (#906) appeared to fail silently for
+        // some sites in dev mode (e.g. https://pulse.asaf.cc returns
+        // ERR_INVALID_AUTH_CREDENTIALS without `[browser-pane-auth]`
+        // ever logging). This entry log narrows the diagnosis:
+        //   - Visible → CEF is calling the callback; early return below
+        //     OR downstream path is the problem.
+        //   - Not visible → CEF is suppressing the call entirely
+        //     (caching, security policy, missing vtable wire-up).
+        // Logs `origin/host/port/realm/is_proxy/has_browser/has_callback`
+        // so all the discriminators are captured even on the silent-
+        // decline branches that follow.
+        let origin_dbg = origin_url.map(CefString::to_string).unwrap_or_default();
+        let host_dbg = host.map(CefString::to_string).unwrap_or_default();
+        let realm_dbg = realm.map(CefString::to_string).unwrap_or_default();
+        tracing::info!(
+            "[browser-pane-auth][ENTRY] origin={:?} host={:?}:{} realm={:?} \
+             is_proxy={} has_browser={} has_callback={}",
+            origin_dbg,
+            host_dbg,
+            port,
+            realm_dbg,
+            is_proxy != 0,
+            browser.is_some(),
+            callback.is_some(),
+        );
+
         // Resolve the pane block_id from the browser ref. If this isn't
         // a browser-pane browser (i.e. it's the host frontend's browser),
         // we have no UI to prompt — decline and let CEF fail the
@@ -1467,6 +1521,14 @@ impl AgentMuxHandler {
             return 0;
         };
         let Some(cb) = callback else {
+            // [DIAG] Previously silent. If we reach here CEF gave us a
+            // browser + a resolvable pane block_id but no callback —
+            // an unusual combination worth logging so the diagnosis
+            // path doesn't have a blind spot.
+            tracing::warn!(
+                "[browser-pane-auth] callback is None (block={}) — declining",
+                block_id,
+            );
             return 0;
         };
 


### PR DESCRIPTION
**Diagnosis-only PR.** No behavior change — three `tracing::*!` calls added.

## Why

`https://pulse.asaf.cc` returns proper `401 WWW-Authenticate: Basic realm=\"Secure Area\"` (verified via `curl -I`), but in the browser pane the navigation fails with `ERR_INVALID_AUTH_CREDENTIALS (-338)` and renders the AgentMux \"Failed to load frontend\" fallback page. The HTTP Basic auth modal never appears.

Investigation: `[browser-pane-auth]` log lines from PR #906's `on_auth_credentials` callback are **completely absent** from `cef-debug.log` for the failing URL. Can't tell from the current logs whether:

- CEF never invoked `on_auth_credentials` (vtable issue, cached failure, security policy) — OR
- CEF invoked it but one of the silent early-return paths fired

## What this adds

| Log line | Location | Captures |
|---|---|---|
| `[browser-pane-auth][ENTRY]` | Top of `on_auth_credentials` BEFORE every early return | origin / host / port / realm / is_proxy / has_browser / has_callback |
| `[load-error][ENTRY]` | Top of `on_load_error` BEFORE ERR_ABORTED filter + sub-frame filter | url / error / is_main_frame / aborted |
| `[browser-pane-auth] callback is None` | Previously-silent early return | block_id (so we know which pane) |

Zero new RPC, no schema change, no UI change.

## Decision tree after merge

After `task dev` rebuilds the host:

1. Reproduce: navigate browser pane to `https://pulse.asaf.cc`.
2. Tail `~/.agentmux/dev/<branch>/logs/cef-debug.log` for `[browser-pane-auth][ENTRY]` and `[load-error][ENTRY]`.
3. Diagnosis branch:
   - **`[browser-pane-auth][ENTRY]` visible** → CEF IS calling the callback. The bug is downstream (callback resolution, event dispatch, modal rendering). Check the immediate next log lines for which early-return fired or what the event dispatch path showed.
   - **`[browser-pane-auth][ENTRY]` absent + `[load-error][ENTRY]` for the same URL** → CEF is suppressing the auth callback entirely. Likely root causes: HTTP cache has cached \"no creds\" response, security policy rejecting the 401 before auth flow, or vtable wire-up gap in the CEF binding.

## What this PR does NOT fix

- The actual auth bug (waiting on diagnosis).
- A separate known bug: `on_load_error` renders the \"Failed to load AgentMux frontend\" page (intended for the host frontend at localhost:5173) for **any** browser-pane load error. That's wrong UI but cosmetic; will be fixed in a follow-up PR.

## Test plan

- After merge → `task dev` rebuild → reload host → navigate to pulse.asaf.cc → check `cef-debug.log` for the new `[ENTRY]` lines.
- No automated test surface — this is unconditional `tracing::info!` plumbing.

## Build status

Local `cargo check -p agentmux-cef` blocked by a separate cef-dll-sys build-dir corruption (rename collision between half-extracted artifacts; unrelated to the diff). The diff is purely additive `tracing::*!` calls so syntactic risk is minimal. Bot review will catch any compile issue, and post-merge `task dev` will surface it cleanly. If it doesn't compile we can revert/amend without losing diagnostic value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)