### PR TITLE
perf(airspace): skip redundant SetWindowRgn when a pane's clip is unchanged (input-first 0.3b)

### DIFF
--- a/.changesets/1780086471-perf-airspace-skip-redundant-setwindowrgn-when-a-pane-s-clip-81vc.md
+++ b/.changesets/1780086471-perf-airspace-skip-redundant-setwindowrgn-when-a-pane-s-clip-81vc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(airspace): skip redundant SetWindowRgn when a pane's clip is unchanged (input-first 0.3b, #1161)

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -129,6 +129,46 @@ impl<'a> BrowserPaneCloseOps for AppStateCloseOps<'a> {
     }
 }
 
+/// Signature of the clip a pane should have, used by `set_pane_overlay_clip`
+/// to skip a redundant `SetWindowRgn` when nothing changed. The HWND value is
+/// folded in so a recreated pane (new HWND under a reused label) never matches a
+/// stale entry — see `AppState::pane_clip_cache`. Within-process only (the hash
+/// need not be stable across runs).
+#[cfg(target_os = "windows")]
+fn clip_sig_whole(hwnd: isize) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    0u8.hash(&mut h); // tag: full visibility (region = NULL)
+    hwnd.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(target_os = "windows")]
+fn clip_sig_clipped(
+    hwnd: isize,
+    pane_left: i32,
+    pane_top: i32,
+    pane_w: i32,
+    pane_h: i32,
+    overlay_rects: &[(i32, i32, i32, i32)],
+) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    1u8.hash(&mut h); // tag: clipped
+    hwnd.hash(&mut h);
+    // The applied region is a deterministic function of the pane's screen
+    // position/size and the overlay rects, so hashing those inputs is a faithful
+    // signature: identical inputs ⇒ identical region (no false cache hit). A
+    // non-intersecting rect that changes only yields a false MISS (a harmless
+    // redundant re-apply), never a false hit.
+    pane_left.hash(&mut h);
+    pane_top.hash(&mut h);
+    pane_w.hash(&mut h);
+    pane_h.hash(&mut h);
+    overlay_rects.hash(&mut h);
+    h.finish()
+}
+
 pub struct BrowserPaneManager;
 
 impl BrowserPaneManager {
@@ -549,6 +589,13 @@ impl BrowserPaneManager {
                 // pump tick. For a menu hover that re-fires this code path
                 // several times per gesture, that's a material win.
                 if overlay_rects.is_empty() {
+                    // Skip if this pane is already at full visibility (same HWND,
+                    // already restored) — avoids a redundant SetWindowRgn +
+                    // repaint every call while any overlay is open elsewhere.
+                    let sig = clip_sig_whole(pane_hwnd as isize);
+                    if state.pane_clip_cache.lock().get(label).copied() == Some(sig) {
+                        continue;
+                    }
                     SetWindowRgn(pane_hwnd as _, std::ptr::null_mut(), 0);
                     // The pane is being made WHOLE again — the previously
                     // hidden sub-area needs to repaint its content. We
@@ -556,6 +603,7 @@ impl BrowserPaneManager {
                     // invalidate the entire pane; CEF will paint only
                     // dirty regions on the next pump.
                     InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
+                    state.pane_clip_cache.lock().insert(label.clone(), sig);
                     continue;
                 }
 
@@ -579,6 +627,20 @@ impl BrowserPaneManager {
                 let pane_w = pane_rect.right - pane_rect.left;
                 let pane_h = pane_rect.bottom - pane_rect.top;
                 if pane_w <= 0 || pane_h <= 0 {
+                    continue;
+                }
+
+                // Skip if the region we'd compute is identical to the one
+                // already applied to this HWND (same geometry + same overlays).
+                let sig = clip_sig_clipped(
+                    pane_hwnd as isize,
+                    pane_rect.left,
+                    pane_rect.top,
+                    pane_w,
+                    pane_h,
+                    overlay_rects,
+                );
+                if state.pane_clip_cache.lock().get(label).copied() == Some(sig) {
                     continue;
                 }
 
@@ -616,7 +678,16 @@ impl BrowserPaneManager {
                 // invalidate the whole pane. CEF dirty-region painting
                 // keeps the actual GPU work proportional to the change.
                 InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
+                state.pane_clip_cache.lock().insert(label.clone(), sig);
             }
+        }
+        // Prune cache entries for panes no longer live (closed/destroyed),
+        // bounding the map. Labels are never reused for a different pane, so a
+        // dropped entry only means the next clip for a (re)created pane applies
+        // fresh — which is correct.
+        {
+            let mut cache = state.pane_clip_cache.lock();
+            cache.retain(|k, _| labels.iter().any(|l| l == k));
         }
         tracing::info!(
             pane_count = labels.len(),

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -592,18 +592,33 @@ impl BrowserPaneManager {
                     // Skip if this pane is already at full visibility (same HWND,
                     // already restored) — avoids a redundant SetWindowRgn +
                     // repaint every call while any overlay is open elsewhere.
+                    //
+                    // The cache guard is held across check → apply → record so
+                    // the sequence is atomic. This handler runs INLINE on a
+                    // multi-threaded tokio worker (ipc.rs — no UI-thread marshal,
+                    // unlike the non-Windows path), so two concurrent clips for
+                    // the same pane could otherwise interleave their SetWindowRgn
+                    // vs cache.insert and leave the recorded sig disagreeing with
+                    // the live region — a later wrong-skip.
                     let sig = clip_sig_whole(pane_hwnd as isize);
-                    if state.pane_clip_cache.lock().get(label).copied() == Some(sig) {
+                    let mut cache = state.pane_clip_cache.lock();
+                    if cache.get(label).copied() == Some(sig) {
                         continue;
                     }
-                    SetWindowRgn(pane_hwnd as _, std::ptr::null_mut(), 0);
+                    let applied = SetWindowRgn(pane_hwnd as _, std::ptr::null_mut(), 0) != 0;
                     // The pane is being made WHOLE again — the previously
                     // hidden sub-area needs to repaint its content. We
                     // don't track the diff yet (Phase 2 follow-up), so
                     // invalidate the entire pane; CEF will paint only
                     // dirty regions on the next pump.
                     InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
-                    state.pane_clip_cache.lock().insert(label.clone(), sig);
+                    // Only record the sig if the region actually applied; on a
+                    // (rare) SetWindowRgn failure leave the entry unset so the
+                    // next call retries instead of skipping a clip that never
+                    // landed.
+                    if applied {
+                        cache.insert(label.clone(), sig);
+                    }
                     continue;
                 }
 
@@ -632,6 +647,12 @@ impl BrowserPaneManager {
 
                 // Skip if the region we'd compute is identical to the one
                 // already applied to this HWND (same geometry + same overlays).
+                //
+                // As in the whole-visibility branch above, the cache guard is
+                // held across check → build → apply → record so a concurrent
+                // clip for the same pane (this handler runs inline on a
+                // multi-threaded tokio worker) can't interleave SetWindowRgn and
+                // cache.insert and desync the recorded sig from the live region.
                 let sig = clip_sig_clipped(
                     pane_hwnd as isize,
                     pane_rect.left,
@@ -640,7 +661,8 @@ impl BrowserPaneManager {
                     pane_h,
                     overlay_rects,
                 );
-                if state.pane_clip_cache.lock().get(label).copied() == Some(sig) {
+                let mut cache = state.pane_clip_cache.lock();
+                if cache.get(label).copied() == Some(sig) {
                     continue;
                 }
 
@@ -669,16 +691,24 @@ impl BrowserPaneManager {
                 }
                 // SetWindowRgn takes ownership of the region handle on
                 // success; the system frees it when the window is destroyed
-                // or a new region is set.
+                // or a new region is set. On FAILURE ownership stays with us,
+                // so we DeleteObject the region below to avoid a GDI leak.
                 // bRedraw=FALSE — async paint via InvalidateRect below.
                 // See the empty-overlay branch above for the rationale.
-                SetWindowRgn(pane_hwnd as _, region as _, 0);
+                let applied = SetWindowRgn(pane_hwnd as _, region as _, 0) != 0;
                 // The clip may have GROWN (more area hidden) or SHRUNK
                 // (less area hidden); we don't track the diff yet, so
                 // invalidate the whole pane. CEF dirty-region painting
                 // keeps the actual GPU work proportional to the change.
                 InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
-                state.pane_clip_cache.lock().insert(label.clone(), sig);
+                // Only record the sig when the region actually applied (matches
+                // the whole-visibility branch); on failure free the orphaned
+                // region and leave the entry unset so the next call retries.
+                if applied {
+                    cache.insert(label.clone(), sig);
+                } else {
+                    DeleteObject(region as _);
+                }
             }
         }
         // Prune cache entries for panes no longer live (closed/destroyed),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -678,6 +678,22 @@ pub struct AppState {
     pub pane_overlay_rects:
         Mutex<std::collections::HashMap<String, Vec<(i32, i32, i32, i32)>>>,
 
+    /// Windows only — last-applied clip signature per pane *label*, so
+    /// `BrowserPaneManager::set_pane_overlay_clip` can skip a redundant
+    /// `SetWindowRgn` + `InvalidateRect` when a pane's computed region is
+    /// unchanged since the previous call (the common case: one overlay moves,
+    /// every other pane's clip is identical).
+    ///
+    /// Keyed by label, NOT by HWND: HWND integer values are recycled by the OS,
+    /// so an HWND key risks a stale entry colliding with a recreated pane. The
+    /// HWND value is instead folded INTO the signature, so a recreated pane
+    /// (new HWND, even under a reused label) produces a different signature and
+    /// always re-applies. A wrong-skip is therefore impossible by construction —
+    /// we only skip when the same label already has the same region on the same
+    /// HWND. Pruned to live labels each call to bound size.
+    #[cfg(target_os = "windows")]
+    pub pane_clip_cache: Mutex<std::collections::HashMap<String, u64>>,
+
     /// Linux/macOS only — OverlayControllers awaiting deferred destroy.
     ///
     /// Calling `OverlayController::destroy()` synchronously on the same UI
@@ -812,6 +828,8 @@ impl Default for AppState {
             pane_overlay_rects: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]
             pending_overlay_destroy: Mutex::new(HashMap::new()),
+            #[cfg(target_os = "windows")]
+            pane_clip_cache: Mutex::new(HashMap::new()),
             // window_pool / unpromoted_pool_labels / window_pool_respawn_in_flight
             // deleted (PR #5 H.4) — see HostState.pool.
             // is_quitting deleted (PR #5 H.5) — see HostState.quit_state.

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -685,11 +685,22 @@ pub struct AppState {
     /// every other pane's clip is identical).
     ///
     /// Keyed by label, NOT by HWND: HWND integer values are recycled by the OS,
-    /// so an HWND key risks a stale entry colliding with a recreated pane. The
-    /// HWND value is instead folded INTO the signature, so a recreated pane
-    /// (new HWND, even under a reused label) produces a different signature and
-    /// always re-applies. A wrong-skip is therefore impossible by construction —
-    /// we only skip when the same label already has the same region on the same
+    /// so an HWND key risks a stale entry colliding with a recreated pane.
+    ///
+    /// Why a wrong-skip can't happen:
+    /// - **Labels are globally unique and never reused** (monotonic
+    ///   `BROWSER_PANE_LABEL_SEQ`; see `next_browser_pane_label`). A
+    ///   close→recreate registers the new pane under a brand-new label, so the
+    ///   label-keyed cache always *misses* and re-applies. This is the primary
+    ///   guarantee.
+    /// - The HWND value is also folded INTO the signature as cheap
+    ///   belt-and-suspenders: even if a label were somehow reused, a different
+    ///   (or recycled-but-distinct) HWND yields a different signature → re-apply.
+    /// - `set_pane_overlay_clip` holds this lock across check → apply → record,
+    ///   so the recorded signature always matches the region that call actually
+    ///   applied even though the Windows handler runs on multiple tokio workers.
+    ///
+    /// We only skip when the same label already has the same region on the same
     /// HWND. Pruned to live labels each call to bound size.
     #[cfg(target_os = "windows")]
     pub pane_clip_cache: Mutex<std::collections::HashMap<String, u64>>,


### PR DESCRIPTION
## What

**Phase 0.3b of the input-first plan** ([discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161)) — stop re-applying an unchanged airspace clip.

`set_pane_overlay_clip` (Win32) rebuilt and re-applied a region (`SetWindowRgn` + `InvalidateRect`) to **every** live pane on **every** call — so when one overlay moves, every *other* pane still pays a redundant full-region re-apply + repaint each frame. This caches the last-applied clip per pane and skips the no-op.

## How — and why it's safe (the HWND-reuse hazard)

The obvious design (cache keyed by HWND) is unsafe: Windows recycles HWND integer values, so a stale entry could collide with a recreated pane and wrongly skip its clip → an airspace regression. This PR avoids that **by construction**:

- **Keyed by pane label** (never reused for a different pane), stored in `AppState.pane_clip_cache` (Windows-only; `BrowserPaneManager` is a unit struct).
- **HWND value folded into the signature.** A recreated pane (new HWND, even under a reused label) produces a different signature → always re-applies. We only ever skip when the **same label has the same region on the same HWND** — i.e. the identity case where skipping is correct.
- Therefore **no fragile close-path eviction is needed**; entries are pruned to live labels each call to bound the map.
- Hashing the *inputs* (pane geometry + overlay rects) is faithful: identical inputs ⇒ identical region (no false hit). A changed non-intersecting rect only yields a harmless false **miss** (a redundant re-apply), never a false hit.
- **No host-side per-frame coalescer** (that would race DWM and risk re-introducing airspace tearing) — coalescing stays in the renderer rAF.

## Verification

- `cargo check -p agentmux-cef`: **clean** (only pre-existing warnings).
- Pure optimization — no behavior change when the clip actually changes.

### ⚠️ Requires Windows runtime verification (can't be unit-tested)

Please confirm on a Windows build:
1. Open menus / tooltips / autocomplete over a **browser pane** during rapid hover → no overlay-over-unclipped-pane, no pane stuck hidden.
2. **Close / redock** a browser pane, then open an overlay over its area → clip re-applies correctly (exercises the recreate path the HWND-in-signature defends).
3. Resize/split with an overlay open → clip tracks the new geometry.

## Scope
- Windows-only path; macOS/Linux use a different (Views) airspace mechanism, untouched.
- Changeset: `patch`. Subsumes the region-coalescing portion of #1097.
