### PR TITLE
fix(cef): never bind a window label to an off-screen warm-pool HWND (fixes window drag)

### DIFF
--- a/.changesets/1780054572-fix-cef-bind-window-label-to-promoted-window-not-off-screen--nxw8.md
+++ b/.changesets/1780054572-fix-cef-bind-window-label-to-promoted-window-not-off-screen--nxw8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): bind window label to promoted window, not off-screen warm-pool HWND (fixes window drag)

--- a/agentmux-cef/src/commands/window/lifecycle.rs
+++ b/agentmux-cef/src/commands/window/lifecycle.rs
@@ -115,6 +115,39 @@ pub fn close_window_by_label(
 #[cfg(target_os = "windows")]
 const FLOATING_PANE_CLASS_NAME: &str = "AgentMuxFloatingPane";
 
+/// X-coordinate threshold (in screen px) below which a top-level window is
+/// treated as an off-screen warm-pool member, not a real user window.
+///
+/// Unpromoted pool windows are created at `POOL_OFFSCREEN_X` = -32000
+/// (`window_pool.rs`) and stay there until promoted — but they remain
+/// `IsWindowVisible`, so the EnumWindows-based fallbacks below would
+/// otherwise enumerate one and bind `"main"` to a window the user can't
+/// see. Drags and closes then act on the hidden pool window instead of the
+/// visible one (root cause of the "window won't drag" regression: every
+/// `set_window_position` faithfully moved an off-screen pool window). A
+/// failed drag can nudge the parked window a few hundred px before the bind
+/// is fixed, so we test against a generous threshold rather than the exact
+/// parking coordinate. No real monitor origin is anywhere near -20000
+/// (even a 4K monitor left of primary sits at ~-3840).
+#[cfg(target_os = "windows")]
+const OFFSCREEN_POOL_THRESHOLD_X: i32 = -20000;
+
+/// True if `hwnd` is parked at the warm-pool's off-screen position (see
+/// `OFFSCREEN_POOL_THRESHOLD_X`). Used by both `find_main_window` and the
+/// `capture_hwnd_for_label` fallback to refuse binding an on-screen label
+/// to a hidden pool window. On `GetWindowRect` failure we return `false`
+/// (can't prove it's a pool window — don't skip).
+#[cfg(target_os = "windows")]
+unsafe fn is_offscreen_pool_window(hwnd: *mut std::ffi::c_void) -> bool {
+    use windows_sys::Win32::Foundation::RECT;
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect;
+    let mut rect: RECT = std::mem::zeroed();
+    if GetWindowRect(hwnd, &mut rect) == 0 {
+        return false;
+    }
+    rect.left < OFFSCREEN_POOL_THRESHOLD_X
+}
+
 /// Like `find_own_top_level_window` but skips floating-pane windows.
 /// Used when the label points at the main window but the reducer-
 /// registry path failed (CEF Views' `BrowserHost::window_handle()`
@@ -152,6 +185,14 @@ unsafe fn find_main_window() -> *mut std::ffi::c_void {
             if class == FLOATING_PANE_CLASS_NAME {
                 return 1;
             }
+        }
+        // Skip unpromoted warm-pool windows parked off-screen. They share
+        // the main window's `Chrome_WidgetWin_1` class (so the class check
+        // above can't catch them) and are `IsWindowVisible`, but they are
+        // NOT the real promoted main window — binding to one breaks
+        // drag/close. See `is_offscreen_pool_window`.
+        if is_offscreen_pool_window(hwnd) {
+            return 1;
         }
         let result_ptr = lparam as *mut *mut std::ffi::c_void;
         *result_ptr = hwnd;
@@ -362,15 +403,33 @@ pub(crate) fn capture_hwnd_for_label(state: &Arc<AppState>, label: &str) {
             }
         }
     }
