### PR TITLE
fix(cef): resolve_frontend_base_url returns Result (no silent localhost:5173 fallback in prod)

### DIFF
--- a/.changesets/1779970865-fix-cef-resolve-frontend-base-url-returns-result-instead-of--xq0k.md
+++ b/.changesets/1779970865-fix-cef-resolve-frontend-base-url-returns-result-instead-of--xq0k.md
@@ -1,0 +1,36 @@
+---
+type: patch
+---
+
+fix(cef): resolve_frontend_base_url returns Result instead of silently emitting localhost:5173 in production
+
+The function's no-frontend-bundle fallback historically returned
+`http://localhost:<vite_port>` — the dev Vite URL — when
+`frontend/index.html` was missing next to the exe. In production
+nothing is listening on that port; the new browser would abort with
+ERR_ABORTED, terminate its renderer, and trigger the unbounded crash
+loop that caused the 2026-05-28 incident (139k crashes in 22 min).
+Same fallback was already documented as buggy in
+`docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md` but that
+fix only patched the dev branch.
+
+Change signature to `Result<String, FrontendUrlError>` with variants
+`AssetsMissing { checked_path }` and `ExeUnresolvable`. Add
+`assets_missing_data_url(&err)` helper that returns a self-contained
+`data:` URL rendering a static "AgentMux install is broken" page —
+no auto-reload, no link back to the broken install, so navigating to
+it can never trigger another crash loop.
+
+All five callers updated to handle the error: open_window,
+window_pool warmup, tab tear-off (drag.rs), floating pane, and the
+renderer-crash recovery page. The crash-recovery path is
+special-cased — if the recovery handler itself can't resolve a URL,
+it loads the assets-missing page directly so the Reload button
+never points at a network URL that would crash again.
+
+Promotes `html_escape` and `js_string_literal` in `client/helpers.rs`
+from `pub(super)` to `pub(crate)`, and the `helpers` module itself
+to `pub(crate) mod`, so window.rs can share them. No behavior change.
+
+Related: #1117 (follow-up tracking issue),
+`docs/retro/retro-portable-rm-running-install-2026-05-28.md`.

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -10,7 +10,7 @@
 /// Reload button's navigation target.
 use super::dlog;
 
