### PR TITLE
fix(macos): patch NSApplication for macOS 26 Tahoe drag crash

### DIFF
--- a/.changesets/1780075756-fix-macos-patch-nsapplication-for-macos-26-tahoe-drag-crash-pqlt.md
+++ b/.changesets/1780075756-fix-macos-patch-nsapplication-for-macos-26-tahoe-drag-crash-pqlt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): patch NSApplication for macOS 26 Tahoe drag crash

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -254,6 +254,18 @@ fn main() {
         "Initializing CEF browser process"
     );
 
+    // macOS 26 Tahoe compat: CEF 146 calls private NSApplication selectors
+    // (e.g. `isHandlingSendEvent`, `isSendingEvent`) during NSDraggingSession
+    // setup. Apple removed them in macOS 26, so the calls go through
+    // `___forwarding___`, find nothing, and `objc_exception_throw` fires —
+    // AppKit's default uncaught-exception handler then calls `_objc_terminate`
+    // and the host dies (EXC_BREAKPOINT / SIGTRAP on CrBrowserMain). Inject
+    // `+[NSApplication resolveInstanceMethod:]` to add typed stubs *before*
+    // the forwarding machinery is entered. Must run before `cef::initialize`.
+    // See docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md and PR #403.
+    #[cfg(target_os = "macos")]
+    unsafe { patch_nsapp_unrecognized_selector() };
+
     // Phase B.6 (post-fix): the named-pipe bind in the launcher is
     // the AUTHORITATIVE single-instance lock — a second launcher
     // hits ERROR_ACCESS_DENIED and never reaches the host. We still
@@ -640,6 +652,125 @@ fn main() {
     let _ = std::fs::remove_file(&port_file);
 
     tracing::info!("AgentMux host shutdown complete");
+}
+
+/// macOS 26 Tahoe compatibility shim.
+///
+/// CEF 146 calls private `NSApplication` selectors (e.g. `isHandlingSendEvent`,
+/// `isSendingEvent`) during `NSDraggingSession` setup that Apple removed in
+/// macOS 26. Without a handler the ObjC runtime walks `___forwarding___`,
+/// finds nothing, and `objc_exception_throw`s; AppKit's default uncaught
+/// handler calls `_objc_terminate()` and the host dies with `EXC_BREAKPOINT`
+/// before Rust panic machinery runs.
+///
+/// We hook `+[NSApplication resolveInstanceMethod:]` on the metaclass —
+/// the earliest point in the ObjC dispatch chain — and install typed stubs
+/// for any unknown selector *before* the forwarding machinery is entered.
+/// Swizzling `doesNotRecognizeSelector:` would not work: that method is
+/// invoked FROM inside `___forwarding___`, and returning normally without
+/// throwing corrupts forwarding state and causes a secondary crash there.
+///
+/// Return-type matters: `isHandlingSendEvent` and `isSendingEvent` return
+/// `BOOL` and callers act on the value. A `void` stub leaves `x0 = self`
+/// (truthy) on ARM64, making CEF think the app is already inside a
+/// `sendEvent:` call and skip normal event routing — which breaks window
+/// drag silently. A maintained allowlist of `BOOL`-returning selectors
+/// gets a `BOOL_no_stub` returning `0` (NO); everything else gets a void
+/// stub, which is safe for the unbounded set of removed Apple-private APIs.
+///
+/// Safety: Called once, before `cef::initialize`. `NSApplication` is a
+/// singleton; adding a `+resolveInstanceMethod:` implementation on its
+/// metaclass at startup is documented Apple behavior. No allocations, no
+/// crossings of language boundaries that hold Rust references.
+///
+/// Ported from PR #403 (a5af, 2026-04-15) with rationale comments expanded.
+/// See `docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md` and
+/// `docs/analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md`.
+#[cfg(target_os = "macos")]
+unsafe fn patch_nsapp_unrecognized_selector() {
+    use std::ffi::{c_char, c_void};
+
+    type Id    = *mut c_void;
+    type Sel   = *const c_void;
+    type Class = *mut c_void;
+
+    extern "C" {
+        fn objc_getClass(name: *const c_char) -> Class;
+        fn object_getClass(obj: Id) -> Class; // on a Class obj → returns metaclass
+        fn sel_registerName(name: *const c_char) -> Sel;
+        fn sel_getName(sel: Sel) -> *const c_char;
+        fn class_addMethod(cls: Class, sel: Sel, imp: usize, types: *const c_char) -> u8;
+    }
+
+    // Void stub — safe for unknown selectors whose return value isn't read.
+    unsafe extern "C" fn void_stub(_self: Id, _cmd: Sel) {}
+
+    // BOOL stub returning 0 (NO). On ARM64 the return value lives in `x0`;
+    // a void stub leaves `x0 = self` (truthy), breaking CEF's sendEvent: guard.
+    unsafe extern "C" fn bool_no_stub(_self: Id, _cmd: Sel) -> u8 { 0 }
+
+    // +resolveInstanceMethod: injected onto NSApplication's metaclass.
+    // The ObjC runtime calls us the first time a selector is sent to an
+    // NSApplication instance that has no implementation. We `class_addMethod`
+    // a typed stub and return YES; the runtime retries the original message
+    // against the freshly added method.
+    unsafe extern "C" fn resolve_instance_method_impl(
+        cls:  Class,
+        _cmd: Sel,
+        sel:  Sel,
+    ) -> u8 {
+        let name = {
+            let ptr = sel_getName(sel);
+            if ptr.is_null() {
+                "<unknown>".to_owned()
+            } else {
+                std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned()
+            }
+        };
+
+        // BOOL-returning getters whose value callers act on. The truthy
+        // garbage a void stub would leave in x0 breaks event routing.
+        const BOOL_NO_SELECTORS: &[&str] = &[
+            "isHandlingSendEvent",
+            "isSendingEvent",
+        ];
+
+        if BOOL_NO_SELECTORS.contains(&name.as_str()) {
+            tracing::warn!(selector = %name, "macOS 26 compat: adding BOOL(NO) stub");
+            class_addMethod(cls, sel, bool_no_stub as usize, b"c@:\0".as_ptr() as _);
+        } else {
+            tracing::warn!(selector = %name, "macOS 26 compat: adding void stub");
+            class_addMethod(cls, sel, void_stub as usize, b"v@:\0".as_ptr() as _);
+        }
+        1 // YES — resolved; runtime retries the original send
+    }
+
+    let cls = objc_getClass(b"NSApplication\0".as_ptr() as _);
+    if cls.is_null() {
+        tracing::warn!("macOS 26 compat: NSApplication class not found");
+        return;
+    }
+
+    // +resolveInstanceMethod: is a class method; it lives on the metaclass.
+    let metacls = object_getClass(cls as Id);
+    if metacls.is_null() {
+        tracing::warn!("macOS 26 compat: NSApplication metaclass not found");
+        return;
+    }
+
+    let sel = sel_registerName(b"resolveInstanceMethod:\0".as_ptr() as _);
+    // "c@::" = BOOL return, id (Class), SEL (cmd), SEL (queried selector)
+    let added = class_addMethod(
+        metacls,
+        sel,
+        resolve_instance_method_impl as usize,
+        b"c@::\0".as_ptr() as _,
+    );
+    if added != 0 {
+        tracing::info!("macOS 26 compat: injected resolveInstanceMethod: into NSApplication metaclass");
+    } else {
+        tracing::warn!("macOS 26 compat: class_addMethod failed (method already exists?)");
+    }
 }
 
 /// Initialize tracing with dual output: rolling daily log file + human-readable stderr.

