### PR TITLE
fix(floating-pane): suppress focus-ring + route window-drag by label

### DIFF
--- a/.changesets/1779899676-fix-floating-pane-suppress-focus-ring-border-route-window-dr-b2bs.md
+++ b/.changesets/1779899676-fix-floating-pane-suppress-focus-ring-border-route-window-dr-b2bs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): suppress focus-ring border + route window-drag/close by label

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -158,20 +158,63 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     Ok(serde_json::Value::Null)
 }
 
+/// Resolve a top-level HWND for the given label. Prefer the reducer
+/// registry (`state.get_browser(label)` → host → window_handle → walk
+/// to root) over the process-wide `find_own_top_level_window` fallback.
+///
+/// Why the label matters: `find_own_top_level_window` does an
+/// `EnumWindows` and returns the *first* visible top-level of the
+/// current process. Z-order puts **owned** windows ABOVE their owner,
+/// so as soon as a floating-pane window exists, every label-less
+/// `get/set_window_position` call (e.g. the main window's
+/// `useWindowDrag`) accidentally targets the floater — dragging the
+/// main window moves the floater instead.
+///
+/// `GetAncestor(hwnd, GA_ROOT)` guard handles the case where CEF
+/// returns the embedded browser's WS_CHILD HWND rather than our
+/// outer top-level — without it, `SetWindowPos` would only shift the
+/// child within its parent, not move the outer floater.
+#[cfg(target_os = "windows")]
+unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
+    use cef::ImplBrowser;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, GA_ROOT};
+
+    if !label.is_empty() {
+        if let Some(browser) = state.get_browser(label) {
+            if let Some(host) = browser.host() {
+                let hwnd = host.window_handle().0 as *mut std::ffi::c_void;
+                if !hwnd.is_null() {
+                    let root = GetAncestor(hwnd, GA_ROOT);
+                    return if root.is_null() { hwnd } else { root };
+                }
+            }
+        }
+    }
+    find_own_top_level_window()
+}
+
 /// Get the current window position on screen.
-pub fn get_window_position(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
+///
+/// Accepts `{ "label": string }` to disambiguate when the process has
+/// multiple top-level windows (e.g. main + floating panes). Without a
+/// label we fall back to `find_own_top_level_window`, which returns
+/// the topmost-Z top-level of the process — wrong when the caller is
+/// the main window but a floater (owned, drawn above) exists.
+pub fn get_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("");
+
     #[cfg(target_os = "windows")]
     unsafe {
         use windows_sys::Win32::UI::WindowsAndMessaging::*;
         use windows_sys::Win32::Foundation::RECT;
-        let hwnd = find_own_top_level_window();
+        let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
             let mut rect: RECT = std::mem::zeroed();
             GetWindowRect(hwnd, &mut rect);
             return Ok(serde_json::json!({ "x": rect.left, "y": rect.top }));
         }
     }
-    let _ = state;
+    let _ = (state, label);
     Ok(serde_json::json!({ "x": 0, "y": 0 }))
 }
 
@@ -229,7 +272,7 @@ pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> R
     unsafe {
         use windows_sys::Win32::UI::WindowsAndMessaging::*;
         use windows_sys::Win32::Foundation::RECT;
-        let hwnd = find_own_top_level_window();
+        let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
             let mut rect: RECT = std::mem::zeroed();
             GetWindowRect(hwnd, &mut rect);

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -235,6 +235,11 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
     use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, GA_ROOT};
 
     if !label.is_empty() {
+        // 1. Try the CEF reducer registry — works for any label whose
+        //    `host.window_handle()` exposes the OS HWND (notably our
+        //    floating-pane windows created via CreateWindowExW +
+        //    set_as_child). For CEF Views (main window) this returns
+        //    NULL on Win32 and we fall through.
         if let Some(browser) = state.get_browser(label) {
             if let Some(host) = browser.host() {
                 let raw = host.window_handle().0 as *mut std::ffi::c_void;
@@ -250,38 +255,48 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
                     );
                     return resolved;
                 }
-                tracing::warn!(
-                    target: "win-resolve",
-                    label = %label,
-                    "[win-resolve] host.window_handle() returned NULL — using class-aware EnumWindows fallback"
-                );
-            } else {
-                tracing::warn!(
-                    target: "win-resolve",
-                    label = %label,
-                    "[win-resolve] browser.host() returned None — using class-aware EnumWindows fallback"
-                );
             }
-        } else {
-            tracing::warn!(
-                target: "win-resolve",
-                label = %label,
-                "[win-resolve] state.get_browser(label) returned None — using class-aware EnumWindows fallback"
-            );
         }
