### PR TITLE
fix(launcher,cef): anchor asset lookup on AGENTMUX_HOME env from launcher

### DIFF
--- a/.changesets/1779971942-fix-launcher-cef-anchor-asset-lookup-on-agentmux-home-env-fr-yb0w.md
+++ b/.changesets/1779971942-fix-launcher-cef-anchor-asset-lookup-on-agentmux-home-env-fr-yb0w.md
@@ -1,0 +1,38 @@
+---
+type: patch
+---
+
+fix(launcher,cef): anchor asset lookup on AGENTMUX_HOME env from launcher instead of fragile current_exe()
+
+Windows's `GetModuleFileName` (called by `std::env::current_exe`)
+keeps returning the path the .exe was *originally loaded from*, even
+after that directory is renamed or unlinked. The 2026-05-28 incident
+exploited this: an external `rm -rf` of the running portable's
+directory left `current_exe()` pointing at an empty path, so
+`current_exe().parent().join("frontend/index.html")` returned ENOENT,
+which (pre-#1119) caused a silent fallback to `localhost:5173` and a
+renderer crash loop. #1119 + #1120 + #1121 catch the symptom; this
+PR removes the root architectural hazard.
+
+`agentmux-launcher` already resolves `real_exe` from its own
+`current_exe()` BEFORE spawning the host — that resolution path
+walks from the launcher's stable on-disk location to the runtime
+dir, so it always points at the directory that actually contains
+the binaries. Export that resolved path to the host as
+`AGENTMUX_HOME`.
+
+`agentmux-cef`'s `resolve_frontend_base_url` (and `RuntimeMode`
+detection) now prefer `AGENTMUX_HOME` over `current_exe().parent()`.
+A new `resolve_host_runtime_dir()` helper centralises the
+preference chain: env var first, `current_exe()` fallback for dev
+mode / standalone invocations where the launcher isn't present.
+
+Fallback to `current_exe()` is preserved so:
+- `task dev` (which can invoke the host directly on Linux/macOS)
+  keeps working without the launcher.
+- Existing standalone smoke tests stay green.
+- Pre-AGENTMUX_HOME launcher builds running against a newer host
+  degrade gracefully (only the rename-hazard reappears, which the
+  earlier PRs catch).
+
+Closes one item of #1117. Composes with #1115, #1119, #1120, #1121.

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -1028,25 +1028,52 @@ pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> Result<String, Fronten
     //      same `dist/cef-dev/` build dir → Dev classification fires
     //      that the launcher would have used.
     let mode = agentmux_common::RuntimeMode::from_env().or_else(|| {
-        std::env::current_exe()
+        resolve_host_runtime_dir()
             .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
             .map(|d| agentmux_common::RuntimeMode::current(&d))
     });
     if matches!(mode, Some(agentmux_common::RuntimeMode::Dev { .. })) {
         return Ok(format!("http://localhost:{}", dev_vite_port()));
     }
-    let exe = std::env::current_exe().map_err(FrontendUrlError::ExeUnresolvable)?;
-    let exe_dir = exe
-        .parent()
-        .ok_or_else(|| FrontendUrlError::AssetsMissing { checked_path: exe.clone() })?
-        .to_path_buf();
-    let index = exe_dir.join("frontend").join("index.html");
+    let runtime_dir = resolve_host_runtime_dir()?;
+    let index = runtime_dir.join("frontend").join("index.html");
     if index.exists() {
         Ok(format!("http://127.0.0.1:{}", ipc_port))
     } else {
         Err(FrontendUrlError::AssetsMissing { checked_path: index })
     }
