### PR TITLE
feat(warden): add widget shell with three-section scaffold (Phase 1 of warden spec)

### DIFF
--- a/.changesets/1779753083-feat-warden-add-widget-shell-with-three-section-scaffold.md
+++ b/.changesets/1779753083-feat-warden-add-widget-shell-with-three-section-scaffold.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(warden): add widget shell with three-section (Host/LAN/Internet) scaffold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`
 | `defwidget@drone` | `drone` | drone | Pinned |
 | `defwidget@help` | `help` | help | Pinned |
 | `defwidget@swarm` | `swarm` | swarm | Pinned |
+| `defwidget@warden` | `warden` | warden | Pinned |
 
 ### Not widgets
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -103,5 +103,18 @@
                 "view": "help"
             }
         }
+    },
+    "defwidget@warden": {
+        "display:order": 10,
+        "display:pinned": true,
+        "icon": "shield-halved",
+        "color": "#8b5cf6",
+        "label": "warden",
+        "description": "Monitor and control AgentMux instances across Host / LAN / Internet layers (spec: SPEC_WARDEN_WIDGET_2026-05-25.md)",
+        "blockdef": {
+            "meta": {
+                "view": "warden"
+            }
+        }
     }
 }

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -19,6 +19,7 @@ import { BrowserViewModel } from "@/app/view/browser/browser";
 import { MemoryViewModel } from "@/app/view/memory/memory";
 import { IdentityPaneViewModel } from "@/app/view/identity/identity-pane";
 import { DroneViewModel } from "@/app/view/drone/drone";
+import { WardenViewModel } from "@/app/view/warden/warden";
 import { invokeCommand } from "@/app/platform/ipc";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
@@ -56,6 +57,7 @@ BlockRegistry.set("browser", BrowserViewModel as any);
 BlockRegistry.set("memory", MemoryViewModel as any);
 BlockRegistry.set("identity", IdentityPaneViewModel as any);
 BlockRegistry.set("drone", DroneViewModel as any);
+BlockRegistry.set("warden", WardenViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
     // Migration shims:

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -1,0 +1,97 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Warden widget shell. Spec: specs/SPEC_WARDEN_WIDGET_2026-05-25.md
+
+.warden-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    font-size: 13px;
+    overflow: auto;
+}
+
+.warden-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.warden-title {
+    font-size: 1.15em;
+    font-weight: 600;
+}
+
+.warden-subtitle {
+    font-size: 0.85em;
+    opacity: 0.6;
+}
+
+.warden-sections {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+}
+
+.warden-section {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--secondary-bg-color, transparent);
+
+    &[data-status="disabled"] {
+        opacity: 0.6;
+    }
+}
+
+.warden-section-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--tertiary-bg-color, transparent);
+}
+
+.warden-section-title {
+    font-weight: 600;
+    min-width: 70px;
+}
+
+.warden-section-summary {
+    flex: 1;
+    opacity: 0.7;
+    font-size: 0.9em;
+}
+
+.warden-section-status {
+    text-transform: uppercase;
+    font-size: 0.7em;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--border-color);
+    opacity: 0.7;
+}
+
+.warden-section-body {
+    padding: var(--space-3);
+}
+
+.warden-section-stub {
+    font-size: 0.9em;
+    opacity: 0.6;
+    line-height: 1.5;
+
+    code {
+        font-family: monospace;
+        font-size: 0.95em;
+        padding: 1px 4px;
+        border-radius: 2px;
+        background: var(--border-color);
+    }
+}

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Warden widget — shell + section stubs. Phase 1 (this PR) registers the
+// view and renders the three-layer scaffold; Host data, LAN data, and
+// enforcement actions land in follow-up PRs.
+//
+// Spec: specs/SPEC_WARDEN_WIDGET_2026-05-25.md
+
+import { For, type JSX } from "solid-js";
+
+import "./warden.scss";
+
+class WardenViewModel implements ViewModel {
+    viewType: string;
+    blockId: string;
+
+    constructor(blockId: string) {
+        this.viewType = "warden";
+        this.blockId = blockId;
+    }
+
+    get viewComponent(): ViewComponent {
+        return WardenView as unknown as ViewComponent;
+    }
+}
+
+interface LayerSection {
+    key: "host" | "lan" | "internet";
+    title: string;
+    summary: string;
+    status: "live" | "stub" | "disabled";
+    body: JSX.Element;
+}
+
+const SECTIONS: LayerSection[] = [
+    {
+        key: "host",
+        title: "Host",
+        summary: "This AgentMux process · jekt tiers 1–2 · < 1 ms",
+        status: "stub",
+        body: (
+            <div class="warden-section-stub">
+                Agent list, identity provenance, capability set, jekt/min, and audit
+                stream land in the next PR. See spec § Phase 2.
+            </div>
+        ),
+    },
+    {
+        key: "lan",
+        title: "LAN",
+        summary: "mDNS-discovered peers · jekt tier 3 · 1–10 ms",
+        status: "stub",
+        body: (
+            <div class="warden-section-stub">
+                Peer list reads through to <code>lan_discovery</code>. Enrollment +
+                policy push wait on lan-awareness Phase 3 (LAN jekt forwarding).
+            </div>
+        ),
+    },
+    {
+        key: "internet",
+        title: "Internet",
+        summary: "AgentBus cloud relay · jekt tier 4 · opt-in",
+        status: "disabled",
+        body: (
+            <div class="warden-section-stub">
+                Closed by default. Cross-network governance ships behind
+                lan-awareness Phase 4 (cloud fallback).
+            </div>
+        ),
+    },
+];
+
+function WardenView({ model: _model }: { model: WardenViewModel }): JSX.Element {
+    return (
+        <div class="warden-pane">
+            <header class="warden-header">
+                <span class="warden-title">Warden</span>
+                <span class="warden-subtitle">3-layer operator surface</span>
+            </header>
+            <div class="warden-sections">
+                <For each={SECTIONS}>
+                    {(section) => (
+                        <section
+                            class="warden-section"
+                            data-status={section.status}
+                            data-layer={section.key}
+                        >
+                            <header class="warden-section-header">
+                                <span class="warden-section-title">{section.title}</span>
+                                <span class="warden-section-summary">{section.summary}</span>
+                                <span class="warden-section-status">{section.status}</span>
+                            </header>
+                            <div class="warden-section-body">{section.body}</div>
+                        </section>
+                    )}
+                </For>
+            </div>
+        </div>
+    );
+}
+
+WardenView.displayName = "WardenView";
+
+export { WardenViewModel };


### PR DESCRIPTION
> **First step of the Warden widget.** Just the shell — registers the widget, renders three sections (Host / LAN / Internet) with phase-status stubs. No backend, no data, no enforcement. Each section announces what it'll fill in and when.
>
> **Spec:** [\`specs/SPEC_WARDEN_WIDGET_2026-05-25.md\`](https://github.com/agentmuxai/agentmux/blob/main/specs/SPEC_WARDEN_WIDGET_2026-05-25.md) (landed via #1032)
> **RFC:** #1033

## What this PR adds

- \`defwidget@warden\` in \`agentmux-srv/src/config/widgets.json\` — pinned, \`shield-halved\` icon, order 10
- \`frontend/app/view/warden/warden.tsx\` — \`WardenViewModel\` (minimal, matches the HelpViewModel pattern) + \`WardenView\` that renders three layer sections
- \`frontend/app/view/warden/warden.scss\` — section layout + status chip styling
- \`BlockRegistry.set("warden", WardenViewModel)\` in \`frontend/app/block/block.tsx\`
- \`CLAUDE.md\` widget table updated

## What's *not* in this PR

| Phase | Goes in PR | Depends on |
|---|---|---|
| L1 read-only (agent list, identity, jekt/min, audit stream) | PR-B | nothing (just backend RPCs) |
| L1 enforcement (kill agent, pause, kill-all) | PR-C | \`governance.json\` schema + enforcer hooks |
| L2 read-only (LAN peer list with drift detection) | PR-D | lan-awareness Phase 3 (LAN forwarding) |
| L2 enforcement (quarantine, policy push) | PR-E | embedded MCP SSE server (Phase 2) |
| L3 (Internet) read + control | PR-F | cloud fallback (Phase 4) |

Each section in the shell renders a \`status\` chip (\`live\` / \`stub\` / \`disabled\`) so the operator can see at a glance which layers are functional. Internet is \`disabled\` by default per the spec's "closed by default at boundary 3" principle.

## Verification

- \`npx tsc --noEmit\` — no errors in any file this PR touches
- JSON validates: \`agentmux-srv/src/config/widgets.json\` parses cleanly

## Manual smoke test

1. \`task dev\`
2. New block → click **warden** in the widget bar
3. Widget opens with three labeled sections, each showing its status chip and a one-line "coming soon" explaining what fills in
4. The widget icon (\`shield-halved\`) renders in the widget bar