### PR TITLE
fix(dev): respect AGENTMUX_VITE_PORT in child window URL resolution

### DIFF
--- a/.changesets/1779849524-fix-dev-respect-agentmux-vite-port-in-child-windows-so-tab-p-8vhs.md
+++ b/.changesets/1779849524-fix-dev-respect-agentmux-vite-port-in-child-windows-so-tab-p-8vhs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): respect AGENTMUX_VITE_PORT in child windows so tab/pane tear-off works on non-5173 dev clones

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -525,8 +525,14 @@ wrap_browser_process_handler! {
                     // Production or portable: always use IPC server
                     format!("http://127.0.0.1:{}", self.ipc_port)
                 } else {
-                    // Dev mode only: Vite HMR server
-                    "http://localhost:5173".to_string()
+                    // Dev mode only: Vite HMR server. Honor AGENTMUX_VITE_PORT
+                    // (per-clone port from Taskfile.yml dev:serve); see
+                    // docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md.
+                    let port: u16 = std::env::var("AGENTMUX_VITE_PORT")
+                        .ok()
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(5173);
+                    format!("http://localhost:{}", port)
                 }
             } else {
                 base_url

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -598,9 +598,23 @@ pub fn inspect_element_at(state: &Arc<AppState>, args: &serde_json::Value) -> Re
     Ok(serde_json::Value::Null)
 }
 
+/// Resolve the dev Vite port. Honors `AGENTMUX_VITE_PORT` (set by
+/// `Taskfile.yml`'s `dev:serve` task when the per-clone deterministic
+/// port differs from 5173); falls back to 5173 otherwise. Without this,
+/// every child window (pool warmups, tab tear-off, floating pane) loads
+/// `localhost:5173` and hits `ERR_CONNECTION_REFUSED` on any other port —
+/// only the main window survives because the launcher passes `--url=…`
+/// on the CLI. See `docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md`.
+fn dev_vite_port() -> u16 {
+    std::env::var("AGENTMUX_VITE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5173)
+}
+
 /// Resolve the base URL for the frontend.
 /// Production: IPC server serves static files from `frontend/` next to the exe.
-/// Dev: Vite dev server at `http://localhost:5173`.
+/// Dev: Vite dev server at `http://localhost:<AGENTMUX_VITE_PORT or 5173>`.
 pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
     // Detect dev mode. Two reachable scenarios:
     //   a) Launcher-managed: AGENTMUX_RUNTIME_MODE is set, from_env()
@@ -616,7 +630,7 @@ pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
             .map(|d| agentmux_common::RuntimeMode::current(&d))
     });
     if matches!(mode, Some(agentmux_common::RuntimeMode::Dev { .. })) {
-        return "http://localhost:5173".to_string();
+        return format!("http://localhost:{}", dev_vite_port());
     }
     let exe_dir = std::env::current_exe()
         .ok()
@@ -628,7 +642,7 @@ pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
     if has_frontend {
         format!("http://127.0.0.1:{}", ipc_port)
     } else {
-        "http://localhost:5173".to_string()
+        format!("http://localhost:{}", dev_vite_port())
     }
 }
 

