### PR TITLE
feat(macos): floating-pane tear-off — chromeless floater + draggable header

### DIFF
--- a/.changesets/1780129794-feat-macos-floating-pane-tear-off-chromeless-floater-working-x4i0.md
+++ b/.changesets/1780129794-feat-macos-floating-pane-tear-off-chromeless-floater-working-x4i0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(macos): floating-pane tear-off — chromeless floater + working header drag

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -154,14 +154,76 @@ pub fn open_floating_pane_window(
 
     #[cfg(not(target_os = "windows"))]
     {
-        // Phase 1 is Windows-only per spec §10. macOS uses
-        // `NSWindow::addChildWindow`; Linux varies. Both are explicit
-        // follow-ups; return a clear error so callers fail loudly.
-        let _ = parsed;
-        let _ = window_label;
-        Err(
-            "open_floating_pane_window: not yet implemented on this platform (Windows only in Phase 1)"
-                .to_string(),
-        )
+        // Phase A (SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md): create a
+        // frameless top-level window via the SAME CEF Views path the regular
+        // tear-off uses (`open_window_at_position` →
+        // `ui_tasks::post_create_window(..., frameless=true)`), but with a
+        // `floatingPaneId` in the URL so the frontend renders
+        // `<FloatingPaneWorkspace>` (chromeless: no tab bar, no widget bar)
+        // instead of `<Workspace>`. Secondary windows are already frameless on
+        // macOS/Linux (window/creation.rs), so this alone produces "just the
+        // pane" — the user's request.
+        //
+        // No DPI scaling on non-Windows: the Windows-only block above is
+        // skipped, and CEF Views positions/sizes in DIP (logical px), which is
+        // exactly what `width`/`height` (from `getBoundingClientRect`) and
+        // `x`/`y` (from the DOM drop event's `screenX/Y`) already are.
+        //
+        // Phase B adds owned-window lifecycle (follows/minimizes/closes with
+        // the source window), JS header-drag, and redock — see the spec.
+        let ipc_port = *state.ipc_port.lock();
+        let ipc_token = &state.ipc_token;
+        let workspace_id = parsed.workspace_id.clone().unwrap_or_default();
+
+        let url = match super::window::resolve_frontend_base_url(ipc_port) {
+            Ok(base_url) => {
+                let separator = if base_url.contains('?') { "&" } else { "?" };
+                let mut u = format!(
+                    "{}{}ipc_port={}&ipc_token={}&windowLabel={}&floatingPaneId={}",
+                    base_url, separator, ipc_port, ipc_token, window_label, parsed.pane_id
+                );
+                if !workspace_id.is_empty() {
+                    u.push_str(&format!("&workspaceId={}", workspace_id));
+                }
+                u
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    label = %window_label,
+                    "[floating-pane] frontend assets unavailable — opening static error page",
+                );
+                super::window::assets_missing_data_url(&e)
+            }
+        };
+
+        // Register the pending window (same as the tear-off cold path). The
+        // floater shares the source instance's sidecar/data dir — it's not a
+        // separate launcher instance — but on non-Windows there is no launcher
+        // bookkeeping, so `FullInstance` (matching `open_window_at_position`)
+        // is the proven kind for this creation path. Phase B (owned window)
+        // may revisit.
+        state.host_dispatch(
+            crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+                entry: crate::state::PendingWindowCreation {
+                    label: window_label.clone(),
+                    kind: crate::state::WindowKind::FullInstance,
+                    parent_instance_id: None,
+                },
+            },
+        );
+
+        crate::ui_tasks::post_create_window(
+            state,
+            &url,
+            &window_label,
+            parsed.x,
+            parsed.y,
+            parsed.width,
+            parsed.height,
+            true, // frameless — secondary windows use the custom title bar
+        );
+
+        Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }
 }

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -1,30 +1,27 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Phase 1 of the floating-pane tear-off feature (issue #810 + spec
-//! `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`).
+//! Floating-pane tear-off — the `open_floating_pane_window` IPC command.
+//! Specs: `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` (Windows,
+//! issue #810) + `docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md`
+//! (macOS/Linux Phase A).
 //!
-//! This module hosts the IPC command and Win32-native primitive that
-//! creates a *subordinate* floating window — a free-positioned palette-
-//! style window OWNED by the source AgentMux main window. Unlike the
-//! existing tab tear-off path (which spawns a full new AgentMux
-//! instance), a floating pane:
+//! Creates a *subordinate* floating window — a free-positioned, chromeless
+//! window showing just the torn-off pane (no tab bar, no widget bar). Unlike
+//! the tab tear-off path (which spawns a full new AgentMux instance), a
+//! floating pane shares the source instance's sidecar, data dir, and reducer
+//! state. The embedded browser loads
+//! `<frontend>?floatingPaneId=<id>&windowLabel=floating-<n>&workspaceId=<ws>`
+//! and the frontend renders `<FloatingPaneWorkspace>` (chromeless).
 //!
-//! - has no taskbar entry (`WS_EX_TOOLWINDOW`),
-//! - has no Alt-Tab entry (also `WS_EX_TOOLWINDOW`),
-//! - minimizes / restores / destroys with its owner,
-//! - shares the source instance's sidecar, data dir, and reducer state.
-//!
-//! Phase 1 ships **only** the windowing primitive. The browser embedded
-//! in the floating window loads
-//! `<frontend>?floatingPaneId=<id>&windowLabel=floating-<n>` and the
-//! frontend renders a minimal placeholder shell that says "Floating
-//! pane: \<id\>". Wiring the *drag-out gesture* to this primitive is
-//! Phase 3. Wiring the full `<Block>` renderer is Phase 2.
-//!
-//! Non-Windows platforms are out of scope per spec §10. The macOS path
-//! is `NSWindow::addChildWindow`; Linux varies by compositor. Both will
-//! be addressed in a follow-up.
+//! Platform primitive differs by OS:
+//! - **Windows**: a raw `WS_POPUP + WS_EX_TOOLWINDOW` HWND OWNED by the source
+//!   main window (no taskbar/Alt-Tab entry; minimizes/restores/destroys with
+//!   its owner), CEF browser embedded — see `crate::floating_pane`.
+//! - **macOS / Linux** (Phase A): a frameless CEF Views window created via the
+//!   same `ui_tasks::post_create_window(frameless=true)` path the regular
+//!   tear-off uses, with `&floatingPaneId=` injected into the URL. Owned-window
+//!   lifecycle + redock are follow-ups (see the macOS spec, Phase B).
 
 use std::sync::Arc;
 

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -40,6 +40,17 @@ pub fn get_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> R
             return Ok(serde_json::json!({ "x": rect.left, "y": rect.top }));
         }
     }