+}
+
+/// Resolve the directory that contains this host build's runtime
+/// assets (`frontend/`, the CEF DLLs, locales, etc.).
+///
+/// Preference order:
+///
+/// 1. **`AGENTMUX_HOME` env var** — set by `agentmux-launcher` from
+///    *its* resolved `real_exe` path at host-spawn time. This is the
+///    authoritative anchor: the launcher always finds the runtime
+///    dir by walking from its own current_exe, so the path it
+///    exports always points at the on-disk files that actually
+///    exist, even if those files were moved or unlinked after host
+///    process startup. See
+///    `docs/retro/retro-portable-rm-running-install-2026-05-28.md`
+///    for why current_exe() is not safe to use directly on Windows.
+/// 2. **Fallback to `std::env::current_exe().parent()`** — used in
+///    dev mode (`task dev` without the launcher) and any other
+///    invocation where AGENTMUX_HOME isn't set. Carries the old
+///    Windows-rename hazard, but those invocations don't survive
+///    a directory move in the same way (dev mode is short-lived).
+fn resolve_host_runtime_dir() -> Result<PathBuf, FrontendUrlError> {
+    if let Some(val) = std::env::var_os("AGENTMUX_HOME") {
+        let path = PathBuf::from(val);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+    let exe = std::env::current_exe().map_err(FrontendUrlError::ExeUnresolvable)?;
+    exe.parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| FrontendUrlError::AssetsMissing { checked_path: exe })
 }
 
 /// Build a self-contained `data:` URL that renders a static

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -234,6 +234,18 @@ fn spawn_host_supervised(
 ) -> Option<tokio::process::Child> {
     use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
 
+    // The launcher's resolved `real_exe` lives in `runtime/`; pass its
+    // parent dir as AGENTMUX_HOME so the host can anchor asset lookups
+    // (frontend/index.html, etc.) on something stable rather than
+    // `std::env::current_exe()`. Windows's GetModuleFileName keeps
+    // returning the original load-time path even after the parent dir
+    // is renamed or unlinked out from under it — the 2026-05-28
+    // incident pattern. AGENTMUX_HOME is whatever path *we* (the
+    // launcher) successfully resolved real_exe through, so it always
+    // points at the runtime dir that actually contains the binaries.
+    // See docs/retro/retro-portable-rm-running-install-2026-05-28.md.
+    let host_runtime_dir = real_exe.parent().map(|p| p.to_path_buf());
+
     let mut host_cmd = tokio::process::Command::new(real_exe);
     host_cmd
         .args(args)
@@ -246,6 +258,9 @@ fn spawn_host_supervised(
         .env("AGENTMUX_LAUNCHER_PIPE", pipe_path)
         .creation_flags(CREATE_SUSPENDED)
         .kill_on_drop(false); // J0 handles cleanup.
+    if let Some(dir) = host_runtime_dir {
+        host_cmd.env("AGENTMUX_HOME", dir);
+    }
     if let Some(name) = splash_event {
         host_cmd.env("AGENTMUX_SPLASH_EVENT", name);
     }


### PR DESCRIPTION
## Summary

- Windows's \`GetModuleFileName\` (called by \`std::env::current_exe\`) returns the .exe's *load-time* path forever, even after that dir is renamed or unlinked. That's how the 2026-05-28 incident stayed invisible to the running process and tripped the silent fallback URL.
- \`agentmux-launcher\` already walks from its own \`current_exe\` to find the runtime dir before spawning the host — that path is always correct because the launcher is freshly invoked. Export that resolved path as \`AGENTMUX_HOME\` on host spawn.
- \`agentmux-cef\`'s \`resolve_frontend_base_url\` (and \`RuntimeMode\` detection) now prefer \`AGENTMUX_HOME\` over \`current_exe().parent()\`. New \`resolve_host_runtime_dir()\` helper centralises the preference chain.
- \`current_exe()\` fallback preserved so \`task dev\` (Linux/macOS, host invoked directly) keeps working, standalone smoke tests stay green, and pre-AGENTMUX_HOME launcher builds degrade gracefully.

The previous PRs in this series (#1115 + #1119 + #1120 + #1121) catch the *symptom* of a wedged install. This one removes the *root architectural hazard*.

Closes one item of #1117. Composes with all prior PRs in the series.

## Test plan

- [x] \`cargo check -p agentmux-cef -p agentmux-launcher\` clean.
- [ ] CI workspace tests.
- [ ] Smoke: \`task dev\` on Windows still resolves the Vite URL correctly (AGENTMUX_HOME absent → falls back to current_exe path → RuntimeMode::Dev detected).
- [ ] Smoke: portable install still resolves frontend correctly (AGENTMUX_HOME present, points at runtime/).
- [ ] Smoke: simulate the 2026-05-28 trigger (move portable dir while running, open new window) — confirm AGENTMUX_HOME still points at original moved path? Or at the new path? (The launcher set it at startup, so it'll point at wherever the runtime was at launch. If runtime is *moved*, this protects against the case where the directory still exists at its old path; if runtime is *deleted entirely*, the prior PRs catch it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)