### PR TITLE
fix(modal): add compact-mode min-width override to 4 modals (audit follow-up to #1039)

### DIFF
--- a/.changesets/1779790254-fix-modal-add-compact-mode-min-width-override-to-launch-prer-shew.md
+++ b/.changesets/1779790254-fix-modal-add-compact-mode-min-width-override-to-launch-prer-shew.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(modal): add compact-mode min-width override to launch/prereq/new-bundle/browser-auth modals

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -12,6 +12,13 @@
     gap: var(--space-3);
     min-width: 440px;
     max-width: 560px;
+
+    // Compact variant — relax the body min-width so the modal can mount
+    // in panes narrower than 440px. The ModalLayer toggles this class
+    // when its mount node is < 400px (see SPEC_MODAL_COMPACT_VARIANT_2026_05_25.md).
+    :where(.modal-layer-mount--compact) & {
+        min-width: 0;
+    }
 }
 
 .agent-new-bundle-modal-field {

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -11,6 +11,13 @@
     gap: var(--space-3);
     min-width: 440px;
     max-width: 540px;
+
+    // Compact variant — relax the body min-width so the modal can mount
+    // in panes narrower than 440px. The ModalLayer toggles this class
+    // when its mount node is < 400px (see SPEC_MODAL_COMPACT_VARIANT_2026_05_25.md).
+    :where(.modal-layer-mount--compact) & {
+        min-width: 0;
+    }
 }
 
 .agent-prereq-modal-list {

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -15,6 +15,13 @@
     gap: 14px;
     min-width: 420px;
     max-width: 540px;
+
+    // Compact variant — relax the body min-width so the modal can mount
+    // in panes narrower than 420px. The ModalLayer toggles this class
+    // when its mount node is < 400px (see SPEC_MODAL_COMPACT_VARIANT_2026_05_25.md).
+    :where(.modal-layer-mount--compact) & {
+        min-width: 0;
+    }
 }
 
 .agent-launch-modal-blurb {

--- a/frontend/app/view/browser/components/BrowserAuthModal.scss
+++ b/frontend/app/view/browser/components/BrowserAuthModal.scss
@@ -11,6 +11,13 @@
     gap: var(--space-3);
     min-width: 380px;
     max-width: 480px;
+
+    // Compact variant — relax the body min-width so the modal can mount
+    // in panes narrower than 380px. The ModalLayer toggles this class
+    // when its mount node is < 400px (see SPEC_MODAL_COMPACT_VARIANT_2026_05_25.md).
+    :where(.modal-layer-mount--compact) & {
+        min-width: 0;
+    }
 }
 
 .browser-auth-modal-field {


### PR DESCRIPTION
## Summary

`SPEC_MODAL_COMPACT_VARIANT_2026_05_25.md` §3 documented the compact
escape-hatch pattern, and #1039 applied it to the **install modal**
only. An audit of all modal bodies turned up 4 more with hard-coded
min-widths that overflow in narrow panes.

## Affected modals

| Modal | min-width | Status before | Status after |
|---|---|---|---|
| AgentInstallModal | 560px | ✅ has override (#1039) | unchanged |
| AgentLaunchModalPanel | 420px | ❌ missing | ✅ fixed |
| AgentNewBundleModal (Identity & Memory) | 440px | ❌ missing | ✅ fixed |
| AgentPrereqModal | 440px | ❌ missing | ✅ fixed |
| BrowserAuthModal | 380px | ❌ missing | ✅ fixed |

The compact threshold is 400px (`COMPACT_THRESHOLD_PX` in
`ModalLayer.tsx`), so all 4 unfixed modals can overflow when the parent
pane is narrower than the base min-width. The browser-auth modal in
particular mounts pane-scoped (#1038), and browser panes go down to
~240px in multi-pane layouts (verified in the #1037/#1038 work).

## Fix

Mirror the install modal pattern exactly — append a
`:where(.modal-layer-mount--compact) & { min-width: 0 }` block to each
of the 4 modal bodies. Cross-reference the spec in each comment so a
future modal audit can grep for `modal-layer-mount--compact` and find
the canonical pattern.

## Why now

User flagged that the modal in a narrow pane still ran wide. Audit
confirmed the pattern wasn't propagated to siblings in #1039. This
PR closes that gap.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: at a narrow browser pane (<400px wide), open
      the HTTP-auth modal — should now collapse to compact layout
- [ ] Same for narrow agent pane: launch/prereq/new-bundle modals
- [x] Mechanical sweep complete — `grep -rln "modal-layer-mount--compact"
      frontend --include "*.scss"` now finds 6 hits (was 2 before)

Changeset: `patch` (RFC #857 Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)