+    // macOS / Linux: CEF Views windows report DIP bounds; read them on the UI
+    // thread. The floating-pane header drag uses this as its absolute-move
+    // baseline, adding CSS-px (= DIP) deltas with no DPR scaling — see
+    // floating-pane-workspace.tsx `posScale()`. (Windows works in physical px
+    // and scales by devicePixelRatio; that path returns above.)
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Some((x, y)) = crate::ui_tasks::get_window_position_blocking(state, label) {
+            return Ok(serde_json::json!({ "x": x, "y": y }));
+        }
+    }
     let _ = (state, label);
     Ok(serde_json::json!({ "x": 0, "y": 0 }))
 }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -251,7 +251,22 @@ async fn route_command(
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_rect" => commands::window::get_window_rect(state, args),
         "set_window_rect" => commands::window::set_window_rect(state, args),
-        "get_window_position" => commands::window::get_window_position(state, args),
+        "get_window_position" => {
+            // Wrap in spawn_blocking — on macOS/Linux `get_window_position`
+            // bounces a CEF Views `bounds()` read through the UI thread and
+            // waits on a bounded channel for up to 250 ms
+            // (ui_tasks::get_window_position_blocking). Without this wrap it
+            // would block a Tokio worker, same as `tear_off_sc_move_handshake`
+            // above. (Windows reads GetWindowRect directly — cheap — but the
+            // wrap is harmless there and keeps the dispatch uniform.)
+            let state_clone = state.clone();
+            let args_clone = args.clone();
+            tokio::task::spawn_blocking(move || {
+                commands::window::get_window_position(&state_clone, &args_clone)
+            })
+            .await
+            .map_err(|e| format!("get_window_position join error: {}", e))?
+        }
         "resolve_window_at_cursor" => commands::window::resolve_window_at_cursor(state, args),
         "update_floating_redock_hover" => commands::window::update_floating_redock_hover(state, args),
         "clear_floating_redock_hover" => commands::window::clear_floating_redock_hover(state, args),

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -234,11 +234,12 @@ async fn route_command(
             commands::window::open_subwindow(state, parent)
         }
         "open_floating_pane_window" => {
-            // Phase 1 of floating-pane tear-off (issue #810 / spec
-            // SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md). Creates a
-            // subordinate `WS_POPUP + WS_EX_TOOLWINDOW` HWND owned by
-            // the source main window, with a CEF browser embedded.
-            // Windows-only; macOS / Linux return a clear error.
+            // Floating-pane tear-off — a chromeless window showing just the
+            // torn-off pane. Windows: a subordinate WS_POPUP+WS_EX_TOOLWINDOW
+            // HWND owned by the source window. macOS/Linux (Phase A): a
+            // frameless CEF Views window with ?floatingPaneId= in the URL.
+            // Specs: SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md +
+            // SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md.
             commands::floating_pane::open_floating_pane_window(state, args)
         }
         "get_instance_number" => Ok(commands::window::get_instance_number(state, args)),

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -297,6 +297,45 @@ pub fn post_set_window_position(state: &Arc<AppState>, label: &str, x: i32, y: i
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Get window absolute position (DIP) — blocking UI-thread read ──────────
+//
+// CEF Views `window.bounds()` must run on the UI thread, but
+// `get_window_position` is a synchronous IPC command dispatched on the
+// (non-UI) IPC thread. Post a task that reads the bounds on the UI thread and
+// hand the DIP origin back over a bounded channel. Used by the macOS / Linux
+// floating-pane header drag, which needs the window's current position as the
+// absolute-move baseline (Windows reads it directly via GetWindowRect, which
+// is thread-agnostic).
+wrap_task! {
+    pub struct GetWindowPositionTask {
+        state: Arc<AppState>,
+        label: String,
+        tx: std::sync::mpsc::SyncSender<Option<(i32, i32)>>,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let pos = get_window_on_ui(&self.state, &self.label).map(|w| {
+                let b = w.bounds();
+                (b.x, b.y)
+            });
+            // Capacity-1, freshly created per call → try_send never blocks
+            // the UI thread.
+            let _ = self.tx.try_send(pos);
+        }
+    }
+}
+
+/// Read a CEF Views window's absolute position (DIP) from the IPC thread by
+/// bouncing through the UI thread. `None` if the window isn't found or the UI
+/// thread doesn't answer within the timeout (e.g. mid-teardown).
+pub fn get_window_position_blocking(state: &Arc<AppState>, label: &str) -> Option<(i32, i32)> {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Option<(i32, i32)>>(1);
+    let mut task = GetWindowPositionTask::new(state.clone(), label.to_string(), tx);
+    post_task(ThreadId::UI, Some(&mut task));
+    rx.recv_timeout(std::time::Duration::from_millis(250)).ok().flatten()
+}
+
 // ── Phase B.9.2 (WRR) — corrective absolute-position move ─────────────────
 //
 // Reducer-driven self-heal. Triggered by `Event::CorrectiveWindowMove` when

--- a/docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md
+++ b/docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md
@@ -1,0 +1,208 @@
+# macOS floating-pane tear-off — implementation spec
+
+**Date:** 2026-05-29
+**Repo state:** `main` @ `7e61fda3` (v0.40.0)
+**Author:** AgentO-asaf
+**Status:** Spec ready to implement (phased)
+**Supersedes/refines:** [`SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md`](./SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md) §3.2 (the macOS "C1" work block) — this spec refines the phasing after discovering that AgentMux's secondary windows are already frameless CEF Views windows, which makes the user-visible fix far cheaper than the NSPanel rewrite that spec assumed.
+**Related:** macOS bring-up PRs #1131, #1169, #1170, #1171, #1172, #1175 (all merged); the C1 work block remains open.
+
+---
+
+## Problem (user report)
+
+> "Tearing a pane is supposed to give a floating window, which works on Windows. On macOS, tearing a pane creates a new window **with a tab bar and widgets bar** — we need just the pane."
+
+On Windows, tearing a pane off produces a **chromeless floating window**: just the pane content, no tab bar, no action-widget bar. On macOS, tearing a pane produces a **full workspace window** with the complete title-bar chrome (tab bar + action widgets). The two platforms diverge entirely in the tear-off code path.
+
+---
+
+## Root cause (precise)
+
+The macOS pane tear-off never routes to the floating-pane rendering path. Tracing the chain:
+
+1. **`frontend/app/drag/CrossWindowDragMonitor.darwin.tsx:147-163`** — `performTearOff()` calls `openTearOffWindow()` for **both** panes and tabs. It never calls `open_floating_pane_window`. (Windows branches: panes → `open_floating_pane_window`, tabs → `openTearOffWindow` — see `CrossWindowDragMonitor.win32.tsx:275-355`.)
+
+2. **`frontend/app/drag/tear-off-pool-helper.ts:43-64`** — `openTearOffWindow()` tries the warm pool (Windows-only; the pool init is `#[cfg(not(target_os = "windows"))] return` in `window_pool.rs:454-459`, so on macOS it's a no-op), then falls through to the cold path `api.openWindowAtPosition()`.
+
+3. **`agentmux-cef/src/commands/drag.rs:374-451`** — `open_window_at_position()` mints a `window-<uuid>` label and builds the URL with `ipc_port`, `ipc_token`, `windowLabel`, and (optionally) `workspaceId` — **never `floatingPaneId`**.
+
+4. **`frontend/app/app.tsx:375-381,422-427`** — `IS_FLOATING_PANE = new URLSearchParams(location.search).has("floatingPaneId")`. With no `floatingPaneId`, the render switch falls back to `<Workspace />` (full tab + widget chrome) instead of `<FloatingPaneWorkspace />` (chromeless).
+
+5. **`agentmux-cef/src/commands/floating_pane.rs:155-166`** — even if the darwin monitor *did* call `open_floating_pane_window`, its `#[cfg(not(target_os = "windows"))]` branch returns `"not yet implemented on this platform"`.
+
+So: macOS pane tear-off has **zero routes** to the chromeless rendering. It always lands in the regular-workspace-window pipeline.
+
+---
+
+## The decisive insight (why this is cheaper than the prior spec assumed)
+
+`SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` §3.2 prescribed a ~400-LOC `agentmux-cef/src/floating_pane_macos.rs` using a raw `NSPanel` + `addChildWindow:ordered:` + `CefWindowInfo::SetAsChild`, mirroring the Windows raw-Win32 floating window. That's because the Windows floating pane **bypasses CEF Views entirely** (raw `CreateWindowExW` with `WS_POPUP | WS_EX_TOOLWINDOW`, custom WNDPROC suppressing the title bar).
+
+But macOS doesn't need that to satisfy the user's actual request, because of two facts the prior spec didn't lean on:
+
+1. **macOS secondary (tear-off) windows are ALREADY frameless.** They're created via CEF Views `window_create_top_level` with `frameless = true` (`commands/window/creation.rs:333` — *"true = frameless: secondary app windows use the same custom title bar as main"*; `app.rs:309-310`, `app.rs:140 fn is_frameless`). There is **no native macOS title bar** on a tear-off window. The chrome the user sees — the tab bar and widget bar — is **pure frontend**: `<Workspace>` renders `<WindowHeader>` (tab bar) + `<SystemStatus>` (action widgets).
+
+2. **The chromeless renderer is 100% platform-agnostic.** `frontend/app/workspace/floating-pane-workspace.tsx` has **zero** `#[cfg]`/platform branching. It renders `<TabContent>` only — no `WindowHeader`, no `SystemStatus` — purely off the `?floatingPaneId=` URL param. The pane/tab branch in the drag monitor, and the backend sagas (`TearOffBlock`, `RedockFloatingPane` in `agentmux-srv`), are also platform-agnostic.
+
+**Therefore: to give the user "just the pane" on macOS, all that's structurally required is for the torn-off window's URL to carry `?floatingPaneId=`.** The window is already frameless; the frontend already knows how to render chromeless. No AppKit. No NSPanel. No new native window primitive.
+
+The NSPanel work the prior spec described is still needed — but only for *behavioral* parity (owned-window lifecycle, JS-driven header drag, redock), not for the user-visible "just the pane" result. This spec splits those apart into Phase A and Phase B.
+
+---
+
+## What's already cross-platform (no macOS work)
+
+| Layer | Component | Status |
+|---|---|---|
+| Frontend render | `floating-pane-workspace.tsx` (`<FloatingPaneWorkspace>`) | Platform-agnostic; renders chromeless from `floatingPaneId` |
+| Frontend switch | `app.tsx` `IS_FLOATING_PANE` → `<Show>` | Platform-agnostic |
+| Frontend branch | drag monitor pane-vs-tab decision (`payload.kind === "tile"`) | Platform-agnostic logic; just needs wiring in `.darwin.tsx` |
+| Backend RPC | `WorkspaceService.TearOffBlock` (saga `agentmux-srv/src/sagas/tear_off_block.rs`) | Platform-agnostic state mutation |
+| Backend RPC | `WorkspaceService.RedockFloatingPane` (saga `redock_floating_pane.rs`) | Platform-agnostic state mutation |
+| Host command | `clear_floating_redock_hover` | Already platform-agnostic (`motion.rs:353-369`) |
+| Host command | `update_floating_redock_hover` dispatch | Platform-agnostic shell; depends on `resolve_window_at_cursor` for the target |
+| Native window | secondary windows via CEF Views `window_create_top_level(frameless=true)` | Already frameless on macOS |
+
+## What's macOS-specific work
+
+| Item | File | Needed for |
+|---|---|---|
+| Route pane tear-off to a `floatingPaneId` window | `CrossWindowDragMonitor.darwin.tsx` | **Phase A** (the user's ask) |
+| `open_floating_pane_window` macOS branch (or `floatingPaneId` injection into the cold path) | `commands/floating_pane.rs` / `commands/drag.rs` | **Phase A** |
+| `get_window_position` macOS impl | `commands/window/motion.rs:32-44` (Windows-only; non-win returns `{x:0,y:0}`) | Phase B (drag) |
+| `set_window_position` macOS impl | `motion.rs:97-126` (Windows `SetWindowPos`; non-win → `ui_tasks::post_set_window_position`) | Phase B (drag) |
+| `resolve_window_at_cursor` macOS impl | `motion.rs:191-293` (Windows Z-order walk; non-win returns nulls) | Phase B (redock) |
+| `get_cursor_point` macOS impl | `commands/drag.rs:200-213` (Windows `GetCursorPos`; non-win returns `{0,0}`) | Phase B (drag/redock) |
+| Owned-window lifecycle (follows parent, minimize/close cascade) | new — CEF Views parent or `addChildWindow` | Phase B (polish) |
+
+---
+
+## Phase A — "just the pane" (small, AppKit-free, ships the user's request)
+
+**Goal:** macOS pane tear-off produces a frameless window whose content is only the pane (no tab bar, no widget bar). Window is independent (not yet owned/follows-parent), positioned at the drop point, draggable via the OS however a frameless CEF Views window normally is. This is the minimal change that resolves the user report.
+
+### A.1 — Route panes through a `floatingPaneId` window in the darwin monitor
+
+In `CrossWindowDragMonitor.darwin.tsx::performTearOff` (currently `:147-163`), branch on `dragType` mirroring `win32.tsx`:
+
+```ts
+async function performTearOff(dragType, payload, sourceWsId, sourceTabId, screenX, screenY) {
+    const api = getApi();
+    if (dragType === "pane" && payload.blockId) {
+        // PANE → chromeless floating window (Phase A: frameless CEF Views + floatingPaneId)
+        const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
+        if (newWsId) {
+            await api.openFloatingPaneWindow({
+                paneId: payload.blockId,
+                workspaceId: newWsId,
+                x: screenX, y: screenY,
+                width: /* captured pane size */, height: /* captured pane size */,
+            });
+        }
+    } else if (dragType === "tab" && payload.tabId) {
+        // TAB → full workspace window (unchanged)
+        const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
+    }
+}
+```
+
+(The `cef-api.ts` `openFloatingPaneWindow` wrapper already exists for the win32 path — reuse it.)
+
+### A.2 — Implement `open_floating_pane_window` for macOS
+
+Two options for the host side. **Recommended: Option 1** (reuse the proven CEF Views frameless path; defer raw AppKit to Phase B).
+
+**Option 1 — CEF Views frameless window + `floatingPaneId` URL (recommended for Phase A).**
+In `commands/floating_pane.rs`, replace the macOS `Err("not yet implemented")` with a path that creates a frameless top-level window (the same `window_create_top_level(frameless=true)` machinery the cold tear-off path already uses) but whose URL carries `&floatingPaneId=<pane_id>&windowLabel=floating-<uuid>&workspaceId=<ws>`. Concretely, factor the URL+window creation out of `open_window_at_position` (`drag.rs:374-451`) into a helper that takes an optional `floating_pane_id`, and have `open_floating_pane_window` call it with the id set. The window is frameless (already true for secondary windows); the frontend renders `<FloatingPaneWorkspace>` because `floatingPaneId` is present. Label `floating-<uuid>` keeps it distinguishable from `window-<uuid>` (consistent with Windows + the orphan-reconciliation exclusion at `window/lifecycle.rs:301`).
+
+- Pros: ~30 lines, no AppKit, reuses a battle-tested path, immediately delivers "just the pane."
+- Cons: window is independent (no owned-window cascade) and gets whatever drag/positioning a normal frameless CEF Views window has. Phase B adds the owned-window + header-drag + redock parity.
+
+**Option 2 — raw `NSPanel` + `addChildWindow` (the prior spec's C1; defer to Phase B).**
+Build `agentmux-cef/src/floating_pane_macos.rs` per `SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` §3.2: an `NSPanel` (`[.titled,.closable,.resizable,.utilityWindow,.nonactivatingPanel,.fullSizeContentView]`), `parentWindow.addChildWindow(panel, ordered:.above)`, `CefWindowInfo::SetAsChild(panel.contentView, rect)`. ~400 LOC. This is full parity but unnecessary for the user-visible "just the pane" fix.
+
+> Decision: ship Option 1 as Phase A. It satisfies the user report with minimal risk. Pursue Option 2's owned-window semantics only if/when the independent-window behavior proves insufficient (see Phase B).
+
+### A.3 — Acceptance (Phase A)
+
+- macOS: drag a pane out → a frameless window appears at the drop point showing **only** the pane (its `BlockFrame` header is the sole chrome; no tab bar, no widget bar). `muxlog host` shows the `floating-<uuid>` label and a URL containing `floatingPaneId`.
+- macOS: drag a **tab** out → still a full workspace window (unchanged).
+- Windows: unchanged (already uses `open_floating_pane_window`).
+- Linux: same routing applies (see "Linux" below).
+
+---
+
+## Phase B — behavioral parity (owned window, header drag, redock)
+
+Phase A gives the right *content*. Phase B makes the floater *behave* like the Windows one. Each piece is independent and can land separately.
+
+### B.1 — Owned-window lifecycle (follows parent, minimize/close cascade)
+
+Windows gets this free from `WS_EX_TOOLWINDOW` + owner HWND. macOS options:
+- If Option 1 (CEF Views) shipped in Phase A: add `addChildWindow:ordered:` on the underlying `NSWindow` of the CEF Views window (reachable via `cef::Window` → native handle), with `.nonactivatingPanel`-equivalent behavior. May require dropping to AppKit for the `addChildWindow` call even though the window itself is CEF Views.
+- If Option 2 (NSPanel) is chosen: owned-window semantics come free from `addChildWindow` + `.nonactivatingPanel` per the xplat spec.
+
+### B.2 — JS-driven header drag
+
+`floating-pane-workspace.tsx:92-386` already implements the drag (mousedown on `[data-role="block-header"]` → `get_window_position` → `set_window_position` with coalescing). It's platform-agnostic JS. It needs the host commands implemented for macOS:
+
+- **`get_window_position`** (`motion.rs:32-44`): macOS — read the window's frame origin. Via CEF Views `cef::Window::bounds()` (cross-platform, already used by `MoveWindowTask` in `ui_tasks.rs`) or raw `[nswindow frame]`. Prefer `cef::Window::bounds()` if the floater is a CEF Views window.
+- **`set_window_position`** (`motion.rs:97-126`): macOS — `cef::Window::set_bounds()` (cross-platform) or `[nswindow setFrameOrigin:]`. Note the non-Windows path already routes to `ui_tasks::post_set_window_position` — verify/extend that it actually moves the window on macOS via `set_bounds`.
+- **`get_cursor_point`** (`drag.rs:200-213`): macOS — `[NSEvent mouseLocation]` (flip Y: AppKit origin is bottom-left; the redock math expects top-left screen coords — convert via main screen height).
+
+### B.3 — Redock (drop onto another window merges the pane back)
+
+`floating-pane-workspace.tsx:276-372` calls `resolve_window_at_cursor` then `RedockFloatingPane`. The saga is platform-agnostic; the resolver isn't:
+
+- **`resolve_window_at_cursor`** (`motion.rs:191-293`): macOS — enumerate this process's windows front-to-back (`[NSApp orderedWindows]`), hit-test the cursor point against each window's frame (excluding `exclude_label`), return the top-most match's label + backend `window_id`. The Windows version walks Z-order via `WindowFromPoint` + `GetAncestor(GA_ROOT)`; the macOS version is the `orderedWindows` analogue.
+- **`update_floating_redock_hover`** already dispatches cross-platform; once `resolve_window_at_cursor` works on macOS, the hover highlight works too.
+
+### B.4 — Resize
+
+Frameless CEF Views windows: confirm edge-resize works on macOS (CEF Views may already provide it; the Windows floater hand-rolls `WM_NCHITTEST` edge bands because raw Win32 has no default). If Option 1 windows don't resize, either enable CEF Views resize or add the macOS edge-hit-test equivalent. Lower priority — note it, don't block on it.
+
+---
+
+## Linux
+
+The same Phase A routing applies to `CrossWindowDragMonitor.linux.tsx` (identical structure to darwin). Linux secondary windows are also frameless CEF Views. The host motion commands have the same Windows-only gating, so Phase B for Linux needs X11/Wayland implementations of `get/set_window_position`, `resolve_window_at_cursor`, `get_cursor_point` — out of scope here but the routing fix (A.1/A.2) is shared. Keep the `open_floating_pane_window` host branch `#[cfg(not(target_os = "windows"))]` so darwin + linux share it where possible, or split `#[cfg(target_os = "macos")]` / `#[cfg(target_os = "linux")]` if the window-creation primitives differ.
+
+---
+
+## Decisions / open questions
+
+1. **Phase A window primitive:** Option 1 (CEF Views frameless + `floatingPaneId`) vs Option 2 (raw NSPanel). **Recommend Option 1** — minimal, AppKit-free, satisfies the user report. Revisit only if independent-window behavior is unacceptable before Phase B lands owned-window semantics.
+2. **Can `addChildWindow` attach to a CEF-Views-owned NSWindow?** (B.1) — needs a spike. If not clean, owned-window semantics may force Option 2 for the final form.
+3. **`cef::Window::bounds()/set_bounds()` for macOS positioning** (B.2) — verify these move a frameless secondary window on macOS before hand-rolling raw `NSWindow` frame math. `MoveWindowTask` (`ui_tasks.rs`) already uses them, suggesting they're cross-platform.
+4. **Pane-size capture:** the darwin monitor must capture the dragged pane's rendered width/height to size the floater (Windows captures `window.outerWidth/Height` and the pane rect — `win32.tsx:293-295`). Port that capture; fall back to a sane default (e.g. the pane's `getBoundingClientRect`).
+
+---
+
+## Acceptance criteria (overall)
+
+**Phase A (the user's request):**
+- [ ] macOS: tear a pane → frameless window with **only the pane** (no tab bar, no widget bar).
+- [ ] macOS: tear a tab → full workspace window (unchanged).
+- [ ] Windows/Linux: tear behavior unchanged from current.
+
+**Phase B (parity):**
+- [ ] Floater follows/minimizes/closes with its source window.
+- [ ] Dragging the pane header moves the floater (no prohibited-cursor regression — see #1175).
+- [ ] Dropping the floater over another AgentMux window redocks the pane into it; dropping on the desktop leaves it standalone.
+- [ ] Floater is edge-resizable.
+
+---
+
+## Work-block estimate
+
+| Phase | Scope | Est. |
+|---|---|---|
+| A.1 + A.2 (Option 1) | darwin monitor branch + `open_floating_pane_window` macOS via CEF-Views-frameless + `floatingPaneId` URL | ~40-80 LOC, 1 PR |
+| B.2 | `get/set_window_position` + `get_cursor_point` macOS (CEF Views `bounds` / NSEvent) | ~60 LOC |
+| B.3 | `resolve_window_at_cursor` macOS (`orderedWindows` hit-test) | ~80 LOC |
+| B.1 | owned-window lifecycle (`addChildWindow` or NSPanel) | ~100-400 LOC depending on Option 1-vs-2 |
+| B.4 | resize | spike + ~0-80 LOC |
+
+Phase A is the high-value, low-risk slice and should ship first as its own PR. Phases B.1-B.4 are independent follow-ups.

--- a/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
@@ -11,8 +11,9 @@
 import { atoms, getApi } from "@/store/global";
 import { invokeCommand } from "@/app/platform/ipc";
 import { WorkspaceService } from "@/app/store/services";
+import { getLayoutModelForStaticTab, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "@/layout/index";
 import { Logger } from "@/util/logger";
-import { openTearOffWindow } from "./tear-off-pool-helper";
+import { openTearOffWindow, measureSourcePaneSize } from "./tear-off-pool-helper";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import type { LayoutNode } from "@/layout/lib/types";
@@ -46,8 +47,17 @@ function CrossWindowDragMonitor(): JSX.Element {
 
             if (!payload) return;
 
+            // Drop coordinates straight from the DOM event. `screenX/Y` are
+            // top-left-origin screen coords in CSS px (= DIP), which is exactly
+            // what CEF Views window positioning expects on macOS — no host
+            // `get_cursor_point` round-trip needed (that command is a Windows-
+            // only `GetCursorPos`; its macOS stub returns 0,0, which would open
+            // the floater in the screen corner).
+            const dropX = e.screenX;
+            const dropY = e.screenY;
+
             await new Promise((r) => setTimeout(r, 50));
-            await handleCrossWindowDragEnd(payload, windowLabelRef);
+            await handleCrossWindowDragEnd(payload, windowLabelRef, dropX, dropY);
         };
 
         // Suppress the "operation not allowed" cursor during a cross-window
@@ -79,14 +89,17 @@ function CrossWindowDragMonitor(): JSX.Element {
     return null;
 }
 
-async function handleCrossWindowDragEnd(payload: DragItemPayload, sourceWindow: string | null) {
-    let cursorPoint: { x: number; y: number };
-    try {
-        cursorPoint = await invokeCommand<{ x: number; y: number }>("get_cursor_point");
-    } catch (e) {
-        Logger.error("dnd:cross", "failed to get cursor position", { error: String(e) });
-        return;
-    }
+async function handleCrossWindowDragEnd(
+    payload: DragItemPayload,
+    sourceWindow: string | null,
+    dropX: number,
+    dropY: number,
+) {
+    // `get_cursor_point` is a Windows-only host command (GetCursorPos); on
+    // macOS it returns 0,0. Use the DOM drop coordinates (top-left origin,
+    // CSS px = DIP) instead — correct for CEF Views positioning and for the
+    // cross-window hit-test below.
+    const cursorPoint = { x: dropX, y: dropY };
 
     let windows: string[];
     try {
@@ -154,9 +167,75 @@ async function performTearOff(
 ) {
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
-        const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
-        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
+        // PANE → chromeless floating window (just the pane: no tab bar, no
+        // widget bar). Mirrors the Windows pane branch
+        // (CrossWindowDragMonitor.win32.tsx). `TearOffBlock` moves the block
+        // into a fresh backend workspace+tab; the floating window's
+        // `initApp` → `initHostNewWindow` path attaches to it via
+        // `?workspaceId=`, and the `?floatingPaneId=` URL param makes the
+        // frontend render `<FloatingPaneWorkspace>` (chromeless) instead of
+        // `<Workspace>`. See SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md.
+
+        // Snapshot the source pane's rendered size BEFORE TearOffBlock —
+        // that mutation unmounts the source DOM element.
+        const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
+            payload.blockId,
+        );
+
+        const newWsId = await WorkspaceService.TearOffBlock(
+            payload.blockId,
+            sourceTabId,
+            sourceWsId,
+            true,
+        );
+        if (!newWsId) {
+            Logger.error("dnd:cross", "TearOffBlock returned no workspace id", {
+                blockId: payload.blockId,
+            });
+            return;
+        }
+
+        // CRITICAL: invoke the IPC FIRST, then mutate the layout on success.
+        // If we deleted the layout node up front and the IPC failed (e.g. the
+        // H.7 mid-close gate rejects), the pane would be orphaned — still in
+        // `blockids` but with no layout node and no floater. Reagent P1 on
+        // PR #1073 (Windows path).
+        try {
+            await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+                pane_id: payload.blockId,
+                workspace_id: newWsId,
+                x: screenX,
+                y: screenY,
+                width: floaterWidth,
+                height: floaterHeight,
+            });
+            Logger.info("dnd:cross", "floating pane spawned (darwin)", {
+                blockId: payload.blockId,
+                newWsId,
+                screenX,
+                screenY,
+            });
+        } catch (e) {
+            Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
+                error: String(e),
+                blockId: payload.blockId,
+            });
+            return;
+        }
+
+        // IPC succeeded → drop the docked node so the pane doesn't render twice.
+        const layoutModel = getLayoutModelForStaticTab();
+        if (layoutModel) {
+            const node = layoutModel.getNodeByBlockId(payload.blockId);
+            if (node) {
+                layoutModel.treeReducer({
+                    type: LayoutTreeActionType.DeleteNode,
+                    nodeId: node.id,
+                } as LayoutTreeDeleteNodeAction);
+            }
+        }
     } else if (dragType === "tab" && payload.tabId) {
+        // TAB → full workspace window (unchanged): tab bar + widgets.
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
         if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
     }

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -25,7 +25,7 @@ import { WorkspaceService } from "@/app/store/services";
 import { getLayoutModelForStaticTab, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "@/layout/index";
 import { invokeCommand } from "@/app/platform/ipc";
 import { Logger } from "@/util/logger";
-import { openTearOffWindow } from "./tear-off-pool-helper";
+import { openTearOffWindow, measureSourcePaneSize } from "./tear-off-pool-helper";
 import { getTabGrabOffset } from "@/app/tab/tab-grab-offset";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
@@ -226,40 +226,6 @@ async function performCrossWindowDrop(
     _sourceTabId: string
 ) {
     // The target window handles the actual move when it receives the cross-drag-end event.
-}
-
-// Fallback floating-pane size if we can't read the source pane's rect
-// (block element not in the DOM for any reason). 720×480 is a comfortable
-// single-block working area without dominating the screen.
-const DEFAULT_FLOATER_WIDTH = 720;
-const DEFAULT_FLOATER_HEIGHT = 480;
-// Defensive lower bounds — protect against degenerate (0-width/height)
-// rects yielding an unusable floater.
-const MIN_FLOATER_WIDTH = 200;
-const MIN_FLOATER_HEIGHT = 120;
-
-/// Measure the source pane's rendered size in CSS / DIP pixels.
-/// `getBoundingClientRect` returns CSS px regardless of DPR; we deliberately
-/// do NOT multiply by `window.devicePixelRatio` here because that's the
-/// SOURCE monitor's scale, and the floater may spawn on a DIFFERENT
-/// monitor (different DPI). Cross-monitor scaling MUST happen on the host
-/// using `GetDpiForMonitor(MonitorFromPoint(x, y))` against the destination
-/// — see `agentmux-cef/src/commands/floating_pane.rs` and the matching
-/// pattern in `agentmux-cef/src/commands/window_pool.rs:684-701` (tab
-/// tear-off).
-///
-/// Must be called BEFORE `TearOffBlock` — that mutation removes the
-/// source pane from the layout and unmounts its DOM element.
-function measureSourcePaneSize(blockId: string): { width: number; height: number } {
-    const el = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
-    if (!el) {
-        return { width: DEFAULT_FLOATER_WIDTH, height: DEFAULT_FLOATER_HEIGHT };
-    }
-    const rect = el.getBoundingClientRect();
-    return {
-        width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width)),
-        height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height)),
-    };
 }
 
 async function performTearOff(

--- a/frontend/app/drag/tear-off-pool-helper.ts
+++ b/frontend/app/drag/tear-off-pool-helper.ts
@@ -24,6 +24,42 @@ import { Logger } from "@/util/logger";
 
 type Api = ReturnType<typeof getApi>;
 
+// Default floater size when the source pane element can't be measured
+// (e.g. it already unmounted). Used by every platform's pane tear-off.
+const DEFAULT_FLOATER_WIDTH = 720;
+const DEFAULT_FLOATER_HEIGHT = 480;
+// Defensive lower bounds — protect against degenerate (0-width/height)
+// rects yielding an unusable floater.
+const MIN_FLOATER_WIDTH = 200;
+const MIN_FLOATER_HEIGHT = 120;
+
+/**
+ * Measure the source pane's rendered size in CSS / DIP pixels.
+ *
+ * Returned values are LOGICAL (CSS) pixels — do NOT multiply by
+ * `window.devicePixelRatio` here. On Windows the floater may spawn on a
+ * DIFFERENT monitor (different DPI), so cross-monitor physical scaling
+ * MUST happen on the host using `GetDpiForMonitor(MonitorFromPoint(x, y))`
+ * against the destination (see `agentmux-cef/src/commands/floating_pane.rs`).
+ * On macOS / Linux CEF Views positions in DIP directly, so the host passes
+ * these through unscaled.
+ *
+ * MUST be called BEFORE `TearOffBlock` — that mutation removes the source
+ * pane from the layout and unmounts its DOM element. Platform-agnostic;
+ * shared by win32 / darwin (/ linux) `CrossWindowDragMonitor` variants.
+ */
+export function measureSourcePaneSize(blockId: string): { width: number; height: number } {
+    const el = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
+    if (!el) {
+        return { width: DEFAULT_FLOATER_WIDTH, height: DEFAULT_FLOATER_HEIGHT };
+    }
+    const rect = el.getBoundingClientRect();
+    return {
+        width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width)),
+        height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height)),
+    };
+}
+
 /**
  * Open a tear-off destination window at `(screenX, screenY)`,
  * preferring the pre-warmed pool. Falls back to cold-path only when

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -32,6 +32,7 @@
  */
 
 import { invokeCommand } from "@/app/platform/ipc";
