### PR TITLE
feat(editor): file-tree explorer rooted at $HOME + header chevron + toolbar

### DIFF
--- a/.changesets/1779817687-feat-editor-file-tree-explorer-toolbar-header-chevron.md
+++ b/.changesets/1779817687-feat-editor-file-tree-explorer-toolbar-header-chevron.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): file-tree explorer rooted at $HOME with header chevron + toolbar (show hidden / collapse all / refresh)

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1141,6 +1141,97 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         }),
     );
 
+    // listeditordir → list directory contents for the editor's file-tree pane.
+    // Symlinks are followed (matches VS Code semantics; the frontend marks
+    // followed symlinks with a ↗ overlay).
+    // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+    engine.register_handler(
+        "listeditordir",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { path: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("listeditordir: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.path);
+                let canonical = expanded.canonicalize()
+                    .map_err(|e| format!("listeditordir: {e}"))?;
+                let read_dir = std::fs::read_dir(&canonical)
+                    .map_err(|e| format!("listeditordir: {e}"))?;
+
+                let mut entries: Vec<serde_json::Value> = Vec::new();
+                for entry in read_dir.flatten() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    // `file_type()` returns the entry's own type — symlinks
+                    // appear as symlinks (no follow). `metadata()` follows
+                    // symlinks, so a symlinked dir reports is_dir=true.
+                    // We need both: is_symlink from file_type, is_dir/size
+                    // from metadata (so a symlink-to-dir reads as a directory,
+                    // matching VS Code).
+                    let is_symlink = entry
+                        .file_type()
+                        .map(|t| t.is_symlink())
+                        .unwrap_or(false);
+                    let metadata = entry.metadata().ok();
+                    let is_dir = metadata.as_ref().map(|m| m.is_dir()).unwrap_or(false);
+                    let size = metadata
+                        .as_ref()
+                        .and_then(|m| if !m.is_dir() { Some(m.len()) } else { None });
+                    let mtime = metadata
+                        .as_ref()
+                        .and_then(|m| m.modified().ok())
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis() as u64);
+
+                    let mut entry_obj = serde_json::json!({
+                        "name": name,
+                        "is_dir": is_dir,
+                        "is_symlink": is_symlink,
+                    });
+                    if let Some(s) = size {
+                        entry_obj["size"] = serde_json::json!(s);
+                    }
+                    if let Some(m) = mtime {
+                        entry_obj["mtime"] = serde_json::json!(m);
+                    }
+                    entries.push(entry_obj);
+                }
+
+                // Folders first, then files; alphabetical, case-insensitive.
+                entries.sort_by(|a, b| {
+                    let a_dir = a["is_dir"].as_bool().unwrap_or(false);
+                    let b_dir = b["is_dir"].as_bool().unwrap_or(false);
+                    let a_name = a["name"].as_str().unwrap_or("").to_lowercase();
+                    let b_name = b["name"].as_str().unwrap_or("").to_lowercase();
+                    match (a_dir, b_dir) {
+                        (true, false) => std::cmp::Ordering::Less,
+                        (false, true) => std::cmp::Ordering::Greater,
+                        _ => a_name.cmp(&b_name),
+                    }
+                });
+
+                Ok(Some(serde_json::json!({
+                    "path": canonical.to_string_lossy(),
+                    "entries": entries,
+                })))
+            })
+        }),
+    );
+
+    // geteditorhome → OS home directory, used as the editor file-tree default root.
+    engine.register_handler(
+        "geteditorhome",
+        Box::new(|_data, _ctx| {
+            Box::pin(async move {
+                let home = dirs::home_dir()
+                    .ok_or_else(|| "geteditorhome: cannot determine home directory".to_string())?;
+                Ok(Some(serde_json::json!({
+                    "home": home.to_string_lossy(),
+                })))
+            })
+        }),
+    );
+
     // CLI handlers (resolvecli, checkcliauth, runclilogin)
     super::cli_handlers::register_cli_handlers(engine, &state);
 

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1183,6 +1183,25 @@ class RpcApiType {
         return client.rpcCall("writeeditorfile", data, opts);
     }
 
