### PR TITLE
feat(agent-pane): scrub orphan in-progress nodes on session reopen

### DIFF
--- a/.changesets/1779903209-feat-agent-pane-scrub-orphan-in-progress-nodes-on-session-re-0emr.md
+++ b/.changesets/1779903209-feat-agent-pane-scrub-orphan-in-progress-nodes-on-session-re-0emr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): scrub orphan in-progress nodes on session reopen

--- a/docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md
+++ b/docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md
@@ -1,0 +1,157 @@
+# SPEC: Orphan in-progress nodes — cancel + collapse on session reopen
+
+**Date:** 2026-05-27
+**Author:** AgentA
+**Status:** Design — bug fix for resumed-session UI inconsistency. No tracking discussion yet.
+
+---
+
+## The bug
+
+Open an agent pane, the agent starts thinking (`thinking` stream events arrive, the parser produces a markdown node with `metadata.thinking = true`, the UI renders "Thinking..."). Close the conversation (close the pane, close the tab, close the app) **before the thought completes**. Re-open the same conversation later.
+
+**Current behavior:** the node renders exactly as it did mid-thought — expanded, with the "Thinking..." spinner label, as if the agent is still actively thinking. It isn't. The session ended. The node is *orphaned*.
+
+**Expected behavior:** the node should be marked as **canceled** (or *interrupted*, *abandoned* — pick the term in §5.2) and should render **collapsed** by default. The user can expand it to see the partial thought, but the UI should not falsely suggest active work.
+
+The same bug applies to any node-level "in progress" state that depends on a closing stream event to complete:
+- **Thinking markdown** (`metadata.thinking = true`) — no explicit "done" flag; UI infers active-thinking from `metadata.thinking` + presence of the live spinner.
+- **Tool blocks** (`type: "tool"`, `status: "running"`) — explicit status field. If the session closes between `tool_call` and `tool_result`, the tool stays at `running` forever.
+- **Pending message rows** in the composer's pending zone — already handled (`PendingMessageExpired` after 30s); not in scope here.
+
+---
+
+## Where it comes from
+
+1. The agent emits stream events; the NDJSON file is append-only.
+2. The stream parser folds deltas into nodes (`currentTextNode`, `currentThinkingNode`).
+3. Tool nodes start with `status: "running"` on `tool_call`, transition to `success` / `failed` on `tool_result`.
+4. Snapshots (`output.state.json`) are saved periodically and on certain events.
+5. **If the session ends without the closing event**, the snapshot captures the dirty state: a thinking node mid-stream or a tool with `status="running"`.
+6. On re-open, the snapshot loads as-is. The reducer has no signal to mark anything as terminated.
+
+The cause is missing terminal-state cleanup at session close. The fix is to detect dirty nodes and rewrite their status at the appropriate moment.
+
+---
+
+## Design
+
+### Where to fix it — three candidate trigger points
+
+| Trigger | Fires when | Pros | Cons |
+|---|---|---|---|
+| **A. SessionEnd reducer** | The pane's stream ends (clean or dirty) | Single chokepoint; runs on every session boundary | Doesn't fire when the **app** is killed mid-thought before any save — the snapshot already on disk is dirty |
+| **B. Snapshot load (SessionStart / HistoryLoaded)** | When a pane mounts and loads a snapshot | Catches the killed-mid-thought case; runs exactly once per mount | The first turn after mount immediately runs cleanup, which is fine but feels like "fixing on read" — slightly weirder mental model |
+| **C. Snapshot save** | Right before writing `output.state.json` | Snapshot on disk is always clean | Snapshot save is owned by the host (Rust), and only the frontend knows about thinking-state semantics. Crossing that boundary widens scope |
+
+**Recommended: A + B.** SessionEnd is the primary path (covers clean stream ends + most normal closes). SessionStart-load is the safety net for app-kill scenarios where SessionEnd never ran. Both call the same scrub helper. The reducer dispatches a new `ScrubOrphanedInProgress` command in both cases.
+
+### What gets scrubbed
+
+For each node in the document:
+
+| Node type | Detection | Action |
+|---|---|---|
+| `markdown` with `metadata.thinking === true` AND no follow-up text/tool/message node in the same turn boundary | "Last in its turn AND turn is closed" | Add `metadata.canceled = true`; render shows "_Canceled — partial thought, click to expand_" + collapsed-by-default |
+| `tool` with `status === "running"` | Status field directly | Set `status = "canceled"`; render shows ⏹ icon + "Canceled" label + collapsed by default |
+| any node whose `streaming` flag is set (currently rare, but reserved) | flag check | Clear `streaming`; mark canceled |
+
+Detection for "last thinking in its turn":
+- A turn is bounded by `user_message` nodes (one user_message starts a turn; the next user_message ends the prior turn) and by `session_end` events.
+- A thinking node is **orphaned** if it's not followed by any other node (text, tool, user_message, etc.) within the same turn AND the turn has ended.
+- In practice: walk the document tail-first, find the latest `user_message`, examine nodes after it; for the most recent thinking node, if it's followed by nothing of higher precedence, it's orphaned.
+
+For the simpler heuristic (which we can ship first): **any `metadata.thinking === true` node that is the document's last node when SessionEnd fires is orphaned.** This catches the common case. The "turn boundary" refinement is a follow-up if needed.
+
+### UI rendering changes
+
+In `MarkdownBlock` (or wherever the thinking node renders):
+
+```ts
+const isCanceled = props.node.metadata?.canceled === true;
+const isThinking = props.node.metadata?.thinking === true;
+
+// Label
+const label = isCanceled
+    ? "⏹ Canceled — partial thought"
+    : (isThinking && isCurrentTurnActive
+        ? "⏳ Thinking..."
+        : "💭 Thought");
+
+// Default-collapsed state
+const defaultCollapsed = isCanceled || !isCurrentTurnActive;
+```
+
+`isCurrentTurnActive` reads from the pane state's `turnPhase.kind === "Streaming"` or similar. We already have this signal — it's what drives the agentActivity busyCount.
+
+Tool blocks (`ToolBlock`): if `status === "canceled"`, render the ⏹ icon, label as "Canceled", collapsed by default. Existing status-icon machinery (success / failed / running) extends with one new case.
+
+### Persistence
+
+Adding `metadata.canceled` and the new `tool.status === "canceled"` value means:
+- Existing snapshots (no canceled marker) → load fine; nodes without the marker render as today (which is the bug we're fixing). The fix only takes effect on **new** SessionEnd / SessionStart cycles.
+- Loaded snapshots get scrubbed on next mount via the SessionStart hook; the document is rewritten with the canceled markers and re-saved on the next snapshot.
+
+Migration: none required. The new fields are additive.
+
+### Reducer action
+
+```ts
+// in agent-document/types.ts
+{ type: "ScrubOrphanedInProgress"; at: number }
+```
+
+Reducer handler:
+1. Walk `state.nodes`.
+2. For each `markdown` node with `metadata.thinking === true` AND (heuristic): is the document's last in-progress thinking → set `metadata = { ...metadata, canceled: true, thinking: false }` (remove the thinking flag so the UI doesn't keep showing the spinner; preserve canceled for the label).
+3. For each `tool` node with `status === "running"` → set `status: "canceled"`.
+4. Lazy-clone: only allocate a new array if anything changed.
+5. Emit a `scrubbed` event with counts for diagnostics.
+
+Called from:
+- `SessionEnd` reducer handler — at session boundary.
+- `SessionStart` / `HistoryLoaded` reducer handler — after the snapshot is loaded.
+
+---
+
+## Out of scope
+
+- Distinguishing **user-canceled** (Esc pressed) from **session-ended-mid-stream** (close, crash). The PR can label all of them as "canceled" — a follow-up can split into "interrupted" (user) vs "ended" (session). Current code already has `Interrupting` phase for user stops; we just don't propagate that into node metadata yet.
+- Cleaning up the **streaming buffer** when the session ends. That's a render-side concern handled by the pane lifecycle.
+- Recovering the *real* completion of a thought when the session is resumed via `--continue`. The agent might continue thinking on resume; if so, the canceled marker would be misleading. Decision: leave it canceled. If the new turn produces fresh thinking, it's a new node. Old canceled nodes stay as-is in history.
+
+---
+
+## Acceptance criteria
+
+- [ ] When SessionEnd fires, any `markdown` node with `metadata.thinking === true` that is the most recent thinking in its turn gets `metadata.canceled = true` and `metadata.thinking = false`.
+- [ ] When SessionEnd fires, any `tool` node with `status === "running"` gets `status: "canceled"`.
+- [ ] When a snapshot is loaded (SessionStart with prior nodes present), the same scrub runs.
+- [ ] Re-opening a previously-orphaned conversation renders the thinking node as "Canceled — partial thought", collapsed by default. Click-to-expand still works.
+- [ ] Re-opening a previously-orphaned conversation with a running tool renders the tool with the ⏹ icon and a "Canceled" label, collapsed.
+- [ ] Reducer test: scrub on SessionEnd transforms in-progress nodes; no-op when nothing is in progress.
+- [ ] Reducer test: scrub is idempotent (running it twice doesn't double-modify).
+- [ ] Snapshot round-trip: save → load → scrub → save → load → identical document (canceled marker preserved).
+- [ ] Existing tests that assert `metadata.thinking === true` after a thinking event are unchanged (scrub is post-session, doesn't affect the parser's live behavior).
+
+---
+
+## Files likely to change
+
+- `frontend/app/store/agent-document/types.ts` — add `ScrubOrphanedInProgress` command + the `canceled` metadata field + the `canceled` tool status.
+- `frontend/app/store/agent-document/reducer.ts` — handler for `ScrubOrphanedInProgress`; call from `SessionEnd` and `SessionStart`/`HistoryLoaded` handlers.
+- `frontend/app/view/agent/components/MarkdownBlock.tsx` (or equivalent thinking renderer) — render path for `canceled`.
+- `frontend/app/view/agent/components/ToolBlock.tsx` — render `canceled` status (icon + label + default-collapsed).
+- `frontend/app/view/agent/components/ToolOverlayLog.tsx` — the inline "Thinking..." label currently lives here; gate on turn-active.
+- Tests: `agent-document/reducer.test.ts`, `MarkdownBlock.test.tsx`, `ToolBlock.test.tsx`.
+
+Estimated scope: ~150 LOC + tests. Single PR.
+
+---
+
+## Open questions
+
+- **Label wording.** "Canceled" vs "Interrupted" vs "Abandoned" vs "Stopped". Suggest "Canceled" for the user-facing label — matches the icon ⏹ and is the most neutral.
+- **Should we preserve the in-progress timestamp?** Optional `metadata.canceledAt: number` for future audit / hover-tooltip. Probably yes; trivial to add.
+- **Should the scrub also clear `pending` user messages?** Already handled by `PendingMessageExpired` (30s timeout). Out of scope for this spec.
+- **Cross-talk with the new turn after resume.** If the user reopens a conversation with a canceled thought and the agent immediately resumes thinking (via `--continue`), do we want to *merge* the canceled thought with the new continuation? Decision: no. The canceled thought stays as historical artifact. New thinking nodes are new.

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -947,5 +947,38 @@ describe("agent document reducer", () => {
             expect(liveAfter.metadata.thinking).toBe(true);
             expect(liveAfter.metadata.canceled).toBeUndefined();
         });
+
+        // Codex P2 round 2 on #1104: useHistoryPagination.loadOlder
+        // dispatches HistoryLoaded with an OLDER page while newer
+        // nodes are already in state.nodes. fresh.last is the page's
+        // tail but NOT the merged document's tail — a completed
+        // thinking block at the end of the page must stay alive.
+        it("does NOT scrub a thinking tail when older page prepends to existing state", () => {
+            const newer = seed([md("text-3"), tool("tool-4", { status: "success" })]);
+            const r = update(newer, {
+                type: "HistoryLoaded",
+                nodes: [md("text-1"), thinkingMd("think-2")],
+            });
+            // Merge order: [text-1, think-2, text-3, tool-4]
+            // think-2 is mid-doc in the merged view; it completed.
+            const think2 = r.state.nodes.find((n) => n.id === "think-2") as any;
+            expect(think2.metadata.thinking).toBe(true);
+            expect(think2.metadata.canceled).toBeUndefined();
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
+        });
+
+        // Even with `hasContentAfter`, a running tool in the older
+        // page IS orphan (status field is positional-independent —
+        // running means tool_result never arrived).
+        it("still scrubs running tools in older pages", () => {
+            const newer = seed([md("text-3")]);
+            const r = update(newer, {
+                type: "HistoryLoaded",
+                nodes: [tool("old-tool", { status: "running" }), md("text-1")],
+            });
+            const oldTool = r.state.nodes.find((n) => n.id === "old-tool") as ToolNode;
+            expect(oldTool.status).toBe("canceled");
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
+        });
     });
 });

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -670,4 +670,148 @@ describe("agent document reducer", () => {
             expect((r.state.nodes[0] as any).content).toBe("hello world");
         });
     });
