### PR TITLE
refactor(agents): partial-update API for updateagentinstance (Phase 3b unblock)

### DIFF
--- a/.changesets/1780036825-refactor-agents-partial-update-api-for-updateagentinstance-d-0x37.md
+++ b/.changesets/1780036825-refactor-agents-partial-update-api-for-updateagentinstance-d-0x37.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agents): partial-update API for updateagentinstance (drops fetch-and-merge)

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -182,6 +182,21 @@ pub struct GitHubContext {
     pub workflow_run_id: Option<u64>,
 }
 
+/// Partial-update payload for [`Store::instance_update_partial`]. Each
+/// `Some` field is written; `None` leaves the column untouched. Mirrors
+/// the mutable subset of `CommandUpdateAgentInstanceData`
+/// (`block_id`/`session_id`/`status`/`github_context`/`ended_at`) — the
+/// only columns `instance_update` ever wrote. `Some("")` for a string
+/// field explicitly clears it.
+#[derive(Debug, Clone, Default)]
+pub struct InstanceUpdate {
+    pub block_id: Option<String>,
+    pub session_id: Option<String>,
+    pub status: Option<String>,
+    pub github_context: Option<String>,
+    pub ended_at: Option<i64>,
+}
+
 /// One row per running/historical execution of an agent definition.
 /// `block_id` / `session_id` / `github_context` are modelled as empty
 /// strings on the wire rather than `Option<String>` to match the
@@ -1250,9 +1265,95 @@ impl Store {
         }
     }
 
+    /// Partial update of an instance's mutable runtime fields. Only
+    /// `Some` fields are written; `None` leaves that column untouched.
+    ///
+    /// Replaces the `updateagentinstance` handler's fetch-and-merge
+    /// (read the full row → fill the unspecified fields → write the
+    /// whole struct back). That read was the only production caller
+    /// that needed `instance_get`'s transient per-launch fields, which
+    /// pinned `instance_get` to the legacy `db_agent_instances` table.
+    /// With a partial write the handler no longer reads the row at all.
+    /// See docs/specs/SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md.
+    ///
+    /// Returns the post-update row (`None` if the id didn't exist or no
+    /// fields were provided) so callers that need `definition_id` for an
+    /// event scope — or want to echo the row back — get it from the
+    /// same authoritative reload this method already runs to refresh the
+    /// registry mirror + Phase-3a dual-write. Those consumers read only
+    /// non-transient fields, so the reload survives a future
+    /// `instance_get` → db_agents flip (Phase 3b.3c).
+    pub fn instance_update_partial(
+        &self,
+        id: &str,
+        upd: &InstanceUpdate,
+    ) -> Result<Option<AgentInstance>, StoreError> {
+        use rusqlite::types::ToSql;
+
+        let mut sets: Vec<&str> = Vec::new();
+        let mut vals: Vec<Box<dyn ToSql>> = Vec::new();
+        if let Some(v) = &upd.block_id {
+            sets.push("block_id = ?");
+            vals.push(Box::new(v.clone()));
+        }
+        if let Some(v) = &upd.session_id {
+            sets.push("session_id = ?");
+            vals.push(Box::new(v.clone()));
+        }
+        if let Some(v) = &upd.status {
+            sets.push("status = ?");
+            vals.push(Box::new(v.clone()));
+        }
+        if let Some(v) = &upd.github_context {
+            // `Some("")` explicitly clears (matches the command contract).
+            sets.push("github_context = ?");
+            vals.push(Box::new(v.clone()));
+        }
+        if let Some(v) = upd.ended_at {
+            sets.push("ended_at = ?");
+            vals.push(Box::new(v));
+        }
+        if sets.is_empty() {
+            // No fields to write. Return the current row unchanged (or
+            // `None` if the id genuinely doesn't exist) so the caller can
+            // still tell a no-op apart from not-found — rather than
+            // conflating both as `None`. No write, no registry/dual-write
+            // reload needed since nothing changed.
+            return self.instance_get(id);
+        }
+
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            let sql = format!(
+                "UPDATE db_agent_instances SET {} WHERE id = ?",
+                sets.join(", ")
+            );
+            vals.push(Box::new(id.to_string()));
+            let params: Vec<&dyn ToSql> = vals.iter().map(|b| b.as_ref()).collect();
+            conn.execute(&sql, params.as_slice())?
+        };
+        if rows == 0 {
+            return Ok(None);
+        }
+        // Reload the authoritative post-update row and refresh the
+        // registry mirror + dual-write — identical to `instance_update`.
+        let fresh = self.instance_get(id)?;
+        if let Some(f) = &fresh {
+            self.registry_upsert_if_named(f);
+            // Phase 3a dual-write (Phase 3b: errors propagate).
+            self.agents_dual_write_instance_update(f)?;
+        }
+        Ok(fresh)
+    }
+
     /// Update mutable instance fields. `id`, `definition_id`,
     /// `parent_instance_id`, `started_at`, `created_at` are immutable
     /// after insert (they describe provenance, not state).