-pub(super) fn js_string_literal(s: &str) -> String {
+pub(crate) fn js_string_literal(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
     for c in s.chars() {
@@ -37,7 +37,7 @@ pub(super) fn js_string_literal(s: &str) -> String {
 /// would break the `format!`-templated string need attention; the input
 /// (CEF status enum + cef-provided error string) is trusted but may
 /// contain `&` / `<` / `>` in some failure modes.
-pub(super) fn html_escape(s: &str) -> String {
+pub(crate) fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -79,7 +79,7 @@ pub struct AgentMuxHandler {
 }
 
 mod handlers;
-mod helpers;
+pub(crate) mod helpers;
 #[cfg(target_os = "windows")]
 mod wndproc;
 
@@ -1277,12 +1277,37 @@ impl AgentMuxHandler {
         // commands::window::resolve_frontend_base_url and its callers
         // (see window.rs:400, window.rs:430, drag.rs:294 — all use the
         // same ipc_port / ipc_token query params).
-        let base_url = crate::commands::window::resolve_frontend_base_url(self.ipc_port);
-        let separator = if base_url.contains('?') { "&" } else { "?" };
-        let app_url = format!(
-            "{}{}ipc_port={}&ipc_token={}",
-            base_url, separator, self.ipc_port, self.state.ipc_token
-        );
+        //
+        // If the resolver returns Err (frontend assets missing — the
+        // 2026-05-28 incident pattern where an external `rm -rf` of a
+        // running portable left current_exe()'s parent dir empty),
+        // short-circuit to the "install broken" static page instead of
+        // pointing the Reload button at a URL that would itself crash.
+        // See docs/retro/retro-portable-rm-running-install-2026-05-28.md.
+        let app_url = match crate::commands::window::resolve_frontend_base_url(self.ipc_port) {
+            Ok(base_url) => {
+                let separator = if base_url.contains('?') { "&" } else { "?" };
+                format!(
+                    "{}{}ipc_port={}&ipc_token={}",
+                    base_url, separator, self.ipc_port, self.state.ipc_token
+                )
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "crash",
+                    error = %e,
+                    "renderer crash recovery: frontend assets unavailable — loading static install-broken page instead of an unresolvable network URL",
+                );
+                let url = crate::commands::window::assets_missing_data_url(&e);
+                if let Some(b) = browser {
+                    if let Some(frame) = b.main_frame() {
+                        let uri = CefString::from(url.as_str());
+                        frame.load_url(Some(&uri));
+                    }
+                }
+                return;
+            }
+        };
 
         let detail_block = if detail.is_empty() {
             String::new()

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -428,15 +428,27 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
     // Build URL with IPC credentials and tear-off params
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
-    let base_url = super::window::resolve_frontend_base_url(ipc_port);
-    let separator = if base_url.contains('?') { "&" } else { "?" };
-    let mut url = format!(
-        "{}{}ipc_port={}&ipc_token={}&windowLabel={}",
-        base_url, separator, ipc_port, ipc_token, label
-    );
-    if !workspace_id.is_empty() {
-        url.push_str(&format!("&workspaceId={}", workspace_id));
-    }
+    let url = match super::window::resolve_frontend_base_url(ipc_port) {
+        Ok(base_url) => {
+            let separator = if base_url.contains('?') { "&" } else { "?" };
+            let mut u = format!(
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}",
+                base_url, separator, ipc_port, ipc_token, label
+            );
+            if !workspace_id.is_empty() {
+                u.push_str(&format!("&workspaceId={}", workspace_id));
+            }
+            u
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                label = %label,
+                "[dnd:cef] frontend assets unavailable — opening static error page on tear-off",
+            );
+            super::window::assets_missing_data_url(&e)
+        }
+    };
 
     // Phase B.5 (window_meta step d) — push the pre-create
     // handoff (label + kind + parent). Tear-offs are FullInstance

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -6,10 +6,12 @@
 //
 // Phase 2: Single-window only. Multi-window commands are stubbed.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use cef::{ImplBrowser, ImplBrowserHost};
 
+use crate::client::helpers::{html_escape, js_string_literal};
 use crate::state::AppState;
 
 /// Get the current zoom factor.
@@ -964,10 +966,60 @@ fn dev_vite_port() -> u16 {
         .unwrap_or(5173)
 }
 
+/// Why `resolve_frontend_base_url` could not return a usable URL.
+///
+/// Returned by `resolve_frontend_base_url` instead of the old silent
+/// fallback to `http://localhost:<vite_port>`, which masked broken
+/// installs as renderer-crash loops in production (see
+/// `docs/retro/retro-portable-rm-running-install-2026-05-28.md`).
+#[derive(Debug)]
+pub(crate) enum FrontendUrlError {
+    /// `std::env::current_exe()` failed. Extraordinarily rare; on
+    /// Windows it would mean we couldn't even resolve our own module
+    /// path, which usually only happens for truly corrupted installs.
+    ExeUnresolvable(std::io::Error),
+    /// We resolved a production install dir but `frontend/index.html`
+    /// is not next to the exe. Either the bundle was never built, was
+    /// deleted (e.g. by an external `rm -rf` of a running portable —
+    /// see retro), or the install layout is otherwise wrong.
+    AssetsMissing { checked_path: PathBuf },
+}
+
+impl std::fmt::Display for FrontendUrlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExeUnresolvable(e) => write!(f, "could not resolve current_exe: {}", e),
+            Self::AssetsMissing { checked_path } => {
+                write!(f, "frontend assets missing at {}", checked_path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrontendUrlError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ExeUnresolvable(e) => Some(e),
+            Self::AssetsMissing { .. } => None,
+        }
+    }
+}
+
 /// Resolve the base URL for the frontend.
-/// Production: IPC server serves static files from `frontend/` next to the exe.
-/// Dev: Vite dev server at `http://localhost:<AGENTMUX_VITE_PORT or 5173>`.
-pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
+///
+/// - **Production:** IPC server serves static files from `frontend/`
+///   next to the exe → returns `http://127.0.0.1:<ipc_port>`.
+/// - **Dev:** Vite dev server at
+///   `http://localhost:<AGENTMUX_VITE_PORT or 5173>`.
+/// - **Production with missing assets:** returns
+///   `Err(FrontendUrlError::AssetsMissing)`. Historically this fell
+///   through to `http://localhost:<vite_port>`, which in production
+///   points at nothing and produced silent renderer crash loops
+///   (issue #1117 / retro 2026-05-28). Callers should now translate
+///   the error into a built-in static error page via
+///   `assets_missing_data_url` rather than navigating to a network
+///   URL.
+pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> Result<String, FrontendUrlError> {
     // Detect dev mode. Two reachable scenarios:
     //   a) Launcher-managed: AGENTMUX_RUNTIME_MODE is set, from_env()
     //      returns Some.
@@ -982,20 +1034,86 @@ pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
             .map(|d| agentmux_common::RuntimeMode::current(&d))
     });
     if matches!(mode, Some(agentmux_common::RuntimeMode::Dev { .. })) {
-        return format!("http://localhost:{}", dev_vite_port());
+        return Ok(format!("http://localhost:{}", dev_vite_port()));
     }
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-    let has_frontend = exe_dir
-        .as_ref()
-        .map(|d| d.join("frontend/index.html").exists())
-        .unwrap_or(false);
-    if has_frontend {
-        format!("http://127.0.0.1:{}", ipc_port)
+    let exe = std::env::current_exe().map_err(FrontendUrlError::ExeUnresolvable)?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| FrontendUrlError::AssetsMissing { checked_path: exe.clone() })?
+        .to_path_buf();
+    let index = exe_dir.join("frontend").join("index.html");
+    if index.exists() {
+        Ok(format!("http://127.0.0.1:{}", ipc_port))
     } else {
-        format!("http://localhost:{}", dev_vite_port())
+        Err(FrontendUrlError::AssetsMissing { checked_path: index })
     }
+}
+
+/// Build a self-contained `data:` URL that renders a static
+/// "AgentMux install is broken" error page. Used by every caller of
+/// `resolve_frontend_base_url` as the navigation target when the
+/// resolver returns `Err` — instead of falling back to a network URL
+/// that almost certainly points at nothing in production.
+///
+/// The page contains no auto-reload and no link back into the broken
+/// install, so navigating to it can never trigger the crash loop the
+/// old silent fallback produced. Only buttons are "Quit" and "Copy
+/// path" (the missing asset path is shown so the user knows what to
+/// reinstall).
+pub(crate) fn assets_missing_data_url(err: &FrontendUrlError) -> String {
+    let (reason, detail) = match err {
+        FrontendUrlError::ExeUnresolvable(e) => (
+            "Could not determine the install directory".to_string(),
+            e.to_string(),
+        ),
+        FrontendUrlError::AssetsMissing { checked_path } => (
+            "AgentMux frontend assets are missing".to_string(),
+            format!("Expected at: {}", checked_path.display()),
+        ),
+    };
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>AgentMux — Install broken</title>
+<style>
+:root {{ color-scheme: dark; }}
+body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+       background: #1e1e2e; color: #cdd6f4;
+       display: flex; justify-content: center; align-items: center;
+       min-height: 100vh; margin: 0; padding: 24px; box-sizing: border-box; }}
+.box {{ text-align: center; max-width: 560px; padding: 36px;
+       background: #181825; border: 1px solid #313244; border-radius: 10px;
+       box-shadow: 0 8px 32px rgba(0,0,0,0.4); }}
+.icon {{ font-size: 36px; line-height: 1; margin-bottom: 12px; }}
+h1 {{ color: #f38ba8; font-size: 22px; margin: 0 0 6px 0; }}
+p {{ color: #bac2de; line-height: 1.55; margin: 0 0 12px 0; font-size: 14px; }}
+.detail code {{ display: inline-block; background: #313244; color: #f9e2af;
+               padding: 6px 10px; border-radius: 4px; font-size: 12px;
+               font-family: ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
+               word-break: break-all; text-align: left; max-width: 100%; }}
+.actions {{ display: flex; gap: 10px; justify-content: center; margin-top: 24px; flex-wrap: wrap; }}
+button {{ padding: 10px 22px; border: 1px solid #45475a; border-radius: 6px;
+         background: #313244; color: #cdd6f4; cursor: pointer;
+         font-size: 13px; font-family: inherit; }}
+button:hover {{ background: #45475a; border-color: #585b70; }}
+</style></head>
+<body><div class="box" role="alertdialog">
+<div class="icon">⚠</div>
+<h1>AgentMux install is broken</h1>
+<p>{reason_safe}.</p>
+<p class="detail"><code>{detail_safe}</code></p>
+<p>Reinstall AgentMux from a fresh portable ZIP to recover. Your saved
+sessions and agent state are in <code>~/.agentmux/</code> and are unaffected.</p>
+<div class="actions">
+<button onclick="navigator.clipboard &amp;&amp; navigator.clipboard.writeText({detail_js})">Copy path</button>
+<button onclick="window.close()">Quit</button>
+</div></div></body></html>"#,
+        reason_safe = html_escape(&reason),
+        detail_safe = html_escape(&detail),
+        detail_js = js_string_literal(&detail),
+    );
+    let b64 = cef::base64_encode(Some(html.as_bytes()));
+    let b64_str = cef::CefString::from(&b64).to_string();
+    format!("data:text/html;base64,{}", b64_str)
 }
 
 /// Open a new full AgentMux instance (status-bar version click, Ctrl+Shift+N,
@@ -1075,13 +1193,23 @@ fn open_window_with_kind(
 
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
-    let base_url = resolve_frontend_base_url(ipc_port);
-
-    let separator = if base_url.contains('?') { "&" } else { "?" };
-    let url = format!(
-        "{}{}ipc_port={}&ipc_token={}&windowLabel={}",
-        base_url, separator, ipc_port, ipc_token, label
-    );
+    let url = match resolve_frontend_base_url(ipc_port) {
+        Ok(base_url) => {
+            let separator = if base_url.contains('?') { "&" } else { "?" };
+            format!(
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}",
+                base_url, separator, ipc_port, ipc_token, label
+            )
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                label = %label,
+                "[window] frontend assets unavailable — opening static error page (the new window will display an 'install broken' notice instead of crash-looping)",
+            );
+            assets_missing_data_url(&e)
+        }
+    };
 
     tracing::info!(label = %label, kind = ?kind, parent = ?parent_instance_id, "[window] open window");
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -193,14 +193,25 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
 
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
-    let base_url = super::window::resolve_frontend_base_url(ipc_port);
-    let separator = if base_url.contains('?') { "&" } else { "?" };
     // The `pool=1` flag tells the frontend to skip its standard
     // workspace init and wait for a `pool:promote` event.
-    let url = format!(
-        "{}{}ipc_port={}&ipc_token={}&windowLabel={}&pool=1",
-        base_url, separator, ipc_port, ipc_token, label
-    );
+    let url = match super::window::resolve_frontend_base_url(ipc_port) {
+        Ok(base_url) => {
+            let separator = if base_url.contains('?') { "&" } else { "?" };
+            format!(
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}&pool=1",
+                base_url, separator, ipc_port, ipc_token, label
+            )
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                label = %label,
+                "[pool] frontend assets unavailable — pool warmup will load static error page (tear-off targets will surface the install-broken notice instead of crash-looping)",
+            );
+            super::window::assets_missing_data_url(&e)
+        }
+    };
 
     // Phase B.5 (window_meta step d) — combined pre-create handoff.
     // Pool windows graduate to tear-off destinations, which are

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -223,8 +223,6 @@ pub fn post_create_floating_window(
     // floating-pane shell instead of the main workspace.
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
-    let base_url = crate::commands::window::resolve_frontend_base_url(ipc_port);
-    let separator = if base_url.contains('?') { "&" } else { "?" };
     // pane_id is a UUID-ish identifier in current callers — no
     // percent-encoding needed today. Use a minimal escape that handles
     // a few special chars in case future callers pass arbitrary names.
@@ -235,19 +233,33 @@ pub fn post_create_floating_window(
     // and rendered the placeholder shell; Phase 2 callers (#1077) pass
     // the newly-created workspace id so the floater renders the actual
     // `<Block>` via the standard new-window init.
-    let mut url = format!(
-        "{}{}ipc_port={}&ipc_token={}&windowLabel={}&floatingPaneId={}",
-        base_url,
-        separator,
-        ipc_port,
-        ipc_token,
-        window_label,
-        escape_query_value(&args.pane_id),
-    );
-    if let Some(ws_id) = args.workspace_id.as_deref().filter(|s| !s.is_empty()) {
-        url.push_str("&workspaceId=");
-        url.push_str(&escape_query_value(ws_id));
-    }
+    let url = match crate::commands::window::resolve_frontend_base_url(ipc_port) {
+        Ok(base_url) => {
+            let separator = if base_url.contains('?') { "&" } else { "?" };
+            let mut u = format!(
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}&floatingPaneId={}",
+                base_url,
+                separator,
+                ipc_port,
+                ipc_token,
+                window_label,
+                escape_query_value(&args.pane_id),
+            );
+            if let Some(ws_id) = args.workspace_id.as_deref().filter(|s| !s.is_empty()) {
+                u.push_str("&workspaceId=");
+                u.push_str(&escape_query_value(ws_id));
+            }
+            u
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                window_label = %window_label,
+                "[floating-pane] frontend assets unavailable — opening static error page",
+            );
+            crate::commands::window::assets_missing_data_url(&e)
+        }
+    };
 
     // Phase B.5 pre-create handoff — same shape as the main
     // open-window path so the existing window_meta plumbing (label →


### PR DESCRIPTION
## Summary

- `agentmux-cef/src/commands/window.rs`'s `resolve_frontend_base_url` historically fell back to `http://localhost:<vite_port>` when `frontend/index.html` was missing next to the exe. In production that points at nothing, the renderer aborts with `ERR_ABORTED`, and the recovery handler loops (139k crashes / 22 min on 2026-05-28).
- Change the signature to `Result<String, FrontendUrlError>` so the failure is explicit and unforgeable.
- Add `assets_missing_data_url(&err)` — a self-contained \`data:\` URL with a static "install is broken" page, no auto-reload, no link back into the broken install.
- All 5 callers (`open_window`, pool warmup, tab tear-off, floating pane, recovery handler) updated to handle the error. The recovery-handler case is special-cased: if the recovery itself can't resolve a URL, it loads the static page directly so the Reload button never targets a network URL that would crash again.

This is fix #1 from issue #1117 (the three-fix defense-in-depth chain). #2 (crash budget) and #3 (log rate-limit) coming next.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean (no new warnings).
- [ ] CI: full workspace check + tests.
- [ ] Smoke (manual): in a dev build, delete \`dist/cef-dev/runtime/frontend/index.html\`, open a new window, confirm the static "install broken" page renders instead of crashing.
- [ ] Smoke: same with a renderer-crash trigger (force-kill a renderer process from Task Manager) — recovery should now show either the normal recovery page (assets present) or the static install-broken page (assets gone); never a loop.

Related:
- Closes one item of #1117
- Retro: \`docs/retro/retro-portable-rm-running-install-2026-05-28.md\`
- Earlier analysis of the dev-side variant: \`docs/analyses/ANALYSIS_DEV_VITE_PORT_HARDCODE_2026-05-26.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)