### PR TITLE
fix(agent-pane): merge same-batch text deltas instead of dropping the update

### DIFF
--- a/.changesets/1779971901-fix-agent-pane-merge-same-batch-text-deltas-instead-of-dropp-ukox.md
+++ b/.changesets/1779971901-fix-agent-pane-merge-same-batch-text-deltas-instead-of-dropp-ukox.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): merge same-batch text deltas instead of dropping the update

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -214,6 +214,60 @@ describe("agent document reducer", () => {
             expect(r.state).toBe(start);
             expect(r.events).toEqual([]);
         });
+
+        it("applies a same-batch update on top of a same-batch new node (text-delta race)", () => {
+            // Regression: Mazs agent showed "Y" instead of "Yep, still here…"
+            // because the parser pre-merged the second text_delta and the
+            // reducer processed updatedNodes before newNodes — so the update
+            // was dropped as orphan and the un-merged first-delta node was
+            // appended. See reports/agentmux/PLAN_AGENT_PANE_TEXT_TRUNCATION_
+            // FIX_2026-05-28.md.
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes:     [md("n1", "Y")],
+                updatedNodes: [md("n1", "Yep, still here. What do you need?")],
+            });
+            expect(r.state.nodes).toHaveLength(1);
+            expect((r.state.nodes[0] as any).content).toBe(
+                "Yep, still here. What do you need?",
+            );
+            expect(r.events[0]).toMatchObject({
+                appendedNew: 1,
+                updateApplied: 1,
+                updateDropped: 0,
+            });
+        });
+
+        it("same-batch new node + update preserves new-node order", () => {
+            // Two new nodes plus an update to one of them, all in one batch.
+            // The appended order is still newNodes order; the update lands
+            // on whichever node it targets without disturbing layout.
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes:     [md("a", "first"), md("b", "second")],
+                updatedNodes: [md("a", "first-updated")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["a", "b"]);
+            expect((r.state.nodes[0] as any).content).toBe("first-updated");
+            expect((r.state.nodes[1] as any).content).toBe("second");
+        });
+
+        it("orphan update (no same-batch new node, no prior state) is still dropped", () => {
+            // Locks down the existing orphan-update contract: the fix must
+            // NOT materialize ghost nodes from updates that have nothing
+            // to anchor to.
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes:     [md("a", "anchor")],
+                updatedNodes: [md("ghost", "drifts away")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["a"]);
+            expect(r.events[0]).toMatchObject({
+                appendedNew: 1,
+                updateApplied: 0,
+                updateDropped: 1,
+            });
+        });
     });
 
     describe("StreamTruncate suppression", () => {

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -317,28 +317,23 @@ export function update(
                 return next;
             };
 
-            // Updates first — they target IDs that are expected to exist.
-            let updateApplied = 0;
-            let updateDropped = 0;
-            for (const upd of command.updatedNodes) {
-                const idx = indexById.get(upd.id);
-                if (idx == null) {
-                    updateDropped++;
-                    continue;
-                }
-                const arr = ensureClone();
-                const existing = arr[idx];
-                if (existing.type === "markdown" && upd.type === "markdown") {
-                    arr[idx] = { ...existing, content: upd.content };
-                } else {
-                    arr[idx] = mergeReplacement(existing, upd);
-                }
-                updateApplied++;
-            }
-
-            // New nodes: dedup against existing IDs; collisions → in-place
-            // update (same protection the original `flushPendingNodes` had
-            // against the rebuild-while-pending race).
+            // New nodes first. useAgentStream decides "new vs update"
+            // by checking its local nodeIdSet as events arrive, but
+            // events that share an animation frame can produce a
+            // newNode AND an updatedNode for the same id — the parser
+            // pre-merges text deltas, so the LATER delta becomes an
+            // update of an id that doesn't exist yet in state. By
+            // appending newNodes first (and registering them in
+            // indexById), a same-batch update can find its target
+            // instead of being dropped as orphan and leaving the
+            // un-merged first-delta version in state. Truly orphan
+            // updates — those with no matching new node in this batch
+            // AND no prior state entry — still drop, preserving the
+            // existing contract (see "drops updates targeting unknown
+            // IDs" test). See REPORT_AGENT_PANE_TEXT_TRUNCATION_2026-
+            // 05-28.md for the user-visible symptom (assistant
+            // response "Yep, still here. What do you need?" rendered
+            // as "Y").
             let appendedNew = 0;
             let collidedAndUpdated = 0;
             let nextIdSet: Set<string> | null = null;
@@ -356,6 +351,27 @@ export function update(
                 if (!nextIdSet) nextIdSet = new Set(state.nodeIdSet);
                 nextIdSet.add(n.id);
                 appendedNew++;
+            }
+
+            // Updates second — indexById now includes both prior
+            // state AND same-batch newNodes, so an update can target
+            // either. Anything still missing is a genuine orphan.
+            let updateApplied = 0;
+            let updateDropped = 0;
+            for (const upd of command.updatedNodes) {
+                const idx = indexById.get(upd.id);
+                if (idx == null) {
+                    updateDropped++;
+                    continue;
+                }
+                const arr = ensureClone();
+                const existing = arr[idx];
+                if (existing.type === "markdown" && upd.type === "markdown") {
+                    arr[idx] = { ...existing, content: upd.content };
+                } else {
+                    arr[idx] = mergeReplacement(existing, upd);
+                }
+                updateApplied++;
             }
 
             if (!next) {


### PR DESCRIPTION
## Summary

Short Claude responses were rendering as their first character only — e.g. `"Yep, still here. What do you need?"` appeared as `"Y"`. The model wrote the full text, the on-disk transcript stored the full text, but the rendered pane lost everything after the first `text_delta`.

Root cause: a loop-order bug in `frontend/app/store/agent-document/reducer.ts`'s `StreamFlush` case. When two `text_delta`s landed in the same animation frame, the parser pre-merged them and `useAgentStream` routed delta-1 to `pendingNew` and delta-2 (merged) to `pendingUpdates` for the same id. The reducer then processed `updatedNodes` *before* `newNodes`, so the update's id wasn't in `indexById` yet (built from prior state, where the node didn't exist) and the update was silently dropped as orphan. The un-merged first-delta node was appended.

Fix: swap the loop order so `newNodes` runs first and extends `indexById`, then `updatedNodes` can find same-batch targets. Orphan updates with neither a same-batch new node nor a prior-state match still drop, preserving the existing contract.

## What changed

- `frontend/app/store/agent-document/reducer.ts` — swap `newNodes` / `updatedNodes` loop order; extend `indexById` inside the new-nodes loop. Long inline comment explaining the race so this doesn't get reverted in the future.
- `frontend/app/store/agent-document/reducer.test.ts` — three regression tests:
  - same-batch new + update for the same id merges (the actual Mazs bug)
  - same-batch new + update preserves new-node order
  - orphan update (no same-batch new, no prior state) is still dropped
- `.changesets/…fix-agent-pane….md` — patch changeset.

All 66 reducer tests pass.

## Live evidence

| Time | Frame |
|------|-------|
| 12:10:24.391 | `content_block_delta {text_delta: "Y"}` |
| 12:10:24.393 | `content_block_delta {text_delta: "ep, still here. What do you need?"}` |
| 12:10:24.395 | `assistant {content: [{text: "Yep, still here. What do you need?"}]}` |

Both deltas captured in `~/.agentmux/channels/stable/logs/agentmuxsrv-v0.39.1.log.2026-05-28` for block `23fcb20d-e750-45d0-be8e-5d7dc0738e1f`. Server-side translator, frontend translator, and stream-parser all produced the right output — the reducer was the failure point.

## Why this design (not a unified upsert pass)

I considered collapsing `newNodes` + `updatedNodes` into a single upsert loop. Rejected because today `StreamFlush({newNodes:[], updatedNodes:[md("ghost")]})` is a no-op (existing test `"drops updates targeting unknown IDs"`), and a naive upsert would materialize ghost nodes. The reducer's "new vs update" split protects against orphan history-reload-race updates and against the tool-decision flow in `agent-view.tsx:367-371`. The split isn't broken — only the assumption that "updates target ids that already exist" was.

## Out of scope (follow-ups)

- `updateDropped` is currently silent telemetry. A `console.warn` from `useAgentStream` when `updateDropped > 0` would surface this class of bug at the source. Tracking separately.
- The other agent translators (`codex`, `kimi`, `gemini`, `acp`) emit `text` events the same way and benefit from this reducer fix; no per-translator changes needed.

## Test plan

- [x] `npx vitest run frontend/app/store/agent-document/reducer.test.ts` → 66/66 pass
- [ ] Reproduce manually: open a Claude agent pane, send a short prompt that elicits a short response, verify the full sentence renders (not just the first letter)
- [ ] Watch for any P0/P1 from Codex review

## Refs

- Diagnosis: `reports/agentmux/REPORT_AGENT_PANE_TEXT_TRUNCATION_2026-05-28.md` (in my workspace)
- Implementation plan: `reports/agentmux/PLAN_AGENT_PANE_TEXT_TRUNCATION_FIX_2026-05-28.md` (in my workspace)