### PR TITLE
feat(warden): LAN section live mDNS peer list (PR-E)

### DIFF
--- a/.changesets/1779756282-feat-warden-lan-section-renders-mdns-peer-list.md
+++ b/.changesets/1779756282-feat-warden-lan-section-renders-mdns-peer-list.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(warden): LAN section renders live mDNS peer list

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -231,14 +231,115 @@ const HostSection = (): JSX.Element => {
     );
 };
 
-// ── Stub sections (unchanged from Phase 1 shell) ─────────────────────
+// ── LAN section ──────────────────────────────────────────────────────
 
-const LanStub = (): JSX.Element => (
-    <div class="warden-section-stub">
-        Peer list reads through to <code>lan_discovery</code>. Enrollment + policy
-        push wait on lan-awareness Phase 3 (LAN jekt forwarding).
-    </div>
-);
+interface LanPeer {
+    instance_id: string;
+    hostname: string;
+    version: string;
+    address: string;
+    port: number;
+    agents: string[];
+    first_seen: number;
+    last_seen: number;
+}
+
+async function fetchLanPeers(): Promise<LanPeer[]> {
+    // /api/lan-instances is a public route (no auth required).
+    const resp = await fetch(getWebServerEndpoint() + "/api/lan-instances");
+    if (!resp.ok) {
+        throw new Error(`warden: GET /api/lan-instances → ${resp.status}`);
+    }
+    const data = await resp.json();
+    return Array.isArray(data) ? (data as LanPeer[]) : [];
+}
+
+const LanSection = (): JSX.Element => {
+    const [peers, setPeers] = createSignal<LanPeer[]>([]);
+    const [loading, setLoading] = createSignal(true);
+    const [error, setError] = createSignal<string | null>(null);
+    const [now, setNow] = createSignal(Date.now());
+
+    const refresh = async () => {
+        try {
+            const list = await fetchLanPeers();
+            setPeers(list);
+            setError(null);
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    onMount(() => {
+        void refresh();
+        const dataTimer = window.setInterval(() => void refresh(), HOST_REFRESH_MS);
+        // `last_seen` is in unix *seconds* on the LAN endpoint (not ms like
+        // ReactiveHandler) — see lan_discovery.rs:135. The clock tick keeps
+        // the relative "Xs ago" column fresh between fetches.
+        const clockTimer = window.setInterval(() => setNow(Date.now()), 1000);
+        onCleanup(() => {
+            window.clearInterval(dataTimer);
+            window.clearInterval(clockTimer);
+        });
+    });
+
+    return (
+        <div class="warden-host">
+            <Show when={error()}>
+                <div class="warden-host-error">⚠ {error()}</div>
+            </Show>
+            <Show
+                when={peers().length > 0}
+                fallback={
+                    <div class="warden-section-stub">
+                        {loading()
+                            ? "Loading…"
+                            : 'No LAN peers. Enable mDNS via the HostPopover toggle ("LAN discovery") on each instance.'}
+                    </div>
+                }
+            >
+                <table class="warden-host-table">
+                    <thead>
+                        <tr>
+                            <th>peer</th>
+                            <th>version</th>
+                            <th>address</th>
+                            <th>agents</th>
+                            <th>last seen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={peers()}>
+                            {(p) => {
+                                const lastSeenMs = p.last_seen * 1000;
+                                return (
+                                    <tr>
+                                        <td class="warden-host-mono">
+                                            {p.hostname || p.instance_id}
+                                        </td>
+                                        <td class="warden-host-mono warden-host-dim">v{p.version}</td>
+                                        <td class="warden-host-mono warden-host-dim">
+                                            {p.address}:{p.port}
+                                        </td>
+                                        <td>{p.agents.length}</td>
+                                        <td>{formatAge(ageMs(lastSeenMs, now()))} ago</td>
+                                    </tr>
+                                );
+                            }}
+                        </For>
+                    </tbody>
+                </table>
+            </Show>
+            <div class="warden-host-footnote">
+                Refreshes every {HOST_REFRESH_MS / 1000}s · mDNS via
+                <code> _agentmux._tcp.local</code>. Cross-instance jekt and
+                quarantine controls land in PR-F (after lan-awareness Phase 3).
+            </div>
+        </div>
+    );
+};
 
 const InternetStub = (): JSX.Element => (
     <div class="warden-section-stub">
@@ -269,8 +370,8 @@ const SECTIONS: LayerSection[] = [
         key: "lan",
         title: "LAN",
         summary: "mDNS-discovered peers · jekt tier 3 · 1–10 ms",
-        status: "stub",
-        render: () => <LanStub />,
+        status: "live",
+        render: () => <LanSection />,
     },
     {
         key: "internet",


### PR DESCRIPTION
> **Phase 3 of the Warden spec — L2 read-only.** The LAN section now reads through to mDNS and renders the live peer list. Cross-instance enforcement still pending lan-awareness Phase 3.
>
> Spec: \`specs/SPEC_WARDEN_WIDGET_2026-05-25.md\`
> Stack: PR-E (this) follows PR-C (#1046 merged), PR-B (#1045 merged), PR-A (#1044 merged) · spec landed in #1032

## What this PR adds

- \`fetchLanPeers()\` calling \`GET /api/lan-instances\` (existing public endpoint, shipped via mDNS in #1032)
- \`LanSection\` component polling every 5 s, rendering: \`peer · version · address · agents · last seen\`
- Same 1 s clock tick approach for age columns
- LAN status chip flips \`stub\` → \`live\`
- Empty-state message points the operator to the HostPopover toggle if they haven't enabled mDNS yet
- Footnote notes that cross-instance jekt / quarantine controls land later

## Backend changes

None. mDNS \`LanDiscovery\` daemon and the \`/api/lan-instances\` route are already on main.

## Verification

- \`npx tsc --noEmit\` — no errors in warden files
- Smoke test: enable \"LAN discovery\" on two AgentMux instances on the same network → both should see the other in the Warden's LAN section within ~5 s