### PR TITLE
feat(host-reducer): pane-state reducer Phase 0 — pane_window_states scaffolding

### DIFF
--- a/.changesets/1780034025-feat-host-reducer-pane-state-reducer-phase-0-pane-window-sta-dmll.md
+++ b/.changesets/1780034025-feat-host-reducer-pane-state-reducer-phase-0-pane-window-sta-dmll.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(host-reducer): pane-state reducer Phase 0 — pane_window_states scaffolding

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -34,9 +34,9 @@ use cef::Browser;
 
 use crate::state::{
     BrowserHandle, BrowserKind, CompletedCreation, CreationPhase, DragSession, EffectKind,
-    InFlightCreation, BrowserPaneEntry, BrowserPaneLifecycle, PendingWindowCreation, PoolState, QuitReason,
-    QuitState, TopLevelCreationOutcome, TopLevelCreationRequest, TopLevelCreationState,
-    TopLevelSource,
+    InFlightCreation, BrowserPaneEntry, BrowserPaneLifecycle, PaneWindowState, PendingWindowCreation,
+    PoolState, QuitReason, QuitState, TopLevelCreationOutcome, TopLevelCreationRequest,
+    TopLevelCreationState, TopLevelSource, WindowPlacement,
 };
 
 /// Capacity of `TopLevelCreationState.history` ring buffer. Configurable
