### PR TITLE
feat(widgets): reorder + slim default widget bar

### DIFF
--- a/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
+++ b/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-feat(widgets): reorder default widget bar — Agent, Swarm, Drone, Warden, Terminal, Editor, Browser, Sysinfo, Help
+feat(widgets): reorder + slim default widget bar — pinned: Agent, Swarm, Drone, Warden; in More: Terminal, Editor, Browser, Sysinfo, Help

--- a/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
+++ b/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(widgets): reorder default widget bar — Agent, Swarm, Drone, Warden, Terminal, Editor, Browser, Sysinfo, Help

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -32,7 +32,7 @@
     },
     "defwidget@browser": {
         "display:order": 7,
-        "display:pinned": true,
+        "display:pinned": false,
         "icon": "globe",
         "label": "Browser",
         "description": "Embedded web browser",
@@ -45,7 +45,7 @@
     },
     "defwidget@editor": {
         "display:order": 6,
-        "display:pinned": true,
+        "display:pinned": false,
         "icon": "file-code",
         "label": "Editor",
         "description": "Code editor with syntax highlighting",
@@ -58,7 +58,7 @@
     },
     "defwidget@terminal": {
         "display:order": 5,
-        "display:pinned": true,
+        "display:pinned": false,
         "icon": "square-terminal",
         "label": "Terminal",
         "blockdef": {
@@ -70,7 +70,7 @@
     },
     "defwidget@sysinfo": {
         "display:order": 8,
-        "display:pinned": true,
+        "display:pinned": false,
         "icon": "chart-line",
         "label": "Sysinfo",
         "blockdef": {
@@ -94,7 +94,7 @@
     },
     "defwidget@help": {
         "display:order": 9,
-        "display:pinned": true,
+        "display:pinned": false,
         "icon": "circle-question",
         "label": "Help",
         "description": "Help and documentation",

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -18,7 +18,7 @@
         }
     },
     "defwidget@swarm": {
-        "display:order": 4,
+        "display:order": 2,
         "display:pinned": true,
         "icon": "bee",
         "color": "#f59e0b",
@@ -31,7 +31,7 @@
         }
     },
     "defwidget@browser": {
-        "display:order": 2,
+        "display:order": 7,
         "display:pinned": true,
         "icon": "globe",
         "label": "Browser",
@@ -44,7 +44,7 @@
         }
     },
     "defwidget@editor": {
-        "display:order": 3,
+        "display:order": 6,
         "display:pinned": true,
         "icon": "file-code",
         "label": "Editor",
@@ -69,7 +69,7 @@
         }
     },
     "defwidget@sysinfo": {
-        "display:order": 6,
+        "display:order": 8,
         "display:pinned": true,
         "icon": "chart-line",
         "label": "Sysinfo",
@@ -80,7 +80,7 @@
         }
     },
     "defwidget@drone": {
-        "display:order": 9,
+        "display:order": 3,
         "display:pinned": true,
         "icon": "diagram-project",
         "color": "#06b6d4",
@@ -93,7 +93,7 @@
         }
     },
     "defwidget@help": {
-        "display:order": 7,
+        "display:order": 9,
         "display:pinned": true,
         "icon": "circle-question",
         "label": "Help",
@@ -105,7 +105,7 @@
         }
     },
     "defwidget@warden": {
-        "display:order": 10,
+        "display:order": 4,
         "display:pinned": true,
         "icon": "shield-halved",
         "color": "#8b5cf6",


### PR DESCRIPTION
## Summary

Two changes to the default widget bar:

1. **Reorder** widgets so the AI/orchestration row leads: Agent → Swarm → Drone → Warden → Terminal → Editor → Browser → Sysinfo → Help.
2. **Slim** the pinned set down to the AI/orchestration row only. Workspace tools (Terminal, Editor, Browser) and the trailing Sysinfo/Help drop into the **More** overflow dropdown by default.

### Pinned bar (default)

| # | Widget | `display:order` | `display:pinned` |
|---|--------|-----------------|------------------|
| 1 | Agent  | 1 | true  |
| 2 | Swarm  | 2 | true  |
| 3 | Drone  | 3 | true  |
| 4 | Warden | 4 | true  |

### In More (default)

| # | Widget   | `display:order` | `display:pinned` |
|---|----------|-----------------|------------------|
| 5 | Terminal | 5 | false |
| 6 | Editor   | 6 | false |
| 7 | Browser  | 7 | false |
| 8 | Sysinfo  | 8 | false |
| 9 | Help     | 9 | false |

## Why

The bar grew organically as widgets were added (`drone=9`, `warden=10` in the old order) and shipped every widget pinned. The result was a long row that hid its information architecture. This default surfaces the agentic surfaces — what AgentMux is *for* — and tucks the always-available workspace tools into More where they remain one click away.

User overrides (`widget:pinned` in `settings.json`) take precedence over both defaults, so anyone who has already customized their bar is unaffected. See `frontend/app/window/action-widgets.tsx:36-48` (`getPinnedKeys`).

## Scope

Single file: `agentmux-srv/src/config/widgets.json`. Changeset included per RFC #857 Phase 2 workflow. No version bump in this PR.

## Test plan

- [ ] `task dev` on a fresh data dir — bar shows Agent, Swarm, Drone, Warden only
- [ ] **More** dropdown shows Terminal, Editor, Browser, Sysinfo, Help in that order
- [ ] Existing user with `widget:pinned` set in `settings.json` sees their own list unchanged
- [ ] Right-click → "Pin to bar" on a More item works and respects the new sort
- [ ] No Rust test regressions (`display:order` assertions in `agentmux-srv/src/backend/wconfig/mod.rs` use synthetic 1.0 / 1.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)