### PR TITLE
feat(dnd): file drop on terminal + agent panes (phase 1)

### DIFF
--- a/.changesets/1780153219-feat-dnd-file-drop-on-terminal-agent-panes-phase-1-o3a8.md
+++ b/.changesets/1780153219-feat-dnd-file-drop-on-terminal-agent-panes-phase-1-o3a8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(dnd): file drop on terminal + agent panes (phase 1)

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -117,6 +117,32 @@ wrap_drag_handler! {
     }
 
     impl DragHandler {
+        // File drop path-capture. The HTML5 drop event in CEF/Chromium hides
+        // full filesystem paths from JS (security model: pages can read `File`
+        // objects but not their host paths). CefDragData::get_file_paths
+        // exposes the real paths during OnDragEnter; we stash them so the
+        // JS-side drop handler can consume them via the consume_drag_paths
+        // IPC a few ms later. Returning 0 (don't cancel) lets the JS drop
+        // event fire normally — required for the existing DragOverlay UI to
+        // run unchanged. Spec: docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md §3.3.
+        fn on_drag_enter(
+            &self,
+            _browser: Option<&mut Browser>,
+            drag_data: Option<&mut DragData>,
+            _mask: DragOperationsMask,
+        ) -> ::std::os::raw::c_int {
+            if let Some(dd) = drag_data {
+                let mut list = CefStringList::new();
+                let _ = dd.file_paths(Some(&mut list));
+                let paths: Vec<String> = list.into_iter().filter(|p| !p.is_empty()).collect();
+                if !paths.is_empty() {
+                    tracing::info!("[drag] captured {} file path(s) via OnDragEnter", paths.len());
+                    crate::drag_stash::put(paths);
+                }
+            }
+            0
+        }
+
         fn on_draggable_regions_changed(
             &self,
             browser: Option<&mut Browser>,

--- a/agentmux-cef/src/drag_stash.rs
+++ b/agentmux-cef/src/drag_stash.rs
@@ -1,0 +1,62 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process stash for file paths captured by `CefDragHandler::on_drag_enter`
+//! and consumed by the `consume_drag_paths` IPC at JS drop time.
+//!
+//! Why: the HTML5 drop event in a CEF browser only surfaces bare filenames,
+//! not full filesystem paths. CEF's DragData exposes the real paths, but only
+//! during the OnDragEnter callback. We stash them here for the JS-side drop
+//! handler to consume a few milliseconds later.
+//!
+//! Single-slot design: only one drag is active in the OS at a time. A new
+//! OnDragEnter overwrites the previous stash. A 5-second TTL evicts stale
+//! entries left behind when a drag enters but the user drops back into the
+//! source app instead of an AgentMux pane.
+//!
+//! Spec: docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md §3.3.
+
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+const TTL: Duration = Duration::from_secs(5);
+
+static STASH: LazyLock<Mutex<Option<(Instant, Vec<String>)>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+pub fn put(paths: Vec<String>) {
+    *STASH.lock().unwrap() = Some((Instant::now(), paths));
+}
+
+/// Take the stash if non-empty and within TTL. Returns the paths and clears
+/// the slot. If TTL expired, the slot is cleared and an empty vec is returned.
+pub fn take() -> Vec<String> {
+    let mut g = STASH.lock().unwrap();
+    if let Some((ts, _)) = g.as_ref() {
+        if ts.elapsed() > TTL {
+            *g = None;
+            return Vec::new();
+        }
+    }
+    g.take().map(|(_, p)| p).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_then_take_returns_paths_and_clears() {
+        put(vec!["/tmp/a".to_string(), "/tmp/b".to_string()]);
+        let out = take();
+        assert_eq!(out, vec!["/tmp/a".to_string(), "/tmp/b".to_string()]);
+        assert!(take().is_empty());
+    }
+
+    #[test]
+    fn empty_take_when_nothing_stashed() {
+        // Ensure clean state in case another test ran first.
+        let _ = take();
+        assert!(take().is_empty());
+    }
+}

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -356,6 +356,7 @@ async fn route_command(
         "ensure_settings_file" => commands::platform::ensure_settings_file(state),
         "open_in_editor" => commands::platform::open_in_editor(args),
         "copy_file_to_dir" => commands::providers::copy_file_to_dir(args),
+        "consume_drag_paths" => Ok(serde_json::json!(crate::drag_stash::take())),
 
         // ---- Command palette ----
         "run_command" => commands::palette::run_command(state, args),

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -27,6 +27,7 @@ mod browser_panes;
 mod client;
 mod commands;
 mod dev_authfile;
+mod drag_stash;
 mod events;
 mod ipc;
 mod launcher_event_bridge;

--- a/docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md
+++ b/docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md
@@ -1,0 +1,268 @@
+# SPEC: Drag-and-drop files into Terminal and Agent panes
+
+**Date:** 2026-05-30
+**Status:** Draft
+**Owner:** Frontend + CEF host + sidecar
+**Scope:** drag-and-drop of files from the OS file manager (and inter-pane in v2) onto a Terminal or Agent pane, with both **host-local** and **containerised/remote** agents supported.
+
+---
+
+## 0. Why this is non-trivial
+
+Two facts make file DnD unusual in AgentMux:
+
+1. **The CEF browser sandbox hides full filesystem paths.** A drop event on a CEF/WebView2 pane exposes only `File` objects with bare filenames (e.g. `report.csv`). The host path (e.g. `C:\Users\me\Downloads\report.csv`) is *not* in the JS event — it has to be captured Rust-side by a `CefDragHandler` and surfaced through IPC. The current placeholder in `frontend/app/view/term/term.tsx:330–344` documents the gap explicitly.
+2. **The terminal's working directory may not live on the host.** For container/SSH/WSL-backed connections, "copy this file into the CWD" means cross-boundary file transport — not a `std::fs::copy`. The current `copy_file_to_dir` IPC (`agentmux-cef/src/commands/providers.rs:685`) is host-local-FS only.
+
+A spec that ignores either point produces a UI that "works" on a developer laptop and silently breaks the moment a real user drops a CSV onto a Dockerised agent.
+
+---
+
+## 1. Current state (audit)
+
+Already merged / in repo:
+
+| Surface | Status |
+|---|---|
+| `DragOverlay` UI in `term.tsx` (the "Copy to /path" hint shown on drag-enter) | ✅ shipped |
+| `dragover` / `drop` listeners gated on `detectHost() === "cef"` | ✅ shipped |
+| `copy_file_to_dir` IPC | ✅ shipped, local-FS only |
+| `cmd:cwd` meta seeded on shell spawn (`shell.rs:690+`) so the destination is known | ✅ shipped |
+| `handleFilesDropped` calling `copy_file_to_dir` per file | ✅ shipped |
+
+Not yet implemented (the part this spec specifies):
+
+| Gap | Symptom today |
+|---|---|
+| CefDragHandler → IPC bridge to get host paths | Toast: "Full path copy requires CefDragHandler integration." Drop is a no-op. |
+| Container / SSH / WSL transport for `copy_file_to_dir` | Would silently copy to a host path that doesn't exist inside the container |
+| Agent-pane drop handler | Drop on an Agent pane is unhandled — falls through to the browser default (navigates away on dev, no-op in CEF) |
+| Multi-file batch + progress UX | Each file fires an independent toast; large files block UI |
+| Inter-pane file drop (drag from File pane → Terminal pane) | Not in scope here — separate spec |
+
+---
+
+## 2. Best-practice research
+
+What other terminals and AI-IDE chat surfaces do on file drop:
+
+| Product | Behavior | Why |
+|---|---|---|
+| **VS Code (integrated terminal)** | Pastes the file's quoted host path at the cursor | The terminal user is presumed to be operating *on* the host; the path *is* the deliverable |
+| **iTerm2** | Pastes `\`-escaped path; modifier (⌥) triggers `scp` upload to remote-session CWD | Recognises the "remote session needs the bytes, not the string" case |
+| **Windows Terminal / Hyper** | Pastes the path | Same model as VS Code |
+| **macOS Terminal.app** | Pastes the path | Same |
+| **Cursor / Claude Code chat input** | Attaches file to context as a chip; agent reads it on next turn | The file is *information for the AI*, not a deliverable to a shell |
+| **ChatGPT desktop** | Same as Cursor: attaches to message |
+| **Cline / Continue / Aider** | Adds file to the agent's tracked-context list ("/add path") |
+| **Warp** | Smart: detects shell, infers `cp` / `scp` / `cat` depending on what's selected |
+
+**Two distinct mental models emerge:**
+
+- **Terminal model**: "the path is the payload." Drop = paste path. Works because the user is at a shell that already has access to that path. Fails when the shell is on a different machine or inside a container.
+- **AI/chat model**: "the bytes are the payload." Drop = attach as context. Path is irrelevant; the agent gets the content.
+
+AgentMux's user direction ("copy it to the working directory") chooses neither model — it picks a third:
+
+- **Materialise-into-CWD model**: "the bytes are the payload, AND the agent reads from disk by path." Drop = transport the file into the agent's working directory so the agent can `read_file CWD/report.csv` in its very next tool call.
+
+This is the right choice for AgentMux specifically because:
+- The agent's main read path is filesystem tool calls, not "attach to chat".
+- The CWD is where the agent already looks for project files. Putting a file there makes it discoverable without a separate "I attached X — please read it" turn.
+- It works identically for host agents and container agents (provided the transport is right) — the agent's prompt and tool calls don't change.
+
+**Best practice cited:** Cursor's `@file` attach + JetBrains AI Assistant's drop-into-context both ALSO materialise to disk under the hood for tools that need a path. This isn't a new model — it's the contract Cursor uses too.
+
+---
+
+## 3. Design
+
+### 3.1 Behavior matrix
+
+| Pane type | Connection | Drop result |
+|---|---|---|
+| Terminal | `local` (host) | Copy file → `cmd:cwd` on host. Toast on success. |
+| Terminal | container / SSH / WSL | Stream file → `cmd:cwd` inside the remote. Toast on success. |
+| Agent | `local` | Copy file → `cmd:cwd` on host **and** insert a reference token (`@filename`) into the composer at the caret. |
+| Agent | container / SSH / WSL | Stream file → `cmd:cwd` inside the remote **and** insert `@filename` into the composer. |
+
+Why a reference token in the agent case: the agent doesn't know to read the new file unless we tell it. The token is a signal in the next user turn ("@report.csv") that the agent's prompt template can expand to "the user dropped report.csv into the CWD; consider it new context." This matches Cursor / Continue behavior.
+
+### 3.2 The destination is always `cmd:cwd`
+
+`cmd:cwd` is already broadcast to the frontend on shell spawn (`shell.rs:690+`) and is the single source of truth for the active working directory. No new meta key. If `cmd:cwd` is missing, drop is rejected with the existing "No working directory detected" toast — the same UX the current half-implementation has.
+
+### 3.3 Capturing the host path (CEF)
+
+The HTML5 path-hiding limitation is solved by a `CefDragHandler` on the Rust side. The flow:
+
+```
+OS drag enters CEF view
+  → CefDragHandler::OnDragEnter (Rust)
+    → reads CefDragData::GetFileNames() — these ARE full paths
+    → stashes the path list keyed by pane window id
+  → JS drop event fires
+    → JS calls invokeCommand("consume_drag_paths", { windowId })
+    → Rust returns the stashed list and clears it
+    → JS calls handleFilesDropped(paths) as it does today
+```
+
+Critical detail: `CefDragHandler::OnDragEnter` must **not** call `SetDragData(null)` or return `true` to swallow — that suppresses the JS event entirely. We let the JS event fire so the existing UI flow (overlay show/hide, per-file iteration) keeps working unchanged; CEF just supplies the missing piece (paths).
+
+A 5-second TTL on the stash prevents leaks if the JS event doesn't fire (window unfocused mid-drag, drop into a non-target region). Cleanup also fires on the next OnDragEnter.
+
+**Linux/macOS:** CEF's `OnDragEnter` behaves the same on all three platforms — the same handler covers all three. (Tauri/WebView2 do not; we are CEF-only now per `agentmux/CLAUDE.md`, so the simpler path holds.)
+
+### 3.4 Cross-boundary transport (`copy_file_to_dir_v2`)
+
+Rename / extend the existing IPC into a connection-aware command that dispatches on `meta.connection`:
+
+```rust
+pub fn copy_file_to_dir_v2(args: &Value) -> Result<Value, String> {
+    let source = args["source_path"].as_str().ok_or(...)?;
+    let target_dir = args["target_dir"].as_str().ok_or(...)?;
+    let conn_name = args["connection"].as_str().unwrap_or("local");
+
+    match resolve_connection(conn_name) {
+        Conn::Local           => copy_local(source, target_dir),
+        Conn::Ssh(cfg)        => copy_via_sftp(source, target_dir, cfg),
+        Conn::Container(cfg)  => copy_via_docker(source, target_dir, cfg),  // `docker cp`
+        Conn::Wsl(distro)     => copy_via_wsl(source, target_dir, distro),  // `wsl -d <distro> -- cp`
+    }
+}
+```
+
+The frontend always passes the source pane's `meta.connection` along with the source path. The sidecar (not the CEF host) actually owns the transport implementations — the CEF host just forwards to a new sidecar RPC `FileTransportCommand`, because (a) sidecar already owns connection configs and (b) the host should not link an SSH/Docker SDK.
+
+The local-FS path stays exactly as it is today (`std::fs::copy` + `deconflict_path`). The Local transport variant is a thin shim over the existing function — zero regression risk for the already-shipped host-only case.
+
+### 3.5 Filename de-collision
+
+Reuse the existing `deconflict_path` helper. If `report.csv` already exists in the CWD, the new file lands as `report (1).csv`, then `report (2).csv`, etc. The returned destination is what's used in the toast and (for Agent panes) in the composer token.
+
+### 3.6 Agent-pane composer integration
+
+After a successful transport, the composer textarea receives an insertion at the current caret position:
+
+```
+" @report (1).csv"      // leading space if caret isn't at start, trailing nothing
+```
+
+Implementation lives in a new hook `useAgentDropAttach` consumed by the agent view. It:
+
+1. Calls the same DragOverlay UI shown on terminal panes (consistent visual language).
+2. Calls the same transport (3.4) — same code path, same toast, same de-collision.
+3. On success, walks up to the composer textarea via the agent view's existing `composerRef` and splices the `@filename` token at the caret.
+
+If the composer isn't mounted (rare race during pane init), the token is queued in agent-view state and inserted on the next composer mount.
+
+### 3.7 Multi-file UX
+
+Drop of N files:
+- A single overlay shows "Copy 3 files to /path" (count, not list).
+- Transport runs concurrently with a semaphore of 4 (avoids OOM on big drops).
+- A single toast on completion summarises: "Copied 3 files to /path." Failures are appended ("2 copied, 1 failed: too large").
+- For Agent panes, all `@filename` tokens are concatenated and inserted as one splice (so the user can backspace once to remove the whole attach list).
+
+### 3.8 Large files
+
+Hard cap: **256 MiB per file** by default, tunable via `dnd:maxfilesizemb` setting. Above the cap the drop is rejected with a toast — we do not want a 4 GiB ISO to silently pin the sidecar for 20 minutes. The cap is enforced sidecar-side (after the file is staged, before transport begins) so the host can't be tricked into starting a transfer it'll abort.
+
+### 3.9 Progress
+
+For files > 8 MiB a progress toast replaces the success toast: a progress bar that updates from the transport's byte counter (already wired for sftp / docker cp via the underlying crates). At < 8 MiB we don't bother — the transport is faster than the toast animation.
+
+---
+
+## 4. Implementation surface
+
+### Frontend (TypeScript)
+
+| File | Change |
+|---|---|
+| `frontend/app/view/term/term.tsx` | Replace the placeholder branch in `onDrop` with a call to `invokeCommand("consume_drag_paths", ...)` then `handleFilesDropped(paths)`. Keep the existing CWD-missing toast. |
+| `frontend/app/view/agent/components/AgentDropZone.tsx` (new, ~80 LoC) | Mirrors the term DragOverlay flow. Owns the composer-token splice. |
+| `frontend/app/view/agent/hooks/useAgentDropAttach.ts` (new, ~120 LoC) | Wires DragOverlay + drop event + composer splice + queue-on-unmount. |
+| `frontend/util/dnd.ts` (new, ~60 LoC) | Shared `consume_drag_paths` invoke + multi-file iteration + de-collision result handling. Used by both term and agent. |
+
+### CEF host (Rust)
+
+| File | Change |
+|---|---|
+| `agentmux-cef/src/client/handlers.rs` | Implement `CefDragHandler` — stash `GetFileNames()` keyed by window id, 5 s TTL. |
+| `agentmux-cef/src/ipc.rs` | Register `consume_drag_paths` (returns + clears the stash). |
+| `agentmux-cef/src/commands/providers.rs` | `copy_file_to_dir` → `copy_file_to_dir_v2`. v1 stays as a deprecated alias for one release (back-compat for any out-of-tree consumer; nothing in-tree calls it). |
+| `agentmux-cef/src/commands/file_transport.rs` (new) | Thin dispatcher to sidecar RPC for non-local connections; passes through to local copy for `"local"`. |
+
+### Sidecar (Rust)
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/backend/file_transport/` (new module) | `local.rs`, `ssh.rs` (sftp via the existing ssh crate), `docker.rs` (`docker cp` via process spawn — no SDK), `wsl.rs` (`wsl -d <distro> --` shell). Each implements a small `Transport` trait. |
+| `agentmux-srv/src/backend/rpc_types.rs` | New `FileTransportCommand { source_path, target_dir, connection, max_bytes }` returning `{ dest_path, bytes_transferred }`. |
+| `agentmux-srv/src/backend/rpc.rs` (handler dispatch) | Wire the command to a `file_transport::dispatch()`. |
+
+### Settings
+
+| Key | Default | Description |
+|---|---|---|
+| `dnd:enabled` | `true` | Master kill-switch — disables both term and agent drop |
+| `dnd:maxfilesizemb` | `256` | Per-file cap (3.8) |
+| `dnd:concurrency` | `4` | Semaphore size for multi-file (3.7) |
+| `dnd:agentinserttoken` | `true` | Whether agent panes also splice an `@filename` token (3.6). Off = transport only, no composer touch. |
+
+---
+
+## 5. Edge cases
+
+| Case | Handling |
+|---|---|
+| Drop into a non-focused pane | Allowed. The pane's `cmd:cwd` is the target regardless of focus. (Matches VS Code; the drop event tells us which pane received it.) |
+| Drop onto pane header / chrome | Bubbles up — drop into header is a no-op for now. (v2 could route header drops to the pane body.) |
+| `cmd:cwd` set to a path the user can't write to | Transport returns the OS error verbatim in the failure toast. We do not pre-check writability — the race window is wider than the check is useful. |
+| Drop of a **directory** | Recursive copy (host) / `docker cp -a` (container) / `scp -r` (ssh). Same de-collision rules as files. The 256 MiB cap is the sum of the tree; abort early if exceeded. |
+| Drop while the agent is mid-turn | Transport runs; the `@filename` splice waits until the agent enters `IDLE` so it lands in the user's next prompt, not in the middle of streaming output. |
+| Two concurrent drops on the same pane | Serialise per pane via a per-pane mutex on the sidecar side. (Prevents two de-collision races picking the same `(1)` suffix.) |
+| Drop a file the agent's container can't `ls` (permissions inside the container) | Transport may succeed (root copied it in) but the agent fails to read it. Surface this as a *second* toast on the first agent tool-call failure — not on the drop itself. |
+| User cancels mid-transfer (closes pane) | Sidecar transfer is best-effort cancelled; partial file is unlinked. We don't leave half-files for the agent to misread. |
+| WSL distro not running | `wsl.rs` starts it on demand (cheap) and proceeds. |
+| Docker daemon down | Surface a single toast: "Drop failed: Docker daemon is not running." Do not retry. |
+
+---
+
+## 6. Security
+
+- **Path traversal:** `target_dir` is always `cmd:cwd`, which is set by the sidecar (not user input). `source_path` comes from the OS drag event captured by CEF, not from JS — JS can't fabricate a path. There is no user-controlled string that becomes part of `target/<source>`.
+- **Symlink races:** the local copy uses `std::fs::copy`, which dereferences symlinks at the source — sane default. For container/ssh transport the underlying crates follow symlinks at the source side, which matches user expectation ("the bytes I see in Finder, not the link").
+- **Sandbox escape:** the agent's process boundary is unchanged. Dropping a file into the agent's CWD does not grant new capabilities — it's bytes on disk the agent could already write itself.
+- **Large-file DoS:** the per-file cap (3.8) and the concurrency semaphore (3.7) bound the worst case.
+
+---
+
+## 7. Out of scope
+
+- **Inter-pane file drop** (drag from a File pane to a Terminal pane). Belongs in a separate spec; the drop **source** has different state-capture needs.
+- **Drop URLs / drop text.** This spec is files-only. Text/URL drop into the agent composer is the existing browser default and stays as-is.
+- **Drop onto a connection-picker.** Dropping a file before the pane has a connection is a v3 idea ("start a terminal here with this file").
+- **Two-way DnD** (drag a file out of a pane). Not requested.
+
+---
+
+## 8. Validation
+
+1. Local terminal: drop `report.csv` from Finder → file appears at `pwd`, toast "Copied report.csv to …" within ~200 ms.
+2. Local terminal with name collision: drop the same file twice → `report.csv` then `report (1).csv`.
+3. Container agent (Docker, claw-style): drop a file → `docker exec <ctr> ls <cwd>` shows it. Agent's next turn references `@report.csv` from the spliced composer token.
+4. SSH terminal: drop a file → file lands at the remote CWD; the file owner is the SSH user.
+5. WSL terminal: drop a file → file lands inside the distro at the CWD reported by `wsl pwd`.
+6. Large file (300 MiB): rejected with size-cap toast within 100 ms.
+7. Mid-drop pane close: no half-file left in CWD.
+8. Two simultaneous drops of differently-named files: both land; no token-splice interleaving in the composer.
+
+---
+
+## 9. Open questions
+
+- **Do we want `@filename` as the token, or `<filename>`?** Token-form depends on the agent's prompt template. Default `@` because Cursor / Continue / Aider all use it and the muscle memory is there. Tunable via `dnd:agentinserttoken` value (boolean today; could become a string template).
+- **Should drag-out be planned now?** Out of scope (§7), but the CEF handler shape will need OnDragStart support for it later. Keep the new module structured so adding OnDragStart is purely additive.
+- **Image previews in the DragOverlay?** Nice but not required. Defer to a follow-up.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -40,6 +40,8 @@ import { usePtyWidth } from "./hooks/usePtyWidth";
 import { useSubagentEvents } from "./hooks/useSubagentEvents";
 import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useAgentCommands } from "./hooks/useAgentCommands";
+import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
+import { DragOverlay } from "@/app/element/dragoverlay";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { ActivityLogPanel } from "./components/ActivityLogPanel";
 import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
@@ -640,6 +642,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     let rootRef: HTMLDivElement | undefined;
 
+    // File-drop attach. Drop a file onto the agent pane → copy it into the
+    // agent's CWD AND splice `@filename` into the composer at the caret, so
+    // the agent sees it on its next turn. Spec:
+    // docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md.
+    const dropAttach = useAgentDropAttach({
+        blockId: model.blockId,
+        rootRef: () => rootRef,
+    });
+
     // Track pane width → PTY cols so tools running inside the agent CLI
     // (git, ls, claude, …) wrap their output to match the pane instead of
     // the hard-coded `cols: 80` the PTY was opened with. ResizeObserver
@@ -708,6 +719,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             onContextMenu={handleContextMenu}
             tabIndex={-1}
         >
+            <DragOverlay message={dropAttach.dropMessage()} visible={dropAttach.isDragOver()} />
             {/* Pane title + back button now live in the block frame header,
                 driven by AgentViewModel.viewName / viewIcon / endIconButtons.
                 See SPEC_AGENT_PANE_FOLLOWUPS item #8. */}

--- a/frontend/app/view/agent/hooks/useAgentDropAttach.ts
+++ b/frontend/app/view/agent/hooks/useAgentDropAttach.ts
@@ -96,8 +96,15 @@ export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
             setIsDragOver(true);
         };
         const onDragLeave = (e: DragEvent) => {
-            // Only clear when leaving the root, not when crossing inner elements.
-            if (e.target === root) setIsDragOver(false);
+            // Only clear when the drag actually leaves the root, not when it
+            // crosses an inner element boundary. `relatedTarget` is where the
+            // cursor is *going*; if it's null or not contained in the root,
+            // the drag has left for real. The previous `e.target === root`
+            // check stuck the overlay open whenever the cursor exited via a
+            // child element (which is most of the time, since the pane is
+            // densely populated with children).
+            const next = e.relatedTarget as Node | null;
+            if (!next || !root.contains(next)) setIsDragOver(false);
         };
         const onDrop = (e: DragEvent) => {
             if (!enabled()) return;

--- a/frontend/app/view/agent/hooks/useAgentDropAttach.ts
+++ b/frontend/app/view/agent/hooks/useAgentDropAttach.ts
@@ -172,14 +172,24 @@ export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
                         successes.length === 1
                             ? `${verb} ${baseName(successes[0].dest!)}`
                             : `${verb} ${successes.length} files`;
+                    // When tokens weren't spliced (user disabled the setting),
+                    // surface the same "mention them in your next message" hint
+                    // that the composer-not-mounted branch above shows — same
+                    // root cause from the user's POV: the agent won't see the
+                    // file unless they reference it explicitly. Failures still
+                    // take precedence in the message body.
+                    const failureLines = failures
+                        .map((f) => `${baseName(f.source)}: ${f.error}`)
+                        .join("\n");
+                    const hint = !tokensInserted
+                        ? `Files are in ${targetCwd}. Mention them in your next message.`
+                        : "";
+                    const message = failureLines || hint;
                     pushNotification({
                         icon: "fa-check",
                         title:
                             failures.length > 0 ? `${title} (${failures.length} failed)` : title,
-                        message:
-                            failures.length > 0
-                                ? failures.map((f) => `${baseName(f.source)}: ${f.error}`).join("\n")
-                                : "",
+                        message,
                         timestamp: new Date().toISOString(),
                         type: failures.length > 0 ? "warning" : "info",
                         expiration: Date.now() + 5000,

--- a/frontend/app/view/agent/hooks/useAgentDropAttach.ts
+++ b/frontend/app/view/agent/hooks/useAgentDropAttach.ts
@@ -62,9 +62,14 @@ export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
 
     const enabledAtom = getSettingsKeyAtom("dnd:enabled");
     const insertTokenAtom = getSettingsKeyAtom("dnd:agentinserttoken");
+    const concurrencyAtom = getSettingsKeyAtom("dnd:concurrency");
 
     const enabled = () => (enabledAtom() ?? true) !== false;
     const insertToken = () => (insertTokenAtom() ?? true) !== false;
+    const concurrency = () => {
+        const v = concurrencyAtom();
+        return typeof v === "number" && v > 0 ? v : undefined;
+    };
 
     const cwd = (): string | undefined => {
         const block = WOS.getObjectValue<Block>(WOS.makeORef("block", opts.blockId));
@@ -125,17 +130,24 @@ export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
                     });
                     return;
                 }
-                const outcome = await copyFilesToDir(paths, targetCwd);
+                const outcome = await copyFilesToDir(paths, targetCwd, { concurrency: concurrency() });
                 const successes = outcome.results.filter((r) => r.dest);
                 const failures = outcome.results.filter((r) => r.error);
 
                 if (successes.length > 0) {
+                    // Track whether the composer actually received tokens. The
+                    // toast wording differs: "Attached" implies the agent will
+                    // see the file via the spliced @-token in its next turn;
+                    // "Copied" is just "the bytes are on disk now — mention
+                    // them yourself."
+                    let tokensInserted = false;
                     if (insertToken()) {
                         const tokens = successes.map((r) => `@${baseName(r.dest!)}`);
-                        const ok = spliceComposerTokens(root, tokens);
-                        if (!ok) {
-                            // Composer not mounted; surface a hint so the user
-                            // knows the file is on disk and can mention it manually.
+                        tokensInserted = spliceComposerTokens(root, tokens);
+                        if (!tokensInserted) {
+                            // Composer not mounted (rare race during pane init).
+                            // Surface a hint so the user knows the file is on
+                            // disk and can mention it manually.
                             const names = successes.map((r) => baseName(r.dest!)).join(", ");
                             pushNotification({
                                 icon: "fa-info-circle",
@@ -148,10 +160,11 @@ export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
                             return;
                         }
                     }
+                    const verb = tokensInserted ? "Attached" : "Copied";
                     const title =
                         successes.length === 1
-                            ? `Attached ${baseName(successes[0].dest!)}`
-                            : `Attached ${successes.length} files`;
+                            ? `${verb} ${baseName(successes[0].dest!)}`
+                            : `${verb} ${successes.length} files`;
                     pushNotification({
                         icon: "fa-check",
                         title:

--- a/frontend/app/view/agent/hooks/useAgentDropAttach.ts
+++ b/frontend/app/view/agent/hooks/useAgentDropAttach.ts
@@ -1,0 +1,193 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Drop file(s) onto an agent pane → copy them into the agent's CWD AND
+ * splice `@filename` tokens into the composer textarea at the caret, so the
+ * agent sees the new file in its next turn.
+ *
+ * Spec: docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md §3.1, §3.6.
+ */
+
+import { createSignal, onCleanup, onMount } from "solid-js";
+import { detectHost } from "@/app/platform/ipc";
+import { getSettingsKeyAtom, pushNotification, WOS } from "@/app/store/global";
+import { baseName, consumeDragPaths, copyFilesToDir } from "@/util/dnd";
+
+interface Opts {
+    blockId: string;
+    /** Returns the agent-view DOM root that should listen for drop events. */
+    rootRef: () => HTMLElement | undefined;
+}
+
+interface UseAgentDropAttachResult {
+    isDragOver: () => boolean;
+    dropMessage: () => string;
+}
+
+/**
+ * Find the composer textarea inside the agent pane and splice the given
+ * tokens at the current caret. If the textarea isn't mounted (rare race
+ * during pane init), returns false so the caller can decide to queue.
+ */
+function spliceComposerTokens(root: HTMLElement, tokens: string[]): boolean {
+    const ta = root.querySelector<HTMLTextAreaElement>("textarea.agent-input");
+    if (!ta) return false;
+    const joined = tokens.join(" ");
+    const caretAtStart = ta.selectionStart === 0;
+    const before = ta.value.slice(0, ta.selectionStart);
+    const after = ta.value.slice(ta.selectionEnd);
+    // Pad with a leading space if the caret isn't at the very start AND the
+    // preceding character isn't already whitespace, so "summarise" + "@x.csv"
+    // doesn't read as "summarise@x.csv".
+    const needsLead = !caretAtStart && before.length > 0 && !/\s$/.test(before);
+    const insert = (needsLead ? " " : "") + joined + (after.startsWith(" ") ? "" : " ");
+    const newVal = before + insert + after;
+    const newCaret = before.length + insert.length;
+    // Use the native setter so React/SolidJS reactive bindings observe the change.
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+    if (setter) {
+        setter.call(ta, newVal);
+    } else {
+        ta.value = newVal;
+    }
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+    ta.setSelectionRange(newCaret, newCaret);
+    ta.focus();
+    return true;
+}
+
+export function useAgentDropAttach(opts: Opts): UseAgentDropAttachResult {
+    const [isDragOver, setIsDragOver] = createSignal(false);
+
+    const enabledAtom = getSettingsKeyAtom("dnd:enabled");
+    const insertTokenAtom = getSettingsKeyAtom("dnd:agentinserttoken");
+
+    const enabled = () => (enabledAtom() ?? true) !== false;
+    const insertToken = () => (insertTokenAtom() ?? true) !== false;
+
+    const cwd = (): string | undefined => {
+        const block = WOS.getObjectValue<Block>(WOS.makeORef("block", opts.blockId));
+        return block?.meta?.["cmd:cwd"];
+    };
+
+    const dropMessage = () => {
+        const c = cwd();
+        return c ? `Copy to ${c}` : "No working directory detected";
+    };
+
+    onMount(() => {
+        if (detectHost() !== "cef") return;
+        const root = opts.rootRef();
+        if (!root) return;
+
+        const onDragOver = (e: DragEvent) => {
+            if (!enabled()) return;
+            // Only treat file drags as drop targets — text/url drops keep
+            // the browser default (paste into composer).
+            const types = e.dataTransfer?.types;
+            if (!types || !Array.from(types).includes("Files")) return;
+            e.preventDefault();
+            setIsDragOver(true);
+        };
+        const onDragLeave = (e: DragEvent) => {
+            // Only clear when leaving the root, not when crossing inner elements.
+            if (e.target === root) setIsDragOver(false);
+        };
+        const onDrop = (e: DragEvent) => {
+            if (!enabled()) return;
+            const files = e.dataTransfer?.files;
+            if (!files || files.length === 0) return;
+            e.preventDefault();
+            setIsDragOver(false);
+            const targetCwd = cwd();
+            if (!targetCwd) {
+                pushNotification({
+                    icon: "fa-triangle-exclamation",
+                    title: "Drop failed",
+                    message: "No working directory detected for this agent pane.",
+                    timestamp: new Date().toISOString(),
+                    type: "warning",
+                    expiration: Date.now() + 8000,
+                });
+                return;
+            }
+            void (async () => {
+                const paths = await consumeDragPaths();
+                if (paths.length === 0) {
+                    pushNotification({
+                        icon: "fa-triangle-exclamation",
+                        title: "Drop failed",
+                        message: `Couldn't read the OS paths for ${files.length} dropped file(s). Try again.`,
+                        timestamp: new Date().toISOString(),
+                        type: "warning",
+                        expiration: Date.now() + 6000,
+                    });
+                    return;
+                }
+                const outcome = await copyFilesToDir(paths, targetCwd);
+                const successes = outcome.results.filter((r) => r.dest);
+                const failures = outcome.results.filter((r) => r.error);
+
+                if (successes.length > 0) {
+                    if (insertToken()) {
+                        const tokens = successes.map((r) => `@${baseName(r.dest!)}`);
+                        const ok = spliceComposerTokens(root, tokens);
+                        if (!ok) {
+                            // Composer not mounted; surface a hint so the user
+                            // knows the file is on disk and can mention it manually.
+                            const names = successes.map((r) => baseName(r.dest!)).join(", ");
+                            pushNotification({
+                                icon: "fa-info-circle",
+                                title: "Files copied",
+                                message: `${names} → ${targetCwd}. Mention them in your next message.`,
+                                timestamp: new Date().toISOString(),
+                                type: "info",
+                                expiration: Date.now() + 6000,
+                            });
+                            return;
+                        }
+                    }
+                    const title =
+                        successes.length === 1
+                            ? `Attached ${baseName(successes[0].dest!)}`
+                            : `Attached ${successes.length} files`;
+                    pushNotification({
+                        icon: "fa-check",
+                        title:
+                            failures.length > 0 ? `${title} (${failures.length} failed)` : title,
+                        message:
+                            failures.length > 0
+                                ? failures.map((f) => `${baseName(f.source)}: ${f.error}`).join("\n")
+                                : "",
+                        timestamp: new Date().toISOString(),
+                        type: failures.length > 0 ? "warning" : "info",
+                        expiration: Date.now() + 5000,
+                    });
+                } else if (failures.length > 0) {
+                    pushNotification({
+                        icon: "fa-triangle-exclamation",
+                        title: `Copy failed (${failures.length} file${failures.length === 1 ? "" : "s"})`,
+                        message: failures
+                            .map((f) => `${baseName(f.source)}: ${f.error}`)
+                            .join("\n"),
+                        timestamp: new Date().toISOString(),
+                        type: "error",
+                        expiration: Date.now() + 12000,
+                    });
+                }
+            })();
+        };
+
+        root.addEventListener("dragover", onDragOver);
+        root.addEventListener("dragleave", onDragLeave);
+        root.addEventListener("drop", onDrop);
+        onCleanup(() => {
+            root.removeEventListener("dragover", onDragOver);
+            root.removeEventListener("dragleave", onDragLeave);
+            root.removeEventListener("drop", onDrop);
+        });
+    });
+
+    return { isDragOver, dropMessage };
+}

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -340,7 +340,15 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 e.preventDefault();
                 setIsDragOver(true);
             };
-            const onDragLeave = () => setIsDragOver(false);
+            const onDragLeave = (e: DragEvent) => {
+                // Only clear when the drag actually leaves the pane — see the
+                // matching comment in useAgentDropAttach. xterm fills the pane
+                // with composited child layers; treating every dragleave as
+                // "drag is gone" caused the overlay to flicker the moment the
+                // cursor crossed into the xterm viewport.
+                const next = e.relatedTarget as Node | null;
+                if (!next || !viewRef.contains(next)) setIsDragOver(false);
+            };
             const onDrop = (e: DragEvent) => {
                 if (!dndEnabled()) return;
                 e.preventDefault();

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -20,6 +20,7 @@ import { DragOverlay } from "@/app/element/dragoverlay";
 import { detectHost, invokeCommand } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { baseName, consumeDragPaths, copyFilesToDir } from "@/util/dnd";
 
 // TermResyncHandler: watches connection status changes and resyncs the terminal controller.
 // Also resyncs when the backend restarts — local terminals have no connStatus change on restart,
@@ -278,7 +279,7 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
 
     const termBg = createMemo(() => computeBgStyleFromMeta(blockData()?.meta));
 
-    const handleFilesDropped = (paths: string[]) => {
+    const handleFilesDropped = async (paths: string[]) => {
         const cwd = blockData()?.meta?.["cmd:cwd"];
         if (!cwd) {
             console.warn("[term-drop] No working directory detected, ignoring drop");
@@ -292,23 +293,31 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             });
             return;
         }
-        for (const filePath of paths) {
-            const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
-            invokeCommand("copy_file_to_dir", { sourcePath: filePath, targetDir: cwd })
-                .then((destPath: any) => {
-                    console.log(`[term-drop] copied ${fileName} → ${destPath}`);
-                })
-                .catch((err: any) => {
-                    const msg = String(err);
-                    pushNotification({
-                        icon: "fa-triangle-exclamation",
-                        title: `Copy failed: ${fileName}`,
-                        message: msg,
-                        timestamp: new Date().toISOString(),
-                        type: "error",
-                        expiration: Date.now() + 12000,
-                    });
-                });
+        const outcome = await copyFilesToDir(paths, cwd);
+        const successes = outcome.results.filter((r) => r.dest);
+        const failures = outcome.results.filter((r) => r.error);
+        if (successes.length > 0) {
+            const summary =
+                successes.length === 1
+                    ? `Copied ${baseName(successes[0].dest!)} to ${cwd}`
+                    : `Copied ${successes.length} files to ${cwd}`;
+            pushNotification({
+                icon: "fa-check",
+                title: failures.length > 0 ? `${summary} (${failures.length} failed)` : summary,
+                message: failures.length > 0 ? failures.map((f) => `${baseName(f.source)}: ${f.error}`).join("\n") : "",
+                timestamp: new Date().toISOString(),
+                type: failures.length > 0 ? "warning" : "info",
+                expiration: Date.now() + 6000,
+            });
+        } else if (failures.length > 0) {
+            pushNotification({
+                icon: "fa-triangle-exclamation",
+                title: `Copy failed (${failures.length} file${failures.length === 1 ? "" : "s"})`,
+                message: failures.map((f) => `${baseName(f.source)}: ${f.error}`).join("\n"),
+                timestamp: new Date().toISOString(),
+                type: "error",
+                expiration: Date.now() + 12000,
+            });
         }
     };
 
@@ -326,21 +335,31 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             const onDrop = (e: DragEvent) => {
                 e.preventDefault();
                 setIsDragOver(false);
-                // HTML5 File API doesn't expose full paths — CEF needs CefDragHandler for that.
-                // For now, log the file names as a placeholder.
                 const files = e.dataTransfer?.files;
-                if (files && files.length > 0) {
-                    const names = Array.from(files).map(f => f.name);
-                    console.log("[term-drop] CEF drop:", names.join(", "), "(full path copy not yet implemented)");
+                if (!files || files.length === 0) return;
+                // HTML5 File API only exposes bare filenames; the OS paths
+                // were captured by CefDragHandler::on_drag_enter and stashed
+                // in the host. Consume the stash now — it's keyed by drag
+                // session, not by pane, so it returns the same N paths the
+                // browser sees as `files`.
+                void consumeDragPaths().then((paths) => {
+                    if (paths.length > 0) {
+                        handleFilesDropped(paths);
+                        return;
+                    }
+                    // Stash empty: TTL expired, or the OnDragEnter callback
+                    // didn't fire (e.g. browser pane child window that
+                    // doesn't carry our DragHandler). Surface a clear
+                    // message rather than silently dropping.
                     pushNotification({
-                        icon: "fa-info-circle",
-                        title: "File drop",
-                        message: `Dropped ${files.length} file(s). Full path copy requires CefDragHandler integration.`,
+                        icon: "fa-triangle-exclamation",
+                        title: "Drop failed",
+                        message: `Couldn't read the OS paths for ${files.length} dropped file(s). Try again.`,
                         timestamp: new Date().toISOString(),
-                        type: "info",
-                        expiration: Date.now() + 5000,
+                        type: "warning",
+                        expiration: Date.now() + 6000,
                     });
-                }
+                });
             };
             viewRef.addEventListener("dragover", onDragOver);
             viewRef.addEventListener("dragleave", onDragLeave);

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -337,6 +337,12 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             if (!viewRef) return;
             const onDragOver = (e: DragEvent) => {
                 if (!dndEnabled()) return;
+                // Only treat file drags as drop targets — text/URL drags keep
+                // their browser default behavior so a selection or link dragged
+                // over a terminal doesn't trigger a misleading "Copy to <cwd>"
+                // overlay. Matches the guard in useAgentDropAttach.
+                const types = e.dataTransfer?.types;
+                if (!types || !Array.from(types).includes("Files")) return;
                 e.preventDefault();
                 setIsDragOver(true);
             };

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Search, useSearch } from "@/app/element/search";
-import { atoms, getOverrideConfigAtom, getSettingsPrefixAtom, pushNotification, WOS } from "@/store/global";
+import { atoms, getOverrideConfigAtom, getSettingsKeyAtom, getSettingsPrefixAtom, pushNotification, WOS } from "@/store/global";
 import { backendStatusAtom } from "@/store/backendStatus";
 import { fireAndForget } from "@/util/util";
 import { computeBgStyleFromMeta } from "@/util/waveutil";
@@ -279,6 +279,14 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
 
     const termBg = createMemo(() => computeBgStyleFromMeta(blockData()?.meta));
 
+    const dndEnabledAtom = getSettingsKeyAtom("dnd:enabled");
+    const dndConcurrencyAtom = getSettingsKeyAtom("dnd:concurrency");
+    const dndEnabled = () => (dndEnabledAtom() ?? true) !== false;
+    const dndConcurrency = () => {
+        const v = dndConcurrencyAtom();
+        return typeof v === "number" && v > 0 ? v : undefined;
+    };
+
     const handleFilesDropped = async (paths: string[]) => {
         const cwd = blockData()?.meta?.["cmd:cwd"];
         if (!cwd) {
@@ -293,7 +301,7 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             });
             return;
         }
-        const outcome = await copyFilesToDir(paths, cwd);
+        const outcome = await copyFilesToDir(paths, cwd, { concurrency: dndConcurrency() });
         const successes = outcome.results.filter((r) => r.dest);
         const failures = outcome.results.filter((r) => r.error);
         if (successes.length > 0) {
@@ -328,11 +336,13 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             // CEF: HTML5 drag events work natively (unlike WebView2)
             if (!viewRef) return;
             const onDragOver = (e: DragEvent) => {
+                if (!dndEnabled()) return;
                 e.preventDefault();
                 setIsDragOver(true);
             };
             const onDragLeave = () => setIsDragOver(false);
             const onDrop = (e: DragEvent) => {
+                if (!dndEnabled()) return;
                 e.preventDefault();
                 setIsDragOver(false);
                 const files = e.dataTransfer?.files;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1340,6 +1340,11 @@ declare global {
         "conn:*"?: boolean;
         "network:lan_discovery"?: boolean;
         "voice:enabled"?: boolean;
+        "dnd:*"?: boolean;
+        "dnd:enabled"?: boolean;
+        "dnd:maxfilesizemb"?: number;
+        "dnd:concurrency"?: number;
+        "dnd:agentinserttoken"?: boolean;
     };
 
     // waveobj.StickerClickOptsType

--- a/frontend/util/dnd.ts
+++ b/frontend/util/dnd.ts
@@ -1,0 +1,83 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Shared drag-and-drop helpers for Terminal and Agent panes.
+ *
+ * The HTML5 drop event in CEF doesn't expose full filesystem paths — only
+ * the bare File objects with display names. The Rust CefDragHandler captures
+ * the real paths on OnDragEnter and stashes them; we read them back here via
+ * `consume_drag_paths` and feed them to the per-file copy IPC.
+ *
+ * Spec: docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md §3.3, §3.4, §3.7.
+ */
+
+import { invokeCommand } from "@/app/platform/ipc";
+
+export interface DropOutcome {
+    /** Source paths that were attempted. */
+    sources: string[];
+    /** Per-source result: destination path on success, error string on failure. */
+    results: Array<{ source: string; dest?: string; error?: string }>;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+
+/**
+ * Read the OS paths captured by the CEF DragHandler stash. Returns an empty
+ * array if the stash has expired or wasn't populated (non-CEF host, drop
+ * with no files, etc.). The caller is expected to fall back gracefully.
+ */
+export async function consumeDragPaths(): Promise<string[]> {
+    try {
+        const paths = await invokeCommand<string[]>("consume_drag_paths", {});
+        return Array.isArray(paths) ? paths : [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Copy each `sourcePath` into `targetDir` with the configured concurrency.
+ * Filename collisions are de-conflicted server-side (`report (1).csv` etc.);
+ * the returned `dest` is the actual landed path.
+ */
+export async function copyFilesToDir(
+    sourcePaths: string[],
+    targetDir: string,
+    opts?: { concurrency?: number },
+): Promise<DropOutcome> {
+    const concurrency = Math.max(1, opts?.concurrency ?? DEFAULT_CONCURRENCY);
+    const results: DropOutcome["results"] = [];
+
+    let nextIdx = 0;
+    const worker = async () => {
+        while (true) {
+            const i = nextIdx++;
+            if (i >= sourcePaths.length) return;
+            const source = sourcePaths[i];
+            try {
+                const dest = await invokeCommand<string>("copy_file_to_dir", {
+                    sourcePath: source,
+                    targetDir,
+                });
+                results[i] = { source, dest };
+            } catch (err: unknown) {
+                results[i] = { source, error: String(err) };
+            }
+        }
+    };
+
+    const workers = Array.from(
+        { length: Math.min(concurrency, sourcePaths.length) },
+        () => worker(),
+    );
+    await Promise.all(workers);
+    return { sources: sourcePaths, results };
+}
+
+/** Extract a display filename from an absolute path (cross-platform). */
+export function baseName(p: string): string {
+    const m = p.match(/[^\\/]+$/);
+    return m ? m[0] : p;
+}

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -17,6 +17,12 @@
     // "term:allowbracketedpaste": true,
     // "term:shiftenternewline":   false,
 
+    // -- Drag and drop (file drop onto Terminal / Agent panes) --
+    // "dnd:enabled":              true,
+    // "dnd:maxfilesizemb":        256,
+    // "dnd:concurrency":          4,
+    // "dnd:agentinserttoken":     true,
+
     // -- Window --
     // "window:transparent":       false,
     // "window:blur":              false,


### PR DESCRIPTION
## Summary

Phase 1 of the file-drop spec. Drop a file from the OS file manager onto a Terminal or Agent pane → it gets copied into the pane's `cmd:cwd` and (for Agent panes) `@filename` is spliced into the composer at the caret.

Spec: [`docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md`](../blob/agent1/pane-file-drop-phase1/docs/specs/SPEC_PANE_FILE_DROP_2026_05_30.md).

## What changed

**CEF host (Rust)**
- New `drag_stash` module — single-slot `Vec<String>` with 5 s TTL.
- `AgentMuxDragHandler::on_drag_enter` reads `DragData::file_paths` and stashes; returns 0 so the JS drop event still fires (no behavior change for existing draggable-regions logic).
- New `consume_drag_paths` IPC drains the stash.

**Frontend**
- New `frontend/util/dnd.ts` — `consumeDragPaths` + `copyFilesToDir` with concurrency-limited (4) per-file iteration; de-collision (`report (1).csv`) is server-side already.
- `term.tsx` — placeholder branch replaced; one summary toast instead of per-file spam.
- `agent-view` — new `useAgentDropAttach` hook owns the drop UX + the composer `@filename` splice. Uses the native HTMLTextAreaElement value setter so reactive bindings see the change; pads with a leading space when the caret isn't preceded by whitespace.
- Settings: documented `dnd:enabled`, `dnd:maxfilesizemb`, `dnd:concurrency`, `dnd:agentinserttoken` in `settings-template.jsonc`. Defaults applied in code: enabled=true, concurrency=4, agentinserttoken=true (size cap is documented but enforced in Phase 2 — see below).

## Closes the "placeholder" gap

Before: dropping a file on a terminal pane showed *"Dropped N files. Full path copy requires CefDragHandler integration."* That toast is gone — the CEF DragHandler now supplies real OS paths and the existing `copy_file_to_dir` IPC actually runs.

## Phase 2 follow-ups (explicit non-goals here)

Carved out of spec §3.4 and §3.8 for follow-up PRs:

- SSH / Docker / WSL transport backends in the sidecar (this PR's `copy_file_to_dir` is host-local-FS only — same as it was before)
- Server-side per-file size cap (`dnd:maxfilesizemb`)
- Large-file progress toast (> 8 MiB)
- Directory drop recursive copy semantics across transports

Local-FS host agents work end-to-end today; remote agents will fall back to the existing host-local copy (which lands the file in the host's filesystem, not inside the container/remote — Phase 2 fixes).

## Test plan

- [ ] Drop a single file onto a terminal pane → file appears in `pwd`; one toast "Copied X to Y"
- [ ] Drop three files at once → single toast "Copied 3 files to Y", no per-file spam
- [ ] Drop a file whose name already exists → de-collision lands as `name (1).ext`, toast and `@token` reflect the new name
- [ ] Drop a file onto an agent pane with empty composer → `@filename ` appears in textarea
- [ ] Drop with caret mid-word (`summarise|`) → ` @filename ` spliced with leading + trailing space
- [ ] Drop with caret already after a space → no double space
- [ ] Drop on agent pane with `dnd:agentinserttoken=false` → file copied, no splice, info toast says "Mention them in your next message"
- [ ] TTL: leave a drag entered for 6+ seconds, then drop into the source app instead → next drop into AgentMux gets fresh paths, not stale ones
- [ ] Drop on pane with no `cmd:cwd` → "No working directory detected" toast, no copy attempted
- [ ] `dnd:enabled=false` → drag still shows browser default, no overlay, no copy

Follow-up to #1191 / #1199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)