### PR TITLE
feat(browser-pane): wrap browser view in pane-scope ModalLayer — HTTP auth modal locks only the pane

### DIFF
--- a/.changesets/1779722120-feat-browser-pane-wrap-browser-view-in-pane-scope-modallayer-9b82.md
+++ b/.changesets/1779722120-feat-browser-pane-wrap-browser-view-in-pane-scope-modallayer-9b82.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(browser-pane): wrap browser view in pane-scope ModalLayer (auth modal locks only the pane)

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -3,6 +3,7 @@
 
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+import { ModalLayer } from "@/element/ModalLayer";
 import { useModalLayer } from "@/element/modal-layer";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
@@ -18,7 +19,33 @@ function tagElement(el: Element | null): string {
     return `${t}${id ? `#${id}` : ""}${cls ? `.${cls}` : ""}`;
 }
 
+/**
+ * Pane-scope modal host. Wraps the browser-pane content in a
+ * `<ModalLayer scope="pane">` so any `useModalLayer()` call inside
+ * resolves to THIS layer rather than the outer tab-scope one
+ * (from `tabcontent.tsx`). The HTTP Basic / Digest auth modal that
+ * fires on a 401-protected URL then locks only this pane —
+ * everything else in the tab (sibling panes, tab bar, title bar)
+ * stays interactive.
+ *
+ * Split into a thin outer + inner so the inner's `useModalLayer()`
+ * call (line below) resolves against the wrapper's context, not the
+ * caller's. Solid's hook resolves up the JSX tree at execution time,
+ * so the consumer must be a CHILD of the provider — putting the
+ * `useModalLayer()` call in the same function body as the
+ * `<ModalLayer>` JSX would have it resolve to the outer (tab) layer
+ * instead.
+ * SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md §5 (browser-auth follow-up).
+ */
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
+    return (
+        <ModalLayer scope="pane">
+            <BrowserViewInner model={props.model} />
+        </ModalLayer>
+    );
+}
+
+function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
     const model = props.model;
     const modalLayer = useModalLayer();
     const _diagTag = `[browser-pane:diag][${model.blockId.slice(0, 7)}]`;


### PR DESCRIPTION
**Follow-up to [#1037](https://github.com/agentmuxai/agentmux/pull/1037).** The auth modal now fires (per #1037), but as a TAB modal — sibling panes go inert. This PR makes it pane-scope.

## Before

After #1037 landed and `OnGetAuthCredentials` started firing, `useModalLayer()` inside `browser-view.tsx` resolved to the OUTER tab-scope `ModalLayer` (from `tabcontent.tsx`) because the browser pane didn't wrap itself in its own pane-scope layer. So the HTTP Basic auth modal opened with the **tab** as its lock region — backdrop covered the whole tab, sibling panes (terminal, agent, another browser) went inert.

User confirmed during dev smoke: \"modal appeared .. can it be made a pane modal? (right now its a tab modal right?)\".

## Fix

Splits `BrowserViewComponent` into a thin outer wrapper + inner function:

```tsx
export function BrowserViewComponent(props): JSX.Element {
    return (
        <ModalLayer scope=\"pane\">
            <BrowserViewInner model={props.model} />
        </ModalLayer>
    );
}

function BrowserViewInner(props): JSX.Element {
    // ... all existing logic, including `useModalLayer()` ...
}
```

The split is required because Solid's hook resolves up the JSX tree at execution time. Putting both the `<ModalLayer>` JSX and the `useModalLayer()` call in the same function body would have the hook resolve to the OUTER (tab) layer — the wrapper hasn't been mounted by the time the hook runs. Splitting ensures the consumer is a CHILD of the provider, so context resolution lands on the pane-scope layer. Same pattern as `AgentViewWrapper` in #1034.

## Effect

When a browser pane navigates to a 401-protected URL:
- Modal backdrop covers only the browser pane.
- `inert` locks only the browser pane content.
- All other panes in the tab (terminal, agent, another browser) stay clickable + scrollable.
- Tab bar + title bar untouched.

Two browser panes hitting concurrent 401s in the same tab can each show their own modal independently (modal-stack semantics per `SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21` §6 already account for non-overlapping pane locks).

## Tests

- **1028 / 1028 vitest pass.**
- `browser-model.test.ts` (10/10) unchanged.
- No new test surface needed; the change is structural (component wrapping) with no logic change in the inner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)