+
+        // 2. Consult the authoritative per-label HWND cache populated
+        //    by `capture_hwnd_for_label` (triggered when the frontend
+        //    signals init-complete via `set_window_init_status`). This
+        //    is the same source `set_window_transparency` uses
+        //    (line 447) and covers the case where `host.window_handle()`
+        //    returns NULL but we'd previously stamped the HWND.
+        let cached = state.window_hwnds.lock().get(label).copied();
+        if let Some(raw_isize) = cached {
+            let raw = raw_isize as *mut std::ffi::c_void;
+            if !raw.is_null() {
+                let root = GetAncestor(raw, GA_ROOT);
+                let resolved = if root.is_null() { raw } else { root };
+                tracing::info!(
+                    target: "win-resolve",
+                    label = %label,
+                    cache_hwnd = ?raw,
+                    root_hwnd = ?resolved,
+                    "[win-resolve] resolved via window_hwnds cache"
+                );
+                return resolved;
+            }
+        }
+
+        tracing::warn!(
+            target: "win-resolve",
+            label = %label,
+            "[win-resolve] reducer-registry + cache both empty — using class-aware EnumWindows fallback"
+        );
     }
 
-    // CEF Views (main window) hides the HWND behind a Views container,
-    // so `BrowserHost::window_handle()` returns NULL on Win32 for the
-    // main browser. Z-order-based `find_own_top_level_window` returns
-    // the floater first (owned windows draw ABOVE their owner). For
-    // the "main" label specifically, enumerate top-levels while
-    // skipping the floating-pane class — gives us a deterministic
-    // main-window HWND regardless of Z-order. For non-"main" labels
-    // we still fall through to the plain EnumWindows (this is rare —
-    // it means a label whose browser is registered but whose host has
-    // no HWND, which shouldn't happen today but keeps the fallback
-    // useful).
+    // 3. EnumWindows last resort. CEF Views (main window) hides its
+    //    HWND behind a Views container, so this branch fires for
+    //    "main" before the user has triggered the init-status path
+    //    (e.g. cold-boot drag attempts). Z-order returns the floater
+    //    first (owned windows draw ABOVE their owner), so for "main"
+    //    we use a class-aware enumerator that skips the floating-pane
+    //    window class — deterministic regardless of Z-order. For
+    //    non-"main" labels with neither cache nor registry entry,
+    //    plain `find_own_top_level_window` is the best we can do.
     let fallback = if label == "main" {
         find_main_window()
     } else {

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -175,6 +175,60 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 /// returns the embedded browser's WS_CHILD HWND rather than our
 /// outer top-level — without it, `SetWindowPos` would only shift the
 /// child within its parent, not move the outer floater.
+/// Class name of the floating-pane outer HWND
+/// (`agentmux-cef/src/floating_pane.rs::CLASS_NAME`). Kept in sync so
+/// `find_main_window` can EnumWindows-skip floaters when CEF Views
+/// hides the main window's HWND.
+#[cfg(target_os = "windows")]
+const FLOATING_PANE_CLASS_NAME: &str = "AgentMuxFloatingPane";
+
+/// Like `find_own_top_level_window` but skips floating-pane windows.
+/// Used when the label points at the main window but the reducer-
+/// registry path failed (CEF Views' `BrowserHost::window_handle()`
+/// returns NULL on Win32 for Views-based browsers). Without the
+/// skip, the floater (owned, drawn ABOVE its owner) would be
+/// enumerated first and we'd target it instead.
+#[cfg(target_os = "windows")]
+unsafe fn find_main_window() -> *mut std::ffi::c_void {
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    let _pid = GetCurrentProcessId();
+    let mut result: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    unsafe extern "system" fn enum_callback(
+        hwnd: *mut std::ffi::c_void,
+        lparam: isize,
+    ) -> i32 {
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+        let mut window_pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, &mut window_pid);
+        if window_pid != GetCurrentProcessId() {
+            return 1;
+        }
+        if IsWindowVisible(hwnd) == 0 {
+            return 1;
+        }
+        // Read the window class name; skip if it matches the floating-
+        // pane class. `GetClassNameW` writes up to `cchClassMaxCount`
+        // UTF-16 code units (excluding the null terminator).
+        let mut buf: [u16; 64] = [0; 64];
+        let len = GetClassNameW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+        if len > 0 {
+            let class = String::from_utf16_lossy(&buf[..len as usize]);
+            if class == FLOATING_PANE_CLASS_NAME {
+                return 1;
+            }
+        }
+        let result_ptr = lparam as *mut *mut std::ffi::c_void;
+        *result_ptr = hwnd;
+        0
+    }
+
+    EnumWindows(Some(enum_callback), &mut result as *mut _ as isize);
+    result
+}
+
 #[cfg(target_os = "windows")]
 unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
     use cef::ImplBrowser;
