### PR TITLE
feat(toggle): square thumbs + tracks across all toggle UIs

### DIFF
--- a/.changesets/1779826600-feat-toggle-square-thumbs-tracks-canonical-toggle-status-bar-bxco.md
+++ b/.changesets/1779826600-feat-toggle-square-thumbs-tracks-canonical-toggle-status-bar-bxco.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(toggle): square thumbs + tracks (canonical Toggle + status-bar LAN discovery)

--- a/frontend/app/element/toggle.scss
+++ b/frontend/app/element/toggle.scss
@@ -30,10 +30,12 @@
             right: 0;
             background-color: var(--toggle-bg-color);
             transition: 0.5s;
-            // Toggle slider is a pill switch — explicit exception in
-            // SPEC_HARD_CORNERS_2026_05_26.md (toggles read as round
-            // on purpose). The thumb (`.slider:before`) is 50% below.
-            border-radius: var(--radius-full);
+            // Square toggle — per 2026-05-26 user request, toggles join
+            // the rest of the chrome on hard corners. The previous
+            // SPEC_HARD_CORNERS_2026_05_26 exception (toggles stayed
+            // round) is rescinded. Pills/avatars/status-dots still use
+            // --radius-full; toggle track + thumb are now square.
+            border-radius: 0;
         }
 
         .slider:before {
@@ -45,7 +47,7 @@
             bottom: 2px;
             background-color: var(--toggle-thumb-color);
             transition: 0.5s;
-            border-radius: 50%;
+            border-radius: 0;
         }
 
         input:checked + .slider {

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -330,7 +330,12 @@
                 width: 12px;
                 height: 12px;
                 background: var(--main-bg-color, #fff);
-                border-radius: 50%;
+                // Square thumb — matches the canonical Toggle component
+                // and the rest of the chrome's hard-corners design
+                // (2026-05-26 toggle audit; supersedes the round-thumb
+                // detail that was still here after the broader
+                // SPEC_HARD_CORNERS_2026_05_26 sweep).
+                border-radius: 0;
                 transition: transform 120ms ease;
             }
 


### PR DESCRIPTION
User audit 2026-05-26 — the canonical \`Toggle\` component and the LAN-discovery toggle in the status-bar host popover both still had round pucks. The broader \`SPEC_HARD_CORNERS_2026_05_26\` sweep explicitly carved out toggles as a \"pills stay round\" exception, but in live testing that exception felt inconsistent with the rest of the chrome.

## Changes

- \`frontend/app/element/toggle.scss\` — \`.slider\` track from \`var(--radius-full)\` to \`0\`; thumb \`:before\` from \`50%\` to \`0\`.
- \`frontend/app/statusbar/StatusBar.scss\` — LAN-discovery toggle thumb \`::before\` from \`50%\` to \`0\` (track was already \`0\`).

## Audit scope

Grepped every \`border-radius: 50%\` and \`border-radius: var(--radius-full)\` across the frontend. Confirmed these two SCSS files are the only toggle implementations. Other circular elements (avatars, MicButton, status-dot, identity avatars, drone/editor indicators, agent picker avatars, setup-wizard step dots, chat message avatars) are circles by design and stay round — they're not toggles.

\`--radius-full\` token is preserved for those legitimate pill / circle uses; only the toggle-specific rules flip.

## Verify

\`task build:frontend\` → ✓ 23.32s clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)