### PR TITLE
feat(editor): icon toggles tree, title shows full file path

### DIFF
--- a/.changesets/1779821048-feat-editor-icon-toggles-tree-and-title-shows-full-path.md
+++ b/.changesets/1779821048-feat-editor-icon-toggles-tree-and-title-shows-full-path.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): pane icon toggles the file-tree (replacing the separate chevron); title bar now shows the full file path

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -27,7 +27,7 @@ export class EditorViewModel implements ViewModel {
     blockId: string;
     nodeModel: BlockNodeModel;
 
-    viewIcon: Accessor<string> = () => "file-code";
+    viewIcon: Accessor<string | IconButtonDecl>;
     viewName: Accessor<string>;
     viewText: Accessor<string | HeaderElem[]>;
     noPadding: Accessor<boolean> = () => true;
@@ -81,26 +81,34 @@ export class EditorViewModel implements ViewModel {
 
         this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
 
-        // Derive view name from file path
+        // Pane title — full file path (or "Editor" when nothing open). Marked
+        // with a trailing `*` when there are unsaved changes. Showing the
+        // complete path (not just the basename) lets the operator know
+        // exactly which file they're editing when multiple panes are open
+        // on similarly-named files (e.g. two `index.ts` in different dirs).
         this.viewName = createMemo(() => {
             const fp = this.filePathAtom();
             if (!fp) return "Editor";
-            const name = fp.split("/").pop() || fp.split("\\").pop() || fp;
-            return this.dirtyAtom() ? `${name} *` : name;
+            return this.dirtyAtom() ? `${fp} *` : fp;
         });
 
-        // Header items — the file-tree chevron toggle.
-        this.viewText = createMemo<HeaderElem[]>(() => {
+        // Pane icon doubles as the file-tree expand/collapse toggle.
+        // Clicking the icon hides/shows the tree column; preference persists
+        // per pane in block meta (`editor:tree_expanded`). The icon glyph
+        // reflects the current state: `folder-tree` when the tree is open,
+        // `folder` when collapsed.
+        this.viewIcon = createMemo<IconButtonDecl>(() => {
             const expanded = this.treeExpandedAtom();
-            return [
-                {
-                    elemtype: "iconbutton",
-                    icon: expanded ? "folder-tree" : "folder",
-                    title: expanded ? "Hide file tree" : "Show file tree",
-                    click: () => void this.toggleTreeExpanded(),
-                },
-            ];
+            return {
+                elemtype: "iconbutton",
+                icon: expanded ? "folder-tree" : "folder",
+                title: expanded ? "Hide file tree" : "Show file tree",
+                click: () => void this.toggleTreeExpanded(),
+            };
         });
+
+        // No additional header items today — the icon owns the tree toggle.
+        this.viewText = () => [];
 
         // Restore persisted tree state from block meta.
         const meta = this.blockAtom()?.meta;


### PR DESCRIPTION
> Two small UX refinements following live use of the new editor file-tree.

## What changes

| Before | After |
|---|---|
| Pane icon was a fixed \`file-code\` glyph | Pane icon is the **file-tree toggle** — \`folder-tree\` when expanded, \`folder\` when collapsed |
| Tree toggle lived as a separate chevron HeaderElem on the right | Removed (icon owns it now) |
| Title showed just the basename (\`main.ts *\`) | Title shows the **full path** (\`/Users/asaf/repo/src/main.ts *\`) |

Why the full path: with two editor panes open on similarly-named files (e.g. two `index.ts` in different dirs), it was easy to lose track. The block frame's existing overflow handling keeps the layout sane.

## Implementation

- `viewIcon` widened from `Accessor<string>` to `Accessor<string | IconButtonDecl>`. The block frame already supports both shapes — see `blockframe.tsx:getViewIconElem`.
- `viewText` returns `[]` since the icon owns the toggle; keeps the right side of the header tidy and lets future header items land there without competing for attention.
- Same `editor:tree_expanded` block-meta key — no migration needed.

## Verification

`npx tsc --noEmit` — clean on every file this PR touches.