### PR TITLE
feat(editor): per-pane zoom + decouple icon-as-toggle from header dblclick

### DIFF
--- a/.changesets/1779853498-feat-editor-per-pane-zoom-decouple-icon-as-toggle-from-heade-wu8f.md
+++ b/.changesets/1779853498-feat-editor-per-pane-zoom-decouple-icon-as-toggle-from-heade-wu8f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): per-pane zoom + decouple icon-as-toggle from header dblclick

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -159,7 +159,14 @@ function getViewIconElem(viewIconUnion: string | IconButtonDecl, blockData: Bloc
         const viewIcon = viewIconUnion as string;
         return <div class="block-frame-view-icon">{getBlockHeaderIcon(viewIcon, blockData)}</div>;
     } else {
-        return <IconButton decl={viewIconUnion} className="block-frame-view-icon" />;
+        // Swallow dblclick so fast clicking on a clickable view icon (e.g.
+        // the editor's tree-toggle) doesn't bubble up to the header's
+        // toggleMagnify handler.
+        return (
+            <span onDblClick={(e) => e.stopPropagation()}>
+                <IconButton decl={viewIconUnion} className="block-frame-view-icon" />
+            </span>
+        );
     }
 }
 

--- a/frontend/app/store/zoom.darwin.ts
+++ b/frontend/app/store/zoom.darwin.ts
@@ -60,7 +60,7 @@ function getBlockZoom(blockId: string): number | null {
     const bcm = getBlockComponentModel(blockId);
     if (!bcm?.viewModel) return null;
     const vt = bcm.viewModel.viewType;
-    if (vt !== "term" && vt !== "agent" && vt !== "swarm") return null;
+    if (vt !== "term" && vt !== "agent" && vt !== "swarm" && vt !== "editor") return null;
 
     const blockOref = WOS.makeORef("block", blockId);
     const blockData = WOS.getObjectValue<Block>(blockOref);

--- a/frontend/app/store/zoom.linux.ts
+++ b/frontend/app/store/zoom.linux.ts
@@ -58,7 +58,7 @@ function getBlockZoom(blockId: string): number | null {
     const bcm = getBlockComponentModel(blockId);
     if (!bcm?.viewModel) return null;
     const vt = bcm.viewModel.viewType;
-    if (vt !== "term" && vt !== "agent" && vt !== "swarm") return null;
+    if (vt !== "term" && vt !== "agent" && vt !== "swarm" && vt !== "editor") return null;
 
     const blockOref = WOS.makeORef("block", blockId);
     const blockData = WOS.getObjectValue<Block>(blockOref);

--- a/frontend/app/store/zoom.win32.ts
+++ b/frontend/app/store/zoom.win32.ts
@@ -59,7 +59,7 @@ function getBlockZoom(blockId: string): number | null {
     const bcm = getBlockComponentModel(blockId);
     if (!bcm?.viewModel) return null;
     const vt = bcm.viewModel.viewType;
-    if (vt !== "term" && vt !== "agent" && vt !== "swarm") return null;
+    if (vt !== "term" && vt !== "agent" && vt !== "swarm" && vt !== "editor") return null;
 
     const blockOref = WOS.makeORef("block", blockId);
     const blockData = WOS.getObjectValue<Block>(blockOref);

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -9,6 +9,7 @@
 // SPEC_EDITOR_FILE_TREE_2026-05-26.md.
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import { useBlockAtom } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
@@ -75,11 +76,32 @@ export class EditorViewModel implements ViewModel {
 
     blockAtom: Accessor<Block | undefined>;
 
+    /** Per-pane zoom factor (1.0 default; clamped 0.5–2.0 by zoom store).
+     *  Backed by `term:zoom` in block meta — the same key terminals and
+     *  agents use, so the universal zoom system (Ctrl+wheel, keyboard
+     *  shortcuts, indicator overlay) Just Works. */
+    zoomAtom!: Accessor<number>;
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
 
         this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
+
+        // Derive zoom from block meta. The zoom store reads/writes `term:zoom`
+        // via SetMetaCommand; this accessor re-renders the view's CSS var
+        // whenever it changes so CodeMirror + the tree resize live.
+        //
+        // Wrapped in `useBlockAtom` (which calls createRoot under the hood) —
+        // a bare createMemo in the constructor wouldn't have a tracking owner,
+        // so it'd read once and never re-evaluate when block meta updates.
+        this.zoomAtom = useBlockAtom(blockId, "editor-zoom", () =>
+            createMemo<number>(() => {
+                const z = this.blockAtom()?.meta?.["term:zoom"];
+                if (typeof z !== "number" || isNaN(z)) return 1.0;
+                return Math.max(0.5, Math.min(2.0, z));
+            }),
+        );
 
         // Pane title — full file path (or "Editor" when nothing open). Marked
         // with a trailing `*` when there are unsaved changes. Showing the

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -80,7 +80,9 @@
     flex-direction: column;
     flex: 1;
     min-height: 0;
-    font-size: 12px;
+    // Tree text follows the per-pane zoom factor (set on .editor-view as
+    // --editor-zoom by editor-view.tsx). Toolbar chrome below is NOT zoomed.
+    font-size: calc(12px * var(--editor-zoom, 1));
     color: var(--main-text-color);
 }
 
@@ -322,7 +324,10 @@
 
     .cm-scroller {
         font-family: var(--termfontfamily, "JetBrains Mono", monospace);
-        font-size: 13px;
+        // CodeMirror text follows the per-pane zoom factor — same source
+        // (--editor-zoom on .editor-view) the file tree uses, so both
+        // resize together.
+        font-size: calc(13px * var(--editor-zoom, 1));
     }
 }
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -70,8 +70,33 @@ async function loadLanguage(lang: string): Promise<Extension | null> {
 export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>): JSX.Element {
     const model = props.model;
     let containerRef: HTMLDivElement | undefined;
+    let rootRef: HTMLDivElement | undefined;
     let cmView: EditorView | null = null;
     const [fileInput, setFileInput] = createSignal("");
+
+    // Ctrl+Wheel zoom — plugs into the universal zoom system (term:zoom on
+    // block meta, same path used by terminal/agent/swarm). Capture phase so
+    // we intercept before CodeMirror's bubble-phase wheel; preventDefault
+    // suppresses CEF's native Ctrl+Scroll page zoom. The view's CSS var
+    // `--editor-zoom` (bound below) drives both the CodeMirror font-size
+    // and the file-tree font-size, so both resize in lockstep.
+    onMount(() => {
+        if (!rootRef) return;
+        const handleCtrlWheel = (ev: WheelEvent) => {
+            if (!ev.ctrlKey) return;
+            ev.preventDefault();
+            ev.stopPropagation();
+            const STEP = 0.1;
+            const current = model.zoomAtom();
+            const next = Math.max(0.5, Math.min(2.0, Math.round((current + (ev.deltaY > 0 ? -STEP : STEP)) * 100) / 100));
+            void RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: `block:${model.blockId}`,
+                meta: { "term:zoom": next === 1.0 ? null : next },
+            });
+        };
+        rootRef.addEventListener("wheel", handleCtrlWheel, { passive: false, capture: true });
+        onCleanup(() => rootRef?.removeEventListener("wheel", handleCtrlWheel, { capture: true }));
+    });
 
     // ── LSP integration (Phase 1 — diagnostics for TS/JS) ────────────
     // One LspClient per (pane, file) — replaced when the file changes
@@ -390,8 +415,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
     return (
         <div
+            ref={(el) => { rootRef = el; }}
             class="editor-view"
             classList={{ "editor-view--tree-collapsed": !model.treeExpandedAtom() }}
+            style={{ "--editor-zoom": String(model.zoomAtom()) }}
         >
             <Show when={model.treeExpandedAtom()}>
                 <div


### PR DESCRIPTION
## Summary

Two small UX wins for the editor pane, shipped together.

### 1. Pane-icon double-click no longer maximizes the pane

The editor pane icon is wired as the file-tree expand/collapse toggle (PR #1071). The pane header itself listens for `onDblClick → toggleMagnify`, so fast double-clicks on the toggle were propagating up and maximizing the pane in addition to toggling — annoying when you're rapidly opening/closing the tree.

Wrapped the iconbutton variant of `getViewIconElem` in a `<span onDblClick={e => e.stopPropagation()}>`. The text-rendered variant (panes that don't use the icon as a clickable toggle) is unchanged, so non-toggle panes still maximize on header double-click. End icons already had this guard.

### 2. Editor pane plugs into the universal per-pane zoom system

Ctrl+Wheel over an editor pane now resizes the CodeMirror text and the file-tree text together. Same `term:zoom` block meta the terminal, agent, and swarm panes use, so the existing keyboard shortcuts (Ctrl+= / Ctrl+- / Ctrl+0) and the zoom indicator overlay work automatically.

- Extended `getBlockZoom` in `zoom.{win32,linux,darwin}.ts` to accept `editor` viewType.
- Added `zoomAtom` to `EditorViewModel`, wrapped in `useBlockAtom` (which uses `createRoot` under the hood). A bare `createMemo` in the constructor wouldn't have a tracking owner and would snapshot once instead of subscribing to meta updates — that was the original bug.
- Wheel listener on the editor root in capture phase; `SetMetaCommand` persists `term:zoom` (clamped 0.5–2.0).
- SCSS reads `--editor-zoom` on `.editor-view` to scale `.cm-scroller` (13px base) and `.file-tree` (12px base). Chrome (toolbar buttons, banners, status chip) is intentionally **not** zoomed.

Spec: [`specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md`](https://github.com/agentmuxai/agentmux/blob/main/specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md) (icon-as-toggle pattern).

## Test plan

- [ ] Editor pane: double-click the folder icon → tree toggles, pane does **not** maximize.
- [ ] Header double-click on title text → pane still maximizes (regression check on non-icon panes).
- [ ] Ctrl+Wheel over the editor → CodeMirror text + file-tree text grow/shrink together; clamps at 0.5x and 2.0x.
- [ ] Ctrl+= / Ctrl+- with editor focused → keyboard zoom works.
- [ ] Ctrl+0 → resets to 1.0x; `term:zoom` is cleared from block meta.
- [ ] Zoom indicator overlay appears with current percentage on keyboard zoom.
- [ ] Toolbar buttons, install banner, status chip do **not** scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)