+import { isWindows } from "@/util/platformutil";
 import { FLOATER_EDGE_RESIZE_BORDER } from "@/app/workspace/floater-resize";
 import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
@@ -43,6 +44,24 @@ import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, onCleanup, onMount, type JSX } from "solid-js";
 
 import "./floating-pane-workspace.scss";
+
+/**
+ * Scale factor for converting a CSS-px drag delta into the host's window-
+ * position coordinate space.
+ *
+ * On Windows the host moves the raw HWND with `SetWindowPos` in PHYSICAL
+ * pixels, so a CSS-px delta must be multiplied by `devicePixelRatio`. On
+ * macOS / Linux the floater is a CEF Views window positioned via
+ * `set_bounds` / `bounds` in DIP (logical) pixels — and 1 CSS px == 1 DIP —
+ * so the delta is applied 1:1 (multiplying by DPR would move the window
+ * `devicePixelRatio`× too fast, e.g. 2× on a Retina display). Re-read per
+ * use so a mid-drag monitor crossing on Windows picks up the new DPR.
+ */
+function posScale(): number {
+    // Only Windows positions in physical px (raw-HWND SetWindowPos); macOS and
+    // Linux use CEF Views DIP (1 CSS px == 1 DIP).
+    return isWindows() ? window.devicePixelRatio || 1 : 1;
+}
 
 function FloatingPaneWorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
