### PR TITLE
chore: release v0.39.0

### DIFF
--- a/.changesets/1779354885-docs-menu-spec-for-menu-positioning-framework-paintable-area-r74k.md
+++ b/.changesets/1779354885-docs-menu-spec-for-menu-positioning-framework-paintable-area-r74k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(menu): spec for menu positioning framework + paintable-area guard

--- a/.changesets/1779355389-feat-menu-usemenuposition-framework-primitive-phase-1-ng7w.md
+++ b/.changesets/1779355389-feat-menu-usemenuposition-framework-primitive-phase-1-ng7w.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(menu): useMenuPosition framework primitive (Phase 1)

--- a/.changesets/1779355644-feat-menu-route-flyoutmenu-popover-through-usemenuposition-p-tjr7.md
+++ b/.changesets/1779355644-feat-menu-route-flyoutmenu-popover-through-usemenuposition-p-tjr7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(menu): route FlyoutMenu + Popover through useMenuPosition (Phase 2)

--- a/.changesets/1779358906-feat-menu-migrate-more-dropdown-tokenbreakdownpopover-to-use-f1c0.md
+++ b/.changesets/1779358906-feat-menu-migrate-more-dropdown-tokenbreakdownpopover-to-use-f1c0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(menu): migrate More dropdown + TokenBreakdownPopover to useMenuPosition (Phase 3)

--- a/.changesets/1779359149-feat-menu-paintable-area-guard-dev-assertion-ci-grep-gate-ph-jlgv.md
+++ b/.changesets/1779359149-feat-menu-paintable-area-guard-dev-assertion-ci-grep-gate-ph-jlgv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(menu): paintable-area guard — dev assertion + CI grep gate (Phase 4)

--- a/.changesets/1779404543-fix-menu-preserve-crossaxis-alignmentaxis-offset-semantics-i-ssb3.md
+++ b/.changesets/1779404543-fix-menu-preserve-crossaxis-alignmentaxis-offset-semantics-i-ssb3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(menu): preserve crossAxis/alignmentAxis offset semantics in Popover

--- a/.changesets/1779462096-fix-menu-route-the-right-click-context-menu-through-computem-ftu3.md
+++ b/.changesets/1779462096-fix-menu-route-the-right-click-context-menu-through-computem-ftu3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(menu): route the right-click context menu through computeMenuPosition

--- a/.changesets/1779817687-feat-editor-file-tree-explorer-toolbar-header-chevron.md
+++ b/.changesets/1779817687-feat-editor-file-tree-explorer-toolbar-header-chevron.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): file-tree explorer rooted at $HOME with header chevron + toolbar (show hidden / collapse all / refresh)

--- a/.changesets/1779818448-fix-agent-show-agent-name-in-composer-placeholder-instead-of-casm.md
+++ b/.changesets/1779818448-fix-agent-show-agent-name-in-composer-placeholder-instead-of-casm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): show agent name in composer placeholder instead of UUID hash

--- a/.changesets/1779818795-feat-editor-multi-root-tree-plus-resize-handle.md
+++ b/.changesets/1779818795-feat-editor-multi-root-tree-plus-resize-handle.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(editor): multi-root file tree (HOME + drives/mounts) and draggable resize handle between tree and editor

--- a/.changesets/1779819856-feat-agent-pane-state-reducer-state-commands-for-composer-de-igg2.md
+++ b/.changesets/1779819856-feat-agent-pane-state-reducer-state-commands-for-composer-de-igg2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane-state): reducer state + commands for composer details panel

--- a/.changesets/1779820613-feat-agent-pane-slim-composer-status-strip-replaces-agentsta-z1ia.md
+++ b/.changesets/1779820613-feat-agent-pane-slim-composer-status-strip-replaces-agentsta-z1ia.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): slim composer status strip replaces AgentStatusLine

--- a/.changesets/1779821048-feat-editor-icon-toggles-tree-and-title-shows-full-path.md
+++ b/.changesets/1779821048-feat-editor-icon-toggles-tree-and-title-shows-full-path.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(editor): pane icon toggles the file-tree (replacing the separate chevron); title bar now shows the full file path

--- a/.changesets/1779823104-fix-composer-strip-correct-scss-mixins-path-build-broke-afte-2q1z.md
+++ b/.changesets/1779823104-fix-composer-strip-correct-scss-mixins-path-build-broke-afte-2q1z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(composer-strip): correct SCSS mixins path (build broke after #1069)

--- a/.changesets/1779823390-feat-floating-pane-phase-3-pane-tear-off-routes-to-floating--jcju.md
+++ b/.changesets/1779823390-feat-floating-pane-phase-3-pane-tear-off-routes-to-floating--jcju.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(floating-pane): Phase 3 — pane tear-off routes to floating child window, not new instance

--- a/.changesets/1779823695-feat-editor-lsp-phase1-typescript-diagnostics.md
+++ b/.changesets/1779823695-feat-editor-lsp-phase1-typescript-diagnostics.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): LSP integration Phase 1 — TypeScript diagnostics via typescript-language-server, with install banner + status chip