@@ -199,29 +253,45 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
                 tracing::warn!(
                     target: "win-resolve",
                     label = %label,
-                    "[win-resolve] host.window_handle() returned NULL — falling back to EnumWindows"
+                    "[win-resolve] host.window_handle() returned NULL — using class-aware EnumWindows fallback"
                 );
             } else {
                 tracing::warn!(
                     target: "win-resolve",
                     label = %label,
-                    "[win-resolve] browser.host() returned None — falling back to EnumWindows"
+                    "[win-resolve] browser.host() returned None — using class-aware EnumWindows fallback"
                 );
             }
         } else {
             tracing::warn!(
                 target: "win-resolve",
                 label = %label,
-                "[win-resolve] state.get_browser(label) returned None — falling back to EnumWindows"
+                "[win-resolve] state.get_browser(label) returned None — using class-aware EnumWindows fallback"
             );
         }
     }
-    let fallback = find_own_top_level_window();
+
+    // CEF Views (main window) hides the HWND behind a Views container,
+    // so `BrowserHost::window_handle()` returns NULL on Win32 for the
+    // main browser. Z-order-based `find_own_top_level_window` returns
+    // the floater first (owned windows draw ABOVE their owner). For
+    // the "main" label specifically, enumerate top-levels while
+    // skipping the floating-pane class — gives us a deterministic
+    // main-window HWND regardless of Z-order. For non-"main" labels
+    // we still fall through to the plain EnumWindows (this is rare —
+    // it means a label whose browser is registered but whose host has
+    // no HWND, which shouldn't happen today but keeps the fallback
+    // useful).
+    let fallback = if label == "main" {
+        find_main_window()
+    } else {
+        find_own_top_level_window()
+    };
     tracing::info!(
         target: "win-resolve",
         label = %label,
         fallback_hwnd = ?fallback,
-        "[win-resolve] EnumWindows fallback"
+        "[win-resolve] class-aware EnumWindows fallback"
     );
     fallback
 }

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -46,24 +46,25 @@ pub fn set_zoom_factor(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 }
 
 /// Close the window. Args: optional `{ "label": string }`; defaults to "main".
-/// (Linux/macOS need the label to act on the right window when called from
-/// a non-main window. Windows resolves per-process via find_own_top_level_window.)
+/// Routes by label via `resolve_window_hwnd` — without that the floater
+/// (owned, drawn above its owner in Z-order) would always swallow the
+/// close because `find_own_top_level_window` returns the topmost-Z
+/// visible top-level of the process.
 pub fn close_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
+
     #[cfg(target_os = "windows")]
     unsafe {
         use windows_sys::Win32::UI::WindowsAndMessaging::*;
-        let hwnd = find_own_top_level_window();
+        let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
             PostMessageW(hwnd, WM_CLOSE, 0, 0);
             return Ok(serde_json::Value::Null);
         }
     }
     #[cfg(not(target_os = "windows"))]
