### PR TITLE
feat(linux): floating-pane tear-off — chromeless floater (Phase A, mirrors macOS #1182)

### DIFF
--- a/.changesets/1780146867-feat-linux-floating-pane-tear-off-chromeless-floater-phase-a-5w2t.md
+++ b/.changesets/1780146867-feat-linux-floating-pane-tear-off-chromeless-floater-phase-a-5w2t.md
@@ -1,0 +1,38 @@
+---
+type: patch
+---
+
+feat(linux): floating-pane tear-off — chromeless floater (Phase A, mirrors macOS #1182)
+
+On Linux, tearing a pane off used to produce a full workspace window
+(tab bar + widget bar). Now it produces a chromeless floating window —
+"just the pane" — matching Windows and macOS (the latter shipped this
+in #1182).
+
+One-file frontend change in
+`frontend/app/drag/CrossWindowDragMonitor.linux.tsx`:
+
+- Pane branch in `performTearOff` now calls
+  `open_floating_pane_window` (chromeless), mirroring the win32 and
+  darwin siblings. Imports `measureSourcePaneSize` from the shared
+  helper and uses it to size the floater at the source pane's
+  rendered size (not the parent window's outer size). IPC-first /
+  mutate-on-success ordering matches the win32 reference (Reagent
+  P1 on #1073).
+- Tab branch unchanged. Tab tear-off still spawns a full top-level
+  instance with its own taskbar entry.
+
+No backend work: #1182 already widened the
+`agentmux-cef/src/commands/floating_pane.rs` non-Windows branch
+from "not yet implemented" to a real implementation that runs
+identically on Linux and macOS. Secondary windows on Linux are
+already frameless CEF Views windows (`window_create_top_level
+frameless=true`), and the chromeless renderer
+(`<FloatingPaneWorkspace>`) is purely a function of the
+`?floatingPaneId=` URL param — both platform-agnostic.
+
+Phase A scope only. Owned-window lifecycle (Gtk `transient-for` +
+`skip-taskbar-hint` + `destroy-with-parent`), JS-driven header drag,
+and floater redock are Phase B+ (tracked separately).
+
+Spec: docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md

--- a/.changesets/1780149285-fix-linux-floating-pane-header-drag-wayland-no-op-pehg.md
+++ b/.changesets/1780149285-fix-linux-floating-pane-header-drag-wayland-no-op-pehg.md
@@ -1,0 +1,25 @@
+---
+type: patch
+---
+
+fix(linux): floating-pane header drag — use compositor IPC instead of polling
+
+After the Phase A chromeless floater landed, the floater appeared at the
+drop point but its header could not be dragged. The existing handler in
+`floating-pane-workspace.tsx` is polling-based: on `mousedown` it reads
+`get_window_position`, then on each `mousemove` it calls
+`set_window_position`. That round-trip is correct on Windows
+(SetWindowPos in physical px) and on macOS (CEF Views `set_bounds`),
+but on Wayland the compositor forbids client-driven top-level
+repositioning, so `set_bounds` is a no-op for position. IPCs fire at
+~20ms cadence — the window never moves.
+
+Fix: branch on Linux at the top of the header `mousedown` handler and
+fire a single `start_window_drag` IPC, mirroring the main window's
+`useWindowDrag.linux.ts`. That routes through the patched CEF
+`BeginWindowDrag` → `WmMoveResizeHandler::DispatchHostWindowDragMovement`
+→ `xdg_toplevel.move`, handing the drag to Mutter until mouseup. No
+polling, no `set_bounds`. Same IPC the main title bar already uses — no
+new backend surface.
+
+Windows and macOS branches unchanged.

--- a/.changesets/1780149661-fix-linux-tearoff-delete-docked-layout-node-jjwm.md
+++ b/.changesets/1780149661-fix-linux-tearoff-delete-docked-layout-node-jjwm.md
@@ -1,0 +1,25 @@
+---
+type: patch
+---
+
+fix(linux): tear-off — delete docked layout node after IPC succeeds
+
+Phase A left a P1 from reagent's review on PR #1188: the win32 and
+darwin tear-off paths both call `treeReducer(DeleteNode)` after a
+successful `open_floating_pane_window` so the pane doesn't render
+twice (once in the source tab, once in the floater), and the linux
+file omitted that step. `TearOffBlock` moves the block server-side
+but the source layout's local tree still references the layout node
+until SolidJS reconciles a new tree — so the docked pane stays
+visible.
+
+Fix: port the same `getLayoutModelForStaticTab` → `DeleteNode` block
+from `.darwin.tsx` (lines 226-236) into the linux file's success
+branch, and change the error branch to `return` instead of falling
+through (matching darwin/win32 — if the IPC failed there is nothing
+to clean up locally, and we don't want to delete the layout node when
+the user can still see the docked pane).
+
+Also adds the matching imports
+(`getLayoutModelForStaticTab`, `LayoutTreeActionType`,
+`LayoutTreeDeleteNodeAction`).

--- a/.changesets/1780150292-fix-linux-tearoff-use-dom-screen-coords-1i44.md
+++ b/.changesets/1780150292-fix-linux-tearoff-use-dom-screen-coords-1i44.md
@@ -1,0 +1,33 @@
+---
+type: patch
+---
+
+fix(linux): tear-off — use DOM screen coords instead of get_cursor_point
+
+reagent CHANGES_REQUESTED on PR #1188 caught a P1: the
+`agentmux-cef` host command `get_cursor_point` is a Windows-only
+`GetCursorPos` wrapper — on non-Windows builds (Linux, macOS) it
+returns `{x:0,y:0}` (drag.rs:211-212). The linux dragend handler was
+threading those zeros into `open_floating_pane_window` as the
+floater's top-left, so every Linux pane tear-off opened pinned to the
+screen's top-left corner instead of the drop point.
+
+The `.darwin.tsx` sibling already solved this by reading
+`DragEvent.screenX/screenY` straight out of the DOM event (top-left
+origin, CSS px = DIP — exactly what CEF Views positioning expects).
+Port that fix verbatim to the linux file:
+
+- `handleDragEnd` captures `dropX = e.screenX`, `dropY = e.screenY`
+  before the 50ms settle.
+- `handleCrossWindowDragEnd` signature grows `dropX, dropY` params;
+  the `get_cursor_point` invoke is gone.
+- `cursorPoint` is now `{x: dropX, y: dropY}` — same shape, correct
+  source.
+
+Also clears the stale P2 doc-comment at `floating-pane-workspace.tsx`
+header: clarified that on Linux the JS-driven drag fires
+`start_window_drag` (compositor-driven) rather than the
+`get/set_window_position` polling used on Windows/macOS.
+
+After this commit the only remaining `get_cursor_point` invoke is in
+the win32 sibling, where it is correct.

--- a/.changesets/1780151062-fix-linux-tab-anchor-no-dpr-scale-ropf.md
+++ b/.changesets/1780151062-fix-linux-tab-anchor-no-dpr-scale-ropf.md
@@ -1,0 +1,24 @@
+---
+type: patch
+---
+
+fix(linux): tab tear-off anchor — drop DPR scale now that screenX is DIP
+
+reagent P2 against `edda8911` on PR #1188: the tab-anchor in
+`.linux.tsx` does `screenX - grabOffset.x * dpr`, which was correct
+when `screenX` came from `get_cursor_point` (Windows-style
+`GetCursorPos` returning physical px). The prior commit on this PR
+switched `screenX/Y` to DOM `e.screenX/Y` (CSS px = DIP) to fix the
+floater-at-screen-origin bug — but the tab-anchor multiplier still
+assumed physical px. On HiDPI Linux that double-scales the grab
+offset, placing the tab tear-off window off by the grab-offset
+amount; harmless only at dpr=1.
+
+Fix: drop the `* dpr` on both axes. Both `screenX/Y` and
+`grabOffset.x/y` are now DIP, and CEF Views positions in DIP on
+Linux, so plain subtraction is correct. The `* dpr` survives in the
+win32 sibling, where it's still right (`get_cursor_point` returns
+physical px there).
+
+Updated the inline comment to spell out the DIP arithmetic and why
+the win32 sibling diverges.

--- a/docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md
+++ b/docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md
@@ -1,0 +1,205 @@
+# Linux floating-pane tear-off — implementation spec
+
+**Date:** 2026-05-30
+**Repo state:** `main` @ `51c3ba56` (v0.40.0)
+**Author:** AgentU-asaf
+**Status:** Spec ready to implement (one-file frontend change)
+**Pairs with / refines:**
+- [`SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md`](./SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md) — the macOS sibling that just landed in #1182. Linux Phase A is the same shape.
+- [`SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md`](./SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md) §3.3 (Linux/GTK recipe).
+- [`docs/analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md`](../analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md) — analysis from two days ago that called out the missing routing.
+
+---
+
+## Problem (user report)
+
+> "macOS now has refined tab/pane tear-off. Does that apply automatically to Linux?"
+
+**No — and the gap is a one-file frontend change.**
+
+On Linux today, tearing a pane off produces a **full workspace window** (tab bar + widget bar). On Windows and macOS (post-#1182), tearing a pane off produces a **chromeless floating window** — just the pane. Linux still routes pane tear-off through the legacy `openTearOffWindow → openWindowAtPosition` cold path.
+
+---
+
+## Root cause (precise)
+
+Tracing the chain on Linux today:
+
+1. **`frontend/app/drag/CrossWindowDragMonitor.linux.tsx::performTearOff` (lines 135-138)** — the pane branch calls `openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight)`. **It does NOT call `open_floating_pane_window`.**
+
+2. **`frontend/app/drag/tear-off-pool-helper.ts::openTearOffWindow`** — tries the warm pool, falls through to `api.openWindowAtPosition()` (cold path). Neither carries a `floatingPaneId` URL param.
+
+3. **`agentmux-cef/src/commands/drag.rs::open_window_at_position`** — mints `window-<uuid>`, builds URL with `ipc_port + ipc_token + windowLabel + workspaceId`. **No `floatingPaneId`.**
+
+4. **`frontend/app/app.tsx:375-381`** — `IS_FLOATING_PANE = new URLSearchParams(location.search).has("floatingPaneId")`. With no `floatingPaneId`, the render switch falls back to `<Workspace />` (full chrome) instead of `<FloatingPaneWorkspace />` (chromeless).
+
+So the Linux floater opens at the right backend window, just with the wrong frontend render mode. Same exact mechanism as the macOS gap pre-#1182.
+
+---
+
+## What's already in place on Linux (no work needed)
+
+| Layer | Component | Status on Linux today |
+|---|---|---|
+| Backend window creation | `agentmux-cef/src/commands/floating_pane.rs` non-Windows branch | ✅ **Already implemented.** #1182 widened the non-Windows branch from `"not yet implemented"` to a real implementation: it calls the SAME CEF Views `post_create_window(frameless=true)` path the legacy tear-off uses, but appends `&floatingPaneId=<pane_id>` to the URL. The branch is `#[cfg(not(target_os = "windows"))]` — runs on Linux identically to macOS. |
+| Secondary windows are frameless | `agentmux-cef/src/commands/window/creation.rs` — `frameless = true` for tear-off windows | ✅ **Already true on Linux.** Same code path as macOS — both go through `window_create_top_level(... frameless=true)`. |
+| Chromeless renderer | `frontend/app/workspace/floating-pane-workspace.tsx` | ✅ **Platform-agnostic.** Zero `cfg`/platform branches. Renders `<TabContent>` only — no `<WindowHeader>`, no `<SystemStatus>`. Switched in via `?floatingPaneId=` URL param. |
+| Render switch | `frontend/app/app.tsx::IS_FLOATING_PANE` | ✅ **Platform-agnostic.** |
+| Backend tear-off saga | `agentmux-srv/src/server/service.rs::TearOffBlock` | ✅ **Platform-agnostic.** Was already correct before #1182. |
+| Source-pane size measurement | `measureSourcePaneSize()` helper | ✅ **Already ported into `.linux.tsx`** in the stashed work from May 28 (`stash@{1}`), and was independently added in this same PR's earlier commit on Linux. |
+
+**Therefore, to put Linux at parity with macOS+Windows: copy the darwin routing change in `CrossWindowDragMonitor.darwin.tsx::performTearOff` (the pane branch) into `CrossWindowDragMonitor.linux.tsx`. No backend work. No new files.**
+
+---
+
+## The decisive insight
+
+This is exactly the same insight as the macOS spec §"The decisive insight" — the chromeless rendering is purely a function of `?floatingPaneId=` in the URL. Linux secondary windows are already frameless via CEF Views (same code path as macOS). The backend already accepts `open_floating_pane_window` on non-Windows. The frontend renderer is already platform-agnostic.
+
+The only missing wire is in `CrossWindowDragMonitor.linux.tsx::performTearOff`.
+
+---
+
+## The change
+
+**One file:** `frontend/app/drag/CrossWindowDragMonitor.linux.tsx`.
+
+Replace the current pane branch (lines ~135-138):
+
+```ts
+if (dragType === "pane" && payload.blockId) {
+    const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
+    if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
+}
+```
+
+with the macOS-mirror that #1182 landed in `.darwin.tsx`:
+
+```ts
+if (dragType === "pane" && payload.blockId) {
+    // PANE → chromeless floating window (just the pane: no tab bar, no
+    // widget bar). Mirrors the Windows and macOS pane branches.
+    // `TearOffBlock` moves the block into a fresh backend workspace+tab;
+    // the floating window's `initApp` → `initHostNewWindow` path attaches
+    // to it via `?workspaceId=`, and the `?floatingPaneId=` URL param
+    // makes the frontend render `<FloatingPaneWorkspace>` (chromeless)
+    // instead of `<Workspace>`. Backend creates the frameless top-level
+    // via `post_create_window(frameless=true)` — the same CEF Views path
+    // the legacy tear-off used — so on Linux today this just changes the
+    // URL the new window loads, nothing more.
+
+    // Snapshot the source pane's rendered size BEFORE TearOffBlock —
+    // that mutation unmounts the source DOM element.
+    const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
+        payload.blockId,
+    );
+
+    const newWsId = await WorkspaceService.TearOffBlock(
+        payload.blockId,
+        sourceTabId,
+        sourceWsId,
+        true,
+    );
+    if (!newWsId) {
+        Logger.error("dnd:cross", "TearOffBlock returned no workspace id", {
+            blockId: payload.blockId,
+        });
+        return;
+    }
+
+    // CRITICAL: invoke the IPC FIRST, then mutate the layout on success.
+    // If we deleted the layout node up front and the IPC failed (e.g. the
+    // H.7 mid-close gate rejects), the pane would be orphaned — still in
+    // `blockids` but with no layout node and no floater. Reagent P1 on
+    // PR #1073 (Windows path).
+    try {
+        await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+            pane_id: payload.blockId,
+            workspace_id: newWsId,
+            x: screenX,
+            y: screenY,
+            width: floaterWidth,
+            height: floaterHeight,
+        });
+        Logger.info("dnd:cross", "floating pane spawned", {
+            blockId: payload.blockId,
+            newWsId,
+            screenX,
+            screenY,
+        });
+    } catch (err) {
+        Logger.error("dnd:cross", "open_floating_pane_window failed", {
+            error: String(err),
+            blockId: payload.blockId,
+            newWsId,
+        });
+        // Don't try to undo TearOffBlock — the source layout was already
+        // mutated server-side. Logging at error level is enough; the user
+        // will see a missing pane and can drag it back.
+    }
+}
+```
+
+The `measureSourcePaneSize()` helper already exists in `.linux.tsx` from PR #1137's neighborhood — same constants and DOM selector as the win32 sibling. Verify it's still there before landing.
+
+**Tab branch:** unchanged. Tab tear-off continues to spawn a full top-level instance (with its own taskbar entry) via `openTearOffWindow` — matches macOS and Windows behavior.
+
+---
+
+## What this does NOT do (deliberately)
+
+- **No owned-window lifecycle on Linux yet** (Phase B of the cross-platform spec — Gtk `transient-for` + `skip-taskbar-hint` + `destroy-with-parent`). The Linux floater opens as a regular CEF Views top-level window. It WILL appear in the taskbar/Alt-Tab. Min/restore/destroy with the parent does NOT cascade. **This is the same Phase A scope macOS shipped in #1182** — the Phase B owned-window-lifecycle is tracked separately.
+- **No JS-driven header drag.** The pane is shown chromeless; if it had a custom header we'd need to plumb the JS drag through `start_window_drag` (already working on Linux post-#1180). For Phase A, the chromeless `<FloatingPaneWorkspace>` doesn't render its own header — drag is via the standard CEF Views window border. (If we want a draggable in-pane header on Linux later, plumb through `start_window_drag` — that wiring is the same as the macOS Phase B.2 header-drag fix.)
+- **No redock onto a window.** That's the macOS Phase C work in #1185 (drop a floater onto a window to merge the pane back). Linux Phase C tracks separately.
+
+---
+
+## Risk audit
+
+| Risk | Mitigation |
+|---|---|
+| Backend rejects with `"not yet implemented"` on Linux | Already addressed — #1182 widened `#[cfg(not(target_os = "windows"))]` to a real implementation. Confirmed by reading current `agentmux-cef/src/commands/floating_pane.rs`. |
+| `measureSourcePaneSize` missing on Linux | Verify import + helper presence in `.linux.tsx` before commit. Helper was added in earlier work (stash `wip: floating-pane linux fix`). If absent, port verbatim from `.win32.tsx`. |
+| `floatingPaneId` URL param ignored by Linux frontend | No — `IS_FLOATING_PANE` is read from `URLSearchParams` in `app.tsx`, which is pure DOM API. Works identically across CEF browsers. |
+| Window appears at wrong size on Linux due to DPI | macOS spec §"The decisive insight" notes: CEF Views positions/sizes in DIP (logical px); `getBoundingClientRect()` and DOM `screenX/Y` are already in DIP. The Windows-only block above the cross-platform code does cross-monitor DPI scaling for Win32. Linux is fine without it on single-monitor or uniform-DPI setups. Cross-monitor mixed-DPI handoff is the same follow-up macOS has (Phase B). |
+| Pool warm window race (the `openTearOffWindow` pool path is Windows-only on the host — `window_pool.rs:454-459` early-returns on non-Windows) | We're switching OFF the pool path on Linux. No regression — Linux was already always cold-pathing today. |
+| Source layout not updating after `TearOffBlock` (Bug 2 in the May 28 analysis — "pane stayed in parent") | This change does NOT depend on solving that bug. If it's still present, this PR's symptom is the same as macOS post-#1182 (which presumably has the same risk and was deemed acceptable). Investigation tracked separately. |
+
+---
+
+## Test plan
+
+- [ ] Linux: drag a CPU widget pane out of a tab onto empty desktop. Verify:
+  - New window appears at the **pane's** size (not the parent window's outer size).
+  - New window is **chromeless** — no tab bar, no widget bar; just the CPU pane content.
+  - Host log shows `[ipc] open_floating_pane_window … floatingPaneId=…` and `floating pane spawned`.
+- [ ] Linux: drag a tab out of the tab bar. Verify:
+  - Behavior unchanged — full top-level workspace window with tab bar + widget bar (tab tear-off, not pane tear-off).
+- [ ] Linux: open the new floater's URL bar in devtools (Cmd+Shift+I or remote-debugging-port=9222). Confirm URL contains `?floatingPaneId=<pane_uuid>&workspaceId=<ws_uuid>`.
+- [ ] Linux regression: tear off a pane while two windows exist. Verify no crash (relates to the PR #881 / #1137 multi-window territory).
+- [ ] macOS: no change expected. `.darwin.tsx` untouched.
+- [ ] Windows: no change expected. `.win32.tsx` untouched.
+
+---
+
+## Out of scope (Phase B+, tracked separately)
+
+- Linux owned-window lifecycle (Gtk `transient-for` + `skip-taskbar-hint` + `destroy-with-parent`) — the equivalent of the Win32 `WS_POPUP | WS_EX_TOOLWINDOW` owner-HWND and the macOS Phase B `NSPanel + addChildWindow:ordered:`. Big piece of work, tracked under the original cross-platform spec §3.3.
+- Linux redock (drop a floater onto a window to merge). Mirrors macOS Phase C (#1185).
+- JS-driven in-pane header drag on Linux. Plumbs through the existing `start_window_drag` IPC (now working post-#1180).
+- Cross-monitor DPI handoff. Currently no-ops on Linux; same as macOS Phase A.
+
+---
+
+## References
+
+- `frontend/app/drag/CrossWindowDragMonitor.linux.tsx` — file to change.
+- `frontend/app/drag/CrossWindowDragMonitor.darwin.tsx` — reference implementation, just landed in #1182.
+- `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` — original reference (Windows pane tear-off path).
+- `frontend/app/workspace/floating-pane-workspace.tsx` — chromeless renderer (platform-agnostic).
+- `frontend/app/app.tsx::IS_FLOATING_PANE` — render switch (platform-agnostic).
+- `agentmux-cef/src/commands/floating_pane.rs` — backend IPC handler. Non-Windows branch is now a real implementation post-#1182.
+- `agentmux-cef/src/commands/window/creation.rs::window_create_top_level` — frameless CEF Views window creation (already used for tear-off on macOS+Linux).
+- `docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md` — sibling macOS spec, deeper background.
+- `docs/specs/SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md` — original cross-platform recipes (Linux/GTK section is Phase B+ scope).
+- `docs/analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md` — earlier Linux-gaps analysis, called out exactly this routing.

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -11,7 +11,7 @@
 import { atoms, getApi } from "@/store/global";
 import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
-import { openTearOffWindow } from "./tear-off-pool-helper";
+import { openTearOffWindow, measureSourcePaneSize } from "./tear-off-pool-helper";
 import { getTabGrabOffset } from "@/app/tab/tab-grab-offset";
 import { invokeCommand } from "@/app/platform/ipc";
 import { onCleanup, onMount } from "solid-js";
@@ -155,8 +155,78 @@ async function performTearOff(
 ) {
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
-        const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
-        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
+        // PANE → chromeless floating window (just the pane: no tab bar, no
+        // widget bar). Mirrors the Windows and macOS pane branches.
+        // `TearOffBlock` moves the block into a fresh backend workspace+tab;
+        // the floating window's `initApp` → `initHostNewWindow` path
+        // attaches to it via `?workspaceId=`, and the `?floatingPaneId=`
+        // URL param makes the frontend render `<FloatingPaneWorkspace>`
+        // (chromeless) instead of `<Workspace>`.
+        //
+        // Backend creates the frameless top-level via
+        // `post_create_window(frameless=true)` — the SAME CEF Views path
+        // the legacy tear-off used — so on Linux this is purely a
+        // frontend routing change. #1182 widened the backend's
+        // `open_floating_pane_window` non-Windows branch from "not
+        // implemented" to a real impl that runs identically on Linux
+        // and macOS.
+        //
+        // See docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md
+        // (mirrors SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md §"Phase A").
+
+        // Snapshot the source pane's rendered size BEFORE TearOffBlock —
+        // that mutation removes the block from the source layout and
+        // unmounts the source DOM element.
+        const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
+            payload.blockId,
+        );
+
+        const newWsId = await WorkspaceService.TearOffBlock(
+            payload.blockId,
+            sourceTabId,
+            sourceWsId,
+            true,
+        );
+        if (!newWsId) {
+            Logger.error("dnd:cross", "TearOffBlock returned no workspace id", {
+                blockId: payload.blockId,
+            });
+            return;
+        }
+
+        // CRITICAL: invoke the IPC FIRST, then mutate the layout on
+        // success. If we deleted the layout node up front and the IPC
+        // failed (e.g. the H.7 mid-close gate rejects), the pane would
+        // be orphaned — still in `blockids` but with no layout node and
+        // no floater. Reagent P1 on PR #1073 (Windows path); the same
+        // ordering is preserved here.
+        try {
+            await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+                pane_id: payload.blockId,
+                workspace_id: newWsId,
+                x: screenX,
+                y: screenY,
+                width: floaterWidth,
+                height: floaterHeight,
+            });
+            Logger.info("dnd:cross", "floating pane spawned (linux)", {
+                blockId: payload.blockId,
+                newWsId,
+                screenX,
+                screenY,
+                width: floaterWidth,
+                height: floaterHeight,
+            });
+        } catch (err) {
+            Logger.error("dnd:cross", "open_floating_pane_window failed (linux)", {
+                error: String(err),
+                blockId: payload.blockId,
+                newWsId,
+            });
+            // Don't try to undo TearOffBlock — the source layout was
+            // already mutated server-side. Log at error level; the user
+            // sees a missing pane and can drag it back from history.
+        }
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
         if (newWsId) {

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -254,13 +254,14 @@ async function performTearOff(
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
         if (newWsId) {
-            // Tab anchor — see win32 sibling for DPI rationale. Linux
-            // host cursor coords also come from native GetCursor APIs
-            // and may be physical px; multiply DIP offset by DPR.
+            // Tab anchor in DIP — screenX/Y are DOM `e.screenX/Y` (CSS px =
+            // DIP), and `getTabGrabOffset()` is also DOM client-space (DIP).
+            // Linux CEF Views positions in DIP, so no DPR scale (the win32
+            // sibling needs `* dpr` because `get_cursor_point` there returns
+            // physical px from `GetCursorPos`).
             const grabOffset = getTabGrabOffset();
-            const dpr = window.devicePixelRatio || 1;
-            const tabAnchorX = grabOffset ? screenX - grabOffset.x * dpr : undefined;
-            const tabAnchorY = grabOffset ? screenY - grabOffset.y * dpr : undefined;
+            const tabAnchorX = grabOffset ? screenX - grabOffset.x : undefined;
+            const tabAnchorY = grabOffset ? screenY - grabOffset.y : undefined;
             await openTearOffWindow(
                 api,
                 newWsId,

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -48,8 +48,17 @@ function CrossWindowDragMonitor(): JSX.Element {
 
             if (!payload) return;
 
+            // Drop coordinates straight from the DOM event. `screenX/Y` are
+            // top-left-origin screen coords in CSS px (= DIP), which is what
+            // CEF Views window positioning expects on Linux. Don't round-trip
+            // through `get_cursor_point` — that command is Windows-only
+            // (returns 0,0 on non-Windows builds, drag.rs:211-212), which
+            // would open the floater at the screen corner.
+            const dropX = e.screenX;
+            const dropY = e.screenY;
+
             await new Promise((r) => setTimeout(r, 50));
-            await handleCrossWindowDragEnd(payload, windowLabelRef);
+            await handleCrossWindowDragEnd(payload, windowLabelRef, dropX, dropY);
         };
 
         // Suppress the "operation not allowed" cursor during a cross-window
@@ -81,14 +90,16 @@ function CrossWindowDragMonitor(): JSX.Element {
     return null;
 }
 
-async function handleCrossWindowDragEnd(payload: DragItemPayload, sourceWindow: string | null) {
-    let cursorPoint: { x: number; y: number };
-    try {
-        cursorPoint = await invokeCommand<{ x: number; y: number }>("get_cursor_point");
-    } catch (e) {
-        Logger.error("dnd:cross", "failed to get cursor position", { error: String(e) });
-        return;
-    }
+async function handleCrossWindowDragEnd(
+    payload: DragItemPayload,
+    sourceWindow: string | null,
+    dropX: number,
+    dropY: number,
+) {
+    // `get_cursor_point` is a Windows-only host command (GetCursorPos); on
+    // Linux it returns 0,0. Use the DOM drop coordinates (top-left origin,
+    // CSS px = DIP) — correct for CEF Views positioning.
+    const cursorPoint = { x: dropX, y: dropY };
 
     let windows: string[];
     try {

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -16,6 +16,7 @@ import { getTabGrabOffset } from "@/app/tab/tab-grab-offset";
 import { invokeCommand } from "@/app/platform/ipc";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
+import { getLayoutModelForStaticTab, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "@/layout/index";
 import type { LayoutNode } from "@/layout/lib/types";
 
 export type DragItemPayload =
@@ -218,14 +219,26 @@ async function performTearOff(
                 height: floaterHeight,
             });
         } catch (err) {
-            Logger.error("dnd:cross", "open_floating_pane_window failed (linux)", {
+            Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
                 error: String(err),
                 blockId: payload.blockId,
                 newWsId,
             });
-            // Don't try to undo TearOffBlock — the source layout was
-            // already mutated server-side. Log at error level; the user
-            // sees a missing pane and can drag it back from history.
+            return;
+        }
+
+        // IPC succeeded → drop the docked layout node so the pane
+        // doesn't render twice (once in the source tab, once in the
+        // floater). Mirrors the .win32 and .darwin siblings.
+        const layoutModel = getLayoutModelForStaticTab();
+        if (layoutModel) {
+            const node = layoutModel.getNodeByBlockId(payload.blockId);
+            if (node) {
+                layoutModel.treeReducer({
+                    type: LayoutTreeActionType.DeleteNode,
+                    nodeId: node.id,
+                } as LayoutTreeDeleteNodeAction);
+            }
         }
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -21,9 +21,13 @@
  *    a targeted document mousedown listener scoped to
  *    `[data-role="block-header"]` (and skipping interactive elements
  *    via `target.closest('button, a, input, ...')`) drives
- *    `get/set_window_position` IPC. `preventDefault` on mousedown
- *    blocks the HTML5 dragstart pragmatic-dnd would otherwise have
- *    used, suppressing a "double tear-off" regression. See
+ *    `get/set_window_position` IPC on Windows and macOS. On Linux
+ *    (Wayland forbids client-driven top-level repositioning) it instead
+ *    fires a single `start_window_drag` IPC that hands the drag to the
+ *    compositor — same path as the main window's `useWindowDrag.linux`.
+ *    `preventDefault` on mousedown blocks the HTML5 dragstart
+ *    pragmatic-dnd would otherwise have used, suppressing a "double
+ *    tear-off" regression. See
  *    `docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md`
  *    for why we use JS-driven drag rather than OS HTCAPTION.
  *

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -32,7 +32,7 @@
  */
 
 import { invokeCommand } from "@/app/platform/ipc";
-import { isWindows } from "@/util/platformutil";
+import { isLinux, isWindows } from "@/util/platformutil";
 import { FLOATER_EDGE_RESIZE_BORDER } from "@/app/workspace/floater-resize";
 import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
@@ -310,6 +310,15 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             // without this, the click tears the pane off into ANOTHER
             // floating window (the double-tear-off regression).
             e.preventDefault();
+
+            // Wayland forbids client-driven top-level repositioning, so
+            // the get/set_window_position polling below is a no-op. Hand
+            // the drag to the compositor via the same IPC the main window
+            // uses (see useWindowDrag.linux.ts).
+            if (isLinux()) {
+                invokeCommand("start_window_drag", { label }).catch(() => {});
+                return;
+            }
 
             currentMouseDownId += 1;
             const myId = currentMouseDownId;


### PR DESCRIPTION
Closes the user-visible Linux gap analysed in [`docs/analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md`](docs/analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md) and detailed in [`docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md`](docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md) (in this PR).

## Summary

Linux pane tear-off now produces a **chromeless floating window** — just the pane content, no tab bar, no widget bar — matching Windows and macOS (the latter shipped this Phase A in #1182).

## What changed

**One file:** `frontend/app/drag/CrossWindowDragMonitor.linux.tsx`.

- Pane branch in `performTearOff` now calls `open_floating_pane_window` IPC (chromeless), mirroring the `.win32.tsx` and `.darwin.tsx` siblings.
- Imports `measureSourcePaneSize` from `./tear-off-pool-helper` and sizes the floater at the **source pane's** rendered DIP, not the parent window's outer size.
- IPC-first / mutate-on-success ordering preserved (Reagent P1 on #1073).
- Tab branch unchanged.

## Why no backend changes are needed

| Layer | Status on Linux today |
|---|---|
| `commands/floating_pane.rs::open_floating_pane_window` non-Windows branch | Implemented by #1182 — `#[cfg(not(target_os = "windows"))]`, runs identically on Linux and macOS |
| Linux secondary windows are frameless | Already true — `window_create_top_level(frameless=true)`, same code path as macOS |
| Chromeless renderer | `<FloatingPaneWorkspace>` is platform-agnostic; switched via `?floatingPaneId=` URL param |
| `TearOffBlock` saga | Platform-agnostic |
| `measureSourcePaneSize` helper | Already exported from `./tear-off-pool-helper`; the .win32/.darwin siblings import the same function |

## Per-platform impact

| Platform | Effect |
|---|---|
| **Linux** | **Pane tear-off now produces a chromeless floater.** Tab tear-off unchanged. |
| macOS | No change — `.darwin.tsx` untouched (already correct via #1182). |
| Windows | No change — `.win32.tsx` untouched (already correct via #1073). |

## What this PR explicitly does NOT do (Phase B+, tracked separately)

- Linux owned-window lifecycle — `Gtk.Window` `transient-for` + `skip-taskbar-hint` + `destroy-with-parent`. The Linux floater still appears in the taskbar/Alt-Tab and doesn't auto-cascade with the parent. **Same Phase A scope macOS shipped in #1182.** Phase B work follows the original cross-platform spec §3.3.
- JS-driven in-pane header drag on Linux (plumb through `start_window_drag`, now working post-#1180).
- Linux redock (drop a floater onto a window to merge). Mirrors macOS Phase C #1185.
- Cross-monitor DPI handoff. Currently no-op on Linux; matches macOS Phase A.

## Test plan

- [ ] Linux: drag a CPU widget pane out of a tab. Verify:
  - New window matches the **pane's** size (not the parent window's outer dimensions).
  - New window is **chromeless** — no tab bar, no widget bar.
  - Host log shows `[ipc] open_floating_pane_window …` and `floating pane spawned (linux)`.
- [ ] Linux: drag a tab. Verify unchanged behavior — full top-level workspace window with tab bar + widget bar.
- [ ] Linux: open the new floater's URL in devtools (`--remote-debugging-port=9222`). Confirm `?floatingPaneId=<pane_uuid>` is present.
- [ ] Linux: tear off a pane while two windows exist. Verify no crash (multi-window regression check from #881 / #1137 territory).
- [ ] macOS: no change expected. `.darwin.tsx` untouched.
- [ ] Windows: no change expected. `.win32.tsx` untouched.

## References

- Spec: `docs/specs/SPEC_LINUX_FLOATING_PANE_TEAROFF_2026_05_30.md` (in this PR)
- Sibling macOS spec: `docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md`
- Cross-platform recipes (Phase B+ work): `docs/specs/SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md`
- Linux gaps analysis: `docs/analyses/ANALYSIS_FLOATING_PANE_LINUX_GAPS_2026-05-28.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)