### PR TITLE
feat(floating-pane): floater = free-floating docked pane, no extra chrome

### DIFF
--- a/.changesets/1779855451-feat-floating-pane-floater-renders-as-a-free-floating-docked-zp8w.md
+++ b/.changesets/1779855451-feat-floating-pane-floater-renders-as-a-free-floating-docked-zp8w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(floating-pane): floater renders as a free-floating docked pane — no extra chrome, no OS controls

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -283,34 +283,27 @@ fn escape_query_value(s: &str) -> String {
 }
 
 /// WndProc for the floating-pane class. Removes the system non-client
-/// area (no native title bar / borders drawn) and maps the docked-pane
-/// standard `BlockFrame_Header` (rendered by the frontend at the top of
-/// the floater) to `HTCAPTION` so the OS handles the drag loop
-/// natively. The per-pane action buttons on the right side of the
-/// header (close, magnify, mic, endIconButtons) are excluded from the
-/// drag region so React can receive their clicks.
+/// area (no native title bar / borders drawn) and maps the 6 CSS-px
+/// edge bands to `HT{LEFT,RIGHT,...}` so the window remains resizable.
 ///
-/// CSS reference (must stay in sync with the docked-pane header):
-///   - pane header height: 33 CSS px (`--header-height` in
-///     `frontend/app/theme.scss:97`)
-///   - action button cluster: right-anchored; reserve 130 CSS px of
-///     click-through to cover the typical button set (close ~28,
-///     magnify ~28, plus padding + extras). Buttons sit at the right
-///     edge per `BlockFrame_Header_End` in
-///     `frontend/app/block/blockframe.tsx`.
+/// Window-drag is intentionally NOT handled here. We tried HTCAPTION
+/// over the pane header but two problems made it unworkable:
 ///
-/// Edge resize zones take precedence over `HTCAPTION` so the corner
-/// resize cursors still work when the cursor is in the header band
-/// near a corner. All CSS-px constants are DPI-scaled via
-/// `GetDpiForWindow`.
+///   1. The pane header sits below tile-layout padding (some y-offset
+///      from the window top), so any hard-coded Y range is fragile.
+///   2. Mouse events in an HTCAPTION zone never reach the CEF child
+///      HWND — buttons inside the header (close / magnify / mic /
+///      view-specific endIconButtons) stop responding.
 ///
