### PR TITLE
feat(fe-log): runtime source-map resolver for piped error stacks

### DIFF
--- a/.changesets/1779856022-feat-fe-log-runtime-source-map-resolver-for-piped-error-stac-73do.md
+++ b/.changesets/1779856022-feat-fe-log-runtime-source-map-resolver-for-piped-error-stac-73do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(fe-log): runtime source-map resolver for piped error stacks

--- a/docs/analysis/AGENT_PANE_REPLACECHILD_CRASH_ON_SEND_2026_05_27.md
+++ b/docs/analysis/AGENT_PANE_REPLACECHILD_CRASH_ON_SEND_2026_05_27.md
@@ -1,0 +1,271 @@
+# Agent pane replaceChild crash on send — root-cause investigation
+
+**Date:** 2026-05-27
+**Status:** Root cause hypothesized in §13 — **FALSIFIED** by §15. Investigation continues.
+**Severity:** Hard blocker — agent pane crashes on every send
+**Reporter:** User testing v0.38.16 (then v0.38.15 + v0.38.11)
+
+---
+
+## 1. Symptom
+
+User opens the agent pane, types any message ("u there"), presses Enter. **Within ~200ms of the first stream event arriving from the backend**, the agent block renders an error fallback (`block-error-boundary`) and the conversation freezes. Reloading the pane brings it back; sending another message reproduces the crash. 100% reproducible across multiple sessions and across multiple builds.
+
+## 2. Evidence (verbatim from host log)
+
+Each crash logs an identical three-line signature:
+
+```
+[fe] [agentActivity] busyCount=1 panes=[<blockId>]
+[fe] WaveObj updated block:<blockId>
+[fe] Missing attribute name 'data-index={index}' on measured element.
+[fe] [block-error-boundary] NotFoundError: Failed to execute 'replaceChild' on 'Node':
+     The node to be replaced is not a child of this node. (block=<blockId>, view=agent)
+[fe] [agentActivity] busyCount=0 panes=[]
+[fe] [agent-document-store] CASCADE_DETECTED: slot disposed mid-dispatch
+     (cmd=StreamFlush, blockId=<blockId>, source=system).
+     A documentAtom subscriber unmounted the pane during this dispatch.
+     Subsequent dispatches in the same callback will throw.
+```
+
+Timing (one observed crash):
+
+| Time (ms) | Event |
+|---|---|
+| +0 | `busyCount=1` — turn began (TurnStart already processed) |
+| +11 | `WaveObj updated block` — block-meta update propagates |
+| +27 | TanStack Virtual warning about a measured element without `data-index` |
+| +237 | `replaceChild` throws inside Solid's reconciler |
+| +251 | `busyCount=0` — fallback rendered, pane considered done |
+| +252 | Cascade detection fires (slot already disposed by the ErrorBoundary) |
+
+## 3. Bisect — falsifying my initial hypothesis
+
+I initially suspected my PR #1068's `TurnStart auto-collapses detailsOpen` write was the trigger and shipped PR #1083 as a hotfix dropping that write. **The crash still reproduced in the hotfix build** (v0.38.15 with the drop in place), proving the auto-collapse write was not the cause. The hotfix is a no-op for this bug.
+
+I then asked the user to test **v0.38.11** — built BEFORE my agent-pane redesign (#1069 / #1075 / #1083). **Same crash, same signature.** This rules out the entire 2026-05-26 agent-pane PR sequence as the culprit. The bug existed before this session's work.
+
+Not yet bisected: 0.38.10, 0.38.8, 0.38.6 — pre-modal-compact builds. Should the user confirm those crash too, the bug is even older.
+
+## 4. What the cascade-detector message actually means
+
+The detector lives in `agent-document-store.ts` after the `setter(state.nodes)` call:
+
+```ts
+slot.setter(slot.state.nodes);     // writes documentAtom signal
+if (!slots.has(blockId)) {          // slot vanished mid-dispatch
+    console.warn("CASCADE_DETECTED: ... A documentAtom subscriber unmounted the pane ...");
+}
+```
+
+The detector observes a **consequence**, not the cause. The "documentAtom subscriber unmounted the pane" is a literal description: a subscriber, while reacting to the documentAtom write, synchronously called `unregisterPane`. That happens via `onCleanup` in `agent-view.tsx` only when the agent-view component itself disposes. The agent-view component disposes when:
+
+1. The pane closes (user action — not happening here).
+2. The block-error-boundary catches a throw and renders the fallback (which doesn't include `<AgentPresentationView>`).
+
+It's path **2**. The `replaceChild` error throws inside a subscriber's render. The error bubbles to `<BlockErrorBoundary>`, which unmounts the agent-view subtree, which fires `onCleanup`, which calls `unregisterPane` → slot deleted. The cascade-detector fires because the deletion happens INSIDE the still-running dispatch callstack.
+
+So the cascade-detector log line is downstream of the real bug. The real bug is the `replaceChild` throw itself.
+
+## 5. What `replaceChild` not-found means in Solid
+
+Solid's reconciler calls `parent.replaceChild(newNode, oldNode)` when it needs to swap a rendered node out (e.g., a `<For>` re-keys, a `<Show>` flips, an HTML attribute changes type). The DOM throws `NotFoundError` when `oldNode.parentNode !== parent` at the moment of the call. Common Solid-specific causes:
+
+| Cause | How to recognize |
+|---|---|
+| **External DOM mutation** — code outside Solid called `innerHTML`, `removeChild`, `replaceChild`, etc., on a node Solid tracks | Look for direct DOM API usage in components (xterm.js, monaco, browser webview, manual measurers) |
+| **Stale element ref** — `ref={...}` callback captured an element that Solid later moved/replaced | Look for `let el; ref={(e) => el = e}` patterns; the captured ref doesn't track Solid's tree |
+| **`<For>` with unstable keys** — same logical item shows up under different keys in successive renders | Look for `<For each={...}>` where the input array's identity isn't stable (e.g. recomputed without memo) |
+| **Conditional `<Show>` reusing an element** — a child node used in BOTH the `fallback` and the `<Show>` body | Look for shared element references |
+| **Manually-managed virtual list — measurement targets** | TanStack Virtual's `measureElement` reads `data-index` and calls some operations on the measured row; if the row was just unmounted by Solid the attribute is gone, the warning fires, and downstream operations work on a stale DOM ref |
+
+The `Missing attribute name 'data-index={index}'` warning at +27ms is from **TanStack Virtual's `measureElement` runtime**. It's the same family — TanStack measured an element that no longer has `data-index` (probably because Solid just unmounted it). The TanStack warning and the Solid throw are **siblings**, both downstream of the same upstream event: **the virtualizer's view of the rendered rows is out of sync with Solid's view at the moment of the first `StreamFlush`**.
+
+## 6. Why `StreamFlush` specifically triggers it
+
+`StreamFlush` is the first command after the agent begins producing output. It commits any buffered nodes onto the documentAtom. Concretely:
+
+- Before flush: documentAtom holds N nodes (history).
+- After flush: documentAtom holds N+K nodes (K new agent-message / tool nodes appended).
+
+The virtualizer reacts: new `virtualizedNodes` partition → `getVirtualItems()` returns more items → some new rows mount, possibly some existing rows shift position. TanStack Virtual asynchronously schedules `measureElement` calls on all visible rows.
+
+**Hypothesis**: there's a race where TanStack measures an element AFTER Solid has dismounted it (no `data-index` warning fires), and Solid's next reconcile tries to replace a child that another reactive pass has already removed.
+
+## 7. Why I can't pin it down without instrumentation
+
+The stack trace is minified to `bpe → wp → Object.fn → Jge → dm → j → wp → Object.fn → Jge → dm`. Solid's render path with no source maps. Doesn't tell me **which component** is reconciling at the failure point.
+
+What I'd need to bisect:
+- **Source maps in production bundle** — currently the Vite prod build strips them. Re-enable for a debug build and the stack becomes readable.
+- **`getOwner()`-instrumented panic handler** — wrap the reconciler in a try/catch that logs `getOwner().componentName` before re-throwing.
+- **Disable virtualization temporarily** — render the document as a plain `<For>` instead of `AgentDocumentVirtualList` and see if the crash still fires. If yes, the virtualizer is innocent; the bug is in a node component. If no, the bug is in the virtualizer / measurement coordination.
+
+## 8. Open hypotheses (ranked by suspicion)
+
+1. **TanStack Virtual + Solid `<For>` row-keying race.** `AgentDocumentVirtualList` renders rows from `getVirtualItems()` inside a Solid `<For>`. If TanStack returns items with a key that Solid mis-maps to a different DOM node on re-render, Solid's reconciler can call `replaceChild` against the wrong parent. This is consistent with the `data-index` warning + replaceChild throw co-occurrence.
+
+2. **A streaming row component throws on partial data.** When the first agent-message node arrives, it has e.g. empty `content` or a transitional shape that the renderer doesn't expect. The throw is internal to the component (not in framework code), but reaches the boundary the same way. The replaceChild error might be a side-effect of trying to render an unmount-mid-render component.
+
+3. **External DOM mutation on a streaming surface.** `<MarkdownRenderer>` or `<AnsiText>` or a code-highlight component might be doing manual DOM work. If it `innerHTML`-mutates a node Solid tracks, the next reconcile fails. Less likely but possible.
+
+4. **`agent-document-store` reducer producing reference-unstable arrays.** If `state.nodes` is being rebuilt on every flush with new object identities for unchanged nodes, the virtualizer over-measures and Solid over-reconciles. Audit the reducer's `StreamFlush` arm.
+
+5. **Backwards-incompatible TanStack Virtual upgrade.** A recent dependency bump may have changed `measureElement`'s contract.
+
+## 9. Proposed investigation path
+
+In priority order:
+
+### 9.1 Build a debug-bundle portable
+
+`task package` with `--mode=development` so the bundle keeps source maps. Reproduce the crash. The stack trace will name the offending component. ~5-10 minute task, totally deterministic.
+
+### 9.2 Read the cascade audit ring
+
+`recordDispatch()` is supposed to capture every dispatch with source / commit / events. The agent-document-store has its own audit slice. Compare an ordinary StreamFlush (when the pane doesn't crash) with the crashing one — what's different about the latter's command payload? The `addedNodes` shape may reveal the bad node.
+
+### 9.3 Disable virtualization (temporary)
+
+Replace `AgentDocumentVirtualList` with a plain `<For each={documentAtom()}>...</For>` in agent-view.tsx for a debug build. If crash stops → virtualizer at fault. If crash persists → a node component throws on first paint of new nodes.
+
+### 9.4 Add a `getOwner()`-aware reconcile wrapper
+
+Monkey-patch Solid's `insertNode` / `replaceChild` calls in the bundle to log the owning component before invoking. Heavy-handed but yields a precise answer.
+
+## 10. Why I should NOT keep shipping hotfixes
+
+Three small reverts so far this session targeted symptoms (TurnStart auto-collapse, padding micro-adjustments, etc.). None addressed the actual `replaceChild`. The pattern matches `feedback_3strikes_term_jumble.md` from memory: **when 3+ fixes fail in the same area, stop and restructure.** That's where we are.
+
+## 11. Recommended next step
+
+The user should choose one:
+
+- **A. Build a debug bundle now**, reproduce, read the source-mapped stack. Highest signal, ~15 minutes. **Recommended.**
+- **B. Temporarily route around the virtualizer** — render the document as a plain list (no virtualization). If the crash stops we've localized to the virtualizer interaction; if it persists we've localized to a node component. ~30 minutes.
+- **C. Live in this state** — agent pane crashes on every send; user can't use the app meaningfully. Not viable.
+
+## 12. What to do about #1083 (the wrong hotfix)
+
+PR #1083 dropped the `TurnStart auto-collapses detailsOpen` write. The drop is **wrong** — that write is the spec-prescribed UX behavior and dropping it does not fix the crash. **Close #1083 without merging** and let the spec write stand. We can re-investigate the original concern (whether that write contributes to ANY race) after the actual replaceChild root cause is fixed.
+
+## 13. ROOT CAUSE IDENTIFIED — 2026-05-27 follow-up
+
+Built a debug-bundle portable with NODE_ENV=development to get source maps and re-read the minified positions. The replaceChild call resolves to:
+
+```js
+}else t.replaceChild(n[a++],e[o++])
+```
+
+This is Solid's **`reconcileArrays`** — the child-array diff loop that `<For>` uses to reconcile its rendered items against the new array. `e` is the prior children, `n` is the new children. `t.replaceChild(n[a], e[o])` fails because **`e[o]` is no longer a child of `t`**.
+
+The For in question is in `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`:
+
+```tsx
+<For each={virtualizer.getVirtualItems()}>
+    {(virtualItem) => {
+        const nodeAccessor = () => partition().virtualizedNodes[virtualItem.index];
+        return <DocumentRow node={nodeAccessor} ... />;
+    }}
+</For>
+```
+
+**Why this breaks:**
+
+Solid's `<For>` keys items by **referential identity** (`===` comparison). TanStack Virtual's `getVirtualItems()` returns a freshly-allocated array of `VirtualItem` objects on every call:
+
+```ts
+interface VirtualItem { key: Key; index: number; start: number; end: number; size: number; lane: number; }
+```
+
+When `StreamFlush` lands → `partition()` recomputes → `virtualizer.getVirtualItems()` returns ALL-NEW objects (even for unchanged rows). Solid's `<For>` sees every item as fresh → re-keys all rows → reconcile from scratch → `replaceChild` called for every row.
+
+Meanwhile, TanStack Virtual has scheduled async `measureElement` ResizeObserver callbacks against the rows. Between Solid's reconcile and the next measurement tick, a row's DOM gets moved (or removed) by Solid, but TanStack's stored reference is now stale. When TanStack measures, the row's `data-index` attribute is gone → the **`Missing attribute name 'data-index={index}' on measured element`** warning fires. When Solid's loop reaches that row in its diff, the parent-child relationship has been mutated under it → `replaceChild` throws.
+
+### The fix
+
+Solid's `<For>` doesn't accept a custom key function. Standard remedies in priority order:
+
+1. **`<Index each={...}>`** — Solid's positional keyer. Each slot in the array gets a stable identity tied to its **position**. Re-rendering the same array shape doesn't churn keys. Trade-off: when items reorder, `<Index>` does NOT move DOM nodes; it re-renders content in place. For a virtual list where order is stable (indexed by virtualizer), this is correct.
+
+2. **`<Key by={(v) => v.key} each={...}>`** from `solid-primitives/keyed` — keys on TanStack's stable `item.key` (which IS stable across renders — it's derived from `keyExtractor(index)`, default `(i) => i`). Adds a small dep.
+
+3. **Manually memoize the items array** — wrap `getVirtualItems()` such that unchanged items return the same reference. Brittle; not recommended.
+
+**Recommended: option 1** (`<Index>`). It's a one-keyword swap in the JSX (`<For>` → `<Index>`) plus a getter wrapper since `<Index>` passes accessors to children instead of values. The semantics match what the virtualizer actually does (positional rows).
+
+### Why this is a long-standing bug
+
+`AgentDocumentVirtualList` was introduced as PR #784 (per the comment about "reagent P1"). The `<For>` keying issue was almost certainly always present — but it only manifests as a crash when the document grows during a streaming render that races with TanStack's measurement. Before this session's testing scenarios, the user may have hit it occasionally; the cascade-detector logs from #878 caught the symptom but the prevention pattern (`dispatchIfRegistered` for async dispatches) didn't apply because this isn't a dispatch race — it's a render race.
+
+### Action
+
+Switch the For to `<Index>` (or `<Key by={item.key}>`). Single-file change with the keying swap. Then rebuild + verify the crash stops.
+
+## 15. Hypothesis falsified — `<For>` keying alone is NOT the cause
+
+Built v0.38.16 with the `<For>` → `<Index>` swap on `AgentDocumentVirtualList`'s virtualizer loop (PR #1086, closed). Reproducer ran identically — same `reconcileArrays` + `replaceChild` stack, same `CASCADE_DETECTED` on `StreamFlush`. The swap is a valid Solid hygiene improvement but it's NOT the trigger.
+
+This means EITHER:
+
+(a) **Another `<For>` exists in the agent document's render tree that mis-keys.** Audit didn't find an obvious candidate in `AgentMessageBlock` / `ToolBlock` / `DocumentRow`. Possible: the markdown/AST renderer trees, a hidden conditional `<For>`, or `<For>` inside an effect-driven component that's NOT in the agent view directory.
+
+(b) **The root cause is not `<For>` keying.** Solid's `reconcileArrays` is the call site, but the underlying cause could be:
+
+  - DocumentRow's `ref={virtualizer.measureElement}` calling TanStack's measure on a node whose Solid-owned children get mutated during measurement. TanStack reads `data-index`, then schedules layout work; if the children of the measured node mutate between the read and the layout, Solid's next reconcile sees DOM out of sync with its model.
+  - An `innerHTML` mutation inside one of the message renderers (markdown/syntax-highlight component might use raw HTML).
+  - A Solid-incompatible ref pattern where a `ref={...}` callback caches a node Solid later moves.
+
+## 16. Concrete next-step proposals
+
+Stop guessing. Use one of these to localize the bug deterministically:
+
+### 16.1 Surgical disable — render document without virtualization
+
+Bypass `AgentDocumentVirtualList` entirely. In `AgentDocumentView.tsx`, replace the call with a plain:
+
+```tsx
+<For each={viewState.nodes()}>
+    {(node) => <DocumentRow node={() => node} ... />}
+</For>
+```
+
+(or `<Index each={viewState.nodes()}>` for symmetry). No virtualizer. No `measureElement`. No `data-index`. If the crash stops → confirms the virtualizer-measurement interaction is the cause. If it persists → the bug is in a node-renderer component.
+
+Cost: O(N) DOM rows; bad for long sessions but FINE for the crash-repro scenario (a fresh agent with 5-10 nodes).
+
+### 16.2 Disable all dynamic node-content renderers — render bare summaries
+
+Replace `DocumentRow`'s body with a stub:
+
+```tsx
+return <div data-index={dataIndex()}>node-{node().id}</div>;
+```
+
+Reload, send. If the crash stops → the bug is in one of the message/tool/markdown renderers. Then bisect by re-enabling them one at a time.
+
+Cost: ugly UI for the diagnosis run.
+
+### 16.3 Instrument `<ErrorBoundary>` to capture component owner
+
+Patch `<BlockErrorBoundary>` to call `getOwner()` and walk up logging component names BEFORE re-throwing. Will name the component whose render failed. 10-line change to `BlockErrorBoundary.tsx`.
+
+### 16.4 Read source-mapped stack via DevTools
+
+Open DevTools (Ctrl+Shift+I) before sending the message, let the crash fire — Chromium's DevTools console resolves source maps and shows the original file:line for each frame. Doesn't require any code change.
+
+### 16.5 Roll back to before PR #784
+
+Per #2 of the file: AgentDocumentVirtualList was introduced as PR #784 (per the comment about reagent P1). Hypothesis: that whole redesign brought in the bug. Test by checking out a tagged build from BEFORE #784 (April 2026 or earlier) and reproducing.
+
+## 17. Recommended next step
+
+**16.4 (DevTools)** — zero code change, deterministic answer, and the user can do it themselves in 30 seconds. Open DevTools (Ctrl+Shift+I or right-click → Inspect Element), focus the Console tab, send "u there" and let it crash. The error in the console will show source-mapped frames pointing at the offending component.
+
+If for some reason DevTools doesn't resolve the maps (CEF can be quirky about that), fall back to 16.1 (surgical-disable virtualization). About 15 minutes to wire.
+
+## 18. References
+
+- `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md` — the original cascade-disposal class of bug. PR #878 added detection; the prevention contract was supposed to be `dispatchIfRegistered` for async paths. The current crash sneaks through because it's NOT async — the cascade is on a synchronous render throw.
+- Solid `replaceChild` family of crashes documented at https://github.com/solidjs/solid/issues — multiple matches.
+- TanStack Virtual `measureElement` contract: https://tanstack.com/virtual/latest/docs/api/virtualizer

--- a/docs/specs/SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md
+++ b/docs/specs/SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md
@@ -1,0 +1,285 @@
+# SPEC: Frontend source-map resolver for piped error stacks
+
+**Date:** 2026-05-27
+**Status:** Draft — ready to implement
+**Trigger:** Debugging the `replaceChild` crash in `AgentDocumentVirtualList` exposed that every captured `error.stack` in the host log shows raw minified positions (`bpe → wp → Object.fn → ...`). Resolving those positions today requires opening DevTools or hand-decoding `.map` files. Both are friction we shouldn't have for a tool we use to debug ourselves.
+
+---
+
+## 1. Why
+
+Every uncaught error, unhandled promise rejection, and `console.error` call inside the renderer is already piped to the host log via `fe_log_structured` (see `frontend/log/error-forwarder.ts` + `frontend/log/log-pipe.ts`). The stack we forward is whatever `Error.stack` was at the moment of capture — which is the **minified bundle position** (line + column inside the rolled-up chunk). Chromium/V8 only apply source maps to stacks shown in DevTools; the runtime `error.stack` string stays raw.
+
+To debug a renderer crash from a host log, we currently:
+
+1. Find the chunk filename + line/column from the captured stack.
+2. Open the bundled `.js` file, scroll to the column position, read minified code.
+3. Open the matching `.js.map`, hand-decode the `mappings` field, or paste into a source-map web tool.
+
+This costs 5-15 minutes per stack frame on a multi-frame crash. **The information IS in the bundle — there's a `.map` next to each `.js` file when Vite emits with `sourcemap: true`.** We just don't read it programmatically.
+
+This spec adds a small runtime resolver that walks each captured `error.stack`, looks up each frame in the matching `.map`, and rewrites the stack to `original-file:original-line:original-column (originalName)` BEFORE forwarding to the host. Net effect: stacks in the host log are immediately useful — no DevTools dance, no hand-decoding.
+
+The resolver is also a strict reliability win for the autonomous-agent workflow: when a Claude-driven agent debugs a renderer crash from logs, it gets source-mapped frames without needing a human at DevTools.
+
+---
+
+## 2. Design summary
+
+A small async resolver, plugged into the error pipe at `error-forwarder.ts`. On the FIRST error of a given chunk filename it lazy-fetches the `.map`, parses it once, and caches the parsed consumer. Subsequent errors in that chunk are fully synchronous lookups.
+
+Each error forwarded to the host:
+- Carries the **raw** stack as `stack_raw` (current `stack` field, renamed) so we never lose ground truth.
+- Carries a **resolved** stack as `stack` (new shape) — `${source}:${line}:${col} (${name})` per frame, where source/line/col come from the source map.
+- Includes a `resolved: true | false | "partial"` flag so log consumers can tell what they're reading.
+
+Async resolution is fire-and-forget; if the `.map` fetch isn't done yet, the resolved stack just shows the raw entries for those frames. The forwarder doesn't block on resolution — errors still pipe within the same microtask.
+
+---
+
+## 3. What gets resolved
+
+`Error.stack` strings in V8/Chromium are formatted as:
+
+```
+NotFoundError: Failed to execute 'replaceChild' ...
+    at bpe (http://127.0.0.1:54169/assets/index-BUzQ6xer.js:3:31187)
+    at wp (http://127.0.0.1:54169/assets/index-BUzQ6xer.js:3:37060)
+    at Object.fn (http://127.0.0.1:54169/assets/index-BUzQ6xer.js:3:36691)
+    ...
+```
+
+A frame line matches the regex `^\s*at (?:(?<funcName>.+?) )?\((?<url>.+?):(?<line>\d+):(?<col>\d+)\)\s*$` (with a no-parens alternative for anonymous frames). The resolver:
+
+1. Extracts `(funcName, url, line, col)` from each frame.
+2. Maps `url` → `chunkName` (e.g. `index-BUzQ6xer.js`).
+3. Loads `chunkName.map` if not cached (see §4).
+4. Looks up `(line, col)` in the source-map consumer; gets `(source, origLine, origColumn, name)`.
+5. Rewrites the frame as `    at ${name || funcName} (${source}:${origLine}:${origColumn})`.
+
+Frames the resolver can't map (e.g. native frames, frames in chunks without a `.map`, partial-map gaps) pass through unchanged.
+
+---
+
+## 4. Caching + fetch strategy
+
+**One-cache-per-chunk.** Parsed `SourceMapConsumer` objects are kept in a `Map<chunkName, SourceMapConsumer | Promise<SourceMapConsumer>>`. The map is module-scope in `frontend/log/source-map-resolver.ts`.
+
+**Lazy load on first error in a chunk.** No upfront fetch. The first error pays a one-time `fetch(/*.map url*/)` + `new SourceMapConsumer(json)`. After that, lookups are synchronous.
+
+**Storing the promise during fetch.** If two errors arrive while the same chunk's `.map` is in flight, they both attach to the same Promise — no double-fetch.
+
+**Failure caching.** If the `.map` 404s or fails to parse, cache an explicit `Map.set(chunkName, FAILED_SENTINEL)` so subsequent errors in that chunk skip the network. Log once (to the host, via the same pipe but flagged) so we know maps are missing.
+
+**Cache eviction:** none. The set of bundled chunks is bounded (~50-100 in our app); memory cost is modest (a few MB at most). No LRU needed.
+
+**Pinned to chunk URL, not bundle hash.** Vite emits filenames like `index-BUzQ6xer.js` with a content hash. The cache key is the full filename, so a new build's chunks naturally get fresh cache entries.
+
+---
+
+## 5. Library choice
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`source-map-js`** (pure JS, ~50KB unpacked) | Maintained fork of Mozilla's `source-map`; sync API; no wasm | None significant |
+| `source-map` (original) | Same API | Last release ages ago; uses wasm (extra fetch + complexity) |
+| `stacktrace-js` | All-in-one wrapper | Heavier (~100KB); fetches maps itself but uses old source-map; opinionated frame format |
+| Hand-rolled VLQ decoder | Zero deps | We're writing source-map software in 2026; no |
+
+**Recommended: `source-map-js`.** Sync API, no wasm overhead, well-maintained, drops straight in.
+
+---
+
+## 6. Integration points
+
+### 6.1 New module
+
+`frontend/log/source-map-resolver.ts`:
+
+```ts
+import { SourceMapConsumer } from "source-map-js";
+
+type CacheEntry = SourceMapConsumer | Promise<SourceMapConsumer> | "failed";
+const cache = new Map<string, CacheEntry>();
+
+/** Resolve a single stack frame line, async. Returns the original line if no map. */
+async function resolveFrame(frame: string): Promise<string> { /* … */ }
+
+/** Resolve every "at ..." line in a stack string. */
+export async function resolveStack(stack: string): Promise<string> { /* … */ }
+
+/** Sync fast-path: resolve frames whose maps are already cached; leave others raw. */
+export function resolveStackSync(stack: string): { resolved: string; partial: boolean } { /* … */ }
+```
+
+Implementation notes:
+
+- `resolveStackSync` returns whatever frames can be resolved RIGHT NOW from the cache, marking `partial: true` if any frame's map isn't cached. Used by the error forwarder so the host log gets SOMETHING immediately even if maps aren't ready.
+- `resolveStack` is the async, complete version. Used by the forwarder to send a follow-up "resolved" log after the maps are fetched.
+
+### 6.2 Wire into `error-forwarder.ts`
+
+Today's `forward()` does:
+
+```ts
+invokeCommand("fe_log_structured", { level, module, message, data });
+```
+
+New shape:
+
+```ts
+async function forward(tag: string, fields: ErrorFields) {
+    if (fields.stack) {
+        const sync = resolveStackSync(fields.stack);
+        const payload = {
+            ...fields,
+            stack_raw: fields.stack,                  // ground truth, always present
+            stack: sync.resolved,                     // resolved-when-possible
+            stack_resolved: sync.partial ? "partial" : true,
+        };
+        invokeCommand("fe_log_structured", { ..., data: payload });
+
+        if (sync.partial) {
+            // Maps weren't ready; resolve async + forward a follow-up.
+            resolveStack(fields.stack).then((fullyResolved) => {
+                invokeCommand("fe_log_structured", {
+                    level: "WARN",
+                    module: tag,
+                    message: "(stack-resolved)",
+                    data: { ...payload, stack: fullyResolved, stack_resolved: true },
+                });
+            });
+        }
+    } else {
+        invokeCommand("fe_log_structured", { ..., data: fields });
+    }
+}
+```
+
+The synchronous-first emit means the host log gets the error at the same instant it does today (no added latency for the primary log line). The async follow-up arrives in a subsequent microtask once maps are loaded; it's tagged so log-readers can correlate the two entries by message+timestamp proximity.
+
+### 6.3 Optionally extend `log-pipe.ts`
+
+`log-pipe.ts` forwards every `console.*` call. Extending the same resolver to `console.error` calls that carry an `Error` argument is a small additional change — same shape, same `data.stack` rewrite. Out of scope for v1 — `console.error` paths often don't carry stacks anyway, and the uncaught-error / rejection paths catch the high-value cases.
+
+---
+
+## 7. Build pipeline considerations
+
+### 7.1 Source maps in production builds
+
+`vite.config.ts` currently emits source maps only when `NODE_ENV === "development"`. We have two choices:
+
+**A. Always emit source maps in portable builds.** Pro: stacks are always resolvable from logs without a special debug bundle. Con: bundle size increases ~30 MB; possible IP leakage to anyone who unpacks the portable.
+
+**B. Emit source maps only in debug builds.** Pro: no bundle bloat in normal portables. Con: when a user reports a crash from a normal portable, we still get raw stacks (resolver no-ops because maps aren't present).
+
+**Recommended: A.** AgentMux is an internal-feel tool; source maps are not a meaningful IP risk. The 30 MB cost is negligible against a 165 MB portable. The "always-resolvable from any log" guarantee is worth the bytes. The `vite.config.ts` change is one line.
+
+Out of scope here: if we later decide AgentMux ships to wider audiences, switch to a CDN-style "hidden maps" pattern (maps live at a different URL, not bundled in the portable). The resolver doesn't care WHERE it fetches from.
+
+### 7.2 Map file accessibility from the renderer
+
+CEF serves the portable's `runtime/frontend/` over `http://127.0.0.1:<port>/assets/...`. Source maps at `.map` URLs work automatically; no host-side change needed. (We verified this works — DevTools resolves stacks today when opened against our debug builds.)
+
+---
+
+## 8. Failure modes + handling
+
+| Scenario | Behavior |
+|---|---|
+| `.map` file 404s | Cache `"failed"`. Log a one-time WARN "[source-map] missing for chunk X" via the same pipe (flagged so it doesn't recurse). All future frames in that chunk pass through raw. |
+| `.map` parse fails | Same as 404 — `"failed"` sentinel, single WARN. |
+| Frame parsing fails (unknown stack format) | Pass the line through unchanged. The full raw stack is also in `stack_raw` regardless. |
+| Resolver itself throws | Catch at the top of `forward()`; emit the raw stack with `stack_resolved: "error"`. Never let logging fail. |
+| Memory pressure | Cache size is bounded by chunk count (~50-100); no eviction. Each consumer is ~50-200KB. Worst-case ~20 MB. Acceptable. |
+| Cross-origin chunk URLs | Same-origin only (the CEF dev server). Cross-origin maps would need CORS — out of scope. |
+
+---
+
+## 9. Performance contract
+
+- **Primary error log line:** zero added latency. Synchronous resolver returns immediately with whatever's cached; emit the line; defer the async resolve to a follow-up.
+- **First error in a chunk:** ~one-time 50-200ms (fetch + parse the map). Doesn't block the primary emit.
+- **Subsequent errors in cached chunks:** ~1ms per frame for the lookup.
+- **Bundle cost:** `source-map-js` is ~50KB unpacked → ~15KB gzipped. Negligible.
+
+---
+
+## 10. Testing
+
+`frontend/log/source-map-resolver.test.ts`:
+
+1. **Happy path.** Inline a synthetic `.map` JSON; verify `resolveStack(rawStack)` rewrites frames to `original.tsx:42:0 (functionName)`.
+2. **Cache hit.** Two stacks in the same chunk; second call must not refetch.
+3. **404 path.** Mock fetch to 404; verify `resolveStackSync` returns `partial: false` with raw stack, and the WARN is emitted once.
+4. **Partial-map gap.** Frame whose `(line, col)` doesn't have a mapping; that one frame stays raw, others resolve.
+5. **Non-Error stack format.** Frame lines that don't match the regex (e.g. native frames) pass through unchanged.
+6. **Recursive-error safety.** The resolver itself throws inside resolveFrame; verify the forwarder still emits the raw stack and doesn't loop.
+
+No integration test needed against the host log — that path is just `invokeCommand`, already covered by `error-forwarder.test.ts`.
+
+---
+
+## 11. Acceptance criteria
+
+1. **A renderer crash logged to the host shows source-mapped frames.** Example: a deliberate `throw new Error("test")` in `agent-view.tsx` produces a host log entry whose `stack` field contains `at AgentPresentationView (frontend/app/view/agent/agent-view.tsx:204:8)` (or similar), NOT `at bpe (http://...:3:31187)`.
+2. **The raw stack is still available** as `stack_raw` so we never lose ground truth.
+3. **Primary log emission is synchronous.** Send 100 throws in a tight loop — no additional latency vs. today.
+4. **Missing maps don't cause secondary errors.** Remove a `.map` from the portable; the same throw still emits the raw stack with a single "[source-map] missing" WARN.
+5. **`task package` portable builds always include `.map` files** in `runtime/frontend/assets/`.
+6. **Existing host-log consumers (muxlog, debug panels) still parse correctly.** The `data` payload change is additive (`stack_raw` is new; `stack` is now resolved when possible) — no field removal.
+
+---
+
+## 12. Out of scope (deferred)
+
+- **Resolving `console.log/warn/info`** that happen to contain stack-like strings. We only touch the error / rejection paths; richer console wrapping is more invasive for less value.
+- **Backend-side resolution.** Rust-side `agentmux_cef::commands::backend` just writes the payload to JSON. If we ever want to resolve stacks server-side (e.g. for a remote log forwarder), the parsing happens identically on a `.map` file — but the live debug case wants resolution AT THE SOURCE.
+- **Stack-frame source-snippet inclusion.** Showing the actual source line in the resolved frame is doable (the `SourceMapConsumer.sourceContentFor(file)` API). Defer — log volume gets noisy.
+- **Chrome `prepareStackTrace` hook.** V8 allows custom `Error.prepareStackTrace`, which would let us resolve at stack-construction time and have `error.stack` BE the resolved form globally. Defer — invasive (every error generation pays the cost) and trickier to test deterministically.
+- **Symbolicating runtime evals (`new Function`, dynamic imports).** Out of scope; we don't use these in hot paths.
+
+---
+
+## 13. Files this redesign touches
+
+```
+package.json                                              + source-map-js dep
+vite.config.ts                                            sourcemap: true (always)
+frontend/log/source-map-resolver.ts                       NEW
+frontend/log/source-map-resolver.test.ts                  NEW
+frontend/log/error-forwarder.ts                           wire resolver into forward()
+frontend/log/error-forwarder.test.ts                      add resolved-vs-raw assertion
+agentmux-cef/src/commands/backend.rs                      (no change — just receives bigger payload)
+```
+
+Estimated diff: ~250 lines added (mostly the resolver + tests), ~10 lines modified.
+
+---
+
+## 14. Migration path
+
+Single PR. No deprecations needed — the `data.stack` field is rewritten in place (raw is moved to `data.stack_raw`); log-consumers that currently parse `data.stack` get a more useful string for free.
+
+For old logs already written with raw stacks, no migration. They stay raw; new ones get resolved.
+
+---
+
+## 15. Risk + revert
+
+Risk: low. The resolver is a layer in front of an existing log pipe; if it fails, errors still get logged with raw stacks (just like today). The `try/catch` at the top of `forward()` enforces this.
+
+Revert: drop the wire-in line in `error-forwarder.ts`. Resolver module + dep stays unused but harmless.
+
+---
+
+## 16. Open questions
+
+1. **Should we also emit a one-line summary** before the resolved stack, e.g. `[stack-resolved 8/12 frames from index-BUzQ6xer.js]` so log readers can spot when resolution is partial? *Recommendation: yes, as a separate INFO log emitted alongside the first partial resolution per chunk. Cheap to add.*
+2. **Should `error.cause` chains be resolved recursively?** When an error wraps another error (`new Error("…", { cause: inner })`), the inner stack also gets piped. *Recommendation: yes; the resolver should walk causes. Trivial extension once the core works.*
+3. **Should we hash-version the cache keys** so multi-instance builds with different bundles in the same Chromium origin don't cross-pollute? The cache lives in renderer memory which is per-portable, so this doesn't apply today. *Recommendation: no, defer.*
+
+---
+
+*End of spec. Ready for go/no-go.*

--- a/frontend/log/error-forwarder.ts
+++ b/frontend/log/error-forwarder.ts
@@ -25,6 +25,7 @@
 // initLogPipe() so any errors during the rest of bootstrap are caught.
 
 import { invokeCommand } from "@/app/platform/ipc";
+import { resolveStack, resolveStackSync } from "./source-map-resolver";
 
 let initialized = false;
 
@@ -56,6 +57,27 @@ function safeStringify(value: unknown): string {
 function forward(tag: string, payload: ForwardedErrorPayload): void {
     try {
         const headline = `${tag} ${payload.name ?? "Error"}: ${payload.message}`;
+
+        // Synchronously resolve whatever stack frames we already have
+        // a cached source-map for. First error in a given bundle chunk
+        // pays a one-time async fetch (deferred to the follow-up below);
+        // subsequent errors in cached chunks resolve fully right here.
+        // See SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md.
+        let stackForLog: string | null = payload.stack;
+        let stackResolved: true | false | "partial" = false;
+        if (payload.stack) {
+            try {
+                const sync = resolveStackSync(payload.stack);
+                stackForLog = sync.resolved;
+                stackResolved = sync.partial ? "partial" : true;
+            } catch {
+                // Resolver itself failed — fall back to the raw stack.
+                // Never break the log pipe.
+                stackForLog = payload.stack;
+                stackResolved = false;
+            }
+        }
+
         // Fire-and-forget — never let logging break the app
         invokeCommand("fe_log_structured", {
             level: "error",
@@ -65,10 +87,48 @@ function forward(tag: string, payload: ForwardedErrorPayload): void {
                 tag,
                 name: payload.name,
                 message: payload.message,
-                stack: payload.stack,
+                stack: stackForLog,
+                stack_raw: payload.stack,
+                stack_resolved: stackResolved,
                 source: payload.source,
             },
         }).catch(() => {});
+
+        // If the synchronous resolver couldn't reach every frame,
+        // kick off the async load + emit a follow-up entry once the
+        // missing `.map` files are fetched. The follow-up is its own
+        // log line so consumers see "headline -> later -> resolved".
+        // Bounded by Promise.allSettled inside resolveStack; if any
+        // map fails, the failed frames stay raw.
+        if (stackResolved === "partial" && payload.stack) {
+            const stackToResolve = payload.stack;
+            void resolveStack(stackToResolve)
+                .then((fullyResolved) => {
+                    try {
+                        invokeCommand("fe_log_structured", {
+                            level: "warn",
+                            module: "uncaught",
+                            message: `${tag} (stack-resolved) ${payload.name ?? "Error"}: ${payload.message}`,
+                            data: {
+                                tag,
+                                name: payload.name,
+                                message: payload.message,
+                                stack: fullyResolved,
+                                stack_raw: stackToResolve,
+                                stack_resolved: true,
+                                source: payload.source,
+                            },
+                        }).catch(() => {});
+                    } catch {
+                        // swallow
+                    }
+                })
+                .catch(() => {
+                    // resolveStack swallows individual failures already;
+                    // a top-level catch here keeps us safe against any
+                    // sync-throw in the chain.
+                });
+        }
     } catch {
         // swallow
     }

--- a/frontend/log/error-forwarder.ts
+++ b/frontend/log/error-forwarder.ts
@@ -25,7 +25,7 @@
 // initLogPipe() so any errors during the rest of bootstrap are caught.
 
 import { invokeCommand } from "@/app/platform/ipc";
-import { resolveStack, resolveStackSync } from "./source-map-resolver";
+import { resolveStack, resolveStackSync, type ResolveStatus } from "./source-map-resolver";
 
 let initialized = false;
 
@@ -63,18 +63,25 @@ function forward(tag: string, payload: ForwardedErrorPayload): void {
         // pays a one-time async fetch (deferred to the follow-up below);
         // subsequent errors in cached chunks resolve fully right here.
         // See SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md.
+        //
+        // `stack_resolved` is a tri-state:
+        //   "resolved" — fully rewritten; trust `stack`.
+        //   "partial"  — pending map load; async follow-up will fire.
+        //   "failed"   — terminal failure; some/all frames still raw,
+        //                no retry coming. (Distinct from "resolved" —
+        //                codex P2 on PR #1090 b80a2ed6.)
         let stackForLog: string | null = payload.stack;
-        let stackResolved: true | false | "partial" = false;
+        let stackResolved: ResolveStatus = "failed";
         if (payload.stack) {
             try {
                 const sync = resolveStackSync(payload.stack);
                 stackForLog = sync.resolved;
-                stackResolved = sync.partial ? "partial" : true;
+                stackResolved = sync.status;
             } catch {
                 // Resolver itself failed — fall back to the raw stack.
                 // Never break the log pipe.
                 stackForLog = payload.stack;
-                stackResolved = false;
+                stackResolved = "failed";
             }
         }
 
@@ -113,9 +120,14 @@ function forward(tag: string, payload: ForwardedErrorPayload): void {
                                 tag,
                                 name: payload.name,
                                 message: payload.message,
-                                stack: fullyResolved,
+                                stack: fullyResolved.resolved,
                                 stack_raw: stackToResolve,
-                                stack_resolved: true,
+                                // After async, the status is either
+                                // "resolved" (everything mapped) or
+                                // "failed" (some chunks terminally
+                                // failed). It cannot be "partial" —
+                                // resolveStack awaits every load.
+                                stack_resolved: fullyResolved.status,
                                 source: payload.source,
                             },
                         }).catch(() => {});

--- a/frontend/log/source-map-resolver.test.ts
+++ b/frontend/log/source-map-resolver.test.ts
@@ -152,4 +152,51 @@ describe("source-map-resolver", () => {
         // Middle line is non-conforming; we keep it as-is.
         expect(resolved).toContain("weird frame [no parens]");
     });
+
+    it("converts V8's 1-based column to 0-based before source-map lookup", async () => {
+        // Codex P2 on PR #1090: V8 `error.stack` columns are 1-based,
+        // source-map-js `originalPositionFor` expects 0-based. Without
+        // the conversion, every lookup shifts one character right.
+        // Strategy: spy on the consumer to capture the column actually
+        // passed into `originalPositionFor`.
+        const consumer = await buildConsumer();
+        const opfSpy = vi.spyOn(consumer, "originalPositionFor");
+        _seedConsumerForTests("index-Hash.js", consumer);
+
+        const stack = [
+            "Error: c",
+            // V8 reports col 7 (1-based). Resolver must call into
+            // source-map-js with column 6 (0-based).
+            "    at bpe (http://x/assets/index-Hash.js:3:7)",
+        ].join("\n");
+        resolveStackSync(stack);
+
+        expect(opfSpy).toHaveBeenCalledWith({ line: 3, column: 6 });
+
+        // Edge: col 0 must not become -1; floor at 0.
+        opfSpy.mockClear();
+        resolveStackSync("Error: c\n    at f (http://x/assets/index-Hash.js:3:0)");
+        expect(opfSpy).toHaveBeenCalledWith({ line: 3, column: 0 });
+    });
+
+    it("failed chunks are terminal — resolveStackSync returns partial: false", async () => {
+        // Codex P2 on PR #1090: after a chunk's `.map` is marked
+        // failed, the sync resolver must NOT treat its frames as
+        // pending — otherwise the forwarder fires another async
+        // follow-up that re-runs the same failed lookup and emits a
+        // duplicate `(stack-resolved)` log line with the still-raw
+        // stack. The failure cache must be terminal.
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404 }) as Response));
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const stack = "Error: z\n    at f (http://x/assets/gone-Hash.js:1:0)";
+
+        // First trip: async load fails; chunk cached as failed.
+        await resolveStack(stack);
+
+        // Second trip: pure sync — chunk should be terminal-failed,
+        // NOT counted as partial.
+        const { partial } = resolveStackSync(stack);
+        expect(partial).toBe(false);
+    });
 });

