### PR TITLE
feat(floating-pane): native title-bar drag + size matches source pane

### DIFF
--- a/.changesets/1779850836-feat-floating-pane-native-title-bar-drag-via-wm-nchittest-si-7ljq.md
+++ b/.changesets/1779850836-feat-floating-pane-native-title-bar-drag-via-wm-nchittest-si-7ljq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(floating-pane): native title-bar drag via WM_NCHITTEST + size matches source pane

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -47,11 +47,19 @@ pub struct OpenFloatingPaneArgs {
     #[serde(default)]
     pub workspace_id: Option<String>,
     /// Screen-space top-left coordinates where the new floating window
-    /// should appear. Typically the cursor position at drop time.
+    /// should appear, in Win32 PHYSICAL pixels. Typically the cursor
+    /// position at drop time (frontend reads from host
+    /// `get_cursor_point` which uses `GetCursorPos`).
     pub x: i32,
     pub y: i32,
-    /// Initial window size. Phase 6 will memo the source pane's last
-    /// docked size; Phase 1 accepts a caller-provided default.
+    /// Initial window size in CSS / DIP pixels (NOT physical). The host
+    /// scales to physical px using the destination monitor's DPI via
+    /// `MonitorFromPoint(x, y)` + `GetDpiForMonitor`. Passing DIP here
+    /// (rather than physical, which would need the frontend to know the
+    /// destination monitor's DPI) lets us correctly cross-DPI handoff —
+    /// e.g. drag from a 100% monitor onto a 150% monitor and the floater
+    /// matches the source pane's visual size on the destination.
+    /// Mirrors the pattern in `commands/window_pool.rs:684-701`.
     pub width: i32,
     pub height: i32,
 }
