### PR TITLE
feat(macos): floating-pane redock — drop a floater onto a window to merge the pane

### DIFF
--- a/.changesets/1780144758-feat-macos-floating-pane-redock-drop-a-floater-onto-a-window-6qyb.md
+++ b/.changesets/1780144758-feat-macos-floating-pane-redock-drop-a-floater-onto-a-window-6qyb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(macos): floating-pane redock — drop a floater onto a window to merge the pane

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -199,6 +199,21 @@ pub fn register_backend_window(_state: &Arc<AppState>, args: &serde_json::Value)
         // `Event::BackendWindowIdRegistered` (delivered via the CEF
         // JS bridge) carries the label → windowId mapping change to
         // every renderer's reducer. No sync emit here.
+        //
+        // On non-Windows there is NO launcher, so the
+        // `Event::BackendWindowIdRegistered` → `apply_event_to_shadow` round
+        // trip that fills `shadow_backend_window_ids` never runs
+        // (`report_backend_window_id_registered` no-ops without a launcher
+        // channel). The host is the sole authority here, so populate the
+        // projection directly. `resolve_window_at_cursor` reads it via
+        // `backend_window_id(label)` to resolve a redock target's window_id;
+        // without this it is always `None` on macOS/Linux and redock silently
+        // fails. See docs/analysis/REPORT_MACOS_FLOATING_PANE_REDOCK_2026_05_30.md.
+        #[cfg(not(target_os = "windows"))]
+        _state
+            .shadow_backend_window_ids
+            .lock()
+            .insert(label.to_string(), window_id.to_string());
     } else {
         tracing::warn!(label = %label, "[window] register_backend_window called with empty window_id — skipped");
     }

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -359,10 +359,24 @@ pub fn resolve_window_at_cursor(
         Ok(serde_json::json!({ "label": null, "window_id": null }))
     }
 
+    // macOS / Linux: CEF Views hit-test. Iterate registered top-level windows
+    // on the UI thread, find the top-most one whose DIP bounds contain the
+    // (DIP) point — the frontend sends DIP here on macOS/Linux (the posScale()
+    // rule), excluding the drag source. Then map label → backend window_id via
+    // the same `backend_window_id` projection (populated directly on non-Windows
+    // by `register_backend_window`, since there's no launcher). Mirrors the
+    // Windows return shape. See
+    // docs/analysis/REPORT_MACOS_FLOATING_PANE_REDOCK_2026_05_30.md.
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = (state, args, x, y, exclude_label);
-        Ok(serde_json::json!({ "label": null, "window_id": null }))
+        let _ = args;
+        match crate::ui_tasks::resolve_window_at_cursor_blocking(state, x, y, exclude_label) {
+            Some(label) => {
+                let wid = state.backend_window_id(&label);
+                Ok(serde_json::json!({ "label": label, "window_id": wid }))
+            }
+            None => Ok(serde_json::json!({ "label": null, "window_id": null })),
+        }
     }
 }
 

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -233,12 +233,14 @@ pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Res
 /// kicks off `RedockFloatingPane`.
 ///
 /// Args: `{ "x": int, "y": int, "exclude_label": string|null }` —
-/// cursor position in physical px (whatever `get_cursor_point`
-/// returned). `exclude_label` is the source floater's label; without
-/// it, `WindowFromPoint` returns the floater itself (the floater
-/// follows the cursor during drag, so it's always at the cursor in
-/// Z-order). We walk top-levels in Z-order from front to back and
-/// return the first match that ISN'T the excluded source.
+/// cursor position in the host coordinate space: physical px on Windows
+/// (from `get_cursor_point`/`GetCursorPos`), DIP on macOS/Linux (from the
+/// DOM drop event's `screenX/Y`; the posScale() rule). `exclude_label` is
+/// the source floater's label; without it the hit-test returns the floater
+/// itself (it follows the cursor during drag, so it's always topmost at the
+/// cursor). Windows walks HWND Z-order front-to-back; macOS/Linux hit-test
+/// CEF Views bounds (see `ui_tasks::resolve_window_at_cursor_blocking`).
+/// Either way we return the first match that ISN'T the excluded source.
 ///
 /// Returns: `{ "label": string|null, "window_id": string|null }`. Both
 /// null means no agentmux window of this process is under the cursor