--- a/docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md
+++ b/docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md
@@ -1,0 +1,125 @@
+# Analysis: Dev Vite port hardcoded in `resolve_frontend_base_url`
+
+**Date:** 2026-05-26
+**Status:** Fix landing in same PR
+
+## TL;DR
+
+`agentmux-cef/src/commands/window.rs:619` hardcodes `http://localhost:5173`
+for dev mode, ignoring the `AGENTMUX_VITE_PORT` env var that `task dev`
+sets when the auto-derived per-clone port differs from 5173. The **main
+window** survives because the launcher passes `--url=$VITE_URL` on the
+CLI, but **every child window** — window-pool warmups, tab tear-off
+windows, and the new floating pane window — calls
+`resolve_frontend_base_url` and loads `localhost:5173`, hitting
+`ERR_CONNECTION_REFUSED` whenever Vite is on any other port.
+
+Surfaced during smoke-testing of #1078 (floating-pane Phase 2) — the
+test session used `AGENTMUX_VITE_PORT=5350` to dodge a collision on the
+auto-derived 5270, and both tab tear-off and pane tear-off failed to
+load their new browsers.
+
+This is **not a regression from #1078** — it has been latent in every
+dev session whose auto-derived Vite port ≠ 5173. The earlier multi-clone
+analysis ([ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md][])
+flagged port 5173 as a "Low severity / loud collision" — wrong: when
+the script *successfully* moves the port off 5173, child windows fail
+silently with cryptic `ERR_CONNECTION_REFUSED` errors and no visible
+explanation in the UI.
+
+## Evidence (dev session 2026-05-26 19:31 PT, Vite on 5350)
+
+Child windows attempted to load 5173:
+
+```
+02:31:16.997  Load error: url=http://localhost:5173/?...&pool=1
+              error=ERR_CONNECTION_REFUSED (-102)              # pool warmup
+02:31:29.839  Load error: url=http://localhost:5173/?...&floatingPaneId=…
+              error=ERR_CONNECTION_REFUSED (-102)              # pane tear-off
+02:31:36.946  Load error: url=http://localhost:5173/?...&workspaceId=…
+              error=ERR_CONNECTION_REFUSED (-102)              # tab tear-off
+```
+
+Main window worked because the launcher invocation passes the resolved
+port on the CLI:
+
+```bash
+# Taskfile.yml dev:serve, after auto-deriving AGENTMUX_VITE_PORT
+./agentmux-launcher.exe --url="$VITE_URL"   # VITE_URL=http://localhost:5350
+```
+
+## Call graph
+
+Every dev child-window URL goes through one function:
+
+| Caller                                              | Purpose                       |
+|-----------------------------------------------------|-------------------------------|
+| `agentmux-cef/src/commands/window_pool.rs:196`      | Pool browser warmup           |
+| `agentmux-cef/src/commands/window.rs:712`           | New top-level window          |
+| `agentmux-cef/src/commands/drag.rs:431`             | Tab tear-off                  |
+| `agentmux-cef/src/floating_pane.rs:209`             | Floating pane (Phase 1+)      |
+| `agentmux-cef/src/client/mod.rs:1280`               | Misc child reloads            |
+
+All of them call `resolve_frontend_base_url(ipc_port)` in
+`agentmux-cef/src/commands/window.rs:604`, whose dev branch returns:
+
+```rust
+if matches!(mode, Some(agentmux_common::RuntimeMode::Dev { .. })) {
+    return "http://localhost:5173".to_string();
+}
+```
+
+## Why the main window dodges the bug
+
+`dist/cef-dev/` is launched as:
+
+```bash
+AGENTMUX_DEV=1 ./agentmux-launcher.exe --url="$VITE_URL"
+```
+
+The host treats `--url=…` as authoritative for the first browser it
+creates (the main window). `resolve_frontend_base_url` is only consulted
+for *subsequent* browsers, where the CLI override no longer applies.
+
+## Fix
+
+Make `resolve_frontend_base_url` honor `AGENTMUX_VITE_PORT`. The env var
+is already exported by `Taskfile.yml`'s `dev:serve` task and inherited
+transitively by the host (launcher → host via tokio::process::Command::spawn,
+which inherits the full env block).
+
+```rust
+fn dev_vite_port() -> u16 {
+    std::env::var("AGENTMUX_VITE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5173)
+}
+```
+
+Apply at both dev-mode branches (the explicit dev path *and* the no-frontend
+production fallback that also returns `localhost:5173`).
+
+~6 lines. Zero risk: identical behavior in the common case (port = 5173);
+correct behavior in the per-clone-derived case.
+
+## What this doesn't fix
+
+- **Pool-exhaustion warning on tear-off** (`[pool] pool exhausted on tear-off
+  — frontend will cold-path`) — orthogonal; cold-path is supposed to work and
+  would have worked if the URL had been correct.
+- **`[on_before_close] no backend window ID registered for label=…floating…
+  — shells may orphan`** — backend window-id-registry plumbing for floating
+  panes is a separate gap, tracked alongside #1079.
+
+## Cross-references
+
+- Issue #1079 — floating-pane C1/C2 (macOS NSPanel + Linux X11 GTK)
+- PR #1078 — Phase 2 (real `<Block>` renderer), shipped 2026-05-26
+- [ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md][] — earlier
+  analysis that under-rated this collision as "Low severity / loud" when
+  in fact silent child-window failures are the real consequence.
+- `Taskfile.yml` `dev:serve` task — derives `AGENTMUX_VITE_PORT` per-clone
+  via cksum-of-cwd modulo 200.
+
+[ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md]: ./ANALYSIS_MULTI_CLONE_TASK_DEV_ISOLATION_2026-05-26.md


### PR DESCRIPTION
## Summary

- `resolve_frontend_base_url` (`commands/window.rs:604`) and the main-window URL fallback (`app.rs:506`) both hardcoded `http://localhost:5173` for dev mode, ignoring `AGENTMUX_VITE_PORT`.
- The main window survived because the launcher passes `--url=\$VITE_URL` on the CLI, but every child window (pool warmups, tab tear-off, floating pane) hit `ERR_CONNECTION_REFUSED` whenever Vite was on any other port.
- Both call sites now read `AGENTMUX_VITE_PORT`, falling back to 5173.

## Surfacing

Caught during smoke-testing of #1078 (floating-pane Phase 2). The test session used `AGENTMUX_VITE_PORT=5350` to dodge a collision on the auto-derived 5270; both tab and pane tear-off failed to load with `localhost:5173` `ERR_CONNECTION_REFUSED`.

This is **not a Phase 2 regression** — it has been latent in every dev session whose per-clone auto-derived Vite port differed from 5173.

## Analysis

See [`docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md`](https://github.com/agentmuxai/agentmux/blob/agentx/fix-dev-vite-port-hardcode/docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md) for the full call graph and evidence.

## Test plan

- [x] `cargo check -p agentmux-cef` — clean
- [ ] `AGENTMUX_VITE_PORT=5350 task dev` → tear off a pane → floating window loads (no `ERR_CONNECTION_REFUSED` in host log)
- [ ] `AGENTMUX_VITE_PORT=5350 task dev` → tear off a tab → new window loads (no `ERR_CONNECTION_REFUSED` in host log)
- [ ] Default `task dev` (port = 5173) → no change in behavior

## Out of scope

- `[on_before_close] no backend window ID registered for label=…floating… — shells may orphan` (separate floating-pane reducer-plumbing gap; tracked alongside #1079)
- Pool-exhaustion cold-path on tear-off (orthogonal; would have worked if the URL had been correct)