### PR TITLE
fix(term): move document.fonts.load() BEFORE terminal.open() — xterm caches metrics at open() time (#1040 follow-up)

### DIFF
--- a/.changesets/1779727244-fix-term-move-document-fonts-load-before-terminal-open-xterm-xm64.md
+++ b/.changesets/1779727244-fix-term-move-document-fonts-load-before-terminal-open-xterm-xm64.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): move document.fonts.load() BEFORE terminal.open() — xterm caches metrics at open() time (#1040 follow-up)

--- a/docs/terminal-jumbled-startup-investigation.md
+++ b/docs/terminal-jumbled-startup-investigation.md
@@ -147,6 +147,71 @@ try {
 } catch (_) { /* font API unavailable or face unknown — fall through */ }
 ```
 
+## Follow-up #2 — PR #1040 also insufficient (2026-05-25, hours later)
+
+After PR #1040 merged and the dev process was restarted to clear the
+FontFaceSet, the user reported the jumbled glyphs STILL reproduced when
+opening many terminals in parallel — "happens more often when I load
+many terminals at once, it's a timing issue."
+
+The real bug: **xterm.js caches cell-width metrics at `terminal.open()`
+time**, using whatever font is currently rendering at that moment. If
+Hack hasn't loaded yet when `open()` runs, xterm caches fallback
+(Courier) metrics into its render service's dimensions object.
+`FitAddon.proposeDimensions()` reads that cached width — not a fresh
+DOM measurement — so it returns wrong cols *forever*, regardless of
+whether Hack has loaded later. The font visually swaps in when it
+finishes loading, but the cached cell width does not invalidate.
+
+Both #1030 and #1040 placed the `await fonts.ready` / `fonts.load(...)`
+**after** `terminal.open()`, which was always too late. The post-open
+await closed the race for proposeDimensions reading the DOM, but
+proposeDimensions doesn't read the DOM — it reads xterm's cached
+metrics. With many terminals opening in parallel, all of them hit
+`open()` before any `fonts.load(...)` resolves, and every one of them
+caches fallback metrics.
+
+### Correct fix (PR #1041)
+
+Await `document.fonts.load(spec)` BEFORE `terminal.open()`. Parallel
+terminals dedupe on the underlying browser load (one network fetch on
+cold cache), then each terminal's `open()` measures cell metrics with
+Hack actually rendered, and the cached width is correct on the first
+try. No rAF re-fit gymnastics, no SIGWINCH-after-the-fact — the
+measurement is right from frame 1.
+
+Sequence with the correct fix, 6 terminals opening simultaneously:
+
+1. T1-T6 each enter `init()`, hit
+   `await document.fonts.load("12px Hack")`.
+2. Browser dedupes — single fetch for the Hack WOFF2.
+3. (cold cache, ~50ms) Hack loads. All 6 awaits unblock.
+4. Each `terminal.open(connectElem)` mounts xterm. xterm measures cell
+   metrics with Hack rendering → caches correct width.
+5. `customFit()` → `proposeDimensions()` returns correct cols.
+6. `sendTermSize()` informs PTY of correct dims.
+7. `resyncController("init")` spawns shell at correct size.
+8. PTY output renders against correct dimensions. No jumble.
+
+The NaN guard in `customFit()` and the post-init rAF re-fit from #1030
+remain as belt-and-suspenders for late layout shifts (CSS animations,
+window-zoom changes), but with the font-before-open fix they are
+defense-in-depth, not the primary mechanism.
+
+### Lesson
+
+When debugging an xterm.js startup race, distinguish three timing
+points: (a) when the font binary loads, (b) when xterm measures cell
+metrics, (c) when the FitAddon reads metrics for sizing. PR #1030 and
+#1040 thought the race was between (a) and (c), and tried to delay (c).
+The real race is between (a) and (b) — once (b) caches wrong metrics,
+(c) is stuck.
+
+The simplest verification of which race is at play: open xterm with
+font Y, swap to font X via `terminal.options.fontFamily = "X"` after
+the fact, and observe whether dimensions update. If they don't, (b) is
+the culprit.
+
 ### Other xterm mounts not yet touched
 
 `AgentInstallModal.tsx` constructs its own `new Terminal()` with its own

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -268,7 +268,13 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             } catch {
                 /* container still 0×0 — ResizeObserver below catches it */
             }
-            terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
+            // The font wait can resolve up to 1s late on cold cache. By then the
+            // user may have already clicked "Install now" and install output is
+            // streaming — writing the idle hint over the top would corrupt the
+            // log. Gate on phase() === "idle". Codex P2 on PR #1041.
+            if (phase() === "idle") {
+                terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
+            }
             // Refit on container resize (modal may animate in from 0×0).
             const tryFit = () => {
                 try {

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -241,24 +241,14 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
 
         fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
-        terminal.open(termRef);
-        const tryFit = () => {
-            try {
-                fitAddon?.fit();
-            } catch {
-                /* container still 0×0 — wait for next resize */
-            }
-        };
-        // Force-load the term font BEFORE the first fit so cell-width
-        // measurement uses real glyph metrics, not fallback (Courier).
-        // Same race as termwrap.ts — see
-        // docs/terminal-jumbled-startup-investigation.md "Follow-up".
-        // fonts.load() actively requests the face and resolves when ready;
-        // fonts.ready alone is vacuous because the WOFF/WOFF2 isn't
-        // requested until something measures a glyph.
+        // Force-load the term font BEFORE terminal.open(). xterm caches
+        // cell-width metrics at open() time using whatever font is currently
+        // rendering — if Hack/JetBrains hasn't loaded yet, the cached width
+        // is fallback (Courier) and sticks. See termwrap.ts for the full
+        // diagnosis and docs/terminal-jumbled-startup-investigation.md.
         const FIT_FONT_TIMEOUT_MS = 1000;
         const fontSpec = (variant: string) => `${variant}12px ${termFont}`;
-        const fontsReady = (async () => {
+        const openAndFit = async () => {
             try {
                 await Promise.race([
                     Promise.all([
@@ -271,18 +261,26 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                     ),
                 ]);
             } catch (_) { /* font API unavailable — fall through */ }
-        })();
-        void fontsReady.then(() => {
-            if (disposed) return;
-            tryFit();
-        });
-        tryFit(); // best-effort initial fit (often fallback metrics on cold cache)
-        // Refit on container resize. The modal may animate in from
-        // 0×0; without an observer the terminal stays at the default
-        // 80×24 indefinitely.
-        resizeObserver = new ResizeObserver(() => tryFit());
-        resizeObserver.observe(termRef);
-        terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
+            if (disposed || !terminal || !termRef) return;
+            terminal.open(termRef);
+            try {
+                fitAddon?.fit();
+            } catch {
+                /* container still 0×0 — ResizeObserver below catches it */
+            }
+            terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
+            // Refit on container resize (modal may animate in from 0×0).
+            const tryFit = () => {
+                try {
+                    fitAddon?.fit();
+                } catch {
+                    /* container still 0×0 — wait for next resize */
+                }
+            };
+            resizeObserver = new ResizeObserver(() => tryFit());
+            resizeObserver.observe(termRef);
+        };
+        void openAndFit();
     });
 
     onCleanup(() => {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -183,7 +183,51 @@ export class TermWrap {
      * Sequence: mount → subscribe → load data → flush held → resync controller.
      */
     async init() {
-        // Mount terminal to DOM
+        // Force-load the configured term font BEFORE `terminal.open()`. xterm.js
+        // caches cell-width metrics at open() time based on whatever font is
+        // *currently* rendering — if Hack hasn't loaded yet, it caches fallback
+        // (Courier) metrics and the cached value sticks even after Hack later
+        // swaps in. `proposeDimensions()` reads the cached width forever; no
+        // amount of post-open fits, rAF re-fits, or SIGWINCH can undo it.
+        //
+        // PR #1030 and #1040 awaited fonts AFTER open() — that closed the
+        // measurement race for proposeDimensions but didn't fix the cached
+        // metrics, so opening many terminals in parallel still reproduced
+        // the jumble (each terminal opened before any fonts.load resolved,
+        // and all 6 cached fallback metrics).
+        //
+        // Why `document.fonts.load(spec)` (not `document.fonts.ready`):
+        //   - `fonts.ready` only awaits already-pending font faces; before
+        //     anything has rendered a glyph in the family, it resolves with
+        //     no work to do.
+        //   - `fonts.load(spec)` actively requests the named face and
+        //     resolves only when it is loaded. Parallel terminals dedupe on
+        //     the underlying load — opening N panes pays the cost once.
+        //
+        // The timeout is essential: a stalled font load would block this
+        // init forever and the pane's PTY would never start (`app-init.ts`
+        // wraps the app-level wait in a 2s race for the same reason).
+        //
+        // We load regular + bold + italic variants xterm.js uses, in parallel.
+        // See docs/terminal-jumbled-startup-investigation.md for the full
+        // chain of debugging that led here.
+        const FIT_FONT_TIMEOUT_MS = 1000;
+        const fontFamily = this.terminal.options.fontFamily ?? "Hack";
+        const fontSize = this.terminal.options.fontSize ?? 12;
+        const fontSpec = (variant: string) => `${variant}${fontSize}px "${fontFamily}"`;
+        try {
+            await Promise.race([
+                Promise.all([
+                    document.fonts?.load(fontSpec("")) ?? Promise.resolve(),
+                    document.fonts?.load(fontSpec("bold ")) ?? Promise.resolve(),
+                    document.fonts?.load(fontSpec("italic ")) ?? Promise.resolve(),
+                ]),
+                new Promise<void>((resolve) => setTimeout(resolve, FIT_FONT_TIMEOUT_MS)),
+            ]);
+        } catch (_) { /* font API unavailable or face unknown — fall through */ }
+
+        // NOW mount terminal to DOM. xterm's first cell-metric measurement
+        // uses the loaded term font, so the cached width matches reality.
         this.terminal.open(this.connectElem);
 
         // Enable cursor blink only while this pane is focused.  The textarea is
@@ -232,53 +276,9 @@ export class TermWrap {
             this.loaded = true;
         }
 
-        // Force-load the configured term font BEFORE the first fit, with a bounded
-        // timeout. proposeDimensions() measures rendered cell width from the DOM; if
-        // the configured term font (e.g. Hack) hasn't loaded yet, FitAddon uses fallback
-        // metrics and computes wrong cols, the PTY is told the wrong size, and TUIs
-        // (Ink/Claude Code) emit cursor sequences that don't line up — visible as
-        // jumbled glyphs until the next resize.
-        //
-        // Why `document.fonts.load(spec)` and not `document.fonts.ready`:
-        //   - `fonts.ready` only awaits font faces that are ALREADY pending. Web fonts
-        //     are loaded lazily — the browser doesn't request the term font's WOFF/WOFF2
-        //     until something actually renders a glyph in that family. `terminal.open()`
-        //     above mounts the DOM but the font request typically isn't initiated until
-        //     `proposeDimensions()` measures a cell. So `await fonts.ready` resolves
-        //     vacuously (no pending loads) and `customFit()` then measures with fallback
-        //     metrics. This was the hole left by PR #1030's first cut — the same jumbled
-        //     glyphs reproduced when opening multiple terminals fast.
-        //   - `fonts.load("12px Hack")` actively REQUESTS the font and resolves only
-        //     when that specific face is ready. Subsequent terminals coalesce on the
-        //     same browser-level cache entry, so opening N panes in parallel waits
-        //     once.
-        //
-        // The timeout is essential: a stalled font load would block
-        // sendTermSize()/resyncController("init") and the pane's PTY would never start
-        // (`frontend/app-init.ts` wraps the app-level wait in a 2s race for the same
-        // reason). The rAF re-fit below catches the case where the font lands just
-        // after the timeout.
-        //
-        // We load the regular + bold + italic variants xterm.js uses, in parallel.
-        // Browsers dedupe identical font face requests, so this costs ~one network
-        // round-trip total on cold cache.
-        const FIT_FONT_TIMEOUT_MS = 1000;
-        const fontFamily = this.terminal.options.fontFamily ?? "Hack";
-        const fontSize = this.terminal.options.fontSize ?? 12;
-        const fontSpec = (variant: string) => `${variant}${fontSize}px "${fontFamily}"`;
-        try {
-            await Promise.race([
-                Promise.all([
-                    document.fonts?.load(fontSpec("")) ?? Promise.resolve(),
-                    document.fonts?.load(fontSpec("bold ")) ?? Promise.resolve(),
-                    document.fonts?.load(fontSpec("italic ")) ?? Promise.resolve(),
-                ]),
-                new Promise<void>((resolve) => setTimeout(resolve, FIT_FONT_TIMEOUT_MS)),
-            ]);
-        } catch (_) { /* font API unavailable or face unknown — fall through */ }
-
-        // NOW fit and tell backend to start/resync the shell controller.
-        // At this point we are fully subscribed and ready to receive data.
+        // Fonts were already loaded above (before terminal.open) so the cached
+        // cell metrics xterm computed at open() time are correct. Fit and tell
+        // backend to start/resync the shell controller.
         this.customFit();
         this.sendTermSize();
         await this.resyncController("init");


### PR DESCRIPTION
## Summary

Third attempt at killing the terminal-pane jumbled-startup race. PRs #1030
and #1040 both placed the font wait AFTER `terminal.open()`. **That was
always too late.** User reported the repro persisted after #1040 merged:
*"happens more often when I load many terminals at once, it's a timing
issue."*

## Real root cause

xterm.js caches cell-width metrics inside its render service at
`terminal.open()` time, using whatever font is currently rendering at
that moment.

- If Hack hasn't loaded yet when `open()` runs, xterm caches **fallback
  (Courier) metrics**.
- `FitAddon.proposeDimensions()` then reads those **cached metrics**, not
  a fresh DOM measurement.
- When Hack later loads, the browser swaps the visual font but xterm's
  cached cell dimensions do **not** invalidate.

So `proposeDimensions()` returns wrong cols forever, regardless of whether
Hack has loaded or how many post-open `customFit()` calls happen.

With many terminals opening in parallel, every terminal hits `open()`
before any `fonts.load(...)` resolves, and all of them cache fallback
metrics simultaneously. The rAF re-fit from #1030 dutifully calls
`customFit()` again — and reads the same stale cached value.

PRs #1030 and #1040 closed the race between font-load and
`proposeDimensions()` reading the DOM, but `proposeDimensions()`
doesn't actually read the DOM in any of the paths that matter — it
reads xterm's cached metrics.

## Fix

Await `document.fonts.load(spec)` **BEFORE** `terminal.open()`. Parallel
terminals dedupe on the underlying browser load (one fetch on cold
cache), then each `open()` measures cell metrics with Hack actually
rendering, and the cached width is correct on the first try.

The NaN guard in `customFit()` and the rAF re-fit from #1030 remain as
belt-and-suspenders for late layout shifts (CSS animations, window-zoom
changes), but they are now defense-in-depth, not the primary mechanism.

## AgentInstallModal

Same restructure — font wait before `terminal.open()`. The xterm there
runs async-after-mount now, so the welcome `writeln()` and the
ResizeObserver setup move inside the async block.

## Files

- `frontend/app/view/term/termwrap.ts` — relocate the font-load block to
  before `terminal.open()`; remove the post-open redundant copy.
- `frontend/app/view/agent/components/AgentInstallModal.tsx` — wrap
  `terminal.open()` + initial fit + welcome line in an async
  `openAndFit()` that awaits fonts first.
- `docs/terminal-jumbled-startup-investigation.md` — added "PR #1040 also
  insufficient" follow-up section with the cached-metrics diagnosis and
  the lesson about distinguishing measurement timing points.

Changeset: `patch` (RFC #857 Phase 2 workflow).

## Test plan

- [x] `npx tsc --noEmit` — clean on edited files.
- [ ] Kill dev process to clear in-memory FontFaceSet, restart `task dev`,
      open 6+ terminal panes back-to-back. Verify no jumble in any pane,
      including the first.
- [ ] Open install modal cold and warm cache — verify no font-size
      overshoot.

## References

- #1030 — original `fonts.ready` fix (insufficient — vacuous resolve).
- #1040 — switched to `fonts.load(spec)` (still insufficient — placed
  after `terminal.open()`).
- xterm.js render-service `dimensions` caching — measured once at open,
  invalidated only on font-option change or DPR change, not on lazy
  font swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)