### PR TITLE
fix(macos,linux): auto-prune stale Chromium SingletonLock in dev:serve

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -650,6 +650,32 @@ tasks:
                   exit 1
                 fi
                 echo "Vite ready at $VITE_URL."
+                # macOS/Linux: auto-prune any stale Chromium SingletonLock
+                # whose target PID is dead. Without this, a crashed host
+                # leaves a `<cache>/SingletonLock` symlink pointing at a
+                # non-existent PID; the next `task dev` reads it, hands off
+                # via process_singleton, and exits with code 24 — the user
+                # sees "AgentMux failed to start" with no obvious recovery.
+                # On macOS 26 Tahoe this used to happen after every drag-
+                # induced crash (see #1138 / SPEC_MACOS_TEAROFF_STABILITY).
+                # Scoped to ~/.agentmux/dev/* so portable/installed locks
+                # are never touched; only flags actually-dead PIDs.
+                if [ "{{OS}}" != "windows" ]; then
+                  for lock in "$HOME/.agentmux/dev/"*/*/cef-cache/SingletonLock; do
+                    [ -L "$lock" ] || continue
+                    target=$(readlink "$lock") || continue
+                    pid="${target##*-}"
+                    [ -n "$pid" ] || continue
+                    if ! kill -0 "$pid" 2>/dev/null; then
+                      cache_dir=$(dirname "$lock")
+                      echo "[singleton] Pruning stale lock at $cache_dir (pid $pid is gone)"
+                      rm -f "$cache_dir/SingletonLock" \
+                            "$cache_dir/SingletonCookie" \
+                            "$cache_dir/SingletonSocket" \
+                            "$cache_dir/ipc-port"
+                    fi
+                  done
+                fi
                 # Inline AGENTMUX_DEV=1 on the launch: go-task's top-level
                 # env: block (on the `dev` task) doesn't propagate into
                 # cmd: shell subprocesses invoked via `task:` on Windows,


### PR DESCRIPTION
## Summary

When the host crashes (on macOS 26 Tahoe today, via the `NSDraggingSession` selector bug — see #1138 / #1170), it leaves a `~/.agentmux/dev/<branch>/<hash>/cef-cache/SingletonLock` symlink pointing at the now-dead PID. The next `task dev` reads it, hands off CLI args via Chromium's process_singleton mechanism, exits with code 24, and the user sees "AgentMux failed to start" with no obvious recovery path beyond hunting down and deleting the lock file by hand.

Adds a 10-line pre-launch sweep in `dev:serve` that walks `~/.agentmux/dev/*/*/cef-cache/SingletonLock`, reads each `<hostname>-<pid>` target, splits off the PID, and `kill -0`-checks it. **Dead → prune (`SingletonLock`, `SingletonCookie`, `SingletonSocket`, `ipc-port`).** Live → leave alone.

## Why this is safe

- Scoped to `~/.agentmux/dev/*` — portable + installed locks are never touched.
- Only fires for `-L` symlinks, not regular files.
- Only deletes when `kill -0 <pid>` reports the PID is verifiably gone (`!= 0`).
- Gated to `{{OS}} != windows` — Windows uses a named-pipe single-instance via the launcher, not a SingletonLock file.
- A healthy parallel `task dev` from a different branch keeps its own lock under a different `<branch-slug>` directory; this prune never reaches it.

## Independent

No dependencies. Can land before or after [#1170](https://github.com/agentmuxai/agentmux/pull/1170). With #1170, this is mostly preventive — crashes should stop. Without #1170, this turns a soft-bricked dev environment into a one-line recovery.

## Test plan

- [ ] On a fresh macOS dev environment, `task dev` launches normally
- [ ] Kill the host externally (`kill -9 <pid>`), rerun `task dev`: `[singleton] Pruning stale lock at <path> (pid <X> is gone)` lands in the task output, host starts a fresh window
- [ ] Two parallel `task dev` runs from different branches → no cross-prune (each branch's lock is under its own `~/.agentmux/dev/<branch-slug>/`)
- [ ] Windows: zero behavioral change (entire block is `if [ \"{{OS}}\" != \"windows\" ]`)

Spec: [`docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md`](https://github.com/agentmuxai/agentmux/blob/agenta/macos-nsapp-tahoe-compat/docs/specs/SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md) §item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)