### PR TITLE
refactor(cef): extract window lifecycle handlers into window/lifecycle.rs

### DIFF
--- a/.changesets/1780032038-refactor-cef-extract-window-lifecycle-handlers-into-commands-m2vm.md
+++ b/.changesets/1780032038-refactor-cef-extract-window-lifecycle-handlers-into-commands-m2vm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(cef): extract window lifecycle handlers into commands/window/lifecycle.rs

--- a/agentmux-cef/src/commands/window/lifecycle.rs
+++ b/agentmux-cef/src/commands/window/lifecycle.rs
@@ -1,0 +1,376 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Window lifecycle commands + HWND resolution helpers for the CEF host.
+//
+// First carve of the `commands/window.rs` modularization
+// (docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md,
+// Plan 1). Holds the close path, the per-label top-level-HWND resolver,
+// the EnumWindows fallbacks, and the per-label HWND cache capture —
+// everything that answers "which OS window does this label map to, and
+// how do we close it." The motion / chrome / transparency / meta /
+// creation handlers stay in `mod.rs` (later carves).
+//
+// `resolve_window_hwnd` and `find_all_own_windows` are `pub(super)`: they
+// are consumed by the motion / transparency handlers that still live in
+// `mod.rs`. `close_window` / `close_window_by_label` are `pub` (dispatched
+// by ipc.rs); `find_own_top_level_window` / `capture_hwnd_for_label` are
+// `pub(crate)` (browser_pane, client, backend resolve them as
+// `commands::window::<name>`). All but the two cross-platform close
+// handlers are Windows-only.
+
+use std::sync::Arc;
+
+use crate::state::AppState;
+
+// Both traits are needed by the Windows-only resolver/capture fns below
+// (`Browser::host` needs ImplBrowser; `BrowserHost::window_handle` needs
+// ImplBrowserHost). cfg-gated so non-Windows builds — where those fns
+// compile out — don't see an unused import.
+#[cfg(target_os = "windows")]
+use cef::{ImplBrowser, ImplBrowserHost};
+
+/// Close the window. Args: optional `{ "label": string }`; defaults to "main".
+/// Routes by label via `resolve_window_hwnd` — without that the floater
+/// (owned, drawn above its owner in Z-order) would always swallow the
+/// close because `find_own_top_level_window` returns the topmost-Z
+/// visible top-level of the process.
+pub fn close_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::*;
+        let hwnd = resolve_window_hwnd(state, label);
+        if !hwnd.is_null() {
+            PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            return Ok(serde_json::Value::Null);
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_close_window(state, label);
+    let _ = (state, label);
+    Ok(serde_json::Value::Null)
+}
+
+/// Close a specific window by label. Used by the tear-off Phase 4
+/// merge path: after the candidate window pulls the dragged tab into
+/// its own workspace via MoveTabToWorkspace, the dragged window is
+/// empty and should be destroyed. Posts WM_CLOSE on Win32; uses the
+/// existing UI-thread close task on other platforms.
+pub fn close_window_by_label(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing label".to_string())?
+        .to_string();
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+        // Route through resolve_window_hwnd so we hit the cached OUTER
+        // top-level HWND. The reducer registry returns CEF's inner
+        // WS_CHILD for `set_as_child` browsers (and for floaters our
+        // outer popup HWND is only in the cache), so going straight to
+        // `host.window_handle()` would WM_CLOSE the embedded child —
+        // after a redock that leaves the outer popup as an empty shell.
+        let hwnd = resolve_window_hwnd(state, &label);
+        if !hwnd.is_null() {
+            PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            return Ok(serde_json::Value::Null);
+        }
+        return Err(format!("no top-level HWND for label {}", label));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        crate::ui_tasks::post_close_window(state, &label);
+        Ok(serde_json::Value::Null)
+    }
+}
+
+/// Resolve a top-level HWND for the given label. Prefer the reducer
+/// registry (`state.get_browser(label)` → host → window_handle → walk
+/// to root) over the process-wide `find_own_top_level_window` fallback.
+///
+/// Why the label matters: `find_own_top_level_window` does an
+/// `EnumWindows` and returns the *first* visible top-level of the
+/// current process. Z-order puts **owned** windows ABOVE their owner,
+/// so as soon as a floating-pane window exists, every label-less
+/// `get/set_window_position` call (e.g. the main window's
+/// `useWindowDrag`) accidentally targets the floater — dragging the
+/// main window moves the floater instead.
+///
+/// `GetAncestor(hwnd, GA_ROOT)` guard handles the case where CEF
+/// returns the embedded browser's WS_CHILD HWND rather than our
+/// outer top-level — without it, `SetWindowPos` would only shift the
+/// child within its parent, not move the outer floater.
+/// Class name of the floating-pane outer HWND
+/// (`agentmux-cef/src/floating_pane.rs::CLASS_NAME`). Kept in sync so
+/// `find_main_window` can EnumWindows-skip floaters when CEF Views
+/// hides the main window's HWND.
+#[cfg(target_os = "windows")]
+const FLOATING_PANE_CLASS_NAME: &str = "AgentMuxFloatingPane";
+
+/// Like `find_own_top_level_window` but skips floating-pane windows.
+/// Used when the label points at the main window but the reducer-
+/// registry path failed (CEF Views' `BrowserHost::window_handle()`
+/// returns NULL on Win32 for Views-based browsers). Without the
+/// skip, the floater (owned, drawn ABOVE its owner) would be
+/// enumerated first and we'd target it instead.
+#[cfg(target_os = "windows")]
+unsafe fn find_main_window() -> *mut std::ffi::c_void {
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    let _pid = GetCurrentProcessId();
+    let mut result: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    unsafe extern "system" fn enum_callback(
+        hwnd: *mut std::ffi::c_void,
+        lparam: isize,
+    ) -> i32 {
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+        let mut window_pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, &mut window_pid);
+        if window_pid != GetCurrentProcessId() {
+            return 1;
+        }
+        if IsWindowVisible(hwnd) == 0 {
+            return 1;
+        }
+        // Read the window class name; skip if it matches the floating-
+        // pane class. `GetClassNameW` writes up to `cchClassMaxCount`
+        // UTF-16 code units (excluding the null terminator).
+        let mut buf: [u16; 64] = [0; 64];
+        let len = GetClassNameW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+        if len > 0 {
+            let class = String::from_utf16_lossy(&buf[..len as usize]);
+            if class == FLOATING_PANE_CLASS_NAME {
+                return 1;
+            }
+        }
+        let result_ptr = lparam as *mut *mut std::ffi::c_void;
+        *result_ptr = hwnd;
+        0
+    }
+
+    EnumWindows(Some(enum_callback), &mut result as *mut _ as isize);
+    result
+}
+
+#[cfg(target_os = "windows")]
+pub(super) unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, IsWindow, GA_ROOT};
+
+    if !label.is_empty() {
+        // 1. Consult the authoritative per-label HWND cache FIRST —
+        //    populated by `capture_hwnd_for_label` for main / pool /
+        //    tear-off windows AND by `floating_pane.rs` for our own
+        //    owned-popup floaters at create time. The cache stores
+        //    the actual outer top-level HWND we want to act on.
+        //    We MUST NOT walk GA_ROOT on cache hits: the cached value
+        //    is already the top-level we want; walking up could land
+        //    on a different owner (e.g. main, for floaters owned by
+        //    main) and cause `close_window_by_label` to post WM_CLOSE
+        //    to the wrong window.
+        //
+        // Liveness guard: `capture_hwnd_for_label` has no eviction
+        // path, and CEF Views can swap the outer HWND on window
+        // recreate. A cache hit pointing at a dead HWND silently
+        // posts WM_CLOSE into the void (broken title-bar close
+        // button observed v0.39.1 → SPEC_WINDOW_HWND_CACHE_STALE_FIX_2026_05_28.md).
+        // Validate via IsWindow before trusting; on stale, evict
+        // and fall through to the registry/EnumWindows paths.
+        let cached = state.window_hwnds.lock().get(label).copied();
+        if let Some(raw_isize) = cached {
+            let raw = raw_isize as *mut std::ffi::c_void;
+            if !raw.is_null() {
+                if IsWindow(raw) != 0 {
+                    tracing::info!(
+                        target: "win-resolve",
+                        label = %label,
+                        cache_hwnd = ?raw,
+                        "[win-resolve] resolved via window_hwnds cache"
+                    );
+                    return raw;
+                }
+                tracing::warn!(
+                    target: "win-resolve",
+                    label = %label,
+                    stale_hwnd = ?raw,
+                    "[win-resolve] cache hit was stale (IsWindow=false); evicting"
+                );
+                state.window_hwnds.lock().remove(label);
+            }
+        }
+
+        // 2. Fall back to the CEF reducer registry. This returns
+        //    `host.window_handle()` which on Win32 is usually a
+        //    WS_CHILD inner HWND for `set_as_child` browsers — so we
+        //    DO need GA_ROOT here to walk up to the top-level. Used
+        //    when capture_hwnd_for_label hasn't run yet (very early
+        //    startup) for non-floater labels.
+        if let Some(browser) = state.get_browser(label) {
+            if let Some(host) = browser.host() {
+                let raw = host.window_handle().0 as *mut std::ffi::c_void;
+                if !raw.is_null() {
+                    let root = GetAncestor(raw, GA_ROOT);
+                    let resolved = if root.is_null() { raw } else { root };
+                    tracing::info!(
+                        target: "win-resolve",
+                        label = %label,
+                        host_hwnd = ?raw,
+                        root_hwnd = ?resolved,
+                        "[win-resolve] resolved via reducer registry + GA_ROOT"
+                    );
+                    return resolved;
+                }
+            }
+        }
+
+        tracing::warn!(
+            target: "win-resolve",
+            label = %label,
+            "[win-resolve] cache + reducer-registry both empty — using class-aware EnumWindows fallback"
+        );
+    }
+
+    // 3. EnumWindows last resort. CEF Views (main window) hides its
+    //    HWND behind a Views container, so this branch fires for
+    //    "main" before the user has triggered the init-status path
+    //    (e.g. cold-boot drag attempts). Z-order returns the floater
+    //    first (owned windows draw ABOVE their owner), so for "main"
+    //    we use a class-aware enumerator that skips the floating-pane
+    //    window class — deterministic regardless of Z-order. For
+    //    non-"main" labels with neither cache nor registry entry,
+    //    plain `find_own_top_level_window` is the best we can do.
+    let fallback = if label == "main" {
+        find_main_window()
+    } else {
+        find_own_top_level_window()
+    };
+    tracing::info!(
+        target: "win-resolve",
+        label = %label,
+        fallback_hwnd = ?fallback,
+        "[win-resolve] class-aware EnumWindows fallback"
+    );
+    fallback
+}
+
+/// Find ALL visible top-level windows belonging to this process.
+#[cfg(target_os = "windows")]
+pub(super) fn find_all_own_windows() -> Vec<*mut std::ffi::c_void> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    let mut results: Vec<*mut std::ffi::c_void> = Vec::new();
+
+    unsafe extern "system" fn enum_callback(
+        hwnd: *mut std::ffi::c_void,
+        lparam: isize,
+    ) -> i32 {
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+        let mut window_pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, &mut window_pid);
+        if window_pid == GetCurrentProcessId() && IsWindowVisible(hwnd) != 0 {
+            let results = &mut *(lparam as *mut Vec<*mut std::ffi::c_void>);
+            results.push(hwnd);
+        }
+        1 // Continue
+    }
+
+    unsafe {
+        EnumWindows(Some(enum_callback), &mut results as *mut _ as isize);
+    }
+    results
+}
+
+/// Find the top-level window belonging to this process.
+/// In CEF Views mode, browser.host().window_handle() returns NULL,
+/// so we enumerate windows and find ours by process ID.
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn find_own_top_level_window() -> *mut std::ffi::c_void {
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+
+    let pid = GetCurrentProcessId();
+    let mut result: *mut std::ffi::c_void = std::ptr::null_mut();
+
+    unsafe extern "system" fn enum_callback(
+        hwnd: *mut std::ffi::c_void,
+        lparam: isize,
+    ) -> i32 {
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+        let mut window_pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, &mut window_pid);
+        if window_pid == GetCurrentProcessId() && IsWindowVisible(hwnd) != 0 {
+            // Store the HWND in the pointer passed via lparam
+            let result_ptr = lparam as *mut *mut std::ffi::c_void;
+            *result_ptr = hwnd;
+            return 0; // Stop enumeration
+        }
+        1 // Continue
+    }
+
+    let _ = pid; // Used inside callback via GetCurrentProcessId()
+    EnumWindows(
+        Some(enum_callback),
+        &mut result as *mut _ as isize,
+    );
+    result
+}
+
+/// Capture and store the HWND for `label` in `AppState::window_hwnds`.
+///
+/// Called from `set_window_init_status` once the frontend signals "ready".
+/// Two-pass approach:
+/// 1. Fast path: `browser.host().window_handle()` — may be non-NULL by this
+///    point even in CEF Views mode (window fully shown).
+/// 2. Fallback: enumerate all process-owned visible HWNDs and pick the one
+///    not yet registered in `window_hwnds`. Reliable because windows are
+///    opened sequentially (pool windows are hidden before promotion).
+#[cfg(target_os = "windows")]
+pub(crate) fn capture_hwnd_for_label(state: &Arc<AppState>, label: &str) {
+    // If a known-good outer HWND was already inserted by the creator
+    // of this window (e.g. `floating_pane.rs::create_owned_popup`
+    // registers the outer floater HWND it built via CreateWindowExW),
+    // DO NOT overwrite it. The fast path below uses
+    // `host.window_handle()` which for `set_as_child` browsers returns
+    // the CEF inner WS_CHILD HWND — replacing the outer HWND with the
+    // child here breaks any IPC that needs to act on the actual
+    // top-level (SetWindowPos drags the child within the parent,
+    // PostMessage(WM_CLOSE) destroys the child only, etc.).
+    if state.window_hwnds.lock().contains_key(label) {
+        tracing::debug!(
+            "[opacity] capture_hwnd_for_label: label={} already registered, preserving",
+            label
+        );
+        return;
+    }
+    // Fast path.
+    if let Some(mut browser) = state.get_browser(label) {
+        if let Some(host) = browser.host() {
+            let hwnd = host.window_handle();
+            if !hwnd.0.is_null() {
+                state.window_hwnds.lock().insert(label.to_string(), hwnd.0 as isize);
+                tracing::debug!("[opacity] captured hwnd fast-path label={} hwnd={:#x}", label, hwnd.0 as isize);
+                return;
+            }
+        }
+    }
+    // Fallback: pick the first visible HWND not already mapped.
+    let known: std::collections::HashSet<isize> = state.window_hwnds.lock().values().cloned().collect();
+    for hwnd_raw in find_all_own_windows() {
+        let raw = hwnd_raw as isize;
+        if !known.contains(&raw) {
+            state.window_hwnds.lock().insert(label.to_string(), raw);
+            tracing::debug!("[opacity] captured hwnd fallback label={} hwnd={:#x}", label, raw);
+            return;
+        }
+    }
+    tracing::warn!("[opacity] capture_hwnd_for_label: no available HWND for label={}", label);
+}

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -5,14 +5,29 @@
 // Ported from src-tauri/src/commands/window.rs.
 //
 // Phase 2: Single-window only. Multi-window commands are stubbed.
