### PR TITLE
fix(floating-pane): deterministic redock-onto-main (no longer depends on the HWND-capture race)

### DIFF
--- a/.changesets/1780061050-fix-floating-pane-redock-onto-main-resolves-via-find-main-wi-n0h4.md
+++ b/.changesets/1780061050-fix-floating-pane-redock-onto-main-resolves-via-find-main-wi-n0h4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): redock onto main resolves via find_main_window when window_hwnds cache misses

--- a/agentmux-cef/src/commands/window/lifecycle.rs
+++ b/agentmux-cef/src/commands/window/lifecycle.rs
@@ -155,7 +155,7 @@ unsafe fn is_offscreen_pool_window(hwnd: *mut std::ffi::c_void) -> bool {
 /// skip, the floater (owned, drawn ABOVE its owner) would be
 /// enumerated first and we'd target it instead.
 #[cfg(target_os = "windows")]
-unsafe fn find_main_window() -> *mut std::ffi::c_void {
+pub(super) unsafe fn find_main_window() -> *mut std::ffi::c_void {
     use windows_sys::Win32::System::Threading::GetCurrentProcessId;
     use windows_sys::Win32::UI::WindowsAndMessaging::*;
 

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -17,7 +17,7 @@ use crate::state::AppState;
 // handlers call these only inside `#[cfg(windows)]` blocks, so the import
 // is gated to match (avoids an unused-import error on other targets).
 #[cfg(target_os = "windows")]
-use super::lifecycle::{find_own_top_level_window, resolve_window_hwnd};
+use super::lifecycle::{find_main_window, find_own_top_level_window, resolve_window_hwnd};
 
 /// Get the current window position on screen.
 ///
@@ -215,6 +215,19 @@ pub fn resolve_window_at_cursor(
             hwnds_by_label.get(exclude_label).copied()
         };
 
+        // Deterministic "main" fallback. `window_hwnds["main"]` is populated
+        // by a startup capture that races the main window becoming
+        // enumerable — when it loses, "main" is absent from the map and the
+        // reverse lookup below can't recognise the main frame, so a floater
+        // dropped onto the main window silently fails to re-dock (the redock
+        // intermittency). `find_main_window()` resolves the real on-screen
+        // main frame independently of the cache (it skips floaters and
+        // off-screen pool windows), so we can recognise main by HWND even
+        // when it never made it into `window_hwnds`. Resolved once here, not
+        // per-iteration. `null` if unresolved → the comparison just never
+        // matches (no regression).
+        let main_hwnd: isize = find_main_window() as isize;
+
         let our_pid = GetCurrentProcessId();
         let mut hwnd = GetTopWindow(std::ptr::null_mut());
         while !hwnd.is_null() {
@@ -245,11 +258,24 @@ pub fn resolve_window_at_cursor(
                                     "window_id": wid,
                                 }));
                             }
+                            // Not in window_hwnds — but if this IS the main
+                            // frame (per the cache-independent resolver),
+                            // recognise it as "main" anyway. This is the
+                            // deterministic redock-onto-main fix: it no longer
+                            // depends on the startup capture having won the
+                            // race to register "main".
+                            if main_hwnd != 0 && h_isize == main_hwnd {
+                                let wid = state.backend_window_id("main");
+                                return Ok(serde_json::json!({
+                                    "label": "main",
+                                    "window_id": wid,
+                                }));
+                            }
                             // Found a window we own but it isn't in
-                            // window_hwnds yet (very early startup or
-                            // a window we don't track). Treat as "no
-                            // agentmux match" and continue Z-order
-                            // walk in case a tracked window sits
+                            // window_hwnds and isn't the main frame (very
+                            // early startup or a window we don't track).
+                            // Treat as "no agentmux match" and continue the
+                            // Z-order walk in case a tracked window sits
                             // behind it.
                         }
                     }


### PR DESCRIPTION
## Problem

Tear-off → drag a floating pane back over the **main window** → redock worked only **intermittently** ("doesn't always redock").

`resolve_window_at_cursor` (the redock detector) reverse-looks-up the cursor's window HWND in `window_hwnds` to get its label. But `window_hwnds["main"]` is populated by a startup `capture_hwnd_for_label` that **races** the main window becoming enumerable. When the capture loses that race, `"main"` is **absent** from the map, so the reverse lookup can't recognise the main frame under the cursor → `target_label: null` → the floater silently fails to re-dock. Once unresolved, it stays unresolved for the whole session (same session-long stickiness as the drag bug).

**Diagnosed live this session:** a "bad" instance logged `capture_hwnd_for_label: no available HWND for label=main` (0 cache hits, all fallback resolutions) and redock-onto-main was dead; a "good" instance that won the race worked. Same binary.

## Fix

In `resolve_window_at_cursor`, resolve the main frame **independently of the cache** via `find_main_window()` — which already skips floaters and off-screen warm-pool windows (#1165) — and recognise a cursor-over window as `"main"` by HWND **even when it isn't in `window_hwnds`**.

- Resolved **once per call** (not per Z-order iteration).
- **Null-safe**: an unresolved main (`0`) never matches → no behavior change in that case.
- The **cached path still wins** when `"main"` is present; this only adds a deterministic fallback for the race-lost case.

`find_main_window` is made `pub(super)` so the sibling `motion` module can call it.

## Why not "fix the capture race" instead?

The cache is also consumed by `resolve_window_hwnd` (drag/close), which **already** falls back to `find_main_window()` — so drag was never affected by the race. This change brings redock detection to the same cache-independent footing. (Continuously/authoritatively populating `window_hwnds["main"]` at promote-time is a reasonable future hardening, but this is the minimal deterministic fix for the user-visible symptom.)

## Test

`cargo check -p agentmux-cef --release` clean. `resolve_window_at_cursor` is entirely Win32 (EnumWindows/GetWindowRect) — not unit-testable without mocking, consistent with the other window handlers; verified by build + live smoke (redock onto main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)