### PR TITLE
fix(linux): enable patched-libcef feature in build:host:linux so window drag works

### DIFF
--- a/.changesets/1780127762-fix-linux-enable-patched-libcef-feature-in-build-host-linux--5xxo.md
+++ b/.changesets/1780127762-fix-linux-enable-patched-libcef-feature-in-build-host-linux--5xxo.md
@@ -1,0 +1,37 @@
+---
+type: patch
+---
+
+fix(linux): enable patched-libcef feature in build:host:linux so window drag works
+
+PR #1131 (`fix(cef): unbreak agentmux-cef compile on macOS with public
+cef-rs 146`) introduced a `patched-libcef` cargo feature on
+`agentmux-cef` to gate the `_cef_window_t::begin_window_drag` FFI call
+(used by `StartWindowDragTask` for native left-click window drag on
+Wayland). It defaulted **off** so macOS could compile against the
+public crates.io `cef-rs 146` before the macOS libcef story was sorted.
+The Linux `build:host:linux` task in `Taskfile.yml` was not updated to
+pass `--features patched-libcef`, so every Linux build after that PR
+compiled the FFI call site OUT and the warn-and-no-op branch IN:
+
+    [start_window_drag] patched-libcef feature disabled — native drag
+    is a no-op. Rebuild with --features patched-libcef ...
+
+User-visible result: clicking-and-dragging the AgentMux title bar on
+Linux did nothing.
+
+Fix: append `--features patched-libcef` to the cargo build in
+`build:host:linux`. The two other pieces that needed to line up are
+both already fine on Linux:
+
+- The `begin_window_drag` slot has been upstreamed into public
+  `cef-dll-sys-146.7.0+146.0.12` (currently pinned in `Cargo.lock`),
+  so no `[patch.crates-io]` override is needed.
+- `task package:linux` already bundles the right `libcef.so` via
+  `scripts/resolve-cef-runtime.sh` — picks the locally-built
+  `~/cef-build/.../libcef.so` (a5af/cef
+  `agentmux/7680-drag-rightclick-and-transparency`) and strips it
+  from ~642 MB → ~422 MB. The runtime ABI guard in
+  `agentmux-cef/src/ui_tasks.rs` still catches mismatch.
+
+macOS and Windows tasks unchanged.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -450,8 +450,18 @@ tasks:
     build:host:linux:
         internal: true
         platforms: [linux]
+        # `--features patched-libcef` enables the call site for
+        # `_cef_window_t::begin_window_drag` (used by StartWindowDragTask
+        # for native left-click window drag on Wayland). The slot is now
+        # part of public `cef-dll-sys-146.7.0+146.0.12` (upstreamed) and
+        # the bundled libcef.so picked by `scripts/resolve-cef-runtime.sh`
+        # implements it — so this flag is safe to default-on for Linux.
+        # Without it, `start_window_drag` IPC compiles as a warn-and-noop
+        # (PR #1131 made the gate default-off so macOS compile could land
+        # before the macOS libcef story was sorted; on Linux we always had
+        # the patched runtime).
         cmds:
-            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef'
+            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef --features patched-libcef'
             - mkdir -p dist/cef
             - cp target/release/agentmux-cef dist/cef/agentmux-cef
             - echo "✓ Built host for Linux"


### PR DESCRIPTION
## Summary

Single-cause regression: native left-click window drag on Linux silently broke after #1131.

**Root cause:** PR #1131 (`fix(cef): unbreak agentmux-cef compile on macOS with public cef-rs 146`) introduced the `patched-libcef` cargo feature on `agentmux-cef` to gate the `_cef_window_t::begin_window_drag` FFI call site. Default off (correct intent at the time — let macOS bringup compile against the public crate without the patched libcef). But `Taskfile.yml::build:host:linux` was not updated to pass the flag, so every Linux build after #1131 compiled the FFI block out and the warn-and-no-op block in:

```
[start_window_drag] patched-libcef feature disabled — native drag is a no-op.
Rebuild with --features patched-libcef and a patched libcef.so
(a5af/cef agentmux/7680-...) to enable.
```

User-visible: title-bar drag did nothing on Linux post-v0.40.0.

## Fix

One-line addition to `build:host:linux` (Taskfile.yml): `--features patched-libcef`. Comment block explains why it's safe to default-on for Linux.

## Why the other two pieces are already correct on Linux

| Layer | Status |
|---|---|
| `cef-dll-sys` binding has `begin_window_drag` slot? | ✅ Upstreamed into public `cef-dll-sys-146.7.0+146.0.12` (currently pinned in `Cargo.lock`). No `[patch.crates-io]` override needed. |
| Bundled `libcef.so` implements `BeginWindowDrag`? | ✅ `scripts/resolve-cef-runtime.sh` picks the locally-built patched `~/cef-build/.../libcef.so` (`a5af/cef agentmux/7680-…`) ahead of the cef-dll-sys cargo cache. `task package:linux` strips it from ~642 MB → ~422 MB. |
| Runtime guard against vanilla libcef sneaking in? | ✅ `agentmux-cef/src/ui_tasks.rs::StartWindowDragTask` checks `runtime_size == size_of::<_cef_window_t>()` and bails clean if not. |

## Per-platform impact

| Platform | Effect |
|---|---|
| Linux | **Window drag restored** (post-#1131 regression fixed). |
| macOS | No change — `build:host:darwin` untouched. macOS still doesn't have a patched libcef.so; the FFI call site stays compiled out by default there until that work lands. |
| Windows | No change — the win32 host doesn't use this code path (gated `#[cfg(not(target_os = "windows"))]`). |

## Test plan

- [ ] Linux: `task package:linux`, launch the AppImage, drag the title bar. Should move the window. Host log should show `[start_window_drag] BeginWindowDrag returned 1 …` (not the "patched-libcef feature disabled" warning).
- [ ] macOS: `task package:macos` (or `cargo build --release -p agentmux-cef` on Darwin) still compiles. (Not regressed — that task line is unchanged.)
- [ ] Windows: `task package` still compiles. (Unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)