@@ -125,6 +125,16 @@ pub struct HostState {
     /// not inside the reducer. See SPEC_PER_WINDOW_OPACITY_2026-05-14.md §7.1.
     pub window_opacities: HashMap<String, f32>,
 
+    /// Pane-state reducer (Phase 0) — per-pane OS-window placement for
+    /// FLOATING panes, keyed by `block_id`. Holds maximize/minimize state +
+    /// the rect to restore to; lifecycle stays in `browser_panes`. Docked
+    /// panes have no entry (their magnify is backend-owned). Currently
+    /// DORMANT — the `ToggleFloatingMaximize` arm exists but no production
+    /// caller dispatches it yet (IPC wiring lands in a later phase). See
+    /// SPEC_PANE_STATE_REDUCER_2026-05-28.md (REVISION 2026-05-29).
+    #[allow(dead_code)]
+    pub pane_window_states: HashMap<String, PaneWindowState>,
+
     /// Lifecycle phase. `Running` is the operating state; the others
     /// gate command acceptance.
     pub lifecycle: HostLifecyclePhase,
@@ -147,6 +157,7 @@ impl Default for HostState {
             quit_state: QuitState::default(),
             top_level_creation: TopLevelCreationState::default(),
             window_opacities: HashMap::new(),
+            pane_window_states: HashMap::new(),
             // Boot directly into Running — nothing in F.1 needs the
             // pre-init guard yet. Future PRs (drag, tear-off hooks)
             // will move boot through Bootstrapping → Running.
@@ -351,6 +362,17 @@ pub enum HostCommand {
     /// `window_opacities`; the IPC handler applies the Win32 side-effect
     /// after `host_dispatch` returns (pure reducer, no I/O inside).
     SetWindowOpacity { label: String, opacity: f32 },
+
+    // ── Pane window-placement (pane-state reducer, Phase 0) ──────────────────
+
+    /// Toggle a FLOATING pane's OS-window maximize (Normal ↔ Maximized).
+    /// The floating half of the shared maximize button (spec §3.3a). The
+    /// reducer flips `pane_window_states[block_id].placement` and emits
+    /// `PaneWindowStateChanged`; the IPC handler applies the
+    /// `ShowWindow(SW_MAXIMIZE/SW_RESTORE)` side-effect AFTER dispatch (pure
+    /// reducer, no I/O). Docked panes never reach here — magnify is routed
+    /// frontend-side to the backend. DORMANT in Phase 0 (no caller yet).
+    ToggleFloatingMaximize { block_id: String },
 }
 
 impl std::fmt::Debug for HostCommand {
@@ -458,6 +480,10 @@ impl std::fmt::Debug for HostCommand {
                 .debug_struct("SetWindowOpacity")
                 .field("label", label)
                 .field("opacity", opacity)
+                .finish(),
+            HostCommand::ToggleFloatingMaximize { block_id } => f
+                .debug_struct("ToggleFloatingMaximize")
+                .field("block_id", block_id)
                 .finish(),
         }
     }
@@ -629,6 +655,20 @@ pub enum HostEvent {
     /// Opacity cleared (opacity >= 1.0 → remove WS_EX_LAYERED).
     WindowOpacityCleared { label: String, version: u64 },
 
+    // ── Pane window-placement events (pane-state reducer, Phase 0) ───────
+
+    /// A floating pane's OS-window placement changed (e.g. via
+    /// `ToggleFloatingMaximize`). The IPC handler applies the matching
+    /// `ShowWindow` side-effect AFTER dispatch; renderers subscribe to keep
+    /// the shared maximize button's icon in sync (replaces PR #1132's
+    /// per-renderer `FloatingPaneContext` direct writes). See
+    /// SPEC_PANE_STATE_REDUCER_2026-05-28.md §3.4.
+    PaneWindowStateChanged {
+        block_id: String,
+        placement: WindowPlacement,
+        version: u64,
+    },
+
     // ── Effect carrier ──────────────────────────────────────────────────
 
     /// Side-effect descriptor. The reducer emits these but never executes
@@ -746,6 +786,7 @@ impl std::fmt::Debug for DispatchOutput {
 /// function takes only `&mut HostState` and produces no I/O.
 mod browsers;
 mod drag;
+mod pane_window;
 mod panes;
 mod pool;
 mod quit;
@@ -819,6 +860,10 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         // Opacity
         HostCommand::SetWindowOpacity { label, opacity } => {
             handle_set_window_opacity(state, label, opacity)
+        }
+        // Pane window-placement (pane-state reducer, Phase 0)
+        HostCommand::ToggleFloatingMaximize { block_id } => {
+            pane_window::handle_toggle_floating_maximize(state, block_id)
         }
     }
 }

--- a/agentmux-cef/src/reducer/pane_window.rs
+++ b/agentmux-cef/src/reducer/pane_window.rs
@@ -1,0 +1,155 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pane window-placement reducer handlers (pane-state reducer, Phase 0).
+//!
+//! Owns the OS-window placement of FLOATING panes — the maximize/restore
+//! state and the rect to restore to — keyed by `block_id` in
+//! `HostState.pane_window_states`. Lifecycle (Live/Closing) is NOT here; it
+//! stays in `HostState.browser_panes` (`panes.rs`).
+//!
+//! Design + rationale: `SPEC_PANE_STATE_REDUCER_2026-05-28.md`
+//! (REVISION 2026-05-29 — folded into `HostState` instead of a standalone
+//! `PaneStateMachine`, mirroring the Phase-H consolidation that deleted
+//! `pane::lifecycle::PaneStateMachine` in commit 151f42e2 because a parallel
+//! pane-state store drifted from the reducer's).
+//!
+//! ## Scope of Phase 0 (this PR)
+//!
+//! - The `pane_window_states` field on `HostState` + its types in
+//!   `crate::state` (`PaneWindowState`, `WindowPlacement`, `PaneRect`).
+//! - The `ToggleFloatingMaximize` arm (the floating half of the shared
+//!   maximize button, spec §3.3a). It is DORMANT — wired into `update()`
+//!   and unit-tested, but no production code dispatches it yet. The IPC
+//!   wiring (refactoring `maximize_window` to dispatch this + apply the
+//!   `ShowWindow` side-effect from the emitted event) lands in a later
+//!   phase, alongside deleting `AppState.floating_restored_rects`.
+//!
+//! ## Out of scope for Phase 0
+//!
+//! - `ReportOSPlacementChange` (Win+Down / system menu → reducer) — later phase.
+//! - `ReportNormalRect` (WM_WINDOWPOSCHANGED debounced) + the backend
+//!   rect-mirror (`block.meta["pane:floating_normal_rect"]`) — later phase.
+//! - Cleanup-on-close eviction folded into the `browser_panes`
+//!   Closing→Closed transition — later phase.
+
+use crate::state::{PaneWindowState, WindowPlacement};
+
+use super::{DispatchOutput, HostEvent, HostState};
+
+/// Toggle a floating pane's OS-window maximize: `Maximized → Normal`, or
+/// anything else (`Normal` / `Minimized`) `→ Maximized`. Inserts a default
+/// `Normal` entry first if the pane has none yet.
+///
+/// Pure: flips `pane_window_states[block_id].placement` and emits
+/// `PaneWindowStateChanged`. The `ShowWindow(SW_MAXIMIZE/SW_RESTORE)`
+/// side-effect is applied by the IPC handler AFTER `host_dispatch` returns —
+/// never inside the reducer (snapshot-and-drop discipline, spec §3.6).
+pub(super) fn handle_toggle_floating_maximize(
+    state: &mut HostState,
+    block_id: String,
+) -> DispatchOutput {
+    // Scope the map borrow so it ends before `bump_version` re-borrows state.
+    let new_placement = {
+        let entry = state
+            .pane_window_states
+            .entry(block_id.clone())
+            .or_insert(PaneWindowState {
+                placement: WindowPlacement::Normal,
+                last_known_normal_rect: None,
+            });
+        let next = match entry.placement {
+            WindowPlacement::Maximized => WindowPlacement::Normal,
+            // Normal or Minimized both enlarge to Maximized.
+            WindowPlacement::Normal | WindowPlacement::Minimized => WindowPlacement::Maximized,
+        };
+        entry.placement = next;
+        next
+    };
+
+    let version = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneWindowStateChanged {
+            block_id,
+            placement: new_placement,
+            version,
+        }],
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reducer::{update, HostCommand};
+
+    fn placement_of(state: &HostState, block_id: &str) -> Option<WindowPlacement> {
+        state
+            .pane_window_states
+            .get(block_id)
+            .map(|e| e.placement)
+    }
+
+    fn last_event_placement(out: &DispatchOutput) -> Option<WindowPlacement> {
+        out.events.iter().rev().find_map(|e| match e {
+            HostEvent::PaneWindowStateChanged { placement, .. } => Some(*placement),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn toggle_inserts_entry_and_maximizes_when_absent() {
+        let mut state = HostState::default();
+        assert!(placement_of(&state, "b1").is_none());
+
+        let out = update(
+            &mut state,
+            HostCommand::ToggleFloatingMaximize { block_id: "b1".into() },
+        );
+
+        assert_eq!(placement_of(&state, "b1"), Some(WindowPlacement::Maximized));
+        assert_eq!(last_event_placement(&out), Some(WindowPlacement::Maximized));
+    }
+
+    #[test]
+    fn toggle_is_an_identity_round_trip() {
+        let mut state = HostState::default();
+        // Normal(implicit) → Maximized → Normal.
+        update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
+        assert_eq!(placement_of(&state, "b1"), Some(WindowPlacement::Maximized));
+        update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
+        assert_eq!(placement_of(&state, "b1"), Some(WindowPlacement::Normal));
+    }
+
+    #[test]
+    fn toggle_emits_versioned_event_each_time() {
+        let mut state = HostState::default();
+        let out1 = update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
+        let out2 = update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
+
+        let v1 = out1.events.iter().find_map(|e| match e {
+            HostEvent::PaneWindowStateChanged { version, .. } => Some(*version),
+            _ => None,
+        });
+        let v2 = out2.events.iter().find_map(|e| match e {
+            HostEvent::PaneWindowStateChanged { version, .. } => Some(*version),
+            _ => None,
+        });
+        assert!(v1.is_some() && v2.is_some());
+        assert!(v2 > v1, "event version must be monotonic across dispatches");
+    }
+
+    #[test]
+    fn minimized_enlarges_to_maximized_not_normal() {
+        let mut state = HostState::default();
+        state.pane_window_states.insert(
+            "b1".into(),
+            PaneWindowState {
+                placement: WindowPlacement::Minimized,
+                last_known_normal_rect: None,
+            },
+        );
+        update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
+        assert_eq!(placement_of(&state, "b1"), Some(WindowPlacement::Maximized));
+    }
+}

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -110,6 +110,9 @@ fn version_increments_monotonically() {
         HostEvent::TopLevelCreationCompleted { version, .. } => *version,
         HostEvent::TopLevelCreationFailed { version, .. } => *version,
         HostEvent::TopLevelQueueLengthChanged { version, .. } => *version,
+        HostEvent::WindowOpacityApplied { version, .. } => *version,
+        HostEvent::WindowOpacityCleared { version, .. } => *version,
+        HostEvent::PaneWindowStateChanged { version, .. } => *version,
         HostEvent::Effect { version, .. } => *version,
         HostEvent::Error { version, .. } => *version,
     };

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -148,6 +148,61 @@ pub struct BrowserPaneEntry {
     pub lifecycle: BrowserPaneLifecycle,
 }
 
+// ── Pane window-placement state (pane-state reducer, Phase 0) ─────────────
+//
+// SPEC_PANE_STATE_REDUCER_2026-05-28.md (REVISION 2026-05-29 — folded into
+// HostState rather than a standalone PaneStateMachine, mirroring the Phase-H
+// consolidation that deleted `pane::lifecycle::PaneStateMachine`).
+//
+// This tracks the OS-window placement of a FLOATING pane (its
+// maximize/restore state + the rect to restore to). It is deliberately
+// SEPARATE from `BrowserPaneEntry`/`BrowserPaneLifecycle` above, which own
+// Live/Closing lifecycle: lifecycle stays in `HostState.browser_panes`;
+// placement lives in `HostState.pane_window_states`. Docked panes have NO
+// entry here — their "maximize" is backend magnify
+// (`LayoutState.magnifiednodeid`), routed by the frontend `<MaximizeButton>`
+// (spec §3.3a, b2), never through this reducer.
+
+/// Screen-space window rectangle in physical pixels. Distinct from
+/// `browser_api::Rect` (web/CSS coordinates) — this is for native window
+/// placement (the floating pane's outer HWND rect).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[allow(dead_code)]
+pub struct PaneRect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+/// OS-window placement for a floating pane. The shared maximize button's
+/// floating half toggles between `Normal` and `Maximized`; `Minimized` is
+/// OS-reported (Win+Down / system) and orthogonal — a minimized floater
+/// un-minimizes back to whichever of Normal/Maximized it held before, so
+/// the reducer remembers the pre-minimize placement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[allow(dead_code)]
+pub enum WindowPlacement {
+    #[default]
+    Normal,
+    Maximized,
+    Minimized,
+}
+
+/// Per-pane window-placement entry, keyed by `block_id` in
+/// `HostState.pane_window_states`. Holds ONLY the floating window's OS
+/// placement and the rect to restore to after un-maximize — NOT lifecycle
+/// (that's `BrowserPaneEntry` in `HostState.browser_panes`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct PaneWindowState {
+    pub placement: WindowPlacement,
+    /// Rect to restore to after un-maximize / un-minimize. `None` until a
+    /// normal-mode rect has been observed (replaces the deleted
+    /// `AppState.floating_restored_rects` stash — spec §4).
+    pub last_known_normal_rect: Option<PaneRect>,
+}
+
 // ── Browser handle registry (H.2) ────────────────────────────────────────
 
 /// Wrapped CEF Browser handle stored in `HostState.browsers`. Replaces the
@@ -1283,6 +1338,14 @@ fn log_host_event(ev: &crate::reducer::HostEvent) {
             target: "host-reducer",
             event = "WindowOpacityCleared",
             label = %label, version,
+        ),
+        // ── Pane window-placement (pane-state reducer, Phase 0) ──────────
+        HostEvent::PaneWindowStateChanged { block_id, placement, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PaneWindowStateChanged",
+            block_id = %block_id,
+            placement = ?placement,
+            version,
         ),
         // ── Effect carrier ───────────────────────────────────────────────
         HostEvent::Effect { effect, version } => tracing::debug!(


### PR DESCRIPTION
## Summary

First slice of the unified pane-state reducer. Adds per-pane **OS-window placement** state for floating panes onto the existing `HostState` — and deliberately **not** as a separate state machine.

Full design: `SPEC_PANE_STATE_REDUCER_2026-05-28.md` (in my workspace; can file as a repo doc if wanted).

## The one design decision worth reviewing

The spec originally proposed a standalone `PaneStateMachine`. Reading the code, that's exactly the pattern **Phase H deleted** in `151f42e2` ("drop PaneStateMachine, reducer is sole pane SoT") — a parallel store that dual-wrote and drifted from the reducer, killed because a cross-state invariant needs a single source of truth. So this folds the new concern into `HostState` instead:

- **Lifecycle** (Live/Closing) stays in `HostState.browser_panes` — untouched.
- **Window placement** (the genuinely new concern) goes in a sibling `HostState.pane_window_states`.

## What's in this PR

- `crate::state`: `PaneRect`, `WindowPlacement` (Normal/Maximized/Minimized), `PaneWindowState { placement, last_known_normal_rect }`. `last_known_normal_rect` is the eventual replacement for `AppState.floating_restored_rects`.
- `HostState.pane_window_states: HashMap<block_id, PaneWindowState>`.
- `HostCommand::ToggleFloatingMaximize { block_id }` → emits `HostEvent::PaneWindowStateChanged { block_id, placement, version }`. Wired into `update()` + `log_host_event`.
- `reducer/pane_window.rs`: `handle_toggle_floating_maximize` (pure; Maximized↔Normal, Minimized→Maximized) + 4 unit tests.

## Scope discipline (Phase 0)

The arm is **DORMANT** — wired + tested, but no production caller dispatches it yet, so **no behavior change**. Later phases wire the IPC (refactor `maximize_window` to dispatch this + apply `ShowWindow` from the event, then delete `floating_restored_rects`) and the docked half (frontend-routed per spec §3.3a "b2"). Docked magnify is **not** handled here — it stays backend-owned (`LayoutState.magnifiednodeid`).

## Incidental fix

The build surfaced a latent gap: `reducer/tests.rs`'s intentionally-exhaustive `extract_version` helper was missing the `WindowOpacity{Applied,Cleared}` arms (added on a prior PR without updating the helper). Added those alongside the new one.

## Test plan

- [x] `cargo test --release -p agentmux-cef reducer::` → 44 pass (4 new in `pane_window`)
- [x] Full `agentmux-cef` compiles
- [x] No production caller dispatches the new command → no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)