-/// This mirrors the agentmux frameless-window pattern in
-/// `agentmux-cef/src/client/wndproc.rs::install_frameless_resize_hook`
-/// — extended with `HTCAPTION`. We don't reuse the main window's
-/// JS-driven `useWindowDrag` hook because that path resolves the HWND
-/// via `find_own_top_level_window` (process-wide `EnumWindows`), which
-/// returns whichever top-level window the OS enumerates first — not
-/// necessarily the calling floating pane.
+/// Window drag is instead JS-driven in
+/// `frontend/app/workspace/floating-pane-workspace.tsx`: a targeted
+/// document-level mousedown listener scoped to `[data-role="block-header"]`,
+/// `preventDefault`-ing to suppress the HTML5 dragstart that
+/// pragmatic-dnd would have used (which otherwise tore the pane off
+/// into a second floating window — the "double tear-off" bug). Same
+/// pattern as the main window's `useWindowDrag` hook.
+///
+/// See `docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md`.
 #[cfg(target_os = "windows")]
 unsafe extern "system" fn floating_pane_wndproc(
     hwnd: *mut std::ffi::c_void,
@@ -321,20 +314,12 @@ unsafe extern "system" fn floating_pane_wndproc(
     use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
     use windows_sys::Win32::UI::WindowsAndMessaging::*;
 
-    // All zone constants are in CSS / DIP pixels and scaled to physical
-    // pixels per the HWND's DPI inside the WM_NCHITTEST branch. Hard-
-    // coded physical-pixel constants here would shrink the hit zones on
-    // HiDPI monitors — a 6-physical-px resize border is 3 CSS px at 200%
-    // DPI and effectively unreachable.
-    //
-    // PANE_HEADER_HEIGHT_CSS matches `--header-height` in
-    // `frontend/app/theme.scss:97`. ACTION_BUTTON_ZONE_CSS is empirical
-    // — large enough to cover the docked-pane action cluster (close,
-    // magnify, mic, view-specific endIconButtons) without intruding on
-    // the title-text area where window drag should be live.
+    // Edge resize zone in CSS / DIP pixels, scaled to physical pixels
+    // per the HWND's DPI inside the WM_NCHITTEST branch. A hard-coded
+    // physical-pixel constant would shrink the hit zone on HiDPI —
+    // a 6-physical-px resize border is 3 CSS px at 200% DPI and
+    // effectively unreachable.
     const RESIZE_BORDER_CSS: i32 = 6;
-    const PANE_HEADER_HEIGHT_CSS: i32 = 33;
-    const ACTION_BUTTON_ZONE_CSS: i32 = 130;
 
     match msg {
         // Claim the entire window rect as client area — no system title
@@ -350,14 +335,13 @@ unsafe extern "system" fn floating_pane_wndproc(
             let mut rect = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
             GetWindowRect(hwnd, &mut rect);
 
-            // Scale all CSS-px zones to physical px against THIS HWND's
-            // current monitor — handles mid-life monitor changes (the
-            // window can move between monitors at different DPIs).
+            // Scale the resize-border CSS px to physical px against
+            // THIS HWND's current monitor — handles mid-life monitor
+            // changes (the window can move between monitors at
+            // different DPIs).
             let dpi = GetDpiForWindow(hwnd) as i32;
             let dpi = if dpi > 0 { dpi } else { 96 };
             let resize_border_px = (RESIZE_BORDER_CSS * dpi / 96).max(1);
-            let header_px = PANE_HEADER_HEIGHT_CSS * dpi / 96;
-            let action_zone_px = ACTION_BUTTON_ZONE_CSS * dpi / 96;
 
             let left = x - rect.left < resize_border_px;
             let right = rect.right - x < resize_border_px;
@@ -388,12 +372,9 @@ unsafe extern "system" fn floating_pane_wndproc(
                 return HTBOTTOM as isize;
             }
 
-            // Pane-header drag zone (excluding the right-anchored action
-            // button cluster so close / magnify / mic / endIconButtons
-            // remain clickable).
-            if y - rect.top < header_px && rect.right - x > action_zone_px {
-                return HTCAPTION as isize;
-            }
+            // Pane-header drag is JS-driven (see floating-pane-workspace.tsx);
+            // we don't map any zone to HTCAPTION here. Fall through to
+            // HTCLIENT so clicks reach CEF and the JS handler.
         }
         _ => {}
     }

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -283,19 +283,26 @@ fn escape_query_value(s: &str) -> String {
 }
 
 /// WndProc for the floating-pane class. Removes the system non-client
-/// area (no native title bar / borders drawn) and maps the frontend's
-/// 30 CSS-px title bar to `HTCAPTION` so the OS handles the drag loop
-/// natively. The close button on the right side of the title bar is
-/// excluded from the drag region so React can receive its click.
+/// area (no native title bar / borders drawn) and maps the docked-pane
+/// standard `BlockFrame_Header` (rendered by the frontend at the top of
+/// the floater) to `HTCAPTION` so the OS handles the drag loop
+/// natively. The per-pane action buttons on the right side of the
+/// header (close, magnify, mic, endIconButtons) are excluded from the
+/// drag region so React can receive their clicks.
 ///
-/// CSS reference (must stay in sync with `frontend/app/workspace/floating-pane-workspace.tsx`):
-///   - title-bar height: 30 CSS px
-///   - close button: 28 CSS px wide, right-anchored; allow 36 CSS px
-///     of click-through to be safe (covers padding-right + button width).
+/// CSS reference (must stay in sync with the docked-pane header):
+///   - pane header height: 33 CSS px (`--header-height` in
+///     `frontend/app/theme.scss:97`)
+///   - action button cluster: right-anchored; reserve 130 CSS px of
+///     click-through to cover the typical button set (close ~28,
+///     magnify ~28, plus padding + extras). Buttons sit at the right
+///     edge per `BlockFrame_Header_End` in
+///     `frontend/app/block/blockframe.tsx`.
 ///
-/// Edge resize zones (6 physical px) take precedence over `HTCAPTION`
-/// so the corner resize cursors still work when the cursor is in the
-/// title-bar band near a corner.
+/// Edge resize zones take precedence over `HTCAPTION` so the corner
+/// resize cursors still work when the cursor is in the header band
+/// near a corner. All CSS-px constants are DPI-scaled via
+/// `GetDpiForWindow`.
 ///
 /// This mirrors the agentmux frameless-window pattern in
 /// `agentmux-cef/src/client/wndproc.rs::install_frameless_resize_hook`
@@ -319,9 +326,15 @@ unsafe extern "system" fn floating_pane_wndproc(
     // coded physical-pixel constants here would shrink the hit zones on
     // HiDPI monitors — a 6-physical-px resize border is 3 CSS px at 200%
     // DPI and effectively unreachable.
+    //
+    // PANE_HEADER_HEIGHT_CSS matches `--header-height` in
+    // `frontend/app/theme.scss:97`. ACTION_BUTTON_ZONE_CSS is empirical
+    // — large enough to cover the docked-pane action cluster (close,
+    // magnify, mic, view-specific endIconButtons) without intruding on
+    // the title-text area where window drag should be live.
     const RESIZE_BORDER_CSS: i32 = 6;
-    const TITLEBAR_HEIGHT_CSS: i32 = 30;
-    const CLOSE_BUTTON_ZONE_CSS: i32 = 36;
+    const PANE_HEADER_HEIGHT_CSS: i32 = 33;
+    const ACTION_BUTTON_ZONE_CSS: i32 = 130;
 
     match msg {
         // Claim the entire window rect as client area — no system title
@@ -343,8 +356,8 @@ unsafe extern "system" fn floating_pane_wndproc(
             let dpi = GetDpiForWindow(hwnd) as i32;
             let dpi = if dpi > 0 { dpi } else { 96 };
             let resize_border_px = (RESIZE_BORDER_CSS * dpi / 96).max(1);
-            let titlebar_px = TITLEBAR_HEIGHT_CSS * dpi / 96;
-            let close_zone_px = CLOSE_BUTTON_ZONE_CSS * dpi / 96;
+            let header_px = PANE_HEADER_HEIGHT_CSS * dpi / 96;
+            let action_zone_px = ACTION_BUTTON_ZONE_CSS * dpi / 96;
 
             let left = x - rect.left < resize_border_px;
             let right = rect.right - x < resize_border_px;
@@ -375,8 +388,10 @@ unsafe extern "system" fn floating_pane_wndproc(
                 return HTBOTTOM as isize;
             }
 
-            // Title bar drag zone (excluding close-button click-through).
-            if y - rect.top < titlebar_px && rect.right - x > close_zone_px {
+            // Pane-header drag zone (excluding the right-anchored action
+            // button cluster so close / magnify / mic / endIconButtons
+            // remain clickable).
+            if y - rect.top < header_px && rect.right - x > action_zone_px {
                 return HTCAPTION as isize;
             }
         }
@@ -487,6 +502,32 @@ fn create_owned_popup(
     if hwnd.is_null() {
         let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
         return Err(format!("CreateWindowExW returned NULL (GetLastError={err})"));
+    }
+
+    // Tell DWM to extend the entire frame into the client area. Without
+    // this, DWM keeps drawing the standard Win32 title bar (and the
+    // minimize/maximize/close caption buttons that come with it) on top
+    // of our client area, even though our `WM_NCCALCSIZE → 0` says the
+    // client area fills the window. Mirrors the main-window setup in
+    // `client/wndproc.rs::setup_native_frameless` — combined with our
+    // WndProc's `WM_NCCALCSIZE`/`WM_NCACTIVATE`/`WM_NCHITTEST`, this
+    // gives a truly chrome-free outer HWND. Only the frontend's 30 CSS-px
+    // header remains, and it's the sole drag/close UI.
+    unsafe {
+        use windows_sys::Win32::Graphics::Dwm::DwmExtendFrameIntoClientArea;
+        use windows_sys::Win32::UI::Controls::MARGINS;
+        let margins = MARGINS {
+            cxLeftWidth: -1,
+            cxRightWidth: -1,
+            cyTopHeight: -1,
+            cyBottomHeight: -1,
+        };
+        let hr = DwmExtendFrameIntoClientArea(hwnd, &margins);
+        if hr != 0 {
+            tracing::warn!(
+                "[floating-pane] DwmExtendFrameIntoClientArea failed hr=0x{hr:08x} — system title bar may still be drawn",
+            );
+        }
     }
 
     unsafe {

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -496,8 +496,10 @@ fn create_owned_popup(
     // client area fills the window. Mirrors the main-window setup in
     // `client/wndproc.rs::setup_native_frameless` — combined with our
     // WndProc's `WM_NCCALCSIZE`/`WM_NCACTIVATE`/`WM_NCHITTEST`, this
-    // gives a truly chrome-free outer HWND. Only the frontend's 30 CSS-px
-    // header remains, and it's the sole drag/close UI.
+    // gives a truly chrome-free outer HWND. The docked-pane's standard
+    // `BlockFrame_Header` (33 CSS px, `--header-height` in theme.scss:97)
+    // is the sole chrome — drag is JS-driven from
+    // `frontend/app/workspace/floating-pane-workspace.tsx`.
     unsafe {
         use windows_sys::Win32::Graphics::Dwm::DwmExtendFrameIntoClientArea;
         use windows_sys::Win32::UI::Controls::MARGINS;

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -419,7 +419,7 @@ fn create_owned_popup(
     use windows_sys::Win32::Foundation::HWND;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         CreateWindowExW, RegisterClassExW, ShowWindow, CS_HREDRAW, CS_VREDRAW, SW_SHOWNOACTIVATE,
-        WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_OVERLAPPEDWINDOW, WS_POPUP,
+        WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_POPUP, WS_THICKFRAME,
     };
 
     // ---- Register the class once per process ----
@@ -483,11 +483,15 @@ fn create_owned_popup(
             class_name_utf16.as_ptr(),
             title_utf16.as_ptr(),
             // WS_POPUP for free positioning (NOT WS_CHILD — children
-            // are clipped to parent's client area). WS_OVERLAPPEDWINDOW
-            // for the resizable border + sysmenu. Phase 6 will
-            // customize the title bar via WM_NCHITTEST; Phase 1 ships
-            // with the default chrome so drag works out of the box.
-            WS_POPUP | WS_OVERLAPPEDWINDOW,
+            // are clipped to parent's client area). WS_THICKFRAME for
+            // the resize border. NO `WS_CAPTION` — Win32 still reserves
+            // title-bar space for WS_CAPTION windows even when
+            // WM_NCCALCSIZE returns 0, which leaves a system title bar
+            // drawn on top of the client area AND truncates the
+            // effective client size (CEF embedded at (0,0,W,H) overruns
+            // the visible client → content cut off bottom+right). The
+            // frontend's `BlockFrame_Header` is the only chrome.
+            WS_POPUP | WS_THICKFRAME,
             x,
             y,
             width,

--- a/docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md
+++ b/docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md
@@ -1,0 +1,259 @@
+# Analysis: How should the floating pane header drag the window?
+
+**Date:** 2026-05-27
+**Status:** Decision pending; recommendation = Option B
+
+## The problem
+
+After stripping the custom title bar from the floating-pane workspace
+(PR #1089), the floater renders the docked-pane's standard
+`BlockFrame_Header` as its sole chrome. Dragging the pane header
+should **move the floating window** — same as how dragging the main
+window's title bar moves it.
+
+What happens instead: pragmatic-dnd's `draggable()` setup on the pane
+header fires its HTML5 `dragstart`, the pane drag-out flow kicks in,
+and the user gets a **new floating window torn off the original
+floating window** — a "double tear-off". The original floater stays
+put. Pane content in the second floater is hidden because no body —
+the workspace gets two confusing single-pane windows.
+
+Pinned in the latest test session: user reports "if I try to drag the
+floating window, it doesnt drag, but creates a new floating window,
+like another tear".
+
+## Why HTCAPTION (current attempt) isn't catching the click
+
+PR #1082 added a custom WndProc on the floating-pane class
+(`agentmux-cef/src/floating_pane.rs::floating_pane_wndproc`) that
+returns `HTCAPTION` for `Y < 33 CSS px` and `(rect.right - x) > 130
+CSS px`. The intent: the OS treats that band as the caption, dispatches
+the click as a non-client event, owns the drag loop, never lets the
+click reach CEF.
+
+The 33 CSS-px figure matches `--header-height` in
+`frontend/app/theme.scss:97` — the height of `BlockFrame_Header`
+itself. But the pane header isn't at `Y=0` of the window. Between the
+window's client-area top and the header's first pixel, there's:
+
+- the TileLayout's outer container padding
+- per-tile padding / gap
+- the block frame's own outer container (the `.block-frame-default`
+  element wraps `.block-frame-default-inner` which contains the
+  header)
+
+In practice the header probably starts around `Y=8..16 CSS px` and
+ends around `Y=41..49`. My zone covers `Y=0..33` — so the **bottom
+portion of the actual pane header** (where most of the title text and
+the action buttons sit) is **outside the HTCAPTION zone**. Clicks
+there pass through `DefWindowProcW → HTCLIENT → CEF → renderer JS →
+pragmatic-dnd → dragstart → tear-off saga.
+
+Bumping the zone to `Y=0..60` would mostly fix it for the current
+layout, but the zone is then sensitive to every CSS change in the
+tile layout, the block frame, or theme.scss. Brittle.
+
+## The three architectural options
+
+### Option A — OS-level via `WM_NCHITTEST → HTCAPTION`
+
+What we have today (broken). The host's WndProc tells the OS "this
+rectangle is the caption"; the OS owns the drag loop.
+
+| | |
+|---|---|
+| **Pros** | Native, zero IPC overhead — perfectly smooth 60-120 Hz tracking. Free Win32 niceties: ESC cancels drag, Win+arrow snap, drag-to-maximize edge gesture, multi-monitor handoff, cursor capture. Survives JS hangs / slowness. Simpler code (no state machine, no throttling). |
+| **Cons** | Hit-test is a coarse Y/X rectangle — can't selectively skip individual buttons inside the zone. **Fragile to layout**: any CSS padding change breaks the zone (current symptom). Mouse events in the zone never reach JS at all — buttons inside HTCAPTION die unless excluded coarsely. Different model from how the main window does drag. |
+| **Layout coupling** | High — zone depends on CSS-level Y offsets that no test enforces. |
+| **Tear-off conflict** | Resolved cleanly when HTCAPTION fires: pragmatic-dnd's mousedown never runs because the OS intercepts before CEF. Broken when the click misses the zone (today's bug). |
+| **Code touchpoints** | `agentmux-cef/src/floating_pane.rs::floating_pane_wndproc` only — ~30 LOC. |
+
+### Option B — JS-driven drag (mousedown + `get/set_window_position` IPC)
+
+Frontend JS listens for mousedown on the header element, queries
+current window position, drives moves via IPC. Same pattern as
+`frontend/app/hook/useWindowDrag.win32.ts` (the main window's drag).
+
+| | |
+|---|---|
+| **Pros** | Selective: `target.matches('button, a, input, ...')` cleanly skips interactive elements. Anchors to the **actual header DOM element** via `closest('[data-role="block-header"]')` — no Y-coordinate guesswork, immune to layout padding. **Same pattern as the main window** — consistent codebase. `e.preventDefault()` on mousedown suppresses HTML5 dragstart → blocks pragmatic-dnd's tear-off cleanly without any frontend gating. All header buttons (close, magnify, mic, view-specific endIconButtons) just work. |
+| **Cons** | IPC roundtrip on every mousemove (~5-15 ms latency per move). Small but theoretically visible lag — well-mitigated by the existing one-in-flight + coalesce throttling in `useWindowDrag.win32.ts:107-125`. Doesn't get free OS niceties (Win+arrow snap, edge drag-to-maximize). Depends on `find_own_top_level_window` returning the floating window's HWND — works by Z-order (the floater is foreground when you click it), but fragile if a second floater later sits on top. More code (mousedown/move/up state machine — though `useWindowDrag` is a working template). |
+| **Layout coupling** | Zero — anchors to a stable DOM attribute (`data-role="block-header"` set in `frontend/app/block/blockframe.tsx:420`). |
+| **Tear-off conflict** | Resolved by `e.preventDefault()` on mousedown in the JS handler — HTML5 dragstart never fires, pragmatic-dnd's draggable() never engages. |
+| **Code touchpoints** | `frontend/app/workspace/floating-pane-workspace.tsx` (new drag listener, ~60 LOC). `agentmux-cef/src/floating_pane.rs::floating_pane_wndproc` — strip the HTCAPTION block, keep edge resize (~20 LOC removed). |
+| **Latent bug** | `set_window_position` / `get_window_position` ignore their `label` arg on Windows (see `agentmux-cef/src/commands/window.rs:223,162`) and use `find_own_top_level_window` — works for the floater because of Z-order but should be fixed properly. Tracked as a follow-up. |
+
+### Option C — Hybrid: thin HTCAPTION moustache + JS for the rest
+
+Add a 4-6 px transparent drag strip above the pane header (or repurpose
+unused space) as HTCAPTION; JS handles everything else.
+
+| | |
+|---|---|
+| **Pros** | Snappy OS-level drag on the thin strip (Win+arrow snap works there). Buttons / clicks elsewhere via JS / pragmatic-dnd. |
+| **Cons** | Requires adding a 4-6 CSS px strip that **wasn't in the docked-pane look** — violates the "exactly like a docked pane" requirement. Two drag mechanisms to maintain. Strip placement awkward: above the header looks weird; below it is worse. |
+| **Layout coupling** | Medium — strip Y is fixed but its physical px size needs DPI scaling. |
+| **Tear-off conflict** | Same as B for the JS-handled regions. |
+| **Code touchpoints** | All of A's + all of B's + the strip rendering. |
+
+## Performance reality check
+
+The main window has used Option B (`useWindowDrag`) since the CEF
+migration with no user complaints about drag lag. Spec context:
+`docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md` documents the
+DPI/throttling fixes that landed for this hook. The same hook
+(throttled, one-in-flight, DPR-aware) works smoothly on a 4K @ 150%
+DPI dev box.
+
+For the floating pane, the move budget is even more forgiving — the
+floater is a single block, no other visual chrome to keep in sync.
+IPC overhead is not a real concern at this scale.
+
+## Cross-cutting concerns
+
+### The `find_own_top_level_window` problem
+
+Both `get_window_position` and `set_window_position` on Windows
+delegate to `find_own_top_level_window`, which does a process-wide
+`EnumWindows` and returns the first visible top-level of the current
+process. This is the right answer when the user is dragging the
+foreground window (which they always are, because they just clicked on
+it to start a drag), but it's wrong for any non-Z-topmost window —
+e.g. a programmatic move of a non-active floater.
+
+For Option B's normal usage path (user clicks → window comes to top →
+user drags), this is fine. But the IPC contract is technically wrong:
+both commands accept a `label` argument that's silently dropped on
+Windows. Fixing them to honor the label (via
+`state.get_browser(label).host().window_handle()`) is a
+~10-LOC follow-up that also benefits the main window when multiple
+top-level windows exist in the same process.
+
+Tracked but **not blocking** this work.
+
+### Click-through inside HTCAPTION zones
+
+Win32 doesn't let DOM elements rendered by CEF receive mouse events
+in an `HTCAPTION` zone — the OS intercepts the click and dispatches
+it as `WM_NCLBUTTONDOWN` to the outer WndProc. CEF's child HWND never
+sees it. This is what makes Option A fundamentally incompatible with
+buttons-inside-the-drag-region.
+
+The only workarounds: native Win32 child controls (not feasible for
+CEF-rendered UI), or excluding buttons from the HTCAPTION zone via X
+rectangle (what we're doing today for the right-anchored action
+cluster, but only works because they're all on one side).
+
+### `data-drag-region` ergonomics for Option B
+
+The main window's `useWindowDrag` walks the DOM looking for
+`data-drag-region` ancestors. A floating-pane drag handler should
+**not** install a global document-level mousedown listener (we'd drag
+the window any time the user clicked any non-button element) — it
+should be scoped to the pane header via either:
+
+- A targeted `addEventListener` on the `[data-role="block-header"]`
+  element (the approach proposed below).
+- OR an explicit `data-drag-region={true}` attribute on the header
+  *only when in a floating context*, plus a fix to `isInDragRegion`
+  to skip interactive elements (`button, a, input, select, textarea,
+  [role="button"]`).
+
+Both are workable; the targeted listener is simpler and doesn't
+require threading floating-context awareness through to the shared
+`BlockFrame_Header` component.
+
+## Recommendation
+
+**Option B**, scoped via the targeted-listener variant.
+
+### Implementation outline
+
+1. **`agentmux-cef/src/floating_pane.rs`** — strip the `HTCAPTION`
+   branch from `floating_pane_wndproc`. Keep the edge resize zones
+   (`HT{LEFT,RIGHT,TOP,BOTTOM,corners}`) and `WM_NCCALCSIZE → 0` /
+   `WM_NCACTIVATE → 1`. ~20 LOC removed.
+
+2. **`frontend/app/workspace/floating-pane-workspace.tsx`** — install
+   a mousedown listener at `onMount` that:
+   - Locates the live block header via `document.querySelector('[data-role="block-header"]')`.
+   - Or attaches at `document` level but gates on `target.closest('[data-role="block-header"]')`.
+   - Skips if the immediate click target is interactive (`target.closest('button, a, input, select, textarea, [role="button"]')`).
+   - On qualifying mousedown: `e.preventDefault()` (kills the HTML5
+     dragstart that pragmatic-dnd would have used), capture
+     `screenX`/`screenY`, IPC `get_window_position` to capture the
+     initial window-top-left.
+   - On mousemove: compute delta in CSS px, scale by `devicePixelRatio`
+     to physical, add to baseline, IPC `set_window_position` (with
+     the established one-in-flight + coalesce pattern from
+     `useWindowDrag.win32.ts:107-125`).
+   - On mouseup: clear the drag state.
+   - Cleanup on `onCleanup`.
+
+   ~60 LOC. Mirror of `useWindowDrag.win32.ts` minus the
+   data-drag-region traversal (we're scoped explicitly to the pane
+   header).
+
+3. **No changes to `BlockFrame_Header`** (`frontend/app/block/blockframe.tsx`)
+   — the docked-pane and floating-pane paths render the exact same
+   component. Window-drag behavior is opted-in by the floating-pane
+   workspace via the listener, not by the header itself.
+
+4. **No changes to pragmatic-dnd setup** in `TileLayout.win32.tsx` —
+   `e.preventDefault()` on mousedown in the floating-pane listener is
+   enough to block the HTML5 dragstart pragmatic-dnd relies on.
+
+### Net effect
+
+- Drag the pane header (title-text area) → window moves smoothly.
+- Click close / magnify / mic / endIconButton → button fires normally.
+- Click anywhere in the block body → reaches the block normally (no
+  drag, no tear-off, no surprises).
+- Resize at edges → still works (kept the edge resize zones in the
+  WndProc).
+- No more accidental "double tear-off".
+
+## What this analysis does NOT fix
+
+- The `find_own_top_level_window` label-vs-Z-order semantic. Tracked
+  as a follow-up: make `set_window_position` / `get_window_position`
+  honor the `label` argument on Windows via
+  `state.get_browser(label).host().window_handle()`.
+- Win+arrow snap and drag-to-maximize gestures on the floater. With
+  Option B we forgo these. If desired, Option C can be added later
+  as a thin HTCAPTION strip on a non-visible part of the chrome (e.g.
+  the very top 4 px of the window, below DwmExtendFrameIntoClientArea's
+  reach).
+- The VS Code drag-accept cursor problem (separate analysis at
+  `docs/analyses/ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md`).
+- Re-dock (Phase 4 per spec #810): dragging a floater back into the
+  source window's tile layout to re-dock. Not yet implemented.
+
+## Cross-references
+
+- `frontend/app/hook/useWindowDrag.win32.ts` — main-window drag
+  reference implementation (one-in-flight + coalesce, DPR scaling,
+  catch-up move on IPC resolution).
+- `frontend/layout/lib/TileLayout.win32.tsx:443-471` — pragmatic-dnd
+  `draggable()` setup on the pane header that we want to suppress
+  for floating-context drags.
+- `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` — orchestrates
+  the cross-window tear-off saga; not changed by this work but its
+  `dragend` listener is what would have fired the double-tear-off.
+- `agentmux-cef/src/floating_pane.rs::floating_pane_wndproc` —
+  current WndProc. Lines to remove: the `HTCAPTION` branch within
+  `WM_NCHITTEST`. Lines to keep: `WM_NCCALCSIZE`, `WM_NCACTIVATE`,
+  edge resize zones.
+- `agentmux-cef/src/client/wndproc.rs` — main window's
+  `install_frameless_resize_hook` (similar pattern, useful reference
+  for the edge resize zones).
+- `agentmux-cef/src/commands/window.rs:162,223,260` —
+  `get_window_position`, `set_window_position`, `start_window_drag`
+  IPC handlers; the latent `label`-vs-`find_own_top_level_window` bug
+  lives here.
+- `frontend/app/block/blockframe.tsx:420` — `data-role="block-header"`
+  attribute used to anchor the drag listener.
+- `frontend/app/theme.scss:97` — `--header-height: 33px`.
+- PR #1082 — original Phase 6 polish (HTCAPTION approach).
+- PR #1089 — chrome cleanup (drop custom title bar, drop `WS_CAPTION`,
+  add `DwmExtendFrameIntoClientArea`, auto-close on empty workspace).

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md
@@ -1,0 +1,340 @@
+# Spec: Floating pane re-dock (with multi-window + drop-target highlighting)
+
+**Date:** 2026-05-27
+**Owner:** AgentX
+**Status:** Draft (informed by user testing of #1089)
+**Phase:** 4 of the floating-pane tear-off rollout (per SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md §9)
+
+## Goal
+
+A user can drag a **floating pane back into any AgentMux window's tile
+layout** to re-dock it. Drop targets across **all source-process
+windows** light up while the drag is in flight, mirroring the existing
+within-window pane-drag affordance:
+
+- Drag the floater by its pane header → all eligible drop targets
+  (tile leaves, split edges, empty layouts) **highlight in real time**.
+- Drop on a target → the floater closes, the block re-attaches to the
+  target tab's layout at the chosen position.
+- Drop off-target → the floater stays put at the new cursor position.
+
+Multi-window aware: if the source process has the main window + two
+other floaters open, dropping into any of them is supported (within
+the source process).
+
+## Background
+
+After PR #1089 the floating pane window has:
+
+- Standard `BlockFrame_Header` as its sole chrome (no system title bar).
+- JS-driven window-drag from the header (mousedown → preventDefault →
+  `get_window_position` / `set_window_position` IPC).
+- Auto-close when the only pane in the floater's workspace is removed.
+
+What we DON'T have:
+
+- No way to bring a floating pane back into a tile layout — only "close
+  it" or "leave it free-floating".
+- No visual feedback when dragging the floater over a target window's
+  layout.
+
+The existing tile-drag flow (`frontend/layout/lib/TileLayout.win32.tsx`)
+DOES highlight drop targets via pragmatic-dnd's `dropTargetForElements`
+when a pane is dragged within a window. We want to extend that across
+windows for floating-pane re-dock.
+
+## Non-goals
+
+- **Cross-instance re-dock** (drag from process A's floater into
+  process B's window). Spec §10 of the original tear-off doc keeps
+  this out of scope; same here. The current cross-instance drag IPC
+  (`startCrossDrag` / `updateCrossDrag` / `completeCrossDrag`) could
+  carry this later as Phase 7.
+- **Re-dock to a NEW tab** in the target window. The drop lands on a
+  tile leaf within a *specific* tab; if the user wants to drop into a
+  not-currently-active tab they'd switch tabs first. Tab-bar-drop is a
+  future polish.
+- **Cross-platform parity**. This spec is Windows-first, following the
+  same staging as Phases 1/3/2. macOS + Linux come after the Win32
+  reference works.
+
+## Architecture
+
+### What changes vs. today's within-window pane drag
+
+The within-window pane drag uses pragmatic-dnd `draggable()` on the
+pane header (`TileLayout.win32.tsx:443-471`) with HTML5 dragstart →
+`dropTargetForElements` on tile leaves → drop fires the reducer's
+re-position command. All in-process, all single-window.
+
+For floating pane re-dock the topology is different:
+
+| Concern | Within-window drag | Floating re-dock |
+|---|---|---|
+| Source pane location | Inside the same window | In a **separate top-level HWND** that owns the source pane |
+| Drag mechanism | HTML5 dragstart (pragmatic-dnd) | Custom: starts as window-move; needs to also signal "this is a re-dock candidate" |
+| Drop targets visible to source | DOM nodes in same window | DOM nodes in **another window's renderer process** |
+| Reducer side | Single-window layout mutation | Cross-window block-move + layout mutation in target + window destroy on source |
+
+### The drag mechanism shift
+
+Today, dragging the floater's header is JS-driven window-move (PR
+#1089). To make re-dock work the same gesture needs to *also* allow
+target windows to detect "a floating pane is hovering over me".
+
+Two clean options:
+
+#### Option A — Reuse HTML5 drag, suppress window-move
+
+Make the floater's pane header use pragmatic-dnd's `draggable()` (same
+as the docked-pane setup but in floating context). Drag fires HTML5
+dragstart → dropTargets in OTHER windows show the highlight via the
+existing `monitorForElements` / `dropTargetForElements` machinery.
+No window-move during drag; the window snaps back to its origin on
+drop-off-target.
+
+- **Pros**: Reuses existing pragmatic-dnd plumbing. Drop-target
+  highlight is automatic — `dropTargetForElements` already exists for
+  in-window tile drops. Cross-window observation works via the
+  process-wide drag-event listeners that AgentMux already installed
+  for tab tear-off (`CrossWindowDragMonitor.win32.tsx`).
+- **Cons**: The floating window doesn't *move* during drag — it stays
+  put while a "ghost preview" follows the cursor. This is jarring for
+  the "I want to reposition this floater" case (user has to release on
+  the desktop / off-target to actually move it, which then... doesn't
+  move it — it just stays).
+- **Workaround**: We could detect drop-off-target in
+  `CrossWindowDragMonitor.win32.tsx` and at that point use the recorded
+  cursor position to move the floater to its drop point. So drop-on-
+  desktop = reposition floater, drop-on-target = re-dock. The user's
+  intent maps cleanly to the drop location.
+
+#### Option B — Keep window-move; layer a transparent "drop probe" overlay
+
+Keep the current JS-driven window-move (so the floater follows the
+cursor). At dragstart, *also* spawn a small transparent click-through
+overlay that emits its own HTML5 drag events at the cursor position,
+which the target windows' dropTargets pick up.
+
+- **Pros**: Floater follows cursor immediately (no jarring snap-back).
+- **Cons**: Two parallel drag mechanisms; coordinating them is
+  fragile. The overlay has to live in *the source window's renderer*
+  but generate events that *other windows' renderers* see — which is
+  exactly what cross-window HTML5 drag does for free if we use Option
+  A. Engineering cost is higher; correctness window is smaller.
+
+**Recommendation: Option A** with the drop-off-target → reposition
+floater workaround. The "ghost preview during drag, real move on
+release" model is what Chrome does for tab tear-off and is well-
+understood. The visual jarring is one-time at drop, not per-frame
+during the drag.
+
+### Highlight model
+
+For drop targets to highlight, the target windows must:
+
+1. Be running pragmatic-dnd's `dropTargetForElements` registrations
+   on their tile leaves (`TileLayout.win32.tsx` already does this).
+2. Receive `dragenter`/`dragover` events for the in-flight drag.
+
+(1) is already in place — every TileLayout instance registers drop
+zones. (2) requires the HTML5 drag's `dataTransfer` to be set up such
+that other windows' renderers observe it.
+
+For HTML5 drag on Windows, dragenter on a different window's renderer
+fires automatically when the OS routes the drag cursor over that
+window. The dataTransfer payload carries the drag's source-window
+identity so dropTargets can decide whether to accept (only accept if
+the source is a floating pane from the same process — reject foreign
+apps).
+
+Existing tab tear-off uses `application/x-tab-drag` (or
+`application/vnd.pdnd` from pragmatic-dnd's element adapter). Floating
+pane re-dock will use a sibling MIME / payload:
+`application/x-floating-pane-redock` or extend the existing
+pragmatic-dnd payload with `{ kind: "floating-pane", blockId,
+sourceWorkspaceId, sourceWindowLabel }`.
+
+### Multi-window state — drop target enumeration
+
+The source process has N top-level windows (main + zero or more
+floaters + zero or more tab tear-off windows). When the floater is
+dragged, all N-1 *other* windows' renderers see the dragenter/over
+events automatically (CEF + Win32 routes them based on cursor
+position). Each renderer's `TileLayout` decides per-leaf whether to
+accept based on the drag payload.
+
+We need to ensure:
+
+- The drag payload identifies the dragged block (`blockId`) and source
+  window (`sourceWindowLabel`).
+- Each TileLayout's `dropTargetForElements` accepts floating-pane drags
+  AND existing pane drags.
+- On drop, the target window's reducer fires the re-dock RPC
+  (described below) — not the existing within-window re-position RPC.
+
+### Reducer / backend changes
+
+Three sites:
+
+**Frontend → backend RPC:** A new `RedockFloatingPane` RPC, called by
+the **target window's** renderer on drop. Payload:
+
+```ts
+RedockFloatingPane({
+    paneId: string;                  // block id of the floater
+    sourceWorkspaceId: string;       // the floater's workspace
+    sourceWindowLabel: string;       // the floater's HWND label
+    targetWorkspaceId: string;       // the target window's workspace
+    targetTabId: string;             // active tab in the target window
+    targetNodeId?: string;           // the leaf to drop next to (or null for first-leaf)
+    dropDirection: "left" | "right" | "top" | "bottom" | "into";
+})
+```
+
+**Backend:** moves the block out of the source workspace's tab and
+into the target tab at the requested position; updates both workspaces'
+state; emits broadcasts to both source and target windows.
+
+**Frontend → host IPC:** After the RPC succeeds, the source window
+calls `closeWindowByLabel(sourceWindowLabel)` to destroy the now-empty
+floater. The existing auto-close-on-empty-tab handler from PR #1089
+already does this when the source's tab becomes empty — so likely no
+new IPC.
+
+## Implementation phases
+
+### Phase 4a — In-frontend re-dock to same instance (Win32)
+
+1. **Floater drag → use pragmatic-dnd**. Replace the JS-driven
+   window-move handler in `floating-pane-workspace.tsx` with a
+   pragmatic-dnd `draggable()` setup on the pane header. Drag payload:
+   `{ kind: "floating-pane", blockId, sourceWorkspaceId,
+   sourceWindowLabel }`.
+
+2. **Cross-window drag observation**.
+   `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` already
+   coordinates cross-window observation for tab tear-off; extend its
+   `dragend` switch to handle `kind: "floating-pane"`:
+   - Dropped over a target window's TileLayout leaf → fire
+     `RedockFloatingPane`.
+   - Dropped off-target → use cursor position to call
+     `set_window_position` and reposition the floater (replaces the
+     previous JS-driven mid-drag move; we move only on release).
+
+3. **TileLayout drop targets accept floating-pane drags**.
+   `TileLayout.win32.tsx:dropTargetForElements`'s `canDrop` returns
+   true for our new payload kind. The drop indicator (the existing
+   "insertion guide" or "split preview" — whatever the current tile
+   layout draws on hover) covers floating-pane drags automatically.
+
+4. **`RedockFloatingPane` RPC** in `agentmux-srv` — moves the block,
+   updates source + target tab `blockids` + layout `leaforder`, emits
+   broadcasts.
+
+5. **Auto-close cascade.** The existing PR #1089 watcher closes the
+   floater when its tab's `blockids` becomes empty — works without
+   change for the re-dock flow because the source workspace's blockids
+   drop after `RedockFloatingPane` mutates state.
+
+**Effort estimate:** ~400-600 LOC (frontend cross-window-monitor
+extension + TileLayout canDrop tweak + new RPC + reducer hook + tests).
+
+### Phase 4b — Drag preview and highlight polish
+
+1. **Custom drag image**. The floating pane's `nativeSetDragImage`
+   currently uses pragmatic-dnd's default. For re-dock we want a
+   visible "ghost" of the pane content while dragging — same kind of
+   bitmap snapshot the within-window pane drag uses
+   (`frontend/layout/lib/TileLayout.win32.tsx::previewElement`).
+
+2. **Drop-target highlight contrast**. Tune the colors/animation so
+   the highlighted leaf is unmistakably the drop site, including
+   when the cursor is over a split edge (drop "next to" vs "into").
+
+**Effort estimate:** ~150 LOC styling + drag-preview wiring.
+
+### Phase 4c — Same-instance, different tab
+
+Drop the floater onto a tab in the target window's tab bar to drop
+into THAT tab's layout (rather than the current tab). Tabbar already
+accepts cross-tab drags from the tab tear-off path; extend it to
+recognize `kind: "floating-pane"` too.
+
+**Effort estimate:** ~100 LOC.
+
+### Phase 4d (deferred) — Cross-instance
+
+Two AgentMux processes; drag floater from process A onto process B's
+window. Reuses the existing cross-instance drag IPC
+(`startCrossDrag`/`updateCrossDrag`/`completeCrossDrag`) that tab
+tear-off already supports for instance-to-instance. Adds block-state
+serialization across process boundaries. Out of scope here; tracked
+as Phase 7 of the original spec.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Drop floater onto its own source window's tile | Treat as a normal re-dock — block moves from the floater's workspace into the source window's workspace + tab. Floater closes via the empty-tab watcher. |
+| Drop onto a TileLayout that's currently magnified | Magnified state preserved; block joins the magnified tab. |
+| Source window closes mid-drag | Floater stays a top-level window; user can release on a target window or off-target. (Source-window close already cascades to floaters owned by it; if that fires, the floater itself dies too — user's drag is interrupted, which matches Win32 behavior for any owned-window cascade.) |
+| Drop onto a target window that's minimized | OS doesn't dispatch dragenter to minimized windows — target stays minimized, drop happens on whatever's behind. Floater repositions to cursor. |
+| Two floaters open, drag one over the other | If the other floater's TileLayout accepts the drop, re-dock into it. The receiving floater now has TWO panes (no longer "single-pane floater" — fine; the existing TileLayout handles multi-pane tabs). |
+| Floater contains a magnified pane and is dragged | Drop accepted normally; magnify state collapses on re-dock (or carries through — TBD, default behavior of moving a magnified block into a new tab). |
+| User drops on the floater itself (drag-over-self) | No-op. canDrop returns false if drop target's window === source window. |
+| Cross-instance drop | Phase 4d; current Phase rejects with no-op or shows "not supported" cursor (reuse existing tab tear-off cross-instance rejection logic if any). |
+| Ephemeral pane drag | Today's `canDrag` check on the pane header excludes ephemeral panes. Floating panes shouldn't be ephemeral by construction, but defensive: same check. |
+
+## Test plan
+
+- [ ] Drag floater into source window's TileLayout leaf — re-docks, floater closes.
+- [ ] Drag floater into a different tab of the source window — Phase 4c.
+- [ ] Drag floater into another floater's TileLayout — second floater grows to multi-pane.
+- [ ] Drag floater into a target window that's not the source — Win32 routes dragenter correctly, target highlights, drop re-docks.
+- [ ] Drop floater on desktop (off-target) — floater repositions to cursor.
+- [ ] Drag floater off-target then release on the source window's NON-tile area (tab bar empty space, status bar, widget bar) — floater repositions to cursor (no re-dock, no acceptance UI).
+- [ ] Drag floater over external app (VS Code) — sees ghost cursor; no drop accepted; floater repositions on release (see also `ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md` re: VS Code's permissive dragover).
+- [ ] Drag while source window is full-screen, second monitor — re-dock works across monitors.
+- [ ] ESC cancels drag — floater stays put at its pre-drag position.
+- [ ] DPI mismatch source vs. target monitor — re-dock places at correct position; size adjusted by the target tile layout's flex.
+- [ ] Re-dock then immediately tear off again (round-trip) — clean state both sides.
+
+## Cross-references
+
+- `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` §5 (re-dock
+  acceptance criteria), §9 (Phase 4 scope).
+- `docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md` —
+  why we have JS-driven drag today and the trade-offs vs. pragmatic-dnd
+  for the floater header.
+- `docs/analyses/ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md`
+  — why external apps still show "accept" cursors during cross-window
+  drag; the floating pane re-dock will inherit this limitation
+  (cosmetic).
+- `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` — existing
+  cross-window drag orchestrator for tab tear-off; extends for
+  floating-pane re-dock.
+- `frontend/layout/lib/TileLayout.win32.tsx` — drop targets and
+  drag-preview templates we reuse.
+- `frontend/app/tab/tabbar.tsx` — Phase 4c reference (cross-tab drop).
+- `agentmux-srv` — host-side `RedockFloatingPane` RPC (new).
+
+## Open questions
+
+1. **Drop indicator visual** — should the target leaf draw a "split
+   preview" (showing where the pane lands relative to the existing
+   leaf) or just a generic "accept" highlight? The within-window pane
+   drag does split-preview; we should match.
+2. **Default re-dock position** — if the user drops without aiming at
+   a specific leaf, where does the block land? Suggestion: into the
+   focused leaf of the target tab.
+3. **Animation** — animate the re-dock (floater shrinks into the
+   target leaf) or hard-cut? Hard-cut is simpler and consistent with
+   tear-off (which is hard-cut today). Animation can be Phase 6 polish.
+4. **`set_window_position` label routing** — pre-existing bug noted in
+   `ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md`. Out-of-target
+   repositioning of the floater on drop-release relies on
+   `set_window_position` honoring the floater's HWND, which works
+   today by Z-order but is technically wrong. Should be fixed before
+   Phase 4 ships so the off-target-release case is robust against any
+   foreground churn.

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -15,12 +15,17 @@
  *  - no `<WindowHeader>` (which carries the tab bar + action widgets)
  *  - no `<StatusBar>`
  *  - no extra title bar — the floater renders the block's standard
- *    pane header (from `BlockFrame_Header` in `block/blockframe.tsx`)
- *    as its sole chrome. Dragging the pane header's title area moves
- *    the floating window via the host's `floating_pane_wndproc` →
- *    `WM_NCHITTEST → HTCAPTION` shim (excluding the rightmost ~130 CSS
- *    px where the per-pane action buttons live, so close / magnify /
- *    mic / endIconButtons remain clickable).
+ *    `BlockFrame_Header` (33 CSS px, `--header-height` in
+ *    `theme.scss:97`) as its sole chrome.
+ *  - window drag is **JS-driven**, installed by the `onMount` below:
+ *    a targeted document mousedown listener scoped to
+ *    `[data-role="block-header"]` (and skipping interactive elements
+ *    via `target.closest('button, a, input, ...')`) drives
+ *    `get/set_window_position` IPC. `preventDefault` on mousedown
+ *    blocks the HTML5 dragstart pragmatic-dnd would otherwise have
+ *    used, suppressing a "double tear-off" regression. See
+ *    `docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md`
+ *    for why we use JS-driven drag rather than OS HTCAPTION.
  *
  * The frontend code path is otherwise identical to the docked case:
  * Block / view-model / RPC subscriptions all behave the same.

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -30,12 +30,46 @@ import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { TabContent } from "@/app/tab/tabcontent";
-import { atoms } from "@/store/global";
-import { Show, type JSX } from "solid-js";
+import { atoms, getApi } from "@/store/global";
+import { Show, createEffect, createMemo, type JSX } from "solid-js";
 
 function FloatingPaneWorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
     const ws = atoms.workspace;
+
+    const windowLabel = createMemo(() => {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("windowLabel") ?? "";
+    });
+
+    // Auto-close the floating window when its workspace becomes empty —
+    // a floater wraps exactly one pane today (single-block workspace),
+    // so closing that pane via the standard BlockFrame_Header × button
+    // should also dismiss the now-purposeless outer window. We watch
+    // `workspace.blockids` and trigger close as soon as it transitions
+    // from non-empty → empty (the `hadBlocks` latch avoids closing on
+    // the brief empty state during initial workspace load).
+    let hadBlocks = false;
+    createEffect(() => {
+        const w = ws();
+        if (!w) return;
+        const blockids = (w as { blockids?: string[] }).blockids ?? [];
+        if (blockids.length > 0) {
+            hadBlocks = true;
+        } else if (hadBlocks) {
+            const label = windowLabel();
+            if (label) {
+                getApi()
+                    .closeWindowByLabel(label)
+                    .catch((e) =>
+                        console.error(
+                            "[floating-pane] auto-close on empty workspace failed",
+                            e,
+                        ),
+                    );
+            }
+        }
+    });
 
     return (
         <div class="flex flex-col w-full flex-grow overflow-hidden">

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -26,12 +26,13 @@
  * Block / view-model / RPC subscriptions all behave the same.
  */
 
+import { invokeCommand } from "@/app/platform/ipc";
 import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { TabContent } from "@/app/tab/tabcontent";
 import { atoms, getApi } from "@/store/global";
-import { Show, createEffect, createMemo, type JSX } from "solid-js";
+import { Show, createEffect, createMemo, onCleanup, onMount, type JSX } from "solid-js";
 
 function FloatingPaneWorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
@@ -69,6 +70,153 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     );
             }
         }
+    });
+
+    // Pane-header drag — JS-driven window move, scoped to the standard
+    // docked-pane header (`[data-role="block-header"]`). Mirrors the
+    // main-window pattern in `frontend/app/hook/useWindowDrag.win32.ts`
+    // (one-in-flight + coalesce, DPR scaling, catch-up move on IPC
+    // resolution, per-mousedown sequence token) — minus the
+    // `data-drag-region` traversal because we scope explicitly to the
+    // pane header instead of opting in via attributes.
+    //
+    // `preventDefault()` on the qualifying mousedown is load-bearing:
+    // it suppresses the HTML5 dragstart pragmatic-dnd would otherwise
+    // use to initiate a pane tear-off (TileLayout.win32.tsx:443-471).
+    // Without it, dragging a floater's header would tear the block off
+    // into ANOTHER floating window — the "double tear-off" bug.
+    //
+    // See docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md.
+    onMount(() => {
+        const INTERACTIVE_SELECTOR =
+            "button, a, input, select, textarea, [role='button']";
+        const HEADER_SELECTOR = '[data-role="block-header"]';
+
+        let currentMouseDownId = 0;
+        let dragging = false;
+        let clickScreenX = 0;
+        let clickScreenY = 0;
+        let initWinX = 0;
+        let initWinY = 0;
+        let latestScreenX = 0;
+        let latestScreenY = 0;
+        let setPosInFlight = false;
+        let pendingPos: { x: number; y: number } | null = null;
+
+        const sendPos = (x: number, y: number): void => {
+            if (setPosInFlight) {
+                pendingPos = { x, y };
+                return;
+            }
+            setPosInFlight = true;
+            invokeCommand("set_window_position", { x, y })
+                .catch(() => {})
+                .finally(() => {
+                    setPosInFlight = false;
+                    if (pendingPos) {
+                        const { x: nx, y: ny } = pendingPos;
+                        pendingPos = null;
+                        sendPos(nx, ny);
+                    }
+                });
+        };
+
+        const onMouseDown = async (e: MouseEvent) => {
+            if (e.button !== 0) return;
+            const target = e.target as HTMLElement | null;
+            if (!target) return;
+            // Must be inside the standard pane header
+            if (!target.closest(HEADER_SELECTOR)) return;
+            // Skip interactive controls within the header so close /
+            // magnify / mic / endIconButton clicks reach their handlers
+            if (target.closest(INTERACTIVE_SELECTOR)) return;
+
+            // Block the HTML5 dragstart pragmatic-dnd would have used —
+            // without this, the click tears the pane off into ANOTHER
+            // floating window (the double-tear-off regression).
+            e.preventDefault();
+
+            currentMouseDownId += 1;
+            const myId = currentMouseDownId;
+            clickScreenX = e.screenX;
+            clickScreenY = e.screenY;
+            latestScreenX = e.screenX;
+            latestScreenY = e.screenY;
+
+            try {
+                const pos = await invokeCommand<{ x: number; y: number }>(
+                    "get_window_position",
+                );
+                // Race guard: bail if mouseup or a newer mousedown
+                // happened during the IPC round-trip
+                if (myId !== currentMouseDownId) return;
+                initWinX = pos.x;
+                initWinY = pos.y;
+                dragging = true;
+                // Catch-up: if the cursor moved during the IPC, fire
+                // one set_window_position immediately so we don't lose
+                // the first few pixels of motion
+                if (
+                    latestScreenX !== clickScreenX ||
+                    latestScreenY !== clickScreenY
+                ) {
+                    const dpr = window.devicePixelRatio || 1;
+                    const tx =
+                        initWinX +
+                        Math.round((latestScreenX - clickScreenX) * dpr);
+                    const ty =
+                        initWinY +
+                        Math.round((latestScreenY - clickScreenY) * dpr);
+                    sendPos(tx, ty);
+                }
+            } catch {
+                // host unavailable — abort drag silently
+            }
+        };
+
+        const onMouseMove = (e: MouseEvent) => {
+            // Track the latest cursor position even before `dragging`
+            // is armed so the catch-up at IPC resolution can use the
+            // most recent value
+            latestScreenX = e.screenX;
+            latestScreenY = e.screenY;
+            if (!dragging) return;
+            // CSS-px delta * devicePixelRatio = physical-px delta added
+            // to the physical-px baseline from get_window_position. Re-
+            // read DPR every move so a mid-drag monitor crossing picks
+            // up the new value automatically.
+            const dpr = window.devicePixelRatio || 1;
+            const tx =
+                initWinX + Math.round((e.screenX - clickScreenX) * dpr);
+            const ty =
+                initWinY + Math.round((e.screenY - clickScreenY) * dpr);
+            sendPos(tx, ty);
+        };
+
+        const onMouseUp = () => {
+            // Invalidate any in-flight mousedown handler — incrementing
+            // the id ensures their `myId !== currentMouseDownId` check
+            // fires when they resolve.
+            currentMouseDownId += 1;
+            dragging = false;
+            // Do NOT clear pendingPos — that would discard the FINAL
+            // queued position (the cursor's location at release time).
+            // Let the in-flight set_window_position complete; its
+            // `.finally` drains pendingPos to the correct end state.
+        };
+
+        // Capture-phase listeners so we run BEFORE pragmatic-dnd's
+        // bubble-phase mousedown handler — preventDefault here blocks
+        // the HTML5 dragstart it would have triggered.
+        document.addEventListener("mousedown", onMouseDown, true);
+        document.addEventListener("mousemove", onMouseMove);
+        document.addEventListener("mouseup", onMouseUp);
+
+        onCleanup(() => {
+            document.removeEventListener("mousedown", onMouseDown, true);
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("mouseup", onMouseUp);
+        });
     });
 
     return (

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -32,6 +32,7 @@ import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { TabContent } from "@/app/tab/tabcontent";
 import { atoms, getApi } from "@/store/global";
+import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, onCleanup, onMount, type JSX } from "solid-js";
 
 function FloatingPaneWorkspaceElem(): JSX.Element {
@@ -43,18 +44,26 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         return params.get("windowLabel") ?? "";
     });
 
-    // Auto-close the floating window when its workspace becomes empty —
-    // a floater wraps exactly one pane today (single-block workspace),
-    // so closing that pane via the standard BlockFrame_Header × button
-    // should also dismiss the now-purposeless outer window. We watch
-    // `workspace.blockids` and trigger close as soon as it transitions
-    // from non-empty → empty (the `hadBlocks` latch avoids closing on
-    // the brief empty state during initial workspace load).
+    // Auto-close the floating window when its only pane is closed.
+    // The Workspace WaveObj has `tabids` but NO `blockids` field — the
+    // block-membership signal lives on the Tab (`tab.blockids`, see
+    // `frontend/types/gotypes.d.ts:1491`). We subscribe to the active
+    // tab and trigger close as soon as its blockids array transitions
+    // from non-empty → empty. The `hadBlocks` latch avoids closing on
+    // the brief empty state during initial workspace load.
+    //
+    // useWaveObjectValue installs an onCleanup tied to the surrounding
+    // reactive owner — calling it inside createEffect refreshes the
+    // subscription whenever tabId changes (the prior effect run's
+    // cleanup decrements the previous refcount).
     let hadBlocks = false;
     createEffect(() => {
-        const w = ws();
-        if (!w) return;
-        const blockids = (w as { blockids?: string[] }).blockids ?? [];
+        const tid = tabId();
+        if (!tid) return;
+        const [tab] = WOS.useWaveObjectValue<Tab>(WOS.makeORef("tab", tid));
+        const t = tab();
+        if (!t) return;
+        const blockids = t.blockids ?? [];
         if (blockids.length > 0) {
             hadBlocks = true;
         } else if (hadBlocks) {
@@ -64,7 +73,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     .closeWindowByLabel(label)
                     .catch((e) =>
                         console.error(
-                            "[floating-pane] auto-close on empty workspace failed",
+                            "[floating-pane] auto-close on empty tab failed",
                             e,
                         ),
                     );

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -14,9 +14,13 @@
  *
  *  - no `<WindowHeader>` (which carries the tab bar + action widgets)
  *  - no `<StatusBar>`
- *  - just a slim draggable title bar (with a close button) plus the
- *    active tab's `<TabContent>` (which contains the tile layout — for
- *    a torn-off pane that layout has exactly one leaf, the block).
+ *  - no extra title bar — the floater renders the block's standard
+ *    pane header (from `BlockFrame_Header` in `block/blockframe.tsx`)
+ *    as its sole chrome. Dragging the pane header's title area moves
+ *    the floating window via the host's `floating_pane_wndproc` →
+ *    `WM_NCHITTEST → HTCAPTION` shim (excluding the rightmost ~130 CSS
+ *    px where the per-pane action buttons live, so close / magnify /
+ *    mic / endIconButtons remain clickable).
  *
  * The frontend code path is otherwise identical to the docked case:
  * Block / view-model / RPC subscriptions all behave the same.
@@ -26,100 +30,22 @@ import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { TabContent } from "@/app/tab/tabcontent";
-import { atoms, getApi } from "@/store/global";
-import { Show, createMemo, type JSX } from "solid-js";
+import { atoms } from "@/store/global";
+import { Show, type JSX } from "solid-js";
 
 function FloatingPaneWorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
     const ws = atoms.workspace;
 
-    const windowLabel = createMemo(() => {
-        const params = new URLSearchParams(window.location.search);
-        return params.get("windowLabel") ?? "";
-    });
-
-    const handleClose = () => {
-        const label = windowLabel();
-        if (!label) {
-            console.warn("[floating-pane] no windowLabel — cannot close via host IPC");
-            return;
-        }
-        getApi()
-            .closeWindowByLabel(label)
-            .catch((e) => console.error("[floating-pane] closeWindowByLabel failed", e));
-    };
-
     return (
         <div class="flex flex-col w-full flex-grow overflow-hidden">
-            {/* Slim title bar.
-                Drag is handled by the host's `floating_pane_wndproc`
-                (agentmux-cef/src/floating_pane.rs): it returns HTCAPTION
-                for the top 30 CSS px (excluding the right 36 CSS px so the
-                close button click passes through). The OS handles the drag
-                loop natively — cross-monitor, cross-DPI safe. The CSS
-                `-webkit-app-region` properties below are kept for
-                documentation/electron-compat, but are no-ops in CEF. */}
-            <div
-                class="floating-pane-titlebar"
-                style={{
-                    display: "flex",
-                    "align-items": "center",
-                    height: "30px",
-                    "padding-left": "12px",
-                    "padding-right": "4px",
-                    "background-color": "var(--main-bg-color, #161620)",
-                    "border-bottom": "1px solid var(--border-color, #262633)",
-                    "user-select": "none",
-                    "-webkit-app-region": "drag",
-                } as any}
-            >
-                <div
-                    style={{
-                        flex: "1 1 auto",
-                        "font-size": "12px",
-                        color: "var(--secondary-text-color, #94a3b8)",
-                    }}
-                >
-                    Floating pane
-                </div>
-                <button
-                    type="button"
-                    onClick={handleClose}
-                    title="Close floating pane"
-                    aria-label="Close"
-                    class="floating-pane-close-btn"
-                    style={{
-                        width: "28px",
-                        height: "22px",
-                        border: "none",
-                        background: "transparent",
-                        color: "var(--secondary-text-color, #94a3b8)",
-                        cursor: "pointer",
-                        "font-size": "16px",
-                        "line-height": "1",
-                        "border-radius": "4px",
-                        "-webkit-app-region": "no-drag",
-                    } as any}
-                    onMouseEnter={(e) => {
-                        (e.currentTarget as HTMLElement).style.background =
-                            "var(--hover-bg-color, rgba(255,255,255,0.1))";
-                        (e.currentTarget as HTMLElement).style.color =
-                            "var(--main-text-color, #e5e7eb)";
-                    }}
-                    onMouseLeave={(e) => {
-                        (e.currentTarget as HTMLElement).style.background = "transparent";
-                        (e.currentTarget as HTMLElement).style.color =
-                            "var(--secondary-text-color, #94a3b8)";
-                    }}
-                >
-                    ×
-                </button>
-            </div>
-
             {/* The torn-off block lives in the new workspace's active
                 tab. Render that tab's TabContent only — no per-tab loop
                 (there's exactly one tab) and no tab bar / widgets bar /
-                status bar to surround it. */}
+                status bar to surround it. The block renders its standard
+                `BlockFrame_Header` which serves as both the title bar
+                and the action surface — exactly as it appears when
+                docked. */}
             <div
                 class="flex flex-row flex-grow overflow-hidden"
                 style={{ "min-height": 0 }}


### PR DESCRIPTION
## Summary

User feedback: \"the pane header on the floating window is the same as the pane header on a docked pane .. treat it as if you tore off the docked pane and it appeared exactly like it did, except freefloating .. make sure no windows or OS-level controls added\".

Three changes to make the floating window render identically to a docked pane:

1. **Removed the custom 30 CSS-px title bar** from \`frontend/app/workspace/floating-pane-workspace.tsx\` (the placeholder header with \"Floating pane\" text + custom × button). The block renders its standard \`BlockFrame_Header\` instead — same icons, title, close, magnify, mic, endIconButtons as docked.

2. **\`DwmExtendFrameIntoClientArea\`** added to \`agentmux-cef/src/floating_pane.rs::create_owned_popup\` after \`CreateWindowExW\`. Without it, DWM kept painting the standard Win32 caption (with min/max/close buttons) on top of our client area, even though \`WM_NCCALCSIZE → 0\` reserved no space for it. Mirrors the main window's \`setup_native_frameless\` pattern.

3. **Updated \`floating_pane_wndproc\` HTCAPTION zone**:
   - height: 33 CSS px (matches \`--header-height\` in \`theme.scss:97\`)
   - excluded right-anchored 130 CSS px so the docked-pane action cluster (close, magnify, mic, endIconButtons) remains clickable. All DPI-scaled via \`GetDpiForWindow\`.

## Net effect

Tear off a pane → floating window appears with the exact docked-pane visual, no OS chrome, no extra widgets. Drag by the title-text area of the pane header moves the window; click the action buttons (right side) to act on the block.

## Test plan

- [ ] Tear off a pane → floating window has no system title bar / min-max-close buttons
- [ ] The block's standard pane header is the only header
- [ ] Drag the title-text area of the pane header → window moves
- [ ] Click the × in the pane header → window closes (single block → workspace empty → cascade)
- [ ] Magnify / mic / endIconButtons on the right still respond to clicks
- [ ] Resize at edges works (DPI-correct 6 CSS px borders)

## Out of scope

- **Full JS-driven drag** — would let action buttons live anywhere in the header (not just the right cluster). Requires data-drag-region threading + host \`set_window_position\` label routing fix. Tracked as a follow-up.
- **VS Code drag-accept cursor** — separate analysis at \`docs/analyses/ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md\` (still uncommitted on a separate branch).