@@ -317,13 +336,13 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     latestScreenX !== clickScreenX ||
                     latestScreenY !== clickScreenY
                 ) {
-                    const dpr = window.devicePixelRatio || 1;
+                    const scale = posScale();
                     const tx =
                         initWinX +
-                        Math.round((latestScreenX - clickScreenX) * dpr);
+                        Math.round((latestScreenX - clickScreenX) * scale);
                     const ty =
                         initWinY +
-                        Math.round((latestScreenY - clickScreenY) * dpr);
+                        Math.round((latestScreenY - clickScreenY) * scale);
                     sendPos(tx, ty);
                 }
             } catch {
@@ -360,15 +379,16 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             latestScreenX = e.screenX;
             latestScreenY = e.screenY;
             if (!dragging) return;
-            // CSS-px delta * devicePixelRatio = physical-px delta added
-            // to the physical-px baseline from get_window_position. Re-
-            // read DPR every move so a mid-drag monitor crossing picks
-            // up the new value automatically.
-            const dpr = window.devicePixelRatio || 1;
+            // CSS-px delta * posScale() = host-coordinate delta added to the
+            // baseline from get_window_position. On Windows posScale() is the
+            // devicePixelRatio (physical px); on macOS/Linux it's 1 (CEF Views
+            // DIP). Re-read every move so a mid-drag monitor crossing on
+            // Windows picks up the new DPR automatically.
+            const scale = posScale();
             const tx =
-                initWinX + Math.round((e.screenX - clickScreenX) * dpr);
+                initWinX + Math.round((e.screenX - clickScreenX) * scale);
             const ty =
-                initWinY + Math.round((e.screenY - clickScreenY) * dpr);
+                initWinY + Math.round((e.screenY - clickScreenY) * scale);
             sendPos(tx, ty);
             pushRedockHover(e.screenX, e.screenY);
         };