-    {
-        let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-        crate::ui_tasks::post_close_window(state, label);
-    }
-    let _ = (state, args);
+    crate::ui_tasks::post_close_window(state, label);
+    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 
@@ -182,15 +183,47 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
     if !label.is_empty() {
         if let Some(browser) = state.get_browser(label) {
             if let Some(host) = browser.host() {
-                let hwnd = host.window_handle().0 as *mut std::ffi::c_void;
-                if !hwnd.is_null() {
-                    let root = GetAncestor(hwnd, GA_ROOT);
-                    return if root.is_null() { hwnd } else { root };
+                let raw = host.window_handle().0 as *mut std::ffi::c_void;
+                if !raw.is_null() {
+                    let root = GetAncestor(raw, GA_ROOT);
+                    let resolved = if root.is_null() { raw } else { root };
+                    tracing::debug!(
+                        target: "win-resolve",
+                        label = %label,
+                        host_hwnd = ?raw,
+                        root_hwnd = ?resolved,
+                        "[win-resolve] resolved via reducer registry"
+                    );
+                    return resolved;
                 }
+                tracing::warn!(
+                    target: "win-resolve",
+                    label = %label,
+                    "[win-resolve] host.window_handle() returned NULL — falling back to EnumWindows"
+                );
+            } else {
+                tracing::warn!(
+                    target: "win-resolve",
+                    label = %label,
+                    "[win-resolve] browser.host() returned None — falling back to EnumWindows"
+                );
             }
+        } else {
+            tracing::warn!(
+                target: "win-resolve",
+                label = %label,
+                "[win-resolve] state.get_browser(label) returned None — falling back to EnumWindows"
+            );
         }
     }
-    find_own_top_level_window()
+    let fallback = find_own_top_level_window();
+    tracing::debug!(
+        target: "win-resolve",
+        label = %label,
+        fallback_hwnd = ?fallback,
+        "[win-resolve] EnumWindows fallback"
+    );
+    fallback
 }
 
 /// Get the current window position on screen.

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -187,7 +187,7 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
                 if !raw.is_null() {
                     let root = GetAncestor(raw, GA_ROOT);
                     let resolved = if root.is_null() { raw } else { root };
-                    tracing::debug!(
+                    tracing::info!(
                         target: "win-resolve",
                         label = %label,
                         host_hwnd = ?raw,
@@ -217,7 +217,7 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
         }
     }
     let fallback = find_own_top_level_window();
-    tracing::debug!(
+    tracing::info!(
         target: "win-resolve",
         label = %label,
         fallback_hwnd = ?fallback,

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -248,7 +248,7 @@ async fn route_command(
         "set_window_opacity" => commands::window::set_window_opacity(state, args),
         "get_window_opacity" => commands::window::get_window_opacity(state, args),
         "start_window_drag" => commands::window::start_window_drag(state, args),
-        "get_window_position" => commands::window::get_window_position(state),
+        "get_window_position" => commands::window::get_window_position(state, args),
         "move_window_by" => commands::window::move_window_by(state, args),
         "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -21,6 +21,21 @@ function isInDragRegion(target: HTMLElement | null): boolean {
     return false;
 }
 
+/// Identify which top-level window we're running in so the host can
+/// route `get/set_window_position` IPC to the right HWND. The renderer
+/// URL carries `windowLabel=…` for every non-main window (the launcher
+/// doesn't add it for `main`); falling back to `"main"` keeps the
+/// main-window's drag pointing at itself.
+///
+/// Necessary because `find_own_top_level_window` on the host walks
+/// process-wide windows in Z-order, and owned floating-pane windows
+/// sit ABOVE their owner — so without a label, the main window's drag
+/// would accidentally move whichever floater is currently topmost.
+function ownWindowLabel(): string {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("windowLabel") || "main";
+}
+
 function installCefDragListener() {
     if (cefDragListenerInstalled || detectHost() !== "cef") return;
     cefDragListenerInstalled = true;
@@ -62,7 +77,9 @@ function installCefDragListener() {
         latestScreenX = e.screenX;
         latestScreenY = e.screenY;
         try {
-            const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+            const pos = await invokeCommand<{ x: number; y: number }>("get_window_position", {
+                label: ownWindowLabel(),
+            });
             // Race guard: bail if a mouseup or a newer mousedown has
             // happened during the IPC round-trip.
             if (myId !== currentMouseDownId) return;
@@ -112,7 +129,7 @@ function installCefDragListener() {
             return;
         }
         setPosInFlight = true;
-        invokeCommand("set_window_position", { x, y })
+        invokeCommand("set_window_position", { x, y, label: ownWindowLabel() })
             .catch(() => {})
             .finally(() => {
                 setPosInFlight = false;

--- a/frontend/app/workspace/floating-pane-workspace.scss
+++ b/frontend/app/workspace/floating-pane-workspace.scss
@@ -1,0 +1,21 @@
+// Suppress the docked-pane focus ring inside a floating-pane window.
+// The standard block-frame draws a 2 CSS-px colored ring (accent or
+// agent color, see `frontend/app/block/block.scss:488,500`) when the
+// block is `.block-focused`. In a single-pane floater the block is
+// always the focused one, so the ring is always visible — which
+// reads as an unwanted "colored border" around the window. The
+// floater wraps a single pane and there's nothing to distinguish
+// "focused" from "unfocused" against, so the ring carries no signal.
+//
+// `!important` is needed: the rules we override are
+// `.block.block-frame-default.block-focused .block-mask` (specificity
+// 0,4,0) and the agent-color variant (0,5,0). Matching those
+// specificities here would require restating the block-frame chain
+// and would still tie on the agent-color rule, where source order
+// would matter. `!important` is the right escape hatch for a scoped
+// view-level override.
+.floating-pane-workspace {
+    .block-mask {
+        border-color: transparent !important;
+    }
+}

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -40,6 +40,8 @@ import { atoms, getApi } from "@/store/global";
 import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, onCleanup, onMount, type JSX } from "solid-js";
 
+import "./floating-pane-workspace.scss";
+
 function FloatingPaneWorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
     const ws = atoms.workspace;
@@ -117,13 +119,19 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         let setPosInFlight = false;
         let pendingPos: { x: number; y: number } | null = null;
 
+        // Capture once per mount — windowLabel is fixed for the
+        // floater's lifetime. Used to route `get/set_window_position`
+        // IPC to OUR HWND (not whichever top-level the OS happens to
+        // enumerate first in Z-order).
+        const label = windowLabel();
+
         const sendPos = (x: number, y: number): void => {
             if (setPosInFlight) {
                 pendingPos = { x, y };
                 return;
             }
             setPosInFlight = true;
-            invokeCommand("set_window_position", { x, y })
+            invokeCommand("set_window_position", { x, y, label })
                 .catch(() => {})
                 .finally(() => {
                     setPosInFlight = false;
@@ -160,6 +168,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             try {
                 const pos = await invokeCommand<{ x: number; y: number }>(
                     "get_window_position",
+                    { label },
                 );
                 // Race guard: bail if mouseup or a newer mousedown
                 // happened during the IPC round-trip
@@ -234,7 +243,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
     });
 
     return (
-        <div class="flex flex-col w-full flex-grow overflow-hidden">
+        <div class="floating-pane-workspace flex flex-col w-full flex-grow overflow-hidden">
             {/* The torn-off block lives in the new workspace's active
                 tab. Render that tab's TabContent only — no per-tab loop
                 (there's exactly one tab) and no tab bar / widgets bar /


### PR DESCRIPTION
Two iterative fixes from user testing of #1089:

## 1. Suppress the colored focus ring on the floater

The standard block-frame draws a 2 CSS-px colored ring (\`--accent-color\` or \`--block-agent-color\`, see \`block.scss:488,500\`) when the block is \`.block-focused\`. In a single-pane floater the block is *always* the focused one, so the ring is always visible and reads as an unwanted "colored border" around the window.

Added a scoped SCSS override on the new \`.floating-pane-workspace\` root class that sets \`.block-mask\` border-color transparent. \`!important\` is needed because the rules being overridden compile to specificity (0,4,0) and (0,5,0); matching that chain manually would still tie on the agent-color variant.

## 2. Route window-drag IPC by label, not Z-order

**User report:** dragging the MAIN window moved the FLOATING window instead.

**Root cause:** \`get/set_window_position\` resolved the HWND via \`find_own_top_level_window\` — process-wide \`EnumWindows\` returning the topmost-Z visible top-level. Owned floating panes sit *above* their owner in Z-order, so as soon as one exists, every label-less position IPC accidentally targets the floater (including the main window's own \`useWindowDrag\` hook).

This is the latent bug called out in \`docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md\` as the open follow-up before Phase 4 (re-dock).

### Backend

- New \`resolve_window_hwnd(state, label)\` helper in \`commands/window.rs\`:
  - Prefers reducer registry: \`state.get_browser(label)\` → host → \`window_handle()\` → \`GetAncestor(hwnd, GA_ROOT)\` so we always return the outer top-level.
  - Falls back to \`find_own_top_level_window\` when no label given (back-compat).
- \`get_window_position\` now takes \`args\` and reads \`label\` (IPC dispatcher in \`ipc.rs\` updated).
- \`set_window_position\` already accepted \`label\` but was ignoring it on Windows; now uses the helper.

### Frontend

- \`useWindowDrag.win32.ts\` (main window): reads \`windowLabel\` from URL query params (defaults to \`"main"\`) and passes it on every position IPC call.
- \`floating-pane-workspace.tsx\` (floater): captures the windowLabel memo's value at mount, threads it through the IPC calls.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean
- [x] \`tsc --noEmit\` clean for touched files
- [ ] With a floating pane open, drag the **main** window's title bar → main window moves (not the floater)
- [ ] Drag the floating pane's header → floater moves (not main)
- [ ] No colored ring around the floating pane
- [ ] Buttons inside the floater's pane header still respond (close/magnify/mic/etc.)

## Cross-references

- \`docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md\` — original analysis flagging this as the open follow-up.
- \`docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md\` — re-dock plan; this fix unblocks the off-target floater repositioning during Phase 4.
- #1089 — preceding chrome cleanup + JS-driven drag PR.