### PR TITLE
feat(storage): db_agents.last_block_id + dual-write maintenance (Phase 3c PR1)

### DIFF
--- a/.changesets/1780053165-feat-storage-add-db-agents-last-block-id-column-dual-write-m-xntr.md
+++ b/.changesets/1780053165-feat-storage-add-db-agents-last-block-id-column-dual-write-m-xntr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(storage): add db_agents.last_block_id column + dual-write maintenance (Phase 3c PR1)

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -267,7 +267,8 @@ impl Store {
                     github_context = ?6,
                     instance_name = ?7,
                     updated_at = ?8,
-                    user_hidden = ?9
+                    user_hidden = ?9,
+                    last_block_id = ?10
                  WHERE id = ?1",
                 params![
                     def.id,
@@ -279,6 +280,7 @@ impl Store {
                     inst.instance_name,
                     now_ms,
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
+                    inst.block_id,
                 ],
             )
         } else if is_continuation {
@@ -308,7 +310,8 @@ impl Store {
                     github_context = ?6,
                     instance_name = ?7,
                     updated_at = ?8,
-                    user_hidden = ?9
+                    user_hidden = ?9,
+                    last_block_id = ?10
                  WHERE id = ?1 AND is_template = 0",
                 params![
                     root_id,
@@ -320,6 +323,7 @@ impl Store {
                     inst.instance_name,
                     now_ms,
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
+                    inst.block_id,
                 ],
             )
         } else {
@@ -334,7 +338,8 @@ impl Store {
                     slug, branch_label,
                     identity_id, memory_id, working_directory, github_context,
                     instance_name,
-                    created_at, updated_at, is_seeded, user_hidden
+                    created_at, updated_at, is_seeded, user_hidden,
+                    last_block_id
                  ) VALUES (
                     ?1, ?2, ?3, ?4,
                     0, ?5,
@@ -344,7 +349,8 @@ impl Store {
                     ?16, ?17,
                     ?18, ?19, ?20, ?21,
                     ?22,
-                    ?23, ?24, 0, ?25
+                    ?23, ?24, 0, ?25,
+                    ?26
                  )
                  ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
@@ -354,7 +360,8 @@ impl Store {
                     github_context = excluded.github_context,
                     instance_name = excluded.instance_name,
                     updated_at = excluded.updated_at,
-                    user_hidden = excluded.user_hidden",
+                    user_hidden = excluded.user_hidden,
+                    last_block_id = excluded.last_block_id",
                 params![
                     inst.id,
                     name,
@@ -381,6 +388,7 @@ impl Store {
                     inst.created_at,
                     inst.created_at, // updated_at = created_at on insert
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
+                    inst.block_id,
                 ],
             )
         };

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -30,7 +30,10 @@ use super::error::StoreError;
 ///        SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md Q2 Decision Y)
 ///   v4 — db_agents consolidation table (Phase 3a; dual-write only,
 ///        reads still on db_agent_definitions / db_agent_instances)
-pub const OBJECT_SCHEMA_VERSION: i64 = 4;
+///   v5 — db_agents.last_block_id (Phase 3c; latest launch's block, so the
+///        consolidated read can find the session snapshot without joining
+///        db_agent_instances)
+pub const OBJECT_SCHEMA_VERSION: i64 = 5;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -315,6 +318,14 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             github_context       TEXT NOT NULL DEFAULT '',
             instance_name        TEXT NOT NULL DEFAULT '',
 
+            -- Latest launch's block (Phase 3c): pointer to the most-recent
+            -- session's block so the consolidated read can locate the
+            -- conversation snapshot without joining db_agent_instances. The
+            -- only transient per-launch field db_agents retains; the rest
+            -- (status/session_id/started_at/ended_at) live on the block and
+            -- retire with db_agent_instances.
+            last_block_id        TEXT NOT NULL DEFAULT '',
+
             -- Provenance
             created_at           INTEGER NOT NULL DEFAULT 0,
             updated_at           INTEGER NOT NULL DEFAULT 0,
@@ -369,9 +380,14 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
     //     templates (Phase 2 of the two-tier picker spec, Q2 Decision Y).
     //     Defaults to 0 (visible) for all existing rows so a migration
     //     never silently hides previously-visible templates.
+    // v5: db_agents.last_block_id — most-recent launch's block (Phase 3c).
+    //     Defaults to '' for existing rows; the dual-write populates it on
+    //     the next launch/continuation. Read side (3b.1b) treats '' as
+    //     "no snapshot" (same as the current empty-block_id fallback).
     for stmt in &[
         "ALTER TABLE db_agent_definitions ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE db_agent_definitions ADD COLUMN user_hidden INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_agents ADD COLUMN last_block_id TEXT NOT NULL DEFAULT ''",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -2887,7 +2887,7 @@ mod tests {
             id: "inst-dw".to_string(),
             definition_id: "tpl-for-inst".to_string(),
             parent_instance_id: String::new(),
-            block_id: String::new(),
+            block_id: "blk-head".to_string(),
             session_id: String::new(),
             status: "running".to_string(),
             github_context: String::new(),
@@ -2915,6 +2915,10 @@ mod tests {
         // instance's resolved workdir ("/wd/maks"). db_agents holds durable
         // agent config; the per-launch resolved cwd lives on the block.
         assert_eq!(read_agent_field(&store, "inst-dw", "working_directory"), Some("/wd/tpl-cfg".to_string()));
+        // last_block_id mirrors the instance's per-launch block (the one
+        // transient field db_agents retains, so My Agents can locate the
+        // filestore snapshot). Non-empty value → non-vacuous assertion.
+        assert_eq!(read_agent_field(&store, "inst-dw", "last_block_id"), Some("blk-head".to_string()));
         // Continuation rows skipped.
         let cont = AgentInstance {
             id: "inst-cont".to_string(),
@@ -2986,7 +2990,7 @@ mod tests {
             id: "inst-fold-1".to_string(),
             definition_id: "user-clone-1".to_string(),
             parent_instance_id: String::new(),
-            block_id: String::new(),
+            block_id: "blk-fold".to_string(),
             session_id: String::new(),
             status: "running".to_string(),
             github_context: "gh-ctx-A".to_string(),
@@ -3013,6 +3017,9 @@ mod tests {
         // cwd, not the instance's resolved workdir ("/wd/folded").
         assert_eq!(read_agent_field(&store, "user-clone-1", "working_directory"), Some("/wd/clone-cfg".to_string()));
         assert_eq!(read_agent_field(&store, "user-clone-1", "github_context"), Some("gh-ctx-A".to_string()));
+        // last_block_id folds onto the user-clone row too (transient
+        // per-launch field; non-empty → non-vacuous).
+        assert_eq!(read_agent_field(&store, "user-clone-1", "last_block_id"), Some("blk-fold".to_string()));
         assert_eq!(read_agent_field(&store, "user-clone-1", "instance_name"), Some("Maks v2".to_string()));
         assert_eq!(read_agent_field(&store, "user-clone-1", "name"), Some("Maks v2".to_string()));
         // is_template stays 0, parent_template_id untouched (still empty


### PR DESCRIPTION
## What

Adds `db_agents.last_block_id` — the **only transient field** `db_agents` needs to retain — plus its dual-write maintenance. This is the additive, write-only column that unblocks the **My Agents** read flip (Phase 3b.1b).

## Why

`MyAgentsList` ← `listrecentsessions` ← `instance_list_named` (the 3b.1b flip) needs the instance's `block_id` to locate the filestore `output.state.json` snapshot (preview / node_count / last_active). The other transient instance fields don't survive the migration:

- `status` / `session_id` / `ended_at` — cross the wire today but have **no live consumer**; they drop with the legacy `db_agent_instances` table.
- `started_at` → use `db_agents.updated_at`.

So one additive column unblocks 3b.1b; everything else dissolves in Phase 3c.

## Changes

**Schema** (`migrations.rs`):
- `OBJECT_SCHEMA_VERSION` 4 → 5
- `last_block_id TEXT NOT NULL DEFAULT ''` on `db_agents` (in `CREATE TABLE` + the additive `ALTER TABLE … ADD COLUMN` list — idempotent dup-column swallow)

**Dual-write** (`dual_write.rs`): `agents_dual_write_instance_create` now mirrors `inst.block_id` → `last_block_id` in all three branches (user-clone UPDATE, continuation UPDATE, template-instance head INSERT + ON CONFLICT DO UPDATE).

> Note: unlike `working_directory` (def-configured, un-folded in #1163), `last_block_id` **is** instance-derived — it names the latest launch's block. That's correct: it's per-launch runtime state.

## Safety

**Write-only by design.** Nothing reads `last_block_id` until the 3b.1b flip. Existing SELECTs use explicit column lists, so the additive column is safe. Backfill of pre-existing rows is deferred to the 3b.1b PR that first reads it.

## Tests

Extended the two create-path dual-write tests with non-vacuous `last_block_id` assertions (head INSERT → `"blk-head"`; user-clone fold UPDATE → `"blk-fold"`). `cargo test -p agentmux-srv dual_write` + `migration` green (12 + 26).

Phase 3c PR1. Tracking: #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)