### PR TITLE
feat(warden): host section recent jekt audit feed (PR-C)

### DIFF
--- a/.changesets/1779756101-feat-warden-host-section-shows-recent-jekt-audit-feed.md
+++ b/.changesets/1779756101-feat-warden-host-section-shows-recent-jekt-audit-feed.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(warden): host section shows recent jekt audit feed

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -159,6 +159,80 @@
     }
 }
 
+.warden-host-section-divider {
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.5;
+    border-top: 1px solid var(--border-color);
+}
+
+.warden-audit-feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 240px;
+    overflow-y: auto;
+    font-size: 0.85em;
+}
+
+.warden-audit-row {
+    display: grid;
+    grid-template-columns: 70px 1fr 40px 50px 1fr;
+    gap: var(--space-2);
+    padding: 2px var(--space-2);
+    border-radius: 2px;
+
+    &[data-success="false"] {
+        background: rgba(239, 68, 68, 0.08);
+    }
+}
+
+.warden-audit-time {
+    opacity: 0.55;
+    font-family: monospace;
+}
+
+.warden-audit-flow {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.warden-audit-status {
+    text-align: center;
+    text-transform: uppercase;
+    font-size: 0.8em;
+
+    &--ok {
+        color: #22c55e;
+    }
+
+    &--err {
+        color: #ef4444;
+    }
+}
+
+.warden-audit-bytes {
+    text-align: right;
+    opacity: 0.55;
+    font-family: monospace;
+}
+
+.warden-audit-error {
+    opacity: 0.8;
+    color: #ef4444;
+    font-size: 0.95em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .warden-host-footnote {
     font-size: 0.8em;
     opacity: 0.5;

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -41,25 +41,54 @@ interface HostAgent {
     last_seen: number;
 }
 
+interface AuditEntry {
+    timestamp: number;
+    source_agent?: string;
+    target_agent: string;
+    block_id: string;
+    message_hash: string;
+    message_length: number;
+    success: boolean;
+    error_message?: string;
+    request_id: string;
+}
+
 const HOST_REFRESH_MS = 5_000;
+const AUDIT_LIMIT = 50;
 // Last-seen newer than this counts as "active"; older is "idle".
 const ACTIVE_THRESHOLD_MS = 30_000;
 
-async function fetchHostAgents(): Promise<HostAgent[]> {
+function authedHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
     if (globalThis.window != null) {
         const authKey = getApi()?.getAuthKey?.();
         if (authKey) headers["X-AuthKey"] = authKey;
     }
+    return headers;
+}
+
+async function fetchHostAgents(): Promise<HostAgent[]> {
     const resp = await fetch(
         getWebServerEndpoint() + "/agentmux/reactive/agents",
-        { headers },
+        { headers: authedHeaders() },
     );
     if (!resp.ok) {
         throw new Error(`warden: GET /agentmux/reactive/agents → ${resp.status}`);
     }
     const data = await resp.json();
     return Array.isArray(data) ? (data as HostAgent[]) : [];
+}
+
+async function fetchHostAudit(): Promise<AuditEntry[]> {
+    const resp = await fetch(
+        getWebServerEndpoint() + `/agentmux/reactive/audit?limit=${AUDIT_LIMIT}`,
+        { headers: authedHeaders() },
+    );
+    if (!resp.ok) {
+        throw new Error(`warden: GET /agentmux/reactive/audit → ${resp.status}`);
+    }
+    const data = await resp.json();
+    return Array.isArray(data) ? (data as AuditEntry[]) : [];
 }
 
 function ageMs(ts: number, now: number): number {
@@ -79,14 +108,19 @@ function agentState(agent: HostAgent, now: number): "active" | "idle" {
 
 const HostSection = (): JSX.Element => {
     const [agents, setAgents] = createSignal<HostAgent[]>([]);
+    const [audit, setAudit] = createSignal<AuditEntry[]>([]);
     const [error, setError] = createSignal<string | null>(null);
     const [loading, setLoading] = createSignal(true);
     const [now, setNow] = createSignal(Date.now());
 
     const refresh = async () => {
         try {
-            const list = await fetchHostAgents();
-            setAgents(list);
+            const [agentList, auditLog] = await Promise.all([
+                fetchHostAgents(),
+                fetchHostAudit().catch(() => [] as AuditEntry[]),
+            ]);
+            setAgents(agentList);
+            setAudit(auditLog);
             setError(null);
         } catch (e) {
             setError(String(e));
@@ -152,9 +186,46 @@ const HostSection = (): JSX.Element => {
                     </tbody>
                 </table>
             </Show>
+            <div class="warden-host-section-divider">Recent jekts (audit)</div>
+            <Show
+                when={audit().length > 0}
+                fallback={
+                    <div class="warden-section-stub">No jekt activity yet.</div>
+                }
+            >
+                <ul class="warden-audit-feed">
+                    <For each={audit().slice(0, 20)}>
+                        {(entry) => (
+                            <li
+                                class="warden-audit-row"
+                                data-success={entry.success ? "true" : "false"}
+                            >
+                                <span class="warden-audit-time">
+                                    {formatAge(ageMs(entry.timestamp, now()))} ago
+                                </span>
+                                <span class="warden-audit-flow">
+                                    <Show when={entry.source_agent} fallback={<span class="warden-host-dim">—</span>}>
+                                        <span class="warden-host-mono">{entry.source_agent}</span>
+                                    </Show>
+                                    {" → "}
+                                    <span class="warden-host-mono">{entry.target_agent}</span>
+                                </span>
+                                <span class={`warden-audit-status warden-audit-status--${entry.success ? "ok" : "err"}`}>
+                                    {entry.success ? "ok" : "err"}
+                                </span>
+                                <span class="warden-audit-bytes">{entry.message_length}b</span>
+                                <Show when={!entry.success && entry.error_message}>
+                                    <span class="warden-audit-error">{entry.error_message}</span>
+                                </Show>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </Show>
             <div class="warden-host-footnote">
-                Refreshes every {HOST_REFRESH_MS / 1000}s. Identity, capabilities, and
-                jekt/min are coming in a follow-up PR.
+                Refreshes every {HOST_REFRESH_MS / 1000}s · last {AUDIT_LIMIT} jekts.
+                Identity, capabilities, and jekt/min counters are coming in a
+                follow-up PR.
             </div>
         </div>
     );


### PR DESCRIPTION
> **Finishes Host L1 read-only.** Adds the recent jekt audit feed below the agent table in the Warden's Host section.
>
> Spec: \`specs/SPEC_WARDEN_WIDGET_2026-05-25.md\`
> Stack: PR-C (this) · follows PR-B (#1045 merged) · follows PR-A (#1044 merged)

## What this PR adds

- New \`AuditEntry\` row type + \`fetchHostAudit()\` (reuses \`GET /agentmux/reactive/audit?limit=50\`, already gated by auth middleware)
- Audit feed under the agent table: \`timestamp · source → target · ok/err · bytes · inline error\`
- Same 5 s refresh tick fetches both agents and audit (Promise.all); 1 s clock tick re-renders the age column without re-fetching
- Failed rows get a subtle red background; error message tail truncates with ellipsis

## Backend changes

None. Reuses the existing reactive-audit endpoint.

## Out of scope

| Capability | Lands in |
|---|---|
| Kill / pause agent | PR-D |
| Identity provenance per agent | PR-D or later |
| Capability set per agent | PR-D |
| LAN peer list | PR-E (mDNS substrate is already live since #1032) |

## Verification

- \`npx tsc --noEmit\` — no errors in warden files
- Existing endpoint already shipped; smoke test = open Warden + spawn an agent + trigger a jekt