### PR TITLE
fix(macos): traffic-light scss stylelint + stale docstring follow-up (#1169 post-merge cleanup)

### DIFF
--- a/.changesets/1780077925-fix-macos-traffic-light-scss-stylelint-comment-stale-docstri-rcve.md
+++ b/.changesets/1780077925-fix-macos-traffic-light-scss-stylelint-comment-stale-docstri-rcve.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): traffic-light scss stylelint comment + stale docstring on win32 move

--- a/frontend/app/window/window-controls.darwin.scss
+++ b/frontend/app/window/window-controls.darwin.scss
@@ -7,6 +7,13 @@
 // Glyphs are hidden at rest and fade in when the mouse enters the group,
 // matching the standard macOS Sequoia / Sonoma behaviour.
 
+/* stylelint-disable color-no-hex --
+   The macOS traffic-light colours (#FF5F57 / #FFBD2E / #28CA41) are OS
+   brand values that must match Apple's HIG exactly. They are not
+   theme-relative and don't map to any semantic token. Sibling
+   window-controls.win32.scss scopes the same exception for the
+   Windows close-button red. */
+
 .traffic-lights {
     display: flex;
     flex-direction: row;

--- a/frontend/app/window/window-controls.darwin.tsx
+++ b/frontend/app/window/window-controls.darwin.tsx
@@ -9,9 +9,10 @@
  * WindowControlsRight — null on macOS (no right-side caption buttons needed).
  *
  * Ported from PR #444 (a5af/feat/macos-traffic-light-controls-v2). The Win11
- * caption-button code on the right side stays inline in `system-status.tsx`
- * on Windows/Linux; only the left-side traffic lights are added here because
- * macOS has no right-side caption buttons.
+ * caption-button code on the right side lives in `window-controls.win32.tsx`
+ * (re-exported by `window-controls.linux.tsx` so Linux gets the same buttons);
+ * only the left-side traffic lights are added here because macOS has no
+ * right-side caption buttons.
  */
 
 import { getApi } from "@/store/global";


### PR DESCRIPTION
## Summary

Reagent (Claude Opus 4.8) [post-merge re-review on #1169](https://github.com/agentmuxai/agentmux/pull/1169#pullrequestreview-) caught two legitimate P2 findings after the merge. Both are real and fixed here:

1. **scss stylelint** — \`window-controls.darwin.scss:53\` introduced three OS-brand traffic-light hex values (\`#FF5F57\` / \`#FFBD2E\` / \`#28CA41\`) without a \`stylelint-disable color-no-hex\` comment scope. The sibling \`window-controls.win32.scss\` correctly scopes the same exception for the Windows close-button red. Without the disable, \`npm run lint:scss\` (globs \`frontend/**/*.scss\`) emits three new \`color-no-hex\` violations on every CI run.

2. **Stale docstring** — \`window-controls.darwin.tsx:12\` claimed the Win11 caption buttons "stay inline in \`system-status.tsx\` on Windows/Linux" — but #1169 moved them out to \`window-controls.win32.tsx\` (re-exported by \`window-controls.linux.tsx\`). Updated the reference so future readers find the actual file.

Tiny PR. Zero behavioral change.

## Test plan

- [x] \`npm run lint:scss\` no longer emits the three \`color-no-hex\` violations on \`window-controls.darwin.scss\`
- [x] Docstring now correctly points at \`window-controls.win32.tsx\` for the Win11 button code
- [ ] No behavioral / visual change on macOS / Windows / Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)