### PR TITLE
feat(editor): tabs Phase 1B — view + tab strip

### DIFF
--- a/.changesets/1779855626-feat-editor-tabs-phase-1b-view-tab-strip-c6tk.md
+++ b/.changesets/1779855626-feat-editor-tabs-phase-1b-view-tab-strip-c6tk.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): tabs Phase 1B — view + tab strip

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -5,10 +5,31 @@
 // It is NOT a standalone IDE — complex editing happens in the agent's terminal
 // or via agent tool calls. This covers quick edits, file viewing, and diffing.
 //
-// File-tree explorer + header chevron toggle landed in Phase 1 of
-// SPEC_EDITOR_FILE_TREE_2026-05-26.md.
+// State management: slice #10 editor-pane-state (frontend/app/store/
+// editor-pane-state-store.ts) owns the tab list, active id, dirty flags, and
+// recently-closed stack. This file is a thin projection layer between that
+// slice and the editor view. Tab-content blobs are held in a view-local Map
+// (this._contentByTab) — content is deliberately NOT in the slice (large,
+// not auditable, not persistable cheaply). The slice tracks contentHash +
+// contentLoaded so it can reason about dirty-vs-disk without holding the
+// buffer.
+//
+// Spec: specs/SPEC_EDITOR_TABS_2026-05-26.md (Phase 1B).
+// Earlier specs: SPEC_EDITOR_FILE_TREE_2026-05-26.md, SPEC_EDITOR_LSP_AND_THEMES_2026-05-26.md.
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import { useBlockAtom } from "@/app/store/global";
+import {
+    EditorPaneEvent,
+    EditorTab,
+    canonicalizePath,
+    deriveLanguage,
+    dispatch,
+    registerEditorPane,
+    setEventSink,
+    snapshot,
+    unregisterEditorPane,
+} from "@/app/store/editor-pane-state-store";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
@@ -18,9 +39,21 @@ import { FileTreeModel } from "./file-tree-model";
 const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
+const META_LEGACY_FILE = "file";
 const TREE_WIDTH_DEFAULT = 240;
 const TREE_WIDTH_MIN = 150;
 const TREE_WIDTH_MAX = 600;
