### PR TITLE
feat(theme): hard corners on buttons + modals; pills/avatars stay round

### DIFF
--- a/.changesets/1779379302-feat-statusbar-opacity-slider-tracks-the-drag-reactive-store-vqdd.md
+++ b/.changesets/1779379302-feat-statusbar-opacity-slider-tracks-the-drag-reactive-store-vqdd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(statusbar): opacity slider % tracks the drag (reactive store)

--- a/.changesets/1779550442-feat-activity-add-global-agent-activity-aggregator-taskbar-i-3060.md
+++ b/.changesets/1779550442-feat-activity-add-global-agent-activity-aggregator-taskbar-i-3060.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(activity): add global agent-activity aggregator (taskbar indicator step 1)

--- a/.changesets/1779554462-tweak-tool-block-bump-post-completion-hold-from-1s-to-5s-i9sg.md
+++ b/.changesets/1779554462-tweak-tool-block-bump-post-completion-hold-from-1s-to-5s-i9sg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-tweak(tool-block): bump post-completion hold from 1s to 5s

--- a/.changesets/1779584279-feat-srv-agent-anchored-session-zones-backend-1ter.md
+++ b/.changesets/1779584279-feat-srv-agent-anchored-session-zones-backend-1ter.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): agent-anchored session zones (backend)

--- a/.changesets/1779585812-feat-agent-default-continue-from-agent-session-zones-fronten-5ota.md
+++ b/.changesets/1779585812-feat-agent-default-continue-from-agent-session-zones-fronten-5ota.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): default-continue from agent session zones (frontend)

--- a/.changesets/1779586908-feat-focus-instrument-last-focused-child-on-intentional-win3-jf84.md
+++ b/.changesets/1779586908-feat-focus-instrument-last-focused-child-on-intentional-win3-jf84.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(focus): instrument LAST_FOCUSED_CHILD on intentional Win32 focus (window-reactivate step 1)

--- a/.changesets/1779595340-feat-picker-two-tier-my-agents-templates-pgqd.md
+++ b/.changesets/1779595340-feat-picker-two-tier-my-agents-templates-pgqd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(picker): two-tier — My Agents + templates

--- a/.changesets/1779599329-feat-picker-hide-templates-cdxo.md
+++ b/.changesets/1779599329-feat-picker-hide-templates-cdxo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(picker): hide templates

--- a/.changesets/1779600998-feat-srv-db-agents-schema-dual-write-a922.md
+++ b/.changesets/1779600998-feat-srv-db-agents-schema-dual-write-a922.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): db_agents schema + dual-write

--- a/.changesets/1779606177-feat-srv-migrate-read-paths-to-db-agents-phase-3b-ds93.md
+++ b/.changesets/1779606177-feat-srv-migrate-read-paths-to-db-agents-phase-3b-ds93.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): migrate read paths to db_agents (Phase 3b)

--- a/.changesets/1779612216-fix-srv-drop-parent-instance-id-filter-from-instance-list-na-w3mr.md
+++ b/.changesets/1779612216-fix-srv-drop-parent-instance-id-filter-from-instance-list-na-w3mr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): drop parent_instance_id filter from instance_list_named so continuation rows appear in My Agents picker (Option E)

--- a/.changesets/1779612433-fix-srv-make-template-promote-migration-self-idempotent-data-tnjc.md
+++ b/.changesets/1779612433-fix-srv-make-template-promote-migration-self-idempotent-data-tnjc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): make template_promote migration self-idempotent (data-invariant-gated, not marker-gated)

--- a/.changesets/1779613227-fix-agent-pass-prior-session-id-through-reattach-so-spawn-in-fv0o.md
+++ b/.changesets/1779613227-fix-agent-pass-prior-session-id-through-reattach-so-spawn-in-fv0o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): pass prior session id through reattach so spawn includes --resume on the first turn

--- a/.changesets/1779631619-fix-agent-failed-tool-panels-collapse-after-the-5s-post-comp-gisc.md
+++ b/.changesets/1779631619-fix-agent-failed-tool-panels-collapse-after-the-5s-post-comp-gisc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): failed tool panels collapse after the 5s post-completion hold like successes

--- a/.changesets/1779632612-docs-spec-per-root-focus-tracking-window-reactivate-step-1-5-1d6q.md
+++ b/.changesets/1779632612-docs-spec-per-root-focus-tracking-window-reactivate-step-1-5-1d6q.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(spec): per-root focus tracking (window-reactivate step 1.5)

--- a/.changesets/1779632856-fix-agent-high-contrast-user-input-color-no-soft-wrap-on-typ-9phh.md
+++ b/.changesets/1779632856-fix-agent-high-contrast-user-input-color-no-soft-wrap-on-typ-9phh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): high-contrast user-input color + no soft-wrap on typed messages

--- a/.changesets/1779633028-fix-agent-mark-startup-injection-user-messages-via-stream-pa-23q6.md
+++ b/.changesets/1779633028-fix-agent-mark-startup-injection-user-messages-via-stream-pa-23q6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): mark startup-injection user messages via stream-parser flag

--- a/.changesets/1779633219-fix-agent-usermessageblock-collapses-startup-injection-on-ho-4rm4.md
+++ b/.changesets/1779633219-fix-agent-usermessageblock-collapses-startup-injection-on-ho-4rm4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): UserMessageBlock collapses startup injection on hover, mirrors ToolBlock

--- a/.changesets/1779633526-refactor-focus-per-root-last-focused-by-root-map-window-reac-go9z.md
+++ b/.changesets/1779633526-refactor-focus-per-root-last-focused-by-root-map-window-reac-go9z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(focus): per-root LAST_FOCUSED_BY_ROOT map (window-reactivate step 1.5)

--- a/.changesets/1779640151-fix-agent-hover-expanded-startup-body-uses-absolute-overlay--xr8e.md
+++ b/.changesets/1779640151-fix-agent-hover-expanded-startup-body-uses-absolute-overlay--xr8e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): hover-expanded startup body uses absolute overlay so summary stays under cursor

--- a/.changesets/1779664479-fix-agent-opaque-overlay-bg-extend-hover-anchor-to-toolblock-uttt.md
+++ b/.changesets/1779664479-fix-agent-opaque-overlay-bg-extend-hover-anchor-to-toolblock-uttt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): opaque overlay bg + extend hover-anchor to ToolBlock for upward expansion near pane bottom

--- a/.changesets/1779665878-fix-test-exclude-claude-worktrees-from-vitest-discovery-to-d-a23h.md
+++ b/.changesets/1779665878-fix-test-exclude-claude-worktrees-from-vitest-discovery-to-d-a23h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(test): exclude .claude/worktrees from vitest discovery to drop 82 duplicate failures

--- a/.changesets/1779666314-fix-test-unstale-browser-pane-title-and-acp-openclaw-oauth-a-p9vd.md
+++ b/.changesets/1779666314-fix-test-unstale-browser-pane-title-and-acp-openclaw-oauth-a-p9vd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(test): unstale browser-pane title and ACP openclaw OAuth assertions

--- a/.changesets/1779666459-feat-focus-top-level-wm-activate-handler-restores-focus-on-w-jqlj.md
+++ b/.changesets/1779666459-feat-focus-top-level-wm-activate-handler-restores-focus-on-w-jqlj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(focus): top-level WM_ACTIVATE handler restores focus on window re-activate (step 2)

--- a/.changesets/1779666876-chore-test-load-testing-library-jest-dom-vitest-types-in-tsc-kt9x.md
+++ b/.changesets/1779666876-chore-test-load-testing-library-jest-dom-vitest-types-in-tsc-kt9x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(test): load @testing-library/jest-dom/vitest types in tsconfig (29 tsc errors → 0)

--- a/.changesets/1779673057-feat-common-channels-version-spanning-data-isolation-increme-8pdo.md
+++ b/.changesets/1779673057-feat-common-channels-version-spanning-data-isolation-increme-8pdo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(common): channels — version-spanning data isolation (Increment A from SPEC_DATA_CHANNELS)

--- a/.changesets/1779694580-fix-window-drop-hand-link-cursor-on-title-bar-widgets-window-mq99.md
+++ b/.changesets/1779694580-fix-window-drop-hand-link-cursor-on-title-bar-widgets-window-mq99.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): drop hand-link cursor on title-bar widgets + Windows window controls

--- a/.changesets/1779694669-fix-term-await-fonts-ready-nan-guard-post-paint-refit-to-fix-361k.md
+++ b/.changesets/1779694669-fix-term-await-fonts-ready-nan-guard-post-paint-refit-to-fix-361k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): await fonts.ready + NaN guard + post-paint refit to fix jumbled startup render

--- a/.changesets/1779694728-feat-srv-safety-lock-refuse-to-open-schema-written-by-newer--yycj.md
+++ b/.changesets/1779694728-feat-srv-safety-lock-refuse-to-open-schema-written-by-newer--yycj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): safety lock — refuse to open schema written by newer binary (channels Increment B.1)

--- a/.changesets/1779697463-chore-modal-drop-modal-v2-references-from-comments-canonical-28es.md
+++ b/.changesets/1779697463-chore-modal-drop-modal-v2-references-from-comments-canonical-28es.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(modal): drop modal-v2 references from comments — canonical modal is the only version

--- a/.changesets/1779699173-feat-add-lan-discovery-toggle-to-hostpopover.md
+++ b/.changesets/1779699173-feat-add-lan-discovery-toggle-to-hostpopover.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(network): add LAN discovery toggle to HostPopover with live daemon start/stop

--- a/.changesets/1779701468-feat-modal-parameterize-modallayer-over-scope-pane-scope-lau-akpm.md
+++ b/.changesets/1779701468-feat-modal-parameterize-modallayer-over-scope-pane-scope-lau-akpm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(modal): parameterize ModalLayer over scope — pane-scope launch modal (SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25)

--- a/.changesets/1779716363-diag-cef-instrument-on-auth-credentials-on-load-error-entry--lr3h.md
+++ b/.changesets/1779716363-diag-cef-instrument-on-auth-credentials-on-load-error-entry--lr3h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-diag(cef): instrument on_auth_credentials + on_load_error entry points (browser-pane auth diagnosis)

--- a/.changesets/1779717830-feat-srv-pre-migration-sqlite-snapshots-increment-b-2-lean-c-t3jb.md
+++ b/.changesets/1779717830-feat-srv-pre-migration-sqlite-snapshots-increment-b-2-lean-c-t3jb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): pre-migration SQLite snapshots — Increment B.2 lean cut from SPEC_DATA_CHANNELS

--- a/.changesets/1779721080-fix-cef-pass-disable-chrome-login-prompt-so-ongetauthcredent-rvvz.md
+++ b/.changesets/1779721080-fix-cef-pass-disable-chrome-login-prompt-so-ongetauthcredent-rvvz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): pass --disable-chrome-login-prompt so OnGetAuthCredentials fires (browser-pane HTTP auth modal)

--- a/.changesets/1779722120-feat-browser-pane-wrap-browser-view-in-pane-scope-modallayer-9b82.md
+++ b/.changesets/1779722120-feat-browser-pane-wrap-browser-view-in-pane-scope-modallayer-9b82.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(browser-pane): wrap browser view in pane-scope ModalLayer (auth modal locks only the pane)

--- a/.changesets/1779723769-feat-modal-compact-variant-for-narrow-lock-regions-auto-trig-cfv5.md
+++ b/.changesets/1779723769-feat-modal-compact-variant-for-narrow-lock-regions-auto-trig-cfv5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(modal): compact variant for narrow lock regions (auto-trigger via ResizeObserver)