--- a/frontend/log/source-map-resolver.test.ts
+++ b/frontend/log/source-map-resolver.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SourceMapConsumer, type RawSourceMap } from "source-map-js";
+
+import {
+    _resetCacheForTests,
+    _seedConsumerForTests,
+    resolveStack,
+    resolveStackSync,
+} from "./source-map-resolver";
+
+/**
+ * Build a SourceMapConsumer from a pre-encoded map literal. source-map-js
+ * doesn't include a generator API, so we hand-author a tiny map with one
+ * mapping point: generated line 3 col 0 → orig.ts line 11 col 5 (name "myFn").
+ *
+ * The version field is the literal number `3` rather than a typed `number`;
+ * `RawSourceMap.version` is typed `3` (literal) in source-map-js, which is
+ * why we use a cast through `as RawSourceMap` instead of an explicit type
+ * annotation on the object literal.
+ */
+async function buildConsumer(): Promise<SourceMapConsumer> {
+    // source-map-js's `.d.ts` types `version` as `string`, but the runtime
+    // accepts the canonical number `3` from the source-map v3 spec. We cast
+    // through `unknown` to keep the runtime value correct without lying
+    // about the field's nominal type.
+    const raw = {
+        version: 3,
+        file: "index-Hash.js",
+        sources: ["src/orig.ts"],
+        sourcesContent: ["function myFn() { /* original */ }\n"],
+        names: ["myFn"],
+        // Three generated lines (two `;;`), one segment on line 3:
+        //   gen line 3, col 0 → orig.ts:11:5 (name myFn).
+        // VLQ encoding of [0, 0, 10, 5, 0] → "AAUKA".
+        mappings: ";;AAUKA",
+    } as unknown as RawSourceMap;
+    return new SourceMapConsumer(raw);
+}
+
+describe("source-map-resolver", () => {
+    beforeEach(() => {
+        _resetCacheForTests();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("resolveStackSync rewrites a frame whose map is seeded", async () => {
+        const consumer = await buildConsumer();
+        _seedConsumerForTests("index-Hash.js", consumer);
+
+        const rawStack = [
+            "NotFoundError: kaboom",
+            "    at bpe (http://127.0.0.1:50000/assets/index-Hash.js:3:0)",
+        ].join("\n");
+
+        const { resolved, partial } = resolveStackSync(rawStack);
+        expect(partial).toBe(false);
+        expect(resolved).toContain("src/orig.ts:11");
+        // Name from the map (myFn) overrides the runtime funcName (bpe).
+        expect(resolved).toContain("myFn");
+    });
+
+    it("resolveStackSync leaves the line raw when the map isn't cached", () => {
+        const rawStack = [
+            "Error: ok",
+            "    at fn (http://127.0.0.1:50000/assets/unknown-Hash.js:3:0)",
+        ].join("\n");
+
+        const { resolved, partial } = resolveStackSync(rawStack);
+        expect(partial).toBe(true);
+        expect(resolved).toContain("unknown-Hash.js");
+    });
+
+    it("resolveStackSync passes non-frame lines through unchanged", async () => {
+        const consumer = await buildConsumer();
+        _seedConsumerForTests("index-Hash.js", consumer);
+
+        const raw = "TypeError: bang";
+        const { resolved, partial } = resolveStackSync(raw);
+        expect(resolved).toBe(raw);
+        // No frames touched ⇒ no partial flag.
+        expect(partial).toBe(false);
+    });
+
+    it("resolveStack fetches missing maps async, then resolves", async () => {
+        const consumer = await buildConsumer();
+        const fetchMock = vi.fn(async (url: string) => {
+            expect(url).toContain("index-Hash.js.map");
+            return {
+                ok: true,
+                json: async () =>
+                    ({
+                        version: 3,
+                        file: "index-Hash.js",
+                        sources: ["src/orig.ts"],
+                        names: ["myFn"],
+                        mappings: ";;AAUKA",
+                    } as unknown as RawSourceMap),
+            } as Response;
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const rawStack = [
+            "Error: x",
+            "    at bpe (http://127.0.0.1:50000/assets/index-Hash.js:3:0)",
+        ].join("\n");
+
+        const out = await resolveStack(rawStack);
+        // Source-map-js may or may not honor names depending on the
+        // exact encoding — assert on the source position, which is
+        // the load-bearing part.
+        expect(out).toContain("src/orig.ts");
+        expect(out).toMatch(/src\/orig\.ts:1[0-9]/);
+        // Consumer is now silently used; suppress unused-warning.
+        void consumer;
+    });
+
+    it("a missing .map (404) is cached as failed; no re-fetch on second call", async () => {
+        const fetchMock = vi.fn(async () => ({
+            ok: false,
+            status: 404,
+        }) as Response);
+        vi.stubGlobal("fetch", fetchMock);
+        // Also stub console.warn so the one-time WARN doesn't pollute
+        // the test runner; we just verify the call count.
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const stack = "Error: y\n    at f (http://x/assets/gone-Hash.js:1:0)";
+
+        const r1 = await resolveStack(stack);
+        const r2 = await resolveStack(stack);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(r1).toContain("gone-Hash.js");
+        expect(r2).toContain("gone-Hash.js");
+        // Single one-shot WARN per failing chunk.
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("frames that don't match V8 format pass through unchanged", () => {
+        const stack = [
+            "Error: malformed",
+            "    weird frame [no parens]",
+            "    at fn (foo.js:1:1)",
+        ].join("\n");
+        const { resolved } = resolveStackSync(stack);
+        // Middle line is non-conforming; we keep it as-is.
+        expect(resolved).toContain("weird frame [no parens]");
+    });
+});

--- a/frontend/log/source-map-resolver.test.ts
+++ b/frontend/log/source-map-resolver.test.ts
@@ -58,8 +58,8 @@ describe("source-map-resolver", () => {
             "    at bpe (http://127.0.0.1:50000/assets/index-Hash.js:3:0)",
         ].join("\n");
 
-        const { resolved, partial } = resolveStackSync(rawStack);
-        expect(partial).toBe(false);
+        const { resolved, status } = resolveStackSync(rawStack);
+        expect(status).toBe("resolved");
         expect(resolved).toContain("src/orig.ts:11");
         // Name from the map (myFn) overrides the runtime funcName (bpe).
         expect(resolved).toContain("myFn");
@@ -71,8 +71,8 @@ describe("source-map-resolver", () => {
             "    at fn (http://127.0.0.1:50000/assets/unknown-Hash.js:3:0)",
         ].join("\n");
 
-        const { resolved, partial } = resolveStackSync(rawStack);
-        expect(partial).toBe(true);
+        const { resolved, status } = resolveStackSync(rawStack);
+        expect(status).toBe("partial");
         expect(resolved).toContain("unknown-Hash.js");
     });
 
@@ -81,10 +81,10 @@ describe("source-map-resolver", () => {
         _seedConsumerForTests("index-Hash.js", consumer);
 
         const raw = "TypeError: bang";
-        const { resolved, partial } = resolveStackSync(raw);
+        const { resolved, status } = resolveStackSync(raw);
         expect(resolved).toBe(raw);
-        // No frames touched ⇒ no partial flag.
-        expect(partial).toBe(false);
+        // No frames touched ⇒ trivially resolved.
+        expect(status).toBe("resolved");
     });
 
     it("resolveStack fetches missing maps async, then resolves", async () => {
@@ -110,12 +110,13 @@ describe("source-map-resolver", () => {
             "    at bpe (http://127.0.0.1:50000/assets/index-Hash.js:3:0)",
         ].join("\n");
 
-        const out = await resolveStack(rawStack);
+        const { resolved, status } = await resolveStack(rawStack);
         // Source-map-js may or may not honor names depending on the
         // exact encoding — assert on the source position, which is
         // the load-bearing part.
-        expect(out).toContain("src/orig.ts");
-        expect(out).toMatch(/src\/orig\.ts:1[0-9]/);
+        expect(resolved).toContain("src/orig.ts");
+        expect(resolved).toMatch(/src\/orig\.ts:1[0-9]/);
+        expect(status).toBe("resolved");
         // Consumer is now silently used; suppress unused-warning.
         void consumer;
     });
@@ -132,12 +133,14 @@ describe("source-map-resolver", () => {
 
         const stack = "Error: y\n    at f (http://x/assets/gone-Hash.js:1:0)";
 
-        const r1 = await resolveStack(stack);
-        const r2 = await resolveStack(stack);
+        const { resolved: r1, status: s1 } = await resolveStack(stack);
+        const { resolved: r2, status: s2 } = await resolveStack(stack);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(r1).toContain("gone-Hash.js");
         expect(r2).toContain("gone-Hash.js");
+        expect(s1).toBe("failed");
+        expect(s2).toBe("failed");
         // Single one-shot WARN per failing chunk.
         expect(warnSpy).toHaveBeenCalledTimes(1);
     });
@@ -179,13 +182,13 @@ describe("source-map-resolver", () => {
         expect(opfSpy).toHaveBeenCalledWith({ line: 3, column: 0 });
     });
 
-    it("failed chunks are terminal — resolveStackSync returns partial: false", async () => {
-        // Codex P2 on PR #1090: after a chunk's `.map` is marked
-        // failed, the sync resolver must NOT treat its frames as
-        // pending — otherwise the forwarder fires another async
-        // follow-up that re-runs the same failed lookup and emits a
-        // duplicate `(stack-resolved)` log line with the still-raw
-        // stack. The failure cache must be terminal.
+    it("failed chunks are terminal — resolveStackSync returns status: 'failed'", async () => {
+        // Codex P2 on PR #1090 (commit 55e1a14d): after a chunk's
+        // `.map` is marked failed, the sync resolver must NOT treat
+        // its frames as pending — otherwise the forwarder fires
+        // another async follow-up that re-runs the same failed lookup
+        // and emits a duplicate `(stack-resolved)` log line with the
+        // still-raw stack. The failure cache must be terminal.
         vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404 }) as Response));
         vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
@@ -195,8 +198,29 @@ describe("source-map-resolver", () => {
         await resolveStack(stack);
 
         // Second trip: pure sync — chunk should be terminal-failed,
-        // NOT counted as partial.
-        const { partial } = resolveStackSync(stack);
-        expect(partial).toBe(false);
+        // distinct from both "resolved" and "partial".
+        const { status } = resolveStackSync(stack);
+        expect(status).toBe("failed");
+    });
+
+    it("'failed' is distinct from 'resolved' — codex P2 on b80a2ed6", async () => {
+        // Codex P2 on PR #1090 commit b80a2ed6: when a chunk's map
+        // permanently fails, the resolver's sync return previously
+        // collapsed back to `partial: false` which the forwarder
+        // emitted as `stack_resolved: true` — a lie, since the
+        // frames are still raw minified positions. Status must
+        // discriminate "fully resolved" from "tried and failed."
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404 }) as Response));
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const stack = "Error: w\n    at f (http://x/assets/lost-Hash.js:1:0)";
+        await resolveStack(stack); // cache as failed
+
+        const { status, resolved } = resolveStackSync(stack);
+        expect(status).not.toBe("resolved");
+        expect(status).toBe("failed");
+        // Frame stays raw — log readers must be able to see that
+        // from the status alone.
+        expect(resolved).toContain("lost-Hash.js");
     });
 });

--- a/frontend/log/source-map-resolver.ts
+++ b/frontend/log/source-map-resolver.ts
@@ -96,30 +96,44 @@ function loadMap(jsUrl: string): Promise<SourceMapConsumer | "failed"> {
 }
 
 /**
- * Resolve a single frame line. Returns the rewritten line, or the
- * original line if no resolution is possible right now.
+ * Resolve a single frame line. Returns the rewritten line and a status:
+ *   - `resolved` — frame was rewritten against a ready consumer.
+ *   - `pending`  — chunk's map isn't loaded yet; async path can retry.
+ *   - `failed`   — chunk's map is permanently unavailable; do NOT retry.
+ *   - `not-a-frame` — line didn't match the V8 frame regex.
  *
- * `consumer` is optional — when omitted, only frames whose chunk is
- * already in the synchronous-ready cache get resolved.
+ * Callers (see `resolveStackSync`) treat `pending` as a reason to fire
+ * the async follow-up, but treat `failed` as terminal — retrying buys
+ * nothing and produces duplicate `(stack-resolved)` log lines for the
+ * same raw stack (codex P2 on PR #1090).
  */
-function resolveFrameSync(line: string): { line: string; resolved: boolean } {
+type FrameStatus = "resolved" | "pending" | "failed" | "not-a-frame";
+
+function resolveFrameSync(line: string): { line: string; status: FrameStatus } {
     const m = line.match(FRAME_RE);
-    if (!m) return { line, resolved: false };
+    if (!m) return { line, status: "not-a-frame" };
     const [, prefix, funcName, url, lineStr, colStr] = m;
     const chunk = chunkOf(url);
     const entry = cache.get(chunk);
-    if (entry?.kind !== "ready") return { line, resolved: false };
+    if (entry == null || entry.kind === "pending") return { line, status: "pending" };
+    if (entry.kind === "failed") return { line, status: "failed" };
 
+    // V8's `error.stack` columns are 1-based; source-map-js's
+    // `originalPositionFor` expects 0-based generated columns. Without
+    // the `-1`, every lookup shifts one character right and at token
+    // boundaries can map to the wrong identifier — defeating the
+    // purpose of the resolver (codex P2 on PR #1090). Floor at 0 to
+    // tolerate any stack format that already gives a 0 column.
     const pos = entry.consumer.originalPositionFor({
         line: Number(lineStr),
-        column: Number(colStr),
+        column: Math.max(0, Number(colStr) - 1),
     });
-    if (pos.source == null || pos.line == null) return { line, resolved: false };
+    if (pos.source == null || pos.line == null) return { line, status: "failed" };
 
     const displayName = pos.name ?? funcName ?? "<anonymous>";
     return {
         line: `${prefix}${displayName} (${pos.source}:${pos.line}${pos.column != null ? `:${pos.column}` : ""})`,
-        resolved: true,
+        status: "resolved",
     };
 }
 
@@ -134,21 +148,19 @@ export function resolveStackSync(stack: string): {
     partial: boolean;
 } {
     const lines = stack.split("\n");
-    let anyUnresolved = false;
-    let anyFrameTouched = false;
+    let anyPending = false;
     const out = lines.map((line) => {
         if (!line.includes(" at ")) return line;
-        anyFrameTouched = true;
-        const { line: next, resolved } = resolveFrameSync(line);
-        if (!resolved) anyUnresolved = true;
+        const { line: next, status } = resolveFrameSync(line);
+        // Only `pending` frames warrant an async follow-up — a `failed`
+        // chunk has already been ruled out by `loadMap` (404 or
+        // unparseable map). Treating failed as partial would loop the
+        // forwarder into emitting duplicate `(stack-resolved)` lines
+        // with the still-raw stack each time (codex P2 on PR #1090).
+        if (status === "pending") anyPending = true;
         return next;
     });
-    return {
-        resolved: out.join("\n"),
-        // `partial` only matters when there was at least one frame
-        // to look at. A stackless string returns partial: false.
-        partial: anyFrameTouched && anyUnresolved,
-    };
+    return { resolved: out.join("\n"), partial: anyPending };
 }
 
 /**

--- a/frontend/log/source-map-resolver.ts
+++ b/frontend/log/source-map-resolver.ts
@@ -143,32 +143,60 @@ function resolveFrameSync(line: string): { line: string; status: FrameStatus } {
  * indicating whether any frame couldn't be resolved (caller can
  * then call {@link resolveStack} for the async follow-up).
  */
+/**
+ * Outcome of a stack resolve.
+ *   - `"resolved"` — every frame was rewritten (or there were no
+ *     frames). Caller can trust the resolved string as fully decoded.
+ *   - `"partial"` — at least one frame's chunk is pending an async
+ *     map load. Caller should fire the async follow-up.
+ *   - `"failed"`  — at least one frame's chunk is terminally failed
+ *     (404, malformed, or in-map miss). Async retry buys nothing;
+ *     the resolved string still contains raw minified positions.
+ *
+ * Priority: pending dominates failed dominates resolved — so a stack
+ * with both pending and failed frames reports `"partial"` (the async
+ * follow-up will eventually re-report as `"failed"` once the pending
+ * loads finish).
+ */
+export type ResolveStatus = "resolved" | "partial" | "failed";
+
 export function resolveStackSync(stack: string): {
     resolved: string;
-    partial: boolean;
+    status: ResolveStatus;
 } {
     const lines = stack.split("\n");
     let anyPending = false;
+    let anyFailed = false;
     const out = lines.map((line) => {
         if (!line.includes(" at ")) return line;
         const { line: next, status } = resolveFrameSync(line);
-        // Only `pending` frames warrant an async follow-up — a `failed`
-        // chunk has already been ruled out by `loadMap` (404 or
-        // unparseable map). Treating failed as partial would loop the
-        // forwarder into emitting duplicate `(stack-resolved)` lines
-        // with the still-raw stack each time (codex P2 on PR #1090).
+        // Track "needs async retry" (pending) separately from
+        // "tried and gave up" (failed). Conflating them either
+        // re-runs the resolver for nothing or — if we ignored
+        // failure — falsely labels a still-raw stack as fully
+        // resolved (codex P2 on PR #1090 b80a2ed6).
         if (status === "pending") anyPending = true;
+        else if (status === "failed") anyFailed = true;
         return next;
     });
-    return { resolved: out.join("\n"), partial: anyPending };
+    return {
+        resolved: out.join("\n"),
+        status: anyPending ? "partial" : anyFailed ? "failed" : "resolved",
+    };
 }
 
 /**
  * Async resolve: ensures every chunk's `.map` is loaded (or marked
  * failed), then runs the synchronous resolver against the stack.
  * Used by the forwarder as a follow-up after the primary emit.
+ *
+ * After awaiting every load, no chunk is `pending` — so the returned
+ * status is always `"resolved"` or `"failed"`, never `"partial"`.
  */
-export async function resolveStack(stack: string): Promise<string> {
+export async function resolveStack(stack: string): Promise<{
+    resolved: string;
+    status: ResolveStatus;
+}> {
     const lines = stack.split("\n");
     const urls = new Set<string>();
     for (const line of lines) {
@@ -179,7 +207,7 @@ export async function resolveStack(stack: string): Promise<string> {
     // resolveFrameSync handles the "failed" sentinel by passing the
     // raw line through.
     await Promise.allSettled(Array.from(urls).map(loadMap));
-    return resolveStackSync(stack).resolved;
+    return resolveStackSync(stack);
 }
 
 /** Test-only helper. Clears all cached maps + failure marks. */

--- a/frontend/log/source-map-resolver.ts
+++ b/frontend/log/source-map-resolver.ts
@@ -1,0 +1,188 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Runtime source-map resolver for piped error stacks.
+ *
+ * V8 (Chromium) only applies source maps to stacks displayed in
+ * DevTools. The runtime `error.stack` string is always the minified
+ * bundle position — `at bpe (http://.../assets/index-Hash.js:3:31187)`.
+ * That string is what `frontend/log/error-forwarder.ts` pipes to the
+ * host via `fe_log_structured`, which means every renderer crash in
+ * the host log requires a manual DevTools dance to decode.
+ *
+ * This module flips that: on first error in a bundle chunk it
+ * lazily fetches the chunk's `.map`, parses it with `source-map-js`,
+ * caches the `SourceMapConsumer`, and rewrites each frame to the
+ * original `source:line:column (name)`. Subsequent errors in the
+ * same chunk are synchronous lookups.
+ *
+ * Spec: docs/specs/SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md.
+ */
+
+import { SourceMapConsumer, type RawSourceMap } from "source-map-js";
+
+/** A chunk's parsed map, an in-flight fetch promise, or a failure sentinel. */
+type CacheEntry =
+    | { kind: "ready"; consumer: SourceMapConsumer }
+    | { kind: "pending"; promise: Promise<SourceMapConsumer | "failed"> }
+    | { kind: "failed" };
+
+const cache = new Map<string, CacheEntry>();
+
+/** Reported once per failing chunk to keep host-log noise low. */
+const reportedFailures = new Set<string>();
+
+/**
+ * Match V8's stack frame format. Two shapes:
+ *   `    at funcName (url:line:col)`
+ *   `    at url:line:col` (anonymous, e.g. eval / top-level)
+ * Spaces are flexible; the trailing nothing-or-newline is implicit.
+ *
+ * Capture groups: 1=funcName (may be empty), 2=url, 3=line, 4=col.
+ */
+const FRAME_RE = /^(\s*at\s+)(?:(.+?)\s+)?\(?([^()\s]+):(\d+):(\d+)\)?\s*$/;
+
+/** Strip the URL down to its chunk filename. */
+function chunkOf(url: string): string {
+    // Match the last "/" -delimited segment that ends in `.js` (with
+    // optional query string). Bare or relative URLs pass through.
+    const m = url.match(/\/([^/]+\.js)(?:\?.*)?$/);
+    return m ? m[1] : url;
+}
+
+/** Build the `.map` URL from a `.js` URL by appending `.map`. */
+function mapUrlOf(jsUrl: string): string {
+    return jsUrl.replace(/(\?.*)?$/, ".map");
+}
+
+/**
+ * Async load + parse a `.map` file for a chunk. Caches the result
+ * (success or failure) so retries are idempotent.
+ */
+function loadMap(jsUrl: string): Promise<SourceMapConsumer | "failed"> {
+    const chunk = chunkOf(jsUrl);
+    const entry = cache.get(chunk);
+    if (entry?.kind === "ready") return Promise.resolve(entry.consumer);
+    if (entry?.kind === "failed") return Promise.resolve("failed");
+    if (entry?.kind === "pending") return entry.promise;
+
+    const promise = (async (): Promise<SourceMapConsumer | "failed"> => {
+        try {
+            const res = await fetch(mapUrlOf(jsUrl));
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const json = (await res.json()) as RawSourceMap;
+            const consumer = new SourceMapConsumer(json);
+            cache.set(chunk, { kind: "ready", consumer });
+            return consumer;
+        } catch (err) {
+            cache.set(chunk, { kind: "failed" });
+            if (!reportedFailures.has(chunk)) {
+                reportedFailures.add(chunk);
+                // One-shot WARN; the consumer of this module (the
+                // error forwarder) typically forwards via the same
+                // log pipe — that's fine, this isn't an error path
+                // that recurses through resolveStack.
+                console.warn(
+                    `[source-map] missing or invalid for chunk ${chunk}: ${(err as Error).message}`,
+                );
+            }
+            return "failed";
+        }
+    })();
+
+    cache.set(chunk, { kind: "pending", promise });
+    return promise;
+}
+
+/**
+ * Resolve a single frame line. Returns the rewritten line, or the
+ * original line if no resolution is possible right now.
+ *
+ * `consumer` is optional — when omitted, only frames whose chunk is
+ * already in the synchronous-ready cache get resolved.
+ */
+function resolveFrameSync(line: string): { line: string; resolved: boolean } {
+    const m = line.match(FRAME_RE);
+    if (!m) return { line, resolved: false };
+    const [, prefix, funcName, url, lineStr, colStr] = m;
+    const chunk = chunkOf(url);
+    const entry = cache.get(chunk);
+    if (entry?.kind !== "ready") return { line, resolved: false };
+
+    const pos = entry.consumer.originalPositionFor({
+        line: Number(lineStr),
+        column: Number(colStr),
+    });
+    if (pos.source == null || pos.line == null) return { line, resolved: false };
+
+    const displayName = pos.name ?? funcName ?? "<anonymous>";
+    return {
+        line: `${prefix}${displayName} (${pos.source}:${pos.line}${pos.column != null ? `:${pos.column}` : ""})`,
+        resolved: true,
+    };
+}
+
+/**
+ * Synchronous resolve: rewrite every frame whose chunk's map is
+ * already cached. Returns the resolved stack + a `partial` flag
+ * indicating whether any frame couldn't be resolved (caller can
+ * then call {@link resolveStack} for the async follow-up).
+ */
+export function resolveStackSync(stack: string): {
+    resolved: string;
+    partial: boolean;
+} {
+    const lines = stack.split("\n");
+    let anyUnresolved = false;
+    let anyFrameTouched = false;
+    const out = lines.map((line) => {
+        if (!line.includes(" at ")) return line;
+        anyFrameTouched = true;
+        const { line: next, resolved } = resolveFrameSync(line);
+        if (!resolved) anyUnresolved = true;
+        return next;
+    });
+    return {
+        resolved: out.join("\n"),
+        // `partial` only matters when there was at least one frame
+        // to look at. A stackless string returns partial: false.
+        partial: anyFrameTouched && anyUnresolved,
+    };
+}
+
+/**
+ * Async resolve: ensures every chunk's `.map` is loaded (or marked
+ * failed), then runs the synchronous resolver against the stack.
+ * Used by the forwarder as a follow-up after the primary emit.
+ */
+export async function resolveStack(stack: string): Promise<string> {
+    const lines = stack.split("\n");
+    const urls = new Set<string>();
+    for (const line of lines) {
+        const m = line.match(FRAME_RE);
+        if (m) urls.add(m[3]);
+    }
+    // Kick off all map loads in parallel; ignore individual failures —
+    // resolveFrameSync handles the "failed" sentinel by passing the
+    // raw line through.
+    await Promise.allSettled(Array.from(urls).map(loadMap));
+    return resolveStackSync(stack).resolved;
+}
+
+/** Test-only helper. Clears all cached maps + failure marks. */
+export function _resetCacheForTests(): void {
+    cache.clear();
+    reportedFailures.clear();
+}
+
+/**
+ * Test-only helper. Seeds a consumer for a chunk so the synchronous
+ * path can resolve frames without a real fetch.
+ */
+export function _seedConsumerForTests(
+    chunk: string,
+    consumer: SourceMapConsumer,
+): void {
+    cache.set(chunk, { kind: "ready", consumer });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "semver": "^7.7.3",
         "shiki": "^3.21.0",
         "solid-js": "^1.9.11",
+        "source-map-js": "^1.2.1",
         "sprintf-js": "^1.1.3",
         "streamdown": "^1.6.11",
         "tailwind-merge": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "semver": "^7.7.3",
     "shiki": "^3.21.0",
     "solid-js": "^1.9.11",
+    "source-map-js": "^1.2.1",
     "sprintf-js": "^1.1.3",
     "streamdown": "^1.6.11",
     "tailwind-merge": "^3.4.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,7 +95,14 @@ export default defineConfig({
     root: ".",
     build: {
         target: ["es2021", "chrome97", "safari13"],
-        sourcemap: process.env.NODE_ENV === "development",
+        // Always emit `.map` files so the runtime source-map resolver
+        // (frontend/log/source-map-resolver.ts) can rewrite raw
+        // `error.stack` positions into original-file frames before
+        // piping to the host log. Adds ~30MB to a portable but the
+        // pay-off — readable stacks for every crash without needing
+        // DevTools — is worth it for an internal tool. Spec:
+        // SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md §7.1.
+        sourcemap: true,
         cssCodeSplit: false,
         outDir: "dist/frontend",
         rollupOptions: {


### PR DESCRIPTION
## Summary

- Rewrites V8 minified `error.stack` positions (the `bpe → wp → ...` flavor) into original-file frames *before* they reach the host log, via a chunk-keyed `SourceMapConsumer` cache.
- Sync-first emit: primary log line goes out immediately with whatever frames are already cached (`stack_resolved: true | false | "partial"`); partial stacks trigger a one-shot async fetch and a follow-up `(stack-resolved)` line. `stack_raw` always travels alongside the resolved stack.
- Vite now emits `.map` files for every build (~30MB cost per portable; the trade-off is documented in `vite.config.ts`).

## Why

The agent-pane `replaceChild` crash on send-message is open with two falsified hypotheses (see `docs/analysis/AGENT_PANE_REPLACECHILD_CRASH_ON_SEND_2026_05_27.md`). Iterating on minified stacks via the DevTools paste-and-decode dance is the bottleneck — this PR removes it for that bug *and* every future renderer crash.

## Files

- `frontend/log/source-map-resolver.ts` — module-scope cache, lazy `.map` fetch, V8 frame regex, one-shot WARN per failing chunk.
- `frontend/log/source-map-resolver.test.ts` — 6 tests covering seeded sync resolve, async fetch + resolve, 404 caching, malformed frames.
- `frontend/log/error-forwarder.ts` — resolver wiring inside `forward()`: sync emit + async follow-up.
- `vite.config.ts` — `sourcemap: true` always.
- `package.json` / lockfile — adds `source-map-js@^1.2.1`.
- `docs/specs/SPEC_FE_SOURCE_MAP_RESOLVER_2026_05_27.md` — full design + acceptance criteria + future patterns.
- `docs/analysis/AGENT_PANE_REPLACECHILD_CRASH_ON_SEND_2026_05_27.md` — the open crash investigation that motivated this work.
- `.changesets/1779856022-...md` — patch changeset.

## Test plan

- [x] `npx vitest run frontend/log/source-map-resolver.test.ts` — 6/6 pass.
- [x] `npx tsc --noEmit -p .` — clean across resolver + forwarder.
- [x] `task build:frontend` — clean (built in 28s).
- [ ] After merge: build a portable, reproduce the agent-pane crash, confirm the host log shows resolved frames pointing at real `.tsx` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)