+
+    // ── ScrubOrphanedInProgress ───────────────────────────────────
+    // Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md
+    //
+    // The scrub runs on three triggers:
+    //   - SessionEnd (clean exit) — folded into the SessionEnd handler.
+    //   - HistoryRestored (snapshot load after app-kill) — folded in.
+    //   - Standalone ScrubOrphanedInProgress command — explicit dispatch.
+    // All three pass through the same helper.
+    describe("ScrubOrphanedInProgress", () => {
+        const thinkingMd = (id: string, content = id): DocumentNode => ({
+            type: "markdown",
+            id,
+            content,
+            timestamp: 0,
+            metadata: { thinking: true },
+        });
+
+        it("flips thinking markdown to canceled and clears thinking flag", () => {
+            const s0 = seed([thinkingMd("t1", "mid-thought"), md("m1")]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999 });
+            const t1 = r.state.nodes[0] as any;
+            expect(t1.metadata.canceled).toBe(true);
+            expect(t1.metadata.thinking).toBe(false);
+            expect(t1.metadata.canceledAt).toBe(9999);
+            // Original content preserved.
+            expect(t1.content).toBe("mid-thought");
+            // Non-thinking nodes untouched.
+            expect((r.state.nodes[1] as any).metadata).toBeUndefined();
+            expect(r.events).toEqual([
+                { type: "orphans-scrubbed", markdownCanceled: 1, toolsCanceled: 0 },
+            ]);
+        });
+
+        it("flips running tools to canceled status", () => {
+            const t1 = tool("t1", { status: "running" });
+            const t2 = tool("t2", { status: "success" });
+            const r = update(seed([t1, t2]), {
+                type: "ScrubOrphanedInProgress",
+                at: 1000,
+            });
+            expect((r.state.nodes[0] as ToolNode).status).toBe("canceled");
+            // Already-completed tool stays as-is.
+            expect((r.state.nodes[1] as ToolNode).status).toBe("success");
+            expect(r.events).toEqual([
+                { type: "orphans-scrubbed", markdownCanceled: 0, toolsCanceled: 1 },
+            ]);
+        });
+
+        it("leaves pending_approval tools alone (decision still in flight)", () => {
+            const t = tool("t1", { status: "pending_approval" });
+            const r = update(seed([t]), {
+                type: "ScrubOrphanedInProgress",
+                at: 1000,
+            });
+            expect((r.state.nodes[0] as ToolNode).status).toBe("pending_approval");
+            expect(r.events).toEqual([]);
+        });
+
+        it("is a no-op when nothing's in progress", () => {
+            const s0 = seed([md("m1"), tool("t1", { status: "success" })]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999 });
+            expect(r.state).toBe(s0); // identity — no allocation
+            expect(r.events).toEqual([]);
+        });
+
+        it("is idempotent — running twice doesn't double-modify", () => {
+            const s0 = seed([thinkingMd("t1"), tool("k1", { status: "running" })]);
+            const r1 = update(s0, { type: "ScrubOrphanedInProgress", at: 1000 });
+            const r2 = update(r1.state, { type: "ScrubOrphanedInProgress", at: 2000 });
+            // Second run is a no-op against the already-scrubbed state.
+            expect(r2.state).toBe(r1.state);
+            expect(r2.events).toEqual([]);
+            // canceledAt was set by the FIRST run and never overwritten
+            // — important: re-scrubbing must not bump the timestamp.
+            const t1 = r1.state.nodes[0] as any;
+            expect(t1.metadata.canceledAt).toBe(1000);
+        });
+    });
+
+    describe("SessionEnd scrubs orphans", () => {
+        const thinkingMd = (id: string): DocumentNode => ({
+            type: "markdown",
+            id,
+            content: id,
+            timestamp: 0,
+            metadata: { thinking: true },
+        });
+
+        it("emits session-ended AND orphans-scrubbed when nodes were dirty", () => {
+            const s0 = seed([thinkingMd("t1"), tool("k1", { status: "running" })]);
+            const r = update(s0, { type: "SessionEnd", at: 5000 });
+            expect(r.state.sessionPhase).toBe("ended");
+            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
+            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            expect(r.events).toEqual([
+                { type: "session-ended", at: 5000 },
+                { type: "orphans-scrubbed", markdownCanceled: 1, toolsCanceled: 1 },
+            ]);
+        });
+
+        it("only emits session-ended when nothing was in progress", () => {
+            const s0 = seed([md("m1")]);
+            const r = update(s0, { type: "SessionEnd", at: 5000 });
+            expect(r.events).toEqual([{ type: "session-ended", at: 5000 }]);
+        });
+    });
+
+    describe("HistoryRestored scrubs orphans in the snapshot", () => {
+        const thinkingMd = (id: string): DocumentNode => ({
+            type: "markdown",
+            id,
+            content: id,
+            timestamp: 0,
+            metadata: { thinking: true },
+        });
+
+        it("scrubs dirty nodes that arrived via snapshot restore", () => {
+            // Snapshot from a prior session was saved mid-thinking;
+            // on resume, the new pane mounts and HistoryRestored
+            // brings in the dirty nodes. Scrub flips them before
+            // the user ever sees a misleading spinner.
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                nodes: [thinkingMd("orphan-think"), tool("orphan-tool", { status: "running" })],
+                fromSnapshot: true,
+            });
+            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
+            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            // session-phase still flips to "active" per the original
+            // contract — we're restoring, not ending.
+            expect(r.state.sessionPhase).toBe("active");
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
+        });
+
+        it("doesn't emit orphans-scrubbed when the snapshot is clean", () => {
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                nodes: [md("m1"), md("m2")],
+                fromSnapshot: true,
+            });
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
+        });
+    });
 });

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -719,6 +719,26 @@ describe("agent document reducer", () => {
             ]);
         });
 
