### PR TITLE
feat(common): per-clone Dev isolation — RuntimeMode::Dev gains clone_id

### DIFF
--- a/.changesets/1779785318-feat-common-per-clone-dev-isolation-runtimemode-dev-now-carr-9ow5.md
+++ b/.changesets/1779785318-feat-common-per-clone-dev-isolation-runtimemode-dev-now-carr-9ow5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(common): per-clone Dev isolation — RuntimeMode::Dev now carries clone_id for two-clones-same-branch parity

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -243,7 +243,7 @@ impl DataPaths {
     /// (it's a fixed ASCII vocabulary).
     pub fn to_env_vars(&self) -> Vec<(&'static str, std::ffi::OsString)> {
         use std::ffi::OsString;
-        vec![
+        let mut vars: Vec<(&'static str, OsString)> = vec![
             ("AGENTMUX_INSTANCE_DIR", self.instance_dir.clone().into_os_string()),
             ("AGENTMUX_DATA_DIR", self.data_dir.clone().into_os_string()),
             ("AGENTMUX_CONFIG_DIR", self.config_dir.clone().into_os_string()),
@@ -260,7 +260,16 @@ impl DataPaths {
             // surface in diagnostics. NOT used to recompute paths
             // (paths flow through the dir vars above).
             ("AGENTMUX_CHANNEL", OsString::from(self.channel.clone())),
-        ]
+        ];
+        // Dev mode also exports AGENTMUX_CLONE_ID so child processes
+        // (host, srv) can reconstruct the full `Dev { branch, clone_id }`
+        // variant via [`RuntimeMode::from_env_with_clone`]. The
+        // mode-string format (`dev:<branch>`) was kept backward-compatible
+        // and doesn't carry clone_id itself — see runtime_mode.rs.
+        if let RuntimeMode::Dev { clone_id: Some(id), .. } = &self.mode {
+            vars.push(("AGENTMUX_CLONE_ID", OsString::from(id.clone())));
+        }
+        vars
     }
 
     /// Reconstruct from env vars set by the launcher. Returns
@@ -278,7 +287,11 @@ impl DataPaths {
         let agents_dir = std::env::var_os("AGENTMUX_AGENTS_DIR")?;
         let instance_runtime_dir = std::env::var_os("AGENTMUX_INSTANCE_RUNTIME_DIR")?;
         let shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR")?;
-        let mode = RuntimeMode::from_env()?;
+        // Pair AGENTMUX_RUNTIME_MODE with AGENTMUX_CLONE_ID so the Dev
+        // variant carries its clone discriminator. Legacy single-var
+        // form (no AGENTMUX_CLONE_ID set) leaves clone_id as None,
+        // which falls back to the pre-PR two-level dev path layout.
+        let mode = RuntimeMode::from_env_with_clone()?;
         // Channel is required from the launcher (same fail-fast
         // discipline as every other dir var). Missing AGENTMUX_CHANNEL
         // means the launcher didn't export it — that's a launcher /
@@ -446,13 +459,32 @@ fn resolve_channel_and_dir(
         }
     }
 
-    // (2) Dev mode default: dev-<branch>, path under dev/<branch>/.
-    if let RuntimeMode::Dev { branch } = mode {
+    // (2) Dev mode default: dev-<branch>[-<clone_id>], path under
+    // dev/<branch>/[<clone_id>/]. The clone_id nests one level deeper
+    // so two clones of the same branch don't collide on data dir,
+    // lockfile, or named-pipe IPC. When clone_id is None (legacy
+    // env-string round-trip or direct test construction) the layout
+    // falls back to the original two-level form for back-compat.
+    // See SPEC_DATA_CHANNELS_2026_05_24.md §2.4 and
+    // docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md.
+    if let RuntimeMode::Dev { branch, clone_id } = mode {
         let safe_branch = sanitize_path_segment(branch).ok_or_else(|| {
             format!("invalid dev branch for path: {:?}", branch)
         })?;
-        let channel = format!("dev-{}", safe_branch);
-        let dir = root.join("dev").join(safe_branch);
+        let safe_clone = clone_id
+            .as_deref()
+            .and_then(sanitize_path_segment)
+            .filter(|s| !s.is_empty());
+        let (channel, dir) = match safe_clone {
+            Some(c) => (
+                format!("dev-{}-{}", safe_branch, c),
+                root.join("dev").join(safe_branch).join(c),
+            ),
+            None => (
+                format!("dev-{}", safe_branch),
+                root.join("dev").join(safe_branch),
+            ),
+        };
         return Ok((channel, dir));
     }
 
@@ -545,6 +577,7 @@ mod tests {
                 "0.33.641",
                 &RuntimeMode::Dev {
                     branch: "main".into(),
+                    clone_id: None,
                 },
             )
             .unwrap();
@@ -573,11 +606,72 @@ mod tests {
     }
 
     #[test]
+    fn dev_paths_under_branch_and_clone_id() {
+        // Two clones of the same branch must resolve to distinct
+        // instance dirs when clone_id is supplied. Same branch +
+        // different clone_id → different paths → distinct lockfile
+        // and pipe namespaces downstream.
+        with_home_override(|root| {
+            clear_channel_env();
+            let a = DataPaths::resolve(
+                "0.39.0",
+                &RuntimeMode::Dev {
+                    branch: "main".into(),
+                    clone_id: Some("aaaaaaaa00000000".into()),
+                },
+            )
+            .unwrap();
+            let b = DataPaths::resolve(
+                "0.39.0",
+                &RuntimeMode::Dev {
+                    branch: "main".into(),
+                    clone_id: Some("bbbbbbbb00000000".into()),
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                a.instance_dir,
+                root.join("dev").join("main").join("aaaaaaaa00000000")
+            );
+            assert_eq!(
+                b.instance_dir,
+                root.join("dev").join("main").join("bbbbbbbb00000000")
+            );
+            assert_ne!(a.instance_dir, b.instance_dir);
+            assert_eq!(a.channel, "dev-main-aaaaaaaa00000000");
+            assert_eq!(b.channel, "dev-main-bbbbbbbb00000000");
+        });
+    }
+
+    #[test]
+    fn dev_paths_legacy_two_level_when_clone_id_none() {
+        // Backward compat: a Dev variant without clone_id (e.g.
+        // constructed by an older launcher binary, or by the
+        // env-string parser) MUST land at the pre-PR two-level dev
+        // path so existing in-flight dev sessions don't lose their
+        // state on first launch after the upgrade.
+        with_home_override(|root| {
+            clear_channel_env();
+            let p = DataPaths::resolve(
+                "0.39.0",
+                &RuntimeMode::Dev {
+                    branch: "main".into(),
+                    clone_id: None,
+                },
+            )
+            .unwrap();
+            assert_eq!(p.instance_dir, root.join("dev").join("main"));
+            assert_eq!(p.channel, "dev-main");
+        });
+    }
+
+    #[test]
     fn dev_paths_under_dev_branch() {
         with_home_override(|root| {
             clear_channel_env();
             let mode = RuntimeMode::Dev {
                 branch: "main".into(),
+                clone_id: None,
             };
             let p = DataPaths::resolve("0.33.639", &mode).unwrap();
             // Dev mode default: on-disk path stays under dev/<branch>/
@@ -619,7 +713,7 @@ mod tests {
 
             let dev = DataPaths::resolve(
                 "0.33.639",
-                &RuntimeMode::Dev { branch: "main".into() },
+                &RuntimeMode::Dev { branch: "main".into(), clone_id: None },
             )
             .unwrap();
             // Override beats the dev/<branch>/ default — channel name
@@ -716,12 +810,12 @@ mod tests {
             clear_channel_env();
             let r = DataPaths::resolve(
                 "0.33.639",
-                &RuntimeMode::Dev { branch: "..".into() },
+                &RuntimeMode::Dev { branch: "..".into(), clone_id: None },
             );
             assert!(r.is_err());
             let r = DataPaths::resolve(
                 "0.33.639",
-                &RuntimeMode::Dev { branch: "foo/bar".into() },
+                &RuntimeMode::Dev { branch: "foo/bar".into(), clone_id: None },
             );
             assert!(r.is_err());
         });
@@ -785,6 +879,7 @@ mod tests {
                 "0.33.639",
                 &RuntimeMode::Dev {
                     branch: "main".into(),
+                    clone_id: None,
                 },
             )
             .unwrap();
@@ -814,10 +909,12 @@ mod tests {
             clear_channel_env();
             let mode = RuntimeMode::Dev {
                 branch: "..".into(),
+                clone_id: None,
             };
             assert!(DataPaths::resolve("0.33.639", &mode).is_err());
             let mode = RuntimeMode::Dev {
                 branch: "foo/bar".into(),
+                clone_id: None,
             };
             assert!(DataPaths::resolve("0.33.639", &mode).is_err());
         });
@@ -938,7 +1035,7 @@ mod tests {
 
             let dev = DataPaths::resolve_path_only(
                 "0.33.639",
-                &RuntimeMode::Dev { branch: "main".into() },
+                &RuntimeMode::Dev { branch: "main".into(), clone_id: None },
             )
             .unwrap();
             // Dev mode default holds — channel name is dev-main, path
@@ -963,7 +1060,7 @@ mod tests {
             // path_only variant.
             let dev_env = DataPaths::resolve(
                 "0.33.639",
-                &RuntimeMode::Dev { branch: "main".into() },
+                &RuntimeMode::Dev { branch: "main".into(), clone_id: None },
             )
             .unwrap();
             assert_eq!(dev_env.channel, "stable");

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -42,9 +42,21 @@ pub enum RuntimeMode {
     /// portable binaries are stateless on disk.
     Portable,
     /// Running from a source-tree build. State lives in
-    /// `~/.agentmux/dev/<branch>/` so different branches don't share
-    /// state.
-    Dev { branch: String },
+    /// `~/.agentmux/dev/<branch>/<clone_id>/` so different branches
+    /// AND different clones of the same branch don't share state.
+    ///
+    /// `clone_id` is a 16-char hex hash of the clone's workspace-root
+    /// path, derived by [`derive_clone_id`] when the launcher detects
+    /// Dev mode. `None` is permitted for backward compatibility with
+    /// callers that construct `RuntimeMode::Dev` directly (tests, the
+    /// `dev:branch` env-string parser that pre-dates this field): in
+    /// that case path resolution falls back to the old two-level
+    /// `dev/<branch>/` layout. See
+    /// `docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md`.
+    Dev {
+        branch: String,
+        clone_id: Option<String>,
+    },
 }
 
 impl RuntimeMode {
@@ -74,7 +86,8 @@ impl RuntimeMode {
         //    build-output dir.
         if exe_dir_is_dev_build(exe_dir) {
             let branch = detect_branch(exe_dir);
-            return Self::Dev { branch };
+            let clone_id = derive_clone_id(exe_dir);
+            return Self::Dev { branch, clone_id };
         }
 
         // 4. AGENTMUX_DEV_BRANCH override. The env-var IS the branch
@@ -91,7 +104,11 @@ impl RuntimeMode {
         if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
             let slug = sanitize_branch_slug(&b);
             if !slug.is_empty() {
-                return Self::Dev { branch: slug };
+                let clone_id = derive_clone_id(exe_dir);
+                return Self::Dev {
+                    branch: slug,
+                    clone_id,
+                };
             }
         }
 
@@ -120,7 +137,8 @@ impl RuntimeMode {
         }
         if exe_dir_is_dev_build(exe_dir) {
             let branch = detect_branch(exe_dir);
-            return Self::Dev { branch };
+            let clone_id = derive_clone_id(exe_dir);
+            return Self::Dev { branch, clone_id };
         }
         Self::Installed
     }
@@ -131,7 +149,11 @@ impl RuntimeMode {
         match self {
             Self::Installed => "installed".to_string(),
             Self::Portable => "portable".to_string(),
-            Self::Dev { branch } => format!("dev:{}", branch),
+            // clone_id is intentionally NOT encoded here; it round-trips
+            // via a dedicated `AGENTMUX_CLONE_ID` env var so the existing
+            // `dev:<branch>` wire format stays backward-compatible with
+            // older launchers / parsers.
+            Self::Dev { branch, .. } => format!("dev:{}", branch),
         }
     }
 
@@ -150,8 +172,36 @@ impl RuntimeMode {
             // followed by a single-segment branch slug — so callers
             // splitting on `/` see the expected shape and the resulting
             // filesystem path is always a child of `dev/`.
-            Self::Dev { branch } => format!("dev/{}", sanitize_branch_slug(branch)),
+            // Slug includes the clone_id when present so two clones of
+            // the same branch land in distinct subdirs. When clone_id
+            // is None (env-roundtrip or direct test construction), fall
+            // back to the legacy two-level layout for compatibility.
+            Self::Dev { branch, clone_id } => {
+                let b = sanitize_branch_slug(branch);
+                match clone_id.as_deref().map(sanitize_clone_id) {
+                    Some(c) if !c.is_empty() => format!("dev/{}/{}", b, c),
+                    _ => format!("dev/{}", b),
+                }
+            }
         }
+    }
+
+    /// Read the runtime mode AND clone_id from the env vars exported
+    /// by the parent process. Pairs `AGENTMUX_RUNTIME_MODE` (variant +
+    /// branch) with `AGENTMUX_CLONE_ID` (Dev-only clone discriminator).
+    /// This is the version every child process (host, srv) should
+    /// call — [`Self::from_env`] is the legacy single-var form kept
+    /// for callers that don't care about clone isolation.
+    pub fn from_env_with_clone() -> Option<Self> {
+        let mode = Self::from_env()?;
+        if let Self::Dev { branch, .. } = mode {
+            let clone_id = std::env::var("AGENTMUX_CLONE_ID")
+                .ok()
+                .map(|s| sanitize_clone_id(&s))
+                .filter(|s| !s.is_empty());
+            return Some(Self::Dev { branch, clone_id });
+        }
+        Some(mode)
     }
 }
 
@@ -181,14 +231,91 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
         if slug.is_empty() {
             return None;
         }
-        return Some(RuntimeMode::Dev { branch: slug });
+        // clone_id is not encoded in this wire format — callers that
+        // care about clone isolation should use [`RuntimeMode::from_env_with_clone`]
+        // which pairs this with `AGENTMUX_CLONE_ID`.
+        return Some(RuntimeMode::Dev {
+            branch: slug,
+            clone_id: None,
+        });
     }
     if trimmed.eq_ignore_ascii_case("dev") {
         return Some(RuntimeMode::Dev {
             branch: "default".to_string(),
+            clone_id: None,
         });
     }
     None
+}
+
+// ── Clone-id derivation ────────────────────────────────────────────────
+
+/// Walk up from `exe_dir` looking for a workspace-root marker, then
+/// hash that absolute (canonical) path with FNV-1a and return a 16-char
+/// hex string. Used as the per-clone discriminator in
+/// `~/.agentmux/dev/<branch>/<clone_id>/`. Returns `None` if no marker
+/// is found (extreme edge case — `task dev` always runs from inside a
+/// clone with `.git`/`Cargo.toml`/`Taskfile.yml`).
+///
+/// Recognized markers (any one suffices, in priority order):
+/// `.git` (dir or file — supports git worktrees), `Cargo.toml`,
+/// `Taskfile.yml`. We prefer `.git` because it identifies the literal
+/// clone, but Cargo.toml is a safe fallback (the workspace root has
+/// a `[workspace]` Cargo.toml).
+pub fn derive_clone_id(exe_dir: &Path) -> Option<String> {
+    let root = find_clone_root(exe_dir)?;
+    // Canonicalize to absorb mixed casing on Windows and resolve `..`
+    // segments. Falls back to the raw path if canonicalize fails
+    // (rare on real filesystems but possible on transient mounts).
+    let canonical = root.canonicalize().unwrap_or(root);
+    let s = canonical.to_string_lossy().to_lowercase();
+    Some(format!("{:016x}", fnv1a_64(s.as_bytes())))
+}
+
+fn find_clone_root(start: &Path) -> Option<std::path::PathBuf> {
+    let mut cur = Some(start);
+    while let Some(p) = cur {
+        if p.join(".git").exists()
+            || p.join("Cargo.toml").is_file()
+            || p.join("Taskfile.yml").is_file()
+        {
+            return Some(p.to_path_buf());
+        }
+        cur = p.parent();
+    }
+    None
+}
+
+/// Lenient sanitization for a clone_id received via env. The launcher
+/// produces a clean 16-hex string, but env vars survive process hops
+/// and could be tampered with — refuse anything that contains path
+/// separators or `..` segments before it lands in a filesystem path.
+fn sanitize_clone_id(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.is_empty()
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains("..")
+        || trimmed.contains('\0')
+    {
+        return String::new();
+    }
+    trimmed.to_string()
+}
+
+// Tiny FNV-1a-64 kept inline so agentmux-common doesn't have to depend
+// on agentmux-launcher. Matches `agentmux-launcher/src/hash.rs`
+// byte-for-byte so hashes are interchangeable.
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET_BASIS;
+    for b in bytes {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
 }
 
 /// True when `exe_dir` (or its parent on macOS app bundles) contains
@@ -362,9 +489,11 @@ mod tests {
             RuntimeMode::Portable,
             RuntimeMode::Dev {
                 branch: "main".into(),
+                clone_id: None,
             },
             RuntimeMode::Dev {
                 branch: "agenta-feature-x".into(),
+                clone_id: None,
             },
         ] {
             let s = mode.to_env_string();
@@ -378,13 +507,15 @@ mod tests {
         assert_eq!(
             parse_mode_string("dev"),
             Some(RuntimeMode::Dev {
-                branch: "default".into()
+                branch: "default".into(),
+                clone_id: None,
             })
         );
         assert_eq!(
             parse_mode_string("DEV"),
             Some(RuntimeMode::Dev {
-                branch: "default".into()
+                branch: "default".into(),
+                clone_id: None,
             })
         );
     }
@@ -401,7 +532,8 @@ mod tests {
                 assert_eq!(
                     mode,
                     RuntimeMode::Dev {
-                        branch: "main".into()
+                        branch: "main".into(),
+                        clone_id: None,
                     }
                 );
             });
@@ -445,17 +577,29 @@ mod tests {
         assert_eq!(RuntimeMode::Portable.dir_slug(), "versions");
         assert_eq!(
             RuntimeMode::Dev {
-                branch: "main".into()
+                branch: "main".into(),
+                clone_id: None,
             }
             .dir_slug(),
             "dev/main"
         );
         assert_eq!(
             RuntimeMode::Dev {
-                branch: "agenta/x".into()
+                branch: "agenta/x".into(),
+                clone_id: None,
             }
             .dir_slug(),
             "dev/agenta-x"
+        );
+        // With a clone_id, the slug nests one level deeper so two
+        // clones on the same branch land in distinct subdirs.
+        assert_eq!(
+            RuntimeMode::Dev {
+                branch: "main".into(),
+                clone_id: Some("abcdef1234567890".into()),
+            }
+            .dir_slug(),
+            "dev/main/abcdef1234567890"
         );
     }
 
@@ -477,7 +621,7 @@ mod tests {
         // are replaced and `..` segment is dropped).
         let m = parse_mode_string("dev:../versions/x").expect("parses");
         match m {
-            RuntimeMode::Dev { branch } => {
+            RuntimeMode::Dev { branch, .. } => {
                 assert!(!branch.contains(".."));
                 assert!(!branch.contains('/'));
                 assert!(!branch.contains('\\'));
@@ -562,5 +706,107 @@ mod tests {
         assert_eq!(sanitize_branch_slug("foo/../bar"), "foo-bar");
         assert_eq!(sanitize_branch_slug(".hidden"), "hidden");
         assert_eq!(sanitize_branch_slug("ok-branch"), "ok-branch");
+    }
+
+    // ── derive_clone_id ─────────────────────────────────────────────
+
+    #[test]
+    fn derive_clone_id_returns_16_hex_chars_when_marker_present() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // Plant a Cargo.toml at the root to act as the clone-root marker.
+        std::fs::write(tmp.path().join("Cargo.toml"), b"[workspace]").unwrap();
+        let nested = tmp.path().join("target/release");
+        std::fs::create_dir_all(&nested).unwrap();
+        let id = derive_clone_id(&nested).expect("found");
+        assert_eq!(id.len(), 16);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn derive_clone_id_is_stable_for_same_clone() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(tmp.path().join("Taskfile.yml"), b"version: 3").unwrap();
+        let exe = tmp.path().join("dist/cef-dev");
+        std::fs::create_dir_all(&exe).unwrap();
+        let a = derive_clone_id(&exe).unwrap();
+        let b = derive_clone_id(&exe).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn derive_clone_id_differs_between_clones() {
+        let tmp1 = tempfile::TempDir::new().expect("tempdir1");
+        let tmp2 = tempfile::TempDir::new().expect("tempdir2");
+        for t in [&tmp1, &tmp2] {
+            std::fs::write(t.path().join("Cargo.toml"), b"[workspace]").unwrap();
+        }
+        let id1 = derive_clone_id(tmp1.path()).unwrap();
+        let id2 = derive_clone_id(tmp2.path()).unwrap();
+        assert_ne!(
+            id1, id2,
+            "two clones at different paths must hash to different ids"
+        );
+    }
+
+    #[test]
+    fn derive_clone_id_returns_none_without_marker() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // No marker at all — caller has no clone root to anchor to.
+        let id = derive_clone_id(tmp.path());
+        assert!(id.is_none());
+    }
+
+    #[test]
+    fn derive_clone_id_walks_up_to_find_marker() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        let deep = tmp.path().join("a/b/c/d");
+        std::fs::create_dir_all(&deep).unwrap();
+        // From a deeply nested subdir, we should still find the .git marker.
+        assert!(derive_clone_id(&deep).is_some());
+    }
+
+    #[test]
+    fn sanitize_clone_id_rejects_traversal() {
+        assert_eq!(sanitize_clone_id("../foo"), "");
+        assert_eq!(sanitize_clone_id("a/b"), "");
+        assert_eq!(sanitize_clone_id("a\\b"), "");
+        assert_eq!(sanitize_clone_id("a..b"), "");
+        assert_eq!(sanitize_clone_id(""), "");
+        assert_eq!(sanitize_clone_id("abcdef1234567890"), "abcdef1234567890");
+    }
+
+    #[test]
+    fn from_env_with_clone_populates_clone_id_for_dev() {
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        with_env("AGENTMUX_RUNTIME_MODE", Some("dev:main"), || {
+            with_env("AGENTMUX_CLONE_ID", Some("deadbeefcafebabe"), || {
+                let m = RuntimeMode::from_env_with_clone().unwrap();
+                assert_eq!(
+                    m,
+                    RuntimeMode::Dev {
+                        branch: "main".into(),
+                        clone_id: Some("deadbeefcafebabe".into()),
+                    }
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn from_env_with_clone_leaves_clone_id_none_when_unset() {
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        with_env("AGENTMUX_RUNTIME_MODE", Some("dev:main"), || {
+            with_env("AGENTMUX_CLONE_ID", None, || {
+                let m = RuntimeMode::from_env_with_clone().unwrap();
+                assert_eq!(
+                    m,
+                    RuntimeMode::Dev {
+                        branch: "main".into(),
+                        clone_id: None,
+                    }
+                );
+            });
+        });
     }
 }

--- a/docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md
+++ b/docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md
@@ -1,0 +1,337 @@
+# Analysis: Multi-clone `task dev` isolation
+
+**Date:** 2026-05-26
+**Status:** Analysis (no code change yet)
+
+## TL;DR
+
+Two clones of `agentmux` on the same Windows host can each independently
+run `task dev` **only if they're on different branches.** On the same
+branch, they collide on:
+
+- the single-instance lockfile,
+- the named-pipe IPC the launcher uses to receive "open" commands,
+- the data dir (`~/.agentmux/dev/<branch>/`) — including logs, CEF cache,
+  channel-scoped state.
+
+The Vite port (5173) is also a hard collision, but it's already loud and
+predictable: `--strictPort` makes the second clone fail fast at Vite
+startup. That's a non-issue (clear error, not silent cross-contamination).
+
+The lockfile + pipe collision is the bad one. The second clone's launcher
+sees the first's pipe, treats it as "another instance of myself", and
+routes its open-pane intent to the first clone's window. Two agents on
+the same branch silently drive the same UI.
+
+**Fix shape:** widen the dev isolation key from `<branch>` to
+`<branch>/<clone-id>`, where `clone-id` is a stable hash of the clone's
+workspace root path. ~40 lines of code in two files, backward compatible,
+reuses the existing FNV-1a hash infrastructure.
+
+This is in keeping with the spirit of the channels design — which already
+isolates installed/portable/dev paths via `RuntimeMode` — and is a
+natural extension of `RuntimeMode::Dev { branch }` to
+`RuntimeMode::Dev { branch, clone_id }`.
+
+---
+
+## Current state | risks | recommended changes (one page)
+
+### Current state
+
+| Resource | Isolation key today | Source |
+|---|---|---|
+| Data dir | `~/.agentmux/dev/<branch>/` | `agentmux-common/src/data_paths.rs:450-457` |
+| Logs / CEF cache / agents | Children of data dir | same |
+| Single-instance lockfile | `instance_runtime_dir/lockfile`, name derived from `data_dir_hash16(instance_dir)` | `agentmux-launcher/src/hash.rs:42-51` |
+| Named-pipe IPC | `\\.\pipe\agentmux-<hash16>\command`, hash of instance_dir | `agentmux-launcher/src/ipc/mod.rs:37-39` |
+| Vite dev port | Hardcoded 5173, `--strictPort` | `Taskfile.yml:622`, `vite.config.ts:114-115` |
+| srv TCP ports (web + ws) | OS-assigned via `bind 127.0.0.1:0` | `agentmux-srv/src/main.rs` |
+| Cargo `target/` | Per-clone (in working tree) | n/a |
+| `dist/cef-dev/` | Per-clone (in working tree) | `Taskfile.yml` |
+| mDNS service name | Per-launch UUID-ish `instance_id` | `agentmux-srv/src/backend/lan_discovery.rs:71` |
+
+### Risk profile (two clones, same branch)
+
+| Resource | Collision? | Severity | Why |
+|---|---|---|---|
+| Data dir + logs + CEF cache | **Yes** | High | Both write to `~/.agentmux/dev/<branch>/` |
+| Single-instance lockfile | **Yes** | Critical | Identical instance_dir → identical hash → same lockfile path |
+| Named-pipe IPC | **Yes** | Critical | Same hash → same pipe name → second launcher routes opens into first instance |
+| Vite port 5173 | Yes (loud) | Low | `--strictPort` fails fast; clear error, no silent damage |
+| srv TCP ports | No | — | Dynamic |
+| `target/`, `dist/cef-dev/` | No | — | In-tree |
+| mDNS | No | — | Per-launch UUID |
+
+### Recommended fix (smallest)
+
+1. Extend `RuntimeMode::Dev` to `Dev { branch, clone_id: Option<String> }`.
+2. Populate `clone_id` at runtime from a hash of the workspace root path
+   (via existing `data_dir_hash16` / FNV-1a).
+3. In `data_paths.rs`, nest dev instances at
+   `~/.agentmux/dev/<branch>/<clone-id>/` instead of
+   `~/.agentmux/dev/<branch>/`.
+4. Export `AGENTMUX_CLONE_ID` in `to_env_vars()` for diagnostics.
+
+That's the whole change. The lockfile and pipe automatically follow
+because they both derive from `instance_dir`. No new mechanism — same
+isolation discipline that already separates installed / portable / dev,
+extended one level deeper for the multi-clone case.
+
+---
+
+## 1. Detailed inventory
+
+### 1.1 Data dir and channel resolution
+
+`agentmux-common/src/data_paths.rs:450-457` — for `RuntimeMode::Dev`:
+
+```rust
+if let RuntimeMode::Dev { branch } = mode {
+    let safe_branch = sanitize_path_segment(branch)?;
+    let channel = format!("dev-{}", safe_branch);
+    let dir = root.join("dev").join(safe_branch);  // ← instance_dir
+    return Ok((channel, dir));
+}
+```
+
+`root` = `~/.agentmux/` (or `AGENTMUX_HOME_OVERRIDE` in tests). For
+**any** clone on branch `main`, `instance_dir` resolves to
+`~/.agentmux/dev/main/`. Every downstream path — logs, CEF cache,
+agents, runtime, db — is a child of this.
+
+### 1.2 Single-instance lockfile and named-pipe IPC
+
+The launcher derives both from the **instance_dir** path:
+
+`agentmux-launcher/src/hash.rs:42-51`:
+
+```rust
+pub fn data_dir_hash16(data_dir: &std::path::Path) -> String {
+    let canonical = data_dir.canonicalize()
+        .unwrap_or_else(|_| data_dir.to_path_buf());
+    let s = canonical.to_string_lossy().to_lowercase();
+    format!("{:016x}", fnv1a_64(s.as_bytes()))
+}
+```
+
+`agentmux-launcher/src/ipc/mod.rs:37-39`:
+
+```rust
+let pipe_name = format!("\\\\.\\pipe\\agentmux-{}\\command", hash);
+```
+
+Two clones at `C:\repo1\agentmux` and `D:\repo2\agentmux`, both on
+branch `main`, both resolve to instance_dir `~/.agentmux/dev/main/`.
+`data_dir_hash16` of that path is **identical** for both clones, so
+both pipe names and both lockfile paths are identical.
+
+What happens on a real second launch:
+
+1. Clone A's `task dev` succeeds: lockfile acquired, pipe created at
+   `\\.\pipe\agentmux-H1234567890ABCDEF\command`, srv spawned, host
+   loads Vite at `localhost:5173`.
+2. Clone B's `task dev` runs the launcher. The launcher checks for an
+   existing single-instance pipe; **it finds Clone A's pipe** and
+   treats it as "I'm already running, route to me." It sends Clone B's
+   intended open-pane command to Clone A's running window.
+3. Clone B's Vite never starts (port 5173 is taken by Clone A's host
+   anyway — that part fails loud).
+4. From Clone B's perspective: launcher exits 0, no visible UI, but
+   Clone A's window opens an extra pane. Silent cross-contamination.
+
+This is the worst failure mode in the inventory.
+
+### 1.3 Vite dev port
+
+`Taskfile.yml:622` and `vite.config.ts:114-115` pin Vite to 5173 with
+`--strictPort`. Second clone gets `EADDRINUSE` and an obvious failure
+in the dev terminal. Not silent. Lower priority to fix because the
+user immediately knows; multi-clone work likely wants different
+Vite ports anyway.
+
+### 1.4 srv TCP ports
+
+`agentmux-srv/src/main.rs` binds the web and ws listeners to
+`127.0.0.1:0`. OS assigns. No collision. Each srv writes its actual
+port into the data dir (under `instance_runtime_dir`) for the host
+to read — also collision-free **once** instance_dir is per-clone.
+
+### 1.5 `target/` and `dist/cef-dev/`
+
+Per-clone (live inside the clone's working tree). Disk cost is
+significant — a Rust `target/` is a few GB and CEF release builds are
+~400MB extracted — but functional isolation is fine. Could be
+optimized with `CARGO_TARGET_DIR` or sccache; out of scope for this
+analysis.
+
+### 1.6 mDNS
+
+`agentmux-srv/src/backend/lan_discovery.rs:71` registers as
+`agentmux-{instance_id}`, where `instance_id` is generated at srv
+boot (not deterministic across launches). Two parallel instances
+register under distinct service names. Safe by accident — they'd
+both *see* each other on the network as if they were two agentmux
+hosts. That might surprise the warden widget's LAN list but it's not
+a collision.
+
+### 1.7 VS Code Bridge
+
+Mentioned in the startup guide as a host service on `:3101`. I did
+not find an obvious in-repo source for it during the grep pass —
+likely an external companion tool (e.g. `@a5af/vscode-bridge`
+installed globally per the user-CLAUDE.md). If it routes file-open
+commands by workspace path, multi-clone is already differentiated by
+path. If it routes by some agentmux-instance identifier, fixing
+clone isolation in agentmux will surface a per-clone identifier the
+bridge can use.
+
+---
+
+## 2. Why "two clones on the same branch" is the real scenario
+
+The naive expectation is that each agent gets its own branch and
+isolation is automatic. In practice:
+
+- A user often has their primary IDE clone on `main` for everyday work.
+- An agent's container or host clone is also on `main` until it starts
+  a feature branch.
+- Two host agents (AgentX, AgentY per CLAUDE.md) might each have their
+  own clone, both starting work from `main`.
+- An agent reviewing a PR pulls the PR's branch — if two agents both
+  review the same PR, they both end up on the same branch.
+
+Same-branch is the steady-state scenario, not the edge case.
+
+---
+
+## 3. Recommended fix
+
+### 3.1 Option A — clone-path hash (recommended)
+
+Extend `RuntimeMode::Dev`:
+
+```rust
+pub enum RuntimeMode {
+    Installed,
+    Portable,
+    Dev { branch: String, clone_id: Option<String> },
+}
+```
+
+When `RuntimeMode::current()` resolves to `Dev`, also resolve the clone
+path. The simplest source is `std::env::current_exe()`:
+
+- In `task dev`: the host runs from `dist/cef-dev/agentmux-cef.exe`.
+- `current_exe().parent().parent()` is the workspace root.
+- Hash that path via the existing `data_dir_hash16` to get a 16-char hex.
+
+Then in `data_paths.rs`:
+
+```rust
+if let RuntimeMode::Dev { branch, clone_id } = mode {
+    let safe_branch = sanitize_path_segment(branch)?;
+    let safe_clone = clone_id
+        .as_deref()
+        .and_then(sanitize_path_segment)
+        .unwrap_or_else(|| "default".to_string());
+    let channel = format!("dev-{}-{}", safe_branch, safe_clone);
+    let dir = root.join("dev").join(safe_branch).join(safe_clone);
+    return Ok((channel, dir));
+}
+```
+
+Export `AGENTMUX_CLONE_ID` from `to_env_vars()` so the launcher, srv,
+and host all observe the same key. The lockfile and pipe re-key
+automatically because they derive from `instance_dir`.
+
+**Pros**
+
+- Zero new config files.
+- Uses existing FNV-1a infra in `agentmux-launcher/src/hash.rs`.
+- Backward compatible: if `clone_id` is `None`, dev mode falls back to
+  the current `dev/<branch>/` layout (preserves existing dev sessions).
+- Aligns with the channels-design philosophy: identity is path-derived,
+  not configured.
+
+**Cons**
+
+- One more dir level in the dev tree (`dev/main/A1B2C3D4.../`). Mildly
+  noisier when poking around manually, but acceptable.
+- Plumbing through `RuntimeMode` touches every call site that
+  constructs `Dev { branch }`. Mostly mechanical — Rust's compiler
+  forces the update.
+
+### 3.2 Option B — `.agentmux-clone-id` file
+
+Drop a `.agentmux-clone-id` (gitignored) in each clone root, content
+= a stable random 8-char id. Read on every launch.
+
+**Pros**
+
+- Human-readable, can be inspected or reset by the user.
+- Doesn't depend on `current_exe()` quirks (e.g. when the exe is run
+  from outside `dist/cef-dev/`).
+
+**Cons**
+
+- Requires extra IO per launch.
+- User can accidentally edit or commit it.
+- Two clones with identical `.agentmux-clone-id` (e.g. cloned by file
+  copy) collide silently — same failure mode in disguise.
+
+Option A is the cleaner default. Option B can be a manual override
+mechanism if path-based derivation has a corner case we miss.
+
+### 3.3 Out of scope for the fix
+
+- Vite port. Already loud. If multi-clone parallel dev becomes
+  routine, add a `AGENTMUX_VITE_PORT` override and let
+  `vite.config.ts` honor it. Two-line change but not required for
+  isolation — only for *simultaneous* loud-failure-free dev.
+- Cargo `target/` deduplication. Significant disk cost. Out of scope.
+- VS Code Bridge. Cross-cutting; depends on the bridge's own routing
+  model.
+
+---
+
+## 4. Implementation sketch
+
+| Step | File | Approx LOC |
+|---|---|---|
+| Add `clone_id: Option<String>` to `RuntimeMode::Dev` | `agentmux-common/src/runtime_mode.rs` | 3 |
+| Helper `derive_clone_id_from_exe()` (current_exe → workspace root → hash) | `agentmux-common/src/runtime_mode.rs` | 12 |
+| Plumb through `RuntimeMode::current()` | same | 4 |
+| Update `to_env_vars()` + `from_env()` for `AGENTMUX_CLONE_ID` | `agentmux-common/src/data_paths.rs` | 6 |
+| Update `resolve_channel_and_dir()` to nest under clone_id | same | 8 |
+| Tests: same-branch-different-clone-paths → distinct dirs; backward-compat when clone_id None | same | 25 |
+| `task dev` integration test (optional) | `tools/` or new | n/a |
+| Total | | ~58 LOC + tests |
+
+Risk is low because the change is localized to path resolution —
+every downstream consumer reads paths from env vars (`AGENTMUX_*_DIR`)
+already, so re-keying the instance dir doesn't require touching
+launcher / srv / host code.
+
+The first release with the fix should be flagged in `VERSION_HISTORY`
+so users who have existing `~/.agentmux/dev/<branch>/` state know it
+will be parked in favor of a new `~/.agentmux/dev/<branch>/<clone-id>/`
+on first launch (their old state isn't migrated; it's fresh per
+clone — which is exactly the point).
+
+---
+
+## 5. References
+
+- `agentmux-common/src/runtime_mode.rs` — `RuntimeMode::Dev` enum
+- `agentmux-common/src/data_paths.rs:450-457` — dev path resolution
+- `agentmux-common/src/data_paths.rs:240-264` — `to_env_vars()`
+- `agentmux-launcher/src/hash.rs:42-51` — `data_dir_hash16`
+- `agentmux-launcher/src/ipc/mod.rs:37-39` — pipe name construction
+- `agentmux-srv/src/main.rs` — srv listener binds (`127.0.0.1:0`)
+- `agentmux-srv/src/backend/lan_discovery.rs:71` — mDNS service name
+- `Taskfile.yml:622`, `vite.config.ts:114-115` — Vite `--strictPort`
+- `docs/specs/SPEC_DATA_CHANNELS_2026_05_24.md` — channels-design
+  precedent for path-keyed isolation
+- CLAUDE.md `### Multiple Instances Run in Parallel` — design
+  intent statement


### PR DESCRIPTION
## Summary

Lets two clones of the same agentmux repo on the same branch run `task dev` simultaneously without colliding on data dir, lockfile, named-pipe IPC, CEF cache, or logs.

## Root cause

The launcher's single-instance lockfile name and named-pipe path are both derived from `data_dir_hash16(instance_dir)`. Two clones at different filesystem paths both on `main` resolve to the identical `~/.agentmux/dev/main/` instance_dir, hash to the same lockfile and pipe namespace, and the second clone's launcher silently routes its open-pane intent into the first clone's already-running window — no error, just cross-contamination.

Full inventory in [`docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md`](https://github.com/agentmuxai/agentmux/blob/agentx/multi-clone-dev-isolation/docs/analyses/ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md).

## Fix

Extend `RuntimeMode::Dev` from `{ branch }` to `{ branch, clone_id: Option<String> }` and nest dev paths at `~/.agentmux/dev/<branch>/<clone_id>/`. `clone_id` is FNV-1a-16-hex of the clone's workspace-root path (first ancestor of the exe dir containing `.git`, `Cargo.toml`, or `Taskfile.yml`). Lockfile + named-pipe + CEF cache + logs all flow from `instance_dir`, so the rest is automatic.

## Implementation notes

- New `derive_clone_id(exe_dir)` in `agentmux-common/src/runtime_mode.rs`. Inline FNV-1a-64 (matches `agentmux-launcher/src/hash.rs` byte-for-byte; avoids cross-crate dep).
- `RuntimeMode::current` / `current_path_only` populate `clone_id` on every Dev classification path.
- `DataPaths::resolve_channel_and_dir` nests under `<clone_id>/` when `Some`; **legacy two-level `dev/<branch>/` when `None`** for back-compat (env-string round-trip path, direct test construction).
- New `AGENTMUX_CLONE_ID` env var; `DataPaths::to_env_vars` exports it for Dev with `Some(clone_id)`; new `RuntimeMode::from_env_with_clone()` pairs `AGENTMUX_RUNTIME_MODE` + `AGENTMUX_CLONE_ID` for full reconstruction in child processes.
- `to_env_string()` continues to emit `dev:<branch>` only — keeping the wire format backward-compatible with older parsers; `clone_id` travels via its dedicated env var.

## Tests

All 75 `agentmux-common` tests pass; full `cargo build --workspace` is clean. New tests:

- `derive_clone_id_*` — stable for same path; differs for different paths; walks up to find marker; returns None when no marker.
- `sanitize_clone_id_rejects_traversal` — env-supplied clone_ids can't escape the dev/ subtree.
- `dev_paths_under_branch_and_clone_id` — two Dev variants on the same branch but different clone_ids resolve to distinct instance dirs and channel names.
- `dev_paths_legacy_two_level_when_clone_id_none` — explicit back-compat assertion (no migration of in-flight dev sessions).
- `from_env_with_clone_*` — AGENTMUX_CLONE_ID round-trips through env for Dev.

## Out of scope (deferred)

- **Vite port 5173.** Stays hardcoded. `--strictPort` already fails loud on the second clone; that's an acceptable degraded experience for now. Real fix is a `AGENTMUX_VITE_PORT` override and a Taskfile knob — small but separate PR.
- **Cargo `target/` dedup.** Significant disk cost per clone but functionally isolated. Out of scope.
- **VS Code Bridge.** External tool; out of scope here.

## Test plan

- [x] `cargo test -p agentmux-common` — 75/75 pass
- [x] `cargo build --workspace` — clean
- [ ] Two clones on the same branch each run `task dev`. Both windows open, both have distinct data dirs at `~/.agentmux/dev/<branch>/<clone-hash>/`, opening a pane in clone A's window does not affect clone B's window.
- [ ] One clone on `main`, one on a feature branch — pre-existing branch-keyed behavior still works; both isolate.
- [ ] Existing single-clone dev sessions (no `AGENTMUX_CLONE_ID` set yet) still launch into the legacy two-level `dev/<branch>/` path on the first launch after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)