### PR TITLE
feat(editor): preview tabs + error panel + binary guard + reactivity fix

### DIFF
--- a/.changesets/1779875373-feat-editor-preview-tabs-centered-error-panel-binary-file-gu-e0ny.md
+++ b/.changesets/1779875373-feat-editor-preview-tabs-centered-error-panel-binary-file-gu-e0ny.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): preview tabs + centered error panel + binary-file guard + memo reactivity fix

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -49,6 +49,11 @@ export interface EditorTab {
     loadError: string | null;
     /** Transient — true once the lazy fetch resolved. Not persisted. */
     contentLoaded: boolean;
+    /** Preview tab — at most one per pane. A single-click in the tree
+     *  opens into the preview slot (replacing the current preview's file).
+     *  Double-click opens as pinned. Editing or explicit pin promotes a
+     *  preview to pinned. Matches VS Code semantics. */
+    isPreview: boolean;
 }
 
 export interface ClosedTab {
@@ -96,8 +101,20 @@ export interface HydratedTab {
 export type EditorCommandSource = "user" | "system" | "cm-update" | "hydrate";
 
 export type EditorPaneCommand =
-    | { type: "OpenFile"; path: string; language?: string; source?: EditorCommandSource }
+    | {
+          type: "OpenFile";
+          path: string;
+          language?: string;
+          /** "preview" (default for tree single-click) → replaces the
+           *  current preview tab if any, else creates a new preview.
+           *  "pinned" (tree double-click, programmatic open) → always
+           *  appends a non-preview tab. Activating an already-open tab
+           *  is unchanged regardless of mode. */
+          mode?: "preview" | "pinned";
+          source?: EditorCommandSource;
+      }
     | { type: "CloseTab"; tabId: string; force?: boolean; source?: EditorCommandSource }
+    | { type: "PinTab"; tabId: string; source?: EditorCommandSource }
     | { type: "SwitchTab"; tabId: string; source?: EditorCommandSource }
     | { type: "ReorderTab"; tabId: string; toIndex: number; source?: EditorCommandSource }
     | { type: "MarkDirty"; tabId: string; source?: EditorCommandSource }
@@ -221,7 +238,7 @@ function findTabByPath(
 }
 
 /** Build a fresh tab record for the given path/language. */
-function makeTab(path: string, language?: string): EditorTab {
+function makeTab(path: string, language?: string, isPreview = false): EditorTab {
     const canon = canonicalizePath(path);
     return {
         id: newTabId(),
@@ -232,6 +249,7 @@ function makeTab(path: string, language?: string): EditorTab {
         contentHash: "",
         loadError: null,
         contentLoaded: false,
+        isPreview,
     };
 }
 
@@ -294,12 +312,27 @@ export function update(
         case "OpenFile": {
             const canon = canonicalizePath(command.path);
             const existing = findTabByPath(state, canon);
+            const requestedMode = command.mode ?? "pinned";
             if (existing) {
-                if (state.activeTabId === existing.id) {
-                    // Already active → still emit TabActivated so the
-                    // view (LSP didOpen, file-tree highlight) has a
-                    // single uniform signal to bind to. No state
-                    // change.
+                // If the existing tab is a preview and the caller asked
+                // for a pinned open (e.g. tree double-click on the file
+                // that's currently in preview), pin it as part of the
+                // activation. Other transitions (preview→preview,
+                // pinned→pinned, pinned→preview) are no-ops for isPreview.
+                const shouldPin = existing.isPreview && requestedMode === "pinned";
+                const existingIdx = state.tabs.findIndex((t) => t.id === existing.id);
+                const updatedTab = shouldPin
+                    ? { ...existing, isPreview: false }
+                    : existing;
+                const nextTabs = shouldPin
+                    ? [
+                          ...state.tabs.slice(0, existingIdx),
+                          updatedTab,
+                          ...state.tabs.slice(existingIdx + 1),
+                      ]
+                    : state.tabs;
+                if (state.activeTabId === existing.id && !shouldPin) {
+                    // Already active and no pin transition → no state change.
                     return {
                         state,
                         events: [
@@ -312,7 +345,11 @@ export function update(
                     };
                 }
                 return {
-                    state: { ...state, activeTabId: existing.id },
+                    state: {
+                        ...state,
+                        tabs: nextTabs,
+                        activeTabId: existing.id,
+                    },
                     events: [
                         {
                             type: "TabActivated",
@@ -322,7 +359,54 @@ export function update(
                     ],
                 };
             }
-            const tab = makeTab(command.path, command.language);
+
+            // New tab. In preview mode, replace the existing preview tab if
+            // one exists — only ONE preview tab per pane. Pinned mode always
+            // appends. Default is "pinned" — that's the safe choice for
+            // programmatic callers (ReopenLastClosed, tests, future drag-
+            // drop). Tree single-click is the only caller that should pass
+            // `mode: "preview"` explicitly.
+            if (requestedMode === "preview") {
+                const previewIdx = state.tabs.findIndex((t) => t.isPreview);
+                if (previewIdx >= 0) {
+                    // Replace the preview slot's contents in place. Reset
+                    // load state so the view re-fetches. The tab id stays
+                    // the same so view-side CodeMirror state for OTHER
+                    // tabs is unaffected.
+                    const newPreview: EditorTab = {
+                        ...state.tabs[previewIdx],
+                        filePath: canon,
+                        language: command.language ?? deriveLanguage(canon),
+                        readOnly: false,
+                        dirty: false,
+                        contentHash: "",
+                        loadError: null,
+                        contentLoaded: false,
+                        isPreview: true,
+                    };
+                    const nextTabs = [
+                        ...state.tabs.slice(0, previewIdx),
+                        newPreview,
+                        ...state.tabs.slice(previewIdx + 1),
+                    ];
+                    return {
+                        state: {
+                            ...state,
+                            tabs: nextTabs,
+                            activeTabId: newPreview.id,
+                        },
+                        events: [
+                            {
+                                type: "TabActivated",
+                                tabId: newPreview.id,
+                                filePath: newPreview.filePath,
+                            },
+                        ],
+                    };
+                }
+            }
+
+            const tab = makeTab(command.path, command.language, requestedMode === "preview");
             const nextTabs = [...state.tabs, tab];
             return {
                 state: {
@@ -339,6 +423,21 @@ export function update(
                     },
                 ],
             };
+        }
+
+        case "PinTab": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0 || !state.tabs[idx].isPreview) {
+                // Defensive: pinning a non-preview tab is a no-op.
+                return { state, events: [] };
+            }
+            const nextTab = { ...state.tabs[idx], isPreview: false };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return { state: { ...state, tabs: nextTabs }, events: [] };
         }
 
         case "CloseTab": {
@@ -436,7 +535,10 @@ export function update(
                 // a redundant signal.
                 return { state, events: [] };
             }
-            const nextTab: EditorTab = { ...tab, dirty: true };
+            // Editing a preview tab promotes it to pinned (matches
+            // VS Code's behavior — once you've started editing, the
+            // tab should survive the next preview-mode tree click).
+            const nextTab: EditorTab = { ...tab, dirty: true, isPreview: false };
             const nextTabs = [
                 ...state.tabs.slice(0, idx),
                 nextTab,
@@ -534,6 +636,10 @@ export function update(
                 contentHash: "",
                 loadError: null,
                 contentLoaded: false,
+                // Hydrated tabs are always pinned — a persisted preview
+                // wouldn't survive the round-trip semantically (the user
+                // committed by closing/reopening the session).
+                isPreview: false,
             }));
             // Enforce invariant 1 — activeTabId must point at a tab
             // in the list, or be null when empty.

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -592,10 +592,19 @@ export function update(
             const idx = findTabIndex(state, command.tabId);
             if (idx < 0) return { state, events: [] };
             const tab = state.tabs[idx];
+            // Preserve contentLoaded if it was already true — only the
+            // initial-load failure path needs to flip it to false. For
+            // operational failures (e.g. save errors), the disk-side
+            // content the view holds is still valid and the centered
+            // error panel must NOT replace CodeMirror; the small top
+            // banner picks the error up via the loadError accessor.
             const nextTab: EditorTab = {
                 ...tab,
                 loadError: command.error,
-                contentLoaded: false,
+                // Stay loaded if we already were; only flip to false
+                // for never-loaded tabs (where contentLoaded is already
+                // false anyway, so this is a no-op for that case).
+                contentLoaded: tab.contentLoaded,
             };
             const nextTabs = [
                 ...state.tabs.slice(0, idx),

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -160,7 +160,6 @@ export class EditorViewModel implements ViewModel {
         // future dirty-confirm modal, LSP coupling). Removed on dispose so
         // no closure over a disposed model survives.
         this._globalHandler = (events: EditorPaneEvent[]) => {
-            console.log("[editor-tabs] _globalHandler called events=", events.map((e) => e.type));
             this._sliceVersion[1]((v) => v + 1);
             for (const ev of events) {
                 if (ev.type === "TabClosed") {
@@ -316,15 +315,22 @@ export class EditorViewModel implements ViewModel {
     }
 
     private async _openFileWithMode(filePath: string, mode: "preview" | "pinned"): Promise<void> {
-        console.log("[editor-tabs] openFile entry path=", filePath, "mode=", mode);
         const canonical = canonicalizePath(filePath);
-        // Claim the loading slot BEFORE dispatching so two synchronous calls
-        // for the same path don't both issue ReadEditorFileCommand. Without
-        // this, the second call would pass _loadingPaths.has() (still empty)
-        // and the .add() below would fire after the first call's RPC already
-        // returned, racing the content write.
+        // If a load is already in flight for this path, we still need to
+        // honor a preview→pinned transition (rapid dbl-click on a tree
+        // row: the single-click added canonical to _loadingPaths, then
+        // the dblclick's pinned-open would early-return and never pin).
+        // Dispatch OpenFile so the slice runs the pin-if-existing logic,
+        // then bail (the RPC's continuation will populate content as
+        // usual).
         if (this._loadingPaths.has(canonical)) {
-            console.log("[editor-tabs] openFile early-return: loading in progress for", canonical);
+            dispatch(this.blockId, {
+                type: "OpenFile",
+                path: filePath,
+                language: detectLanguage(filePath),
+                mode,
+                source: "user",
+            });
             return;
         }
         this._loadingPaths.add(canonical);
@@ -342,19 +348,16 @@ export class EditorViewModel implements ViewModel {
             mode,
             source: "user",
         });
-        console.log("[editor-tabs] openFile dispatched, events=", events.map((e) => e.type));
 
         // Find the tab id (just-opened or pre-existing).
         const opened = events.find(
             (e) => e.type === "TabOpened" || e.type === "TabActivated",
         );
         if (!opened || (opened.type !== "TabOpened" && opened.type !== "TabActivated")) {
-            console.log("[editor-tabs] openFile: no TabOpened/TabActivated event — aborting");
             this._loadingPaths.delete(canonical);
             return;
         }
         const tabId = opened.tabId;
-        console.log("[editor-tabs] openFile: tabId=", tabId.slice(0, 8));
 
         // If the slice considers content loaded for this tab AND we have it
         // in the view-local cache, we're done. The slice's contentLoaded
@@ -363,7 +366,6 @@ export class EditorViewModel implements ViewModel {
         // correctly force a reload in that case.
         const sliceTab = snapshot(this.blockId)?.tabs.find((t) => t.id === tabId);
         if (sliceTab?.contentLoaded && this._contentByTab.has(tabId)) {
-            console.log("[editor-tabs] openFile: content already loaded for", tabId.slice(0, 8));
             this._loadingPaths.delete(canonical);
             return;
         }
@@ -375,7 +377,16 @@ export class EditorViewModel implements ViewModel {
                 path: filePath,
             });
             const content = result?.content ?? "";
-            console.log("[editor-tabs] readeditorfile resolved, contentLen=", content.length);
+
+            // Re-check the slice: the preview slot's path may have been
+            // swapped out from under us by a faster click while this RPC
+            // was in flight. Without this check we'd write THIS file's
+            // content into a tab now showing a DIFFERENT file. Validate
+            // by canonicalized path because the slice canonicalizes too.
+            const tabNow = snapshot(this.blockId)?.tabs.find((t) => t.id === tabId);
+            if (!tabNow || tabNow.filePath !== canonical) {
+                return;
+            }
 
             // Refuse content that looks binary or that would freeze the
             // renderer in CodeMirror. Specifically:
@@ -400,7 +411,6 @@ export class EditorViewModel implements ViewModel {
             this._contentVersion[1]((v) => v + 1);
 
             const hash = await sha256Hex(content);
-            console.log("[editor-tabs] dispatching TabContentLoaded for", tabId.slice(0, 8));
             dispatch(this.blockId, {
                 type: "TabContentLoaded",
                 tabId,

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -234,22 +234,30 @@ export class EditorViewModel implements ViewModel {
         );
 
         // Pane title — full file path of active tab, with `*` for dirty.
-        this.viewName = createMemo(() => {
-            const fp = this.filePathAtom();
-            if (!fp) return "Editor";
-            return this.dirtyAtom() ? `${fp} *` : fp;
-        });
+        // Wrap in useBlockAtom for the same reason as tabsAtom/activeIdAtom —
+        // a bare createMemo in the constructor doesn't sit inside a tracking
+        // owner, so block-frame subscribers reading `viewName()` wouldn't
+        // always see updates when the active tab changes.
+        this.viewName = useBlockAtom(blockId, "editor-view-name", () =>
+            createMemo<string>(() => {
+                const fp = this.filePathAtom();
+                if (!fp) return "Editor";
+                return this.dirtyAtom() ? `${fp} *` : fp;
+            }),
+        );
 
         // Pane icon doubles as the file-tree expand/collapse toggle.
-        this.viewIcon = createMemo<IconButtonDecl>(() => {
-            const expanded = this.treeExpandedAtom();
-            return {
-                elemtype: "iconbutton",
-                icon: expanded ? "folder-tree" : "folder",
-                title: expanded ? "Hide file tree" : "Show file tree",
-                click: () => void this.toggleTreeExpanded(),
-            };
-        });
+        this.viewIcon = useBlockAtom(blockId, "editor-view-icon", () =>
+            createMemo<IconButtonDecl>(() => {
+                const expanded = this.treeExpandedAtom();
+                return {
+                    elemtype: "iconbutton",
+                    icon: expanded ? "folder-tree" : "folder",
+                    title: expanded ? "Hide file tree" : "Show file tree",
+                    click: () => void this.toggleTreeExpanded(),
+                };
+            }),
+        );
 
         this.viewText = () => [];
 

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -160,6 +160,7 @@ export class EditorViewModel implements ViewModel {
         // future dirty-confirm modal, LSP coupling). Removed on dispose so
         // no closure over a disposed model survives.
         this._globalHandler = (events: EditorPaneEvent[]) => {
+            console.log("[editor-tabs] _globalHandler called events=", events.map((e) => e.type));
             this._sliceVersion[1]((v) => v + 1);
             for (const ev of events) {
                 if (ev.type === "TabClosed") {
@@ -172,19 +173,32 @@ export class EditorViewModel implements ViewModel {
 
         // Projections from the slice's slot cell. Reading sliceVersionAtom
         // creates the Solid dependency that makes these re-evaluate.
-        this.tabsAtom = createMemo<EditorTab[]>(() => {
-            this.sliceVersionAtom();
-            return snapshot(this.blockId)?.tabs ?? [];
-        });
-        this.activeIdAtom = createMemo<string | null>(() => {
-            this.sliceVersionAtom();
-            return snapshot(this.blockId)?.activeTabId ?? null;
-        });
-        this.activeTabAtom = createMemo<EditorTab | null>(() => {
-            const id = this.activeIdAtom();
-            const tabs = this.tabsAtom();
-            return tabs.find((t) => t.id === id) ?? null;
-        });
+        //
+        // Wrapped in `useBlockAtom` (which calls createRoot under the hood) —
+        // a bare createMemo here would be created in the constructor's
+        // non-reactive scope. It'd compute its initial value but downstream
+        // subscribers (createEffect in editor-view) wouldn't reliably re-run
+        // when the source signals change. Same fix as the zoomAtom in
+        // PR #1084 — see that comment for context.
+        this.tabsAtom = useBlockAtom(blockId, "editor-tabs-list", () =>
+            createMemo<EditorTab[]>(() => {
+                this.sliceVersionAtom();
+                return snapshot(this.blockId)?.tabs ?? [];
+            }),
+        );
+        this.activeIdAtom = useBlockAtom(blockId, "editor-tabs-active-id", () =>
+            createMemo<string | null>(() => {
+                this.sliceVersionAtom();
+                return snapshot(this.blockId)?.activeTabId ?? null;
+            }),
+        );
+        this.activeTabAtom = useBlockAtom(blockId, "editor-tabs-active-tab", () =>
+            createMemo<EditorTab | null>(() => {
+                const id = this.activeIdAtom();
+                const tabs = this.tabsAtom();
+                return tabs.find((t) => t.id === id) ?? null;
+            }),
+        );
 
         // Derived: per-active-tab signals. Existing consumers see the same
         // shape as before — they just track whichever tab is active.
@@ -200,11 +214,13 @@ export class EditorViewModel implements ViewModel {
             return tab != null && !tab.contentLoaded && tab.loadError == null;
         };
 
-        this.contentAtom = createMemo<string>(() => {
-            this._contentVersion[0](); // dep on content bumps
-            const id = this.activeIdAtom();
-            return id ? this._contentByTab.get(id) ?? "" : "";
-        });
+        this.contentAtom = useBlockAtom(blockId, "editor-tabs-content", () =>
+            createMemo<string>(() => {
+                this._contentVersion[0](); // dep on content bumps
+                const id = this.activeIdAtom();
+                return id ? this._contentByTab.get(id) ?? "" : "";
+            }),
+        );
 
         // Per-pane zoom (PR #1084). Wrapped in useBlockAtom (which calls
         // createRoot under the hood) — a bare createMemo here wouldn't have
@@ -268,14 +284,41 @@ export class EditorViewModel implements ViewModel {
     }
 
     // ── Tab actions (dispatched into the slice) ──────────────────────
+    /** Open a file as a *pinned* tab (the default). Use for explicit-open
+     *  paths like double-click in the tree, path-input submit, drag-drop,
+     *  programmatic open. The pinned tab survives subsequent tree clicks. */
     async openFile(filePath: string): Promise<void> {
+        return this._openFileWithMode(filePath, "pinned");
+    }
+
+    /** Open a file as a *preview* tab (VS Code-style). Use for tree single-
+     *  click: at most ONE preview tab per pane; subsequent single-clicks
+     *  replace its file. Editing the preview promotes it to pinned. */
+    async openFilePreview(filePath: string): Promise<void> {
+        return this._openFileWithMode(filePath, "preview");
+    }
+
+    /** Convert the active tab from preview → pinned. The view calls this
+     *  when the user double-clicks the preview tab in the strip. No-op if
+     *  the tab is already pinned. */
+    pinActiveTab(): void {
+        const tab = this.activeTabAtom();
+        if (!tab || !tab.isPreview) return;
+        dispatch(this.blockId, { type: "PinTab", tabId: tab.id, source: "user" });
+    }
+
+    private async _openFileWithMode(filePath: string, mode: "preview" | "pinned"): Promise<void> {
+        console.log("[editor-tabs] openFile entry path=", filePath, "mode=", mode);
         const canonical = canonicalizePath(filePath);
         // Claim the loading slot BEFORE dispatching so two synchronous calls
         // for the same path don't both issue ReadEditorFileCommand. Without
         // this, the second call would pass _loadingPaths.has() (still empty)
         // and the .add() below would fire after the first call's RPC already
         // returned, racing the content write.
-        if (this._loadingPaths.has(canonical)) return;
+        if (this._loadingPaths.has(canonical)) {
+            console.log("[editor-tabs] openFile early-return: loading in progress for", canonical);
+            return;
+        }
         this._loadingPaths.add(canonical);
 
         // Dispatch OpenFile. The slice either activates an existing tab (and
@@ -288,33 +331,68 @@ export class EditorViewModel implements ViewModel {
             type: "OpenFile",
             path: filePath,
             language: detectLanguage(filePath),
+            mode,
             source: "user",
         });
+        console.log("[editor-tabs] openFile dispatched, events=", events.map((e) => e.type));
 
         // Find the tab id (just-opened or pre-existing).
         const opened = events.find(
             (e) => e.type === "TabOpened" || e.type === "TabActivated",
         );
         if (!opened || (opened.type !== "TabOpened" && opened.type !== "TabActivated")) {
+            console.log("[editor-tabs] openFile: no TabOpened/TabActivated event — aborting");
             this._loadingPaths.delete(canonical);
             return;
         }
         const tabId = opened.tabId;
+        console.log("[editor-tabs] openFile: tabId=", tabId.slice(0, 8));
 
-        // If content's already loaded for this tab, we're done.
-        if (this._contentByTab.has(tabId)) {
+        // If the slice considers content loaded for this tab AND we have it
+        // in the view-local cache, we're done. The slice's contentLoaded
+        // flag is the source of truth: it's reset to false when a preview
+        // tab's file is swapped (same tabId, different path) so we
+        // correctly force a reload in that case.
+        const sliceTab = snapshot(this.blockId)?.tabs.find((t) => t.id === tabId);
+        if (sliceTab?.contentLoaded && this._contentByTab.has(tabId)) {
+            console.log("[editor-tabs] openFile: content already loaded for", tabId.slice(0, 8));
             this._loadingPaths.delete(canonical);
             return;
         }
+        // Stale view-local content (preview-swap left it behind) — evict
+        // so the about-to-fire RPC populates the new file's content.
+        this._contentByTab.delete(tabId);
         try {
             const result = await RpcApi.ReadEditorFileCommand(TabRpcClient, {
                 path: filePath,
             });
             const content = result?.content ?? "";
+            console.log("[editor-tabs] readeditorfile resolved, contentLen=", content.length);
+
+            // Refuse content that looks binary or that would freeze the
+            // renderer in CodeMirror. Specifically:
+            //   1. Any NUL byte → binary (text files don't contain U+0000).
+            //   2. Single line over 100K chars → would block the layout
+            //      thread laying out a half-megabyte-wide line (real-world
+            //      hit: Windows NTUSER.DAT regtrans-ms files come through
+            //      as 512KB of one line).
+            // Both fast checks; bail before stashing content or hashing.
+            const refusal = sniffUnopenable(content);
+            if (refusal) {
+                dispatch(this.blockId, {
+                    type: "TabContentLoadFailed",
+                    tabId,
+                    error: refusal,
+                    source: "system",
+                });
+                return;
+            }
+
             this._contentByTab.set(tabId, content);
             this._contentVersion[1]((v) => v + 1);
 
             const hash = await sha256Hex(content);
+            console.log("[editor-tabs] dispatching TabContentLoaded for", tabId.slice(0, 8));
             dispatch(this.blockId, {
                 type: "TabContentLoaded",
                 tabId,
@@ -460,6 +538,36 @@ export class EditorViewModel implements ViewModel {
 function clampTreeWidth(w: number): number {
     if (!Number.isFinite(w)) return TREE_WIDTH_DEFAULT;
     return Math.max(TREE_WIDTH_MIN, Math.min(TREE_WIDTH_MAX, Math.round(w)));
+}
+
+/** Sniff content that's unsafe to hand to CodeMirror. Returns a human-readable
+ *  refusal message (used as the tab's loadError) or null when the content is
+ *  fine to render. Cheap — scans up to the first 4096 bytes for NUL.
+ *
+ *  Why this lives in the model: CodeMirror will faithfully try to lay out
+ *  half-a-megabyte of binary on one line (the trigger case was a Windows
+ *  NTUSER.DAT regtrans-ms file at 512KB) and block the renderer indefinitely.
+ *  The 10MB read cap doesn't catch it because the file is small. */
+const MAX_BYTES_FOR_NUL_SNIFF = 4096;
+const MAX_SINGLE_LINE_CHARS = 100_000;
+
+function sniffUnopenable(content: string): string | null {
+    // NUL-byte sniff — any U+0000 in the first few KB means binary.
+    const sniffLen = Math.min(content.length, MAX_BYTES_FOR_NUL_SNIFF);
+    for (let i = 0; i < sniffLen; i++) {
+        if (content.charCodeAt(i) === 0) {
+            return "This file looks binary (contains NUL bytes) and can't be displayed in the editor.";
+        }
+    }
+    // Single-line-too-long sniff — even a "text" file is unsafe to render if
+    // it has no newline within the first 100K chars. CodeMirror's layout
+    // engine handles long files line-by-line; a single 100K+ line stalls it.
+    const firstNewline = content.indexOf("\n");
+    const lineLen = firstNewline === -1 ? content.length : firstNewline;
+    if (lineLen > MAX_SINGLE_LINE_CHARS) {
+        return `This file's first line is ${lineLen.toLocaleString()} characters long — too wide to render. Open it in an external editor.`;
+    }
+    return null;
 }
 
 // ── Language detection ──────────────────────────────────────────────────────

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -53,6 +53,17 @@ function Tab(props: { tab: EditorTab; active: boolean; model: EditorViewModel })
         if (!props.active) props.model.switchTab(props.tab.id);
     };
 
+    const onDblClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        // Double-clicking a preview tab pins it (matches VS Code). For an
+        // already-pinned tab, dblclick is a no-op at the strip layer
+        // (.editor-tab-strip already stops the dblclick from reaching the
+        // pane header, so the pane won't maximize either).
+        if (props.tab.isPreview) {
+            props.model.pinActiveTab();
+        }
+    };
+
     const onCloseClick = (e: MouseEvent) => {
         e.stopPropagation();
         props.model.closeTab(props.tab.id);
@@ -64,10 +75,12 @@ function Tab(props: { tab: EditorTab; active: boolean; model: EditorViewModel })
             classList={{
                 "editor-tab--active": props.active,
                 "editor-tab--dirty": props.tab.dirty,
+                "editor-tab--preview": props.tab.isPreview,
             }}
-            title={props.tab.filePath}
+            title={props.tab.isPreview ? `${props.tab.filePath} (preview — double-click to pin)` : props.tab.filePath}
             onMouseDown={onMouseDown}
             onClick={onClick}
+            onDblClick={onDblClick}
         >
             <span class="editor-tab-label">{basename()}</span>
             <button

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -297,6 +297,16 @@
             opacity: 1;
         }
     }
+
+    // Preview tab — italic title (matches VS Code). At most one preview
+    // tab per pane; tree single-click replaces its file in place, tree
+    // double-click (or editing) pins it. Visual cue tells the user this
+    // tab is "transient".
+    &--preview {
+        .editor-tab-label {
+            font-style: italic;
+        }
+    }
 }
 
 .editor-tab-label {
@@ -401,6 +411,65 @@
     color: var(--error-color);
     font-size: 12px;
     border-bottom: 1px solid rgba(255, 80, 80, 0.3);
+}
+
+// Full-pane error panel — shown when the active tab failed to load (the
+// CodeMirror body is suppressed). Centered card with the file path, the
+// error text, and a Close-tab button.
+.editor-error-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    color: var(--main-text-color);
+    text-align: center;
+}
+
+.editor-error-panel-icon {
+    font-size: 32px;
+    color: var(--error-color, #d97706);
+    line-height: 1;
+}
+
+.editor-error-panel-title {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.editor-error-panel-path {
+    font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    word-break: break-all;
+    max-width: 500px;
+}
+
+.editor-error-panel-message {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    max-width: 500px;
+    background: rgba(255, 80, 80, 0.08);
+    border: 1px solid rgba(255, 80, 80, 0.25);
+    border-radius: 3px;
+    padding: var(--space-2) var(--space-3);
+}
+
+.editor-error-panel-close {
+    margin-top: var(--space-2);
+    padding: var(--space-1-5) var(--space-3);
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    color: var(--main-text-color);
+    cursor: pointer;
+    font-size: 12px;
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.05));
+    }
 }
 
 .editor-codemirror {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -243,6 +243,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
     // Build or rebuild CodeMirror when the active tab changes
     const setupEditor = async (content: string, language: string, readOnly: boolean) => {
+        console.log("[editor-tabs] setupEditor entry language=", language, "contentLen=", content.length, "containerRef=", !!containerRef);
         if (!containerRef) return;
 
         // Destroy previous instance
@@ -297,6 +298,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             }),
             parent: containerRef,
         });
+        console.log("[editor-tabs] setupEditor built cmView, doc lines=", cmView.state.doc.lines);
     };
 
     onMount(() => {
@@ -347,6 +349,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     createEffect(() => {
         const activeId = model.activeIdAtom(); // reactive: tab change
         const loading = model.loadingAtom(); // reactive: wait for content
+        console.log("[editor-tabs] createEffect run activeId=", activeId?.slice(0, 8), "loading=", loading, "containerRef=", !!containerRef);
         if (!activeId || loading || !containerRef) return;
 
         untrack(() => {
@@ -354,6 +357,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             const content = model.contentAtom();
             const lang = model.languageAtom();
             const readOnly = model.readOnlyAtom();
+            console.log("[editor-tabs] createEffect proceeding path=", path, "lang=", lang, "contentLen=", content.length);
 
             // Snapshot outgoing tab's CodeMirror state for cursor/scroll/
             // undo preservation. Skipped on first mount (no prevId).
@@ -467,7 +471,8 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         model={model.treeModel}
                         activeFilePath={model.filePathAtom()}
                         showHidden={model.showHiddenAtom()}
-                        onFileClick={(path) => void model.openFile(path)}
+                        onFileClick={(path) => void model.openFilePreview(path)}
+                        onFileDblClick={(path) => void model.openFile(path)}
                         onToggleHidden={() => void model.toggleShowHidden()}
                     />
                     <Show when={!model.filePathAtom()}>
@@ -508,7 +513,31 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                     <div class="editor-loading">Loading...</div>
                 </Show>
 
-                <Show when={model.errorAtom()}>
+                {/* Full-pane error panel when a file failed to load (e.g.
+                    invalid path, permission denied, binary). Replaces the
+                    CodeMirror body for the active tab while the error sticks.
+                    Operational errors that occur with content already loaded
+                    (e.g. save failures) still surface via the top banner
+                    below. */}
+                <Show when={model.errorAtom() && model.activeTabAtom() && !model.activeTabAtom()?.contentLoaded}>
+                    <div class="editor-error-panel" role="alert">
+                        <div class="editor-error-panel-icon" aria-hidden="true">⚠</div>
+                        <div class="editor-error-panel-title">Couldn't open file</div>
+                        <div class="editor-error-panel-path">{model.filePathAtom()}</div>
+                        <div class="editor-error-panel-message">{model.errorAtom()}</div>
+                        <button
+                            class="editor-error-panel-close"
+                            onClick={() => {
+                                const tab = model.activeTabAtom();
+                                if (tab) model.closeTab(tab.id);
+                            }}
+                        >
+                            Close tab
+                        </button>
+                    </div>
+                </Show>
+
+                <Show when={model.errorAtom() && model.activeTabAtom()?.contentLoaded}>
                     <div class="editor-error">{model.errorAtom()}</div>
                 </Show>
 
@@ -562,7 +591,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 </Show>
 
                 <Show
-                    when={model.filePathAtom() && !model.loadingAtom()}
+                    when={
+                        model.filePathAtom() &&
+                        !model.loadingAtom() &&
+                        // Don't render CodeMirror when the active tab failed
+                        // to load — the centered error panel takes the body.
+                        !(model.errorAtom() && model.activeTabAtom() && !model.activeTabAtom()?.contentLoaded)
+                    }
                     fallback={
                         <Show when={!model.treeExpandedAtom()}>
                             <div class="editor-open-prompt">

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -243,7 +243,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
     // Build or rebuild CodeMirror when the active tab changes
     const setupEditor = async (content: string, language: string, readOnly: boolean) => {
-        console.log("[editor-tabs] setupEditor entry language=", language, "contentLen=", content.length, "containerRef=", !!containerRef);
         if (!containerRef) return;
 
         // Destroy previous instance
@@ -298,7 +297,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             }),
             parent: containerRef,
         });
-        console.log("[editor-tabs] setupEditor built cmView, doc lines=", cmView.state.doc.lines);
     };
 
     onMount(() => {
@@ -349,7 +347,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     createEffect(() => {
         const activeId = model.activeIdAtom(); // reactive: tab change
         const loading = model.loadingAtom(); // reactive: wait for content
-        console.log("[editor-tabs] createEffect run activeId=", activeId?.slice(0, 8), "loading=", loading, "containerRef=", !!containerRef);
         if (!activeId || loading || !containerRef) return;
 
         untrack(() => {
@@ -357,7 +354,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             const content = model.contentAtom();
             const lang = model.languageAtom();
             const readOnly = model.readOnlyAtom();
-            console.log("[editor-tabs] createEffect proceeding path=", path, "lang=", lang, "contentLen=", content.length);
 
             // Snapshot outgoing tab's CodeMirror state for cursor/scroll/
             // undo preservation. Skipped on first mount (no prevId).

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -17,7 +17,12 @@ interface FileTreeProps {
     model: FileTreeModel;
     activeFilePath: string;
     showHidden: boolean;
+    /** Called on file row single-click — VS Code-style "preview" open
+     *  (replaces the current preview tab if any). */
     onFileClick: (path: string) => void;
+    /** Called on file row double-click — pins the tab so subsequent
+     *  preview-opens don't replace it. */
+    onFileDblClick?: (path: string) => void;
     onToggleHidden: () => void;
 }
 
@@ -42,6 +47,7 @@ export function FileTree(props: FileTreeProps): JSX.Element {
                             activeFilePath={props.activeFilePath}
                             showHidden={props.showHidden}
                             onFileClick={props.onFileClick}
+                            onFileDblClick={props.onFileDblClick}
                         />
                     )}
                 </For>
@@ -101,6 +107,7 @@ interface TreeNodeProps {
     activeFilePath: string;
     showHidden: boolean;
     onFileClick: (path: string) => void;
+    onFileDblClick?: (path: string) => void;
 }
 
 function TreeNode(props: TreeNodeProps): JSX.Element {
@@ -120,7 +127,20 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
         if (props.isDir) {
             void props.model.toggleExpand(props.path);
         } else {
+            // Single-click → preview-open (VS Code-style). The browser will
+            // also fire `dblclick` separately when it's a double-click —
+            // that path handles pinning. We don't try to suppress this
+            // first click: if it preview-opens then dblclick pins the same
+            // tab, the user sees the file load once and the tab persist.
             props.onFileClick(props.path);
+        }
+    };
+
+    const handleDblClick = (e: MouseEvent) => {
+        if (props.isDir) return;
+        e.stopPropagation();
+        if (props.onFileDblClick) {
+            props.onFileDblClick(props.path);
         }
     };
 
@@ -134,6 +154,7 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                 }}
                 style={{ "padding-left": `${4 + props.depth * 16}px` }}
                 onClick={handleClick}
+                onDblClick={handleDblClick}
                 title={props.path}
             >
                 <Show
@@ -179,6 +200,7 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                             activeFilePath={props.activeFilePath}
                             showHidden={props.showHidden}
                             onFileClick={props.onFileClick}
+                            onFileDblClick={props.onFileDblClick}
                         />
                     )}
                 </For>


### PR DESCRIPTION
## Summary

Bundle of editor-pane improvements landed together — they share infrastructure (the `EditorViewModel` signal-projection layer and the slice's tab list), so reviewing them as one PR is easier than splitting.

### 1. VS Code-style preview tabs (Phase 2 of `SPEC_EDITOR_TABS`)

- **Tree single-click** opens a file in a *preview* tab (italic title). Subsequent single-clicks **replace its file in-place** — at most one preview tab per pane.
- **Tree double-click** pins the tab.
- **Double-click on a preview tab in the strip** pins it.
- **Editing a preview tab** auto-promotes it to pinned (matches VS Code).

Slice changes:
- New `isPreview: boolean` on `EditorTab`.
- New `mode?: "preview" | "pinned"` option on `OpenFile` (default **pinned** for programmatic safety — only the tree-click site passes `mode: \"preview\"`).
- New `PinTab` command.
- `MarkDirty` auto-pins.
- `OpenFile` on a path that's currently the preview, with `mode=pinned`, now **pins it** rather than just activating (handles the dblclick-pinning-existing-preview flow correctly).

View-model changes:
- `openFile(path)` → pinned (legacy semantics preserved for existing callers).
- `openFilePreview(path)` → preview slot.
- `pinActiveTab()` → for the tab strip's dblclick handler.
- **Stale-cache fix**: preview-swap mutates the same `tabId` but resets `contentLoaded=false` in the slice. The view-model's content cache now consults `tab.contentLoaded` from the slice and reloads when stale.

View changes:
- `file-tree.tsx`: separate `onFileClick` (preview) / `onFileDblClick` (pinned) callbacks.
- `editor-tab-strip.tsx`: italic label on preview tabs, dblclick handler pins, contextual title attribute explains the affordance.

### 2. Centered error panel for invalid files

When a tab fails to load, CodeMirror is suppressed and a full-pane card replaces it: icon + file path + error message + Close-tab button. Operational errors *after* content loaded (e.g. save failures) still surface via the existing small top banner.

### 3. Binary-content / long-line guard

A NUL-byte sniff (first 4 KB) rejects binary files; a single-line-length sniff (>100 K chars) rejects pathological text. The trigger case was a Windows `NTUSER.DAT` regtrans-ms file (512 KB on one line) that hung CodeMirror's layout thread indefinitely. The 10 MB read cap didn't catch it. The refusal message flows through `TabContentLoadFailed` → the centered error panel.

### 4. Reactivity fix for slice projections

The slice's `tabsAtom` / `activeIdAtom` / `activeTabAtom` / `contentAtom` `createMemo`s were created in the model constructor **outside any reactive root**, so subscribers wouldn't reliably re-run on slice mutations. Wrapped in `useBlockAtom` (which uses `createRoot` under the hood) — same fix PR #1084 applied to `zoomAtom`. Without this, clicking a file would fire all the right dispatches but the `createEffect` in `editor-view` would never re-run and CodeMirror would never build for the loaded content.

### 5. Module-level event-sink fan-out

Replaced the per-instance `setEventSink` in `EditorViewModel` with a module-level singleton that fans out to a `Set` of per-instance handlers. The previous design was last-writer-wins: opening a second editor pane silently disabled the first pane's slice subscription.

## Diagnostics

Kept the `[editor-tabs]` `console.log` lines — we're still iterating and the host-log output has been the key to landing the right fixes (slice-sink wake-up, reactivity wrap, stale-cache evict). Strip in a follow-up once the surface stabilizes.

## Test plan

- [x] `npx vitest run frontend/app/store/editor-pane-state-store.test.ts` → 35/35 passing
- [x] `npx tsc --noEmit` clean for editor files
- [ ] Smoke test in `task dev`:
  - Tree single-click → italic preview tab opens; subsequent single-clicks REPLACE the file in the same tab.
  - Tree double-click → pinned tab (non-italic).
  - Double-click preview tab in strip → pins it (italic gone).
  - Open `.regtrans-ms` or any binary → centered error card with "looks binary" message, **renderer doesn't freeze**.
  - Open valid file → loads normally.
  - Open multiple panes simultaneously → both work independently (the fan-out fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)