+    ///
+    /// Retained as a full-struct convenience for store tests + internal
+    /// callers; the `updateagentinstance` handler now uses
+    /// [`Self::instance_update_partial`] so it no longer reads the row
+    /// to merge.
     pub fn instance_update(&self, inst: &AgentInstance) -> Result<bool, StoreError> {
         let rows = {
             let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1276,13 +1276,17 @@ impl Store {
     /// With a partial write the handler no longer reads the row at all.
     /// See docs/specs/SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md.
     ///
-    /// Returns the post-update row (`None` if the id didn't exist or no
-    /// fields were provided) so callers that need `definition_id` for an
-    /// event scope — or want to echo the row back — get it from the
-    /// same authoritative reload this method already runs to refresh the
-    /// registry mirror + Phase-3a dual-write. Those consumers read only
-    /// non-transient fields, so the reload survives a future
+    /// Returns the post-update row so callers that need `definition_id`
+    /// for an event scope — or want to echo the row back — get it from
+    /// the same authoritative reload this method already runs to refresh
+    /// the registry mirror + Phase-3a dual-write. Those consumers read
+    /// only non-transient fields, so the reload survives a future
     /// `instance_get` → db_agents flip (Phase 3b.3c).
+    ///
+    /// `None` is reserved for **not-found** (the id doesn't exist). An
+    /// all-`None` update on an existing id is a no-op that returns the
+    /// unchanged row — so callers can distinguish "nothing to change"
+    /// from "no such instance".
     pub fn instance_update_partial(
         &self,
         id: &str,

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -19,7 +19,7 @@ pub mod skills;
 pub mod snapshot;
 pub mod store;
 
-pub use agents::{AgentDefinition, AgentInstance, InstanceStatus};
+pub use agents::{AgentDefinition, AgentInstance, InstanceStatus, InstanceUpdate};
 pub use content::AgentContent;
 pub use error::StoreError;
 #[allow(unused_imports)]

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -1071,6 +1071,80 @@ mod tests {
     }
 
     #[test]
+    fn test_instance_update_partial() {
+        use crate::backend::storage::InstanceUpdate;
+        let store = v6_test_store();
+        let mut agent = sample_agent("defp", "agent-p");
+        store.agent_def_insert(&mut agent).unwrap();
+        let inst = AgentInstance {
+            id: "instp".to_string(),
+            definition_id: "defp".to_string(),
+            parent_instance_id: String::new(),
+            block_id: "block-1".to_string(),
+            session_id: "sess-1".to_string(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: "ctx-1".to_string(),
+            started_at: 1000,
+            ended_at: 0,
+            created_at: 1000,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        store.instance_create(&inst).unwrap();
+
+        // Update ONLY status — other columns must be preserved.
+        let fresh = store
+            .instance_update_partial(
+                "instp",
+                &InstanceUpdate { status: Some("stopped".into()), ..Default::default() },
+            )
+            .unwrap()
+            .expect("row");
+        assert_eq!(fresh.status, "stopped");
+        assert_eq!(fresh.block_id, "block-1", "block_id must be untouched");
+        assert_eq!(fresh.session_id, "sess-1", "session_id must be untouched");
+        assert_eq!(fresh.github_context, "ctx-1", "github_context must be untouched");
+
+        // Update ONLY session_id — status from the prior write persists.
+        let fresh = store
+            .instance_update_partial(
+                "instp",
+                &InstanceUpdate { session_id: Some("sess-2".into()), ..Default::default() },
+            )
+            .unwrap()
+            .expect("row");
+        assert_eq!(fresh.session_id, "sess-2");
+        assert_eq!(fresh.status, "stopped", "status from prior partial write persists");
+
+        // `Some("")` explicitly clears a string column.
+        let fresh = store
+            .instance_update_partial(
+                "instp",
+                &InstanceUpdate { github_context: Some(String::new()), ..Default::default() },
+            )
+            .unwrap()
+            .expect("row");
+        assert_eq!(fresh.github_context, "", "Some(\"\") clears");
+
+        // All-`None` no-op returns the unchanged row (NOT None — that's
+        // reserved for not-found so the handler can tell them apart).
+        let noop = store
+            .instance_update_partial("instp", &InstanceUpdate::default())
+            .unwrap();
+        assert!(noop.is_some(), "no-op on an existing id returns the row");
+        assert_eq!(noop.unwrap().session_id, "sess-2");
+
+        // Not-found returns None.
+        let missing = store
+            .instance_update_partial("nope", &InstanceUpdate { status: Some("x".into()), ..Default::default() })
+            .unwrap();
+        assert!(missing.is_none(), "not-found returns None");
+    }
+
+    #[test]
     fn test_agent_def_list_orders_by_last_used() {
         let store = v6_test_store();
         // Three definitions; none launched yet.

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1401,44 +1401,33 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandUpdateAgentInstanceData = serde_json::from_value(data)
                     .map_err(|e| format!("updateagentinstance: {e}"))?;
-                let existing = wstore
-                    .instance_get(&cmd.id)
+                // Partial write — only the fields the command provided.
+                // No fetch-and-merge: this used to `instance_get` the full
+                // row to fill the unspecified fields, which was the sole
+                // production caller needing `instance_get`'s transient
+                // per-launch columns. The store builds a dynamic UPDATE
+                // and returns the post-write row (for the event scope +
+                // response) from the reload it already runs.
+                // SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md.
+                let upd = crate::backend::storage::InstanceUpdate {
+                    block_id: cmd.block_id,
+                    session_id: cmd.session_id,
+                    status: cmd.status,
+                    github_context: cmd.github_context,
+                    ended_at: cmd.ended_at,
+                };
+                let fresh = wstore
+                    .instance_update_partial(&cmd.id, &upd)
                     .map_err(|e| format!("updateagentinstance: {e}"))?
                     .ok_or_else(|| format!("updateagentinstance: not found id={}", cmd.id))?;
-                let merged = AgentInstance {
-                    id: existing.id.clone(),
-                    definition_id: existing.definition_id.clone(),
-                    parent_instance_id: existing.parent_instance_id.clone(),
-                    block_id: cmd.block_id.unwrap_or(existing.block_id),
-                    session_id: cmd.session_id.unwrap_or(existing.session_id),
-                    status: cmd.status.unwrap_or(existing.status),
-                    github_context: cmd.github_context.unwrap_or(existing.github_context),
-                    started_at: existing.started_at,
-                    ended_at: cmd.ended_at.unwrap_or(existing.ended_at),
-                    created_at: existing.created_at,
-                    // identity_id / memory_id / instance_name /
-                    // working_directory are immutable post-create
-                    // (mid-session credential rotation is out of scope
-                    // — launch a new instance with a different bundle
-                    // or use ContinueNamedAgentCommand). display_hidden
-                    // is mutated via instance_set_hidden, not here.
-                    identity_id: existing.identity_id.clone(),
-                    memory_id: existing.memory_id.clone(),
-                    instance_name: existing.instance_name.clone(),
-                    working_directory: existing.working_directory.clone(),
-                    display_hidden: existing.display_hidden,
-                };
-                wstore
-                    .instance_update(&merged)
-                    .map_err(|e| format!("updateagentinstance: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
-                    event: format!("agentinstances:changed:{}", merged.definition_id),
+                    event: format!("agentinstances:changed:{}", fresh.definition_id),
                     scopes: vec![],
                     sender: String::new(),
                     persist: 0,
                     data: None,
                 });
-                Ok(Some(serde_json::to_value(&merged).unwrap_or_default()))
+                Ok(Some(serde_json::to_value(&fresh).unwrap_or_default()))
             })
         }),
     );

--- a/docs/specs/SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md
+++ b/docs/specs/SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md
@@ -1,0 +1,104 @@
+# SPEC: `updateagentinstance` partial-update refactor (2026-05-29)
+
+**Author:** AgentA
+**Status:** Scope / plan — ready to implement.
+**Why:** Single highest-leverage unblock for Phase 3b. It removes the `instance_get` fetch-and-merge in the update path, which is the *only* production code that needs transient per-launch fields out of `instance_get` — clearing the blocker on **3b.3c** (`instance_get` → db_agents) and, bundled, **3b.3b** (`instance_list` status-filter).
+**Refs:** `docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md` (Phase 3b status table); `project_agent_migration_2026_05_28` memory.
+
+---
+
+## 1. Current shape (the problem)
+
+`updateagentinstance` handler (`agent_handlers.rs:1396`) does **fetch-and-merge**:
+
+```rust
+let existing = wstore.instance_get(&cmd.id)?...;        // FULL row incl. transient fields
+let merged = AgentInstance {
+    block_id:  cmd.block_id.unwrap_or(existing.block_id),
+    session_id: cmd.session_id.unwrap_or(existing.session_id),
+    status:    cmd.status.unwrap_or(existing.status),
+    github_context: cmd.github_context.unwrap_or(existing.github_context),
+    ended_at:  cmd.ended_at.unwrap_or(existing.ended_at),
+    ...all other fields copied from `existing`...
+};
+wstore.instance_update(&merged)?;                       // writes back the whole struct
+Ok(Some(serde_json::to_value(&merged)))                 // returns merged to frontend
+```
+
+`instance_update` (`agents.rs:1256`) is **already a partial SQL UPDATE** — it only writes 5 columns (`block_id, session_id, status, github_context, ended_at`). The struct's other fields are ignored. Then it re-reads via `instance_get` to refresh the registry mirror + Phase-3a dual-write.
+
+So the only reason the handler reads the full row is to **fill the 4 non-provided of those 5 fields** before handing a whole `AgentInstance` to `instance_update`. That read is what pins `instance_get` to the legacy `db_agent_instances` table (transient `block_id`/`session_id`/`status`/`started_at`/`ended_at` have no home on `db_agents`).
+
+## 2. Findings that make this safe (verified 2026-05-29)
+
+- **`instance_get` has exactly one production caller that needs transient fields: the update handler.** The only other production call is `instance_update`'s own internal post-write reload — and its consumers (`registry_upsert_if_named`, `agents_dual_write_instance_update`) read **only non-transient fields**: `instance_name`, `parent_instance_id`, `definition_id`, `id`, `github_context`. The dual-write code comments confirm `block_id`/`session_id`/`status`/`ended_at` are *not* modelled on `db_agents`. Everything else calling `instance_get` is a test.
+- **No live caller passes a status filter to `instance_list`.** Only store-tests call `instance_list(_, Some(status))`. The `instance_list_legacy` fallback exists solely to serve that test-only branch. So **3b.3b is largely a delete**, not a migration.
+- **`status` (and block/session/ended_at) remain transient** — they still live in `db_agent_instances` and are written by `instance_update`. Phase 3c retires that table; until then transient state stays there. This refactor does *not* move transient writes.
+
+## 3. Open decision (must resolve before coding)
+
+**What does the handler return?** Today it returns the `merged` `AgentInstance` (full struct, incl. transient). With a partial update we no longer build `merged`. Options:
+
+| Option | Behavior | Cost |
+|---|---|---|
+| **A. Return the partial echo** | Return `{ id, ...the fields that were set }` (or just `{ id }`). | Frontend must not depend on a full instance back. **Verify consumers first.** |
+| **B. Re-read + return full** | After the partial write, `instance_get` the row and return it. | Keeps the response shape, but re-introduces an `instance_get` call — which is *fine* as long as it's a read-only response that doesn't pin the migration (the response can read legacy until 3c; or read db_agents post-3b.3c and return empty transient fields). |
+
+**Action item:** grep the frontend for the `updateagentinstance` RPC response consumer. If it's fire-and-forget (likely — most instance updates are status/session writes), choose **A**. If it reads the returned instance, choose **B** and decide whether the returned transient fields matter.
+
+**RESOLVED (2026-05-29): choose A.** `UpdateAgentInstanceCommand` has **zero callers** in the frontend — only the generated RPC wrapper (`rpc-api.ts:1026`) exists, nothing invokes it. No consumer reads the response, so returning a minimal `{ id }` (or `null`) is risk-free. No need to re-read for the response.
+
+## 4. Proposed API
+
+```rust
+/// Partial update of an instance's mutable runtime fields. Only `Some`
+/// fields are written; `None` leaves the column untouched. Replaces the
+/// caller-side fetch-and-merge that pinned `instance_get` to the legacy
+/// transient row.
+pub struct InstanceUpdate {
+    pub block_id: Option<String>,
+    pub session_id: Option<String>,
+    pub status: Option<String>,
+    pub github_context: Option<String>,
+    pub ended_at: Option<i64>,
+}
+
+impl Store {
+    pub fn instance_update_partial(&self, id: &str, upd: &InstanceUpdate)
+        -> Result<bool, StoreError>;
+}
+```
+
+`instance_update_partial` builds a dynamic `UPDATE db_agent_instances SET <only-Some columns> WHERE id = ?` (no-op / `Ok(false)` if all `None`), then runs the same post-write reload → `registry_upsert_if_named` + `agents_dual_write_instance_update`. Because those consumers need only non-transient fields, the reload can flip to a `db_agents`-backed `instance_get` in 3b.3c without breaking them.
+
+`CommandUpdateAgentInstanceData` already mirrors `InstanceUpdate` exactly (`id` + the 5 `Option` fields) — `From<CommandUpdateAgentInstanceData> for InstanceUpdate` is a trivial move.
+
+## 5. Sub-PR sequence
+
+1. **PR α — partial-update API + handler rewrite (the unblocker).**
+   - Add `InstanceUpdate` + `instance_update_partial`. Keep the old `instance_update(&AgentInstance)` temporarily (other callers? grep — `instance_repoint_definition` is separate; check) or migrate its callers.
+   - Rewrite the handler: drop the `instance_get` fetch-and-merge; call `instance_update_partial(cmd.id, &cmd.into())`. Resolve §3 (response shape).
+   - Tests: cover partial writes (set only `status`; set only `session_id`; all-`None` no-op; confirm untouched columns preserved).
+   - **No read-flip yet** — `instance_get` still reads legacy. This PR is pure decoupling + must be behavior-identical at the SQL level. Ship + verify.
+
+2. **PR β — 3b.3c: flip `instance_get` → db_agents.**
+   - Now that no production caller needs transient fields from it, point `instance_get` at `db_agents WHERE id = ?` (same projection shape as `instance_list`'s no-status case — transient fields returned as empty defaults).
+   - Update the store-tests that assert transient fields from `instance_get` (they must move to asserting via the legacy path or be re-pointed).
+   - `instance_update`'s internal reload now reads db_agents — verify registry mirror + dual-write still get `instance_name`/`github_context`/etc.
+
+3. **PR γ — 3b.3b: drop the `instance_list` status-filter legacy branch.**
+   - Delete the `if status.is_some() → instance_list_legacy` branch and the `instance_list_legacy` helper (no live caller). Either drop the `status` param from `instance_list` entirely or keep it as an accepted-but-ignored arg for signature stability — decide based on the test churn.
+   - Update/remove the store-tests that pass `Some(status)`.
+
+(β and γ are independent of each other; both depend on α only for β. γ could even land first since it's pure dead-code removal — but bundling after α keeps the "transient fields" story in one arc.)
+
+## 6. Risks
+
+- **Response-shape regression (§3).** The one real behavioral decision. Mitigated by checking frontend consumers before choosing A vs B.
+- **`instance_update` other callers.** Grep for `instance_update(` — if callers other than the handler + tests exist, they need migrating to `instance_update_partial` or the old method kept. (Initial scan: the handler + internal tests; `instance_repoint_definition` is a distinct method.)
+- **Test coupling.** Several store-tests assert `instance_get(...).status` and `instance_list(_, Some(...))`. These are the main churn; they're testing the legacy transient surface and must be re-pointed when β/γ land.
+- **Dual-write timing.** The reload→dual-write must keep firing; `instance_update_partial` must replicate `instance_update`'s post-write reload exactly (don't drop the `agents_dual_write_instance_update` call — Phase 3b propagates its errors).
+
+## 7. What this unblocks
+
+α alone clears the *only* production dependency on `instance_get`'s transient fields → β (3b.3c) becomes a clean read-flip, and γ (3b.3b) a dead-code delete. After β + γ, the remaining Phase 3b items are 3b.1b (`instance_list_named`, blocked on the `listrecentsessions` per-launch story) and 3b.5 (`agent_def_get` working_directory fold) — then Phase 3c retires the legacy tables.


### PR DESCRIPTION
**PR α** of the partial-update refactor ([scope](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_UPDATEAGENTINSTANCE_PARTIAL_UPDATE_2026_05_29.md)). Pure decoupling — no read-flip yet.

## Problem
The `updateagentinstance` handler did **fetch-and-merge**: `instance_get` the full row (transient per-launch fields included) → fill the unspecified of 5 mutable fields → write the whole struct back. That read is the **only** production caller needing `instance_get`'s transient columns, pinning it to legacy `db_agent_instances` and blocking 3b.3c.

## Change
- New `InstanceUpdate` (all-`Option`) + `Store::instance_update_partial(id, &upd)` — dynamic `UPDATE … SET <only Some cols> WHERE id=?`, same post-write reload (registry mirror + dual-write) as `instance_update`. Returns the post-update row, so the handler keeps its `agentinstances:changed:<definition_id>` event + response **from the reload it already runs** (no extra query).
- Handler rewritten to call it directly — fetch-and-merge gone.
- No-fields update returns the unchanged row; `None` reserved for not-found (handler can still distinguish).
- `instance_update(&AgentInstance)` kept as test/internal helper.

SQL behavior identical (same 5 columns). The reload's consumers read only **non-transient** fields, so the follow-up can flip `instance_get` → db_agents (3b.3c) without breaking them.

## Resolved open question
`UpdateAgentInstanceCommand` has **zero frontend callers** → response shape is free; returns the fresh row.

## Tests
5 unit cases (status-only · session-only · `Some("")` clear · all-None no-op · not-found). `cargo test -p agentmux-srv test_instance_update_partial` green; `cargo check -p agentmux-srv` clean.

Follow-ups: **β** flips `instance_get` → db_agents (3b.3c); **γ** deletes the `instance_list` status-filter legacy branch (3b.3b, no live caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)