### PR TITLE
feat(editor): multi-root file tree + resize handle between tree and editor

### DIFF
--- a/.changesets/1779818795-feat-editor-multi-root-tree-plus-resize-handle.md
+++ b/.changesets/1779818795-feat-editor-multi-root-tree-plus-resize-handle.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): multi-root file tree (HOME + drives/mounts) and draggable resize handle between tree and editor

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -35,6 +35,44 @@ use super::service::update_object_meta;
 
 use super::AppState;
 
+/// Enumerate drives/mounts accessible from the current OS user.
+/// Used by the `geteditorroots` RPC so the editor file-tree exposes
+/// every reachable filesystem root, not just $HOME.
+/// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md (multi-root follow-up).
+#[cfg(target_os = "windows")]
+fn list_drives() -> Vec<serde_json::Value> {
+    let mut drives = Vec::new();
+    for letter in b'A'..=b'Z' {
+        let path = format!("{}:\\", letter as char);
+        if std::path::Path::new(&path).exists() {
+            drives.push(serde_json::json!({
+                "name": format!("{}:", letter as char),
+                "path": path,
+            }));
+        }
+    }
+    drives
+}
+
+#[cfg(not(target_os = "windows"))]
+fn list_drives() -> Vec<serde_json::Value> {
+    let mut drives = vec![serde_json::json!({ "name": "/", "path": "/" })];
+    for mount_dir in ["/mnt", "/media", "/Volumes"] {
+        if let Ok(entries) = std::fs::read_dir(mount_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    drives.push(serde_json::json!({
+                        "name": entry.file_name().to_string_lossy().to_string(),
+                        "path": path.to_string_lossy().to_string(),
+                    }));
+                }
+            }
+        }
+    }
+    drives
+}
+
 /// Incoming WebSocket message envelope.
 /// Supports both ping/pong messages and wscommand-based RPC.
 #[derive(Deserialize)]
