### PR TITLE
fix(dnd): suppress 'operation not allowed' cursor during cross-window tear-off (macOS+Linux)

### DIFF
--- a/.changesets/1780077925-fix-macos-traffic-light-scss-stylelint-comment-stale-docstri-rcve.md
+++ b/.changesets/1780077925-fix-macos-traffic-light-scss-stylelint-comment-stale-docstri-rcve.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): traffic-light scss stylelint comment + stale docstring on win32 move

--- a/.changesets/1780080618-fix-dnd-suppress-prohibited-cursor-during-cross-window-tear--zbul.md
+++ b/.changesets/1780080618-fix-dnd-suppress-prohibited-cursor-during-cross-window-tear--zbul.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dnd): suppress prohibited-cursor during cross-window tear-off on macOS+Linux

--- a/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
@@ -50,8 +50,30 @@ function CrossWindowDragMonitor(): JSX.Element {
             await handleCrossWindowDragEnd(payload, windowLabelRef);
         };
 
+        // Suppress the "operation not allowed" cursor during a cross-window
+        // drag. WebKit (and all HTML5 DnD implementations) shows the
+        // prohibited-circle cursor whenever the cursor is over a region with
+        // no `dragover` preventDefault — i.e., everywhere outside our own
+        // tab bar and the workspace surface. The JS-driven tear-off on
+        // `dragend` then completes successfully, so the user sees a clear
+        // mismatch: cursor says "no", behavior says "yes". Telling the
+        // browser "this is a valid drop target everywhere" while a cross-
+        // window drag is in flight (i.e. _currentDragPayload is set) keeps
+        // the cursor on the "move" affordance throughout, matching the
+        // actual outcome. Gated on payload so we don't hijack unrelated DnD
+        // sessions (file drops, etc.).
+        const handleDragOver = (e: DragEvent) => {
+            if (_currentDragPayload == null) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+        };
+
+        document.addEventListener("dragover", handleDragOver);
         document.addEventListener("dragend", handleDragEnd);
-        onCleanup(() => document.removeEventListener("dragend", handleDragEnd));
+        onCleanup(() => {
+            document.removeEventListener("dragover", handleDragOver);
+            document.removeEventListener("dragend", handleDragEnd);
+        });
     });
 
     return null;

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -51,8 +51,30 @@ function CrossWindowDragMonitor(): JSX.Element {
             await handleCrossWindowDragEnd(payload, windowLabelRef);
         };
 
+        // Suppress the "operation not allowed" cursor during a cross-window
+        // drag. WebKitGTK (and all HTML5 DnD implementations) shows the
+        // prohibited-circle cursor whenever the cursor is over a region with
+        // no `dragover` preventDefault — i.e., everywhere outside our own
+        // tab bar and the workspace surface. The JS-driven tear-off on
+        // `dragend` then completes successfully, so the user sees a clear
+        // mismatch: cursor says "no", behavior says "yes". Telling the
+        // browser "this is a valid drop target everywhere" while a cross-
+        // window drag is in flight (i.e. _currentDragPayload is set) keeps
+        // the cursor on the "move" affordance throughout, matching the
+        // actual outcome. Gated on payload so we don't hijack unrelated DnD
+        // sessions (file drops, etc.).
+        const handleDragOver = (e: DragEvent) => {
+            if (_currentDragPayload == null) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+        };
+
+        document.addEventListener("dragover", handleDragOver);
         document.addEventListener("dragend", handleDragEnd);
-        onCleanup(() => document.removeEventListener("dragend", handleDragEnd));
+        onCleanup(() => {
+            document.removeEventListener("dragover", handleDragOver);
+            document.removeEventListener("dragend", handleDragEnd);
+        });
     });
 
     return null;

--- a/frontend/app/window/window-controls.darwin.scss
+++ b/frontend/app/window/window-controls.darwin.scss
@@ -7,6 +7,13 @@
 // Glyphs are hidden at rest and fade in when the mouse enters the group,
 // matching the standard macOS Sequoia / Sonoma behaviour.
 
