### PR TITLE
feat(floating-pane): MVP re-dock — drop floater over agentmux window

### DIFF
--- a/.changesets/1779902149-feat-floating-pane-mvp-re-dock-drop-floater-over-agentmux-wi-xrs6.md
+++ b/.changesets/1779902149-feat-floating-pane-mvp-re-dock-drop-floater-over-agentmux-wi-xrs6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(floating-pane): MVP re-dock — drop floater over agentmux window to redock its block

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -451,8 +451,13 @@ pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Res
 /// the answer is another agentmux window in the same process,
 /// kicks off `RedockFloatingPane`.
 ///
-/// Args: `{ "x": int, "y": int }` — cursor position in physical px
-/// (whatever `get_cursor_point` returned).
+/// Args: `{ "x": int, "y": int, "exclude_label": string|null }` —
+/// cursor position in physical px (whatever `get_cursor_point`
+/// returned). `exclude_label` is the source floater's label; without
+/// it, `WindowFromPoint` returns the floater itself (the floater
+/// follows the cursor during drag, so it's always at the cursor in
+/// Z-order). We walk top-levels in Z-order from front to back and
+/// return the first match that ISN'T the excluded source.
 ///
 /// Returns: `{ "label": string|null, "window_id": string|null }`. Both
 /// null means no agentmux window of this process is under the cursor