+//
+// Modularization (docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md,
+// Plan 1): the close path + HWND-resolution helpers live in `lifecycle.rs`.
+// Motion / chrome / transparency / meta / creation handlers remain here
+// pending later carves.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use cef::{ImplBrowser, ImplBrowserHost};
-
 use crate::client::helpers::{html_escape, js_string_literal};
 use crate::state::AppState;
+
+mod lifecycle;
+// Cross-platform command handlers dispatched by ipc.rs.
+pub use lifecycle::{close_window, close_window_by_label};
+// Windows-only helpers other modules resolve as `commands::window::<name>`
+// (browser_pane / client / backend call sites are all `#[cfg(windows)]`).
+#[cfg(target_os = "windows")]
+pub(crate) use lifecycle::{capture_hwnd_for_label, find_own_top_level_window};
+// Windows-only helpers used by the motion / transparency handlers that
+// still live in this file.
+#[cfg(target_os = "windows")]
+use lifecycle::{find_all_own_windows, resolve_window_hwnd};
 
 /// Get the current zoom factor.
 pub fn get_zoom_factor(state: &Arc<AppState>) -> serde_json::Value {
@@ -47,67 +62,6 @@ pub fn set_zoom_factor(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     Ok(serde_json::Value::Null)
 }
 
-/// Close the window. Args: optional `{ "label": string }`; defaults to "main".
-/// Routes by label via `resolve_window_hwnd` — without that the floater
-/// (owned, drawn above its owner in Z-order) would always swallow the
-/// close because `find_own_top_level_window` returns the topmost-Z
-/// visible top-level of the process.
-pub fn close_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
-    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-
-    #[cfg(target_os = "windows")]
-    unsafe {
-        use windows_sys::Win32::UI::WindowsAndMessaging::*;
-        let hwnd = resolve_window_hwnd(state, label);
-        if !hwnd.is_null() {
-            PostMessageW(hwnd, WM_CLOSE, 0, 0);
-            return Ok(serde_json::Value::Null);
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
-    crate::ui_tasks::post_close_window(state, label);
-    let _ = (state, label);
-    Ok(serde_json::Value::Null)
-}
-
-/// Close a specific window by label. Used by the tear-off Phase 4
-/// merge path: after the candidate window pulls the dragged tab into
-/// its own workspace via MoveTabToWorkspace, the dragged window is
-/// empty and should be destroyed. Posts WM_CLOSE on Win32; uses the
-/// existing UI-thread close task on other platforms.
-pub fn close_window_by_label(
-    state: &Arc<AppState>,
-    args: &serde_json::Value,
-) -> Result<serde_json::Value, String> {
-    let label = args
-        .get("label")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "missing label".to_string())?
-        .to_string();
-
-    #[cfg(target_os = "windows")]
-    unsafe {
-        use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-        // Route through resolve_window_hwnd so we hit the cached OUTER
-        // top-level HWND. The reducer registry returns CEF's inner
-        // WS_CHILD for `set_as_child` browsers (and for floaters our
-        // outer popup HWND is only in the cache), so going straight to
-        // `host.window_handle()` would WM_CLOSE the embedded child —
-        // after a redock that leaves the outer popup as an empty shell.
-        let hwnd = resolve_window_hwnd(state, &label);
-        if !hwnd.is_null() {
-            PostMessageW(hwnd, WM_CLOSE, 0, 0);
-            return Ok(serde_json::Value::Null);
-        }
-        return Err(format!("no top-level HWND for label {}", label));
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        crate::ui_tasks::post_close_window(state, &label);
-        Ok(serde_json::Value::Null)
-    }
-}
 
 /// Minimize the window. Args: optional `{ "label": string }`; defaults to "main".
 pub fn minimize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
@@ -161,176 +115,6 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     Ok(serde_json::Value::Null)
 }
 
