### PR TITLE
chore: release v0.38.6

### DIFF
--- a/.changesets/1779782816-fix-lan-discovery-mdns-hostname-suffix.md
+++ b/.changesets/1779782816-fix-lan-discovery-mdns-hostname-suffix.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): normalize mDNS hostname with .local. suffix so service registration succeeds on Windows / non-mDNS hosts

--- a/.changesets/1779785256-docs-readme-refresh-widget-table-all-pinned-add-warden.md
+++ b/.changesets/1779785256-docs-readme-refresh-widget-table-all-pinned-add-warden.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(readme): refresh widget table — all-pinned default, add Warden, drop stale More tier

--- a/.changesets/1779785318-feat-common-per-clone-dev-isolation-runtimemode-dev-now-carr-9ow5.md
+++ b/.changesets/1779785318-feat-common-per-clone-dev-isolation-runtimemode-dev-now-carr-9ow5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(common): per-clone Dev isolation — RuntimeMode::Dev now carries clone_id for two-clones-same-branch parity

--- a/.changesets/1779788711-fix-widgets-preserve-solid-reactivity-in-actionwidget-so-res-ishy.md
+++ b/.changesets/1779788711-fix-widgets-preserve-solid-reactivity-in-actionwidget-so-res-ishy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(widgets): preserve Solid reactivity in ActionWidget so responsive collapse to icon-only works

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.5"
+version = "0.38.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.5"
+version = "0.38.6"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.5"
+version = "0.38.6"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.5"
+version = "0.38.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.5"
+version = "0.38.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.5"
+version = "0.38.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.38.6 — 2026-05-26
+
+- fix(lan): normalize mDNS hostname with .local. suffix so service registration succeeds on Windows / non-mDNS hosts
+- docs(readme): refresh widget table — all-pinned default, add Warden, drop stale More tier
+- feat(common): per-clone Dev isolation — RuntimeMode::Dev now carries clone_id for two-clones-same-branch parity
+- fix(widgets): preserve Solid reactivity in ActionWidget so responsive collapse to icon-only works
+
 ## 0.38.5 — 2026-05-26
 
 - chore: version bump (post-release rebuild to give the next portable a distinct version label from prior 0.38.4 portables on the build machine)
@@ -481,6 +488,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.38.6 | 2026-05-26 | 164.8 MiB | 346.1 MiB | |
 | 0.37.3 | 2026-05-21 | 164.7 MiB | 345.6 MiB | |
 | 0.36.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.35.0 | 2026-05-19 | 164.6 MiB | 345.6 MiB | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.5",
+  "version": "0.38.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.5",
+      "version": "0.38.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.5",
+  "version": "0.38.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release v0.38.6. Consumes 4 pending changesets from PRs merged since
v0.38.4 release earlier today.

## Included since v0.38.5

- **fix(lan):** normalize mDNS hostname with `.local.` suffix so
  service registration succeeds on Windows / non-mDNS hosts
- **docs(readme):** refresh widget table — all-pinned default, add
  Warden, drop stale More tier
- **feat(common):** per-clone Dev isolation — `RuntimeMode::Dev` now
  carries `clone_id` for two-clones-same-branch parity
- **fix(widgets):** preserve Solid reactivity in ActionWidget so
  responsive collapse to icon-only works ([#1054](https://github.com/agentmuxai/agentmux/pull/1054))

## Version consistency

All 5 version-bearing files agree at 0.38.6:

| File | Value |
|---|---|
| `package.json` | 0.38.6 |
| `Cargo.toml` (workspace) | 0.38.6 |
| `Cargo.lock` (workspace members) | 0.38.6 |
| `package-lock.json` | 0.38.6 |
| `VERSION_HISTORY.md` head | 0.38.6 |

Verified by `scripts/release.sh`'s post-bump invariant check (RFC #857
Phase 2 release-consistency gate).

## Test plan

- [x] Portable built locally (`task package` → 165 MB ZIP)
- [x] Launched locally — Warden widget visible, hard corners
      applied, widget bar collapses to icons at narrow widths,
      PSReadLine thaw active
- [ ] Reviewer: verify release-consistency invariant; merge with
      squash to keep main history linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)