### PR TITLE
fix(editor-pane-state): wake subscribers on every state change

### DIFF
--- a/.changesets/1779872611-fix-editor-pane-state-call-eventsink-whenever-state-changes--nxo7.md
+++ b/.changesets/1779872611-fix-editor-pane-state-call-eventsink-whenever-state-changes--nxo7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor-pane-state): call eventSink whenever state changes, not only when events array is non-empty

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -644,7 +644,14 @@ export function dispatch(
     const result = update(prev, command);
     slot.state = result.state;
 
-    if (eventSink && result.events.length > 0) {
+    // Call the sink whenever STATE changed, even if no semantic events were
+    // emitted (e.g. TabContentLoaded mutates the tab record but doesn't
+    // currently emit an event). Subscribers use this as the cue to re-read
+    // their projections; without it, view-side derivations bound to slice
+    // state (active-tab `contentLoaded`, `loadError`, etc.) silently miss
+    // the update and the UI looks frozen. The empty-events case is a no-op
+    // for code that iterates `events` and a wake-up for code that doesn't.
+    if (eventSink && result.state !== prev) {
         eventSink(result.events);
     }
 


### PR DESCRIPTION
## Summary

**Bug:** After PR #1088 (editor tabs Phase 1B) merged, clicking a file in the file tree fires the backend \`readeditorfile\` RPC and updates block meta — but the editor pane stays blank. Looks frozen even though all events flow.

**Root cause:** The slot \`dispatch\` was gating \`eventSink(events)\` on \`result.events.length > 0\`. The reducer's \`TabContentLoaded\` handler mutates the tab record (sets \`contentLoaded: true\`, stores \`contentHash\`) but returns \`events: []\` — Phase 1A shipped without the spec's \`TabReady\` event. So:

1. User clicks file → \`openFile\` → dispatch \`OpenFile\` → slice creates a tab + emits \`TabOpened\`/\`TabActivated\` (events array non-empty → sink fires → \`sliceVersion\` bumps → view re-renders) ✓
2. \`readeditorfile\` resolves → dispatch \`TabContentLoaded\` → slice updates \`tab.contentLoaded = true\` but events array is empty → **sink does NOT fire** → \`sliceVersion\` doesn't bump → \`loadingAtom\` projection silently misses the update → \`createEffect\` doesn't re-run → \`setupEditor\` never builds CodeMirror → pane stays blank ✗

## Fix

Call \`eventSink\` whenever \`result.state\` reference changes, regardless of events array length. The empty-events case is a no-op for consumers that iterate \`events\` and a wake-up for consumers (like view projections) that don't.

The no-op SwitchTab/ReorderTab paths correctly DON'T fire the sink because they return the original \`state\` reference unchanged.

## Test plan

- [x] \`npx vitest run frontend/app/store/editor-pane-state-store.test.ts\` → 35/35 still passing
- [ ] Smoke test in \`task dev\`: open editor pane → click file in tree → file opens in pane (currently broken without this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)