### PR TITLE
feat(warden): host section live agent list (PR-B of Warden rollout)

### DIFF
--- a/.changesets/1779753431-feat-warden-host-section-renders-live-agent-list.md
+++ b/.changesets/1779753431-feat-warden-host-section-renders-live-agent-list.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(warden): host section renders live agent list from reactive registry

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -95,3 +95,72 @@
         background: var(--border-color);
     }
 }
+
+// ── Host section ──────────────────────────────────────────────────────
+
+.warden-host {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.warden-host-error {
+    font-size: 0.85em;
+    color: var(--warning-color, #d97706);
+}
+
+.warden-host-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+
+    th {
+        text-align: left;
+        font-weight: 500;
+        opacity: 0.6;
+        padding: var(--space-1) var(--space-2);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    td {
+        padding: var(--space-1) var(--space-2);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    tr[data-state="idle"] td {
+        opacity: 0.7;
+    }
+}
+
+.warden-host-mono {
+    font-family: monospace;
+}
+
+.warden-host-dim {
+    opacity: 0.55;
+}
+
+.warden-host-state {
+    display: inline-block;
+    text-transform: uppercase;
+    font-size: 0.7em;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: 3px;
+
+    &--active {
+        background: rgba(34, 197, 94, 0.15);
+        color: #22c55e;
+    }
+
+    &--idle {
+        background: var(--border-color);
+        opacity: 0.7;
+    }
+}
+
+.warden-host-footnote {
+    font-size: 0.8em;
+    opacity: 0.5;
+    line-height: 1.5;
+}

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -1,13 +1,19 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Warden widget — shell + section stubs. Phase 1 (this PR) registers the
-// view and renders the three-layer scaffold; Host data, LAN data, and
-// enforcement actions land in follow-up PRs.
+// Warden widget — three-layer operator surface (Host / LAN / Internet).
+//
+// Phase 1 shell shipped the section scaffold. This PR (Phase 2 of the
+// spec — Host L1 read-only) lights up the Host section: it fetches the
+// agent list from /agentmux/reactive/agents on mount and refreshes every
+// 5 s. LAN and Internet remain stubs until their substrates land.
 //
 // Spec: specs/SPEC_WARDEN_WIDGET_2026-05-25.md
 
-import { For, type JSX } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+
+import { getApi } from "@/store/global";
+import { getWebServerEndpoint } from "@/util/endpoints";
 
 import "./warden.scss";
 
@@ -25,12 +31,159 @@ class WardenViewModel implements ViewModel {
     }
 }
 
+// ── Host section data ────────────────────────────────────────────────
+
+interface HostAgent {
+    agent_id: string;
+    block_id: string;
+    tab_id?: string;
+    registered_at: number;
+    last_seen: number;
+}
+
+const HOST_REFRESH_MS = 5_000;
+// Last-seen newer than this counts as "active"; older is "idle".
+const ACTIVE_THRESHOLD_MS = 30_000;
+
+async function fetchHostAgents(): Promise<HostAgent[]> {
+    const headers: Record<string, string> = {};
+    if (globalThis.window != null) {
+        const authKey = getApi()?.getAuthKey?.();
+        if (authKey) headers["X-AuthKey"] = authKey;
+    }
+    const resp = await fetch(
+        getWebServerEndpoint() + "/agentmux/reactive/agents",
+        { headers },
+    );
+    if (!resp.ok) {
+        throw new Error(`warden: GET /agentmux/reactive/agents → ${resp.status}`);
+    }
+    const data = await resp.json();
+    return Array.isArray(data) ? (data as HostAgent[]) : [];
+}
+
+function ageMs(ts: number, now: number): number {
+    // `last_seen` / `registered_at` are unix millis from the Rust backend.
+    return Math.max(0, now - ts);
+}
+
+function formatAge(ms: number): string {
+    if (ms < 60_000) return `${Math.floor(ms / 1000)}s`;
+    if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+    return `${Math.floor(ms / 3_600_000)}h`;
+}
+
+function agentState(agent: HostAgent, now: number): "active" | "idle" {
+    return ageMs(agent.last_seen, now) < ACTIVE_THRESHOLD_MS ? "active" : "idle";
+}
+
+const HostSection = (): JSX.Element => {
+    const [agents, setAgents] = createSignal<HostAgent[]>([]);
+    const [error, setError] = createSignal<string | null>(null);
+    const [loading, setLoading] = createSignal(true);
+    const [now, setNow] = createSignal(Date.now());
+
+    const refresh = async () => {
+        try {
+            const list = await fetchHostAgents();
+            setAgents(list);
+            setError(null);
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    onMount(() => {
+        void refresh();
+        const dataTimer = window.setInterval(() => void refresh(), HOST_REFRESH_MS);
+        // Tick `now` once per second so age columns update without a fresh
+        // fetch. Cheap — just re-renders the existing rows.
+        const clockTimer = window.setInterval(() => setNow(Date.now()), 1000);
+        onCleanup(() => {
+            window.clearInterval(dataTimer);
+            window.clearInterval(clockTimer);
+        });
+    });
+
+    return (
+        <div class="warden-host">
+            <Show when={error()}>
+                <div class="warden-host-error">⚠ {error()}</div>
+            </Show>
+            <Show
+                when={agents().length > 0}
+                fallback={
+                    <div class="warden-section-stub">
+                        {loading() ? "Loading…" : "No agents registered on this host."}
+                    </div>
+                }
+            >
+                <table class="warden-host-table">
+                    <thead>
+                        <tr>
+                            <th>agent</th>
+                            <th>block</th>
+                            <th>last seen</th>
+                            <th>state</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={agents()}>
+                            {(a) => {
+                                const state = () => agentState(a, now());
+                                return (
+                                    <tr data-state={state()}>
+                                        <td class="warden-host-mono">{a.agent_id}</td>
+                                        <td class="warden-host-mono warden-host-dim">
+                                            {a.block_id.slice(0, 8)}
+                                        </td>
+                                        <td>{formatAge(ageMs(a.last_seen, now()))} ago</td>
+                                        <td>
+                                            <span class={`warden-host-state warden-host-state--${state()}`}>
+                                                {state()}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                );
+                            }}
+                        </For>
+                    </tbody>
+                </table>
+            </Show>
+            <div class="warden-host-footnote">
+                Refreshes every {HOST_REFRESH_MS / 1000}s. Identity, capabilities, and
+                jekt/min are coming in a follow-up PR.
+            </div>
+        </div>
+    );
+};
+
+// ── Stub sections (unchanged from Phase 1 shell) ─────────────────────
+
+const LanStub = (): JSX.Element => (
+    <div class="warden-section-stub">
+        Peer list reads through to <code>lan_discovery</code>. Enrollment + policy
+        push wait on lan-awareness Phase 3 (LAN jekt forwarding).
+    </div>
+);
+
+const InternetStub = (): JSX.Element => (
+    <div class="warden-section-stub">
+        Closed by default. Cross-network governance ships behind lan-awareness
+        Phase 4 (cloud fallback).
+    </div>
+);
+
+// ── Layer scaffold ────────────────────────────────────────────────────
+
 interface LayerSection {
     key: "host" | "lan" | "internet";
     title: string;
     summary: string;
     status: "live" | "stub" | "disabled";
-    body: JSX.Element;
+    render: () => JSX.Element;
 }
 
 const SECTIONS: LayerSection[] = [
@@ -38,37 +191,22 @@ const SECTIONS: LayerSection[] = [
         key: "host",
         title: "Host",
         summary: "This AgentMux process · jekt tiers 1–2 · < 1 ms",
-        status: "stub",
-        body: (
-            <div class="warden-section-stub">
-                Agent list, identity provenance, capability set, jekt/min, and audit
-                stream land in the next PR. See spec § Phase 2.
-            </div>
-        ),
+        status: "live",
+        render: () => <HostSection />,
     },
     {
         key: "lan",
         title: "LAN",
         summary: "mDNS-discovered peers · jekt tier 3 · 1–10 ms",
         status: "stub",
-        body: (
-            <div class="warden-section-stub">
-                Peer list reads through to <code>lan_discovery</code>. Enrollment +
-                policy push wait on lan-awareness Phase 3 (LAN jekt forwarding).
-            </div>
-        ),
+        render: () => <LanStub />,
     },
     {
         key: "internet",
         title: "Internet",
         summary: "AgentBus cloud relay · jekt tier 4 · opt-in",
         status: "disabled",
-        body: (
-            <div class="warden-section-stub">
-                Closed by default. Cross-network governance ships behind
-                lan-awareness Phase 4 (cloud fallback).
-            </div>
-        ),
+        render: () => <InternetStub />,
     },
 ];
 
@@ -92,7 +230,7 @@ function WardenView({ model: _model }: { model: WardenViewModel }): JSX.Element 
                                 <span class="warden-section-summary">{section.summary}</span>
                                 <span class="warden-section-status">{section.status}</span>
                             </header>
-                            <div class="warden-section-body">{section.body}</div>
+                            <div class="warden-section-body">{section.render()}</div>
                         </section>
                     )}
                 </For>


### PR DESCRIPTION
> **Phase 1 of the Warden spec — Host L1 read-only, minimum viable slice.** The Host section now shows the actual agents registered on this AgentMux instance. LAN and Internet still stubbed.
>
> **Spec:** [\`specs/SPEC_WARDEN_WIDGET_2026-05-25.md\`](https://github.com/agentmuxai/agentmux/blob/main/specs/SPEC_WARDEN_WIDGET_2026-05-25.md)
> **Stack:** PR-B (this) follows PR-A (#1044, shell — merged)

## What this PR does

- Host section in \`WardenView\` fetches \`GET /agentmux/reactive/agents\` on mount + every 5 s
- Renders a table: \`agent\`, \`block\` (short hash), \`last seen\` (age), \`state\` (active < 30 s, else idle)
- Separate 1-s clock tick updates the age column without re-fetching
- Host section's status chip flips from \`stub\` → \`live\`
- LAN and Internet sections unchanged (still stubs/disabled)

## Out of scope (each its own PR)

| Capability | Lands in |
|---|---|
| Identity provenance per agent | PR-C |
| Capability set per agent | PR-D |
| jekt/min counter | needs new backend metric |
| Audit event stream | PR-C |
| Kill / pause buttons | PR-D (governance enforcement) |
| LAN peer list | PR-E (after lan-awareness Phase 3) |

## Backend changes

**None.** Reuses the existing \`/agentmux/reactive/agents\` HTTP endpoint, already gated by \`auth_middleware\`. A dedicated \`GET /agentmux/warden/snapshot\` endpoint can come when LAN and Internet layers need wrapping into a single snapshot shape — keeping this PR small.

## Verification

- \`npx tsc --noEmit\` — no errors in any file this PR touches
- Smoke test: open Warden widget, Host section should populate with whatever agents are registered

## Manual smoke test

1. \`task dev\`
2. Spawn an agent pane (any kind — the agent registers via shell hooks)
3. Open the Warden widget
4. Host section shows that agent, status \`active\`, age counting up in real time
5. Close the agent pane → after ~30 s the row's state chip turns \`idle\`
6. Force-quit the agent (kill pid) → row eventually drops on next 5 s refresh