### PR TITLE
feat(layout): WxH badge at pane corner during resize

### DIFF
--- a/.changesets/1779792165-feat-layout-show-wxh-badge-at-pane-corner-during-resize-qppn.md
+++ b/.changesets/1779792165-feat-layout-show-wxh-badge-at-pane-corner-during-resize-qppn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(layout): show WxH badge at pane corner during resize

--- a/docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md
+++ b/docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md
@@ -25,15 +25,23 @@ hit-testing, focus, or pane content.
 
 ### 2.1 Visibility
 
-The badge mounts on **every visible pane** while `layoutModel.isResizing()`
+The badge mounts on **every visible pane** while `layoutModel.isSplitterDragging()`
 is `true`. It unmounts when the signal flips back to `false` (drag end /
 splitter release / ESC cancel).
+
+**Why not `isResizing()`?** `LayoutModel.isResizing` is true for both
+splitter drags AND container resizes (window resize, initial layout
+observation). Gating on `isResizing` causes the badge to briefly flash
+on every pane during a window resize, which the spec explicitly excludes.
+`isSplitterDragging` is a separate memo that returns true *only* for
+splitter-drag `pendingTreeAction`s. Codex P2 on PR #1057.
 
 | State                                | Badge mounted? |
 |--------------------------------------|----------------|
 | Idle (no drag)                       | No             |
 | Splitter drag in progress            | **Yes (all panes)** |
