### PR TITLE
fix(host-reducer): co-evict pane window-placement on close (Phase 1)

### DIFF
--- a/.changesets/1780034475-fix-host-reducer-co-evict-pane-window-placement-state-on-pan-vpi7.md
+++ b/.changesets/1780034475-fix-host-reducer-co-evict-pane-window-placement-state-on-pan-vpi7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host-reducer): co-evict pane window-placement state on pane close (Phase 1)

--- a/agentmux-cef/src/reducer/pane_window.rs
+++ b/agentmux-cef/src/reducer/pane_window.rs
@@ -82,12 +82,33 @@ pub(super) fn handle_toggle_floating_maximize(
 mod tests {
     use super::*;
     use crate::reducer::{update, HostCommand};
+    use crate::state::{BrowserPaneEntry, BrowserPaneLifecycle};
 
     fn placement_of(state: &HostState, block_id: &str) -> Option<WindowPlacement> {
         state
             .pane_window_states
             .get(block_id)
             .map(|e| e.placement)
+    }
+
+    /// Seed a Live lifecycle entry + a Maximized placement entry for the
+    /// same block, so close/drain/abort arms have something to co-evict.
+    fn seed_pane(state: &mut HostState, block_id: &str, label: &str) {
+        state.browser_panes.insert(
+            block_id.to_string(),
+            BrowserPaneEntry {
+                block_id: block_id.to_string(),
+                label: label.to_string(),
+                lifecycle: BrowserPaneLifecycle::Live,
+            },
+        );
+        state.pane_window_states.insert(
+            block_id.to_string(),
+            PaneWindowState {
+                placement: WindowPlacement::Maximized,
+                last_known_normal_rect: None,
+            },
+        );
     }
 
     fn last_event_placement(out: &DispatchOutput) -> Option<WindowPlacement> {
@@ -151,5 +172,70 @@ mod tests {
         );
         update(&mut state, HostCommand::ToggleFloatingMaximize { block_id: "b1".into() });
         assert_eq!(placement_of(&state, "b1"), Some(WindowPlacement::Maximized));
+    }
+
+    // ── Phase 1: cleanup-on-close — placement is co-evicted wherever a
+    // pane's lifecycle ends, so it can never leak. ───────────────────────
+
+    #[test]
+    fn complete_close_co_evicts_placement() {
+        let mut state = HostState::default();
+        seed_pane(&mut state, "b1", "browser-pane-b1-1");
+        assert!(placement_of(&state, "b1").is_some());
+
+        update(&mut state, HostCommand::CompleteBrowserPaneClose { block_id: "b1".into() });
+
+        assert!(placement_of(&state, "b1").is_none(), "placement must be evicted on close");
+        assert!(!state.browser_panes.contains_key("b1"), "lifecycle entry also gone");
+    }
+
+    #[test]
+    fn drain_by_label_co_evicts_placement() {
+        let mut state = HostState::default();
+        seed_pane(&mut state, "b1", "browser-pane-b1-1");
+
+        update(&mut state, HostCommand::DrainBrowserPaneByLabel {
+            label: "browser-pane-b1-1".into(),
+        });
+
+        assert!(placement_of(&state, "b1").is_none(), "placement must be evicted on drain");
+    }
+
+    #[test]
+    fn abort_create_co_evicts_placement() {
+        let mut state = HostState::default();
+        seed_pane(&mut state, "b1", "browser-pane-b1-1");
+
+        update(&mut state, HostCommand::AbortBrowserPaneCreate {
+            block_id: "b1".into(),
+            reason: "browser_host returned 0".into(),
+        });
+
+        assert!(placement_of(&state, "b1").is_none(), "placement must be evicted on abort");
+    }
+
+    #[test]
+    fn close_without_placement_entry_is_clean() {
+        // Docked panes never have a placement entry; closing one must not
+        // panic or misbehave — the remove is a no-op.
+        let mut state = HostState::default();
+        state.browser_panes.insert(
+            "docked1".into(),
+            BrowserPaneEntry {
+                block_id: "docked1".into(),
+                label: "browser-pane-docked1-1".into(),
+                lifecycle: BrowserPaneLifecycle::Live,
+            },
+        );
+        // No pane_window_states entry.
+        let out = update(&mut state, HostCommand::CompleteBrowserPaneClose {
+            block_id: "docked1".into(),
+        });
+        assert!(!state.browser_panes.contains_key("docked1"));
+        assert!(state.pane_window_states.is_empty());
+        assert!(matches!(
+            out.events.as_slice(),
+            [HostEvent::BrowserPaneClosed { .. }]
+        ));
     }
 }

--- a/agentmux-cef/src/reducer/panes.rs
+++ b/agentmux-cef/src/reducer/panes.rs
@@ -133,6 +133,12 @@ pub(super) fn handle_drain_browser_pane_by_label(state: &mut HostState, label: S
         None => return DispatchOutput::default(),
     };
     state.browser_panes.remove(&block_id);
+    // Co-evict window-placement state in the SAME arm that ends the pane's
+    // lifecycle, so placement can never outlive the pane (cleanup by
+    // construction — the structural replacement for the leak-prone manual
+    // cleanup of AppState.floating_restored_rects). No-op if absent: docked
+    // panes never have a placement entry. See SPEC_PANE_STATE_REDUCER §4.
+    state.pane_window_states.remove(&block_id);
     let v = state.bump_version();
     DispatchOutput {
         events: vec![HostEvent::BrowserPaneClosed {
@@ -148,6 +154,9 @@ pub(super) fn handle_complete_browser_pane_close(state: &mut HostState, block_id
     if state.browser_panes.remove(&block_id).is_none() {
         return DispatchOutput::default(); // idempotent
     }
+    // Co-evict window-placement state alongside the lifecycle entry — see
+    // handle_drain_browser_pane_by_label. No-op if absent.
+    state.pane_window_states.remove(&block_id);
     let v = state.bump_version();
     DispatchOutput {
         events: vec![HostEvent::BrowserPaneClosed { block_id, version: v }],
@@ -161,6 +170,9 @@ pub(super) fn handle_abort_browser_pane_create(
     reason: String,
 ) -> DispatchOutput {
     state.browser_panes.remove(&block_id);
+    // Co-evict window-placement state — see handle_drain_browser_pane_by_label.
+    // No-op if absent.
+    state.pane_window_states.remove(&block_id);
     let v = state.bump_version();
     DispatchOutput {
         events: vec![HostEvent::BrowserPaneCreationFailed { block_id, reason, version: v }],


### PR DESCRIPTION
## Summary

Phase 1 of the pane-state reducer. **Stacked on #1154 (Phase 0)** — this PR's base is `agenty/pane-state-reducer-phase0`, so the diff shows only Phase 1's changes. GitHub will auto-retarget to `main` when #1154 merges.

## The invariant

Wherever a pane's lifecycle ends, its window-placement entry (`HostState.pane_window_states`) is evicted **in the same reducer arm**. Cleanup by construction — the structural replacement for the leak-prone manual `floating_restored_rects` cleanup that Codex flagged on PR #1132 round 3.

Adds `pane_window_states.remove(&block_id)` to the three arms that remove a pane from `browser_panes`:
- `handle_complete_browser_pane_close`
- `handle_drain_browser_pane_by_label`
- `handle_abort_browser_pane_create`

## No behavior change

Every co-eviction is a no-op when absent — docked panes never have a placement entry, and the placement map is still only populated in tests until the IPC wiring phase. So existing close/drain/abort flows are unchanged; this just guarantees the new map can't leak once it's populated.

## Tests

- 4 new (8 total in `pane_window`): each of close/drain/abort co-evicts placement; plus a docked-pane-no-placement no-op case asserting the close still emits exactly `BrowserPaneClosed`.
- `cargo test --release -p agentmux-cef reducer::` → 48 pass.

## Review note

Base is the Phase 0 branch (stacked PR). Review #1154 first; this builds directly on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)