### PR TITLE
feat(window-drag): smooth Windows title-bar drag via host-side native move loop

### DIFF
--- a/.changesets/1780128496-feat-window-drag-windows-title-bar-drag-via-host-side-native-26s2.md
+++ b/.changesets/1780128496-feat-window-drag-windows-title-bar-drag-via-host-side-native-26s2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(window-drag): Windows title-bar drag via host-side native move loop (VS Code-smooth, zero per-move IPC)

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -188,8 +188,11 @@ pub fn set_window_rect(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 }
 
 /// Initiate window drag (for frameless windows).
-/// Windows: sends WM_NCLBUTTONDOWN/HTCAPTION via Win32 — find_own_top_level_window
-/// resolves the per-process HWND so multi-window works without a label.
+/// Windows: resolves the top-level HWND label-aware (`resolve_window_hwnd`, so a
+/// floating pane drags itself) and posts a host-side manual move loop on the CEF
+/// UI thread (`post_win32_begin_move` → `ui_tasks::Win32BeginMoveTask`). The raw
+/// WM_NCLBUTTONDOWN/HTCAPTION OS move loop does NOT work for a CEF window
+/// (Chromium's frame swallows it), so the host drives the loop itself.
 /// Linux/macOS: dispatches CefWindow::BeginWindowDrag on the UI thread; needs
 /// the source window's label so non-main windows drag themselves rather than
 /// the main window. Frontend reads `?windowLabel=…` from its URL and passes
