### PR TITLE
refactor(cef): extract window transparency/opacity handlers into window/transparency.rs

### DIFF
--- a/.changesets/1780033446-refactor-cef-extract-window-transparency-opacity-handlers-in-dv2m.md
+++ b/.changesets/1780033446-refactor-cef-extract-window-transparency-opacity-handlers-in-dv2m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(cef): extract window transparency/opacity handlers into commands/window/transparency.rs

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -24,10 +24,6 @@ pub use lifecycle::{close_window, close_window_by_label};
 // (browser_pane / client / backend call sites are all `#[cfg(windows)]`).
 #[cfg(target_os = "windows")]
 pub(crate) use lifecycle::{capture_hwnd_for_label, find_own_top_level_window};
-// Windows-only helper used by the transparency handlers that still live
-// in this file.
-#[cfg(target_os = "windows")]
-use lifecycle::find_all_own_windows;
 
 mod motion;
 // Position / drag / redock-hover command handlers, all dispatched by ipc.rs.
@@ -36,6 +32,10 @@ pub use motion::*;
 mod chrome;
 // Minimize / maximize command handlers, dispatched by ipc.rs.
 pub use chrome::*;
+
+mod transparency;
+// Transparency + per-window opacity command handlers, dispatched by ipc.rs.
+pub use transparency::*;
 
 /// Get the current zoom factor.
 pub fn get_zoom_factor(state: &Arc<AppState>) -> serde_json::Value {
@@ -73,81 +73,6 @@ pub fn set_zoom_factor(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 
 
 
-/// Set window transparency/blur effects for a single window.
-///
-/// Targets exactly the window identified by `label` (from the frontend's URL
-/// `windowLabel` param). Uses the `window_hwnds` map populated by
-/// `capture_hwnd_for_label`. Falls back to `find_all_own_windows()` only
-/// if the label's HWND hasn't been captured yet (e.g. very early startup).
-pub fn set_window_transparency(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
-    let transparent = args.get("transparent").and_then(|v| v.as_bool()).unwrap_or(false);
-    let opacity = args.get("opacity").and_then(|v| v.as_f64()).unwrap_or(0.8);
-    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main").to_string();
-    tracing::info!("set_window_transparency: label={} transparent={} opacity={}", label, transparent, opacity);
-
-    #[cfg(target_os = "windows")]
-    {
-        let hwnd_raw = state.window_hwnds.lock().get(label.as_str()).copied();
-        let hwnds: Vec<*mut std::ffi::c_void> = if let Some(raw) = hwnd_raw {
-            vec![raw as *mut std::ffi::c_void]
-        } else {
-            // HWND not yet captured (early startup). Fall back to process
-            // enumeration as a best-effort. This path is temporary — once
-            // set_window_init_status fires, future calls use the map.
-            tracing::warn!("set_window_transparency: no hwnd for label={}, falling back to find_all_own_windows", label);
-            find_all_own_windows()
-        };
-        for hwnd in hwnds {
-            unsafe {
-                if transparent {
-                    apply_window_opacity(hwnd, opacity);
-                } else {
-                    remove_window_opacity(hwnd);
-                }
-            }
-            tracing::info!("set_window_transparency: applied to {:?}", hwnd);
-        }
-    }
-
-    let _ = state;
-    #[cfg(not(target_os = "windows"))]
-    let _ = (transparent, opacity);
-
-    Ok(serde_json::Value::Null)
-}
-
-
-/// Apply window-level opacity via WS_EX_LAYERED + SetLayeredWindowAttributes.
-/// This makes the entire window semi-transparent (content + chrome).
-#[cfg(target_os = "windows")]
-unsafe fn apply_window_opacity(hwnd: *mut std::ffi::c_void, opacity: f64) {
-    use windows_sys::Win32::UI::WindowsAndMessaging::*;
-
-    let alpha = (opacity.clamp(0.0, 1.0) * 255.0) as u8;
-
-    // Add WS_EX_LAYERED extended style
-    let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-    SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style | WS_EX_LAYERED as isize);
-
-    // LWA_ALPHA = 0x02
-    let result = SetLayeredWindowAttributes(hwnd, 0, alpha, 0x02);
-    if result != 0 {
-        tracing::info!("Applied window opacity: {} (alpha={})", opacity, alpha);
-    } else {
-        tracing::warn!("SetLayeredWindowAttributes failed");
-    }
-}
-
-/// Remove window opacity — restore to fully opaque by removing WS_EX_LAYERED.
-#[cfg(target_os = "windows")]
-unsafe fn remove_window_opacity(hwnd: *mut std::ffi::c_void) {
-    use windows_sys::Win32::UI::WindowsAndMessaging::*;
-    let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-    if (ex_style & WS_EX_LAYERED as isize) != 0 {
-        SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style & !(WS_EX_LAYERED as isize));
-        tracing::info!("Removed window opacity (WS_EX_LAYERED cleared)");
-    }
-}
 
 /// Get the current window label.
 /// The frontend passes its own label (extracted from URL params) as an arg.