+        // Codex + reagent P2 on #1104: scrubbing must also close
+        // the streaming log. Otherwise ToolBlock's live-tail branch
+        // (gated on log.open) keeps rendering a canceled tool as
+        // streaming.
+        it("closes log.open when canceling a streamed-into running tool", () => {
+            const t1: ToolNode = {
+                ...tool("t1", { status: "running" }),
+                log: { chunks: [chunk("partial output")], open: true },
+            };
+            const r = update(seed([t1]), {
+                type: "ScrubOrphanedInProgress",
+                at: 1000,
+            });
+            const scrubbed = r.state.nodes[0] as ToolNode;
+            expect(scrubbed.status).toBe("canceled");
+            expect(scrubbed.log?.open).toBe(false);
+            // Chunks preserved — historical output stays visible.
+            expect(scrubbed.log?.chunks.length).toBe(1);
+        });
+
         it("leaves pending_approval tools alone (decision still in flight)", () => {
             const t = tool("t1", { status: "pending_approval" });
             const r = update(seed([t]), {

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -813,5 +813,70 @@ describe("agent document reducer", () => {
             });
             expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
         });
+
+        // Codex P2 on #1104: HistoryRestored arriving AFTER live
+        // stream events have populated state.nodes must not flip
+        // those live nodes to canceled — only the snapshot replay
+        // gets sanitized.
+        it("does NOT scrub live thinking nodes already in state.nodes", () => {
+            // Live event landed first: an actively-streaming thinking
+            // markdown is in state.nodes.
+            const live = thinkingMd("live-think");
+            const base = seed([live]);
+            // Now the snapshot read returns — bringing only a clean
+            // historical node. The live thinking should stay thinking.
+            const r = update(base, {
+                type: "HistoryRestored",
+                nodes: [md("snap-1")],
+                fromSnapshot: true,
+            });
+            // No orphans event — fresh was clean and live was untouched.
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
+            const liveAfter = r.state.nodes.find((n) => n.id === "live-think") as any;
+            expect(liveAfter.metadata.thinking).toBe(true);
+            expect(liveAfter.metadata.canceled).toBeUndefined();
+        });
+    });
+
+    // Codex P2 on #1104 (gap 2): HistoryLoaded is the legacy/NDJSON
+    // fallback path. Contract said it scrubs; reducer wasn't doing it.
+    describe("HistoryLoaded scrubs orphans in the replay", () => {
+        const thinkingMd = (id: string): DocumentNode => ({
+            type: "markdown",
+            id,
+            content: id,
+            timestamp: 0,
+            metadata: { thinking: true },
+        });
+
+        it("flips dirty nodes from the legacy/NDJSON replay", () => {
+            const r = update(initialState(), {
+                type: "HistoryLoaded",
+                nodes: [thinkingMd("orphan-think"), tool("orphan-tool", { status: "running" })],
+            });
+            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
+            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
+        });
+
+        it("doesn't emit orphans-scrubbed when the replay is clean", () => {
+            const r = update(initialState(), {
+                type: "HistoryLoaded",
+                nodes: [md("m1"), md("m2")],
+            });
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
+        });
+
+        it("leaves live thinking nodes already in state.nodes untouched", () => {
+            const live = thinkingMd("live-think");
+            const base = seed([live]);
+            const r = update(base, {
+                type: "HistoryLoaded",
+                nodes: [md("hist-1")],
+            });
+            const liveAfter = r.state.nodes.find((n) => n.id === "live-think") as any;
+            expect(liveAfter.metadata.thinking).toBe(true);
+            expect(liveAfter.metadata.canceled).toBeUndefined();
+        });
     });
 });

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -688,19 +688,62 @@ describe("agent document reducer", () => {
             metadata: { thinking: true },
         });
 