@@ -197,15 +200,14 @@ pub fn set_window_rect(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     #[cfg(target_os = "windows")]
     {
-        // ReleaseCapture() + WM_NCLBUTTONDOWN(HTCAPTION) starts the OS modal
-        // move loop — but BOTH must run on the CEF UI thread, the thread that
-        // OWNS the renderer's mouse capture. This handler runs on a tokio IPC
-        // worker, where `ReleaseCapture()` is a NO-OP (it releases only the
-        // calling thread's capture), so the renderer keeps capture and the move
-        // loop never engages. That is the historical "WM_NCLBUTTONDOWN loses
-        // mouse state". HWND lookup is thread-safe, so resolve here (label-aware,
-        // so a floating pane drags itself, not main) and marshal the begin-move
-        // onto the UI thread.
+        // The native move loop must run on the CEF UI thread (it owns the
+        // renderer's mouse capture). This IPC handler is on a tokio worker, so
+        // we only do thread-safe HWND lookup here (label-aware, so a floating
+        // pane drags itself, not main) and marshal the move loop onto the UI
+        // thread via `post_win32_begin_move`. The loop itself is a manual
+        // SetCapture + GetMessage + SetWindowPos loop (`ui_tasks::Win32BeginMoveTask`),
+        // NOT WM_NCLBUTTONDOWN — Chromium's frame swallows that NC message, so
+        // the OS modal move loop never engages for a CEF window.
         let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
         let hwnd = unsafe {
             let h = resolve_window_hwnd(state, label);

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -196,15 +196,31 @@ pub fn set_window_rect(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 /// it here; missing → "main" for backward compatibility.
 pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     #[cfg(target_os = "windows")]
-    unsafe {
-        use windows_sys::Win32::UI::WindowsAndMessaging::*;
-        use windows_sys::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
-        let hwnd = find_own_top_level_window();
+    {
+        // ReleaseCapture() + WM_NCLBUTTONDOWN(HTCAPTION) starts the OS modal
+        // move loop — but BOTH must run on the CEF UI thread, the thread that
+        // OWNS the renderer's mouse capture. This handler runs on a tokio IPC
+        // worker, where `ReleaseCapture()` is a NO-OP (it releases only the
+        // calling thread's capture), so the renderer keeps capture and the move
+        // loop never engages. That is the historical "WM_NCLBUTTONDOWN loses
+        // mouse state". HWND lookup is thread-safe, so resolve here (label-aware,
+        // so a floating pane drags itself, not main) and marshal the begin-move
+        // onto the UI thread.
+        let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
+        let hwnd = unsafe {
+            let h = resolve_window_hwnd(state, label);
+            if h.is_null() {
+                find_own_top_level_window()
+            } else {
+                h
+            }
+        };
         if !hwnd.is_null() {
-            ReleaseCapture();
-            SendMessageW(hwnd, WM_NCLBUTTONDOWN, 2 /* HTCAPTION */, 0);
-            return Ok(serde_json::Value::Null);
+            crate::ui_tasks::post_win32_begin_move(hwnd as usize as u64);
+        } else {
+            tracing::warn!("[start_window_drag] no HWND resolved for label={}", label);
         }
+        return Ok(serde_json::Value::Null);
     }
     #[cfg(not(target_os = "windows"))]
     {

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -315,6 +315,7 @@ wrap_task! {
                 // 3. Modal move loop on the UI thread.
                 let mut msg: MSG = std::mem::zeroed();
                 let mut moves: u32 = 0;
+                let mut cancelled = false;
                 loop {
                     // Safety net: end if the button is up but no WM_LBUTTONUP came.
                     if !lbutton_down() {
@@ -330,18 +331,23 @@ wrap_task! {
                     }
                     match msg.message {
                         WM_MOUSEMOVE => {
-                            let mut cur = POINT { x: 0, y: 0 };
-                            GetCursorPos(&mut cur);
-                            SetWindowPos(
-                                h,
-                                std::ptr::null_mut(),
-                                x0 + (cur.x - anchor.x),
-                                y0 + (cur.y - anchor.y),
-                                0,
-                                0,
-                                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-                            );
-                            moves += 1;
+                            // After Esc-cancel we keep looping (so the renderer
+                            // still gets its balancing WM_LBUTTONUP on release)
+                            // but stop moving the window.
+                            if !cancelled {
+                                let mut cur = POINT { x: 0, y: 0 };
+                                GetCursorPos(&mut cur);
+                                SetWindowPos(
+                                    h,
+                                    std::ptr::null_mut(),
+                                    x0 + (cur.x - anchor.x),
+                                    y0 + (cur.y - anchor.y),
+                                    0,
+                                    0,
+                                    SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+                                );
+                                moves += 1;
+                            }
                         }
                         WM_LBUTTONUP => {
                             // Let Chromium see the up so its input state stays
@@ -351,7 +357,11 @@ wrap_task! {
                             break;
                         }
                         WM_KEYDOWN if (msg.wParam as u16) == VK_ESCAPE => {
-                            // Cancel: restore the start position.
+                            // Cancel: restore the start position, but DON'T break
+                            // — keep capture and keep looping so the eventual
+                            // WM_LBUTTONUP is still dispatched to balance the
+                            // renderer's mousedown (reagent P1 / spec §5.1).
+                            // Further moves are ignored via `cancelled`.
                             SetWindowPos(
                                 h,
                                 std::ptr::null_mut(),
@@ -361,7 +371,7 @@ wrap_task! {
                                 0,
                                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
                             );
-                            break;
+                            cancelled = true;
                         }
                         WM_TIMER => {
                             // Our wake tick — consume it; the top-of-loop

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -237,16 +237,16 @@ pub fn post_start_drag(state: &Arc<AppState>, label: &str) {
 #[cfg(target_os = "windows")]
 pub fn post_start_drag(_state: &Arc<AppState>, _label: &str) {}
 
-// ── Win32 native window move (HTCAPTION modal loop) ───────────────────────
+// ── Win32 host-side manual native move loop ───────────────────────────────
 //
-// Despite the module header's "Win32 is safe from any thread" note,
-// `ReleaseCapture()` is THREAD-SPECIFIC — it releases only the CALLING
-// thread's mouse capture — and the OS modal move loop must be initiated on the
-// thread that owns the window's capture: the CEF UI thread. The previous
-// inline path (motion.rs, on a tokio worker) made `ReleaseCapture()` a no-op,
-// so the renderer kept capture and `WM_NCLBUTTONDOWN` never engaged the move
-// loop ("loses mouse state"). This task runs it on the UI thread. The HWND is
-// resolved by the caller (thread-safe) and passed in as a u64.
+// The raw `WM_NCLBUTTONDOWN(HTCAPTION)` trick does NOT work with a CEF/Chromium
+// window: Chromium's HWNDMessageHandler swallows the non-client message and only
+// runs an OS drag for `-webkit-app-region:drag` regions (which we can't use —
+// they suppress renderer events). Instrumented proof: on the UI thread with
+// `release_ok=true`, SendMessage(WM_NCLBUTTONDOWN) returned in 0.4ms — the move
+// loop never engaged. So we run the move loop OURSELVES, on the UI thread (which
+// owns the window + capture), driving `SetWindowPos` per mouse-move with zero
+// per-move IPC. Full design + risks: SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.
 #[cfg(target_os = "windows")]
 wrap_task! {
     pub struct Win32BeginMoveTask {
@@ -255,32 +255,113 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
-            use windows_sys::Win32::Foundation::HWND;
-            use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetCapture, ReleaseCapture};
-            use windows_sys::Win32::UI::WindowsAndMessaging::{
-                SendMessageW, HTCAPTION, WM_NCLBUTTONDOWN,
+            use windows_sys::Win32::Foundation::{HWND, POINT, RECT};
+            use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+                GetAsyncKeyState, ReleaseCapture, SetCapture, VK_ESCAPE, VK_LBUTTON,
             };
+            use windows_sys::Win32::UI::WindowsAndMessaging::{
+                DispatchMessageW, GetCursorPos, GetMessageW, GetWindowRect, PostQuitMessage,
+                SetWindowPos, TranslateMessage, MSG, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+                WM_KEYDOWN, WM_LBUTTONUP, WM_MOUSEMOVE,
+            };
+
             let h = self.hwnd as HWND;
+            // High bit of GetAsyncKeyState = key currently down.
+            let lbutton_down = || unsafe {
+                (GetAsyncKeyState(VK_LBUTTON as i32) as u16 & 0x8000) != 0
+            };
+
             unsafe {
-                // Diagnostics: who holds capture before we release, and whether
-                // ReleaseCapture actually did anything (it only does when we're
-                // on the capturing thread — the whole reason for being here).
-                let cap_before = GetCapture() as usize;
-                let released = ReleaseCapture();
+                // 0. Bail if the press already ended (fast click / late task).
+                if !lbutton_down() {
+                    tracing::info!(
+                        "[start_window_drag] manual move loop skipped — button already up hwnd={:#x}",
+                        self.hwnd
+                    );
+                    return;
+                }
+
+                // 1. Capture the mouse to THIS (UI) thread so WM_MOUSEMOVE /
+                //    WM_LBUTTONUP route to our GetMessage loop. ReleaseCapture
+                //    first to drop any capture Chromium set on the press.
+                ReleaseCapture();
+                SetCapture(h);
+
+                // 2. Anchor in physical screen px — no devicePixelRatio math.
+                let mut anchor = POINT { x: 0, y: 0 };
+                GetCursorPos(&mut anchor);
+                let mut r: RECT = std::mem::zeroed();
+                GetWindowRect(h, &mut r);
+                let (x0, y0) = (r.left, r.top);
                 tracing::info!(
-                    "[start_window_drag] win32 begin-move on UI thread hwnd={:#x} capture_before={:#x} release_ok={}",
-                    self.hwnd,
-                    cap_before,
-                    released != 0
+                    "[start_window_drag] manual move loop begin hwnd={:#x} anchor=({},{}) origin=({},{})",
+                    self.hwnd, anchor.x, anchor.y, x0, y0
                 );
-                // WM_NCLBUTTONDOWN(HTCAPTION) enters the OS modal move loop,
-                // which blocks the UI thread until the user releases the button.
-                // The loop pumps messages, so child HWNDs move + paint with the
-                // window; CEF task processing resumes when the loop returns.
-                SendMessageW(h, WM_NCLBUTTONDOWN, HTCAPTION as usize, 0);
+
+                // 3. Modal move loop on the UI thread.
+                let mut msg: MSG = std::mem::zeroed();
+                let mut moves: u32 = 0;
+                loop {
+                    // Safety net: end if the button is up but no WM_LBUTTONUP came.
+                    if !lbutton_down() {
+                        break;
+                    }
+                    let got = GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0);
+                    if got <= 0 {
+                        if got == 0 {
+                            // WM_QUIT — don't swallow app shutdown.
+                            PostQuitMessage(msg.wParam as i32);
+                        }
+                        break;
+                    }
+                    match msg.message {
+                        WM_MOUSEMOVE => {
+                            let mut cur = POINT { x: 0, y: 0 };
+                            GetCursorPos(&mut cur);
+                            SetWindowPos(
+                                h,
+                                std::ptr::null_mut(),
+                                x0 + (cur.x - anchor.x),
+                                y0 + (cur.y - anchor.y),
+                                0,
+                                0,
+                                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+                            );
+                            moves += 1;
+                        }
+                        WM_LBUTTONUP => {
+                            // Let Chromium see the up so its input state stays
+                            // balanced against the mousedown the renderer got
+                            // (SPEC §5.1).
+                            DispatchMessageW(&msg);
+                            break;
+                        }
+                        WM_KEYDOWN if (msg.wParam as u16) == VK_ESCAPE => {
+                            // Cancel: restore the start position.
+                            SetWindowPos(
+                                h,
+                                std::ptr::null_mut(),
+                                x0,
+                                y0,
+                                0,
+                                0,
+                                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+                            );
+                            break;
+                        }
+                        _ => {
+                            // Keep the app alive (paint, DPI changes, sent msgs).
+                            TranslateMessage(&msg);
+                            DispatchMessageW(&msg);
+                        }
+                    }
+                }
+
+                // 4. Always release capture.
+                ReleaseCapture();
                 tracing::info!(
-                    "[start_window_drag] win32 move loop returned hwnd={:#x}",
-                    self.hwnd
+                    "[start_window_drag] manual move loop end hwnd={:#x} moves={}",
+                    self.hwnd, moves
                 );
             }
         }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -237,6 +237,62 @@ pub fn post_start_drag(state: &Arc<AppState>, label: &str) {
 #[cfg(target_os = "windows")]
 pub fn post_start_drag(_state: &Arc<AppState>, _label: &str) {}
 
+// ── Win32 native window move (HTCAPTION modal loop) ───────────────────────
+//
+// Despite the module header's "Win32 is safe from any thread" note,
+// `ReleaseCapture()` is THREAD-SPECIFIC — it releases only the CALLING
+// thread's mouse capture — and the OS modal move loop must be initiated on the
+// thread that owns the window's capture: the CEF UI thread. The previous
+// inline path (motion.rs, on a tokio worker) made `ReleaseCapture()` a no-op,
+// so the renderer kept capture and `WM_NCLBUTTONDOWN` never engaged the move
+// loop ("loses mouse state"). This task runs it on the UI thread. The HWND is
+// resolved by the caller (thread-safe) and passed in as a u64.
+#[cfg(target_os = "windows")]
+wrap_task! {
+    pub struct Win32BeginMoveTask {
+        hwnd: u64,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            use windows_sys::Win32::Foundation::HWND;
+            use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetCapture, ReleaseCapture};
+            use windows_sys::Win32::UI::WindowsAndMessaging::{
+                SendMessageW, HTCAPTION, WM_NCLBUTTONDOWN,
+            };
+            let h = self.hwnd as HWND;
+            unsafe {
+                // Diagnostics: who holds capture before we release, and whether
+                // ReleaseCapture actually did anything (it only does when we're
+                // on the capturing thread — the whole reason for being here).
+                let cap_before = GetCapture() as usize;
+                let released = ReleaseCapture();
+                tracing::info!(
+                    "[start_window_drag] win32 begin-move on UI thread hwnd={:#x} capture_before={:#x} release_ok={}",
+                    self.hwnd,
+                    cap_before,
+                    released != 0
+                );
+                // WM_NCLBUTTONDOWN(HTCAPTION) enters the OS modal move loop,
+                // which blocks the UI thread until the user releases the button.
+                // The loop pumps messages, so child HWNDs move + paint with the
+                // window; CEF task processing resumes when the loop returns.
+                SendMessageW(h, WM_NCLBUTTONDOWN, HTCAPTION as usize, 0);
+                tracing::info!(
+                    "[start_window_drag] win32 move loop returned hwnd={:#x}",
+                    self.hwnd
+                );
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn post_win32_begin_move(hwnd: u64) {
+    let mut task = Win32BeginMoveTask::new(hwnd);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Move window ───────────────────────────────────────────────────────────
 
 wrap_task! {

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -257,12 +257,12 @@ wrap_task! {
         fn execute(&self) {
             use windows_sys::Win32::Foundation::{HWND, POINT, RECT};
             use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
-                GetAsyncKeyState, ReleaseCapture, SetCapture, VK_ESCAPE, VK_LBUTTON,
+                GetAsyncKeyState, GetCapture, ReleaseCapture, SetCapture, VK_ESCAPE, VK_LBUTTON,
             };
             use windows_sys::Win32::UI::WindowsAndMessaging::{
-                DispatchMessageW, GetCursorPos, GetMessageW, GetWindowRect, PostQuitMessage,
-                SetWindowPos, TranslateMessage, MSG, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
-                WM_KEYDOWN, WM_LBUTTONUP, WM_MOUSEMOVE,
+                DispatchMessageW, GetCursorPos, GetMessageW, GetWindowRect, KillTimer,
+                PostQuitMessage, SetTimer, SetWindowPos, TranslateMessage, MSG, SWP_NOACTIVATE,
+                SWP_NOSIZE, SWP_NOZORDER, WM_KEYDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_TIMER,
             };
 
             let h = self.hwnd as HWND;
@@ -285,7 +285,21 @@ wrap_task! {
                 //    WM_LBUTTONUP route to our GetMessage loop. ReleaseCapture
                 //    first to drop any capture Chromium set on the press.
                 ReleaseCapture();
-                SetCapture(h);
+                let prev_capture = SetCapture(h);
+                // Confirm we actually hold capture; if not, mouse moves won't
+                // reach our loop and the drag would silently no-op (reagent #1).
+                if GetCapture() != h {
+                    tracing::warn!(
+                        "[start_window_drag] SetCapture did not take hwnd={:#x} prev={:#x}",
+                        self.hwnd, prev_capture as usize
+                    );
+                }
+                // Wake the loop ~10x/sec even with no mouse input, so a stolen
+                // capture or a missed WM_LBUTTONUP can't hang the UI thread —
+                // the top-of-loop button-state check then ends the drag
+                // (reagent #2; the blocking-GetMessage hang noted in the spec).
+                const DRAG_TICK_ID: usize = 0xD9A6;
+                SetTimer(h, DRAG_TICK_ID, 100, None);
 
                 // 2. Anchor in physical screen px — no devicePixelRatio math.
                 let mut anchor = POINT { x: 0, y: 0 };
@@ -349,6 +363,10 @@ wrap_task! {
                             );
                             break;
                         }
+                        WM_TIMER => {
+                            // Our wake tick — consume it; the top-of-loop
+                            // button-state check re-runs on the next iteration.
+                        }
                         _ => {
                             // Keep the app alive (paint, DPI changes, sent msgs).
                             TranslateMessage(&msg);
@@ -357,7 +375,8 @@ wrap_task! {
                     }
                 }
 
-                // 4. Always release capture.
+                // 4. Stop the wake tick and release capture.
+                KillTimer(h, DRAG_TICK_ID);
                 ReleaseCapture();
                 tracing::info!(
                     "[start_window_drag] manual move loop end hwnd={:#x} moves={}",

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -261,8 +261,9 @@ wrap_task! {
             };
             use windows_sys::Win32::UI::WindowsAndMessaging::{
                 DispatchMessageW, GetCursorPos, GetMessageW, GetWindowRect, KillTimer,
-                PostQuitMessage, SetTimer, SetWindowPos, TranslateMessage, MSG, SWP_NOACTIVATE,
-                SWP_NOSIZE, SWP_NOZORDER, WM_KEYDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_TIMER,
+                PeekMessageW, PostQuitMessage, SendMessageW, SetTimer, SetWindowPos,
+                TranslateMessage, MSG, PM_REMOVE, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+                WM_KEYDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_TIMER,
             };
 
             let h = self.hwnd as HWND;
@@ -317,8 +318,22 @@ wrap_task! {
                 let mut moves: u32 = 0;
                 let mut cancelled = false;
                 loop {
-                    // Safety net: end if the button is up but no WM_LBUTTONUP came.
+                    // Safety net: GetAsyncKeyState reflects PHYSICAL button state,
+                    // which can lead the message queue — so a release arriving
+                    // just after a WM_MOUSEMOVE/WM_TIMER would trip this check and
+                    // break BEFORE the queued WM_LBUTTONUP is dispatched, leaving
+                    // the up to land off-window post-ReleaseCapture and Chromium's
+                    // mousedown unbalanced (reagent P1 / spec §5.1). So before
+                    // breaking, drain a queued WM_LBUTTONUP (capture still held)
+                    // and dispatch it; if none is queued yet, synthesize one so
+                    // the renderer always sees its balancing up.
                     if !lbutton_down() {
+                        let mut up: MSG = std::mem::zeroed();
+                        if PeekMessageW(&mut up, h, WM_LBUTTONUP, WM_LBUTTONUP, PM_REMOVE) != 0 {
+                            DispatchMessageW(&up);
+                        } else {
+                            SendMessageW(h, WM_LBUTTONUP, 0, 0);
+                        }
                         break;
                     }
                     let got = GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0);

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -373,9 +373,11 @@ wrap_task! {
                             );
                             cancelled = true;
                         }
-                        WM_TIMER => {
-                            // Our wake tick — consume it; the top-of-loop
+                        WM_TIMER if msg.wParam == DRAG_TICK_ID => {
+                            // Our wake tick — consume ONLY ours; the top-of-loop
                             // button-state check re-runs on the next iteration.
+                            // Other timers fall through to the `_` arm so CEF's
+                            // own timers aren't dropped during the drag.
                         }
                         _ => {
                             // Keep the app alive (paint, DPI changes, sent msgs).

--- a/docs/specs/SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.md
+++ b/docs/specs/SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.md
@@ -1,0 +1,197 @@
+---
+title: Window drag — host-side manual native move loop (Windows)
+status: Approved — implementing
+date: 2026-05-29
+author: AgentX
+front: window-drag (UX-latency umbrella #1161)
+supersedes_approach: "Option B (raw WM_NCLBUTTONDOWN) in SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md — proven dead, see §1"
+related:
+  - "docs/specs/SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md (problem statement + Option A/B)"
+  - "docs/analysis/ANALYSIS_UX_LATENCY_THREE_FRONTS_2026_05_29.md"
+  - "docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md (the DPI hack this removes)"
+---
+
+# Window drag — host-side manual native move loop (Windows)
+
+## 1. Spike result — why the OS move loop can't be reused
+
+The previous spike wired the frontend to fire one `start_window_drag` on the 4px
+threshold and had the host run `ReleaseCapture()` + `SendMessageW(WM_NCLBUTTONDOWN,
+HTCAPTION)`. First attempt failed because it ran on the tokio IPC worker, where
+`ReleaseCapture()` is a no-op (it's thread-specific). After marshaling it onto the
+**CEF UI thread**, the instrumented log was conclusive:
+
+```
+begin-move on UI thread  hwnd=0x14b00fec  capture_before=0x14b00fec  release_ok=true
+move loop returned       hwnd=0x14b00fec        ← 0.4 ms later
+```
+
+`release_ok=true` (threading is correct now), but `SendMessageW(WM_NCLBUTTONDOWN)`
+**returns in 0.4 ms instead of blocking for the drag** — i.e. the OS modal move loop
+**never engages**. Chromium's custom window frame (`HWNDMessageHandler`) intercepts
+non-client messages and only runs an OS window-drag for `-webkit-app-region:drag`
+regions — which AgentMux can't use because they suppress all renderer events (and
+kill the title-bar context menu). **The OS will not run the move loop for a CEF
+window, so we run it ourselves**, natively, on the UI thread — no per-move IPC.
+
+This is the deliberate realization of the original "freeze the content, do the move,
+update on release" idea, placed in the native layer instead of fighting it in JS.
+
+## 2. Goal & non-goals
+
+**Goal:** title-bar drag tracks the cursor at input rate (VS Code-smooth), zero
+per-move IPC, no `devicePixelRatio` hand-correction, right-click + double-click
+preserved.
+
+**Non-goals (v1):** Aero Snap / snap-assist (see §6 tradeoff), live content updates
+*during* the drag (content shows its last frame and moves with the window — by
+design), tab tear-off (separate gesture, unchanged).
+
+## 3. Architecture
+
+Frontend is **unchanged** from the current native path (`useWindowDrag.win32.ts`):
+arm on mousedown over a `data-drag-region`, and on the 4px threshold fire **one**
+fire-and-forget `start_window_drag` IPC. Everything else is host-side.
+
+Host: `start_window_drag` (motion.rs) resolves the top-level HWND label-aware
+(thread-safe) and posts `Win32BeginMoveTask` to the **CEF UI thread** (already wired
+as `post_win32_begin_move`). The task runs a **manual move loop** on the UI thread.
+
+```
+renderer mousedown→4px ─▶ start_window_drag IPC ─▶ motion.rs resolve HWND
+                                                  └▶ post_task(UI, Win32BeginMoveTask)
+                                                        └▶ manual move loop (this spec)
+```
+
+## 4. The manual move loop (UI thread)
+
+Pseudocode (Rust / windows-sys; full impl in `ui_tasks.rs::Win32BeginMoveTask`):
+
+```
+fn execute():
+  h = self.hwnd as HWND
+  // 0. Bail if the press already ended (fast click / late task).
+  if !(GetAsyncKeyState(VK_LBUTTON) & 0x8000): return
+
+  // 1. Take capture so all mouse input routes to THIS (UI) thread's queue.
+  ReleaseCapture(); SetCapture(h)
+
+  // 2. Anchor in PHYSICAL screen px — no DPI math needed.
+  GetCursorPos(&anchor); GetWindowRect(h, &r); (x0,y0) = (r.left, r.top)
+
+  // 3. Pump our own modal loop.
+  loop:
+    if !(GetAsyncKeyState(VK_LBUTTON) & 0x8000): break        // safety: button up
+    if GetMessageW(&msg, NULL, 0,0) <= 0: { repost WM_QUIT; break }
+    match msg.message:
+      WM_MOUSEMOVE:
+        GetCursorPos(&cur)
+        SetWindowPos(h, NULL, x0+(cur.x-anchor.x), y0+(cur.y-anchor.y),
+                     0,0, SWP_NOSIZE|SWP_NOZORDER|SWP_NOACTIVATE)
+      WM_LBUTTONUP:
+        DispatchMessageW(&msg)   // let Chromium see the up (input-state balance, §5)
+        break
+      WM_KEYDOWN if wParam==VK_ESCAPE:
+        SetWindowPos(h, NULL, x0,y0, 0,0, SWP_NOSIZE|SWP_NOZORDER|SWP_NOACTIVATE) // cancel → restore
+        break
+      _: TranslateMessage(&msg); DispatchMessageW(&msg)        // keep app alive (paint/DPI/etc)
+
+  // 4. Always release.
+  ReleaseCapture()
+```
+
+**Coordinate model:** `GetCursorPos`, `GetWindowRect`, `SetWindowPos` are all
+physical px → the `* devicePixelRatio` correction (and `SPEC_WINDOW_DRAG_DPI_FIX`)
+is **deleted**. A mid-drag monitor crossing with a different scale fires
+`WM_DPICHANGED`, which is dispatched in the `_` arm (Chromium resizes); the anchor
+delta stays valid because we re-read `GetCursorPos` each move and offset from the
+fixed `(x0,y0)` origin (which itself moved only via our `SetWindowPos`). If a DPI
+resize is observed to desync the origin in testing, re-read `GetWindowRect` on
+`WM_DPICHANGED` (listed as a follow-up, not v1-blocking).
+
+## 5. Sharp edges (designed-for)
+
+1. **Renderer input-state consistency (highest risk).** The renderer received the
+   original `mousedown` (web content). While we hold capture and *consume*
+   `WM_MOUSEMOVE`/`WM_LBUTTONUP`, the renderer does **not** see them, so without care
+   Chromium can be left believing a button is still down (stuck selection / odd next
+   click). **Mitigation (v1):** `DispatchMessageW` the terminating `WM_LBUTTONUP` (do
+   not just `break` on it) so Chromium completes the down→up pair. **Must
+   runtime-verify**: after a drag, click a button / select text in the window behaves
+   normally. If this proves insufficient, fall back to the **no-capture variant**
+   (§7) which never steals the renderer's input.
+
+2. **Nested modal loop.** Running `GetMessageW` inside a CEF UI-thread task is a
+   nested message loop; CEF's own loop is suspended until we return. Standard for
+   modal drags, but: (a) CEF `post_task` work queues until release (fine for a short
+   drag), (b) never hold an `AppState`/parking_lot lock across the loop (we don't),
+   (c) handle `GetMessageW` returning `0` (WM_QUIT) by reposting `PostQuitMessage` and
+   bailing so app-quit isn't swallowed.
+
+3. **Button released off-window / capture stolen.** `WM_CAPTURECHANGED` is *sent*
+   (not posted), so it won't surface in `GetMessageW`; the per-iteration
+   `GetAsyncKeyState(VK_LBUTTON)` check is the safety net that ends the loop if the
+   up is missed.
+
+4. **Re-entrancy / double start.** The frontend sets `dragInitiated=true` and stops
+   tracking after firing once, so only one task starts per press. The `GetAsyncKeyState`
+   bail (step 0) covers a late task whose press already ended.
+
+5. **Floating panes.** HWND is resolved label-aware (`resolve_window_hwnd(label)`),
+   so a floating pane drags itself, not main.
+
+## 6. Tradeoffs vs Option A (CEF `BeginWindowDrag`)
+
+| | B′ manual loop (this spec) | A: CEF BeginWindowDrag |
+|---|---|---|
+| CEF patch / libcef rebuild | **None** | Required (Win32 impl + `patched-libcef`) |
+| Aero Snap / snap-assist | **Lost** (v1) — can add manual edge-snap later | Free (OS owns the move) |
+| Renderer input consistency | Must manage (§5.1) | Clean (goes through Chromium input) |
+| Content during drag | Frozen last frame moves w/ window | Same |
+| Effort | **Medium**, in-tree | Large (build infra) |
+
+B′ is the pragmatic ship-now path. If §5.1 can't be made clean, A is the fallback.
+
+## 7. Alternative kept on file — no-capture poll
+
+If capture+consume causes renderer-input issues: **don't `SetCapture`**; instead poll
+`GetCursorPos` + `GetAsyncKeyState(VK_LBUTTON)` each frame, `SetWindowPos` the delta,
+and pump pending messages via `PeekMessageW` + a `MsgWaitForMultipleObjectsEx(~8ms)`
+wait. The renderer keeps its input (gets its own `mouseup` → consistent state); cost
+is a busier loop. Slightly less smooth, strictly safer for input state.
+
+## 8. Flag & rollout
+
+- Native is default; legacy JS path stays behind `localStorage['agentmux.win32NativeDrag']='0'`
+  (already implemented) for one release as a fallback.
+- Phased: land behind the flag → run the bench + manual matrix → flip default → delete
+  the JS path next release.
+
+## 9. Measurement (gate for merge)
+
+Extend the **#1176 input-latency bench** with a drag harness measuring **cursor→window
+lag** (sample window rect via the WRR `LOCATIONCHANGE` stream vs synthetic cursor):
+- **Success:** lag ≈ one frame and **flat under injected IPC jitter** (the move left
+  the IPC path entirely — there is no per-move IPC anymore).
+- `set_window_position` call-count during a drag = **0**; exactly one `start_window_drag`
+  per drag.
+- Re-run @ 100/125/150% scale — the 125% lag must be **gone** (DPI math removed).
+- Existing `[start_window_drag] manual move loop …` host logs confirm engagement.
+
+## 10. Acceptance criteria
+
+- [ ] Drag tracks the cursor smoothly (no jitter), lag flat & jitter-insensitive.
+- [ ] No regression @ 125/150% scale (expect improvement).
+- [ ] **After a drag, the window's UI is fully interactive** (no stuck button/selection
+      state) — the §5.1 verification.
+- [ ] Right-click title-bar menu + double-click-maximize still work.
+- [ ] Esc mid-drag cancels and restores the start position.
+- [ ] Floating pane drags itself, not main.
+- [ ] JS path still reachable via the localStorage flag.
+
+## 11. Out of scope / follow-ups
+
+- Aero Snap (manual edge detection + snap layouts).
+- `WM_DPICHANGED` origin re-read if cross-monitor desync is observed.
+- Porting to a single cross-platform path if Option A's `BeginWindowDrag` later lands
+  on Windows.

--- a/docs/specs/SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md
+++ b/docs/specs/SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md
@@ -1,0 +1,218 @@
+---
+title: Window drag — replace per-mousemove IPC with the OS native move loop
+status: Draft / Proposed
+date: 2026-05-29
+author: AgentX
+front: window-drag (UX-latency umbrella #1161)
+related:
+  - "#1161 Typing/input-responsiveness umbrella (the broader 'remove UX latency' effort)"
+  - "#1097 SetWindowRgn airspace cost (sibling native-path latency)"
+  - "PR #1178 perf(airspace): region-cache (sibling, in-flight)"
+  - "docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md (the DPI hand-correction this spec deletes)"
+  - "Codex PR #734 (rounds 2-4: the race-guarding this spec deletes)"
+  - "docs/analysis/ANALYSIS_UX_LATENCY_THREE_FRONTS_2026_05_29.md (findings this spec implements)"
+---
+
+# Window drag → OS native move loop (Windows)
+
+## 1. Problem
+
+On Windows, dragging the main window (or a floating-pane window) by its title bar
+**lags the cursor**, and the lag gets visibly worse at non-100% display scale.
+
+The cost is **entirely self-inflicted by the frontend**. `useWindowDrag.win32.ts`
+drives the *whole* drag in JavaScript:
+
+- **mousedown** in a `data-drag-region` → `await get_window_position` (one IPC
+  round-trip *before the drag even arms*).
+- **every mousemove (~120 Hz)** → compute `target = initWin + delta * devicePixelRatio`,
+  then `set_window_position` over HTTP-IPC. The window's new position is **gated on
+  that round-trip completing** (`useWindowDrag.win32.ts:143-161` → `:126-142` →
+  `ipc.ts:51` fetch → `motion.rs:92` `SetWindowPos`).
+
+Each move pays: localhost `fetch` (connection + HTTP framing + JSON) → tokio worker
+dispatch → `GetWindowRect` + `SetWindowPos` → JSON response → promise resolution.
+A one-in-flight coalescer (`:124-142`) drops intermediate moves, so under any IPC
+jitter the window updates at the **round-trip rate, not the input rate** — the lag.
+
+It also carries a whole tail of accidental complexity that exists *only* to paper
+over the JS-driven approach:
+
+- DPI hand-correction (`* devicePixelRatio`, `:103-105`, `:157-159`) — the source
+  of the documented ~20% lag at Win11 125% scale (`SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md`).
+- Per-mousedown sequence token, catch-up move, one-in-flight coalescer — three
+  rounds of race-guarding from Codex PR #734 (`:43-65`, `:113-142`, `:163-175`).
+
+## 2. The key realization
+
+There is **nothing to "freeze" during a window move.** (This spec supersedes the
+"freeze the DOM during drag" idea — see the verdict in
+`ANALYSIS_UX_LATENCY_THREE_FRONTS_2026_05_29.md §Drag`.)
+
+A *pure move* changes the window's position, not its size:
+
+- The floating-pane wndproc handles `WM_SIZE` but has **no `WM_MOVE` handler**
+  (`floating_pane.rs`), so child pane HWNDs follow the parent automatically — **zero
+  reflow**.
+- `set_pane_overlay_clip` (the airspace `SetWindowRgn` path) is **not** triggered by
+  a move — its only frontend trigger sweeps on DOM `resize`/`scroll`
+  (`pane-overlay-auto.ts`), and a window move changes no inner content size.
+- The OS already composites the last frame of every child HWND and moves them as one.
+
+So the renderer should not be involved in a move *at all*. The fix is not to suppress
+renderer work — it's to **stop generating it**.
+
+## 3. The capability already exists (and is unused)
+
+The Win32 host **already implements the native move loop** — it's just never called
+from the Windows frontend:
+
+```rust
+// agentmux-cef/src/commands/window/motion.rs:135  start_window_drag()
+#[cfg(target_os = "windows")]
+unsafe {
+    let hwnd = find_own_top_level_window();
+    if !hwnd.is_null() {
+        ReleaseCapture();
+        SendMessageW(hwnd, WM_NCLBUTTONDOWN, 2 /* HTCAPTION */, 0);
+        return Ok(serde_json::Value::Null);
+    }
+}
+```
+
+`WM_NCLBUTTONDOWN` + `HTCAPTION` makes `DefWindowProc` run the **OS modal move loop**:
+the OS moves the frame and all child HWNDs following the cursor until the user releases
+the button — **zero further IPC, zero renderer involvement**, and Aero Snap / multi-
+monitor / shake-to-minimize all work for free.
+
+**The Linux/macOS frontend already uses this pattern** (`useWindowDrag.linux.ts`): on
+mousedown it arms, and on a 4px threshold-crossing mousemove it fires **one**
+fire-and-forget `start_window_drag` IPC; the compositor takes over. Host side, the
+non-Windows arm routes to `CefWindow::BeginWindowDrag()` (a CEF patch — `xdg_toplevel.move`
+on Wayland / `_NET_WM_MOVERESIZE` on X11).
+
+**Only the Windows frontend opts out**, and the file says why
+(`useWindowDrag.win32.ts:7`):
+
+> `WM_NCLBUTTONDOWN doesn't work because the async IPC roundtrip loses mouse state.`
+
+## 4. Root cause of "loses mouse state"
+
+The `WM_NCLBUTTONDOWN`/`HTCAPTION` modal loop only engages if the **left button is
+still physically down and capture is consistent** when `DefWindowProc` processes the
+message. Two things break that in the current shape:
+
+1. **CEF already captured the pointer.** The renderer takes pointer capture on the
+   web-content mousedown. When the raw `SendMessageW(WM_NCLBUTTONDOWN)` arrives, the
+   move loop's hit-test/capture handoff conflicts with CEF's capture and the loop
+   exits immediately. `ReleaseCapture()` (already present) helps but isn't integrated
+   with CEF's input pipeline.
+2. **Async IPC latency.** If `start_window_drag` is *awaited* (or simply slow), the
+   `WM_NCLBUTTONDOWN` lands after the button state / capture has diverged from the
+   press.
+
+The Linux/macOS path avoids both by initiating the OS drag **from inside CEF**
+(`BeginWindowDrag()`), which preserves capture and mouse state. Windows has no
+equivalent wired — it uses the raw `SendMessage` hack, which is exactly why it
+"loses mouse state."
+
+## 5. Proposal
+
+Delete the per-mousemove JS drag on Windows and hand the move to the OS, mirroring
+the Linux path. Two implementation options, recommended in order:
+
+### Option B (cheap spike — try first)
+Point the existing Win32 `start_window_drag` at the frontend with correct timing:
+
+- **Frontend (`useWindowDrag.win32.ts`):** rewrite to mirror `useWindowDrag.linux.ts`:
+  - mousedown in `data-drag-region` → arm (record press point), **do not** `preventDefault`,
+    **do not** `await get_window_position`.
+  - mousemove crossing a 4px threshold while the button is held → fire **one**
+    fire-and-forget `invokeCommand("start_window_drag", { label })`, then stop tracking.
+  - mouseup → disarm. dblclick → `maximize_window` (unchanged).
+  - **Delete** `set_window_position`/`sendPos`, the `* devicePixelRatio` math, the
+    sequence token, catch-up, and one-in-flight coalescer — all unnecessary once the
+    OS owns the move.
+- **Host:** unchanged (`start_window_drag` already does `ReleaseCapture()` +
+  `SendMessageW(WM_NCLBUTTONDOWN, HTCAPTION)`).
+
+The bet: the historical "loses mouse state" came from **awaiting** the IPC and/or the
+`get_window_position` round-trip delaying arm — not from a fundamental Win32
+limitation. Firing one fire-and-forget message on the threshold-crossing mousemove
+(button still held) may now just work. **Spike on Win11 @ 125% scale before committing.**
+
+### Option A (correct fix — fallback if B loses state)
+Port `CefWindow::BeginWindowDrag()` to Windows and route through it:
+
+- Confirm whether the CEF patch that added `BeginWindowDrag` to the `CefWindow` API
+  (used by Linux/mac) already has a Windows/Aura implementation; if not, add one
+  (on Windows it ultimately still issues the `WM_NCLBUTTONDOWN` move, but **from
+  inside CEF's input handling**, so capture/mouse-state stay consistent).
+- Change the Win32 arm of `start_window_drag` (`motion.rs:136`) to call
+  `BeginWindowDrag()` instead of the raw `ReleaseCapture` + `SendMessageW`.
+- Frontend change is identical to Option B.
+
+Option A is the durable, cross-platform-consistent answer; Option B is a 1-hour
+experiment that might make A unnecessary.
+
+## 6. What we gain / what to watch
+
+**Gain**
+- Window tracks the cursor at input rate, **insensitive to IPC jitter**.
+- **Deletes** the DPI hand-correction (`SPEC_WINDOW_DRAG_DPI_FIX`) and its 125%-scale
+  bug class — the OS moves in physical px natively.
+- **Deletes** ~120 lines of race-guarding (PR #734 rounds 2-4).
+- Aero Snap, snap-assist, multi-monitor DPI transitions, shake-to-minimize: free.
+
+**Watch (open questions / must-verify)**
+- **Tab tear-off** (drag a *tab* below the bar to spawn a new window) is a separate
+  gesture on a separate element; confirm it does **not** share the title-bar
+  `data-drag-region` path and is unaffected.
+- **Floating-pane windows** must drag themselves, not "main." The native loop uses
+  `find_own_top_level_window()` (no label) — verify it resolves the correct HWND for
+  an owned floater (the JS path used `ownWindowLabel()` + `resolve_window_hwnd` for
+  exactly this reason — `motion.rs:128-134`, `useWindowDrag.win32.ts:24-37`).
+- **Modal loop blocks the UI thread** until drop (standard Windows behavior). Confirm
+  no timer/IPC starvation issue during a long drag (renderer is on its own process/
+  threads, so this should be invisible).
+- **Right-click / context menu** on the title bar must still fire (Linux kept the
+  region `HTCLIENT` precisely for this — `useWindowDrag.linux.ts:13`). Verify on Win32.
+
+## 7. Measurement (gate for merge)
+
+Extend the **#1176 input-latency bench harness** with a **drag harness** that measures
+*cursor→window lag*, not handler time:
+
+- Script a constant-velocity drag; each frame sample the window rect (the WRR
+  `LOCATIONCHANGE` stream, `win_event.rs:352`, is a ready position source) vs. the
+  synthetic cursor.
+- **Before:** lag tracks IPC round-trip rate and **grows under injected localhost
+  jitter**.
+- **After (success):** lag is ~one frame and **insensitive to injected IPC jitter** —
+  the proof the move left the IPC path.
+- Assert `set_window_position` call-count during a drag drops to **0**, and exactly
+  **one** `start_window_drag` fires per drag (on the threshold crossing).
+- Re-run at **100% / 125% / 150%** Win11 scale — expect the 125% lag to *disappear*
+  (DPI math removed), not regress.
+
+Freebie shipped alongside: demote the per-`LOCATIONCHANGE` `tracing::info!`
+(`win_event.rs:236-240`, fires 5-20×/s during a drag) to `debug!`.
+
+## 8. Rollout
+
+1. Land the `tracing` demotion (independent, trivial).
+2. **Spike Option B** behind a runtime flag (`AGENTMUX_NATIVE_WINDOW_DRAG=1` or a
+   settings toggle) so the JS path remains the default fallback during validation.
+3. Run the drag harness + manual matrix (tear-off, floaters, context menu, snap,
+   multi-monitor @ 3 scales).
+4. If B holds mouse state → flip the flag default to native, delete the JS path next
+   release. If B loses state → implement Option A, same validation.
+
+## 9. Acceptance criteria
+
+- [ ] Drag lag is flat and jitter-insensitive in the harness; `set_window_position`
+      count = 0 during drag.
+- [ ] No regression at 125%/150% scale (expect improvement).
+- [ ] Tab tear-off, floating-pane drag-self, title-bar context menu, dblclick-maximize
+      all still work on Windows.
+- [ ] JS drag path remains behind a flag for one release as fallback.

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -2,13 +2,49 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Windows-specific window drag hook.
-// Tauri: data-drag-region is handled at the WebView/OS level.
-// CEF: JS-driven window move — track mouse delta, set window position via IPC.
-// WM_NCLBUTTONDOWN doesn't work because the async IPC roundtrip loses mouse state.
+//
+// Two implementations, chosen at install time:
+//
+//  - NATIVE (default) — SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md.
+//    Keep the title bar HTCLIENT (so right-click / contextmenu still fire),
+//    detect drag intent in JS, and on a 4px threshold hand the move to the OS
+//    via ONE fire-and-forget `start_window_drag` IPC. The host runs
+//    `ReleaseCapture()` + `SendMessageW(WM_NCLBUTTONDOWN, HTCAPTION)`, so the
+//    OS modal move loop tracks the cursor with ZERO further IPC — matching
+//    VS Code / Electron smoothness. This mirrors useWindowDrag.linux.ts.
+//
+//  - LEGACY JS (fallback) — JS-driven per-mousemove `set_window_position`.
+//    Smooth-but-laggy: the window position is gated on an IPC round-trip per
+//    move, so it lags the cursor under any host jitter. Kept behind a runtime
+//    opt-out while the native path is validated, because of a historical note
+//    that the native `WM_NCLBUTTONDOWN` path "loses mouse state" (this hook is
+//    the spike that verifies whether that still reproduces — the previous
+//    attempt awaited an IPC before sending; the native path here never awaits).
+//
+// Toggle: native is ON by default. To force the legacy JS path, set
+//   localStorage['agentmux.win32NativeDrag'] = '0'
+// in DevTools and reload the window.
 
 import { detectHost, invokeCommand } from "@/app/platform/ipc";
 
 let cefDragListenerInstalled = false;
+
+// Threshold in CSS pixels before we treat a press+move as a window drag.
+// Below this the press is a normal click (buttons inside a drag region still
+// work). 4px matches Chrome's default drag threshold (and the Linux hook).
+const DRAG_THRESHOLD_PX = 4;
+
+/// Native OS move loop is the default. Set localStorage
+/// 'agentmux.win32NativeDrag' = '0' (then reload) to fall back to the legacy
+/// JS-driven drag. Wrapped in try/catch because localStorage can throw in
+/// locked-down contexts.
+function useNativeDrag(): boolean {
+    try {
+        return localStorage.getItem("agentmux.win32NativeDrag") !== "0";
+    } catch {
+        return true;
+    }
+}
 
 function isInDragRegion(target: HTMLElement | null): boolean {
     let el = target;
@@ -21,106 +57,157 @@ function isInDragRegion(target: HTMLElement | null): boolean {
     return false;
 }
 
-/// Identify which top-level window we're running in so the host can
-/// route `get/set_window_position` IPC to the right HWND. The renderer
-/// URL carries `windowLabel=…` for every non-main window (the launcher
-/// doesn't add it for `main`); falling back to `"main"` keeps the
-/// main-window's drag pointing at itself.
-///
-/// Necessary because `find_own_top_level_window` on the host walks
-/// process-wide windows in Z-order, and owned floating-pane windows
-/// sit ABOVE their owner — so without a label, the main window's drag
-/// would accidentally move whichever floater is currently topmost.
+/// Identify which top-level window we're running in so the host can route
+/// drag/maximize IPC to the right HWND. The renderer URL carries
+/// `windowLabel=…` for every non-main window (the launcher doesn't add it for
+/// `main`); falling back to `"main"` keeps the main window pointing at itself.
 function ownWindowLabel(): string {
-    const params = new URLSearchParams(window.location.search);
-    return params.get("windowLabel") || "main";
+    try {
+        return new URLSearchParams(window.location.search).get("windowLabel") || "main";
+    } catch {
+        return "main";
+    }
 }
 
-function installCefDragListener() {
-    if (cefDragListenerInstalled || detectHost() !== "cef") return;
-    cefDragListenerInstalled = true;
+// ── NATIVE path ──────────────────────────────────────────────────────────
+// Mirrors useWindowDrag.linux.ts: arm on mousedown, hand the move to the OS
+// on threshold crossing, let the OS modal loop run the rest. No per-move IPC,
+// no DPI math, no race-guarding — the OS owns the move.
+function installNativeDragListener() {
+    let pressX = 0;
+    let pressY = 0;
+    let pressArmed = false; // mousedown seen, waiting for threshold-crossing motion
+    let dragInitiated = false; // start_window_drag has been sent
 
-    // Per-mousedown sequence token. Each press increments
-    // `currentMouseDownId`; the async `get_window_position` handler
-    // captures the value at press time and bails if it doesn't still
-    // match when the promise resolves.
-    //
-    // Without the sequence token, a rapid press → release → press
-    // sequence with a slow IPC could let the OLDER request arm drag
-    // using the older click coords (a shared boolean would already
-    // be true again from the newer press). Codex P2 PR #734 round 2.
+    document.addEventListener(
+        "mousedown",
+        (e: MouseEvent) => {
+            // Left button only; right/middle pass through to standard handling
+            // (contextmenu etc) — the whole reason we keep the region HTCLIENT.
+            if (e.button !== 0) return;
+            if (!isInDragRegion(e.target as HTMLElement)) return;
+            pressX = e.clientX;
+            pressY = e.clientY;
+            pressArmed = true;
+            dragInitiated = false;
+            // No preventDefault: a sub-threshold click must still reach child
+            // handlers, and the button must stay "down" for the OS move loop.
+        },
+        true,
+    );
+
+    document.addEventListener(
+        "mousemove",
+        (e: MouseEvent) => {
+            if (!pressArmed || dragInitiated) return;
+            // Primary button released (possibly outside the webview) → disarm
+            // so a stray hover after an interrupted press can't start a drag.
+            if ((e.buttons & 1) === 0) {
+                pressArmed = false;
+                return;
+            }
+            const dx = Math.abs(e.clientX - pressX);
+            const dy = Math.abs(e.clientY - pressY);
+            if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return;
+            // Threshold crossed — the button is still physically down here,
+            // which is exactly what the WM_NCLBUTTONDOWN modal loop needs.
+            // Fire ONE fire-and-forget IPC and stop tracking; the OS runs the
+            // move until the user releases. NEVER await it on the input path.
+            dragInitiated = true;
+            pressArmed = false;
+            invokeCommand("start_window_drag", { label: ownWindowLabel() }).catch(() => {
+                dragInitiated = false;
+            });
+        },
+        true,
+    );
+
+    document.addEventListener(
+        "mouseup",
+        () => {
+            pressArmed = false;
+            dragInitiated = false;
+        },
+        true,
+    );
+
+    document.addEventListener(
+        "dblclick",
+        (e: MouseEvent) => {
+            if (e.button !== 0) return;
+            if (!isInDragRegion(e.target as HTMLElement)) return;
+            e.preventDefault();
+            pressArmed = false;
+            dragInitiated = false;
+            invokeCommand("maximize_window", { label: ownWindowLabel() }).catch(() => {});
+        },
+        true,
+    );
+}
+
+// ── LEGACY JS path (fallback) ──────────────────────────────────────────────
+// JS-driven window move: track mouse delta, set absolute window position via
+// IPC per mousemove. Kept verbatim (Codex PR #734 race-guarding intact) behind
+// the localStorage opt-out. See the file header for why it lags.
+function installJsDragListener() {
+    // Per-mousedown sequence token. Each press increments `currentMouseDownId`;
+    // the async `get_window_position` handler captures the value at press time
+    // and bails if it doesn't still match when the promise resolves.
+    // (Codex P2 PR #734 round 2.)
     let currentMouseDownId = 0;
     let dragging = false;
     let clickScreenX = 0;
     let clickScreenY = 0;
     let initWinX = 0;
     let initWinY = 0;
-    // Track the latest cursor position seen during a press, even
-    // before `dragging` is armed. When the get_window_position IPC
-    // resolves we can immediately catch up with one set_window_position
-    // call against the latest cursor — otherwise mousemoves during
-    // the initial round-trip are silently dropped (codex P2 PR #734
-    // round 4).
+    // Latest cursor position seen during a press, even before `dragging` is
+    // armed, so the get_window_position resolution can catch up (PR #734 r4).
     let latestScreenX = 0;
     let latestScreenY = 0;
 
-    document.addEventListener("mousedown", async (e: MouseEvent) => {
-        if (e.button !== 0) return;
-        if (!isInDragRegion(e.target as HTMLElement)) return;
-        e.preventDefault();
-        currentMouseDownId += 1;
-        const myId = currentMouseDownId;
-        // Capture press coords synchronously — used as the baseline
-        // for both the live drag math and the catch-up move below.
-        clickScreenX = e.screenX;
-        clickScreenY = e.screenY;
-        latestScreenX = e.screenX;
-        latestScreenY = e.screenY;
-        try {
-            const pos = await invokeCommand<{ x: number; y: number }>("get_window_position", {
-                label: ownWindowLabel(),
-            });
-            // Race guard: bail if a mouseup or a newer mousedown has
-            // happened during the IPC round-trip.
-            if (myId !== currentMouseDownId) return;
-            initWinX = pos.x;
-            initWinY = pos.y;
-            dragging = true;
-            // Catch-up: if the cursor moved during the IPC, fire one
-            // set_window_position immediately against the latest known
-            // position so we don't lose the first few pixels of motion.
-            //
-            // DPI scaling: `e.screenX` exposes CSS pixels (Blink divides
-            // physical by combined browser-zoom under use-zoom-for-dsf,
-            // default on Windows since Chrome 54); `initWinX` from
-            // `get_window_position` and `set_window_position` use Win32
-            // physical pixels in this PMv2 process. Multiply the CSS-
-            // pixel delta by devicePixelRatio + round before adding to
-            // the physical baseline. Without this, Win11's default 125%
-            // scale makes the window lag the cursor by ~20%.
-            // See docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md.
-            if (latestScreenX !== clickScreenX || latestScreenY !== clickScreenY) {
-                const dpr = window.devicePixelRatio || 1;
-                const tx = initWinX + Math.round((latestScreenX - clickScreenX) * dpr);
-                const ty = initWinY + Math.round((latestScreenY - clickScreenY) * dpr);
-                sendPos(tx, ty);
+    document.addEventListener(
+        "mousedown",
+        async (e: MouseEvent) => {
+            if (e.button !== 0) return;
+            if (!isInDragRegion(e.target as HTMLElement)) return;
+            e.preventDefault();
+            currentMouseDownId += 1;
+            const myId = currentMouseDownId;
+            clickScreenX = e.screenX;
+            clickScreenY = e.screenY;
+            latestScreenX = e.screenX;
+            latestScreenY = e.screenY;
+            try {
+                const pos = await invokeCommand<{ x: number; y: number }>("get_window_position", {
+                    label: ownWindowLabel(),
+                });
+                // Race guard: bail if a mouseup or a newer mousedown happened
+                // during the IPC round-trip.
+                if (myId !== currentMouseDownId) return;
+                initWinX = pos.x;
+                initWinY = pos.y;
+                dragging = true;
+                // Catch-up: if the cursor moved during the IPC, fire one
+                // set_window_position immediately against the latest position.
+                // DPI: e.screenX is CSS px; initWinX is Win32 physical px —
+                // multiply the CSS delta by devicePixelRatio + round.
+                // See docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md.
+                if (latestScreenX !== clickScreenX || latestScreenY !== clickScreenY) {
+                    const dpr = window.devicePixelRatio || 1;
+                    const tx = initWinX + Math.round((latestScreenX - clickScreenX) * dpr);
+                    const ty = initWinY + Math.round((latestScreenY - clickScreenY) * dpr);
+                    sendPos(tx, ty);
+                }
+            } catch {
+                // host unavailable — abort drag
             }
-        } catch {
-            // host unavailable — abort drag
-        }
-    }, true);
+        },
+        true,
+    );
 
-    // One-in-flight + coalesce. Native mousemove fires at ~120Hz; the
-    // IPC round-trip can be slower under load. If two requests overlap
-    // and the older one resolves AFTER the newer (e.g. transient host
-    // jitter), the window snaps backward to the older absolute position.
-    // Codex P2 PR #734 round 3.
-    //
-    // Strategy: at most one set_window_position in flight. If more
-    // mousemoves arrive while in flight, stash the latest pending
-    // position; on completion, fire that. Older positions are dropped
-    // — they're stale by definition. Keeps the window tracking the
-    // most recent cursor without ordering hazards.
+    // One-in-flight + coalesce: at most one set_window_position in flight; if
+    // more mousemoves arrive, stash the latest and fire on completion. Older
+    // positions are dropped (stale). (Codex P2 PR #734 round 3.)
     let setPosInFlight = false;
     let pendingPos: { x: number; y: number } | null = null;
     const sendPos = (x: number, y: number): void => {
@@ -141,19 +228,11 @@ function installCefDragListener() {
             });
     };
     document.addEventListener("mousemove", (e: MouseEvent) => {
-        // Track latest cursor position even before `dragging` is armed
-        // so the catch-up at IPC resolution can use the most recent
-        // value (otherwise initial mousemoves during the round-trip
-        // are dropped).
         latestScreenX = e.screenX;
         latestScreenY = e.screenY;
         if (!dragging) return;
-        // DPI scaling: CSS-pixel delta * devicePixelRatio = physical
-        // delta, added to the physical-pixel baseline from
-        // `get_window_position`. Re-read DPR every move so a mid-drag
-        // monitor crossing (with different scale) picks up the new
-        // value automatically. Spec:
-        // docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md §4.1-4.2.
+        // CSS-pixel delta * devicePixelRatio = physical delta. Re-read DPR
+        // every move so a mid-drag monitor crossing picks up the new scale.
         const dpr = window.devicePixelRatio || 1;
         const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
         const ty = initWinY + Math.round((e.screenY - clickScreenY) * dpr);
@@ -161,26 +240,35 @@ function installCefDragListener() {
     });
 
     document.addEventListener("mouseup", () => {
-        // Invalidate any in-flight mousedown handler — incrementing
-        // the id ensures their `myId !== currentMouseDownId` check
-        // fires when they resolve.
         currentMouseDownId += 1;
         dragging = false;
-        // Do NOT clear pendingPos — that would discard the FINAL
-        // queued position (the cursor's location at release time)
-        // and leave the window stranded at the previous in-flight
-        // position. Let the in-flight set_window_position complete
-        // naturally; its `.finally` will drain pendingPos to its
-        // correct end state. (codex P2 PR #734 round 4.)
+        // Do NOT clear pendingPos — let the in-flight set_window_position drain
+        // to the cursor's release position. (PR #734 round 4.)
     });
 
-    document.addEventListener("dblclick", (e: MouseEvent) => {
-        if (e.button !== 0) return;
-        if (!isInDragRegion(e.target as HTMLElement)) return;
-        e.preventDefault();
-        dragging = false;
-        invokeCommand("maximize_window").catch(() => {});
-    }, true);
+    document.addEventListener(
+        "dblclick",
+        (e: MouseEvent) => {
+            if (e.button !== 0) return;
+            if (!isInDragRegion(e.target as HTMLElement)) return;
+            e.preventDefault();
+            dragging = false;
+            invokeCommand("maximize_window").catch(() => {});
+        },
+        true,
+    );
+}
+
+function installCefDragListener() {
+    if (cefDragListenerInstalled || detectHost() !== "cef") return;
+    cefDragListenerInstalled = true;
+    if (useNativeDrag()) {
+        console.info("[window-drag] win32: NATIVE OS move loop (start_window_drag)");
+        installNativeDragListener();
+    } else {
+        console.info("[window-drag] win32: legacy JS-driven drag (set_window_position)");
+        installJsDragListener();
+    }
 }
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -33,7 +33,7 @@ let cefDragListenerInstalled = false;
 // work). 4px matches Chrome's default drag threshold (and the Linux hook).
 const DRAG_THRESHOLD_PX = 4;
 
-/// Native OS move loop is the default. Set localStorage
+/// Host-side native move loop is the default. Set localStorage
 /// 'agentmux.win32NativeDrag' = '0' (then reload) to fall back to the legacy
 /// JS-driven drag. Wrapped in try/catch because localStorage can throw in
 /// locked-down contexts.
@@ -91,7 +91,8 @@ function installNativeDragListener() {
             pressArmed = true;
             dragInitiated = false;
             // No preventDefault: a sub-threshold click must still reach child
-            // handlers, and the button must stay "down" for the OS move loop.
+            // handlers, and the button must stay "down" so the host's manual
+            // move loop (which polls GetAsyncKeyState(VK_LBUTTON)) keeps running.
         },
         true,
     );

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -108,10 +108,10 @@ function installNativeDragListener() {
             const dx = Math.abs(e.clientX - pressX);
             const dy = Math.abs(e.clientY - pressY);
             if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return;
-            // Threshold crossed — the button is still physically down here,
-            // which is exactly what the WM_NCLBUTTONDOWN modal loop needs.
-            // Fire ONE fire-and-forget IPC and stop tracking; the OS runs the
-            // move until the user releases. NEVER await it on the input path.
+            // Threshold crossed (button still down). Fire ONE fire-and-forget
+            // IPC and stop tracking; the host then runs a manual native move
+            // loop on its UI thread until the user releases. NEVER await it on
+            // the input path.
             dragInitiated = true;
             pressArmed = false;
             invokeCommand("start_window_drag", { label: ownWindowLabel() }).catch(() => {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -5,21 +5,20 @@
 //
 // Two implementations, chosen at install time:
 //
-//  - NATIVE (default) — SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md.
+//  - NATIVE (default) — SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.md.
 //    Keep the title bar HTCLIENT (so right-click / contextmenu still fire),
-//    detect drag intent in JS, and on a 4px threshold hand the move to the OS
-//    via ONE fire-and-forget `start_window_drag` IPC. The host runs
-//    `ReleaseCapture()` + `SendMessageW(WM_NCLBUTTONDOWN, HTCAPTION)`, so the
-//    OS modal move loop tracks the cursor with ZERO further IPC — matching
-//    VS Code / Electron smoothness. This mirrors useWindowDrag.linux.ts.
+//    detect drag intent in JS, and on a 4px threshold hand the move to the host
+//    via ONE fire-and-forget `start_window_drag` IPC. The host then runs a
+//    manual native move loop on its UI thread (SetCapture + GetMessage +
+//    SetWindowPos per WM_MOUSEMOVE), tracking the cursor with ZERO further IPC
+//    — matching VS Code / Electron smoothness. (The raw WM_NCLBUTTONDOWN OS
+//    move loop does NOT work for a CEF window — Chromium's frame swallows it —
+//    so the host drives the loop itself.) Mirrors useWindowDrag.linux.ts.
 //
 //  - LEGACY JS (fallback) — JS-driven per-mousemove `set_window_position`.
 //    Smooth-but-laggy: the window position is gated on an IPC round-trip per
 //    move, so it lags the cursor under any host jitter. Kept behind a runtime
-//    opt-out while the native path is validated, because of a historical note
-//    that the native `WM_NCLBUTTONDOWN` path "loses mouse state" (this hook is
-//    the spike that verifies whether that still reproduces — the previous
-//    attempt awaited an IPC before sending; the native path here never awaits).
+//    opt-out while the host-side native move loop is validated.
 //
 // Toggle: native is ON by default. To force the legacy JS path, set
 //   localStorage['agentmux.win32NativeDrag'] = '0'

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -69,9 +69,10 @@ function ownWindowLabel(): string {
 }
 
 // ── NATIVE path ──────────────────────────────────────────────────────────
-// Mirrors useWindowDrag.linux.ts: arm on mousedown, hand the move to the OS
-// on threshold crossing, let the OS modal loop run the rest. No per-move IPC,
-// no DPI math, no race-guarding — the OS owns the move.
+// Mirrors useWindowDrag.linux.ts: arm on mousedown, and on threshold crossing
+// hand the move to the HOST, which runs a manual native move loop on its UI
+// thread (SetCapture + GetMessage + SetWindowPos). No per-move IPC, no DPI
+// math, no race-guarding — the host owns the move loop.
 function installNativeDragListener() {
     let pressX = 0;
     let pressY = 0;
@@ -262,7 +263,7 @@ function installCefDragListener() {
     if (cefDragListenerInstalled || detectHost() !== "cef") return;
     cefDragListenerInstalled = true;
     if (useNativeDrag()) {
-        console.info("[window-drag] win32: NATIVE OS move loop (start_window_drag)");
+        console.info("[window-drag] win32: host-side native move loop (start_window_drag)");
         installNativeDragListener();
     } else {
         console.info("[window-drag] win32: legacy JS-driven drag (set_window_position)");


### PR DESCRIPTION
## What
Windows title-bar drag was JS-driven (per-mousemove **awaited** `set_window_position` IPC), so the window tracked the IPC round-trip rate, not the cursor — jittery, worse at 125% scale.

Replaced with a **host-side native move loop on the CEF UI thread**: frontend fires ONE fire-and-forget `start_window_drag` on the 4px threshold; the host runs `SetCapture` + `GetMessage` loop + `SetWindowPos` per `WM_MOUSEMOVE` in physical px. **Zero per-move IPC**, no `devicePixelRatio` math, no PR #734 race-guarding.

## Why not the OS move loop
The raw `ReleaseCapture` + `WM_NCLBUTTONDOWN(HTCAPTION)` trick is incompatible with CEF — Chromium's frame swallows the NC message (instrumented: move loop returned in 0.4ms, **0 moves**). So we run the loop ourselves. Full trail: `docs/specs/SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.md` (+ `..._NATIVE_MOVE_LOOP`).

## Verification
Runtime-tested via `task dev` on Win11: drags now process **moves=232..1004** per drag at input rate — smooth, and the window stays fully interactive after (the dispatched terminating `WM_LBUTTONUP` keeps Chromium's input state balanced). Native is default; legacy JS path stays behind `localStorage['agentmux.win32NativeDrag']='0'` for one release.

## Follow-ups
- Aero Snap not yet wired for the manual loop.
- Esc cancels + restores start position.
- Floating-pane drag/resize could use the same technique (analysis pending).