-    // Fallback: pick the first visible HWND not already mapped.
+    // Fallback: pick the first eligible visible HWND not already mapped.
+    //
+    // For on-screen labels (`main`, tear-off `window-*`, promoted pool
+    // windows) we MUST skip windows still parked at the warm-pool's
+    // off-screen position: those are unpromoted pool members that are
+    // `IsWindowVisible` but invisible to the user. Grabbing one binds the
+    // label to a hidden window, so drag/close act on the wrong window
+    // (root cause of the "window won't drag" regression). When capturing a
+    // pool label itself the window legitimately IS off-screen, so the skip
+    // is disabled for `window-pool-*` labels.
+    let capturing_pool_label = label.starts_with("window-pool-");
     let known: std::collections::HashSet<isize> = state.window_hwnds.lock().values().cloned().collect();
     for hwnd_raw in find_all_own_windows() {
         let raw = hwnd_raw as isize;
-        if !known.contains(&raw) {
-            state.window_hwnds.lock().insert(label.to_string(), raw);
-            tracing::debug!("[opacity] captured hwnd fallback label={} hwnd={:#x}", label, raw);
-            return;
+        if known.contains(&raw) {
+            continue;
         }
+        if !capturing_pool_label && unsafe { is_offscreen_pool_window(hwnd_raw) } {
+            tracing::debug!(
+                "[opacity] capture_hwnd_for_label: skipping off-screen pool window {:#x} for label={}",
+                raw, label
+            );
+            continue;
+        }
+        state.window_hwnds.lock().insert(label.to_string(), raw);
+        tracing::debug!("[opacity] captured hwnd fallback label={} hwnd={:#x}", label, raw);
+        return;
     }
     tracing::warn!("[opacity] capture_hwnd_for_label: no available HWND for label={}", label);
 }


### PR DESCRIPTION
## Symptom

Window drag silently no-ops — the title bar responds, `set_window_position` fires ~60×/sec, `SetWindowPos` returns success, but the visible window never moves.

## Root cause (confirmed live, not theory)

`window_hwnds["main"]` was bound to an **unpromoted warm-pool window**.

The warm pool keeps `POOL_TARGET_SIZE` (=2) windows parked off-screen at `(-32000, -32000)` for instant tab tear-off. They stay `IsWindowVisible` until promoted. When `capture_hwnd_for_label("main")`'s fast path returns `NULL` (CEF Views hides the outer HWND on Win32), the fallback picks *"the first `IsWindowVisible` process window not already mapped"* — and in EnumWindows Z-order that can be a pool window. Every subsequent drag faithfully moved an **off-screen** pool window, so nothing visible happened.

**Live evidence** (running 0.39.3 portable):
- Host log: `[win-resolve] resolved via window_hwnds cache  label=main  cache_hwnd=0xff04bc` on every drag tick.
- `0xff04bc` = top-level `Chrome_WidgetWin_1` titled `'A'` at rect `(-32170, -32054)` — a parked pool window.
- The **real** visible window was `0x1a057c` (`'S'`) at `(135, 235)`.

### Relationship to #1133

This is the **live-but-wrong** sibling of the **dead-HWND** case #1133 fixed. #1133 added `IsWindow`-based eviction — but a pool window is *alive*, so eviction never fires and the wrong bind sticks for the whole session (which is why drag is reliably broken, not flaky). 

**Not** caused by the window.rs carve (#1144): `git show` confirms that was a byte-identical pure move of this code. The bug predates it.

## Fix

Both EnumWindows fallbacks now refuse off-screen pool windows:

- **`is_offscreen_pool_window(hwnd)`** — `rect.left < OFFSCREEN_POOL_THRESHOLD_X` (`-20000`). Well below any real monitor origin (a 4K monitor left of primary sits at ~-3840), yet generous enough to still catch a pool window nudged a few hundred px by a failed drag (that's why the observed coord was -32170, not exactly -32000).
- **`find_main_window`** (the resolve fallback for `"main"`) — skips such windows alongside its existing floating-pane-class skip (pool windows share `Chrome_WidgetWin_1`, so a class check can't catch them — needs a position check).
- **`capture_hwnd_for_label`** fallback — skips them for on-screen labels; the skip is **disabled for `window-pool-*` labels** (those legitimately *are* off-screen).

Net: an on-screen label can no longer bind to a hidden pool window, so the wrong HWND can't enter the cache in the first place. This also closes the residual close-button case #1133 only half-fixed.

## Verification

`cargo check -p agentmux-cef --release` clean. Verified empirically on a portable build against the exact failing instance (see PR thread). Pool-label capture path unaffected (skip gated off for `window-pool-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)