### PR TITLE
feat(launcher): drive srv + host via agentmux-launcher on macOS/Linux task dev (Phase 1)

### DIFF
--- a/.changesets/1780148517-feat-launcher-drive-srv-and-host-via-agentmux-launcher-on-ma-83i3.md
+++ b/.changesets/1780148517-feat-launcher-drive-srv-and-host-via-agentmux-launcher-on-ma-83i3.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(launcher): drive srv and host via agentmux-launcher on macOS/Linux task dev (Phase 1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "agentmux-common",
  "chrono",
  "dirs",
+ "libc",
  "png",
  "proptest",
  "rusqlite",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -466,10 +466,16 @@ tasks:
         # before the macOS libcef story was sorted; on Linux we always had
         # the patched runtime).
         cmds:
-            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef --features patched-libcef'
+            # Phase 1 (SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30): build
+            # the launcher alongside the host so the flat dev layout (launcher
+            # + host + srv co-located in dist/cef-dev/) has it — same as
+            # build:host:darwin. Without this, dev:serve's launcher-not-found
+            # guard hard-fails on Linux.
+            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef --features patched-libcef && PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-launcher'
             - mkdir -p dist/cef
             - cp target/release/agentmux-cef dist/cef/agentmux-cef
-            - echo "✓ Built host for Linux"
+            - cp target/release/agentmux-launcher dist/cef/agentmux-launcher
+            - echo "✓ Built host + launcher for Linux"
 
     bundle:
         desc: Bundle runtime binaries alongside the host executable.
@@ -589,7 +595,7 @@ tasks:
 
     dev:serve:
         internal: true
-        desc: Start Vite dev server and host concurrently, via the launcher (Windows) or direct host invocation (Unix).
+        desc: Start Vite dev server and the app concurrently, via the launcher (launcher → srv + host on all platforms; Windows uses the runtime/ layout, macOS/Linux a flat layout).
         cmds:
             - task: build:host
             - task: bundle
@@ -613,10 +619,13 @@ tasks:
                 #            so dev mirrors the package-portable runtime.
                 #            See docs/specs/SPEC_LAUNCHER_DEV_INTEGRATION_2026-05-13.md.
                 #
-                #   Unix:    legacy flat layout — host + DLLs in DEV_DIR
-                #            directly, launcher bypassed. Phase 7 cross-
-                #            platform parity will integrate the launcher
-                #            on Unix (launcher main.rs:153).
+                #   Unix:    flat layout — launcher + host + srv co-located
+                #            in DEV_DIR (no runtime/ subdir, so the host's
+                #            ../Frameworks resolution + asset anchoring stay
+                #            byte-identical to the legacy direct-invoke path).
+                #            The launcher drives srv + host here too (Phase 1,
+                #            SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30);
+                #            `task dev:standalone` is the direct-invoke hatch.
                 #
                 # Either way the staging dir (dist/cef/) is never locked by
                 # the running process, so the next build can overwrite it.
@@ -655,7 +664,7 @@ tasks:
                   fi
                   cp "$SRV_SRC" "$DEV_DIR/agentmux-srv" 2>/dev/null || true
                   if [ ! -f "$DEV_DIR/agentmux-launcher" ]; then
-                    echo "❌ $DEV_DIR/agentmux-launcher not found — build:host:darwin should have staged it"
+                    echo "❌ $DEV_DIR/agentmux-launcher not found — build:host:{{OS}} should have staged it"
                     exit 1
                   fi
                   if [ ! -f "$DEV_DIR/agentmux-srv" ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -442,10 +442,15 @@ tasks:
         internal: true
         platforms: [darwin]
         cmds:
-            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef'
+            # Phase 1 (SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30): the
+            # launcher now drives srv + host on macOS dev too, so build it
+            # alongside the host. They co-locate in dist/cef-dev/ (flat
+            # layout) — see dev:serve's Unix branch.
+            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef -p agentmux-launcher'
             - mkdir -p dist/cef
             - cp target/release/agentmux-cef dist/cef/agentmux-cef
-            - echo "✓ Built host for macOS"
+            - cp target/release/agentmux-launcher dist/cef/agentmux-launcher
+            - echo "✓ Built host + launcher for macOS"
 
     build:host:linux:
         internal: true
@@ -627,9 +632,37 @@ tasks:
                   cp dist/bin/agentmux-srv-*-windows.x64.exe "$DEV_DIR/runtime/" 2>/dev/null || true
                   echo "Built $DEV_DIR with launcher layout (launcher at root, host + DLLs + srv in runtime/)"
                 else
+                  # Unix flat layout (Phase 1,
+                  # SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30): launcher
+                  # + host + srv all co-located in DEV_DIR. The launcher is
+                  # already inside dist/cef/ (staged by build:host:darwin),
+                  # so the `cp -r` below brings it across with the host. Flat
+                  # — NOT runtime/ — so the host's `../Frameworks` resolution
+                  # and current_exe()-based asset anchoring stay byte-identical
+                  # to the legacy direct-invoke path (launcher's runtime_dir
+                  # falls back to exe_dir when there's no runtime/ subdir).
                   mkdir -p "$DEV_DIR"
                   cp -r dist/cef/* "$DEV_DIR"/
-                  echo "Copied dist/cef → $DEV_DIR (flat layout, launcher bypassed on Unix)"
+                  # srv binary — launcher's resolve_srv_binary candidate 4 is
+                  # launcher_exe_dir/agentmux-srv (plain name). DEV_DIR is
+                  # wiped each run so the plain name can't go stale. Copy the
+                  # EXACT version-matched srv (dist/bin holds older versions
+                  # too — a glob would match several and break `cp`).
+                  if [ "{{OS}}" = "darwin" ]; then
+                    SRV_SRC="dist/bin/agentmux-srv-{{.VERSION}}-darwin.arm64"
+                  else
+                    SRV_SRC="dist/bin/agentmux-srv-{{.VERSION}}-linux.x64"
+                  fi
+                  cp "$SRV_SRC" "$DEV_DIR/agentmux-srv" 2>/dev/null || true
+                  if [ ! -f "$DEV_DIR/agentmux-launcher" ]; then
+                    echo "❌ $DEV_DIR/agentmux-launcher not found — build:host:darwin should have staged it"
+                    exit 1
+                  fi
+                  if [ ! -f "$DEV_DIR/agentmux-srv" ]; then
+                    echo "❌ $DEV_DIR/agentmux-srv not found — build:backend should have produced dist/bin/agentmux-srv-*"
+                    exit 1
+                  fi
+                  echo "Built $DEV_DIR with flat launcher layout (launcher + host + srv co-located)"
                 fi
 
                 # Linux: register the .desktop file + hicolor icons so the
@@ -742,7 +775,14 @@ tasks:
                 if [ "{{OS}}" = "windows" ]; then
                   cd "$DEV_DIR" && AGENTMUX_DEV=1 ./agentmux-launcher.exe --url="$VITE_URL"
                 else
-                  cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-cef{{exeExt}} --url="$VITE_URL"
+                  # Phase 1: launch via the launcher (it spawns srv, hands the
+                  # host its endpoints, and supervises both). LD_LIBRARY_PATH=.
+                  # so the launcher-spawned host finds libcef next to it (Linux);
+                  # the host inherits it through tokio's spawn. The launcher +
+                  # host + srv share the terminal's process group, so Ctrl+C
+                  # reaches all three. `task dev:standalone` keeps the direct
+                  # host-invoke escape hatch.
+                  cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-launcher{{exeExt}} --url="$VITE_URL"
                 fi
 
     dev:standalone:serve:

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -76,6 +76,37 @@ fn suppress_os_crash_dialogs() {
 #[cfg(not(target_os = "windows"))]
 fn suppress_os_crash_dialogs() {}
 
+/// True when a launcher is THIS host's actual parent process this run.
+///
+/// The launcher (which spawns the host directly) stamps
+/// `AGENTMUX_LAUNCHER_PID` with its own pid; since we are its direct
+/// child, that pid equals our `getppid()`. This distinguishes a fresh,
+/// authoritative launcher hand-off from a STALE `AGENTMUX_BACKEND_WS`
+/// inherited down the environment from a parent agentmux pane (whose
+/// launcher pid will not match our real parent). Used only to relax the
+/// dev-build "ignore the env hand-off" rule for the macOS/Linux Phase 1
+/// launcher dev integration.
+///
+/// Unix-only — on other platforms it returns `false`, leaving the
+/// existing dev-build behavior unchanged.
+#[cfg(unix)]
+fn launcher_is_genuine_parent() -> bool {
+    match std::env::var("AGENTMUX_LAUNCHER_PID")
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+    {
+        // SAFETY: getppid() takes no arguments, touches no memory, and is
+        // documented as always succeeding.
+        Some(pid) => pid == unsafe { libc::getppid() },
+        None => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn launcher_is_genuine_parent() -> bool {
+    false
+}
+
 fn main() {
     // Phase 0 (service supervision & recovery): suppress the Windows crash
     // modal so a fault terminates the process immediately instead of freezing
@@ -393,7 +424,18 @@ fn main() {
         // Consuming it would connect to the parent's srv instead of
         // spawning our own, so the dev frontend runs against the wrong
         // (parent's) backend and no dev-version srv is ever started.
-        let launcher_provided = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+        //
+        // EXCEPTION (macOS/Linux Phase 1 launcher dev integration,
+        // SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30): when a launcher
+        // is our GENUINE parent this run (it stamped AGENTMUX_LAUNCHER_PID
+        // with its pid == our getppid), the env it set is fresh + ours —
+        // adopt its launcher-owned srv instead of double-spawning. The
+        // getppid match can't be satisfied by a value merely inherited
+        // down the env from a parent pane, so `task dev:standalone`
+        // (direct host invoke) still spawns its own srv.
+        let launcher_provided = if agentmux_common::is_dev_build_exe(&host_exe_dir)
+            && !launcher_is_genuine_parent()
+        {
             None
         } else {
             sidecar::use_launcher_endpoints(&app_state)

--- a/agentmux-cef/src/parent_process.rs
+++ b/agentmux-cef/src/parent_process.rs
@@ -61,12 +61,13 @@ pub fn parent_is_agentmux_launcher() -> Option<bool> {
 
 #[cfg(not(target_os = "windows"))]
 pub fn parent_is_agentmux_launcher() -> Option<bool> {
-    // Linux/macOS launcher integration is on a separate roadmap
-    // (Phase 7 cross-platform parity per
-    // SPEC_LAUNCHER_DEV_INTEGRATION_2026-05-13.md). On those
-    // platforms the host is invoked directly by `task dev` and IPC
-    // is not in play, so the parent-check is moot — return None and
-    // let the path-based guard decide.
+    // The launcher now drives srv + host on macOS/Linux dev too (Phase 1,
+    // SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30), but the launcher↔host
+    // IPC pipe is still deferred to Phase 2 — so there is no IPC parent-
+    // identity check to perform here yet. (The host's srv-adoption decision
+    // uses a separate, direct getppid == AGENTMUX_LAUNCHER_PID check in
+    // main.rs::launcher_is_genuine_parent.) Return None and let the path-
+    // based guard decide until the Unix IPC transport lands.
     None
 }
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -22,6 +22,9 @@ tokio = { version = "1", features = [
     "io-util",
     "time",
     "sync",
+    # Phase 1 macOS/Linux dev integration: tokio::signal::unix (SIGINT /
+    # SIGTERM handlers in run_unix's supervise loop).
+    "signal",
     # Phase B.2: tokio::net::windows::named_pipe lives in this feature.
     "net",
     # Phase D.2: tokio::fs (OpenOptions, File, rename) for the event-log
@@ -84,6 +87,14 @@ windows-sys = { version = "0.59", features = [
     # DeleteObject, GetClientRect for the layered popup window.
     "Win32_Graphics_Gdi",
 ] }
+
+[target.'cfg(unix)'.dependencies]
+# Phase 1 macOS/Linux dev integration (SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_
+# 2026_05_30): the Unix supervisor sends SIGTERM to its children on
+# shutdown so the CEF host can reap its render subprocesses gracefully
+# (a tokio start_kill SIGKILL would orphan them). `kill(2)` is the only
+# libc surface we need; tokio's process_group handles the spawn side.
+libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -588,11 +588,32 @@ async fn run_unix(
                 }
             }
             srv_status = srv_child.wait() => {
+                use std::os::unix::process::ExitStatusExt;
                 match srv_status {
-                    Ok(s) => log(&format!(
-                        "srv exited UNEXPECTEDLY (host still running) with code {} — terminating launcher",
-                        s.code().unwrap_or(1)
-                    )),
+                    Ok(s) => {
+                        // Mirror the host arm's group-shutdown guard. On a
+                        // terminal Ctrl+C srv gets SIGINT DIRECTLY (it shares
+                        // our foreground process group); its own signal handler
+                        // shuts it down gracefully and it exits with code 0
+                        // (agentmux-srv/src/main.rs — SIGINT/SIGTERM → cancel
+                        // token → clean exit). srv_child.wait() can win this
+                        // select! race against our own SIGINT arm, so a clean
+                        // (code 0) or signal-killed exit is a group teardown,
+                        // NOT an unexpected srv death — don't log a scary
+                        // message and break 1 (reagent #1193 P2).
+                        let group_shutdown = matches!(
+                            s.signal(),
+                            Some(sig) if sig == libc::SIGINT || sig == libc::SIGTERM || sig == libc::SIGHUP
+                        );
+                        if s.success() || group_shutdown {
+                            log("srv exited as part of shutdown — shutting down");
+                            break 0;
+                        }
+                        log(&format!(
+                            "srv exited UNEXPECTEDLY (host still running) with code {} — terminating launcher",
+                            s.code().unwrap_or(1)
+                        ));
+                    }
                     Err(e) => log(&format!("FATAL: srv wait failed: {}", e)),
                 }
                 break 1;

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -78,7 +78,22 @@ fn main() {
 async fn launcher_main() {
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");
     let exe_dir = exe_path.parent().expect("exe has no parent directory");
-    let runtime_dir = exe_dir.join("runtime");
+    // Production + Windows dev use a `runtime/` subdir (launcher at root,
+    // host + libs + srv under runtime/). The macOS/Linux `task dev` flat
+    // layout (Phase 1, SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30)
+    // drops the launcher next to the host in dist/cef-dev/ so the host's
+    // `../Frameworks` resolution and asset anchoring are byte-identical to
+    // the legacy direct-invoke path — no `runtime/` to descend into. Fall
+    // back to exe_dir when there's no runtime/ subdir. Windows always has
+    // one, so its behavior is unchanged.
+    let runtime_dir = {
+        let rt = exe_dir.join("runtime");
+        if rt.is_dir() {
+            rt
+        } else {
+            exe_dir.to_path_buf()
+        }
+    };
 
     log(&format!(
         "starting — exe={} runtime={}",
@@ -127,6 +142,26 @@ async fn launcher_main() {
 
     let real_exe = find_cef_binary(&runtime_dir);
     log(&format!("resolved CEF binary: {}", real_exe.display()));
+    // Self-spawn guard: if host resolution ever points back at the
+    // launcher's own binary (the flat dev layout's failure mode —
+    // launcher + host co-located), spawning it would recurse into an
+    // unbounded launcher fork bomb. find_cef_binary excludes
+    // `agentmux-launcher` by name; this is the loud backstop in case a
+    // future binary slips past that filter. Compare canonicalized paths
+    // so symlink/`./` differences don't defeat the check.
+    if let (Ok(a), Ok(b)) = (
+        std::fs::canonicalize(&real_exe),
+        std::fs::canonicalize(&exe_path),
+    ) {
+        if a == b {
+            log(&format!(
+                "FATAL: host resolved to the launcher's own binary ({}) — refusing to self-spawn",
+                a.display()
+            ));
+            eprintln!("AgentMux runtime is misconfigured (host == launcher). Aborting.");
+            std::process::exit(1);
+        }
+    }
     if !real_exe.exists() {
         log(&format!(
             "FATAL: CEF binary not found at {}",
@@ -191,15 +226,13 @@ async fn launcher_main() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // Phase 7 covers cross-platform parity. For now the legacy
-        // exec-into-host path is preserved on macOS/Linux. Phase B.1
-        // is Windows-only.
-        log("exec into CEF host (Unix)");
-        use std::os::unix::process::CommandExt;
-        let err = std::process::Command::new(&real_exe).args(&args).exec();
-        log(&format!("FATAL: exec failed: {}", err));
-        eprintln!("Failed to launch AgentMux: {}", err);
-        std::process::exit(1);
+        // Phase 1 (SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30):
+        // the launcher now owns srv + host on macOS/Linux too — it
+        // spawns the backend, hands the host its endpoints via env,
+        // and supervises both with the same crash budget Windows uses.
+        // The legacy exec-into-host escape hatch lives in
+        // `task dev:standalone` (host invoked directly, no launcher).
+        run_unix(exe_dir, &real_exe, &args).await;
     }
 }
 
@@ -207,10 +240,9 @@ async fn launcher_main() {
 /// `docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md`): on an
 /// abnormal host exit the launcher relaunches the host, but at most
 /// `HOST_RESTART_BUDGET` times within `HOST_RESTART_WINDOW` — a crash budget
-/// so a deterministic crash cannot spin forever (spec §10-A).
-#[cfg(target_os = "windows")]
+/// so a deterministic crash cannot spin forever (spec §10-A). Shared by
+/// the Windows (`run_windows`) and Unix (`run_unix`) supervisors.
 const HOST_RESTART_BUDGET: usize = 3;
-#[cfg(target_os = "windows")]
 const HOST_RESTART_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Spawn the CEF host suspended, assign it to the launcher's Job Object, and
@@ -301,6 +333,282 @@ fn spawn_host_supervised(
         return None;
     }
     Some(host_child)
+}
+
+/// Spawn the CEF host on Unix with the srv endpoints + canonical
+/// data-dir env handed off, mirroring `spawn_host_supervised` minus the
+/// Windows-only machinery (Job Object assignment, CREATE_SUSPENDED /
+/// resume, named-pipe handle, splash event). `disable_gpu` is the retry
+/// ladder's degraded rung (software rendering). Returns the running
+/// child or `None` if spawn failed.
+///
+/// AGENTMUX_HOME is intentionally NOT set: on the flat dev layout the
+/// host's `current_exe().parent()` fallback resolves to the same dir the
+/// launcher would export, so omitting it keeps asset + framework lookup
+/// byte-identical to the legacy direct-invoke (`task dev:standalone`)
+/// path. Phase 2 will set it once the production runtime/ layout lands
+/// on macOS.
+#[cfg(not(target_os = "windows"))]
+fn spawn_host_unix(
+    real_exe: &std::path::Path,
+    args: &[String],
+    srv: &srv_spawner::SrvSpawnResult,
+    host_env: &[(&'static str, std::ffi::OsString)],
+    disable_gpu: bool,
+) -> Option<tokio::process::Child> {
+    let mut host_cmd = tokio::process::Command::new(real_exe);
+    host_cmd
+        .args(args)
+        .env("AGENTMUX_BACKEND_WS", &srv.ws_endpoint)
+        .env("AGENTMUX_BACKEND_WEB", &srv.web_endpoint)
+        .env("AGENTMUX_BACKEND_PID", srv.pid.to_string())
+        .env("AGENTMUX_AUTH_KEY", &srv.auth_key)
+        .env("AGENTMUX_INSTANCE_ID", &srv.instance_id)
+        // Parent-identity stamp: our pid == the host's getppid (we spawn it
+        // directly). A dev-build host normally ignores AGENTMUX_BACKEND_WS
+        // (it could be a stale value inherited from a parent agentmux pane);
+        // this lets the host verify the hand-off is genuinely ours THIS run
+        // and adopt our launcher-owned srv instead of double-spawning. See
+        // agentmux-cef/src/main.rs::launcher_is_genuine_parent.
+        .env("AGENTMUX_LAUNCHER_PID", std::process::id().to_string())
+        .envs(host_env.iter().cloned())
+        // We reap children ourselves on shutdown (SIGTERM, then SIGKILL
+        // backstop) — kill_on_drop would SIGKILL the host the moment the
+        // Child is dropped, robbing CEF of the chance to reap its render
+        // subprocesses cleanly.
+        .kill_on_drop(false);
+    if disable_gpu {
+        host_cmd.arg("--disable-gpu");
+    }
+    match host_cmd.spawn() {
+        Ok(c) => {
+            let pid = c.id().unwrap_or(0);
+            log(&format!("spawned CEF host pid={} (unix)", pid));
+            Some(c)
+        }
+        Err(e) => {
+            log(&format!("failed to spawn CEF host: {}", e));
+            None
+        }
+    }
+}
+
+/// Send SIGTERM to a child so it can shut down gracefully — for the CEF
+/// host that means reaping its render subprocesses (a tokio `start_kill`
+/// SIGKILL would orphan them); for srv it's a clean shutdown. No-op if the
+/// child has already exited (its pid may have been reaped). Best-effort:
+/// the SIGKILL grace-window backstop in `run_unix` catches anything that
+/// ignores SIGTERM.
+#[cfg(not(target_os = "windows"))]
+fn terminate_child_gracefully(child: &tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        // SAFETY: kill(2) with a process-scoped pid + a constant signal —
+        // no memory is touched. A stale pid just returns ESRCH (ignored).
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+}
+
+/// Await the next delivery of a Unix signal, or never resolve if the
+/// signal stream couldn't be installed. Lets `run_unix`'s `select!`
+/// treat an absent handler as "this branch is dormant" rather than
+/// special-casing `Option` at every poll.
+#[cfg(not(target_os = "windows"))]
+async fn next_signal(s: &mut Option<tokio::signal::unix::Signal>) {
+    match s {
+        Some(sig) => {
+            sig.recv().await;
+        }
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Unix (macOS/Linux) main flow, Phase 1: resolve paths → spawn srv →
+/// spawn host with srv endpoints in env → supervised wait → cleanup.
+///
+/// Differs from `run_windows` only where the OS forces it:
+///   * No Job Object — children inherit the launcher's process group, so
+///     a terminal Ctrl+C (SIGINT to the foreground group) already reaches
+///     host + srv directly. We additionally install SIGINT/SIGTERM
+///     handlers so `kill <launcher-pid>` (signal to the launcher alone)
+///     also tears the tree down deterministically.
+///   * No named-pipe IPC yet (Phase 2): srv is launched WITHOUT an
+///     AGENTMUX_SRV_PIPE_PATH, so it skips binding its IPC pipe — exactly
+///     as in today's `task dev` direct-invoke mode.
+///   * Cleanup is SIGTERM-then-SIGKILL (we own the reap) rather than
+///     KILL_ON_JOB_CLOSE.
+///
+/// srv's stdin write-end is held for the launcher's lifetime — its EOF is
+/// srv's parent-death backstop if the launcher is SIGKILLed (the one case
+/// our signal handlers can't cover).
+#[cfg(not(target_os = "windows"))]
+async fn run_unix(
+    launcher_exe_dir: &std::path::Path,
+    real_exe: &std::path::Path,
+    args: &[String],
+) {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    // 1. Resolve + create data dirs (same authority as run_windows: srv +
+    //    host receive these via env so they can't drift).
+    let paths = match data_dir::resolve_paths(launcher_exe_dir, version) {
+        Ok(p) => p,
+        Err(e) => {
+            log(&format!("FATAL: path resolution failed: {}", e));
+            eprintln!("Failed to resolve AgentMux data directories: {}", e);
+            std::process::exit(1);
+        }
+    };
+    log(&format!(
+        "paths resolved: data={} config={} user_home={} portable={}",
+        paths.data_dir.display(),
+        paths.config_dir.display(),
+        paths.user_home_dir.display(),
+        paths.portable_root.is_some(),
+    ));
+    if let Err(e) = data_dir::ensure_dirs(&paths) {
+        log(&format!("FATAL: failed to create data dirs: {}", e));
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+
+    // 2. Spawn srv. Empty pipe path → srv skips its IPC bind (Phase 2
+    //    wires the Unix-socket transport). spawn_srv is already
+    //    Unix-clean (the job_handle param is #[cfg(windows)]).
+    let srv_pipe_path = String::new();
+    let (srv_result, mut srv_child) =
+        match srv_spawner::spawn_srv(launcher_exe_dir, &paths, &srv_pipe_path).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                log(&format!("FATAL: srv spawn failed: {}", e));
+                eprintln!("Failed to start backend: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+    // CRITICAL (same rationale as run_windows): take srv's stdin out of
+    // the Child so tokio's wait() can't close it and trip srv's
+    // parent-watch EOF. Held until launcher exit.
+    let _srv_stdin_keepalive = srv_child.stdin.take();
+
+    // 3. Spawn the host with srv endpoints in env.
+    let host_env = paths.common.to_env_vars();
+    let mut host_child = match spawn_host_unix(real_exe, args, &srv_result, &host_env, false) {
+        Some(c) => c,
+        None => {
+            log("FATAL: could not start CEF host — terminating");
+            eprintln!("Failed to launch AgentMux.");
+            terminate_child_gracefully(&srv_child);
+            let _ = srv_child.start_kill();
+            std::process::exit(1);
+        }
+    };
+
+    // 4. Signal handlers for `kill <launcher-pid>` (a terminal Ctrl+C
+    //    already signals the whole foreground group; these cover the
+    //    launcher-only case and make Ctrl+C deterministic too).
+    let mut sigint = signal(SignalKind::interrupt()).ok();
+    let mut sigterm = signal(SignalKind::terminate()).ok();
+    if sigint.is_none() || sigterm.is_none() {
+        log("WARN: failed to install one or more signal handlers — \
+             relying on default termination + srv stdin-EOF backstop");
+    }
+
+    // 5. Supervised wait loop — host crash budget mirrors run_windows.
+    log("entering supervised host + srv wait (unix)");
+    let mut host_restarts: Vec<std::time::Instant> = Vec::new();
+    let mut last_abnormal_code: Option<i32> = None;
+    let mut host_degraded = false;
+    let exit_code = loop {
+        tokio::select! {
+            host_status = host_child.wait() => {
+                let code = match host_status {
+                    Ok(s) => s.code().unwrap_or(1),
+                    Err(e) => {
+                        log(&format!("FATAL: host wait failed: {}", e));
+                        break 1;
+                    }
+                };
+                if code == 0 {
+                    log("CEF host exited cleanly (code 0) — shutting down");
+                    break 0;
+                }
+                let now = std::time::Instant::now();
+                host_restarts.retain(|t| now.duration_since(*t) < HOST_RESTART_WINDOW);
+                if host_restarts.len() >= HOST_RESTART_BUDGET {
+                    log(&format!(
+                        "CEF host exited abnormally (code {}); restart budget exhausted \
+                         ({} in {}s) — giving up",
+                        code,
+                        host_restarts.len(),
+                        HOST_RESTART_WINDOW.as_secs()
+                    ));
+                    break code;
+                }
+                host_restarts.push(now);
+                if last_abnormal_code == Some(code) {
+                    host_degraded = true;
+                }
+                last_abnormal_code = Some(code);
+                log(&format!(
+                    "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
+                    code,
+                    host_restarts.len(),
+                    HOST_RESTART_BUDGET,
+                    if host_degraded { ", degraded: --disable-gpu" } else { "" }
+                ));
+                match spawn_host_unix(real_exe, args, &srv_result, &host_env, host_degraded) {
+                    Some(c) => host_child = c,
+                    None => {
+                        log("host relaunch failed to spawn — giving up");
+                        break code;
+                    }
+                }
+            }
+            srv_status = srv_child.wait() => {
+                match srv_status {
+                    Ok(s) => log(&format!(
+                        "srv exited UNEXPECTEDLY (host still running) with code {} — terminating launcher",
+                        s.code().unwrap_or(1)
+                    )),
+                    Err(e) => log(&format!("FATAL: srv wait failed: {}", e)),
+                }
+                break 1;
+            }
+            _ = next_signal(&mut sigint) => {
+                log("received SIGINT — shutting down");
+                break 0;
+            }
+            _ = next_signal(&mut sigterm) => {
+                log("received SIGTERM — shutting down");
+                break 0;
+            }
+        }
+    };
+
+    // 6. Cleanup. SIGTERM both children so the host reaps its render
+    //    subprocesses (and srv shuts down cleanly), wait a short grace
+    //    window, then SIGKILL any survivor. Dropping the stdin keepalive
+    //    is srv's secondary shutdown trigger (parent-watch EOF).
+    log("terminating children (SIGTERM → grace → SIGKILL)");
+    terminate_child_gracefully(&host_child);
+    terminate_child_gracefully(&srv_child);
+    drop(_srv_stdin_keepalive);
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_millis(1500),
+        async {
+            let _ = host_child.wait().await;
+            let _ = srv_child.wait().await;
+        },
+    )
+    .await;
+    let _ = host_child.start_kill();
+    let _ = srv_child.start_kill();
+    log(&format!("launcher exiting with code {}", exit_code));
+    std::process::exit(exit_code);
 }
 
 /// Windows main flow: resolve paths → create J0 → spawn srv → spawn
@@ -1060,6 +1368,13 @@ fn find_cef_binary(runtime_dir: &std::path::Path) -> std::path::PathBuf {
             if name.starts_with(prefix)
                 && !name.starts_with(cef_prefix)
                 && !name.starts_with("agentmux-srv")
+                // CRITICAL for the flat dev layout (macOS/Linux Phase 1):
+                // launcher + host + srv share one dir, so the launcher
+                // binary itself matches `agentmux-*`. Without this guard
+                // the launcher resolves ITSELF as the host and spawns a
+                // recursive launcher fork bomb. On Windows the launcher
+                // lives at the root (not in runtime/), so this is a no-op.
+                && !name.starts_with("agentmux-launcher")
                 && name.ends_with(ext)
             {
                 return entry.path();

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -525,13 +525,32 @@ async fn run_unix(
     let exit_code = loop {
         tokio::select! {
             host_status = host_child.wait() => {
-                let code = match host_status {
-                    Ok(s) => s.code().unwrap_or(1),
+                use std::os::unix::process::ExitStatusExt;
+                let status = match host_status {
+                    Ok(s) => s,
                     Err(e) => {
                         log(&format!("FATAL: host wait failed: {}", e));
                         break 1;
                     }
                 };
+                // Host killed by a signal. On a terminal Ctrl+C the host gets
+                // SIGINT DIRECTLY (it shares our foreground process group), so
+                // host_child.wait() can win the select! race against our own
+                // SIGINT arm. Without this guard the host's signal-death has no
+                // exit code → unwrap_or(1) → it looks like a crash and we'd
+                // relaunch a replacement host that the SIGINT arm then has to
+                // kill (reagent #1193 P2). Treat the group-shutdown signals
+                // (SIGINT/SIGTERM/SIGHUP) as a clean shutdown; real crash
+                // signals (SIGSEGV, SIGABRT, …) still fall through to the
+                // crash-budget relaunch below.
+                if let Some(sig) = status.signal() {
+                    if sig == libc::SIGINT || sig == libc::SIGTERM || sig == libc::SIGHUP {
+                        log(&format!("CEF host terminated by signal {} (group shutdown) — shutting down", sig));
+                        break 0;
+                    }
+                    log(&format!("CEF host killed by signal {} (crash) — entering crash-budget relaunch", sig));
+                }
+                let code = status.code().unwrap_or(1);
                 if code == 0 {
                     log("CEF host exited cleanly (code 0) — shutting down");
                     break 0;


### PR DESCRIPTION
## What

Integrates **agentmux-launcher** into `task dev` on **macOS/Linux** — previously the launcher was in the loop only on Windows. The launcher now spawns srv, hands the host its backend endpoints via env, and supervises both with the same crash budget Windows uses. So the saga coordinator / srv-lifecycle / host-supervision paths are now exercised in dev on every platform.

Implements **Phase 1** of `SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30.md` (#1187, the spec — review/merge that separately). Continues the deferred Phase 7 of the original launcher dev-integration spec.

`task dev:standalone` remains the direct host-invoke escape hatch.

## How

**`agentmux-launcher/src/main.rs`**
- `run_unix()` — Unix supervisor mirroring `run_windows` minus Windows-only machinery (Job Object, `CREATE_SUSPENDED`/resume, named-pipe handle, splash). Resolves data dirs → spawns srv via the already-Unix-clean `spawn_srv` → spawns host with `AGENTMUX_BACKEND_*` in env → supervises both with the shared `HOST_RESTART_BUDGET` crash budget (+ `--disable-gpu` degraded rung).
- `spawn_host_unix()`, `terminate_child_gracefully()` (SIGTERM so CEF reaps its render subprocesses; SIGKILL grace-window backstop), SIGINT/SIGTERM handlers. srv's stdin write-end is held for the launcher's lifetime (its EOF is srv's parent-death backstop).
- `runtime_dir` falls back to `exe_dir` when there's no `runtime/` subdir → **flat dev layout**, keeping the host's `../Frameworks` resolution + asset anchoring **byte-identical** to the legacy direct-invoke path.

**Two gotchas found + fixed during bring-up:**
1. **Launcher fork bomb** — in the flat layout the launcher is the host's *sibling*, and `find_cef_binary`'s scan matched `agentmux-launcher` (it's `agentmux-*`, not `-cef`/`-srv`), so the launcher resolved **itself** as the host and spawned recursively. Fixed by excluding `agentmux-launcher` from the scan, plus a canonicalized self-spawn guard as a loud backstop.
2. **Double srv** — a dev-build host deliberately ignores `AGENTMUX_BACKEND_WS` (it may be a stale value inherited from a parent agentmux pane), so it double-spawned its own srv next to the launcher's. Fixed with `launcher_is_genuine_parent()` in **`agentmux-cef/src/main.rs`**: the launcher stamps `AGENTMUX_LAUNCHER_PID` (= its pid == the host's `getppid`, since it spawns the host directly), and the host adopts the launcher's srv only when that matches. A stale inherited value can't satisfy the `getppid` match, so `task dev:standalone` still spawns its own srv. Unix-only; **Windows unchanged**.

**`Taskfile.yml`** — `build:host:darwin` builds + stages `agentmux-launcher`; `dev:serve`'s Unix branch co-locates launcher + host + srv in `dist/cef-dev/` (flat) and invokes `./agentmux-launcher`.

**Deps** — launcher gains a unix-only `libc` (graceful SIGTERM) + the tokio `signal` feature.

## Verified on macOS

- Single **launcher → {host, srv}** tree — host **adopts** the launcher's srv, no double-spawn; host's only children are CEF's own helpers (gpu/network/storage/renderers).
- Launcher log: `resolved CEF binary: …/agentmux-cef` → `srv … ready` → `spawned CEF host pid=… (unix)` → `entering supervised host + srv wait (unix)`.
- Frontend boots (startup-bench completes, renderers up).
- `SIGTERM` tears the whole tree down cleanly: `received SIGTERM → terminating children (SIGTERM → grace → SIGKILL) → launcher exiting with code 0`.
- Per-branch dev data dir (`~/.agentmux/dev/<branch>/`) preserved → test-session continuity.

## Out of scope (later phases)
- Phase 2: flock single-instance + Unix-socket IPC transport (srv launched without a pipe path here, matching today's dev mode).
- Phase 3: supervision/cleanup parity (host parent-death backstop for the launcher-SIGKILL case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)