### PR TITLE
diag(statusbar): instrument sysinfo channel to bisect agent-pane cascade freeze

### DIFF
--- a/.changesets/1780029130-diag-statusbar-sysinfo-channel-instrumentation-to-bisect-age-afum.md
+++ b/.changesets/1780029130-diag-statusbar-sysinfo-channel-instrumentation-to-bisect-age-afum.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(statusbar): sysinfo channel instrumentation to bisect agent-pane cascade freeze

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -315,10 +315,26 @@ impl Broker {
 
         let client = match &inner.client {
             Some(c) => c,
-            None => return,
+            None => {
+                // Diagnostic for agent-pane cascade freeze (2026-05-28):
+                // if the bridge gets dropped, every publish silently no-ops.
+                tracing::warn!(target: "wps-diag", event = %event.event,
+                    "broker.publish: client is None — no delivery");
+                return;
+            }
         };
 
         let route_ids = Self::get_matching_routes(&inner, &event);
+        // Diagnostic for agent-pane cascade freeze (2026-05-28): if sysinfo
+        // is published but no routes match, the status-bar widgets will
+        // freeze. Pair with `[fe] sysinfo:* handler` console logs to
+        // distinguish broker-drop from FE-scheduler-stall. Remove once
+        // the cascade root cause lands.
+        if route_ids.is_empty() && event.event == "sysinfo" {
+            tracing::warn!(target: "wps-diag",
+                scopes = ?event.scopes,
+                "broker.publish: 0 routes for sysinfo event");
+        }
         for route_id in route_ids {
             client.send_event(&route_id, event.clone());
         }

--- a/docs/analysis/ANALYSIS_AGENT_PANE_CRASH_2026_05_28_PM.md
+++ b/docs/analysis/ANALYSIS_AGENT_PANE_CRASH_2026_05_28_PM.md
@@ -1,0 +1,241 @@
+# Analysis: agent-pane crash + status-bar uptime freeze (2026-05-28 PM)
+
+**Author:** AgentA
+**Status:** Diagnosed from live host + sidecar logs. Recurrence of a known crash class — sixth in a 9-day stretch of fixes for this same family.
+**Reporter:** user (this session) — "we got a pane crash" + "the timing counter stopped (universal clock on bottom left of status bar)"
+**Build:** v0.39.2 (current portable, also the dev build)
+**Block id:** `ad77d90f-e99e-4423-94c6-e93b7d4acda5`
+**Wall time of crash:** 2026-05-28 19:51:19.270 Z
+
+---
+
+## 1. Symptom
+
+Two simultaneous user-visible problems:
+
+1. **Agent pane crashed** during an active turn — replaced by the `block-error-boundary` fallback. `NotFoundError: Failed to execute 'replaceChild' on 'Node': The node to be replaced is not a child of this node` inside SolidJS's reconciler.
+2. **Status-bar uptime counter froze** ("universal clock on bottom left"). This is the `formatUptime(uptimeSecs())` readout in `frontend/app/statusbar/BackendStatus.tsx:141-143`, driven by the `sysinfo` event ts (line 64-79).
+
+The two are almost certainly connected — same dispatch storm.
+
+## 2. Timeline (host log, sub-second resolution)
+
+```
+19:51:15.276  user send-message:enter (block=ad77d90, len=20)
+19:51:15.276  agent:dispatch:PendingMessageQueued (user-source)
+19:51:15.287  agent:dispatch:PendingMessageAccepted (system-source)
+19:51:15.287  agent:dispatch:TurnStart
+19:51:15.299  agent:virt:partition (streamCount=58, virtCount=84, frontier=toolu_01)
+19:51:15.319  agent:dispatch:StreamFlushObserved
+19:51:15.854  agent:dispatch:StreamWatchdogTick (5 s cadence, normal)
+19:51:18.788  agent:dispatch:TokensIn
+19:51:18.805  agent:virt:partition (streamCount=59, virtCount=84)
+19:51:18.830  agent:dispatch:StreamFlushObserved
+19:51:19.237  agent:virt:partition (streamCount=59, virtCount=84)  ← idle-ish, no growth
+19:51:19.256  agent:dispatch:StreamUnsubscribe ← session_end propagated to view
+19:51:19.270  ERROR  [block-error-boundary] NotFoundError replaceChild
+              (stack=$0e → reconcileArrays → insertExpression → Qme → runComputation)
+19:51:19.295  [agentActivity] busyCount=0 panes=[]  ← view layer notices "no longer busy"
+19:51:19.295  WARN  [agent-document-store] CASCADE_DETECTED:
+              slot disposed mid-dispatch (cmd=StreamFlush, blockId=ad77d90, source=system).
+              "A documentAtom subscriber unmounted the pane during this dispatch.
+               Subsequent dispatches in the same callback will throw."
+19:51:19.305  WARN  [perf] long-task 66.0 ms
+19:51:19.701  WARN  [block-error-boundary] (stack-resolved) same error, source-mapped
+```
+
+Sidecar log corroborates the natural turn end (not a backend kill):
+
+```
+19:51:21.401  INFO  subprocess exited block_id=ad77d90 exit_code=0
+19:51:21.401  INFO  agent health transition Healthy → Idle
+```
+
+After the crash the host log shows only focus / SetActiveTab events — no further `[fe] agentActivity` heartbeats and no further `sysinfo`-driven uptime ticks. The status bar clock froze at the crash instant because the same `waveEventSubscribe` plumbing the agent pane shares with status-bar widgets stopped delivering for whatever subset got marked disposed in the cascade.
+
+### 2a. New evidence: ALL status-bar perf indicators froze (not just the clock)
+
+User confirmation in the same session: "the clock and all the performance indicators in the status bar are frozen, I never saw that before". This rules out a per-widget render bug and points squarely at the shared `sysinfo` event channel.
+
+Both status-bar consumers subscribe to the same channel:
+
+- `frontend/app/statusbar/BackendStatus.tsx:67-80` — uptime, `eventType: "sysinfo", scope: "local"`
+- `frontend/app/statusbar/SystemStats.tsx:47-67` — CPU/GPU/Mem/Net/Disk, `eventType: "sysinfo", scope: "local"`
+
+The dispatch table in `frontend/app/store/wps.ts:126-144`:
+
+```ts
+function handleWaveEvent(event: WaveEvent) {
+    const subjects = waveEventSubjects.get(event.event);
+    if (subjects == null) return;
+    for (const scont of subjects) {
+        if (isBlank(scont.scope)) { scont.handler(event); continue; }
+        if (event.scopes == null) continue;
+        if (event.scopes.includes(scont.scope)) scont.handler(event);
+    }
+}
+```
+
+`waveEventSubjects` is a process-global `Map<string, WaveEventSubjectContainer[]>`. Every subscribe pushes a new container with a unique UUID id (line 67-74). Every unsubscribe removes by id (line 91-95) and re-sends the eventsub RPC to the backend (line 102-104). **Crucially**, when the last subscriber for an eventType is removed, the entire key is deleted from the map (line 96-98) and the re-sub message tells the backend "stop sending us this event."
+
+#### Two plausible failure modes
+
+**A. The cascade dropped sysinfo subscribers as collateral damage.** If the cascade unwind during the crash ran `onCleanup` callbacks across the workspace tree — not just the per-block tree — both `BackendStatus` and `SystemStats` would call their `unsub?.()`. The map entry for `"sysinfo"` would be deleted, the eventsub re-sub would notify the backend, and the backend would stop emitting. This matches the observed silence in the host log. SolidJS error handling does NOT normally cascade `onCleanup` past the catching boundary, but if the reconcileArrays error left a half-disposed parent computation, downstream `onCleanup` callbacks could fire in the wrong order — exactly the `feedback_solidjs_reactive_leak` shape.
+
+**B. The status-bar's createEffect / onMount became disposed.** The handler closures stay registered in `waveEventSubjects` (so the backend keeps emitting), but when the event fires and `scont.handler(event)` calls `setUptimeSecs(...)` etc., the signal's parent computation is already disposed — the write succeeds but no render fan-out happens. The user sees frozen values. This would be invisible in logs because there's no error path; the signal write silently goes nowhere.
+
+#### Distinguishing A from B — user-confirmed in-session
+
+The user opened a sysinfo widget pane post-crash and reported "the status bar now is updating". This is decisive:
+
+- The widget pane's mount calls `waveEventSubscribe({ eventType: "sysinfo", scope: "local" })`.
+- Every subscribe (line 78-80 in `wps.ts`) — whether or not the eventType already exists in the map — re-issues `updateWaveEventSub(eventType)`, which sends an `eventsub` RPC to the backend.
+- The pre-existing status-bar handlers were still registered in `waveEventSubjects` (they would not have started receiving events again otherwise; their subscribe calls only run once at workspace mount and there was no remount).
+- Therefore the backend had **stopped emitting `sysinfo`** between the crash and the widget mount, and the widget's re-sub command got it to resume.
+
+This means **failure is on the eventsub aggregator side**, not on the frontend subscriber map. The cascade unwind fired `onCleanup` for some pane-scoped subscriber(s), each calling `updateWaveEventSub` for their eventTypes. Most likely path: an unsubscribe for a `block:<id>`-scoped sysinfo subscriber (if one existed inside the agent pane) caused the backend to recompute its sysinfo emit-list. If the backend's logic treats "0 subscribers for any scope" as "stop emitting", a transient empty state during the unwind would explain it — even though the workspace-scope subscribers are still registered.
+
+**Next code dive:** check the sidecar's eventsub handler logic for sysinfo. If it's keyed only on "is anyone subscribed" without scope-awareness, that's the bug. If it's scope-aware, the bug is in the FE's eventsub message — perhaps it omits the workspace-scope subscribers when it sends the re-sub.
+
+### 2c. Dive results — eventsub aggregator is **NOT** the bug
+
+Read paths:
+- `agentmux-srv/src/backend/wps.rs:184-210` — `Broker::subscribe`. Idempotent: calls `unsubscribe_nolock` first then re-adds, so a clean re-sub fully refreshes the (route, event) state.
+- `agentmux-srv/src/backend/wps.rs:382-412` — `get_matching_routes`. Scope-aware: walks `all_subs` (allscopes subscribers), `scope_subs` (exact match), `star_subs` (pattern match). Dedups via `HashMap<&str, ()>`.
+- `agentmux-srv/src/backend/wps.rs:449-458` — `add_unique` / `add_to_scope_map`. Both dedup-safe. The frontend sending `scopes: ["local", "local"]` collapses to one entry; no double-counting bug.
+- `agentmux-srv/src/backend/sysinfo.rs:144-188` — emitter is unconditional `loop { ticker.tick().await; ... broker.publish(event); }`. No "are there subscribers" gate; the broker decides delivery via `get_matching_routes`.
+- `agentmux-srv/src/server/websocket.rs:507-549` — eventsub / eventunsub / eventunsuball wired straight through to `broker.subscribe("ws-main", _)`, `broker.unsubscribe("ws-main", _)`, `broker.unsubscribe_all("ws-main")`.
+- `agentmux-srv/src/server/websocket.rs:264-270` — **on WS disconnect, the only cleanup is `event_bus.unregister_ws(&conn_id)` + `messagebus.unregister(agent_id)`. NO `broker.unsubscribe_all("ws-main")`.** The broker's subscription state persists across WS reconnects.
+- `agentmux-srv/src/backend/eventbus.rs:164-177` — `EventBusBridge::send_event` ignores the `route_id` argument and broadcasts to every registered watch (every WS connection). So as long as broker has "ws-main" subscribed, every connected window gets the event.
+
+**Verdict:** the eventsub aggregator does exactly what it should given correct input. The bug **must** be in the frontend's outbound `eventsub` / `eventunsub` traffic — specifically, the frontend must have sent something during the cascade that told the broker to drop "ws-main" from sysinfo.
+
+### 2d. Where the frontend's outbound traffic goes wrong
+
+`frontend/app/store/wps.ts:36-51`:
+
+```ts
+function makeWaveReSubCommand(eventType: string): RpcMessage {
+    let subjects = waveEventSubjects.get(eventType);
+    if (subjects == null) {
+        return { command: "eventunsub", data: eventType };
+    }
+    let subreq: SubscriptionRequest = { event: eventType, scopes: [], allscopes: false };
+    for (const scont of subjects) {
+        if (isBlank(scont.scope)) {
+            subreq.allscopes = true;
+            subreq.scopes = [];
+            break;
+        }
+        subreq.scopes.push(scont.scope);
+    }
+    return { command: "eventsub", data: subreq };
+}
+```
+
+The function sends `eventunsub` whenever the map entry is absent. The map entry becomes absent when `waveEventUnsubscribe` removes the last subscriber for that eventType (line 96-98). The cascade ran `onCleanup` callbacks that called `unsub?.()` on a number of subscriptions belonging to the agent pane — none of those should touch sysinfo because the agent pane doesn't subscribe to sysinfo.
+
+**Two remaining candidate mechanisms:**
+
+1. **The cascade disposed `BackendStatus` / `SystemStats` reactive scopes without unmounting their DOM.** SolidJS `onCleanup` is owner-scoped — if some upstream `<Show>` / `<For>` in the workspace tree got reactively invalidated and its computation tree torn down, child owners (including the status-bar components') get disposed. The DOM nodes stay attached because Solid doesn't auto-unmount on owner disposal; it just stops reactivity. The user sees frozen values precisely because the components are "alive" in the DOM but dead in the reactive graph. Their `onCleanup` callbacks ran, `unsub?.()` fired, the sysinfo map entry emptied, `updateWaveEventSub("sysinfo")` sent `eventunsub`, broker removed "ws-main".
+
+2. **The scheduler got stuck.** SolidJS uses a microtask-flushed render queue. An uncaught error during reconciliation can leave queued work that never runs. Subsequent signal writes appear silent — the handler fires the write, the scheduler queues a render task, the task never executes. Opening the sysinfo pane creates new owners + effects which appear to bump the scheduler back into life.
+
+(1) is more consistent with the observation that opening the pane immediately restored ALL status-bar widgets — that would only happen if either (a) the broker resumed emitting OR (b) the scheduler resumed flushing. The pane mount provides (a) by sending a fresh `eventsub`. For (b), it would have to be a coincidence — possible but less parsimonious.
+
+### 2e. Whether (1) and (2) can be distinguished
+
+Add a single line at the BackendStatus handler (line 71 of `frontend/app/statusbar/BackendStatus.tsx`):
+
+```ts
+handler: (event) => {
+    console.log("[fe] sysinfo handler fired ts=", (event as any)?.data?.ts);
+    // ... existing body
+}
+```
+
+Then re-build and reproduce. On next status-bar freeze:
+- If `[fe] sysinfo handler fired` is silent → broker stopped emitting → mechanism (1)
+- If `[fe] sysinfo handler fired` continues firing but the displayed value still freezes → scheduler stuck → mechanism (2)
+
+Same instrumentation in `SystemStats.tsx` line 51 for redundancy.
+
+### 2f. Practical fix vs. structural fix
+
+**Practical fix (1 line in `BackendStatus` + 1 line in `SystemStats`):** move the `waveEventSubscribe` call from `onMount` to a top-level call inside the component function (so it runs once at module-level if the file uses a singleton component, or hoist the subscription out of the component lifecycle altogether). This guarantees the subscription survives reactive-tree damage. Tradeoff: leaks the subscription if the workspace ever truly unmounts. Acceptable for a singleton workspace root.
+
+**Structural fix:** add a `waveEventSubscribePersistent` helper that hooks into a root-level dispose registry, independent of the calling component's owner. Status-bar and other workspace-singleton subscriptions opt in. Tradeoff: another API surface; needs care for reconnect semantics. Cleaner long-term.
+
+Either fix isolates status-bar telemetry from the agent-pane crash blast radius. **Neither fixes the underlying agent-pane crash** — that still wants the dispatcher-level "no writes inside writes" structural fix from §6.
+
+### 2b. Implication
+
+The cascade damage reaches beyond the per-block boundary. That makes the structural fix (queue dispatches; disallow writes inside writes) materially more important than the prior 5 fixes implied — every one of those treated this as a per-pane render bug. The status-bar freeze proves it's actually a workspace-root reactive-graph integrity bug. **The pane crash is a *symptom*; the integrity bug is the bug.**
+
+## 3. Root cause (this incident, in the context of the broader pattern)
+
+This is a recurrence of the `CASCADE_DETECTED` family. The cascade detector itself was added in PR #878 specifically to surface this scenario:
+
+> *"A documentAtom subscriber unmounted the pane during this dispatch. Subsequent dispatches in the same callback will throw."*
+
+The sequence that produced this incident:
+
+1. Backend emits `session_end` (subprocess exited cleanly, exit 0).
+2. View dispatches `StreamUnsubscribe`, which the reducer translates into `turnPhase = Done`.
+3. **Inside the same render tick**, a follow-up `StreamFlush` ships (most likely from the buffered text-delta queue that the post-Unsubscribe code path drains).
+4. The `Done` phase transition causes one of the conditionally-mounted view sections (something gated on `isWorking` / `turnPhase.kind`) to unmount — disposing a `documentAtom` subscriber.
+5. The buffered `StreamFlush` from step 3 then runs against that already-disposed subscriber slot. SolidJS's `reconcileArrays` walks the prior DOM children, finds a row whose `parentNode` is no longer the virtualizer container, and throws `replaceChild`.
+6. `block-error-boundary` catches it and renders the fallback. The pane "crashed" from the user's perspective.
+
+The downstream effect — uptime/clock freeze — is consistent with the cascade tearing down enough of the shared subscription graph that `sysinfo` no longer reaches the status-bar widgets either. (Confirmation needs DevTools, but the host log goes silent on `agentActivity` ticks the moment the crash fires.)
+
+## 4. What's already been done about this crash class (last 9 days)
+
+In rough chronological order — all targeting `replaceChild` / `reconcileArrays` errors on the agent pane during streaming:
+
+| Commit | PR | Date | Fix |
+|---|---|---|---|
+| `49b8b2ff` | — | 2026-05-26 | Drop `TurnStart` auto-collapse — the same `CASCADE_DETECTED` signature. PR #1068 had added `detailsOpen: false` to the TurnStart reducer arm; that flip raced StreamFlush. |
+| `68d9c46e` | — | 2026-05-26 | Swap `<For each={virtualizer.getVirtualItems()}>` → `<Index ...>`. TanStack returns fresh VirtualItem objects each render; Solid's `<For>` re-keyed everything → reconcile-from-scratch every tick. |
+| `e224fb95` | #1101 | 2026-05-27 | Per-instance `idPrefix` for stream-parser node ids (id-collision render gap). |
+| `768b62a6` | #1101r2 | 2026-05-27 | Codex P1 follow-up: replace random prefix with deterministic snapshot skip-set. |
+| `fb2078f1` | #1104 | 2026-05-27 | Scrub orphan in-progress nodes on session reopen. |
+| `dfbb2616` | #1122 | 2026-05-28 (AM) | Process newNodes before updatedNodes in StreamFlush, so same-batch updates aren't dropped as orphans. (Author: AgentY.) |
+
+That makes today's incident the **seventh** in this class. The fix list above closed every known reproducer the team encountered through 2026-05-28 AM — but the `StreamUnsubscribe → StreamFlush → cascade` ordering (this incident) is a path none of those targeted. **49b8b2ff** is the closest analog: it removed an unmount-causing reducer write from `TurnStart`. The same surgery is needed on the `StreamUnsubscribe` path.
+
+## 5. Hypothesis for the offending unmount
+
+`agent-view.tsx` has several conditionally-mounted sub-trees that key off `turnPhase` / `isWorking` / `pendingMessages`. Each one is a candidate for the "subscriber unmounted mid-dispatch" cascade. Highest-suspicion set:
+
+1. **`AgentDisconnectedBanner`** (`agent-view.tsx:836`) — mounts when `turnPhase.kind === "Disconnected"`. If `StreamUnsubscribe` first flips the phase to `Disconnected` (not `Done`) and then a buffered flush runs, the banner mounting inserts DOM into the same conditional tree that the flush is reconciling against.
+2. **The pending-zone "Send now" button** (`PendingMessagesPanel`, gated on `workingFromPhase`). Its visibility flips on every Submitting↔Streaming↔Done transition — same family as the bug we are about to fix in [ANALYSIS_SEND_NOW_FLASH](./ANALYSIS_SEND_NOW_FLASH_2026_05_28.md). If a final StreamFlush coincides with the phase leaving the working set, the conditional inside `PendingMessagesPanel` unmounts mid-dispatch.
+3. **The composer details panel** (`<Show when={detailsOpenAtom()}>`). Same shape as 49b8b2ff if any reducer arm in the Unsubscribe path writes `detailsOpen`.
+
+The render trail captured in the crash payload shows no `DetailsToggle` command immediately before the crash, so (3) is the least likely. The `agent:dispatch:StreamUnsubscribe` literal-string match plus the absence of any `Disconnected`-related signal in the trail makes (1) the leading hypothesis. (2) is also live; the timing-jitter window on Submitting/Streaming/Interrupting transitions is exactly where this class of bug breeds.
+
+## 6. Proposed next actions (priority order)
+
+1. **Defer further dispatches scheduled in the same task as `StreamUnsubscribe`.** This is the architectural fix — the cascade exists because the dispatcher allows a write inside a write. The reducer queue should drain `StreamUnsubscribe` to completion, run lifecycle reactions, and only then permit the buffered `StreamFlush`. (See `frontend/app/store/agent-pane-state/dispatch-queue.ts` or equivalent if it exists; otherwise this is a new layer.)
+2. **Add a regression test reproducing this incident's exact dispatch sequence:** `TurnStart → StreamFlush(node_X) → StreamFlush(node_X+1) → StreamUnsubscribe → buffered StreamFlush`. Assert that the buffered StreamFlush dispatches against a *still-mounted* subscriber, or is dropped if the subscriber is gone — but never the in-between state that crashes here.
+3. **Audit every `<Show when={...}>` inside `agent-view.tsx` that keys off `turnPhase` or pendingMessages.** Each is a cascade vector if its predicate flips during a flush. The candidates list above is a starting point — but the audit should be exhaustive.
+4. **Diagnose the status-bar uptime freeze separately.** Verify with a `console.log` inside the `BackendStatus.tsx` sysinfo handler whether events stop entirely or just become rare. If they stop, it's a subscription-graph teardown (and would be fixed by item 1). If they continue but the handler doesn't run, it's a Jotai/store-level issue.
+
+## 7. Why a one-off fix is the wrong call here
+
+PRs #49b8b2ff / #68d9c46e / #1101 / #1104 / #1122 are five fixes for this same crash class in 12 days. Each one closed *its* reproducer. None addressed the underlying invariant: **the reducer dispatcher allows a write inside a write, and the agent view has too many subscribers gated on transient predicates that flip mid-dispatch.** Patching the next one (e.g. "don't unmount AgentDisconnectedBanner during StreamUnsubscribe") buys days. Closing the invariant — either by queuing dispatches or by collapsing the gating predicates onto a single stable phase — buys years.
+
+The user's "we had a lot of work dedicated to this sort of crash" framing fits exactly: each fix has been local, none has been structural. The right next move is the dispatch-queue / write-during-write fix, not another patch in this layer.
+
+## 8. Open questions for the user
+
+- Was the affected pane idle when the crash happened, or were you actively reading the response as it streamed? (The exit_code=0 says the turn finished cleanly; the question is whether your eyes were on it.)
+- Did the status bar's other readouts (CPU / Mem / Net) also stop, or just the uptime? (Tells us whether the entire sysinfo channel froze, vs only the uptime subscription.)
+- Did the crash recover (i.e. did clicking "Reload" in the error boundary restore the pane), or did the whole window need to come back?
+
+## 9. Artifacts
+
+- Host log: `~/.agentmux/channels/stable/logs/agentmux-host-v0.39.2.log.2026-05-28`
+- Sidecar log: `~/.agentmux/logs/agentmuxsrv-v0.39.2.log.2026-05-28`
+- Render trail captured in the crash payload (lines 6–7 of `tool-results/bnvjz6lmh.txt`)
+- Stack trace (resolved): `$0e → reconcileArrays → insertExpression → Qme → runComputation`

--- a/docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md
+++ b/docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md
@@ -1,51 +1,64 @@
 # Analysis: Large-file modularization candidates (2026-05-28)
 
 **Author:** AgentA
-**Status:** Survey doc — not a commitment. Use as an inventory when picking the next R-style refactor.
-**Related:** [SPEC_STORE_MODULARIZATION_2026_05_27.md](../specs/SPEC_STORE_MODULARIZATION_2026_05_27.md) — the playbook that R.2–R.6 followed for `store.rs`.
+**Status:** Survey doc + detailed sub-PR carve plans. R.1 of store.rs landed today; this updated revision adds full plans for the remaining 4 candidates.
+**Related:** [SPEC_STORE_MODULARIZATION_2026_05_27.md](../specs/SPEC_STORE_MODULARIZATION_2026_05_27.md) — the playbook R.2–R.6 followed for `store.rs`.
 
 ---
 
 ## Why this exists
 
-Today's session shipped 5 modularization PRs against `store.rs`, taking it from 6,226 → 4,836 lines and pulling out 6 cleanly-scoped sibling modules. The pattern is now well-rehearsed: identify a subsystem in a giant file, build a `mod.rs` re-export shim, add a sibling file with the subsystem's struct + `impl Store {}` block, leave a comment breadcrumb in the donor file. Each PR was ~150–650 LOC moved, ~30 minutes start to merged.
+Today's session shipped 6 modularization PRs against `store.rs` (R.1–R.6), taking it from **6,226 → 3,306 lines (-47%)** and pulling out 7 cleanly-scoped sibling modules. The pattern is now well-rehearsed: identify a subsystem in a giant file, build a `mod.rs` re-export shim, add a sibling file with the subsystem's struct + `impl Store {}` block, leave a comment breadcrumb in the donor file. Each PR was ~150–650 LOC moved, ~30 minutes start to merged.
 
-This doc maps the next set of fat files in the repo and ranks them by extraction value. It is **not** a commitment — it's the menu the next person resuming this work can pick from.
+This doc maps the next set of fat files in the repo and ranks them by extraction value, with concrete sub-PR carve plans for each top candidate.
 
 ## Method
 
-- `wc -l` over all `.rs` and `.ts/.tsx` files (excluding `node_modules`, `target`, `dist`).
+- `wc -l` over all `.rs` and `.ts/.tsx` files (excluding `node_modules`, `target`, `dist`, `.claude/worktrees`).
 - For each top file, scanned the `pub fn` / `impl` / `// ==== section ====` boundaries to gauge how cleanly the file partitions.
-- Cross-checked test-file ratios — a 4,000-line test file is usually a different problem than a 4,000-line source file.
+- For each top candidate, listed the exact symbols + line spans + dependency surface, so the carve can be executed without re-reading the whole file.
+- Cross-checked test-file ratios — a 4,000-line test file is a different problem than a 4,000-line source file.
 
-## Inventory — Rust
+## Current state (post-R.1)
+
+| File | Pre-session | Post-session | Delta |
+|---|---|---|---|
+| `agentmux-srv/src/backend/storage/store.rs` | 6,226 | **3,306** | -47% ✅ |
+| `agentmux-srv/src/backend/storage/agents.rs` | — | 1,556 | new (R.1) |
+| `agentmux-srv/src/backend/storage/identities.rs` | — | ~480 | new (R.2) |
+| `agentmux-srv/src/backend/storage/memory_bundles.rs` | — | ~290 | new (R.3) |
+| `agentmux-srv/src/backend/storage/content.rs` | — | ~280 | new (R.4a) |
+| `agentmux-srv/src/backend/storage/skills.rs` | — | ~220 | new (R.4b) |
+| `agentmux-srv/src/backend/storage/history.rs` | — | ~250 | new (R.4c) |
+| `agentmux-srv/src/backend/storage/dual_write.rs` | — | ~260 | new (R.5) |
+| `agentmux-srv/src/backend/storage/registry_mirror.rs` | — | ~180 | new (R.6) |
+
+**store.rs modularization plan is complete.** Next session can move on to the candidates below.
+
+## Inventory — Rust (top 20 source files, excluding tests & worktrees)
 
 | File | LOC | Verdict | Notes |
 |---|---|---|---|
-| `agentmux-srv/src/backend/storage/store.rs` | 4,836 | 🟡 **R.1 pending** — the agents subsystem (~1,500 LOC: `agent_def_*`, `instance_*`, `AgentDefinition`, `AgentInstance`, `InstanceStatus`) is the last piece of the modularization plan in `SPEC_STORE_MODULARIZATION_2026_05_27.md`. Carved out: `R.0` rename, `R.2` identities, `R.3` memory_bundles, `R.4` content/skills/history, `R.5` dual_write (deletes in Phase 3c), `R.6` registry_mirror. Once R.1 lands the file drops below 3,500. |
 | `agentmux-launcher/src/reducer/tests.rs` | 4,113 | 🟢 **Skip** — test file. Splitting a test module by sub-system is fine but rarely worth the churn. Revisit only if test discovery becomes painful. |
-| `agentmux-srv/src/server/agent_handlers.rs` | 3,456 | 🔴 **Candidate** — every `register_handler!` block is an independent unit. Natural carves: `agent_def_handlers.rs` (createagent / updateagent / deleteagent / listagents / agentdefhide), `agent_instance_handlers.rs` (createagentinstance / updateagentinstance / deleteagentinstance / listagentinstances / getagentinstance), `named_agent_handlers.rs` (listnamedagents / continuenamedagent / hidenamedagent), `template_promote_handlers.rs`. Estimated 4 sub-PRs, ~600–900 LOC each. **Cross-cutting concern:** all of these share `state.wstore` + `state.broker` and a common `WshRpcEngine` registration ritual; carving needs a `register_all` entry that each sub-module contributes to. |
+| `agentmux-srv/src/server/agent_handlers.rs` | 3,456 | 🔴 **Top candidate.** 6 `register_*_handlers` functions stack into one file. Natural carves: agents + skills + history + identities + sessions + memories. **See detailed plan below.** |
+| `agentmux-srv/src/backend/storage/store.rs` | 3,306 | 🟢 **Done** (R.1–R.6 shipped today). Further splits would chase phantom gains. |
 | `agentmux-srv/src/reducer.rs` | 3,069 | 🟡 **Maybe** — pure state-machine code. Already partitioned internally by `Command` variant. Cleanest carve is by command family (window, workspace, tab, block, saga). Risk: tightly coupled tests; reducer tests rely on whole-state-machine assertions. Defer until tests are quieter. |
-| `agentmux-srv/src/server/service.rs` | 2,581 | 🟡 **Maybe** — bootstrap glue. Some sections (the WS upgrade path, the HTTP-asset path, the IPC server, the broker bootstrap) could be separated. But this is "do once on startup" code with no hot path, so the maintenance cost is bounded. Lower priority. |
+| `agentmux-srv/src/server/service.rs` | 2,581 | 🟡 **Maybe** — bootstrap glue. Some sections (WS upgrade, HTTP-asset, IPC server, broker bootstrap) could be separated. But this is "do once on startup" code with no hot path, so the maintenance cost is bounded. Lower priority. |
 | `agentmux-srv/src/backend/agent_session.rs` | 2,396 | 🟡 **Maybe** — contains the `template_promote` migration (~700 LOC) and the per-block agent-session glue. Splitting `template_promote_migration.rs` out is a clean win; the rest is harder to factor. |
-| `agentmux-srv/src/backend/rpc_types.rs` | 2,271 | 🟡 **Skip-ish** — type definitions only. The pain isn't *finding* a type — every editor handles 2k-line type files. Lower value than code-extraction targets. Could split by RPC family if review velocity becomes a bottleneck. |
+| `agentmux-srv/src/backend/rpc_types.rs` | 2,271 | 🟢 **Skip-ish** — type definitions only. The pain isn't *finding* a type — every editor handles 2k-line type files. Lower value than code-extraction targets. |
 | `agentmux-common/src/ipc.rs` | 2,033 | 🟢 **Skip** — IPC enum + tag-dispatch table. Splitting an enum doesn't help readability. |
-| `agentmux-srv/src/backend/blockcontroller/shell.rs` | 1,836 | 🔴 **Candidate** — controller subprocess management. Splitting could yield `shell_spawn.rs`, `shell_io.rs`, `shell_lifecycle.rs`, `shell_tests.rs`. Bigger risk than store.rs because the state machine is intricate (Phase B reducer ports), but the file has clear functional zones. |
-| `agentmux-launcher/src/saga/mod.rs` | 1,829 | 🟡 **Maybe** — `mod.rs` containing all the saga implementations is a smell; the dir already has `delete_block.rs`, `delete_workspace.rs`, etc. Each saga's "definition + step impls" pair could move out to a `<saga>.rs` peer. |
-| `agentmux-srv/src/server/app_api.rs` | 1,811 | 🟡 **Maybe** — same pattern as `agent_handlers.rs` but mixed RPC families. Lower priority than the agent handlers because it's already mid-density. |
-| `agentmux-cef/src/client/mod.rs` | 1,803 | 🔴 **Candidate** — the CEF client `mod.rs` carries the `AgentMuxHandler` impl block with all the lifecycle (lifespan, load, request, display, etc.) handlers inline. Natural carve: one file per CEF handler interface (`lifespan.rs`, `load.rs`, `request.rs`, `display.rs`). Same `impl AgentMuxHandler` split pattern as store.rs's `impl Store` split. ~4 sub-PRs, ~400 LOC each. |
+| `agentmux-srv/src/backend/blockcontroller/shell.rs` | 1,836 | 🔴 **Candidate.** Controller subprocess management. Has clear functional zones. **See detailed plan below.** |
+| `agentmux-launcher/src/saga/mod.rs` | 1,829 | 🟡 **Maybe** — `mod.rs` containing all the saga implementations is a smell; the dir already has `delete_block.rs`, `delete_workspace.rs`, etc. Each saga's definition + step impls could move out to a `<saga>.rs` peer. |
+| `agentmux-cef/src/client/mod.rs` | 1,825 | 🔴 **Candidate.** The CEF client `mod.rs` carries all the CEF handler trait impls inline. **See detailed plan below.** |
+| `agentmux-srv/src/server/app_api.rs` | 1,811 | 🟡 **Maybe** — same pattern as `agent_handlers.rs` but mixed RPC families. Lower priority. |
 | `agentmux-srv/src/persist_subscriber.rs` | 1,588 | 🟢 **Skip** — sequential append-only event handling. Few subsystems to separate. |
-| `agentmux-srv/src/server/identity_handlers.rs` | 1,509 | 🟡 **Maybe** — already focused; carving wouldn't yield clean boundaries because identity-bundle + identity-account RPCs share a lot of helper context. |
-| `agentmux-srv/src/server/websocket.rs` | 1,490 | 🟢 **Skip-ish** — connection + frame handling. Not much to gain from splitting. |
-| `agentmux-cef/src/commands/window.rs` | 1,445 | 🔴 **Candidate — user-flagged** | See detailed plan below. |
-| `agentmux-srv/src/identity/resolver.rs` | 1,434 | 🟡 **Maybe** — the actual resolver is ~600 LOC; the rest is OAuth probe code (~400 LOC) and the test module (~400 LOC). Carving `oauth_probe.rs` out would help, since the probe is independent of the resolver dispatch. |
-| `agentmux-cef/src/state.rs` | 1,300 | 🟢 **Skip** — AppState struct + a handful of constructors. Already focused. |
+| `agentmux-srv/src/backend/storage/agents.rs` | 1,556 | 🟢 **Just landed (R.1)** — leave alone. |
+| `agentmux-srv/src/server/identity_handlers.rs` | 1,509 | 🟡 **Maybe** — already focused; identity-bundle + identity-account RPCs share helper context. |
+| `agentmux-srv/src/server/websocket.rs` | 1,490 | 🟢 **Skip-ish** — connection + frame handling. Not much to gain. |
+| `agentmux-cef/src/commands/window.rs` | 1,462 | 🔴 **Candidate — user-flagged.** **See detailed plan below.** |
+| `agentmux-srv/src/identity/resolver.rs` | 1,434 | 🟡 **Maybe** — resolver is ~600 LOC, OAuth probe is ~400 LOC, tests are ~400 LOC. `oauth_probe.rs` carve is a clean win. |
+| `agentmux-cef/src/state.rs` | 1,300 | 🟢 **Skip** — `AppState` struct + constructors. Already focused. |
 | `agentmux-srv/src/backend/blockcontroller/subprocess.rs` | 1,254 | 🟡 **Maybe** — Win32 process spawning + pipe management. Could carve `windows_pipes.rs`, `process_spawn.rs`. Lower priority than `shell.rs`. |
-| `agentmux-srv/src/main.rs` | 1,134 | 🟢 **Skip** — bootstrap. Inevitable that it's long; refactoring wouldn't help readability. |
-| `agentmux-common/src/data_paths.rs` | 1,091 | 🟢 **Skip** — path-resolution constants + helpers. Already organized. |
-| `agentmux-launcher/src/main.rs` | 1,077 | 🟢 **Skip** — launcher main loop. Similar reasoning to srv main. |
-| `agentmux-srv/src/backend/storage/migrations.rs` | 1,036 | 🟡 **Maybe** — each `migrate_to_vN` could be its own file. Easy carve but limited churn benefit. Defer. |
-| `agentmux-cef/src/launcher_ipc.rs` | 1,022 | 🟢 **Skip** — small surface (IPC client). |
 
 ## Inventory — TypeScript
 
@@ -55,44 +68,145 @@ This doc maps the next set of fat files in the repo and ranks them by extraction
 | `frontend/app/store/agent-pane-state/reducer.test.ts` | 2,143 | 🟢 **Skip** — tests. |
 | `frontend/app/store/rpc-api.ts` | 1,344 | 🟢 **Skip** — generated thin wrappers. |
 | `frontend/app/store/browser-pane-state/reducer.test.ts` | 1,060 | 🟢 **Skip** — tests. |
-| `frontend/app/view/agent/components/AgentLaunchModal.tsx` | 1,020 | 🔴 **Candidate** — big React component with multiple `Show when=`-gated subviews (identity tab, memory tab, name & cwd, continue-mode list). Carving each tab into its own file (`<TabName>Panel.tsx`) is the cleanest split. |
+| `frontend/app/view/agent/components/AgentLaunchModal.tsx` | 1,020 | 🔴 **Candidate** — big SolidJS component with multiple `Show when=`-gated subviews (identity tab, memory tab, name & cwd, continue-mode list). Carving each tab into its own file (`<TabName>Panel.tsx`) is the cleanest split. |
 | `frontend/app/tab/tabbar.tsx` | 1,008 | 🟡 **Maybe** — drag-and-drop tab-bar. Could carve `tabbar-drag.ts` (hit-test + drag-state) out of the rendering logic. |
 | `frontend/app/store/agent-document/reducer.test.ts` | 1,006 | 🟢 **Skip** — tests. |
 | `frontend/app/store/global.ts` | 1,002 | 🟡 **Maybe** — Jotai atoms by topic. Could move each atom-family to its own file. Low cost, low pain — defer. |
 | `frontend/app/view/agent/agent-view.tsx` | 958 | 🟡 **Maybe** — already partitioned by section components. Splitting harder than it looks. |
 
-## Detailed plan: `agentmux-cef/src/commands/window.rs`
+---
 
-This file is user-flagged and has cleanly-grouped sections. Proposed carve into a `agentmux-cef/src/commands/window/` directory:
+# Detailed sub-PR plans
+
+Each plan below is concrete enough to execute without re-discovering the file structure. Symbol names, approximate line spans, and shared-state surfaces are listed.
+
+## Plan 1: `agentmux-cef/src/commands/window.rs` (1,462 LOC → 6 sub-PRs)
+
+User-flagged; cleanest partitions of the four candidates. Carve into `agentmux-cef/src/commands/window/`.
+
+| New module | Symbols (line spans approx.) | LOC est. | Dependencies |
+|---|---|---|---|
+| `mod.rs` | `pub use lifecycle::*; pub use motion::*; pub use chrome::*; pub use transparency::*; pub use meta::*; pub use creation::*;` | ~15 | none |
+| `lifecycle.rs` | `close_window` (55), `close_window_by_label` (78), `resolve_window_hwnd` (235), `find_main_window` (194), `find_own_top_level_window` (733), `find_all_own_windows` (703), `capture_hwnd_for_label` (1337), `FLOATING_PANE_CLASS_NAME` const (185) | ~300 | `state.window_hwnds`, Win32 `IsWindow` |
+| `motion.rs` | `get_window_position` (342), `set_window_position` (405), `move_window_by` (368), `start_window_drag` (448), `resolve_window_at_cursor` (493), `update_floating_redock_hover` (595), `clear_floating_redock_hover` (640) | ~300 | `state.window_hwnds`, `state.floating_redock_hover` |
+| `chrome.rs` | `minimize_window` (113), `maximize_window` (138) | ~50 | `state.window_hwnds` |
+| `transparency.rs` | `set_window_transparency` (664), `set_window_opacity` (1386), `get_window_opacity` (1446), `apply_window_opacity` (767), `remove_window_opacity` (787) | ~150 | `state.window_hwnds`, Win32 `SetLayeredWindowAttributes` |
+| `meta.rs` | `get_zoom_factor` (18), `set_zoom_factor` (26), `get_window_label` (798), `is_main_window` (805), `get_double_click_time` (820), `list_window_instances` (843), `list_windows` (883), `focus_window` (901), `get_instance_number` (912), `register_backend_window` (923), `toggle_devtools` (955), `inspect_element_at` (964) | ~280 | `state.window_hwnds`, `state.zoom_factor`, devtools APIs |
+| `creation.rs` | `open_new_window` (1167), `open_subwindow` (1176), `open_window_with_kind` (1216), `resolve_frontend_base_url` (1039), `assets_missing_data_url` (1107), `dev_vite_port` (979), `resolve_host_runtime_dir` (1083), `get_offset_position` (1291), `get_secondary_window_size` (1314), `FrontendUrlError` enum | ~400 | `state.runtime_dir`, frontend bundle resolution |
+
+**Recommended start:** `lifecycle.rs` first — contains close-button code path fixed in #1133, natural continuation. **Estimated total:** 6 sub-PRs × ~30 min = ~3 hours.
+
+**Caller-update strategy:** `pub use` shim in `mod.rs` means callers (mostly `ipc.rs` dispatcher) don't have to change. Verify after each sub-PR with `cargo check -p agentmux-cef`.
+
+---
+
+## Plan 2: `agentmux-srv/src/server/agent_handlers.rs` (3,456 LOC → 4 sub-PRs)
+
+This is the biggest non-storage file in the repo. It contains **6 `register_*_handlers` entry functions** that stack ~50+ individual `engine.register_handler!` blocks. The natural carve is one file per RPC family.
+
+Current top-level structure (line spans):
+
+| Entry function | Line | Approximate body span | Handler count |
+|---|---|---|---|
+| `register_agent_handlers` | 87 | 87–1,090 | ~22 handlers (agents, skills, history, identities, named_agents) |
+| `register_v6_handlers` | 1,092 | 1,092–2,013 | ~15 handlers (agent_def_*, fork, hide, list_hidden) |
+| `register_agent_session_handlers` | 2,015 | 2,015–2,145 | 4 handlers (session read/write/append/archive) |
+| `register_v7_handlers` | 2,147 | 2,147–2,443 | ~10 handlers (identity_bundle_*, identity_binding_*, memory_*) |
+| `read_session_preview` | 2,445 | 2,445–2,505 | helper |
+| `collapse_preview` | 2,506 | 2,506+ | helper |
+
+Carve into `agentmux-srv/src/server/agent_handlers/`:
 
 | New module | Contents | LOC est. |
 |---|---|---|
-| `mod.rs` | re-exports for the existing flat `commands::window::*` import sites | ~15 |
-| `lifecycle.rs` | `close_window`, `close_window_by_label`, `resolve_window_hwnd`, `capture_hwnd_for_label`, `find_own_top_level_window`, `find_main_window`, the `EnumWindows` helpers | ~350 |
-| `motion.rs` | `get_window_position`, `set_window_position`, `move_window_by`, `start_window_drag`, `resolve_window_at_cursor`, `update_floating_redock_hover`, `clear_floating_redock_hover` | ~300 |
-| `chrome.rs` | `minimize_window`, `maximize_window` | ~200 |
-| `transparency.rs` | `set_window_transparency`, `set_window_opacity`, `get_window_opacity` | ~150 |
-| `meta.rs` | `get_window_label`, `is_main_window`, `list_window_instances`, `list_windows`, `focus_window`, `get_instance_number`, `register_backend_window`, `get_zoom_factor`, `set_zoom_factor`, `get_double_click_time`, `toggle_devtools`, `inspect_element_at` | ~250 |
-| `creation.rs` | `open_new_window`, `open_subwindow`, the `FrontendUrlError` family, `resolve_frontend_base_url`, `assets_missing_data_url` | ~250 |
+| `mod.rs` | `pub use core::register_agent_handlers; pub use v6::register_v6_handlers; pub use sessions::register_agent_session_handlers; pub use v7::register_v7_handlers;` + module-local helpers (`read_session_preview`, `collapse_preview`) | ~80 |
+| `core.rs` | `register_agent_handlers` — agents/skills/history/identities/named_agents (the v5 surface) | ~1,000 |
+| `v6.rs` | `register_v6_handlers` — agent_def_* + fork/hide/list_hidden | ~920 |
+| `sessions.rs` | `register_agent_session_handlers` — read/write/append/archive + list_archives | ~130 |
+| `v7.rs` | `register_v7_handlers` — identity bundles, identity bindings, memory CRUD | ~300 |
 
-Estimated 6 sub-PRs, each ~30 minutes. Same playbook as `store.rs`: each sub-PR uses a `pub use` shim in `mod.rs` so callers don't have to update their `use` paths.
+**Caller-update strategy:** `service.rs` (or wherever `register_*_handlers` get called) keeps the same imports because `mod.rs` re-exports them. Sub-PR order recommendation: `sessions.rs` first (smallest, lowest risk), then `v7.rs`, then `v6.rs`, then `core.rs`. Each sub-PR ~30 min. **Estimated total:** 4 sub-PRs × ~30 min = ~2 hours.
+
+**Cross-cutting concern:** all handlers share `state.wstore`, `state.broker`, `state.identity_resolver`. The carve preserves these as constructor arguments, so the change is purely "where does the file live."
+
+---
+
+## Plan 3: `agentmux-cef/src/client/mod.rs` (1,825 LOC → 4 sub-PRs)
+
+The CEF client `mod.rs` carries the `AgentMuxHandler` struct + all CEF handler trait impls inline. CEF handlers come in families (lifespan, load, request, display, render-process, browser-process) — each is a discrete trait impl block.
+
+Carve into `agentmux-cef/src/client/`:
+
+| New module | Contents | LOC est. |
+|---|---|---|
+| `mod.rs` | `AgentMuxHandler` struct, `new()`, registration of all sub-impls, `pub use` for cross-module helpers | ~250 |
+| `lifespan.rs` | `impl LifeSpanHandler for AgentMuxHandler` — `on_after_created`, `on_before_close`, `do_close`, popup lifecycle, window-list bookkeeping | ~500 |
+| `load.rs` | `impl LoadHandler for AgentMuxHandler` — `on_loading_state_change`, `on_load_start`, `on_load_end`, `on_load_error`, ready-state propagation | ~350 |
+| `request.rs` | `impl RequestHandler` + `impl ResourceRequestHandler` — URL filtering, custom scheme handling, asset interception | ~400 |
+| `display.rs` | `impl DisplayHandler` + misc — title/favicon/status/tooltip/console-message; status-bar updates | ~250 |
+| `dispatch.rs` | The IPC message dispatch `on_process_message_received` (still the largest single fn) — if it's >400 LOC alone, this gets its own file. | ~250 |
+
+**Higher risk than handlers** because the impl-block layout has to thread `self.state.inner.lock()` carefully; some lifespan callbacks coordinate with `do_close` via state flags. But the existing impl is already partitioned by trait, so the cuts are obvious.
+
+**Sub-PR order:** `display.rs` first (smallest impl, lowest cross-impl coupling), then `load.rs`, then `request.rs`, then `lifespan.rs` (largest + most state coupling). **Estimated total:** 4 sub-PRs × ~45 min = ~3 hours.
+
+**Caller-update strategy:** CEF trait impls don't need callers to change — registrations happen via the `Handler` trait method returns. All sub-modules add `impl Foo for AgentMuxHandler` blocks; Rust merges them at link time. No `pub use` shim needed for trait impls.
+
+---
+
+## Plan 4: `agentmux-srv/src/backend/blockcontroller/shell.rs` (1,836 LOC → 4 sub-PRs)
+
+Controller subprocess management. Has clear functional zones for spawn, IO, lifecycle, and tests. Higher risk than store.rs because the state machine is intricate (Phase B reducer ports), but the file partitions cleanly.
+
+Carve into `agentmux-srv/src/backend/blockcontroller/shell/`:
+
+| New module | Contents | LOC est. |
+|---|---|---|
+| `mod.rs` | `ShellProc` struct + public API (`spawn`, `kill`, `input`, `resize`, `status`) — keeps the public surface | ~250 |
+| `spawn.rs` | `spawn_shell`, Win32 ConPTY setup, Unix PTY setup, environment construction, shell-path resolution (calls into `detect_local_shell_path_*`) | ~500 |
+| `io.rs` | PTY read loop, terminal data forwarding to broker, input-write fn, base64 encoding | ~400 |
+| `lifecycle.rs` | Exit-code capture, SIGINT signaling, cleanup, retry policy | ~400 |
+| `tests.rs` (already exists if module has tests) | unchanged | — |
+
+**Risk:** the state machine across spawn → io → lifecycle is implicit; carving might force exposing internal handles via `pub(super)`. **Mitigation:** add one comment at the top of `mod.rs` documenting the lifecycle contract before extracting.
+
+**Sub-PR order:** `spawn.rs` first (most self-contained), then `io.rs`, then `lifecycle.rs`. Defer the test module split. **Estimated total:** 4 sub-PRs × ~45 min = ~3 hours.
+
+---
 
 ## Recommended next moves (priority order)
 
-1. **R.1 store.rs agents extraction** — already-spec'd, blocked only by review-time. Finishing this lands the modularization plan that's two-thirds done.
-2. **`window.rs` carve** (~6 sub-PRs) — user-flagged; clean partitions; no semantic risk since these are flat command handlers with shared state pattern.
-3. **`agent_handlers.rs` carve** (~4 sub-PRs) — biggest win-per-PR; pure RPC handler split. The cross-cutting `register_all` rejigger is a one-time cost.
-4. **`client/mod.rs` (CEF) carve** (~4 sub-PRs) — splits the CEF handler interfaces. Higher risk than handlers because the impl-block layout has to thread `inner.lock()` carefully — but the existing impl is already partitioned by trait, so the cuts are obvious.
+1. **`window.rs` carve (Plan 1)** — user-flagged; clean partitions; 6 sub-PRs but the first one is the close-button code we just fixed today. Natural momentum.
+2. **`agent_handlers.rs` carve (Plan 2)** — biggest win-per-PR; pure RPC handler split. The shared `WshRpcEngine` argument is the only cross-cutting concern, and it's already an argument so no refactor needed.
+3. **`client/mod.rs` carve (Plan 3)** — splits the CEF handler trait impls. Higher risk than handlers because of state coupling, but the trait boundaries make the cuts obvious.
+4. **`shell.rs` carve (Plan 4)** — lower priority because the state machine is intricate and the file is "only" 1,836 LOC. Defer until 1, 2, 3 are done and there's appetite for the risk.
 
-After those four, every Rust file in the repo is under 1,800 LOC. That's the natural stopping point — further splits start to chase phantom gains.
+After those four land, every Rust file in the repo is under 1,800 LOC. **That's the natural stopping point** — further splits start to chase phantom gains.
 
 ## What we are NOT going to extract
 
-- Test files (they grow with feature count; if a test file is slow, the answer is test-runner sharding, not module splits).
-- Generated files (`gotypes.d.ts`, `rpc-api.ts`).
-- Tiny config/constants files (under 200 LOC).
-- The `enum` + `tag dispatch` files (`ipc.rs`, `rpc_types.rs`) — splitting an enum spreads exhaustiveness checks across files for no readability gain.
+- **Test files** (they grow with feature count; if a test file is slow, the answer is test-runner sharding, not module splits).
+- **Generated files** (`gotypes.d.ts`, `rpc-api.ts`).
+- **Tiny config/constants files** (under 200 LOC).
+- **`enum` + `tag dispatch` files** (`ipc.rs`, `rpc_types.rs`) — splitting an enum spreads exhaustiveness checks across files for no readability gain.
+- **`store.rs` further splits** — R.1–R.6 cleared the modularization-worth boundaries; what remains is the irreducible Store core.
+
+## Pattern: the R-style modularization playbook
+
+For any flat file with `>1500 LOC` and clean functional partitions:
+
+1. **Identify** subsystems via `grep -nE "^pub fn|^impl"` and reading section comments.
+2. **Create** a sibling directory `<name>/` with a `mod.rs` that re-exports from sub-modules.
+3. **Move** each subsystem to its own file, preserving identical signatures.
+4. **Add** `pub use submod::*;` (for flat functions) or sibling `impl Type {}` blocks (for methods).
+5. **Leave** a one-line breadcrumb comment in the donor file: `// Moved to submod.rs (R.N)`.
+6. **Verify** with `cargo check -p <crate>` after each sub-PR; the compiler is the safety net.
+7. **One sub-PR per subsystem.** Each is reviewable as a pure-move diff; mixing logic changes defeats the point.
+
+This pattern has shipped 7 times today (R.0–R.6 for store.rs) and is the reference for the 4 plans above.
 
 ## Closing note
 
-This survey took ~10 minutes to assemble. The pattern from R.2–R.6 (sibling module + `impl Store {}` block + comment breadcrumb) generalizes — anything that compiles as a flat collection of `pub fn`s sharing a small state argument is a candidate. The bar is "does this file partition cleanly into > 3 functional zones each addressable to a different sub-team?" If yes, modularize. If no, leave alone.
+Pre-session: 6 Rust files >2,000 LOC in the source tree. Post-R.6: still 6 (store.rs went from 6,226 to 3,306; agents.rs is new at 1,556). After Plans 1–4 ship: **3** Rust files >2,000 LOC (reducer.rs, service.rs, agent_session.rs), all 🟡 *Maybe* — and every one of them has its own bespoke risk profile that doesn't fit the R-style playbook.
+
+The work to "get every source file under 1,800 LOC" is bounded at ~12 hours of focused PRs.

--- a/docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md
+++ b/docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md
@@ -1,0 +1,183 @@
+# Analysis: "Send now" button flashes on every send (2026-05-28)
+
+**Author:** AgentA
+**Status:** Bug confirmed, root cause identified, fix proposed.
+**Reported by:** user (this session) — "it flashes a 'send now' panel even when the agent isn't busy."
+**Affected file:** `frontend/app/view/agent/agent-view.tsx:811-825`
+**Related spec:** `docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md`
+
+---
+
+## Symptom
+
+After a user types into the composer and hits Send from an idle pane, the "Send now" affordance (the ⏭ button inside the queued-message header) flickers visible for ~50–200 ms before disappearing. The flash happens on every send, including the very first one in an idle pane — where logically "Send now" should never apply because there is no in-flight turn to interrupt.
+
+## Root cause
+
+`PendingMessagesPanel` is rendered with `showSendNow` gated on two predicates:
+
+```tsx
+// frontend/app/view/agent/agent-view.tsx:811
+<PendingMessagesPanel
+    pendingMessages={pendingMessagesAtom[0]}
+    showSendNow={() =>
+        workingFromPhase(agentAtoms().turnPhaseAtom[0]()) &&
+        pendingMessagesAtom[0]().length > 0
+    }
+    onSendImmediately={() => { commands.stopAgent(); }}
+/>
+```
+
+`workingFromPhase` (defined in `frontend/app/store/agent-pane-state/types.ts:288`) returns `true` for `{Submitting, Streaming, Interrupting}`:
+
+```ts
+export function workingFromPhase(phase: TurnPhase): boolean {
+    const k = phase.kind;
+    return k === "Submitting" || k === "Streaming" || k === "Interrupting";
+}
+```
+
+The state machine (per SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23 §6) flows on every send:
+
+```
+Idle ──TurnStart──► Submitting ──agent-message-accepted──► Streaming
+                       ▲
+                       │ pendingMessages.length > 0
+                       │ (the message that JUST got typed)
+                       │
+                       └── showSendNow = true   ← flash window
+```
+
+The mechanism inside `handleSendMessage` (composer path):
+
+1. Push the new message onto `pendingMessagesAtom`.
+2. Dispatch `TurnStart` → phase becomes `Submitting`.
+3. Render runs: both predicates are true → `Send now` button paints.
+4. Backend emits `agent-message-accepted` (typically 50–200 ms later) → `useAgentStream.ts:296-317` removes the entry from `pendingMessages` and promotes it to a `user_message` document node. Phase advances to `Streaming`.
+5. Render runs again: `pendingMessages.length === 0` → button hides.
+
+That render window between steps 3 and 5 is the visible flash.
+
+## Why it's wrong (semantics)
+
+"Send now" means *interrupt the running turn so this queued message gets processed immediately*. The button only makes sense when:
+1. Something is currently in flight that we could SIGINT.
+2. There is at least one queued message waiting behind it.
+
+During `Submitting`, neither premise holds: the message you just typed *is* the would-be running turn, not a queue waiting behind one. There is nothing to interrupt — the backend hasn't even acknowledged the message yet. Pressing "Send now" during Submitting would call `commands.stopAgent()` against a turn that doesn't exist as a CLI process; the SIGINT either lands nowhere or aborts the user's own intended message.
+
+The genuine "Send now" scenario is:
+
+```
+Streaming ── user types and sends ──► Streaming (pendingMessages=[A])
+                                          │
+                                          └── showSendNow = true   ← legit
+```
+
+Here the agent is genuinely busy, A is buffered behind it, and SIGINT followed by drain is exactly what the user wants.
+
+## Why this was missed in PR B / PR G
+
+PR #992 (turn-phase PR B, merged 2026-05-23) switched the predicate from the legacy `turnActive` boolean to `workingFromPhase`. PR #997 (PR G, merged 2026-05-23) removed `turnActive` entirely. The inline comment captures the author's intent:
+
+```tsx
+// frontend/app/view/agent/agent-view.tsx:814-818
+// "Send now" appears whenever the agent is working
+// (Submitting / Streaming / Interrupting) and the
+// user has at least one queued message. PR G removed
+// the legacy `turnActive` boolean — the working set
+// is now defined purely by `turnPhase`.
+```
+
+The phrase "agent is working" conflated two distinct conditions:
+- **Working in the indicator sense** — "show a spinner, the pane is doing something." All three phases qualify.
+- **Working in the interruptible-turn sense** — "there is a CLI subprocess actively streaming that SIGINT would stop." Only `Streaming` and `Interrupting` qualify.
+
+The flash flowed from using the indicator-sense predicate for the interruptible-turn UI.
+
+## Proposed fix
+
+Add a sibling predicate next to `workingFromPhase` and use it at the one call site:
+
+```ts
+// frontend/app/store/agent-pane-state/types.ts (new export)
+/**
+ * Returns true iff there is an in-flight turn that SIGINT can interrupt.
+ * Same shape as `workingFromPhase`, but excludes `Submitting` — during
+ * Submitting the would-be turn is itself sitting in the pending queue
+ * waiting for `agent-message-accepted`, so there is no CLI process to
+ * interrupt. Used by the "Send now" affordance, which is meaningful
+ * only when the queue genuinely sits behind a running turn.
+ */
+export function isInterruptibleTurn(phase: TurnPhase): boolean {
+    const k = phase.kind;
+    return k === "Streaming" || k === "Interrupting";
+}
+```
+
+```tsx
+// frontend/app/view/agent/agent-view.tsx (one-line swap)
+showSendNow={() =>
+    isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]()) &&
+    pendingMessagesAtom[0]().length > 0
+}
+```
+
+Update the inline comment to reflect the new gate.
+
+## Why not the "compare timestamps" alternative
+
+A stricter approach is to give each pending message an `enqueuedAt` and only show Send Now when any pending message was enqueued *before* the current turn's `startedAt`. This handles the rare case where a user sends a second message during the Submitting window of the first.
+
+Rejected because:
+1. The current `PendingMessage` shape does not carry `enqueuedAt`; adding it requires touching the reducer, the dispatch path, and the document slice.
+2. Submitting is bounded — `SubmitTimeoutElapsed` (`types.ts:389`) caps it at the spec-defined timeout (~2 s). The "second message during Submitting" window is small.
+3. Behavior during Submitting is unambiguous either way: both messages are awaiting ack; SIGINT-then-drain has no useful semantic. Hiding Send Now during Submitting is correct, not a workaround.
+
+## Test plan
+
+Three pure-reducer unit tests in `frontend/app/store/agent-pane-state/types.test.ts` (or alongside the existing `state.test.ts:62-88` test for `workingFromPhase`):
+
+```ts
+test("isInterruptibleTurn = false during Idle / Submitting / Done / Disconnected", () => {
+    expect(isInterruptibleTurn({ kind: "Idle" })).toBe(false);
+    expect(isInterruptibleTurn({ kind: "Submitting", since: 0 })).toBe(false);
+    expect(isInterruptibleTurn({ kind: "Done", outcome: "completed", at: 0 })).toBe(false);
+    expect(isInterruptibleTurn({ kind: "Disconnected", since: 0 })).toBe(false);
+});
+
+test("isInterruptibleTurn = true during Streaming / Interrupting", () => {
+    expect(isInterruptibleTurn({ kind: "Streaming", since: 0, lastEventAt: 0 })).toBe(true);
+    expect(isInterruptibleTurn({ kind: "Interrupting", since: 0, reason: "user" })).toBe(true);
+});
+
+test("isInterruptibleTurn excludes the same Submitting set workingFromPhase includes", () => {
+    expect(workingFromPhase({ kind: "Submitting", since: 0 })).toBe(true);
+    expect(isInterruptibleTurn({ kind: "Submitting", since: 0 })).toBe(false);
+});
+```
+
+Manual smoke test:
+1. Open an idle pane, type a message, hit Enter.
+2. Watch the queued-zone header during the send. Expected: no "Send now" button paints at any point.
+3. Start a long-running turn (e.g. `bash -c 'for i in 1 2 3 4 5; do echo $i; sleep 1; done'` via the bash tool).
+4. While it streams, type a second message and hit Enter. Expected: "Send now" button paints, click it → first turn stops, second message processes.
+
+## Risk
+
+Minimal. The predicate is a one-call-site change with a strict subset of the original `workingFromPhase` truth values, so behavior can only go from "button visible" to "button hidden" — never the reverse. The legitimate case (queue behind a running turn) is unaffected because that path runs through `Streaming` / `Interrupting`, both still included.
+
+The `PendingMessagesPanel` itself (the queued-zone visibility) is unchanged — it remains gated on `pendingMessages.length > 0` only (line 32). The bug is solely about the inner "Send now" button, not the whole zone.
+
+## Out of scope
+
+- The brief paint of the queued-message *zone* (amber border + spinner dot) during the optimistic-enqueue window is intentional per `AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC` — that color shift is the user's visible "queued → accepted" signal.
+- The decision-prompt overlay and the disconnected banner (also gated on phase) are correctly using their respective predicates.
+
+## Files touched by the fix
+
+- `frontend/app/store/agent-pane-state/types.ts` — add `isInterruptibleTurn` export.
+- `frontend/app/view/agent/agent-view.tsx` — swap predicate at line 819; update inline comment.
+- `frontend/app/view/agent/state.test.ts` (or sibling) — three unit tests.
+
+Total diff: ~30 lines added, 1 line changed.

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -64,12 +64,20 @@ const BackendStatus = (): JSX.Element => {
     // Drive uptime from sysinfo event timestamp so all windows update in sync.
     // The backend broadcasts sysinfo with a server-side ts (ms epoch); all windows
     // receive the same ts and compute the same integer, eliminating phase drift.
+    //
+    // Diagnostic instrumentation (2026-05-28): the per-agent-pane cascade
+    // crash has been observed to leave this widget's value frozen until a
+    // sysinfo widget pane is opened. The console.log distinguishes:
+    //   - log silent + DOM frozen  → backend stopped delivering (broker drop)
+    //   - log fires + DOM frozen   → SolidJS scheduler / render-effect stuck
+    // Remove once the cascade root cause lands.
     onMount(() => {
         const unsub = waveEventSubscribe({
             eventType: "sysinfo",
             scope: "local",
             handler: (event) => {
                 const ts: number | undefined = (event as WaveEvent)?.data?.ts;
+                console.log("[fe] sysinfo:BackendStatus handler ts=", ts);
                 const start = startedAt();
                 if (ts != null && start != null) {
                     setUptimeSecs(Math.floor((ts - start) / 1000));

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -44,12 +44,16 @@ function memColor(used: number, total: number): string {
 const SystemStats = (): JSX.Element => {
     const [stats, setStats] = createSignal<SysStats | null>(null);
 
+    // Diagnostic instrumentation (2026-05-28): pairs with BackendStatus
+    // to confirm whether the agent-pane cascade freeze is broker-side
+    // (handler silent) or scheduler-side (handler fires, DOM stays stale).
     onMount(() => {
         const unsub = waveEventSubscribe({
             eventType: "sysinfo",
             scope: "local",
             handler: (event) => {
                 const vals = (event as WaveEvent)?.data?.values;
+                console.log("[fe] sysinfo:SystemStats handler vals=", vals != null);
                 if (vals == null) return;
                 setStats({
                     cpu: vals["cpu"] ?? 0,


### PR DESCRIPTION
## What

Diagnostic instrumentation (no behavior change) for the agent-pane cascade crash whose side effect froze **all** status-bar perf indicators (CPU/Mem/Net/Disk/uptime) until a sysinfo widget pane was opened — which re-armed the broker subscription. See \`docs/analysis/ANALYSIS_AGENT_PANE_CRASH_2026_05_28_PM.md\` (included) for the full timeline + sidecar dive.

The instrumentation bisects two candidate mechanisms on the next repro:

- **FE** (\`BackendStatus.tsx\`, \`SystemStats.tsx\`): a \`console.log\` inside each sysinfo handler.
  - silent + DOM frozen → backend stopped delivering (broker dropped the subscriber)
  - fires + DOM frozen → SolidJS scheduler/render-effect stalled
- **Sidecar** (\`wps.rs\` \`Broker::publish\`): a \`tracing::warn!(target: "wps-diag", …)\` when the client is \`None\` OR when a \`sysinfo\` event publishes to **zero** routes. The "0 routes for sysinfo" line is the smoking gun for the broker-drop path.

## Why merge it (we never reproduced)

The freeze is intermittent and tied to the (separately-fixed) cascade crash family. Landing the instrumentation means the **next** occurrence is captured in the host + sidecar logs instead of needing a live repro. All three log sites are explicitly tagged for removal once the root cause lands.

## Also included (analysis docs)

- \`ANALYSIS_AGENT_PANE_CRASH_2026_05_28_PM.md\` — timeline, the 6-fix history of this crash class, the sidecar eventsub dive (eventsub aggregator is NOT the bug; it's the FE re-sub on cascade unwind).
- \`ANALYSIS_SEND_NOW_FLASH_2026_05_28.md\` — diagnosis behind the merged #1139 fix.
- \`ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md\` — refreshed post-R.6 survey with 4 carve plans.

## Verification

FE \`tsc\` clean (pre-existing errors only); \`cargo check -p agentmux-srv\` clean. Rebased on current main, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)