-        it("flips thinking markdown to canceled and clears thinking flag", () => {
-            const s0 = seed([thinkingMd("t1", "mid-thought"), md("m1")]);
+        it("flips thinking markdown to canceled when it's the last node", () => {
+            // Spec's simple heuristic: thinking is orphaned only when
+            // it's the document's tail (parser was mid-thought when
+            // the session ended). Historical thinking nodes followed
+            // by anything else completed normally and stay untouched.
+            const s0 = seed([md("m1"), thinkingMd("t1", "mid-thought")]);
             const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999 });
-            const t1 = r.state.nodes[0] as any;
+            const t1 = r.state.nodes[1] as any;
             expect(t1.metadata.canceled).toBe(true);
             expect(t1.metadata.thinking).toBe(false);
             expect(t1.metadata.canceledAt).toBe(9999);
             // Original content preserved.
             expect(t1.content).toBe("mid-thought");
-            // Non-thinking nodes untouched.
-            expect((r.state.nodes[1] as any).metadata).toBeUndefined();
+            // Non-thinking node untouched.
+            expect((r.state.nodes[0] as any).metadata).toBeUndefined();
             expect(r.events).toEqual([
                 { type: "orphans-scrubbed", markdownCanceled: 1, toolsCanceled: 0 },
+            ]);
+        });
+
+        // Codex + reagent P1 on PR #1104: stream-parser never writes
+        // `thinking: false` onto a completed thinking node (it only
+        // clears its local pointer). So in any multi-turn session
+        // — thinking → tool → text → thinking → text … — every
+        // prior thinking block keeps `metadata.thinking === true`
+        // forever. Scrub MUST guard against that or every reopen
+        // relabels all reasoning as canceled.
+        it("does NOT scrub thinking markdown followed by other nodes", () => {
+            const s0 = seed([
+                thinkingMd("turn1-think", "reasoned about X"),
+                md("turn1-text", "answer for X"),
+                thinkingMd("turn2-think", "reasoned about Y"),
+                md("turn2-text", "answer for Y"),
+            ]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999 });
+            // No allocation, no events — both historical thinking
+            // blocks were completed (text follows each one).
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("scrubs tool-running anywhere in doc but leaves prior thinking alone", () => {
+            // Realistic snapshot of an app-killed session: prior
+            // turn's thinking → text → new turn's tool started but
+            // never finished. Only the running tool is orphan.
+            const s0 = seed([
+                thinkingMd("prior-think", "prior reasoning"),
+                md("prior-text", "prior answer"),
+                tool("t1", { status: "running" }),
+            ]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999 });
+            expect((r.state.nodes[0] as any).metadata.canceled).toBeUndefined();
+            expect((r.state.nodes[0] as any).metadata.thinking).toBe(true);
+            expect((r.state.nodes[2] as ToolNode).status).toBe("canceled");
+            expect(r.events).toEqual([
+                { type: "orphans-scrubbed", markdownCanceled: 0, toolsCanceled: 1 },
             ]);
         });
 
@@ -757,7 +800,9 @@ describe("agent document reducer", () => {
         });
 
         it("is idempotent — running twice doesn't double-modify", () => {
-            const s0 = seed([thinkingMd("t1"), tool("k1", { status: "running" })]);
+            // Thinking must be at the tail to be scrubbed under the
+            // last-node heuristic.
+            const s0 = seed([tool("k1", { status: "running" }), thinkingMd("t1")]);
             const r1 = update(s0, { type: "ScrubOrphanedInProgress", at: 1000 });
             const r2 = update(r1.state, { type: "ScrubOrphanedInProgress", at: 2000 });
             // Second run is a no-op against the already-scrubbed state.
@@ -765,7 +810,7 @@ describe("agent document reducer", () => {
             expect(r2.events).toEqual([]);
             // canceledAt was set by the FIRST run and never overwritten
             // — important: re-scrubbing must not bump the timestamp.
-            const t1 = r1.state.nodes[0] as any;
+            const t1 = r1.state.nodes[1] as any;
             expect(t1.metadata.canceledAt).toBe(1000);
         });
     });
