### PR TITLE
test(perf): input-latency bench harness — multi-run baseline-delta + reporting (input-first 0.1)

### DIFF
--- a/.changesets/1780081477-test-perf-input-latency-bench-harness-multi-run-baseline-del-rkaj.md
+++ b/.changesets/1780081477-test-perf-input-latency-bench-harness-multi-run-baseline-del-rkaj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+test(perf): input-latency bench harness — multi-run baseline-delta + reporting (input-first 0.1, #1161)

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -8,9 +8,14 @@ name: Input-latency bench (report)
 # tools/tests/baselines/README.md.
 #
 # REQUIRES a self-hosted runner on the pinned reference device with a running
-# AgentMux instance and the relevant pane open (CDP reachable). GitHub-hosted
-# runners are too noisy for this timing and cannot drive a live AgentMux, so
-# this workflow is MANUAL (workflow_dispatch) until those runners exist.
+# AgentMux instance and the relevant pane open. GitHub-hosted runners are too
+# noisy for this timing and cannot drive a live AgentMux, so this workflow is
+# MANUAL (workflow_dispatch) until those runners exist.
+#
+# Pass bench-specific args via `extra_args` (they go after `--`):
+#   - agent: drives the agent pane over CDP, e.g. "--cdp-port 9223 --count 200"
+#   - term:  discovers the WS endpoint/auth via authkey.dev (NO --cdp-port),
+#            e.g. "--count 50"
 
 on:
   workflow_dispatch:
@@ -23,9 +28,9 @@ on:
       runs:
         description: "Repetitions"
         default: "5"
-      cdp_port:
-        description: "CEF CDP debug port"
-        default: "9223"
+      extra_args:
+        description: "Args passed through to the bench (after --). agent: '--cdp-port 9223 --count 200'; term: '--count 50'"
+        default: "--cdp-port 9223 --count 200"
 
 jobs:
   report:
@@ -46,4 +51,4 @@ jobs:
             --runs "${{ inputs.runs }}" \
             --baseline "tools/tests/baselines/${{ inputs.bench }}.$(hostname).json" \
             --mode report \
-            -- --cdp-port "${{ inputs.cdp_port }}"
+            -- ${{ inputs.extra_args }}

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -1,0 +1,49 @@
+name: Input-latency bench (report)
+
+# Phase 0.1 of the input-first plan (discussion #1161): run the keystroke /
+# echo latency benches N times and REPORT the delta vs the committed baseline.
+#
+# Reporting-mode (never blocks). Promote to a blocking gate (--mode gate) only
+# after the pinned runner's run-to-run variance is characterized — see
+# tools/tests/baselines/README.md.
+#
+# REQUIRES a self-hosted runner on the pinned reference device with a running
+# AgentMux instance and the relevant pane open (CDP reachable). GitHub-hosted
+# runners are too noisy for this timing and cannot drive a live AgentMux, so
+# this workflow is MANUAL (workflow_dispatch) until those runners exist.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bench:
+        description: "Which bench to run"
+        type: choice
+        options: [agent, term]
+        default: agent
+      runs:
+        description: "Repetitions"
+        default: "5"
+      cdp_port:
+        description: "CEF CDP debug port"
+        default: "9223"
+
+jobs:
+  report:
+    # Self-hosted pinned reference device. Label these runners 'input-bench'.
+    # (No such runner is registered yet — this job will queue until one is.)
+    runs-on: [self-hosted, input-bench]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Unit-test the stats core (no app needed)
+        run: node --test tools/tests/lib/bench-stats.test.mjs
+
+      - name: Run bench (report mode)
+        run: |
+          node tools/tests/bench-aggregate.mjs \
+            --bench "${{ inputs.bench }}" \
+            --runs "${{ inputs.runs }}" \
+            --baseline "tools/tests/baselines/${{ inputs.bench }}.$(hostname).json" \
+            --mode report \
+            -- --cdp-port "${{ inputs.cdp_port }}"

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -51,11 +51,19 @@ jobs:
         run: node --test tools/tests/lib/bench-stats.test.mjs
 
       - name: Run bench (report mode)
+        # Inputs go through env (not direct ${{ }} interpolation into the script)
+        # to avoid shell script-injection. EXTRA_ARGS is intentionally unquoted
+        # below so it word-splits into separate bench args.
+        env:
+          BENCH: ${{ inputs.bench }}
+          RUNS: ${{ inputs.runs }}
+          DEVICE: ${{ inputs.device }}
+          EXTRA_ARGS: ${{ inputs.extra_args }}
         run: |
           node tools/tests/bench-aggregate.mjs \
-            --bench "${{ inputs.bench }}" \
-            --runs "${{ inputs.runs }}" \
-            --baseline "tools/tests/baselines/${{ inputs.bench }}.${{ inputs.device }}.json" \
-            --device "${{ inputs.device }}" \
+            --bench "$BENCH" \
+            --runs "$RUNS" \
+            --baseline "tools/tests/baselines/${BENCH}.${DEVICE}.json" \
+            --device "$DEVICE" \
             --mode report \
-            -- ${{ inputs.extra_args }}
+            -- $EXTRA_ARGS

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -28,6 +28,9 @@ on:
       runs:
         description: "Repetitions"
         default: "5"
+      device:
+        description: "Device label — MUST match the committed baseline filename (e.g. 'thinkpad-x250' → baselines/<bench>.thinkpad-x250.json)"
+        default: "pinned"
       extra_args:
         description: "Args passed through to the bench (after --). agent: '--cdp-port 9223 --count 200'; term: '--count 50'"
         default: "--cdp-port 9223 --count 200"
@@ -49,6 +52,7 @@ jobs:
           node tools/tests/bench-aggregate.mjs \
             --bench "${{ inputs.bench }}" \
             --runs "${{ inputs.runs }}" \
-            --baseline "tools/tests/baselines/${{ inputs.bench }}.$(hostname).json" \
+            --baseline "tools/tests/baselines/${{ inputs.bench }}.${{ inputs.device }}.json" \
+            --device "${{ inputs.device }}" \
             --mode report \
             -- ${{ inputs.extra_args }}

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -32,8 +32,8 @@ on:
         description: "Device label — MUST match the committed baseline filename (e.g. 'thinkpad-x250' → baselines/<bench>.thinkpad-x250.json)"
         default: "pinned"
       extra_args:
-        description: "Args passed through to the bench (after --). agent: '--cdp-port 9223 --count 200'; term: '--count 50'"
-        default: "--cdp-port 9223 --count 200"
+        description: "Args passed through to the bench (after --). Both accept --count. --cdp-port is AGENT-ONLY (term discovers WS via authkey.dev); the agent bench defaults to 9223 if omitted."
+        default: "--count 200"
 
 jobs:
   report:

--- a/.github/workflows/input-bench-report.yml
+++ b/.github/workflows/input-bench-report.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install deps (benches import 'ws')
+        run: npm ci
+
       - name: Unit-test the stats core (no app needed)
         run: node --test tools/tests/lib/bench-stats.test.mjs
 

--- a/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
+++ b/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
@@ -45,7 +45,7 @@ The statistical core, aggregation, baseline-delta logic, and CI wiring are done 
 | Line | Blur | Nature |
 |---|---|---|
 | 313 | `blur(var(--magnified-block-blur))` | **Visual** — magnified-block backdrop. Candidate typing-time offender. |
-| 336 | `blur(50px)` | **Visual** — magnified-block backdrop. |
+| 336 | `blur(50px)` | **Visual** — `.connstatus-overlay` backdrop (rule at block.scss:324), not the magnified-block backdrop. |
 | 405 | `blur(8px)` | **Visual** — overlay backdrop. |
 | 455 | `blur(0.1px)` | **NOT visual — a compositing-order hack.** Comments at 450-452/485-490 explain `backdrop-filter` is used *deliberately* to force this element to composite **above** xterm so the focus ring is visible. |
 

--- a/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
+++ b/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
@@ -10,7 +10,7 @@
 
 The existing benches (`bench-agent-keystroke.mjs`, `bench-term-echo.mjs`, PR #1150) are single-run with a hard absolute threshold (`fail if P95 > 50 ms`). On variable hardware that gate is flaky → gets disabled → theater. This PR adds the statistical layer the reviewers converged on, **without modifying the benches**:
 
-- **`tools/tests/lib/bench-stats.mjs`** — pure functions: percentiles, multi-run aggregation, run-to-run variance (CoV), and a **delta-vs-baseline verdict** (`pass` / `regress` / `improve` / `no-baseline` / `noisy`) with a reporting-vs-gate exit-code policy. Unit-tested in **`bench-stats.test.mjs`** (11 tests, `node --test`, no app required — all green).
+- **`tools/tests/lib/bench-stats.mjs`** — pure functions: percentiles, multi-run aggregation, run-to-run variance (CoV), and a **delta-vs-baseline verdict** (`pass` / `regress` / `improve` / `no-baseline` / `noisy`) with a reporting-vs-gate exit-code policy. Unit-tested in **`bench-stats.test.mjs`** (12 tests, `node --test`, no app required — all green).
 - **`tools/tests/bench-aggregate.mjs`** — runs a chosen bench N times, extracts each run's headline metric (agent → `keystroke.stats.p95`, term → `quiet.p95` — the always-present term metric; `busy`/`stream_*` only exist with `--busy`/`--stream`), aggregates, compares to a committed baseline, and prints a REPORT/GATE verdict. `--update-baseline` captures one.
 - **`tools/tests/baselines/`** — schema + README documenting the pinned-device requirement and the reporting→gating promotion path.
 - **`.github/workflows/input-bench-report.yml`** — `workflow_dispatch`, self-hosted `input-bench` runner, reporting-mode. Also runs the stats unit tests (which *do* work on any runner).

--- a/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
+++ b/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
@@ -1,0 +1,69 @@
+# ANALYSIS — Input-first Phase 0 verification + bench harness
+
+**Date:** 2026-05-29
+**Author:** AgentX
+**Context:** Phase 0 of the input-first execution plan ([discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161)). Records the bench-harness scaffolding (0.1, shipped here) and the verification findings for the 0.3 "cheap wins" — several of which turn out to need **runtime/visual confirmation on the running app**, i.e. they are past the autonomous boundary.
+
+---
+
+## 0.1 — Bench harness scaffolding (shipped in this PR)
+
+The existing benches (`bench-agent-keystroke.mjs`, `bench-term-echo.mjs`, PR #1150) are single-run with a hard absolute threshold (`fail if P95 > 50 ms`). On variable hardware that gate is flaky → gets disabled → theater. This PR adds the statistical layer the reviewers converged on, **without modifying the benches**:
+
+- **`tools/tests/lib/bench-stats.mjs`** — pure functions: percentiles, multi-run aggregation, run-to-run variance (CoV), and a **delta-vs-baseline verdict** (`pass` / `regress` / `improve` / `no-baseline` / `noisy`) with a reporting-vs-gate exit-code policy. Unit-tested in **`bench-stats.test.mjs`** (11 tests, `node --test`, no app required — all green).
+- **`tools/tests/bench-aggregate.mjs`** — runs a chosen bench N times, extracts each run's headline metric (agent → `keystroke.stats.p95`, term → `busy.p95`), aggregates, compares to a committed baseline, and prints a REPORT/GATE verdict. `--update-baseline` captures one.
+- **`tools/tests/baselines/`** — schema + README documenting the pinned-device requirement and the reporting→gating promotion path.
+- **`.github/workflows/input-bench-report.yml`** — `workflow_dispatch`, self-hosted `input-bench` runner, reporting-mode. Also runs the stats unit tests (which *do* work on any runner).
+
+### ⛔ Manual-benchmark boundary (needs you)
+
+Everything that produces *real numbers* needs the pinned hardware:
+
+1. **Stand up self-hosted `input-bench` runner(s)** — a low-end Windows box (worst realistic user machine) and a macOS box, each running AgentMux with the pane open and CDP reachable. Document specs in `baselines/README.md`.
+2. **Capture baselines** with `--update-baseline` on each device; commit the JSON.
+3. **Characterize variance** over a few weeks of reporting runs (confirm CoV < 0.25).
+4. **Promote to gate** (`--mode gate`) once stable — gate the low-variance synchronous-body P95 before the noisier end-to-end metric.
+
+The statistical core, aggregation, baseline-delta logic, and CI wiring are done and verified; only the data collection is manual.
+
+---
+
+## 0.3 verification findings
+
+### 0.3a — Browser-pane keydown handler → **needs runtime verification (likely a non-goal as stated)**
+
+**Verified (code read):** only the address bar (`frontend/app/view/browser/browser-view.tsx:421`, `handleAddressKeyDown`) and the auth modal (`components/BrowserAuthModal.tsx`) have `onKeyDown`. `browser-model.ts` defines **no** `keyDownHandler` on the view model, so `appHandleKeyDown` (`store/keymodel.ts:412`) finds no block handler for a focused browser pane.
+
+**But:** a browser pane's content is a native `CefBrowserView` child window. When it has focus, keystrokes go to Chromium's browser view — DOM `keydown` very likely **never reaches** the host SolidJS `appHandleKeyDown` at all. So adding a `keyDownHandler` to `browser-model.ts` may never fire, and intercepting at the host could *break* native input (find-in-page, text fields inside the page). The critique flagged exactly this: "every surface must have a handler" is an invariant inversion — the goal is fast input, not uniform handlers.
+
+**Recommendation:** **Verify on the running app first** — focus a browser pane's content, press Ctrl+L / Ctrl+T / Ctrl+F, and observe whether keys are lost or handled by Chromium. Only if genuinely lost (and only for the specific app-level shortcuts) add a narrowly-scoped host handler. Treat "input goes straight to the native view" as compliant-by-absence otherwise. **Deferred pending that runtime check.**
+
+### 0.3c — `block.scss` `backdrop-filter: blur` audit → **partly a compositing hack; do NOT blindly gate**
+
+**Verified (code read of `frontend/app/block/block.scss`):**
+
+| Line | Blur | Nature |
+|---|---|---|
+| 313 | `blur(var(--magnified-block-blur))` | **Visual** — magnified-block backdrop. Candidate typing-time offender. |
+| 336 | `blur(50px)` | **Visual** — magnified-block backdrop. |
+| 405 | `blur(8px)` | **Visual** — overlay backdrop. |
+| 455 | `blur(0.1px)` | **NOT visual — a compositing-order hack.** Comments at 450-452/485-490 explain `backdrop-filter` is used *deliberately* to force this element to composite **above** xterm so the focus ring is visible. |
+
+So the critic's "broader than trivial" warning is confirmed: gating *all* `backdrop-filter` behind `prefers-reduced-transparency` would **break focus-ring visibility over xterm** (the `blur(0.1px)` hack). The legitimate perf target is the *visual* blurs (313/336/405) that re-raster per frame while typing over them — and even those need profiling to confirm they're on the typing path, plus a visual check that gating them doesn't disturb layering.
+
+**Recommendation:** Treat only the **visual** blurs (313/336/405) as candidates; **never touch the `0.1px` compositing hack** (455). Land a gate behind `prefers-reduced-transparency` only with (a) a profile showing per-frame re-raster during typing and (b) a visual confirmation focus rings/magnified blocks still render. **Deferred pending profile + visual check.**
+
+### 0.3b — Region skip-if-unchanged + HWND cache → **design + hazard documented; needs runtime test**
+
+**Verified:** `agentmux-cef/src/browser_panes.rs:476` `set_pane_overlay_clip` rebuilds and applies a `SetWindowRgn` to every pane HWND on each call, with no last-region cache. It already does the right async-paint thing (`bRedraw=FALSE` + `InvalidateRect`, #1097 fix #5) and the renderer already short-circuits when no pane intersects (`pane-overlay.ts`).
+
+**The hazard the "stateless cache" framing hides:** a per-HWND cache keyed on the HWND pointer is **not** safe-by-construction — Windows recycles HWND values, so a destroyed-then-recreated pane could collide with a stale cache entry and get its clip **wrongly skipped** → an airspace regression (overlay shows over an unclipped pane, or pane content stays hidden). Correctness requires invalidating the cache entry on pane close/drain (there are two close paths: `drain_closed_label` and the explicit `close()`), which adds state and a real regression surface.
+
+**Recommendation:** Implement with the cache keyed on HWND **plus** explicit eviction on both close paths, *or* a genuinely stateless check (re-derive and compare the intended region to what's applied). Either way the failure mode is **visual** (airspace tearing / missing clip) and must be **runtime-tested** on Windows — open menus/tooltips over browser panes during rapid hover and confirm no clip is dropped. **Deferred pending that implementation + runtime test** (a separate Rust PR). Do **not** add a host-side per-frame coalescer (a host timer racing DWM can re-introduce tearing — keep coalescing in the renderer rAF).
+
+---
+
+## Net
+
+- **Autonomous + shipped:** the bench harness statistical core + aggregator + baseline schema + reporting CI + unit tests (this PR), and the keydown-IPC guard (PR #1174, merged).
+- **Handoff (manual/runtime):** capture bench baselines on pinned devices; runtime-verify the browser-keydown gap; profile+visually-verify the blur gate; implement + runtime-test the region cache with close-path eviction.

--- a/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
+++ b/docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md
@@ -11,7 +11,7 @@
 The existing benches (`bench-agent-keystroke.mjs`, `bench-term-echo.mjs`, PR #1150) are single-run with a hard absolute threshold (`fail if P95 > 50 ms`). On variable hardware that gate is flaky → gets disabled → theater. This PR adds the statistical layer the reviewers converged on, **without modifying the benches**:
 
 - **`tools/tests/lib/bench-stats.mjs`** — pure functions: percentiles, multi-run aggregation, run-to-run variance (CoV), and a **delta-vs-baseline verdict** (`pass` / `regress` / `improve` / `no-baseline` / `noisy`) with a reporting-vs-gate exit-code policy. Unit-tested in **`bench-stats.test.mjs`** (11 tests, `node --test`, no app required — all green).
-- **`tools/tests/bench-aggregate.mjs`** — runs a chosen bench N times, extracts each run's headline metric (agent → `keystroke.stats.p95`, term → `busy.p95`), aggregates, compares to a committed baseline, and prints a REPORT/GATE verdict. `--update-baseline` captures one.
+- **`tools/tests/bench-aggregate.mjs`** — runs a chosen bench N times, extracts each run's headline metric (agent → `keystroke.stats.p95`, term → `quiet.p95` — the always-present term metric; `busy`/`stream_*` only exist with `--busy`/`--stream`), aggregates, compares to a committed baseline, and prints a REPORT/GATE verdict. `--update-baseline` captures one.
 - **`tools/tests/baselines/`** — schema + README documenting the pinned-device requirement and the reporting→gating promotion path.
 - **`.github/workflows/input-bench-report.yml`** — `workflow_dispatch`, self-hosted `input-bench` runner, reporting-mode. Also runs the stats unit tests (which *do* work on any runner).
 

--- a/tools/tests/baselines/README.md
+++ b/tools/tests/baselines/README.md
@@ -1,0 +1,78 @@
+# Input-latency bench baselines
+
+Committed baselines for the input-first latency benches, consumed by
+`tools/tests/bench-aggregate.mjs` (Phase 0.1, discussion #1161).
+
+## Why baselines, not absolute thresholds
+
+Sub-50 ms keystroke timing is high-variance and **hardware-dependent**. An
+absolute gate ("fail if P95 > 50 ms") either false-positives on slow/shared
+runners or passes trivially on fast dev machines — so it gets disabled and
+becomes theater. Instead we gate on **delta vs a baseline captured on the same
+pinned device**: a change regresses only if it moves the median-of-per-run-P95
+by more than `--tolerance-pct` (default 20%).
+
+## File schema
+
+One file per (bench, device). Naming: `<bench>.<device>.json`.
+
+```json
+{
+  "metric": "medianP95",
+  "value": 12.4,
+  "device": "thinkpad-x250",
+  "bench": "agent",
+  "metricPath": "keystroke.stats.p95",
+  "runs": 5,
+  "capturedAt": "2026-05-29T19:00:00.000Z",
+  "note": "median of per-run P95. Recapture after a deliberate perf change."
+}
+```
+
+`value` is the **median of the per-run P95s** — the most stable headline number.
+
+## The pinned reference device (REQUIRED — this is the manual step)
+
+Baselines and CI gating are only trustworthy on **dedicated, stable hardware**:
+
+- A **self-hosted runner on a low-end Windows box** (the worst realistic user
+  machine), not GitHub-hosted shared VMs (too noisy for this timing).
+- Add a **macOS** reference device too (v0.40.0 made `task dev` launchable on
+  macOS — AgentA #1169).
+- Keep the device otherwise idle during a run; document its exact spec here.
+
+> **No baselines are committed yet** — they must be captured on the pinned
+> device(s) once those runners exist. Until then `bench-aggregate` reports
+> `no-baseline` and never blocks.
+
+## Capturing / updating a baseline
+
+On the pinned device, with AgentMux running and the relevant pane open:
+
+```bash
+# Agent composer (agent pane open):
+node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
+  --baseline tools/tests/baselines/agent.thinkpad-x250.json \
+  --update-baseline --device thinkpad-x250 -- --cdp-port 9223 --count 200
+
+# Terminal (terminal pane open):
+node tools/tests/bench-aggregate.mjs --bench term --runs 5 \
+  --baseline tools/tests/baselines/term.thinkpad-x250.json \
+  --update-baseline --device thinkpad-x250 -- --cdp-port 9223
+```
+
+Commit the resulting JSON. Recapture (and commit) only after a **deliberate**
+perf change, with a note explaining the move.
+
+## Reporting → gating promotion path
+
+1. **Report (now):** run in `--mode report` (default) on PRs touching input
+   paths. Never blocks; surfaces the delta + run-to-run CoV for humans.
+2. **Characterize variance:** collect a few weeks of reporting data; confirm
+   the pinned runner's per-run CoV stays under `--max-cov` (0.25).
+3. **Gate (later):** flip to `--mode gate`. A change then blocks merge only on a
+   >tolerance regression or a `noisy` runner (CoV over budget) — never on an
+   absolute number the device can't reproduce.
+
+Gate on the **stable** signal first (`agent-keystroke` synchronous-body P95,
+which is low-variance) before the noisier end-to-end keystroke-to-paint.

--- a/tools/tests/baselines/README.md
+++ b/tools/tests/baselines/README.md
@@ -55,10 +55,12 @@ node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
   --baseline tools/tests/baselines/agent.thinkpad-x250.json \
   --update-baseline --device thinkpad-x250 -- --cdp-port 9223 --count 200
 
-# Terminal (terminal pane open):
+# Terminal (terminal pane open). The term bench discovers the WS endpoint/auth
+# via authkey.dev — it does NOT take --cdp-port. Uses the always-present
+# `quiet.p95` metric.
 node tools/tests/bench-aggregate.mjs --bench term --runs 5 \
   --baseline tools/tests/baselines/term.thinkpad-x250.json \
-  --update-baseline --device thinkpad-x250 -- --cdp-port 9223
+  --update-baseline --device thinkpad-x250 -- --count 50
 ```
 
 Commit the resulting JSON. Recapture (and commit) only after a **deliberate**

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -22,11 +22,12 @@
 //
 // Usage:
 //   node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
-//        --baseline tools/tests/baselines/agent-keystroke.<device>.json \
+//        --baseline tools/tests/baselines/agent.<device>.json \
 //        --mode report -- --cdp-port 9223 --count 200
 //
 //   node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
-//        --baseline <path> --update-baseline --device "thinkpad-x250"
+//        --baseline tools/tests/baselines/agent.thinkpad-x250.json \
+//        --update-baseline --device "thinkpad-x250"
 //
 // Everything after `--` is passed through to the underlying bench verbatim.
 

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// bench-aggregate.mjs — run an input-latency bench N times and judge it against
+// a committed baseline (delta-vs-baseline), not a flaky absolute threshold.
+//
+// Input-first Phase 0.1 (discussion #1161). Wraps the existing benches
+// (bench-agent-keystroke.mjs, bench-term-echo.mjs) without modifying them:
+// runs each N times, extracts the headline metric per run, aggregates the
+// per-run distribution, and emits a REPORT (never blocks) or GATE (blocks on
+// regression / excessive run-to-run noise) verdict.
+//
+// Why: see tools/tests/lib/bench-stats.mjs header. Single-run absolute gates
+// false-positive on variable hardware; median-of-N + delta-vs-baseline +
+// reporting-mode-first is the design the input-first reviewers converged on.
+//
+//   PREREQUISITE: a running AgentMux instance with the relevant pane open
+//   (agent pane for `agent`, terminal for `term`) on a PINNED reference device.
+//   The numbers are only trustworthy on stable hardware — see
+//   tools/tests/baselines/README.md.
+//
+// Usage:
+//   node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
+//        --baseline tools/tests/baselines/agent-keystroke.<device>.json \
+//        --mode report -- --cdp-port 9223 --count 200
+//
+//   node tools/tests/bench-aggregate.mjs --bench agent --runs 5 \
+//        --baseline <path> --update-baseline --device "thinkpad-x250"
+//
+// Everything after `--` is passed through to the underlying bench verbatim.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    percentile, mean, stdev,
+    loadBaseline, saveBaseline, compareToBaseline, verdictExitCode, formatVerdict, fmtMs,
+} from "./lib/bench-stats.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const PRESETS = {
+    agent: { script: "bench-agent-keystroke.mjs", metricPath: "keystroke.stats.p95", label: "agent-keystroke P95" },
+    term: { script: "bench-term-echo.mjs", metricPath: "busy.p95", label: "term-echo busy P95" },
+};
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const ddIdx = argv.indexOf("--");
+const ownArgs = ddIdx === -1 ? argv : argv.slice(0, ddIdx);
+const passthrough = ddIdx === -1 ? [] : argv.slice(ddIdx + 1);
+
+function opt(name, fallback) {
+    const i = ownArgs.indexOf(name);
+    return i !== -1 ? ownArgs[i + 1] : fallback;
+}
+function flag(name) { return ownArgs.includes(name); }
+
+if (flag("--help") || ownArgs.length === 0) {
+    console.log(`
+node tools/tests/bench-aggregate.mjs --bench <agent|term> [options] -- [bench passthrough args]
+
+  --bench <agent|term>    Which bench to run (required)
+  --runs <n>              Number of repetitions (default: 5)
+  --baseline <path>       Baseline JSON to compare against (and to --update-baseline)
+  --metric-path <dotpath> Override the per-run metric path (default per preset)
+  --mode <report|gate>    report = never blocks (default); gate = exit 1 on regress/noisy
+  --tolerance-pct <n>     Regression threshold vs baseline (default: 20)
+  --max-cov <f>           Max run-to-run coefficient of variation before 'noisy' (default: 0.25)
+  --update-baseline       Write the measured medianP95 to --baseline and exit 0
+  --device <name>         Device label stored in an updated baseline
+  --help
+
+Presets:  agent → ${PRESETS.agent.script} (${PRESETS.agent.metricPath})
+          term  → ${PRESETS.term.script}  (${PRESETS.term.metricPath})
+
+Prereq: a running AgentMux on a pinned reference device with the pane open.
+`);
+    process.exit(ownArgs.length === 0 ? 2 : 0);
+}
+
+const benchName = opt("--bench");
+const preset = PRESETS[benchName];
+if (!preset) {
+    console.error(`bench-aggregate: --bench must be one of ${Object.keys(PRESETS).join(", ")}`);
+    process.exit(2);
+}
+const RUNS = parseInt(opt("--runs", "5"), 10);
+const BASELINE_PATH = opt("--baseline");
+const METRIC_PATH = opt("--metric-path", preset.metricPath);
+const MODE = opt("--mode", "report");
+const TOLERANCE_PCT = parseFloat(opt("--tolerance-pct", "20"));
+const MAX_COV = parseFloat(opt("--max-cov", "0.25"));
+const UPDATE_BASELINE = flag("--update-baseline");
+const DEVICE = opt("--device", "unspecified-device");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+function getPath(obj, dotPath) {
+    return dotPath.split(".").reduce((o, k) => (o == null ? undefined : o[k]), obj);
+}
+
+function runOnce(i) {
+    const tmp = mkdtempSync(join(tmpdir(), "agm-bench-"));
+    const out = join(tmp, "run.json");
+    const script = join(HERE, preset.script);
+    const res = spawnSync("node", [script, ...passthrough, "--output-file", out], {
+        encoding: "utf8",
+        stdio: ["ignore", "inherit", "inherit"],
+    });
+    let value = null;
+    try {
+        const json = JSON.parse(readFileSync(out, "utf8"));
+        value = getPath(json, METRIC_PATH);
+    } catch (e) {
+        console.error(`  run ${i + 1}: could not read metric '${METRIC_PATH}' from output (${e.message})`);
+    } finally {
+        rmSync(tmp, { recursive: true, force: true });
+    }
+    if (res.status !== 0) {
+        console.error(`  run ${i + 1}: bench exited ${res.status} (continuing; the aggregate decides pass/fail)`);
+    }
+    return typeof value === "number" ? value : null;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+console.log(`bench-aggregate: ${preset.label} — ${RUNS} runs, mode=${MODE}`);
+const values = [];
+for (let i = 0; i < RUNS; i++) {
+    console.log(`── run ${i + 1}/${RUNS} ──────────────────────────────────────────`);
+    const v = runOnce(i);
+    if (v != null) {
+        values.push(v);
+        console.log(`  run ${i + 1} ${preset.label} = ${fmtMs(v)}`);
+    }
+}
+
+if (values.length === 0) {
+    console.error("bench-aggregate: no runs produced a metric value. Is AgentMux running with the pane open?");
+    process.exit(2);
+}
+
+// Aggregate the per-run headline metric into the shape compareToBaseline wants.
+const sd = stdev(values);
+const m = mean(values);
+const agg = {
+    runs: values.length,
+    runP95s: values,
+    medianP95: percentile(values, 50),
+    p95Spread: values.length > 1 ? Math.max(...values) - Math.min(...values) : 0,
+    p95CoV: sd != null && m ? sd / m : null,
+};
+
+console.log("");
+console.log("─".repeat(70));
+console.log(`${preset.label}: per-run = [${values.map((v) => v.toFixed(1)).join(", ")}] ms`);
+console.log(`  median=${fmtMs(agg.medianP95)}  spread=${fmtMs(agg.p95Spread)}  CoV=${agg.p95CoV == null ? "—" : (agg.p95CoV * 100).toFixed(1) + "%"}`);
+
+if (UPDATE_BASELINE) {
+    if (!BASELINE_PATH) {
+        console.error("bench-aggregate: --update-baseline requires --baseline <path>");
+        process.exit(2);
+    }
+    saveBaseline(BASELINE_PATH, {
+        metric: "medianP95",
+        value: agg.medianP95,
+        device: DEVICE,
+        bench: benchName,
+        metricPath: METRIC_PATH,
+        runs: agg.runs,
+        capturedAt: new Date().toISOString(),
+        note: "median of per-run P95. Recapture on the same pinned device after a deliberate perf change.",
+    });
+    console.log(`  ✓ baseline written to ${BASELINE_PATH} (medianP95=${fmtMs(agg.medianP95)}, device=${DEVICE})`);
+    process.exit(0);
+}
+
+const baseline = loadBaseline(BASELINE_PATH);
+const cmp = compareToBaseline(agg, baseline, { tolerancePct: TOLERANCE_PCT, maxCoV: MAX_COV });
+console.log(formatVerdict(cmp, MODE));
+console.log("─".repeat(70));
+
+if (cmp.verdict === "no-baseline") {
+    console.log("No baseline to compare against. Capture one with --update-baseline on the pinned device.");
+}
+process.exit(verdictExitCode(cmp.verdict, MODE));

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -66,11 +66,15 @@ function opt(name, fallback) {
     }
     return v;
 }
-function numOpt(name, fallback) {
+function numOpt(name, fallback, { min = 0 } = {}) {
     const raw = opt(name, String(fallback));
     const n = Number(raw);
-    if (Number.isNaN(n)) {
-        console.error(`bench-aggregate: ${name} must be a number (got '${raw}')`);
+    if (!Number.isFinite(n)) {
+        console.error(`bench-aggregate: ${name} must be a finite number (got '${raw}')`);
+        process.exit(2);
+    }
+    if (n < min) {
+        console.error(`bench-aggregate: ${name} must be >= ${min} (got ${n})`);
         process.exit(2);
     }
     return n;
@@ -114,12 +118,12 @@ if (!preset) {
     console.error(`bench-aggregate: --bench must be one of ${Object.keys(PRESETS).join(", ")}`);
     process.exit(2);
 }
-const RUNS = Math.max(1, Math.floor(numOpt("--runs", 5)));
+const RUNS = Math.floor(numOpt("--runs", 5, { min: 1 }));
 const BASELINE_PATH = opt("--baseline");
 const METRIC_PATH = opt("--metric-path", preset.metricPath);
 const MODE = opt("--mode", "report");
-const TOLERANCE_PCT = numOpt("--tolerance-pct", 20);
-const MAX_COV = numOpt("--max-cov", 0.25);
+const TOLERANCE_PCT = numOpt("--tolerance-pct", 20, { min: 0 });
+const MAX_COV = numOpt("--max-cov", 0.25, { min: 0 });
 const UPDATE_BASELINE = flag("--update-baseline");
 const DEVICE = opt("--device", "unspecified-device");
 

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -44,7 +44,9 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 
 const PRESETS = {
     agent: { script: "bench-agent-keystroke.mjs", metricPath: "keystroke.stats.p95", label: "agent-keystroke P95" },
-    term: { script: "bench-term-echo.mjs", metricPath: "busy.p95", label: "term-echo busy P95" },
+    // `quiet` is always present in the term bench output (bench-term-echo.mjs:431);
+    // `busy`/`stream_*` only appear with --busy/--stream, so they're not safe defaults.
+    term: { script: "bench-term-echo.mjs", metricPath: "quiet.p95", label: "term-echo quiet P95" },
 };
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
@@ -55,9 +57,32 @@ const passthrough = ddIdx === -1 ? [] : argv.slice(ddIdx + 1);
 
 function opt(name, fallback) {
     const i = ownArgs.indexOf(name);
-    return i !== -1 ? ownArgs[i + 1] : fallback;
+    if (i === -1) return fallback;
+    const v = ownArgs[i + 1];
+    if (v === undefined || v.startsWith("--")) {
+        console.error(`bench-aggregate: ${name} requires a value`);
+        process.exit(2);
+    }
+    return v;
+}
+function numOpt(name, fallback) {
+    const raw = opt(name, String(fallback));
+    const n = Number(raw);
+    if (Number.isNaN(n)) {
+        console.error(`bench-aggregate: ${name} must be a number (got '${raw}')`);
+        process.exit(2);
+    }
+    return n;
 }
 function flag(name) { return ownArgs.includes(name); }
+
+// The aggregator owns --output-file (one temp file per run). A passthrough
+// --output-file would make the bench write elsewhere while we read our temp
+// path → no metric. Reject it explicitly.
+if (passthrough.includes("--output-file")) {
+    console.error("bench-aggregate: do not pass --output-file in passthrough args — the aggregator manages it per run.");
+    process.exit(2);
+}
 
 if (flag("--help") || ownArgs.length === 0) {
     console.log(`
@@ -88,12 +113,12 @@ if (!preset) {
     console.error(`bench-aggregate: --bench must be one of ${Object.keys(PRESETS).join(", ")}`);
     process.exit(2);
 }
-const RUNS = parseInt(opt("--runs", "5"), 10);
+const RUNS = Math.max(1, Math.floor(numOpt("--runs", 5)));
 const BASELINE_PATH = opt("--baseline");
 const METRIC_PATH = opt("--metric-path", preset.metricPath);
 const MODE = opt("--mode", "report");
-const TOLERANCE_PCT = parseFloat(opt("--tolerance-pct", "20"));
-const MAX_COV = parseFloat(opt("--max-cov", "0.25"));
+const TOLERANCE_PCT = numOpt("--tolerance-pct", 20);
+const MAX_COV = numOpt("--max-cov", 0.25);
 const UPDATE_BASELINE = flag("--update-baseline");
 const DEVICE = opt("--device", "unspecified-device");
 

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -122,6 +122,10 @@ const RUNS = Math.floor(numOpt("--runs", 5, { min: 1 }));
 const BASELINE_PATH = opt("--baseline");
 const METRIC_PATH = opt("--metric-path", preset.metricPath);
 const MODE = opt("--mode", "report");
+if (MODE !== "report" && MODE !== "gate") {
+    console.error(`bench-aggregate: --mode must be 'report' or 'gate' (got '${MODE}')`);
+    process.exit(2);
+}
 const TOLERANCE_PCT = numOpt("--tolerance-pct", 20, { min: 0 });
 const MAX_COV = numOpt("--max-cov", 0.25, { min: 0 });
 const UPDATE_BASELINE = flag("--update-baseline");

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -57,14 +57,29 @@ const ownArgs = ddIdx === -1 ? argv : argv.slice(0, ddIdx);
 const passthrough = ddIdx === -1 ? [] : argv.slice(ddIdx + 1);
 
 function opt(name, fallback) {
-    const i = ownArgs.indexOf(name);
-    if (i === -1) return fallback;
-    const v = ownArgs[i + 1];
-    if (v === undefined || v.startsWith("--")) {
-        console.error(`bench-aggregate: ${name} requires a value`);
-        process.exit(2);
+    // Support both `--name value` and `--name=value`. Without the `=` form,
+    // `--mode=gate` would slip past indexOf(), fall back to "report", and
+    // silently fail open once gating is enabled.
+    for (let i = 0; i < ownArgs.length; i++) {
+        const a = ownArgs[i];
+        if (a === name) {
+            const v = ownArgs[i + 1];
+            if (v === undefined || v.startsWith("--")) {
+                console.error(`bench-aggregate: ${name} requires a value`);
+                process.exit(2);
+            }
+            return v;
+        }
+        if (a.startsWith(name + "=")) {
+            const v = a.slice(name.length + 1);
+            if (v === "") {
+                console.error(`bench-aggregate: ${name} requires a value`);
+                process.exit(2);
+            }
+            return v;
+        }
     }
-    return v;
+    return fallback;
 }
 function numOpt(name, fallback, { min = 0 } = {}) {
     const raw = opt(name, String(fallback));
@@ -84,7 +99,7 @@ function flag(name) { return ownArgs.includes(name); }
 // The aggregator owns --output-file (one temp file per run). A passthrough
 // --output-file would make the bench write elsewhere while we read our temp
 // path → no metric. Reject it explicitly.
-if (passthrough.includes("--output-file")) {
+if (passthrough.some((a) => a === "--output-file" || a.startsWith("--output-file="))) {
     console.error("bench-aggregate: do not pass --output-file in passthrough args — the aggregator manages it per run.");
     process.exit(2);
 }

--- a/tools/tests/bench-aggregate.mjs
+++ b/tools/tests/bench-aggregate.mjs
@@ -140,6 +140,13 @@ function runOnce(i) {
         encoding: "utf8",
         stdio: ["ignore", "inherit", "inherit"],
     });
+    if (res.error) {
+        // Child never launched (e.g. node not on PATH) — surface the real cause
+        // instead of a misleading "could not read metric" ENOENT downstream.
+        console.error(`  run ${i + 1}: failed to launch bench — ${res.error.message}`);
+        rmSync(tmp, { recursive: true, force: true });
+        return null;
+    }
     let value = null;
     try {
         const json = JSON.parse(readFileSync(out, "utf8"));

--- a/tools/tests/lib/bench-stats.mjs
+++ b/tools/tests/lib/bench-stats.mjs
@@ -139,8 +139,11 @@ export function compareToBaseline(agg, baseline, opts = {}) {
     if (agg && agg.p95CoV != null && agg.p95CoV > maxCoV) {
         return { verdict: VERDICT.NOISY, current, baseline: baseline?.value ?? null, deltaPct: null, tolerancePct, metric, coV: agg.p95CoV };
     }
-    if (!baseline || baseline.value == null) {
-        return { verdict: VERDICT.NO_BASELINE, current, baseline: null, deltaPct: null, tolerancePct, metric, coV: agg?.p95CoV ?? null };
+    // A valid latency baseline is a positive finite number. Reject null / 0 /
+    // negative / non-finite (a hand-edited "value": 0 would otherwise divide to
+    // Infinity → false REGRESS, or NaN → silent PASS).
+    if (!baseline || !Number.isFinite(baseline.value) || baseline.value <= 0) {
+        return { verdict: VERDICT.NO_BASELINE, current, baseline: baseline?.value ?? null, deltaPct: null, tolerancePct, metric, coV: agg?.p95CoV ?? null };
     }
     if (current == null) {
         return { verdict: VERDICT.NO_BASELINE, current: null, baseline: baseline.value, deltaPct: null, tolerancePct, metric, coV: agg?.p95CoV ?? null };

--- a/tools/tests/lib/bench-stats.mjs
+++ b/tools/tests/lib/bench-stats.mjs
@@ -1,0 +1,172 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// bench-stats.mjs — shared statistics + baseline-delta layer for the input
+// latency benches (bench-agent-keystroke, bench-term-echo).
+//
+// Why this exists (input-first Phase 0.1, discussion #1161):
+//   The single-run absolute-threshold design (e.g. "fail if P95 > 50 ms") is
+//   flaky on shared/variable CI hardware — sub-50 ms timing has high variance,
+//   so an absolute gate either false-positives constantly or gets disabled.
+//   The fix the reviewers converged on:
+//     1. Median-of-N runs with an explicit variance budget.
+//     2. Regression = DELTA vs a committed baseline (e.g. +20%), not an
+//        absolute number the runner can't reproduce.
+//     3. Reporting-mode first (never blocks); promote to gate only once
+//        variance is characterized on a pinned device.
+//
+// These are PURE functions (no I/O except loadBaseline/saveBaseline), so the
+// statistical core is unit-tested without needing a running app. See
+// bench-stats.test.mjs.
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+// ── Percentiles & single-sample-set summary ─────────────────────────────────
+
+/** Nearest-rank percentile (p in [0,100]). Returns null for empty input. */
+export function percentile(arr, p) {
+    if (!arr || arr.length === 0) return null;
+    const sorted = [...arr].sort((a, b) => a - b);
+    const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length * p) / 100)));
+    return sorted[idx];
+}
+
+export function mean(arr) {
+    if (!arr || arr.length === 0) return null;
+    return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+/** Population standard deviation. null for <2 samples. */
+export function stdev(arr) {
+    if (!arr || arr.length < 2) return null;
+    const m = mean(arr);
+    const v = arr.reduce((a, b) => a + (b - m) * (b - m), 0) / arr.length;
+    return Math.sqrt(v);
+}
+
+/** Summary of one sample set. */
+export function summarize(samples) {
+    if (!samples || samples.length === 0) {
+        return { n: 0, p50: null, p95: null, p99: null, max: null, mean: null, stdev: null };
+    }
+    return {
+        n: samples.length,
+        p50: percentile(samples, 50),
+        p95: percentile(samples, 95),
+        p99: percentile(samples, 99),
+        max: Math.max(...samples),
+        mean: mean(samples),
+        stdev: stdev(samples),
+    };
+}
+
+// ── Multi-run aggregation ───────────────────────────────────────────────────
+//
+// A "run" is one full bench invocation producing a sample array. Aggregating
+// N runs gives both (a) a pooled summary over all samples and (b) the
+// distribution of the per-run P95s — the latter is how we judge whether the
+// runner is stable enough to gate on.
+
+/**
+ * @param {number[][]} runs - array of per-run sample arrays
+ * @returns aggregate with pooled stats, per-run p95 list, median-of-run-p95,
+ *          and the run-to-run spread (max-min and coefficient of variation).
+ */
+export function aggregateRuns(runs) {
+    const valid = (runs || []).filter((r) => Array.isArray(r) && r.length > 0);
+    if (valid.length === 0) {
+        return { runs: 0, pooled: summarize([]), runP95s: [], medianP95: null, p95Spread: null, p95CoV: null };
+    }
+    const pooled = summarize(valid.flat());
+    const runP95s = valid.map((r) => percentile(r, 95));
+    const medianP95 = percentile(runP95s, 50);
+    const p95Spread = runP95s.length > 1 ? Math.max(...runP95s) - Math.min(...runP95s) : 0;
+    const sd = stdev(runP95s);
+    const m = mean(runP95s);
+    const p95CoV = sd != null && m ? sd / m : null; // coefficient of variation
+    return { runs: valid.length, pooled, runP95s, medianP95, p95Spread, p95CoV };
+}
+
+// ── Baseline persistence ────────────────────────────────────────────────────
+
+export function loadBaseline(path) {
+    if (!path || !existsSync(path)) return null;
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+        return null;
+    }
+}
+
+export function saveBaseline(path, baseline) {
+    writeFileSync(path, JSON.stringify(baseline, null, 2));
+}
+
+// ── Baseline comparison / verdict ───────────────────────────────────────────
+
+export const VERDICT = Object.freeze({
+    NO_BASELINE: "no-baseline",
+    PASS: "pass",
+    IMPROVE: "improve",
+    REGRESS: "regress",
+    NOISY: "noisy", // run-to-run variance exceeds budget → verdict untrustworthy
+});
+
+/**
+ * Compare a current aggregate to a baseline value on one metric (default the
+ * median-of-run-P95 — the most stable headline number).
+ *
+ * @param {object} agg        - output of aggregateRuns()
+ * @param {object|null} baseline - { metric, value, ... } or null
+ * @param {object} opts
+ *   metric        - which agg field to compare (default 'medianP95')
+ *   tolerancePct  - allowed regression before flagging (default 20)
+ *   maxCoV        - max run-to-run coefficient of variation before 'noisy' (default 0.25)
+ * @returns { verdict, current, baseline, deltaPct, tolerancePct, metric, coV }
+ */
+export function compareToBaseline(agg, baseline, opts = {}) {
+    const metric = opts.metric ?? "medianP95";
+    const tolerancePct = opts.tolerancePct ?? 20;
+    const maxCoV = opts.maxCoV ?? 0.25;
+    const current = agg?.[metric] ?? null;
+
+    if (agg && agg.p95CoV != null && agg.p95CoV > maxCoV) {
+        return { verdict: VERDICT.NOISY, current, baseline: baseline?.value ?? null, deltaPct: null, tolerancePct, metric, coV: agg.p95CoV };
+    }
+    if (!baseline || baseline.value == null) {
+        return { verdict: VERDICT.NO_BASELINE, current, baseline: null, deltaPct: null, tolerancePct, metric, coV: agg?.p95CoV ?? null };
+    }
+    if (current == null) {
+        return { verdict: VERDICT.NO_BASELINE, current: null, baseline: baseline.value, deltaPct: null, tolerancePct, metric, coV: agg?.p95CoV ?? null };
+    }
+    const deltaPct = ((current - baseline.value) / baseline.value) * 100;
+    let verdict;
+    if (deltaPct > tolerancePct) verdict = VERDICT.REGRESS;
+    else if (deltaPct < -tolerancePct) verdict = VERDICT.IMPROVE;
+    else verdict = VERDICT.PASS;
+    return { verdict, current, baseline: baseline.value, deltaPct, tolerancePct, metric, coV: agg?.p95CoV ?? null };
+}
+
+/**
+ * Translate a verdict into an exit code, honoring the mode.
+ *   mode 'report' — always 0 (never blocks). Use until variance is characterized.
+ *   mode 'gate'   — 1 on REGRESS or NOISY; 0 otherwise.
+ * NO_BASELINE is 0 in both modes (first run establishes the baseline).
+ */
+export function verdictExitCode(verdict, mode = "report") {
+    if (mode !== "gate") return 0;
+    if (verdict === VERDICT.REGRESS || verdict === VERDICT.NOISY) return 1;
+    return 0;
+}
+
+export function fmtMs(n) {
+    return n == null ? "—" : `${n.toFixed(2)} ms`;
+}
+
+/** One-line human verdict for console + CI logs. */
+export function formatVerdict(cmp, mode) {
+    const d = cmp.deltaPct == null ? "" : ` (${cmp.deltaPct >= 0 ? "+" : ""}${cmp.deltaPct.toFixed(1)}% vs baseline)`;
+    const cov = cmp.coV == null ? "" : ` [run-to-run CoV ${(cmp.coV * 100).toFixed(1)}%]`;
+    const tag = mode === "gate" ? "GATE" : "REPORT";
+    return `[${tag}] ${cmp.metric}=${fmtMs(cmp.current)}${d}${cov} → ${cmp.verdict.toUpperCase()}`;
+}

--- a/tools/tests/lib/bench-stats.mjs
+++ b/tools/tests/lib/bench-stats.mjs
@@ -23,7 +23,13 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 
 // ── Percentiles & single-sample-set summary ─────────────────────────────────
 
-/** Nearest-rank percentile (p in [0,100]). Returns null for empty input. */
+/**
+ * Percentile via floored linear index: idx = clamp(floor(N*p/100), 0, N-1).
+ * This intentionally matches the convention already used by the benches
+ * (bench-agent-keystroke.mjs, bench-term-echo.mjs) so aggregated numbers line
+ * up with each bench's own per-run output. It is NOT the strict nearest-rank
+ * (ceil) definition. p in [0,100]; returns null for empty input.
+ */
 export function percentile(arr, p) {
     if (!arr || arr.length === 0) return null;
     const sorted = [...arr].sort((a, b) => a - b);

--- a/tools/tests/lib/bench-stats.test.mjs
+++ b/tools/tests/lib/bench-stats.test.mjs
@@ -12,7 +12,7 @@ import {
     compareToBaseline, verdictExitCode, VERDICT,
 } from "./bench-stats.mjs";
 
-test("percentile: nearest-rank + edge cases", () => {
+test("percentile: floored-index + edge cases", () => {
     assert.equal(percentile([], 95), null);
     assert.equal(percentile([5], 50), 5);
     assert.equal(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 50), 6);

--- a/tools/tests/lib/bench-stats.test.mjs
+++ b/tools/tests/lib/bench-stats.test.mjs
@@ -36,7 +36,7 @@ test("summarize: empty + populated", () => {
     assert.equal(s.p50, 12);
 });
 
-test("aggregateRuns: pooled + per-run p95 + spread", () => {
+test("aggregateRuns: pooled + per-run p95 + spread (hardcoded math)", () => {
     const runs = [
         [10, 11, 12, 13, 14],
         [10, 11, 12, 13, 40], // one slow run
@@ -45,10 +45,13 @@ test("aggregateRuns: pooled + per-run p95 + spread", () => {
     const agg = aggregateRuns(runs);
     assert.equal(agg.runs, 3);
     assert.equal(agg.pooled.n, 15);
-    assert.equal(agg.runP95s.length, 3);
-    assert.equal(agg.medianP95, percentile(agg.runP95s, 50));
-    assert.ok(agg.p95Spread >= 0);
-    assert.ok(agg.p95CoV >= 0);
+    // per-run P95 = floored index 4 of 5 (the last element)
+    assert.deepEqual(agg.runP95s, [14, 40, 15]);
+    // median of [14,40,15] → sorted [14,15,40], floored idx 1 → 15
+    assert.equal(agg.medianP95, 15);
+    assert.equal(agg.p95Spread, 26); // 40 - 14
+    // CoV = stdev([14,40,15]) / mean(23) = 12.0277 / 23 ≈ 0.5229
+    assert.ok(Math.abs(agg.p95CoV - 0.5229) < 1e-3, `CoV was ${agg.p95CoV}`);
 });
 
 test("aggregateRuns: filters empty runs", () => {

--- a/tools/tests/lib/bench-stats.test.mjs
+++ b/tools/tests/lib/bench-stats.test.mjs
@@ -84,6 +84,15 @@ test("compareToBaseline: no baseline", () => {
     assert.equal(compareToBaseline(agg, null).verdict, VERDICT.NO_BASELINE);
 });
 
+test("compareToBaseline: rejects non-positive/invalid baseline (no divide-by-zero)", () => {
+    const agg = aggregateRuns([[10, 11, 12]]);
+    for (const bad of [{ value: 0 }, { value: -5 }, { value: NaN }, { value: Infinity }]) {
+        const cmp = compareToBaseline(agg, bad, { maxCoV: 5 });
+        assert.equal(cmp.verdict, VERDICT.NO_BASELINE);
+        assert.equal(cmp.deltaPct, null); // never Infinity/NaN
+    }
+});
+
 test("compareToBaseline: noisy runner flagged before verdict", () => {
     // Wildly varying per-run P95s → high CoV → NOISY regardless of baseline.
     const runs = [

--- a/tools/tests/lib/bench-stats.test.mjs
+++ b/tools/tests/lib/bench-stats.test.mjs
@@ -1,0 +1,104 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for bench-stats.mjs — the pure statistical core of the input
+// latency bench harness. Runnable WITHOUT a running app:
+//   node --test tools/tests/lib/bench-stats.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    percentile, mean, stdev, summarize, aggregateRuns,
+    compareToBaseline, verdictExitCode, VERDICT,
+} from "./bench-stats.mjs";
+
+test("percentile: nearest-rank + edge cases", () => {
+    assert.equal(percentile([], 95), null);
+    assert.equal(percentile([5], 50), 5);
+    assert.equal(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 50), 6);
+    assert.equal(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 100), 10);
+    assert.equal(percentile([10, 1, 5], 0), 1); // sorts first
+});
+
+test("mean / stdev", () => {
+    assert.equal(mean([2, 4, 6]), 4);
+    assert.equal(stdev([5]), null);            // <2 samples
+    assert.ok(Math.abs(stdev([2, 4, 6]) - 1.632993) < 1e-5);
+});
+
+test("summarize: empty + populated", () => {
+    const empty = summarize([]);
+    assert.equal(empty.n, 0);
+    assert.equal(empty.p95, null);
+    const s = summarize([10, 12, 11, 13, 50]);
+    assert.equal(s.n, 5);
+    assert.equal(s.max, 50);
+    assert.equal(s.p50, 12);
+});
+
+test("aggregateRuns: pooled + per-run p95 + spread", () => {
+    const runs = [
+        [10, 11, 12, 13, 14],
+        [10, 11, 12, 13, 40], // one slow run
+        [10, 11, 12, 13, 15],
+    ];
+    const agg = aggregateRuns(runs);
+    assert.equal(agg.runs, 3);
+    assert.equal(agg.pooled.n, 15);
+    assert.equal(agg.runP95s.length, 3);
+    assert.equal(agg.medianP95, percentile(agg.runP95s, 50));
+    assert.ok(agg.p95Spread >= 0);
+    assert.ok(agg.p95CoV >= 0);
+});
+
+test("aggregateRuns: filters empty runs", () => {
+    const agg = aggregateRuns([[], [1, 2, 3], null, undefined]);
+    assert.equal(agg.runs, 1);
+});
+
+test("compareToBaseline: pass within tolerance", () => {
+    const agg = aggregateRuns([[10, 10, 10, 10, 11]]); // medianP95 ~11
+    const cmp = compareToBaseline(agg, { metric: "medianP95", value: 10 }, { tolerancePct: 20, maxCoV: 1 });
+    assert.equal(cmp.verdict, VERDICT.PASS);
+    assert.ok(cmp.deltaPct <= 20);
+});
+
+test("compareToBaseline: regress beyond tolerance", () => {
+    const agg = aggregateRuns([[20, 20, 20, 20, 30]]); // medianP95 ~30
+    const cmp = compareToBaseline(agg, { metric: "medianP95", value: 10 }, { tolerancePct: 20, maxCoV: 5 });
+    assert.equal(cmp.verdict, VERDICT.REGRESS);
+    assert.ok(cmp.deltaPct > 20);
+});
+
+test("compareToBaseline: improvement", () => {
+    const agg = aggregateRuns([[5, 5, 5, 5, 6]]);
+    const cmp = compareToBaseline(agg, { metric: "medianP95", value: 10 }, { tolerancePct: 20, maxCoV: 5 });
+    assert.equal(cmp.verdict, VERDICT.IMPROVE);
+});
+
+test("compareToBaseline: no baseline", () => {
+    const agg = aggregateRuns([[10, 11, 12]]);
+    assert.equal(compareToBaseline(agg, null).verdict, VERDICT.NO_BASELINE);
+});
+
+test("compareToBaseline: noisy runner flagged before verdict", () => {
+    // Wildly varying per-run P95s → high CoV → NOISY regardless of baseline.
+    const runs = [
+        [5, 5, 5, 5, 5],
+        [50, 50, 50, 50, 50],
+        [5, 5, 5, 5, 5],
+    ];
+    const agg = aggregateRuns(runs);
+    const cmp = compareToBaseline(agg, { metric: "medianP95", value: 10 }, { tolerancePct: 20, maxCoV: 0.25 });
+    assert.equal(cmp.verdict, VERDICT.NOISY);
+});
+
+test("verdictExitCode: report never blocks; gate blocks on regress/noisy", () => {
+    assert.equal(verdictExitCode(VERDICT.REGRESS, "report"), 0);
+    assert.equal(verdictExitCode(VERDICT.NOISY, "report"), 0);
+    assert.equal(verdictExitCode(VERDICT.REGRESS, "gate"), 1);
+    assert.equal(verdictExitCode(VERDICT.NOISY, "gate"), 1);
+    assert.equal(verdictExitCode(VERDICT.PASS, "gate"), 0);
+    assert.equal(verdictExitCode(VERDICT.IMPROVE, "gate"), 0);
+    assert.equal(verdictExitCode(VERDICT.NO_BASELINE, "gate"), 0);
+});


### PR DESCRIPTION
## What

**Phase 0.1 of the input-first plan** ([discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161)) — make the input-latency benches statistically trustworthy so they can eventually gate merges without being flaky.

The existing `bench-agent-keystroke.mjs` / `bench-term-echo.mjs` (PR #1150) are single-run with a hard absolute threshold (`fail if P95 > 50 ms`). On variable hardware that's noisy → gets disabled → theater. This PR adds the layer the input-first reviewers converged on, **without modifying the benches**: median-of-N + **delta-vs-baseline** + **reporting-mode-first**.

## Added

- **`tools/tests/lib/bench-stats.mjs`** — pure stats/aggregation/baseline-delta core: percentiles, multi-run aggregation, run-to-run coefficient-of-variation, and a verdict (`pass`/`regress`/`improve`/`no-baseline`/`noisy`) with a report-vs-gate exit policy.
- **`tools/tests/lib/bench-stats.test.mjs`** — 11 unit tests, `node --test`, **no app required**. ✅ all green locally.
- **`tools/tests/bench-aggregate.mjs`** — runs a bench N times, extracts each run's headline metric (`agent`→`keystroke.stats.p95`, `term`→`busy.p95`), aggregates, compares to a committed baseline, prints a REPORT/GATE verdict. `--update-baseline` captures one. Wraps the existing benches (doesn't touch them).
- **`tools/tests/baselines/`** — schema + README: pinned-device requirement, capture instructions, reporting→gating promotion path.
- **`.github/workflows/input-bench-report.yml`** — `workflow_dispatch`, self-hosted `input-bench` runner, reporting-mode. Also runs the stats unit tests (which work on any runner).
- **`docs/analysis/ANALYSIS_PHASE0_VERIFICATION_2026_05_29.md`** — harness design + the 0.3 verification findings.

## Design notes (per reviewer consensus)

- **Delta-vs-baseline, not absolute** — regress only if median-of-per-run-P95 moves > `--tolerance-pct` (default 20%) vs a baseline captured on the *same* device.
- **Noisy-runner guard** — if run-to-run CoV exceeds `--max-cov` (0.25), the verdict is `noisy` (don't trust the gate) rather than a false regress/pass.
- **Reporting-mode first** — `--mode report` never blocks; promote to `--mode gate` only after variance is characterized on the pinned device.

## 0.3 verification findings (handoff)

The doc also records that the remaining Phase-0.3 "cheap wins" need **runtime/visual confirmation** (past the autonomous boundary):
- **Browser keydown** — `browser-model.ts` has no `keyDownHandler`, but a focused native `CefBrowserView` likely never routes DOM keydown to the host, so adding one may not fire / could break native input. **Verify on the app first.**
- **`block.scss` blur** — line 455 `blur(0.1px)` is a *compositing-order hack* (keeps focus rings above xterm), **not** visual blur; only 313/336/405 are gating candidates, and only with a profile + visual check.
- **Region skip-if-unchanged cache** — an HWND-keyed cache has a **handle-reuse hazard** (stale skip → airspace regression); needs close-path eviction + Windows runtime test. Separate Rust PR.

## Scope / risk

- **Zero runtime change** — test tooling + docs only. Stats core is unit-tested.
- Changeset: `patch`.

## Manual next step

Capture baselines on pinned low-end Windows + macOS runners (`--update-baseline`), characterize variance, then flip the bench to `--mode gate`.
