### PR TITLE
feat(term): term:disablerafcoalesce — opt-in double-rAF tear-out for typing smoothness

### DIFF
--- a/.changesets/1780156312-feat-term-disablerafcoalesce.md
+++ b/.changesets/1780156312-feat-term-disablerafcoalesce.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(term): term:disablerafcoalesce — opt-in double-rAF tear-out for typing smoothness (input-first #1161)

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -67,6 +67,9 @@ pub struct SettingsType {
     #[serde(rename = "term:disablewebgl", default, skip_serializing_if = "is_false")]
     pub term_disable_web_gl: bool,
 
+    #[serde(rename = "term:disablerafcoalesce", default, skip_serializing_if = "is_false")]
+    pub term_disable_raf_coalesce: bool,
+
     #[serde(rename = "term:localshellpath", default, skip_serializing_if = "String::is_empty")]
     pub term_local_shell_path: String,
 

--- a/docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md
+++ b/docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md
@@ -1,0 +1,90 @@
+# SPEC: Terminal double-rAF tear-out (experiment)
+
+**Status:** Experimental — behind a default-off setting
+**Date:** 2026-05-30
+**Author:** AgentY
+**Setting:** `term:disablerafcoalesce` (boolean, default `false`)
+**Tracks:** [`SPEC_INPUT_RESPONSIVENESS_*`](./SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md) · [discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161) · bench PR #1203
+
+---
+
+## TL;DR
+
+The terminal PTY→screen path runs **two `requestAnimationFrame` coalescers in series**:
+
+```
+PTY msg → [our Stage-1 rAF: termwrap.scheduleRafWrite/armRaf] → terminal.write()
+        → [xterm's own rAF: RenderDebouncer] → paint
+```
+
+xterm.js already renders at most **once per animation frame** (its `RenderDebouncer`
+guards on `_animationFrame` and merges dirty rows). Our Stage-1 rAF is therefore a
+**second, unsynchronized frame gate**. Two gates in series can add up to ~32 ms and
+**beat against each other** — the likely cause of the uneven frame pacing ("not
+silky" hiccups) measured while holding a key: ~56 fps, frame p50 16.7 ms with a
+33–50 ms tail, **0 JS long-tasks**, sub-ms xterm marks (PR #1203 diagnostic).
+
+VS Code (same xterm.js, same Chromium) uses **only** xterm's built-in debouncer.
+
+This change adds `term:disablerafcoalesce`. When set, `scheduleRafWrite()` writes
+**straight to `terminal.write()`** and lets xterm own coalescing — removing our
+Stage-1 rAF. Default is unchanged behavior (coalesce on).
+
+## Why we have the Stage-1 rAF (don't delete blindly)
+
+Full provenance — it fixed real bugs, in four commits:
+
+| Commit | PR | Author | What |
+|---|---|---|---|
+| `ab9c38d6` | #208 (2026-03-22) | AgentA | **Introduced it.** Ink TUIs emit cursor-up + content as separate WS messages; two `terminal.write()`s snapped the viewport up-then-down = **double flash**. On **Windows 10** DWM presents each snap as a distinct frame; **on Windows 11 they coalesce within vsync (invisible).** Stage-1 rAF merges same-frame chunks into one write. |
+| `7f442735` | #235 | AgentA | Added `writeInFlight` guard — a slow write (large scrollback) let a second concurrent rAF write reintroduce the flash. |
+| `5bcf503f` | #276 | AgentA | Added the ≤512 B **fast-path** — the rAF was taxing echo; small writes bypass it. |
+| `e58707766` | #926 | AgentY | Removed `writeInFlight` from the fast path — it still stalled echo during big writes ("sporadic jitter"). |
+
+The arc #235→#276→#926 is a **progressive retreat**: each step carved the echo
+path back *out* of the coalescer because the extra frame gate kept causing
+latency. The tear-out is the logical end of that arc — but the **original Win10
+flash is the load-bearing reason it exists**, so removal must be Win10-verified.
+
+## Behavior
+
+- `term:disablerafcoalesce` absent/`false` (default): unchanged. ≤512 B echoes
+  fast-path; larger/streamed chunks buffer into our rAF, merged once per frame.
+- `term:disablerafcoalesce: true`: every PTY write goes **directly** to
+  `terminal.write()`; xterm's `RenderDebouncer` is the only frame gate.
+
+Wired: `term.tsx` reads the setting → `TermWrap` `coalesceWrites` option →
+early-return branch in `scheduleRafWrite()`. Plumbed through schema, gotypes,
+and `wconfig` so the key round-trips.
+
+## Verification protocol (the point of the flag)
+
+A/B on the **same build** (no rebuild — just edit `settings.json`, settings hot-reload):
+
+### Test 1 — does the Windows-10 scroll-flash regress? (BLOCKING)
+This is the reason the coalescer exists. **Must run on a real Windows 10 machine.**
+1. Open a terminal, run an Ink TUI that redraws heavily (e.g. a Claude Code / Codex
+   session, or any full-screen `ink`/`blessed` app that emits cursor-up + content).
+2. Baseline: `term:disablerafcoalesce` unset. Note scroll stability.
+3. Tear-out: set `term:disablerafcoalesce: true`, reload, repeat the same workload.
+4. **PASS** = no viewport up/down flash in tear-out mode. **FAIL** = flash returns →
+   xterm's debouncer alone is insufficient; do NOT flip the default (consider a
+   smaller targeted merge instead of a full second rAF).
+
+### Test 2 — do the typing hiccups improve?
+On both Win10 and Win11:
+1. Focus a terminal, run `node tools/tests/term-keyrepeat-hiccups.mjs --secs 18`
+   while holding a key, with the flag OFF → record VALID baseline.
+2. Set the flag ON, reload, repeat.
+3. Compare jank-frame counts (>33 ms) and the p99/max frame tail. Expect the
+   tail to shrink if the double-rAF beat was the cause.
+
+### Test 3 — streaming throughput / ordering (no regression)
+`node tools/tests/bench-term-echo.mjs --stream --busy` with flag on vs off —
+confirm no new ordering violations and no echo-latency regression under load.
+
+## Rollout
+
+If Test 1 passes on Win10 AND Tests 2–3 show improvement with no regression,
+a follow-up flips the default (or removes Stage-1 entirely). Until then this ships
+**default-off** — pure opt-in, safe for all users.

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -184,6 +184,7 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 keydownHandler: model.handleTerminalKeydown.bind(model),
                 useWebGl: !ts?.["term:disablewebgl"],
                 sendDataHandler: model.sendDataToController.bind(model),
+                coalesceWrites: !ts?.["term:disablerafcoalesce"],
             }
         );
         window.term = termWrap;

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -49,6 +49,12 @@ type TermWrapOptions = {
     keydownHandler?: (e: KeyboardEvent) => boolean;
     useWebGl?: boolean;
     sendDataHandler?: (data: string) => void;
+    // When false, bypass our own RAF write-coalescer and write straight to
+    // xterm.js, letting its built-in RenderDebouncer own frame coalescing.
+    // Removes the "double rAF" (our rAF feeding xterm's rAF). Default true
+    // (keep the Tier-3 Win10 scroll-flash fix, PR #208). Toggled by the
+    // `term:disablerafcoalesce` setting — see SPEC_TERM_DOUBLE_RAF_TEAROUT.
+    coalesceWrites?: boolean;
 };
 
 /**
@@ -87,6 +93,9 @@ export class TermWrap {
     private rafBuffer: Uint8Array[] = [];
     private rafPending: boolean = false;
     private writeInFlight: boolean = false;
+    // Stage-1 RAF coalescer toggle. true = coalesce (default, Tier-3 fix);
+    // false = write straight to xterm (double-rAF tear-out experiment).
+    private coalesceWrites: boolean = true;
     // Thaw-cycle handles — cleared in dispose() so callbacks don't fire
     // on a disposed Terminal. dispose() doesn't null `this.terminal`, so
     // a null-check guard alone isn't enough.
@@ -105,6 +114,7 @@ export class TermWrap {
         this.loaded = false;
         this.blockId = blockId;
         this.sendDataHandler = waveOptions.sendDataHandler;
+        this.coalesceWrites = waveOptions.coalesceWrites ?? true;
         this.ptyOffset = 0;
         this.dataBytesProcessed = 0;
         this.lastUpdated = Date.now();
@@ -485,6 +495,24 @@ export class TermWrap {
     private static readonly RAF_BYPASS_THRESHOLD = 512; // bytes
 
     private scheduleRafWrite(data: Uint8Array) {
+        // Double-rAF tear-out (term:disablerafcoalesce=true): bypass our Stage-1
+        // rAF coalescer entirely and write straight to xterm.js. xterm's own
+        // RenderDebouncer already coalesces same-frame writes into one render, so
+        // our extra rAF is a SECOND frame gate in series — adding latency and
+        // beating against xterm's rAF (uneven frame pacing / "hiccups"). Writing
+        // direct lets xterm own coalescing, matching how VS Code drives xterm.
+        //
+        // EXPERIMENTAL — default is coalesce=true. Our Stage-1 rAF was added to
+        // fix a real Windows-10 DWM scroll-flash with Ink TUIs (cursor-up +
+        // content arriving as separate WS messages presented as two frames; PR
+        // #208). On Windows 11 the compositor coalesces those within vsync, so
+        // the fix may be obsolete there. MUST be re-verified on Windows 10
+        // before flipping the default. See SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.
+        if (!this.coalesceWrites) {
+            if (data.length <= 32) markStart('term-echo-render');
+            this.doTerminalWrite(data, null);
+            return;
+        }
         // Fast path: small data, nothing buffered — bypass RAF to eliminate echo delay.
         // writeInFlight is intentionally NOT checked here: xterm.js serialises all
         // terminal.write() calls internally, so a concurrent small write always lands

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1297,6 +1297,7 @@ declare global {
         "term:zoom"?: number;
         "term:theme"?: string;
         "term:disablewebgl"?: boolean;
+        "term:disablerafcoalesce"?: boolean;
         "term:localshellpath"?: string;
         "term:localshellopts"?: string[];
         "term:scrollback"?: number;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -35,6 +35,10 @@
         "term:disablewebgl": {
           "type": "boolean"
         },
+        "term:disablerafcoalesce": {
+          "type": "boolean",
+          "description": "EXPERIMENTAL. Bypass AgentMux's own RAF write-coalescer and write PTY output straight to xterm.js (which coalesces internally). Removes a redundant frame gate that can cause uneven typing frame-pacing. Default false. The coalescer originally fixed a Windows-10 DWM scroll-flash (PR #208) — verify no flash regression on Windows 10 before relying on this. See SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30."
+        },
         "term:localshellpath": {
           "type": "string"
         },


### PR DESCRIPTION
## What

Adds a default-off setting **`term:disablerafcoalesce`** that **tears out our Stage-1 rAF write-coalescer** in the terminal, so PTY output writes straight to xterm.js and xterm's own `RenderDebouncer` is the only frame gate.

Tracks the input-first umbrella ([#1161](https://github.com/agentmuxai/agentmux/discussions/1161)). Companion to the measurement tooling in #1203.

## Why — the "double rAF"

The PTY→screen path runs **two `requestAnimationFrame` coalescers in series**:

```
PTY msg -> [our Stage-1 rAF: termwrap.scheduleRafWrite/armRaf] -> terminal.write()
        -> [xterm's own rAF: RenderDebouncer] -> paint
```

xterm.js already renders **at most once per animation frame** (`RenderDebouncer` guards on `_animationFrame`, merges dirty rows). Our Stage-1 rAF is a **second, unsynchronized frame gate** — can add up to ~32 ms and **beat against** xterm's rAF → uneven frame pacing.

Measured with the #1203 diagnostic (VALID 18s hold-key, v0.40.1): **~56 fps, frame p50 16.7 ms with a 33–50 ms tail, 0 JS long-tasks, sub-ms xterm marks** → the stutter is render-path, not JS. VS Code drives the same xterm.js with **only** the built-in debouncer.

## Provenance — why Stage-1 exists (don't merge-flip blindly)

4-commit arc:

| Commit | PR | What |
|---|---|---|
| `ab9c38d6` | #208 | **Introduced it** — Ink TUIs emit cursor-up + content as separate WS messages -> viewport snapped up/down = **double flash**. **Windows 10** DWM shows each snap as a frame; **Windows 11 coalesces within vsync (invisible).** |
| `7f442735` | #235 | `writeInFlight` guard (slow write let a 2nd concurrent rAF reintroduce the flash) |
| `5bcf503f` | #276 | <=512 B echo fast-path (rAF was taxing echo) |
| `e58707766` | #926 | removed `writeInFlight` from fast path (still stalled echo) |

#235->#276->#926 is a progressive retreat carving the echo path back *out* of the coalescer. This is the end of that arc — but the **original flash is Windows-10-specific**, so removal must be Win10-verified.

## Design — why a default-off flag

A/B on the **same build** (settings hot-reload, no rebuild): flip `term:disablerafcoalesce` and compare. Default off = zero risk to other users. Wired `term.tsx` -> `TermWrap.coalesceWrites` -> early-return in `scheduleRafWrite()`; plumbed through `schema/settings.json`, `gotypes.d.ts`, and `wconfig/types.rs` so the key round-trips.

## Verification protocol (full detail in the spec)

1. **Win10 scroll-flash regression (BLOCKING)** — run an Ink TUI on real Windows 10, flag off vs on; PASS = no viewport flash in tear-out mode.
2. **Hiccups** — `term-keyrepeat-hiccups.mjs` (#1203) hold-key, flag off vs on; expect the 33–50 ms frame tail to shrink.
3. **Throughput/ordering** — `bench-term-echo.mjs --stream --busy`, no new ordering violations or echo regression.

Flip the default only if Test 1 passes on Win10 and 2–3 improve. `docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md`.

## Build / verify
- `npx tsc --noEmit`: **no new errors** (the 27 reported all pre-exist on main — test fixtures + `React` namespace + layout test types; none touch term write path or the new setting)
- `cargo check -p agentmux-srv`: **clean (0 errors)**

## Scope
Frontend term write path + setting plumbing (schema/gotypes/wconfig) + spec. Default-off, behavior unchanged unless the setting is set. Changeset: `patch`.