+
+/** Hash a string with SHA-256 → hex. Used for the slice's contentHash field
+ *  so the saga (Phase 1C) can decide whether a tab is dirty vs. disk. Cheap;
+ *  files are capped at 10 MB by the read RPC. */
+async function sha256Hex(s: string): Promise<string> {
+    const buf = new TextEncoder().encode(s);
+    const digest = await crypto.subtle.digest("SHA-256", buf);
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}
 
 export class EditorViewModel implements ViewModel {
     viewType = "editor";
@@ -36,32 +69,38 @@ export class EditorViewModel implements ViewModel {
         return null; // overridden by barrel via Object.defineProperty
     }
 
-    // Editor state
-    private _filePath = createSignal<string>("");
-    filePathAtom: Accessor<string> = this._filePath[0];
-    setFilePath = this._filePath[1];
+    // ── Slice projection ───────────────────────────────────────────────
+    // A version counter signal triggers Solid re-evaluation whenever the
+    // slice's slot cell mutates. We use a setEventSink callback (set in the
+    // constructor) to bump the counter on every dispatch.
+    private _sliceVersion = createSignal<number>(0);
+    sliceVersionAtom: Accessor<number> = this._sliceVersion[0];
 
-    private _content = createSignal<string>("");
-    contentAtom: Accessor<string> = this._content[0];
-    setContent = this._content[1];
+    tabsAtom: Accessor<EditorTab[]>;
+    activeIdAtom: Accessor<string | null>;
+    activeTabAtom: Accessor<EditorTab | null>;
 
-    private _language = createSignal<string>("");
-    languageAtom: Accessor<string> = this._language[0];
+    // ── Derived accessors (preserve the old surface so editor-view.tsx
+    //    keeps working unchanged) ────────────────────────────────────
+    filePathAtom: Accessor<string>;
+    languageAtom: Accessor<string>;
+    dirtyAtom: Accessor<boolean>;
+    readOnlyAtom: Accessor<boolean>;
+    errorAtom: Accessor<string | null>;
+    loadingAtom: Accessor<boolean>;
 
-    private _loading = createSignal<boolean>(false);
-    loadingAtom: Accessor<boolean> = this._loading[0];
+    /** Content of the active tab. Sourced from the view-local Map; signals
+     *  re-evaluation when the active tab changes OR when its content
+     *  loads/updates. */
+    contentAtom: Accessor<string>;
 
-    private _dirty = createSignal<boolean>(false);
-    dirtyAtom: Accessor<boolean> = this._dirty[0];
-    setDirty = this._dirty[1];
+    // ── Per-tab content store (view-local) ────────────────────────────
+    // Content blobs by tabId. Keys removed on TabClosed.
+    private _contentByTab = new Map<string, string>();
+    // Bump-counter signal so contentAtom re-evaluates when we mutate the Map.
+    private _contentVersion = createSignal<number>(0);
 
-    private _readOnly = createSignal<boolean>(false);
-    readOnlyAtom: Accessor<boolean> = this._readOnly[0];
-
-    private _error = createSignal<string | null>(null);
-    errorAtom: Accessor<string | null> = this._error[0];
-
-    // File-tree state (per-pane, persisted in block meta)
+    // ── Tree state (per-pane, persisted in block meta) ──────────────────
     private _treeExpanded = createSignal<boolean>(true);
     treeExpandedAtom: Accessor<boolean> = this._treeExpanded[0];
 
@@ -74,6 +113,15 @@ export class EditorViewModel implements ViewModel {
     treeModel = new FileTreeModel();
 
     blockAtom: Accessor<Block | undefined>;
+    zoomAtom!: Accessor<number>;
+
+    /** Tabs that started loading via openFile — used so concurrent dispatches
+     *  for the same path don't double-fetch. */
+    private _loadingPaths = new Set<string>();
+
+    /** Slice event subscribers wired from the view (for snapshot/restore of
+     *  CodeMirror state, dirty-confirm modal, LSP didOpen/didClose). */
+    private _eventSubscribers = new Set<(event: EditorPaneEvent) => void>();
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
@@ -81,11 +129,66 @@ export class EditorViewModel implements ViewModel {
 
         this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
 
-        // Pane title — full file path (or "Editor" when nothing open). Marked
-        // with a trailing `*` when there are unsaved changes. Showing the
-        // complete path (not just the basename) lets the operator know
-        // exactly which file they're editing when multiple panes are open
-        // on similarly-named files (e.g. two `index.ts` in different dirs).
+        // Register this pane's slot in the slice.
+        registerEditorPane(blockId);
+
+        // Wire the slice's global event sink so we re-render when any pane's
+        // dispatch mutates state. Since the sink is a singleton, multiple
+        // editor panes co-exist by all bumping their own version on EVERY
+        // event — cheap and correct.
+        //
+        // We use setEventSink rather than per-instance subscription because
+        // the slice's API is global; the cost is negligible (one signal bump
+        // per dispatch). View-level subscribers (LSP, CodeMirror state
+        // snapshot/restore) attach via `onSliceEvent` below.
+        setEventSink((events: EditorPaneEvent[]) => {
+            // Bump version → all accessors below re-evaluate.
+            this._sliceVersion[1]((v) => v + 1);
+            for (const ev of events) {
+                if (ev.type === "TabClosed") {
+                    this._contentByTab.delete(ev.tabId);
+                }
+                for (const sub of this._eventSubscribers) sub(ev);
+            }
+        });
+
+        // Projections from the slice's slot cell. Reading sliceVersionAtom
+        // creates the Solid dependency that makes these re-evaluate.
+        this.tabsAtom = createMemo<EditorTab[]>(() => {
+            this.sliceVersionAtom();
+            return snapshot(this.blockId)?.tabs ?? [];
+        });
+        this.activeIdAtom = createMemo<string | null>(() => {
+            this.sliceVersionAtom();
+            return snapshot(this.blockId)?.activeTabId ?? null;
+        });
+        this.activeTabAtom = createMemo<EditorTab | null>(() => {
+            const id = this.activeIdAtom();
+            const tabs = this.tabsAtom();
+            return tabs.find((t) => t.id === id) ?? null;
+        });
+
+        // Derived: per-active-tab signals. Existing consumers see the same
+        // shape as before — they just track whichever tab is active.
+        this.filePathAtom = () => this.activeTabAtom()?.filePath ?? "";
+        this.languageAtom = () => this.activeTabAtom()?.language ?? "";
+        this.dirtyAtom = () => this.activeTabAtom()?.dirty ?? false;
+        this.readOnlyAtom = () => this.activeTabAtom()?.readOnly ?? false;
+        this.errorAtom = () => this.activeTabAtom()?.loadError ?? null;
+        // "Loading" is true between OpenFile and TabContentLoaded — i.e. the
+        // active tab exists but its content hasn't arrived yet.
+        this.loadingAtom = () => {
+            const tab = this.activeTabAtom();
+            return tab != null && !tab.contentLoaded && tab.loadError == null;
+        };
+
+        this.contentAtom = createMemo<string>(() => {
+            this._contentVersion[0](); // dep on content bumps
+            const id = this.activeIdAtom();
+            return id ? this._contentByTab.get(id) ?? "" : "";
+        });
+
+        // Pane title — full file path of active tab, with `*` for dirty.
         this.viewName = createMemo(() => {
             const fp = this.filePathAtom();
             if (!fp) return "Editor";
@@ -93,10 +196,6 @@ export class EditorViewModel implements ViewModel {
         });
 
         // Pane icon doubles as the file-tree expand/collapse toggle.
-        // Clicking the icon hides/shows the tree column; preference persists
-        // per pane in block meta (`editor:tree_expanded`). The icon glyph
-        // reflects the current state: `folder-tree` when the tree is open,
-        // `folder` when collapsed.
         this.viewIcon = createMemo<IconButtonDecl>(() => {
             const expanded = this.treeExpandedAtom();
             return {
@@ -107,8 +206,16 @@ export class EditorViewModel implements ViewModel {
             };
         });
 
-        // No additional header items today — the icon owns the tree toggle.
         this.viewText = () => [];
+
+        // Per-pane zoom (PR #1084).
+        this.zoomAtom = useBlockAtom(blockId, "editor-zoom", () =>
+            createMemo<number>(() => {
+                const z = this.blockAtom()?.meta?.["term:zoom"];
+                if (typeof z !== "number" || isNaN(z)) return 1.0;
+                return Math.max(0.5, Math.min(2.0, z));
+            }),
+        );
 
         // Restore persisted tree state from block meta.
         const meta = this.blockAtom()?.meta;
@@ -123,83 +230,170 @@ export class EditorViewModel implements ViewModel {
             this._treeWidth[1](clampTreeWidth(persistedWidth));
         }
 
-        // Load file from block meta on init
-        if (meta?.["file"]) {
-            void this.openFile(meta["file"] as string);
+        // Backwards-compat hydration: existing block meta uses `file` (the
+        // pre-tabs key). If present, restore as a single tab. The saga in
+        // Phase 1C will own the new `editor:tabs` key; this branch stays
+        // until 1C lands + one minor version of grace.
+        const legacyFile = meta?.[META_LEGACY_FILE];
+        if (typeof legacyFile === "string" && legacyFile) {
+            void this.openFile(legacyFile);
         }
     }
 
-    async openFile(filePath: string): Promise<void> {
-        this._loading[1](true);
-        this._error[1](null);
-        this.setFilePath(filePath);
-        this._language[1](detectLanguage(filePath));
+    // ── Event subscription (used by editor-view.tsx for CodeMirror state
+    //    snapshot/restore + future modals) ──────────────────────────────
+    onSliceEvent(handler: (event: EditorPaneEvent) => void): () => void {
+        this._eventSubscribers.add(handler);
+        return () => this._eventSubscribers.delete(handler);
+    }
 
+    // ── Tab actions (dispatched into the slice) ──────────────────────
+    async openFile(filePath: string): Promise<void> {
+        const canonical = canonicalizePath(filePath);
+        if (this._loadingPaths.has(canonical)) return;
+
+        // First: dispatch OpenFile. The slice either activates an existing
+        // tab (and emits only TabActivated) or appends a new one (TabOpened +
+        // TabActivated). We then load content if the tab hasn't loaded yet.
+        const events = dispatch(this.blockId, {
+            type: "OpenFile",
+            path: filePath,
+            source: "user",
+        });
+
+        // Find the tab id (just-opened or pre-existing).
+        const opened = events.find(
+            (e) => e.type === "TabOpened" || e.type === "TabActivated",
+        );
+        if (!opened || (opened.type !== "TabOpened" && opened.type !== "TabActivated")) return;
+        const tabId = opened.tabId;
+
+        // If content's already loaded for this tab, we're done.
+        if (this._contentByTab.has(tabId)) return;
+
+        this._loadingPaths.add(canonical);
         try {
             const result = await RpcApi.ReadEditorFileCommand(TabRpcClient, {
                 path: filePath,
             });
-            this.setContent(result?.content ?? "");
-            this._readOnly[1](result?.read_only ?? false);
-            this._dirty[1](false);
+            const content = result?.content ?? "";
+            this._contentByTab.set(tabId, content);
+            this._contentVersion[1]((v) => v + 1);
 
-            // Store file path in block meta
-            await RpcApi.SetMetaCommand(TabRpcClient, {
-                oref: makeORef("block", this.blockId),
-                meta: { file: filePath },
+            const hash = await sha256Hex(content);
+            dispatch(this.blockId, {
+                type: "TabContentLoaded",
+                tabId,
+                contentHash: hash,
+                readOnly: result?.read_only ?? false,
+                source: "system",
             });
-        } catch (e: any) {
-            this._error[1](e?.message ?? String(e));
+
+            // Backwards-compat: persist the active file path under the legacy
+            // meta key so a downgrade (or a Phase 1C-less build) restores it.
+            // The 1C saga replaces this with the full editor:tabs persistence.
+            await this.persistMeta({ [META_LEGACY_FILE]: filePath });
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            dispatch(this.blockId, {
+                type: "TabContentLoadFailed",
+                tabId,
+                error: message,
+                source: "system",
+            });
         } finally {
-            this._loading[1](false);
+            this._loadingPaths.delete(canonical);
+        }
+    }
+
+    closeTab(tabId: string): void {
+        // Phase 1B: force-close even for dirty tabs (matches today's
+        // behavior — pane closes silently lose unsaved changes). The
+        // dirty-confirm modal lands in a follow-up commit; until then,
+        // `force: true` short-circuits the RequestDirtyConfirm path.
+        dispatch(this.blockId, { type: "CloseTab", tabId, force: true, source: "user" });
+    }
+
+    switchTab(tabId: string): void {
+        dispatch(this.blockId, { type: "SwitchTab", tabId, source: "user" });
+    }
+
+    reopenLastClosed(): void {
+        dispatch(this.blockId, { type: "ReopenLastClosed", source: "user" });
+    }
+
+    /** Called by CodeMirror's updateListener on every change. Updates the
+     *  view-local content Map and dispatches MarkDirty on the first transition
+     *  from clean → dirty. (The slice no-ops MarkDirty on already-dirty.) */
+    onContentChange(content: string): void {
+        const tabId = this.activeIdAtom();
+        if (!tabId) return;
+        this._contentByTab.set(tabId, content);
+        // No content-version bump here — CodeMirror is the source of truth
+        // for the live buffer; contentAtom doesn't need to re-fire on every
+        // keystroke (that would defeat CodeMirror's incremental rendering).
+        if (!this.dirtyAtom()) {
+            dispatch(this.blockId, {
+                type: "MarkDirty",
+                tabId,
+                source: "cm-update",
+            });
         }
     }
 
     async saveFile(): Promise<void> {
         if (this.readOnlyAtom()) return;
-        const filePath = this.filePathAtom();
-        if (!filePath) return;
+        const tab = this.activeTabAtom();
+        if (!tab) return;
+        const content = this._contentByTab.get(tab.id) ?? "";
 
         try {
             await RpcApi.WriteEditorFileCommand(TabRpcClient, {
-                path: filePath,
-                content: this.contentAtom(),
+                path: tab.filePath,
+                content,
             });
-            this._dirty[1](false);
-            this._error[1](null);
-        } catch (e: any) {
-            this._error[1](`Save failed: ${e?.message ?? String(e)}`);
+            dispatch(this.blockId, {
+                type: "ClearDirty",
+                tabId: tab.id,
+                source: "system",
+            });
+            // Recompute content hash since disk now matches buffer.
+            const hash = await sha256Hex(content);
+            dispatch(this.blockId, {
+                type: "TabContentLoaded",
+                tabId: tab.id,
+                contentHash: hash,
+                readOnly: tab.readOnly,
+                source: "system",
+            });
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            dispatch(this.blockId, {
+                type: "TabContentLoadFailed",
+                tabId: tab.id,
+                error: `Save failed: ${message}`,
+                source: "system",
+            });
         }
     }
 
-    onContentChange(content: string): void {
-        this.setContent(content);
-        this._dirty[1](true);
-    }
-
-    /** Toggle file-tree visibility. Persists to block meta. */
+    // ── Tree state (unchanged from Phase 1A of file-tree spec) ─────────
     async toggleTreeExpanded(): Promise<void> {
         const next = !this._treeExpanded[0]();
         this._treeExpanded[1](next);
         await this.persistMeta({ [META_TREE_EXPANDED]: next });
     }
 
-    /** Toggle hidden-file visibility in the tree. Persists to block meta. */
     async toggleShowHidden(): Promise<void> {
         const next = !this._showHidden[0]();
         this._showHidden[1](next);
         await this.persistMeta({ [META_SHOW_HIDDEN]: next });
     }
 
-    /**
-     * Live tree-width update during drag — fast signal-only path, no RPC.
-     * Use `commitTreeWidth()` on mouseup to persist.
-     */
     setTreeWidth(width: number): void {
         this._treeWidth[1](clampTreeWidth(width));
     }
 
-    /** Persist the current tree width to block meta. Call on drag-release. */
     async commitTreeWidth(): Promise<void> {
         await this.persistMeta({ [META_TREE_WIDTH]: this._treeWidth[0]() });
     }
@@ -211,9 +405,9 @@ export class EditorViewModel implements ViewModel {
                 meta,
             });
         } catch {
-            // Persistence failure isn't fatal — the in-memory signal still
-            // drives the current pane's behavior. On reopen, the previous
-            // persisted value (or default) wins.
+            // Persistence failure isn't fatal — in-memory signal still drives
+            // the current pane's behavior. On reopen, the previous persisted
+            // value (or default) wins.
         }
     }
 
@@ -221,7 +415,11 @@ export class EditorViewModel implements ViewModel {
         return false;
     }
 
-    dispose(): void {}
+    dispose(): void {
+        this._eventSubscribers.clear();
+        this._contentByTab.clear();
+        unregisterEditorPane(this.blockId);
+    }
 }
 
 function clampTreeWidth(w: number): number {
@@ -229,51 +427,6 @@ function clampTreeWidth(w: number): number {
     return Math.max(TREE_WIDTH_MIN, Math.min(TREE_WIDTH_MAX, Math.round(w)));
 }
 
-// ── Language detection ──────────────────────────────────────────────────────
-
-const EXTENSION_MAP: Record<string, string> = {
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".mjs": "javascript",
-    ".cjs": "javascript",
-    ".py": "python",
-    ".rs": "rust",
-    ".html": "html",
-    ".htm": "html",
-    ".css": "css",
-    ".scss": "css",
-    ".json": "json",
-    ".md": "markdown",
-    ".markdown": "markdown",
-    ".yaml": "yaml",
-    ".yml": "yaml",
-    ".toml": "toml",
-    ".sh": "shell",
-    ".bash": "shell",
-    ".zsh": "shell",
-    ".ps1": "powershell",
-    ".sql": "sql",
-    ".go": "go",
-    ".java": "java",
-    ".c": "c",
-    ".cpp": "cpp",
-    ".h": "c",
-    ".hpp": "cpp",
-    ".xml": "html",
-    ".svg": "html",
-};
-
-function detectLanguage(filePath: string): string {
-    const lower = filePath.toLowerCase();
-    for (const [ext, lang] of Object.entries(EXTENSION_MAP)) {
-        if (lower.endsWith(ext)) return lang;
-    }
-    // Special filenames
-    const name = lower.split("/").pop() || "";
-    if (name === "dockerfile") return "shell";
-    if (name === "makefile") return "shell";
-    if (name === "cargo.toml" || name === "cargo.lock") return "toml";
-    return "text";
-}
+// Re-export `deriveLanguage` so callers that previously imported
+// `detectLanguage` from this module continue to work.
+export { deriveLanguage as detectLanguage };

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -504,8 +504,16 @@ const EXTENSION_MAP: Record<string, string> = {
 };
 
 export function detectLanguage(filePath: string): string {
-    const i = filePath.lastIndexOf(".");
-    if (i < 0) return "text";
-    const ext = filePath.slice(i).toLowerCase();
-    return EXTENSION_MAP[ext] ?? "text";
+    const lower = filePath.toLowerCase();
+    // Extension lookup. Use endsWith so multi-segment extensions like
+    // `.test.tsx` still resolve via the trailing component.
+    for (const [ext, lang] of Object.entries(EXTENSION_MAP)) {
+        if (lower.endsWith(ext)) return lang;
+    }
+    // Special bareword filenames (no extension or unusual conventions).
+    const name = lower.split(/[\\/]/).pop() ?? "";
+    if (name === "dockerfile") return "shell";
+    if (name === "makefile") return "shell";
+    if (name === "cargo.toml" || name === "cargo.lock") return "toml";
+    return "text";
 }

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -23,7 +23,6 @@ import {
     EditorPaneEvent,
     EditorTab,
     canonicalizePath,
-    deriveLanguage,
     dispatch,
     registerEditorPane,
     setEventSink,
@@ -281,10 +280,14 @@ export class EditorViewModel implements ViewModel {
 
         // Dispatch OpenFile. The slice either activates an existing tab (and
         // emits only TabActivated) or appends a new one (TabOpened +
-        // TabActivated). We then load content if the tab hasn't loaded yet.
+        // TabActivated). Pass the *mapped* language (detectLanguage) — the
+        // slice's bare `deriveLanguage` returns raw extensions, which
+        // downstream lookups (loadLanguage in editor-view, LSP support
+        // table) don't recognize.
         const events = dispatch(this.blockId, {
             type: "OpenFile",
             path: filePath,
+            language: detectLanguage(filePath),
             source: "user",
         });
 
@@ -459,6 +462,50 @@ function clampTreeWidth(w: number): number {
     return Math.max(TREE_WIDTH_MIN, Math.min(TREE_WIDTH_MAX, Math.round(w)));
 }
 
-// Re-export `deriveLanguage` so callers that previously imported
-// `detectLanguage` from this module continue to work.
-export { deriveLanguage as detectLanguage };
+// ── Language detection ──────────────────────────────────────────────────────
+// Maps file extensions to the canonical names the rest of the editor expects:
+// `loadLanguage` in editor-view.tsx, LSP_SUPPORTED_LANGUAGES in install-hints.ts.
+// The slice's `deriveLanguage` returns raw extensions ("ts", "py") — fine as a
+// fallback label, but downstream lookups need the mapped form ("typescript",
+// "python"). Keep this map in sync with `loadLanguage`'s switch.
+
+const EXTENSION_MAP: Record<string, string> = {
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".py": "python",
+    ".rs": "rust",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".scss": "css",
+    ".json": "json",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".ps1": "powershell",
+    ".sql": "sql",
+    ".go": "go",
+    ".java": "java",
+    ".c": "c",
+    ".cpp": "cpp",
+    ".h": "c",
+    ".hpp": "cpp",
+    ".xml": "html",
+    ".svg": "html",
+};
+
+export function detectLanguage(filePath: string): string {
+    const i = filePath.lastIndexOf(".");
+    if (i < 0) return "text";
+    const ext = filePath.slice(i).toLowerCase();
+    return EXTENSION_MAP[ext] ?? "text";
+}

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -1,0 +1,85 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Editor tab strip — Phase 1B of SPEC_EDITOR_TABS_2026-05-26.md.
+// Renders above CodeMirror; one tab per open file. Click to activate,
+// × (hover-shown) to close, middle-click to close. No overflow chip yet
+// (tabs compress to min-width when crowded); chip lands in Phase 2.
+
+import { For, type JSX } from "solid-js";
+import type { EditorViewModel } from "./editor-model";
+import type { EditorTab } from "@/app/store/editor-pane-state-store";
+
+interface Props {
+    model: EditorViewModel;
+}
+
+export function EditorTabStrip(props: Props): JSX.Element {
+    const tabs = props.model.tabsAtom;
+    const activeId = props.model.activeIdAtom;
+
+    return (
+        <div
+            class="editor-tab-strip"
+            // Double-click inside the strip should not maximize the pane —
+            // matches the icon-toggle pattern from blockframe.tsx.
+            onDblClick={(e) => e.stopPropagation()}
+        >
+            <For each={tabs()}>
+                {(tab) => <Tab tab={tab} active={activeId() === tab.id} model={props.model} />}
+            </For>
+        </div>
+    );
+}
+
+function Tab(props: { tab: EditorTab; active: boolean; model: EditorViewModel }): JSX.Element {
+    const basename = () => {
+        const fp = props.tab.filePath;
+        const i = Math.max(fp.lastIndexOf("/"), fp.lastIndexOf("\\"));
+        return i >= 0 ? fp.slice(i + 1) : fp;
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+        // Middle-click → close (matches VS Code / Chrome convention).
+        if (e.button === 1) {
+            e.preventDefault();
+            props.model.closeTab(props.tab.id);
+        }
+    };
+
+    const onClick = (e: MouseEvent) => {
+        // Ignore middle-click here — onMouseDown already handled it.
+        if (e.button !== 0) return;
+        if (!props.active) props.model.switchTab(props.tab.id);
+    };
+
+    const onCloseClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        props.model.closeTab(props.tab.id);
+    };
+
+    return (
+        <div
+            class="editor-tab"
+            classList={{
+                "editor-tab--active": props.active,
+                "editor-tab--dirty": props.tab.dirty,
+            }}
+            title={props.tab.filePath}
+            onMouseDown={onMouseDown}
+            onClick={onClick}
+        >
+            <span class="editor-tab-label">{basename()}</span>
+            <button
+                class="editor-tab-close"
+                onClick={onCloseClick}
+                title={props.tab.dirty ? "Close (unsaved changes)" : "Close"}
+                aria-label="Close tab"
+            >
+                {/* The × always renders for dirty tabs (since closing prompts
+                    the user in a follow-up commit); hover-shown otherwise. */}
+                ×
+            </button>
+        </div>
+    );
+}

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -238,6 +238,95 @@
     overflow: hidden;
 }
 
+// ── Tab strip (Phase 1B of SPEC_EDITOR_TABS_2026-05-26.md) ─────────────────
+// Chrome above CodeMirror — not zoomed by --editor-zoom. Tabs flex 80–140px;
+// overflow chip lands in Phase 2.
+
+.editor-tab-strip {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    height: 28px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--secondary-bg-color, var(--block-bg-color));
+    overflow-x: hidden;
+}
+
+.editor-tab {
+    flex: 1 1 140px;
+    min-width: 80px;
+    max-width: 200px;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 0 var(--space-1) 0 var(--space-2);
+    border-right: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+    user-select: none;
+    font-size: 11px;
+    overflow: hidden;
+    transition: background 80ms ease, color 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.03);
+        color: var(--main-text-color);
+
+        .editor-tab-close {
+            opacity: 1;
+        }
+    }
+
+    &--active {
+        background: var(--block-bg-color);
+        color: var(--main-text-color);
+        // Subtle bottom-border that visually connects the active tab to the
+        // editor area below (the strip's own border-bottom is hidden under
+        // the active tab via the negative margin trick).
+        box-shadow: inset 0 -2px 0 0 var(--accent-color);
+    }
+
+    &--dirty {
+        // Dirty tabs always show their × so the user knows close requires
+        // confirmation (modal lands in a follow-up commit).
+        .editor-tab-close {
+            opacity: 1;
+        }
+    }
+}
+
+.editor-tab-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.editor-tab-close {
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 80ms ease, background 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.1);
+    }
+}
+
 .editor-open-prompt {
     display: flex;
     flex-direction: column;

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -16,6 +16,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { settingsAtom } from "@/store/global";
 import type { EditorViewModel } from "./editor-model";
+import { EditorTabStrip } from "./editor-tab-strip";
 import { FileTree } from "./file-tree";
 import { LspClient, type LspState } from "./lsp/lsp-client";
 import { lspDiagnosticsExtension } from "./lsp/lsp-extensions";
@@ -208,7 +209,14 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         return isWin ? decoded.replace(/\//g, "\\") : decoded;
     };
 
-    // Build or rebuild CodeMirror when content/language changes
+    // Per-tab CodeMirror state cache — preserves cursor, selection, scroll,
+    // undo history across tab switches. Populated on tab switch (snapshot of
+    // outgoing), cleared on TabClosed via the slice event subscription
+    // wired below.
+    const cmStates = new Map<string, EditorState>();
+    let activeTabIdForCm: string | null = null;
+
+    // Build or rebuild CodeMirror when the active tab changes
     const setupEditor = async (content: string, language: string, readOnly: boolean) => {
         if (!containerRef) return;
 
@@ -306,30 +314,57 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         document.addEventListener("mouseup", onUp);
     };
 
-    // Rebuild only when a NEW file is opened (path changes), not on every
-    // keystroke. contentAtom is updated by onContentChange on every keypress —
-    // reading it inside a tracked effect would destroy+recreate CodeMirror
-    // on every keystroke. untrack() prevents SolidJS from subscribing to
-    // those inner reads.
+    // Rebuild CodeMirror on tab change. Tracks activeIdAtom (not just
+    // filePathAtom) so we get a unique trigger per tab — multiple tabs
+    // could share the same path in pathological cases, but each has its own
+    // id. The outgoing tab's state is snapshotted into cmStates BEFORE the
+    // rebuild so we can restore it on the next switch back.
     createEffect(() => {
-        const path = model.filePathAtom(); // reactive dependency
-        const loading = model.loadingAtom(); // reactive dependency
-        if (!loading && path && containerRef) {
-            untrack(() => {
-                const content = model.contentAtom();
-                const lang = model.languageAtom();
-                const readOnly = model.readOnlyAtom();
-                void setupEditor(content, lang, readOnly).then(() => {
-                    // Kick off LSP after CodeMirror is up so the Compartment
-                    // reconfigure has somewhere to land.
-                    void startLspIfSupported(path, lang, content);
-                });
+        const activeId = model.activeIdAtom(); // reactive: tab change
+        const loading = model.loadingAtom(); // reactive: wait for content
+        if (!activeId || loading || !containerRef) return;
+
+        untrack(() => {
+            const path = model.filePathAtom();
+            const content = model.contentAtom();
+            const lang = model.languageAtom();
+            const readOnly = model.readOnlyAtom();
+
+            // Snapshot outgoing tab's CodeMirror state for cursor/scroll/
+            // undo preservation. Skipped on first mount (no prevId).
+            if (activeTabIdForCm && activeTabIdForCm !== activeId && cmView) {
+                cmStates.set(activeTabIdForCm, cmView.state);
+            }
+            activeTabIdForCm = activeId;
+
+            // If we have a saved state for this tab, restore via setState
+            // on the existing cmView (no destroy). Otherwise build fresh.
+            const saved = cmStates.get(activeId);
+            if (saved && cmView) {
+                cmView.setState(saved);
+                // Re-wire LSP for the now-active file's content.
+                void startLspIfSupported(path, lang, content);
+                return;
+            }
+            void setupEditor(content, lang, readOnly).then(() => {
+                void startLspIfSupported(path, lang, content);
             });
+        });
+    });
+
+    // Clear cached CodeMirror state when its tab closes, so re-opening
+    // the same file later starts fresh (matches user expectation —
+    // closed-then-reopened ≠ "still has unsaved changes").
+    const unsubSliceEvents = model.onSliceEvent((event) => {
+        if (event.type === "TabClosed") {
+            cmStates.delete(event.tabId);
         }
     });
 
     onCleanup(() => {
         void teardownLsp();
+        unsubSliceEvents();
+        cmStates.clear();
         cmView?.destroy();
         cmView = null;
     });
@@ -438,6 +473,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             </Show>
 
             <div class="editor-main-column">
+                <Show when={model.tabsAtom().length > 0}>
+                    <EditorTabStrip model={model} />
+                </Show>
+
                 <Show when={model.loadingAtom()}>
                     <div class="editor-loading">Loading...</div>
                 </Show>


### PR DESCRIPTION
## Summary

Phase 1B of the editor tabs feature. Builds on the slice scaffolding from #1087 (Phase 1A) — wires the `EditorViewModel` to slice #10 (`editor-pane-state`) and renders a tab strip above CodeMirror.

Spec: `specs/SPEC_EDITOR_TABS_2026-05-26.md` (untracked locally; not in this PR).

## What's in

- **EditorViewModel** — single-file signals removed; all derived accessors (`filePathAtom`, `dirtyAtom`, `readOnlyAtom`, `errorAtom`, `loadingAtom`, `languageAtom`) now derive from the slice's active tab. `contentAtom` reads from a view-local `Map<tabId, content>` (content deliberately not in the slice — large blobs, not auditable). `openFile` dispatches `OpenFile`, loads content via RPC, dispatches `TabContentLoaded` with sha256 hash. New `closeTab` / `switchTab` / `reopenLastClosed` action methods. New `onSliceEvent(handler)` subscription for view-side reactions to slice events.
- **EditorTabStrip** (new component) — renders one tab per open file. Click to activate, × (hover-shown, always for dirty) to close, middle-click to close. Title attr shows full path; active tab gets `--accent-color` underline. Tab strip stops dblclick propagation so fast clicks don't maximize the pane (matches the icon-toggle pattern from #1071/#1084).
- **editor-view.tsx** — per-tab `Map<string, EditorState>` for cursor/selection/scroll/undo preservation across tab switches. The `createEffect` now tracks `activeIdAtom` (not just `filePathAtom`); snapshots the outgoing tab's state before rebuilding. `cmStates` Map is cleared on `TabClosed` events via the slice subscription.
- **editor-view.scss** — tab strip styles (28px high, 80–140px tabs, hover/active/dirty modifiers).
- **Backwards-compat hydration** — existing block meta key `"file"` (the single-file key) still restores as a one-tab list on first mount. The 1C saga will replace this with `editor:tabs` persistence.

## Out of scope (follow-ups)

- **Dirty-confirm modal** — current behavior: × force-closes dirty tabs, matching today's pane-close behavior. Modal lands in a follow-up commit that consumes the slice's `RequestDirtyConfirm` event.
- **Keyboard shortcuts** (Ctrl+W, Ctrl+Tab, Ctrl+1..9, Ctrl+Shift+T) — needs `keymodel.ts` registration.
- **Right-click context menu** (Close, Close others, Close to the right, Copy path, Reveal in tree).
- **Overflow chip** when tabs don't fit — tabs compress to 80px min for now.
- **Persistence saga** — Phase 1C. The legacy `file` meta is still written for the active tab so downgrade/saga-less builds keep working.
- **Global default tabs fallback** — Phase 1C.

## Test plan

- [x] `npx tsc --noEmit` clean for editor files
- [x] `npx vitest run frontend/app/store/editor-pane-state-store.test.ts` → 35/35 still passing
- [ ] Smoke test in `task dev`: open file from tree → new tab appears, content loads. Click another file → second tab, switches content. Click first tab → switches back, **cursor + scroll preserved** (the key UX win). Type to dirty → underline pulses, × stays visible. Close active tab → right neighbor activates. Close only tab → pane shows empty-state.
- [ ] Backwards compat: open a pane with existing `meta.file` set → it hydrates as a one-tab list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)