### PR TITLE
fix(term): use document.fonts.load() to force-load Hack before first fit (#1030 follow-up)

### DIFF
--- a/.changesets/1779725954-fix-term-use-document-fonts-load-to-force-load-hack-before-f-yo5i.md
+++ b/.changesets/1779725954-fix-term-use-document-fonts-load-to-force-load-hack-before-f-yo5i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): use document.fonts.load() to force-load Hack before first fit (#1030 follow-up)

--- a/docs/terminal-jumbled-startup-investigation.md
+++ b/docs/terminal-jumbled-startup-investigation.md
@@ -76,3 +76,91 @@ Three changes in `frontend/app/view/term/termwrap.ts`:
 
 Together these eliminate the three known root causes: pre-font-load
 measurement, NaN propagation, and post-mount layout shift.
+
+## Follow-up — PR #1030 was insufficient (2026-05-25)
+
+After PR #1030 merged, the jumbled-glyph repro **resurfaced** when opening
+multiple terminal panes in quick succession on a cold cache. Diagnosis:
+
+`await document.fonts.ready` is **not** the right primitive. Per the CSS
+Font Loading spec, `fonts.ready` returns a Promise that resolves when no
+currently-pending font loads remain. It does **not** request specific fonts.
+Browsers load web fonts lazily — the WOFF/WOFF2 download for `Hack` is only
+kicked off when something actually needs to render a glyph in that family.
+
+In `TermWrap.init()` the sequence was:
+
+1. `terminal.open()` mounts the xterm DOM with `font-family: Hack`. The
+   browser sees the rule but **does not request `Hack` yet** — nothing has
+   asked it to paint a glyph in that family.
+2. `await document.fonts.ready` — the FontFaceSet has zero pending loads
+   *at this instant*, so the Promise resolves immediately.
+3. `customFit()` → `proposeDimensions()` measures cell width. The
+   measurement step is what finally triggers `Hack` to be requested, but
+   the measurement returns synchronously using fallback metrics.
+4. Wrong `cols` → `sendTermSize()` informs PTY of wrong size →
+   `resyncController("init")` spawns shell → Ink emits cursor sequences
+   sized to the wrong cols → jumbled.
+
+The rAF re-fit a frame later would catch this *if* the `Hack` request
+completed within that frame, but on cold cache it typically takes
+20–300ms. By then Ink has already painted corrupted output that survives
+the eventual SIGWINCH redraw (cursor-positioning sequences already issued
+against the wrong dimensions cannot be undone by resizing).
+
+When opening multiple terminals in parallel, each `TermWrap.init()` hits
+the same race independently. After the first successful Hack load, the
+browser caches the face and later terminals measure correctly — but the
+*first* terminal (and any others racing alongside it) lose.
+
+### Proper fix
+
+Replace `await document.fonts.ready` with
+`await document.fonts.load(`${fontSize}px "${fontFamily}"`)`. The `load()`
+method **actively requests** the named face and resolves only when that
+specific face is ready. Subsequent calls in parallel terminals coalesce
+on the browser's font cache, so opening N panes pays the network cost
+once.
+
+We also load `bold` and `italic` variants in parallel, because xterm.js
+renders bold/italic cells with separate font faces. Without those
+pre-loads, the first bold or italic glyph triggers another lazy fetch
+and the same race recurs at smaller scale.
+
+The bounded timeout (1s) and the rAF re-fit afterwards are kept as
+belt-and-suspenders.
+
+```ts
+const FIT_FONT_TIMEOUT_MS = 1000;
+const fontFamily = this.terminal.options.fontFamily ?? "Hack";
+const fontSize = this.terminal.options.fontSize ?? 12;
+const fontSpec = (variant: string) => `${variant}${fontSize}px "${fontFamily}"`;
+try {
+    await Promise.race([
+        Promise.all([
+            document.fonts?.load(fontSpec("")) ?? Promise.resolve(),
+            document.fonts?.load(fontSpec("bold ")) ?? Promise.resolve(),
+            document.fonts?.load(fontSpec("italic ")) ?? Promise.resolve(),
+        ]),
+        new Promise<void>((resolve) => setTimeout(resolve, FIT_FONT_TIMEOUT_MS)),
+    ]);
+} catch (_) { /* font API unavailable or face unknown — fall through */ }
+```
+
+### Other xterm mounts not yet touched
+
+`AgentInstallModal.tsx` constructs its own `new Terminal()` with its own
+`FitAddon` and calls `fitAddon.fit()` immediately, with no font-load wait.
+The install modal renders short ANSI status lines, not full TUIs, so the
+practical impact is small — but the same race exists. Fix at the same
+time or in a follow-up; the pattern is identical.
+
+### References (additions)
+
+- MDN — `FontFaceSet.load()`:
+  <https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/load>
+  *"Resolves once the requested fonts have all loaded."*
+- CSS Font Loading Module Level 3, §3.4 The FontFaceSet Interface:
+  <https://drafts.csswg.org/css-font-loading-3/#font-face-set-interface>
+- xterm.js #4830 — multiple users hit this exact pattern with web fonts;
+  consensus workaround is `document.fonts.load()` before `fit()`.

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -249,7 +249,34 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 /* container still 0×0 — wait for next resize */
             }
         };
