### PR TITLE
fix(cef): auto-close crash-loop terminal page so dead window releases its instance number

### DIFF
--- a/.changesets/1779971690-fix-cef-auto-close-crash-loop-terminal-page-so-the-dead-wind-amu1.md
+++ b/.changesets/1779971690-fix-cef-auto-close-crash-loop-terminal-page-so-the-dead-wind-amu1.md
@@ -1,0 +1,30 @@
+---
+type: patch
+---
+
+fix(cef): auto-close crash-loop terminal page so the dead window releases its instance number
+
+When `on_render_process_terminated` trips the crash budget (added in
+the prior PR), the resulting "Window stopped recovering" page sits
+indefinitely waiting for the user to click Quit. During that wait
+the dead browser remains in the host's window registry, so the
+launcher's instance counter still includes it — UI shows "2 windows"
+even though only 1 is real, which was one of the user-visible
+symptoms of the 2026-05-28 incident.
+
+Add a 30s countdown to the terminal page that calls `window.close()`
+when it expires. `window.close()` triggers the existing
+`on_before_close` path, which sends `ReportWindowClosed` to the
+launcher, which emits `Event::WindowInstanceReleased`, which
+decrements the user-visible window count. No new IPC protocol or
+host state needed — this just reuses the close-cleanup chain that
+already exists for normal window closes.
+
+Any keystroke or mouse-down on the page cancels the auto-close
+(hidden via `display: none` on the countdown line), so the message
+stays readable as long as the user wants. Single-shot listeners
+(`{ once: true }`) avoid leaking handlers if the user interacts
+multiple times.
+
+Closes one item of #1117. Depends on the crash-budget PR for the
+page to be reachable in the first place.

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1692,8 +1692,18 @@ impl AgentMuxHandler {
 /// page, this one has NO reload button and NO `frame.load_url` target — it
 /// only offers Quit. That's the whole point: navigating away from it cannot
 /// re-enter `on_render_process_terminated` and restart the loop.
+///
+/// Auto-closes after `CRASH_LOOP_AUTO_CLOSE_SECS` so the dead window doesn't
+/// linger in the host's window registry indefinitely. When `window.close()`
+/// fires, the existing `on_before_close` path runs and `ReportWindowClosed`
+/// → launcher → `Event::WindowInstanceReleased` chain decrements the
+/// user-visible window count (fix for #1117 follow-up "decouple window count
+/// from window lifecycle"). A visible countdown gives the user time to read
+/// the message; clicking "Close this window" (or any keystroke / mouse
+/// activity) cancels the auto-close so it's never surprising.
 fn crash_loop_terminal_page(reason: &str, error_code: i32, crashes_in_window: usize) -> String {
     use crate::client::helpers::html_escape;
+    const CRASH_LOOP_AUTO_CLOSE_SECS: u32 = 30;
     format!(
         r#"<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><title>AgentMux — Crash loop</title>
@@ -1710,13 +1720,11 @@ body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans
 h1 {{ color: #f38ba8; font-size: 22px; margin: 0 0 6px 0; }}
 .reason {{ color: #a6adc8; font-size: 14px; margin: 0 0 20px 0; font-style: italic; }}
 p {{ color: #bac2de; line-height: 1.55; margin: 0 0 12px 0; font-size: 14px; }}
-.detail code {{ display: inline-block; background: #313244; color: #f9e2af;
-               padding: 6px 10px; border-radius: 4px; font-size: 12px;
-               font-family: ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
-               word-break: break-all; }}
+.countdown {{ color: #a6adc8; font-size: 13px; margin-top: 16px; }}
+.countdown span {{ color: #f9e2af; font-weight: 600; }}
 button {{ padding: 10px 22px; border: 1px solid #45475a; border-radius: 6px;
          background: #313244; color: #cdd6f4; cursor: pointer;
-         font-size: 13px; font-family: inherit; margin-top: 24px; }}
+         font-size: 13px; font-family: inherit; margin-top: 16px; }}
 button:hover {{ background: #45475a; border-color: #585b70; }}
 .footer {{ color: #6c7086; font-size: 11px; margin-top: 18px;
           font-family: ui-monospace, monospace; }}
@@ -1730,12 +1738,37 @@ Auto-recovery is disabled to prevent a crash loop.</p>
 <p>Your other AgentMux windows and your saved sessions are not affected —
 they remain available. Close this window and open a fresh one to continue.</p>
 <button onclick="window.close()">Close this window</button>
+<p class="countdown">Auto-closing in <span id="countdown">{auto_close_secs}</span> s
+(any keypress or click cancels)</p>
 <div class="footer">error_code={error_code}</div>
-</div></body></html>"#,
+</div>
+<script>
+// Auto-close so the dead window doesn't linger in the host window
+// registry — when window.close() fires, on_before_close runs the
+// normal ReportWindowClosed → WindowInstanceReleased chain and the
+// UI window count snaps to the live count. Any user interaction
+// cancels (so the message stays readable as long as the user wants).
+let secs = {auto_close_secs};
+const el = document.getElementById('countdown');
+let cancelled = false;
+const cancel = () => {{ cancelled = true; el.parentElement.style.display = 'none'; }};
+document.addEventListener('keydown', cancel, {{ once: true }});
+document.addEventListener('mousedown', cancel, {{ once: true }});
+const tick = () => {{
+    if (cancelled) return;
+    secs -= 1;
+    if (secs <= 0) {{ window.close(); return; }}
+    el.textContent = String(secs);
+    setTimeout(tick, 1000);
+}};
+setTimeout(tick, 1000);
+</script>
+</body></html>"#,
         reason_safe = html_escape(reason),
         window_secs = CRASH_BUDGET_WINDOW.as_secs(),
         crashes_in_window = crashes_in_window,
         error_code = error_code,
+        auto_close_secs = CRASH_LOOP_AUTO_CLOSE_SECS,
     )
 }
 


### PR DESCRIPTION
## Summary

- When the crash budget (#1120) trips, the "Window stopped recovering" page sits until the user clicks Quit. During that wait the dead browser stays in the host's window registry, so the launcher's instance counter still includes it — UI shows "2 windows" even when only 1 is real. This was one of the user-visible symptoms of the 2026-05-28 incident.
- Add a 30s countdown to the terminal page that calls \`window.close()\` on expiry. \`window.close()\` triggers the existing \`on_before_close\` path → \`ReportWindowClosed\` → \`Event::WindowInstanceReleased\` → UI window count decrements. No new IPC protocol or host state.
- Any keystroke / mouse-down cancels the auto-close (countdown hides), so the message stays readable as long as the user wants. Listeners are single-shot.

This is the "decouple window count from window lifecycle" follow-up from issue #1117, implemented as the minimal viable fix (reuses existing cleanup chain rather than adding a new "instance abandoned" protocol).

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean.
- [ ] Manual smoke: trip the crash budget (force-kill a renderer 4× in <10s), confirm terminal page renders with countdown, wait 30s, confirm window closes and host log shows \`Event::WindowInstanceReleased\` for that label.
- [ ] Manual smoke: trip budget, click anywhere within 30s, confirm countdown disappears and window stays open until manual close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)