@@ -780,11 +825,12 @@ describe("agent document reducer", () => {
         });
 
         it("emits session-ended AND orphans-scrubbed when nodes were dirty", () => {
-            const s0 = seed([thinkingMd("t1"), tool("k1", { status: "running" })]);
+            // Last-node thinking + running tool earlier in the doc.
+            const s0 = seed([tool("k1", { status: "running" }), thinkingMd("t1")]);
             const r = update(s0, { type: "SessionEnd", at: 5000 });
             expect(r.state.sessionPhase).toBe("ended");
-            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
-            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[0] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[1] as any).metadata.canceled).toBe(true);
             expect(r.events).toEqual([
                 { type: "session-ended", at: 5000 },
                 { type: "orphans-scrubbed", markdownCanceled: 1, toolsCanceled: 1 },
@@ -812,13 +858,16 @@ describe("agent document reducer", () => {
             // on resume, the new pane mounts and HistoryRestored
             // brings in the dirty nodes. Scrub flips them before
             // the user ever sees a misleading spinner.
+            // Thinking has to be tail-of-doc to qualify as orphan
+            // under the simple heuristic (anything after it means
+            // the parser had already transitioned away).
             const r = update(initialState(), {
                 type: "HistoryRestored",
-                nodes: [thinkingMd("orphan-think"), tool("orphan-tool", { status: "running" })],
+                nodes: [tool("orphan-tool", { status: "running" }), thinkingMd("orphan-think")],
                 fromSnapshot: true,
             });
-            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
-            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[0] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[1] as any).metadata.canceled).toBe(true);
             // session-phase still flips to "active" per the original
             // contract — we're restoring, not ending.
             expect(r.state.sessionPhase).toBe("active");
@@ -872,10 +921,10 @@ describe("agent document reducer", () => {
         it("flips dirty nodes from the legacy/NDJSON replay", () => {
             const r = update(initialState(), {
                 type: "HistoryLoaded",
-                nodes: [thinkingMd("orphan-think"), tool("orphan-tool", { status: "running" })],
+                nodes: [tool("orphan-tool", { status: "running" }), thinkingMd("orphan-think")],
             });
-            expect((r.state.nodes[0] as any).metadata.canceled).toBe(true);
-            expect((r.state.nodes[1] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[0] as ToolNode).status).toBe("canceled");
+            expect((r.state.nodes[1] as any).metadata.canceled).toBe(true);
             expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
         });
 

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -883,6 +883,28 @@ describe("agent document reducer", () => {
             expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(false);
         });
 
+        // Codex P2 r3 on #1104: HistoryRestored represents the
+        // COMPLETE pre-close history. If the snapshot's own tail is
+        // mid-thought, it's the orphan candidate even when live
+        // arrivals have populated state.nodes during the async read
+        // window. (The pagination guard belongs to HistoryLoaded
+        // only, where `fresh` is a sub-range of a larger doc.)
+        it("scrubs snapshot-tail thinking even after live arrivals", () => {
+            const live = md("live-text", "live content");
+            const base = seed([live]);
+            const r = update(base, {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("snap-1"), thinkingMd("snap-tail")],
+            });
+            const snapTail = r.state.nodes.find((n) => n.id === "snap-tail") as any;
+            expect(snapTail.metadata.canceled).toBe(true);
+            // Live node untouched.
+            const liveAfter = r.state.nodes.find((n) => n.id === "live-text") as any;
+            expect(liveAfter.metadata).toBeUndefined();
+            expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
+        });
+
         // Codex P2 on #1104: HistoryRestored arriving AFTER live
         // stream events have populated state.nodes must not flip
         // those live nodes to canceled — only the snapshot replay

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -45,6 +45,18 @@ import {
 function scrubOrphanedInProgress(
     nodes: DocumentNode[],
     at: number,
+    opts?: {
+        /**
+         * True when `nodes` is a prepended sub-range of the merged
+         * document (older history page or restored snapshot, with
+         * other content already in `state.nodes` following it).
+         * In that case `nodes[last]` is NOT the merged tail, so the
+         * last-node thinking heuristic must not fire. Tools are
+         * still scrubbed by their explicit status field. Codex P2
+         * on PR #1104 (HistoryLoaded.loadOlder pagination case).
+         */
+        hasContentAfter?: boolean;
+    },
 ): { nodes: DocumentNode[]; markdownCanceled: number; toolsCanceled: number } | null {
     let next: DocumentNode[] | null = null;
     let markdownCanceled = 0;
@@ -61,7 +73,8 @@ function scrubOrphanedInProgress(
     // thought" on session reopen. Codex + reagent P1 on PR #1104.
     // Tools have an explicit status field so scrub them anywhere
     // they appear with status:"running".
-    const lastIdx = nodes.length - 1;
+    const hasContentAfter = opts?.hasContentAfter === true;
+    const lastIdx = hasContentAfter ? -1 : nodes.length - 1;
 
     for (let i = 0; i < nodes.length; i++) {
         const n = nodes[i];
@@ -182,8 +195,18 @@ export function update(
             // already says HistoryLoaded scrubs, but the reducer
             // wasn't doing it. Scrub only `fresh` (same fix as
             // HistoryRestored — keep live nodes untouched).
+            //
+            // `hasContentAfter: state.nodes.length > 0` — see codex
+            // P2 r2 on #1104. `useHistoryPagination.loadOlder`
+            // dispatches HistoryLoaded with an OLDER page while
+            // newer nodes are already in state.nodes; in that case
+            // `fresh.last` is not the merged tail and a completed
+            // thinking block at the end of the page must not be
+            // canceled. Tools are still scrubbed by status field.
             // Spec: SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
-            const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
+            const scrubResult = scrubOrphanedInProgress(fresh, nowMs, {
+                hasContentAfter: state.nodes.length > 0,
+            });
             const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
             const loadEvents: ReducerResult["events"] = [
                 {
@@ -243,7 +266,14 @@ export function update(
             // that way (StreamFlush markdown updates only replace
             // content, not metadata). Live nodes pass through
             // untouched; only the replay gets sanitized.
-            const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
+            //
+            // `hasContentAfter` — codex P2 r2: if state.nodes already
+            // has live content, a thinking node at the end of fresh
+            // is not the merged tail and must not be canceled. Tools
+            // unaffected (status field is independent of position).
+            const scrubResult = scrubOrphanedInProgress(fresh, nowMs, {
+                hasContentAfter: state.nodes.length > 0,
+            });
             const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
             const mergedNodes = [...scrubbedFresh, ...state.nodes];
             const restoreEvents: ReducerResult["events"] = [

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -267,13 +267,14 @@ export function update(
             // content, not metadata). Live nodes pass through
             // untouched; only the replay gets sanitized.
             //
-            // `hasContentAfter` — codex P2 r2: if state.nodes already
-            // has live content, a thinking node at the end of fresh
-            // is not the merged tail and must not be canceled. Tools
-            // unaffected (status field is independent of position).
-            const scrubResult = scrubOrphanedInProgress(fresh, nowMs, {
-                hasContentAfter: state.nodes.length > 0,
-            });
+            // Do NOT pass `hasContentAfter` here — codex P2 r3 on
+            // #1104. A snapshot represents the COMPLETE pre-close
+            // history; its own tail IS the orphan candidate if it's
+            // mid-thought, regardless of any live arrivals that may
+            // have slipped in during the async read window. (The
+            // pagination guard belongs to HistoryLoaded only, where
+            // `fresh` is a sub-range of a larger doc.)
+            const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
             const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
             const mergedNodes = [...scrubbedFresh, ...state.nodes];
             const restoreEvents: ReducerResult["events"] = [

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -68,7 +68,14 @@ function scrubOrphanedInProgress(
         }
         if (n.type === "tool" && n.status === "running") {
             if (!next) next = nodes.slice();
-            next[i] = { ...n, status: "canceled" };
+            // Close the streaming log alongside the status flip.
+            // `log.open === true` makes ToolBlock / ToolOverlayLog
+            // render the live-tail "↳ latest stream output" branch,
+            // which keeps a canceled orphan looking like an actively-
+            // streaming tool — defeats the spec's "never with a
+            // spinner" goal. Codex + reagent P2 on PR #1104.
+            const closedLog = n.log != null ? { ...n.log, open: false } : n.log;
+            next[i] = { ...n, status: "canceled", log: closedLog };
             toolsCanceled++;
             continue;
         }

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -50,9 +50,26 @@ function scrubOrphanedInProgress(
     let markdownCanceled = 0;
     let toolsCanceled = 0;
 
+    // Spec's "simple heuristic" (SPEC_ORPHAN_THINKING_NODES §Design):
+    // a thinking markdown is orphaned only when it's the document's
+    // last node. Historical thinking blocks keep metadata.thinking
+    // forever (the stream-parser closes its local pointer on the
+    // next non-thinking event but never writes thinking:false onto
+    // the stored node, and StreamFlush markdown updates replace
+    // content only, not metadata). Without the last-node guard we'd
+    // relabel every prior turn's reasoning as "⏹ Canceled — partial
+    // thought" on session reopen. Codex + reagent P1 on PR #1104.
+    // Tools have an explicit status field so scrub them anywhere
+    // they appear with status:"running".
+    const lastIdx = nodes.length - 1;
+
     for (let i = 0; i < nodes.length; i++) {
         const n = nodes[i];
-        if (n.type === "markdown" && n.metadata?.thinking === true) {
+        if (
+            n.type === "markdown" &&
+            n.metadata?.thinking === true &&
+            i === lastIdx
+        ) {
             if (!next) next = nodes.slice();
             next[i] = {
                 ...n,

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -22,6 +22,62 @@ import {
     TRUNCATE_GRACE_MS,
 } from "./types";
 
+/**
+ * Walk the document and mark orphaned in-progress nodes as canceled.
+ *
+ * Returns `null` if nothing changed (so the caller can skip the
+ * state allocation), otherwise an object with the rewritten nodes +
+ * counts for the audit event. Idempotent — re-running over an
+ * already-scrubbed document returns `null`.
+ *
+ * Two transformations:
+ *   - Markdown nodes with `metadata.thinking === true` → flip
+ *     `thinking` off and set `canceled: true` (+ `canceledAt`).
+ *   - Tool nodes with `status === "running"` → set
+ *     `status: "canceled"`.
+ *
+ * `pending_approval` tools are left alone: they represent a user
+ * decision still in flight, not an interrupted stream. The user
+ * sees the decision panel on next open and can decide explicitly.
+ *
+ * Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+ */
+function scrubOrphanedInProgress(
+    nodes: DocumentNode[],
+    at: number,
+): { nodes: DocumentNode[]; markdownCanceled: number; toolsCanceled: number } | null {
+    let next: DocumentNode[] | null = null;
+    let markdownCanceled = 0;
+    let toolsCanceled = 0;
+
+    for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        if (n.type === "markdown" && n.metadata?.thinking === true) {
+            if (!next) next = nodes.slice();
+            next[i] = {
+                ...n,
+                metadata: {
+                    ...n.metadata,
+                    thinking: false,
+                    canceled: true,
+                    canceledAt: at,
+                },
+            };
+            markdownCanceled++;
+            continue;
+        }
+        if (n.type === "tool" && n.status === "running") {
+            if (!next) next = nodes.slice();
+            next[i] = { ...n, status: "canceled" };
+            toolsCanceled++;
+            continue;
+        }
+    }
+
+    if (!next) return null;
+    return { nodes: next, markdownCanceled, toolsCanceled };
+}
+
 export function update(
     state: AgentDocumentState,
     command: AgentDocumentCommand,
@@ -41,11 +97,34 @@ export function update(
                 events: [{ type: "session-started", at: command.at }],
             };
 
-        case "SessionEnd":
+        case "SessionEnd": {
+            // SessionEnd is the natural moment to mark any nodes
+            // left in-progress as canceled — the stream is over,
+            // they're never going to complete. Cleanup runs here
+            // (clean exits) AND on HistoryRestored / HistoryLoaded
+            // (covers the app-kill case where SessionEnd never
+            // fired and a dirty snapshot lives on disk).
+            // Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+            const scrub = scrubOrphanedInProgress(state.nodes, command.at);
+            const events: ReducerResult["events"] = [
+                { type: "session-ended", at: command.at },
+            ];
+            if (scrub) {
+                events.push({
+                    type: "orphans-scrubbed",
+                    markdownCanceled: scrub.markdownCanceled,
+                    toolsCanceled: scrub.toolsCanceled,
+                });
+                return {
+                    state: { ...state, sessionPhase: "ended", nodes: scrub.nodes },
+                    events,
+                };
+            }
             return {
                 state: { ...state, sessionPhase: "ended" },
-                events: [{ type: "session-ended", at: command.at }],
+                events,
             };
+        }
 
         case "HistoryLoaded": {
             if (command.nodes.length === 0) {
@@ -105,20 +184,36 @@ export function update(
                 nextIdSet.add(n.id);
                 fresh.push(n);
             }
+            // Scrub orphans in the freshly-restored snapshot. The
+            // snapshot was saved while the prior session was running
+            // and could contain a thinking node mid-stream or a
+            // tool stuck at `status="running"`. The user shouldn't
+            // see those as live on next open. Spec:
+            // SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+            const mergedNodes = [...fresh, ...state.nodes];
+            const scrub = scrubOrphanedInProgress(mergedNodes, nowMs);
+            const restoreEvents: ReducerResult["events"] = [
+                {
+                    type: "history-restored",
+                    restoredCount: fresh.length,
+                    fromSnapshot: true,
+                },
+            ];
+            if (scrub) {
+                restoreEvents.push({
+                    type: "orphans-scrubbed",
+                    markdownCanceled: scrub.markdownCanceled,
+                    toolsCanceled: scrub.toolsCanceled,
+                });
+            }
             return {
                 state: {
                     ...state,
-                    nodes: [...fresh, ...state.nodes],
+                    nodes: scrub ? scrub.nodes : mergedNodes,
                     nodeIdSet: nextIdSet,
                     sessionPhase: "active",
                 },
-                events: [
-                    {
-                        type: "history-restored",
-                        restoredCount: fresh.length,
-                        fromSnapshot: true,
-                    },
-                ],
+                events: restoreEvents,
             };
         }
 
@@ -288,6 +383,29 @@ export function update(
                         ? state
                         : { ...state, nodes: [], nodeIdSet: new Set<string>() },
                 events: [{ type: "user-cleared", clearedCount: cleared }],
+            };
+        }
+
+        case "ScrubOrphanedInProgress": {
+            // Standalone entry point — callers that want to scrub
+            // without crossing a session boundary (e.g., a follow-up
+            // pass triggered by external state). The SessionEnd and
+            // HistoryRestored handlers above also call the same
+            // `scrubOrphanedInProgress` helper directly; this case
+            // exists for explicit dispatchers and for testability.
+            // Idempotent: returns state unchanged if nothing's
+            // in-progress.
+            const scrub = scrubOrphanedInProgress(state.nodes, command.at);
+            if (!scrub) return { state, events: [] };
+            return {
+                state: { ...state, nodes: scrub.nodes },
+                events: [
+                    {
+                        type: "orphans-scrubbed",
+                        markdownCanceled: scrub.markdownCanceled,
+                        toolsCanceled: scrub.toolsCanceled,
+                    },
+                ],
             };
         }
     }

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -149,19 +149,39 @@ export function update(
                     ],
                 };
             }
+            // Scrub orphans in the freshly-loaded replay. Same reason
+            // as HistoryRestored: the legacy/NDJSON fallback path
+            // (useHistoryPagination, no-snapshot path) can replay a
+            // session that ended with a thinking block or a
+            // `status:"running"` tool — those must not render as live
+            // on reopen. Codex P2 on #1104: the command contract
+            // already says HistoryLoaded scrubs, but the reducer
+            // wasn't doing it. Scrub only `fresh` (same fix as
+            // HistoryRestored — keep live nodes untouched).
+            // Spec: SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+            const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
+            const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
+            const loadEvents: ReducerResult["events"] = [
+                {
+                    type: "history-loaded",
+                    addedCount: fresh.length,
+                    duplicatesDropped: duplicates,
+                },
+            ];
+            if (scrubResult) {
+                loadEvents.push({
+                    type: "orphans-scrubbed",
+                    markdownCanceled: scrubResult.markdownCanceled,
+                    toolsCanceled: scrubResult.toolsCanceled,
+                });
+            }
             return {
                 state: {
                     ...state,
-                    nodes: [...fresh, ...state.nodes],
+                    nodes: [...scrubbedFresh, ...state.nodes],
                     nodeIdSet: nextIdSet,
                 },
-                events: [
-                    {
-                        type: "history-loaded",
-                        addedCount: fresh.length,
-                        duplicatesDropped: duplicates,
-                    },
-                ],
+                events: loadEvents,
             };
         }
 
@@ -190,8 +210,18 @@ export function update(
             // tool stuck at `status="running"`. The user shouldn't
             // see those as live on next open. Spec:
             // SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
-            const mergedNodes = [...fresh, ...state.nodes];
-            const scrub = scrubOrphanedInProgress(mergedNodes, nowMs);
+            //
+            // Scrub ONLY `fresh` (the historical snapshot). Codex P2
+            // on #1104: scrubbing the merged array would also cancel
+            // live nodes that landed in state.nodes during the async
+            // snapshot-read window — a thinking markdown still being
+            // streamed would get flipped to canceled and stay rendered
+            // that way (StreamFlush markdown updates only replace
+            // content, not metadata). Live nodes pass through
+            // untouched; only the replay gets sanitized.
+            const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
+            const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
+            const mergedNodes = [...scrubbedFresh, ...state.nodes];
             const restoreEvents: ReducerResult["events"] = [
                 {
                     type: "history-restored",
@@ -199,17 +229,17 @@ export function update(
                     fromSnapshot: true,
                 },
             ];
-            if (scrub) {
+            if (scrubResult) {
                 restoreEvents.push({
                     type: "orphans-scrubbed",
-                    markdownCanceled: scrub.markdownCanceled,
-                    toolsCanceled: scrub.toolsCanceled,
+                    markdownCanceled: scrubResult.markdownCanceled,
+                    toolsCanceled: scrubResult.toolsCanceled,
                 });
             }
             return {
                 state: {
                     ...state,
-                    nodes: scrub ? scrub.nodes : mergedNodes,
+                    nodes: mergedNodes,
                     nodeIdSet: nextIdSet,
                     sessionPhase: "active",
                 },

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -106,7 +106,23 @@ export type AgentDocumentCommand =
      */
     | { type: "StreamTruncate"; reason: string }
     /** User invoked /clear — always honored. */
-    | { type: "UserClear" };
+    | { type: "UserClear" }
+    /**
+     * Scrub orphaned in-progress nodes. Walks `nodes[]` and:
+     *  - flips any markdown with `metadata.thinking === true` to
+     *    `metadata.canceled === true` (clearing the thinking flag).
+     *  - flips any `tool` with `status === "running"` to
+     *    `status: "canceled"`.
+     *
+     * Dispatched as a side-effect of `SessionEnd` (clean exits)
+     * and `HistoryRestored` / `HistoryLoaded` (resumed sessions
+     * where the kill happened before `SessionEnd` ever fired).
+     * Idempotent — running it twice is a no-op against the
+     * already-scrubbed state.
+     *
+     * Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+     */
+    | { type: "ScrubOrphanedInProgress"; at: number };
 
 /**
  * Audit events emitted by the reducer. v1 logs them via the dispatcher's
@@ -148,7 +164,14 @@ export type AgentDocumentEvent =
           /** Reason the chunk was rejected without touching state. */
           reason: "unknown-tool-id" | "node-not-tool" | "duplicate";
       }
-    | { type: "user-cleared"; clearedCount: number };
+    | { type: "user-cleared"; clearedCount: number }
+    | {
+          type: "orphans-scrubbed";
+          /** Thinking-markdown nodes flipped to canceled. */
+          markdownCanceled: number;
+          /** Tool nodes whose status flipped from "running" → "canceled". */
+          toolsCanceled: number;
+      };
 
 export interface ReducerResult {
     state: AgentDocumentState;

--- a/frontend/app/view/agent/components/MarkdownBlock.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.tsx
@@ -7,7 +7,7 @@
 
 import { Markdown } from "@/app/element/markdown";
 import clsx from "clsx";
-import { type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 import type { MarkdownNode } from "../types";
 
 interface MarkdownBlockProps {
@@ -21,14 +21,50 @@ export const MarkdownBlock = (props: MarkdownBlockProps): JSX.Element => {
     // capture the first reference and freeze. Access props.node.X at
     // each site so Solid's reactivity tracks the read. (codex P1 on
     // PR #786 / virt redesign.)
+
+    // Canceled thinking — orphan-scrub flipped this on at the last
+    // SessionEnd or HistoryRestored. Render collapsed by default
+    // with a "⏹ Canceled" label; click to expand the partial
+    // content. Spec:
+    // `docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md`.
+    const isCanceled = (): boolean => props.node.metadata?.canceled === true;
+    const [expanded, setExpanded] = createSignal(false);
+
     return (
-        <div
-            class={clsx("agent-markdown-block", {
-                "thinking-block": props.node.metadata?.thinking,
-            })}
+        <Show
+            when={isCanceled()}
+            fallback={
+                <div
+                    class={clsx("agent-markdown-block", {
+                        "thinking-block": props.node.metadata?.thinking,
+                    })}
+                >
+                    <Markdown text={props.node.content} />
+                </div>
+            }
         >
-            <Markdown text={props.node.content} />
-        </div>
+            <div class="agent-markdown-block markdown-canceled">
+                <button
+                    type="button"
+                    class="markdown-canceled-header"
+                    onClick={() => setExpanded((v) => !v)}
+                    aria-expanded={expanded()}
+                >
+                    <span class="markdown-canceled-icon" aria-hidden="true">⏹</span>
+                    <span class="markdown-canceled-label">
+                        Canceled — partial thought
+                    </span>
+                    <span class="markdown-canceled-chevron" aria-hidden="true">
+                        {expanded() ? "▾" : "▸"}
+                    </span>
+                </button>
+                <Show when={expanded()}>
+                    <div class="markdown-canceled-body">
+                        <Markdown text={props.node.content} />
+                    </div>
+                </Show>
+            </div>
+        </Show>
     );
 };
 

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -66,6 +66,7 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
     success: "✓",
     failed: "✗",
     denied: "⊘",
+    canceled: "⏹",
 };
 
 // 150ms enter delay prevents accidental expansions while scrolling past
@@ -233,6 +234,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 running: props.node.status === "running",
                 success: props.node.status === "success",
                 failed: props.node.status === "failed",
+                canceled: props.node.status === "canceled",
             })}
         >
             <div class="agent-tool-summary" onClick={props.onTogglePin}>

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -41,6 +41,7 @@ const STATUS_LABEL: Record<ToolNode["status"], string> = {
     success: "ok",
     failed: "failed",
     denied: "denied",
+    canceled: "canceled",
 };
 
 export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { parseHistoryLines } from "./parseHistoryLines";
+import type { ToolNode } from "./types";
+
+// The Claude translator passes through events that already match the
+// StreamEvent shape (`if (this.isStreamEvent(rawEvent))` branch), so
+// each test line is JSON-stringified StreamEvent.
+const line = (event: object): string => JSON.stringify(event);
+
+describe("parseHistoryLines", () => {
+    it("merges same-id tool_call → tool_result so the tool ends success, not stuck running", () => {
+        // Codex P1 on PR #1104: the previous "first-wins by id" rule
+        // dropped the tool_result event during replay, leaving the
+        // tool stuck at `status: "running"` on rendered history pages.
+        // The orphan-scrub pass would then turn it into "canceled",
+        // mislabeling a successfully-completed tool.
+        const lines = [
+            line({ type: "tool_call", tool: "Bash", id: "tool-1", params: { command: "ls" } }),
+            line({ type: "tool_result", tool: "Bash", id: "tool-1", status: "success", duration: 0.1 }),
+        ];
+        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        expect(nodes).toHaveLength(1);
+        const tool = nodes[0] as ToolNode;
+        expect(tool.id).toBe("tool-1");
+        expect(tool.status).toBe("success");
+    });
+
+    it("preserves insertion order across same-id replacements", () => {
+        // Tool replays in the middle of text shouldn't move the tool
+        // to the end — its position is where its `tool_call` first
+        // appeared in the stream.
+        const lines = [
+            line({ type: "text", content: "before" }),
+            line({ type: "tool_call", tool: "Read", id: "tool-1", params: { file_path: "x" } }),
+            line({ type: "text", content: "after" }),
+            // tool_result lands later but should NOT push the tool past "after".
+            line({ type: "tool_result", tool: "Read", id: "tool-1", status: "success", duration: 0 }),
+        ];
+        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        expect(nodes).toHaveLength(3);
+        expect(nodes[0].type).toBe("markdown");
+        expect(nodes[1].type).toBe("tool");
+        expect((nodes[1] as ToolNode).status).toBe("success");
+        expect(nodes[2].type).toBe("markdown");
+    });
+
+    it("accumulates streaming thinking deltas in place (last delta = full text)", () => {
+        // Streaming markdown / thinking deltas share an id; each event
+        // carries the running accumulated content (parser appends and
+        // emits a fresh object each time). With first-wins this would
+        // freeze the rendered thought at "Let me " forever; with
+        // last-wins, the final delta's full text is preserved.
+        const lines = [
+            line({ type: "thinking", content: "Let me " }),
+            line({ type: "thinking", content: "think about this..." }),
+        ];
+        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        expect(nodes).toHaveLength(1);
+        const node = nodes[0] as any;
+        expect(node.type).toBe("markdown");
+        expect(node.content).toBe("Let me think about this...");
+        expect(node.metadata.thinking).toBe(true);
+    });
+
+    it("skips corrupt and stderr lines silently", () => {
+        const lines = [
+            "{ not json",
+            line({ type: "stderr", content: "ignore me" }),
+            line({ type: "text", content: "real text" }),
+            "",
+            "   ",
+        ];
+        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        expect(nodes).toHaveLength(1);
+        expect((nodes[0] as any).content).toBe("real text");
+    });
+});

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -28,7 +28,16 @@ export function parseHistoryLines(
     const translator = createTranslator(outputFormat);
     const parser = new ClaudeCodeStreamParser();
     const nodes: DocumentNode[] = [];
-    const seen = new Set<string>();
+    // Same-id events update IN PLACE rather than first-wins.
+    // The previous "skip if seen" rule dropped legitimate state
+    // transitions during replay — most importantly, a `tool_result`
+    // arriving after its `tool_call` would be discarded, leaving the
+    // tool stuck at `status: "running"` on the rendered page even
+    // though it completed successfully. Codex P1 on PR #1104. Streaming
+    // markdown/thinking deltas also share an id; same rule means the
+    // accumulated tail (the last delta containing the full text) wins,
+    // which is the same end state the live stream produces.
+    const indexById = new Map<string, number>();
 
     for (const line of lines) {
         const trimmed = line.trim();
@@ -51,9 +60,16 @@ export function parseHistoryLines(
         for (const event of streamEvents) {
             const node = parser.parseLine(JSON.stringify(event));
             if (!node) continue;
-            if (seen.has(node.id)) continue;
-            seen.add(node.id);
-            nodes.push(node);
+            const existing = indexById.get(node.id);
+            if (existing != null) {
+                // Replace at the original position so insertion order
+                // tracks where the id first appeared (which is where
+                // the live render would have placed it).
+                nodes[existing] = node;
+            } else {
+                indexById.set(node.id, nodes.length);
+                nodes.push(node);
+            }
         }
     }
 

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -41,6 +41,63 @@
             margin-block: 4px;
         }
 
+        // Canceled thinking — orphan-scrub flipped metadata.canceled
+        // on at SessionEnd / HistoryRestored / HistoryLoaded. Render
+        // collapsed by default with a "⏹ Canceled — partial thought"
+        // header; click expands the body. Mirrors thinking-block
+        // chrome (muted border + dim background) so the visual lineage
+        // is clear, but no italic — this content is no longer "in
+        // flight". Spec: SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+        &.markdown-canceled {
+            opacity: 0.7;
+            border-left: 2px solid var(--secondary-text-color);
+            padding-left: var(--space-2);
+            background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+            margin-block: 4px;
+
+            .markdown-canceled-header {
+                display: flex;
+                align-items: center;
+                gap: var(--space-1);
+                padding: var(--space-0-5) 0;
+                background: transparent;
+                border: none;
+                color: var(--secondary-text-color);
+                font-size: 11px;
+                font-family: var(--fixed-font, monospace);
+                cursor: pointer;
+                width: 100%;
+                text-align: left;
+
+                &:hover {
+                    color: var(--main-text-color);
+                }
+            }
+
+            .markdown-canceled-icon {
+                flex-shrink: 0;
+                width: 12px;
+                text-align: center;
+            }
+
+            .markdown-canceled-label {
+                flex: 1 1 auto;
+                font-style: italic;
+            }
+
+            .markdown-canceled-chevron {
+                flex-shrink: 0;
+                width: 12px;
+                text-align: center;
+                font-size: 10px;
+            }
+
+            .markdown-canceled-body {
+                padding-top: var(--space-1);
+                font-style: italic;
+            }
+        }
+
         p {
             margin: 1px 0;
         }
@@ -86,6 +143,18 @@
 
         &.failed {
             border-left: 2px solid var(--error-color);
+        }
+
+        // Canceled — orphan-scrub flipped status from "running" on
+        // SessionEnd / HistoryRestored / HistoryLoaded. Muted border
+        // (same hue as the canceled markdown chrome) + dimmed surface
+        // so the ⏹ icon row reads as terminal-but-incomplete, not
+        // success/failed. Body is hidden by default (no `.expanded`)
+        // per the existing collapse contract.
+        // Spec: SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+        &.canceled {
+            border-left: 2px solid var(--secondary-text-color);
+            opacity: 0.7;
         }
 
         // Single-line collapsed summary — see docs/specs/tool-collapse.md.
@@ -159,9 +228,10 @@
         }
 
         // Status icon color variants for the collapsed row
-        &.success .agent-tool-status-icon { color: var(--success-color); }
-        &.failed  .agent-tool-status-icon { color: var(--error-color); }
-        &.running .agent-tool-status-icon { color: var(--warning-color); }
+        &.success  .agent-tool-status-icon { color: var(--success-color); }
+        &.failed   .agent-tool-status-icon { color: var(--error-color); }
+        &.running  .agent-tool-status-icon { color: var(--warning-color); }
+        &.canceled .agent-tool-status-icon { color: var(--secondary-text-color); }
 
         .agent-tool-content {
             padding: 0 var(--space-1) var(--space-1) var(--space-4);

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -64,6 +64,23 @@ export interface MarkdownNode {
     timestamp?: number; // Unix ms — when this node was first received
     metadata?: {
         thinking?: boolean; // Whether this is a thinking block
+        /**
+         * Set when the node was a thinking block whose stream
+         * ended before completion (pane closed, app killed, etc.).
+         * On the next session open, the orphan-scrub pass on
+         * SessionEnd / HistoryLoaded flips this to `true` and
+         * clears `thinking` — so the UI can render the partial
+         * content as historical-canceled (collapsed by default,
+         * "⏹ Canceled — partial thought" label) instead of
+         * misleadingly showing a live "Thinking..." spinner on
+         * something the agent will never finish.
+         *
+         * Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+         */
+        canceled?: boolean;
+        /** Unix ms when the orphan-scrub pass marked this node
+         *  canceled. Optional; primarily for future audit/tooltip. */
+        canceledAt?: number;
     };
 }
 
@@ -201,9 +218,15 @@ export interface ToolNode {
      *  - `success`           — completed without error
      *  - `failed`            — completed with error
      *  - `denied`            — user denied the call via the decision panel
+     *  - `canceled`          — was running when the session ended;
+     *                          the orphan-scrub pass on SessionEnd /
+     *                          HistoryLoaded transitioned it. Render
+     *                          collapsed with the ⏹ icon, never with a
+     *                          spinner. Spec:
+     *                          SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
      *  Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.2.
      */
-    status: "running" | "pending_approval" | "success" | "failed" | "denied";
+    status: "running" | "pending_approval" | "success" | "failed" | "denied" | "canceled";
     duration?: number; // Seconds
     result?: ToolResult;
     /** Live streaming buffer. Populated when the provider emits
@@ -529,6 +552,7 @@ export const STATUS_ICONS: Record<string, string> = {
     running: "⏳",
     success: "✓",
     failed: "✗",
+    canceled: "⏹",
 };
 
 /**


### PR DESCRIPTION
## Bug

Close a pane (or kill the app) while the agent is mid-thought OR has a tool running. The `metadata.thinking=true` markdown and `status="running"` tool get persisted to the snapshot without ever transitioning to a terminal state. On reopen, the UI renders them as if the agent is still actively working: expanded markdown with "Thinking…" spinner, tool block stuck on its running spinner.

## Fix

Scrub the dirty states at two natural moments:

1. **SessionEnd** — clean exits (pane close, stream tear-down).
2. **HistoryRestored** — covers the app-kill case where SessionEnd never fired and the dirty snapshot lives on disk.

Scrub semantics:
- Markdown with `metadata.thinking === true` → flip thinking off, set `canceled: true` (+ `canceledAt`).
- Tool with `status === "running"` → set `status: "canceled"`.
- `pending_approval` tools left alone (user decision still in flight).
- Lazy-clone, identity-return when clean.
- Idempotent (canceledAt set by the first scrub is not bumped on re-run).

## UI

- **MarkdownBlock**: when `metadata.canceled === true`, renders collapsed `⏹ Canceled — partial thought` with click-to-expand.
- **ToolBlock**: `canceled` is part of the `ToolNode.status` union; status-icon `⏹`, class `canceled`, `autoExpanded()` no longer matches (default-collapsed, hover-peek still works, pin still wins).

## New reducer command (also exposed standalone)

```ts
{ type: "ScrubOrphanedInProgress", at: number }
```

## Files

- `frontend/app/view/agent/types.ts` — add `metadata.canceled` / `metadata.canceledAt` on MarkdownNode, add `"canceled"` to ToolNode.status union, add `canceled` to STATUS_ICONS
- `frontend/app/store/agent-document/types.ts` — new command + event types
- `frontend/app/store/agent-document/reducer.ts` — `scrubOrphanedInProgress()` helper + standalone case + integration into SessionEnd + HistoryRestored
- `frontend/app/view/agent/components/MarkdownBlock.tsx` — canceled render path
- `frontend/app/view/agent/components/ToolBlock.tsx` — canceled status + class
- `frontend/app/view/agent/components/ToolBlockOverlay.tsx` — STATUS_LABEL gets `canceled`
- `docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md` — full design

## Tests

- [x] 53/53 agent-document reducer tests pass (8 new)
- [x] 155/155 stream-parser + agent component tests pass
- [x] `npx tsc --noEmit -p .` clean across all modified files

## Out of scope (per spec §Out of scope)

- Distinguishing **user-canceled** (Esc) from **session-ended-mid-stream** — both currently land as "canceled". Follow-up can split.
- Recovering completion on `--continue` resume. Decision: canceled thoughts stay as historical artifacts; new continuations are new nodes.
- Cross-session re-merge of canceled-then-continued thoughts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)