+/* stylelint-disable color-no-hex --
+   The macOS traffic-light colours (#FF5F57 / #FFBD2E / #28CA41) are OS
+   brand values that must match Apple's HIG exactly. They are not
+   theme-relative and don't map to any semantic token. Sibling
+   window-controls.win32.scss scopes the same exception for the
+   Windows close-button red. */
+
 .traffic-lights {
     display: flex;
     flex-direction: row;

--- a/frontend/app/window/window-controls.darwin.tsx
+++ b/frontend/app/window/window-controls.darwin.tsx
@@ -9,9 +9,10 @@
  * WindowControlsRight — null on macOS (no right-side caption buttons needed).
  *
  * Ported from PR #444 (a5af/feat/macos-traffic-light-controls-v2). The Win11
- * caption-button code on the right side stays inline in `system-status.tsx`
- * on Windows/Linux; only the left-side traffic lights are added here because
- * macOS has no right-side caption buttons.
+ * caption-button code on the right side lives in `window-controls.win32.tsx`
+ * (re-exported by `window-controls.linux.tsx` so Linux gets the same buttons);
+ * only the left-side traffic lights are added here because macOS has no
+ * right-side caption buttons.
  */
 
 import { getApi } from "@/store/global";


### PR DESCRIPTION
## Symptom

On macOS (WebKit) and Linux (WebKitGTK), tearing out a tab or pane shows the prohibited-circle cursor animation throughout the drag, but the tear-off operation completes successfully. Mismatch between cursor affordance and actual behavior — user wonders if they did something wrong.

## Root cause

HTML5 drag-and-drop shows the prohibited cursor whenever the cursor sits over a region whose \`dragover\` handler doesn't call \`preventDefault()\`. AgentMux's cross-window tear-off drives the *actual* tear-off from the \`dragend\` event (\`CrossWindowDragMonitor.{darwin,linux}.tsx:handleCrossWindowDragEnd → performTearOff\`), but installs **no** \`dragover\` listener — so every pixel outside the source tab bar shows the "no" cursor right up until drop. Then \`dragend\` fires, JS opens the tear-off window, and the user is left with a misleading visual.

## Fix

In both \`CrossWindowDragMonitor.darwin.tsx\` and \`CrossWindowDragMonitor.linux.tsx\`, install a document-level \`dragover\` listener that calls \`preventDefault()\` and sets \`dataTransfer.dropEffect = "move"\` whenever \`_currentDragPayload\` is non-null. The browser then treats the whole page as a valid drop target for the duration of the cross-window drag, and the cursor stays on the "move" affordance — matching the actual outcome. Gated on the payload so we don't hijack unrelated DnD sessions (file drops, future drop targets, etc.).

## What this does NOT do

- **Win32**: unaffected — \`CrossWindowDragMonitor.win32.tsx\` doesn't have this issue because Win32 tab tear-off uses a different path (pointer capture + native modal-drag loop per [PLAN_TAB_TEAROFF_PHASE1_WIN32_2026-05-07.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/PLAN_TAB_TEAROFF_PHASE1_WIN32_2026-05-07.md)) and doesn't surface this HTML5 artifact.
- **Tear-off behavior itself**: still entirely driven by the \`dragend\` handler. This PR only changes the cursor affordance during the drag.

## Test plan

- [ ] macOS: drag a tab out of the tab bar → cursor shows the "move" affordance the entire time, not the prohibited circle
- [ ] Linux: same as macOS
- [ ] macOS + Linux: tear-off behavior unchanged (new workspace opens, source tab is removed)
- [ ] Windows: zero behavioral change (win32 monitor untouched)
- [ ] File drops / other DnD sessions: unaffected — listener no-ops when no \`_currentDragPayload\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)