@@ -1227,6 +1265,25 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     .ok_or_else(|| "geteditorhome: cannot determine home directory".to_string())?;
                 Ok(Some(serde_json::json!({
                     "home": home.to_string_lossy(),
+                })))
+            })
+        }),
+    );
+
+    // geteditorroots → home + every reachable drive/mount on the system.
+    // The editor file-tree renders these as sibling top-level roots so the
+    // user can navigate to anywhere on the machine, not just inside $HOME.
+    // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md (multi-root follow-up)
+    engine.register_handler(
+        "geteditorroots",
+        Box::new(|_data, _ctx| {
+            Box::pin(async move {
+                let home = dirs::home_dir()
+                    .ok_or_else(|| "geteditorroots: cannot determine home directory".to_string())?;
+                let drives = list_drives();
+                Ok(Some(serde_json::json!({
+                    "home": home.to_string_lossy(),
+                    "drives": drives,
                 })))
             })
         }),

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1202,6 +1202,16 @@ class RpcApiType {
         return client.rpcCall("geteditorhome", data, opts);
     }
 
+    // command "geteditorroots" [call] — home + drives/mounts. The editor
+    // file-tree renders these as sibling top-level roots.
+    GetEditorRootsCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<{ home: string; drives: { name: string; path: string }[] }> {
+        return client.rpcCall("geteditorroots", data, opts);
+    }
+
     // command "resolvecli" [call]
     ResolveCliCommand(client: RpcClient, data: CommandResolveCliData, opts?: RpcOpts): Promise<ResolveCliResult> {
         return client.rpcCall("resolvecli", data, opts);

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -17,6 +17,10 @@ import { FileTreeModel } from "./file-tree-model";
 
 const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
+const META_TREE_WIDTH = "editor:tree_width";
+const TREE_WIDTH_DEFAULT = 240;
+const TREE_WIDTH_MIN = 150;
+const TREE_WIDTH_MAX = 600;
 
 export class EditorViewModel implements ViewModel {
     viewType = "editor";
@@ -64,6 +68,9 @@ export class EditorViewModel implements ViewModel {
     private _showHidden = createSignal<boolean>(false);
     showHiddenAtom: Accessor<boolean> = this._showHidden[0];
 
+    private _treeWidth = createSignal<number>(TREE_WIDTH_DEFAULT);
+    treeWidthAtom: Accessor<number> = this._treeWidth[0];
+
     treeModel = new FileTreeModel();
 
     blockAtom: Accessor<Block | undefined>;
@@ -102,6 +109,10 @@ export class EditorViewModel implements ViewModel {
         }
         if (meta?.[META_SHOW_HIDDEN] === true) {
             this._showHidden[1](true);
+        }
+        const persistedWidth = meta?.[META_TREE_WIDTH];
+        if (typeof persistedWidth === "number") {
+            this._treeWidth[1](clampTreeWidth(persistedWidth));
         }
 
         // Load file from block meta on init
@@ -172,6 +183,19 @@ export class EditorViewModel implements ViewModel {
         await this.persistMeta({ [META_SHOW_HIDDEN]: next });
     }
 
+    /**
+     * Live tree-width update during drag — fast signal-only path, no RPC.
+     * Use `commitTreeWidth()` on mouseup to persist.
+     */
+    setTreeWidth(width: number): void {
+        this._treeWidth[1](clampTreeWidth(width));
+    }
+
+    /** Persist the current tree width to block meta. Call on drag-release. */
+    async commitTreeWidth(): Promise<void> {
+        await this.persistMeta({ [META_TREE_WIDTH]: this._treeWidth[0]() });
+    }
+
     private async persistMeta(meta: Record<string, unknown>): Promise<void> {
         try {
             await RpcApi.SetMetaCommand(TabRpcClient, {
@@ -190,6 +214,11 @@ export class EditorViewModel implements ViewModel {
     }
 
     dispose(): void {}
+}
+
+function clampTreeWidth(w: number): number {
+    if (!Number.isFinite(w)) return TREE_WIDTH_DEFAULT;
+    return Math.max(TREE_WIDTH_MIN, Math.min(TREE_WIDTH_MAX, Math.round(w)));
 }
 
 // ── Language detection ──────────────────────────────────────────────────────

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -21,13 +21,30 @@
 // ── Tree column ─────────────────────────────────────────────────────────────
 
 .editor-tree-column {
-    width: 240px;
-    flex: 0 0 240px;
+    // width + flex set inline by editor-view.tsx (driven by treeWidthAtom)
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--border-color);
     overflow: hidden;
     background: var(--secondary-bg-color, var(--block-bg-color));
+}
+
+// Vertical resize strip between the tree column and the main editor column.
+// 4px wide; cursor flips to col-resize on hover; the center 1px line acts as
+// the visual border. Drag handlers live in editor-view.tsx (track global
+// mousemove until mouseup so the user can drag past the strip without
+// losing grip). Per-pane width persists via `editor:tree_width` in block meta.
+.editor-tree-resize-handle {
+    flex: 0 0 4px;
+    width: 4px;
+    cursor: col-resize;
+    background: var(--border-color);
+    transition: background 80ms ease;
+    position: relative;
+
+    &:hover,
+    &:active {
+        background: var(--accent-color, var(--main-text-color));
+    }
 }
 
 .editor-tree-path-input {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -116,10 +116,11 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     };
 
     onMount(() => {
-        // Load file tree root from backend's home dir.
-        void RpcApi.GetEditorHomeCommand(TabRpcClient, {}).then((res) => {
+        // Load file-tree roots from backend: $HOME (auto-expanded) +
+        // every reachable drive/mount (sibling roots, collapsed).
+        void RpcApi.GetEditorRootsCommand(TabRpcClient, {}).then((res) => {
             if (res?.home) {
-                void model.treeModel.setRootAndLoad(res.home);
+                void model.treeModel.setRootsAndLoad(res.home, res.drives ?? []);
             }
         });
 
@@ -130,6 +131,29 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             void setupEditor(content, lang, readOnly);
         }
     });
+
+    // Resize-handle drag — tracks global mousemove until release so the user
+    // can drag past the handle without losing the grip. Live updates the
+    // tree-width signal; persists once on mouseup.
+    const handleResizeMouseDown = (e: MouseEvent) => {
+        e.preventDefault();
+        const startX = e.clientX;
+        const startWidth = model.treeWidthAtom();
+        const onMove = (ev: MouseEvent) => {
+            model.setTreeWidth(startWidth + (ev.clientX - startX));
+        };
+        const onUp = () => {
+            document.removeEventListener("mousemove", onMove);
+            document.removeEventListener("mouseup", onUp);
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+            void model.commitTreeWidth();
+        };
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+        document.addEventListener("mousemove", onMove);
+        document.addEventListener("mouseup", onUp);
+    };
 
     // Rebuild only when a NEW file is opened (path changes), not on every
     // keystroke. contentAtom is updated by onContentChange on every keypress —
@@ -168,7 +192,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             classList={{ "editor-view--tree-collapsed": !model.treeExpandedAtom() }}
         >
             <Show when={model.treeExpandedAtom()}>
-                <div class="editor-tree-column">
+                <div
+                    class="editor-tree-column"
+                    style={{
+                        width: `${model.treeWidthAtom()}px`,
+                        flex: `0 0 ${model.treeWidthAtom()}px`,
+                    }}
+                >
                     <FileTree
                         model={model.treeModel}
                         activeFilePath={model.filePathAtom()}
@@ -198,6 +228,11 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         </div>
                     </Show>
                 </div>
+                <div
+                    class="editor-tree-resize-handle"
+                    onMouseDown={handleResizeMouseDown}
+                    title="Drag to resize file tree"
+                />
             </Show>
 
             <div class="editor-main-column">

--- a/frontend/app/view/editor/file-tree-model.ts
+++ b/frontend/app/view/editor/file-tree-model.ts
@@ -88,10 +88,14 @@ export class FileTreeModel {
         const roots: Root[] = [
             { name: homeName, path: home, isHome: true },
             ...drives
-                // Don't double-show the drive that hosts HOME (e.g. C:\ when
-                // HOME is C:\Users\…). User can still reach it by collapsing
-                // HOME and expanding from a different angle if needed.
-                .filter((d) => !home.toLowerCase().startsWith(d.path.toLowerCase()))
+                // Don't double-show the drive that hosts HOME on Windows
+                // (e.g. hide C:\ when HOME is C:\Users\…). UNIX `/` is the
+                // exception: every HOME starts with `/`, but `/` is the only
+                // way to reach /etc, /opt, /mnt etc., so we always keep it.
+                .filter((d) => {
+                    if (d.path === "/") return true;
+                    return !home.toLowerCase().startsWith(d.path.toLowerCase());
+                })
                 .map((d) => ({ name: d.name, path: d.path, isHome: false })),
         ];
         this._roots[1](roots);

--- a/frontend/app/view/editor/file-tree-model.ts
+++ b/frontend/app/view/editor/file-tree-model.ts
@@ -3,9 +3,14 @@
 //
 // State for the editor pane's file-tree explorer.
 //
-// Two reactive bags:
-//   - `expandedAtom: Set<string>`   — which folder paths are currently open
-//   - `dataAtom:     Map<string,…>` — fetched child rows + load phase per path
+// Three reactive bags:
+//   - `rootsAtom:    Root[]`         — top-level entries (HOME + drives/mounts)
+//   - `expandedAtom: Set<string>`    — which folder paths are currently open
+//   - `dataAtom:     Map<string,…>`  — fetched child rows + load phase per path
+//
+// HOME is the primary root and is auto-expanded on first load; drives/mounts
+// are sibling roots, collapsed by default — user can navigate anywhere on
+// the system without leaving the tree.
 //
 // Lazy-load on first expand; subsequent collapse keeps the data cached so
 // re-expanding is instant. Refresh re-fetches every currently-expanded path.
@@ -17,6 +22,15 @@
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { createSignal, type Accessor } from "solid-js";
+
+export interface Root {
+    /** Display name (e.g. "asaf", "C:", "/", "Macintosh HD") */
+    name: string;
+    /** Absolute path the tree expands under */
+    path: string;
+    /** Marks the user's HOME root — gets auto-expanded on load */
+    isHome: boolean;
+}
 
 interface NodeData {
     phase: "loading" | "loaded" | "error";
@@ -52,8 +66,8 @@ export class FileTreeModel {
     private _data = createSignal<Map<string, NodeData>>(new Map());
     dataAtom: Accessor<Map<string, NodeData>> = this._data[0];
 
-    private _root = createSignal<string>("");
-    rootAtom: Accessor<string> = this._root[0];
+    private _roots = createSignal<Root[]>([]);
+    rootsAtom: Accessor<Root[]> = this._roots[0];
 
     isExpanded(path: string): boolean {
         return this._expanded[0]().has(path);
@@ -64,11 +78,25 @@ export class FileTreeModel {
     }
 
     /**
-     * Set the tree root and immediately expand + load it. Called once on
-     * mount after `GetEditorHomeCommand` returns.
+     * Set the roots (HOME + drives/mounts) and auto-expand HOME.
+     * Called once on mount after `GetEditorRootsCommand` returns.
      */
-    async setRootAndLoad(home: string): Promise<void> {
-        this._root[1](home);
+    async setRootsAndLoad(home: string, drives: { name: string; path: string }[]): Promise<void> {
+        // Derive HOME's display name from the path's basename.
+        const homeName =
+            home.split(/[\\/]/).filter(Boolean).pop() ?? home;
+        const roots: Root[] = [
+            { name: homeName, path: home, isHome: true },
+            ...drives
+                // Don't double-show the drive that hosts HOME (e.g. C:\ when
+                // HOME is C:\Users\…). User can still reach it by collapsing
+                // HOME and expanding from a different angle if needed.
+                .filter((d) => !home.toLowerCase().startsWith(d.path.toLowerCase()))
+                .map((d) => ({ name: d.name, path: d.path, isHome: false })),
+        ];
+        this._roots[1](roots);
+
+        // Auto-expand HOME (only); drives stay collapsed.
         const next = new Set(this._expanded[0]());
         next.add(home);
         this._expanded[1](next);
@@ -97,10 +125,9 @@ export class FileTreeModel {
         await Promise.all(paths.map((p) => this.load(p)));
     }
 
-    /** Close every folder except the root. */
+    /** Close every folder. Roots stay rendered (they're the top-level entries). */
     collapseAll(): void {
-        const root = this._root[0]();
-        this._expanded[1](root ? new Set<string>([root]) : new Set<string>());
+        this._expanded[1](new Set<string>());
     }
 
     private async load(path: string): Promise<void> {

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -11,7 +11,7 @@
 // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
 
 import { createMemo, For, Show, type JSX } from "solid-js";
-import { FileTreeModel, isHiddenName, joinPath } from "./file-tree-model";
+import { FileTreeModel, isHiddenName, joinPath, type Root } from "./file-tree-model";
 
 interface FileTreeProps {
     model: FileTreeModel;
@@ -22,12 +22,6 @@ interface FileTreeProps {
 }
 
 export function FileTree(props: FileTreeProps): JSX.Element {
-    const rootName = createMemo(() => {
-        const r = props.model.rootAtom();
-        if (!r) return "";
-        return r.split(/[\\/]/).filter(Boolean).pop() ?? r;
-    });
-
     return (
         <div class="file-tree">
             <FileTreeToolbar
@@ -36,19 +30,21 @@ export function FileTree(props: FileTreeProps): JSX.Element {
                 onToggleHidden={props.onToggleHidden}
             />
             <div class="file-tree-body">
-                <Show when={props.model.rootAtom()}>
-                    <TreeNode
-                        model={props.model}
-                        path={props.model.rootAtom()}
-                        name={rootName()}
-                        depth={0}
-                        isDir={true}
-                        isSymlink={false}
-                        activeFilePath={props.activeFilePath}
-                        showHidden={props.showHidden}
-                        onFileClick={props.onFileClick}
-                    />
-                </Show>
+                <For each={props.model.rootsAtom()}>
+                    {(root: Root) => (
+                        <TreeNode
+                            model={props.model}
+                            path={root.path}
+                            name={root.name}
+                            depth={0}
+                            isDir={true}
+                            isSymlink={false}
+                            activeFilePath={props.activeFilePath}
+                            showHidden={props.showHidden}
+                            onFileClick={props.onFileClick}
+                        />
+                    )}
+                </For>
             </div>
         </div>
     );


### PR DESCRIPTION
> Two follow-ups to #1064 the user surfaced while looking at the live build.

## What lands

### 1. Multi-root tree (HOME + drives + mounts)

The tree was stuck at \`\$HOME\`. Now it shows HOME as the auto-expanded primary root, plus every drive/mount as a sibling root (collapsed). User can navigate anywhere on the system without leaving the tree.

- Backend (\`websocket.rs\`):
  - New \`geteditorroots\` RPC returning \`{ home, drives[] }\`
  - New \`list_drives()\` helper with \`#[cfg]\` gates — Windows enumerates A–Z; Unix includes \`/\` plus mounts under \`/mnt\`, \`/media\`, \`/Volumes\`
- Frontend (\`file-tree-model.ts\`):
  - \`rootsAtom: Root[]\` replaces single \`rootAtom\`
  - The drive hosting HOME is de-duplicated so it doesn't appear twice (no \`C:\\` row when HOME is \`C:\Users\…\`)
- Frontend (\`file-tree.tsx\`): top-level renders \`<For each={rootsAtom()}>\` producing one row per filesystem root

### 2. Draggable resize handle

The boundary between tree and editor was a static 240px. Now drag it.

- 4px-wide col-resize strip between tree column and main editor column
- Live updates the tree-width signal during drag (no RPC on every pixel)
- Persists on mouseup via \`editor:tree_width\` in block meta (per-pane)
- Min 150px, max 600px, default 240px
- Drag handlers attach to \`document\` (mousemove/mouseup) so the user can drag past the strip without losing grip; body cursor + user-select locked during drag

## Source of decisions

Both fall under the spec's Phase 2 (\`specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md\` § Implementation phases → Phase 2). User asked for them after seeing the Phase 1 build, so pulling them forward in a tight follow-up rather than batching with later phases.

## Verification

- \`cargo check -p agentmux-srv\` — passes
- \`npx tsc --noEmit\` — no errors in any file this PR touches