@@ -99,6 +107,34 @@ pub fn open_floating_pane_window(
 
     let window_id = uuid::Uuid::new_v4();
     let window_label = format!("floating-{}", window_id.simple());
+
+    // Scale incoming CSS / DIP size to PHYSICAL pixels using the
+    // DESTINATION monitor's DPI. The frontend can't do this — it only
+    // knows its own (source) monitor's DPR. The destination monitor is
+    // wherever (x, y) lands. Mirrors `commands/window_pool.rs:684-701`.
+    #[cfg(target_os = "windows")]
+    let parsed = {
+        use windows_sys::Win32::Foundation::POINT;
+        use windows_sys::Win32::Graphics::Gdi::{MonitorFromPoint, MONITOR_DEFAULTTONEAREST};
+        use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+        let pt = POINT { x: parsed.x, y: parsed.y };
+        let dpi_scale: f32 = unsafe {
+            let monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+            let mut dpi_x: u32 = 0;
+            let mut dpi_y: u32 = 0;
+            let hr = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+            if hr != 0 || dpi_x == 0 {
+                1.0
+            } else {
+                dpi_x as f32 / 96.0
+            }
+        };
+        OpenFloatingPaneArgs {
+            width: (parsed.width as f32 * dpi_scale).round() as i32,
+            height: (parsed.height as f32 * dpi_scale).round() as i32,
+            ..parsed
+        }
+    };
 
     tracing::info!(
         pane_id = %parsed.pane_id,

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -314,7 +314,12 @@ unsafe extern "system" fn floating_pane_wndproc(
     use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
     use windows_sys::Win32::UI::WindowsAndMessaging::*;
 
-    const RESIZE_BORDER: i32 = 6;
+    // All zone constants are in CSS / DIP pixels and scaled to physical
+    // pixels per the HWND's DPI inside the WM_NCHITTEST branch. Hard-
+    // coded physical-pixel constants here would shrink the hit zones on
+    // HiDPI monitors — a 6-physical-px resize border is 3 CSS px at 200%
+    // DPI and effectively unreachable.
+    const RESIZE_BORDER_CSS: i32 = 6;
     const TITLEBAR_HEIGHT_CSS: i32 = 30;
     const CLOSE_BUTTON_ZONE_CSS: i32 = 36;
 
@@ -332,10 +337,19 @@ unsafe extern "system" fn floating_pane_wndproc(
             let mut rect = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
             GetWindowRect(hwnd, &mut rect);
 
-            let left = x - rect.left < RESIZE_BORDER;
-            let right = rect.right - x < RESIZE_BORDER;
-            let top = y - rect.top < RESIZE_BORDER;
-            let bottom = rect.bottom - y < RESIZE_BORDER;
+            // Scale all CSS-px zones to physical px against THIS HWND's
+            // current monitor — handles mid-life monitor changes (the
+            // window can move between monitors at different DPIs).
+            let dpi = GetDpiForWindow(hwnd) as i32;
+            let dpi = if dpi > 0 { dpi } else { 96 };
+            let resize_border_px = (RESIZE_BORDER_CSS * dpi / 96).max(1);
+            let titlebar_px = TITLEBAR_HEIGHT_CSS * dpi / 96;
+            let close_zone_px = CLOSE_BUTTON_ZONE_CSS * dpi / 96;
+
+            let left = x - rect.left < resize_border_px;
+            let right = rect.right - x < resize_border_px;
+            let top = y - rect.top < resize_border_px;
+            let bottom = rect.bottom - y < resize_border_px;
             if top && left {
                 return HTTOPLEFT as isize;
             }
@@ -362,10 +376,6 @@ unsafe extern "system" fn floating_pane_wndproc(
             }
 
             // Title bar drag zone (excluding close-button click-through).
-            let dpi = GetDpiForWindow(hwnd) as i32;
-            let dpi = if dpi > 0 { dpi } else { 96 };
-            let titlebar_px = TITLEBAR_HEIGHT_CSS * dpi / 96;
-            let close_zone_px = CLOSE_BUTTON_ZONE_CSS * dpi / 96;
             if y - rect.top < titlebar_px && rect.right - x > close_zone_px {
                 return HTCAPTION as isize;
             }

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -282,6 +282,100 @@ fn escape_query_value(s: &str) -> String {
     out
 }
 
+/// WndProc for the floating-pane class. Removes the system non-client
+/// area (no native title bar / borders drawn) and maps the frontend's
+/// 30 CSS-px title bar to `HTCAPTION` so the OS handles the drag loop
+/// natively. The close button on the right side of the title bar is
+/// excluded from the drag region so React can receive its click.
+///
+/// CSS reference (must stay in sync with `frontend/app/workspace/floating-pane-workspace.tsx`):
+///   - title-bar height: 30 CSS px
+///   - close button: 28 CSS px wide, right-anchored; allow 36 CSS px
+///     of click-through to be safe (covers padding-right + button width).
+///
+/// Edge resize zones (6 physical px) take precedence over `HTCAPTION`
+/// so the corner resize cursors still work when the cursor is in the
+/// title-bar band near a corner.
+///
+/// This mirrors the agentmux frameless-window pattern in
+/// `agentmux-cef/src/client/wndproc.rs::install_frameless_resize_hook`
+/// — extended with `HTCAPTION`. We don't reuse the main window's
+/// JS-driven `useWindowDrag` hook because that path resolves the HWND
+/// via `find_own_top_level_window` (process-wide `EnumWindows`), which
+/// returns whichever top-level window the OS enumerates first — not
+/// necessarily the calling floating pane.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn floating_pane_wndproc(
+    hwnd: *mut std::ffi::c_void,
+    msg: u32,
+    wparam: usize,
+    lparam: isize,
+) -> isize {
+    use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    const RESIZE_BORDER: i32 = 6;
+    const TITLEBAR_HEIGHT_CSS: i32 = 30;
+    const CLOSE_BUTTON_ZONE_CSS: i32 = 36;
+
+    match msg {
+        // Claim the entire window rect as client area — no system title
+        // bar / borders drawn. WS_THICKFRAME (via WS_OVERLAPPEDWINDOW)
+        // still gives us the resize border for `WM_NCHITTEST` to map.
+        WM_NCCALCSIZE if wparam == 1 => return 0,
+        // Suppress the DWM activation border repaint.
+        WM_NCACTIVATE => return 1,
+        WM_NCHITTEST => {
+            let x = (lparam & 0xFFFF) as i16 as i32;
+            let y = ((lparam >> 16) & 0xFFFF) as i16 as i32;
+
+            let mut rect = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
+            GetWindowRect(hwnd, &mut rect);
+
+            let left = x - rect.left < RESIZE_BORDER;
+            let right = rect.right - x < RESIZE_BORDER;
+            let top = y - rect.top < RESIZE_BORDER;
+            let bottom = rect.bottom - y < RESIZE_BORDER;
+            if top && left {
+                return HTTOPLEFT as isize;
+            }
+            if top && right {
+                return HTTOPRIGHT as isize;
+            }
+            if bottom && left {
+                return HTBOTTOMLEFT as isize;
+            }
+            if bottom && right {
+                return HTBOTTOMRIGHT as isize;
+            }
+            if left {
+                return HTLEFT as isize;
+            }
+            if right {
+                return HTRIGHT as isize;
+            }
+            if top {
+                return HTTOP as isize;
+            }
+            if bottom {
+                return HTBOTTOM as isize;
+            }
+
+            // Title bar drag zone (excluding close-button click-through).
+            let dpi = GetDpiForWindow(hwnd) as i32;
+            let dpi = if dpi > 0 { dpi } else { 96 };
+            let titlebar_px = TITLEBAR_HEIGHT_CSS * dpi / 96;
+            let close_zone_px = CLOSE_BUTTON_ZONE_CSS * dpi / 96;
+            if y - rect.top < titlebar_px && rect.right - x > close_zone_px {
+                return HTCAPTION as isize;
+            }
+        }
+        _ => {}
+    }
+
+    DefWindowProcW(hwnd, msg, wparam, lparam)
+}
+
 /// CreateWindowExW wrapper that produces the owned `WS_POPUP +
 /// WS_EX_TOOLWINDOW` HWND used as the floating-pane outer shell.
 ///
@@ -299,8 +393,8 @@ fn create_owned_popup(
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Foundation::HWND;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DefWindowProcW, RegisterClassExW, ShowWindow, CS_HREDRAW, CS_VREDRAW,
-        SW_SHOWNOACTIVATE, WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_OVERLAPPEDWINDOW, WS_POPUP,
+        CreateWindowExW, RegisterClassExW, ShowWindow, CS_HREDRAW, CS_VREDRAW, SW_SHOWNOACTIVATE,
+        WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_OVERLAPPEDWINDOW, WS_POPUP,
     };
 
     // ---- Register the class once per process ----
@@ -313,8 +407,9 @@ fn create_owned_popup(
     // TODO(phase-6, codex P1 on #811 — explicitly deferred): The
     // documented CEF embedding pattern is for the host's wndproc to
     // intercept WM_CLOSE and route through `CloseBrowser(false)` so
-    // DoClose fires before destroy. Phase 1 uses DefWindowProcW —
-    // the OS X-button cascade still works end-to-end:
+    // DoClose fires before destroy. Today the OS X-button cascade
+    // still works end-to-end via `floating_pane_wndproc`'s fallthrough
+    // to `DefWindowProcW(WM_CLOSE)`:
     //
     //   1. User clicks X → DefWindowProcW(WM_CLOSE) → DestroyWindow.
     //   2. Outer HWND's WM_DESTROY cascades into the CEF child HWND
@@ -325,21 +420,15 @@ fn create_owned_popup(
     //
     // What's *skipped*: the DoClose hook's chance to cancel close
     // (e.g. for a "Are you sure?" prompt). Floating panes have no
-    // such prompt, so this is harmless for Phase 1. The full custom
-    // wndproc is Phase 6 polish per spec §9. Files this needs to
-    // touch: replace `lpfnWndProc: Some(DefWindowProcW)` with a
-    // custom proc; add a `OnceLock<Arc<AppState>>` accessor (mirror
-    // `wrr::win_event::app_state`); in WM_CLOSE iterate
-    // `state.list_browsers()` and call `host.close_browser(false)`
-    // on any whose `window_handle()`'s GA_ROOT ancestor matches our
-    // outer HWND.
+    // such prompt, so this is harmless. The full WM_CLOSE → CloseBrowser
+    // routing is still future work.
     CLASS_REGISTERED.call_once(|| unsafe {
         let h_instance =
             windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(std::ptr::null());
         let wnd_class = WNDCLASSEXW {
             cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
             style: CS_HREDRAW | CS_VREDRAW,
-            lpfnWndProc: Some(DefWindowProcW),
+            lpfnWndProc: Some(floating_pane_wndproc),
             cbClsExtra: 0,
             cbWndExtra: 0,
             hInstance: h_instance,

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -228,12 +228,32 @@ async function performCrossWindowDrop(
     // The target window handles the actual move when it receives the cross-drag-end event.
 }
 
-// Default floating-pane size when we don't have a captured source rect
-// (the tearoff-pane-size spec — agenta/feat-tearoff-match-source-size —
-// will refine this to use the source pane's measured dimensions). 720×480
-// is a comfortable single-block working area without dominating the screen.
+// Fallback floating-pane size if we can't read the source pane's rect
+// (block element not in the DOM for any reason). 720×480 is a comfortable
+// single-block working area without dominating the screen.
 const DEFAULT_FLOATER_WIDTH = 720;
 const DEFAULT_FLOATER_HEIGHT = 480;
+// Defensive lower bounds — protect against degenerate (0-width/height)
+// rects yielding an unusable floater.
+const MIN_FLOATER_WIDTH = 200;
+const MIN_FLOATER_HEIGHT = 120;
+
+/// Measure the source pane's rendered size and convert to physical pixels
+/// (Win32 host expects physical px; `getBoundingClientRect` returns CSS px).
+/// Must be called BEFORE `TearOffBlock` — that mutation removes the source
+/// pane from the layout and unmounts its DOM element.
+function measureSourcePaneSize(blockId: string): { width: number; height: number } {
+    const el = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
+    if (!el) {
+        return { width: DEFAULT_FLOATER_WIDTH, height: DEFAULT_FLOATER_HEIGHT };
+    }
+    const rect = el.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    return {
+        width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width * dpr)),
+        height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height * dpr)),
+    };
+}
 
 async function performTearOff(
     dragType: "pane" | "tab",
@@ -258,6 +278,15 @@ async function performTearOff(
         //
         // Tab tear-off (branch below) is unchanged — tabs continue
         // to spawn a brand-new instance with its own taskbar entry.
+
+        // Snapshot the source pane's rendered size BEFORE TearOffBlock —
+        // that mutation removes the block from the source layout and the
+        // DOM element disappears. The floater opens at the same size as
+        // the source pane (Win32 physical px).
+        const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
+            payload.blockId,
+        );
+
         const newWsId = await WorkspaceService.TearOffBlock(
             payload.blockId,
             sourceTabId,
@@ -284,8 +313,8 @@ async function performTearOff(
                 workspace_id: newWsId,
                 x: screenX,
                 y: screenY,
-                width: DEFAULT_FLOATER_WIDTH,
-                height: DEFAULT_FLOATER_HEIGHT,
+                width: floaterWidth,
+                height: floaterHeight,
             });
             Logger.info("dnd:cross", "floating pane spawned", {
                 blockId: payload.blockId,

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -238,20 +238,27 @@ const DEFAULT_FLOATER_HEIGHT = 480;
 const MIN_FLOATER_WIDTH = 200;
 const MIN_FLOATER_HEIGHT = 120;
 
-/// Measure the source pane's rendered size and convert to physical pixels
-/// (Win32 host expects physical px; `getBoundingClientRect` returns CSS px).
-/// Must be called BEFORE `TearOffBlock` — that mutation removes the source
-/// pane from the layout and unmounts its DOM element.
+/// Measure the source pane's rendered size in CSS / DIP pixels.
+/// `getBoundingClientRect` returns CSS px regardless of DPR; we deliberately
+/// do NOT multiply by `window.devicePixelRatio` here because that's the
+/// SOURCE monitor's scale, and the floater may spawn on a DIFFERENT
+/// monitor (different DPI). Cross-monitor scaling MUST happen on the host
+/// using `GetDpiForMonitor(MonitorFromPoint(x, y))` against the destination
+/// — see `agentmux-cef/src/commands/floating_pane.rs` and the matching
+/// pattern in `agentmux-cef/src/commands/window_pool.rs:684-701` (tab
+/// tear-off).
+///
+/// Must be called BEFORE `TearOffBlock` — that mutation removes the
+/// source pane from the layout and unmounts its DOM element.
 function measureSourcePaneSize(blockId: string): { width: number; height: number } {
     const el = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
     if (!el) {
         return { width: DEFAULT_FLOATER_WIDTH, height: DEFAULT_FLOATER_HEIGHT };
     }
     const rect = el.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
     return {
-        width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width * dpr)),
-        height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height * dpr)),
+        width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width)),
+        height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height)),
     };
 }
 

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -52,11 +52,13 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
     return (
         <div class="flex flex-col w-full flex-grow overflow-hidden">
             {/* Slim title bar.
-                `-webkit-app-region: drag` lets the OS move the floater when
-                the user drags any non-button area. On Windows the agentmux
-                NCHITTEST shim returns HTCAPTION here, so the standard Win32
-                drag loop kicks in (cross-monitor, cross-DPI safe). Buttons
-                opt out via `-webkit-app-region: no-drag`. */}
+                Drag is handled by the host's `floating_pane_wndproc`
+                (agentmux-cef/src/floating_pane.rs): it returns HTCAPTION
+                for the top 30 CSS px (excluding the right 36 CSS px so the
+                close button click passes through). The OS handles the drag
+                loop natively — cross-monitor, cross-DPI safe. The CSS
+                `-webkit-app-region` properties below are kept for
+                documentation/electron-compat, but are no-ops in CEF. */}
             <div
                 class="floating-pane-titlebar"
                 style={{


### PR DESCRIPTION
> **Stacked on top of #1081** (the dev Vite-port URL fix). When that merges, this PR's base will auto-rebase to `main` and the diff will collapse to just these changes.

## Summary

Two Phase-6 polish items for the floating-pane tear-off (issue #1079 / spec `SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`):

1. **Native title-bar drag** — the floating pane's outer HWND uses a custom WndProc that returns `HTCAPTION` over the top 30 CSS px (excluding the close button's 36 CSS px zone on the right). The OS handles the drag loop natively — cross-monitor and cross-DPI safe.
2. **Size matches source pane** — at tear-off time the frontend measures the source pane's `getBoundingClientRect`, multiplies by `devicePixelRatio` for Win32 physical-px conversion, and passes that to `open_floating_pane_window`. Defensive min clamps (200×120) + fallback to the prior 720×480 if the DOM element isn't found.

## Host details (`floating_pane.rs`)

`floating_pane_wndproc` mirrors the existing `install_frameless_resize_hook` pattern in `agentmux-cef/src/client/wndproc.rs` and adds:

- `WM_NCCALCSIZE → 0` — claims the entire window rect as client area so the system title bar isn't drawn. Without this, the user sees doubled-up chrome (system title bar above the frontend's custom 30 px header).
- `WM_NCACTIVATE → 1` — suppresses the DWM activation border repaint.
- `WM_NCHITTEST` — 6 px edge resize zones, then `HTCAPTION` for the top 30 CSS px excluding the rightmost 36 CSS px (where the close button sits). All measurements DPI-scaled via `GetDpiForWindow`.

## Why not reuse `useWindowDrag` (the main window's hook)?

The main window's drag is JS-driven (`useWindowDrag.win32.ts` → `get_window_position` / `set_window_position` via IPC). The Phase 1 spec for floating panes referenced this as the pattern to mirror, but it has a latent multi-window bug: both backend handlers resolve the HWND via `find_own_top_level_window`, which does a process-wide `EnumWindows` and returns whichever top-level window the OS enumerates first — **not** the calling floating pane. The native WM_NCHITTEST path is self-contained, faster (no IPC roundtrip per mousemove), and side-steps that bug for the floating-pane case.

## Frontend details (`CrossWindowDragMonitor.win32.tsx`)

`measureSourcePaneSize(blockId)`:
1. Find source pane via `[data-blockid=…]` (the standard pane identifier from `blockframe.tsx:755`).
2. Read `getBoundingClientRect()` — CSS px.
3. Multiply by `window.devicePixelRatio` to match Win32's physical-px expectation.
4. Min-clamp to (200, 120) defensively.
5. Fall back to (720, 480) only if the element isn't found.

Must be called **before** `TearOffBlock` — that mutation removes the block from the source layout and the DOM element unmounts.

## Test plan

- [x] `cargo check -p agentmux-cef` — clean
- [x] Frontend TS check — no new errors on either touched file
- [ ] `task dev` → tear off a pane → floating window:
  - Has no system title bar above the custom header
  - Drags by clicking + dragging the custom header
  - Close button still works (click passes through, not interpreted as drag)
  - Opens at roughly the same dimensions as the source pane (not 720×480)
  - Resize at edges works (6 px corner zones)

## Out of scope

- macOS NSPanel + Linux X11 GTK primitives (still tracked in #1079)
- WM_CLOSE → `CloseBrowser(false)` routing (noted in the inline TODO; default cascade still works)
- The `[on_before_close] no backend window ID registered for label=…floating… — shells may orphan` warning (separate reducer-plumbing gap)