### PR TITLE
fix(window): canonical label-based window resolution (P1)

### DIFF
--- a/.changesets/1780145316-fix-window-resolve-minimize-maximize-drag-pane-parent-by-win-xqs3.md
+++ b/.changesets/1780145316-fix-window-resolve-minimize-maximize-drag-pane-parent-by-win-xqs3.md
@@ -1,0 +1,19 @@
+---
+type: patch
+---
+
+fix(window): canonical label-based window resolution (P1)
+
+Route minimize / maximize / drag / browser-pane-parent through the canonical
+`resolve_window_hwnd(label)` instead of `find_own_top_level_window`, which
+returns the process's first-visible top-level — the floater when one exists,
+so those actions hit the wrong window.
+
+Also fixes redock-onto-main silently failing (no landing ghost, no dock): a
+warm-pool window promoted on-screen to serve as main keeps its `window-pool-*`
+label in the HWND cache while `main` is left with no live HWND, so
+`resolve_window_at_cursor` handed back the stale pool label and it never matched
+the target window's frontend `main` identity. It now resolves the
+cache-independent main frame (`find_main_window`) as `main` even when the
+reverse-map label is a lingering pool label. Adds permanent `redock-resolve`
+and `browser_pane` lifecycle instrumentation (kept, per the regression history).

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -133,6 +133,15 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
 /// the pane during the *initial* navigation focus steal.
 pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
     tracing::info!("[pane-load-end] pane page loaded; reinstalling focus subclass");
