### PR TITLE
feat(agent-pane): IME composition + agent-keystroke perf marks + slash TODO

### DIFF
--- a/.changesets/1780032967-feat-agent-pane-ime-composition-handling-agent-keystroke-per-oxtb.md
+++ b/.changesets/1780032967-feat-agent-pane-ime-composition-handling-agent-keystroke-per-oxtb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): IME composition handling + agent-keystroke perf marks + slash matcher TODO

--- a/frontend/app/view/agent/commands/registry.ts
+++ b/frontend/app/view/agent/commands/registry.ts
@@ -66,6 +66,13 @@ export class SlashCommandRegistry {
      * Autocomplete — commands whose name or primary alias starts with
      * the given prefix (lowercase-insensitive). Returns unique commands
      * sorted by category then name.
+     *
+     * Currently called on every keystroke from AgentFooter.handleInput.
+     * The matcher operates on a small fixed list (~tens of entries) so
+     * per-call cost is negligible. If a future source pushes this past
+     * ~50 entries (history, semantic match, agent-specific commands),
+     * time-slice with scheduler.yield() per SPEC_INPUT_RESPONSIVENESS
+     * §6.3 — don't ship a blocking matcher into the keystroke path.
      */
     completions(prefix: string, ctx: SlashCommandContext): SlashCommand[] {
         const p = prefix.toLowerCase();

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -7,6 +7,7 @@
 
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import { markEnd, markStart } from "@/perf";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
@@ -263,8 +264,17 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         return props.getCompletions(p);
     });
 