@@ -681,87 +606,3 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
 // ── Per-window opacity (SPEC_PER_WINDOW_OPACITY_2026-05-14.md) ───────────────
 
 
-/// Set opacity on exactly one window by label.
-///
-/// Routes through the host reducer (`HostCommand::SetWindowOpacity`) so the
-/// change is auditable. The reducer emits `WindowOpacityApplied`; `host_dispatch`
-/// reads the event and calls the Win32 helper directly (Win32 window-style ops
-/// are safe from any thread). Replaces the global `set_window_transparency` path
-/// for per-window calls.
-pub fn set_window_opacity(
-    state: &Arc<AppState>,
-    args: &serde_json::Value,
-) -> Result<serde_json::Value, String> {
-    let label = args
-        .get("label")
-        .and_then(|v| v.as_str())
-        .ok_or("set_window_opacity: missing label")?
-        .to_string();
-    let opacity = args
-        .get("opacity")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(1.0)
-        .clamp(0.0, 1.0);
-
-    let out = state.host_dispatch(crate::reducer::HostCommand::SetWindowOpacity {
-        label: label.clone(),
-        opacity: opacity as f32,
-    });
-
-    // Apply Win32 side-effect synchronously based on emitted event.
-    // Reagent P1 on #868: the reducer emits `WindowOpacityApplied` for
-    // opacity < 1.0 (clamped translucent value) and `WindowOpacityCleared`
-    // for opacity >= 1.0. Matching only `WindowOpacityApplied` left
-    // windows semi-transparent after the user restored full opacity.
-    // Match both arms.
-    #[cfg(target_os = "windows")]
-    for ev in &out.events {
-        match ev {
-            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {
-                let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
-                if let Some(raw) = hwnd_raw {
-                    let hwnd = raw as *mut std::ffi::c_void;
-                    unsafe { apply_window_opacity(hwnd, *ev_opacity as f64); }
-                } else {
-                    tracing::warn!("[opacity] set_window_opacity: no hwnd for label={}", ev_label);
-                }
-            }
-            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label, .. } => {
-                let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
-                if let Some(raw) = hwnd_raw {
-                    let hwnd = raw as *mut std::ffi::c_void;
-                    unsafe { remove_window_opacity(hwnd); }
-                } else {
-                    tracing::warn!("[opacity] set_window_opacity: no hwnd for label={} (clear)", ev_label);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    let _ = out;
-    Ok(serde_json::Value::Null)
-}
-
-/// Return the currently tracked opacity for a label.
-///
-/// Reads from `HostState.window_opacities` — reflects the last value applied
-/// via `set_window_opacity`, not the Win32 layer. Used by the frontend to
-/// restore opacity on window init without an extra IPC round-trip.
-pub fn get_window_opacity(
-    state: &Arc<AppState>,
-    args: &serde_json::Value,
-) -> Result<serde_json::Value, String> {
-    let label = args
-        .get("label")
-        .and_then(|v| v.as_str())
-        .unwrap_or("main");
-    let opacity = state
-        .host_state
-        .lock()
-        .window_opacities
-        .get(label)
-        .copied()
-        .unwrap_or(1.0);
-    Ok(serde_json::json!(opacity))
-}

--- a/agentmux-cef/src/commands/window/transparency.rs
+++ b/agentmux-cef/src/commands/window/transparency.rs
@@ -1,0 +1,182 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Window transparency / per-window opacity handlers for the CEF host.
+//
+// Fourth carve of the commands/window.rs modularization (Plan 1). Pure
+// move — no behavior change.
+//
+// `set_window_transparency`, `set_window_opacity`, `get_window_opacity`
+// are `pub` and dispatched by ipc.rs (re-exported `pub use transparency::*`).
+// `apply_window_opacity` / `remove_window_opacity` are private Win32 helpers
+// used only by the two setters here. `find_all_own_windows` comes from the
+// sibling `lifecycle` module (the fallback when a label's HWND hasn't been
+// captured yet).
+
+use std::sync::Arc;
+
+use crate::state::AppState;
+
+#[cfg(target_os = "windows")]
+use super::lifecycle::find_all_own_windows;
+
+/// Set window transparency/blur effects for a single window.
+///
+/// Targets exactly the window identified by `label` (from the frontend's URL
+/// `windowLabel` param). Uses the `window_hwnds` map populated by
+/// `capture_hwnd_for_label`. Falls back to `find_all_own_windows()` only
+/// if the label's HWND hasn't been captured yet (e.g. very early startup).
+pub fn set_window_transparency(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let transparent = args.get("transparent").and_then(|v| v.as_bool()).unwrap_or(false);
+    let opacity = args.get("opacity").and_then(|v| v.as_f64()).unwrap_or(0.8);
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main").to_string();
+    tracing::info!("set_window_transparency: label={} transparent={} opacity={}", label, transparent, opacity);
+
+    #[cfg(target_os = "windows")]
+    {
+        let hwnd_raw = state.window_hwnds.lock().get(label.as_str()).copied();
+        let hwnds: Vec<*mut std::ffi::c_void> = if let Some(raw) = hwnd_raw {
+            vec![raw as *mut std::ffi::c_void]
+        } else {
+            // HWND not yet captured (early startup). Fall back to process
+            // enumeration as a best-effort. This path is temporary — once
+            // set_window_init_status fires, future calls use the map.
+            tracing::warn!("set_window_transparency: no hwnd for label={}, falling back to find_all_own_windows", label);
+            find_all_own_windows()
+        };
+        for hwnd in hwnds {
+            unsafe {
+                if transparent {
+                    apply_window_opacity(hwnd, opacity);
+                } else {
+                    remove_window_opacity(hwnd);
+                }
+            }
+            tracing::info!("set_window_transparency: applied to {:?}", hwnd);
+        }
+    }
+
+    let _ = state;
+    #[cfg(not(target_os = "windows"))]
+    let _ = (transparent, opacity);
+
+    Ok(serde_json::Value::Null)
+}
+
+
+/// Apply window-level opacity via WS_EX_LAYERED + SetLayeredWindowAttributes.
+/// This makes the entire window semi-transparent (content + chrome).
+#[cfg(target_os = "windows")]
+unsafe fn apply_window_opacity(hwnd: *mut std::ffi::c_void, opacity: f64) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    let alpha = (opacity.clamp(0.0, 1.0) * 255.0) as u8;
+
+    // Add WS_EX_LAYERED extended style
+    let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style | WS_EX_LAYERED as isize);
+
+    // LWA_ALPHA = 0x02
+    let result = SetLayeredWindowAttributes(hwnd, 0, alpha, 0x02);
+    if result != 0 {
+        tracing::info!("Applied window opacity: {} (alpha={})", opacity, alpha);
+    } else {
+        tracing::warn!("SetLayeredWindowAttributes failed");
+    }
+}
+
+/// Remove window opacity — restore to fully opaque by removing WS_EX_LAYERED.
+#[cfg(target_os = "windows")]
+unsafe fn remove_window_opacity(hwnd: *mut std::ffi::c_void) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+    let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    if (ex_style & WS_EX_LAYERED as isize) != 0 {
+        SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style & !(WS_EX_LAYERED as isize));
+        tracing::info!("Removed window opacity (WS_EX_LAYERED cleared)");
+    }
+}
+
+/// Set opacity on exactly one window by label.
+///
+/// Routes through the host reducer (`HostCommand::SetWindowOpacity`) so the
+/// change is auditable. The reducer emits `WindowOpacityApplied`; `host_dispatch`
+/// reads the event and calls the Win32 helper directly (Win32 window-style ops
+/// are safe from any thread). Replaces the global `set_window_transparency` path
+/// for per-window calls.
+pub fn set_window_opacity(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .ok_or("set_window_opacity: missing label")?
+        .to_string();
+    let opacity = args
+        .get("opacity")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0)
+        .clamp(0.0, 1.0);
+
+    let out = state.host_dispatch(crate::reducer::HostCommand::SetWindowOpacity {
+        label: label.clone(),
+        opacity: opacity as f32,
+    });
+
+    // Apply Win32 side-effect synchronously based on emitted event.
+    // Reagent P1 on #868: the reducer emits `WindowOpacityApplied` for
+    // opacity < 1.0 (clamped translucent value) and `WindowOpacityCleared`
+    // for opacity >= 1.0. Matching only `WindowOpacityApplied` left
+    // windows semi-transparent after the user restored full opacity.
+    // Match both arms.
+    #[cfg(target_os = "windows")]
+    for ev in &out.events {
+        match ev {
+            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {
+                let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
+                if let Some(raw) = hwnd_raw {
+                    let hwnd = raw as *mut std::ffi::c_void;
+                    unsafe { apply_window_opacity(hwnd, *ev_opacity as f64); }
+                } else {
+                    tracing::warn!("[opacity] set_window_opacity: no hwnd for label={}", ev_label);
+                }
+            }
+            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label, .. } => {
+                let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
+                if let Some(raw) = hwnd_raw {
+                    let hwnd = raw as *mut std::ffi::c_void;
+                    unsafe { remove_window_opacity(hwnd); }
+                } else {
+                    tracing::warn!("[opacity] set_window_opacity: no hwnd for label={} (clear)", ev_label);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let _ = out;
+    Ok(serde_json::Value::Null)
+}
+
+/// Return the currently tracked opacity for a label.
+///
+/// Reads from `HostState.window_opacities` — reflects the last value applied
+/// via `set_window_opacity`, not the Win32 layer. Used by the frontend to
+/// restore opacity on window init without an extra IPC round-trip.
+pub fn get_window_opacity(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("main");
+    let opacity = state
+        .host_state
+        .lock()
+        .window_opacities
+        .get(label)
+        .copied()
+        .unwrap_or(1.0);
+    Ok(serde_json::json!(opacity))
+}


### PR DESCRIPTION
Fourth sub-PR of the \`commands/window.rs\` modularization (Plan 1). **Pure move — no behavior change.**

Extracted to \`window/transparency.rs\`:
- \`set_window_transparency\`, \`set_window_opacity\`, \`get_window_opacity\` (\`pub\`, dispatched by ipc.rs via \`pub use transparency::*\`)
- private Win32 helpers \`apply_window_opacity\` / \`remove_window_opacity\` (no external callers; used only by the two setters, which both moved)

mod.rs dropped its \`use lifecycle::find_all_own_windows\` import — the only consumer (\`set_window_transparency\`) moved; transparency.rs imports it from \`lifecycle\` under \`#[cfg(windows)]\`. \`set_window_opacity\` routes through \`crate::reducer::HostCommand\` (fully-qualified, no new import).

- [x] \`cargo check -p agentmux-cef --release\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)