### PR TITLE
fix(agent-pane): suppress Send-now flash by excluding Submitting

### DIFF
--- a/.changesets/1780001472-fix-agent-pane-suppress-send-now-flash-by-excluding-submitti-3rgt.md
+++ b/.changesets/1780001472-fix-agent-pane-suppress-send-now-flash-by-excluding-submitti-3rgt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): suppress Send-now flash by excluding Submitting from the predicate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.39.2"
+version = "0.39.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,10 @@
 # AgentMux Version History
 
+## 0.39.3 — 2026-05-28
+
+- (no semantic content — internal portable-build counter increment from `task package`; auto-appended by `scripts/bump-wrapper.sh` to satisfy the release-consistency invariant)
+
+
 ## 0.39.2 — 2026-05-28
 
 - (no semantic content — internal portable-build counter increment from `task package`; auto-appended by `scripts/bump-wrapper.sh` to satisfy the release-consistency invariant)

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -291,6 +291,28 @@ export function workingFromPhase(phase: TurnPhase): boolean {
 }
 
 /**
+ * Selector — `true` iff there is an in-flight turn that SIGINT can
+ * interrupt. Same shape as {@link workingFromPhase}, but **excludes
+ * `Submitting`** — during Submitting the would-be turn is itself
+ * sitting in the pending queue waiting for `agent-message-accepted`,
+ * so there is no CLI process to interrupt yet.
+ *
+ * Used by the "Send now" affordance (`PendingMessagesPanel`), which
+ * is meaningful only when the queue genuinely sits behind a running
+ * turn. Gating that button on the broader `workingFromPhase` caused
+ * a brief flash on every send: the freshly-typed message was in
+ * `pendingMessages` for ~50–200 ms while the phase sat in `Submitting`,
+ * lighting the button before `agent-message-accepted` cleared the
+ * queue. Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
+ *
+ * Returns true ⇔ `phase.kind ∈ {Streaming, Interrupting}`.
+ */
+export function isInterruptibleTurn(phase: TurnPhase): boolean {
+    const k = phase.kind;
+    return k === "Streaming" || k === "Interrupting";
+}
+
+/**
  * Selector — `true` iff the pane is in the `Disconnected` phase. PR F:
  * drives the {@link AgentDisconnectedBanner} visibility, replacing any
  * ad-hoc "streaming.active === false but turn was active" checks. Pure

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -23,7 +23,7 @@ import {
     registerActivity as registerAgentActivity,
     unregisterActivity as unregisterAgentActivity,
 } from "@/app/store/agentActivity";
-import { workingFromPhase } from "@/app/store/agent-pane-state/types";
+import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
@@ -811,12 +811,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
                 showSendNow={() =>
-                    // "Send now" appears whenever the agent is working
-                    // (Submitting / Streaming / Interrupting) and the
-                    // user has at least one queued message. PR G removed
-                    // the legacy `turnActive` boolean — the working set
-                    // is now defined purely by `turnPhase`.
-                    workingFromPhase(agentAtoms().turnPhaseAtom[0]()) &&
+                    // "Send now" appears only when there is an in-flight
+                    // turn that SIGINT can actually interrupt — i.e.
+                    // Streaming / Interrupting. `Submitting` is excluded
+                    // because the message in the queue during Submitting
+                    // IS the would-be turn; there is no CLI process to
+                    // stop yet. Gating on the broader `workingFromPhase`
+                    // caused a brief flash on every send.
+                    // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
+                    isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]()) &&
                     pendingMessagesAtom[0]().length > 0
                 }
                 onSendImmediately={() => {

--- a/frontend/app/view/agent/state.test.ts
+++ b/frontend/app/view/agent/state.test.ts
@@ -6,7 +6,7 @@ import {
     createAgentAtoms,
     type AgentAtoms,
 } from "./state";
-import { workingFromPhase } from "@/app/store/agent-pane-state/types";
+import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 
 let atoms: AgentAtoms;
 
@@ -86,6 +86,57 @@ describe("createAgentAtoms", () => {
             reason: "stream-unsubscribed",
         });
         expect(workingFromPhase(getPhase())).toBe(false);
+    });
+
+    // ── isInterruptibleTurn — "Send now" affordance gating ──────────────
+    // The pending-queue "Send now" button is meaningful only when a CLI
+    // process is in flight that SIGINT can interrupt — i.e. Streaming or
+    // Interrupting. `Submitting` is excluded because the message itself
+    // is the would-be turn, still waiting for `agent-message-accepted`.
+    // Gating on `workingFromPhase` caused a brief flash on every send.
+    // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
+    test("isInterruptibleTurn = false for Idle / Submitting / Done / Disconnected", () => {
+        const [getPhase, setPhase] = atoms.turnPhaseAtom;
+
+        expect(getPhase().kind).toBe("Idle");
+        expect(isInterruptibleTurn(getPhase())).toBe(false);
+
+        setPhase({ kind: "Submitting", submittedAt: 1, pendingContent: "" });
+        expect(isInterruptibleTurn(getPhase())).toBe(false);
+
+        setPhase({ kind: "Done", outcome: "completed", finishedAt: 1 });
+        expect(isInterruptibleTurn(getPhase())).toBe(false);
+
+        setPhase({
+            kind: "Disconnected",
+            lastKind: "Streaming",
+            lastConnectedAt: 1,
+            reason: "stream-unsubscribed",
+        });
+        expect(isInterruptibleTurn(getPhase())).toBe(false);
+    });
+
+    test("isInterruptibleTurn = true for Streaming / Interrupting", () => {
+        const [getPhase, setPhase] = atoms.turnPhaseAtom;
+
+        setPhase({
+            kind: "Streaming",
+            bufferSize: 0,
+            toolsActive: 0,
+            lastEventMs: 1,
+        });
+        expect(isInterruptibleTurn(getPhase())).toBe(true);
+
+        setPhase({ kind: "Interrupting", reason: "user", sigintSentAt: 1 });
+        expect(isInterruptibleTurn(getPhase())).toBe(true);
+    });
+
+    test("isInterruptibleTurn excludes the Submitting case that workingFromPhase includes", () => {
+        const submitting = { kind: "Submitting", submittedAt: 1, pendingContent: "" } as const;
+        // The exact divergence point: this is why the Send-now flash
+        // existed and why a separate predicate was needed.
+        expect(workingFromPhase(submitting)).toBe(true);
+        expect(isInterruptibleTurn(submitting)).toBe(false);
     });
 
     test("Interrupting phase drives the 'Stopping…' label", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.39.2",
+      "version": "0.39.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The pending-queue "Send now" button flickered for ~50–200 ms on every send-message from an agent pane, including from a fully idle pane. Root cause: the predicate at `agent-view.tsx:819` gated on `workingFromPhase(turnPhase)` which returns true for `{Submitting, Streaming, Interrupting}` — but during `Submitting` the message you just typed is itself in the pending queue waiting for `agent-message-accepted`. Both predicates were briefly true on every send → button paints → ~50–200 ms later it hides.

## Fix

- Add `isInterruptibleTurn(phase: TurnPhase): boolean` next to `workingFromPhase` — same shape, strict subset, true only for `{Streaming, Interrupting}`.
- Swap the predicate at the single call site. Inline comment updated.
- Three unit-test cases pinning the new predicate, including an anti-regression test asserting the exact `Submitting` divergence point between the two helpers.

Behavior can only go "button visible → button hidden", never the reverse. The queued-zone itself (amber border, spinner, message list) is unchanged.

## Test plan

- [x] `npx vitest run frontend/app/view/agent/state.test.ts` — 9/9 pass (3 new).
- [ ] Smoke: idle pane, type a message, hit Enter; no "Send now" button paints during the Submitting window.
- [ ] Smoke: start a long Streaming turn, type a second message; "Send now" appears, click it → first turn stops, queued message processes.

## Background

- PRs #495 (Send-now intro), #992 (turn-phase B switched the predicate to `workingFromPhase`), #997 (PR G removed legacy `turnActive`).
- Diagnosis: `docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md` (in the parallel diagnostic branch — not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)