+    if let Some(block_id) = resolve_pane_block_id(state, browser) {
+        let url = {
+            let mut b: cef::Browser = browser.clone();
+            b.main_frame()
+                .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
+                .unwrap_or_default()
+        };
+        crate::browser_pane::trace::pane_trace(&block_id, "load-end", &format!("url={url}"));
+    }
 
     #[cfg(target_os = "windows")]
     {

--- a/agentmux-cef/src/browser_pane/creation.rs
+++ b/agentmux-cef/src/browser_pane/creation.rs
@@ -18,8 +18,9 @@
 //!     CEF client. Phase 4 will flip this direction by moving the pane
 //!     callbacks into `pane/callbacks.rs`; until then, `client` is fine as
 //!     a one-way dependency.
-//!   - `crate::commands::window::find_own_top_level_window` for the parent
-//!     HWND (CEF Views returns null on Alloy).
+//!   - `crate::commands::window::resolve_window_hwnd` to resolve the parent
+//!     HWND from the pane's target `window_label` (CEF Views returns null on
+//!     Alloy, so the Windows native-child path needs the HWND explicitly).
 
 use std::sync::Arc;
 
@@ -34,10 +35,11 @@ wrap_task! {
         label: String,
         url: String,
         rect: Rect,
-        // Linux/macOS only: which top-level CefWindow to attach the pane
-        // overlay to (looked up in `state.windows`). Windows path doesn't
-        // read this field — `find_own_top_level_window` resolves the
-        // calling window's HWND directly.
+        // The pane's TARGET top-level window. Both platforms read it:
+        // Linux/macOS looks up the CefWindow to attach the overlay to (in
+        // `state.windows`); Windows resolves it to the parent HWND via
+        // `resolve_window_hwnd`, so a redocked pane is parented to its target
+        // window rather than the process's first-visible top-level (the floater).
         window_label: String,
     }
 
@@ -47,8 +49,8 @@ wrap_task! {
             //
             // Two completely separate paths by platform:
             //   - Windows: native child window via WindowInfo::set_as_child +
-            //     browser_host_create_browser. Requires the parent HWND from
-            //     find_own_top_level_window.
+            //     browser_host_create_browser. Requires the parent HWND,
+            //     resolved from `window_label` via `resolve_window_hwnd`.
             //   - Linux / macOS: CEF Views via browser_view_create +
             //     Window::add_overlay_view. The Windows native-child path does
             //     not work on Wayland (cef#2804) and is officially unsupported
@@ -72,13 +74,47 @@ wrap_task! {
 
             #[cfg(target_os = "windows")]
             {
-                // Get parent HWND via Win32 enumeration (CEF Views returns null).
+                // Resolve the parent HWND from the pane's TARGET `window_label`,
+                // NOT `find_own_top_level_window` (which returns the process's
+                // FIRST visible top-level). Under redock churn the still-alive
+                // floater is that first window, so the redocked pane was parented
+                // to the dying floater and cascade-destroyed when its HWND died
+                // → black render. Proven via the `create-parent` pane-trace:
+                // requested_window=main but parent_hwnd == the floater's HWND.
+                // `resolve_window_hwnd` is cache-first + IsWindow-guarded and
+                // handles `main` and `floating-*` identically.
                 let parent_hwnd_raw = unsafe {
-                    crate::commands::window::find_own_top_level_window()
+                    crate::commands::window::resolve_window_hwnd(&self.state, &self.window_label)
                 };
                 if parent_hwnd_raw.is_null() {
-                    tracing::error!(block_id = %self.block_id, "cannot find main window HWND — aborting browser pane creation");
+                    tracing::error!(block_id = %self.block_id, window_label = %self.window_label, "cannot resolve target window HWND — aborting browser pane creation");
                     return;
+                }
+
+                // [pane-trace] CONFIRM the parent window. `find_own_top_level_window`
+                // returns the process's FIRST visible top-level, NOT necessarily
+                // `window_label`'s window. Under redock churn the dying floater can
+                // be that first window, so the freshly-redocked pane gets parented
+                // to it and is cascade-destroyed when the floater's HWND dies
+                // (child-before-parent) → black render. If `actual_parent_label`
+                // here is a `floating-*` while `requested_window` is `main`, that's
+                // the bug. DO NOT REMOVE (see browser_pane::trace).
+                {
+                    let actual_parent_label = self
+                        .state
+                        .window_hwnds
+                        .lock()
+                        .iter()
+                        .find(|(_, h)| **h == parent_hwnd_raw as isize)
+                        .map(|(l, _)| l.clone());
+                    crate::browser_pane::trace::pane_trace(
+                        &self.block_id,
+                        "create-parent",
+                        &format!(
+                            "requested_window={} parent_hwnd={:?} actual_parent_label={:?}",
+                            self.window_label, parent_hwnd_raw, actual_parent_label
+                        ),
+                    );
                 }
 
                 // Phase B.5 (window_meta step d) — pre-create handoff.

--- a/agentmux-cef/src/browser_pane/mod.rs
+++ b/agentmux-cef/src/browser_pane/mod.rs
@@ -10,6 +10,7 @@
 pub mod auth;
 pub mod callbacks;
 pub mod creation;
+pub mod trace;
 #[cfg(target_os = "windows")]
 pub mod hwnd;
 #[cfg(not(target_os = "windows"))]

--- a/agentmux-cef/src/browser_pane/trace.rs
+++ b/agentmux-cef/src/browser_pane/trace.rs
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistent lifecycle trace for browser panes.
+//!
+//! **DO NOT REMOVE.** Browser-pane re-create under tear-off/redock churn
+//! (create-while-Closing — #1168 — and the black-render-on-redock that
+//! followed) is a recurring race surface. This trace is kept in
+//! permanently so the *next* investigation starts from data, not guesswork.
+//!
+//! Every event carries a process-global monotonic `seq` and the pane's
+//! `block` id, so the full interleaved churn (several panes
+//! creating/closing/loading at once) can be reconstructed from one log.
+//!
+//! Filter: `muxlog host pane-trace`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static PANE_TRACE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Emit one browser-pane lifecycle trace line.
+///
+/// - `block_id` — the pane's block id (logged truncated to 8 chars).
+/// - `event` — lifecycle phase, one of: `create-request` (a create was
+///   asked for), `create-deferred-closing` (create deferred because the
+///   prior pane is still Closing; the reducer replays it on close-completion),
+///   `create-parent` (the resolved parent window + HWND, Windows),
+///   `load-end`, `load-error`, `close`.
+/// - `detail` — free-form context (url, error code, label, …).
+pub fn pane_trace(block_id: &str, event: &str, detail: &str) {
+    let seq = PANE_TRACE_SEQ.fetch_add(1, Ordering::Relaxed);
+    let block: String = block_id.chars().take(8).collect();
+    tracing::info!(
+        target: "pane-trace",
+        "[pane-trace] seq={} block={} event={} {}",
+        seq,
+        block,
+        event,
+        detail,
+    );
+}

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -216,9 +216,19 @@ impl BrowserPaneManager {
                     block_id,
                     "browser pane create deferred — block_id still Closing; reducer will replay on close-completion"
                 );
+                crate::browser_pane::trace::pane_trace(
+                    block_id,
+                    "create-deferred-closing",
+                    "old entry still Closing; reducer will replay on close-completion",
+                );
                 Ok(())
             }
             RegisterResult::Fresh(label) => {
+                crate::browser_pane::trace::pane_trace(
+                    block_id,
+                    "create-request",
+                    &format!("url={url} label={label} win={window_label}"),
+                );
                 let mut task = CreateBrowserPaneTask::new(
                     state.clone(),
                     block_id.to_string(),
@@ -300,6 +310,7 @@ impl BrowserPaneManager {
     /// user expects to persist across close). If beforeunload becomes
     /// important, revisit.
     pub fn close(&self, block_id: &str, state: &Arc<AppState>) {
+        crate::browser_pane::trace::pane_trace(block_id, "close", "");
         // Phase H.1.d (PR #5) — sole pane-close entry point. The reducer
         // flips Live→Closing atomically and returns the entry's label iff
         // the transition fired. None means missing or already-Closing —

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1188,7 +1188,7 @@ impl AgentMuxHandler {
 
     fn on_load_error(
         &mut self,
-        _browser: Option<&mut Browser>,
+        browser: Option<&mut Browser>,
         frame: Option<&mut Frame>,
         error_code: Errorcode,
         error_text: Option<&CefString>,
@@ -1221,6 +1221,28 @@ impl AgentMuxHandler {
             is_main_frame,
             error_code_raw == sys::cef_errorcode_t::ERR_ABORTED,
         );
+
+        // Persistent pane lifecycle trace (see browser_pane::trace). Recorded
+        // BEFORE the ERR_ABORTED early-return below, because ERR_ABORTED on a
+        // pane's main frame is exactly the black-render-on-redock signature
+        // (the re-created pane's navigation was aborted mid-load).
+        if self.is_browser_pane && is_main_frame {
+            if let Some(b) = browser.as_deref() {
+                if let Some(block_id) =
+                    crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
+                {
+                    crate::browser_pane::trace::pane_trace(
+                        &block_id,
+                        "load-error",
+                        &format!(
+                            "url={failed_url_dbg} err={error_text_dbg}({}) aborted={}",
+                            error_code_raw as i32,
+                            error_code_raw == sys::cef_errorcode_t::ERR_ABORTED,
+                        ),
+                    );
+                }
+            }
+        }
 
         if error_code_raw == sys::cef_errorcode_t::ERR_ABORTED {
             return;

--- a/agentmux-cef/src/commands/window/chrome.rs
+++ b/agentmux-cef/src/commands/window/chrome.rs
@@ -11,28 +11,29 @@ use std::sync::Arc;
 
 use crate::state::AppState;
 
-// Resolved per-process top-level HWND lives in the sibling `lifecycle`
-// module; used only inside the `#[cfg(windows)]` branches below.
+// Canonical label→top-level-HWND resolver from the sibling `lifecycle`
+// module. We resolve by LABEL (not `find_own_top_level_window`, which returns
+// the process's first visible top-level = the floater when one exists, so
+// minimize/maximize would act on the wrong window). See P1 in
+// docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md.
 #[cfg(target_os = "windows")]
-use super::lifecycle::find_own_top_level_window;
+use super::lifecycle::resolve_window_hwnd;
 
 /// Minimize the window. Args: optional `{ "label": string }`; defaults to "main".
 pub fn minimize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     #[cfg(target_os = "windows")]
     unsafe {
         use windows_sys::Win32::UI::WindowsAndMessaging::*;
-        let hwnd = find_own_top_level_window();
+        let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
             ShowWindow(hwnd, SW_MINIMIZE);
             return Ok(serde_json::Value::Null);
         }
     }
     #[cfg(not(target_os = "windows"))]
-    {
-        let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-        crate::ui_tasks::post_minimize_window(state, label);
-    }
-    let _ = (state, args);
+    crate::ui_tasks::post_minimize_window(state, label);
+    let _ = (state, args, label);
     Ok(serde_json::Value::Null)
 }
 
@@ -43,10 +44,11 @@ pub fn minimize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 /// reads its own label from the `?windowLabel=…` URL query and passes it
 /// here so non-main windows act on the right CEF window.
 pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     #[cfg(target_os = "windows")]
     unsafe {
         use windows_sys::Win32::UI::WindowsAndMessaging::*;
-        let hwnd = find_own_top_level_window();
+        let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
             let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
             placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
@@ -60,11 +62,8 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
         }
     }
     #[cfg(not(target_os = "windows"))]
-    {
-        let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-        crate::ui_tasks::post_maximize_window(state, label);
-    }
-    let _ = (state, args);
+    crate::ui_tasks::post_maximize_window(state, label);
+    let _ = (state, args, label);
     Ok(serde_json::Value::Null)
 }
 

--- a/agentmux-cef/src/commands/window/lifecycle.rs
+++ b/agentmux-cef/src/commands/window/lifecycle.rs
@@ -204,7 +204,7 @@ pub(super) unsafe fn find_main_window() -> *mut std::ffi::c_void {
 }
 
 #[cfg(target_os = "windows")]
-pub(super) unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
+pub(crate) unsafe fn resolve_window_hwnd(state: &Arc<AppState>, label: &str) -> *mut std::ffi::c_void {
     use windows_sys::Win32::UI::WindowsAndMessaging::{GetAncestor, IsWindow, GA_ROOT};
 
     if !label.is_empty() {
@@ -333,6 +333,17 @@ pub(super) fn find_all_own_windows() -> Vec<*mut std::ffi::c_void> {
 /// Find the top-level window belonging to this process.
 /// In CEF Views mode, browser.host().window_handle() returns NULL,
 /// so we enumerate windows and find ours by process ID.
+///
+/// ⚠️ **LABEL-LESS LAST RESORT — never call this when a window label is
+/// available.** It returns the process's FIRST visible top-level, and owned
+/// floater popups draw ABOVE their owner in Z-order, so once any floater
+/// exists this returns the *floater*, not main. That is the root of the
+/// recurring "wrong window" bug class (#1165, #1166, the 2026-05-30
+/// browser-pane parent bug). Any handler that has a `label` must resolve via
+/// [`resolve_window_hwnd`] instead. The only legitimate callers are the
+/// non-"main" fallback inside `resolve_window_hwnd` and genuinely label-less
+/// paths (the floater's own owner at create, the deprecated `move_window_by`).
+/// See P1 in docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md.
 #[cfg(target_os = "windows")]
 pub(crate) unsafe fn find_own_top_level_window() -> *mut std::ffi::c_void {
     use windows_sys::Win32::UI::WindowsAndMessaging::*;

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -18,7 +18,7 @@ pub use lifecycle::{close_window, close_window_by_label};
 // Windows-only helpers other modules resolve as `commands::window::<name>`
 // (browser_pane / client / backend call sites are all `#[cfg(windows)]`).
 #[cfg(target_os = "windows")]
-pub(crate) use lifecycle::{capture_hwnd_for_label, find_own_top_level_window};
+pub(crate) use lifecycle::{capture_hwnd_for_label, find_own_top_level_window, resolve_window_hwnd};
 
 mod motion;
 // Position / drag / redock-hover command handlers, all dispatched by ipc.rs.

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -209,6 +209,7 @@ pub fn set_window_rect(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 /// the main window. Frontend reads `?windowLabel=…` from its URL and passes
 /// it here; missing → "main" for backward compatibility.
 pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     #[cfg(target_os = "windows")]
     {
         // The native move loop must run on the CEF UI thread (it owns the
@@ -236,11 +237,8 @@ pub fn start_window_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Res
         return Ok(serde_json::Value::Null);
     }
     #[cfg(not(target_os = "windows"))]
-    {
-        let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-        crate::ui_tasks::post_start_drag(state, label);
-    }
-    let _ = (state, args);
+    crate::ui_tasks::post_start_drag(state, label);
+    let _ = (state, args, label);
     Ok(serde_json::Value::Null)
 }
 
@@ -286,8 +284,24 @@ pub fn resolve_window_at_cursor(
         use windows_sys::Win32::Foundation::RECT;
         use windows_sys::Win32::System::Threading::GetCurrentProcessId;
         use windows_sys::Win32::UI::WindowsAndMessaging::{
-            GetTopWindow, GetWindow, GetWindowLongW, GetWindowRect, GetWindowThreadProcessId,
-            IsWindowVisible, GWL_EXSTYLE, GW_HWNDNEXT, WS_EX_TRANSPARENT,
+            GetClassNameW, GetTopWindow, GetWindow, GetWindowLongW, GetWindowRect,
+            GetWindowThreadProcessId, IsWindowVisible, GWL_EXSTYLE, GW_HWNDNEXT, WS_EX_TRANSPARENT,
+        };
+        // [redock-resolve] permanent diagnostic for the recurring theme-1
+        // "main not recognised as a redock target → no landing ghost on main"
+        // bug. `muxlog host redock-resolve`. DO NOT REMOVE (see the architecture
+        // doc §0 theme 1).
+        let class_of = |h: isize| -> String {
+            if h == 0 {
+                return String::new();
+            }
+            let mut buf = [0u16; 64];
+            let n = GetClassNameW(h as *mut _, buf.as_mut_ptr(), buf.len() as i32);
+            if n > 0 {
+                String::from_utf16_lossy(&buf[..n as usize])
+            } else {
+                String::new()
+            }
         };
 
         // Snapshot the label↔HWND map once, then walk top-level
@@ -344,38 +358,64 @@ pub fn resolve_window_at_cursor(
                             && y >= rect.top
                             && y < rect.bottom
                         {
-                            if let Some(label) = label_by_hwnd.get(&h_isize) {
+                            tracing::info!(
+                                target: "redock-resolve",
+                                hwnd = %format!("{:#x}", h_isize),
+                                class = %class_of(h_isize),
+                                label = ?label_by_hwnd.get(&h_isize),
+                                is_main_hwnd = (main_hwnd != 0 && h_isize == main_hwnd),
+                                main_hwnd = %format!("{:#x}", main_hwnd),
+                                "cursor inside window"
+                            );
+                            // Resolution precedence (P1). The HWND→label
+                            // reverse map can carry a STALE `window-pool-*`
+                            // label for a promoted main frame: a warm-pool
+                            // window moved on-screen to serve as the user's
+                            // main window keeps its pool label in
+                            // `window_hwnds` while "main" is left with no live
+                            // HWND (proven 2026-05-30 — redock onto main
+                            // resolved the pool label, so the target rendered no
+                            // ghost and the drop was rejected: no dock).
+                            // `find_main_window` is the cache-INDEPENDENT
+                            // authority on which HWND is the main frame, so when
+                            // the cached label is a lingering pool label AND
+                            // this HWND is the main frame, "main" wins. Real
+                            // labels (floating-* / additional windows / an
+                            // already-correct "main") are used verbatim, so
+                            // multi-window resolution is unchanged.
+                            let is_main_frame = main_hwnd != 0 && h_isize == main_hwnd;
+                            let resolved_label: Option<&str> = match label_by_hwnd.get(&h_isize) {
+                                Some(l) if l.starts_with("window-pool-") && is_main_frame => {
+                                    Some("main")
+                                }
+                                Some(l) => Some(l.as_str()),
+                                None if is_main_frame => Some("main"),
+                                None => None,
+                            };
+                            if let Some(label) = resolved_label {
                                 let wid = state.backend_window_id(label);
                                 return Ok(serde_json::json!({
                                     "label": label,
                                     "window_id": wid,
                                 }));
                             }
-                            // Not in window_hwnds — but if this IS the main
-                            // frame (per the cache-independent resolver),
-                            // recognise it as "main" anyway. This is the
-                            // deterministic redock-onto-main fix: it no longer
-                            // depends on the startup capture having won the
-                            // race to register "main".
-                            if main_hwnd != 0 && h_isize == main_hwnd {
-                                let wid = state.backend_window_id("main");
-                                return Ok(serde_json::json!({
-                                    "label": "main",
-                                    "window_id": wid,
-                                }));
-                            }
-                            // Found a window we own but it isn't in
-                            // window_hwnds and isn't the main frame (very
-                            // early startup or a window we don't track).
-                            // Treat as "no agentmux match" and continue the
-                            // Z-order walk in case a tracked window sits
-                            // behind it.
+                            // Owned but untracked and not the main frame (very
+                            // early startup or a window we don't track). Treat
+                            // as "no agentmux match" and continue the Z-order
+                            // walk in case a tracked window sits behind it.
                         }
                     }
                 }
             }
             hwnd = GetWindow(hwnd, GW_HWNDNEXT);
         }
+        tracing::info!(
+            target: "redock-resolve",
+            x, y,
+            main_hwnd = %format!("{:#x}", main_hwnd),
+            main_class = %class_of(main_hwnd),
+            "no agentmux window matched at cursor — no ghost / redock target"
+        );
         Ok(serde_json::json!({ "label": null, "window_id": null }))
     }
 

--- a/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
+++ b/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
@@ -1,0 +1,215 @@
+# Architecture: Floating Panes, Tear-Off, Redock & Browser-Pane Lifecycle
+
+**Date:** 2026-05-30
+**Author:** AgentA
+**Status:** Living reference — written to stop the redock/floating regression cycle
+**Audience:** anyone touching tear-off, floating windows, redock, browser-pane lifecycle, or window-HWND resolution
+
+> **Why this doc exists.** This subsystem has regressed repeatedly (#1157, #1159, #1165, #1166, #1168, #1173, #1177, and the 2026-05-30 parent-HWND bug). Each fix touched one of ~7 entangled systems and broke another. This document maps the whole thing **once**, names the recurring failure modes, and proposes a modularization that makes the failure modes structurally impossible — so we stop playing whack-a-mole.
+
+---
+
+## 0. TL;DR — the recurring root causes
+
+Every regression in this area is an instance of one of these five themes:
+
+1. **Wrong-window HWND resolution.** Four overlapping resolvers (`resolve_window_hwnd`, `find_main_window`, `find_own_top_level_window`, `capture_hwnd_for_label`) + a lazily-evicted cache. `find_own_top_level_window` returns the *first visible top-level* — which is the **floater** (owned windows draw above their owner), not main. Anything that resolves a window **without a label** silently targets the floater. *(Latest instance: the 2026-05-30 browser-pane parent bug — a redocked pane parented to the dying floater → black.)*
+2. **Create-while-closing / redock re-create races.** Redock = the *same* `block_id` closes in the floater and re-creates in the target **at nearly the same time**. The old browser's async `on_before_close` can evict the new entry; the new create can race the old close. #1168 fixed one path; residual intermittent black is another.
+3. **Owner cascade.** Floaters are Win32 *owned* popups of the source window → owned windows are force-destroyed with the owner (close cascade), pinned above the owner (Z-order), and `GetParent(floater)` returns the owner (so `GA_ROOT` of the floater's CEF child lands on **main**).
+4. **Coordinate-system drift.** CSS px ↔ physical px ↔ DIP ↔ DPR. Pane rects are CSS×DPR; floaters may spawn on another monitor.
+5. **Fire-and-forget IPC coordination.** Redock is a *sequence* of frontend→host IPC calls (`resolve_window_at_cursor` → `RedockFloatingPane` → block moves → floater auto-closes → pane re-creates) with no transaction boundary; the frontend layout (`onNodeDelete → DeleteBlock`) races the backend move.
+
+**The proposal (§9):** collapse window resolution to one canonical label→HWND function (ban label-less resolution), thread the **target window label** explicitly through pane creation, and model redock as an **atomic backend MOVE** owned by the reducer rather than a frontend-orchestrated close-then-recreate.
+
+---
+
+## 1. Entities & glossary
+
+| Term | What it is | Lifetime / owner |
+|---|---|---|
+| **Docked pane** | A pane (`Block`) rendered inside a window's tile layout. | The window's workspace/tab. |
+| **Floater / floating pane** | A torn-off pane in its own frameless `WS_POPUP` window (`floating-<uuid>` label). | Its own workspace+tab; the OS window is owned by the source window (today). |
+| **Window** | A top-level CEF/host window: `main`, `window-*`, promoted pool windows. | Host process. |
+| **Browser pane** | A pane whose content is a *native child browser* (`browser-pane-<block_id>-<seq>` label) embedded via `set_as_child`. Has a **second HWND** (the web-content child) layered over the frontend. | Reducer `HostState.browser_panes`, keyed by `block_id`. |
+| **`window_hwnds` cache** | `Mutex<HashMap<String/*label*/, isize/*HWND*/>>` on `AppState`. The authoritative label→outer-top-level-HWND map. | Host (`state.rs:763`). |
+| **Pool window** | Pre-warmed off-screen CEF window (parked at x=-32000) for fast tear-off/promote. | `window_pool.rs`. |
+
+**Label conventions:** `main`, `window-*`, `floating-<uuid>`, `browser-pane-<block_id>-<seq>`, `window-pool-*`. The `-<seq>` on browser panes is a monotonic counter so close-then-recreate of the same block doesn't collide (`reducer/mod.rs:202`).
+
+---
+
+## 2. Operation flows (frontend → host)
+
+### 2.1 Tear-off (docked pane → floater)
+1. **Drag start** — pragmatic-dnd `draggable()` on `[data-role="block-header"]` (`TileLayout.win32.tsx:439`). On Win32 the dragHandle API is avoided (breaks WebView2 dragstart).
+2. **Drop detection** — `CrossWindowDragMonitor.win32.tsx`: `dragend`, or an **800ms fallback timer** after `dragleave` that polls `get_mouse_button_state` (OLE drops over native apps don't deliver `dragend`).
+3. **`performTearOff()`** (`CrossWindowDragMonitor.win32.tsx:265`): `measureSourcePaneSize()` (CSS px — *not* ×DPR, floater may land on another monitor) → `TearOffBlock` RPC (new workspace+tab) → **`open_floating_pane_window` IPC FIRST, delete docked layout node only on success** (avoids orphaned workspace).
+4. **Host** (`floating_pane.rs`): `open_floating_pane_window` validates, DPI-scales CSS→physical, allocates `floating-<uuid>`, posts `CreateFloatingWindowTask`.
+5. **New renderer** loads `?workspaceId=…&windowLabel=floating-…&floatingPaneId=…`. `app.tsx:375` detects `floatingPaneId` → renders `<FloatingPaneWorkspace/>` (no tab bar / status bar; just the 33px `BlockFrame_Header`).
+
+### 2.2 Header move (JS-driven window drag)
+`floating-pane-workspace.tsx` `onMount`:
+- `onMouseDown` on `[data-role="block-header"]` (skipping `INTERACTIVE_SELECTOR`) → **`preventDefault()` is load-bearing** (blocks the HTML5 dragstart that would *re-tear-off* the block — "double tear-off") → `get_window_position` → `dragging=true`, guarded by `currentMouseDownId`.
+- `onMouseMove` → coalesced `set_window_position` (one IPC in-flight, last wins, DPR-scaled delta).
+- During drag, throttled `update_floating_redock_hover` (~50ms) drives the drop-target highlight.
+
+### 2.3 Edge-resize (floater only)
+`floating-pane-workspace.tsx:130-260` — a 12px (`FLOATER_EDGE_RESIZE_BORDER`) invisible **pointer** grab-band → `get_window_rect`/`set_window_rect`. Browser floaters inset their web-content child by the band depth (`browser-view.tsx:114`) so the frontend owns the band. **Note:** the band overlaps the top of the 33px header → grabbing the top edge resizes instead of moving (a known UX sharp-edge; reagent flagged it on #1177).
+
+### 2.4 Redock (floater → drop on a window)
+`onMouseUp` → `clear_floating_redock_hover` → `tryRedockAtCursor()` (`floating-pane-workspace.tsx:409`):
+1. `resolve_window_at_cursor({x, y, exclude_label: self})` → target `{label, window_id}` (walks real top-level frames, matches `window_hwnds`).
+2. Load target workspace via WaveObj graph (non-pinning `reloadWaveObject`, non-reactive `getObjectValue` — avoids refcount leak in the async mouseup with no reactive owner).
+3. `RedockFloatingPane(blockId, sourceTabId, sourceWsId, targetTabId, targetWsId)` → backend moves the block → source `tab.blockids` empties → **auto-close watcher** dismisses the floater.
+
+### 2.5 Browser-pane lifecycle (frontend side)
+`browser-view.tsx`: `createPane` → `browser_pane_create({block_id, url, window_label, ...rect})`; placeholder rect → `browser_pane_resize` (deduped, RAF during reflow); `onCleanup` → **`browser_pane_close` BEFORE disconnecting observers** (flips backend to `Closing` so late IPC no-ops). Focus: `main_window_focus` on address-bar mousedown/focus; `browser_pane_focus` on content click.
+
+---
+
+## 3. Browser-pane lifecycle (host) — the state machine
+
+**States** (`HostState.browser_panes`, keyed by `block_id`, `state.rs:134`): `Live` → `Closing{since}` → *removed*. Every op short-circuits when `Closing`.
+
+**Create** (`browser_panes.rs:157`): `TryRegisterBrowserPaneLive` → `RegisterResult`:
+- `Fresh(label)` → post `CreateBrowserPaneTask`.
+- `AlreadyLive(label)` → re-navigate existing.
+- `Closing` → **stash the create params in the reducer under the same lock that observed `Closing`** (`reducer/panes.rs:104`), replay on close-completion. **This is the #1168 fix.** Comment (`browser_panes.rs:204`): *"old CEF Browser mid-teardown — don't overwrite (its `on_before_close → DrainBrowserPaneByLabel` would evict the NEW entry)."*
+
+**CreateBrowserPaneTask::execute** (`browser_pane/creation.rs`): resolve parent HWND → `set_as_child(parent, rect)` → `browser_host_create_browser`.
+> ⚠️ **THE 2026-05-30 BUG:** parent was resolved via `find_own_top_level_window()` (first visible top-level). On redock the floater is still alive and on top, so the redocked pane (`window_label=main`) was parented to the **dying floater** → cascade-destroyed mid-load (`ERR_ABORTED`) → black. **Fix (proven, parked on `agenta/browser-pane-redock-fix-wip`):** resolve from `window_label` via `resolve_window_hwnd`. See §8.
+
+**Close** (`browser_panes.rs:302`): `EnqueueBrowserPaneClose` (Live→Closing) → `close_with` → `UnregisterBrowser` (atomic take, `removed_browser`) → `destroy_hwnd`: **`ShowWindow(SW_HIDE)` then `DestroyWindow` then `InvalidateRect(parent)`** (DWM otherwise leaves the last GPU frame "stuck"). We deliberately **do not** `host.close_browser(force)` — Alloy treats pane+main as one close unit and quits the app. → `CompleteBrowserPaneClose` (remove entry, return any deferred create to replay) → `replay_pending_create` → `spawn_pool_window`.
+
+**Async drain** (`on_before_close_browser_pane` → `drain_closed_label`, idempotent): drains the reducer entry, replays deferred create, refills pool.
+
+**App-exit gate** (`client/mod.rs:843`): counts *user-facing* browsers via `user_visibility_snapshot()` (single atomic lock) — **excludes pool windows and `browser-pane-*`, but counts `floating-*`** → a surviving floater keeps the app alive. The `"no backend window ID registered … shells may orphan"` warning (`client/mod.rs:1063`) fires when a closing label has no backend window id.
+
+**Reducer events:** `BrowserPaneCreateRequested` / `BrowserPaneLive` / `BrowserPaneClosing` / `BrowserPaneClosed` / `BrowserUnregistered`. **TOCTOU lesson (#1168 / PR #660):** cross-arm state (deferred create, removed browser) must live *in* `HostState` and move atomically with the observation — never a sidecar `Mutex` on `AppState`.
+
+---
+
+## 4. Window-HWND resolution — the fragile core
+
+`commands/window/lifecycle.rs`. **Three-tier `resolve_window_hwnd(state, label)`** (line 207):
+1. **Cache** (`window_hwnds[label]`) guarded by `IsWindow` (lazy-evict on stale — `SPEC_WINDOW_HWND_CACHE_STALE_FIX`). **Cache hits are returned verbatim — never GA_ROOT-walked** (that would land on the floater's owner=main).
+2. **Reducer registry** (`get_browser(label).host().window_handle()` → `GA_ROOT`) — GA_ROOT needed because `set_as_child` returns the inner `WS_CHILD`.
+3. **EnumWindows fallback:** `label=="main"` → `find_main_window` (skips `AgentMuxFloatingPane` class **and** off-screen pool windows < `OFFSCREEN_POOL_THRESHOLD_X = -20000`); else → `find_own_top_level_window` (first visible — **the trap**).
+
+**Cache writers:** `floating_pane.rs:145` (pre-registers the floater outer HWND at create — without it, `close_window_by_label("floating-…")` would WM_CLOSE **main**), and `capture_hwnd_for_label` (walks to GA_ROOT once at window-ready, guarded against overwriting pre-registered floaters and against binding to off-screen pool windows).
+
+**`find_own_top_level_window` is the recurring footgun.** Doc comment (`lifecycle.rs:99`): *"returns the first visible top-level… owned windows draw ABOVE their owner, so as soon as a floating-pane window exists, every label-less `get/set_window_position` accidentally targets the floater — dragging the main window moves the floater instead."* It must **never** be used when a label is available.
+
+**The dual of the footgun — an on-screen pool window mislabeled as main (proven 2026-05-30).** `find_main_window`'s pool skip (`is_offscreen_pool_window` = `rect.left < OFFSCREEN_POOL_THRESHOLD_X`) only catches pool windows *parked* off-screen. A warm-pool window **promoted on-screen** to serve as the user's main window — which *every* fresh launch does (windows boot in `pool mode — deferring init until promote`) — but never **relabeled** evades it: `window_hwnds` still maps `window-pool-<uuid> → its HWND` while `main` is left with *no live HWND* (`resolve_window_hwnd("main")` logs *"no available HWND for label=main"*) and `find_main_window` returns the pool HWND *as* main. The frontend, meanwhile, defaults `myLabel = ?windowLabel ?? "main"`, so it identifies as `main`. Captured via the permanent `redock-resolve` trace: `resolve_window_at_cursor` over the on-screen main handed back the stale `window-pool-*` label, which never matched the target's `myLabel === "main"` ghost gate → **no landing ghost, no dock onto main** (terminal *and* browser panes; this is the long-running "redock-onto-main doesn't work" class). **Fix:** when the HWND under the cursor is the cache-independent main frame (`find_main_window`) *and* its reverse-map label is a lingering `window-pool-*`, resolve it as `main`, reconciling the OS cache with the frontend's identity. The deeper cure is to make **promotion relabel** the window (`window-pool-* → main`) so the cache, the backend, and the frontend agree — tracked as a P1/P2 follow-up.
+
+---
+
+## 5. The floater OS window (`floating_pane.rs`)
+
+`create_owned_popup` → `CreateWindowExW(WS_POPUP | WS_THICKFRAME, WS_EX_TOOLWINDOW, owner = source-main-HWND)` + `DwmExtendFrameIntoClientArea(-1)` + `SW_SHOWNOACTIVATE`. **The owner = source window** buys no-taskbar/no-Alt-Tab *and* the minimize/restore/**destroy** cascade — but also: pinned-above-owner Z-order, and `GetParent(floater)=owner` (so the floater's CEF child's `GA_ROOT` = main, the reason the cache pre-register exists).
+
+`floating_pane_wndproc`: `WM_NCCALCSIZE→0` (frameless), `WM_NCHITTEST` maps a 6px (`RESIZE_BORDER_CSS`) native band (mostly moot — CEF child consumes hit-testing; edge-resize is JS-driven per #1177), `WM_SIZE` resizes the **bottom-most direct child** (the frontend browser) — *not* `GW_CHILD` (the web-content child), which would stretch the page over the header (#1173).
+
+> **Parked experiment** (`agenta/floater-independence-wip`): create the popup **unowned** (`owner=null`) → floaters survive the source window's close + follow normal activation Z-order (last-clicked-to-front). Verified to deliver those two behaviors; not shipped because it surfaced the latent `onNodeDelete`-on-redock race separately.
+
+---
+
+## 6. Coordinate systems
+
+| Layer | Unit | Notes |
+|---|---|---|
+| Frontend DOM | CSS px | `getBoundingClientRect()` |
+| Win32 / `SetWindowPos` | physical px | CSS × `devicePixelRatio` |
+| CEF Views (Linux/macOS) | DIP | × zoom factor |
+| Tear-off size | CSS px (no DPR) | floater may spawn on another monitor |
+| Browser-pane rect | CSS × DPR | retro 2026-04-19: hardcoded DPR=1 broke HiDPI |
+
+**Rule:** convert at the IPC boundary; label every rect with its unit.
+
+---
+
+## 7. Fix history & the themes they map to
+
+| PR | What it fixed | Theme (§0) |
+|---|---|---|
+| #1157 | Co-evict pane window-placement state on close | 2 |
+| #1159 | Reducer-backed floater maximize/restore | — |
+| #1165 | Never bind a label to an off-screen pool HWND (window-drag) | 1 |
+| #1166 | Deterministic redock-onto-main (don't depend on HWND-capture race) | 1, 5 |
+| #1168 | Deterministic re-create-after-close (redocked panes always load) | 2 |
+| #1173 | Maximize sizes the frontend child, not the web-content child | 5 (owner/children) |
+| #1177 | Edge-resize floaters by dragging edges/corners | — |
+| **2026-05-30** | **Browser-pane parent = `window_label`, not first-visible** | **1** |
+| **2026-05-30** | **Redock-onto-main when main is an unrelabeled on-screen pool window** — `resolve_window_at_cursor` resolves the `find_main_window` frame as `main` over a stale `window-pool-*` reverse-map label | **1** |
+
+Cross-cutting themes from the docs catalog: HWND/label-binding races (1), create-while-closing TOCTOU (2), CEF Alloy renderer-process sharing, coordinate drift (4), reactive-owner cascade, dual drag mechanisms, Linux/macOS Views gaps.
+
+---
+
+## 8. Current open issue (2026-05-30)
+
+**Symptom:** redocking a **browser** pane sometimes renders it **black** (terminal/agent redock is unaffected).
+
+**Proven (via the new `browser_pane::trace` `[pane-trace]` instrumentation — on the wip branch):** the redocked pane is created with `requested_window=main` but `parent_hwnd == the floater's HWND`; the floater's HWND dies → its child (the pane) is destroyed first (child-before-parent) → `ERR_ABORTED` → black. **Deterministic** part fixed by resolving the parent from `window_label`.
+
+**Residual:** even with the fix the pane *occasionally* still goes black. Hypothesis: the create-while-closing race (theme 2) is still reachable in a narrow window — the floater pane's `Closing` and the target's `Fresh` create interleave such that the target create resolves a parent or load that the close then tears down. Needs the `[pane-trace]` `seq`-ordered log under a fresh profile to confirm whether it's (a) `create-deferred-closing` → replay landing late, or (b) a second wrong-parent slip.
+
+**Parked artifacts (nothing lost):**
+- `agenta/browser-pane-redock-fix-wip` — the parent-HWND fix + the **permanent** `browser_pane/trace.rs` lifecycle instrumentation (keep it; this area keeps needing it).
+- `agenta/floater-independence-wip` — the unowned-floater (survival + z-order) experiment.
+
+---
+
+## 9. Modularization proposal — make the failure modes impossible
+
+The five themes share a root: **identity (which window?) and ownership (whose lifecycle?) are resolved implicitly, late, and in multiple places.** Make them explicit and single-sourced.
+
+### P1. One canonical window resolver; ban label-less resolution
+- Collapse `resolve_window_hwnd` / `find_main_window` / `find_own_top_level_window` / `capture_hwnd_for_label` behind **one** API: `window_hwnd(label) -> Option<HWND>`. Internally it owns the cache + the fallbacks.
+- **Delete `find_own_top_level_window` from any call site that has a label.** It (and `move_window_by`) are the recurring wrong-window source. If a caller truly has no label, that's a bug to fix, not a fallback to use.
+- *This single change would have prevented #1165, #1166, and the 2026-05-30 parent bug.*
+
+### P2. Thread the target window explicitly through pane creation
+- `CreateBrowserPaneTask` already carries `window_label`. Make the parent HWND come **only** from `window_hwnd(window_label)` (the fix), and have the `OpenFloatingPaneArgs`/create path carry the source/target window label end-to-end (the pre-existing TODO in `floating_pane.rs`/`creation.rs`). No `find_own_top_level_window` in any create path.
+
+### P3. Model redock as an atomic backend MOVE, not frontend-orchestrated close+recreate
+- Today redock = `RedockFloatingPane` (block move) **+** floater auto-close **+** pane close in floater **+** pane create in target **+** frontend `onNodeDelete → DeleteBlock` — five independently-scheduled steps that race (the black render *and* the "block is in tab A not B" `onNodeDelete` error both come from this).
+- Introduce a single reducer-owned **PaneLocation** state machine: `Docked(window, tab)` ⇄ `Floating(floater)` with one transition `Redock{from_floater, to_window, to_tab}` that (a) re-parents the browser's HWND to the target window **without** a destroy+recreate where possible, or (b) if a recreate is unavoidable, sequences close-then-create deterministically (extending #1168) and suppresses the frontend `DeleteBlock` for a block that is *moving* (the `markRedocking` idea, but enforced in the reducer/move, not a frontend flag).
+
+### P4. Decouple floater OS-window lifetime from the source window
+- Adopt the unowned-floater model (parked branch) so closing a window can't cascade-destroy floaters, and Z-order is last-clicked-to-front — removing theme 3 entirely. Re-anchor no-taskbar via `WS_EX_TOOLWINDOW` (already independent of owner).
+
+### P5. Keep the lifecycle trace permanent + add `seq` to the frontend
+- `browser_pane::trace` (`[pane-trace] seq=… block=… event=…`) stays in. Add the matching frontend `[pane-trace]` (create/close/move with the same `block_id`) so a single `muxlog host pane-trace` reconstructs the full cross-window churn. (Per user: do **not** remove instrumentation; remove only in the far future.)
+
+### P6. A redock/floating integration test harness
+- The retros show manual testing misses intermittent races (and a test harness was silently broken for weeks). Add a deterministic harness that scripts tear-off → redock × N for terminal **and** browser panes and asserts `load-end` (not `load-error`) on every redock — so a regression is caught by CI, not by the user on the 11th browser.
+
+**Sequencing:** P1+P2 are small, high-leverage, and fix the current deterministic bug class. P3+P4 are the structural wins (one PaneLocation owner). P5+P6 are the guardrails. Do them as **separate, single-concern PRs**, each verified on a **fresh profile** against the full checklist (dock · redock · terminal+browser resize · z-order · survival · browsers-render), reverting any PR that reddens the checklist before stacking the next — the discipline that this session proved we need.
+
+---
+
+## 10. Appendix — authoritative file map
+
+| Concern | File(s) |
+|---|---|
+| Tear-off (frontend) | `frontend/layout/lib/TileLayout.win32.tsx`, `frontend/app/drag/CrossWindowDragMonitor.win32.tsx`, `frontend/app-init.ts`, `frontend/app/app.tsx` |
+| Floater workspace (frontend) | `frontend/app/workspace/floating-pane-workspace.tsx`, `frontend/app/workspace/floater-resize.ts` |
+| Browser pane (frontend) | `frontend/app/view/browser/browser-view.tsx`, `frontend/app/platform/pane-rect-registry.ts` |
+| Layout / onNodeDelete | `frontend/app/tab/tabcontent.tsx`, `frontend/layout/lib/{layoutTree,layoutPersistence}.ts` |
+| Floater OS window (host) | `agentmux-cef/src/floating_pane.rs`, `agentmux-cef/src/commands/floating_pane.rs` |
+| Window resolution (host) | `agentmux-cef/src/commands/window/lifecycle.rs`, `…/motion.rs`, `…/mod.rs` |
+| Browser-pane lifecycle (host) | `agentmux-cef/src/browser_panes.rs`, `agentmux-cef/src/browser_pane/{creation,callbacks,trace}.rs` |
+| Reducer | `agentmux-cef/src/reducer/{mod,panes,browsers}.rs`, `agentmux-cef/src/state.rs` |
+| App-exit / orphan gate | `agentmux-cef/src/client/mod.rs` |
+| `window_hwnds` cache | `agentmux-cef/src/state.rs:763` |
+
+| Spec / analysis | Path |
+|---|---|
+| Tear-off | `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` |
+| Edge-resize | `docs/specs/SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md` |
+| Header drag | `docs/analyses/ANALYSIS_FLOATING_PANE_HEADER_DRAG_2026-05-27.md` |
+| HWND cache stale | `docs/specs/SPEC_WINDOW_HWND_CACHE_STALE_FIX_2026_05_28.md` |
+| Redock load race | `docs/analysis/ANALYSIS_BROWSER_PANE_REDOCK_LOAD_RACE_2026_05_29.md` |
+| Browser-pane state | `docs/specs/browser-pane-state-catalog.md`, `…/browser-pane-reducer-roadmap.md` |
+| Per-window opacity (cache origin) | `docs/specs/SPEC_PER_WINDOW_OPACITY_2026-05-14.md` |


### PR DESCRIPTION
## P1 — canonical label-based window resolution

Implements **P1** from `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` §9: collapse window-HWND resolution behind the canonical `resolve_window_hwnd(label)` and **eliminate `find_own_top_level_window` from call sites that have a label** (it returns the process's first-visible top-level — the *floater* when one exists — root cause #1 of the recurring docking regressions).

### What changed
- **minimize / maximize / drag** (`chrome.rs`, `motion.rs`) — resolve via `resolve_window_hwnd(label)`, not `find_own_top_level_window`, so they act on the labeled window instead of whatever floater the OS enumerates first.
- **browser-pane creation parent** (`browser_pane/creation.rs`) — parent comes from `window_label` via `resolve_window_hwnd`, so a redocked pane is never parented to the dying floater (child-before-parent destroy → `ERR_ABORTED` → black render).
- **redock-onto-main** (`resolve_window_at_cursor`) — see below; the headline fix.
- `find_own_top_level_window` gets a ⚠️ doc warning; `resolve_window_hwnd` widened to `pub(crate)`.

### The redock-onto-main fix (proven this session)
Long-standing symptom: **dragging a floater onto the main window showed no landing ghost and never docked** (terminal *and* browser panes). Proven via the new `redock-resolve` trace:

- Every fresh launch boots windows in `pool mode — deferring init until promote`, then **promotes a warm-pool window on-screen to serve as main but never relabels it**. `window_hwnds` keeps `window-pool-<uuid> → its HWND` while `main` is left with **no live HWND** (`resolve_window_hwnd("main")` logs *"no available HWND for label=main"*).
- So `find_main_window` returns the pool HWND, and `resolve_window_at_cursor` handed back the **stale pool label** — which never matched the target window's frontend identity (`myLabel = ?windowLabel ?? "main"`), so the ghost gate (`target_label === myLabel`) failed and the drop had no valid `main` target.
- **Fix:** when the HWND under the cursor is the cache-independent main frame (`find_main_window`) **and** its reverse-map label is a lingering `window-pool-*`, resolve it as `"main"`, reconciling the OS-HWND cache with the frontend's identity. Real floaters / additional windows are untouched (zero multi-window regression surface).

The deeper cure — make **promotion relabel** the window so the cache, the backend, and the frontend agree — is captured as a P1/P2 follow-up in the architecture doc.

### Instrumentation (permanent, kept per the regression history)
- `browser_pane::trace` `[pane-trace]` lifecycle log.
- `redock-resolve` window-resolution trace (`muxlog host redock-resolve`) — logs `find_main_window`'s answer vs. the window under the cursor + `is_main_hwnd`.

### Verification
- `cargo check -p agentmux-cef --release` clean; `cargo test -p agentmux-cef` → **112 passed, 0 failed**.
- Built `--fresh` and smoke-tested end-to-end: floater→main now shows the landing ghost **and** docks (`workspace.RedockFloatingPane` completes); floater→floater unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
