### PR TITLE
fix(agent-pane): collapse 3 hover events into one auto-expand panel

### DIFF
--- a/.changesets/1780002518-fix-agent-pane-collapse-3-hover-events-into-one-auto-expand--p5w5.md
+++ b/.changesets/1780002518-fix-agent-pane-collapse-3-hover-events-into-one-auto-expand--p5w5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): collapse 3 hover events into one auto-expand panel

--- a/docs/specs/SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md
+++ b/docs/specs/SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md
@@ -1,0 +1,203 @@
+# SPEC: Tool-hover consolidation (2026-05-28)
+
+**Author:** AgentA
+**Reporter:** user (this session) — "in the agent pane, there appears to be 3 separate events happening on a tool hover, a small time popup, a larger log popup, and a fast expand/collapse. There should be NO expand/collapse on hover. It only is supposed to happen on new messages. We want the small popup (it's just the time) to be at the top of the larger popup, so it's just 1 popup. Also, in the large log popup, we repeat the same info in the line and in the popup, lets get rid of the dupe."
+**Affected files (primary):**
+- `frontend/app/view/agent/components/ToolBlock.tsx` (335 LOC)
+- `frontend/app/view/agent/components/ToolBlockOverlay.tsx` (80 LOC)
+- `frontend/app/view/agent/components/ToolOverlayLog.tsx` (259 LOC — body only, no header change)
+- `frontend/app/view/agent/styles/_document-nodes.scss` (tool styling)
+- `frontend/app/view/agent/components/ToolBlock.test.tsx` (tests for hover behavior)
+
+**Supersedes/amends:** `docs/specs/tool-collapse.md` (the hover-expand model that this spec removes).
+**Predecessors:**
+- `docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md` — three-slot overlay layout
+- `docs/specs/SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md` — 150 ms enter delay, mouseleave-only collapse
+- `docs/specs/SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md` — Phase B auto-expand for running/pending_approval
+- `docs/specs/SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md` — hover-anchor mechanism (overlay direction picker)
+
+---
+
+## 1. Symptom inventory
+
+The user observes **three distinct visual events** when hovering a tool row in the agent pane:
+
+1. **Small time popup** — a small box appears briefly. It currently shows the tool *summary* text (browser-native `title=` attribute on `.agent-tool-name` at `ToolBlock.tsx:242`), but the user reads it as "the time popup" — likely conflated with the duration `(N.Ns)` shown beside the tool name. The browser-native tooltip has its own delay (~500 ms on Windows Chrome) so it appears *before or after* the larger panel depending on cursor speed.
+2. **Larger log popup** — the `.agent-tool-panel` overlay with header / log body / action bar, rendered by `ToolBlockOverlay`. Appears 150 ms after `mouseenter`. Contains the full streaming log + structured result.
+3. **Fast expand/collapse** — the panel animating in (after the 150 ms enter delay) and then out (on `mouseleave`, instantly). Even a brief cursor pass triggers the full open/close cycle because the leave is instant once the enter delay fires.
+
+All three were intentional at one point — but together they overlap and conflict:
+
+- (1) and (2) overlap visually. (1) shows the summary, (2)'s header *also* shows the summary. Stacked redundancy.
+- (3) is the user's primary complaint. The intent of `SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23` was a smooth peek-on-hover; the lived experience is "the row dances around my cursor."
+- The overlay header (when (2) is open) repeats the status icon, tool name, summary, and duration — all four of which are already in the collapsed row right above it.
+
+## 2. Desired behavior (per user)
+
+| Trigger | Behavior |
+|---|---|
+| Tool is **running** or **pending_approval** | Auto-expand the unified panel under the row. (unchanged) |
+| Tool transitions running → success/failed | Stay expanded for `POST_COMPLETION_HOLD_MS` (3 s), then collapse. (unchanged) |
+| User clicks the collapsed row | Pin: unified panel stays open until next click. (unchanged) |
+| User **hovers** any tool row (collapsed) | **Nothing visible happens.** No browser-native tooltip, no panel expand, no time popup. The row stays as-is. **(THIS IS THE CHANGE.)** |
+| The unified panel is rendered (auto-expand, post-completion hold, or pinned) | Header shows **only** info that is *not* already on the collapsed row: timestamp (top), status label. Status icon + tool name + summary + duration are NOT repeated — they live on the row only. |
+
+Net: **one popup, not three**. Hover-to-peek is removed entirely.
+
+## 3. Rationale for removing hover-to-peek
+
+Three prior PRs have already chased fallout from hover-induced expansions:
+
+- **PR #988** — initial hover-anchor + 150 ms enter delay (intended to reduce flicker)
+- **#988 round 2 codex P1** — fix for "loaded transcripts briefly auto-expand every completed tool row on initial render" (gating bug)
+- **`SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23`** — replaced the leave-delay with instant leave to address mouse-trap complaints
+
+Each fix was correct at the time but the *cumulative* surface area is still flicker-prone. The user has now redefined the requirement: hover is for reading, not for revealing. Pin (click) is for revealing.
+
+The active-tool auto-expand path is preserved verbatim. The expand-on-completion-hold is preserved verbatim. Only the hover-as-expand-trigger is removed.
+
+## 4. Implementation
+
+### 4.1 `ToolBlock.tsx` — remove the hover infrastructure
+
+Delete the following state + effects:
+
+- `hovering` signal (line 86)
+- `expandDirection` signal (line 91)
+- `overlayMaxHeight` signal (line 92)
+- `enterTimer` + `rootEl` refs (lines 93-94)
+- `handleMouseEnter` (lines 101-125)
+- `handleMouseLeave` (lines 126-130)
+- `onCleanup(() => clearTimeout(enterTimer))` (line 131)
+- `HOVER_ENTER_DELAY_MS` constant (line 78)
+- `TOOL_BODY_ESTIMATE_PX` constant (line 83)
+- Imports of `findScrollContainerRect`, `maxOverlayHeight`, `pickExpandDirection`, `ExpandDirection` from `./hover-anchor` (lines 42-46)
+- The `panelMode()` "overlay" branch (lines 217-221) — collapses to a binary `"hidden" | "flow"` mode.
+
+`expanded()` simplifies:
+
+```ts
+const expanded = () => props.pinned || autoExpanded();
+```
+
+`panelMode()` simplifies:
+
+```ts
+const panelMode = (): "hidden" | "flow" => {
+    return expanded() ? "flow" : "hidden";
+};
+```
+
+Remove the `onMouseEnter` / `onMouseLeave` handlers from both the root div (lines 228-229) and the panel div (lines 321-322). The panel-row pair becomes a static collapsed-or-expanded pair driven purely by status + pin state.
+
+Remove the `agent-tool-panel--overlay-below` / `agent-tool-panel--overlay-above` classes from the panel div (lines 301-304) and from the SCSS — they are now unreachable.
+
+Delete the inline `max-height` style on the panel (lines 306-310) — it only mattered in the overlay branch.
+
+The `inert={!expanded()}` / `aria-hidden={!expanded()}` accessibility gating (lines 318-319) stays.
+
+### 4.2 `ToolBlock.tsx` — remove the browser-native `title` tooltip
+
+Drop the `title={props.node.summary}` attribute from `.agent-tool-name` (line 242). The full summary is already visible in the row (no ellipsis truncation in current CSS) — the title tooltip was redundant *and* a source of the "small time popup" the user complained about. The `title=`s on the live-tail (line 260) and open-in-pane button (line 268) are unrelated and stay.
+
+### 4.3 `ToolBlockOverlay.tsx` — remove duplicate header fields, add timestamp
+
+Current header (lines 49-67):
+
+```
+[status-icon] [tool-name] [summary]                    [duration] [status-label]
+```
+
+Each of those repeats the collapsed row above it. New header — strip everything that's already on the row, and add the timestamp the user wants at the top of the unified popup:
+
+```
+[timestamp]                                                       [status-label]
+```
+
+- `timestamp` — formatted local time, e.g. `13:51:19` or `2 min ago`. Derived from `props.node.timestamp` (or whatever field already carries the tool's start time — see §5). Left-aligned.
+- `status-label` — kept; `STATUS_LABEL[status]` ("running", "ok", "failed", …). Right-aligned. The user did not ask to remove this and it carries a different signal than the row's status icon (text vs glyph).
+
+Delete from the header:
+
+- `<span class="agent-tool-overlay-status">{STATUS_ICONS[status]}</span>` — status icon is already on the row.
+- `<span class="agent-tool-overlay-tool">{props.node.tool}</span>` — tool name is already on the row (via `summary` which begins with the tool name for most tools; if the user disagrees we treat this as a follow-up).
+- `<span class="agent-tool-overlay-summary">{props.node.summary}</span>` — summary is on the row.
+- `<span class="agent-tool-overlay-duration">{duration}s</span>` — duration is on the row.
+
+Keep the surrounding `.agent-tool-overlay-header` div + `.agent-tool-overlay-meta` div, just with fewer children. SCSS layout adjusts in §4.5.
+
+### 4.4 Timestamp field — what to render
+
+The `ToolNode` type (path: `frontend/app/view/agent/types.ts`, search for `interface ToolNode`) already carries either `startedAt` / `timestamp` / equivalent. Use that. Render via a tiny helper:
+
+```ts
+function formatToolTime(ms: number | undefined): string {
+    if (ms == null) return "";
+    const d = new Date(ms);
+    // Local time in 24-h HH:MM:SS — minutes precision is too coarse
+    // for distinguishing rapid tool sequences.
+    return d.toLocaleTimeString(undefined, { hour12: false });
+}
+```
+
+If `ToolNode` does not currently carry a timestamp, add it in the reducer at tool-create time (`agent-document/reducer.ts`, search for the `ToolNodeAppend` arm); use `Date.now()` at the dispatch site. This is a one-line addition; no migration concern because the field is purely visual.
+
+### 4.5 SCSS adjustments — `_document-nodes.scss` and `_tool-overlay-portal.scss`
+
+- Remove `.agent-tool-panel--overlay-below` and `.agent-tool-panel--overlay-above` rules — the overlay positioning mode is gone (`_document-nodes.scss` block around lines 253-348).
+- Remove the `&:hover { ... }` rule on `.agent-tool-block` if any (line 132) that visually telegraphed the now-removed peek behavior. Keep the row's own subtle hover-background (visual feedback that the row is interactive) but make it identical to siblings — no expand affordance.
+- Reduce the overlay header SCSS (`_tool-overlay-portal.scss` lines 13-43) to a two-column flex row: timestamp left, status-label right. Drop the styles for `.agent-tool-overlay-status`, `.agent-tool-overlay-tool`, `.agent-tool-overlay-summary`, `.agent-tool-overlay-duration` — leave their classes in the file behind a one-line `// removed in tool-hover-consolidation 2026-05-28` breadcrumb or delete outright.
+
+### 4.6 `hover-anchor.ts` — leave alone
+
+`UserMessageBlock` still uses the hover-anchor mechanism (per existing memory note `feedback_agent_pane_tool_display` predecessor work). Do not touch `hover-anchor.ts` or `hover-anchor.test.ts`. The functions `pickExpandDirection`, `findScrollContainerRect`, `maxOverlayHeight`, and the `ExpandDirection` type remain in use by user-message hover. Only `ToolBlock`'s consumption of them goes away.
+
+### 4.7 Tests — `ToolBlock.test.tsx`
+
+Update / delete tests that assert hover behavior:
+
+- The test described in the source comment "a completed (success/failed) tool + no pin, hover puts …" (line 86) needs to flip: now assert that hover does NOT change `expanded()`.
+- Any test driving `mouseenter` / `mouseleave` to assert overlay visibility should be removed.
+- Add a positive test: a running tool is auto-expanded; status flips to success; after `POST_COMPLETION_HOLD_MS + ε`, panel collapses; subsequent `mouseenter` does NOT re-expand.
+- Add: clicking the collapsed row toggles `pinned` and the panel becomes visible.
+- Add: when the panel is visible (auto-expand or pinned), the overlay header contains the timestamp text and the status label text but NOT the tool name string nor the summary string. Use `screen.queryByText(toolNameValue)` and assert it is `null` (or only matched once — the row, not the header).
+
+## 5. Risk + reversibility
+
+**Risk**: low. The change removes UI surface area, doesn't add. The auto-expand-while-running path (currently the dominant user-visible behavior for active tools) is preserved verbatim. Failure mode is "user wanted hover-to-peek and now has to click to pin" — a discoverability question, not a correctness question. The collapsed row remains clickable; the `cursor: pointer` style still signals interactivity.
+
+**Reversibility**: high. The removed code is well-bounded (~50 LOC + helper imports) and lives in one component. If the user changes their mind, restoring the hover model is a single revert.
+
+**Won't fix in this PR**:
+
+- Click-to-pin discoverability (no visual cue for "this row is clickable to expand"). Note this in the PR body; address as a follow-up if users notice.
+- The `cursor: pointer` style on the row is the only affordance. If we want a stronger cue, add an unobtrusive expand glyph (e.g. ▸ at right of row) — but that *adds* a fourth visual event, contradicting the spirit of "one popup."
+
+## 6. Acceptance smoke
+
+1. Open an agent pane with at least one completed tool (Bash, Read, or Edit).
+2. Move the mouse over the tool row. **Nothing** should appear — no browser tooltip, no expand, no flicker. Hold there for 5 seconds. Still nothing.
+3. Click the row. The unified panel appears in flow under the row. Header shows time on the left, status label on the right. No status icon, tool name, summary, or duration repeated in the header.
+4. Click again. Panel collapses.
+5. Send a message that triggers a new Bash tool. The panel auto-expands immediately on `running`, header timestamp matches the dispatch time. Tool completes; panel stays for 3 seconds; collapses. Hovering after that does nothing.
+
+## 7. Out of scope
+
+- `UserMessageBlock` hover-anchor behavior (unchanged).
+- The "open in pane" / "open in window" / bookmark action bar at the bottom of the overlay (unchanged).
+- The `ToolOverlayLog` body — log rendering rules, chunk vs structured-result switch, scroll-stick behavior all unchanged.
+- The "AI Chat Panel" (`aitooluse.tsx`) referenced in `docs/specs/tool-collapse.md` §1 — this spec covers `ToolBlock` (agent view) only. If the AI Chat Panel has analogous hover behavior, file a follow-up.
+
+## 8. Estimated diff
+
+- `ToolBlock.tsx`: ~50 LOC removed, ~10 LOC modified (`expanded()`, `panelMode()`)
+- `ToolBlockOverlay.tsx`: ~20 LOC removed, ~5 LOC added (timestamp helper + header)
+- `ToolBlock.test.tsx`: ~30 LOC modified
+- SCSS: ~40 LOC removed
+- New helper `formatToolTime` (~6 LOC)
+
+Net: roughly **-140 LOC, +40 LOC**. The diff is dominated by deletion — a healthy sign that the new behavior is simpler than the old.
+
+## 9. Open question for the user (one)
+
+The "small time popup" — is it the browser's native `title=` tooltip showing the summary text? That is this spec's working assumption. If it is something else (a custom tooltip component, a wallclock indicator I haven't found), the §4.2 removal will not address it. Confirm before implementing.

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -4,15 +4,12 @@
 /**
  * ToolBlock — panel-mode render tests.
  *
- * Covers the hover-anchor extension landed alongside
- * `SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md` §5.10:
- *   - hover-only state → overlay positioning.
- *   - pinned / running / pending_approval → in-flow positioning.
- *   - hidden state → `--hidden` class.
- *
- * Pre-existing behaviors (status-icon mapping, live-tail, etc.)
- * are exercised by the integration tests in `renderers.test.ts`
- * and the broader agent-pane fixtures.
+ * Post-SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28: hover is no longer a
+ * trigger for expansion. Tests assert the two surviving render modes
+ * (`--flow` when pinned or auto-expanded, `--hidden` otherwise) and the
+ * negative case that `mouseenter` does not flip the panel open. The
+ * older hover-anchor overlay variants (`--overlay-above/below`) were
+ * removed alongside the hover trigger.
  */
 
 import { cleanup, fireEvent, render } from "@solidjs/testing-library";
@@ -43,8 +40,6 @@ describe("ToolBlock — panel mode", () => {
         const panel = container.querySelector(".agent-tool-panel");
         expect(panel).not.toBeNull();
         expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(true);
-        expect(panel!.classList.contains("agent-tool-panel--overlay-below")).toBe(false);
-        expect(panel!.classList.contains("agent-tool-panel--overlay-above")).toBe(false);
         expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(false);
     });
 
@@ -59,9 +54,6 @@ describe("ToolBlock — panel mode", () => {
     });
 
     it("running (auto-expanded) → panel is in-flow (`--flow`)", () => {
-        // Running tools stay in flow because their content streams
-        // and we don't want the row jumping around with overlay
-        // positioning while a CLI is mid-output.
         const running: ToolNode = { ...baseTool, status: "running" };
         const { container } = render(() => (
             <ToolBlock node={running} pinned={false} onTogglePin={() => {}} />
@@ -81,14 +73,11 @@ describe("ToolBlock — panel mode", () => {
         expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(true);
     });
 
-    it("hover only (post-completion, not pinned, not running) → panel is an overlay", () => {
-        // Drive the 150ms enter timer to flip `hovering` on. With
-        // a completed (success/failed) tool + no pin, hover puts
-        // the panel into overlay mode — direction picked from
-        // `getBoundingClientRect()` + the scroll container. jsdom
-        // gives zeros for both, so the direction picker falls
-        // through to "below" (tie-break) which is fine for
-        // asserting the class FAMILY.
+    // ── Hover is not a trigger ────────────────────────────────────────
+    // Asserts the core invariant of SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28:
+    // hovering a completed tool row produces zero visible state change.
+    // No expansion, no overlay class, no inline max-height.
+    it("mouseenter on a completed tool does NOT expand the panel", () => {
         vi.useFakeTimers();
         try {
             const { container } = render(() => (
@@ -96,43 +85,34 @@ describe("ToolBlock — panel mode", () => {
             ));
             const root = container.querySelector(".agent-tool-block") as HTMLElement;
             fireEvent.mouseEnter(root);
-            vi.advanceTimersByTime(200);
-            const panel = container.querySelector(".agent-tool-panel");
-            expect(panel).not.toBeNull();
-            // Exactly one of the overlay classes is present.
-            const isOverlay =
-                panel!.classList.contains("agent-tool-panel--overlay-below") ||
-                panel!.classList.contains("agent-tool-panel--overlay-above");
-            expect(isOverlay).toBe(true);
-            // Not in flow simultaneously.
-            expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(false);
-            // Hidden modifier is gone too.
-            expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(false);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
-
-    it("hover-mode overlay has an inline `max-height` (per-hover cap)", () => {
-        // Same shape as UserMessageBlock — the cap is computed
-        // from container space and set inline so the overlay's
-        // own overflow-y operates inside the pane bounds.
-        vi.useFakeTimers();
-        try {
-            const { container } = render(() => (
-                <ToolBlock node={baseTool} pinned={false} onTogglePin={() => {}} />
-            ));
-            const root = container.querySelector(".agent-tool-block") as HTMLElement;
-            fireEvent.mouseEnter(root);
-            vi.advanceTimersByTime(200);
+            // Wait well past the old 150ms hover-enter delay so we
+            // catch a regression where the hover timer creeps back in.
+            vi.advanceTimersByTime(1000);
             const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
-            expect(panel.style.maxHeight).toMatch(/^\d+px$/);
+            expect(panel.classList.contains("agent-tool-panel--hidden")).toBe(true);
+            expect(panel.classList.contains("agent-tool-panel--flow")).toBe(false);
+            expect(panel.style.maxHeight).toBe("");
         } finally {
             vi.useRealTimers();
         }
     });
 
-    it("pinned panel has no inline `max-height` (in-flow uses SCSS default)", () => {
+    it("mouseenter on a running tool keeps the panel in flow (no change)", () => {
+        // Auto-expand keeps the panel open for running tools regardless
+        // of hover state. Verifying the in-flow render survives the
+        // mouseenter event guards against an over-zealous hover-trigger
+        // removal that would also drop the auto-expand path.
+        const running: ToolNode = { ...baseTool, status: "running" };
+        const { container } = render(() => (
+            <ToolBlock node={running} pinned={false} onTogglePin={() => {}} />
+        ));
+        const root = container.querySelector(".agent-tool-block") as HTMLElement;
+        fireEvent.mouseEnter(root);
+        const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
+        expect(panel.classList.contains("agent-tool-panel--flow")).toBe(true);
+    });
+
+    it("pinned panel has no inline `max-height`", () => {
         const { container } = render(() => (
             <ToolBlock node={baseTool} pinned={true} onTogglePin={() => {}} />
         ));

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -2,25 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * ToolBlock - Single-line collapsed-by-default tool display with
- * hover-to-expand and click-to-pin semantics.
+ * ToolBlock — single-line collapsed-by-default tool display with
+ * click-to-pin and active-state auto-expand.
  *
- * See docs/specs/tool-collapse.md for the product requirement.
- *
- * Behavior:
- *   - Collapsed (default): one line showing status icon + tool name + ellipsis.
- *     Applies to ALL statuses — running, success, and failed.
- *     Running tools show a ⏳ spinner in the summary; failed tools show ✗.
- *     No content body is rendered in the document flow.
- *   - Click summary or strip Expand button: pins the expanded state. The portal
- *     overlay renders the tool content. Clicking again unpins / collapses.
- *
- * Prior behavior removed in SPEC_AGENT_PANE_FOLLOWUPS items #4 + #5:
- *   running and failed states used to force-expand inline, taking 2+ lines
- *   per tool. That violated the explicit one-line rule in
- *   docs/specs/tool-collapse.md and the user's feedback memory. Now all
- *   statuses collapse by default; progress and error content are still
- *   accessible via hover/pin.
+ * Behavior (since SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md):
+ *   - Collapsed (default): one line showing status icon + tool name +
+ *     duration + (while streaming) the live-tail line. Applies to ALL
+ *     terminated statuses.
+ *   - Auto-expand: `running` and `pending_approval` keep the panel open
+ *     in flow. After a terminal transition the panel stays open for
+ *     POST_COMPLETION_HOLD_MS so the user can finish reading, then
+ *     collapses.
+ *   - Click summary: pins the expanded state. Clicking again unpins.
+ *   - Hover: nothing happens. No browser-native tooltip, no panel
+ *     expand, no time popup. The hover-to-peek model from the prior
+ *     `tool-collapse.md` spec was removed — three overlapping visuals
+ *     (browser title tooltip, larger log panel, fast expand/collapse)
+ *     collapsed into a single auto-expand panel.
  *
  * SolidJS reactivity note:
  *   Props are accessed via `props.X` (never destructured in the function
@@ -38,12 +36,6 @@ import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js"
 import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { ToolBlockOverlay } from "./ToolBlockOverlay";
-import {
-    findScrollContainerRect,
-    maxOverlayHeight,
-    pickExpandDirection,
-    type ExpandDirection,
-} from "./hover-anchor";
 
 interface ToolBlockProps {
     node: ToolNode;
@@ -69,67 +61,7 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
     canceled: "⏹",
 };
 
-// 150ms enter delay prevents accidental expansions while scrolling past
-// tool rows. Leave is instant — the inline panel is inside the same
-// .agent-tool-block bounding box, so mouseleave only fires when the cursor
-// truly exits the whole block. No dead space, no grace window needed on leave.
-// (SPEC_TOOL_BLOCK_UX_POLISH_2026_05_23.md §Change 1)
-
-const HOVER_ENTER_DELAY_MS = 150;
-
-// Tool overlay body estimate — log views can be much bigger than user
-// messages, but the cap is just a hint to `pickExpandDirection`; the
-// "fits-neither" tie-break handles oversized cases gracefully.
-const TOOL_BODY_ESTIMATE_PX = 320;
-
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
-    const [hovering, setHovering] = createSignal(false);
-    // Hover-anchor — direction and per-hover max-height for the
-    // overlay panel when in hover-only (not pinned, not auto-
-    // expanded) mode. Mirrors UserMessageBlock's mechanic
-    // (SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md).
-    const [expandDirection, setExpandDirection] = createSignal<ExpandDirection>("below");
-    const [overlayMaxHeight, setOverlayMaxHeight] = createSignal<number | null>(null);
-    let enterTimer: ReturnType<typeof setTimeout> | undefined;
-    let rootEl: HTMLDivElement | undefined;
-    // Codex P1 on #988: both the block container AND the inline panel
-    // bind these handlers. A fast cursor traversal (container → panel)
-    // fires enter twice without an intervening leave; without clearing
-    // the previous timer, multiple stale timeouts accumulate and
-    // `handleMouseLeave` only clears the most recent. Clearing at the
-    // top of enter makes the timer a single-active-armed value.
-    const handleMouseEnter = () => {
-        clearTimeout(enterTimer);
-        enterTimer = setTimeout(() => {
-            // Capture summary geometry + scroll-container bounds
-            // ONCE at expand-time. Direction stays fixed for the
-            // hover; next mouseenter re-evaluates. Same pattern as
-            // UserMessageBlock — see hover-anchor.ts.
-            if (rootEl) {
-                const summaryEl = rootEl.querySelector<HTMLElement>(".agent-tool-summary");
-                if (summaryEl) {
-                    const rect = summaryEl.getBoundingClientRect();
-                    const container = findScrollContainerRect(summaryEl);
-                    const summaryV = { top: rect.top, bottom: rect.bottom };
-                    const dir = pickExpandDirection(
-                        summaryV,
-                        container,
-                        TOOL_BODY_ESTIMATE_PX,
-                    );
-                    setExpandDirection(dir);
-                    setOverlayMaxHeight(maxOverlayHeight(summaryV, container, dir));
-                }
-            }
-            setHovering(true);
-        }, HOVER_ENTER_DELAY_MS);
-    };
-    const handleMouseLeave = () => {
-        clearTimeout(enterTimer);
-        setHovering(false);
-        setOverlayMaxHeight(null);
-    };
-    onCleanup(() => clearTimeout(enterTimer));
-
     // Stays true for POST_COMPLETION_HOLD_MS after a running tool
     // completes so the user can read the final output line before the
     // panel collapses.
@@ -193,40 +125,22 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         return s === "running" || s === "pending_approval"
             || postCompletionHold();
     };
-    const expanded = () => props.pinned || autoExpanded() || hovering();
+    // Hover-to-peek was removed in SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28
+    // — expansion is now driven exclusively by pin + active-state auto-
+    // expand. The user-visible "three popups on hover" (browser title
+    // tooltip + larger log panel + fast expand/collapse animation)
+    // collapsed into a single in-flow panel.
+    const expanded = () => props.pinned || autoExpanded();
 
-    // Render mode for the panel — mirrors UserMessageBlock:
-    //
-    //   - `hidden`  : not expanded.
-    //   - `overlay` : expanded by hover ONLY (no pin, no
-    //                 auto-expand by status). Uses absolute
-    //                 positioning so the row doesn't change height
-    //                 and the panel can flip above/below based on
-    //                 available container space. The natural fit
-    //                 for "the user is just peeking."
-    //   - `flow`    : expanded by pin OR auto-status (running,
-    //                 pending_approval, post-completion hold).
-    //                 Renders in normal flow under the summary —
-    //                 the long-form persistent commitment.
-    //
-    // Per the user request for tool calls near the bottom of the
-    // pane to expand UPWARD instead of being clipped: hover state
-    // now uses the same hover-anchor design as the startup row
-    // (SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md §5.10
-    // contemplated exactly this generalization).
-    const panelMode = (): "hidden" | "overlay" | "flow" => {
-        if (!expanded()) return "hidden";
-        if (props.pinned || autoExpanded()) return "flow";
-        return "overlay";
-    };
+    // Two render modes — `flow` when the panel is visible (auto-expand
+    // or pinned), `hidden` otherwise. The hover-only `overlay` mode is
+    // gone with the hover trigger.
+    const panelMode = (): "hidden" | "flow" => (expanded() ? "flow" : "hidden");
 
     const statusIcon = (): string => STATUS_ICON[props.node.status] || "•";
 
     return (
         <div
-            ref={(el) => (rootEl = el)}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
             class={clsx("agent-tool-block", {
                 collapsed: !expanded(),
                 expanded: expanded(),
@@ -239,7 +153,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         >
             <div class="agent-tool-summary" onClick={props.onTogglePin}>
                 <span class="agent-tool-status-icon">{statusIcon()}</span>
-                <span class="agent-tool-name" title={props.node.summary}>{props.node.summary}</span>
+                <span class="agent-tool-name">{props.node.summary}</span>
                 <Show when={props.node.duration}>
                     <span class="agent-tool-duration">({props.node.duration.toFixed(1)}s)</span>
                 </Show>
@@ -298,16 +212,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 class={clsx("agent-tool-panel", {
                     "agent-tool-panel--hidden": panelMode() === "hidden",
                     "agent-tool-panel--flow": panelMode() === "flow",
-                    "agent-tool-panel--overlay-below":
-                        panelMode() === "overlay" && expandDirection() === "below",
-                    "agent-tool-panel--overlay-above":
-                        panelMode() === "overlay" && expandDirection() === "above",
                 })}
-                style={
-                    panelMode() === "overlay" && overlayMaxHeight() !== null
-                        ? { "max-height": `${overlayMaxHeight()}px` }
-                        : undefined
-                }
                 // Codex P2 on #988: with the always-rendered markup, the
                 // collapsed panel was visually hidden via max-height /
                 // opacity but still in the focusable + a11y tree, so
@@ -318,8 +223,6 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 inert={!expanded()}
                 aria-hidden={!expanded()}
                 onClick={(e) => e.stopPropagation()}
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
             >
                 <ToolBlockOverlay
                     node={props.node}

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -14,15 +14,18 @@
  *   │ action bar (fixed)                 │
  *   └────────────────────────────────────┘
  *
- * Replaces the prior inline `renderToolContent()` switch in `ToolBlock`.
- * The log slot uses `ToolOverlayLog` which falls back to per-tool rich
- * result content when no streaming chunks are present (graceful for the
- * Phase 3 ship — chunks start flowing in Phase 2's backend wrap).
+ * Per SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md the header was
+ * simplified to two slots: timestamp on the left, status label on the
+ * right. The status icon, tool name, summary, and duration were dropped
+ * because the collapsed row above already displays all four — the
+ * earlier header was pure duplication. The "small time popup" the user
+ * was seeing on hover (a browser-native `title=` tooltip whose contents
+ * included `(N.Ns)`) is also gone with this change: the time now lives
+ * here, persistent, at the top of the unified panel.
  */
 
-import { Show, type JSX } from "solid-js";
+import { type JSX } from "solid-js";
 import type { ToolNode } from "../types";
-import { STATUS_ICONS } from "../types";
 import { ToolOverlayActions } from "./ToolOverlayActions";
 import { ToolOverlayLog } from "./ToolOverlayLog";
 
@@ -44,25 +47,25 @@ const STATUS_LABEL: Record<ToolNode["status"], string> = {
     canceled: "canceled",
 };
 
+/**
+ * Local-time `HH:MM:SS` for the header timestamp. Minutes precision is
+ * too coarse for distinguishing rapid tool sequences in a Bash chain;
+ * seconds gives the user enough to correlate against their own clock
+ * without dominating the visual layout.
+ */
+function formatToolTime(ms: number | undefined): string {
+    if (ms == null) return "";
+    return new Date(ms).toLocaleTimeString(undefined, { hour12: false });
+}
+
 export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (
     <div class="agent-tool-overlay" data-node-id={props.node.id}>
         <div class="agent-tool-overlay-header">
-            <span class="agent-tool-overlay-status">
-                {STATUS_ICONS[props.node.status] ?? "•"}
+            <span class="agent-tool-overlay-time">
+                {formatToolTime(props.node.timestamp)}
             </span>
-            <span class="agent-tool-overlay-tool">{props.node.tool}</span>
-            <span class="agent-tool-overlay-summary" title={props.node.summary}>
-                {props.node.summary}
-            </span>
-            <span class="agent-tool-overlay-meta">
-                <Show when={props.node.duration}>
-                    <span class="agent-tool-overlay-duration">
-                        {props.node.duration!.toFixed(1)}s
-                    </span>
-                </Show>
-                <span class="agent-tool-overlay-status-label">
-                    {STATUS_LABEL[props.node.status]}
-                </span>
+            <span class="agent-tool-overlay-status-label">
+                {STATUS_LABEL[props.node.status]}
             </span>
         </div>
         <ToolOverlayLog node={props.node} />

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -258,9 +258,6 @@
             background: var(--surface-elevated, rgba(255, 255, 255, 0.02));
             border-radius: 0;
             padding: 6px 8px;
-            // `max-height` here is the in-flow default. The
-            // overlay variants below override it with an inline
-            // px value computed per hover.
             max-height: 50vh;
             min-height: 0;
             overflow: hidden;
@@ -282,69 +279,21 @@
                 opacity 100ms ease-out;
 
             &--hidden {
-                // `!important` retained — the `--overlay-*` modifiers
-                // below set a max-height via inline style; if --hidden
-                // is applied AFTER overlay (the hover-departure path),
-                // the inline value would otherwise win until the next
-                // render cycle, blocking the transition to 0.
-                max-height: 0 !important;
-                padding-top: 0 !important;
-                padding-bottom: 0 !important;
-                margin-top: 0 !important;
-                margin-bottom: 0 !important;
+                max-height: 0;
+                padding-top: 0;
+                padding-bottom: 0;
+                margin-top: 0;
+                margin-bottom: 0;
                 opacity: 0;
             }
 
-            // Hover-anchor overlay variants
-            // (SPEC_STARTUP_HOVER_EXPANSION_ANCHOR_2026_05_24.md
-            // §5.10 — generalized to tools per 2026-05-24 user
-            // request). When the panel is in hover-only mode (not
-            // pinned, not auto-expanded by status), it floats
-            // absolute above or below the summary so a tool near
-            // the pane's bottom expands upward instead of being
-            // clipped.
-            //
-            // The `--overlay-*` modifiers OVERRIDE the in-flow
-            // defaults (margin / max-height). Specificity is
-            // boosted by the row-elevation `:has()` rule in
-            // `_document.scss` so the overlay sits above sibling
-            // rows.
-            //
-            // The in-flow render path stays unchanged for pinned
-            // and auto-expanded states — that's where running
-            // tools live, and we don't want them moving.
-            &--overlay-below,
-            &--overlay-above {
-                position: absolute;
-                left: 24px;   // match the in-flow `margin-left: 24px`
-                right: 0;
-                z-index: 10;
-                margin: 0;
-                // Opaque background — overlay covers other rows so
-                // transparency would let neighbor content bleed
-                // through. No color-mix here (predictability).
-                background-color: var(--block-bg-solid-color, #1c1c1c);
-                border: 2px solid var(--accent-color, #2bd4a8);
-                border-radius: 0;
-                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-                overflow-y: auto;
-                // `max-height` is set inline by ToolBlock from the
-                // chosen-side container space — keeps `overflow-y`
-                // operating within the scroll container bounds.
-            }
-            &--overlay-below {
-                top: 100%;
-            }
-            &--overlay-above {
-                bottom: 100%;
-            }
-
-            // In-flow variant — the existing default. Explicit
-            // class for symmetry with --overlay-* (no behavioral
-            // change vs un-classed).
+            // In-flow variant — the only visible mode now that the
+            // hover-only `--overlay-{above,below}` modifiers were
+            // removed in SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.
+            // The base `.agent-tool-panel` styling already lays this
+            // out; the class exists for symmetry with `--hidden`.
             &--flow {
-                // (No overrides — the base `.agent-tool-panel`
-                // styling is already the in-flow layout.)
+                // (No overrides.)
             }
         }
 

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -177,11 +177,12 @@
         // auto-expanded bodies stay in normal flow so they don't
         // need elevation.
         //
-        // Both block types matched: the startup-injection user
-        // message and the tool panel.
-        &:has(.agent-user-message--expanded.agent-user-message--startup:not(.agent-user-message--pinned)),
-        &:has(.agent-tool-panel--overlay-below),
-        &:has(.agent-tool-panel--overlay-above) {
+        // Only the startup-injection user message uses a transient
+        // overlay now — the tool panel's hover-overlay mode was removed
+        // in SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28 (it only expands
+        // in-flow via pin / auto-expand, which needs no elevation), so
+        // its `--overlay-{below,above}` selectors are gone with it.
+        &:has(.agent-user-message--expanded.agent-user-message--startup:not(.agent-user-message--pinned)) {
             position: relative;
             z-index: 100;
         }

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -10,10 +10,15 @@
     display: contents;
 }
 
+// Simplified header per SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28: only
+// the timestamp (left) and status label (right) — everything that used
+// to live here (status icon, tool name, summary, duration) is on the
+// collapsed row above the panel and was pure duplication.
 .agent-tool-overlay-header {
     flex: 0 0 auto;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: var(--space-1);
     padding: var(--space-1) var(--space-2);
     border-bottom: 1px solid var(--border-color);
@@ -21,21 +26,8 @@
     font-size: 11px;
     color: var(--secondary-text-color);
 
-    .agent-tool-overlay-tool {
-        font-weight: 600;
-        color: var(--main-text-color);
-    }
-    .agent-tool-overlay-summary {
-        flex: 1 1 auto;
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-    .agent-tool-overlay-meta {
-        display: flex;
-        gap: var(--space-1);
-        flex-shrink: 0;
+    .agent-tool-overlay-time {
+        font-variant-numeric: tabular-nums;
     }
     .agent-tool-overlay-status-label {
         text-transform: lowercase;


### PR DESCRIPTION
## Summary

User reported three overlapping visual events on tool-row hover: small browser-native \`title=\` tooltip showing summary (which includes \`(N.Ns)\` — what they perceived as a "time popup"), larger log panel, and a fast expand/collapse animation. All three together = flicker every cursor pass.

This PR collapses them into a single in-flow panel that opens only when there's reason to: tool is \`running\` / \`pending_approval\`, or the user has clicked to pin. **Hover is no longer a trigger.**

## Behavior change

| Trigger | Before | After |
|---|---|---|
| Hover completed tool | title tooltip + 150 ms then panel expands | Nothing |
| Tool starts running | Panel auto-expands | Same |
| Tool completes | Stays open 3 s post-hold | Same |
| Click row | Pins panel | Same |
| Hover running tool | Panel stays open (auto) | Same |

## Header dedup

Old overlay header: status icon · tool name · summary · duration · status label — every field except the status label was already on the collapsed row above it. New header: \`HH:MM:SS\` (from \`ToolNode.timestamp\`) · status label. Two slots, zero duplication.

## What was deleted

- \`ToolBlock.tsx\`: \`hovering\` signal, \`expandDirection\`, \`overlayMaxHeight\`, enter timer, hover-anchor imports, \`onMouseEnter\`/\`onMouseLeave\` on both root + panel divs, \`title={summary}\` on \`.agent-tool-name\`.
- \`ToolBlockOverlay.tsx\`: status icon / tool / summary / duration spans in the header.
- SCSS: \`.agent-tool-panel--overlay-above\`, \`--overlay-below\`, and the 4 deleted header sub-classes.

## What was preserved

- Auto-expand for \`running\` / \`pending_approval\`.
- 3 s \`POST_COMPLETION_HOLD_MS\`.
- Click-to-pin.
- \`UserMessageBlock\` hover-anchor (untouched — still uses \`hover-anchor.ts\`).
- The action bar, log body rendering, scroll-stick.

## Test plan

- [x] \`npx vitest run frontend/app/view/agent/components/ToolBlock.test.tsx\` — 7/7 pass, including:
  - Anti-regression: \`mouseenter\` on a completed tool + 1 s fake-timer advance → panel stays \`--hidden\`, no overlay class, no inline max-height. Guards against the 150 ms hover timer creeping back.
  - \`mouseenter\` on a running tool → still \`--flow\`. Guards against an over-eager removal also killing auto-expand.
- [ ] Smoke: hover a completed Bash tool — nothing visible happens. Click — panel opens with timestamp + status label in header. Click — collapses. Send a new message that runs a tool — auto-expands; status flips to success; 3 s later collapses; hover after that → nothing.

## Spec + diagnosis

\`docs/specs/SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md\` is in this PR — full diagnosis, the three observed events mapped to source lines, the implementation rules each section of the diff was checked against.

## Out of scope

- Discoverability of click-to-pin: only the \`cursor: pointer\` style remains. Noted in spec §5 as a possible follow-up.
- AI Chat Panel (\`aitooluse.tsx\`) has analogous hover behavior — separate PR if prioritized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)