### PR TITLE
fix(widgets): preserve Solid reactivity in ActionWidget so responsive collapse to icon-only works

### DIFF
--- a/.changesets/1779788711-fix-widgets-preserve-solid-reactivity-in-actionwidget-so-res-ishy.md
+++ b/.changesets/1779788711-fix-widgets-preserve-solid-reactivity-in-actionwidget-so-res-ishy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(widgets): preserve Solid reactivity in ActionWidget so responsive collapse to icon-only works

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -98,27 +98,29 @@ function unpinWidget(shortName: string, settings: Record<string, any>, wmap: Rec
 
 // ── ActionWidget ──────────────────────────────────────────────────────────────
 
-const ActionWidget = ({
-    widget,
-    iconOnly,
-    onContextMenu,
-}: {
+// NOTE: don't destructure props in the signature — Solid props are getters
+// that lose reactivity when destructured outside an effect (Solid issue
+// #1224). Access via `props.iconOnly` so the `<Show>` below stays reactive
+// to upstream `tooNarrow` changes. Without this fix the responsive widget
+// bar collapse-to-icons never visually applies even though `tooNarrow`
+// computes correctly — diagnosed live via the fe_log pipe.
+const ActionWidget = (props: {
     widget: WidgetConfigType;
     iconOnly: boolean;
     onContextMenu?: (e: MouseEvent) => void;
 }): JSX.Element => (
-    <div onContextMenu={onContextMenu}>
+    <div onContextMenu={props.onContextMenu}>
         <Tooltip
-            content={widget.description || widget.label}
+            content={props.widget.description || props.widget.label}
             placement="bottom"
             divClassName="flex flex-row items-center gap-1 px-2 py-0.5 text-secondary hover:bg-hoverbg hover:text-white cursor-pointer rounded-sm h-full"
-            divOnClick={() => handleWidgetSelect(widget)}
+            divOnClick={() => handleWidgetSelect(props.widget)}
         >
-            <div style={{ color: widget.color }} class="text-sm">
-                <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
+            <div style={{ color: props.widget.color }} class="text-sm">
+                <i class={makeIconClass(props.widget.icon, true, { defaultIcon: "browser" })}></i>
             </div>
-            <Show when={!iconOnly && !isBlank(widget.label)}>
-                <div class="text-xs whitespace-nowrap">{widget.label}</div>
+            <Show when={!props.iconOnly && !isBlank(props.widget.label)}>
+                <div class="text-xs whitespace-nowrap">{props.widget.label}</div>
             </Show>
         </Tooltip>
     </div>


### PR DESCRIPTION
## Summary

PR #975 introduced a responsive widget bar that's supposed to collapse to
icon-only when the title bar is too narrow to fit all labeled widgets +
tabs + window controls. The math correctly detects "too narrow," but the
visible bar never re-rendered when the `tooNarrow` signal flipped — so
labeled widgets stayed visible and pushed the window controls off the
right edge of the title bar.

## Root cause

Classic SolidJS reactivity gotcha. `ActionWidget` destructured its props
in the parameter list:

```ts
const ActionWidget = ({ widget, iconOnly, onContextMenu }: {...}) => (
    ...
    <Show when={!iconOnly && !isBlank(widget.label)}>...
);
```

Destructuring evaluates the prop getters **once** at component creation.
The `<Show when={!iconOnly && ...}>` then references a captured boolean
constant, not the live signal. Per
[Solid issue #1224](https://github.com/solidjs/solid/issues/1224),
destructured props lose reactivity outside an effect.

## Fix

Take props as a single object and read `props.iconOnly` inside the
`<Show>`. JSX expressions are wrapped in effects, so the getter access
subscribes to the signal correctly:

```ts
const ActionWidget = (props: {...}) => (
    ...
    <Show when={!props.iconOnly && !isBlank(props.widget.label)}>...
);
```

## Diagnosis evidence

Diagnosed live by adding temporary instrumentation to the measure
function in `action-widgets.tsx`. The `console.info` calls flow through
the existing `fe_log_structured` IPC pipe to the host log, so they show
up via `muxlog`:

```
[action-widgets:measure] {
  call: 1, headerW: 503, labeledW: 654, buttonsW: 138, minTab: 120,
  sum: 912, next: true, skipReason: null
}
```

`next: true` (i.e. `tooNarrow` should be `true`) on every measure call,
but the bar stayed visually labeled. That gap between "math says
collapse" and "DOM stays labeled" pinned the bug to the prop-passing
layer, and Solid's documented destructured-props pitfall was the
specific cause.

## Test plan

- [x] Tested live via Vite HMR before commit — narrowed window, widgets
      collapsed to icons, controls became visible again
- [x] `npx tsc --noEmit` clean on the touched file
- [ ] Reviewer: confirm the fix on a fresh build at a narrow window
      width — labels should disappear before window controls are pushed
      off-screen

Changeset: `patch` (RFC #857 Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)