@@ -417,7 +419,10 @@ pub fn update_floating_redock_hover(
     // Emit on every call (frontend throttles ~50 ms upstream). The
     // event must carry the cursor position so target renderers can
     // compute which TILE the cursor is over and highlight just that
-    // leaf (not the whole window). Cursor is in physical screen px.
+    // leaf (not the whole window). The cursor is in the sender's host
+    // coordinate space — physical screen px on Windows, DIP on
+    // macOS/Linux (the posScale() rule) — and the receiver inverts it
+    // accordingly (app-init.ts divides by DPR only on Windows).
     let payload = serde_json::json!({
         "target_label": new_target.clone(),
         "source_label": source_label,

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -268,8 +268,29 @@ async fn route_command(
             .await
             .map_err(|e| format!("get_window_position join error: {}", e))?
         }
-        "resolve_window_at_cursor" => commands::window::resolve_window_at_cursor(state, args),
-        "update_floating_redock_hover" => commands::window::update_floating_redock_hover(state, args),
+        "resolve_window_at_cursor" => {
+            // spawn_blocking — on macOS/Linux this bounces a CEF Views bounds
+            // hit-test through the UI thread (up to 250 ms), same as
+            // get_window_position above. Windows reads HWND rects directly.
+            let state_clone = state.clone();
+            let args_clone = args.clone();
+            tokio::task::spawn_blocking(move || {
+                commands::window::resolve_window_at_cursor(&state_clone, &args_clone)
+            })
+            .await
+            .map_err(|e| format!("resolve_window_at_cursor join error: {}", e))?
+        }
+        "update_floating_redock_hover" => {
+            // spawn_blocking — calls resolve_window_at_cursor internally, which
+            // blocks on the UI thread for up to 250 ms on macOS/Linux.
+            let state_clone = state.clone();
+            let args_clone = args.clone();
+            tokio::task::spawn_blocking(move || {
+                commands::window::update_floating_redock_hover(&state_clone, &args_clone)
+            })
+            .await
+            .map_err(|e| format!("update_floating_redock_hover join error: {}", e))?
+        }
         "clear_floating_redock_hover" => commands::window::clear_floating_redock_hover(state, args),
         "move_window_by" => commands::window::move_window_by(state, args),
         "set_window_position" => commands::window::set_window_position(state, args),

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -336,6 +336,81 @@ pub fn get_window_position_blocking(state: &Arc<AppState>, label: &str) -> Optio
     rx.recv_timeout(std::time::Duration::from_millis(250)).ok().flatten()
 }
 
+// ── Resolve which window is under a screen point (DIP) — blocking UI read ──
+//
+// The macOS/Linux analogue of the Windows HWND Z-order walk in
+// `commands/window/motion.rs::resolve_window_at_cursor`. Used by floating-pane
+// REDOCK to find the AgentMux window the cursor is over at drop time. CEF Views
+// `bounds()` must run on the UI thread, so iterate the registered top-level
+// windows there and hit-test the DIP point against each.
+//
+// Overlap rule (pragmatic first cut — see the redock report): exclude the drag
+// source; among the rest, prefer a non-"main" match (a floater/tear-off stacked
+// above main is almost always the intended target) over "main"; "main" wins
+// only when it's the sole match. True Z-order among multiple overlapping
+// non-main windows is a follow-up (would need `[NSApp orderedWindows]` + a
+// label↔NSWindow registry).
+wrap_task! {
+    pub struct ResolveWindowAtCursorTask {
+        state: Arc<AppState>,
+        x: i32,
+        y: i32,
+        exclude_label: String,
+        tx: std::sync::mpsc::SyncSender<Option<String>>,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let windows = self.state.windows.lock();
+            let mut main_match = false;
+            let mut best_other: Option<String> = None;
+            for (label, window) in windows.iter() {
+                if label.as_str() == self.exclude_label {
+                    continue;
+                }
+                let b = window.bounds();
+                let hit = self.x >= b.x
+                    && self.x < b.x + b.width
+                    && self.y >= b.y
+                    && self.y < b.y + b.height;
+                if !hit {
+                    continue;
+                }
+                if label.as_str() == "main" {
+                    main_match = true;
+                } else {
+                    // Deterministic pick among overlapping non-main windows:
+                    // lexicographically smallest label. (HashMap iteration
+                    // order is otherwise nondeterministic.)
+                    match &best_other {
+                        Some(cur) if cur.as_str() <= label.as_str() => {}
+                        _ => best_other = Some(label.clone()),
+                    }
+                }
+            }
+            let result = best_other.or(if main_match { Some("main".to_string()) } else { None });
+            let _ = self.tx.try_send(result);
+        }
+    }
+}
+
+/// Resolve the label of the top-most AgentMux window containing the DIP screen
+/// point `(x, y)`, excluding `exclude_label` (the drag source). `None` if the
+/// point is over the desktop / an external app / only the source window, or if
+/// the UI thread doesn't answer within the timeout.
+pub fn resolve_window_at_cursor_blocking(
+    state: &Arc<AppState>,
+    x: i32,
+    y: i32,
+    exclude_label: &str,
+) -> Option<String> {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Option<String>>(1);
+    let mut task =
+        ResolveWindowAtCursorTask::new(state.clone(), x, y, exclude_label.to_string(), tx);
+    post_task(ThreadId::UI, Some(&mut task));
+    rx.recv_timeout(std::time::Duration::from_millis(250)).ok().flatten()
+}
+
 // ── Phase B.9.2 (WRR) — corrective absolute-position move ─────────────────
 //
 // Reducer-driven self-heal. Triggered by `Event::CorrectiveWindowMove` when

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -42,6 +42,7 @@ import {
 import { loadFonts } from "@/util/fontutil";
 import { primeAccountCache } from "@/app/view/identity/identity-model";
 import { setKeyUtilPlatform } from "@/util/keyutil";
+import { isWindows } from "@/util/platformutil";
 import { render } from "solid-js/web";
 import { benchMark, benchDump } from "@/util/startup-bench";
 import { ContextMenuModel } from "@/app/store/contextmenu";
@@ -173,15 +174,20 @@ function installFloatingRedockHoverListener(): void {
                 clearPlaceholder();
                 return;
             }
-            const cursorPxX = payload.cursor_x;
-            const cursorPxY = payload.cursor_y;
-            if (typeof cursorPxX !== "number" || typeof cursorPxY !== "number") {
+            const cursorX = payload.cursor_x;
+            const cursorY = payload.cursor_y;
+            if (typeof cursorX !== "number" || typeof cursorY !== "number") {
                 clearPlaceholder();
                 return;
             }
-            const dpr = window.devicePixelRatio || 1;
-            const clientX = cursorPxX / dpr - window.screenX;
-            const clientY = cursorPxY / dpr - window.screenY;
+            // The broadcast cursor is in the host's coordinate space: physical
+            // px on Windows (divide by DPR to get CSS px), DIP on macOS/Linux
+            // (already CSS px — no divide). Inverse of the sender's posScale()
+            // in floating-pane-workspace.tsx. Without this the drop-zone
+            // highlight lands wrong on a Retina display.
+            const invScale = isWindows() ? window.devicePixelRatio || 1 : 1;
+            const clientX = cursorX / invScale - window.screenX;
+            const clientY = cursorY / invScale - window.screenY;
             const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
             const leafEl = el?.closest("[data-blockid]") as HTMLElement | null;
             if (!leafEl) {

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -360,9 +360,12 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             const now = performance.now();
             if (now - lastHoverPushAt < HOVER_PUSH_THROTTLE_MS) return;
             lastHoverPushAt = now;
-            const dpr = window.devicePixelRatio || 1;
-            const px = Math.round(screenX * dpr);
-            const py = Math.round(screenY * dpr);
+            // Host coordinate space: physical px on Windows, DIP on macOS/Linux
+            // (posScale). resolve_window_at_cursor / the hover hit-test compare
+            // against the same space.
+            const scale = posScale();
+            const px = Math.round(screenX * scale);
+            const py = Math.round(screenY * scale);
             const sourceLabel = windowLabel();
             if (!sourceLabel) return;
             invokeCommand("update_floating_redock_hover", {
@@ -429,10 +432,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         const tryRedockAtCursor = async (screenX: number, screenY: number) => {
             const ourLabel = windowLabel();
             if (!ourLabel) return;
-            // `mouseup.screenX/Y` are CSS pixels; host expects physical.
-            const dpr = window.devicePixelRatio || 1;
-            const px = Math.round(screenX * dpr);
-            const py = Math.round(screenY * dpr);
+            // `mouseup.screenX/Y` are CSS px. Host coordinate space: physical px
+            // on Windows (× DPR), DIP on macOS/Linux (× 1) — posScale().
+            const scale = posScale();
+            const px = Math.round(screenX * scale);
+            const py = Math.round(screenY * scale);
 
             let target: { label: string | null; window_id: string | null };
             try {


### PR DESCRIPTION
## Summary

Dragging a floating pane over another AgentMux window and dropping it now **merges the pane into that window's active tab** (with a live drop-zone highlight), and the emptied floater **auto-closes** — matching Windows. Implements the plan in [`REPORT_MACOS_FLOATING_PANE_REDOCK_2026_05_30.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/analysis/REPORT_MACOS_FLOATING_PANE_REDOCK_2026_05_30.md) (PR #1183).

Follows PR #1182 (macOS tear-off — chromeless floater + draggable header). **Verified working on macOS.**

## The redock mutation was already cross-platform

`RedockFloatingPane` is a saga over the backend (agentmux-srv) reducer dispatching `Command::MoveBlock`; the frontend reads the same WaveObject graph to resolve the target tab. **No new backend-reducer or saga code** — the macOS gaps were all in window *resolution*:

### Gap 1 — `resolve_window_at_cursor` had no macOS impl
Add a CEF Views hit-test: `ResolveWindowAtCursorTask` / `resolve_window_at_cursor_blocking` (`ui_tasks.rs`) iterate the registered top-level windows on the UI thread and hit-test the DIP cursor against each `bounds()`, excluding the drag source. Overlap rule (pragmatic first cut): prefer a non-`main` match over `main`; true Z-order among overlapping non-main windows is a follow-up (would need `[NSApp orderedWindows]` + a label↔NSWindow registry). Wired into the non-Windows branch of `resolve_window_at_cursor` (`motion.rs`); dispatch wrapped in `spawn_blocking` (`ipc.rs`) — along with `update_floating_redock_hover` which calls it — since both now block the UI thread up to 250 ms (same pattern as `get_window_position` in #1182).

### Gap 2 — `backend_window_id(label)` was always `None` on macOS
`shadow_backend_window_ids` is fed only by the Windows launcher (`apply_event_to_shadow`). Without a launcher, populate it directly in `register_backend_window` on non-Windows (`meta.rs`), so the resolved target carries a real `window_id` — else the frontend redock bails (`if (!target.label || !target.window_id) return`).

### Gap 3 — coordinate space
The frontend now sends the redock cursor in DIP on macOS/Linux (`posScale()` in `pushRedockHover` + `tryRedockAtCursor`, `floating-pane-workspace.tsx`), and the hover-highlight receiver (`app-init.ts`) inverts it platform-aware (divide by DPR only on Windows) so the drop-zone highlight lands under the cursor on Retina.

## Scope

- **Windows**: unchanged (HWND Z-order walk + physical px throughout).
- Out of scope (follow-ups): true Z-order among overlapping non-main windows (Gap 1 note); edge-resize DIP parity (same coordinate issue as the drag, Phase B.4 in the spec); the pre-existing `cache_path` in-memory-storage warning on all macOS secondary windows.

## Test plan

Verified on macOS 26 / Apple Silicon:
- [x] Tear a pane → drag the floater over the main window → drop-zone highlight appears → release → pane merges into main's active tab, floater auto-closes.
- [x] `registered backend window ID label=main window_id=…` populates the shadow map (Gap 2).
- [x] Drop over the desktop → floater stays put, no errors.
- [x] Host + frontend compile / type-check clean.
- [ ] Windows: no behavioral change (HWND path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)