### PR TITLE
feat(warden): host soft-deregister button (PR-D)

### DIFF
--- a/.changesets/1779756482-feat-warden-soft-deregister-agent-button.md
+++ b/.changesets/1779756482-feat-warden-soft-deregister-agent-button.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(warden): host section adds soft-deregister button per agent

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -159,6 +159,33 @@
     }
 }
 
+.warden-host-actions {
+    text-align: right;
+    width: 24px;
+}
+
+.warden-host-deregister {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--main-text-color);
+    opacity: 0.4;
+    cursor: pointer;
+    width: 20px;
+    height: 20px;
+    border-radius: 3px;
+    font-size: 1em;
+    line-height: 1;
+    padding: 0;
+    transition: opacity 100ms ease, background 100ms ease, border-color 100ms ease;
+
+    &:hover {
+        opacity: 1;
+        background: rgba(239, 68, 68, 0.1);
+        border-color: rgba(239, 68, 68, 0.3);
+        color: #ef4444;
+    }
+}
+
 .warden-host-section-divider {
     margin-top: var(--space-2);
     padding-top: var(--space-2);

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -91,6 +91,29 @@ async function fetchHostAudit(): Promise<AuditEntry[]> {
     return Array.isArray(data) ? (data as AuditEntry[]) : [];
 }
 
+/**
+ * Deregister an agent from the local ReactiveHandler. This is a *soft*
+ * enforcement action — it removes the agent's routing entry so future
+ * jekts return "agent not found", but does NOT kill the underlying PTY
+ * process (that's owned by the pane / block controller). The agent's
+ * shell auto-register hook may re-register on its next heartbeat.
+ *
+ * Hard kill (PTY termination) lives outside Warden — see future PR.
+ */
+async function deregisterAgent(agentId: string): Promise<void> {
+    const resp = await fetch(
+        getWebServerEndpoint() + "/agentmux/reactive/unregister",
+        {
+            method: "POST",
+            headers: { ...authedHeaders(), "Content-Type": "application/json" },
+            body: JSON.stringify({ agent_id: agentId }),
+        },
+    );
+    if (!resp.ok) {
+        throw new Error(`warden: POST /agentmux/reactive/unregister → ${resp.status}`);
+    }
+}
+
 function ageMs(ts: number, now: number): number {
     // `last_seen` / `registered_at` are unix millis from the Rust backend.
     return Math.max(0, now - ts);
@@ -129,6 +152,19 @@ const HostSection = (): JSX.Element => {
         }
     };
 
+    const handleDeregister = async (agentId: string) => {
+        const confirmed = globalThis.window?.confirm(
+            `Deregister agent "${agentId}"?\n\nThis removes its routing entry so future jekts return "agent not found". The underlying process keeps running and may re-register on its next heartbeat.`,
+        );
+        if (!confirmed) return;
+        try {
+            await deregisterAgent(agentId);
+            void refresh();
+        } catch (e) {
+            setError(String(e));
+        }
+    };
+
     onMount(() => {
         void refresh();
         const dataTimer = window.setInterval(() => void refresh(), HOST_REFRESH_MS);
@@ -161,6 +197,7 @@ const HostSection = (): JSX.Element => {
                             <th>block</th>
                             <th>last seen</th>
                             <th>state</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -178,6 +215,15 @@ const HostSection = (): JSX.Element => {
                                             <span class={`warden-host-state warden-host-state--${state()}`}>
                                                 {state()}
                                             </span>
+                                        </td>
+                                        <td class="warden-host-actions">
+                                            <button
+                                                class="warden-host-deregister"
+                                                title="Deregister (soft kill — removes from jekt routing, leaves process running)"
+                                                onClick={() => void handleDeregister(a.agent_id)}
+                                            >
+                                                ×
+                                            </button>
                                         </td>
                                     </tr>
                                 );


### PR DESCRIPTION
> **First slice of L1 enforcement.** Each agent row in the Warden's Host section gets a × button that does a *soft* deregister — removes the agent's entry from the reactive registry so future jekts return "agent not found", but does NOT kill the underlying process.
>
> Spec: \`specs/SPEC_WARDEN_WIDGET_2026-05-25.md\`
> Stack: PR-D (this) follows PR-E (#1047 merged), PR-C (#1046 merged), PR-B (#1045 merged), PR-A (#1044 merged)

## Why soft

Hard kill (PTY termination) is out of scope here:
- Process lifecycle is owned by the block controller, not the reactive routing layer
- A "deregister" is reversible (the agent's shell auto-register hook restores routing on next heartbeat)
- The blast-radius is well-defined: routing only

The confirmation dialog spells this out so the operator isn't surprised when the row reappears 30 s later.

## What this PR adds

- \`deregisterAgent(agentId)\` calling \`POST /agentmux/reactive/unregister\` with the auth header
- \`handleDeregister\` in \`HostSection\` — \`window.confirm\` first, then POST, then immediate refresh
- × button per row (\`warden-host-deregister\`) with hover state turning red
- Tooltip clarifies "removes from jekt routing, leaves process running"

## Backend changes

**None.** The reactive-unregister endpoint already exists.

## Out of scope (each its own PR)

| Capability | When |
|---|---|
| Hard kill (PTY termination) | Future PR — needs block-controller hook |
| Pause host (stop all inbound jekts) | Future PR |
| Kill-all (emergency stop) | Future PR |
| \`governance.json\` policy file | Future PR |
| Approval queue / human-in-the-loop | Future PR |
| Capability revocation per agent | Future PR |

## Verification

- \`npx tsc --noEmit\` — no errors in warden files
- Smoke test: spawn an agent → see it in Warden Host → click × → confirm → row drops on next 5 s poll; if shell heartbeat re-registers, row reappears