--- a/.changesets/1779825199-fix-agent-pane-wrap-user-input-smooth-tool-block-collapse-3s-1yrw.md
+++ b/.changesets/1779825199-fix-agent-pane-wrap-user-input-smooth-tool-block-collapse-3s-1yrw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): wrap user input + smooth tool-block collapse + 3s hold

--- a/.changesets/1779826600-feat-toggle-square-thumbs-tracks-canonical-toggle-status-bar-bxco.md
+++ b/.changesets/1779826600-feat-toggle-square-thumbs-tracks-canonical-toggle-status-bar-bxco.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(toggle): square thumbs + tracks (canonical Toggle + status-bar LAN discovery)

--- a/.changesets/1779828464-feat-floating-pane-phase-2-real-block-renderer-via-initapp-c-v4yz.md
+++ b/.changesets/1779828464-feat-floating-pane-phase-2-real-block-renderer-via-initapp-c-v4yz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(floating-pane): Phase 2 — real Block renderer via initApp + chromeless workspace

--- a/.changesets/1779848292-feat-build-task-package-auto-appends-version-history-entry-t-wr4w.md
+++ b/.changesets/1779848292-feat-build-task-package-auto-appends-version-history-entry-t-wr4w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(build): task package auto-appends VERSION_HISTORY entry to fix recurring reagent drift

--- a/.changesets/1779849524-fix-dev-respect-agentmux-vite-port-in-child-windows-so-tab-p-8vhs.md
+++ b/.changesets/1779849524-fix-dev-respect-agentmux-vite-port-in-child-windows-so-tab-p-8vhs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dev): respect AGENTMUX_VITE_PORT in child windows so tab/pane tear-off works on non-5173 dev clones

--- a/.changesets/1779850836-feat-floating-pane-native-title-bar-drag-via-wm-nchittest-si-7ljq.md
+++ b/.changesets/1779850836-feat-floating-pane-native-title-bar-drag-via-wm-nchittest-si-7ljq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(floating-pane): native title-bar drag via WM_NCHITTEST + size matches source pane

--- a/.changesets/1779853498-feat-editor-per-pane-zoom-decouple-icon-as-toggle-from-heade-wu8f.md
+++ b/.changesets/1779853498-feat-editor-per-pane-zoom-decouple-icon-as-toggle-from-heade-wu8f.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(editor): per-pane zoom + decouple icon-as-toggle from header dblclick

--- a/.changesets/1779854764-feat-editor-slice-10-editor-pane-state-phase-1a-scaffolding-6ezb.md
+++ b/.changesets/1779854764-feat-editor-slice-10-editor-pane-state-phase-1a-scaffolding-6ezb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): slice #10 editor-pane-state — Phase 1A scaffolding

--- a/.changesets/1779855451-feat-floating-pane-floater-renders-as-a-free-floating-docked-zp8w.md
+++ b/.changesets/1779855451-feat-floating-pane-floater-renders-as-a-free-floating-docked-zp8w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(floating-pane): floater renders as a free-floating docked pane — no extra chrome, no OS controls

--- a/.changesets/1779855626-feat-editor-tabs-phase-1b-view-tab-strip-c6tk.md
+++ b/.changesets/1779855626-feat-editor-tabs-phase-1b-view-tab-strip-c6tk.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): tabs Phase 1B — view + tab strip

--- a/.changesets/1779856022-feat-fe-log-runtime-source-map-resolver-for-piped-error-stac-73do.md
+++ b/.changesets/1779856022-feat-fe-log-runtime-source-map-resolver-for-piped-error-stac-73do.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(fe-log): runtime source-map resolver for piped error stacks

--- a/.changesets/1779872611-fix-editor-pane-state-call-eventsink-whenever-state-changes--nxo7.md
+++ b/.changesets/1779872611-fix-editor-pane-state-call-eventsink-whenever-state-changes--nxo7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor-pane-state): call eventSink whenever state changes, not only when events array is non-empty

--- a/.changesets/1779875373-feat-editor-preview-tabs-centered-error-panel-binary-file-gu-e0ny.md
+++ b/.changesets/1779875373-feat-editor-preview-tabs-centered-error-panel-binary-file-gu-e0ny.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): preview tabs + centered error panel + binary-file guard + memo reactivity fix