+    // IME composition state — true between compositionstart and compositionend.
+    // CJK / Vietnamese / any IME user types into a composition buffer; intermediate
+    // values fire `input` events but should NOT trigger slash-autocomplete matching
+    // (the prefix is unfinished) and Enter must NOT submit (it's confirming a
+    // candidate). Tracked as a plain `let` instead of a signal — read synchronously
+    // in handlers, never drives JSX. See SPEC_INPUT_RESPONSIVENESS §6.2.
+    let composingRef = false;
+
     const updateAutocomplete = (): void => {
         if (!textareaRef) return;
+        if (composingRef) return;
         const val = textareaRef.value;
         // Show the dropdown only when the value starts with `/` AND
         // contains no space — once the user types past the command name
@@ -293,15 +303,30 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // per 16ms. Flag is per-component-instance (captured in closure).
     let typingScrollPending = false;
     const handleInput = () => {
+        // Perf marks per SPEC_INPUT_RESPONSIVENESS §7.1. Target: handler
+        // body P95 < 5 ms. The mark span ends BEFORE the RAF enqueue so
+        // we measure only the synchronous handler cost.
+        markStart("agent-keystroke");
         updateAutocomplete();
         const cb = props.onTyping;
-        if (!cb) return;
-        if (typingScrollPending) return;
+        if (!cb) {
+            markEnd("agent-keystroke", "done");
+            return;
+        }
+        if (typingScrollPending) {
+            markEnd("agent-keystroke", "coalesced");
+            return;
+        }
         typingScrollPending = true;
+        markStart("agent-input-raf");
         requestAnimationFrame(() => {
             typingScrollPending = false;
+            markEnd("agent-input-raf", "fired");
+            markStart("agent-input-raf-cb");
             cb();
+            markEnd("agent-input-raf-cb", "done");
         });
+        markEnd("agent-keystroke", "scheduled");
     };
 
     // ── Voice input handle ───────────────────────────────────────────
@@ -364,6 +389,9 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         const message = textareaRef.value;
         if (!message.trim()) return;
         if (props.onSendMessage) {
+            // agent-submit span per SPEC_INPUT_RESPONSIVENESS §7.1. Includes
+            // the synchronous onSendMessage cost (WS send, slice dispatch).
+            markStart("agent-submit");
             props.onSendMessage(message);
             textareaRef.value = "";
             setAutocompletePrefix(null);
@@ -371,10 +399,19 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             // document signal synchronously before this point, so jumpToBottom
             // will include the just-added node in scrollHeight.
             props.onTyping?.();
+            markEnd("agent-submit", "sent");
         }
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
+        // IME composition guard: when a CJK / Vietnamese / etc. IME is
+        // converting (between compositionstart and compositionend),
+        // Enter/Tab/Arrows/Esc confirm or navigate composition candidates
+        // — the IME, not our handler, owns them. `keyCode === 229` is
+        // Safari's quirk where it emits a synthetic keydown for IME
+        // events without setting `isComposing`. Both checks are
+        // load-bearing. See SPEC_INPUT_RESPONSIVENESS §6.2.
+        if (e.isComposing || e.keyCode === 229) return;
         // Autocomplete keys take precedence when the dropdown is open
         // and has at least one match. Tab/Enter accept the selection;
         // arrows navigate; Esc dismisses without affecting text.
@@ -456,6 +493,16 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     placeholder={`Send message to ${props.agentName}...`}
                     onKeyDown={handleKeyDown}
                     onInput={handleInput}
+                    onCompositionStart={() => {
+                        composingRef = true;
+                    }}
+                    onCompositionEnd={() => {
+                        composingRef = false;
+                        // The textarea value updated during the composition
+                        // but we skipped slash matching. Run it now so the
+                        // dropdown reflects the committed text.
+                        updateAutocomplete();
+                    }}
                     rows={1}
                 />
                 <div class="agent-input-hint">


### PR DESCRIPTION
## Summary

First PR landing the input-responsiveness work scoped in [\`SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md\`](../blob/main/docs/specs/SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md) (spec ships in a separate doc PR). Implements **items 1, 2, and 5** from the spec's action items. Items 3, 4, 6, 7 ship as follow-up PRs per the [execution plan](../blob/main/docs/specs/PLAN_INPUT_RESPONSIVENESS_EXECUTION_2026_05_29.md).

## Item 1 — IME composition handling (real user-facing bug fix)

The agent composer's Enter handler previously submitted unconditionally, which incorrectly fired the prompt when a CJK / Vietnamese / IME user pressed Enter to confirm a composition candidate.

- Early return in \`handleKeyDown\` if \`e.isComposing || e.keyCode === 229\` (Safari quirk).
- \`onCompositionStart\` / \`onCompositionEnd\` JSX props on the textarea flip a \`composingRef\` boolean.
- \`updateAutocomplete()\` skips while composing — slash matching on intermediate IME state would flash the dropdown.
- \`compositionend\` re-runs \`updateAutocomplete()\` so the dropdown reflects committed text once the IME finalizes.

## Item 2 — \`agent-keystroke\` perf marks

Four mark pairs mirroring the terminal pattern from \`SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19\`:

| Mark | Span |
|---|---|
| \`agent-keystroke\` | \`onInput\` entry → return (handler cost only) |
| \`agent-input-raf\` | RAF enqueue → callback start (queue depth) |
| \`agent-input-raf-cb\` | callback start → end (coalesced scroll cost) |
| \`agent-submit\` | submit handler entry → \`onSendMessage\` return |

Uses existing \`markStart\` / \`markEnd\` from \`@/perf\` (~50 ns each, production-safe). Enables the agent-keystroke bench in PR C and surfaces agent input latency in the dev-mode Perf HUD.

## Item 5 — slash matcher TODO comment

Current matcher operates on a small fixed list; \`scheduler.yield()\` would be premature. Added a TODO comment in \`registry.ts:completions()\` so any future expansion of the completion source (history, semantic match, etc.) cites the spec and time-slices.

## Items 3, 4, 6, 7

Follow-up PRs per the execution plan:
- **Item 3** — \`tools/tests/bench-agent-keystroke.mjs\` (depends on this PR's perf marks).
- **Item 4** — lint guardrail against layout reads in input handlers (independent).
- **Items 6, 7** — gated on a profiling pass first.

## Test plan

- [x] TypeScript checks pass (\`tsc --noEmit\`)
- [ ] Manual: type a CJK/Vietnamese sequence in the agent composer, press Enter to confirm a candidate → text commits, prompt does NOT submit. Press Enter again → prompt submits.
- [ ] Manual: open agent pane, type a character, verify \`agent-keystroke\` measure appears in the dev-mode Perf HUD (\`Ctrl+Shift+P\`).
- [ ] Manual: type \`/\` then a partial command → dropdown appears; press Esc → dropdown clears; type past the command → dropdown clears.

## Spec + plan

The spec (\`SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md\`) and execution plan (\`PLAN_INPUT_RESPONSIVENESS_EXECUTION_2026_05_29.md\`) ship in a separate doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)