-| Magnified-pane edge drag in progress | **Yes (all panes)** |
+| Magnified-pane edge drag in progress | **Yes (all panes)** — when wired through `isSplitterDragging` |
+| Window / container resize            | No (intentional — see above) |
 | Pane move drag (pragmatic-dnd reorder) | No (sizes don't change) |
 | Tab tear-off drag                    | No             |
 | Pane being resized via keyboard      | Optional follow-up — out of scope for v1 |

--- a/docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md
+++ b/docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md
@@ -1,0 +1,255 @@
+# SPEC: Pane resize dimension overlay (WxH badge)
+
+**Date:** 2026-05-26
+**Status:** Draft — ready to implement
+**Author:** AgentA
+**Tracking discussion:** TBD
+
+---
+
+## 1. Purpose
+
+When any pane is being resized (the user is dragging a tile-layout splitter
+or a magnified pane edge), show a small `WxH` badge in the bottom-left corner
+of **every** pane in the layout. The badge gives live numeric feedback so the
+user can dial a specific size — e.g. "make this terminal exactly 800×400" —
+without external tooling, and so multiple panes' proportional changes are
+visible at a glance during a drag.
+
+The badge is read-only telemetry: it never accepts input, and never affects
+hit-testing, focus, or pane content.
+
+---
+
+## 2. Behavior
+
+### 2.1 Visibility
+
+The badge mounts on **every visible pane** while `layoutModel.isResizing()`
+is `true`. It unmounts when the signal flips back to `false` (drag end /
+splitter release / ESC cancel).
+
+| State                                | Badge mounted? |
+|--------------------------------------|----------------|
+| Idle (no drag)                       | No             |
+| Splitter drag in progress            | **Yes (all panes)** |
+| Magnified-pane edge drag in progress | **Yes (all panes)** |
+| Pane move drag (pragmatic-dnd reorder) | No (sizes don't change) |
+| Tab tear-off drag                    | No             |
+| Pane being resized via keyboard      | Optional follow-up — out of scope for v1 |
+
+The "every pane" rule is intentional: when you drag a splitter between A and
+B, every other pane in the same row/column also shifts proportionally, and
+users often want to see the cascade.
+
+### 2.2 Content
+
+Format: `<width>×<height>` using the multiplication sign (U+00D7), e.g.
+`812×437`. Values are integer CSS pixels read from the pane's host element
+(`clientWidth × clientHeight`).
+
+No padding/border breakdown, no font-cell counts (terminals already render
+their own status on resize via xterm's cursor row), no DPI-scaled values —
+CSS pixels match what every other surface in the app reports.
+
+### 2.3 Position
+
+Bottom-left corner of the pane content area, **inside** the pane's clip
+rect, with a small inset matching `--space-2` (8px):
+
+```
+┌─────────────────────────┐
+│                         │
+│   pane content          │
+│                         │
+│                         │
+│ ┌─────┐                 │
+│ │812×437│ ←── badge      │
+│ └─────┘                 │
+└─────────────────────────┘
+```
+
+Bottom-left was picked over bottom-right or center because:
+
+- Terminal panes have their cursor + prompt at bottom-left; the badge sits
+  flush above the same baseline and reads as a status indicator.
+- Browser panes have a scrollbar on the right; bottom-left avoids the
+  reserved-edge collision.
+- Agent panes' "Send / Stop" buttons live bottom-right (per
+  `SPEC_AGENT_PANE_BOTTOM_BUTTONS_2026_04_22.md`). Bottom-left is the
+  only consistently-empty corner.
+
+### 2.4 Style
+
+Single SCSS rule on `.pane-size-badge`:
+
+```scss
+.pane-size-badge {
+    position: absolute;
+    left: var(--space-2);
+    bottom: var(--space-2);
+    z-index: 30;                        // above pane content, below modals (50+)
+    padding: 2px var(--space-1-5);
+    font-family: var(--termfontfamily, monospace);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.4;
+    color: var(--main-text-color);
+    background: color-mix(in srgb, var(--main-bg-color) 88%, transparent);
+    border: 1px solid var(--border-color);
+    border-radius: 0;                   // hard-corners design (SPEC_HARD_CORNERS_2026_05_26)
+    pointer-events: none;               // never blocks pane interactions
+    user-select: none;
+    backdrop-filter: blur(2px);         // legibility over busy content
+    white-space: nowrap;
+    // Match the design system's monospace status pills.
+    letter-spacing: 0.02em;
+}
+```
+
+No fade-in animation. The badge appears the instant `isResizing()` flips
+true and disappears the instant it flips false — any easing would lag the
+drag.
+
+---
+
+## 3. Implementation outline
+
+### 3.1 New file
+
+`frontend/app/block/pane-size-badge.tsx` — SolidJS component:
+
+```tsx
+import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { useLayoutModel } from "@/layout";
+
+interface PaneSizeBadgeProps {
+    /** Element to measure. Usually the pane's outer frame. */
+    target: () => HTMLElement | undefined;
+}
+
+export const PaneSizeBadge = (props: PaneSizeBadgeProps): JSX.Element => {
+    const layoutModel = useLayoutModel();
+    const [size, setSize] = createSignal<{ w: number; h: number } | null>(null);
+
+    let ro: ResizeObserver | null = null;
+
+    onMount(() => {
+        const el = props.target();
+        if (!el) return;
+        // Seed with the current rect so the first paint shows real numbers
+        // (otherwise the badge briefly shows nothing on resize start).
+        const r = el.getBoundingClientRect();
+        setSize({ w: Math.round(r.width), h: Math.round(r.height) });
+        ro = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const cr = entry.contentRect;
+                setSize({ w: Math.round(cr.width), h: Math.round(cr.height) });
+            }
+        });
+        ro.observe(el);
+    });
+
+    onCleanup(() => { ro?.disconnect(); ro = null; });
+
+    return (
+        <Show when={layoutModel.isResizing() && size()}>
+            <div class="pane-size-badge" aria-hidden="true">
+                {size()!.w}×{size()!.h}
+            </div>
+        </Show>
+    );
+};
+```
+
+### 3.2 Mount point
+
+Add to `frontend/app/block/blockframe.tsx` (every pane renders through
+`<BlockFrame>` regardless of view type). Conditional on
+`layoutModel.isResizing()` so the ResizeObserver isn't paying the cost
+when idle.
+
+The badge is **outside** the pane's scroll container but **inside** the
+pane's `position: relative` outer frame, so `position: absolute` anchors
+to the pane edge (not the viewport) and the badge clips with the pane on
+overlap.
+
+### 3.3 SCSS
+
+Single file: `frontend/app/block/pane-size-badge.scss`, imported once
+from `frontend/app/app.scss` (next to the other block-level rules).
+
+### 3.4 No new state
+
+`layoutModel.isResizing()` already exists (see
+`frontend/layout/lib/types.ts:252` and `TileLayout.{win32,linux,darwin}.tsx`)
+and is flipped by `onResizeStart` / `onResizeEnd` in
+`frontend/layout/lib/layoutResize.ts`. No new reducer, no new event, no
+new IPC.
+
+For magnified-pane edge resize (RFC #404), that surface also has its own
+"is dragging" signal — wire it into the same `<Show when={...}>` predicate
+with an `||` if it's separate from `isResizing()`. Verify before merging
+whether magnified-pane drag already toggles `isResizing()`; if not, plumb
+through.
+
+---
+
+## 4. Edge cases
+
+| Case                                | Behavior                                           |
+|-------------------------------------|----------------------------------------------------|
+| Pane height < ~50px                 | Badge still renders; the 11px text + 4px padding fits at ≥30px tall. Below that, the badge will overflow the pane edge — acceptable transient at extreme sizes. |
+| Single-pane layout (no resize possible) | `isResizing()` never flips true → badge never mounts. No-op. |
+| Pane that just unmounted mid-drag (e.g. close while dragging) | Solid's `<Show>` unmounts the badge with the parent. `onCleanup` disconnects the observer. |
+| Modal open during resize            | Modals are `z-index ≥ 50`; badge is `z-index: 30`. Modal occludes — correct, since the user can't resize past the modal anyway. |
+| Terminal pane with xterm at bottom-left | Badge sits over the terminal's cursor row for the duration of the drag. xterm doesn't lose focus and resumes input after release. Acceptable — the drag itself already obscures the cursor. |
+| Reduced-motion preference           | No animations exist, so nothing to disable. |
+| Pinned magnified pane               | Magnification doesn't change `isResizing()` — badge only mounts during the magnify-edge drag itself. |
+| RTL layout                          | `left: var(--space-2)` flips to right under `[dir="rtl"]` via a logical-property pass — out of scope for v1; revisit when AgentMux adds an RTL theme. |
+
+---
+
+## 5. Out of scope (follow-ups)
+
+- **Persistent display.** Some IDE-style users want WxH always visible. Add
+  a settings toggle `layout:always-show-pane-size: bool` later if requested
+  — not v1.
+- **Aspect-ratio readout.** Bottom-left could also show "16:9" or "4:3"
+  during the drag for video / mockup-aligned panes. Defer.
+- **Snap markers.** "WxH" near a sibling pane's size could highlight when
+  the user lands on a clean snap. Defer.
+- **Keyboard resize.** If/when arrow-key splitter resize lands, reuse the
+  same badge by also flipping `isResizing()` for the keystroke duration
+  (debounced 300ms).
+
+---
+
+## 6. Acceptance criteria
+
+1. Drag any splitter in a multi-pane tab → every pane in that tab shows a
+   `WxH` badge at its bottom-left, updating live (≥30 fps tracking the
+   mouse) until release.
+2. Release the splitter → all badges unmount within one frame.
+3. Open a modal mid-drag (impossible by user input, but verify via test) →
+   modal overlays badges, badges still unmount on release.
+4. Single-pane tab → no badge ever appears.
+5. Numbers match `getBoundingClientRect()` of the pane frame (within ±1px
+   for sub-pixel rounding).
+6. Badge does not affect pane content scroll position, focus, or
+   pointer-event hit-testing (test by clicking through the badge's bounding
+   box while idle — should hit the underlying content).
+
+---
+
+## 7. References
+
+- `frontend/layout/lib/layoutResize.ts` — `onResizeStart`,
+  `onResizeMove`, `onResizeEnd`
+- `frontend/layout/lib/types.ts:252` — `isResizing: Accessor<boolean>`
+- `frontend/layout/lib/TileLayout.{win32,linux,darwin}.tsx` — consumers of
+  `isResizing()` for the `animate` class gating
+- `frontend/app/block/blockframe.tsx` — mount point for the badge
+- `docs/specs/SPEC_HARD_CORNERS_2026_05_26.md` — radius token guidance
+- `docs/specs/SPEC_AGENT_PANE_BOTTOM_BUTTONS_2026_04_22.md` — bottom-right
+  reservation, justifying bottom-left choice

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -39,6 +39,7 @@ import clsx from "clsx";
 import type { JSX } from "solid-js";
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, Suspense } from "solid-js";
 import "./block.scss";
+import "./pane-size-badge.scss";
 import { BlockErrorBoundary } from "./BlockErrorBoundary";
 import { BlockFrame } from "./blockframe";
 import { blockViewToIcon, blockViewToName } from "./blockutil";

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -802,10 +802,12 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
                 />
             </Show>
             {/* Pane size badge — bottom-left WxH while any pane is being
-                resized. No-op when isResizing() is false.
+                resized. The Show gate keeps the badge component (and its
+                ResizeObserver) mounted *only* during the drag, so idle
+                panes do no observer work. Codex P2 on PR #1057.
                 SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md. */}
-            <Show when={!props.preview}>
-                <PaneSizeBadge nodeModel={nodeModel} target={frameEl} />
+            <Show when={!props.preview && nodeModel.isResizing()}>
+                <PaneSizeBadge target={frameEl} />
             </Show>
             {/* BlockMask is last in DOM so it paints above all block content,
                 including hardware-accelerated WebGL surfaces */}

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -801,12 +801,15 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
                     connBtnRef={connBtnRef}
                 />
             </Show>
-            {/* Pane size badge — bottom-left WxH while any pane is being
-                resized. The Show gate keeps the badge component (and its
-                ResizeObserver) mounted *only* during the drag, so idle
-                panes do no observer work. Codex P2 on PR #1057.
+            {/* Pane size badge — bottom-left WxH while a splitter is
+                being dragged. Gated on `isSplitterDragging` (not
+                `isResizing`) so a window-resize tick doesn't flash the
+                badge on every pane. The Show keeps the component (and
+                its ResizeObserver) mounted only during the drag, so
+                idle panes do no observer work. Codex P2 rounds 1 + 2
+                on PR #1057.
                 SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md. */}
-            <Show when={!props.preview && nodeModel.isResizing()}>
+            <Show when={!props.preview && nodeModel.isSplitterDragging()}>
                 <PaneSizeBadge target={frameEl} />
             </Show>
             {/* BlockMask is last in DOM so it paints above all block content,

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -33,6 +33,7 @@ import { CopyButton } from "../element/copybutton";
 import { detectAgentColor, detectAgentFromEnv, detectAgentTextColor, getEffectiveTitle } from "./autotitle";
 import { buildPaneContextMenu } from "./pane-actions";
 import { BlockFrameProps } from "./blocktypes";
+import { PaneSizeBadge } from "./pane-size-badge";
 import { TitleBar } from "./titlebar";
 
 const NumActiveConnColors = 8;
@@ -654,6 +655,11 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     let connBtnRef: { current: HTMLDivElement | null } = { current: null };
     const noHeader = util.useAtomValueSafe(props.viewModel?.noHeader);
 
+    // Captured outer-frame ref for PaneSizeBadge. Live as long as the
+    // frame is mounted; cleared on unmount via the callback ref.
+    // SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md.
+    const [frameEl, setFrameEl] = createSignal<HTMLDivElement | undefined>(undefined);
+
     // Agent color for border — matches header color on agent-loaded terminals
     const blockAgentColor = createMemo(() => {
         if (!props.preview && blockData()?.meta?.view === "term") {
@@ -750,7 +756,12 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
             onClick={props.blockModel?.onClick}
             onFocusIn={props.blockModel?.onFocusCapture}
             onContextMenu={onBodyContextMenu}
-            ref={props.blockModel?.blockRef ? (el) => { props.blockModel.blockRef.current = el; } : undefined}
+            ref={(el) => {
+                setFrameEl(el);
+                if (props.blockModel?.blockRef) {
+                    props.blockModel.blockRef.current = el;
+                }
+            }}
             style={
                 {
                     "--magnified-block-opacity": magnifiedBlockOpacity(),
@@ -789,6 +800,12 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
                     setChangeConnModalOpen={(v) => changeConnModalAtom._set(v)}
                     connBtnRef={connBtnRef}
                 />
+            </Show>
+            {/* Pane size badge — bottom-left WxH while any pane is being
+                resized. No-op when isResizing() is false.
+                SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md. */}
+            <Show when={!props.preview}>
+                <PaneSizeBadge nodeModel={nodeModel} target={frameEl} />
             </Show>
             {/* BlockMask is last in DOM so it paints above all block content,
                 including hardware-accelerated WebGL surfaces */}

--- a/frontend/app/block/pane-size-badge.scss
+++ b/frontend/app/block/pane-size-badge.scss
@@ -1,0 +1,28 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// PaneSizeBadge — bottom-left `WxH` overlay during pane resize.
+// Spec: SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md.
+
+.pane-size-badge {
+    position: absolute;
+    left: var(--space-2);
+    bottom: var(--space-2);
+    // Above pane content (BlockMask uses var(--zindex-block-mask),
+    // overlays sit at 20) but below modals (50+).
+    z-index: 30;
+    padding: 2px var(--space-1-5);
+    font-family: var(--termfontfamily, monospace);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+    color: var(--main-text-color);
+    background: color-mix(in srgb, var(--main-bg-color) 88%, transparent);
+    border: 1px solid var(--border-color);
+    border-radius: 0;             // hard-corners design (SPEC_HARD_CORNERS_2026_05_26)
+    backdrop-filter: blur(2px);   // legibility over busy content
+    pointer-events: none;         // never blocks pane interactions
+    user-select: none;
+    white-space: nowrap;
+}

--- a/frontend/app/block/pane-size-badge.tsx
+++ b/frontend/app/block/pane-size-badge.tsx
@@ -5,43 +5,56 @@
  * PaneSizeBadge — small `<width>×<height>` overlay rendered at the
  * bottom-left of a pane while any pane in the tab is being resized.
  *
- * Mounts inside every `<BlockFrame_Default>` (so every visible pane
- * gets one) but only RENDERS while the LayoutModel's `isResizing()`
- * signal is true. The signal is global to the tab — dragging any
- * splitter cascades sizes across siblings, so every pane shows its
- * current rect while the drag is in flight.
+ * Lifetime is gated by the caller (see `blockframe.tsx` — wraps the
+ * mount in `<Show when={nodeModel.isResizing()}>`), so this component
+ * only exists during a drag. The ResizeObserver attaches on mount
+ * (drag start) and detaches on unmount (drag end); zero work runs in
+ * the idle steady state. Codex P2 on PR #1057.
+ *
+ * Both the seed measurement and the observer callback read the **border
+ * box** so the displayed value never jumps when the first ResizeObserver
+ * tick lands — `getBoundingClientRect()` and `entry.borderBoxSize[0]`
+ * agree, while `entry.contentRect` would report ~2px smaller because
+ * `.block-frame-default` has `padding: 1px`. Codex P2 on PR #1057.
  *
  * Spec: docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md.
  */
 
-import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
-
-import { NodeModel } from "@/layout/index";
+import { createSignal, onCleanup, onMount, type JSX } from "solid-js";
 
 interface PaneSizeBadgeProps {
-    nodeModel: NodeModel;
     /** Accessor for the pane's outer frame. Measured via ResizeObserver. */
     target: () => HTMLElement | undefined;
 }
 
 export const PaneSizeBadge = (props: PaneSizeBadgeProps): JSX.Element => {
-    const [size, setSize] = createSignal<{ w: number; h: number } | null>(null);
+    const [size, setSize] = createSignal<{ w: number; h: number }>({ w: 0, h: 0 });
     let ro: ResizeObserver | null = null;
 
     onMount(() => {
         const el = props.target();
         if (!el) return;
-        // Seed the signal with the current rect so the first paint
-        // during a drag shows real numbers — without this, the badge
-        // briefly renders empty until the first ResizeObserver tick
-        // (which only fires when the size actually changes).
+        // Seed with the border-box rect synchronously so the very first
+        // paint of the badge shows real numbers (without the seed the
+        // ResizeObserver fires once after mount, briefly showing 0×0).
         const r = el.getBoundingClientRect();
         setSize({ w: Math.round(r.width), h: Math.round(r.height) });
 
         ro = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                const cr = entry.contentRect;
-                setSize({ w: Math.round(cr.width), h: Math.round(cr.height) });
+                // borderBoxSize matches getBoundingClientRect (border-box).
+                // contentRect excludes padding and would show a 2px jump
+                // on the first tick against the seed value.
+                const box = entry.borderBoxSize?.[0];
+                if (box) {
+                    setSize({ w: Math.round(box.inlineSize), h: Math.round(box.blockSize) });
+                } else {
+                    // Safari < 17 / older Chromium fallback — borderBoxSize
+                    // missing from the entry payload. Re-read the element
+                    // directly to keep the same box model.
+                    const rr = el.getBoundingClientRect();
+                    setSize({ w: Math.round(rr.width), h: Math.round(rr.height) });
+                }
             }
         });
         ro.observe(el);
@@ -53,14 +66,9 @@ export const PaneSizeBadge = (props: PaneSizeBadgeProps): JSX.Element => {
     });
 
     return (
-        // `nodeModel.isResizing()` is wired to `LayoutModel.isResizing`
-        // — same memo for every node, so it flips for the whole tab.
-        // See `frontend/layout/lib/layoutNodeModels.ts:52`.
-        <Show when={props.nodeModel.isResizing() && size()}>
-            <div class="pane-size-badge" aria-hidden="true">
-                {size()!.w}×{size()!.h}
-            </div>
-        </Show>
+        <div class="pane-size-badge" aria-hidden="true">
+            {size().w}×{size().h}
+        </div>
     );
 };
 