--- a/.changesets/1779725954-fix-term-use-document-fonts-load-to-force-load-hack-before-f-yo5i.md
+++ b/.changesets/1779725954-fix-term-use-document-fonts-load-to-force-load-hack-before-f-yo5i.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): use document.fonts.load() to force-load Hack before first fit (#1030 follow-up)

--- a/.changesets/1779750444-fix-term-psreadline-cursor-desync-thaw-on-terminal-init.md
+++ b/.changesets/1779750444-fix-term-psreadline-cursor-desync-thaw-on-terminal-init.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): PSReadLine cursor-desync thaw on terminal init (#1042)

--- a/.changesets/1779753083-feat-warden-add-widget-shell-with-three-section-scaffold.md
+++ b/.changesets/1779753083-feat-warden-add-widget-shell-with-three-section-scaffold.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(warden): add widget shell with three-section (Host/LAN/Internet) scaffold

--- a/.changesets/1779753431-feat-warden-host-section-renders-live-agent-list.md
+++ b/.changesets/1779753431-feat-warden-host-section-renders-live-agent-list.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(warden): host section renders live agent list from reactive registry

--- a/.changesets/1779756101-feat-warden-host-section-shows-recent-jekt-audit-feed.md
+++ b/.changesets/1779756101-feat-warden-host-section-shows-recent-jekt-audit-feed.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(warden): host section shows recent jekt audit feed

--- a/.changesets/1779756282-feat-warden-lan-section-renders-mdns-peer-list.md
+++ b/.changesets/1779756282-feat-warden-lan-section-renders-mdns-peer-list.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(warden): LAN section renders live mDNS peer list

--- a/.changesets/1779756482-feat-warden-soft-deregister-agent-button.md
+++ b/.changesets/1779756482-feat-warden-soft-deregister-agent-button.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(warden): host section adds soft-deregister button per agent

--- a/.changesets/1779784502-feat-theme-hard-corners-on-buttons-modals-pills-avatars-stay-ngnb.md
+++ b/.changesets/1779784502-feat-theme-hard-corners-on-buttons-modals-pills-avatars-stay-ngnb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(theme): hard corners on buttons + modals; pills/avatars stay round

--- a/.changesets/1779784502-feat-theme-hard-corners-on-buttons-modals-pills-avatars-stay-ngnb.md
+++ b/.changesets/1779784502-feat-theme-hard-corners-on-buttons-modals-pills-avatars-stay-ngnb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(theme): hard corners on buttons + modals; pills/avatars stay round

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.3"
+version = "0.38.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.3"
+version = "0.38.5"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.3"
+version = "0.38.5"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.3"
+version = "0.38.5"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.3"
+version = "0.38.5"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.3"
+version = "0.38.5"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,54 @@
 # AgentMux Version History
 
+## 0.38.4 — 2026-05-26
+
+- feat(statusbar): opacity slider % tracks the drag (reactive store)
+- feat(activity): add global agent-activity aggregator (taskbar indicator step 1)
+- tweak(tool-block): bump post-completion hold from 1s to 5s
+- feat(srv): agent-anchored session zones (backend)
+- feat(agent): default-continue from agent session zones (frontend)
+- feat(focus): instrument LAST_FOCUSED_CHILD on intentional Win32 focus (window-reactivate step 1)
+- feat(picker): two-tier — My Agents + templates
+- feat(picker): hide templates
+- feat(srv): db_agents schema + dual-write
+- feat(srv): migrate read paths to db_agents (Phase 3b)
+- fix(srv): drop parent_instance_id filter from instance_list_named so continuation rows appear in My Agents picker (Option E)
+- fix(srv): make template_promote migration self-idempotent (data-invariant-gated, not marker-gated)
+- fix(agent): pass prior session id through reattach so spawn includes --resume on the first turn
+- fix(agent): failed tool panels collapse after the 5s post-completion hold like successes
+- docs(spec): per-root focus tracking (window-reactivate step 1.5)
+- fix(agent): high-contrast user-input color + no soft-wrap on typed messages
+- fix(agent): mark startup-injection user messages via stream-parser flag
+- fix(agent): UserMessageBlock collapses startup injection on hover, mirrors ToolBlock
+- refactor(focus): per-root LAST_FOCUSED_BY_ROOT map (window-reactivate step 1.5)
+- fix(agent): hover-expanded startup body uses absolute overlay so summary stays under cursor
+- fix(agent): opaque overlay bg + extend hover-anchor to ToolBlock for upward expansion near pane bottom
+- fix(test): exclude .claude/worktrees from vitest discovery to drop 82 duplicate failures
+- fix(test): unstale browser-pane title and ACP openclaw OAuth assertions
+- feat(focus): top-level WM_ACTIVATE handler restores focus on window re-activate (step 2)
+- chore(test): load @testing-library/jest-dom/vitest types in tsconfig (29 tsc errors → 0)
+- feat(common): channels — version-spanning data isolation (Increment A from SPEC_DATA_CHANNELS)
+- fix(window): drop hand-link cursor on title-bar widgets + Windows window controls
+- fix(term): await fonts.ready + NaN guard + post-paint refit to fix jumbled startup render
+- feat(srv): safety lock — refuse to open schema written by newer binary (channels Increment B.1)
+- chore(modal): drop modal-v2 references from comments — canonical modal is the only version
+- feat(network): add LAN discovery toggle to HostPopover with live daemon start/stop
+- feat(modal): parameterize ModalLayer over scope — pane-scope launch modal (SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25)
+- diag(cef): instrument on_auth_credentials + on_load_error entry points (browser-pane auth diagnosis)
+- feat(srv): pre-migration SQLite snapshots — Increment B.2 lean cut from SPEC_DATA_CHANNELS
+- fix(cef): pass --disable-chrome-login-prompt so OnGetAuthCredentials fires (browser-pane HTTP auth modal)
+- feat(browser-pane): wrap browser view in pane-scope ModalLayer (auth modal locks only the pane)
+- feat(modal): compact variant for narrow lock regions (auto-trigger via ResizeObserver)
+- fix(term): use document.fonts.load() to force-load Hack before first fit (#1030 follow-up)
+- fix(term): PSReadLine cursor-desync thaw on terminal init (#1042)
+- feat(warden): add widget shell with three-section (Host/LAN/Internet) scaffold
+- feat(warden): host section renders live agent list from reactive registry
+- feat(warden): host section shows recent jekt audit feed
+- feat(warden): LAN section renders live mDNS peer list
+- feat(warden): host section adds soft-deregister button per agent
+- feat(theme): hard corners on buttons + modals; pills/avatars stay round
+
+
 ## 0.38.3 — 2026-05-23
 
 - feat(widgets): responsive labels collapse to icons on narrow title bars; all widgets pinned by default

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,9 @@
 # AgentMux Version History
 
+## 0.38.5 — 2026-05-26
+
+- chore: version bump (post-release rebuild to give the next portable a distinct version label from prior 0.38.4 portables on the build machine)
+
 ## 0.38.4 — 2026-05-26
 
 - feat(statusbar): opacity slider % tracks the drag (reactive store)

--- a/docs/specs/SPEC_HARD_CORNERS_2026_05_26.md
+++ b/docs/specs/SPEC_HARD_CORNERS_2026_05_26.md
@@ -1,0 +1,156 @@
+# SPEC: Hard corners on buttons and modals
+
+**Date:** 2026-05-26
+**Author:** AgentA (Claude Opus 4.7)
+**Scope:** Frontend visual refresh — flatten rounded corners on interactive surfaces (buttons, modal panels, dialog chrome) to a sharp, square aesthetic. Pills and avatars stay round.
+
+---
+
+## TL;DR
+
+AgentMux currently uses a rounded-corner radius scale of `3 / 6 / 10 / 16 px` (`--radius-sm` → `--radius-xl`) plus `--radius-full` (9999px) for pills/avatars. The active visual direction is to **drop the corner rounding on all buttons and modal chrome** for a sharper, more terminal-native look. Pills (avatars, status chips, badges) keep their `--radius-full` treatment so they remain visually distinct from action buttons.
+
+**The change is a token edit, not a 265-file refactor.** The radius tokens already centralize the rounding; setting the small/medium tokens to `0` propagates instantly. The minority of call sites that hard-code radii in pixels (~150 of 265 usages) are audited in a one-pass sweep and moved to either the token or `0` as appropriate.
+
+---
+
+## 1. Current state
+
+`frontend/app/theme.scss` defines:
+
+```scss
+--radius-sm:   3px;   // chips, small buttons
+--radius-md:   6px;   // standard buttons, inputs, cards
+--radius-lg:   10px;  // modal panels, large containers
+--radius-xl:   16px;  // hero cards
+--radius-full: 9999px; // pills, avatars, status dots
+```
+
+Distribution (frontend):
+
+| Form | Count | Notes |
+|---|---|---|
+| `var(--radius-sm)` | 5 | Token-correct, easy to flatten |
+| `var(--radius-md)` | 4 | Token-correct |
+| `var(--radius-lg)` | 1 | Token-correct |
+| **Hard-coded `border-radius: <Npx>`** | ~255 | Need audit; most are buttons/cards/inputs |
+| Total | 265 | |
+
+Most components were written before the token scale was introduced, so they hard-code 4/6/8px values directly.
+
+---
+
+## 2. Visual contract
+
+| Surface | Before | After |
+|---|---|---|
+| Standard buttons (primary, secondary, ghost) | 6px | **0** |
+| Modal panel | 10px | **0** |
+| Modal close button, modal-btn (confirm/destructive) | 4–6px | **0** |
+| Input fields, search bars | 4–6px | **0** |
+| Cards, popovers, dropdown menus | 4–8px | **0** |
+| Block frames (pane chrome) | varies | **0** |
+| Hover-highlight backgrounds | 4–6px | **0** |
+| Focus rings | rounded inset | **0 (square)** |
+| **Pills, avatars, status dots, badges** | 9999px | **9999px (unchanged)** |
+| **Color swatches, image thumbnails** | 4–8px | **unchanged** (decorative, not interactive) |
+| **Window edge** | OS-managed | **unchanged** |
+
+Sharp corners across all *interactive* elements. Curved corners only where they convey "this is round on purpose" (pills, avatars, certain decorative elements).
+
+---
+
+## 3. Implementation
+
+### Step A — token flip (low-risk, instant propagation)
+
+In `frontend/app/theme.scss`:
+
+```scss
+--radius-sm:   0px;
+--radius-md:   0px;
+--radius-lg:   0px;
+--radius-xl:   0px;
+--radius-full: 9999px; // unchanged
+```
+
+This catches the 10 call sites already using the token scale. No downstream changes needed for those.
+
+Optional: rename `--radius-sm/md/lg/xl` → `--radius-flat` (single token = 0) since they all collapse to the same value. Skip the rename in this pass to keep the diff minimal; do it in a follow-up if the squarification sticks.
+
+### Step B — hard-coded-radius audit + sweep
+
+Run:
+
+```sh
+grep -rn "border-radius:" frontend/ --include "*.scss" --include "*.css" \
+  | grep -v "var(--radius-full)" \
+  | grep -v "9999px" \
+  | grep -v "50%"
+```
+
+For each match, classify:
+
+1. **Interactive surface** (button, input, card, modal, popover, dropdown, hover-bg) → replace value with `0`.
+2. **Pill/avatar/status** (`border-radius: 9999px` or `50%`) → leave alone.
+3. **Decorative / image** (color swatch, thumbnail, sticker) → leave alone for now; designer call.
+4. **Border-radius on a `<canvas>` or terminal cell** → leave alone; might be used for visual mask.
+
+Bulk replace `border-radius: 4px;` / `6px;` / `8px;` → `border-radius: 0;` only on interactive surfaces. Use `var(--radius-md)` where the pattern is already token-aware so future flexes are easy.
+
+### Step C — focus rings
+
+The `--shadow-focus-ring` token (and the few `outline: ... ;` rules) often pair with rounded corners. With corners at 0, the focus ring should also be a sharp rectangle. Verify:
+
+- `:focus-visible` outlines: stay solid, no `border-radius` needed since they follow the host's box.
+- `box-shadow` focus rings (`var(--shadow-focus-ring)`): no change needed; they wrap the host's actual corner.
+
+### Step D — manual verification surfaces
+
+Visit and visually confirm sharp corners (no regressions) on:
+
+- Title bar buttons (min/max/close, widget bar, More dropdown)
+- Tab bar tabs (corners stay slightly rounded by design — call out exception below)
+- Block frame (pane chrome)
+- Hamburger menu (≡)
+- Settings menu / context menus
+- ConfirmModal, AgentLaunchModal, AgentInstallModal, all `<Modal>` panels
+- Status bar popovers (Host, Backend, Lan)
+- Search bar (Ctrl+F)
+- Agent pane: identity dropdown, memory dropdown, OAuth panel, tool blocks
+- Browser pane: address bar, find-on-page
+
+### Exception — tab bar tabs
+
+The chrome-style tabs at the top use a custom shape (`border-radius: 8px 8px 0 0;` — top-rounded only) that's part of the tab metaphor. **Tabs keep their top rounding.** Without it, tabs visually merge with the tab body. This is the one place where rounded corners convey structural meaning (tab is a "card sticking up out of the bar"), so leave alone.
+
+---
+
+## 4. Risks and edge cases
+
+- **Loss of visual hierarchy:** without rounding, similar-colored buttons in adjacent rows can blend. Mitigation: rely on existing border + hover backgrounds for separation; consider increasing `--border-color` contrast if separation feels weak after the sweep.
+- **Pill vs button confusion:** with most rounding gone, the `--radius-full` pills become very visually distinct. Likely fine (the whole point) but verify on the status-bar popover row where pills and buttons coexist.
+- **Image thumbnails with `border-radius: 4px`:** the SPEC explicitly leaves these alone. Designer can decide later if those should also flatten.
+- **macOS / Linux native chrome:** title bar buttons on macOS are traffic lights (round) and Linux are typically rounded. These are OS-managed (when traffic-light controls are enabled per PR #444). Not touched by this spec.
+
+---
+
+## 5. Out of scope
+
+- Renaming the radius tokens to a single `--radius-flat` (follow-up).
+- Decorative radii on images / color swatches.
+- Tab shape (preserves its own pattern).
+- Round avatars (preserved by design).
+
+---
+
+## 6. Delivery
+
+Single small PR:
+
+- `frontend/app/theme.scss` — token flip (sm/md/lg/xl → `0px`).
+- ~25-50 grep/edit sweeps across `frontend/**/*.scss` for hard-coded radii on interactive surfaces.
+- Visual smoke per §3D.
+- This spec rides with the code in the same PR (`feedback_no_doc_only_prs`).
+
+Reviewer flag: this is a visual change; eyes on the running build matter more than diff math. Squash + ship with the spec attached.

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -49,7 +49,7 @@ a.plain-link {
 
 *::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color);
-    border-radius: 4px;
+    border-radius: 0;
     margin: 0 1px 0 1px;
 }
 
@@ -126,7 +126,7 @@ a {
     .flash-error {
         background: var(--error-color);
         color: var(--main-text-color);
-        border-radius: 4px;
+        border-radius: 0;
         padding: 10px;
         display: flex;
         flex-direction: column;

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -181,7 +181,7 @@
                     min-width: 0;
                     font-weight: 400;
                     color: var(--main-text-color);
-                    border-radius: 2px;
+                    border-radius: 0;
                     padding: auto;
 
                     &:hover {
@@ -334,7 +334,7 @@
             overflow: hidden;
             background: var(--conn-status-overlay-bg-color);
             backdrop-filter: blur(50px);
-            border-radius: 6px;
+            border-radius: 0;
             box-shadow: 0px 13px 16px 0px rgb(from var(--block-bg-color) r g b / 40%);
 
             .connstatus-content {
@@ -389,7 +389,7 @@
                             letter-spacing: 0.11px;
                             text-wrap: wrap;
                             max-height: 80px;
-                            border-radius: 8px;
+                            border-radius: 0;
                             padding: 5px;
                             padding-left: 0;
                             position: relative;
@@ -401,7 +401,7 @@
                                 top: 0;
                                 right: 4px;
                                 float: right;
-                                border-radius: 4px;
+                                border-radius: 0;
                                 backdrop-filter: blur(8px);
                                 padding: 0.286em;
                                 align-items: center;

--- a/frontend/app/block/titlebar.scss
+++ b/frontend/app/block/titlebar.scss
@@ -54,7 +54,7 @@
         flex: 1;
         background: rgba(255, 255, 255, 0.05);
         border: 1px solid var(--accent-color);
-        border-radius: 3px;
+        border-radius: 0;
         padding: var(--space-0-5) var(--space-1-5);
         font-size: 12px;
         font-weight: 500;

--- a/frontend/app/drag/drag-overlay.scss
+++ b/frontend/app/drag/drag-overlay.scss
@@ -13,7 +13,7 @@
     justify-content: center;
     background: rgba(34, 197, 94, 0.08);
     border: 2px dashed var(--accent-color);
-    border-radius: 8px;
+    border-radius: 0;
     pointer-events: none;
     animation: cross-drag-fade-in 0.15s ease-out;
 

--- a/frontend/app/element/blockstats.scss
+++ b/frontend/app/element/blockstats.scss
@@ -13,7 +13,7 @@
     opacity: 0.5;
     white-space: nowrap;
     padding: 1px var(--space-1-5);
-    border-radius: 3px;
+    border-radius: 0;
     background: rgba(0, 0, 0, 0.3);
     pointer-events: none;
 

--- a/frontend/app/element/button.scss
+++ b/frontend/app/element/button.scss
@@ -16,7 +16,7 @@
     padding-right: var(--space-5);
     align-items: center;
     gap: var(--space-1);
-    border-radius: 6px;
+    border-radius: 0;
     height: auto;
     line-height: 16px;
     white-space: nowrap;

--- a/frontend/app/element/collapsiblemenu.scss
+++ b/frontend/app/element/collapsiblemenu.scss
@@ -53,7 +53,7 @@
 
     &:hover {
         background-color: var(--button-grey-hover-bg);
-        border-radius: 4px;
+        border-radius: 0;
     }
 }
 

--- a/frontend/app/element/emojipalette.scss
+++ b/frontend/app/element/emojipalette.scss
@@ -29,7 +29,7 @@
 
     &:hover {
         background-color: rgba(0, 0, 0, 0.1);
-        border-radius: 5px;
+        border-radius: 0;
     }
 }
 

--- a/frontend/app/element/expandablemenu.scss
+++ b/frontend/app/element/expandablemenu.scss
@@ -17,7 +17,7 @@
     padding: var(--space-2) var(--space-3); /* Left and right padding, we'll adjust this for the right side */
     cursor: pointer;
     box-sizing: border-box;
-    border-radius: 4px;
+    border-radius: 0;
 
     .label {
         @include mixins.ellipsis();

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -34,7 +34,7 @@
     line-height: normal;
     letter-spacing: -0.12px;
     width: 100%;
-    border-radius: 2px;
+    border-radius: 0;
 
     .label {
         @include mixins.ellipsis();
@@ -58,7 +58,7 @@
 
     &:hover {
         background-color: var(--hover-bg-color);
-        border-radius: 2px;
+        border-radius: 0;
     }
 }
 

--- a/frontend/app/element/iconbutton.scss
+++ b/frontend/app/element/iconbutton.scss
@@ -38,7 +38,7 @@
     }
 
     &.toggle {
-        border-radius: 3px;
+        border-radius: 0;
         padding: 1px;
         &.active {
             opacity: 1;

--- a/frontend/app/element/input.scss
+++ b/frontend/app/element/input.scss
@@ -10,7 +10,7 @@
     color: var(--form-element-text-color);
     background: var(--form-element-bg-color);
     border: 2px solid var(--form-element-border-color);
-    border-radius: 6px;
+    border-radius: 0;
     padding: var(--space-1) 7px;
 
     &:focus {
@@ -30,7 +30,7 @@
 .input-group {
     display: flex;
     align-items: center;
-    border-radius: 6px;
+    border-radius: 0;
     position: relative;
     width: 100%;
     border: 2px solid var(--form-element-border-color);
@@ -66,7 +66,7 @@
     .input {
         border: none;
         flex-grow: 1;
-        border-radius: none;
+        border-radius: 0;
 
         &:focus {
             border-color: transparent;

--- a/frontend/app/element/markdown.scss
+++ b/frontend/app/element/markdown.scss
@@ -123,7 +123,7 @@
 
         blockquote {
             margin: 0.286em 0.714em;
-            border-radius: 4px;
+            border-radius: 0;
             background-color: var(--panel-bg-color);
             padding: 0.143em 0.286em 0.143em 0.429em;
         }
@@ -132,7 +132,7 @@
             background-color: var(--panel-bg-color);
             margin: 0.286em 0.714em;
             padding: 0.4em 0.7em;
-            border-radius: 4px;
+            border-radius: 0;
             position: relative;
 
             code {
@@ -150,7 +150,7 @@
                 position: absolute;
                 top: 0;
                 right: 0;
-                border-radius: 4px;
+                border-radius: 0;
                 backdrop-filter: blur(8px);
                 margin: 0.143em;
                 padding: 0.286em;
@@ -168,7 +168,7 @@
             color: var(--main-text-color);
             font: var(--fixed-font);
             font-size: var(--markdown-fixed-font-size);
-            border-radius: 4px;
+            border-radius: 0;
         }
 
         pre.selected {
@@ -184,7 +184,7 @@
                 padding: 0.857em;
                 background-color: var(--highlight-bg-color);
                 border: 1px solid var(--border-color);
-                border-radius: 8px;
+                border-radius: 0;
                 transition: background-color 0.2s ease;
             }
 
@@ -195,7 +195,7 @@
                 width: 2.857em;
                 height: 2.857em;
                 background-color: black;
-                border-radius: 8px;
+                border-radius: 0;
                 margin-right: 0.857em;
             }
 

--- a/frontend/app/element/menu-frame.scss
+++ b/frontend/app/element/menu-frame.scss
@@ -10,7 +10,7 @@
 @mixin menu-frame {
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: 0;
     box-shadow: 0px 8px 24px 0px rgba(0, 0, 0, 0.3);
     padding: var(--space-0-5);
 }

--- a/frontend/app/element/multilineinput.scss
+++ b/frontend/app/element/multilineinput.scss
@@ -14,7 +14,7 @@
     height: auto;
     padding: 5px;
     border: 1px solid var(--form-element-border-color);
-    border-radius: 4px;
+    border-radius: 0;
     min-height: 26px;
 
     &:focus-visible {

--- a/frontend/app/element/popover.scss
+++ b/frontend/app/element/popover.scss
@@ -9,7 +9,7 @@
     display: flex;
     padding: var(--space-0-5);
     gap: 1px;
-    border-radius: 4px;
+    border-radius: 0;
     border: 1px solid var(--border-color);
     background: var(--main-bg-color);
     box-shadow: var(--shadow-md);

--- a/frontend/app/element/toggle.scss
+++ b/frontend/app/element/toggle.scss
@@ -30,7 +30,10 @@
             right: 0;
             background-color: var(--toggle-bg-color);
             transition: 0.5s;
-            border-radius: 33px;
+            // Toggle slider is a pill switch — explicit exception in
+            // SPEC_HARD_CORNERS_2026_05_26.md (toggles read as round
+            // on purpose). The thumb (`.slider:before`) is 50% below.
+            border-radius: var(--radius-full);
         }
 
         .slider:before {

--- a/frontend/app/element/zoomindicator.scss
+++ b/frontend/app/element/zoomindicator.scss
@@ -18,7 +18,7 @@
     background: rgba(0, 0, 0, 0.8);
     color: white;
     padding: var(--space-4) var(--space-8);
-    border-radius: 8px;
+    border-radius: 0;
     font-size: 48px;
     font-weight: 600;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);

--- a/frontend/app/errors/ErrorBanner.scss
+++ b/frontend/app/errors/ErrorBanner.scss
@@ -14,7 +14,7 @@
     padding: var(--space-2) var(--space-2-5);
     background: color-mix(in srgb, var(--error-color, #ff6b6b) 12%, transparent);
     border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 40%, transparent);
-    border-radius: 6px;
+    border-radius: 0;
     color: var(--main-text-color);
     font-size: var(--text-sm, 13px);
     line-height: 1.4;
@@ -72,7 +72,7 @@
     padding: var(--space-1) var(--space-1-5);
     background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     font-family: var(--fixed-font, monospace);
     font-size: 11px;
     white-space: pre-wrap;
@@ -91,7 +91,7 @@
     letter-spacing: 0.04em;
     background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
     color: var(--secondary-text-color);
-    border-radius: 3px;
+    border-radius: 0;
     user-select: text;
     white-space: nowrap;
 }

--- a/frontend/app/modals/bundle-manager-modal.scss
+++ b/frontend/app/modals/bundle-manager-modal.scss
@@ -38,7 +38,7 @@
     width: 100%;
     padding: 8px 10px;
     border: none;
-    border-radius: 6px;
+    border-radius: 0;
     background: transparent;
     color: var(--main-text-color);
     font-size: 13px;

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -59,7 +59,7 @@
     color: var(--secondary-text-color);
     background: var(--panel-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     padding: 1px 5px;
     flex-shrink: 0;
     font-family: var(--base-font, inherit);
@@ -78,7 +78,7 @@
     }
     &::-webkit-scrollbar-thumb {
         background: var(--border-color);
-        border-radius: 3px;
+        border-radius: 0;
     }
 }
 

--- a/frontend/app/modals/typeaheadmodal.scss
+++ b/frontend/app/modals/typeaheadmodal.scss
@@ -19,7 +19,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    border-radius: 6px;
+    border-radius: 0;
     border: 1px solid var(--modal-border-color);
     background: var(--modal-bg-color);
     box-shadow: 0px 13px 16px 0px rgba(0, 0, 0, 0.4);
@@ -84,7 +84,7 @@
             align-items: center;
             gap: var(--space-2);
             align-self: stretch;
-            border-radius: 4px;
+            border-radius: 0;
 
             &.selected {
                 background-color: rgb(from var(--accent-color) r g b / 0.5);

--- a/frontend/app/modals/userinputmodal.scss
+++ b/frontend/app/modals/userinputmodal.scss
@@ -22,7 +22,7 @@
     .userinput-inputbox {
         resize: none;
         background-color: var(--panel-bg-color);
-        border-radius: 6px;
+        border-radius: 0;
         margin: 0;
         border: var(--border-color);
         padding: 5px 0 5px var(--space-4);

--- a/frontend/app/notification/notificationitem.scss
+++ b/frontend/app/notification/notificationitem.scss
@@ -83,7 +83,7 @@
         padding: var(--space-4) var(--space-6) var(--space-4) var(--space-4);
         align-items: flex-start;
         gap: var(--space-3);
-        border-radius: 8px;
+        border-radius: 0;
         border: 0.5px solid rgba(255, 255, 255, 0.12);
         background: var(--modal-bg-color);
         box-shadow: 0px 8px 32px 0px rgba(0, 0, 0, 0.25);

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -73,7 +73,7 @@
         padding: 0 5px;
         height: 100%;
         white-space: nowrap;
-        border-radius: 2px;
+        border-radius: 0;
 
         &.clickable {
             cursor: pointer;
@@ -160,7 +160,7 @@
             background: var(--modal-bg-color);
             color: var(--main-text-color);
             border: 1px solid var(--border-color);
-            border-radius: 3px;
+            border-radius: 0;
             font-size: 11px;
             white-space: nowrap;
             max-width: 320px;
@@ -217,7 +217,7 @@
         opacity: 0.4;
         font-size: 10px;
         padding: 0 5px;
-        border-radius: 2px;
+        border-radius: 0;
         // Button reset so the chip looks identical whether it's a
         // <span> (offline) or a <button> (clickable instance panel).
         background: transparent;
@@ -257,7 +257,7 @@
     margin-left: 4px;
     padding: 0 3px;
     border: 1px solid var(--accent-color);
-    border-radius: 3px;
+    border-radius: 0;
     font-size: 0.85em;
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -270,7 +270,7 @@
     left: 0;
     background: var(--modal-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     padding: var(--space-2) 10px;
     min-width: 200px;
     z-index: var(--zindex-modal-wrapper);
@@ -316,7 +316,7 @@
             width: 28px;
             height: 14px;
             background: var(--border-color);
-            border-radius: 7px;
+            border-radius: 0;
             position: relative;
             cursor: pointer;
             transition: background 120ms ease;
@@ -358,7 +358,7 @@
        no semantic token maps to "always white regardless of theme". */
     color: #fff; /* stylelint-disable-line color-no-hex */
     border: none;
-    border-radius: 3px;
+    border-radius: 0;
     cursor: pointer;
     font-size: 11px;
     opacity: 0.85;

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -55,7 +55,7 @@
     color: var(--secondary-text-color);
     cursor: pointer;
     padding: 2px 4px;
-    border-radius: 3px;
+    border-radius: 0;
     font-size: 12px;
     line-height: 1;
 
@@ -86,7 +86,7 @@
     width: 100%;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 4px;
+    border-radius: 0;
     padding: var(--space-1) var(--space-1-5);
     color: var(--main-text-color);
     font-size: 12px;
@@ -143,7 +143,7 @@
     border: 1px solid var(--border-color);
     color: var(--main-text-color);
     padding: var(--space-1) var(--space-2);
-    border-radius: 4px;
+    border-radius: 0;
     font-size: 12px;
     cursor: pointer;
 

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -17,7 +17,7 @@
     font-size: inherit;
     cursor: pointer;
     white-space: nowrap;
-    border-radius: 2px;
+    border-radius: 0;
     opacity: 0.7;
     transition: background 80ms ease, opacity 80ms ease;
 
@@ -60,7 +60,7 @@
 .token-usage-breakdown {
     background: var(--modal-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     color: var(--main-text-color);
     font-size: 12px;
@@ -154,7 +154,7 @@
         font-family: inherit;
         font-size: 11px;
         padding: var(--space-0-5) var(--space-2);
-        border-radius: 3px;
+        border-radius: 0;
         cursor: pointer;
         transition: background 80ms ease, border-color 80ms ease;
 

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -104,7 +104,7 @@
             outline: none;
             border: 1px solid rgb(from var(--main-text-color) r g b / 0.179);
             padding: var(--space-0-5) var(--space-1-5);
-            border-radius: 2px;
+            border-radius: 0;
         }
     }
 
@@ -270,7 +270,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     padding: var(--space-1) var(--space-1-5);
     background: transparent;
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--secondary-text-color);
     font-size: 11px;
     cursor: pointer;
@@ -290,7 +290,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
 .tab-color-swatch {
     width: 20px;
     height: 20px;
-    border-radius: 4px;
+    border-radius: 0;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -131,7 +131,7 @@
     --modal-bg-color: #232323;
     --modal-header-bottom-border-color: rgba(241, 246, 243, 0.15);
     --modal-border-color: rgba(255, 255, 255, 0.12); /* toggle colors */
-    --modal-border-radius: 6px;
+    --modal-border-radius: 0; /* SPEC_HARD_CORNERS_2026_05_26 */
     --toggle-bg-color: var(--border-color);
     --modal-shadow-color: rgba(0, 0, 0, 0.8);
     --modal-box-shadow: box-shadow: 0px 8px 24px 0px var(--modal-shadow-color);
@@ -260,11 +260,12 @@
     --text-heading: var(--font-weight-bold)   var(--text-xl)   / var(--leading-tight)  var(--font-sans);
     --text-title:   var(--font-weight-bold)   var(--text-2xl)  / var(--leading-tight)  var(--font-sans);
 
-    // Radius scale — chips → modals → pills.
-    --radius-sm:   3px;
-    --radius-md:   6px;
-    --radius-lg:   10px;
-    --radius-xl:   16px;
+    // Radius scale — hard corners on interactive surfaces; pills/avatars
+    // keep `--radius-full`. Spec: SPEC_HARD_CORNERS_2026_05_26.md.
+    --radius-sm:   0;
+    --radius-md:   0;
+    --radius-lg:   0;
+    --radius-xl:   0;
     --radius-full: 9999px;
 
     // Shadow scale. `--shadow-modal` is explicitly named so modal specs

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -40,7 +40,7 @@
     color: var(--main-text-color);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     outline: none;
 
     &:focus {
@@ -61,7 +61,7 @@
     color: var(--main-text-color);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     outline: none;
     resize: vertical;
     font-family: inherit;
@@ -83,7 +83,7 @@
     padding: var(--space-1-5) var(--space-2);
     background: color-mix(in srgb, var(--error-color, #ff6b6b) 10%, transparent);
     border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 30%, transparent);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--error-color, #ff6b6b);
     font-size: var(--text-sm);
 }

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -29,7 +29,7 @@
     padding: var(--space-2) var(--space-2-5);
     background: color-mix(in srgb, var(--warning-color, #e9b800) 6%, transparent);
     border: 1px solid color-mix(in srgb, var(--warning-color, #e9b800) 30%, transparent);
-    border-radius: 6px;
+    border-radius: 0;
 }
 
 .agent-prereq-modal-icon {
@@ -85,7 +85,7 @@
     code {
         padding: 1px 4px;
         background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
-        border-radius: 3px;
+        border-radius: 0;
         font-size: 0.9em;
     }
 }

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.scss
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.scss
@@ -13,7 +13,7 @@
     padding: var(--space-4);
     margin: var(--space-3) 0;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 0;
     background-color: var(--panel-bg, rgba(255, 255, 255, 0.02));
 }
 
@@ -114,7 +114,7 @@
     padding: var(--space-2) var(--space-3);
     background-color: var(--input-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--main-text-color);
     font-family: var(--mono-font-family);
     font-size: 12px;
@@ -131,7 +131,7 @@
     padding: var(--space-2) var(--space-3);
     background-color: var(--input-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--main-text-color);
     font-family: var(--mono-font-family);
     font-size: 12px;
@@ -148,7 +148,7 @@
     padding: var(--space-3);
     background-color: var(--input-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -184,7 +184,7 @@
     font-weight: 500;
     padding: var(--space-2) var(--space-3);
     background-color: rgba(16, 185, 129, 0.08);
-    border-radius: 4px;
+    border-radius: 0;
 }
 
 .pre-launch-auth-panel-failed {
@@ -194,7 +194,7 @@
     padding: var(--space-3);
     background-color: rgba(239, 68, 68, 0.08);
     border: 1px solid rgba(239, 68, 68, 0.3);
-    border-radius: 4px;
+    border-radius: 0;
 }
 
 .pre-launch-auth-panel-failed-message {

--- a/frontend/app/view/agent/styles/_action-bar.scss
+++ b/frontend/app/view/agent/styles/_action-bar.scss
@@ -25,7 +25,7 @@
             color: var(--secondary-text-color);
             background: transparent;
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             cursor: pointer;
             white-space: nowrap;
             transition: background 0.1s, color 0.1s;

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -158,7 +158,7 @@
         padding: 10px var(--space-3);
         background: var(--panel-bg-color, rgba(74, 158, 255, 0.08));
         border: 1px solid var(--accent-color);
-        border-radius: 6px;
+        border-radius: 0;
         box-shadow: 0 0 12px rgba(74, 158, 255, 0.15);
     }
 
@@ -176,7 +176,7 @@
         align-items: center;
         padding: var(--space-2) 10px;
         background: rgba(0, 0, 0, 0.35);
-        border-radius: 4px;
+        border-radius: 0;
         cursor: default;
 
         &:hover .agent-auth-url-copy {
@@ -206,7 +206,7 @@
         background: var(--accent-color);
         color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
-        border-radius: 3px;
+        border-radius: 0;
         cursor: pointer;
         opacity: 0;
         transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
@@ -232,7 +232,7 @@
             padding: var(--space-1-5) 10px;
             background: rgba(0, 0, 0, 0.35);
             border: 1px solid rgba(74, 158, 255, 0.3);
-            border-radius: 4px;
+            border-radius: 0;
             color: var(--main-text-color);
             font-size: 11px;
             font-family: var(--fixed-font, monospace);

--- a/frontend/app/view/agent/styles/_bookmarks.scss
+++ b/frontend/app/view/agent/styles/_bookmarks.scss
@@ -59,7 +59,7 @@
         font-size: 10px;
         color: var(--secondary-text-color);
         background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
-        border-radius: 8px;
+        border-radius: 0;
         padding: 1px var(--space-1-5);
         min-width: 16px;
         text-align: center;
@@ -125,7 +125,7 @@
         background: var(--main-bg-color);
         color: var(--main-text-color);
         border: 1px solid var(--accent-color);
-        border-radius: 2px;
+        border-radius: 0;
         padding: 1px var(--space-1);
         outline: none;
         min-width: 0;
@@ -146,7 +146,7 @@
         padding: 0;
         background: none;
         border: none;
-        border-radius: 2px;
+        border-radius: 0;
         cursor: pointer;
         color: var(--secondary-text-color);
         font-size: 13px;

--- a/frontend/app/view/agent/styles/_connection-status.scss
+++ b/frontend/app/view/agent/styles/_connection-status.scss
@@ -39,7 +39,7 @@
                 padding: var(--space-1-5) 10px;
                 background: transparent;
                 border: 1px solid var(--border-color);
-                border-radius: 4px;
+                border-radius: 0;
                 color: var(--secondary-text-color);
                 font-size: 12px;
                 cursor: pointer;
@@ -106,7 +106,7 @@
                 padding: var(--space-1-5) var(--space-3);
                 background: var(--error-color);
                 border: none;
-                border-radius: 4px;
+                border-radius: 0;
                 color: var(--main-bg-color);
                 font-size: 11px;
                 font-weight: 500;
@@ -147,7 +147,7 @@
                 padding: 10px var(--space-5);
                 background: var(--accent-color);
                 border: none;
-                border-radius: 4px;
+                border-radius: 0;
                 color: var(--main-bg-color);
                 font-size: 12px;
                 font-weight: 500;
@@ -178,7 +178,7 @@
                 code {
                     background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
                     padding: var(--space-0-5) var(--space-1);
-                    border-radius: 2px;
+                    border-radius: 0;
                 }
             }
 
@@ -192,7 +192,7 @@
                     padding: 10px var(--space-3);
                     background: var(--main-bg-color);
                     border: 1px solid var(--border-color);
-                    border-radius: 4px;
+                    border-radius: 0;
                     color: var(--main-text-color);
                     font-family: inherit;
                     font-size: 12px;

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -213,7 +213,7 @@
         padding: 1px var(--space-1-5);
         background: color-mix(in srgb, var(--accent-color) 12%, transparent);
         border: 1px solid color-mix(in srgb, var(--accent-color) 40%, transparent);
-        border-radius: 10px;
+        border-radius: 0;
         color: var(--accent-color);
         font-family: inherit;
         font-size: 10px;
@@ -328,7 +328,7 @@
         background: var(--main-bg-color);
         color: var(--main-text-color);
         border: 1px solid var(--border-color);
-        border-radius: 3px;
+        border-radius: 0;
         padding: var(--space-0-5) var(--space-1);
         font-size: 11px;
         font-family: inherit;

--- a/frontend/app/view/agent/styles/_decision-panel.scss
+++ b/frontend/app/view/agent/styles/_decision-panel.scss
@@ -12,7 +12,7 @@
     margin: 0 var(--space-1-5);
     background: color-mix(in srgb, var(--warning-color) 8%, var(--main-bg-color));
     border: 1px solid color-mix(in srgb, var(--warning-color) 50%, transparent);
-    border-radius: 4px;
+    border-radius: 0;
     font-size: 12px;
     flex-shrink: 0;
 
@@ -41,7 +41,7 @@
     padding: var(--space-1) var(--space-3);
     background: color-mix(in srgb, var(--warning-color) 6%, var(--main-bg-color));
     border: 1px solid color-mix(in srgb, var(--warning-color) 40%, transparent);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--warning-color);
     font-family: inherit;
     font-size: 11px;
@@ -106,7 +106,7 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     padding: 2px 5px;
-    border-radius: 2px;
+    border-radius: 0;
     background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
     color: var(--secondary-text-color);
     font-weight: 500;
@@ -142,7 +142,7 @@
             color: var(--accent-color);
             background: color-mix(in srgb, var(--accent-color) 8%, transparent);
             padding: 1px 4px;
-            border-radius: 2px;
+            border-radius: 0;
         }
     }
 }
@@ -152,7 +152,7 @@
     padding: var(--space-1-5) var(--space-2);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     max-height: 160px;
     overflow-y: auto;
     font-family: var(--fixed-font, monospace);
@@ -189,7 +189,7 @@
     align-items: center;
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-1);
-    border-radius: 2px;
+    border-radius: 0;
     cursor: pointer;
     transition: background 80ms ease;
 
@@ -233,7 +233,7 @@
     color: var(--main-text-color);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     padding: var(--space-1) var(--space-2);
     resize: vertical;
     outline: none;
@@ -264,7 +264,7 @@
     font-family: inherit;
     font-size: 12px;
     font-weight: 500;
-    border-radius: 3px;
+    border-radius: 0;
     cursor: pointer;
     border: 1px solid transparent;
     transition: background 80ms ease, border-color 80ms ease;

--- a/frontend/app/view/agent/styles/_disconnected-banner.scss
+++ b/frontend/app/view/agent/styles/_disconnected-banner.scss
@@ -15,7 +15,7 @@
         padding: var(--space-1) var(--space-2);
         background: color-mix(in srgb, var(--error-color) 12%, transparent);
         border: 1px solid color-mix(in srgb, var(--error-color) 50%, transparent);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 12px;
         flex-shrink: 0;
         color: var(--main-text-color);
@@ -56,7 +56,7 @@
         color: var(--error-color);
         font-size: 11px;
         line-height: 1.4;
-        border-radius: 3px;
+        border-radius: 0;
         transition: background 0.1s, color 0.1s;
         flex-shrink: 0;
 

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -48,13 +48,13 @@
         code {
             background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
             padding: 1px var(--space-1);
-            border-radius: 2px;
+            border-radius: 0;
         }
 
         pre {
             background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
             padding: var(--space-1) var(--space-1-5);
-            border-radius: 3px;
+            border-radius: 0;
             overflow-x: auto;
         }
     }
@@ -142,7 +142,7 @@
                 padding: 0 6px;
                 color: var(--accent-color, #2bd4a8);
                 background: rgba(43, 212, 168, 0.08);
-                border-radius: 3px;
+                border-radius: 0;
                 font-family: var(--fixed-font, monospace);
                 font-size: 11px;
                 white-space: nowrap;
@@ -186,7 +186,7 @@
             margin: 4px 0 8px 24px;
             border-left: 2px solid var(--accent-color, #2bd4a8);
             background: var(--surface-elevated, rgba(255, 255, 255, 0.02));
-            border-radius: 0 4px 4px 0;
+            border-radius: 0;
             padding: 6px 8px;
             // `max-height` here is the in-flow default. The
             // overlay variants below override it with an inline
@@ -256,7 +256,7 @@
                 // through. No color-mix here (predictability).
                 background-color: var(--block-bg-solid-color, #1c1c1c);
                 border: 2px solid var(--accent-color, #2bd4a8);
-                border-radius: 4px;
+                border-radius: 0;
                 box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
                 overflow-y: auto;
                 // `max-height` is set inline by ToolBlock from the
@@ -287,7 +287,7 @@
         .agent-tool-open-pane {
             background: none;
             border: 1px solid var(--border-color);
-            border-radius: 3px;
+            border-radius: 0;
             color: var(--accent-color);
             cursor: pointer;
             font-size: 13px;
@@ -323,7 +323,7 @@
             background: var(--accent-color);
             color: var(--main-bg-color);
             border: none;
-            border-radius: 3px;
+            border-radius: 0;
             cursor: pointer;
             font-size: 11px;
 
@@ -442,7 +442,7 @@
         color: var(--secondary-text-color);
         padding: var(--space-1) var(--space-1-5);
         background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
-        border-radius: 3px;
+        border-radius: 0;
     }
 
     // === Bash Output ===
@@ -585,7 +585,7 @@
             .agent-message-body {
                 background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
                 padding: var(--space-1) var(--space-1-5);
-                border-radius: 3px;
+                border-radius: 0;
                 margin: 0;
                 white-space: pre-wrap;
             }
@@ -600,7 +600,7 @@
         padding: var(--space-2) var(--space-3);
         border: 1px solid var(--border-color);
         border-left: 2px solid var(--accent-color);
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         transition: all 0.15s;
         user-select: none;
@@ -683,7 +683,7 @@
         padding: 3px var(--space-1);
         background: color-mix(in srgb, var(--user-input-color) 14%, transparent);
         border-left: 3px solid var(--user-input-color);
-        border-radius: 2px;
+        border-radius: 0;
         user-select: text;
         cursor: text;
         // Establish a positioning context for the overlay body
@@ -761,7 +761,7 @@
             // covers. Border doubles as the visual link back to
             // the summary's accent.
             border: 2px solid var(--user-input-color);
-            border-radius: 4px;
+            border-radius: 0;
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
             // Same padding as the inline `pre` would have, so the
             // overlay's content lines up with the summary above it.
@@ -871,7 +871,7 @@
                     font-size: 0.9em;
                     line-height: 1;
                     padding: 2px 6px;
-                    border-radius: 3px;
+                    border-radius: 0;
                     cursor: pointer;
                     opacity: 0.6;
 
@@ -939,7 +939,7 @@
         .agent-tool-read-content {
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
-            border-radius: 3px;
+            border-radius: 0;
             max-height: 400px;
             overflow-y: auto;
             margin: 0;
@@ -976,7 +976,7 @@
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
             padding: var(--space-1) var(--space-1-5);
-            border-radius: 3px;
+            border-radius: 0;
             max-height: 400px;
             overflow-y: auto;
             margin: 0;
@@ -990,7 +990,7 @@
         background: var(--main-bg-color);
         border: 1px solid var(--border-color);
         padding: var(--space-1) var(--space-1-5);
-        border-radius: 3px;
+        border-radius: 0;
         max-height: 400px;
         overflow-y: auto;
         margin: 0;
@@ -1033,7 +1033,7 @@
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
             padding: var(--space-1) var(--space-1-5);
-            border-radius: 3px;
+            border-radius: 0;
             max-height: 400px;
             overflow-y: auto;
             margin: var(--space-1) 0 0 0;

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -52,7 +52,7 @@
             // must be fully opaque so content underneath doesn't bleed through.
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
             pointer-events: none;
             opacity: 0;
@@ -82,7 +82,7 @@
             padding: 1px var(--space-1);
             background: transparent;
             border: none;
-            border-radius: 3px;
+            border-radius: 0;
             color: var(--secondary-text-color);
             cursor: pointer;
             font-size: 11px;

--- a/frontend/app/view/agent/styles/_focused-overlay.scss
+++ b/frontend/app/view/agent/styles/_focused-overlay.scss
@@ -57,7 +57,7 @@
         color: var(--secondary-text-color);
         font-size: 12px;
         padding: var(--space-0-5) var(--space-1);
-        border-radius: 3px;
+        border-radius: 0;
         line-height: 1;
 
         &:hover {
@@ -96,7 +96,7 @@
 
     .agent-focused-rename-btn {
         padding: var(--space-1) var(--space-3);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 12px;
         cursor: pointer;
         border: 1px solid var(--border-color, rgba(255, 255, 255, 0.2));

--- a/frontend/app/view/agent/styles/_header-controls.scss
+++ b/frontend/app/view/agent/styles/_header-controls.scss
@@ -75,7 +75,7 @@
         .agent-control-btn {
             padding: var(--space-1-5) var(--space-3);
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
             color: var(--main-text-color);
             font-size: 11px;
@@ -164,7 +164,7 @@
         padding: var(--space-1-5) var(--space-3);
         background: color-mix(in srgb, var(--accent-color) 10%, transparent);
         border: 1px solid var(--accent-color);
-        border-radius: 4px;
+        border-radius: 0;
         color: var(--accent-color);
         font-size: 11px;
         cursor: pointer;

--- a/frontend/app/view/agent/styles/_identity-panel.scss
+++ b/frontend/app/view/agent/styles/_identity-panel.scss
@@ -41,7 +41,7 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-1-5);
-    border-radius: 3px;
+    border-radius: 0;
 
     &:hover {
         background: color-mix(in srgb, var(--highlight-bg-color) 50%, transparent);
@@ -100,7 +100,7 @@
     background: var(--panel-bg-color, var(--main-bg-color));
     color: var(--main-text-color);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     padding: var(--space-0-5) var(--space-1);
     max-width: 140px;
     cursor: pointer;
@@ -121,7 +121,7 @@
     font-size: 11px;
     background: none;
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
     padding: var(--space-0-5) 5px;
     cursor: pointer;
@@ -154,7 +154,7 @@
     color: var(--error-color);
     padding: var(--space-1) var(--space-1-5);
     background: color-mix(in srgb, var(--error-color) 10%, transparent);
-    border-radius: 3px;
+    border-radius: 0;
 }
 
 .agent-identity-unsaved {

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -70,7 +70,7 @@
     padding: var(--space-1-5);
     background: #0d0e0f;
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     overflow: hidden;
 
     .xterm {
@@ -82,7 +82,7 @@
     padding: var(--space-1) var(--space-1-5);
     background: color-mix(in srgb, var(--error-color, #ff6b6b) 12%, transparent);
     border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 40%, transparent);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--error-color, #ff6b6b);
     font-size: var(--text-sm);
 }

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -49,7 +49,7 @@
     color: var(--main-text-color);
     background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     padding: var(--space-1-5) var(--space-2);
     outline: none;
 
@@ -90,7 +90,7 @@
     gap: var(--space-2);
     padding: var(--space-1-5) var(--space-2);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     cursor: pointer;
     transition: background 0.08s, border-color 0.08s;
 
@@ -124,7 +124,7 @@
     padding: var(--space-1-5) var(--space-2);
     background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
     border: 1px dashed var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
 
     code {
         font-family: var(--termfontfamily, monospace);
@@ -144,7 +144,7 @@
     color: var(--error-color);
     padding: var(--space-1-5) var(--space-2);
     background: color-mix(in srgb, var(--error-color) 10%, transparent);
-    border-radius: 3px;
+    border-radius: 0;
 }
 
 // Advanced disclosure — collapsed by default. Reveals the container-image
@@ -236,7 +236,7 @@
     padding: var(--space-1-5) var(--space-2);
     border: 1px dashed var(--border-color);
     background: transparent;
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--main-text-color);
     font-size: var(--text-sm);
     cursor: pointer;
@@ -287,7 +287,7 @@
     padding: 0;
     border: 1px solid var(--border-color);
     background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--main-text-color);
     font-size: 16px;
     font-weight: 500;

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -63,7 +63,7 @@
             padding: var(--space-0-5) var(--space-2);
             background: color-mix(in srgb, var(--accent-color) 20%, transparent);
             border: 1px solid var(--accent-color);
-            border-radius: 3px;
+            border-radius: 0;
             color: var(--accent-color);
             font-family: inherit;
             font-size: 10px;
@@ -85,7 +85,7 @@
         .agent-pending-item {
             padding: 3px 5px;
             border-left: 2px solid var(--warning-color);
-            border-radius: 2px;
+            border-radius: 0;
             background: color-mix(in srgb, var(--warning-color) 4%, transparent);
             pre {
                 margin: 0;
@@ -113,7 +113,7 @@
                 padding: 3px var(--space-1);
                 background: var(--main-bg-color);
                 border: 1px solid var(--border-color);
-                border-radius: 2px;
+                border-radius: 0;
                 color: var(--main-text-color);
                 font-family: inherit;
                 font-size: 12px;

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -105,7 +105,7 @@
         align-items: center;
         gap: var(--space-3);
         padding: var(--space-2) var(--space-3);
-        border-radius: 4px;
+        border-radius: 0;
         background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
 
         &:hover {
@@ -123,7 +123,7 @@
         all: unset;
         cursor: pointer;
         padding: 4px 10px;
-        border-radius: 4px;
+        border-radius: 0;
         font-size: var(--text-xs, 0.75rem);
         font-weight: 500;
         color: var(--accent-color);
@@ -145,7 +145,7 @@
         padding: var(--space-3) 14px;
         border: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
-        border-radius: 6px;
+        border-radius: 0;
         cursor: pointer;
         transition: all 0.15s;
         color: var(--main-text-color);
@@ -202,7 +202,7 @@
             text-transform: uppercase;
             color: #fff; /* stylelint-disable-line color-no-hex */
             background: var(--warning-color, #e9b800);
-            border-radius: 4px 0 4px 0;
+            border-radius: 0;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
             pointer-events: none;
             z-index: 1;
@@ -233,7 +233,7 @@
             color: var(--secondary-text-color);
             background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
             border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
-            border-radius: 3px;
+            border-radius: 0;
             cursor: pointer;
             opacity: 0;
             transition: opacity 0.12s ease-out, background 0.12s, color 0.12s, border-color 0.12s;
@@ -336,7 +336,7 @@
             color: var(--main-text-color);
             background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
             border: 1px solid var(--accent-color);
-            border-radius: 3px;
+            border-radius: 0;
             padding: 1px 5px;
             outline: none;
 
@@ -354,7 +354,7 @@
             padding: 0;
             border: 1px solid var(--border-color);
             background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
-            border-radius: 3px;
+            border-radius: 0;
             color: var(--main-text-color);
             font-size: 11px;
             cursor: pointer;
@@ -392,7 +392,7 @@
     .agent-card-settings-panel {
         margin: var(--space-1) 0 var(--space-3) 0;
         border: 1px solid var(--accent-color);
-        border-radius: 6px;
+        border-radius: 0;
         background: color-mix(in srgb, var(--main-bg-color) 95%, transparent);
         overflow: hidden;
         // Guarantee a visible content area below the header. Without
@@ -425,7 +425,7 @@
             border: 1px solid var(--border-color);
             background: transparent;
             color: var(--secondary-text-color);
-            border-radius: 4px;
+            border-radius: 0;
             font-size: 12px;
             cursor: pointer;
             transition: all 0.1s;
@@ -451,7 +451,7 @@
             color: var(--secondary-text-color);
             font-size: 14px;
             cursor: pointer;
-            border-radius: 4px;
+            border-radius: 0;
 
             &:hover {
                 color: var(--main-text-color);
@@ -486,7 +486,7 @@
         gap: var(--space-3);
         padding: var(--space-3);
         margin: var(--space-2) 0;
-        border-radius: 6px;
+        border-radius: 0;
         background: rgba(245, 158, 11, 0.08);
         border: 1px solid rgba(245, 158, 11, 0.3);
 

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -46,7 +46,7 @@
         color: color-mix(in srgb, var(--secondary-text-color) 75%, transparent);
         padding: var(--space-2) var(--space-3);
         border: 1px dashed var(--border-color);
-        border-radius: 6px;
+        border-radius: 0;
         background: transparent;
         text-align: center;
         font-style: italic;
@@ -77,7 +77,7 @@
         width: 100%;
         border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
         background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
-        border-radius: 5px;
+        border-radius: 0;
         cursor: pointer;
         text-align: left;
         color: var(--main-text-color);

--- a/frontend/app/view/agent/styles/_retry-empty.scss
+++ b/frontend/app/view/agent/styles/_retry-empty.scss
@@ -20,7 +20,7 @@
         background: var(--accent-color);
         color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         &:hover { opacity: 0.85; }
         &:active { opacity: 0.7; }
@@ -50,7 +50,7 @@
         border: 1px solid var(--accent-color);
         background: transparent;
         color: var(--accent-color);
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         font-size: 13px;
         transition: background 0.15s, color 0.15s;

--- a/frontend/app/view/agent/styles/_search.scss
+++ b/frontend/app/view/agent/styles/_search.scss
@@ -26,7 +26,7 @@
         background: var(--main-bg-color);
         color: var(--main-text-color);
         border: 1px solid var(--border-color);
-        border-radius: 3px;
+        border-radius: 0;
         padding: 3px var(--space-1-5);
         font-size: 12px;
         font-family: inherit;
@@ -63,7 +63,7 @@
         justify-content: center;
         background: none;
         border: 1px solid transparent;
-        border-radius: 3px;
+        border-radius: 0;
         cursor: pointer;
         color: var(--secondary-text-color);
         font-size: 11px;
@@ -95,7 +95,7 @@
         background: color-mix(in srgb, var(--accent-color) 10%, transparent) !important; /* stylelint-disable-line declaration-no-important */
         // Left border acts as a gutter indicator
         border-left: 3px solid var(--accent-color) !important; /* stylelint-disable-line declaration-no-important */
-        border-radius: 2px;
+        border-radius: 0;
         // Small padding-left offset to compensate for the border
         padding-left: var(--space-1);
         // Brief animation so the highlight is immediately noticeable when

--- a/frontend/app/view/agent/styles/_session-digest.scss
+++ b/frontend/app/view/agent/styles/_session-digest.scss
@@ -11,7 +11,7 @@
         padding: var(--space-1-5) var(--space-2);
         background: color-mix(in srgb, var(--accent-color) 8%, transparent);
         border: 1px solid var(--accent-color);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 12px;
         flex-shrink: 0;
     }
@@ -46,7 +46,7 @@
         opacity: 0.75;
         font-size: 12px;
         line-height: 1;
-        border-radius: 3px;
+        border-radius: 0;
         transition: opacity 0.1s, background 0.1s;
         flex-shrink: 0;
 

--- a/frontend/app/view/agent/styles/_setup-wizard.scss
+++ b/frontend/app/view/agent/styles/_setup-wizard.scss
@@ -105,7 +105,7 @@
         .setup-wizard-error {
             background: color-mix(in srgb, var(--error-color) 10%, transparent);
             border: 1px solid var(--error-color);
-            border-radius: 4px;
+            border-radius: 0;
             padding: var(--space-2) var(--space-3);
             margin-bottom: var(--space-4);
             font-size: 12px;
@@ -142,7 +142,7 @@
 
         .setup-wizard-cli-card {
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             padding: var(--space-3);
             display: flex;
             justify-content: space-between;
@@ -214,7 +214,7 @@
                     code {
                         background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
                         padding: var(--space-0-5) var(--space-1-5);
-                        border-radius: 2px;
+                        border-radius: 0;
                     }
 
                     a {
@@ -255,7 +255,7 @@
             align-items: center;
             gap: var(--space-3);
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             padding: var(--space-3);
             cursor: pointer;
             transition: all 0.15s;
@@ -290,7 +290,7 @@
 
         .setup-wizard-summary {
             border: 1px solid var(--border-color);
-            border-radius: 4px;
+            border-radius: 0;
             padding: var(--space-4);
             margin-bottom: var(--space-4);
             display: flex;
@@ -314,7 +314,7 @@
                     code {
                         background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
                         padding: 1px var(--space-1);
-                        border-radius: 2px;
+                        border-radius: 0;
                         font-size: 11px;
                     }
                 }
@@ -329,7 +329,7 @@
 
         .setup-wizard-btn {
             padding: var(--space-2) var(--space-4);
-            border-radius: 4px;
+            border-radius: 0;
             font-size: 12px;
             font-weight: 500;
             cursor: pointer;

--- a/frontend/app/view/agent/styles/_slash.scss
+++ b/frontend/app/view/agent/styles/_slash.scss
@@ -90,7 +90,7 @@
         overflow-y: auto;
         background: var(--main-bg-color);
         border: 1px solid color-mix(in srgb, var(--accent-color) 50%, var(--border-color));
-        border-radius: 3px;
+        border-radius: 0;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
         z-index: 50;
         font-size: 12px;
@@ -171,7 +171,7 @@
     .slash-help__close {
         background: none;
         border: 1px solid transparent;
-        border-radius: 3px;
+        border-radius: 0;
         cursor: pointer;
         color: var(--secondary-text-color);
         font-size: 16px;

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -83,7 +83,7 @@
         gap: var(--space-0-5);
         padding: var(--space-0-5) var(--space-1);
         border: none;
-        border-radius: 3px;
+        border-radius: 0;
         background: transparent;
         color: var(--main-text-color);
         font-size: 11px;

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -6,7 +6,7 @@
     height: 14px;
     object-fit: contain;
     display: block;
-    border-radius: 2px;
+    border-radius: 0;
 }
 
 .browser-view {
@@ -32,7 +32,7 @@
     width: 28px;
     height: 28px;
     border: none;
-    border-radius: 4px;
+    border-radius: 0;
     background: transparent;
     color: var(--main-text-color);
     font-size: 14px;
@@ -62,7 +62,7 @@
     height: 28px;
     padding: 0 10px;
     border: 1px solid var(--border-color);
-    border-radius: 14px;
+    border-radius: 0;
     background: var(--form-element-bg-color);
     color: var(--main-text-color);
     font-family: var(--termfontfamily, "JetBrains Mono", monospace);

--- a/frontend/app/view/browser/components/BrowserAuthModal.scss
+++ b/frontend/app/view/browser/components/BrowserAuthModal.scss
@@ -30,7 +30,7 @@
     color: var(--main-text-color);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     outline: none;
 
     &:focus {

--- a/frontend/app/view/bundle-summary.scss
+++ b/frontend/app/view/bundle-summary.scss
@@ -37,7 +37,7 @@
         background: var(--accent-color);
         color: var(--accent-text-color, #fff);
         border: none;
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         font-size: 13px;
 

--- a/frontend/app/view/chat/userlist.scss
+++ b/frontend/app/view/chat/userlist.scss
@@ -20,7 +20,7 @@
 
 .user-status-item:hover {
     background-color: var(--button-grey-hover-bg);
-    border-radius: 4px;
+    border-radius: 0;
 }
 
 .user-status-icon {

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -29,7 +29,7 @@
     color: inherit;
     font-size: 14px;
     padding: 4px 8px;
-    border-radius: 3px;
+    border-radius: 0;
     &:focus, &:hover {
         border-color: var(--border-color);
         outline: none;
@@ -46,7 +46,7 @@
     border: 1px solid var(--border-color);
     color: inherit;
     padding: 4px 12px;
-    border-radius: 3px;
+    border-radius: 0;
     cursor: pointer;
     font-size: 12px;
     &:hover { background: color-mix(in srgb, var(--main-text-color) 8%, transparent); }
@@ -71,7 +71,7 @@
     color: #ef4444;
     padding: 4px 8px;
     font-size: 11px;
-    border-radius: 3px;
+    border-radius: 0;
     z-index: 5;
 }
 
@@ -116,7 +116,7 @@
     padding: 6px 8px;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 3px;
+    border-radius: 0;
     cursor: pointer;
     color: inherit;
     text-align: left;
@@ -186,7 +186,7 @@
     width: 160px;
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: 0;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
     cursor: pointer;
     transition: border-color 80ms ease;
@@ -203,7 +203,7 @@
     padding: 4px 8px;
     background: var(--block-color, var(--accent-color));
     color: white;
-    border-radius: 5px 5px 0 0;
+    border-radius: 0;
     font-size: 11px;
     font-weight: 500;
 }
@@ -278,7 +278,7 @@
 .drone-input {
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 3px;
+    border-radius: 0;
     padding: 4px 8px;
     color: inherit;
     font-family: inherit;

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -33,7 +33,7 @@
     width: 350px;
     padding: var(--space-1-5) 10px;
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     background: var(--form-element-bg-color);
     color: var(--main-text-color);
     font-family: var(--termfontfamily, "JetBrains Mono", monospace);
@@ -48,7 +48,7 @@
 .editor-open-btn {
     padding: var(--space-1-5) var(--space-4);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     background: var(--accent-color);
     color: var(--main-text-color);
     cursor: pointer;

--- a/frontend/app/view/identity/identity-pane-view.scss
+++ b/frontend/app/view/identity/identity-pane-view.scss
@@ -27,7 +27,7 @@
         background: var(--accent-color);
         color: var(--accent-text-color, #fff);
         border: none;
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         font-size: 13px;
 
@@ -91,7 +91,7 @@
         margin-bottom: 12px;
         background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
         color: var(--error-text-color, #ff8080);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 13px;
     }
 
@@ -197,7 +197,7 @@
         background: transparent;
         color: var(--accent-color);
         border: 1px solid var(--accent-color);
-        border-radius: 3px;
+        border-radius: 0;
         cursor: pointer;
 
         &:hover {
@@ -218,7 +218,7 @@
     .identity-pane-save-btn {
         padding: 6px 14px;
         border: 1px solid var(--border-color);
-        border-radius: 4px;
+        border-radius: 0;
         background: transparent;
         color: var(--main-text-color);
         cursor: pointer;
@@ -274,7 +274,7 @@
         background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
         color: var(--main-text-color);
         border: 1px solid var(--border-color);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 13px;
         font-family: inherit;
 

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -22,7 +22,7 @@
     }
     &::-webkit-scrollbar-thumb {
         background: var(--border-color);
-        border-radius: 2px;
+        border-radius: 0;
     }
 }
 
@@ -86,6 +86,6 @@
     color: var(--secondary-text-color);
     background: var(--panel-bg-color);
     padding: 1px 5px;
-    border-radius: 3px;
+    border-radius: 0;
 }
 

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -53,7 +53,7 @@
     }
     &::-webkit-scrollbar-thumb {
         background: var(--border-color);
-        border-radius: 2px;
+        border-radius: 0;
     }
 }
 
@@ -105,7 +105,7 @@
 .identity-agent-chip {
     font-size: 11px;
     padding: 1px var(--space-1-5);
-    border-radius: 3px;
+    border-radius: 0;
     background: var(--panel-bg-color);
     color: var(--main-text-color);
 }
@@ -123,7 +123,7 @@
 .identity-btn {
     padding: var(--space-1) var(--space-3);
     font-size: 12px;
-    border-radius: 4px;
+    border-radius: 0;
     border: 1px solid transparent;
     cursor: pointer;
     transition: opacity 0.1s;

--- a/frontend/app/view/identity/styles/_empty-states.scss
+++ b/frontend/app/view/identity/styles/_empty-states.scss
@@ -21,7 +21,7 @@
 .identity-empty-add {
     padding: 5px 14px;
     font-size: 12px;
-    border-radius: 4px;
+    border-radius: 0;
     border: 1px solid var(--accent-color);
     background: transparent;
     color: var(--accent-color);

--- a/frontend/app/view/identity/styles/_form-overlay.scss
+++ b/frontend/app/view/identity/styles/_form-overlay.scss
@@ -44,7 +44,7 @@
     cursor: pointer;
     font-size: 14px;
     padding: var(--space-0-5) var(--space-1-5);
-    border-radius: 3px;
+    border-radius: 0;
 
     &:hover { background: var(--hover-bg-color); }
 }
@@ -62,7 +62,7 @@
     }
     &::-webkit-scrollbar-thumb {
         background: var(--border-color);
-        border-radius: 2px;
+        border-radius: 0;
     }
 }
 
@@ -83,7 +83,7 @@
     font-size: 12px;
     background: var(--form-element-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--main-text-color);
     outline: none;
     width: 100%;
@@ -98,7 +98,7 @@
     font-size: 12px;
     background: rgba(239, 68, 68, 0.1);
     border: 1px solid rgba(239, 68, 68, 0.3);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--error-color);
 }
 
@@ -107,7 +107,7 @@
     font-size: 11px;
     background: rgba(245, 158, 11, 0.1);
     border: 1px solid rgba(245, 158, 11, 0.3);
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--warning-color);
 }
 

--- a/frontend/app/view/identity/styles/_header.scss
+++ b/frontend/app/view/identity/styles/_header.scss
@@ -29,7 +29,7 @@
 .identity-tab {
     padding: 3px 10px;
     font-size: 12px;
-    border-radius: 4px;
+    border-radius: 0;
     border: none;
     background: transparent;
     color: var(--secondary-text-color);
@@ -51,7 +51,7 @@
     margin-left: auto;
     padding: 3px 10px;
     font-size: 12px;
-    border-radius: 4px;
+    border-radius: 0;
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--accent-color);

--- a/frontend/app/view/identity/styles/_provider-badge.scss
+++ b/frontend/app/view/identity/styles/_provider-badge.scss
@@ -11,7 +11,7 @@
     justify-content: center;
     width: 26px;
     height: 22px;
-    border-radius: 3px;
+    border-radius: 0;
     flex-shrink: 0;
 
     /* stylelint-disable color-no-hex --

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -28,7 +28,7 @@
         background: var(--accent-color);
         color: var(--accent-text-color, #fff);
         border: none;
-        border-radius: 4px;
+        border-radius: 0;
         cursor: pointer;
         font-size: 13px;
 
@@ -89,7 +89,7 @@
         margin-bottom: 12px;
         background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
         color: var(--error-text-color, #ff8080);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 13px;
     }
 
@@ -142,7 +142,7 @@
         margin: 0;
         padding: 8px;
         background: var(--code-bg-color, rgba(0, 0, 0, 0.2));
-        border-radius: 4px;
+        border-radius: 0;
         white-space: pre-wrap;
         font-family: var(--mono-font, "JetBrains Mono", monospace);
         font-size: 12px;
@@ -162,7 +162,7 @@
     .memory-view-save-btn {
         padding: 6px 14px;
         border: 1px solid var(--border-color);
-        border-radius: 4px;
+        border-radius: 0;
         background: transparent;
         color: var(--main-text-color);
         cursor: pointer;
@@ -219,7 +219,7 @@
         background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
         color: var(--main-text-color);
         border: 1px solid var(--border-color);
-        border-radius: 4px;
+        border-radius: 0;
         font-size: 13px;
         font-family: inherit;
 

--- a/frontend/app/view/subagent/subagent-view.scss
+++ b/frontend/app/view/subagent/subagent-view.scss
@@ -63,7 +63,7 @@
     font-size: 10px;
     background: var(--highlight-bg-color);
     padding: 1px 5px;
-    border-radius: 3px;
+    border-radius: 0;
     white-space: nowrap;
 }
 
@@ -72,7 +72,7 @@
     font-weight: 600;
     text-transform: uppercase;
     padding: 1px var(--space-1-5);
-    border-radius: 3px;
+    border-radius: 0;
     letter-spacing: 0.5px;
 
     &.subagent-status-active {
@@ -189,7 +189,7 @@
     margin: var(--space-1) 0 var(--space-0-5) var(--space-4);
     padding: var(--space-1-5) var(--space-2);
     background: var(--highlight-bg-color);
-    border-radius: 4px;
+    border-radius: 0;
     font-size: 11px;
     font-family: var(--termfontfamily);
     line-height: 1.4;
@@ -223,7 +223,7 @@
     left: 50%;
     transform: translateX(-50%);
     padding: var(--space-1) var(--space-3);
-    border-radius: 12px;
+    border-radius: 0;
     border: 1px solid var(--border-color);
     background: var(--panel-bg-color);
     color: var(--main-text-color);

--- a/frontend/app/view/swarm/styles/_detail.scss
+++ b/frontend/app/view/swarm/styles/_detail.scss
@@ -14,7 +14,7 @@
     cursor: pointer;
     font-size: 18px;
     padding: 4px 8px;
-    border-radius: 4px;
+    border-radius: 0;
     line-height: 1;
 
     &:hover {
@@ -70,7 +70,7 @@
     color: var(--accent-color);
     border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
     padding: var(--space-2) var(--space-3);
-    border-radius: 4px;
+    border-radius: 0;
     cursor: pointer;
     font-size: 12px;
     font-family: inherit;

--- a/frontend/app/view/swarm/styles/_header.scss
+++ b/frontend/app/view/swarm/styles/_header.scss
@@ -28,7 +28,7 @@
     font-size: 11px;
     font-family: inherit;
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: 0;
     transition: all 0.1s;
 
     &:hover {

--- a/frontend/app/view/swarm/styles/_subagent-card.scss
+++ b/frontend/app/view/swarm/styles/_subagent-card.scss
@@ -11,7 +11,7 @@
     gap: 10px;
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     cursor: pointer;
     transition: all 0.15s;
 

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -170,7 +170,7 @@
             &::-webkit-scrollbar-thumb {
                 display: none;
                 background-color: var(--scrollbar-thumb-color);
-                border-radius: 4px;
+                border-radius: 0;
                 margin: 0 1px 0 1px;
 
                 &:hover {
@@ -200,7 +200,7 @@
     font-size: 10px;
     font-family: var(--termfontfamily, monospace);
     padding: var(--space-0-5) var(--space-1-5);
-    border-radius: 4px;
+    border-radius: 0;
     background: rgba(200, 120, 0, 0.75);
     /* Pure white on the amber warning badge — intentional contrast. */
     color: #fff; /* stylelint-disable-line color-no-hex */

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -40,7 +40,7 @@
 
 .warden-section {
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 0;
     background: var(--secondary-bg-color, transparent);
 
     &[data-status="disabled"] {
@@ -73,7 +73,7 @@
     font-size: 0.7em;
     letter-spacing: 0.05em;
     padding: 2px 6px;
-    border-radius: 3px;
+    border-radius: 0;
     background: var(--border-color);
     opacity: 0.7;
 }
@@ -91,7 +91,7 @@
         font-family: monospace;
         font-size: 0.95em;
         padding: 1px 4px;
-        border-radius: 2px;
+        border-radius: 0;
         background: var(--border-color);
     }
 }
@@ -146,7 +146,7 @@
     font-size: 0.7em;
     letter-spacing: 0.05em;
     padding: 2px 6px;
-    border-radius: 3px;
+    border-radius: 0;
 
     &--active {
         background: rgba(34, 197, 94, 0.15);
@@ -172,7 +172,7 @@
     cursor: pointer;
     width: 20px;
     height: 20px;
-    border-radius: 3px;
+    border-radius: 0;
     font-size: 1em;
     line-height: 1;
     padding: 0;
@@ -213,7 +213,7 @@
     grid-template-columns: 70px 1fr 40px 50px 1fr;
     gap: var(--space-2);
     padding: 2px var(--space-2);
-    border-radius: 2px;
+    border-radius: 0;
 
     &[data-success="false"] {
         background: rgba(239, 68, 68, 0.08);

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -36,7 +36,7 @@
     // interaction is click-to-activate. `cursor: grabbing` is still
     // applied during the actual drag (`:active`) so the user gets a
     // real signal while a drag is in progress.
-    border-radius: 4px;
+    border-radius: 0;
     transition: opacity 120ms ease;
     touch-action: none;
 
@@ -57,7 +57,7 @@
     width: 2px;
     height: 18px;
     background-color: var(--accent-color);
-    border-radius: 1px;
+    border-radius: 0;
     flex-shrink: 0;
     pointer-events: none;
 }
@@ -78,7 +78,7 @@
     // shouldn't read as a link.) Dropdown menu items inside
     // `.action-widget-more-dropdown` keep `cursor: pointer` — they're
     // a menu list, the link cursor is conventional there.
-    border-radius: 4px;
+    border-radius: 0;
     color: var(--secondary-text-color);
     font-size: 12px;
     white-space: nowrap;
@@ -120,7 +120,7 @@
         font-size: 12px;
         line-height: normal;
         letter-spacing: -0.12px;
-        border-radius: 2px;
+        border-radius: 0;
         gap: var(--space-1);
 
         &:hover {

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -74,7 +74,7 @@
     }
 
     .tile-node {
-        border-radius: calc(var(--block-border-radius) + 2px);
+        border-radius: 0;
         overflow: hidden;
         width: 100%;
         height: 100%;
@@ -211,7 +211,7 @@
         // Codex P2 on PR #829.
         background-color: rgba(var(--accent-color-rgb), 0.2);
         border: 1px solid rgba(var(--accent-color-rgb), 0.5);
-        border-radius: calc(var(--block-border-radius) + 2px);
+        border-radius: 0;
         box-sizing: border-box;
         opacity: 1;
         transform: scale(1);

--- a/frontend/tailwindsetup.css
+++ b/frontend/tailwindsetup.css
@@ -82,7 +82,7 @@ svg [aria-label="tip"] g path {
 /* Monaco editor scrollbar styling */
 .monaco-editor .slider {
     background: rgba(255, 255, 255, 0.4);
-    border-radius: 4px;
+    border-radius: 0;
     transition: background 0.2s ease;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.3",
+  "version": "0.38.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.3",
+      "version": "0.38.4",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.4",
+  "version": "0.38.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.4",
+      "version": "0.38.5",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.3",
+  "version": "0.38.5",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Flatten the rounding on interactive surfaces (buttons, modals, popovers,
dropdowns, cards, inputs) to square edges. Pills, avatars, status dots,
badges, and toggle sliders keep their pill shape — they convey "this
thing is round on purpose."

Spec: [`docs/specs/SPEC_HARD_CORNERS_2026_05_26.md`](docs/specs/SPEC_HARD_CORNERS_2026_05_26.md)

## Implementation

1. **Token flip** in `frontend/app/theme.scss`:
   - `--radius-sm/md/lg/xl` → all `0`
   - `--modal-border-radius` → `0`
   - `--radius-full` stays at `9999px` (pills, avatars, toggles)
   - `--block-border-radius` was already `0` (no change)

2. **Bulk sweep** across `frontend/`: 232 hard-coded `border-radius: Npx`
   → `0` on 77 SCSS/CSS files. Preserved: `var(--radius-full)`,
   `9999px`, `999px`, `50%`, any `var(--<token>)` reference.

3. **Toggle slider** explicitly reverted to `var(--radius-full)` —
   the bulk sweep flattened its 33px pill track; toggles are an
   explicit "round on purpose" exception per the spec. Comment in
   `toggle.scss` cross-references the spec.

## Visual smoke

Eyes on the running build matter more than diff math. Verified
via Vite HMR before commit:

- Title bar buttons (min/max/close), widget bar, More dropdown
- Tab bar
- Block frame (pane chrome)
- Hamburger menu, settings menu, context menus
- ConfirmModal, AgentLaunchModal, AgentInstallModal, all `<Modal>`
- Status bar popovers (Host, Backend, Lan)
- Agent pane: identity / memory dropdowns, OAuth panel, tool blocks
- Browser pane: address bar, find-on-page

## Known visual edge cases

These compound/asymmetric radii were also flattened in the sweep:

- Tool-panel callout `0 4px 4px 0` (asymmetric right-rounding paired
  with a left accent rule, in `_document-nodes.scss`)
- Warning badge `4px 0 4px 0` (diagonal corners in `_picker.scss`)
- Drone block label `5px 5px 0 0` (top-only rounding in `drone-view.scss`)

If any read as visual regressions, revert that specific line — the
spec's tab top-rounding exception (`5px 5px 0 0`) was preserved in
`tab.scss` because tabs already use 0 there (verified pre-sweep).

## Test plan

- [x] Vite HMR'd; smoke walked through the surfaces above
- [ ] Reviewer: spot-check the three known compound-radius edge cases
- [ ] Reviewer: confirm toggle sliders still look like switches

Changeset: `patch` (RFC #857 Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)