### PR TITLE
docs(readme): refresh widget table — all-pinned + add Warden

### DIFF
--- a/.changesets/1779785256-docs-readme-refresh-widget-table-all-pinned-add-warden.md
+++ b/.changesets/1779785256-docs-readme-refresh-widget-table-all-pinned-add-warden.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(readme): refresh widget table — all-pinned default, add Warden, drop stale More tier

--- a/README.md
+++ b/README.md
@@ -74,18 +74,19 @@ task package:linux     # Linux AppImage (writes to ~/Desktop)
 
 ## Widgets
 
-The widget bar shows pinned widgets directly; the rest live in a **More** dropdown. Pin/unpin any widget by right-clicking it. The canonical list is `agentmux-srv/src/config/widgets.json`.
+Every widget is pinned by default — the widget bar shows the full set directly, collapsing to icon-only when the title bar is narrow. The canonical list is `agentmux-srv/src/config/widgets.json`.
 
-| Widget | Icon | View | Description | Tier |
-|--------|------|------|-------------|------|
-| **Agent** | sparkles | `agent` | AI agent with streaming output and tool execution | Pinned |
-| **Browser** | globe | `browser` | Embedded native `CefBrowserView` | Pinned |
-| **Terminal** | square-terminal | `term` | Terminal with xterm.js and real PTY | Pinned |
-| **Sysinfo** | chart-line | `sysinfo` | Live system metrics (CPU, memory, network, disk) | Pinned |
-| **Editor** | file-code | `editor` | Code editor with syntax highlighting | More |
-| **Swarm** | bee | `swarm` | Multi-agent orchestration overview | More |
-| **Drone** | diagram-project | `drone` | Visual DAG-of-blocks drone engine | More |
-| **Help** | circle-question | `help` | Built-in documentation and help | More |
+| Widget | Icon | View | Description |
+|--------|------|------|-------------|
+| **Agent** | sparkles | `agent` | AI agent with streaming output and tool execution |
+| **Browser** | globe | `browser` | Embedded native `CefBrowserView` |
+| **Terminal** | square-terminal | `term` | Terminal with xterm.js and real PTY |
+| **Sysinfo** | chart-line | `sysinfo` | Live system metrics (CPU, memory, network, disk) |
+| **Editor** | file-code | `editor` | Code editor with syntax highlighting |
+| **Swarm** | bee | `swarm` | Multi-agent orchestration overview |
+| **Drone** | diagram-project | `drone` | Visual DAG-of-blocks drone engine |
+| **Help** | circle-question | `help` | Built-in documentation and help |
+| **Warden** | shield-halved | `warden` | Monitor and control agents across Host / LAN / Internet layers |
 
 ### Not widgets — opened from elsewhere
 


### PR DESCRIPTION
> Brings the README's Widgets section in line with the canonical layout in \`agentmux-srv/src/config/widgets.json\` and the CLAUDE.md widget table. Same refresh as agentmuxai/agentmux-docs#45 on the docs site.

## What was stale

The README's widget table still:
- Claimed a "More" dropdown that no longer exists
- Listed half the widgets as \`More\` tier (Editor, Swarm, Drone, Help)
- Was missing the Warden widget that shipped in #1044

## Changes

- Drop the **Tier** column — every widget is pinned now, the column conveys no info
- Rewrite the intro paragraph: "Every widget is pinned by default ... collapses to icon-only when the title bar is narrow"
- Add the **Warden** row (shield-halved icon, view `warden`)

The "Not widgets" subsection below is already correct (Identity, Memory, Settings, DevTools, Subagent) — no change.

## Verification

Just a README diff. No build / test impact.