--- a/.changesets/1779878222-feat-agents-dedupe-continuation-chains-in-my-agents-picker-p-5pb6.md
+++ b/.changesets/1779878222-feat-agents-dedupe-continuation-chains-in-my-agents-picker-p-5pb6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agents): dedupe continuation chains in My Agents picker (Phase 3b.1) + tracking spec

--- a/.changesets/1779878889-perf-pane-overlay-short-circuit-ipc-coalesce-on-raf-drop-cla-24xe.md
+++ b/.changesets/1779878889-perf-pane-overlay-short-circuit-ipc-coalesce-on-raf-drop-cla-24xe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-perf(pane-overlay): short-circuit IPC + coalesce on rAF + drop class observation (Agent2 #1097)

--- a/.changesets/1779879606-fix-ui-title-case-widget-bar-and-pane-labels-s48t.md
+++ b/.changesets/1779879606-fix-ui-title-case-widget-bar-and-pane-labels-s48t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): title-case widget bar and pane labels

--- a/.changesets/1779884283-refactor-store-rename-wstore-store-wave-fork-relic-modulariz-lbtq.md
+++ b/.changesets/1779884283-refactor-store-rename-wstore-store-wave-fork-relic-modulariz-lbtq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(store): rename wstore → store (Wave-fork relic) + modularization spec (R.0)

--- a/.changesets/1779885643-fix-agent-pane-sticky-frontier-partition-render-trail-diagno-hpm9.md
+++ b/.changesets/1779885643-fix-agent-pane-sticky-frontier-partition-render-trail-diagno-hpm9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): render-gap (stream-parser id collision) + replaceChild crash (sticky-frontier partition)

--- a/.changesets/1779899676-fix-floating-pane-suppress-focus-ring-border-route-window-dr-b2bs.md
+++ b/.changesets/1779899676-fix-floating-pane-suppress-focus-ring-border-route-window-dr-b2bs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): suppress focus-ring border + route window-drag/close by label

--- a/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
+++ b/.changesets/1779900108-feat-widgets-reorder-default-widget-bar-agent-swarm-drone-wa-o8o6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(widgets): reorder + slim default widget bar — pinned: Agent, Swarm, Drone, Warden; in More: Terminal, Editor, Browser, Sysinfo, Help

--- a/.changesets/1779902576-feat-browser-slice-9-extension-phase-1a-multi-tab-scaffoldin-ort3.md
+++ b/.changesets/1779902576-feat-browser-slice-9-extension-phase-1a-multi-tab-scaffoldin-ort3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser): slice #9 extension — Phase 1A multi-tab scaffolding

--- a/.changesets/1779904158-feat-tabs-workspace-tabs-adopt-editor-style-basis-shrink-ell-1bux.md
+++ b/.changesets/1779904158-feat-tabs-workspace-tabs-adopt-editor-style-basis-shrink-ell-1bux.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tabs): workspace tabs adopt editor-style basis + shrink + ellipsis (160/64/220 px)

--- a/.changesets/1779904645-feat-empty-tab-show-user-host-version-on-the-empty-tab-logo--f8cs.md
+++ b/.changesets/1779904645-feat-empty-tab-show-user-host-version-on-the-empty-tab-logo--f8cs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(empty-tab): show user@host + version on the empty-tab logo panel

--- a/.changesets/1779911834-feat-agent-picker-install-ribbon-green-instead-of-yellow-for-ezpx.md
+++ b/.changesets/1779911834-feat-agent-picker-install-ribbon-green-instead-of-yellow-for-ezpx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-picker): install ribbon green instead of yellow (forward action, not warning)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.38.14"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.38.14"
+version = "0.39.0"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.38.14"
+version = "0.39.0"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.38.14"
+version = "0.39.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.38.14"
+version = "0.39.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.38.14"
+version = "0.39.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,49 @@
 # AgentMux Version History
 
