### PR TITLE
feat(editor): slice #10 editor-pane-state — Phase 1A scaffolding

### DIFF
--- a/.changesets/1779854764-feat-editor-slice-10-editor-pane-state-phase-1a-scaffolding-6ezb.md
+++ b/.changesets/1779854764-feat-editor-slice-10-editor-pane-state-phase-1a-scaffolding-6ezb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): slice #10 editor-pane-state — Phase 1A scaffolding

--- a/frontend/app/store/editor-pane-state-store.test.ts
+++ b/frontend/app/store/editor-pane-state-store.test.ts
@@ -1,0 +1,525 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for slice #10 editor-pane-state (Phase 1A).
+ *
+ * Pure reducer / slot store tests — no DOM, no CEF context, no view
+ * wiring. The 17 numbered behaviours from the Phase 1A spec each map
+ * to at least one `it(...)` below; the suite name calls out which
+ * invariant the test pins. Invariant 16 (active id always points at
+ * a tab or is null) is checked by `assertActiveInvariant` at the end
+ * of every test that touches the tab list.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+    canonicalizePath,
+    dispatch,
+    dispatchIfRegistered,
+    type EditorPaneEvent,
+    type EditorPaneState,
+    MAX_RECENTLY_CLOSED,
+    registerEditorPane,
+    resetAllSlots,
+    setEventSink,
+    snapshot,
+    unregisterEditorPane,
+    update,
+    initialState,
+} from "./editor-pane-state-store";
+
+function assertActiveInvariant(state: EditorPaneState): void {
+    if (state.tabs.length === 0) {
+        expect(state.activeTabId).toBeNull();
+        return;
+    }
+    expect(state.activeTabId).not.toBeNull();
+    expect(state.tabs.find((t) => t.id === state.activeTabId)).toBeTruthy();
+}
+
+function eventTypes(events: EditorPaneEvent[]): string[] {
+    return events.map((e) => e.type);
+}
+
+describe("editor-pane-state-store (slice #10, Phase 1A)", () => {
+    afterEach(() => {
+        resetAllSlots();
+    });
+
+    // ─── slot lifecycle ──────────────────────────────────────────────
+
+    it("dispatch on unregistered blockId throws (no silent drops)", () => {
+        expect(() =>
+            dispatch("nope", { type: "OpenFile", path: "C:/x.ts" }),
+        ).toThrowError(/unregistered pane/);
+    });
+
+    it("dispatchIfRegistered on unregistered blockId returns [] silently", () => {
+        const events = dispatchIfRegistered("ghost", {
+            type: "OpenFile",
+            path: "C:/x.ts",
+        });
+        expect(events).toEqual([]);
+    });
+
+    it("registerEditorPane is idempotent — re-registering keeps state", () => {
+        registerEditorPane("blk-1");
+        dispatch("blk-1", { type: "OpenFile", path: "C:/x.ts" });
+        registerEditorPane("blk-1"); // no-op
+        expect(snapshot("blk-1")?.tabs.length).toBe(1);
+    });
+
+    it("unregisterEditorPane removes the slot", () => {
+        registerEditorPane("blk-1");
+        unregisterEditorPane("blk-1");
+        expect(snapshot("blk-1")).toBeNull();
+        expect(() =>
+            dispatch("blk-1", { type: "OpenFile", path: "C:/x.ts" }),
+        ).toThrowError(/unregistered pane/);
+    });
+
+    it("multi-pane: dispatches don't cross blockIds", () => {
+        registerEditorPane("blk-a");
+        registerEditorPane("blk-b");
+        dispatch("blk-a", { type: "OpenFile", path: "C:/a.ts" });
+        dispatch("blk-b", { type: "OpenFile", path: "C:/b.ts" });
+        expect(snapshot("blk-a")?.tabs[0].filePath).toBe("c:/a.ts");
+        expect(snapshot("blk-b")?.tabs[0].filePath).toBe("c:/b.ts");
+    });
+
+    it("emits events through the configured sink (whole batch)", () => {
+        const sink = vi.fn<(events: EditorPaneEvent[]) => void>();
+        setEventSink(sink);
+        registerEditorPane("blk-1");
+        dispatch("blk-1", { type: "OpenFile", path: "C:/x.ts" });
+        expect(sink).toHaveBeenCalledTimes(1);
+        const batch = sink.mock.calls[0][0];
+        expect(batch[0].type).toBe("TabOpened");
+    });
+
+    it("snapshot returns null for unknown blockId", () => {
+        expect(snapshot("nope")).toBeNull();
+    });
+
+    // ─── invariant 1: OpenFile with new path → appends + activates ───
+
+    it("OpenFile (new path) appends a tab and activates it", () => {
+        const s0 = initialState();
+        const { state, events } = update(s0, {
+            type: "OpenFile",
+            path: "C:/repo/index.ts",
+        });
+        expect(state.tabs.length).toBe(1);
+        expect(state.tabs[0].filePath).toBe("c:/repo/index.ts");
+        expect(state.activeTabId).toBe(state.tabs[0].id);
+        expect(events.length).toBe(1);
+        expect(events[0].type).toBe("TabOpened");
+        if (events[0].type === "TabOpened") {
+            expect(events[0].atIndex).toBe(0);
+            expect(events[0].filePath).toBe("c:/repo/index.ts");
+        }
+        assertActiveInvariant(state);
+    });
+
+    // ─── invariant 2: OpenFile (existing, canonicalized) → activate ──
+
+    it("OpenFile (existing path, mixed slashes) activates existing tab, no append", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/repo/a.ts" }).state;
+        const firstId = s.tabs[0].id;
+        // switch to something else first so we observe TabActivated
+        s = update(s, { type: "OpenFile", path: "C:/repo/b.ts" }).state;
+        expect(s.tabs.length).toBe(2);
+        expect(s.activeTabId).toBe(s.tabs[1].id);
+
+        const r = update(s, { type: "OpenFile", path: "C:\\repo\\a.ts" });
+        expect(r.state.tabs.length).toBe(2); // not appended
+        expect(r.state.activeTabId).toBe(firstId);
+        expect(eventTypes(r.events)).toEqual(["TabActivated"]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 3: CloseTab clean → drops + neighbour-activate ────
+
+    it("CloseTab on clean tab drops it, activates right-neighbour, records recentlyClosed", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/c.ts" }).state;
+        const [a, b, c] = s.tabs;
+        // activate the middle tab so its closure picks a right
+        // neighbour rather than the trivial last-tab case.
+        s = update(s, { type: "SwitchTab", tabId: b.id }).state;
+
+        const r = update(s, { type: "CloseTab", tabId: b.id });
+        expect(r.state.tabs.map((t) => t.id)).toEqual([a.id, c.id]);
+        expect(r.state.activeTabId).toBe(c.id);
+        expect(r.state.recentlyClosed.map((e) => e.filePath)).toEqual([
+            "c:/b.ts",
+        ]);
+        expect(eventTypes(r.events)).toEqual(["TabClosed", "TabActivated"]);
+        assertActiveInvariant(r.state);
+    });
+
+    it("CloseTab on rightmost active tab falls back to left neighbour", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        const [a, b] = s.tabs;
+        expect(s.activeTabId).toBe(b.id);
+        const r = update(s, { type: "CloseTab", tabId: b.id });
+        expect(r.state.activeTabId).toBe(a.id);
+        assertActiveInvariant(r.state);
+    });
+
+    it("CloseTab on inactive tab does not change activeTabId", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        const [a, b] = s.tabs;
+        // active is b; close a (inactive)
+        const r = update(s, { type: "CloseTab", tabId: a.id });
+        expect(r.state.activeTabId).toBe(b.id);
+        // no TabActivated since the active tab didn't move
+        expect(eventTypes(r.events)).toEqual(["TabClosed"]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 4: CloseTab dirty + !force → confirm event ────────
+
+    it("CloseTab on dirty tab without force returns RequestDirtyConfirm, no state change", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        s = update(s, { type: "MarkDirty", tabId: a.id }).state;
+        const before = s;
+        const closeCmd = { type: "CloseTab" as const, tabId: a.id, force: false };
+        const r = update(s, closeCmd);
+        expect(r.state).toBe(before);
+        expect(r.events.length).toBe(1);
+        expect(r.events[0].type).toBe("RequestDirtyConfirm");
+        if (r.events[0].type === "RequestDirtyConfirm") {
+            expect(r.events[0].tabId).toBe(a.id);
+            expect(r.events[0].originalCommand).toEqual(closeCmd);
+        }
+    });
+
+    // ─── invariant 5: CloseTab dirty + force → drops same as clean ───
+
+    it("CloseTab on dirty tab WITH force drops the tab", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        s = update(s, { type: "MarkDirty", tabId: a.id }).state;
+        const r = update(s, { type: "CloseTab", tabId: a.id, force: true });
+        expect(r.state.tabs).toEqual([]);
+        expect(r.state.activeTabId).toBeNull();
+        expect(eventTypes(r.events)).toEqual(["TabClosed"]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 6: CloseTab on only tab → null active, empty list ─
+
+    it("CloseTab on the only tab leaves the pane empty and active null", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        const r = update(s, { type: "CloseTab", tabId: a.id });
+        expect(r.state.tabs).toEqual([]);
+        expect(r.state.activeTabId).toBeNull();
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 7: SwitchTab → unknown id → no-op ─────────────────
+
+    it("SwitchTab to a non-existent tab id is a no-op, no events", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const before = s;
+        const r = update(s, { type: "SwitchTab", tabId: "no-such-tab" });
+        expect(r.state).toBe(before);
+        expect(r.events).toEqual([]);
+        assertActiveInvariant(r.state);
+    });
+
+    it("SwitchTab to already-active id is a no-op", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        const r = update(s, { type: "SwitchTab", tabId: a.id });
+        expect(r.events).toEqual([]);
+    });
+
+    it("SwitchTab to a different existing tab updates activeTabId + emits TabActivated", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        const [a, b] = s.tabs;
+        expect(s.activeTabId).toBe(b.id);
+        const r = update(s, { type: "SwitchTab", tabId: a.id });
+        expect(r.state.activeTabId).toBe(a.id);
+        expect(eventTypes(r.events)).toEqual(["TabActivated"]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 8: ReorderTab clamps toIndex ──────────────────────
+
+    it("ReorderTab clamps toIndex to [0, tabs.length - 1]", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/c.ts" }).state;
+        const [a, b, c] = s.tabs;
+
+        // negative clamps to 0 — moves a (idx 0) to 0 → no change
+        let r = update(s, { type: "ReorderTab", tabId: a.id, toIndex: -5 });
+        expect(r.state.tabs.map((t) => t.id)).toEqual([a.id, b.id, c.id]);
+
+        // beyond last clamps to last (2) — moves a to the end
+        r = update(s, { type: "ReorderTab", tabId: a.id, toIndex: 99 });
+        expect(r.state.tabs.map((t) => t.id)).toEqual([b.id, c.id, a.id]);
+
+        // mid-list move
+        r = update(s, { type: "ReorderTab", tabId: c.id, toIndex: 0 });
+        expect(r.state.tabs.map((t) => t.id)).toEqual([c.id, a.id, b.id]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 9: MarkDirty / ClearDirty emit only on transitions ─
+
+    it("MarkDirty flips flag and emits TabDirtied, second call is a no-op", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        let r = update(s, { type: "MarkDirty", tabId: a.id });
+        expect(r.state.tabs[0].dirty).toBe(true);
+        expect(eventTypes(r.events)).toEqual(["TabDirtied"]);
+        const r2 = update(r.state, { type: "MarkDirty", tabId: a.id });
+        expect(r2.events).toEqual([]);
+        expect(r2.state).toBe(r.state);
+    });
+
+    it("ClearDirty flips flag and emits TabSaved, second call is a no-op", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        s = update(s, { type: "MarkDirty", tabId: a.id }).state;
+        let r = update(s, { type: "ClearDirty", tabId: a.id });
+        expect(r.state.tabs[0].dirty).toBe(false);
+        expect(eventTypes(r.events)).toEqual(["TabSaved"]);
+        // ClearDirty on already-clean tab → no event
+        const r2 = update(r.state, { type: "ClearDirty", tabId: a.id });
+        expect(r2.events).toEqual([]);
+    });
+
+    // ─── invariant 10: TabContentLoaded sets loaded + hash, clears err ─
+
+    it("TabContentLoaded sets contentLoaded, contentHash, clears loadError", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        // seed a prior error so we can observe the clear
+        s = update(s, {
+            type: "TabContentLoadFailed",
+            tabId: a.id,
+            error: "boom",
+        }).state;
+        expect(s.tabs[0].loadError).toBe("boom");
+        const r = update(s, {
+            type: "TabContentLoaded",
+            tabId: a.id,
+            contentHash: "abc123",
+        });
+        expect(r.state.tabs[0].contentLoaded).toBe(true);
+        expect(r.state.tabs[0].contentHash).toBe("abc123");
+        expect(r.state.tabs[0].loadError).toBeNull();
+    });
+
+    // ─── invariant 11: TabContentLoadFailed sets error, keeps !loaded ─
+
+    it("TabContentLoadFailed sets loadError and keeps contentLoaded false", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const [a] = s.tabs;
+        const r = update(s, {
+            type: "TabContentLoadFailed",
+            tabId: a.id,
+            error: "ENOENT",
+        });
+        expect(r.state.tabs[0].loadError).toBe("ENOENT");
+        expect(r.state.tabs[0].contentLoaded).toBe(false);
+    });
+
+    // ─── invariant 12: ReopenLastClosed on empty stack → no-op ──────
+
+    it("ReopenLastClosed on empty stack is a no-op", () => {
+        const s = initialState();
+        const r = update(s, { type: "ReopenLastClosed" });
+        expect(r.state).toBe(s);
+        expect(r.events).toEqual([]);
+    });
+
+    // ─── invariant 13: ReopenLastClosed pops + dispatches OpenFile ───
+
+    it("ReopenLastClosed pops the stack and re-opens the file", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        const [a, b] = s.tabs;
+        s = update(s, { type: "CloseTab", tabId: a.id }).state;
+        // a is in recentlyClosed; b is the active sole tab
+        expect(s.recentlyClosed.map((e) => e.filePath)).toEqual(["c:/a.ts"]);
+
+        const r = update(s, { type: "ReopenLastClosed" });
+        // a is re-opened (new tab id, same path), b stays
+        expect(r.state.tabs.length).toBe(2);
+        expect(r.state.tabs.map((t) => t.filePath).sort()).toEqual([
+            "c:/a.ts",
+            "c:/b.ts",
+        ]);
+        expect(r.state.recentlyClosed).toEqual([]);
+        expect(eventTypes(r.events)).toEqual(["TabOpened"]);
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 14: HydrateFromMeta bulk-restores ────────────────
+
+    it("HydrateFromMeta bulk-restores tabs + activeTabId, all contentLoaded=false, emits TabsRestored", () => {
+        const s = initialState();
+        const r = update(s, {
+            type: "HydrateFromMeta",
+            tabs: [
+                { id: "t-1", filePath: "C:/repo/x.ts" },
+                { id: "t-2", filePath: "C:/repo/y.ts" },
+            ],
+            activeTabId: "t-2",
+        });
+        expect(r.state.tabs.length).toBe(2);
+        expect(r.state.tabs.every((t) => !t.contentLoaded)).toBe(true);
+        expect(r.state.activeTabId).toBe("t-2");
+        expect(r.state.tabs[0].filePath).toBe("c:/repo/x.ts"); // canonicalized
+        expect(eventTypes(r.events)).toEqual(["TabsRestored"]);
+        if (r.events[0].type === "TabsRestored") {
+            expect(r.events[0].fromDefaults).toBe(false);
+            expect(r.events[0].tabIds).toEqual(["t-1", "t-2"]);
+        }
+        assertActiveInvariant(r.state);
+    });
+
+    it("HydrateFromDefaults emits TabsRestored with fromDefaults=true", () => {
+        const s = initialState();
+        const r = update(s, {
+            type: "HydrateFromDefaults",
+            tabs: [{ id: "t-1", filePath: "C:/x.ts" }],
+            activeTabId: "t-1",
+        });
+        if (r.events[0].type === "TabsRestored") {
+            expect(r.events[0].fromDefaults).toBe(true);
+        }
+    });
+
+    it("HydrateFromMeta with stale activeTabId falls back to first tab", () => {
+        const r = update(initialState(), {
+            type: "HydrateFromMeta",
+            tabs: [{ id: "t-1", filePath: "C:/a.ts" }],
+            activeTabId: "does-not-exist",
+        });
+        expect(r.state.activeTabId).toBe("t-1");
+        assertActiveInvariant(r.state);
+    });
+
+    it("HydrateFromMeta with empty tabs → empty pane, active null", () => {
+        const r = update(initialState(), {
+            type: "HydrateFromMeta",
+            tabs: [],
+            activeTabId: null,
+        });
+        expect(r.state.tabs).toEqual([]);
+        expect(r.state.activeTabId).toBeNull();
+        assertActiveInvariant(r.state);
+    });
+
+    // ─── invariant 15: recentlyClosed capped at MAX_RECENTLY_CLOSED ──
+
+    it("recentlyClosed capped at 10 — oldest evicted on overflow", () => {
+        let s = initialState();
+        // open + close 12 distinct tabs in sequence
+        for (let i = 0; i < 12; i++) {
+            s = update(s, { type: "OpenFile", path: `C:/file-${i}.ts` }).state;
+            const id = s.tabs[s.tabs.length - 1].id;
+            s = update(s, { type: "CloseTab", tabId: id }).state;
+        }
+        expect(s.recentlyClosed.length).toBe(MAX_RECENTLY_CLOSED);
+        // the two oldest entries (file-0, file-1) were evicted
+        const paths = s.recentlyClosed.map((e) => e.filePath);
+        expect(paths[0]).toBe("c:/file-2.ts");
+        expect(paths[paths.length - 1]).toBe("c:/file-11.ts");
+    });
+
+    // ─── invariant 17: tab ids are unique within a pane ─────────────
+
+    it("Tab ids are unique within a pane (no dup-by-path)", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/b.ts" }).state;
+        s = update(s, { type: "OpenFile", path: "C:/c.ts" }).state;
+        // open an existing path — must NOT mint a new id
+        s = update(s, { type: "OpenFile", path: "C:/a.ts" }).state;
+        const ids = s.tabs.map((t) => t.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(s.tabs.length).toBe(3);
+    });
+
+    // ─── extra coverage: RenameFile + canonicalize + slot dispatch ──
+
+    it("RenameFile updates a matching tab's filePath, no-op on no match", () => {
+        let s = initialState();
+        s = update(s, { type: "OpenFile", path: "C:/old.ts" }).state;
+        const [t] = s.tabs;
+        const r = update(s, {
+            type: "RenameFile",
+            oldPath: "C:/old.ts",
+            newPath: "C:/new.ts",
+        });
+        expect(r.state.tabs[0].id).toBe(t.id);
+        expect(r.state.tabs[0].filePath).toBe("c:/new.ts");
+
+        const r2 = update(r.state, {
+            type: "RenameFile",
+            oldPath: "C:/missing.ts",
+            newPath: "C:/x.ts",
+        });
+        expect(r2.state).toBe(r.state);
+    });
+
+    it("canonicalizePath normalizes slashes, drive case, doubled slashes", () => {
+        expect(canonicalizePath("C:\\Repo\\Foo.ts")).toBe("c:/Repo/Foo.ts");
+        expect(canonicalizePath("C:/a//b/c")).toBe("c:/a/b/c");
+        expect(canonicalizePath("C:/a/")).toBe("c:/a");
+        expect(canonicalizePath("")).toBe("");
+    });
+
+    it("slot dispatch path: OpenFile via dispatch updates the snapshot", () => {
+        registerEditorPane("blk-x");
+        const events = dispatch("blk-x", { type: "OpenFile", path: "C:/foo.ts" });
+        expect(events.length).toBe(1);
+        expect(events[0].type).toBe("TabOpened");
+        const snap = snapshot("blk-x")!;
+        expect(snap.tabs.length).toBe(1);
+        expect(snap.activeTabId).toBe(snap.tabs[0].id);
+        assertActiveInvariant(snap);
+    });
+
+    it("setEventSink(null) detaches the sink", () => {
+        const sink = vi.fn<(events: EditorPaneEvent[]) => void>();
+        setEventSink(sink);
+        registerEditorPane("blk-1");
+        dispatch("blk-1", { type: "OpenFile", path: "C:/a.ts" });
+        expect(sink).toHaveBeenCalledTimes(1);
+        setEventSink(null);
+        dispatch("blk-1", { type: "OpenFile", path: "C:/b.ts" });
+        expect(sink).toHaveBeenCalledTimes(1); // not called again
+    });
+});

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -1,0 +1,690 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Editor pane state store — slice #10 of the frontend reducer roadmap.
+ * Phase 1A: pure reducer + slot store + audit-ring integration. No view
+ * wiring, no saga, no CodeMirror references — those land in Phase 1B/1C.
+ * Spec: `specs/SPEC_EDITOR_TABS_2026-05-26.md` §"State management" and
+ * §"Phase 1A".
+ *
+ * The editor pane today owns one file at a time; this slice is the
+ * foundation for the multi-file tab strip. The slot cell owns:
+ *   - `tabs[]` — ordered list, each with id/filePath/language/dirty/etc.
+ *   - `activeTabId` — id of the currently-active tab, or null when empty.
+ *   - `recentlyClosed[]` — bounded ring (max 10) feeding Ctrl+Shift+T.
+ *
+ * Per-tab CodeMirror state lives OUTSIDE this cell (the view holds it
+ * in a Map keyed by tabId — it's not serializable and shouldn't be in
+ * the audit ring). The reducer only owns the data the persistence /
+ * audit / LSP-coupling layers need.
+ *
+ * Pattern matches slice #4 (`agent-pane-state-store.ts`) and slice #9
+ * (`browser-pane-state-store.ts`) — same `update(state, command) →
+ * { state, events }` shape, same slot lifecycle, same
+ * `recordDispatch` audit integration, same "throw on unregistered
+ * dispatch" rule.
+ */
+
+import { type CommandSource, recordDispatch } from "./command-source";
+
+// ─────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────
+
+export interface EditorTab {
+    /** Stable per-pane id (uuid). Survives reorders. */
+    id: string;
+    /** Canonicalized absolute path (see `canonicalizePath`). */
+    filePath: string;
+    /** Derived from extension at open time. */
+    language: string;
+    /** Set when content-load returns read-only. */
+    readOnly: boolean;
+    /** True between first change and save. */
+    dirty: boolean;
+    /** sha256 of last-loaded content; `""` before load resolves. */
+    contentHash: string;
+    /** Error message from the most recent load attempt; null when fine. */
+    loadError: string | null;
+    /** Transient — true once the lazy fetch resolved. Not persisted. */
+    contentLoaded: boolean;
+}
+
+export interface ClosedTab {
+    filePath: string;
+    closedAt: number;
+}
+
+export interface EditorPaneState {
+    tabs: EditorTab[];
+    activeTabId: string | null;
+    /** Capped at MAX_RECENTLY_CLOSED, oldest evicted on overflow. */
+    recentlyClosed: ClosedTab[];
+}
+
+export const MAX_RECENTLY_CLOSED = 10;
+
+export const initialState = (): EditorPaneState => ({
+    tabs: [],
+    activeTabId: null,
+    recentlyClosed: [],
+});
+
+// Hydration shapes — input to bulk-restore commands. Note these don't
+// carry transient fields; the reducer reconstructs full tabs with
+// `contentLoaded: false`.
+export interface HydratedTab {
+    id: string;
+    filePath: string;
+    language?: string;
+    readOnly?: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Commands
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Optional `source` tag on every command — the echo-loop guard hook
+ * for Phase 1B. The view dispatches CodeMirror updates with
+ * `source: "cm-update"`; the reducer skips emitting `TabContentChanged`
+ * for commands whose source indicates the change originated from the
+ * reducer itself (e.g. `"hydrate"` for the initial doc the view writes
+ * back to CodeMirror after a HydrateFromMeta). See slice #2 convention.
+ */
+export type EditorCommandSource = "user" | "system" | "cm-update" | "hydrate";
+
+export type EditorPaneCommand =
+    | { type: "OpenFile"; path: string; language?: string; source?: EditorCommandSource }
+    | { type: "CloseTab"; tabId: string; force?: boolean; source?: EditorCommandSource }
+    | { type: "SwitchTab"; tabId: string; source?: EditorCommandSource }
+    | { type: "ReorderTab"; tabId: string; toIndex: number; source?: EditorCommandSource }
+    | { type: "MarkDirty"; tabId: string; source?: EditorCommandSource }
+    | { type: "ClearDirty"; tabId: string; source?: EditorCommandSource }
+    | {
+          type: "TabContentLoaded";
+          tabId: string;
+          contentHash: string;
+          readOnly?: boolean;
+          source?: EditorCommandSource;
+      }
+    | { type: "TabContentLoadFailed"; tabId: string; error: string; source?: EditorCommandSource }
+    | { type: "ReopenLastClosed"; source?: EditorCommandSource }
+    | {
+          type: "HydrateFromMeta";
+          tabs: HydratedTab[];
+          activeTabId: string | null;
+          source?: EditorCommandSource;
+      }
+    | {
+          type: "HydrateFromDefaults";
+          tabs: HydratedTab[];
+          activeTabId: string | null;
+          source?: EditorCommandSource;
+      }
+    | { type: "RenameFile"; oldPath: string; newPath: string; source?: EditorCommandSource };
+
+// ─────────────────────────────────────────────────────────────────────
+// Events
+// ─────────────────────────────────────────────────────────────────────
+
+export type EditorPaneEvent =
+    | { type: "TabOpened"; tabId: string; filePath: string; atIndex: number }
+    | { type: "TabClosed"; tabId: string; filePath: string }
+    | { type: "TabActivated"; tabId: string; filePath: string }
+    | {
+          type: "TabsRestored";
+          tabIds: string[];
+          activeTabId: string | null;
+          fromDefaults: boolean;
+      }
+    | { type: "TabDirtied"; tabId: string }
+    | { type: "TabSaved"; tabId: string }
+    | { type: "TabContentChanged"; tabId: string }
+    | {
+          type: "RequestDirtyConfirm";
+          tabId: string;
+          originalCommand: EditorPaneCommand;
+      }
+    | {
+          type: "GlobalDefaultTabsChanged";
+          tabs: { filePath: string }[];
+          activeTabId: string | null;
+      };
+
+export interface ReducerResult {
+    state: EditorPaneState;
+    events: EditorPaneEvent[];
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Canonicalize a filesystem path so `C:/x` and `C:\x` resolve to the
+ * same tab. Phase 1A approach (cheap, deterministic, no I/O):
+ *   - normalize backslashes to forward slashes
+ *   - collapse repeated slashes
+ *   - lowercase the Windows drive letter
+ *   - strip a trailing slash (except for a bare "/" or drive root)
+ *
+ * Symlink resolution is intentionally out of scope — that requires
+ * filesystem I/O which can't sit inside a pure reducer. The saga in
+ * Phase 1C may canonicalize further before dispatching; the reducer's
+ * job is just to make trivially-equivalent paths collide.
+ */
+export function canonicalizePath(path: string): string {
+    if (!path) return path;
+    let p = path.replace(/\\/g, "/");
+    p = p.replace(/\/{2,}/g, "/");
+    // Windows drive letter — lowercase for stable equality.
+    if (/^[A-Za-z]:\//.test(p)) {
+        p = p[0].toLowerCase() + p.slice(1);
+    }
+    // Strip trailing slash unless this is the root.
+    if (p.length > 1 && p.endsWith("/") && !/^[a-z]:\/$/.test(p)) {
+        p = p.slice(0, -1);
+    }
+    return p;
+}
+
+/** Derive a CodeMirror-friendly language id from a file extension.
+ *  Phase 1A keeps this minimal — the view's existing extension-to-mode
+ *  table can supersede it once we wire 1B. */
+export function deriveLanguage(path: string): string {
+    const m = /\.([A-Za-z0-9]+)$/.exec(path);
+    if (!m) return "text";
+    return m[1].toLowerCase();
+}
+
+function newTabId(): string {
+    // crypto.randomUUID is available in modern Chromium (host runtime)
+    // and the test environment (vitest on Node ≥ 19). Fallback path
+    // covers older Node just in case.
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `tab-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function findTabIndex(state: EditorPaneState, tabId: string): number {
+    return state.tabs.findIndex((t) => t.id === tabId);
+}
+
+function findTabByPath(
+    state: EditorPaneState,
+    canonicalPath: string,
+): EditorTab | undefined {
+    return state.tabs.find((t) => t.filePath === canonicalPath);
+}
+
+/** Build a fresh tab record for the given path/language. */
+function makeTab(path: string, language?: string): EditorTab {
+    const canon = canonicalizePath(path);
+    return {
+        id: newTabId(),
+        filePath: canon,
+        language: language ?? deriveLanguage(canon),
+        readOnly: false,
+        dirty: false,
+        contentHash: "",
+        loadError: null,
+        contentLoaded: false,
+    };
+}
+
+/**
+ * Pick the new active id after `tabId` has been removed from `prevTabs`.
+ * Matches VS Code: prefer the right neighbor of the closed tab; fall
+ * back to the left when closing the rightmost tab; null when no tabs
+ * remain.
+ */
+function pickNextActiveId(
+    prevTabs: EditorTab[],
+    closedIndex: number,
+): string | null {
+    const remaining = prevTabs.length - 1;
+    if (remaining <= 0) return null;
+    // After removing closedIndex, the right neighbor's NEW index is
+    // closedIndex (since everything to the right shifts left). If
+    // closedIndex was at the end, fall back to the new last tab
+    // (which is the old left neighbor).
+    if (closedIndex < remaining) {
+        return prevTabs[closedIndex + 1].id;
+    }
+    return prevTabs[closedIndex - 1].id;
+}
+
+function pushRecentlyClosed(
+    list: ClosedTab[],
+    entry: ClosedTab,
+): ClosedTab[] {
+    const next = [...list, entry];
+    if (next.length > MAX_RECENTLY_CLOSED) {
+        return next.slice(next.length - MAX_RECENTLY_CLOSED);
+    }
+    return next;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Reducer
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Pure reducer. Returns the next state plus any events to emit. Never
+ * throws; defensive no-ops (e.g. SwitchTab on a missing id) return the
+ * input state with an empty events array.
+ *
+ * Invariants enforced:
+ *   1. `activeTabId` points to a tab in `tabs[]` or is null when
+ *      `tabs[]` is empty.
+ *   2. Tab `id`s are unique within a pane (the helper that mints ids
+ *      uses uuids; activate-existing prevents accidental dup-by-path).
+ *   3. `recentlyClosed.length <= MAX_RECENTLY_CLOSED`.
+ *   4. `MarkDirty` / `ClearDirty` emit their events only on actual
+ *      transitions (idempotent).
+ */
+export function update(
+    state: EditorPaneState,
+    command: EditorPaneCommand,
+): ReducerResult {
+    switch (command.type) {
+        case "OpenFile": {
+            const canon = canonicalizePath(command.path);
+            const existing = findTabByPath(state, canon);
+            if (existing) {
+                if (state.activeTabId === existing.id) {
+                    // Already active → still emit TabActivated so the
+                    // view (LSP didOpen, file-tree highlight) has a
+                    // single uniform signal to bind to. No state
+                    // change.
+                    return {
+                        state,
+                        events: [
+                            {
+                                type: "TabActivated",
+                                tabId: existing.id,
+                                filePath: existing.filePath,
+                            },
+                        ],
+                    };
+                }
+                return {
+                    state: { ...state, activeTabId: existing.id },
+                    events: [
+                        {
+                            type: "TabActivated",
+                            tabId: existing.id,
+                            filePath: existing.filePath,
+                        },
+                    ],
+                };
+            }
+            const tab = makeTab(command.path, command.language);
+            const nextTabs = [...state.tabs, tab];
+            return {
+                state: {
+                    ...state,
+                    tabs: nextTabs,
+                    activeTabId: tab.id,
+                },
+                events: [
+                    {
+                        type: "TabOpened",
+                        tabId: tab.id,
+                        filePath: tab.filePath,
+                        atIndex: nextTabs.length - 1,
+                    },
+                ],
+            };
+        }
+
+        case "CloseTab": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) {
+                // Defensive no-op — closing an already-closed tab is
+                // benign (double-click on the × button, stale IPC).
+                return { state, events: [] };
+            }
+            const tab = state.tabs[idx];
+            if (tab.dirty && !command.force) {
+                // The view shows a confirm modal; on confirm it
+                // re-dispatches the same command with `force: true`.
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "RequestDirtyConfirm",
+                            tabId: tab.id,
+                            originalCommand: command,
+                        },
+                    ],
+                };
+            }
+            const nextTabs = [...state.tabs.slice(0, idx), ...state.tabs.slice(idx + 1)];
+            const wasActive = state.activeTabId === tab.id;
+            const nextActiveId = wasActive
+                ? pickNextActiveId(state.tabs, idx)
+                : state.activeTabId;
+            const closedEntry: ClosedTab = {
+                filePath: tab.filePath,
+                closedAt: Date.now(),
+            };
+            const nextState: EditorPaneState = {
+                tabs: nextTabs,
+                activeTabId: nextActiveId,
+                recentlyClosed: pushRecentlyClosed(state.recentlyClosed, closedEntry),
+            };
+            const events: EditorPaneEvent[] = [
+                { type: "TabClosed", tabId: tab.id, filePath: tab.filePath },
+            ];
+            if (wasActive && nextActiveId != null) {
+                const newActive = nextTabs.find((t) => t.id === nextActiveId)!;
+                events.push({
+                    type: "TabActivated",
+                    tabId: newActive.id,
+                    filePath: newActive.filePath,
+                });
+            }
+            return { state: nextState, events };
+        }
+
+        case "SwitchTab": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) {
+                // Defensive — clicking a stale tab id (e.g. a tab
+                // that was closed between render and click) is a
+                // no-op, not a crash.
+                return { state, events: [] };
+            }
+            if (state.activeTabId === command.tabId) {
+                return { state, events: [] };
+            }
+            const tab = state.tabs[idx];
+            return {
+                state: { ...state, activeTabId: tab.id },
+                events: [
+                    { type: "TabActivated", tabId: tab.id, filePath: tab.filePath },
+                ],
+            };
+        }
+
+        case "ReorderTab": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            if (state.tabs.length <= 1) return { state, events: [] };
+            const clamped = Math.max(
+                0,
+                Math.min(state.tabs.length - 1, command.toIndex),
+            );
+            if (clamped === idx) return { state, events: [] };
+            const next = [...state.tabs];
+            const [moved] = next.splice(idx, 1);
+            next.splice(clamped, 0, moved);
+            return { state: { ...state, tabs: next }, events: [] };
+        }
+
+        case "MarkDirty": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            if (tab.dirty) {
+                // Already dirty → no event re-emission. The view
+                // model's title `*` is already on; no listener needs
+                // a redundant signal.
+                return { state, events: [] };
+            }
+            const nextTab: EditorTab = { ...tab, dirty: true };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return {
+                state: { ...state, tabs: nextTabs },
+                events: [{ type: "TabDirtied", tabId: tab.id }],
+            };
+        }
+
+        case "ClearDirty": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            if (!tab.dirty) {
+                return { state, events: [] };
+            }
+            const nextTab: EditorTab = { ...tab, dirty: false };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return {
+                state: { ...state, tabs: nextTabs },
+                events: [{ type: "TabSaved", tabId: tab.id }],
+            };
+        }
+
+        case "TabContentLoaded": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            const nextTab: EditorTab = {
+                ...tab,
+                contentLoaded: true,
+                contentHash: command.contentHash,
+                loadError: null,
+                readOnly: command.readOnly ?? tab.readOnly,
+            };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return { state: { ...state, tabs: nextTabs }, events: [] };
+        }
+
+        case "TabContentLoadFailed": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            const nextTab: EditorTab = {
+                ...tab,
+                loadError: command.error,
+                contentLoaded: false,
+            };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return { state: { ...state, tabs: nextTabs }, events: [] };
+        }
+
+        case "ReopenLastClosed": {
+            if (state.recentlyClosed.length === 0) {
+                return { state, events: [] };
+            }
+            const last = state.recentlyClosed[state.recentlyClosed.length - 1];
+            const trimmed = state.recentlyClosed.slice(0, -1);
+            // Re-route through the OpenFile pathway so we get the
+            // standard activate-if-exists + TabOpened semantics. The
+            // popped entry is removed BEFORE the OpenFile reduces so
+            // a tab that happens to still be in the list (e.g. it
+            // was reopened by another route between close+reopen)
+            // just activates.
+            const sub = update(
+                { ...state, recentlyClosed: trimmed },
+                { type: "OpenFile", path: last.filePath },
+            );
+            return sub;
+        }
+
+        case "HydrateFromMeta":
+        case "HydrateFromDefaults": {
+            const fromDefaults = command.type === "HydrateFromDefaults";
+            const tabs: EditorTab[] = command.tabs.map((t) => ({
+                id: t.id,
+                filePath: canonicalizePath(t.filePath),
+                language: t.language ?? deriveLanguage(t.filePath),
+                readOnly: t.readOnly ?? false,
+                dirty: false,
+                contentHash: "",
+                loadError: null,
+                contentLoaded: false,
+            }));
+            // Enforce invariant 1 — activeTabId must point at a tab
+            // in the list, or be null when empty.
+            const activeStillPresent =
+                command.activeTabId != null &&
+                tabs.some((t) => t.id === command.activeTabId);
+            const activeId = activeStillPresent
+                ? command.activeTabId
+                : tabs.length > 0
+                  ? tabs[0].id
+                  : null;
+            const nextState: EditorPaneState = {
+                tabs,
+                activeTabId: activeId,
+                recentlyClosed: state.recentlyClosed,
+            };
+            return {
+                state: nextState,
+                events: [
+                    {
+                        type: "TabsRestored",
+                        tabIds: tabs.map((t) => t.id),
+                        activeTabId: activeId,
+                        fromDefaults,
+                    },
+                ],
+            };
+        }
+
+        case "RenameFile": {
+            const canonOld = canonicalizePath(command.oldPath);
+            const canonNew = canonicalizePath(command.newPath);
+            const idx = state.tabs.findIndex((t) => t.filePath === canonOld);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            const nextTab: EditorTab = { ...tab, filePath: canonNew };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return { state: { ...state, tabs: nextTabs }, events: [] };
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Slot store
+// ─────────────────────────────────────────────────────────────────────
+
+interface Slot {
+    state: EditorPaneState;
+}
+
+const slots = new Map<string, Slot>();
+
+/**
+ * Event sink — installed by the view (Phase 1B) and by the saga
+ * (Phase 1C). The default is a no-op so tests run without DOM. The
+ * sink receives the events array from a single dispatch call.
+ *
+ * Signature differs from slices #4/#9 (which pass blockId + single
+ * event) — the editor saga needs the full event batch atomically so
+ * it can write `editor:tabs` + `editor:active_tab_id` in one block-meta
+ * mutation rather than racing N separate writes. The `blockId` is
+ * already part of every event's downstream lookup via the dispatch
+ * site that emitted the batch.
+ */
+type EventSink = (events: EditorPaneEvent[]) => void;
+let eventSink: EventSink | null = null;
+
+export function setEventSink(sink: EventSink | null): void {
+    eventSink = sink;
+}
+
+/**
+ * Register an editor pane. Call SYNCHRONOUSLY from the model's
+ * constructor so subsequent dispatches see a live slot. Re-registering
+ * an existing blockId is a no-op (the slot keeps its state — see
+ * `agent-pane-state-store.ts`'s comment on idempotency for hot-reload
+ * paths).
+ */
+export function registerEditorPane(blockId: string): void {
+    if (slots.has(blockId)) return;
+    slots.set(blockId, { state: initialState() });
+}
+
+export function unregisterEditorPane(blockId: string): void {
+    slots.delete(blockId);
+}
+
+/**
+ * Apply a command. Throws on unregistered blockId — silent drops would
+ * defeat the reducer's audit value (same rule as the other slices).
+ */
+export function dispatch(
+    blockId: string,
+    command: EditorPaneCommand,
+    source: CommandSource = "system",
+): EditorPaneEvent[] {
+    const slot = slots.get(blockId);
+    if (!slot) {
+        throw new Error(
+            `[editor-pane] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerEditorPane must be called synchronously in the EditorViewModel constructor.`,
+        );
+    }
+    const prev = slot.state;
+    const result = update(prev, command);
+    slot.state = result.state;
+
+    if (eventSink && result.events.length > 0) {
+        eventSink(result.events);
+    }
+
+    recordDispatch({
+        slice: "editor-pane",
+        key: blockId,
+        command,
+        events: result.events,
+        source,
+        at: Date.now(),
+    });
+
+    return result.events;
+}
+
+/**
+ * Soft-dispatch variant. Returns an empty event array if the slot is
+ * already gone instead of throwing. Use ONLY from async contexts
+ * (RAF / setTimeout / await continuations / subscription handlers)
+ * where a normal dispatch can race against the pane's onCleanup
+ * unregistering the slot. Synchronous component-body dispatches MUST
+ * continue to use `dispatch` — a missing slot there is a registration-
+ * order bug and the throw is the right signal.
+ */
+export function dispatchIfRegistered(
+    blockId: string,
+    command: EditorPaneCommand,
+    source: CommandSource = "system",
+): EditorPaneEvent[] {
+    if (!slots.has(blockId)) return [];
+    return dispatch(blockId, command, source);
+}
+
+/** Snapshot — diagnostics + tests only. */
+export function snapshot(blockId: string): EditorPaneState | null {
+    return slots.get(blockId)?.state ?? null;
+}
+
+/** Test/dev helper — clears every slot AND resets the event sink. */
+export function resetAllSlots(): void {
+    slots.clear();
+    eventSink = null;
+}


### PR DESCRIPTION
## Summary

Phase 1A of the editor tabs feature. **Slice scaffolding only — no UI, no view-model wiring, no saga.** The next two PRs (Phase 1B view migration + tab strip, Phase 1C srv-side persistence saga) build on this foundation.

Spec: [`specs/SPEC_EDITOR_TABS_2026-05-26.md`](../blob/main/specs/SPEC_EDITOR_TABS_2026-05-26.md) — sections "State management — slice #10 editor-pane-state" and "Phase 1A".

## What's in

- `frontend/app/store/editor-pane-state-store.ts` (690 lines) — pure reducer + types + slot store + audit-ring integration
- `frontend/app/store/editor-pane-state-store.test.ts` (525 lines) — **35 invariant tests, all passing**

Follows the conventions from slices #4 (agent-pane-state) and #9 (browser-pane-state):

- Pure `update(state, command) → { state, events }` reducer
- Slot store keyed by `blockId` with `register / unregister / dispatch / dispatchIfRegistered / snapshot / resetAllSlots / setEventSink`
- Echo-loop guard via `source` field on commands (slice #2 convention)
- `recordDispatch` audit integration — slice name `"editor-pane"`

### Commands

`OpenFile`, `CloseTab`, `SwitchTab`, `ReorderTab`, `MarkDirty`, `ClearDirty`, `TabContentLoaded`, `TabContentLoadFailed`, `ReopenLastClosed`, `HydrateFromMeta`, `HydrateFromDefaults`, `RenameFile`

### Events

`TabOpened`, `TabClosed`, `TabActivated`, `TabsRestored`, `TabDirtied`, `TabSaved`, `TabContentChanged`, `RequestDirtyConfirm`, `GlobalDefaultTabsChanged`

### Invariants covered by tests

1. OpenFile with new path → appends, activates, emits TabOpened
2. OpenFile with existing path (canonicalized: `C:/x` matches `C:\x`) → activates existing, no append
3. CloseTab on clean → drops, activates right-neighbor (or left if rightmost), pushes to `recentlyClosed`
4. CloseTab on dirty without `force` → state unchanged, emits `RequestDirtyConfirm` carrying original command
5. CloseTab on dirty with `force: true` → drops same as clean
6. CloseTab on only tab → activeTabId becomes null
7. SwitchTab to non-existent id → no-op
8. ReorderTab clamps toIndex to `[0, tabs.length - 1]`
9. MarkDirty / ClearDirty emit only on actual transitions
10. TabContentLoaded sets `contentLoaded: true`, hash, clears `loadError`
11. TabContentLoadFailed sets error, keeps `contentLoaded: false`
12. ReopenLastClosed on empty stack → no-op
13. ReopenLastClosed pops + re-dispatches as OpenFile
14. HydrateFromMeta bulk-restores, all `contentLoaded: false`
15. `recentlyClosed` capped at 10, oldest evicted
16. Active id always points to a tab or is null when empty (asserted in every activation-touching test)
17. Tab ids unique within a pane

Plus 18 additional edge-case tests (hydration with stale activeTabId, slot lifecycle, canonicalizePath details, etc.).

## Deliberate choices (called out in code)

- **Single-file layout** for the slice (types + reducer + slot store all in `editor-pane-state-store.ts`) — easy to split if reviewers prefer the per-folder layout of slices #4/#9.
- **`setEventSink((events) => void)`** — array-shaped to give the 1C saga atomicity (write `editor:tabs` + `editor:active_tab_id` in one transaction per dispatch). Differs from slices #4/#9 which use per-event callbacks; deliberate per spec.
- **OpenFile on already-active tab still emits TabActivated** — uniform signal for downstream consumers (LSP didOpen, file-tree highlight) so they don't need a no-op special case.
- **Cheap path canonicalization only** (slash/drive-case/double-slash normalization). Symlink resolution is out of scope for a pure reducer — comment notes the 1C saga can pre-canonicalize further if needed.

## Test plan

- [x] `npx vitest run frontend/app/store/editor-pane-state-store.test.ts` — 35/35 passing
- [x] `npx tsc --noEmit` — no errors in the new files
- [ ] Reviewer: spot-check that the audit ring records dispatches with slice name `"editor-pane"`

## What's next

- **Phase 1B** — view migration + tab strip render + close/dirty-confirm + Ctrl+Tab keymap. Foreground PR.
- **Phase 1C** — srv-side saga subscribing to TabOpened/TabClosed/TabActivated/ReorderTab → SetMeta(`editor:tabs`, `editor:active_tab_id`). Migration from legacy `editor:file_path`. Global fallback writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)