### PR TITLE
chore(perf): input-handler sync-IPC CI guardrail (input-first I2, Phase 0.2)

### DIFF
--- a/.changesets/1780080501-chore-perf-add-input-handler-sync-ipc-ci-guardrail-input-fir-ikfk.md
+++ b/.changesets/1780080501-chore-perf-add-input-handler-sync-ipc-ci-guardrail-input-fir-ikfk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(perf): add input-handler sync-IPC CI guardrail (input-first I2, #1161)

--- a/.github/workflows/input-handler-sync-ipc.yml
+++ b/.github/workflows/input-handler-sync-ipc.yml
@@ -1,0 +1,40 @@
+name: Input-handler sync-IPC guardrail
+
+# Enforces input-first invariant I2 (follow-up to discussion #1161, built on
+# SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md):
+#   "No synchronous IPC on any input path, ever."
+#
+# A keystroke handler may DISPATCH host work (fire-and-forget invokeCommand)
+# but must never BLOCK on it before paint. See
+# docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md for the audit baseline.
+#
+# Path-filtered — only runs when an in-scope file is modified.
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/app/store/keymodel.ts'
+      - 'frontend/app/view/term/termViewModel.ts'
+      - 'frontend/app/view/launcher/launcher.tsx'
+      - 'frontend/app/view/agent/components/AgentFooter.tsx'
+      - 'tools/lint/check-input-handler-sync-ipc.sh'
+      - '.github/workflows/input-handler-sync-ipc.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/app/store/keymodel.ts'
+      - 'frontend/app/view/term/termViewModel.ts'
+      - 'frontend/app/view/launcher/launcher.tsx'
+      - 'frontend/app/view/agent/components/AgentFooter.tsx'
+      - 'tools/lint/check-input-handler-sync-ipc.sh'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run check
+        run: bash tools/lint/check-input-handler-sync-ipc.sh

--- a/docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md
+++ b/docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md
@@ -1,0 +1,60 @@
+# ANALYSIS — Keydown-path synchronous-IPC audit
+
+**Date:** 2026-05-29
+**Author:** AgentX
+**Scope:** Phase 0.2 of the input-first execution plan (follow-up to [discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161)), enforcing invariant **I2 — "No synchronous IPC on any input path, ever."**
+**Builds on:** `docs/specs/SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md`
+
+---
+
+## Why this audit
+
+The input-first review identified the renderer↔host IPC layer as the highest-severity, hardest-to-see typing-latency threat: a synchronous renderer→host round-trip reachable from a `keydown` handler adds latency with **no JS-layer workaround**. Unlike the layout-read regression (already CI-guarded), there was no guard ensuring the keystroke path never blocks on IPC. This audit establishes the baseline and ships a guard to keep it.
+
+## What "synchronous IPC on the input path" means here
+
+The host IPC transport is **async by construction** — `invokeCommand()` (`frontend/app/platform/ipc.ts:30`) issues `fetch("http://127.0.0.1:${port}/ipc", …)` and returns a Promise. So a keystroke handler that *dispatches* a command fire-and-forget is **compliant** with I2 — it returns immediately and the result settles later. The violations are the **blocking** shapes:
+
+1. `await invokeCommand(...)` / `await fetch(...)` inside an input handler — stalls the handler on a round-trip before paint.
+2. An `async` `keyDownHandler` (returns a Promise) — the central dispatch in `store/keymodel.ts` treats the return as a synchronous boolean; making it async breaks that contract and invites awaited IPC.
+3. Synchronous XHR (`XMLHttpRequest` + `.open(…, false)`) — always blocking; unacceptable on any path.
+
+## How the input path actually dispatches
+
+Central dispatch is `appHandleKeyDown()` (`frontend/app/store/keymodel.ts:369`, entry via `:433`):
+
+```
+keydown → appHandleKeyDown(waveEvent): boolean
+  ├─ active chord? → chord handler (sync, returns boolean)
+  ├─ global keymap handler (sync, returns boolean — may fire-and-forget invokeCommand)
+  └─ focused block's viewModel.keyDownHandler(waveEvent): boolean  (keymodel.ts:412-413)
+```
+
+Every handler returns a **synchronous boolean** (consumed or not). Block-level handlers: `termViewModel.ts:390`, `launcher.tsx:63` — both synchronous.
+
+## Findings — baseline is CLEAN
+
+| Check | Result |
+|---|---|
+| `await invokeCommand` / `await fetch` inside input-dispatch files | **None** |
+| `async keyDownHandler` / `keyDownHandler(): Promise` | **None** — all return synchronous `boolean` |
+| Synchronous XHR (`open(…, false)`) anywhere in `frontend/app` | **None** |
+| Fire-and-forget `invokeCommand` from keymap handlers | Present and **compliant** (dispatch, not await) |
+
+The keystroke path does not block on IPC today. This is the property to preserve.
+
+## Guard shipped
+
+- **`tools/lint/check-input-handler-sync-ipc.sh`** — grep+awk scan (mirrors `check-input-handler-layout-reads.sh`). Flags awaited-IPC and async key handlers within the input-dispatch scope (`keymodel.ts`, `termViewModel.ts`, `launcher.tsx`, `AgentFooter.tsx`) plus a repo-wide synchronous-XHR ban. Comment lines skipped; escape hatch `// perf:allow-input-ipc — <why>`.
+- **`.github/workflows/input-handler-sync-ipc.yml`** — path-filtered PR + main check.
+
+Verified locally: passes clean on current `main`; exits non-zero on an injected `await invokeCommand` in scope; escape-hatch and comment-skip honored.
+
+## Cross-platform note
+
+This audit is **platform-independent** — it concerns JS on the renderer thread, identical across Windows/macOS/Linux. (The separate Win32 `SetWindowRgn` airspace path — `agentmux-cef/src/browser_panes.rs` — is already off the keydown path and is handled by Phase 0.3's stateless region cache; macOS NSView embedding is officially unsupported by CEF per `creation_views.rs:9`, so native-pane region work is per-platform and out of scope here.)
+
+## Next (per execution plan)
+
+- Phase 0.1 — statistically-real bench harness (pinned low-end Windows + macOS runner; delta-vs-baseline; reporting-mode first).
+- Phase 0.3 — browser-pane keydown handler (verify it's a real gap first), region skip-if-unchanged + HWND cache, `block.scss` blur audit.

--- a/tools/lint/check-input-handler-sync-ipc.sh
+++ b/tools/lint/check-input-handler-sync-ipc.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Synchronous-IPC guardrail for input-handler hot paths.
+#
+# Enforces invariant I2 from the input-first execution plan (follow-up to
+# discussion #1161, built on SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md):
+#   "No synchronous IPC on any input path, ever."
+#
+# A keystroke handler may *dispatch* host work (fire-and-forget
+# `invokeCommand(...)` / `getApi()....()` — async, returns immediately) but
+# must never *block* on it before the frame paints. The two blocking shapes:
+#
+#   1. `await invokeCommand(...)` / `await fetch(...)` inside an input handler
+#      — stalls the handler on a renderer->host round-trip.
+#   2. An `async` keyDownHandler (returns a Promise) — the dispatch layer in
+#      store/keymodel.ts treats the return as a synchronous boolean; making it
+#      async both breaks that contract and invites awaited IPC.
+#   3. Synchronous XHR (`new XMLHttpRequest()` ... `.open(..., false)`) — always
+#      blocking; never acceptable on any path, banned repo-wide here.
+#
+# Audit baseline (2026-05-29): the input path is CLEAN — keyDownHandlers are
+# synchronous boolean-returning functions, fire-and-forget invokeCommand is
+# compliant, no synchronous XHR. This guard locks that in.
+# See docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md.
+#
+# Scope (the input-dispatch surface):
+#   - frontend/app/store/keymodel.ts                       — central appHandleKeyDown dispatch
+#   - frontend/app/view/term/termViewModel.ts              — terminal keyDownHandler
+#   - frontend/app/view/launcher/launcher.tsx              — launcher keyDownHandler
+#   - frontend/app/view/agent/components/AgentFooter.tsx   — agent composer
+# Plus a repo-wide ban on synchronous XHR.
+#
+# Escape hatch: any line containing `perf:allow-input-ipc` is skipped, with a
+# justification on the same line, e.g.:
+#   await invokeCommand("x"); // perf:allow-input-ipc — not on a keystroke path
+#
+# Exit codes: 0 clean · 1 violations · 2 usage/script error
+#
+# v1: grep + awk text scan, file-level scope. Coarse but fast (<1s). Escalate
+# to an AST-aware ESLint rule if false-positive volume warrants.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Input-dispatch files in scope for the awaited-IPC / async-handler checks.
+SCOPE=(
+  frontend/app/store/keymodel.ts
+  frontend/app/view/term/termViewModel.ts
+  frontend/app/view/launcher/launcher.tsx
+  frontend/app/view/agent/components/AgentFooter.tsx
+)
+
+EXISTING_SCOPE=()
+for f in "${SCOPE[@]}"; do
+  [[ -f "$f" ]] && EXISTING_SCOPE+=("$f")
+done
+
+if [[ ${#EXISTING_SCOPE[@]} -eq 0 ]]; then
+  echo "check-input-handler-sync-ipc: no files in scope (paths moved?)" >&2
+  exit 2
+fi
+
+# Awaited IPC: `await invokeCommand(` / `await fetch(`
+AWAIT_IPC='\bawait[[:space:]]+(invokeCommand|fetch)[[:space:]]*\('
+# Async key handler: `async keyDownHandler` or `keyDownHandler(...): Promise`
+ASYNC_HANDLER='(async[[:space:]]+keyDownHandler|keyDownHandler[^=]*:[[:space:]]*Promise)'
+SCOPED_BANNED="($AWAIT_IPC|$ASYNC_HANDLER)"
+
+# Synchronous XHR — repo-wide (frontend).
+SYNC_XHR='\.open\([^)]*,[[:space:]]*false[[:space:]]*[,)]'
+
+# awk filter: drop comment lines and escape-hatched lines.
+filter_awk='
+{
+  file = $1; line = $2
+  content = ""
+  for (i = 3; i <= NF; i++) content = content (i == 3 ? "" : ":") $i
+  if (content ~ /perf:allow-input-ipc/) next
+  stripped = content
+  sub(/^[ \t]+/, "", stripped)
+  if (stripped ~ /^\/\//) next
+  if (stripped ~ /^\*/)   next
+  if (stripped ~ /^\/\*/) next
+  print file ":" line ":" content
+}'
+
+scoped_hits=$(grep -nHE "$SCOPED_BANNED" "${EXISTING_SCOPE[@]}" 2>/dev/null | awk -F: "$filter_awk" || true)
+xhr_hits=$(grep -rnHE "$SYNC_XHR" frontend/app --include='*.ts' --include='*.tsx' 2>/dev/null | awk -F: "$filter_awk" || true)
+
+violations=""
+[[ -n "$scoped_hits" ]] && violations+="$scoped_hits"$'\n'
+[[ -n "$xhr_hits" ]] && violations+="$xhr_hits"$'\n'
+violations="$(printf '%s' "$violations" | sed '/^$/d')"
+
+if [[ -z "$violations" ]]; then
+  echo "✓ check-input-handler-sync-ipc: clean (${#EXISTING_SCOPE[@]} dispatch files + repo-wide sync-XHR scan)"
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+✗ check-input-handler-sync-ipc: synchronous-IPC violations on the input path.
+
+Invariant I2 (input-first execution plan): "No synchronous IPC on any input path, ever."
+A keystroke handler may DISPATCH host work, but must never BLOCK on it before paint.
+
+Violations:
+EOF
+echo "$violations" >&2
+cat >&2 <<'EOF'
+
+Fixes:
+  - Replace `await invokeCommand(...)` with fire-and-forget `invokeCommand(...)`
+    (it returns immediately; let the result update state asynchronously).
+  - Keep keyDownHandler synchronous (return boolean). Move any async work into a
+    dispatched task; don't make the handler `async`.
+  - Never use synchronous XHR. Use `fetch` (async) or `invokeCommand`.
+  - Genuinely off the keystroke path? Add `// perf:allow-input-ipc — <why>`.
+
+EOF
+exit 1


### PR DESCRIPTION
## What

**Phase 0.2 of the input-first execution plan** ([discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161)) — enforce invariant **I2: "No synchronous IPC on any input path, ever."**

The renderer↔host IPC layer is the highest-severity, hardest-to-see typing-latency threat: a synchronous renderer→host round-trip reachable from a `keydown` handler adds latency with **no JS-layer workaround**. There was no guard ensuring the keystroke path never *blocks* on IPC. This PR audits the path and ships the guard.

## Audit baseline — clean ✅

The IPC transport is async by construction (`invokeCommand()` → `fetch(.../ipc)`), so fire-and-forget dispatch from a keystroke handler is **compliant**. The blocking shapes (the actual violations) are absent today:

| Check | Result |
|---|---|
| `await invokeCommand` / `await fetch` in input-dispatch files | none |
| `async keyDownHandler` / returns `Promise` | none — all return sync `boolean` |
| Synchronous XHR (`open(…, false)`) in `frontend/app` | none |

Central dispatch `appHandleKeyDown` (`store/keymodel.ts:369`) and block handlers (`termViewModel.ts:390`, `launcher.tsx:63`) are all synchronous. Full write-up: `docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md`.

## The guard

- **`tools/lint/check-input-handler-sync-ipc.sh`** — grep+awk scan mirroring `check-input-handler-layout-reads.sh`. Flags awaited-IPC + async key handlers in the input-dispatch scope (`keymodel.ts`, `termViewModel.ts`, `launcher.tsx`, `AgentFooter.tsx`) and a repo-wide synchronous-XHR ban. Comment-skip + `// perf:allow-input-ipc — <why>` escape hatch.
- **`.github/workflows/input-handler-sync-ipc.yml`** — path-filtered PR + `main` check.

Verified locally: passes clean on this branch; exits non-zero on an injected `await invokeCommand` in scope; comment-skip and escape-hatch honored.

## Why this shape (not a broad invokeCommand ban)

A keystroke handler *may* dispatch host work fire-and-forget (returns immediately, settles later) — that's compliant. Banning all `invokeCommand` in handlers would false-positive on the many legitimate keymap dispatches. The guard targets only the **blocking** shapes.

## Scope / risk

- **Zero runtime change** — CI tooling + docs only. No behavior touched.
- Cross-platform (renderer-thread JS). The Win32 `SetWindowRgn` airspace path is separate and already off the keydown path (Phase 0.3).
- Changeset: `patch`.

## Part of

Input-first Phase 0. Subsumes the keydown-IPC-audit item (M4) from the consolidated typing-perf work; complements the shipped layout-read guard (#1148). Next: Phase 0.1 bench harness, Phase 0.3 cheap wins.