### PR DESCRIPTION
## Summary

Tearing a pane off on **macOS** produced a full workspace window (tab bar + widget bar); Windows produced a chromeless floating window. This makes macOS match — **"just the pane"** — and makes the floater **draggable** by its header.

Spec: [`docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md`](https://github.com/agentmuxai/agentmux/blob/agenta/macos-floating-pane-tearoff-phase-a/docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md) (Phase A + the Phase B.2 header-drag fix).

## The key insight (why this is small)

The prior cross-platform spec assumed macOS needed a ~400-LOC raw `NSPanel` rewrite. It doesn't, because:
- macOS secondary windows are **already frameless** CEF Views windows (`window_create_top_level(frameless=true)`). There's no native macOS title bar — the tab bar + widget bar are **pure frontend** (`<Workspace>` → `WindowHeader` + `SystemStatus`).
- The chromeless renderer `<FloatingPaneWorkspace>` and the `?floatingPaneId=` switch in `app.tsx` are **100% platform-agnostic**.

So "just the pane" needed only the torn-off window's URL to carry `?floatingPaneId=`. No AppKit.

## Phase A — route pane tear-off to the chromeless floating window

- **`CrossWindowDragMonitor.darwin.tsx`** — pane tear-off now calls `open_floating_pane_window` (chromeless), mirroring the Windows pane branch: measure source pane size → `TearOffBlock` → IPC-first → delete the docked layout node on success. Tab tear-off unchanged (full window). Drop position comes from the DOM `dragend` event's `screenX/Y` (top-left-origin CSS px = DIP, exactly what CEF Views wants) since the host `get_cursor_point` is a Windows-only `GetCursorPos` stub.
- **`commands/floating_pane.rs`** — the non-Windows branch (was "not implemented") now creates a frameless window via the same `post_create_window(frameless=true)` path the tear-off cold path uses, with `&floatingPaneId=` in the URL. No DPI scaling on non-Windows (CEF Views is DIP).
- **`tear-off-pool-helper.ts`** — extracted the shared `measureSourcePaneSize` + floater-size constants (were win32-local); win32 now imports them.

## Phase B.2 — make the floater header-draggable on macOS

The floating-pane drag is absolute (read base via `get_window_position`, then `set_window_position(base + delta)`). Two macOS bugs made it unusable:
1. `get_window_position` returned `{0,0}` on macOS (Windows-only `GetWindowRect`) → wrong baseline → window jumped to the corner.
2. The frontend multiplied the CSS delta by `devicePixelRatio` — correct for Windows (physical-px `SetWindowPos`) but wrong for CEF Views (DIP), so on Retina the window moved **2× too fast**.

Fixes:
- **Host** — `get_window_position` now reads the CEF Views window's DIP bounds on macOS/Linux. Because `bounds()` must run on the CEF UI thread but the IPC command runs on the IPC thread, a new `GetWindowPositionTask` + `get_window_position_blocking` bounces through the UI thread over a bounded channel (250 ms timeout). `set_window_position` already used `set_bounds` (DIP) — no change.
- **Frontend** — `posScale()` returns `devicePixelRatio` only on Windows (physical px) and `1` on macOS/Linux (CEF Views DIP), replacing the raw `devicePixelRatio` in the move-delta math.

## Scope / platform impact

- **Windows**: unchanged — its pane path already used `open_floating_pane_window` with raw-HWND physical-px positioning.
- **Linux**: the host floating-pane branch + `posScale()` already handle Linux, but the **Linux monitor still routes panes through the full-window path** in Phase A (its monitor is unchanged) — a trivial follow-up.
- Out of scope (tracked in the spec as Phase B.3 / B.4): macOS **redock** (`resolve_window_at_cursor` is still a macOS stub) and **edge-resize** parity (same DIP coordinate issue as the drag).
- Pre-existing, unrelated: `create_isolated_request_context` logs `cache_path is not a child of root_cache_path → in-memory storage` for **every** macOS secondary window (tear-off tabs too) — not introduced here; its own follow-up.

## Test plan

Verified on macOS 26 / Apple Silicon / cef 146.7.0:
- [x] Tear a pane → frameless window showing **only the pane** (no tab bar, no widget bar), at the drop point, sized to the source pane.
- [x] Drag the floater by its header → follows the cursor 1:1 (no 2× overshoot, no corner-jump).
- [x] Tear a **tab** → still a full workspace window (unchanged).
- [x] Host + frontend compile/type-check clean.
- [ ] Windows: no behavioral change (paths unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)