+    // command "listeditordir" [call] — list directory contents for the editor file-tree.
+    // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+    ListEditorDirCommand(
+        client: RpcClient,
+        data: { path: string },
+        opts?: RpcOpts,
+    ): Promise<{ path: string; entries: DirEntry[] }> {
+        return client.rpcCall("listeditordir", data, opts);
+    }
+
+    // command "geteditorhome" [call] — return the OS home dir (file-tree default root).
+    GetEditorHomeCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<{ home: string }> {
+        return client.rpcCall("geteditorhome", data, opts);
+    }
+
     // command "resolvecli" [call]
     ResolveCliCommand(client: RpcClient, data: CommandResolveCliData, opts?: RpcOpts): Promise<ResolveCliResult> {
         return client.rpcCall("resolvecli", data, opts);

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -1,15 +1,22 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
-
+//
 // NOTE: Editor is a pane-level view for editing files with syntax highlighting.
 // It is NOT a standalone IDE — complex editing happens in the agent's terminal
 // or via agent tool calls. This covers quick edits, file viewing, and diffing.
+//
+// File-tree explorer + header chevron toggle landed in Phase 1 of
+// SPEC_EDITOR_FILE_TREE_2026-05-26.md.
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
+import { FileTreeModel } from "./file-tree-model";
+
+const META_TREE_EXPANDED = "editor:tree_expanded";
+const META_SHOW_HIDDEN = "editor:show_hidden";
 
 export class EditorViewModel implements ViewModel {
     viewType = "editor";
@@ -18,7 +25,7 @@ export class EditorViewModel implements ViewModel {
 
     viewIcon: Accessor<string> = () => "file-code";
     viewName: Accessor<string>;
-    viewText: Accessor<string | HeaderElem[]> = () => [];
+    viewText: Accessor<string | HeaderElem[]>;
     noPadding: Accessor<boolean> = () => true;
 
     get viewComponent(): ViewComponent {
@@ -50,6 +57,15 @@ export class EditorViewModel implements ViewModel {
     private _error = createSignal<string | null>(null);
     errorAtom: Accessor<string | null> = this._error[0];
 
+    // File-tree state (per-pane, persisted in block meta)
+    private _treeExpanded = createSignal<boolean>(true);
+    treeExpandedAtom: Accessor<boolean> = this._treeExpanded[0];
+
+    private _showHidden = createSignal<boolean>(false);
+    showHiddenAtom: Accessor<boolean> = this._showHidden[0];
+
+    treeModel = new FileTreeModel();
+
     blockAtom: Accessor<Block | undefined>;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
@@ -66,10 +82,31 @@ export class EditorViewModel implements ViewModel {
             return this.dirtyAtom() ? `${name} *` : name;
         });
 
-        // Load file from block meta on init
+        // Header items — the file-tree chevron toggle.
+        this.viewText = createMemo<HeaderElem[]>(() => {
+            const expanded = this.treeExpandedAtom();
+            return [
+                {
+                    elemtype: "iconbutton",
+                    icon: expanded ? "folder-tree" : "folder",
+                    title: expanded ? "Hide file tree" : "Show file tree",
+                    click: () => void this.toggleTreeExpanded(),
+                },
+            ];
+        });
+
+        // Restore persisted tree state from block meta.
         const meta = this.blockAtom()?.meta;
+        if (meta?.[META_TREE_EXPANDED] === false) {
+            this._treeExpanded[1](false);
+        }
+        if (meta?.[META_SHOW_HIDDEN] === true) {
+            this._showHidden[1](true);
+        }
+
+        // Load file from block meta on init
         if (meta?.["file"]) {
-            this.openFile(meta["file"] as string);
+            void this.openFile(meta["file"] as string);
         }
     }
 
@@ -119,6 +156,33 @@ export class EditorViewModel implements ViewModel {
     onContentChange(content: string): void {
         this.setContent(content);
         this._dirty[1](true);
+    }
+
+    /** Toggle file-tree visibility. Persists to block meta. */
+    async toggleTreeExpanded(): Promise<void> {
+        const next = !this._treeExpanded[0]();
+        this._treeExpanded[1](next);
+        await this.persistMeta({ [META_TREE_EXPANDED]: next });
+    }
+
+    /** Toggle hidden-file visibility in the tree. Persists to block meta. */
+    async toggleShowHidden(): Promise<void> {
+        const next = !this._showHidden[0]();
+        this._showHidden[1](next);
+        await this.persistMeta({ [META_SHOW_HIDDEN]: next });
+    }
+
+    private async persistMeta(meta: Record<string, unknown>): Promise<void> {
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: makeORef("block", this.blockId),
+                meta,
+            });
+        } catch {
+            // Persistence failure isn't fatal — the in-memory signal still
+            // drives the current pane's behavior. On reopen, the previous
+            // persisted value (or default) wins.
+        }
     }
 
     giveFocus(): boolean {

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -1,13 +1,224 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Editor pane: file-tree column on the left + CodeMirror on the right.
+// Tree column visibility toggled by the header chevron.
+// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
 
 .editor-view {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     height: 100%;
     width: 100%;
     overflow: hidden;
     background: var(--block-bg-color);
+
+    &.editor-view--tree-collapsed {
+        // Only main column visible; tree column not rendered
+    }
+}
+
+// ── Tree column ─────────────────────────────────────────────────────────────
+
+.editor-tree-column {
+    width: 240px;
+    flex: 0 0 240px;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border-color);
+    overflow: hidden;
+    background: var(--secondary-bg-color, var(--block-bg-color));
+}
+
+.editor-tree-path-input {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-1-5);
+    border-top: 1px solid var(--border-color);
+    background: var(--block-bg-color);
+
+    .editor-open-input {
+        flex: 1;
+        min-width: 0;
+        width: auto;
+        padding: var(--space-1) var(--space-1-5);
+        font-size: 11px;
+    }
+
+    .editor-open-btn {
+        padding: var(--space-1) var(--space-2);
+        font-size: 11px;
+
+        &:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+    }
+}
+
+// ── File tree ───────────────────────────────────────────────────────────────
+
+.file-tree {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    font-size: 12px;
+    color: var(--main-text-color);
+}
+
+.file-tree-toolbar {
+    display: flex;
+    gap: 2px;
+    padding: var(--space-1);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--secondary-bg-color, var(--block-bg-color));
+}
+
+// Pure-CSS instant tooltip — same pattern as the status bar's `data-tip`,
+// scoped here so it doesn't leak. No JS, no entry animation; tooltip is
+// visible the same frame mouseenter fires.
+.file-tree-toolbar [data-tip] {
+    position: relative;
+
+    &:hover::after,
+    &:focus-visible::after {
+        content: attr(data-tip);
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 50%;
+        transform: translateX(-50%);
+        padding: var(--space-1) var(--space-1-5);
+        background: var(--modal-bg-color, #2a2a2a);
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 3px;
+        font-size: 11px;
+        white-space: nowrap;
+        pointer-events: none;
+        z-index: 1000;
+    }
+}
+
+.file-tree-toolbar-btn {
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+    font-size: 11px;
+    transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--main-text-color);
+    }
+
+    &:active {
+        background: rgba(255, 255, 255, 0.1);
+    }
+
+    &--active {
+        background: rgba(255, 255, 255, 0.08);
+        color: var(--accent-color);
+        border-color: var(--border-color);
+    }
+}
+
+.file-tree-body {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: var(--space-1) 0;
+}
+
+.file-tree-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 2px var(--space-1);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.04);
+    }
+
+    &--active {
+        background: rgba(var(--accent-color-rgb, 100, 150, 255), 0.15);
+        color: var(--accent-color, var(--main-text-color));
+    }
+
+    &--dir {
+        // Folders read slightly bolder to anchor the eye
+        font-weight: 500;
+    }
+}
+
+.file-tree-chevron {
+    width: 10px;
+    font-size: 9px;
+    color: var(--secondary-text-color);
+    opacity: 0.7;
+    flex: 0 0 auto;
+}
+
+.file-tree-chevron-spacer {
+    width: 10px;
+    flex: 0 0 auto;
+}
+
+.file-tree-icon {
+    width: 14px;
+    font-size: 11px;
+    opacity: 0.8;
+    flex: 0 0 auto;
+    text-align: center;
+}
+
+.file-tree-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.file-tree-symlink {
+    opacity: 0.5;
+    font-size: 10px;
+    margin-left: 2px;
+}
+
+.file-tree-loading {
+    padding: 2px var(--space-1);
+    color: var(--secondary-text-color);
+    font-size: 11px;
+    opacity: 0.6;
+    font-style: italic;
+}
+
+.file-tree-error {
+    padding: 2px var(--space-1);
+    color: var(--error-color, #d97706);
+    font-size: 11px;
+}
+
+// ── Main column (CodeMirror or empty-state) ─────────────────────────────────
+
+.editor-main-column {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }
 
 .editor-open-prompt {
@@ -18,10 +229,18 @@
     height: 100%;
     gap: var(--space-3);
     color: var(--secondary-text-color);
+    padding: var(--space-4);
 }
 
 .editor-open-label {
     font-size: 14px;
+}
+
+.editor-open-hint {
+    font-size: 11px;
+    opacity: 0.6;
+    text-align: center;
+    max-width: 320px;
 }
 
 .editor-open-row {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -1,5 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Editor view — file-tree column on the left + CodeMirror on the right.
+// Tree visibility toggled by the header chevron (model.treeExpandedAtom).
+// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
 
 import { createEffect, createSignal, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
 import { EditorView, basicSetup } from "codemirror";
@@ -7,7 +11,10 @@ import { EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { search } from "@codemirror/search";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import type { EditorViewModel } from "./editor-model";
+import { FileTree } from "./file-tree";
 import "./editor-view.scss";
 
 // ── Language loader ─────────────────────────────────────────────────────────
@@ -109,6 +116,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     };
 
     onMount(() => {
+        // Load file tree root from backend's home dir.
+        void RpcApi.GetEditorHomeCommand(TabRpcClient, {}).then((res) => {
+            if (res?.home) {
+                void model.treeModel.setRootAndLoad(res.home);
+            }
+        });
+
         const content = model.contentAtom();
         const lang = model.languageAtom();
         const readOnly = model.readOnlyAtom();
@@ -144,45 +158,88 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         const path = fileInput().trim();
         if (path) {
             void model.openFile(path);
+            setFileInput("");
         }
     };
 
     return (
-        <div class="editor-view">
-            <Show when={!model.filePathAtom()}>
-                <div class="editor-open-prompt">
-                    <div class="editor-open-label">Open a file</div>
-                    <div class="editor-open-row">
-                        <input
-                            class="editor-open-input"
-                            type="text"
-                            placeholder="/path/to/file.ts"
-                            value={fileInput()}
-                            onInput={(e) => setFileInput(e.currentTarget.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter") handleOpenFile();
-                            }}
-                        />
-                        <button class="editor-open-btn" onClick={handleOpenFile}>
-                            Open
-                        </button>
-                    </div>
+        <div
+            class="editor-view"
+            classList={{ "editor-view--tree-collapsed": !model.treeExpandedAtom() }}
+        >
+            <Show when={model.treeExpandedAtom()}>
+                <div class="editor-tree-column">
+                    <FileTree
+                        model={model.treeModel}
+                        activeFilePath={model.filePathAtom()}
+                        showHidden={model.showHiddenAtom()}
+                        onFileClick={(path) => void model.openFile(path)}
+                        onToggleHidden={() => void model.toggleShowHidden()}
+                    />
+                    <Show when={!model.filePathAtom()}>
+                        <div class="editor-tree-path-input">
+                            <input
+                                class="editor-open-input"
+                                type="text"
+                                placeholder="/path/to/file.ts"
+                                value={fileInput()}
+                                onInput={(e) => setFileInput(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") handleOpenFile();
+                                }}
+                            />
+                            <button
+                                class="editor-open-btn"
+                                onClick={handleOpenFile}
+                                disabled={!fileInput().trim()}
+                            >
+                                Open
+                            </button>
+                        </div>
+                    </Show>
                 </div>
             </Show>
 
-            <Show when={model.loadingAtom()}>
-                <div class="editor-loading">Loading...</div>
-            </Show>
+            <div class="editor-main-column">
+                <Show when={model.loadingAtom()}>
+                    <div class="editor-loading">Loading...</div>
+                </Show>
 
-            <Show when={model.errorAtom()}>
-                <div class="editor-error">{model.errorAtom()}</div>
-            </Show>
+                <Show when={model.errorAtom()}>
+                    <div class="editor-error">{model.errorAtom()}</div>
+                </Show>
 
-            <div
-                class="editor-codemirror"
-                ref={containerRef}
-                style={{ display: model.filePathAtom() && !model.loadingAtom() ? "block" : "none" }}
-            />
+                <Show
+                    when={model.filePathAtom() && !model.loadingAtom()}
+                    fallback={
+                        <Show when={!model.treeExpandedAtom()}>
+                            <div class="editor-open-prompt">
+                                <div class="editor-open-label">Open a file</div>
+                                <div class="editor-open-row">
+                                    <input
+                                        class="editor-open-input"
+                                        type="text"
+                                        placeholder="/path/to/file.ts"
+                                        value={fileInput()}
+                                        onInput={(e) => setFileInput(e.currentTarget.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter") handleOpenFile();
+                                        }}
+                                    />
+                                    <button class="editor-open-btn" onClick={handleOpenFile}>
+                                        Open
+                                    </button>
+                                </div>
+                                <div class="editor-open-hint">
+                                    Show the file tree from the header chevron to browse your files.
+                                </div>
+                            </div>
+                        </Show>
+                    }
+                >
+                    <div class="editor-codemirror" ref={containerRef} />
+                </Show>
+            </div>
         </div>
     );
 }

--- a/frontend/app/view/editor/file-tree-model.ts
+++ b/frontend/app/view/editor/file-tree-model.ts
@@ -1,0 +1,131 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// State for the editor pane's file-tree explorer.
+//
+// Two reactive bags:
+//   - `expandedAtom: Set<string>`   — which folder paths are currently open
+//   - `dataAtom:     Map<string,…>` — fetched child rows + load phase per path
+//
+// Lazy-load on first expand; subsequent collapse keeps the data cached so
+// re-expanding is instant. Refresh re-fetches every currently-expanded path.
+// Hidden-file filtering is applied at render time, not at fetch — so toggling
+// the eye button is free, no RPC.
+//
+// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { createSignal, type Accessor } from "solid-js";
+
+interface NodeData {
+    phase: "loading" | "loaded" | "error";
+    entries?: DirEntry[];
+    error?: string;
+}
+
+// Names hidden when show-hidden is OFF.
+// Dotfiles match via leading '.' (handled in `isHiddenName`).
+const HIDDEN_NAMES = new Set(["node_modules", "Thumbs.db", "$RECYCLE.BIN"]);
+
+export function isHiddenName(name: string): boolean {
+    if (name.startsWith(".")) return true;
+    return HIDDEN_NAMES.has(name);
+}
+
+/**
+ * Join a parent path and a child name using the parent's existing separator
+ * (Windows-style if the parent contains `\`, else POSIX). The backend
+ * canonicalizes paths so this stays consistent across the tree.
+ */
+export function joinPath(base: string, name: string): string {
+    if (!base) return name;
+    const sep = base.includes("\\") ? "\\" : "/";
+    if (base.endsWith(sep) || base.endsWith("/")) return base + name;
+    return base + sep + name;
+}
+
+export class FileTreeModel {
+    private _expanded = createSignal<Set<string>>(new Set());
+    expandedAtom: Accessor<Set<string>> = this._expanded[0];
+
+    private _data = createSignal<Map<string, NodeData>>(new Map());
+    dataAtom: Accessor<Map<string, NodeData>> = this._data[0];
+
+    private _root = createSignal<string>("");
+    rootAtom: Accessor<string> = this._root[0];
+
+    isExpanded(path: string): boolean {
+        return this._expanded[0]().has(path);
+    }
+
+    getNodeData(path: string): NodeData | undefined {
+        return this._data[0]().get(path);
+    }
+
+    /**
+     * Set the tree root and immediately expand + load it. Called once on
+     * mount after `GetEditorHomeCommand` returns.
+     */
+    async setRootAndLoad(home: string): Promise<void> {
+        this._root[1](home);
+        const next = new Set(this._expanded[0]());
+        next.add(home);
+        this._expanded[1](next);
+        await this.load(home);
+    }
+
+    /** Toggle expand/collapse on a folder. Lazy-loads the first time. */
+    async toggleExpand(path: string): Promise<void> {
+        if (this.isExpanded(path)) {
+            const next = new Set(this._expanded[0]());
+            next.delete(path);
+            this._expanded[1](next);
+        } else {
+            const next = new Set(this._expanded[0]());
+            next.add(path);
+            this._expanded[1](next);
+            if (!this._data[0]().has(path)) {
+                await this.load(path);
+            }
+        }
+    }
+
+    /** Re-fetch every currently-expanded path. Preserves expansion state. */
+    async refresh(): Promise<void> {
+        const paths = Array.from(this._expanded[0]());
+        await Promise.all(paths.map((p) => this.load(p)));
+    }
+
+    /** Close every folder except the root. */
+    collapseAll(): void {
+        const root = this._root[0]();
+        this._expanded[1](root ? new Set<string>([root]) : new Set<string>());
+    }
+
+    private async load(path: string): Promise<void> {
+        const setData = (updater: (map: Map<string, NodeData>) => void) => {
+            const next = new Map(this._data[0]());
+            updater(next);
+            this._data[1](next);
+        };
+        setData((map) => {
+            map.set(path, { phase: "loading" });
+        });
+        try {
+            const result = await RpcApi.ListEditorDirCommand(TabRpcClient, { path });
+            setData((map) => {
+                map.set(result.path, { phase: "loaded", entries: result.entries });
+                // If the canonical path differs from the input (e.g. symlink
+                // resolution), key both so the tree row matches.
+                if (result.path !== path) {
+                    map.set(path, { phase: "loaded", entries: result.entries });
+                }
+            });
+        } catch (e: any) {
+            setData((map) => {
+                map.set(path, { phase: "error", error: e?.message ?? String(e) });
+            });
+        }
+    }
+}

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -1,0 +1,208 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Editor file-tree explorer — recursive tree + toolbar.
+// State lives in FileTreeModel (file-tree-model.ts); this file is rendering.
+//
+// Tooltips use the `data-tip` CSS pattern (pure :hover::after, instant — no
+// JS, no delay). SCSS rules in editor-view.scss scope `[data-tip]:hover::after`
+// to the file-tree-toolbar so they don't leak to the rest of the editor.
+//
+// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+
+import { createMemo, For, Show, type JSX } from "solid-js";
+import { FileTreeModel, isHiddenName, joinPath } from "./file-tree-model";
+
+interface FileTreeProps {
+    model: FileTreeModel;
+    activeFilePath: string;
+    showHidden: boolean;
+    onFileClick: (path: string) => void;
+    onToggleHidden: () => void;
+}
+
+export function FileTree(props: FileTreeProps): JSX.Element {
+    const rootName = createMemo(() => {
+        const r = props.model.rootAtom();
+        if (!r) return "";
+        return r.split(/[\\/]/).filter(Boolean).pop() ?? r;
+    });
+
+    return (
+        <div class="file-tree">
+            <FileTreeToolbar
+                model={props.model}
+                showHidden={props.showHidden}
+                onToggleHidden={props.onToggleHidden}
+            />
+            <div class="file-tree-body">
+                <Show when={props.model.rootAtom()}>
+                    <TreeNode
+                        model={props.model}
+                        path={props.model.rootAtom()}
+                        name={rootName()}
+                        depth={0}
+                        isDir={true}
+                        isSymlink={false}
+                        activeFilePath={props.activeFilePath}
+                        showHidden={props.showHidden}
+                        onFileClick={props.onFileClick}
+                    />
+                </Show>
+            </div>
+        </div>
+    );
+}
+
+interface FileTreeToolbarProps {
+    model: FileTreeModel;
+    showHidden: boolean;
+    onToggleHidden: () => void;
+}
+
+function FileTreeToolbar(props: FileTreeToolbarProps): JSX.Element {
+    return (
+        <div class="file-tree-toolbar">
+            <button
+                type="button"
+                class="file-tree-toolbar-btn"
+                classList={{ "file-tree-toolbar-btn--active": props.showHidden }}
+                data-tip={props.showHidden ? "Hide hidden files" : "Show hidden files"}
+                aria-label={props.showHidden ? "Hide hidden files" : "Show hidden files"}
+                onClick={props.onToggleHidden}
+            >
+                <i class={`fa ${props.showHidden ? "fa-eye" : "fa-eye-slash"}`} />
+            </button>
+            <button
+                type="button"
+                class="file-tree-toolbar-btn"
+                data-tip="Collapse all folders"
+                aria-label="Collapse all folders"
+                onClick={() => props.model.collapseAll()}
+            >
+                <i class="fa fa-square-minus" />
+            </button>
+            <button
+                type="button"
+                class="file-tree-toolbar-btn"
+                data-tip="Refresh tree"
+                aria-label="Refresh tree"
+                onClick={() => void props.model.refresh()}
+            >
+                <i class="fa fa-arrows-rotate" />
+            </button>
+        </div>
+    );
+}
+
+interface TreeNodeProps {
+    model: FileTreeModel;
+    path: string;
+    name: string;
+    depth: number;
+    isDir: boolean;
+    isSymlink: boolean;
+    activeFilePath: string;
+    showHidden: boolean;
+    onFileClick: (path: string) => void;
+}
+
+function TreeNode(props: TreeNodeProps): JSX.Element {
+    const expanded = createMemo(() => props.model.isExpanded(props.path));
+    const nodeData = createMemo(() => props.model.getNodeData(props.path));
+    const isActive = createMemo(() => props.path === props.activeFilePath);
+
+    const filteredEntries = createMemo(() => {
+        const data = nodeData();
+        if (!data?.entries) return [];
+        if (props.showHidden) return data.entries;
+        return data.entries.filter((e) => !isHiddenName(e.name));
+    });
+
+    const handleClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        if (props.isDir) {
+            void props.model.toggleExpand(props.path);
+        } else {
+            props.onFileClick(props.path);
+        }
+    };
+
+    return (
+        <div>
+            <div
+                class="file-tree-row"
+                classList={{
+                    "file-tree-row--active": isActive(),
+                    "file-tree-row--dir": props.isDir,
+                }}
+                style={{ "padding-left": `${4 + props.depth * 16}px` }}
+                onClick={handleClick}
+                title={props.path}
+            >
+                <Show
+                    when={props.isDir}
+                    fallback={<span class="file-tree-chevron-spacer" />}
+                >
+                    <i
+                        class={`fa fa-chevron-${expanded() ? "down" : "right"} file-tree-chevron`}
+                    />
+                </Show>
+                <i class={`fa fa-${iconForEntry(props.name, props.isDir, isActive())} file-tree-icon`} />
+                <span class="file-tree-label">{props.name}</span>
+                <Show when={props.isSymlink}>
+                    <span class="file-tree-symlink" aria-label="symlink">↗</span>
+                </Show>
+            </div>
+            <Show when={props.isDir && expanded()}>
+                <Show when={nodeData()?.phase === "loading"}>
+                    <div
+                        class="file-tree-loading"
+                        style={{ "padding-left": `${4 + (props.depth + 1) * 16}px` }}
+                    >
+                        Loading…
+                    </div>
+                </Show>
+                <Show when={nodeData()?.phase === "error"}>
+                    <div
+                        class="file-tree-error"
+                        style={{ "padding-left": `${4 + (props.depth + 1) * 16}px` }}
+                    >
+                        ⚠ {nodeData()?.error}
+                    </div>
+                </Show>
+                <For each={filteredEntries()}>
+                    {(entry) => (
+                        <TreeNode
+                            model={props.model}
+                            path={joinPath(props.path, entry.name)}
+                            name={entry.name}
+                            depth={props.depth + 1}
+                            isDir={entry.is_dir}
+                            isSymlink={entry.is_symlink}
+                            activeFilePath={props.activeFilePath}
+                            showHidden={props.showHidden}
+                            onFileClick={props.onFileClick}
+                        />
+                    )}
+                </For>
+            </Show>
+        </div>
+    );
+}
+
+function iconForEntry(name: string, isDir: boolean, isActive: boolean): string {
+    if (isDir) return "folder";
+    // Active file gets a filled-dot indicator (`circle-dot`) per spec.
+    if (isActive) return "circle-dot";
+    const lower = name.toLowerCase();
+    if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(lower)) return "file-code";
+    if (/\.(py|rs|go|java|c|cpp|h|hpp|sh|bash|zsh|ps1)$/.test(lower)) return "file-code";
+    if (/\.(html|htm|css|scss|sass|less|svg|xml)$/.test(lower)) return "file-code";
+    if (/\.(json|toml|yaml|yml|ini|env|conf)$/.test(lower)) return "file-code";
+    if (/\.(md|markdown|txt|rst|adoc)$/.test(lower)) return "file-lines";
+    if (/\.(png|jpe?g|gif|webp|bmp|ico)$/.test(lower)) return "file-image";
+    if (/\.pdf$/.test(lower)) return "file-pdf";
+    if (/\.(zip|tar|gz|7z|rar|bz2|xz)$/.test(lower)) return "file-zipper";
+    return "file";
+}

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -51,6 +51,15 @@ declare global {
         last_seen: number;
     };
 
+    // Editor file-tree row. Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+    type DirEntry = {
+        name: string;
+        is_dir: boolean;
+        is_symlink: boolean;
+        size?: number;
+        mtime?: number; // unix millis
+    };
+
     type WritableWaveObjectAtom<T extends WaveObj> = SignalAtom<T>;
 
     type ThrottledValueAtom<T> = SignalAtom<T>;