-/// Resolve a top-level HWND for the given label. Prefer the reducer
-/// registry (`state.get_browser(label)` → host → window_handle → walk
-/// to root) over the process-wide `find_own_top_level_window` fallback.
-///
-/// Why the label matters: `find_own_top_level_window` does an
-/// `EnumWindows` and returns the *first* visible top-level of the
-/// current process. Z-order puts **owned** windows ABOVE their owner,
-/// so as soon as a floating-pane window exists, every label-less
-/// `get/set_window_position` call (e.g. the main window's
-/// `useWindowDrag`) accidentally targets the floater — dragging the
-/// main window moves the floater instead.
-///
-/// `GetAncestor(hwnd, GA_ROOT)` guard handles the case where CEF
-/// returns the embedded browser's WS_CHILD HWND rather than our
-/// outer top-level — without it, `SetWindowPos` would only shift the
-/// child within its parent, not move the outer floater.
-/// Class name of the floating-pane outer HWND
-/// (`agentmux-cef/src/floating_pane.rs::CLASS_NAME`). Kept in sync so
-/// `find_main_window` can EnumWindows-skip floaters when CEF Views
-/// hides the main window's HWND.
-#[cfg(target_os = "windows")]
-const FLOATING_PANE_CLASS_NAME: &str = "AgentMuxFloatingPane";
-
-/// Like `find_own_top_level_window` but skips floating-pane windows.
-/// Used when the label points at the main window but the reducer-
-/// registry path failed (CEF Views' `BrowserHost::window_handle()`
-/// returns NULL on Win32 for Views-based browsers). Without the
-/// skip, the floater (owned, drawn ABOVE its owner) would be
-/// enumerated first and we'd target it instead.
-#[cfg(target_os = "windows")]
-unsafe fn find_main_window() -> *mut std::ffi::c_void {
-    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-    use windows_sys::Win32::UI::WindowsAndMessaging::*;
-
-    let _pid = GetCurrentProcessId();
-    let mut result: *mut std::ffi::c_void = std::ptr::null_mut();
-
-    unsafe extern "system" fn enum_callback(
-        hwnd: *mut std::ffi::c_void,
-        lparam: isize,
-    ) -> i32 {
-        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-        let mut window_pid: u32 = 0;
-        GetWindowThreadProcessId(hwnd, &mut window_pid);
-        if window_pid != GetCurrentProcessId() {
-            return 1;
-        }
-        if IsWindowVisible(hwnd) == 0 {
-            return 1;
-        }
-        // Read the window class name; skip if it matches the floating-
-        // pane class. `GetClassNameW` writes up to `cchClassMaxCount`
-        // UTF-16 code units (excluding the null terminator).
-        let mut buf: [u16; 64] = [0; 64];
-        let len = GetClassNameW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
-        if len > 0 {
-            let class = String::from_utf16_lossy(&buf[..len as usize]);
-            if class == FLOATING_PANE_CLASS_NAME {
-                return 1;
-            }
-        }
-        let result_ptr = lparam as *mut *mut std::ffi::c_void;
-        *result_ptr = hwnd;
-        0
-    }
-
-    EnumWindows(Some(enum_callback), &mut result as *mut _ as isize);
-    result
-}
-
-#[cfg(target_os = "windows")]
-unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
-    use cef::ImplBrowser;
-    use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, IsWindow, GA_ROOT};
-
-    if !label.is_empty() {
-        // 1. Consult the authoritative per-label HWND cache FIRST —
-        //    populated by `capture_hwnd_for_label` for main / pool /
-        //    tear-off windows AND by `floating_pane.rs` for our own
-        //    owned-popup floaters at create time. The cache stores
-        //    the actual outer top-level HWND we want to act on.
-        //    We MUST NOT walk GA_ROOT on cache hits: the cached value
-        //    is already the top-level we want; walking up could land
-        //    on a different owner (e.g. main, for floaters owned by
-        //    main) and cause `close_window_by_label` to post WM_CLOSE
-        //    to the wrong window.
-        //
-        // Liveness guard: `capture_hwnd_for_label` has no eviction
-        // path, and CEF Views can swap the outer HWND on window
-        // recreate. A cache hit pointing at a dead HWND silently
-        // posts WM_CLOSE into the void (broken title-bar close
-        // button observed v0.39.1 → SPEC_WINDOW_HWND_CACHE_STALE_FIX_2026_05_28.md).
-        // Validate via IsWindow before trusting; on stale, evict
-        // and fall through to the registry/EnumWindows paths.
-        let cached = state.window_hwnds.lock().get(label).copied();
-        if let Some(raw_isize) = cached {
-            let raw = raw_isize as *mut std::ffi::c_void;
-            if !raw.is_null() {
-                if IsWindow(raw) != 0 {
-                    tracing::info!(
-                        target: "win-resolve",
-                        label = %label,
-                        cache_hwnd = ?raw,
-                        "[win-resolve] resolved via window_hwnds cache"
-                    );
-                    return raw;
-                }
-                tracing::warn!(
-                    target: "win-resolve",
-                    label = %label,
-                    stale_hwnd = ?raw,
-                    "[win-resolve] cache hit was stale (IsWindow=false); evicting"
-                );
-                state.window_hwnds.lock().remove(label);
-            }
-        }
-
-        // 2. Fall back to the CEF reducer registry. This returns
-        //    `host.window_handle()` which on Win32 is usually a
-        //    WS_CHILD inner HWND for `set_as_child` browsers — so we
-        //    DO need GA_ROOT here to walk up to the top-level. Used
-        //    when capture_hwnd_for_label hasn't run yet (very early
-        //    startup) for non-floater labels.
-        if let Some(browser) = state.get_browser(label) {
-            if let Some(host) = browser.host() {
-                let raw = host.window_handle().0 as *mut std::ffi::c_void;
-                if !raw.is_null() {
-                    let root = GetAncestor(raw, GA_ROOT);
-                    let resolved = if root.is_null() { raw } else { root };
-                    tracing::info!(
-                        target: "win-resolve",
-                        label = %label,
-                        host_hwnd = ?raw,
-                        root_hwnd = ?resolved,
-                        "[win-resolve] resolved via reducer registry + GA_ROOT"
-                    );
-                    return resolved;
-                }
-            }
-        }
-
-        tracing::warn!(
-            target: "win-resolve",
-            label = %label,
-            "[win-resolve] cache + reducer-registry both empty — using class-aware EnumWindows fallback"
-        );
-    }
-
-    // 3. EnumWindows last resort. CEF Views (main window) hides its
-    //    HWND behind a Views container, so this branch fires for
-    //    "main" before the user has triggered the init-status path
-    //    (e.g. cold-boot drag attempts). Z-order returns the floater
-    //    first (owned windows draw ABOVE their owner), so for "main"
-    //    we use a class-aware enumerator that skips the floating-pane
-    //    window class — deterministic regardless of Z-order. For
-    //    non-"main" labels with neither cache nor registry entry,
-    //    plain `find_own_top_level_window` is the best we can do.
-    let fallback = if label == "main" {
-        find_main_window()
-    } else {
-        find_own_top_level_window()
-    };
-    tracing::info!(
-        target: "win-resolve",
-        label = %label,
-        fallback_hwnd = ?fallback,
-        "[win-resolve] class-aware EnumWindows fallback"
-    );
-    fallback
-}
 
 /// Get the current window position on screen.
 ///