-        tryFit();
+        // Force-load the term font BEFORE the first fit so cell-width
+        // measurement uses real glyph metrics, not fallback (Courier).
+        // Same race as termwrap.ts — see
+        // docs/terminal-jumbled-startup-investigation.md "Follow-up".
+        // fonts.load() actively requests the face and resolves when ready;
+        // fonts.ready alone is vacuous because the WOFF/WOFF2 isn't
+        // requested until something measures a glyph.
+        const FIT_FONT_TIMEOUT_MS = 1000;
+        const fontSpec = (variant: string) => `${variant}12px ${termFont}`;
+        const fontsReady = (async () => {
+            try {
+                await Promise.race([
+                    Promise.all([
+                        document.fonts?.load(fontSpec("")) ?? Promise.resolve(),
+                        document.fonts?.load(fontSpec("bold ")) ?? Promise.resolve(),
+                        document.fonts?.load(fontSpec("italic ")) ?? Promise.resolve(),
+                    ]),
+                    new Promise<void>((resolve) =>
+                        setTimeout(resolve, FIT_FONT_TIMEOUT_MS),
+                    ),
+                ]);
+            } catch (_) { /* font API unavailable — fall through */ }
+        })();
+        void fontsReady.then(() => {
+            if (disposed) return;
+            tryFit();
+        });
+        tryFit(); // best-effort initial fit (often fallback metrics on cold cache)
         // Refit on container resize. The modal may animate in from
         // 0×0; without an observer the terminal stays at the default
         // 80×24 indefinitely.

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -232,24 +232,50 @@ export class TermWrap {
             this.loaded = true;
         }
 
-        // Wait for web fonts to load before the first fit, but with a bounded timeout.
-        // proposeDimensions() measures rendered cell width from the DOM; if the configured
-        // term font (e.g. Hack) hasn't loaded yet, FitAddon uses fallback metrics and computes
-        // wrong cols, the PTY is told the wrong size, and TUIs (Ink/Claude Code) emit cursor
-        // sequences that don't line up — visible as jumbled glyphs until the next resize.
+        // Force-load the configured term font BEFORE the first fit, with a bounded
+        // timeout. proposeDimensions() measures rendered cell width from the DOM; if
+        // the configured term font (e.g. Hack) hasn't loaded yet, FitAddon uses fallback
+        // metrics and computes wrong cols, the PTY is told the wrong size, and TUIs
+        // (Ink/Claude Code) emit cursor sequences that don't line up — visible as
+        // jumbled glyphs until the next resize.
         //
-        // The timeout is essential: document.fonts.ready can hang under certain conditions
-        // (frontend/app-init.ts wraps the app-level wait in a 2s race for the same reason).
-        // Without it, a stalled font load would block sendTermSize()/resyncController("init")
-        // and the pane's PTY would never start. The rAF re-fit below catches the case where
-        // the font lands just after the timeout, so a missed wait isn't fatal.
+        // Why `document.fonts.load(spec)` and not `document.fonts.ready`:
+        //   - `fonts.ready` only awaits font faces that are ALREADY pending. Web fonts
+        //     are loaded lazily — the browser doesn't request the term font's WOFF/WOFF2
+        //     until something actually renders a glyph in that family. `terminal.open()`
+        //     above mounts the DOM but the font request typically isn't initiated until
+        //     `proposeDimensions()` measures a cell. So `await fonts.ready` resolves
+        //     vacuously (no pending loads) and `customFit()` then measures with fallback
+        //     metrics. This was the hole left by PR #1030's first cut — the same jumbled
+        //     glyphs reproduced when opening multiple terminals fast.
+        //   - `fonts.load("12px Hack")` actively REQUESTS the font and resolves only
+        //     when that specific face is ready. Subsequent terminals coalesce on the
+        //     same browser-level cache entry, so opening N panes in parallel waits
+        //     once.
+        //
+        // The timeout is essential: a stalled font load would block
+        // sendTermSize()/resyncController("init") and the pane's PTY would never start
+        // (`frontend/app-init.ts` wraps the app-level wait in a 2s race for the same
+        // reason). The rAF re-fit below catches the case where the font lands just
+        // after the timeout.
+        //
+        // We load the regular + bold + italic variants xterm.js uses, in parallel.
+        // Browsers dedupe identical font face requests, so this costs ~one network
+        // round-trip total on cold cache.
         const FIT_FONT_TIMEOUT_MS = 1000;
