### PR TITLE
fix(cef): never request OS credential/keychain access in any runtime mode

### DIFF
--- a/.changesets/1780158422-fix-cef-never-request-os-credential-keychain-access-in-any-r-cyfh.md
+++ b/.changesets/1780158422-fix-cef-never-request-os-credential-keychain-access-in-any-r-cyfh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): never request OS credential/keychain access in any runtime mode

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -423,52 +423,36 @@ wrap_app! {
                 // Upstream: https://github.com/chromiumembedded/cef/issues/3603
                 cmd.append_switch(Some(&CefString::from("disable-chrome-login-prompt")));
 
-                // Suppress OS credential prompts on first-run dev / portable
-                // launches. **Dev-only** — gated to `RuntimeMode::Dev` because
-                // these switches weaken Chromium's at-rest encryption of
-                // cookies / passwords by routing OSCrypt to an unencrypted
-                // basic store (and, on macOS, mocking the Keychain entirely).
-                // Enabling them in a packaged AppImage / .app / installer
-                // build would silently degrade credential security on user
-                // machines — production builds keep the platform-native
-                // backend so OSCrypt can derive a real encryption key from
-                // gnome-keyring / kwallet / Keychain / CredVault.
-                //
-                // The prompt-on-first-launch UX issue only matters in dev
-                // (devs don't want to authenticate Keychain on every
-                // `task dev` against a fresh per-branch data dir). Released
-                // builds run once per user; the prompt is appropriate there.
-                let is_dev_runtime = matches!(
-                    agentmux_common::RuntimeMode::from_env().or_else(|| {
-                        std::env::current_exe()
-                            .ok()
-                            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-                            .map(|d| agentmux_common::RuntimeMode::current(&d))
-                    }),
-                    Some(agentmux_common::RuntimeMode::Dev { .. })
-                );
-                if is_dev_runtime {
-                    // `--password-store=basic` swaps Chromium's password
-                    // backend from the platform-native store (Keychain on
-                    // macOS, gnome-keyring/kwallet on Linux, CredVault on
-                    // Windows) to an in-process unencrypted store. The
-                    // native backends pop an "AgentMux wants to use your
-                    // confidential information stored in Login" prompt
-                    // the first time Chromium touches them, even if
-                    // AgentMux never actually saves a password.
-                    let ps_key = CefString::from("password-store");
-                    let ps_val = CefString::from("basic");
-                    cmd.append_switch_with_value(Some(&ps_key), Some(&ps_val));
+                // Never request OS credential / keychain access — in ANY
+                // runtime mode (dev, installed, portable), on any platform.
+                // These switches route Chromium's OSCrypt away from the
+                // platform-native credential store, which otherwise pops an
+                // "AgentMux wants to use your confidential information stored
+                // in Login" prompt the first time it's touched — and on macOS
+                // that modal BLOCKS browser startup, so the app hangs with no
+                // window. AgentMux never saves a password, so OSCrypt only
+                // matters for the cookie jar; for a local single-user
+                // workbench (data dir 0700) an obfuscation-key store is an
+                // acceptable tradeoff vs prompting the user for keychain
+                // access. This reverses the earlier "prompt is appropriate for
+                // released builds" gating. See
+                // docs/specs/SPEC_SUPPRESS_OS_CREDENTIAL_PROMPTS_2026_05_30.md
+                // and docs/retro/retro-macos-keychain-prompt-2026-05-30.md.
 
-                    // macOS belt-and-suspenders: `--use-mock-keychain`
-                    // redirects every keychain call to an in-process mock,
-                    // including OSCrypt's encryption-key derivation that
-                    // bypasses the password store. Without it, Chromium
-                    // still surfaces a Keychain auth dialog on first run
-                    // as OSCrypt fetches its encryption key.
-                    #[cfg(target_os = "macos")]
-                    cmd.append_switch(Some(&CefString::from("use-mock-keychain")));
-                }
+                // `--password-store=basic` swaps Chromium's password backend
+                // from the platform-native store (Keychain on macOS,
+                // gnome-keyring/kwallet on Linux, CredVault on Windows) to an
+                // in-process basic store — no native-backend prompt.
+                let ps_key = CefString::from("password-store");
+                let ps_val = CefString::from("basic");
+                cmd.append_switch_with_value(Some(&ps_key), Some(&ps_val));
+
+                // macOS belt-and-suspenders: even with password-store=basic,
+                // OSCrypt still fetches its encryption key from the Keychain
+                // unless the keychain itself is mocked. `--use-mock-keychain`
+                // redirects those calls to an in-process mock. macOS-only.
+                #[cfg(target_os = "macos")]
+                cmd.append_switch(Some(&CefString::from("use-mock-keychain")));
 
                 // GPU compositing runs in a separate process (Chromium default).
                 // This allows Chromium to restart the GPU process transparently

--- a/docs/retro/retro-macos-keychain-prompt-2026-05-30.md
+++ b/docs/retro/retro-macos-keychain-prompt-2026-05-30.md
@@ -1,0 +1,124 @@
+# Retro: packaged macOS app triggers a Keychain "confidential information" prompt (and hangs on it)
+
+**Date:** 2026-05-30
+**Severity:** High (trust/UX showstopper + blocks first launch)
+**Surfaced by:** first launch of the signed `AgentMux.app` (v0.40.1) built via the new `task package:macos`.
+**Status:** root-caused; fix proposed (not yet applied).
+
+---
+
+## What happened
+
+Launching the packaged, Developer-ID-signed `AgentMux.app` (installed/stable runtime mode)
+popped the macOS dialog:
+
+> **"AgentMux wants to use your confidential information stored in 'Login' in your keychain."**
+
+Worse, the app **hung with no window** (browser process at 0% CPU; the GPU child logged
+`child_thread_impl.cc:902 Terminating current process after 15 seconds with no connection`).
+The hang and the prompt are the **same event**: Chromium's `OSCrypt` initialization blocks on the
+modal Keychain dialog during browser startup, so the message loop never runs, no window is created,
+and the spawned GPU subprocess times out waiting to connect.
+
+This was initially mis-diagnosed as a CEF macOS subprocess/Helper-app IPC problem. It is not — the
+process was simply parked behind a system modal that only appears on the user's screen, invisible to
+CLI process checks (which just see a "hung" 0%-CPU process).
+
+## Root cause
+
+The switches that keep Chromium away from the OS credential store —
+`--password-store=basic` and (macOS) `--use-mock-keychain` — are **gated to `RuntimeMode::Dev`** in
+`agentmux-cef/src/app.rs` (~L441–471):
+
+```rust
+let is_dev_runtime = matches!(RuntimeMode…, Some(RuntimeMode::Dev { .. }));
+if is_dev_runtime {
+    cmd.append_switch_with_value("password-store", "basic");
+    #[cfg(target_os = "macos")]
+    cmd.append_switch("use-mock-keychain");
+}
+```
+
+A packaged `.app` resolves to `RuntimeMode::Installed`, so the block is skipped. Chromium's `OSCrypt`
+then derives its cookie/password encryption key from the **macOS Keychain**, which triggers the
+confidential-information prompt the first time it's touched — even though AgentMux never asks to save a
+password. The code comment at that site literally predicts this dialog text.
+
+### Why the gating existed
+
+A prior review (reagent P1, earlier in the CEF-migration work) intentionally restricted these switches
+to dev because they weaken Chromium's at-rest encryption: `--password-store=basic` routes `OSCrypt` to
+an in-process store with an obfuscation-only key (no Keychain-derived key), and `--use-mock-keychain`
+mocks the Keychain entirely. The rationale recorded in the comment: *"Released builds run once per
+user; the prompt is appropriate there."*
+
+That rationale conflicts with the product requirement, restated by the user: **AgentMux must not ask the
+OS for credentials / confidential access.** The conflict was latent until macOS packaging actually
+existed (it was a `[TODO]` stub until today), so no installed-mode macOS build had ever exercised the
+non-dev path before.
+
+## Contributing factors
+
+- **No installed-mode macOS build existed until now**, so the prod credential path was never run on
+  macOS — the regression had nowhere to surface.
+- **The hang masked the cause.** The Keychain modal renders on-screen only; headless/CLI verification
+  saw a 0%-CPU "hang" and chased a CEF-IPC red herring. (Lesson: a packaged GUI app that "hangs at 0%
+  CPU right after init" should be eyeballed on screen for a system modal before deep IPC debugging.)
+- The same gating affects **Linux AppImage** and **Windows installer** builds (gnome-keyring/kwallet/
+  CredVault prompts), but those weren't in focus today.
+
+## Impact
+
+Every end user of a packaged AgentMux build hits an OS credential prompt on first launch (Keychain on
+macOS). On macOS it additionally **blocks the app from opening** until dismissed — and dismissing it may
+leave `OSCrypt` in a degraded state. This is a hard blocker for shipping a usable macOS release.
+
+## Fix options
+
+1. **Apply `--password-store=basic` (+ macOS `--use-mock-keychain`) in ALL runtime modes** (remove the
+   dev gate, or extend it to installed/portable). Pro: no prompt, app launches, matches the product
+   requirement. Con: reverses the reagent P1 decision — cookie/password encryption at rest uses an
+   obfuscation key, not a Keychain-derived one. For AgentMux's threat model (a local, single-user agent
+   workbench; data dir already `0700`; no shared multi-user secrets in the cookie jar) this is an
+   acceptable, documented tradeoff. **Recommended.**
+2. **Keep Keychain-backed encryption but pre-authorize** the app's access (stable signing identity +
+   a keychain access group / partition-id ACL so it never prompts). Complex and brittle: the prompt is
+   per-app-identity, and local/dev signatures vary; still prompts for ad-hoc builds.
+3. **Per-user first-run choice / setting.** Doesn't remove the default prompt; just defers the policy.
+
+## Recommendation
+
+Take **option 1**, scoped to a small, well-gated change in `agentmux-cef/src/app.rs`: drop the
+`is_dev_runtime` condition around the `password-store`/`use-mock-keychain` switches (the
+`#[cfg(target_os = "macos")]` on `use-mock-keychain` stays — no Windows behavior change). Update the
+comment to record the reversed tradeoff and link this retro. Re-package the macOS `.app` and confirm:
+(a) no Keychain prompt, (b) the window opens, (c) the GPU subprocess connects. Then revisit Linux/Windows
+parity.
+
+## Action items
+
+- [ ] Ungate the OSCrypt switches (option 1) — `agentmux-cef/src/app.rs`. Keep the macOS `cfg`.
+- [ ] Re-run `task package:macos`; verify no prompt + window opens + renderer connects.
+- [ ] Note the encryption tradeoff in the code comment + `docs/macos-signing.md`.
+- [ ] Decide Linux/Windows parity (same prompt on those installed builds).
+- [ ] Only then resume the v0.40.1 macOS release-asset upload (still also blocked on notarization — the
+      Apple Developer agreement 403, tracked in the build-cleanup issue).
+
+## Update (post-fix verification, 2026-05-30)
+
+Implemented option 1 (`agentmux-cef/src/app.rs`: ungate the OSCrypt switches; macOS `cfg` kept) and
+re-packaged + launched the installed-mode `.app`:
+
+- **Keychain prompt: GONE.** Before the fix the app hung GPU-only at the keychain modal; after the fix it
+  progresses *past* OSCrypt init and spawns the full subprocess set (gpu / network / storage / service /
+  utility) and attempts the renderer. The credential-prompt hang is resolved — the credentials fix is
+  **complete and verified**.
+- **Separate issue uncovered:** with the keychain block removed, the **renderer/GPU subprocesses now
+  crash-loop** in the signed, hardened-runtime bundle (274 crashes / 10 s → crash-budget abort → the
+  "Window stopped recovering" page). This is the *other*, independent hard part of macOS CEF packaging
+  (self-reexec subprocesses under a signed bundle identity — likely needs Helper.app bundles and/or
+  hardened-runtime/entitlements tuning). It is **not** a credentials problem and does not affect this
+  fix. Tracked with the `task package:macos` / macOS-packaging work, not here.
+
+So: this retro's incident (the credential prompt + its hang) is **fixed**. A usable distributable macOS
+build additionally needs the subprocess-crash work above + notarization (Apple-agreement 403).

