### PR TITLE
fix(cef): unbreak agentmux-cef compile on macOS with public cef-rs 146

### DIFF
--- a/.changesets/1779988310-fix-cef-unbreak-agentmux-cef-compile-on-macos-with-public-ce-7c8w.md
+++ b/.changesets/1779988310-fix-cef-unbreak-agentmux-cef-compile-on-macos-with-public-ce-7c8w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): unbreak agentmux-cef compile on macOS with public cef-rs 146

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -16,6 +16,13 @@ default = []
 sandbox = ["cef/sandbox"]
 # Opt-in for dev_authfile unit tests that touch the filesystem and Win32 ACL APIs
 test-authfile = []
+# Enables call sites that depend on the AgentMux libcef fork
+# (https://github.com/a5af/cef, branch agentmux/7680-drag-rightclick-and-transparency).
+# Specifically: `_cef_window_t::begin_window_drag` (used by StartWindowDragTask).
+# Requires a matching patched cef-dll-sys via [patch.crates-io] in the workspace
+# Cargo.toml. Default OFF so unpatched checkouts compile — native left-click
+# window drag is a no-op without the patch.
+patched-libcef = []
 
 [package.metadata.cef.bundle]
 # No helper needed without sandbox

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -152,6 +152,34 @@ const EVENTFLAG_CONTROL_DOWN: u32 = 1 << 2;
 const VK_P: i32 = 0x50; // Ctrl+P — command palette (not print)
 const VK_G: i32 = 0x47; // Ctrl+G — (reserve for app use)
 
