### PR TITLE
fix(agent): show agent name in composer placeholder instead of UUID hash

### DIFF
--- a/.changesets/1779818448-fix-agent-show-agent-name-in-composer-placeholder-instead-of-casm.md
+++ b/.changesets/1779818448-fix-agent-show-agent-name-in-composer-placeholder-instead-of-casm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): show agent name in composer placeholder instead of UUID hash

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -107,6 +107,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const providerKey = (): string => block()?.meta?.["agentProvider"] ?? agentId;
     const provider = () => getProvider(providerKey());
     const outputFormat = (): string => block()?.meta?.["agentOutputFormat"] ?? "claude-stream-json";
+    // Human-readable display name for the composer placeholder. Matches
+    // the same fallback chain used by the onMount log() on line 380 —
+    // single source of truth for "what to call this agent in the UI."
+    // Reactive: the textarea placeholder updates if the user renames
+    // the agent without remounting the pane.
+    const agentName = (): string => block()?.meta?.["agentName"] ?? agentId;
 
     // Overlay tab signal — lives in the component so SolidJS can track it.
     // The model's _setOverlayTab callback is wired on mount and cleaned up on unmount.
@@ -882,7 +888,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     providerId={provider()?.id ?? ""}
                 />
                 <AgentFooter
-                    agentId={agentId}
+                    agentName={agentName()}
                     onSendMessage={handleSendMessage}
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -187,7 +187,14 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
 AgentStatusLine.displayName = "AgentStatusLine";
 
 interface AgentFooterProps {
-    agentId: string;
+    /**
+     * Display name for the composer placeholder ("Send message to …").
+     * The caller derives this from `block().meta.agentName ?? agentId`
+     * so the placeholder shows the human-readable name (e.g. "Claude")
+     * instead of the hex agent UUID. Same fallback chain used elsewhere
+     * in `agent-view.tsx` (see the log() call on line 380).
+     */
+    agentName: string;
     onSendMessage?: (message: string) => void | Promise<void>;
     /**
      * Called when the user types in the composer. Used to tell the document
@@ -446,7 +453,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 <textarea
                     ref={textareaRef}
                     class="agent-input"
-                    placeholder={`Send message to ${props.agentId}...`}
+                    placeholder={`Send message to ${props.agentName}...`}
                     onKeyDown={handleKeyDown}
                     onInput={handleInput}
                     rows={1}


### PR DESCRIPTION
The \"Send message to …\" placeholder in the conversation-mode textarea was rendering the agent's UUID hex hash (e.g. \`Send message to f3a8b1c9…\`) instead of the human-readable name.

## Cause

\`AgentFooter\` had an \`agentId: string\` prop that was used **only** for the placeholder. The caller in \`agent-view.tsx\` passed \`agentId={agentId}\` — where \`agentId\` is \`block().meta.agentId\` (the UUID).

## Fix

- Rename the prop to \`agentName\` (it's display-only) in \`AgentFooter.tsx\`.
- Derive at the caller via the same \`block().meta.agentName ?? agentId\` fallback already used elsewhere in \`agent-view.tsx\` (the \`onMount\` log() call on line 380). Single source of truth — whatever the rest of the UI calls the agent, the composer placeholder calls it too.
- The accessor is reactive, so the placeholder updates if the user renames the agent without remounting the pane.

## Verification

- \`npx tsc --noEmit\` clean (no new TS errors in touched files)
- Vite full build was blocked by esbuild OOM during local smoke (running 0.38.13 portable + build pressure exhausted page file — same dual-subprocess pattern documented in \`docs/analysis/CRASH_OOM_DUAL_SUBPROCESS_2026_05_26.md\`). Next portable rebuild will catch any non-TS regression.

## Includes

VERSION_HISTORY backfill for 0.38.12 + 0.38.13 (both no-semantic-content portable-counter bumps from \`task package\` after the Phase 1+2 modal landings) to keep reagent's release-consistency gate satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)