@@ -698,68 +482,6 @@ pub fn set_window_transparency(state: &Arc<AppState>, args: &serde_json::Value) 
     Ok(serde_json::Value::Null)
 }
 
-/// Find ALL visible top-level windows belonging to this process.
-#[cfg(target_os = "windows")]
-fn find_all_own_windows() -> Vec<*mut std::ffi::c_void> {
-    use windows_sys::Win32::UI::WindowsAndMessaging::*;
-    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-
-    let mut results: Vec<*mut std::ffi::c_void> = Vec::new();
-
-    unsafe extern "system" fn enum_callback(
-        hwnd: *mut std::ffi::c_void,
-        lparam: isize,
-    ) -> i32 {
-        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-        let mut window_pid: u32 = 0;
-        GetWindowThreadProcessId(hwnd, &mut window_pid);
-        if window_pid == GetCurrentProcessId() && IsWindowVisible(hwnd) != 0 {
-            let results = &mut *(lparam as *mut Vec<*mut std::ffi::c_void>);
-            results.push(hwnd);
-        }
-        1 // Continue
-    }
-
-    unsafe {
-        EnumWindows(Some(enum_callback), &mut results as *mut _ as isize);
-    }
-    results
-}
-
-/// Find the top-level window belonging to this process.
-/// In CEF Views mode, browser.host().window_handle() returns NULL,
-/// so we enumerate windows and find ours by process ID.
-#[cfg(target_os = "windows")]
-pub(crate) unsafe fn find_own_top_level_window() -> *mut std::ffi::c_void {
-    use windows_sys::Win32::UI::WindowsAndMessaging::*;
-    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-
-    let pid = GetCurrentProcessId();
-    let mut result: *mut std::ffi::c_void = std::ptr::null_mut();
-
-    unsafe extern "system" fn enum_callback(
-        hwnd: *mut std::ffi::c_void,
-        lparam: isize,
-    ) -> i32 {
-        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
-        let mut window_pid: u32 = 0;
-        GetWindowThreadProcessId(hwnd, &mut window_pid);
-        if window_pid == GetCurrentProcessId() && IsWindowVisible(hwnd) != 0 {
-            // Store the HWND in the pointer passed via lparam
-            let result_ptr = lparam as *mut *mut std::ffi::c_void;
-            *result_ptr = hwnd;
-            return 0; // Stop enumeration
-        }
-        1 // Continue
-    }
-
-    let _ = pid; // Used inside callback via GetCurrentProcessId()
-    EnumWindows(
-        Some(enum_callback),
-        &mut result as *mut _ as isize,
-    );
-    result
-}
 
 /// Apply window-level opacity via WS_EX_LAYERED + SetLayeredWindowAttributes.
 /// This makes the entire window semi-transparent (content + chrome).
