### PR TITLE
docs(floating-pane): cross-platform field docs for OpenFloatingPaneArgs

### DIFF
--- a/.changesets/1780131062-docs-floating-pane-cross-platform-field-docs-for-openfloatin-zzjm.md
+++ b/.changesets/1780131062-docs-floating-pane-cross-platform-field-docs-for-openfloatin-zzjm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(floating-pane): cross-platform field docs for OpenFloatingPaneArgs x/y/width/height

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -44,19 +44,24 @@ pub struct OpenFloatingPaneArgs {
     #[serde(default)]
     pub workspace_id: Option<String>,
     /// Screen-space top-left coordinates where the new floating window
-    /// should appear, in Win32 PHYSICAL pixels. Typically the cursor
-    /// position at drop time (frontend reads from host
-    /// `get_cursor_point` which uses `GetCursorPos`).
+    /// should appear, at the drop point. Coordinate space is per-platform
+    /// (the consistent "Windows = physical px, macOS/Linux = DIP" rule):
+    /// - **Windows**: PHYSICAL px — the frontend reads `get_cursor_point`
+    ///   (`GetCursorPos`).
+    /// - **macOS/Linux**: DIP (top-left, CSS px) — the frontend uses the DOM
+    ///   `dragend` event's `screenX/Y`, and the host applies no scaling
+    ///   (CEF Views positions in DIP).
     pub x: i32,
     pub y: i32,
-    /// Initial window size in CSS / DIP pixels (NOT physical). The host
-    /// scales to physical px using the destination monitor's DPI via
-    /// `MonitorFromPoint(x, y)` + `GetDpiForMonitor`. Passing DIP here
-    /// (rather than physical, which would need the frontend to know the
-    /// destination monitor's DPI) lets us correctly cross-DPI handoff —
-    /// e.g. drag from a 100% monitor onto a 150% monitor and the floater
-    /// matches the source pane's visual size on the destination.
-    /// Mirrors the pattern in `commands/window_pool.rs:684-701`.
+    /// Initial window size in CSS / DIP pixels (NOT physical).
+    /// - **Windows**: the host scales to physical px using the DESTINATION
+    ///   monitor's DPI via `MonitorFromPoint(x, y)` + `GetDpiForMonitor`
+    ///   (`#[cfg(target_os = "windows")]` below) — the frontend can't, since
+    ///   it only knows its source monitor's DPR. This makes cross-DPI handoff
+    ///   correct (drag from a 100% monitor onto a 150% one and the floater
+    ///   keeps the source pane's visual size). Mirrors
+    ///   `commands/window_pool.rs:684-701`.
+    /// - **macOS/Linux**: passed through unscaled — CEF Views sizes in DIP.
     pub width: i32,
     pub height: i32,
 }


### PR DESCRIPTION
## Summary

Doc-only follow-up to #1182 (merged). Reagent's trailing review flagged two stale `OpenFloatingPaneArgs` field docs that still described only the Windows contract:

- **`x`/`y`** said "in Win32 PHYSICAL pixels … `get_cursor_point`/`GetCursorPos`" — but Phase A feeds these from the DOM `dragend` `screenX/Y` (top-left DIP) on macOS/Linux, with no host scaling.
- **`width`/`height`** said "the host scales to physical px via `MonitorFromPoint` + `GetDpiForMonitor`" — that scaling is `#[cfg(target_os = "windows")]` only; the non-Windows branch passes them through unscaled (DIP).

Both now state the per-platform contract (the consistent "Windows = physical px + DPI scaling, macOS/Linux = DIP, no scaling" rule established in #1182). #1182's `bc533470` refreshed the module + dispatch comments but missed these field docs.

No code change. `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)