+## 0.39.0 — 2026-05-27
+
+- docs(menu): spec for menu positioning framework + paintable-area guard
+- feat(menu): useMenuPosition framework primitive (Phase 1)
+- feat(menu): route FlyoutMenu + Popover through useMenuPosition (Phase 2)
+- feat(menu): migrate More dropdown + TokenBreakdownPopover to useMenuPosition (Phase 3)
+- feat(menu): paintable-area guard — dev assertion + CI grep gate (Phase 4)
+- fix(menu): preserve crossAxis/alignmentAxis offset semantics in Popover
+- fix(menu): route the right-click context menu through computeMenuPosition
+- feat(editor): file-tree explorer rooted at $HOME with header chevron + toolbar (show hidden / collapse all / refresh)
+- fix(agent): show agent name in composer placeholder instead of UUID hash
+- feat(editor): multi-root file tree (HOME + drives/mounts) and draggable resize handle between tree and editor
+- feat(agent-pane-state): reducer state + commands for composer details panel
+- feat(agent-pane): slim composer status strip replaces AgentStatusLine
+- feat(editor): pane icon toggles the file-tree (replacing the separate chevron); title bar now shows the full file path
+- fix(composer-strip): correct SCSS mixins path (build broke after #1069)
+- feat(floating-pane): Phase 3 — pane tear-off routes to floating child window, not new instance
+- feat(editor): LSP integration Phase 1 — TypeScript diagnostics via typescript-language-server, with install banner + status chip
+- fix(agent-pane): wrap user input + smooth tool-block collapse + 3s hold
+- feat(toggle): square thumbs + tracks (canonical Toggle + status-bar LAN discovery)
+- feat(floating-pane): Phase 2 — real Block renderer via initApp + chromeless workspace
+- feat(build): task package auto-appends VERSION_HISTORY entry to fix recurring reagent drift
+- fix(dev): respect AGENTMUX_VITE_PORT in child windows so tab/pane tear-off works on non-5173 dev clones
+- feat(floating-pane): native title-bar drag via WM_NCHITTEST + size matches source pane
+- feat(editor): per-pane zoom + decouple icon-as-toggle from header dblclick
+- feat(editor): slice #10 editor-pane-state — Phase 1A scaffolding
+- feat(floating-pane): floater renders as a free-floating docked pane — no extra chrome, no OS controls
+- feat(editor): tabs Phase 1B — view + tab strip
+- feat(fe-log): runtime source-map resolver for piped error stacks
+- fix(editor-pane-state): call eventSink whenever state changes, not only when events array is non-empty
+- feat(editor): preview tabs + centered error panel + binary-file guard + memo reactivity fix
+- feat(agents): dedupe continuation chains in My Agents picker (Phase 3b.1) + tracking spec
+- perf(pane-overlay): short-circuit IPC + coalesce on rAF + drop class observation (Agent2 #1097)
+- fix(ui): title-case widget bar and pane labels
+- refactor(store): rename wstore → store (Wave-fork relic) + modularization spec (R.0)
+- fix(agent-pane): render-gap (stream-parser id collision) + replaceChild crash (sticky-frontier partition)
+- fix(floating-pane): suppress focus-ring border + route window-drag/close by label
+- feat(widgets): reorder + slim default widget bar — pinned: Agent, Swarm, Drone, Warden; in More: Terminal, Editor, Browser, Sysinfo, Help
+- feat(browser): slice #9 extension — Phase 1A multi-tab scaffolding
+- feat(tabs): workspace tabs adopt editor-style basis + shrink + ellipsis (160/64/220 px)
+- feat(empty-tab): show user@host + version on the empty-tab logo panel
+- feat(agent-picker): install ribbon green instead of yellow (forward action, not warning)
+
+
 ## 0.38.14 — 2026-05-26
 
 - (no semantic content — internal portable-build counter increment from `task package`; the build itself failed mid-Vite-transpile from an SCSS import error introduced by #1069, so the bump landed without a portable; #1072 fixes the import. Backfilled to satisfy the release-consistency invariant)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.38.14",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.38.14",
+      "version": "0.39.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.38.14",
+  "version": "0.39.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes 41 pending changesets across the editor / browser / menu / floating-pane / build areas. Highest-bump-tier across the queue was `minor` (feature work), so 0.38.14 → **0.39.0**.

## Headline changes since v0.38.14

- **Editor pane**: file-tree explorer with multi-root support, resize handle, icon-as-toggle, full-path title, per-pane zoom, LSP Phase 1 (TypeScript diagnostics), multi-file tabs Phase 1 (preview + pinned), binary-file guard
- **Browser pane**: multi-tab Phase 1A slice scaffolding (no UI yet)
- **Menu hover perf**: pane-rect intersection short-circuit, rAF coalescing, `bRedraw=FALSE` + async paint, dropped `class` observation (discussion #1097 fixes 1+2+3+5)
- **Menu positioning framework**: `useMenuPosition` primitive across FlyoutMenu/Popover/More/TokenBreakdownPopover + paintable-area-aware boundary + CI gate
- **Floating panes**: Phase 2 real block renderer, Phase 3 tear-off, window-drag-label fix
- **Build**: `task package` auto-appends VERSION_HISTORY, monotonic auto-bump
- **Slice-store work**: editor-pane-state (#10), browser-pane-state extension (Phase 1A)
- **Workspace tabs**: editor-style sizing + ellipsis
- **Empty-tab panel**: user@host + version line
- **Agent UI polish**: composer status strip, install ribbon green

## Test plan

- [x] All five version locations agree at 0.39.0 (`bump verify`)
- [ ] CI green on this branch
- [ ] After merge: tag `v0.39.0` on GitHub, run `task package` for portable

🤖 Generated with [Claude Code](https://claude.com/claude-code)