@@ -1324,57 +1046,6 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
 
 // ── Per-window opacity (SPEC_PER_WINDOW_OPACITY_2026-05-14.md) ───────────────
 
-/// Capture and store the HWND for `label` in `AppState::window_hwnds`.
-///
-/// Called from `set_window_init_status` once the frontend signals "ready".
-/// Two-pass approach:
-/// 1. Fast path: `browser.host().window_handle()` — may be non-NULL by this
-///    point even in CEF Views mode (window fully shown).
-/// 2. Fallback: enumerate all process-owned visible HWNDs and pick the one
-///    not yet registered in `window_hwnds`. Reliable because windows are
-///    opened sequentially (pool windows are hidden before promotion).
-#[cfg(target_os = "windows")]
-pub(crate) fn capture_hwnd_for_label(state: &Arc<AppState>, label: &str) {
-    use cef::ImplBrowserHost;
-    // If a known-good outer HWND was already inserted by the creator
-    // of this window (e.g. `floating_pane.rs::create_owned_popup`
-    // registers the outer floater HWND it built via CreateWindowExW),
-    // DO NOT overwrite it. The fast path below uses
-    // `host.window_handle()` which for `set_as_child` browsers returns
-    // the CEF inner WS_CHILD HWND — replacing the outer HWND with the
-    // child here breaks any IPC that needs to act on the actual
-    // top-level (SetWindowPos drags the child within the parent,
-    // PostMessage(WM_CLOSE) destroys the child only, etc.).
-    if state.window_hwnds.lock().contains_key(label) {
-        tracing::debug!(
-            "[opacity] capture_hwnd_for_label: label={} already registered, preserving",
-            label
-        );
-        return;
-    }
-    // Fast path.
-    if let Some(mut browser) = state.get_browser(label) {
-        if let Some(host) = browser.host() {
-            let hwnd = host.window_handle();
-            if !hwnd.0.is_null() {
-                state.window_hwnds.lock().insert(label.to_string(), hwnd.0 as isize);
-                tracing::debug!("[opacity] captured hwnd fast-path label={} hwnd={:#x}", label, hwnd.0 as isize);
-                return;
-            }
-        }
-    }
-    // Fallback: pick the first visible HWND not already mapped.
-    let known: std::collections::HashSet<isize> = state.window_hwnds.lock().values().cloned().collect();
-    for hwnd_raw in find_all_own_windows() {
-        let raw = hwnd_raw as isize;
-        if !known.contains(&raw) {
-            state.window_hwnds.lock().insert(label.to_string(), raw);
-            tracing::debug!("[opacity] captured hwnd fallback label={} hwnd={:#x}", label, raw);
-            return;
-        }
-    }
-    tracing::warn!("[opacity] capture_hwnd_for_label: no available HWND for label={}", label);
-}
 
 /// Set opacity on exactly one window by label.
 ///