@@ -470,50 +475,91 @@ pub fn resolve_window_at_cursor(
 ) -> Result<serde_json::Value, String> {
     let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let exclude_label = args
+        .get("exclude_label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
 
     #[cfg(target_os = "windows")]
     unsafe {
-        use windows_sys::Win32::Foundation::POINT;
+        use windows_sys::Win32::Foundation::{POINT, RECT};
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
         use windows_sys::Win32::UI::WindowsAndMessaging::{
-            GetAncestor, WindowFromPoint, GA_ROOT,
+            GetTopWindow, GetWindow, GetWindowLongW, GetWindowRect, GetWindowThreadProcessId,
+            IsWindowVisible, GWL_EXSTYLE, GW_HWNDNEXT, WS_EX_TRANSPARENT,
         };
 
-        let pt = POINT { x, y };
-        let mut hwnd = WindowFromPoint(pt);
-        if hwnd.is_null() {
-            return Ok(serde_json::json!({ "label": null, "window_id": null }));
-        }
-        // Walk to the top-level root — `WindowFromPoint` returns the
-        // deepest child window at the point, but we want the top-level
-        // owner for the label lookup.
-        let root = GetAncestor(hwnd, GA_ROOT);
-        if !root.is_null() {
-            hwnd = root;
-        }
-        let hwnd_isize = hwnd as isize;
-
-        // Reverse-lookup label in the per-label HWND cache populated
-        // by `capture_hwnd_for_label`. Same cache that
-        // `resolve_window_hwnd` consults — keeps both directions in
-        // sync.
-        let label = {
-            let map = state.window_hwnds.lock();
-            map.iter()
-                .find_map(|(k, v)| if *v == hwnd_isize { Some(k.clone()) } else { None })
+        // Snapshot the label↔HWND map once, then walk top-level
+        // windows in Z-order (front to back) until we find a visible
+        // same-process window whose rect contains the cursor AND
+        // whose label isn't the excluded source.
+        let hwnds_by_label: std::collections::HashMap<String, isize> = {
+            state.window_hwnds.lock().clone()
+        };
+        // Reverse map for O(1) HWND → label lookup.
+        let label_by_hwnd: std::collections::HashMap<isize, String> = hwnds_by_label
+            .iter()
+            .map(|(k, v)| (*v, k.clone()))
+            .collect();
+        let exclude_hwnd: Option<isize> = if exclude_label.is_empty() {
+            None
+        } else {
+            hwnds_by_label.get(exclude_label).copied()
         };
 
-        match label {
-            Some(l) => {
-                let wid = state.backend_window_id(&l);
-                Ok(serde_json::json!({ "label": l, "window_id": wid }))
+        let our_pid = GetCurrentProcessId();
+        let mut hwnd = GetTopWindow(std::ptr::null_mut());
+        while !hwnd.is_null() {
+            if IsWindowVisible(hwnd) != 0 {
+                let mut window_pid: u32 = 0;
+                GetWindowThreadProcessId(hwnd, &mut window_pid);
+                if window_pid == our_pid {
+                    let h_isize = hwnd as isize;
+                    let is_excluded = exclude_hwnd == Some(h_isize);
+                    // Skip click-through / transparent windows
+                    // (defensive — agentmux doesn't currently create
+                    // any, but we don't want a hypothetical overlay
+                    // to swallow the hit-test).
+                    let ex_style = GetWindowLongW(hwnd, GWL_EXSTYLE) as u32;
+                    let is_transparent = (ex_style & WS_EX_TRANSPARENT) != 0;
+                    if !is_excluded && !is_transparent {
+                        let mut rect: RECT = std::mem::zeroed();
+                        if GetWindowRect(hwnd, &mut rect) != 0
+                            && x >= rect.left
+                            && x < rect.right
+                            && y >= rect.top
+                            && y < rect.bottom
+                        {
+                            if let Some(label) = label_by_hwnd.get(&h_isize) {
+                                let wid = state.backend_window_id(label);
+                                return Ok(serde_json::json!({
+                                    "label": label,
+                                    "window_id": wid,
+                                }));
+                            }
+                            // Found a window we own but it isn't in
+                            // window_hwnds yet (very early startup or
+                            // a window we don't track). Treat as "no
+                            // agentmux match" and continue Z-order
+                            // walk in case a tracked window sits
+                            // behind it.
+                        }
+                    }
+                }
             }
-            None => Ok(serde_json::json!({ "label": null, "window_id": null })),
+            hwnd = GetWindow(hwnd, GW_HWNDNEXT);
+            // Bound the walk defensively against EnumWindow loops on
+            // pathological window managers (shouldn't happen on Win32
+            // but cheap).
+            let _ = POINT { x, y };
         }
+        let _ = exclude_label;
+        Ok(serde_json::json!({ "label": null, "window_id": null }))
     }
 
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = (state, args, x, y);
+        let _ = (state, args, x, y, exclude_label);
         Ok(serde_json::json!({ "label": null, "window_id": null }))
     }
 }

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -484,7 +484,7 @@ pub fn resolve_window_at_cursor(
 
     #[cfg(target_os = "windows")]
     unsafe {
-        use windows_sys::Win32::Foundation::{POINT, RECT};
+        use windows_sys::Win32::Foundation::RECT;
         use windows_sys::Win32::System::Threading::GetCurrentProcessId;
         use windows_sys::Win32::UI::WindowsAndMessaging::{
             GetTopWindow, GetWindow, GetWindowLongW, GetWindowRect, GetWindowThreadProcessId,
@@ -550,10 +550,6 @@ pub fn resolve_window_at_cursor(
                 }
             }
             hwnd = GetWindow(hwnd, GW_HWNDNEXT);
-            // Bound the walk defensively against EnumWindow loops on
-            // pathological window managers (shouldn't happen on Win32
-            // but cheap).
-            let _ = POINT { x, y };
         }
         let _ = exclude_label;
         Ok(serde_json::json!({ "label": null, "window_id": null }))
@@ -567,13 +563,13 @@ pub fn resolve_window_at_cursor(
 }
 
 /// Update the host's "active floating-pane redock hover" state.
-/// Called from the dragged floater's mousemove (throttled) so target
-/// windows can render a highlight overlay while the floater hovers
-/// over them. The host computes the resolved target via the same
-/// Z-order walk as `resolve_window_at_cursor` (with the dragged
-/// floater excluded), and emits the `floating-redock:hover-state`
-/// event ONLY when the target changes — mousemove fires at high
-/// frequency but the visual highlight only cares about transitions.
+/// Called from the dragged floater's mousemove (throttled ~50ms upstream)
+/// so target windows can render a per-tile drop preview while the floater
+/// hovers over them. The host resolves the target window via the same
+/// Z-order walk as `resolve_window_at_cursor` (with the dragged floater
+/// excluded) and emits `floating-redock:hover-state` on every call —
+/// the target renderer needs the live cursor position to pick which
+/// LEAF the cursor is over (not just transitions between windows).
 ///
 /// Args: `{ "source_label": string, "x": int, "y": int }`. Returns
 /// `{ "target_label": string|null }` for callers that want to
@@ -599,8 +595,6 @@ pub fn update_floating_redock_hover(
         .get("label")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-
-    *state.active_redock_target.lock() = new_target.clone();
 
     // Emit on every call (frontend throttles ~50 ms upstream). The
     // event must carry the cursor position so target renderers can
@@ -629,13 +623,12 @@ pub fn clear_floating_redock_hover(
     state: &Arc<AppState>,
     _args: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    state.active_redock_target.lock().take();
-    // Always emit on clear, even if prev was None. The frontend
-    // listener uses target_label as a sentinel and removing the
-    // placeholder unconditionally on null is cheap; emitting
-    // unconditionally guarantees the cleanup fires even if the
-    // last mousemove resolved to None (cursor over the floater
-    // itself between an in/out boundary) and so `prev` was None.
+    // Always emit, even if no prior hover was active. The frontend
+    // listener uses target_label=null as a teardown sentinel and
+    // removing a non-existent placeholder is a cheap no-op; emitting
+    // unconditionally guarantees cleanup fires even if the last
+    // mousemove resolved to None (cursor over the floater itself
+    // between in/out boundaries).
     crate::events::emit_event_to_top_level_windows(
         state,
         "floating-redock:hover-state",

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -85,17 +85,17 @@ pub fn close_window_by_label(
 
     #[cfg(target_os = "windows")]
     unsafe {
-        use cef::{ImplBrowser, ImplBrowserHost};
         use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-        // Phase H.2.b — reducer-aware lookup with fallback.
-        if let Some(browser) = state.get_browser(&label) {
-            if let Some(host) = browser.host() {
-                let hwnd = host.window_handle();
-                if !hwnd.0.is_null() {
-                    PostMessageW(hwnd.0 as *mut std::ffi::c_void, WM_CLOSE, 0, 0);
-                    return Ok(serde_json::Value::Null);
-                }
-            }
+        // Route through resolve_window_hwnd so we hit the cached OUTER
+        // top-level HWND. The reducer registry returns CEF's inner
+        // WS_CHILD for `set_as_child` browsers (and for floaters our
+        // outer popup HWND is only in the cache), so going straight to
+        // `host.window_handle()` would WM_CLOSE the embedded child —
+        // after a redock that leaves the outer popup as an empty shell.
+        let hwnd = resolve_window_hwnd(state, &label);
+        if !hwnd.is_null() {
+            PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            return Ok(serde_json::Value::Null);
         }
         return Err(format!("no top-level HWND for label {}", label));
     }
@@ -551,7 +551,6 @@ pub fn resolve_window_at_cursor(
             }
             hwnd = GetWindow(hwnd, GW_HWNDNEXT);
         }
-        let _ = exclude_label;
         Ok(serde_json::json!({ "label": null, "window_id": null }))
     }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -627,14 +627,18 @@ pub fn clear_floating_redock_hover(
     state: &Arc<AppState>,
     _args: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let prev = state.active_redock_target.lock().take();
-    if prev.is_some() {
-        crate::events::emit_event_to_top_level_windows(
-            state,
-            "floating-redock:hover-state",
-            &serde_json::json!({ "target_label": serde_json::Value::Null }),
-        );
-    }
+    state.active_redock_target.lock().take();
+    // Always emit on clear, even if prev was None. The frontend
+    // listener uses target_label as a sentinel and removing the
+    // placeholder unconditionally on null is cheap; emitting
+    // unconditionally guarantees the cleanup fires even if the
+    // last mousemove resolved to None (cursor over the floater
+    // itself between an in/out boundary) and so `prev` was None.
+    crate::events::emit_event_to_top_level_windows(
+        state,
+        "floating-redock:hover-state",
+        &serde_json::json!({ "target_label": serde_json::Value::Null }),
+    );
     Ok(serde_json::Value::Null)
 }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -564,6 +564,79 @@ pub fn resolve_window_at_cursor(
     }
 }
 
+/// Update the host's "active floating-pane redock hover" state.
+/// Called from the dragged floater's mousemove (throttled) so target
+/// windows can render a highlight overlay while the floater hovers
+/// over them. The host computes the resolved target via the same
+/// Z-order walk as `resolve_window_at_cursor` (with the dragged
+/// floater excluded), and emits the `floating-redock:hover-state`
+/// event ONLY when the target changes — mousemove fires at high
+/// frequency but the visual highlight only cares about transitions.
+///
+/// Args: `{ "source_label": string, "x": int, "y": int }`. Returns
+/// `{ "target_label": string|null }` for callers that want to
+/// piggyback on this for the resolved target.
+pub fn update_floating_redock_hover(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let source_label = args
+        .get("source_label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let resolve_args = serde_json::json!({
+        "x": args.get("x").cloned().unwrap_or(serde_json::Value::Null),
+        "y": args.get("y").cloned().unwrap_or(serde_json::Value::Null),
+        "exclude_label": source_label,
+    });
+    let resolved = resolve_window_at_cursor(state, &resolve_args)?;
+    let new_target = resolved
+        .get("label")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let prev_target = {
+        let mut guard = state.active_redock_target.lock();
+        let prev = guard.clone();
+        *guard = new_target.clone();
+        prev
+    };
+
+    if prev_target != new_target {
+        let payload = serde_json::json!({
+            "target_label": new_target.clone(),
+            "source_label": source_label,
+        });
+        crate::events::emit_event_to_top_level_windows(
+            state,
+            "floating-redock:hover-state",
+            &payload,
+        );
+    }
+
+    Ok(serde_json::json!({ "target_label": new_target }))
+}
+
+/// Clear the active floating-pane redock hover state. Called from the
+/// dragged floater's mouseup (and any drag-cancel path). Emits the
+/// `floating-redock:hover-state` event with `target_label: null` so
+/// target windows tear down their highlight overlay.
+pub fn clear_floating_redock_hover(
+    state: &Arc<AppState>,
+    _args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let prev = state.active_redock_target.lock().take();
+    if prev.is_some() {
+        crate::events::emit_event_to_top_level_windows(
+            state,
+            "floating-redock:hover-state",
+            &serde_json::json!({ "target_label": serde_json::Value::Null }),
+        );
+    }
+    Ok(serde_json::Value::Null)
+}
+
 /// Set window transparency/blur effects for a single window.
 ///
 /// Targets exactly the window identified by `label` (from the frontend's URL

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -235,11 +235,36 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
     use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, GA_ROOT};
 
     if !label.is_empty() {
-        // 1. Try the CEF reducer registry — works for any label whose
-        //    `host.window_handle()` exposes the OS HWND (notably our
-        //    floating-pane windows created via CreateWindowExW +
-        //    set_as_child). For CEF Views (main window) this returns
-        //    NULL on Win32 and we fall through.
+        // 1. Consult the authoritative per-label HWND cache FIRST —
+        //    populated by `capture_hwnd_for_label` for main / pool /
+        //    tear-off windows AND by `floating_pane.rs` for our own
+        //    owned-popup floaters at create time. The cache stores
+        //    the actual outer top-level HWND we want to act on.
+        //    We MUST NOT walk GA_ROOT on cache hits: the cached value
+        //    is already the top-level we want; walking up could land
+        //    on a different owner (e.g. main, for floaters owned by
+        //    main) and cause `close_window_by_label` to post WM_CLOSE
+        //    to the wrong window.
+        let cached = state.window_hwnds.lock().get(label).copied();
+        if let Some(raw_isize) = cached {
+            let raw = raw_isize as *mut std::ffi::c_void;
+            if !raw.is_null() {
+                tracing::info!(
+                    target: "win-resolve",
+                    label = %label,
+                    cache_hwnd = ?raw,
+                    "[win-resolve] resolved via window_hwnds cache"
+                );
+                return raw;
+            }
+        }
+
+        // 2. Fall back to the CEF reducer registry. This returns
+        //    `host.window_handle()` which on Win32 is usually a
+        //    WS_CHILD inner HWND for `set_as_child` browsers — so we
+        //    DO need GA_ROOT here to walk up to the top-level. Used
+        //    when capture_hwnd_for_label hasn't run yet (very early
+        //    startup) for non-floater labels.
         if let Some(browser) = state.get_browser(label) {
             if let Some(host) = browser.host() {
                 let raw = host.window_handle().0 as *mut std::ffi::c_void;
@@ -251,40 +276,17 @@ unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::f
                         label = %label,
                         host_hwnd = ?raw,
                         root_hwnd = ?resolved,
-                        "[win-resolve] resolved via reducer registry"
+                        "[win-resolve] resolved via reducer registry + GA_ROOT"
                     );
                     return resolved;
                 }
             }
         }
 
-        // 2. Consult the authoritative per-label HWND cache populated
-        //    by `capture_hwnd_for_label` (triggered when the frontend
-        //    signals init-complete via `set_window_init_status`). This
-        //    is the same source `set_window_transparency` uses
-        //    (line 447) and covers the case where `host.window_handle()`
-        //    returns NULL but we'd previously stamped the HWND.
-        let cached = state.window_hwnds.lock().get(label).copied();
-        if let Some(raw_isize) = cached {
-            let raw = raw_isize as *mut std::ffi::c_void;
-            if !raw.is_null() {
-                let root = GetAncestor(raw, GA_ROOT);
-                let resolved = if root.is_null() { raw } else { root };
-                tracing::info!(
-                    target: "win-resolve",
-                    label = %label,
-                    cache_hwnd = ?raw,
-                    root_hwnd = ?resolved,
-                    "[win-resolve] resolved via window_hwnds cache"
-                );
-                return resolved;
-            }
-        }
-
         tracing::warn!(
             target: "win-resolve",
             label = %label,
-            "[win-resolve] reducer-registry + cache both empty — using class-aware EnumWindows fallback"
+            "[win-resolve] cache + reducer-registry both empty — using class-aware EnumWindows fallback"
         );
     }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -1172,6 +1172,22 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
 #[cfg(target_os = "windows")]
 pub(crate) fn capture_hwnd_for_label(state: &Arc<AppState>, label: &str) {
     use cef::ImplBrowserHost;
+    // If a known-good outer HWND was already inserted by the creator
+    // of this window (e.g. `floating_pane.rs::create_owned_popup`
+    // registers the outer floater HWND it built via CreateWindowExW),
+    // DO NOT overwrite it. The fast path below uses
+    // `host.window_handle()` which for `set_as_child` browsers returns
+    // the CEF inner WS_CHILD HWND — replacing the outer HWND with the
+    // child here breaks any IPC that needs to act on the actual
+    // top-level (SetWindowPos drags the child within the parent,
+    // PostMessage(WM_CLOSE) destroys the child only, etc.).
+    if state.window_hwnds.lock().contains_key(label) {
+        tracing::debug!(
+            "[opacity] capture_hwnd_for_label: label={} already registered, preserving",
+            label
+        );
+        return;
+    }
     // Fast path.
     if let Some(mut browser) = state.get_browser(label) {
         if let Some(host) = browser.host() {

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -445,6 +445,79 @@ pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Res
     Ok(serde_json::Value::Null)
 }
 
+/// Resolve which agentmux window is under the cursor. Used by the
+/// floating-pane re-dock flow: on the floater's mouseup, the
+/// frontend asks "what window is the cursor over now?" and, if
+/// the answer is another agentmux window in the same process,
+/// kicks off `RedockFloatingPane`.
+///
+/// Args: `{ "x": int, "y": int }` — cursor position in physical px
+/// (whatever `get_cursor_point` returned).
+///
+/// Returns: `{ "label": string|null, "window_id": string|null }`. Both
+/// null means no agentmux window of this process is under the cursor
+/// (cursor is over the desktop, an external app, etc.). `window_id`
+/// is the backend windowId mapped via the launcher's
+/// `BackendWindowIdRegistered` projection — frontend uses it to
+/// load the WaveWindow / Workspace and figure out the active tab.
+///
+/// Instance / version isolation is free: another agentmux instance's
+/// HWNDs are NOT in this process's `window_hwnds` map, so cross-
+/// process drag-over-then-drop won't accidentally re-dock there.
+pub fn resolve_window_at_cursor(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::Foundation::POINT;
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            GetAncestor, WindowFromPoint, GA_ROOT,
+        };
+
+        let pt = POINT { x, y };
+        let mut hwnd = WindowFromPoint(pt);
+        if hwnd.is_null() {
+            return Ok(serde_json::json!({ "label": null, "window_id": null }));
+        }
+        // Walk to the top-level root — `WindowFromPoint` returns the
+        // deepest child window at the point, but we want the top-level
+        // owner for the label lookup.
+        let root = GetAncestor(hwnd, GA_ROOT);
+        if !root.is_null() {
+            hwnd = root;
+        }
+        let hwnd_isize = hwnd as isize;
+
+        // Reverse-lookup label in the per-label HWND cache populated
+        // by `capture_hwnd_for_label`. Same cache that
+        // `resolve_window_hwnd` consults — keeps both directions in
+        // sync.
+        let label = {
+            let map = state.window_hwnds.lock();
+            map.iter()
+                .find_map(|(k, v)| if *v == hwnd_isize { Some(k.clone()) } else { None })
+        };
+
+        match label {
+            Some(l) => {
+                let wid = state.backend_window_id(&l);
+                Ok(serde_json::json!({ "label": l, "window_id": wid }))
+            }
+            None => Ok(serde_json::json!({ "label": null, "window_id": null })),
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (state, args, x, y);
+        Ok(serde_json::json!({ "label": null, "window_id": null }))
+    }
+}
+
 /// Set window transparency/blur effects for a single window.
 ///
 /// Targets exactly the window identified by `label` (from the frontend's URL

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -585,9 +585,11 @@ pub fn update_floating_redock_hover(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    let cursor_x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0);
+    let cursor_y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0);
     let resolve_args = serde_json::json!({
-        "x": args.get("x").cloned().unwrap_or(serde_json::Value::Null),
-        "y": args.get("y").cloned().unwrap_or(serde_json::Value::Null),
+        "x": cursor_x,
+        "y": cursor_y,
         "exclude_label": source_label,
     });
     let resolved = resolve_window_at_cursor(state, &resolve_args)?;
@@ -596,24 +598,23 @@ pub fn update_floating_redock_hover(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let prev_target = {
-        let mut guard = state.active_redock_target.lock();
-        let prev = guard.clone();
-        *guard = new_target.clone();
-        prev
-    };
+    *state.active_redock_target.lock() = new_target.clone();
 
-    if prev_target != new_target {
-        let payload = serde_json::json!({
-            "target_label": new_target.clone(),
-            "source_label": source_label,
-        });
-        crate::events::emit_event_to_top_level_windows(
-            state,
-            "floating-redock:hover-state",
-            &payload,
-        );
-    }
+    // Emit on every call (frontend throttles ~50 ms upstream). The
+    // event must carry the cursor position so target renderers can
+    // compute which TILE the cursor is over and highlight just that
+    // leaf (not the whole window). Cursor is in physical screen px.
+    let payload = serde_json::json!({
+        "target_label": new_target.clone(),
+        "source_label": source_label,
+        "cursor_x": cursor_x,
+        "cursor_y": cursor_y,
+    });
+    crate::events::emit_event_to_top_level_windows(
+        state,
+        "floating-redock:hover-state",
+        &payload,
+    );
 
     Ok(serde_json::json!({ "target_label": new_target }))
 }

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -127,6 +127,23 @@ wrap_task! {
                 "[floating-pane] outer HWND created",
             );
 
+            // Register the outer HWND in `state.window_hwnds` under the
+            // floater's label. Without this, `resolve_window_hwnd(label)`
+            // falls through to the reducer-registry path which goes
+            // host.window_handle() (returns the CEF inner WS_CHILD) →
+            // GetAncestor(GA_ROOT), and in our setup GA_ROOT lands on
+            // MAIN's HWND (not the outer floater), so any
+            // close_window_by_label("floating-…") would actually post
+            // WM_CLOSE to MAIN and cascade-destroy every owned floater.
+            //
+            // Capturing the known-good outer HWND here ensures the
+            // cache lookup (added to resolve_window_hwnd) returns the
+            // right window for floater-targeted IPCs.
+            self.state
+                .window_hwnds
+                .lock()
+                .insert(self.window_label.clone(), outer_hwnd as isize);
+
             // CEF embed — the browser is a WS_CHILD of the outer HWND.
             let rect = Rect {
                 x: 0,

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -250,6 +250,8 @@ async fn route_command(
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_position" => commands::window::get_window_position(state, args),
         "resolve_window_at_cursor" => commands::window::resolve_window_at_cursor(state, args),
+        "update_floating_redock_hover" => commands::window::update_floating_redock_hover(state, args),
+        "clear_floating_redock_hover" => commands::window::clear_floating_redock_hover(state, args),
         "move_window_by" => commands::window::move_window_by(state, args),
         "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -249,6 +249,7 @@ async fn route_command(
         "get_window_opacity" => commands::window::get_window_opacity(state, args),
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_position" => commands::window::get_window_position(state, args),
+        "resolve_window_at_cursor" => commands::window::resolve_window_at_cursor(state, args),
         "move_window_by" => commands::window::move_window_by(state, args),
         "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -690,14 +690,6 @@ pub struct AppState {
     #[cfg(target_os = "windows")]
     pub window_hwnds: Mutex<HashMap<String, isize>>,
 
-    /// Active floating-pane redock target label, if any. Set by
-    /// `update_floating_redock_hover` (called from the dragged
-    /// floater's mousemove) and cleared by `clear_floating_redock_hover`
-    /// on drop. Used to throttle event emissions — only emit
-    /// `floating-redock:hover-state` when the target window actually
-    /// changes (mousemove fires at high frequency; the rendered
-    /// highlight overlay only cares about target transitions).
-    pub active_redock_target: Mutex<Option<String>>,
 }
 
 impl Default for AppState {
@@ -713,7 +705,6 @@ impl Default for AppState {
             window_id: Mutex::new(None),
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
-            active_redock_target: Mutex::new(None),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -689,6 +689,15 @@ pub struct AppState {
     /// enumerating all process windows. See SPEC_PER_WINDOW_OPACITY_2026-05-14.md §5.
     #[cfg(target_os = "windows")]
     pub window_hwnds: Mutex<HashMap<String, isize>>,
+
+    /// Active floating-pane redock target label, if any. Set by
+    /// `update_floating_redock_hover` (called from the dragged
+    /// floater's mousemove) and cleared by `clear_floating_redock_hover`
+    /// on drop. Used to throttle event emissions — only emit
+    /// `floating-redock:hover-state` when the target window actually
+    /// changes (mousemove fires at high frequency; the rendered
+    /// highlight overlay only cares about target transitions).
+    pub active_redock_target: Mutex<Option<String>>,
 }
 
 impl Default for AppState {
@@ -704,6 +713,7 @@ impl Default for AppState {
             window_id: Mutex::new(None),
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
+            active_redock_target: Mutex::new(None),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({

--- a/agentmux-srv/src/sagas/mod.rs
+++ b/agentmux-srv/src/sagas/mod.rs
@@ -47,6 +47,7 @@ pub mod delete_workspace;
 pub mod log;
 pub mod promote_block_to_tab;
 pub mod recovery;
+pub mod redock_floating_pane;
 pub mod restore_torn_off_tab;
 pub mod tear_off_block;
 pub mod tear_off_tab;

--- a/agentmux-srv/src/sagas/redock_floating_pane.rs
+++ b/agentmux-srv/src/sagas/redock_floating_pane.rs
@@ -1,0 +1,368 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// RedockFloatingPane saga — moves a block from a floating pane's
+// (single-block) workspace into an existing tab in a different
+// workspace. The inverse of `tear_off_block`.
+//
+// Used by the floating-pane re-dock flow (Phase 4a per
+// `docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md`): the user
+// drops a floater over another agentmux window's tile area; that
+// window's frontend computes the drop and calls this RPC.
+//
+// **Steps:**
+// 1. `MoveBlock { block_id, src=source_tab, dst=target_tab,
+//    dst_index: <position in target> }`
+//
+// After the move:
+// * Source workspace's tab is empty → frontend's empty-tab watcher
+//   (PR #1089) closes the floating window.
+// * Target tab's `blockids` now includes the moved block. The frontend
+//   target window updates its layout local-state to add a leaf and
+//   persists via the standard `UpdateObject` path. The saga itself
+//   does not touch LayoutState — same pattern as within-window pane
+//   drag (frontend mutates layout locally, persists, backend just
+//   stores).
+//
+// **Compensation:** single-step saga, so no in-saga compensation
+// chain needed. If MoveBlock fails, the reducer's validation rejects
+// up-front and nothing has changed yet.
+
+use agentmux_common::ipc::Command;
+use serde_json::{json, Value};
+
+use super::{
+    alloc_saga_id, classify_run_saga_result, emit_saga_started, emit_terminal, run_saga, SagaCtx,
+};
+use crate::server::AppState;
+
+/// Run the RedockFloatingPane saga. On success, returns
+/// `{ "block_id": "...", "target_tab_id": "..." }`.
+///
+/// `dst_index` defaults to the end of the target tab's blockids if
+/// callers don't have a specific drop position (Phase 4a MVP). Phase
+/// 4b polish will let callers specify a drop position relative to a
+/// target leaf + direction (left/right/top/bottom/into).
+pub async fn run(
+    state: &AppState,
+    block_id: String,
+    source_tab_id: String,
+    source_workspace_id: String,
+    target_tab_id: String,
+    target_workspace_id: String,
+    dst_index: Option<u32>,
+) -> Result<Value, String> {
+    // Pre-conditions: block exists and belongs to source_tab; source
+    // tab is in source_workspace; target tab is in target_workspace;
+    // source != target (callers should already check, but a no-op
+    // re-dock is a programmer mistake worth surfacing).
+    let dst_index_resolved = {
+        let s = state.srv_state.lock().await;
+        match s.blocks.get(&block_id) {
+            None => {
+                return Err(format!(
+                    "RedockFloatingPane: block not found: {}",
+                    block_id
+                ));
+            }
+            Some(block) if block.tab_id != source_tab_id => {
+                return Err(format!(
+                    "RedockFloatingPane: block {} is in tab {}, not {}",
+                    block_id, block.tab_id, source_tab_id
+                ));
+            }
+            _ => {}
+        }
+        match s.tabs.get(&source_tab_id) {
+            None => {
+                return Err(format!(
+                    "RedockFloatingPane: source tab not found: {}",
+                    source_tab_id
+                ));
+            }
+            Some(tab) if tab.workspace_id != source_workspace_id => {
+                return Err(format!(
+                    "RedockFloatingPane: source tab {} is in workspace {}, not {}",
+                    source_tab_id, tab.workspace_id, source_workspace_id
+                ));
+            }
+            _ => {}
+        }
+        let target_tab = match s.tabs.get(&target_tab_id) {
+            None => {
+                return Err(format!(
+                    "RedockFloatingPane: target tab not found: {}",
+                    target_tab_id
+                ));
+            }
+            Some(tab) if tab.workspace_id != target_workspace_id => {
+                return Err(format!(
+                    "RedockFloatingPane: target tab {} is in workspace {}, not {}",
+                    target_tab_id, tab.workspace_id, target_workspace_id
+                ));
+            }
+            Some(tab) => tab,
+        };
+        if source_tab_id == target_tab_id {
+            return Err(
+                "RedockFloatingPane: source and target are the same tab — use MoveBlockToTab"
+                    .to_string(),
+            );
+        }
+        // Default insertion: append at the end of the target tab's
+        // blockids.
+        dst_index.unwrap_or(target_tab.block_ids.len() as u32)
+    };
+
+    let saga_id = alloc_saga_id(state);
+    if let Err(e) = emit_saga_started(
+        state,
+        saga_id,
+        "redock_floating_pane",
+        json!({
+            "block_id": &block_id,
+            "source_tab_id": &source_tab_id,
+            "target_tab_id": &target_tab_id,
+            "dst_index": dst_index_resolved,
+        }),
+    )
+    .await
+    {
+        return Err(e);
+    }
+    let ctx = SagaCtx::new(state, saga_id);
+    let result = run_saga(
+        "redock_floating_pane",
+        run_inner(
+            ctx,
+            block_id,
+            source_tab_id,
+            target_tab_id,
+            dst_index_resolved,
+        ),
+    )
+    .await;
+    emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    block_id: String,
+    source_tab_id: String,
+    target_tab_id: String,
+    dst_index: u32,
+) -> Result<Value, String> {
+    ctx.dispatch(Command::MoveBlock {
+        block_id: block_id.clone(),
+        src_tab_id: source_tab_id,
+        dst_tab_id: target_tab_id.clone(),
+        dst_index,
+    })
+    .await
+    .map_err(|e| format!("RedockFloatingPane MoveBlock: {}", e))?;
+
+    Ok(json!({
+        "block_id": block_id,
+        "target_tab_id": target_tab_id,
+        "dst_index": dst_index,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::{Block, Tab};
+    use crate::server::tests::test_state;
+    use agentmux_common::ipc::Event;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<agentmux_common::ipc::Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    async fn seed_workspace_with_block(
+        state: &crate::server::AppState,
+        ws_name: &str,
+    ) -> (String, String, String) {
+        let ws_evs = dispatch_apply(
+            state,
+            Command::CreateWorkspace {
+                name: ws_name.into(),
+            },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t".into(),
+            },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk_evs = dispatch_apply(
+            state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+                meta: Value::Null,
+            },
+        )
+        .await;
+        let block_id = blk_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        (ws_id, tab_id, block_id)
+    }
+
+    #[tokio::test]
+    async fn happy_path_moves_block_between_workspaces() {
+        let state = test_state();
+        let (src_ws, src_tab, block_id) = seed_workspace_with_block(&state, "src").await;
+        // Seed a destination workspace with one tab (no blocks yet).
+        let dst_ws_evs = dispatch_apply(
+            &state,
+            Command::CreateWorkspace { name: "dst".into() },
+        )
+        .await;
+        let dst_ws = dst_ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let dst_tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab {
+                workspace_id: dst_ws.clone(),
+                name: "dt".into(),
+            },
+        )
+        .await;
+        let dst_tab = dst_tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        let result = run(
+            &state,
+            block_id.clone(),
+            src_tab.clone(),
+            src_ws.clone(),
+            dst_tab.clone(),
+            dst_ws.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result["block_id"], block_id);
+        assert_eq!(result["target_tab_id"], dst_tab);
+
+        // Reducer: source tab is empty; target tab has the block.
+        let s = state.srv_state.lock().await;
+        assert!(s.tabs[&src_tab].block_ids.is_empty());
+        assert_eq!(s.tabs[&dst_tab].block_ids, vec![block_id.clone()]);
+        assert_eq!(s.blocks[&block_id].tab_id, dst_tab);
+
+        // SQLite: matches.
+        drop(s);
+        let dst_tab_obj = state.wstore.get::<Tab>(&dst_tab).unwrap().unwrap();
+        assert_eq!(dst_tab_obj.blockids, vec![block_id.clone()]);
+        let block = state.wstore.get::<Block>(&block_id).unwrap().unwrap();
+        assert_eq!(block.parentoref, format!("tab:{}", dst_tab));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_source_and_target_are_same_tab() {
+        let state = test_state();
+        let (ws, tab, block_id) = seed_workspace_with_block(&state, "w").await;
+        let err = run(
+            &state,
+            block_id,
+            tab.clone(),
+            ws.clone(),
+            tab,
+            ws,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.contains("source and target are the same tab"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_when_block_not_in_source_tab() {
+        let state = test_state();
+        let (ws, tab, _block_id) = seed_workspace_with_block(&state, "w").await;
+        let dst_ws_evs = dispatch_apply(
+            &state,
+            Command::CreateWorkspace { name: "dst".into() },
+        )
+        .await;
+        let dst_ws = dst_ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let dst_tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab {
+                workspace_id: dst_ws.clone(),
+                name: "dt".into(),
+            },
+        )
+        .await;
+        let dst_tab = dst_tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let err = run(
+            &state,
+            "ghost-block".into(),
+            tab,
+            ws,
+            dst_tab,
+            dst_ws,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("block not found"), "got: {}", err);
+    }
+}

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2100,6 +2100,26 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     obj: Some(wave_obj_to_value(&dst_tab)),
                 });
             }
+            // CRITICAL: WaveObjUpdates in the response only reach the
+            // CALLING renderer (the floater that's about to close). The
+            // TARGET window's renderer is a different process and won't
+            // see the layout change unless we explicitly broadcast on
+            // the event bus. Mirrors the pattern in `app_api.rs:399-410`.
+            // Without this the target tab.blockids includes the new
+            // block but its layout.leaforder doesn't → block invisible.
+            for update in &updates {
+                let oref = format!("{}:{}", update.otype, update.oid);
+                if let Ok(data) = serde_json::to_value(update) {
+                    state.event_bus.broadcast_event(
+                        &crate::backend::eventbus::WSEventType {
+                            eventtype: "waveobj:update".to_string(),
+                            oref,
+                            data: Some(data),
+                        },
+                    );
+                }
+            }
+
             WebReturnType::success_data_updates(
                 serde_json::json!({
                     "redocked": true,

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2038,12 +2038,17 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 return WebReturnType::error(reason);
             }
 
-            // Layout setup for the target tab — grow a leaf for the
-            // moved block. Best-effort, mirrors the TearOffBlock pattern.
-            if let Err(e) = append_block_to_target_layout(store, &target_tab_id, &block_id) {
+            // Target layout: enqueue an "insert" action on its
+            // `pendingbackendactions` so the target window's frontend
+            // grows a new leaf for the redocked block through its
+            // standard LayoutTreeActionType.InsertNode reducer.
+            // Direct rootnode writes don't propagate because the
+            // LayoutModel doesn't auto-sync from external WaveObj
+            // updates — see `queue_target_layout_insert`'s docstring.
+            if let Err(e) = queue_target_layout_insert(store, &target_tab_id, &block_id) {
                 tracing::warn!(
                     target_tab = %target_tab_id,
-                    "RedockFloatingPane: target layout setup failed: {} (block in tab but layout malformed)",
+                    "RedockFloatingPane: target layout insert-action enqueue failed: {}",
                     e
                 );
             }
@@ -2480,73 +2485,46 @@ fn setup_torn_off_block_layout(
     Ok(())
 }
 
-/// Floating-pane re-dock — grow the target tab's layout tree to
-/// include a new leaf for the redocked block. Three cases:
+/// Floating-pane re-dock — enqueue an "insert" action on the TARGET
+/// tab's `LayoutState.pendingbackendactions` so the target window's
+/// frontend adds a new leaf for the redocked block through its
+/// `LayoutTreeActionType.InsertNode` reducer pathway.
 ///
-/// * Empty target layout (no rootnode) → same as
-///   `setup_torn_off_block_layout`: the new leaf becomes the root.
-/// * Existing root is a leaf → wrap both in a flex-row container so
-///   the new leaf sits beside the existing one.
-/// * Existing root is a container → append the new leaf as a child.
-///
-/// Best-effort, mirrors `setup_torn_off_block_layout`'s contract:
-/// failure leaves the block in the target tab's `blockids` but with
-/// no leaf in the layout tree (the frontend would render an "empty
-/// pane" until manually fixed). Layout migration to the reducer is
-/// E.4 territory.
-fn append_block_to_target_layout(
+/// Why this and not direct rootnode/leaforder writes? The frontend's
+/// LayoutModel maintains its own in-memory tree state and doesn't
+/// auto-sync from external `LayoutState` WaveObj updates — so a
+/// backend `store.update` to the rootnode lands in the WOS cache
+/// but the LayoutModel never picks it up, and the next frontend-
+/// initiated `object.UpdateObject` overwrites the backend version
+/// with the LayoutModel's stale tree. The pending-actions queue
+/// (`onBackendUpdate` in `layoutPersistence.ts:50`) is the canonical
+/// channel for "backend wants the frontend to mutate its layout
+/// tree". Source-delete on tear-off uses the same channel via
+/// `queue_source_layout_delete`.
+fn queue_target_layout_insert(
     store: &Store,
     target_tab_id: &str,
     block_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target_tab = store.must_get::<Tab>(target_tab_id)?;
-    let mut layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
-
-    let new_node_id = uuid::Uuid::new_v4().to_string();
-    let new_leaf = LayoutNode {
-        id: new_node_id.clone(),
-        flex_direction: FlexDirection::Row,
-        size: 1.0,
-        children: Vec::new(),
-        data: Some(LayoutNodeData {
-            block_id: block_id.to_string(),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-
-    match layout.rootnode.take() {
-        None => {
-            layout.rootnode = Some(new_leaf);
-        }
-        Some(existing_root) if existing_root.data.is_some() => {
-            // Existing root is a leaf — wrap in a flex-row container.
-            let container_id = uuid::Uuid::new_v4().to_string();
-            layout.rootnode = Some(LayoutNode {
-                id: container_id,
-                flex_direction: FlexDirection::Row,
-                size: 1.0,
-                children: vec![existing_root, new_leaf],
-                data: None,
-                ..Default::default()
-            });
-        }
-        Some(mut existing_container) => {
-            // Existing root is a container — append the new leaf as
-            // an additional child.
-            existing_container.children.push(new_leaf);
-            layout.rootnode = Some(existing_container);
-        }
-    }
-
-    let mut leaforder = layout.leaforder.take().unwrap_or_default();
-    leaforder.push(LeafOrderEntry {
-        nodeid: new_node_id,
+    let mut target_layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
+    let mut actions = target_layout.pendingbackendactions.take().unwrap_or_default();
+    actions.push(LayoutActionData {
+        // Matches `LayoutTreeActionType.InsertNode = "insert"` in
+        // `frontend/layout/lib/types.ts:73`.
+        actiontype: "insert".to_string(),
+        actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
+        nodesize: None,
+        indexarr: None,
+        focused: true,
+        magnified: false,
+        ephemeral: false,
+        targetblockid: String::new(),
+        position: String::new(),
     });
-    layout.leaforder = Some(leaforder);
-
-    store.update(&mut layout)?;
+    target_layout.pendingbackendactions = Some(actions);
+    store.update(&mut target_layout)?;
     Ok(())
 }
 

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2060,7 +2060,23 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             }
 
             let mut updates = Vec::new();
+            // Layout updates MUST come first — `append_block_to_target_layout`
+            // and `queue_source_layout_delete` write straight to wstore via
+            // `store.update`, which is NOT auto-broadcast (only the SQLite
+            // row gets a new version). Without these entries in the response,
+            // the target window's frontend never sees the new leaf and
+            // renders nothing; the source's pending delete action never
+            // gets pulled either. Both layouts are read AFTER the helpers
+            // run so we capture the fresh state.
             if let Ok(src_tab) = store.must_get::<Tab>(&source_tab_id) {
+                if let Ok(src_layout) = store.must_get::<LayoutState>(&src_tab.layoutstate) {
+                    updates.push(WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: OTYPE_LAYOUT.to_string(),
+                        oid: src_tab.layoutstate.clone(),
+                        obj: Some(wave_obj_to_value(&src_layout)),
+                    });
+                }
                 updates.push(WaveObjUpdate {
                     updatetype: "update".into(),
                     otype: OTYPE_TAB.to_string(),
@@ -2069,6 +2085,14 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 });
             }
             if let Ok(dst_tab) = store.must_get::<Tab>(&target_tab_id) {
+                if let Ok(dst_layout) = store.must_get::<LayoutState>(&dst_tab.layoutstate) {
+                    updates.push(WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: OTYPE_LAYOUT.to_string(),
+                        oid: dst_tab.layoutstate.clone(),
+                        obj: Some(wave_obj_to_value(&dst_layout)),
+                    });
+                }
                 updates.push(WaveObjUpdate {
                     updatetype: "update".into(),
                     otype: OTYPE_TAB.to_string(),

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1987,6 +1987,105 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 updates,
             )
         }
+        // Floating-pane Phase 4a — re-dock a floater's block back into
+        // an existing tab in another workspace. Same shape as
+        // TearOffBlock's RPC handler: saga handles the reducer-state
+        // move (MoveBlock); layout writes are wcore-direct (the
+        // target's layout grows a leaf; the source's layout enqueues
+        // a delete action). Source floater closes via PR #1089's
+        // empty-tab watcher once its tab.blockids is empty.
+        // Spec: docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md
+        ("workspace", "RedockFloatingPane") => {
+            let block_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let source_tab_id: String = match service::get_arg(args, 1) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let source_ws_id: String = match service::get_arg(args, 2) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let target_tab_id: String = match service::get_arg(args, 3) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let target_ws_id: String = match service::get_arg(args, 4) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            tracing::info!(
+                block_id = %block_id,
+                source_tab = %source_tab_id,
+                source_ws = %source_ws_id,
+                target_tab = %target_tab_id,
+                target_ws = %target_ws_id,
+                "[dnd:svc] RedockFloatingPane via saga"
+            );
+            let saga_result = crate::sagas::redock_floating_pane::run(
+                state,
+                block_id.clone(),
+                source_tab_id.clone(),
+                source_ws_id.clone(),
+                target_tab_id.clone(),
+                target_ws_id.clone(),
+                None,
+            )
+            .await;
+            if let Err(reason) = saga_result {
+                return WebReturnType::error(reason);
+            }
+
+            // Layout setup for the target tab — grow a leaf for the
+            // moved block. Best-effort, mirrors the TearOffBlock pattern.
+            if let Err(e) = append_block_to_target_layout(store, &target_tab_id, &block_id) {
+                tracing::warn!(
+                    target_tab = %target_tab_id,
+                    "RedockFloatingPane: target layout setup failed: {} (block in tab but layout malformed)",
+                    e
+                );
+            }
+            // Source tab: queue a layout-delete action so the source
+            // floater's frontend removes the leaf from its tree. The
+            // tab will then have empty blockids → PR #1089's auto-close
+            // watcher fires → floater window dismisses.
+            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+                tracing::warn!(
+                    source_tab = %source_tab_id,
+                    "RedockFloatingPane: source layout delete-action enqueue failed: {}",
+                    e
+                );
+            }
+
+            let mut updates = Vec::new();
+            if let Ok(src_tab) = store.must_get::<Tab>(&source_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: source_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&src_tab)),
+                });
+            }
+            if let Ok(dst_tab) = store.must_get::<Tab>(&target_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: target_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&dst_tab)),
+                });
+            }
+            WebReturnType::success_data_updates(
+                serde_json::json!({
+                    "redocked": true,
+                    "block_id": block_id,
+                    "target_tab_id": target_tab_id,
+                }),
+                updates,
+            )
+        }
+
         // Phase E.5.5 — TearOffTab migrated to saga. Closes the
         // smoke regression where wcore::tear_off_tab created the new
         // workspace bypassing the reducer, leaving the new window's
@@ -2333,6 +2432,76 @@ fn setup_torn_off_block_layout(
         nodeid: node_id,
         blockid: block_id.to_string(),
     }]);
+    store.update(&mut layout)?;
+    Ok(())
+}
+
+/// Floating-pane re-dock — grow the target tab's layout tree to
+/// include a new leaf for the redocked block. Three cases:
+///
+/// * Empty target layout (no rootnode) → same as
+///   `setup_torn_off_block_layout`: the new leaf becomes the root.
+/// * Existing root is a leaf → wrap both in a flex-row container so
+///   the new leaf sits beside the existing one.
+/// * Existing root is a container → append the new leaf as a child.
+///
+/// Best-effort, mirrors `setup_torn_off_block_layout`'s contract:
+/// failure leaves the block in the target tab's `blockids` but with
+/// no leaf in the layout tree (the frontend would render an "empty
+/// pane" until manually fixed). Layout migration to the reducer is
+/// E.4 territory.
+fn append_block_to_target_layout(
+    store: &Store,
+    target_tab_id: &str,
+    block_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let target_tab = store.must_get::<Tab>(target_tab_id)?;
+    let mut layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
+
+    let new_node_id = uuid::Uuid::new_v4().to_string();
+    let new_leaf = LayoutNode {
+        id: new_node_id.clone(),
+        flex_direction: FlexDirection::Row,
+        size: 1.0,
+        children: Vec::new(),
+        data: Some(LayoutNodeData {
+            block_id: block_id.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    match layout.rootnode.take() {
+        None => {
+            layout.rootnode = Some(new_leaf);
+        }
+        Some(existing_root) if existing_root.data.is_some() => {
+            // Existing root is a leaf — wrap in a flex-row container.
+            let container_id = uuid::Uuid::new_v4().to_string();
+            layout.rootnode = Some(LayoutNode {
+                id: container_id,
+                flex_direction: FlexDirection::Row,
+                size: 1.0,
+                children: vec![existing_root, new_leaf],
+                data: None,
+                ..Default::default()
+            });
+        }
+        Some(mut existing_container) => {
+            // Existing root is a container — append the new leaf as
+            // an additional child.
+            existing_container.children.push(new_leaf);
+            layout.rootnode = Some(existing_container);
+        }
+    }
+
+    let mut leaforder = layout.leaforder.take().unwrap_or_default();
+    leaforder.push(LeafOrderEntry {
+        nodeid: new_node_id,
+        blockid: block_id.to_string(),
+    });
+    layout.leaforder = Some(leaforder);
+
     store.update(&mut layout)?;
     Ok(())
 }

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_PHASE_4A_SCOPING_2026-05-27.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_PHASE_4A_SCOPING_2026-05-27.md
@@ -1,0 +1,177 @@
+# Phase 4a Re-dock — MVP scope decision
+
+**Date:** 2026-05-27
+**Status:** Decision pending
+**Parent spec:** [`SPEC_FLOATING_PANE_REDOCK_2026-05-27.md`](./SPEC_FLOATING_PANE_REDOCK_2026-05-27.md)
+
+## Why this doc
+
+The parent spec calls for the full Chrome-tab-style re-dock UX: drag a
+floater's pane header → target windows' tile layouts highlight in real
+time → drop onto a leaf to re-dock. After a read-only audit of the
+existing pane-drag and cross-window-drag plumbing, the implementation
+splits cleanly into two stages, and the user's iteration cadence
+(rapid drag/close/restart cycles) suggests we should choose the
+smaller MVP first.
+
+## Two options on the table
+
+### Option A — MVP: drop-position re-dock, no highlight
+
+**UX**
+
+- Drag the floater by its pane header — window follows the cursor
+  (today's JS-driven drag is unchanged).
+- Release the floater while the cursor sits over another AgentMux
+  window's tile area → block re-docks into that tile at the cursor's
+  position. The source floater auto-closes via PR #1089's empty-tab
+  watcher.
+- Release anywhere else → floater stays where it lands.
+
+**No visible highlight while dragging.** The user drops "blind" —
+they'll know they hit a valid target only after release.
+
+**Implementation**
+
+- **Backend** (`agentmux-srv` + `agentmux-cef`):
+  - New `try_redock_at_cursor` IPC.
+  - Host calls Win32 `WindowFromPoint(cursor_pos)` → HWND. Looks up
+    HWND in the reducer registry (`state.window_hwnds`); if matched,
+    that's a same-process agentmux window. Otherwise no-op.
+  - Backend `RedockFloatingPane` saga: validates source+target tabs,
+    moves block via existing `MoveBlock` reducer command, updates target
+    tab's layout `leaforder` at a default position (focused leaf or
+    first leaf), broadcasts to both windows.
+- **Frontend** (`floating-pane-workspace.tsx`):
+  - Keep the existing JS-driven mousedown drag loop unchanged.
+  - On mouseup add a single call to `try_redock_at_cursor({ paneId,
+    sourceWorkspaceId, sourceWindowLabel })`.
+  - On success (server reports redocked), let the empty-tab watcher
+    close the floater.
+  - On no-op, do nothing extra — floater is already at the cursor
+    position from the existing JS drag.
+
+**LOC estimate:** ~250
+**Risk:** Low. Reuses existing `MoveBlock`. No new cross-renderer
+protocol. No HTML5 drag/drop reroute. Behavior under failure is
+"floater stays where it was dropped", which is the most forgiving
+possible default.
+
+**Instance / version isolation:** Free. The reducer registry only
+knows HWNDs from the current process; another version's floater can't
+be re-docked into ours because its HWND isn't in our registry.
+
+### Option B — Full: drop-target highlight + cross-renderer drag
+
+**UX**
+
+- Same as A, **plus**: while dragging, every tile in every target
+  window highlights as the cursor crosses it. The user sees a
+  Chrome-tab-style "split preview" identical to within-window pane
+  drag (`.tile-layout .placeholder` overlay).
+- Cursor over an external app (VS Code etc.) shows the standard
+  no-drop cursor (subject to VS Code's permissive dragover behavior —
+  see [`ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md`](../analyses/ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md)).
+
+**Implementation**
+
+- Backend additions from Option A, **plus** a host-side "active
+  floating drag" relay:
+  - `set_floating_drag_active({ paneId, sourceWorkspaceId,
+    sourceWindowLabel })` — floater renderer signals start.
+  - `clear_floating_drag_active` — floater renderer signals end.
+  - Host emits a `floating-drag-active` event when state changes;
+    target renderers receive it via the existing event bus.
+- Frontend (floater): replace JS-driven drag with pragmatic-dnd
+  `draggable()`. On dragStart → `set_floating_drag_active` + capture
+  source rect for the drag image. On drop → `clear_floating_drag_active`
+  + either re-dock IPC (on-target) or `set_window_position` to cursor
+  (off-target, no during-drag follow-along like today).
+- Frontend (target windows): in `TileLayout.win32.tsx`, when the
+  `floating-drag-active` event fires, install a one-shot mousemove
+  listener that polls cursor-vs-tile-bounds, calls
+  `determineDropDirection()`, and renders the existing `.placeholder`
+  overlay. On mouseup → if drop on a tile, fire `RedockFloatingPane`
+  with the computed direction; else no-op.
+
+**LOC estimate:** ~600
+**Risk:** Medium. New cross-renderer protocol. Polling vs event-driven
+trade-offs on the highlight render. Drag image generation for the
+floater drag preview. More surface for visual bugs (during-drag
+artifacts, stuck highlights on dragend cancel, etc.).
+
+**The "no during-drag follow-along" subtlety:** With pragmatic-dnd as
+the drag source, the OS owns the drag preview (a ghost / bitmap), not
+the window itself. The floater window stays put during the drag and
+only repositions on release (drop-off-target). That's the standard
+Chrome tab tear-off model — different from today's "window follows
+the cursor during drag" behavior. Acceptable, but it IS a UX
+difference the user would notice.
+
+## Comparison
+
+| Concern | Option A (MVP) | Option B (Full) |
+|---|---|---|
+| LOC | ~250 | ~600 |
+| Drop-target highlight during drag | ❌ no | ✅ yes |
+| Window follows cursor during drag | ✅ yes (unchanged) | ❌ no (pragmatic-dnd ghost preview) |
+| Re-dock on drop | ✅ | ✅ |
+| Re-dock works across multiple windows | ✅ | ✅ |
+| Cross-instance / cross-version safety | ✅ free (HWND registry filter) | ✅ same |
+| New cross-renderer protocol | ❌ none | ⚠️ new event + IPC pair |
+| Risk of regressions | Low | Medium |
+| Time to ship | ~half a session | ~full session, possibly two |
+
+## Recommendation
+
+**Ship Option A first**, then add Option B's highlight as a
+follow-up PR once the re-dock plumbing is in place and stable.
+
+Rationale:
+
+1. **The re-dock is the load-bearing feature.** The highlight is
+   polish on top. Splitting them de-risks the work.
+2. **Option A preserves the current floater drag behavior** (window
+   follows cursor). Option B changes it to a pragmatic-dnd ghost
+   preview — a separate UX shift that's worth introducing on its own
+   merits, not as a side effect of "re-dock landed".
+3. **The retro on the current PR chain** (#1081, #1082, #1089, #1094)
+   shows each merge surfaced one or two follow-up bugs the user
+   caught in real-time iteration. A smaller PR keeps that cadence
+   working — easier to identify which change caused which symptom.
+
+If the user disagrees and wants Option B in one shot, the existing
+spec at `SPEC_FLOATING_PANE_REDOCK_2026-05-27.md` §4a is the
+complete recipe.
+
+## What this doc does NOT decide
+
+- The default drop position when re-docking (focused leaf? first
+  leaf? cursor-relative direction?). Option A defaults to the focused
+  leaf for simplicity; Option B would compute direction from cursor.
+- Cross-instance re-dock — both options remain in-process only;
+  cross-instance is Phase 4d in the parent spec, deferred.
+- Drag preview ghost styling — only relevant under Option B.
+- Re-dock to a different tab in the target window (Phase 4c, deferred
+  in both options).
+
+## Next steps after decision
+
+Whichever option:
+
+1. Branch from current main (`agentx/floating-pane-redock-phase-4a`
+   already created at `ea176058`).
+2. Backend first: `RedockFloatingPane` saga + IPC (~150 LOC).
+3. Frontend wiring (option-specific).
+4. Manual end-to-end test via `task dev`: tear off → re-dock back →
+   verify source closes + block appears in target.
+5. ReAgent review + merge.
+
+## Cross-references
+
+- [`SPEC_FLOATING_PANE_REDOCK_2026-05-27.md`](./SPEC_FLOATING_PANE_REDOCK_2026-05-27.md) — parent spec
+- [`SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`](./SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md) — Phase 4 acceptance criteria
+- [`ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md`](../analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md) — why floater drag is JS-driven today
+- [`ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md`](../analyses/ANALYSIS_EXTERNAL_APP_ACCEPTS_PANE_DRAG_2026-05-26.md) — VS Code dragover quirk
+- `agentmux-srv/src/sagas/tear_off_block.rs:40-177` — saga template for `RedockFloatingPane`
+- `frontend/layout/lib/TileLayout.win32.tsx:661-752` — existing pane-drop targets to extend under Option B

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -80,36 +80,69 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
 
 /**
  * Subscribe to the host's `floating-redock:hover-state` event so this
- * window paints the redock highlight overlay when a floater is being
- * dragged over it. The host computes the target window via the same
- * Z-order walk `resolve_window_at_cursor` uses, with the dragged
- * floater excluded, so the highlight appears on whatever real window
- * the cursor is over (not the floater itself).
+ * window paints a per-tile highlight when a floater is being dragged
+ * over it. The host computes the target window via the same Z-order
+ * walk `resolve_window_at_cursor` uses (with the dragged floater
+ * excluded) and emits this event on every mousemove update; payload
+ * includes the cursor position in physical screen px.
  *
- * Each window's renderer runs this in its own JS context (separate
- * renderer process per CEF browser), so the toggle is local — the
- * host fans the same event out to every top-level renderer and each
- * decides whether the event targets it.
+ * Each window's renderer runs this in its own JS context. When the
+ * event targets our window:
+ *   1. Convert cursor screen-physical-px → client CSS px using DPR +
+ *      `window.screenX/screenY` (matches `tabbar.tsx`'s
+ *      `physicalToClientX/Y` pattern).
+ *   2. `document.elementFromPoint(clientX, clientY)` → walk to the
+ *      nearest `[data-blockid]` ancestor (the block frame root —
+ *      `frontend/app/block/blockframe.tsx:755`).
+ *   3. Toggle `.floating-redock-target-leaf` on that block; remove
+ *      from any other previously-highlighted block.
  *
- * The visual rule lives in `app/app.scss::body.floating-redock-hover-target`.
- * Implementation matches the tear-off hover pattern in
- * `app/tab/tabbar.tsx::listenEvent("tearoff:hover-*")`.
+ * The visual rule lives in `app/app.scss::.floating-redock-target-leaf`.
  */
 function installFloatingRedockHoverListener(): void {
     const myLabel =
         new URLSearchParams(window.location.search).get("windowLabel") || "main";
+    let highlighted: HTMLElement | null = null;
+    const clearHighlight = () => {
+        if (highlighted) {
+            highlighted.classList.remove("floating-redock-target-leaf");
+            highlighted = null;
+        }
+    };
     fireAndForget(async () => {
         const { listenEvent } = await import("@/app/platform/ipc");
-        await listenEvent<{ target_label: string | null; source_label?: string }>(
-            "floating-redock:hover-state",
-            (payload) => {
-                if (payload?.target_label === myLabel) {
-                    document.body.classList.add("floating-redock-hover-target");
-                } else {
-                    document.body.classList.remove("floating-redock-hover-target");
-                }
-            },
-        );
+        await listenEvent<{
+            target_label: string | null;
+            source_label?: string;
+            cursor_x?: number;
+            cursor_y?: number;
+        }>("floating-redock:hover-state", (payload) => {
+            if (!payload || payload.target_label !== myLabel) {
+                clearHighlight();
+                return;
+            }
+            const cursorPxX = payload.cursor_x;
+            const cursorPxY = payload.cursor_y;
+            if (typeof cursorPxX !== "number" || typeof cursorPxY !== "number") {
+                clearHighlight();
+                return;
+            }
+            // Physical screen → CSS client (matches tabbar.tsx pattern).
+            const dpr = window.devicePixelRatio || 1;
+            const clientX = cursorPxX / dpr - window.screenX;
+            const clientY = cursorPxY / dpr - window.screenY;
+            const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+            const leaf = el?.closest("[data-blockid]") as HTMLElement | null;
+            if (!leaf) {
+                clearHighlight();
+                return;
+            }
+            if (leaf !== highlighted) {
+                clearHighlight();
+                leaf.classList.add("floating-redock-target-leaf");
+                highlighted = leaf;
+            }
+        });
     });
 }
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -80,7 +80,7 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
 
 /**
  * Subscribe to the host's `floating-redock:hover-state` event so this
- * window paints a per-tile highlight when a floater is being dragged
+ * window paints a drop-slot preview when a floater is being dragged
  * over it. The host computes the target window via the same Z-order
  * walk `resolve_window_at_cursor` uses (with the dragged floater
  * excluded) and emits this event on every mousemove update; payload
@@ -88,29 +88,81 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
  *
  * Each window's renderer runs this in its own JS context. When the
  * event targets our window:
- *   1. Convert cursor screen-physical-px → client CSS px using DPR +
- *      `window.screenX/screenY` (matches `tabbar.tsx`'s
- *      `physicalToClientX/Y` pattern).
+ *   1. Convert cursor screen-physical-px → client CSS px (DPR +
+ *      `window.screenX/Y`, same pattern as `tabbar.tsx`).
  *   2. `document.elementFromPoint(clientX, clientY)` → walk to the
- *      nearest `[data-blockid]` ancestor (the block frame root —
- *      `frontend/app/block/blockframe.tsx:755`).
- *   3. Toggle `.floating-redock-target-leaf` on that block; remove
- *      from any other previously-highlighted block.
+ *      nearest `[data-blockid]` ancestor.
+ *   3. Run `determineDropDirection` (from `@/layout/lib/utils`) on
+ *      the cursor's position within the leaf — same helper as
+ *      within-window pane drag — to classify the drop as
+ *      Center / Top / Right / Bottom / Left (and Outer variants).
+ *   4. Render a singleton overlay div positioned over the
+ *      half/quadrant/full-leaf that maps to that direction (e.g. Top
+ *      → top half of leaf; Center → full leaf; OuterRight → right
+ *      fifth of leaf).
  *
- * The visual rule lives in `app/app.scss::.floating-redock-target-leaf`.
+ * The block STILL lands as a sibling in the target tab's layout for
+ * MVP (backend ignores the direction). Phase 4b will wire the
+ * direction through `RedockFloatingPane` so the block lands in the
+ * exact slot the user previewed.
  */
 function installFloatingRedockHoverListener(): void {
     const myLabel =
         new URLSearchParams(window.location.search).get("windowLabel") || "main";
-    let highlighted: HTMLElement | null = null;
-    const clearHighlight = () => {
-        if (highlighted) {
-            highlighted.classList.remove("floating-redock-target-leaf");
-            highlighted = null;
+    let placeholderEl: HTMLDivElement | null = null;
+
+    const ensurePlaceholder = (): HTMLDivElement => {
+        if (!placeholderEl) {
+            placeholderEl = document.createElement("div");
+            placeholderEl.className = "floating-redock-drop-placeholder";
+            document.body.appendChild(placeholderEl);
+        }
+        return placeholderEl;
+    };
+    const clearPlaceholder = () => {
+        if (placeholderEl) {
+            placeholderEl.remove();
+            placeholderEl = null;
         }
     };
+
+    // Map a DropDirection to a sub-rect (top, left, width, height in
+    // client CSS px) within the leaf rect. Mirrors the visual the
+    // within-window pane drag's `.placeholder` provides:
+    //   Center      → full leaf
+    //   Top/Bottom  → half along that axis
+    //   Left/Right  → half along that axis
+    //   Outer*      → thin (1/5) band against that edge
+    const rectForDirection = (leaf: DOMRect, dir: number): { top: number; left: number; width: number; height: number } => {
+        // DropDirection enum: Top=0, Right=1, Bottom=2, Left=3,
+        //   OuterTop=4, OuterRight=5, OuterBottom=6, OuterLeft=7,
+        //   Center=8.
+        switch (dir) {
+            case 0: // Top
+                return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height / 2 };
+            case 1: // Right
+                return { top: leaf.top, left: leaf.left + leaf.width / 2, width: leaf.width / 2, height: leaf.height };
+            case 2: // Bottom
+                return { top: leaf.top + leaf.height / 2, left: leaf.left, width: leaf.width, height: leaf.height / 2 };
+            case 3: // Left
+                return { top: leaf.top, left: leaf.left, width: leaf.width / 2, height: leaf.height };
+            case 4: // OuterTop
+                return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height / 5 };
+            case 5: // OuterRight
+                return { top: leaf.top, left: leaf.left + (4 * leaf.width) / 5, width: leaf.width / 5, height: leaf.height };
+            case 6: // OuterBottom
+                return { top: leaf.top + (4 * leaf.height) / 5, left: leaf.left, width: leaf.width, height: leaf.height / 5 };
+            case 7: // OuterLeft
+                return { top: leaf.top, left: leaf.left, width: leaf.width / 5, height: leaf.height };
+            case 8: // Center
+            default:
+                return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height };
+        }
+    };
+
     fireAndForget(async () => {
         const { listenEvent } = await import("@/app/platform/ipc");
+        const { determineDropDirection } = await import("@/layout/lib/utils");
         await listenEvent<{
             target_label: string | null;
             source_label?: string;
@@ -118,30 +170,44 @@ function installFloatingRedockHoverListener(): void {
             cursor_y?: number;
         }>("floating-redock:hover-state", (payload) => {
             if (!payload || payload.target_label !== myLabel) {
-                clearHighlight();
+                clearPlaceholder();
                 return;
             }
             const cursorPxX = payload.cursor_x;
             const cursorPxY = payload.cursor_y;
             if (typeof cursorPxX !== "number" || typeof cursorPxY !== "number") {
-                clearHighlight();
+                clearPlaceholder();
                 return;
             }
-            // Physical screen → CSS client (matches tabbar.tsx pattern).
             const dpr = window.devicePixelRatio || 1;
             const clientX = cursorPxX / dpr - window.screenX;
             const clientY = cursorPxY / dpr - window.screenY;
             const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
-            const leaf = el?.closest("[data-blockid]") as HTMLElement | null;
-            if (!leaf) {
-                clearHighlight();
+            const leafEl = el?.closest("[data-blockid]") as HTMLElement | null;
+            if (!leafEl) {
+                clearPlaceholder();
                 return;
             }
-            if (leaf !== highlighted) {
-                clearHighlight();
-                leaf.classList.add("floating-redock-target-leaf");
-                highlighted = leaf;
+            const leafRect = leafEl.getBoundingClientRect();
+            const dir = determineDropDirection(
+                {
+                    width: leafRect.width,
+                    height: leafRect.height,
+                    left: leafRect.left,
+                    top: leafRect.top,
+                },
+                { x: clientX, y: clientY },
+            );
+            if (dir === undefined) {
+                clearPlaceholder();
+                return;
             }
+            const slot = rectForDirection(leafRect, dir);
+            const ph = ensurePlaceholder();
+            ph.style.top = `${slot.top}px`;
+            ph.style.left = `${slot.left}px`;
+            ph.style.width = `${slot.width}px`;
+            ph.style.height = `${slot.height}px`;
         });
     });
 }

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -48,6 +48,7 @@ import { ContextMenuModel } from "@/app/store/contextmenu";
 import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
+import { fireAndForget } from "@/util/util";
 import { scheduleRevealLift } from "@/store/tab-reveal";
 import { installLauncherEventBridge } from "@/util/launcher-events";
 import { installSrvEventBridge } from "@/util/srv-events";
@@ -76,6 +77,41 @@ window.removeNotificationById = removeNotificationById;
 window.modalsModel = modalsModel;
 
 const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
+
+/**
+ * Subscribe to the host's `floating-redock:hover-state` event so this
+ * window paints the redock highlight overlay when a floater is being
+ * dragged over it. The host computes the target window via the same
+ * Z-order walk `resolve_window_at_cursor` uses, with the dragged
+ * floater excluded, so the highlight appears on whatever real window
+ * the cursor is over (not the floater itself).
+ *
+ * Each window's renderer runs this in its own JS context (separate
+ * renderer process per CEF browser), so the toggle is local — the
+ * host fans the same event out to every top-level renderer and each
+ * decides whether the event targets it.
+ *
+ * The visual rule lives in `app/app.scss::body.floating-redock-hover-target`.
+ * Implementation matches the tear-off hover pattern in
+ * `app/tab/tabbar.tsx::listenEvent("tearoff:hover-*")`.
+ */
+function installFloatingRedockHoverListener(): void {
+    const myLabel =
+        new URLSearchParams(window.location.search).get("windowLabel") || "main";
+    fireAndForget(async () => {
+        const { listenEvent } = await import("@/app/platform/ipc");
+        await listenEvent<{ target_label: string | null; source_label?: string }>(
+            "floating-redock:hover-state",
+            (payload) => {
+                if (payload?.target_label === myLabel) {
+                    document.body.classList.add("floating-redock-hover-target");
+                } else {
+                    document.body.classList.remove("floating-redock-hover-target");
+                }
+            },
+        );
+    });
+}
 
 /**
  * Initialize the window-instance-number atom and seed the reducer
@@ -692,6 +728,7 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     t = performance.now();
     initGlobalEventSubs(initOpts);
     subscribeToConnEvents();
+    installFloatingRedockHoverListener();
     tlog("initEventSubs", t);
 
     // Prime the identity-account cache from the DB so synchronous callers

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -34,21 +34,28 @@ body {
     background-color: transparent;
 }
 
-// Highlight overlay rendered when a floating pane is being dragged
-// over this window — host emits `floating-redock:hover-state` with
-// our window's label as `target_label`, app-init's listener toggles
-// this class on body. Visual cue: a thick accent-colored inner ring
-// + a subtle backdrop tint so the user knows where the block will
-// land on release. Pointer-events:none on the ring so the user's
-// drag still flows through to the host's mouseup.
-body.floating-redock-hover-target::after {
+// Per-tile highlight rendered when a floating pane is being dragged
+// over this window AND the cursor is over a specific block. The host
+// emits `floating-redock:hover-state` with our window's label as
+// `target_label` and the cursor in physical screen px; app-init's
+// listener finds the leaf under the cursor and toggles this class on
+// the block frame.
+//
+// Visual cue: an inset 4 CSS-px accent ring + subtle accent tint on
+// the targeted block ONLY (not the whole window). Pointer-events
+// none so the in-flight drag still flows through to mouseup.
+.block.floating-redock-target-leaf {
+    position: relative;
+}
+.block.floating-redock-target-leaf::after {
     content: "";
-    position: fixed;
+    position: absolute;
     inset: 0;
     pointer-events: none;
     z-index: 9999;
     box-shadow: inset 0 0 0 4px var(--accent-color);
-    background-color: rgba(from var(--accent-color) r g b / 0.08);
+    background-color: rgba(from var(--accent-color) r g b / 0.12);
+    border-radius: var(--block-border-radius);
 }
 
 a.plain-link {

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -34,28 +34,22 @@ body {
     background-color: transparent;
 }
 
-// Per-tile highlight rendered when a floating pane is being dragged
-// over this window AND the cursor is over a specific block. The host
-// emits `floating-redock:hover-state` with our window's label as
-// `target_label` and the cursor in physical screen px; app-init's
-// listener finds the leaf under the cursor and toggles this class on
-// the block frame.
-//
-// Visual cue: an inset 4 CSS-px accent ring + subtle accent tint on
-// the targeted block ONLY (not the whole window). Pointer-events
-// none so the in-flight drag still flows through to mouseup.
-.block.floating-redock-target-leaf {
-    position: relative;
-}
-.block.floating-redock-target-leaf::after {
-    content: "";
-    position: absolute;
-    inset: 0;
+// Drop-slot preview rendered when a floating pane is being dragged
+// over a specific block in this window. `app-init.ts` runs
+// `determineDropDirection` on the cursor + leaf rect (same helper as
+// within-window pane drag) and positions this singleton overlay
+// over the half/quarter/full-leaf that corresponds to the resolved
+// direction. Same accent visual as the within-window `.placeholder`
+// drop indicator so users see the same affordance whether they're
+// dragging a docked pane or a floater.
+.floating-redock-drop-placeholder {
+    position: fixed;
     pointer-events: none;
     z-index: 9999;
-    box-shadow: inset 0 0 0 4px var(--accent-color);
-    background-color: rgba(from var(--accent-color) r g b / 0.12);
+    background-color: rgba(from var(--accent-color) r g b / 0.18);
+    border: 2px solid var(--accent-color);
     border-radius: var(--block-border-radius);
+    transition: top 120ms ease-out, left 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
 a.plain-link {

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -34,6 +34,23 @@ body {
     background-color: transparent;
 }
 
+// Highlight overlay rendered when a floating pane is being dragged
+// over this window — host emits `floating-redock:hover-state` with
+// our window's label as `target_label`, app-init's listener toggles
+// this class on body. Visual cue: a thick accent-colored inner ring
+// + a subtle backdrop tint so the user knows where the block will
+// land on release. Pointer-events:none on the ring so the user's
+// drag still flows through to the host's mouseup.
+body.floating-redock-hover-target::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
+    box-shadow: inset 0 0 0 4px var(--accent-color);
+    background-color: rgba(from var(--accent-color) r g b / 0.08);
+}
+
 a.plain-link {
     color: var(--secondary-text-color);
 }

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -218,6 +218,22 @@ class WorkspaceServiceType {
     TearOffTab(tabId: string, sourceWsId: string): Promise<string> {
         return WOS.callBackendService("workspace", "TearOffTab", Array.from(arguments))
     }
+
+    // Re-dock a floating pane's block into an existing tab in another
+    // workspace. The inverse of TearOffBlock. Source floater auto-closes
+    // via the empty-tab watcher in floating-pane-workspace.tsx (PR #1089)
+    // once its tab.blockids becomes empty.
+    //
+    // @returns { redocked: true, block_id, target_tab_id } (and object updates)
+    RedockFloatingPane(
+        blockId: string,
+        sourceTabId: string,
+        sourceWsId: string,
+        targetTabId: string,
+        targetWsId: string,
+    ): Promise<{ redocked: boolean; block_id?: string; target_tab_id?: string }> {
+        return WOS.callBackendService("workspace", "RedockFloatingPane", Array.from(arguments))
+    }
 }
 
 export const WorkspaceService = new WorkspaceServiceType();

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -198,6 +198,28 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             }
         };
 
+        // Throttled redock-hover push — drives the highlight overlay
+        // on whichever agentmux window the cursor is currently over.
+        // ~50 ms cadence is plenty for highlight tracking and keeps
+        // IPC load minimal during fast drags.
+        const HOVER_PUSH_THROTTLE_MS = 50;
+        let lastHoverPushAt = 0;
+        const pushRedockHover = (screenX: number, screenY: number) => {
+            const now = performance.now();
+            if (now - lastHoverPushAt < HOVER_PUSH_THROTTLE_MS) return;
+            lastHoverPushAt = now;
+            const dpr = window.devicePixelRatio || 1;
+            const px = Math.round(screenX * dpr);
+            const py = Math.round(screenY * dpr);
+            const sourceLabel = windowLabel();
+            if (!sourceLabel) return;
+            invokeCommand("update_floating_redock_hover", {
+                source_label: sourceLabel,
+                x: px,
+                y: py,
+            }).catch(() => {});
+        };
+
         const onMouseMove = (e: MouseEvent) => {
             // Track the latest cursor position even before `dragging`
             // is armed so the catch-up at IPC resolution can use the
@@ -215,6 +237,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             const ty =
                 initWinY + Math.round((e.screenY - clickScreenY) * dpr);
             sendPos(tx, ty);
+            pushRedockHover(e.screenX, e.screenY);
         };
 
         const onMouseUp = (e: MouseEvent) => {
@@ -241,6 +264,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             // `window_hwnds` map — another agentmux version's HWNDs
             // aren't in it, so cross-process drops silently no-op.
             if (wasDragging) {
+                // Always clear the hover state on release — the highlight
+                // overlay needs to disappear whether or not we ended up
+                // over a target. Fire-and-forget; the redock attempt
+                // below doesn't depend on this completing.
+                invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                 void tryRedockAtCursor(e.screenX, e.screenY);
             }
         };

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -306,13 +306,18 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             }
 
             // Resolve target's active tab via the WaveObj graph:
-            // window → workspace.activetabid.
+            // window → workspace.activetabid. Use the non-pinning
+            // `reloadWaveObject` — `loadAndPinWaveObject` would bump
+            // `refCount` with no matching unpin in this async flow,
+            // leaking one ref on each of the target Window + Workspace
+            // per successful redock so the cache cleanup never evicts
+            // them.
             let targetWs: Workspace;
             try {
-                const targetWindow = await WOS.loadAndPinWaveObject<WaveWindow>(
+                const targetWindow = await WOS.reloadWaveObject<WaveWindow>(
                     WOS.makeORef("window", target.window_id),
                 );
-                targetWs = await WOS.loadAndPinWaveObject<Workspace>(
+                targetWs = await WOS.reloadWaveObject<Workspace>(
                     WOS.makeORef("workspace", targetWindow.workspaceid),
                 );
             } catch (e) {

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -36,6 +36,7 @@ import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { TabContent } from "@/app/tab/tabcontent";
+import { WorkspaceService } from "@/store/services";
 import { atoms, getApi } from "@/store/global";
 import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, onCleanup, onMount, type JSX } from "solid-js";
@@ -216,16 +217,118 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             sendPos(tx, ty);
         };
 
-        const onMouseUp = () => {
+        const onMouseUp = (e: MouseEvent) => {
             // Invalidate any in-flight mousedown handler — incrementing
             // the id ensures their `myId !== currentMouseDownId` check
             // fires when they resolve.
             currentMouseDownId += 1;
+            const wasDragging = dragging;
             dragging = false;
             // Do NOT clear pendingPos — that would discard the FINAL
             // queued position (the cursor's location at release time).
             // Let the in-flight set_window_position complete; its
             // `.finally` drains pendingPos to the correct end state.
+
+            // Floating-pane re-dock (Phase 4a MVP): if we just finished
+            // a drag and the cursor landed over another agentmux window
+            // in this process, fire RedockFloatingPane to move our
+            // single block into that window's active tab. The source
+            // workspace's tab.blockids becomes empty → the createEffect
+            // above auto-closes this floater.
+            //
+            // Cross-instance / cross-version safety is free: the host's
+            // `resolve_window_at_cursor` looks up HWND in this process's
+            // `window_hwnds` map — another agentmux version's HWNDs
+            // aren't in it, so cross-process drops silently no-op.
+            if (wasDragging) {
+                void tryRedockAtCursor(e.screenX, e.screenY);
+            }
+        };
+
+        const tryRedockAtCursor = async (screenX: number, screenY: number) => {
+            const ourLabel = windowLabel();
+            if (!ourLabel) return;
+            // `mouseup.screenX/Y` are CSS pixels; host expects physical.
+            const dpr = window.devicePixelRatio || 1;
+            const px = Math.round(screenX * dpr);
+            const py = Math.round(screenY * dpr);
+
+            let target: { label: string | null; window_id: string | null };
+            try {
+                target = await invokeCommand<{
+                    label: string | null;
+                    window_id: string | null;
+                }>("resolve_window_at_cursor", { x: px, y: py });
+            } catch (e) {
+                console.error("[floating-pane] resolve_window_at_cursor failed", e);
+                return;
+            }
+            if (
+                !target.label ||
+                !target.window_id ||
+                target.label === ourLabel
+            ) {
+                // Cursor over desktop, external app, or our own floater
+                // — leave floater at the dropped position.
+                return;
+            }
+
+            // Resolve target's active tab via the WaveObj graph:
+            // window → workspace.activetabid.
+            let targetWs: Workspace;
+            try {
+                const targetWindow = await WOS.loadAndPinWaveObject<WaveWindow>(
+                    WOS.makeORef("window", target.window_id),
+                );
+                targetWs = await WOS.loadAndPinWaveObject<Workspace>(
+                    WOS.makeORef("workspace", targetWindow.workspaceid),
+                );
+            } catch (e) {
+                console.error(
+                    "[floating-pane] failed to resolve target window's workspace",
+                    e,
+                );
+                return;
+            }
+            const targetTabId = targetWs.activetabid;
+            const targetWsId = targetWs.oid;
+            if (!targetTabId || !targetWsId) {
+                console.warn(
+                    "[floating-pane] target window has no active tab — skipping redock",
+                );
+                return;
+            }
+
+            // Source identifiers — the floater's only-tab + only-block.
+            const sourceTabId = tabId();
+            const sourceWs = ws();
+            if (!sourceTabId || !sourceWs) return;
+            const sourceWsId = sourceWs.oid;
+            const [sourceTab] = WOS.useWaveObjectValue<Tab>(
+                WOS.makeORef("tab", sourceTabId),
+            );
+            const sourceTabObj = sourceTab();
+            const sourceBlockId = sourceTabObj?.blockids?.[0];
+            if (!sourceBlockId) {
+                console.warn(
+                    "[floating-pane] floater has no block to redock — skipping",
+                );
+                return;
+            }
+
+            try {
+                await WorkspaceService.RedockFloatingPane(
+                    sourceBlockId,
+                    sourceTabId,
+                    sourceWsId,
+                    targetTabId,
+                    targetWsId,
+                );
+                // After successful redock, source tab.blockids empties
+                // → the auto-close watcher dismisses the floater.
+            } catch (e) {
+                console.error("[floating-pane] RedockFloatingPane failed", e);
+            }
         };
 
         // Capture-phase listeners so we run BEFORE pragmatic-dnd's

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -336,10 +336,13 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             const sourceWs = ws();
             if (!sourceTabId || !sourceWs) return;
             const sourceWsId = sourceWs.oid;
-            const [sourceTab] = WOS.useWaveObjectValue<Tab>(
+            // Non-reactive read: `useWaveObjectValue` would register an
+            // `onCleanup` against the current reactive owner, but we're inside
+            // an async mouseup callback with no owner — the refCount would
+            // never get decremented and we'd leak a Tab subscription per drop.
+            const sourceTabObj = WOS.getObjectValue<Tab>(
                 WOS.makeORef("tab", sourceTabId),
             );
-            const sourceTabObj = sourceTab();
             const sourceBlockId = sourceTabObj?.blockids?.[0];
             if (!sourceBlockId) {
                 console.warn(

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -255,19 +255,23 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
 
             let target: { label: string | null; window_id: string | null };
             try {
+                // exclude_label = our own floater's label. Without this,
+                // the host's Z-order walk would return the floater itself
+                // — it's at the cursor (the JS-driven drag follows the
+                // cursor), so it's always topmost where the cursor is.
                 target = await invokeCommand<{
                     label: string | null;
                     window_id: string | null;
-                }>("resolve_window_at_cursor", { x: px, y: py });
+                }>("resolve_window_at_cursor", {
+                    x: px,
+                    y: py,
+                    exclude_label: ourLabel,
+                });
             } catch (e) {
                 console.error("[floating-pane] resolve_window_at_cursor failed", e);
                 return;
             }
-            if (
-                !target.label ||
-                !target.window_id ||
-                target.label === ourLabel
-            ) {
+            if (!target.label || !target.window_id) {
                 // Cursor over desktop, external app, or our own floater
                 // — leave floater at the dropped position.
                 return;


### PR DESCRIPTION
## Summary
- Implements floating-pane re-dock (Phase 4a of #1079): drag a torn-off floater back over an agentmux window and drop to redock as a docked pane.
- Backend `RedockFloatingPane` saga handles cross-tab/cross-window MoveBlock with target-side layout sync via `pendingbackendactions`.
- Host adds Win32 Z-order cursor resolution (skipping the source floater) plus hover IPCs that drive a ghost drop-slot preview in the target window.
- Frontend renders per-tile drop placeholders using `determineDropDirection` (same affordance as within-window pane drag), JS-driven floater drag (window follows cursor), and an auto-close watcher when the floater's tab empties.

## What's in
**Backend (agentmux-srv):**
- New `sagas/redock_floating_pane.rs` — validates source/target tabs+block, executes MoveBlock with optional dst_index. Unit tests for happy path, same-tab rejection, missing-block rejection.
- New `workspace.RedockFloatingPane` RPC in `service.rs`.
- `queue_target_layout_insert` helper appends an `"insert"` action to the target layout's `pendingbackendactions` (LayoutModel doesn't sync from external WaveObj writes — the queue is the working pattern).
- Explicit `event_bus.broadcast_event` for `waveobj:update` to reach the target renderer.

**Host (agentmux-cef):**
- `resolve_window_at_cursor` — Win32 Z-order walk via `GetTopWindow`+`GetWindow(GW_HWNDNEXT)`, skips source floater via `exclude_label`.
- `update_floating_redock_hover` / `clear_floating_redock_hover` — emit `floating-redock:hover-state` events with cursor + target label.
- `resolve_window_hwnd` reordered: cache lookup first (no GA_ROOT walk on cache hits), then reducer registry + GA_ROOT, then class-aware EnumWindows fallback.
- `capture_hwnd_for_label`: early-return if label already registered (preserves floater's outer HWND).
- `floating_pane_wndproc`: WS_POPUP + WS_THICKFRAME, no caption; DwmExtendFrameIntoClientArea; WM_NCCALCSIZE→0, WM_NCACTIVATE→1, edge-resize hit testing.
- `find_main_window`: EnumWindows skipping the `AgentMuxFloatingPane` class.

**Frontend:**
- `floating-pane-workspace.tsx` renders the block with its standard BlockFrame_Header (no custom title bar). JS-driven drag handler with one-in-flight + coalesce; throttled `update_floating_redock_hover` on mousemove; redock + clear-hover on mouseup. Auto-close when `tab.blockids` empties.
- `app-init.ts` `installFloatingRedockHoverListener` — singleton `.floating-redock-drop-placeholder` positioned via `rectForDirection(leafRect, dir)` (Center=full, Top/Bottom/Left/Right=half, Outer*=1/5 band). Uses `elementFromPoint` + `closest('[data-blockid]')` to find the target leaf; DPR-aware cursor→client conversion.
- `store/services.ts`: `RedockFloatingPane(blockId, sourceTabId, sourceWsId, targetTabId, targetWsId)` wrapper.
- `app.scss`: `.floating-redock-drop-placeholder` rule (accent border, transitions).

## Cross-instance isolation
Window resolution is per-process via the `window_hwnds` registry — multiple agentmux versions/instances can run simultaneously and never accept each other's floaters (verified by design: a v0.39.0 floater's source label isn't registered in a v0.39.1 host's registry, so `resolve_window_at_cursor` returns no match).

## Test plan
- [x] Tear off a pane, drag, release over the source window → ghost preview shows correct tile/direction, drop redocks the pane
- [x] Tear off, drag, release outside any agentmux window → no-op, floater stays
- [x] Drag the floater itself (window follows cursor; no system caption)
- [x] Close button on the floater closes the floater only (not the main window)
- [x] Close the floater's last block → floater auto-closes
- [x] Multiple floaters open simultaneously → closing one doesn't cascade
- [x] Logs verify cache-first window resolution (no GA_ROOT walks on cache hits) and ~1–2ms saga latency

## Notes for review
- Tracking issue: #1079
- Scoping decision doc: `docs/specs/SPEC_FLOATING_PANE_REDOCK_PHASE_4A_SCOPING_2026-05-27.md`
- Follow-up phases (4b+) will add: drop-index selection within a leaf, cross-window redock between two agentmux windows, OS-level drag accept indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)