### PR TITLE
feat(agents): instance_get_by_name reads from db_agents (Phase 3b.2)

### DIFF
--- a/.changesets/1779943493-feat-agents-instance-get-by-name-reads-from-db-agents-phase--chhf.md
+++ b/.changesets/1779943493-feat-agents-instance-get-by-name-reads-from-db-agents-phase--chhf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agents): instance_get_by_name reads from db_agents (Phase 3b.2)

--- a/agentmux-srv/src/backend/storage/agents_consolidate.rs
+++ b/agentmux-srv/src/backend/storage/agents_consolidate.rs
@@ -358,6 +358,22 @@ pub fn run_consolidate_migration(
             } else {
                 inst.instance_name.clone()
             };
+            // Stamp `updated_at` with the folded instance's
+            // `created_at` (its launch moment). Without this, the
+            // backfill UPDATE leaves `updated_at` as whatever the
+            // def's edit time was — which makes `db_agents.updated_at`
+            // useless as a "most-recently-used" sort key for migrated
+            // stores, breaking the ordering invariant that the live
+            // dual-write (`agents_dual_write_instance_insert`) maintains
+            // for new launches. Codex P2 on PR #1110 — surfaced via the
+            // first read-flip (`instance_get_by_name`) ordering by
+            // `updated_at DESC`.
+            //
+            // The loop iterates `ORDER BY i.created_at DESC`, so the
+            // FIRST instance per def_id is the most recent, and that's
+            // the one whose `created_at` we want imprinted as
+            // `updated_at`. Collision warns skip subsequent rows for
+            // the same def.
             tx.execute(
                 "UPDATE db_agents SET
                     name = ?1,
@@ -366,8 +382,9 @@ pub fn run_consolidate_migration(
                     working_directory = ?4,
                     github_context = ?5,
                     instance_name = ?6,
-                    user_hidden = ?7
-                 WHERE id = ?8 AND is_template = 0",
+                    user_hidden = ?7,
+                    updated_at = MAX(updated_at, ?8)
+                 WHERE id = ?9 AND is_template = 0",
                 params![
                     name,
                     inst.identity_id,
@@ -376,6 +393,7 @@ pub fn run_consolidate_migration(
                     inst.github_context,
                     inst.instance_name,
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
+                    inst.created_at,
                     inst.definition_id,
                 ],
             )?;
@@ -637,6 +655,81 @@ mod tests {
             )
             .unwrap();
         assert_eq!(identity, "id-RECENT", "most-recent instance's bindings must win");
+    }
+
+    #[test]
+    fn fold_into_user_clone_stamps_updated_at_from_instance_created_at() {
+        // Codex P2 on PR #1110: ordering `db_agents` by `updated_at`
+        // would misbehave on migrated stores if the fold UPDATE
+        // didn't write `updated_at`. After the fix, the folded
+        // user-clone row's `updated_at` equals the most-recent
+        // instance's `created_at` (the launch moment), not the def's
+        // edit time — matching what the live dual-write
+        // (`agents_dual_write_instance_insert`) stamps for new
+        // launches.
+        let mut conn = fresh_conn();
+        // Def created at t=1000 (insert_def uses ?4 for both
+        // created_at and updated_at).
+        insert_def(&conn, "tpl-1", "Coder", 1, "");
+        insert_def(&conn, "def-u1", "User Coder", 0, "tpl-1");
+        // Instance launched at t=5000 — later than the def.
+        insert_instance(
+            &conn, "inst-1", "def-u1", "Maks", "id-1", "mem-1", "/wd/m", 5000, false,
+        );
+
+        run_consolidate_migration(&mut conn, None).unwrap();
+
+        let updated_at: i64 = conn
+            .query_row(
+                "SELECT updated_at FROM db_agents WHERE id = 'def-u1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            updated_at, 5000,
+            "folded user-clone row's updated_at must reflect the instance's launch time, \
+             not the def's edit time, so ORDER BY updated_at picks the right row"
+        );
+    }
+
+    #[test]
+    fn fold_into_user_clone_keeps_higher_updated_at() {
+        // MAX(updated_at, ?) semantics: if the def was edited AFTER
+        // the instance launched, the def's edit time should stay as
+        // updated_at (the def edit IS the most-recent touch).
+        let mut conn = fresh_conn();
+        insert_def(&conn, "tpl-1", "Coder", 1, "");
+        // Def edited at t=8000.
+        conn.execute(
+            "UPDATE db_agent_definitions SET updated_at = 8000 WHERE id = 'tpl-1'",
+            [],
+        )
+        .unwrap();
+        insert_def(&conn, "def-u1", "User Coder", 0, "tpl-1");
+        conn.execute(
+            "UPDATE db_agent_definitions SET updated_at = 8000 WHERE id = 'def-u1'",
+            [],
+        )
+        .unwrap();
+        // Now insert an OLDER instance.
+        insert_instance(
+            &conn, "inst-1", "def-u1", "Maks", "id-1", "mem-1", "/wd/m", 3000, false,
+        );
+
+        run_consolidate_migration(&mut conn, None).unwrap();
+
+        let updated_at: i64 = conn
+            .query_row(
+                "SELECT updated_at FROM db_agents WHERE id = 'def-u1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            updated_at, 8000,
+            "later def edit beats older instance launch — MAX(updated_at, inst.created_at)"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -2213,11 +2213,30 @@ impl Store {
         Ok(out)
     }
 
-    /// Look up the most recent (by `started_at`) named instance that
-    /// matches the given `instance_name`. Used by the launch modal to
-    /// detect name collisions ("did you mean to continue?") and by
-    /// `ContinueNamedAgentCommand` to resolve the canonical row when
-    /// the caller only knows the name. Hidden rows are excluded.
+    /// Look up the canonical named-agent row matching `instance_name`.
+    /// Used by the launch modal to detect name collisions ("did you
+    /// mean to continue?") and by `ContinueNamedAgentCommand` to
+    /// resolve the consolidated row when the caller only knows the
+    /// name. Hidden rows are excluded.
+    ///
+    /// Phase 3b.2: reads from the consolidated `db_agents` table —
+    /// `is_template = 0` (named user agent), `instance_name` matches,
+    /// `user_hidden = 0`. Continuation chains are pre-collapsed in
+    /// `db_agents` (one row per logical agent), so this returns the
+    /// canonical agent regardless of how many launches its chain has.
+    /// MRU tiebreak is by `updated_at` (the dual-write touches it on
+    /// every continuation), then `created_at` for stable order.
+    ///
+    /// The legacy `db_agent_instances` carried per-launch runtime
+    /// state (`block_id`, `session_id`, `status`, `started_at`,
+    /// `ended_at`, `parent_instance_id`) that has no analog in
+    /// `db_agents` — those fields are returned as their `AgentInstance`
+    /// defaults (empty strings, 0). Callers wanting transient state
+    /// should consult runtime sources (the controller, the block
+    /// row); none of the documented use cases need it (collision
+    /// detection only cares about identity / cwd; ContinueNamed only
+    /// cares about `id` + bindings).
+    /// Spec: docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md §3b.
     pub fn instance_get_by_name(
         &self,
         instance_name: &str,
@@ -2226,18 +2245,46 @@ impl Store {
             return Ok(None);
         }
         let conn = self.conn.lock().unwrap();
+        // `definition_id` mapping: db_agents folds the def and the
+        // user-clone instance into ONE row (keyed by def.id) for
+        // is_seeded=0 agents. For seeded-template projections,
+        // parent_template_id points at the template. Either way, the
+        // consolidated row's "definition" is `COALESCE(parent_template_id,
+        // id)` — the legacy `definition_id` semantics from the caller's
+        // perspective. Empty parent_template_id (folded user-clone)
+        // resolves to the row's own id.
         let mut stmt = conn.prepare(
-            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at,
+            "SELECT id,
+                    CASE WHEN parent_template_id = '' THEN id ELSE parent_template_id END AS def_id,
+                    github_context, created_at,
                     identity_id, memory_id, instance_name, working_directory,
-                    display_hidden
-             FROM db_agent_instances
+                    user_hidden
+             FROM db_agents
              WHERE instance_name = ?1
-               AND display_hidden = 0
-             ORDER BY started_at DESC
+               AND is_template = 0
+               AND user_hidden = 0
+             ORDER BY updated_at DESC, created_at DESC
              LIMIT 1",
         )?;
-        let result = stmt.query_row(params![instance_name], map_instance_row);
+        let result = stmt.query_row(params![instance_name], |row| {
+            Ok(AgentInstance {
+                id: row.get(0)?,
+                definition_id: row.get(1)?,
+                parent_instance_id: String::new(),
+                block_id: String::new(),
+                session_id: String::new(),
+                status: String::new(),
+                github_context: row.get(2)?,
+                started_at: row.get(3)?, // created_at — best proxy for the consolidated row
+                ended_at: 0,
+                created_at: row.get(3)?,
+                identity_id: row.get(4)?,
+                memory_id: row.get(5)?,
+                instance_name: row.get(6)?,
+                working_directory: row.get(7)?,
+                display_hidden: row.get::<_, i64>(8)? != 0,
+            })
+        });
         match result {
             Ok(a) => Ok(Some(a)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -4426,6 +4473,99 @@ mod tests {
             "five-row chain (1 head + 4 continuations) must collapse to one entry"
         );
         assert_eq!(picker_rows[0].id, "c4", "newest continuation wins");
+    }
+
+    #[test]
+    fn instance_get_by_name_reads_from_db_agents() {
+        // Phase 3b.2 — the consolidated `db_agents` table is the new
+        // authority for named-agent lookups. After `instance_create`'s
+        // dual-write, the helper must surface the agent by name with
+        // the bindings populated from `db_agents`. Transient runtime
+        // fields (block_id, session_id, status, started_at as launch
+        // moment, ended_at, parent_instance_id) have no analog in the
+        // consolidated row and come back as their type defaults.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let mut head = make_named_inst("inst-1", "Maks", &agents_root);
+        head.identity_id = "id-1".to_string();
+        head.memory_id = "mem-1".to_string();
+        head.github_context = "ghctx".to_string();
+        store.instance_create(&head).unwrap();
+
+        let got = store
+            .instance_get_by_name("Maks")
+            .unwrap()
+            .expect("should find by name");
+        // Folded user-clone: the def and the instance share ONE
+        // db_agents row keyed by def.id (def-mirror is_seeded=0 in
+        // the test fixture). The caller still sees `definition_id`
+        // populated — via the COALESCE in the query, an empty
+        // parent_template_id resolves to the row's own id.
+        assert_eq!(got.id, "def-mirror");
+        assert_eq!(got.definition_id, "def-mirror");
+        assert_eq!(got.instance_name, "Maks");
+        assert_eq!(got.identity_id, "id-1");
+        assert_eq!(got.memory_id, "mem-1");
+        assert_eq!(got.github_context, "ghctx");
+        assert!(!got.display_hidden);
+        // Transient fields default to empty / 0 — see doc comment.
+        assert_eq!(got.parent_instance_id, "");
+        assert_eq!(got.block_id, "");
+        assert_eq!(got.session_id, "");
+        assert_eq!(got.status, "");
+        assert_eq!(got.ended_at, 0);
+    }
+
+    #[test]
+    fn instance_get_by_name_returns_none_for_missing_name() {
+        let (_tmp, store, _reg) = store_with_registry();
+        assert!(store.instance_get_by_name("does-not-exist").unwrap().is_none());
+    }
+
+    #[test]
+    fn instance_get_by_name_excludes_hidden_rows() {
+        // user_hidden = 1 (via display_hidden) must filter out — both
+        // the launch modal collision detect and ContinueNamed depend
+        // on "forgotten" agents being invisible.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let mut inst = make_named_inst("inst-hidden", "Ghost", &agents_root);
+        inst.display_hidden = true;
+        store.instance_create(&inst).unwrap();
+        assert!(store.instance_get_by_name("Ghost").unwrap().is_none());
+    }
+
+    #[test]
+    fn instance_get_by_name_empty_input_returns_none() {
+        let (_tmp, store, _reg) = store_with_registry();
+        assert!(store.instance_get_by_name("").unwrap().is_none());
+    }
+
+    #[test]
+    fn instance_get_by_name_collapses_continuation_chain_to_one_row() {
+        // Continuations live in `db_agent_instances` (each launch =
+        // one row). The Phase 3a dual-write projects them into ONE
+        // canonical row in `db_agents` (keyed on the original head's
+        // id, with bindings updated each continuation). So a 4-deep
+        // chain with the same name surfaces as exactly one row here —
+        // no MRU-row tie-breaking needed at this layer.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head", "Maks", &agents_root);
+        store.instance_create(&head).unwrap();
+
+        let mut cont = make_named_inst("inst-cont", "Maks", &agents_root);
+        cont.parent_instance_id = "inst-head".to_string();
+        store.instance_create(&cont).unwrap();
+
+        let got = store.instance_get_by_name("Maks").unwrap().expect("found");
+        // Only one db_agents row exists for the whole chain (the
+        // folded user-clone row keyed by def-mirror); both
+        // continuations updated its bindings.
+        assert_eq!(got.id, "def-mirror");
+        assert_eq!(got.instance_name, "Maks");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -2703,13 +2703,15 @@ impl Store {
     /// Its template-config fields are copied from the parent definition;
     /// `parent_template_id` points at that definition.
     ///
-    /// Continuation rows (`parent_instance_id` non-empty) are skipped —
-    /// they're not "agents" in the new model, they're a vestigial
-    /// pre-Option-E continuation chain that the consolidation retires.
+    /// Continuations (`parent_instance_id` non-empty) mirror their
+    /// new bindings into the chain's existing `db_agents` row rather
+    /// than creating a separate one. The chain root is resolved via
+    /// `agents_projection_key_for_inst`. Codex P2 on PR #1110 — without
+    /// this, a named-agent rebind (continue with different identity,
+    /// memory, cwd, or github context) never reaches the consolidated
+    /// row and Phase 3b readers see stale data.
     pub(crate) fn agents_dual_write_instance_create(&self, inst: &AgentInstance) -> Result<(), StoreError> {
-        if !inst.parent_instance_id.is_empty() {
-            return Ok(());
-        }
+        let is_continuation = !inst.parent_instance_id.is_empty();
         let conn = self.conn.lock().unwrap();
         // Pull the parent definition for the cmd-config fields.
         let def = match Self::load_definition_for_dual_write(&conn, &inst.definition_id)? {
@@ -2743,25 +2745,18 @@ impl Store {
         // `parent_template_id = def.id` (which would point at a
         // non-template row and produce a shape inconsistent with what
         // backfill produced for identical data).
-        let res = if def.is_seeded == 0 {
-            // Reagent P2 round 3 on #1013: don't write `inst.created_at`
-            // here — the user-clone def may already have a fresher
-            // `updated_at` from a prior `agent_def_update` (e.g. user
-            // renamed the agent after first launch). Wall-clock now()
-            // is the right monotonic stamp (matches what
-            // `agents_dual_write_instance_update` writes on subsequent
-            // touches). Avoids Phase 3b readers sorting on a regressed
-            // timestamp.
-            //
-            // Phase 3b: also bump strictly past the table's GLOBAL
-            // `MAX(updated_at)` so that successive fast-fire launches
-            // (e.g. a rapid relaunch after a crash, or tests that drive
-            // the store in-memory) end up with a strict total order on
-            // the sort key. Per-row floor isn't enough: two distinct
-            // defs touched in the same millisecond would tie. SQLite
-            // millisecond resolution on Windows collides under fast
-            // test loops; the table-wide max is the only monotonic
-            // floor we can use without adding a column.
+        // Monotonic-bump helper. See the original comment below for
+        // the full reasoning; extracted into a closure so both the
+        // user-clone path and the new continuation-mirror path can
+        // reuse it. Successive fast-fire launches (e.g. test loops on
+        // Windows millisecond-resolution clocks) need the strict
+        // global ordering to survive ORDER BY updated_at.
+        //
+        // Reagent P2 round 3 on #1013: don't write `inst.created_at`
+        // here — the user-clone def may already have a fresher
+        // `updated_at` from a prior `agent_def_update`. Wall-clock
+        // now() is the right monotonic stamp.
+        let now_ms = {
             let wall_now: i64 = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as i64)
@@ -2773,7 +2768,14 @@ impl Store {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap_or(0);
-            let now_ms = std::cmp::max(wall_now, global_prior.saturating_add(1));
+            std::cmp::max(wall_now, global_prior.saturating_add(1))
+        };
+
+        let res = if def.is_seeded == 0 {
+            // User-clone def — one db_agents row per def, keyed by
+            // def.id. Continuations and head launches both UPDATE the
+            // same row. (The chain's identity has nothing to do with
+            // which row gets touched here; it's always def.id.)
             conn.execute(
                 "UPDATE db_agents SET
                     name = ?2,
@@ -2797,7 +2799,49 @@ impl Store {
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
                 ],
             )
+        } else if is_continuation {
+            // Template-instance continuation — UPDATE the chain head's
+            // row with the new bindings. The head's id is found via
+            // `agents_projection_key_for_inst` (which walks parent
+            // _instance_id up to the root). No new row is created;
+            // there's exactly one db_agents row per logical agent.
+            // Codex P2 on PR #1110.
+            let root_id = match Self::agents_projection_key_for_inst(&conn, &inst.id) {
+                Some((k, _)) => k,
+                None => {
+                    tracing::warn!(
+                        instance_id = %inst.id,
+                        parent_instance_id = %inst.parent_instance_id,
+                        "db_agents dual-write: continuation chain has no resolvable root; skipping mirror",
+                    );
+                    return Ok(());
+                }
+            };
+            conn.execute(
+                "UPDATE db_agents SET
+                    name = ?2,
+                    identity_id = ?3,
+                    memory_id = ?4,
+                    working_directory = ?5,
+                    github_context = ?6,
+                    instance_name = ?7,
+                    updated_at = ?8,
+                    user_hidden = ?9
+                 WHERE id = ?1 AND is_template = 0",
+                params![
+                    root_id,
+                    name,
+                    inst.identity_id,
+                    inst.memory_id,
+                    inst.working_directory,
+                    inst.github_context,
+                    inst.instance_name,
+                    now_ms,
+                    if inst.display_hidden { 1_i64 } else { 0_i64 },
+                ],
+            )
         } else {
+            // Template-instance head — INSERT a new row keyed by inst.id.
             conn.execute(
                 "INSERT INTO db_agents (
                     id, name, icon, description,
@@ -2866,10 +2910,13 @@ impl Store {
     /// only the fields that `instance_update` writes (block + session +
     /// status + github_context + ended_at) — name/bindings come from
     /// the original create.
+    ///
+    /// Continuations flow through here too — `agents_projection_key_for_inst`
+    /// walks up the chain to the head's id, so a continuation's
+    /// `github_context` refresh lands on the canonical row (codex P2 on
+    /// PR #1110, paired with the create-path fix in
+    /// `agents_dual_write_instance_create`).
     pub(crate) fn agents_dual_write_instance_update(&self, inst: &AgentInstance) -> Result<(), StoreError> {
-        if !inst.parent_instance_id.is_empty() {
-            return Ok(());
-        }
         let conn = self.conn.lock().unwrap();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3019,20 +3066,44 @@ impl Store {
         conn: &Connection,
         inst_id: &str,
     ) -> Option<(String, bool)> {
+        // Codex P2 on PR #1110: continuations of template-instances
+        // must resolve to the chain HEAD's id, not the continuation's
+        // own id — there's exactly one db_agents row per logical
+        // agent, keyed by the head. Walk up `parent_instance_id` via
+        // a recursive CTE; the row whose parent is `''` (or whose
+        // parent no longer exists) is the root.
+        //
+        // For user-clone defs (`is_seeded = 0`) the projection key is
+        // the def.id regardless of where in the chain we are — the
+        // existing one-row-per-def behavior is unchanged. Only the
+        // is_seeded=1 (template) branch needs the chain walk.
         conn.query_row(
-            "SELECT i.id, i.definition_id, COALESCE(d.is_seeded, 1) AS is_seeded
-             FROM db_agent_instances i
-             LEFT JOIN db_agent_definitions d ON i.definition_id = d.id
-             WHERE i.id = ?1",
+            "WITH RECURSIVE chain(id, parent_instance_id, definition_id) AS (
+                SELECT id, parent_instance_id, definition_id
+                FROM db_agent_instances WHERE id = ?1
+                UNION ALL
+                SELECT p.id, p.parent_instance_id, p.definition_id
+                FROM db_agent_instances p
+                JOIN chain c ON p.id = c.parent_instance_id
+             )
+             SELECT c.id, c.definition_id, COALESCE(d.is_seeded, 1) AS is_seeded
+             FROM chain c
+             LEFT JOIN db_agent_definitions d ON c.definition_id = d.id
+             WHERE c.parent_instance_id = ''
+                OR NOT EXISTS (
+                    SELECT 1 FROM db_agent_instances q
+                    WHERE q.id = c.parent_instance_id
+                )
+             LIMIT 1",
             params![inst_id],
             |row| {
-                let id: String = row.get(0)?;
+                let root_id: String = row.get(0)?;
                 let def_id: String = row.get(1)?;
                 let is_seeded: i64 = row.get(2)?;
                 Ok(if is_seeded == 0 {
-                    (def_id, true)  // folded into def-projection
+                    (def_id, true)      // folded into def-projection
                 } else {
-                    (id, false)     // instance-projection in its own row
+                    (root_id, false)    // chain head's row
                 })
             },
         ).ok()
@@ -4540,6 +4611,43 @@ mod tests {
     fn instance_get_by_name_empty_input_returns_none() {
         let (_tmp, store, _reg) = store_with_registry();
         assert!(store.instance_get_by_name("").unwrap().is_none());
+    }
+
+    #[test]
+    fn continuation_mirrors_bindings_into_db_agents_user_clone_path() {
+        // Codex P2 on PR #1110: when a named agent is continued with
+        // different identity/memory/cwd/github_context, those bindings
+        // must reach db_agents — otherwise `instance_get_by_name`
+        // (which reads from db_agents) returns the head's stale data.
+        // For user-clone defs (is_seeded=0), the projection is keyed
+        // by def.id and the existing UPDATE handles both head and
+        // continuation.
+        let (tmp, store, _reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        // Original launch with one set of bindings.
+        let mut head = make_named_inst("inst-head", "Maks", &agents_root);
+        head.identity_id = "id-original".to_string();
+        head.memory_id = "mem-original".to_string();
+        store.instance_create(&head).unwrap();
+
+        // Continuation with NEW bindings.
+        let mut cont = make_named_inst("inst-cont", "Maks", &agents_root);
+        cont.parent_instance_id = "inst-head".to_string();
+        cont.identity_id = "id-NEW".to_string();
+        cont.memory_id = "mem-NEW".to_string();
+        cont.github_context = "ghctx-NEW".to_string();
+        store.instance_create(&cont).unwrap();
+
+        // The folded db_agents row reflects the continuation's bindings.
+        let got = store.instance_get_by_name("Maks").unwrap().expect("found");
+        assert_eq!(got.id, "def-mirror");
+        assert_eq!(
+            got.identity_id, "id-NEW",
+            "continuation bindings must overwrite the head's"
+        );
+        assert_eq!(got.memory_id, "mem-NEW");
+        assert_eq!(got.github_context, "ghctx-NEW");
     }
 
     #[test]

--- a/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
+++ b/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
@@ -127,13 +127,16 @@ All in `wstore.rs` (2372–2881). Each fires after the corresponding legacy writ
 
 Suggested PR carving (one per row, ~30-80 LOC + tests each):
 
-| Sub-PR | Read path migrated | Risk | Notes |
-|---|---|---|---|
-| 3b.1 | `instance_list_named` → `db_agents WHERE is_template=0` with MRU-first ordering | Low — already grouped by definition in `db_agents` | **Fixes the "4 Claudes" bug as a side effect.** Ship first for user-visible win. |
-| 3b.2 | `instance_get_by_name` → `db_agents WHERE name=? AND is_template=0` | Low | One-row lookup. |
-| 3b.3 | `instance_get` / `instance_list` → `db_agents` (with `is_template=0` filter) | Medium | Many callers; need a compatibility shim if rough corners surface. |
-| 3b.4 | `instance_get_active_for_block` → block.meta.agentId → `db_agents` | Medium | Block now references agent directly; pull credentials from there. |
-| 3b.5 | `agent_def_get`, `user_clone_defs_for_template`, `agent_def_delete_seeded` | Low | Internal helpers — straightforward. |
+| Sub-PR | Read path migrated | Risk | Status | Notes |
+|---|---|---|---|---|
+| 3b.1a | `instance_list_named` picker dedup via CTE on legacy table | Low | ✅ shipped PR #1096 | **Fixes the "4 Claudes" bug.** Reads still come from `db_agent_instances` — see 3b.1b. |
+| 3b.1b | `instance_list_named` → `db_agents` (true flip) | Medium | ⏳ pending | Splitting from 3b.1a: the dedup-via-CTE shipped first to fix the user-visible bug; the actual read flip is deferred until per-launch fields (block_id/session_id/status/started_at/ended_at) have a defined story for callers like `listrecentsessions`. |
+| 3b.2 | `instance_get_by_name` → `db_agents WHERE is_template=0` | Low | ✅ shipped (this PR) | One-row lookup. Function had **zero callers** in the live tree, so blast radius nil. COALESCE on `parent_template_id` resolves the folded user-clone case. |
+| 3b.3 | `instance_get` / `instance_list` → `db_agents` (with `is_template=0` filter) | Medium | ⏳ pending | Many callers; need a compatibility shim if rough corners surface. |
+| 3b.4 | `instance_get_active_for_block` → block.meta.agentId → `db_agents` | Medium | ⏳ pending | Block now references agent directly; pull credentials from there. |
+| 3b.5 | `agent_def_get`, `user_clone_defs_for_template`, `agent_def_delete_seeded` | Low | ⏳ pending | Internal helpers — straightforward. |
+
+**Correction (2026-05-28):** the original 3b.1 row above conflated two pieces of work — the user-visible dedup fix (CTE on the legacy table) and the actual read flip to `db_agents`. PR #1096 shipped the first; the second became 3b.1b. The "true flip" rows (3b.1b, 3b.2, 3b.3, 3b.4) are the only ones that change which table the SQL `FROM` clause names.
 
 Each sub-PR: read swap + targeted handler test that asserts the new behavior + smoke test against the existing handler's existing tests (no regressions). Use feature flag `AGENTMUX_PHASE_3B=1` if any sub-PR needs to dark-launch.
 


### PR DESCRIPTION
## Summary

First true read-flip of an agent storage path under Phase 3b of the consolidation plan ([SPEC_AGENT_ARCHITECTURE_2026_05_27.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md)).

`instance_get_by_name` now reads from the consolidated `db_agents` table (filtered on `is_template = 0` AND `user_hidden = 0`) instead of legacy `db_agent_instances`. Function had **zero callers** in the live tree, so this is a safe place to land the new shape for upcoming callers (launch-modal collision detect, ContinueNamedAgentCommand).

Tracking discussion: **#1095**.

## Mapping highlights

- `definition_id` ← `COALESCE(NULLIF(parent_template_id, ''), id)`. Folded user-clones (`is_seeded = 0`) share ONE db_agents row keyed by def.id with empty `parent_template_id`; the COALESCE resolves to the row's own id, preserving the legacy `inst.definition_id` semantics for both folded and template-instance projections.
- Continuation chains **pre-collapse** in db_agents (the dual-write folds successive launches under the chain head's row), so no MRU tie-break is needed at this layer — one row per logical agent.
- Transient per-launch fields (`block_id`, `session_id`, `status`, `started_at` as launch moment, `ended_at`, `parent_instance_id`) have no analog in db_agents and come back as type defaults. None of the documented callers touch these.

## Spec correction

The 3b.1 row was conflated work — PR #1096 shipped CTE-dedup on the legacy table (the "4 Claudes" fix) but didn't actually flip the `FROM` clause to `db_agents`. Split into:

- **3b.1a** ✅ shipped #1096 — CTE dedup (user-facing bug fix)
- **3b.1b** ⏳ pending — true read flip (needs a story for the transient per-launch fields `listrecentsessions` consumes)

Only "true flips" count toward the migration goal of dropping the legacy tables in 3c.

## Test plan

- [x] `cargo test -p agentmux-srv --release instance_get_by_name` — 5/5 pass
- [x] `cargo test -p agentmux-srv --release instance` — 39/39 pass (no regression in adjacent instance_* tests)
- [ ] reagent + codex pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)