### PR TITLE
fix(agent-pane): drop TurnStart auto-collapse — causes Solid replaceChild crash

### DIFF
--- a/.changesets/1779851568-fix-agent-pane-drop-turnstart-auto-collapse-causes-solid-rep-liyu.md
+++ b/.changesets/1779851568-fix-agent-pane-drop-turnstart-auto-collapse-causes-solid-rep-liyu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): drop TurnStart auto-collapse (causes Solid replaceChild crash)

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -2114,15 +2114,19 @@ describe("agent-pane-state reducer", () => {
             expect(s.composerUnreadCount).toBe(1);
         });
 
-        it("TurnStart auto-collapses an open details panel", () => {
-            // Cross-arm interaction: sending a message hides the panel
-            // so the user isn't dropdown-staring as the turn begins.
+        it("TurnStart preserves details-panel state (cascade hotfix 2026-05-27)", () => {
+            // The TurnStart auto-collapse was removed because writing
+            // to detailsOpen co-occurred with the first StreamFlush
+            // and triggered a Solid replaceChild reconcile crash —
+            // see reducer.ts TurnStart arm + analysis in
+            // docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md.
+            // detailsOpen stays whatever the user last set it to.
             let s = ready(100);
             s = update(s, { type: "DetailsExpand" }).state;
             expect(s.detailsOpen).toBe(true);
             const r = update(s, { type: "TurnStart", at: 200 });
-            expect(r.state.detailsOpen).toBe(false);
-            // And the turn still actually started — no side-effects
+            expect(r.state.detailsOpen).toBe(true);
+            // The turn still actually started — no side-effects
             // on the existing TurnStart contract.
             expect(r.state.turnPhase.kind).toBe("Submitting");
         });

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -351,12 +351,24 @@ export function update(
                         submittedAt: command.at,
                         pendingContent: "",
                     },
-                    // Auto-collapse the composer details panel on send:
-                    // the user pressed Enter, they don't want to be
-                    // looking at a dropdown over the textarea while the
-                    // turn starts.
-                    // SPEC_AGENT_COMPOSER_SLIM_STATUS_2026_05_26.md §5.4.
-                    detailsOpen: false,
+                    // NOTE: the spec calls for auto-collapsing the
+                    // composer details panel here on send. Live
+                    // testing 2026-05-27 found that this write
+                    // co-occurs with the first `StreamFlush` against
+                    // agent-document-store and triggers a Solid
+                    // replaceChild reconcile crash via the cascade-
+                    // disposal path documented in
+                    // `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md`
+                    // (signature: `data-index={index}` virt-row warning
+                    // immediately preceding `NotFoundError: Failed to
+                    // execute 'replaceChild'` and a CASCADE_DETECTED on
+                    // `StreamFlush`). Auto-collapse will return after
+                    // the cascade root cause is fixed structurally;
+                    // until then, the user clicks ▴ to close the
+                    // panel themselves. Minor UX hit; the crash is
+                    // a hard blocker. Spec
+                    // SPEC_AGENT_COMPOSER_SLIM_STATUS_2026_05_26.md
+                    // §5.4 will get a follow-up note.
                 },
                 events,
             };


### PR DESCRIPTION
User-reproducible crash in v0.38.16: send any message → agent pane crashes with `NotFoundError: Failed to execute 'replaceChild' on 'Node'`. 100% reproducible across sessions, persists after pane reload.

## Root cause

PR #1068 added a `detailsOpen: false` write to the `TurnStart` reducer arm (auto-collapse on send-message, per spec §5.4). That write fires at the same tick as the first `StreamFlush` against agent-document-store. The flip causes `<Show when={detailsOpenAtom()}>` to unmount `AgentControlBar` + `ActivityLogPanel`, triggering the documented cascade-disposal:

```
CASCADE_DETECTED: slot disposed mid-dispatch
  cmd=StreamFlush, blockId=...
  "A documentAtom subscriber unmounted the pane during this dispatch"
```

Solid then reconciles against a disposed pane → `replaceChild` error.

See `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md` for the bug class.

## Fix

Drop the `detailsOpen: false` write from `TurnStart`. The reducer arm leaves `detailsOpen` alone; users click ▴ themselves.

Small UX cost (panel stays open during turn); crash beats UX every time.

Future structural work (deferred): identify the specific documentAtom subscriber that disposes synchronously and route it through `dispatchIfRegistered`. Auto-collapse returns once cascade root is fixed.

## Tests

Updated reducer test to assert detailsOpen is PRESERVED (not flipped) by TurnStart. Suite: 137/137 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)