### PR TITLE
chore: bump version to v0.39.1 (portable build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.39.0"
+version = "0.39.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,10 @@
 # AgentMux Version History
 
+## 0.39.1 — 2026-05-27
+
+- (no semantic content — internal portable-build counter increment from `task package`; auto-appended by `scripts/bump-wrapper.sh` to satisfy the release-consistency invariant)
+
+
 ## 0.39.0 — 2026-05-27
 
 - docs(menu): spec for menu positioning framework + paintable-area guard

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Auto-bump from `task package` — the bump is required because the portable artifact carries its version in the binary + data-dir path, so v0.39.0 portable would collide with the in-tree v0.39.0 codebase.

This is the standard portable-release pattern: every `task package` advances the counter. The portable `agentmux-0.39.1-x64-portable.zip` (172 MB) will be uploaded to the v0.39.1 GitHub release after this merges.

Note: v0.39.0 release tag (created earlier) will be deleted — the v0.39.0 → v0.39.1 gap is a single `chore: bump` with no semantic content (no changesets), so the v0.39.0 tag would be confusing (release-with-no-asset vs release-with-asset). Replacing with v0.39.1.

Single `chore` commit, no semantic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)