+        const fontFamily = this.terminal.options.fontFamily ?? "Hack";
+        const fontSize = this.terminal.options.fontSize ?? 12;
+        const fontSpec = (variant: string) => `${variant}${fontSize}px "${fontFamily}"`;
         try {
             await Promise.race([
-                document.fonts?.ready ?? Promise.resolve(),
+                Promise.all([
+                    document.fonts?.load(fontSpec("")) ?? Promise.resolve(),
+                    document.fonts?.load(fontSpec("bold ")) ?? Promise.resolve(),
+                    document.fonts?.load(fontSpec("italic ")) ?? Promise.resolve(),
+                ]),
                 new Promise<void>((resolve) => setTimeout(resolve, FIT_FONT_TIMEOUT_MS)),
             ]);
-        } catch (_) { /* font API unavailable — fall through with fallback metrics */ }
+        } catch (_) { /* font API unavailable or face unknown — fall through */ }
 
         // NOW fit and tell backend to start/resync the shell controller.
         // At this point we are fully subscribed and ready to receive data.


### PR DESCRIPTION
## Summary

Follow-up to PR #1030. The jumbled-glyph repro **resurfaced** when opening
multiple terminal panes in quick succession on a cold cache — user-reported on
2026-05-25 against the latest dev build (which already contains #1030).

## Why #1030 was insufficient

`await document.fonts.ready` was the wrong primitive. Per the CSS Font Loading
spec, `fonts.ready` returns a Promise that resolves when no font loads are
currently pending. It does **not** request specific fonts.

Browsers load web fonts lazily — the WOFF/WOFF2 for `Hack` is not requested
until something actually renders a glyph in that family. In `TermWrap.init()`:

1. `terminal.open()` mounts the xterm DOM with `font-family: Hack`. Browser
   sees the rule but does **not** request `Hack` yet (nothing has asked it to
   paint a glyph in that family).
2. `await document.fonts.ready` resolves **immediately** — zero pending loads.
3. `customFit()` → `proposeDimensions()` measures cell width. The measurement
   step is what finally triggers `Hack` to be requested, but
   `proposeDimensions()` returns synchronously using fallback metrics.
4. Wrong `cols` → SIGWINCH at wrong size → PTY spawns → Ink emits cursor
   sequences sized to wrong cols → jumbled glyphs.

The rAF re-fit a frame later cannot undo cursor-positioning sequences Ink has
already issued against the wrong dimensions. Resize/zoom "clicked it into
place" because that triggered a fresh full redraw.

## Fix

Replace `fonts.ready` with `document.fonts.load(`${fontSize}px "${fontFamily}"`)`.

`load()` actively **requests** the named face and resolves only when that face
is available. Parallel terminals coalesce on the browser font cache, so
opening N panes in parallel pays the network cost once.

Also pre-load `bold` and `italic` variants xterm.js uses (cells render with
separate font faces; without pre-load the first bold/italic glyph would
trigger the same race at smaller scale).

The 1s bounded race and post-init rAF re-fit from #1030 are kept as
belt-and-suspenders.

## Other xterm mount: AgentInstallModal

Applied the same pattern to the install modal's parallel `new Terminal()` /
`fitAddon.fit()` codepath. Lower practical impact (renders short npm output,
not a TUI), but the same race is present.

## Files

- `frontend/app/view/term/termwrap.ts` — swap `fonts.ready` for explicit
  `fonts.load()` of regular + bold + italic.
- `frontend/app/view/agent/components/AgentInstallModal.tsx` — same pattern.
- `docs/terminal-jumbled-startup-investigation.md` — added "PR #1030 was
  insufficient" follow-up section with the spec analysis and final fix.

Changeset: `patch` (RFC #857 Phase 2 workflow — no version bump in this PR).

## Test plan

- [x] `npx tsc --noEmit` on edited files — clean.
- [ ] `task dev` running with HMR — open ≥3 fresh terminal panes back-to-back
      on a cold cache (kill DEV data dir to force), verify no jumbled output
      and Claude Code's prompt renders correctly first time.
- [ ] Open the agent install modal cold-cache, verify the xterm container
      sizes correctly on first paint (no fallback-font overshoot).
- [ ] Compare cold vs warm cache — once Hack is in the browser cache the
      `fonts.load()` resolves synchronously so there's no perceptible delay.

## References

- MDN — `FontFaceSet.load()` —
  <https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/load>
- CSS Font Loading Module Level 3, §3.4 —
  <https://drafts.csswg.org/css-font-loading-3/#font-face-set-interface>
- xterm.js #4830 — community consensus workaround is `fonts.load()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)