--- a/docs/analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md
+++ b/docs/analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md
@@ -1,0 +1,209 @@
+# Report — macOS tab/pane tear-off crashes the host with `EXC_BREAKPOINT` / unrecognized selector
+
+**Date:** 2026-05-29
+**Repo state:** `main` @ `53d781af` (v0.40.0) + PR-in-flight macOS fixes (`agenta/macos-cef-framework-bundling`, HEAD `d4bd036f`)
+**Author:** AgentO-asaf
+**Status:** Diagnostic report, no patch — macOS tear-off is intentionally unimplemented and needs Phase 7 / Phase C1 work to make any drag-initiating gesture safe.
+**Related issue:** [#1138](https://github.com/agentmuxai/agentmux/issues/1138) (initial crash filing — same root cause; this expands it with code-path evidence)
+**Related specs:**
+- `docs/specs/SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` — explicit "Out of scope: Floater on macOS / Linux. Windows-only initially."
+- `docs/specs/PLAN_TAB_TEAROFF_PHASE1_WIN32_2026-05-07.md` — "Scope: Win32 only. macOS / Linux defer to Phase 2."
+- `docs/specs/RESEARCH_TAB_TEAROFF_CROSS_PLATFORM_2026-05-07.md` — confirms there is no portable tear-off path; each OS needs a bespoke drag loop.
+
+---
+
+## TL;DR
+
+Every tab/pane tear-off attempt on macOS crashes `agentmux-cef` (the host) with an uncaught Objective-C `unrecognized selector` exception, surfacing as `EXC_BREAKPOINT` / `SIGTRAP` on the main thread. The Rust side is innocent — the macOS branches in `commands/drag.rs`, `commands/tear_off_hook.rs`, and `commands/window_pool.rs` are intentionally no-op stubs marked for Phase 7. The crash originates in **CEF's macOS code** when Chromium tries to drive a drag/drop session through an `NSWindow`/`NSView` subclass that AgentMux never set up. The cross-platform spec confirms macOS is out of scope for current floating-pane work; this report documents the gap so a future Phase 7 / C1 implementation has a starting point.
+
+There are six distinct crash diagnostics on this machine from `task dev` sessions yesterday and today, all with identical signatures. The crash is 100% reproducible by attempting to drag any pane header.
+
+---
+
+## Crash signature (identical across all six diagnostic reports)
+
+From `~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-29-094108.ips` (and five other reports from 2026-05-28):
+
+```
+Exception:       EXC_BREAKPOINT (SIGTRAP) — (Breakpoint) brk 1
+Faulting thread: CrBrowserMain (com.apple.main-thread)
+asi[0]:          "unrecognized selector sent to instance %p"
+asi[1]:          "unrecognized selector sent to instance 0x118001a3f00"
+```
+
+Top of the stack (Cocoa exception-handling path):
+
+```
++[NSApplication _crashOnException:]              + 256
+-[NSApplication reportException:]                + 460
+NSApplicationUncaughtExceptionHandler            + 152
+__handleUncaughtException                        + 820
+_objc_terminate()                                + 144
+std::__terminate(void (*)())
+__exceptionPreprocess                            + 164
+objc_exception_throw                             + 88
++[NSObject(NSObject) instanceMethodSignatureForSelector:]
+___forwarding___                                 + 1480
+_CF_forwarding_prep_0                            + 96
+ChromeWebAppShortcutCopierMain  <CEF code>
+... <CEF event loop>
+[NSApplication run]
+```
+
+The crash report's `asi[]` only captures `"unrecognized selector sent to instance %p"` (the format string) — not the actual selector name. **Without an `NSExceptionHandler` installed before the throw, we can't see which method CEF called that AgentMux's window doesn't respond to.** Capturing this is the first action item in §7 below.
+
+The Rust process never gets a chance to log a panic. AppKit's `_crashOnException` calls `_objc_terminate()`, which terminates the process without unwinding — the host log stops mid-stream (last entries are usually a `[fe] focusedChild focus`, `[ipc] main_window_focus`, or `WaveObj updated layout` line, depending on what the user was doing when they initiated the drag).
+
+---
+
+## What the host code actually does on macOS
+
+### 1. Tear-off RPC is gated to Windows; macOS gets a no-op stub
+
+`agentmux-cef/src/commands/tear_off_hook.rs`:
+
+```rust
+#[cfg(not(target_os = "windows"))]
+pub fn start_tear_off_tracking(
+    _state: std::sync::Arc<crate::state::AppState>,
+    _source_label: String,
+    _dragged_label: String,
+    _tab_id: String,
+    _source_ws_id: String,
+    _dest_ws_id: String,
+    _original_tab_index: usize,
+    _was_pinned: bool,
+    ...
+) { /* no-op */ }
+```
+
+`agentmux-cef/src/commands/drag.rs`:
+
+```rust
+#[cfg(not(target_os = "windows"))]
+fn hit_test_windows(_state: &Arc<AppState>, _screen_x: f64, _screen_y: f64) -> Option<String> {
+    None
+}
+
+// ... handshake_ms computation:
+#[cfg(not(target_os = "windows"))]
+let handshake_ms: f64 = {
+    // Phase 7 adds macOS (NSWindow performWindowDragWithEvent) +
+    // Linux (_NET_WM_MOVERESIZE / xdg_toplevel.move) equivalents.
+    // For now the non-Windows path is a no-op so the IPC contract
+    // exists and the rest of the pipeline can be cross-platform.
+    let _ = (state, &dest_label);
+    0.0
+};
+```
+
+So the Rust side neither initiates a drag loop nor talks to AppKit. The IPC contract is preserved, the call returns immediately, the renderer carries on.
+
+### 2. Frontend uses HTML5 drag + pointer capture; CEF handles the rest
+
+`frontend/app/tab/droppable-tab.tsx` sets up the drag handlers; the comments mention the "cross-window tear-off path" but the actual native window-positioning is delegated to CEF / the host. On Windows, `tear_off_hook` takes over with `SetWindowPos` per `RESEARCH_TAB_TEAROFF_CROSS_PLATFORM_2026-05-07.md` §3.2 (path-2, the Win32 custom drag loop). On macOS, with the host stub doing nothing, the drag operation falls through to **Chromium's own macOS code path** — which is where the unrecognized-selector throw happens.
+
+### 3. CEF's macOS implementation expects an `NSWindow` subclass with drag/pasteboard delegate methods
+
+CEF for macOS forwards drag events through an `NSDraggingSource` / `NSDraggingDestination` machinery rooted at the application's window. When CEF dispatches one of those delegate selectors (e.g. `draggingEntered:`, `draggingUpdated:`, `prepareForDragOperation:`, `performDragOperation:`, `draggingEnded:`), the receiver in the AgentMux process is the `NSWindow` instance CEF created via `cef::Window` — and that window doesn't subclass anything that implements the expected drag protocol. The selector dispatch goes through `___forwarding___`, fails to find a handler, and `objc_exception_throw` fires.
+
+`grep -rn "NSDraggingDestination\|NSDraggingSource\|registerForDraggedTypes\|prepareForDragOperation\|draggingEntered" agentmux-cef/src/` returns **zero** matches. AgentMux has no native AppKit code at all — it relies entirely on whatever CEF's cef-rs wrapper provides. cef-rs 146.7.0's `cef::Window` doesn't expose a way to install a custom NSDraggingDestination, and CEF's internal NSWindow subclass apparently assumes the embedder will install one.
+
+### 4. The `floating_pane` module exists but only implements the Windows primitive
+
+`agentmux-cef/src/floating_pane.rs` is the host primitive for the floating-pane tear-off (separate from tab tear-off). It builds the floating window via Win32 APIs (`SetWindowLong`, `WM_NCHITTEST`, etc.). The `SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` spec explicitly lays out the macOS equivalent (`NSPanel` + `addChildWindow:ordered:` + child-window focus chain → see spec §3.2) and tracks it as **C1**, ~400 lines, "macOS-only; mirrors Windows Phase 1 structure". `floating_pane_macos.rs` (or `mod macos` inside the existing module) is unimplemented; the issue is referenced in the spec's open work list.
+
+---
+
+## Why this crash is not caused by the in-flight macOS PR work
+
+Quick reality check on the surrounding PR-in-flight work (`agenta/macos-cef-framework-bundling`, the branch this report sits on):
+
+| Change | Could it cause this crash? |
+|---|---|
+| `bundle:darwin` Framework copy + GL libs | No — affects startup library loading only |
+| `framework_dir_path` / `resources_dir_path` in CefSettings | No — affects pak/locale resolution at init, not drag |
+| `password-store=basic` + `use-mock-keychain` | No — OSCrypt subsystem only |
+| `patched-libcef` feature gate around `begin_window_drag` | No — that call site is `#[cfg(not(target_os = "windows"))]` AND requires a feature flag we don't enable |
+| `on_pre_key_event` signature per-platform split | No — keyboard handler only, never invoked from drag |
+| Traffic-light `WindowControlsLeft` + `--default-indent: 0px` then back to 10px | No — pure DOM/CSS; the receiver in the crash is a `NSWindow`, not any HTML element |
+| `-webkit-app-region: drag` on `.window-header` (today's drag-fix commit) | **Possibly**, see below. |
+
+The drag-fix CSS change (`window-header.darwin.scss` adding `-webkit-app-region: drag`) is the one place where my work intersects with macOS native drag. After that commit, Chromium's `on_draggable_regions_changed` callback fires (verified in `agentmux-host-v0.40.0.log.2026-05-29` at `16:35:26.379731Z`: "13 regions — \"1200x33@0,0 drag=true\"…"), and the Rust side calls `cef::Window::set_draggable_regions(regions)`. That call may, transitively, exercise the same AppKit code path that ends up looking for a drag-protocol selector on the AgentMux NSWindow.
+
+However:
+
+- The crash signature predates that commit. Yesterday's six crash reports from 2026-05-28 are pre-traffic-lights and pre-drag-CSS, and have the identical signature. So **the underlying NSException bug is not caused by my CSS**; it's structural.
+- My CSS may have *widened* the window of opportunity (now any title-bar drag attempts the system path, where previously only pane-header tear-off did). That's a tractable workaround: revert the drag CSS so the host doesn't tempt CEF into the broken path on every window-title-bar drag. Users would lose window drag again (which they didn't have anyway pre-commit), but pane drag would still crash on its own initiative.
+
+---
+
+## Reproduction
+
+100% reproducible on this branch with the v0.40.0 host:
+
+1. `rm -f ~/.agentmux/dev/<branch>/<hash>/cef-cache/{SingletonLock,SingletonCookie,SingletonSocket,ipc-port}` to clear singleton turds from prior crashes.
+2. `task dev` — wait for "✅ Main application loaded successfully".
+3. Click and drag any pane header more than a few pixels.
+4. Host exits in ≤200 ms. `agentmux-srv` survives, orphaned. The host log ends mid-event; a new `.ips` lands under `~/Library/Logs/DiagnosticReports/agentmux-cef-<timestamp>.ips`.
+
+Also reproducible by attempting tab tear-off (drag a tab out of the tab bar), and reproducible just-by-loading on the v0.40.0 build at `16:41:08Z` today — that one is a single-click somewhere followed by Chromium's own delayed drag setup, suggesting some autorelease-pool / runloop-source path also triggers the same selector miss.
+
+---
+
+## Side effects on `task dev` UX
+
+Each crash leaves a stale `SingletonLock` symlink in the CEF cache pointing at the dead PID. The *next* `task dev` invocation does a Chromium process_singleton handoff to that dead PID and exits with code 24 — making the app look like it "won't start". The fix is the manual `rm` above, but **the experience is awful**: a single accidental drag costs a full host restart cycle including a confusing "AgentMux failed to start" banner if the user clicks Reload.
+
+Recommendation: add a small launch-side guard that prunes the lock if the named PID is gone (`kill -0 <pid>`), so a stale singleton from a prior crash gets cleaned up by `task dev` itself. Five lines in `dev:serve`'s shell snippet.
+
+---
+
+## What's needed to fix this properly
+
+Two layers, in order:
+
+### Layer 1 — Stop the bleeding so dev is usable on macOS today
+
+**Option A: defensive `NSWindow` subclass / category.** Install an early `responds_to_selector:`-defaulting override on the AgentMux NSWindow so missing drag-protocol selectors return `nil` instead of throwing. At worst this makes drag a no-op instead of fatal. Probably 30–50 lines of `objc2` from Rust, gated `#[cfg(target_os = "macos")]`, hooked into `main.rs` right after CEF init.
+
+Tradeoff: this masks the real bug. We don't know which selector is missing; we'd hide the crash but tear-off and any future feature dependent on Cocoa drag delegate methods would still silently misbehave.
+
+**Option B: install an `NSExceptionHandler` early.** Trap the throw, log the selector name + class + stack, then either re-raise (preserving the crash for diagnostics) or swallow (making it a soft error). This is the **prerequisite** for any real fix because we currently don't know which selector AgentMux's NSWindow is missing.
+
+**Option C: revert `-webkit-app-region: drag` on macOS.** Returns drag to "not implemented" (as it was on `main` before this PR). User-visible loss: no window drag from the title bar. Pane/tab tear-off still crashes the same way it did before this PR, so this doesn't fix the original report — it just narrows the surface area to "deliberately initiated tear-off gestures crash" rather than "system-driven drag also triggers it on autorelease."
+
+Recommendation: **(B) first** — install the exception handler so we have data — then revisit whether (A) is a sufficient guard once we know the selector. (C) is independent and only relevant if (B) reveals that the autorelease/draggable-regions path is a *separate* selector miss from the tear-off path.
+
+### Layer 2 — Build real macOS tear-off (long-running)
+
+This is the **C1** work block from `SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md`:
+
+- Implement `agentmux-cef/src/floating_pane_macos.rs` (or `mod macos` inside the existing module) with `NSPanel` + `addChildWindow:ordered:`.
+- Wire `commands::drag::start_tear_off_tracking`'s `#[cfg(target_os = "macos")]` branch to call into the new module and drive `NSWindow.performWindowDragWithEvent:` instead of the no-op stub.
+- Implement an `NSDraggingDestination`-conforming view AgentMux owns, so the receiver of the drag-protocol selectors is *our* view, not whatever default object CEF leaves in place. This is also what prevents the unrecognized-selector throw.
+
+Per the spec, this is "~400 lines, Medium effort, mirrors Windows Phase 1 structure." Not in scope for the current PR.
+
+---
+
+## Action items
+
+1. **Install `NSExceptionHandler` in `agentmux-cef/src/main.rs`** (early, before `cef_initialize`). Log selector name + class + receiver address + stack to the tracing layer. Re-raise. — *Smallest amount of work; biggest diagnostic payoff.*
+2. **Update [#1138](https://github.com/agentmuxai/agentmux/issues/1138) with this report** and link to `SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` so the work block is connected to the user-visible crash.
+3. **Add `dev:serve` SingletonLock pruning** so a stale `.../SingletonLock -> hostname-<dead-pid>` symlink gets cleaned up automatically on the next launch. Five lines in `Taskfile.yml`. Massively improves the UX of recovering from any host crash on macOS.
+4. **(Optional)** Decide whether to revert the `.window-header` `-webkit-app-region: drag` on macOS until (1) gives us enough info to know if it's a different selector. The drag CSS shipped today restores title-bar window drag (the feature the user noticed was missing) but increases the surface area of CEF's drag code path; without (1) we can't tell if that surface area also triggers the same throw.
+
+---
+
+## Appendix: the six crash diagnostics on this machine
+
+```
+~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-29-094108.ips
+~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-28-120731.ips
+~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-28-111209.ips
+~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-28-110037.ips
+~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-28-...                 (and others)
+```
+
+All identical signatures. Today's (post-traffic-lights + drag CSS) is structurally identical to yesterday's (pre-traffic-lights + no drag CSS). That's the strongest evidence that the bug pre-exists the in-flight macOS PR work and is owned by the missing native tear-off implementation.

--- a/docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md
+++ b/docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md
@@ -1,0 +1,225 @@
+# macOS Tear-off Stability — implementation spec
+
+**Date:** 2026-05-29
+**Repo state:** `main` @ `53d781af` (v0.40.0)
+**Author:** AgentO-asaf
+**Status:** Spec ready to implement
+**Closes:** [#1138](https://github.com/agentmuxai/agentmux/issues/1138)
+**Source report:** [`docs/analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md`](../analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md)
+**Prior art:** [PR #403](https://github.com/agentmuxai/agentmux/pull/403) — `fix(macos): patch NSApplication for macOS 26 Tahoe drag crash` (open since 2026-04-15, mixed scope, can't merge as-is)
+**Related (not in scope):** [`SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md`](./SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md) §3.2 (C1 work block — real macOS tear-off implementation, deferred)
+
+---
+
+## Problem
+
+`agentmux-cef` crashes on macOS 26 Tahoe whenever a user initiates any drag gesture that exercises Cocoa's `NSDraggingSession` machinery — pane drag, tab tear-off, sometimes just window-titlebar drag. Six identical crash diagnostics on the dev machine in two days; 100% reproducible. The host process exits in <200 ms with `EXC_BREAKPOINT / SIGTRAP` after `objc_terminate()`. The Rust panic machinery never runs.
+
+Root cause (confirmed via PR #403's investigation): **CEF 146 still calls private `NSApplication` selectors that Apple removed in macOS 26.** `isHandlingSendEvent`, `isSendingEvent`, `setEffectiveAppearance:`, and similar are dispatched during `NSDraggingSession` setup. The receiver (`NSApplication`'s singleton) has no implementation, so the ObjC runtime walks `___forwarding___`, finds nothing, and `objc_exception_throw`s. The default AppKit `NSApplicationUncaughtExceptionHandler` catches it and calls `_objc_terminate()` — the host dies.
+
+Compounding UX issue: the dead host leaves a stale `~/.../cef-cache/SingletonLock` symlink pointing at the now-dead PID. The next `task dev` invocation reads that symlink, treats it as an "existing instance", hands off CLI args via process_singleton, and exits with code 24. The user sees "AgentMux failed to start" with no obvious recovery — they have to find and delete the lock file by hand.
+
+## TL;DR
+
+Two surgical fixes that together make macOS dev usable on Tahoe today, without doing the long-running C1 work:
+
+1. **Inject `+resolveInstanceMethod:` into `NSApplication`'s metaclass** at host startup, before `cef::initialize`. Unknown selectors get typed stubs (BOOL→NO for `isHandlingSendEvent` / `isSendingEvent`, void→() for everything else). The ObjC runtime never enters `___forwarding___`, the throw never happens, drag completes. macOS-only (`#[cfg(target_os = "macos")]`), ~100 lines of `unsafe extern "C"` FFI, ported verbatim from PR #403 with attribution.
+2. **Prune stale `SingletonLock` symlinks before launching the host** in `task dev:serve`. ~10 lines of bash that reads the lock target, splits off the PID, and `kill -0`s it; if dead, `rm` the lock + cookie + socket + ipc-port files. Five-second fix to a one-week-long developer paper cut.
+
+Neither implements real macOS tear-off (that's still C1). They make the existing no-op tear-off path *not crash* and recover gracefully when it does.
+
+---
+
+## Why this works
+
+### The metaclass-method injection
+
+CEF on macOS 26 calls APIs that Apple removed. The standard Cocoa response is `NSInvalidArgumentException — unrecognized selector sent to instance 0x118001a3f00`. Three places to intervene:
+
+1. **Override the `NSApplicationUncaughtExceptionHandler`.** Caught after the throw, no useful recovery — the exception is already in flight, autorelease pool is partial, drag session state is undefined. Best for *logging*, not for *preventing*.
+2. **Swizzle `-[NSObject doesNotRecognizeSelector:]`.** Called from inside `___forwarding___`. Returning normally without throwing corrupts forwarding state — secondary crash inside `___forwarding___` itself. **Don't do this.** (PR #403's commit history shows they tried; this exact failure mode is documented in its doc-comment.)
+3. **Inject `+[NSApplication resolveInstanceMethod:]`.** Called *before* `___forwarding___`. Add a typed stub method to the class on the fly, return `YES`, runtime retries the original message send against the freshly-added method, message lands. This is the documented Apple-blessed path for dynamic message resolution. ← **what we do.**
+
+### Why return-type matters for the stub
+
+`isHandlingSendEvent` returns `BOOL`. On ARM64 the return value lives in `x0`. If we install a `void` stub for it, `x0` carries the leftover value (typically `self`, which is non-nil → truthy). CEF reads that and concludes "the app is already inside a `sendEvent:` call, skip routing" — breaking window drag silently *even after we stop the crash*. PR #403's `bool_no_stub` returns `0` in `x0`; this is the right ABI for `BOOL` selectors.
+
+So the stub-injection function maintains a small allowlist of selectors that must return `BOOL` (currently `isHandlingSendEvent`, `isSendingEvent`). Everything else gets the void stub.
+
+### Why the metaclass, not the class
+
+`+resolveInstanceMethod:` is a *class method*. Class methods live in the metaclass. `object_getClass(NSApplication)` returns the metaclass; that's where `class_addMethod` has to install the resolver. PR #403 has the dance right.
+
+### Why this is forward-compatible
+
+Apple may un-deprecate these selectors, restore them, or change CEF's dispatch path. Our resolver only kicks in for *unknown* selectors — selectors `NSApplication` does implement go through the normal fast path and never reach `+resolveInstanceMethod:`. When the underlying CEF bug is fixed upstream (and we bump to a CEF version that no longer calls the removed selectors), this code is dead but harmless and can be deleted in a one-line follow-up.
+
+### Why we don't need an `NSExceptionHandler` first
+
+The original plan (per the analysis report §7) was to install `NSExceptionHandler` to discover the missing selector. PR #403 already did that discovery — the selectors are known (`isHandlingSendEvent`, `isSendingEvent`, plus an unbounded set of other void-returning selectors caught by the generic stub). We can skip the diagnostic step and go straight to the fix, copying PR #403's code with attribution.
+
+If a *new* missing selector shows up later (different macOS minor release, different CEF version), the `resolve_instance_method_impl` already logs every selector it stubs (`tracing::warn!(selector = %name, "...")`), so the catchall stays observable.
+
+### SingletonLock pruning rationale
+
+Chromium's process_singleton on POSIX is documented to use a `SingletonLock` symlink whose target is `<hostname>-<pid>`. A live instance owns it; on clean exit, it's deleted. On crash, it's stranded. New launches read the target, `kill(pid, 0)`-check whether the PID is alive; if alive, hand off and exit; if **dead**, prune and proceed.
+
+Chromium itself does the live/dead check — but only after it's bound to the lock path; CEF's `process_singleton` *does* do this. Empirically, on macOS the current code path exits with code 24 (CEF_RESULT_CODE_NORMAL_EXIT_PROCESS_NOTIFIED) *without* pruning, so something between Chromium's behavior and CEF 146's macOS-specific build is short-circuiting it. The cheapest workaround is to do the check *outside* the host in shell — `task dev:serve` already has a multi-line bash block that auto-selects a Vite port; adding the SingletonLock check is the same shape.
+
+---
+
+## Detailed design
+
+### Item 1 — `agentmux-cef/src/main.rs`: `patch_nsapp_unrecognized_selector()`
+
+Port verbatim from PR #403 with attribution comment. Structure:
+
+```rust
+/// macOS 26 Tahoe compat — see SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md and PR #403.
+#[cfg(target_os = "macos")]
+unsafe fn patch_nsapp_unrecognized_selector() {
+    use std::ffi::{c_char, c_void};
+
+    type Id    = *mut c_void;
+    type Sel   = *const c_void;
+    type Class = *mut c_void;
+
+    extern "C" {
+        fn objc_getClass(name: *const c_char) -> Class;
+        fn object_getClass(obj: Id) -> Class;
+        fn sel_registerName(name: *const c_char) -> Sel;
+        fn sel_getName(sel: Sel) -> *const c_char;
+        fn class_addMethod(cls: Class, sel: Sel, imp: usize, types: *const c_char) -> u8;
+    }
+
+    unsafe extern "C" fn void_stub(_self: Id, _cmd: Sel) {}
+    unsafe extern "C" fn bool_no_stub(_self: Id, _cmd: Sel) -> u8 { 0 }
+
+    unsafe extern "C" fn resolve_instance_method_impl(cls: Class, _cmd: Sel, sel: Sel) -> u8 {
+        let name = std::ffi::CStr::from_ptr(sel_getName(sel)).to_string_lossy().into_owned();
+        const BOOL_NO_SELECTORS: &[&str] = &["isHandlingSendEvent", "isSendingEvent"];
+        if BOOL_NO_SELECTORS.contains(&name.as_str()) {
+            tracing::warn!(selector = %name, "macOS 26 compat: adding BOOL(NO) stub");
+            class_addMethod(cls, sel, bool_no_stub as usize, b"c@:\0".as_ptr() as _);
+        } else {
+            tracing::warn!(selector = %name, "macOS 26 compat: adding void stub");
+            class_addMethod(cls, sel, void_stub as usize, b"v@:\0".as_ptr() as _);
+        }
+        1 // YES
+    }
+
+    let cls = objc_getClass(b"NSApplication\0".as_ptr() as _);
+    if cls.is_null() { tracing::warn!("macOS 26 compat: NSApplication class not found"); return; }
+    let metacls = object_getClass(cls as Id);
+    if metacls.is_null() { tracing::warn!("macOS 26 compat: NSApplication metaclass not found"); return; }
+    let sel = sel_registerName(b"resolveInstanceMethod:\0".as_ptr() as _);
+    let added = class_addMethod(metacls, sel, resolve_instance_method_impl as usize,
+        b"c@::\0".as_ptr() as _);
+    if added != 0 {
+        tracing::info!("macOS 26 compat: injected resolveInstanceMethod: into NSApplication metaclass");
+    } else {
+        tracing::warn!("macOS 26 compat: class_addMethod failed (already exists?)");
+    }
+}
+```
+
+Call site (early in `main()`, *before* `cef::initialize`):
+
+```rust
+#[cfg(target_os = "macos")]
+unsafe { patch_nsapp_unrecognized_selector() };
+```
+
+The right insertion point on current `main` (post-refactor) is after logging setup and before the `cef_app::AgentMuxApp::new` construction — the function only depends on the ObjC runtime, so it's safe at any point before CEF init.
+
+No new crate dependencies. Pure `extern "C"` against `libobjc` (loaded automatically on macOS). PR #403 used this approach to avoid pulling in `objc2` or `cocoa` crates for ~50 lines of FFI; we follow suit.
+
+### Item 2 — `Taskfile.yml::dev:serve`: SingletonLock auto-prune
+
+In `dev:serve`, immediately before the host launch block (after Vite is up, before `./agentmux-cef --url=...`), add a small bash check:
+
+```bash
+# Auto-prune stale Chromium SingletonLock if its target PID is dead.
+# Without this, a crashed host leaves a symlink pointing at a non-existent
+# PID, and the next `task dev` hands off via process_singleton and exits
+# with code 24 — looking like "AgentMux failed to start" to the user.
+# See SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md §2.
+if [ "{{OS}}" != "windows" ]; then
+  # Resolve the CEF cache dir — same derivation rule as the host
+  # (instance_data_dir / cef-cache).  Locate it via the current
+  # agentmux-cef config's instance hash; fall back to a glob.
+  for lock in "$HOME/.agentmux/dev/"*/*/cef-cache/SingletonLock; do
+    [ -L "$lock" ] || continue
+    target=$(readlink "$lock") || continue
+    # target is "<hostname>-<pid>"; split.
+    pid="${target##*-}"
+    [ -n "$pid" ] || continue
+    if ! kill -0 "$pid" 2>/dev/null; then
+      cache_dir=$(dirname "$lock")
+      echo "[singleton] Pruning stale lock $lock (pid $pid is gone)"
+      rm -f "$cache_dir/SingletonLock" "$cache_dir/SingletonCookie" \
+            "$cache_dir/SingletonSocket" "$cache_dir/ipc-port"
+    fi
+  done
+fi
+```
+
+Risk: in the (very narrow) window where a parallel `task dev` from a *different* AgentMux dev clone owns the lock for a different branch, our prune touches it. Mitigation: the glob is scoped to `$HOME/.agentmux/dev/`, the lock check is `-L` (only symlinks, not regular files), the `kill -0` only flags actually-dead PIDs, and the rm only fires when dead. A live, healthy second instance is safe.
+
+### Out of scope
+
+- **Real macOS tear-off (C1 work block).** `agentmux-cef/src/floating_pane_macos.rs` with `NSPanel` + `addChildWindow:ordered:` + native `NSDraggingDestination` view. Estimated ~400 lines per the cross-platform tearoff spec §3.2. Tracked there; not duplicated here.
+- **`NSExceptionHandler` install.** Not needed once we have item 1; the BOOL/void allowlist captures the known crashing selectors and the resolver logs new ones if Apple removes more in future macOS releases.
+- **CEF upgrade past the Apple-private-selector breakage.** When CEF maintainers fix this upstream and we bump, this code becomes dead — delete it. Until then, this is a load-bearing macOS-only `unsafe` block.
+- **Reverting `-webkit-app-region: drag` on macOS.** With item 1 in place, the drag path that the CSS opens up should no longer crash. The CSS stays.
+
+---
+
+## Acceptance criteria
+
+A fresh clone on macOS 26 Tahoe:
+
+```bash
+git clone git@github.com:agentmuxai/agentmux.git
+cd agentmux
+task dev
+```
+
+1. Host starts; `muxlog host '"macOS 26 compat: injected resolveInstanceMethod:"'` shows the resolver was installed.
+2. Drag a pane header → pane moves, no crash. `muxlog host '"macOS 26 compat: adding"'` shows each missing selector being stubbed once.
+3. Drag the window by its title bar → window moves, no crash. `isHandlingSendEvent` and `isSendingEvent` get `BOOL(NO)` stubs (visible in muxlog).
+4. Kill the host externally (`kill -9 <pid>`); rerun `task dev`. The launch surfaces `[singleton] Pruning stale lock …` and proceeds normally to a fresh window instead of exiting with code 24.
+5. Windows + Linux: zero behavioral change (item 1 is `#[cfg(target_os = "macos")]`; item 2 is `if [ "{{OS}}" != "windows" ]`, and Linux has the same singleton mechanic on POSIX).
+
+---
+
+## PR rollout
+
+Three independent PRs, in dependency order. The first two are already in flight or queued; this spec adds the next two.
+
+| PR | Branch | Base | Contents | Status |
+|---|---|---|---|---|
+| **PR #1131** | `agenta/macos-host-compile-fix-cef146` | `main` | Compile fix — per-platform `on_pre_key_event` + `patched-libcef` feature gate around `begin_window_drag` | Open |
+| **PR (new)** | `agenta/macos-cef-framework-bundling` | `main` | Runtime fix — `bundle:darwin` framework + GL libs, `framework_dir_path`/`resources_dir_path`, keychain switches, traffic-light port, `-webkit-app-region: drag` | Branch pushed, no PR yet — opening as part of this rollout |
+| **PR (new)** | `agenta/macos-nsapp-tahoe-compat` | `main` | This spec, item 1 — `patch_nsapp_unrecognized_selector()` | New |
+| **PR (new)** | `agenta/macos-singleton-lock-guard` | `main` | This spec, item 2 — SingletonLock auto-prune in `dev:serve` | New |
+
+Independent so each can be reviewed, approved, and merged separately. None of them require the others to land first — the compile fix is necessary for any macOS build to exist, but the NSApp patch is a `#[cfg(target_os = "macos")]` Rust addition that compiles regardless and goes through `cargo check` for all platforms via the existing CI machinery.
+
+Closes [#1138](https://github.com/agentmuxai/agentmux/issues/1138) when item 1 lands. Closes the SingletonLock UX issue (no separate filing yet) when item 2 lands.
+
+---
+
+## Action items
+
+- [x] Author this spec.
+- [ ] Open PR for `agenta/macos-cef-framework-bundling` (currently has commits, no PR yet) — runtime fix + traffic lights + drag CSS.
+- [ ] Branch + open PR for `agenta/macos-nsapp-tahoe-compat` — port `patch_nsapp_unrecognized_selector` from PR #403 with attribution.
+- [ ] Branch + open PR for `agenta/macos-singleton-lock-guard` — auto-prune snippet in `dev:serve`.
+- [ ] On approval, merge each.
+
+---
+
+## Acknowledgements
+
+The metaclass-injection approach, the BOOL-vs-void return-type allowlist, the rationale comments, and the diagnosis that this is a macOS 26 Tahoe regression in CEF 146's call to private `NSApplication` selectors — all from **PR #403** (a5af, 2026-04-15). This spec ports the load-bearing piece into a current-main-compatible branch and pairs it with the SingletonLock UX fix.


### PR DESCRIPTION
## Summary

Closes [#1138](https://github.com/agentmuxai/agentmux/issues/1138).

Inject `+[NSApplication resolveInstanceMethod:]` at host startup, before `cef::initialize`, so that the private NSApplication selectors CEF 146 calls during NSDraggingSession setup (which Apple removed in macOS 26 Tahoe) get typed stubs *before* the ObjC `___forwarding___` machinery runs. The stubs prevent `objc_exception_throw` and the subsequent `_objc_terminate()` that kills the host with `EXC_BREAKPOINT` before Rust panic machinery sees anything.

**Depends on:** [#1131](https://github.com/agentmuxai/agentmux/pull/1131) (the macOS compile fix). Without #1131, `agentmux-cef` doesn't build on macOS so this PR can't run.

**Ported from:** [PR #403](https://github.com/agentmuxai/agentmux/pull/403) (a5af, 2026-04-15) which mixed this patch with other macOS bring-up work that has since been done differently in #1131 and #1169. This PR ports just the load-bearing patch with attribution.

## What's in the PR

1. `agentmux-cef/src/main.rs` — adds `patch_nsapp_unrecognized_selector()` and calls it once, after logging init, before `cef::initialize`. `#[cfg(target_os = "macos")]`, ~100 lines of `unsafe extern \"C\"` against libobjc, no new crate dependencies.
2. `docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md` — implementation spec covering this PR + the follow-up SingletonLock UX fix.
3. `docs/analysis/REPORT_MACOS_TEAROFF_DRAG_CRASH_2026_05_29.md` — code-walk report tying the crash signature in 6 user-machine diagnostic reports to the macOS Phase 7 / C1 work gap.

## Why this approach

`+resolveInstanceMethod:` is the **earliest** point in the ObjC dispatch chain — called before `___forwarding___`. We add a typed stub on the metaclass and return `YES`; the runtime retries the original message send against the real method, message lands, no exception.

The alternative — swizzling `-[NSObject doesNotRecognizeSelector:]` — does **not** work: that method is called *from inside* `___forwarding___`, and returning normally without throwing corrupts forwarding state, causing a secondary crash in `___forwarding___` itself.

Return type matters: `isHandlingSendEvent` and `isSendingEvent` return `BOOL`. A `void` stub leaves `x0 = self` (truthy) on ARM64, and CEF reads that as "the app is already inside a `sendEvent:` call, skip event routing" — breaking window drag silently *even after the crash stops*. So we maintain a small allowlist of BOOL-returning selectors that get a `bool_no_stub` returning 0; everything else gets the void stub (safe for the unbounded set of removed Apple-private APIs).

## What this does NOT do

- **Real macOS tear-off.** That's the C1 work block in `SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` §3.2 — `NSPanel` + `addChildWindow:ordered:` + native `NSDraggingDestination` view. ~400 lines, separate effort. With this PR's patch in place, the existing no-op tear-off Rust stub still doesn't actually tear off — it just no longer **crashes** when CEF's macOS code tries to drive the drag session through Apple-private APIs.
- **Auto-prune stale `SingletonLock`.** Crashes leave a stale lock pointing at a dead PID; next `task dev` hands off via process_singleton and exits code 24. Fix in a follow-up PR per the spec §item 2.

## Test plan

After this lands on top of #1131:

- [ ] `task dev` launches on macOS 26 Tahoe; no Keychain prompt
- [ ] Drag a pane header → no `EXC_BREAKPOINT`; `muxlog host '\"macOS 26 compat: adding\"'` shows each stubbed selector once
- [ ] Drag the window title bar → no crash; `isHandlingSendEvent` + `isSendingEvent` get BOOL(NO) stubs
- [x] Builds on macOS (verified locally, \`cargo check -p agentmux-cef --release\` finishes 3.24s after rebase on #1131)
- [ ] Windows: zero behavioral change (patch is `#[cfg(target_os = \"macos\")]`)
- [ ] Linux: zero behavioral change (same `cfg` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)