### PR TITLE
fix(dnd): suppress tear-off drag snapback on macOS/Linux (pane + tab)

### DIFF
--- a/.changesets/1780145378-fix-dnd-suppress-tear-off-drag-snapback-on-macos-linux-for-p-3alr.md
+++ b/.changesets/1780145378-fix-dnd-suppress-tear-off-drag-snapback-on-macos-linux-for-p-3alr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dnd): suppress tear-off drag snapback on macOS/Linux for pane + tab

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -3,6 +3,8 @@
 
 import { Logger } from "@/util/logger";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
+import { isWindows } from "@/util/platformutil";
 import { createMemo, onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import clsx from "clsx";
@@ -95,6 +97,17 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 });
             },
             onDragStart: () => {
+                // Suppress the WebKit/WebKitGTK "drop rejected" snapback on
+                // tab tear-off (macOS/Linux): the tab is released outside any
+                // pragmatic-dnd drop target (the new window is created on
+                // dragend), so the browser would otherwise animate the drag
+                // ghost back into the source window. preventUnhandled makes the
+                // drop "handled" so the ghost just vanishes on release.
+                // Windows is excluded — its SC_MOVE tear-off path relies on
+                // the existing behavior, and the move cursor there isn't fixed
+                // by PR #1175 (darwin/linux only). In-window tab reorder still
+                // works via pragmatic-dnd's own drop targets.
+                if (!isWindows()) preventUnhandled.start();
                 setGlobalDragTabId(props.tabId);
                 setInsertionPoint(null);
                 setIsDragging(true);
@@ -107,6 +120,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 });
             },
             onDrop: () => {
+                if (!isWindows()) preventUnhandled.stop();
                 setGlobalDragTabId(null);
                 setIsDragging(false);
                 // Do NOT clear setTabGrabOffset here. pragmatic-dnd's

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -77,14 +77,16 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 // anchor the new window so the cursor stays on the same
                 // pixel of the same tab across the handoff.
                 //
-                // Note: we DO NOT suppress the OS drag image even though
-                // the spec drafted it. SC_MOVE doesn't actually engage
-                // during the HTML5 drag (pragmatic-dnd's OLE capture
-                // blocks the modal move-loop), so the new window only
-                // appears on mouseup. Suppressing the OS ghost leaves
-                // the user with a no-drop cursor and zero visual
-                // feedback during drag — strictly worse. Spec §4.5
-                // updated to reflect this.
+                // Note: we DO NOT suppress the OS drag image — the ghost
+                // following the cursor is the only drag feedback (SC_MOVE
+                // doesn't engage during the HTML5 drag; the new window
+                // appears on mouseup). We keep the ghost AND stop the
+                // "drop rejected" snapback via `preventUnhandled` in
+                // onDragStart/onDrop (macOS/Linux). An earlier note here
+                // argued against suppressing the ghost because it left a
+                // no-drop cursor with zero feedback — that's moot now:
+                // PR #1175 fixed the cursor (→ "move"), and this path
+                // keeps the ghost and only removes the snapback.
                 const tabRect = tabWrapRef.getBoundingClientRect();
                 setTabGrabOffset({
                     x: location.current.input.clientX - tabRect.left,

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -8,6 +8,7 @@
 
 import { getSettingsKeyAtom } from "@/app/store/global";
 import { draggable, dropTargetForElements, monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import clsx from "clsx";
 import { toPng } from "html-to-image";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
@@ -399,6 +400,17 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     }
                 },
                 onDragStart: () => {
+                    // Suppress WebKit's "drop rejected" snapback: a pane
+                    // tear-off releases the drag OUTSIDE any pragmatic-dnd
+                    // drop target (the floater is created on `dragend`), so
+                    // the browser would otherwise animate the drag preview
+                    // back into the source window ("it doesn't want to go").
+                    // preventUnhandled makes every element a drop target in
+                    // the browser's eyes, so the drop is "handled" and there's
+                    // no snapback — the preview just vanishes on release.
+                    // In-window rearrange still works via pragmatic-dnd's own
+                    // drop targets. Stopped in onDrop.
+                    preventUnhandled.start();
                     globalDragNodeId = props.node.id;
                     globalDragLayoutModel = props.layoutModel;
                     props.layoutModel.activeDrag._set(true);
@@ -406,6 +418,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     setCurrentDragPayload({ kind: "tile", node: props.node });
                 },
                 onDrop: () => {
+                    preventUnhandled.stop();
                     globalDragNodeId = null;
                     globalDragLayoutModel = null;
                     props.layoutModel.activeDrag._set(false);

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -7,6 +7,7 @@
 
 import { getApi, getSettingsKeyAtom } from "@/app/store/global";
 import { draggable, dropTargetForElements, monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import clsx from "clsx";
 import { toPng } from "html-to-image";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
@@ -379,6 +380,14 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     }
                 },
                 onDragStart: () => {
+                    // Suppress WebKitGTK's "drop rejected" snapback — a pane
+                    // tear-off releases outside any pragmatic-dnd drop target
+                    // (floater created on dragend), so the browser would
+                    // otherwise animate the drag preview back into the source
+                    // window. preventUnhandled makes the drop "handled" so the
+                    // preview just vanishes on release. In-window rearrange
+                    // still works via pragmatic-dnd's own drop targets.
+                    preventUnhandled.start();
                     globalDragNodeId = props.node.id;
                     globalDragLayoutModel = props.layoutModel;
                     props.layoutModel.activeDrag._set(true);
@@ -387,6 +396,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     getApi().setJsDragActive(true).catch(() => {});
                 },
                 onDrop: () => {
+                    preventUnhandled.stop();
                     globalDragNodeId = null;
                     globalDragLayoutModel = null;
                     props.layoutModel.activeDrag._set(false);


### PR DESCRIPTION
## Summary

Dragging a pane or tab out to tear it off played WebKit/WebKitGTK's "drop rejected" **snapback** animation — the drag ghost flying back into the source window ("it acts like it doesn't want to go") — even though the tear-off completed. The drag is released **outside any pragmatic-dnd drop target** (the new floater/window is created on `dragend`), so the browser treats the drop as unhandled and snaps the preview back to origin.

Fix: pragmatic-dnd's [`preventUnhandled.start()`](https://atlassian.design/components/pragmatic-drag-and-drop/core-package/utilities/prevent-unhandled) on drag start (stopped in `onDrop`). It makes every element a drop target in the browser's eyes, so the drop is "handled" → **no snapback**. The drag preview still follows the cursor during the drag (not suppressed); in-window rearrange still works via pragmatic-dnd's own drop targets.

## Changes

- **Pane**: `TileLayout.darwin.tsx` + `TileLayout.linux.tsx` (platform-split; **win32 unchanged**).
- **Tab**: `droppable-tab.tsx` (shared) gated `!isWindows()`.

## Scope

Scoped to **macOS/Linux**, matching PR #1175 (the move-cursor fix): on Windows the SC_MOVE tear-off path relies on the current behavior and the move cursor there isn't fixed, so suppressing the snapback could leave worse feedback. The stale "don't suppress the OS ghost — it leaves a no-drop cursor with zero feedback" comment in `droppable-tab.tsx` is now moot — #1175 fixed the cursor, and this keeps the ghost (just no snapback).

## Test plan

- [ ] macOS: tear a **pane** out → no ghost flying back into the source window; the floater appears at the drop point.
- [ ] macOS: tear a **tab** out → same, no snapback.
- [ ] macOS: rearranging a pane/tab **within** the window still works (pragmatic-dnd drop targets unaffected).
- [ ] Windows: no behavioral change (`!isWindows()` gate / win32 files untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)