### PR DESCRIPTION
First sub-PR of the \`commands/window.rs\` modularization (Plan 1 in [the candidates analysis](https://github.com/agentmuxai/agentmux/blob/main/docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md)). **Pure move — no behavior change.**

\`window.rs\` → \`window/mod.rs\` (git rename), with the close path + HWND-resolution helpers carved into \`window/lifecycle.rs\`:

> \`close_window\`, \`close_window_by_label\`, \`resolve_window_hwnd\`, \`find_main_window\`, \`find_all_own_windows\`, \`find_own_top_level_window\`, \`capture_hwnd_for_label\`, \`FLOATING_PANE_CLASS_NAME\`

\`mod.rs\`: **1462 → 1133 LOC**. Motion / chrome / transparency / meta / creation handlers stay in mod.rs (later carves).

## Visibility

| Symbol | Visibility | Why |
|---|---|---|
| \`close_window\`, \`close_window_by_label\` | \`pub\` (re-exported unconditional) | cross-platform, dispatched by ipc.rs |
| \`find_own_top_level_window\`, \`capture_hwnd_for_label\` | \`pub(crate)\` (re-exported \`#[cfg(windows)]\`) | browser_pane / client / backend resolve as \`commands::window::<name>\` (all \`#[cfg(windows)]\` call sites) |
| \`resolve_window_hwnd\`, \`find_all_own_windows\` | private → \`pub(super)\` | motion / transparency handlers still in mod.rs call them |
| \`find_main_window\`, \`FLOATING_PANE_CLASS_NAME\` | private to lifecycle | only used internally |

## Import fix-ups (the only non-mechanical part)

- Removed the now-unused \`use cef::{ImplBrowser, ImplBrowserHost}\` from mod.rs; added it cfg-gated to lifecycle.rs. The moved fns' inline single-trait \`use\`s were partial — \`resolve_window_hwnd\` needs \`ImplBrowserHost\` for \`window_handle()\`, \`capture_hwnd_for_label\` needs \`ImplBrowser\` for \`host()\` — both previously came from the top-level import.
- Dropped a latent unused \`GetCurrentProcessId\` fn-top import the move surfaced in \`find_all_own_windows\`.

## Test plan

- [x] \`cargo check -p agentmux-cef --release\` — clean (0 errors; lone warning pre-exists in browser_pane, unrelated). A pure move that type-checks the whole crate in release is the verification.
- Behavior identical: same functions, same Win32 logic, same close-button path fixed in #1133 — just relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)