### PR TITLE
fix(install-modal): unshrinkable xterm in compact panes

### DIFF
--- a/.changesets/1779813541-fix-install-modal-allow-xterm-container-to-shrink-in-compact-wmja.md
+++ b/.changesets/1779813541-fix-install-modal-allow-xterm-container-to-shrink-in-compact-wmja.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(install-modal): allow xterm container to shrink in compact panes (flex-shrink trap)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.9"
+version = "0.38.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.9"
+version = "0.38.10"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.9"
+version = "0.38.10"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.9"
+version = "0.38.10"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.9"
+version = "0.38.10"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.9"
+version = "0.38.10"
 
 [profile.release]
 strip = true

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -23,6 +23,19 @@
     :where(.modal-layer-mount--compact) & {
         min-width: 0;
         min-height: 200px;
+
+        // Flex-shrink trap: `.agent-install-modal-term` defaults to
+        // `min-width: auto` (intrinsic content size), so xterm.js
+        // renders at its default 80 cols (~600px canvas) and the
+        // outer `.modal-panel { overflow: auto }` exposes the
+        // overflow as a horizontal scrollbar — modal appears wide
+        // and unshrinkable in narrow panes despite the body's
+        // min-width: 0 override. Force the flex child to allow
+        // sub-content shrinking so FitAddon's first resize tick
+        // lands at the actual pane width.
+        .agent-install-modal-term {
+            min-width: 0;
+        }
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.9",
+  "version": "0.38.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.9",
+      "version": "0.38.10",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.9",
+  "version": "0.38.10",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
The install modal was visually staying wide with a horizontal scrollbar even with the `:where(.modal-layer-mount--compact)` body min-width override applied (added in PR #1039, surfaced as still broken when smoke-testing v0.38.10).

## Cause

Classic flex-shrink trap: the flex child `.agent-install-modal-term` defaults to `min-width: auto` (intrinsic content size). xterm.js renders at its default 80 cols (~600px canvas), and the outer `.modal-panel { overflow: auto }` exposes the overflow as a horizontal scrollbar. Modal appears wide and won't shrink in narrow panes.

## Fix

Add `min-width: 0` to `.agent-install-modal-term` inside the compact override so the flex child can shrink below its intrinsic content size. FitAddon then resizes xterm to fit on its first ResizeObserver tick (same path that already governs xterm sizing — no new wiring).

The body's `min-height: 200px` override added in #1039 already addressed the vertical version of this trap. This completes the pair.

## Verification

- `task build:frontend` clean (✓ 22.92s)
- Will validate live by opening an install modal in a narrow pane after the next portable build

🤖 Generated with [Claude Code](https://claude.com/claude-code)