--- a/frontend/app/block/pane-size-badge.tsx
+++ b/frontend/app/block/pane-size-badge.tsx
@@ -3,13 +3,14 @@
 
 /**
  * PaneSizeBadge — small `<width>×<height>` overlay rendered at the
- * bottom-left of a pane while any pane in the tab is being resized.
+ * bottom-left of a pane while a splitter is being dragged.
  *
  * Lifetime is gated by the caller (see `blockframe.tsx` — wraps the
- * mount in `<Show when={nodeModel.isResizing()}>`), so this component
- * only exists during a drag. The ResizeObserver attaches on mount
+ * mount in `<Show when={nodeModel.isSplitterDragging()}>`), so this
+ * component only exists during a splitter drag — NOT during window
+ * or container resize. The ResizeObserver attaches on mount
  * (drag start) and detaches on unmount (drag end); zero work runs in
- * the idle steady state. Codex P2 on PR #1057.
+ * the idle steady state. Codex P2 rounds 1 + 2 on PR #1057.
  *
  * Both the seed measurement and the observer callback read the **border
  * box** so the displayed value never jumps when the first ResizeObserver

--- a/frontend/app/block/pane-size-badge.tsx
+++ b/frontend/app/block/pane-size-badge.tsx
@@ -1,0 +1,67 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PaneSizeBadge — small `<width>×<height>` overlay rendered at the
+ * bottom-left of a pane while any pane in the tab is being resized.
+ *
+ * Mounts inside every `<BlockFrame_Default>` (so every visible pane
+ * gets one) but only RENDERS while the LayoutModel's `isResizing()`
+ * signal is true. The signal is global to the tab — dragging any
+ * splitter cascades sizes across siblings, so every pane shows its
+ * current rect while the drag is in flight.
+ *
+ * Spec: docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md.
+ */
+
+import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+
+import { NodeModel } from "@/layout/index";
+
+interface PaneSizeBadgeProps {
+    nodeModel: NodeModel;
+    /** Accessor for the pane's outer frame. Measured via ResizeObserver. */
+    target: () => HTMLElement | undefined;
+}
+
+export const PaneSizeBadge = (props: PaneSizeBadgeProps): JSX.Element => {
+    const [size, setSize] = createSignal<{ w: number; h: number } | null>(null);
+    let ro: ResizeObserver | null = null;
+
+    onMount(() => {
+        const el = props.target();
+        if (!el) return;
+        // Seed the signal with the current rect so the first paint
+        // during a drag shows real numbers — without this, the badge
+        // briefly renders empty until the first ResizeObserver tick
+        // (which only fires when the size actually changes).
+        const r = el.getBoundingClientRect();
+        setSize({ w: Math.round(r.width), h: Math.round(r.height) });
+
+        ro = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const cr = entry.contentRect;
+                setSize({ w: Math.round(cr.width), h: Math.round(cr.height) });
+            }
+        });
+        ro.observe(el);
+    });
+
+    onCleanup(() => {
+        ro?.disconnect();
+        ro = null;
+    });
+
+    return (
+        // `nodeModel.isResizing()` is wired to `LayoutModel.isResizing`
+        // — same memo for every node, so it flips for the whole tab.
+        // See `frontend/layout/lib/layoutNodeModels.ts:52`.
+        <Show when={props.nodeModel.isResizing() && size()}>
+            <div class="pane-size-badge" aria-hidden="true">
+                {size()!.w}×{size()!.h}
+            </div>
+        </Show>
+    );
+};
+
+PaneSizeBadge.displayName = "PaneSizeBadge";

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -295,6 +295,13 @@ export class LayoutModel {
      */
     isResizing: () => boolean;
     /**
+     * True ONLY when a resize handle (splitter) is currently being dragged.
+     * Unlike `isResizing`, this does NOT flip on window/container resize.
+     * Use this when surfacing UI tied to splitter drags specifically
+     * (e.g. the pane WxH badge — codex P2 on PR #1057).
+     */
+    isSplitterDragging: () => boolean;
+    /**
      * True if the whole TileLayout container is being resized.
      * @internal
      */
@@ -400,10 +407,13 @@ export class LayoutModel {
             this.pendingTreeAction = atomWithThrottle<LayoutTreeAction>(null, 10);
 
             this.isContainerResizing = createSignalAtom(false);
-            this.isResizing = createMemo(() => {
+            this.isSplitterDragging = createMemo(() => {
                 const pendingAction = this.pendingTreeAction.throttledValueAtom();
+                return pendingAction?.type === LayoutTreeActionType.ResizeNode;
+            });
+            this.isResizing = createMemo(() => {
                 const isWindowResizing = this.isContainerResizing();
-                return isWindowResizing || pendingAction?.type === LayoutTreeActionType.ResizeNode;
+                return isWindowResizing || this.isSplitterDragging();
             });
 
             this.displayContainerRef = { current: null };

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -50,6 +50,7 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                 }),
                 numLeafs: model.numLeafs,
                 isResizing: model.isResizing,
+                isSplitterDragging: model.isSplitterDragging,
                 isMagnified: createMemo(() => {
                     const treeState = model.localTreeStateAtom();
                     return treeState.magnifiedNodeId === nodeid;

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -250,6 +250,12 @@ export interface NodeModel {
     addEphemeralNodeToLayout: () => void;
     animationTimeS: Accessor<number>;
     isResizing: Accessor<boolean>;
+    /**
+     * True ONLY when a resize handle (splitter) is being dragged.
+     * Unlike `isResizing`, does NOT flip on window/container resize.
+     * Codex P2 on PR #1057.
+     */
+    isSplitterDragging: Accessor<boolean>;
     isFocused: Accessor<boolean>;
     isMagnified: Accessor<boolean>;
     isEphemeral: Accessor<boolean>;


### PR DESCRIPTION
While any splitter is being dragged, every pane in the tab shows a small `<width>×<height>` overlay at its bottom-left in CSS pixels. Disappears the instant the drag ends.

## Why

When dialing in a specific pane size (e.g. "make this terminal exactly 800×400" or matching a video-pane to a 16:9 source) we currently have no live feedback during the drag. The badge gives numeric ground truth without external tooling, and surfaces the proportional cascade across siblings during a multi-pane resize.

## How

- New component `frontend/app/block/pane-size-badge.tsx` — uses `nodeModel.isResizing()` (same memo as `LayoutModel.isResizing()` per `layoutNodeModels.ts:52`, so it's tab-global) and a ResizeObserver on the pane's outer frame for live numbers.
- Mounted inside every `<BlockFrame_Default>` via the existing outer-div ref (extended with a local `frameEl` signal so the badge can target the frame element directly without prop drilling).
- SCSS in `pane-size-badge.scss`, imported once from `block.tsx` alongside `block.scss`. Hard corners, monospace, `pointer-events: none`, `z-index: 30` (above content, below modals).
- Skipped for preview frames (`Show when={!props.preview}`).

No new reducer, no new event, no new IPC — reuses existing `isResizing` plumbing.

## Out of scope

Deferred follow-ups documented in the spec §5:
- Always-on display toggle (`layout:always-show-pane-size`)
- Aspect-ratio readout ("16:9")
- Snap markers
- Keyboard resize integration

## Spec

`docs/specs/SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md` — acceptance criteria in §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)