--- a/docs/specs/SPEC_SUPPRESS_OS_CREDENTIAL_PROMPTS_2026_05_30.md
+++ b/docs/specs/SPEC_SUPPRESS_OS_CREDENTIAL_PROMPTS_2026_05_30.md
@@ -1,0 +1,94 @@
+# Spec: Never request OS credential / keychain access (all runtime modes)
+
+**Date:** 2026-05-30
+**Status:** Spec → implementation
+**Related:** `docs/retro/retro-macos-keychain-prompt-2026-05-30.md` (the incident this fixes)
+
+---
+
+## Problem
+
+A packaged AgentMux build (installed/portable runtime mode) pops an OS credential prompt on first
+launch — on macOS the **"AgentMux wants to use your confidential information stored in 'Login' in your
+keychain"** dialog. On macOS this prompt is **modal and blocks browser startup**, so the app hangs with
+no window until it's dismissed.
+
+Root cause (`agentmux-cef/src/app.rs`): the Chromium switches that route `OSCrypt` away from the OS
+credential store — `--password-store=basic` (all platforms) and `--use-mock-keychain` (macOS) — are
+gated to `RuntimeMode::Dev`. Installed/portable builds skip them, so `OSCrypt` derives its cookie/
+password encryption key from the platform-native backend (macOS Keychain, Linux gnome-keyring/kwallet,
+Windows CredVault) and prompts the first time it's touched — even though AgentMux never saves a password.
+
+The dev gate was a deliberate prior decision (the prompt was deemed "appropriate" for released builds,
+and the switches weaken at-rest credential encryption). It was never exercised on macOS because
+`task package:macos` was a TODO stub until 2026-05-30, so the conflict with the product requirement —
+**AgentMux must not ask the OS for credential/keychain access in any build** — only just surfaced.
+
+## Goal
+
+No AgentMux build, in any runtime mode (Dev / Installed / Portable), on any platform, requests OS
+credential or keychain access. The app launches without a system credential modal.
+
+## Non-goals
+
+- Keychain-grade at-rest encryption of the Chromium cookie jar (see Tradeoff).
+- Changing how AgentMux's own auth/identity bundles are stored (that's app-level, already `0700`, and
+  unrelated to Chromium's `OSCrypt`).
+
+## Design
+
+Remove the `is_dev_runtime` gate around the `OSCrypt` switches in `agentmux-cef/src/app.rs` so they
+apply unconditionally:
+
+- `--password-store=basic` — appended for **all** runtime modes and platforms. Routes `OSCrypt` to an
+  in-process basic store instead of the platform-native backend → no gnome-keyring/kwallet/CredVault/
+  Keychain prompt.
+- `--use-mock-keychain` — appended for **all** runtime modes, **macOS only** (`#[cfg(target_os = "macos")]`
+  stays). Belt-and-suspenders: even with `password-store=basic`, macOS `OSCrypt` still fetches its
+  encryption key from the Keychain unless the keychain itself is mocked.
+
+The `RuntimeMode` resolution that fed the gate is deleted (it's no longer needed). Comments are updated
+to record the new, intentional behavior and link the retro.
+
+### Why this is Windows-safe (regression guardrail)
+
+- The change only **removes a condition** around two `cmd.append_switch*` calls — both are
+  platform-agnostic `CefString` switch appends. `--password-store=basic` on Windows routes `OSCrypt`
+  to the basic store (suppressing the CredVault prompt) — the desired behavior there too.
+- `--use-mock-keychain` keeps its `#[cfg(target_os = "macos")]` — no change to what Windows/Linux compile.
+- No type/state changes, no new platform-specific reads → no `#[cfg]`-shaped compile break (the failure
+  mode of #1192). The diff is a net deletion of the gate.
+
+## Tradeoff (explicit)
+
+With `--password-store=basic`, Chromium's cookie jar is encrypted at rest with a hardcoded obfuscation
+key rather than an OS-credential-derived key. For AgentMux's threat model this is acceptable:
+
+- AgentMux is a **local, single-user agent workbench**; the data dir is already owner-only (`0700`).
+- The cookie jar holds session cookies for the user's own logged-in services — not shared multi-user
+  secrets — and an attacker with read access to a `0700` home dir has already lost regardless of OSCrypt.
+- The product requirement (no OS credential prompts) is a hard constraint; this is the standard way CEF
+  apps satisfy it.
+
+This reverses the earlier "prompt is appropriate for released builds" decision; the reversal and its
+rationale are recorded in the code comment + the retro.
+
+## Implementation
+
+- `agentmux-cef/src/app.rs`: delete the `is_dev_runtime` computation and the `if is_dev_runtime { … }`
+  wrapper; append `--password-store=basic` (always) and `--use-mock-keychain` (always, macOS `cfg`).
+  Rewrite the comment block.
+
+## Verification
+
+1. `cargo build -p agentmux-cef` (host compiles).
+2. Re-run `task package:macos`; launch the signed `.app`:
+   - **No** Keychain "confidential information" prompt.
+   - The window **opens** (confirming the prompt-induced hang is resolved — same root cause).
+   - A `renderer` subprocess spawns; `lsappinfo` shows the app `Foreground` with a Dock tile.
+3. Spot-check Linux/Windows parity is unaffected at compile time (no `cfg` break).
+
+## Rollout
+
+- Land this as its own PR (the credential fix). It is a prerequisite for any usable packaged macOS
+  build; the `task package:macos` tooling + notarization (Apple-agreement 403) are tracked separately.


### PR DESCRIPTION
## Symptom

A packaged AgentMux build (installed/portable) pops the macOS dialog **"AgentMux wants to use your confidential information stored in 'Login' in your keychain"** on first launch. On macOS this modal **blocks Chromium startup**, so the app hangs with no window (the GPU subprocess times out with "no connection"). Equivalent prompts exist on Linux (gnome-keyring/kwallet) and Windows (CredVault).

## Root cause

`agentmux-cef/src/app.rs` gated the switches that keep Chromium's `OSCrypt` away from the OS credential store — `--password-store=basic` and (macOS) `--use-mock-keychain` — to `RuntimeMode::Dev`. Installed/portable builds skipped them, so `OSCrypt` derives its cookie encryption key from the **platform-native credential store** and prompts the first time it's touched — even though AgentMux never saves a password.

The gate was a deliberate prior decision ("the prompt is appropriate for released builds") but was **never exercised on macOS** because `task package:macos` was a TODO stub until now — so the conflict with the product requirement (*no OS credential prompts*) was latent.

## Fix

Ungate the switches so they apply in **all** runtime modes (dev / installed / portable):
- `--password-store=basic` — appended on every platform.
- `--use-mock-keychain` — appended in all modes, **macOS only** (`#[cfg]` kept).

The diff is a **net deletion** of the `is_dev_runtime` condition around two platform-agnostic `append_switch` calls — no type/state/`cfg` changes, so **no Windows compile risk** (the #1192 failure mode is avoided).

### Tradeoff (documented in the spec + code comment)

Chromium's cookie jar is then encrypted at rest with an obfuscation key rather than an OS-credential-derived one. Acceptable for AgentMux's **local single-user** threat model (data dir already `0700`; the cookie jar holds the user's own session cookies, not shared secrets). This reverses the earlier "prompt is appropriate for released builds" decision.

## Verification

Re-packaged the installed-mode `.app` and launched it:
- **Keychain prompt: gone.** Before the fix the app hung GPU-only at the keychain modal; after, it progresses *past* OSCrypt init and spawns the full subprocess set + attempts the renderer. The credential-prompt hang is resolved.
- A **separate** signed-bundle subprocess crash-loop surfaced (renderer/GPU under hardened runtime) — that's the independent hard part of macOS CEF packaging (Helper apps / hardened-runtime), **not** a credentials issue; tracked with the `task package:macos` work.

## Docs
- Spec: `docs/specs/SPEC_SUPPRESS_OS_CREDENTIAL_PROMPTS_2026_05_30.md`
- Retro (incident + mis-diagnosis lesson): `docs/retro/retro-macos-keychain-prompt-2026-05-30.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)