--- a/specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+++ b/specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
@@ -1,0 +1,399 @@
+# Spec: Editor Pane — File Tree Explorer + Extensions
+
+**Branch:** `agenty/editor-file-tree-spec`
+**Status:** Draft — design
+**Date:** 2026-05-26
+**Author:** AgentY
+
+---
+
+## TL;DR
+
+The Editor pane is **CodeMirror 6 + an empty-state path input** today. Users have to know (or paste) an absolute path to open anything. This spec adds:
+
+1. A **collapsible file-tree explorer** down the pane's left side, rooted at `$HOME`
+2. A **header toggle** (`📁` chevron) that expands/collapses the tree; default state **expanded**
+3. **Click-to-load** — clicking any file replaces the editor's current document
+4. A **research-backed proposal** for extension support — strong recommendation to ride CodeMirror 6's native extension model (curated, settings-toggleable) rather than reinvent VS Code's extension-host architecture
+
+Spec covers UX, backend RPCs (one new + one helper), frontend component breakdown, and a phased rollout. Phase 1 is the tree. Extensions live behind their own follow-up.
+
+---
+
+## Current state
+
+The editor pane (`frontend/app/view/editor/`) is ~380 lines across four files:
+
+| File | Role |
+|------|------|
+| `editor.tsx` | Barrel — wires `viewComponent` onto the model |
+| `editor-model.ts` | `EditorViewModel` — file path / content / language / dirty / readOnly signals, `openFile()`, `saveFile()`, `onContentChange()` |
+| `editor-view.tsx` | `EditorViewComponent` — CodeMirror lifecycle + empty-state path input |
+| `editor-view.scss` | Styling |
+
+Active features:
+- CodeMirror 6 with lazy-loaded language packs (7 languages: TS/JS, Python, Rust, HTML, CSS, JSON, Markdown)
+- `oneDark` theme (fixed), `lineWrapping`, `basicSetup`, search
+- Ctrl+S → save, dirty tracking (`* ` suffix in pane title)
+- Read-only support (set by backend response)
+- File path persisted in block meta — restored on pane reopen
+
+Backend RPCs already in place:
+- `ReadEditorFileCommand({ path }) → { content, read_only }`
+- `WriteEditorFileCommand({ path, content }) → void`
+
+What's missing:
+- No file discovery surface (no tree, no recent files, no breadcrumb)
+- Empty state is a literal path input — bad for anyone who doesn't already know the path
+- No browse from one open file to a sibling
+
+---
+
+## Goals
+
+1. **Discovery** — the operator can open the editor with no path and immediately see their files
+2. **Familiar** — file tree matches VS Code / GitHub web conventions (chevron expand/collapse, indent, type icons, single-click loads)
+3. **Reversible** — header toggle hides the tree to give CodeMirror the full pane width; preference persists per-pane in block meta
+4. **No regressions** — the existing path-input + Ctrl+S + dirty state continue to work; clicking a file in the tree is *additive*, not a replacement
+
+## Non-goals (this spec)
+
+- Multi-root workspaces (single root = `$HOME`)
+- Rename / delete / new-file / cut / copy / paste / drag-drop in the tree
+- File watching (live updates when files appear/disappear outside the app)
+- Symbol/outline navigation within the file
+- Git decorations (modified, staged, conflicted)
+- Multi-cursor / multi-tab document model (one file open per pane stays the model)
+- VS Code-extension compatibility (see § Extensions for why)
+
+Each of these is a sensible future-PR; calling them out so this spec stays focused.
+
+---
+
+## UX design
+
+### Layout
+
+```
+┌─ Editor — main.tsx * ─────────────────────── [📁 chevron] [other header items] ─┐
+├──────────────────┬────────────────────────────────────────────────────────────┤
+│ ▼ asaf            │  import { ... } from "...";                              │
+│   ▶ Desktop       │                                                          │
+│   ▼ src           │  export function foo() {                                 │
+│     ▼ components  │    return bar;                                           │
+│     ▶ utils       │  }                                                       │
+│     ● main.tsx    │                                                          │
+│   ▶ tests         │                                                          │
+│   ▶ node_modules  │                                                          │
+│   ▶ .git          │                                                          │
+└──────────────────┴────────────────────────────────────────────────────────────┘
+```
+
+Tree column on the left (default ~240 px wide, resizable via a vertical drag handle); CodeMirror fills the right. The currently-open file gets a filled-dot indicator (`●` instead of the file icon) and the row is highlighted.
+
+When the user clicks the header chevron, the tree column slides closed and the chevron rotates to indicate "expand to show tree":
+
+```
+┌─ Editor — main.tsx * ────────────────────── [▶ chevron] [other header items] ─┐
+├──────────────────────────────────────────────────────────────────────────────┤
+│  import { ... } from "...";                                                  │
+│  ...                                                                         │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Header toggle
+
+Placed at the **left** end of the pane header (per the existing `viewText` slot), before any other items. Icon: `folder-tree` (FontAwesome). State:
+
+- **Expanded** (default): icon shows `chevron-left` next to the folder; click collapses
+- **Collapsed**: icon shows `folder-tree` only; click expands
+
+Persisted to block meta as `editor:tree_expanded` (boolean). Default `true`. The setting is *per pane* — two editor panes in the same window can have independent tree states.
+
+### Tree behavior
+
+| Interaction | Behavior |
+|---|---|
+| Click chevron next to a folder row | Expand if collapsed, collapse if expanded (lazy-load on first expand) |
+| Click a folder row (not the chevron) | Same as clicking the chevron — toggle |
+| Click a file row | Calls `model.openFile(absolutePath)` — replaces the editor's current document |
+| Double-click a file row | Same as single-click (left for future "open in new pane" gesture) |
+| Hover a row | Background tint; reveals chevron rotation |
+| Right-click a row | (Out of scope this PR; future context menu) |
+| Arrow keys (when tree focused) | Up/Down navigates rows; Right expands / focuses first child; Left collapses / jumps to parent |
+| Enter | Same as single-click on the focused row |
+| Drag the column divider | Resize the tree column. Width persists per pane as `editor:tree_width` (default 240) |
+
+The active file's row stays selected (highlighted background + filled-dot icon) across scrolls; if it's off-screen, opening a sibling auto-scrolls it into view.
+
+### File / folder visuals
+
+- **Folders** — `chevron-right` (collapsed) or `chevron-down` (expanded) + small folder icon
+- **Files** — language-typed icon mapped by extension (e.g. `file-code` for `.ts`, `file-image` for `.png`, plain `file` fallback). Reuses the `defwidget` icon vocabulary so the visual is consistent with the widget bar
+- **Hidden files** (`.git`, `.DS_Store`, dotfiles, plus `node_modules`) — **hidden by default**. Togglable via the toolbar (§Toolbar below)
+- **Symlinks** — **followed** (VS Code semantics). Symlinked rows get a small `↗` overlay on the icon so they're identifiable
+- **Indentation** — 16 px per level, with a faint vertical guideline at each level (subtle, matches VS Code)
+
+### Toolbar
+
+A row of **small square icon buttons** at the **top** of the tree column (more discoverable than bottom, matches VS Code's view-toolbar placement). For v1, three buttons:
+
+| Button | Type | Default | Tooltip | Behavior |
+|---|---|---|---|---|
+| `eye` / `eye-slash` | toggle | off (hidden) | "Show hidden files" / "Hide hidden files" | Flips visibility of dotfiles + standard noise (`node_modules`, `.git`, `.DS_Store`, `Thumbs.db`). State per-pane in block meta as `editor:show_hidden`. |
+| `square-minus` | action | — | "Collapse all folders" | One-shot — collapses every expanded folder back to the root. |
+| `arrows-rotate` | action | — | "Refresh tree" | Re-fetches the currently expanded folder paths; keeps expansion state. |
+
+Buttons are 24×24 px, transparent background, icon-only. Hover gives a subtle background tint. Active toggles (when "on") get a filled background to signal state.
+
+#### Tooltips — **0 ms show delay**
+
+Use the existing **`data-tip` CSS pattern** that the status bar already uses (`frontend/app/statusbar/StatusBar.scss`). It's a pure-CSS `:hover::after` reveal with `content: attr(data-tip)` — **no JS, no delay, no animation**. Mouse enters the button → tooltip is visible the same frame.
+
+The toolbar's SCSS adds a scoped `[data-tip]:hover::after` block (don't reach for the existing status-bar one — keep scope tight to the editor). Markup is plain:
+
+```tsx
+<button class="editor-tree-toolbar-btn" data-tip="Show hidden files" aria-label="Show hidden files" onClick={...}>
+    <i class="fa fa-eye" />
+</button>
+```
+
+Do **not** add a native `title` attribute alongside `data-tip` — would create a double tooltip. `aria-label` covers screen-reader a11y.
+
+Future toolbar buttons (Phase 2):
+- `magnifying-glass` — filter input (highlight + filter modes, matching VS Code)
+- `house` — jump tree root back to `$HOME` (relevant once multi-root or directory-browse beyond home arrives)
+
+### Empty-state pane vs tree
+
+When the pane has no file open (`filePathAtom() === ""`), CodeMirror is hidden and the tree fills the pane width (tree column expands to 100% if there's room). The path-input empty-state moves to a smaller affordance at the **bottom** of the tree:
+
+```
+┌─ Editor ─ [📁 chevron] ──────────────────────┐
+│ 👁  ⊟  🔄                                    │ ← toolbar (top)
+├─────────────────────────────────────────────│
+│ ▼ asaf                                       │
+│   ▼ src                                      │
+│     main.tsx                                 │
+│     util.ts                                  │
+│   ...                                        │
+├─────────────────────────────────────────────│
+│ Open by path: [/path/to/file.ts__________] │
+└──────────────────────────────────────────────┘
+```
+
+So path-input is preserved as an escape hatch (useful when an LLM hands you an absolute path), but the tree is the primary surface.
+
+---
+
+## Backend
+
+One new RPC + one helper. Both live in `agentmux-srv/src/server/` (probably alongside the existing `ReadEditorFileCommand` handler).
+
+### `ListEditorDirectoryCommand`
+
+```
+Request:  { path: string }
+Response: {
+    path: string,            // canonical absolute path of the listed dir
+    entries: DirEntry[],     // sorted: folders first then files, each alphabetical
+}
+
+DirEntry: {
+    name: string,            // basename only
+    is_dir: boolean,
+    size?: number,           // bytes (files only; omitted for dirs)
+    mtime?: number,          // unix ms (omitted on platforms without it)
+}
+```
+
+Behavior:
+- Path is normalized and canonicalized server-side (resolves symlinks, `..`)
+- Errors map to existing editor error semantics (`EACCES` → "permission denied", `ENOENT` → "not found", etc.)
+- Sort: folders first (alphabetical, case-insensitive), then files (alphabetical, case-insensitive). Dotfiles included in the response — frontend hides them per the visibility toggle
+- Pagination is **not** in v1 — the spec assumes any single directory fits in a single response. A `node_modules/` with 5k entries would still render. If this becomes a problem, we add a `limit` + cursor in a follow-up
+- The endpoint is auth-gated under the same auth middleware as the rest of `/agentmux/*`
+
+### `GetEditorHomeCommand` (helper)
+
+```
+Request:  {}
+Response: { home: string }   // OS home dir, e.g. "C:\Users\asaf"
+```
+
+Resolved server-side via Rust `dirs::home_dir()` (already a dependency). Lets the frontend ask once at mount and avoid hard-coding `process.env.HOME` (which doesn't behave consistently across CEF, Tauri, etc.).
+
+---
+
+## Frontend
+
+### Files added
+
+| File | Role |
+|------|------|
+| `frontend/app/view/editor/file-tree.tsx` | `FileTree` component — recursive tree rendering, expand/collapse state, click handlers |
+| `frontend/app/view/editor/file-tree-model.ts` | Tree state — Map of `path → { expanded, loading, entries }`; lazy-load on expand |
+| `frontend/app/view/editor/file-tree-types.ts` | `DirEntry`, tree node types |
+
+### Files modified
+
+| File | Change |
+|------|--------|
+| `editor-view.tsx` | Split layout into `tree-column` + `cm-column`; mount `FileTree`; wire click → `model.openFile()` |
+| `editor-view.scss` | Tree column styles, divider, hover, active row, indent guides |
+| `editor-model.ts` | Adds `treeExpandedAtom` + `setTreeExpanded()`; persists via `SetMetaCommand` (key `editor:tree_expanded`). Header `viewText` exposes the chevron toggle item |
+| `frontend/app/store/rpc-api.ts` | Add `ListEditorDirectoryCommand`, `GetEditorHomeCommand` typed wrappers |
+
+### State machine for tree nodes
+
+Each folder node has three states: `unloaded`, `loading`, `loaded`. Click expand → if `unloaded`, transition `unloaded → loading → loaded` (RPC call); if already `loaded`, just toggle visibility. State is held in the tree model, not in the DOM — collapsing a folder keeps its loaded children in memory so re-expand is instant.
+
+```
+                 click expand
+unloaded ──────────────────────► loading
+                                    │
+                                    │ ListEditorDirectoryCommand
+                                    ▼
+                                  loaded ◄──┐
+                                    │       │ click expand
+                                    │       │ click collapse
+                                    └───────┘
+```
+
+Errors transition `loading → error`; subsequent click attempts retry.
+
+### Performance
+
+- Single directory render is O(n) DOM nodes. For sane HOMEs that's fine. If a user navigates into a 10k-entry directory we'll see jank — the spec calls this a known limitation, with virtualization (à la `@tanstack/solid-virtual`) listed as future work
+- No tree-wide watching in v1. Tree is a snapshot per expand; refresh requires re-collapsing + re-expanding (or a small "refresh" affordance, TBD)
+
+---
+
+## Extensions support
+
+The user's prompt asks: *"we may also want to support code extensions."* Real recommendation here, based on the research:
+
+### Tier A — CodeMirror 6 extension shipping (RECOMMENDED for v1)
+
+CodeMirror 6's design is a tree of composable extensions imported from npm. We already use this model (`basicSetup`, `oneDark`, `search`, language packs are extensions). **Adding more is just adding imports**; no plugin runtime needed.
+
+Examples of high-value CM6 extensions worth bundling:
+- `@codemirror/lint` — diagnostic underlines (paired with a backend linter or `tsc --noEmit`)
+- `@codemirror/autocomplete` — context-aware completion (works without a language server for many cases)
+- `@codemirror/commands` — full default keymap (history, indent, etc.)
+- `@uiw/codemirror-themes-all` — large theme catalog
+- `vim` / `emacs` mode (`@replit/codemirror-vim`, `@replit/codemirror-emacs`)
+
+**Settings hook:** `editor:extensions` in `settings.json` — a string array of enabled extension keys. Default set on first launch; user toggles per their preference. Adding a new extension is a one-PR change (add the import + key + settings entry).
+
+This gets us "VS Code parity for what users actually use day-to-day" without standing up a plugin system.
+
+### Tier B — User-supplied extensions / plugin API (future)
+
+This is the "VS Code-style extensibility" path: let third-party authors ship plugins that AgentMux loads at runtime. **Recommendation: defer indefinitely until there's clear user demand.** Why:
+
+- CodeMirror itself has no plugin-host architecture — every "plugin" is a tree-shaken ES module. Loading user code at runtime requires either dynamic `import()` from a trusted local source or a sandbox we'd have to build
+- VS Code's extension-host model is enormous (process isolation, contribution points, activation events, manifest schema, marketplace, signing). Replicating it is a multi-quarter project
+- Most CodeMirror functionality the user cares about (themes, languages, vim mode, linting) already exists as an npm-able extension we can ship in Tier A
+
+If demand emerges, the migration is: switch from a hardcoded extension array to one assembled from a manifest read at boot, drop user packages into `~/.agentmux/channels/<channel>/editor-extensions/`, and load them via dynamic `import()`. That's a follow-up spec, not this one.
+
+### Tier C — Language Server Protocol (LSP) integration (future, big win)
+
+LSP gives us real diagnostics, completion, hover docs, go-to-definition — what users actually expect from an IDE — by talking to off-the-shelf language servers (rust-analyzer, tsserver, pyright, etc.). CodeMirror has a `codemirror-languageserver` community extension that bridges LSP to CM6 facets.
+
+**Recommendation: separate spec.** LSP brings process-management complexity (one server per workspace, per language) that's worth its own design discussion. The file-tree spec doesn't depend on it.
+
+---
+
+## Implementation phases
+
+### Phase 1 — Tree shell + RPC + click-to-load (the spec's primary scope)
+
+- Backend: `ListEditorDirectoryCommand` + `GetEditorHomeCommand`
+- Frontend: `file-tree.tsx` + `file-tree-model.ts`; mount in `editor-view.tsx`; header chevron toggle; per-pane meta persistence
+- File click → `model.openFile()`; current file highlighted; basic visuals
+- Acceptance: open editor pane, see HOME tree, click a `.ts` file, syntax-highlighted content loads
+
+### Phase 2 — Polish
+
+- Hidden-file toggle (eye icon)
+- Resizable column divider
+- Keyboard navigation (arrows, Enter)
+- Refresh affordance per folder
+- Active-file auto-scroll-into-view
+
+### Phase 3 — Extensions (Tier A from §Extensions)
+
+- Bundle a curated extension set: lint, autocomplete, commands, theme catalog
+- `editor:extensions` settings array + UI toggles (in the Settings widget that opens settings.json, or a small inline picker)
+- Document the supported extension keys on docs.agentmux.ai
+
+### Phase 4 — Stretch / open-ended
+
+- Multi-root workspaces (`editor:workspace_roots` array in settings)
+- File watching for live tree updates (mDNS-style local FS notify; respect debouncing)
+- LSP integration (Tier C)
+- Symbol outline (`@codemirror/lang-*` parse trees already give us most of what we'd need)
+
+Each phase is independently shippable — Phase 1 is the only one in this spec's primary scope.
+
+---
+
+## Open questions
+
+1. **What's a "file"?** — `dirs::home_dir()` may be a network share; listing a slow share blocks the RPC. Should we add a timeout + "Listing taking a while…" indicator? Skip for v1; revisit if it hurts.
+2. **Theme** — `oneDark` is hardcoded. Should the tree pick up the same theme tokens (background, accent) automatically? Recommend yes; pull the theme's `--editor-bg`, `--accent` etc. from CodeMirror CSS variables and reuse them.
+
+**Decided** (locked into the spec body):
+
+- ✅ **Tree column persistence: per-pane.** Stored in block meta as `editor:tree_expanded` + `editor:tree_width`. Two editor panes in the same window can have independent tree states (e.g. one full-width for diffs, one tree-open for browsing).
+- ✅ **Hidden files: hide by default.** Dotfiles + `node_modules` + standard noise (`.DS_Store`, `Thumbs.db`) hidden on first launch. Toolbar `eye` toggle flips per-pane (`editor:show_hidden` in block meta).
+- ✅ **Symlinks: follow.** Matches VS Code semantics. Symlinked rows get a small `↗` overlay so they're identifiable.
+- ✅ **Tree refresh: explicit only.** Toolbar `arrows-rotate` button refreshes the currently expanded folders. No background watcher in v1.
+
+---
+
+## Acceptance criteria
+
+### Phase 1
+
+- [ ] Editor pane opens with a tree column on the left, rooted at `$HOME`
+- [ ] Tree's expand/collapse chevrons work; clicking a folder toggles visibility
+- [ ] Clicking a file calls `model.openFile()` and the editor loads the content with syntax highlighting
+- [ ] The active file's row is visually marked (highlight + filled-dot icon)
+- [ ] Header chevron toggles tree visibility; preference persists per-pane across reload
+- [ ] Toolbar with 3 buttons (`eye` / `square-minus` / `arrows-rotate`); tooltips appear instantly on hover (no delay) via the `data-tip` CSS pattern
+- [ ] Hidden files (dotfiles, `node_modules`, `.DS_Store`, `Thumbs.db`) hidden by default; `eye` toggle flips per-pane and persists
+- [ ] Collapse-all action returns the tree to root-only state in one click
+- [ ] Refresh action re-fetches expanded folders without losing expansion state
+- [ ] Symlinks are followed; symlinked rows carry a `↗` overlay
+- [ ] No regression on the existing path-input flow or Ctrl+S save
+- [ ] Backend `ListEditorDirectoryCommand` returns folders-first, alphabetical, with `is_dir` / `size` / `mtime`
+- [ ] Backend `GetEditorHomeCommand` returns the correct OS home dir on Windows / macOS / Linux
+
+### Phase 2 (nice-to-have, not gating)
+
+- [ ] Hidden files toggle works
+- [ ] Resizable divider persists width
+- [ ] Arrow-key navigation across tree rows
+
+### Phase 3 (extensions)
+
+- [ ] `editor:extensions` setting controls which CM6 extensions activate
+- [ ] At least one new extension shipped (autocomplete or lint)
+- [ ] Documented on docs.agentmux.ai
+
+---
+
+## References
+
+- [VS Code UX guidelines — Tree Views](https://code.visualstudio.com/api/ux-guidelines/overview)
+- [VS Code Tree View API](https://code.visualstudio.com/api/extension-guides/tree-view)
+- [Tree View UX patterns](https://uxpatterns.dev/patterns/data-display/tree-view)
+- [Interaction Design for Trees — Hagan Rivers](https://medium.com/@hagan.rivers/interaction-design-for-trees-5e915b408ed2)
+- [CodeMirror 6 reference manual](https://codemirror.net/docs/ref/)
+- [CodeMirror 6 — list of core extensions](https://codemirror.net/docs/extensions/)
+- [Plugin vs Extension — CodeMirror discuss](https://discuss.codemirror.net/t/plugin-vs-extension/5203)
+- Existing code: `frontend/app/view/editor/{editor.tsx,editor-model.ts,editor-view.tsx}`
+- Backend RPC pattern: `RpcApi.ReadEditorFileCommand` (`frontend/app/store/rpc-api.ts` + the handler in `agentmux-srv/src/server/`)


### PR DESCRIPTION
> Phase 1 of [`SPEC_EDITOR_FILE_TREE_2026-05-26.md`](../blob/main/specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md). Adds a collapsible file-tree explorer down the left of the editor pane, rooted at the OS home dir, with a header chevron toggle (default expanded), click-to-load, and a small toolbar.

## What lands

### Backend (`agentmux-srv/src/server/websocket.rs`)

- **`listeditordir`** — list a directory's entries. Follows symlinks for `is_dir`/`size` (matches VS Code semantics) but reports `is_symlink` separately so the frontend can mark followed symlinks with `↗`. Folders first, alphabetical case-insensitive.
- **`geteditorhome`** — returns `dirs::home_dir()` so the frontend has the canonical root.

### Frontend

- **`file-tree-model.ts`** — state machine. `Map<path, NodeData>` caches loaded children; `Set<path>` tracks expanded folders. Lazy-load on first expand; collapse keeps the cache so re-expand is instant. Refresh re-fetches every expanded path. Collapse-all returns to root-only.
- **`file-tree.tsx`** — recursive tree + toolbar (3 buttons: `eye` show-hidden toggle, `square-minus` collapse-all, `arrows-rotate` refresh). Active file row carries the `circle-dot` icon; symlinked rows carry a `↗` overlay. Hidden-file filter applied at render time (dotfiles + `node_modules` + `.DS_Store` + `Thumbs.db`).
- **`editor-model.ts`** — adds `treeExpandedAtom` + `showHiddenAtom` (per-pane, persisted to block meta as `editor:tree_expanded` / `editor:show_hidden`). Header chevron toggle in the `viewText` HeaderElem slot.
- **`editor-view.tsx`** — two-column layout; empty-state path-input moves under the tree when no file is open.
- **`editor-view.scss`** — tree column, toolbar, scoped `data-tip` CSS rules for **instant tooltips** (pure `:hover::after`, no JS delay), row hover/active states, depth-aware indent.
- **`custom.d.ts`** — `DirEntry` ambient type.

## Decisions from spec discussion (already locked in)

| | |
|---|---|
| Tree column persistence | Per-pane (block meta) |
| Hidden files default | Hidden (dotfiles + `node_modules` + `.DS_Store` + `Thumbs.db`) |
| Symlinks | Followed, marked with `↗` overlay |
| Tree refresh | Explicit only — toolbar button |
| Tooltip delay | **0ms** via `data-tip` CSS pattern |

## Out of scope (future phases)

Phase 2 polish (resizable divider, arrow-key nav), Phase 3 extensions (additional curated CodeMirror extensions), Phase 4 stretch (LSP, multi-root, file watching). All listed in the spec.

## Verification

- `cargo check -p agentmux-srv` — passes
- `npx tsc --noEmit` — no errors in any file this PR touches
- Manual: spec was reviewed with the user before implementation; UX matches the decided shape.