+// cef-rs declares `on_pre_key_event`'s `os_event` differently per platform:
+//   Windows → Option<&mut MSG>     (typed)
+//   Linux   → Option<&mut XEvent>  (typed)
+//   macOS   → *mut u8              (raw)
+// A single signature can't satisfy all three, so we expand the macro per
+// target and forward to a shared body.
+fn handle_pre_key_event(
+    event: Option<&KeyEvent>,
+    is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
+) -> ::std::os::raw::c_int {
+    if let Some(ev) = event {
+        let ctrl = (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0;
+        if ctrl && matches!(ev.windows_key_code, VK_P | VK_G) {
+            // Tell CEF this is a keyboard shortcut so it dispatches
+            // the keydown event to JavaScript instead of handling it
+            // as a built-in browser action (print dialog, etc.).
+            if let Some(flag) = is_keyboard_shortcut {
+                *flag = 1;
+            }
+            // Return 0 = not consumed at pre-key stage; CEF will
+            // still call on_key_event where we return 0 again,
+            // letting JS handle it via the normal keydown path.
+        }
+    }
+    0 // not consumed
+}
+
+#[cfg(target_os = "windows")]
 wrap_keyboard_handler! {
     struct AgentMuxKeyboardHandler;
 
@@ -160,24 +188,44 @@ wrap_keyboard_handler! {
             &self,
             _browser: Option<&mut Browser>,
             event: Option<&KeyEvent>,
-            _os_event: Option<&mut crate::OsKeyEvent>,
+            _os_event: Option<&mut cef::sys::MSG>,
             is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
         ) -> ::std::os::raw::c_int {
-            if let Some(ev) = event {
-                let ctrl = (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0;
-                if ctrl && matches!(ev.windows_key_code, VK_P | VK_G) {
-                    // Tell CEF this is a keyboard shortcut so it dispatches
-                    // the keydown event to JavaScript instead of handling it
-                    // as a built-in browser action (print dialog, etc.).
-                    if let Some(flag) = is_keyboard_shortcut {
-                        *flag = 1;
-                    }
-                    // Return 0 = not consumed at pre-key stage; CEF will
-                    // still call on_key_event where we return 0 again,
-                    // letting JS handle it via the normal keydown path.
-                }
-            }
-            0 // not consumed
+            handle_pre_key_event(event, is_keyboard_shortcut)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+wrap_keyboard_handler! {
+    struct AgentMuxKeyboardHandler;
+
+    impl KeyboardHandler {
+        fn on_pre_key_event(
+            &self,
+            _browser: Option<&mut Browser>,
+            event: Option<&KeyEvent>,
+            _os_event: Option<&mut cef::sys::XEvent>,
+            is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
+        ) -> ::std::os::raw::c_int {
+            handle_pre_key_event(event, is_keyboard_shortcut)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+wrap_keyboard_handler! {
+    struct AgentMuxKeyboardHandler;
+
+    impl KeyboardHandler {
+        fn on_pre_key_event(
+            &self,
+            _browser: Option<&mut Browser>,
+            event: Option<&KeyEvent>,
+            _os_event: *mut u8,
+            is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
+        ) -> ::std::os::raw::c_int {
+            handle_pre_key_event(event, is_keyboard_shortcut)
         }
     }
 }

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -49,19 +49,6 @@ use std::sync::Arc;
 
 use cef::*;
 
-/// Platform-specific type for OS key events in KeyboardHandler.
-/// Matches `cef_event_handle_t` after deref:
-///   - Windows:  *mut MSG          → MSG
-///   - Linux:    *mut XEvent       → _XEvent (libX11)
-///   - macOS:    *mut c_void       → c_void  (NSEvent-backed; cef-dll-sys
-///                                            uses an opaque pointer here)
-#[cfg(target_os = "windows")]
-pub type OsKeyEvent = cef::sys::MSG;
-#[cfg(target_os = "linux")]
-pub type OsKeyEvent = cef::sys::_XEvent;
-#[cfg(target_os = "macos")]
-pub type OsKeyEvent = std::ffi::c_void;
-
 /// Suppress the Windows "Application Error" / WER crash dialog so an unhandled
 /// fault (a Chromium `LOG(FATAL)`, an `abort()`, a breakpoint) terminates the
 /// process immediately instead of wedging it behind a modal the user must

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -196,11 +196,29 @@ wrap_task! {
                         );
                         return;
                     }
-                    if let Some(f) = (*raw_ptr).begin_window_drag {
-                        let result = f(raw_ptr);
-                        tracing::info!("[start_window_drag] BeginWindowDrag returned {} label={}", result, self.label);
-                    } else {
-                        tracing::warn!("[start_window_drag] BeginWindowDrag fn ptr is null label={}", self.label);
+                    // begin_window_drag is appended to _cef_window_t by the
+                    // AgentMux fork of cef-dll-sys (see docs/cef-build/
+                    // build-patched-libcef.md). Unpatched builds (default
+                    // crates.io cef-dll-sys) lack the field — gated behind
+                    // the `patched-libcef` cargo feature so default builds
+                    // compile.
+                    #[cfg(feature = "patched-libcef")]
+                    {
+                        if let Some(f) = (*raw_ptr).begin_window_drag {
+                            let result = f(raw_ptr);
+                            tracing::info!("[start_window_drag] BeginWindowDrag returned {} label={}", result, self.label);
+                        } else {
+                            tracing::warn!("[start_window_drag] BeginWindowDrag fn ptr is null label={}", self.label);
+                        }
+                    }
+                    #[cfg(not(feature = "patched-libcef"))]
+                    {
+                        let _ = raw_ptr;
+                        tracing::warn!(
+                            "[start_window_drag] patched-libcef feature disabled — native drag is a no-op. \
+                             Rebuild with --features patched-libcef and a patched libcef.so (a5af/cef agentmux/7680-...) to enable. label={}",
+                            self.label
+                        );
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

- Splits `wrap_keyboard_handler!` into three `#[cfg(target_os = ...)]` blocks so the `on_pre_key_event` trait impl matches cef-rs's per-platform `os_event` signature (`Option<&mut MSG>` / `Option<&mut XEvent>` / `*mut u8`). Removes the now-unused `OsKeyEvent` type alias.
- Gates the `_cef_window_t::begin_window_drag` FFI call site behind a new `patched-libcef` cargo feature (default off) so unpatched checkouts (= default crates.io `cef-dll-sys`) compile. Patched builds (`--features patched-libcef`) behave identically to before.

Closes #1130.

## Why this matters

A fresh clone at `main` HEAD fails `cargo build -p agentmux-cef` on macOS:

```
error[E0053]: method `on_pre_key_event` has an incompatible type for trait
   --> agentmux-cef/src/client/handlers.rs:163:24

error[E0609]: no field `begin_window_drag` on type `_cef_window_t`
   --> agentmux-cef/src/ui_tasks.rs:199:49
```

Both are real defects in `main`. The only CI workflow today is `release-consistency.yml`, which doesn't compile the Rust host on any platform — so this drift went unnoticed. Filing a follow-up issue for adding a `cargo check` matrix CI job would close the gap that allowed this in.

## Behavior

| Build | macOS | Linux | Windows |
|-------|-------|-------|---------|
| Default (`task dev`, `cargo build`) | Compiles + runs. Native left-click window drag is a no-op (warns once per attempt). | Same as macOS. | Unchanged — drag is Windows-native via WM_NCLBUTTONDOWN, doesn't go through `begin_window_drag`. |
| `--features patched-libcef` (with patched `cef-dll-sys` via `[patch.crates-io]`) | Identical to prior behavior. | Identical to prior behavior. | Unchanged. |

The runtime ABI-mismatch guard in `StartWindowDragTask` (size-check against `cef_base_ref_counted_t.size`) is preserved, so a `--features patched-libcef` binary running against an unpatched `libcef.dylib` still no-ops cleanly with a warn.

## Test plan

- [x] `cargo check -p agentmux-cef --release` — clean (warnings only).
- [x] `cargo build --release -p agentmux-cef` — finishes in 43.6s on Apple Silicon.
- [x] `task dev` advances past the compile stage and starts the host (then panics at `cef-rs library_loader.rs:20` because `libcef.dylib` isn't bundled — separate runtime/setup issue, not in scope).
- [ ] Windows: confirm `cargo build -p agentmux-cef` still passes (unchanged code paths, but verifying CI).
- [ ] `cargo build --features patched-libcef` against a patched `cef-dll-sys` to confirm the gated path still compiles.

## Notes for reviewers

- Default branch on a clean clone now compiles on macOS but the host still won't launch without bundling a `libcef.dylib`. That's a separate dev-setup issue worth filing.
- `OsKeyEvent` is removed from `agentmux-cef/src/main.rs` — verified it had no other consumers (grep returned only the now-rewritten `handlers.rs:163` site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)