### PR TITLE
refactor(term): remove the Stage-1 RAF write-coalescer (double-rAF)

### DIFF
--- a/.changesets/1780156312-feat-term-disablerafcoalesce.md
+++ b/.changesets/1780156312-feat-term-disablerafcoalesce.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(term): term:disablerafcoalesce — opt-in double-rAF tear-out for typing smoothness (input-first #1161)

--- a/.changesets/1780161722-refactor-term-remove-double-raf.md
+++ b/.changesets/1780161722-refactor-term-remove-double-raf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(term): remove the Stage-1 RAF write-coalescer (double-rAF) — xterm RenderDebouncer is the only frame gate (input-first #1161)

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -67,9 +67,6 @@ pub struct SettingsType {
     #[serde(rename = "term:disablewebgl", default, skip_serializing_if = "is_false")]
     pub term_disable_web_gl: bool,
 
-    #[serde(rename = "term:disablerafcoalesce", default, skip_serializing_if = "is_false")]
-    pub term_disable_raf_coalesce: bool,
-
     #[serde(rename = "term:localshellpath", default, skip_serializing_if = "String::is_empty")]
     pub term_local_shell_path: String,
 

--- a/docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md
+++ b/docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md
@@ -1,90 +1,107 @@
-# SPEC: Terminal double-rAF tear-out (experiment)
+# SPEC: Remove the terminal Stage-1 RAF write-coalescer (double-rAF)
 
-**Status:** Experimental — behind a default-off setting
+**Status:** Implemented — pending Windows-10 verification before release
 **Date:** 2026-05-30
 **Author:** AgentY
-**Setting:** `term:disablerafcoalesce` (boolean, default `false`)
+**PR:** #1211 (supersedes #1206, which added an opt-in flag — now removed)
 **Tracks:** [`SPEC_INPUT_RESPONSIVENESS_*`](./SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md) · [discussion #1161](https://github.com/agentmuxai/agentmux/discussions/1161) · bench PR #1203
 
 ---
 
 ## TL;DR
 
-The terminal PTY→screen path runs **two `requestAnimationFrame` coalescers in series**:
+The terminal PTY→screen path ran **two `requestAnimationFrame` coalescers in series**:
 
 ```
 PTY msg → [our Stage-1 rAF: termwrap.scheduleRafWrite/armRaf] → terminal.write()
         → [xterm's own rAF: RenderDebouncer] → paint
 ```
 
-xterm.js already renders at most **once per animation frame** (its `RenderDebouncer`
-guards on `_animationFrame` and merges dirty rows). Our Stage-1 rAF is therefore a
-**second, unsynchronized frame gate**. Two gates in series can add up to ~32 ms and
-**beat against each other** — the likely cause of the uneven frame pacing ("not
-silky" hiccups) measured while holding a key: ~56 fps, frame p50 16.7 ms with a
-33–50 ms tail, **0 JS long-tasks**, sub-ms xterm marks (PR #1203 diagnostic).
+xterm.js already renders **at most once per animation frame** (its `RenderDebouncer`
+guards on `_animationFrame` and merges dirty rows). Our Stage-1 rAF was therefore a
+**second, unsynchronized frame gate** — it added latency and **beat against** xterm's
+rAF, producing the uneven frame pacing ("not silky" hiccups) measured while holding a
+key: ~56 fps, frame p50 16.7 ms with a 33–50 ms tail, **0 JS long-tasks**, sub-ms
+xterm marks (PR #1203 diagnostic). VS Code (same xterm.js, same Chromium) uses **only**
+xterm's built-in debouncer.
 
-VS Code (same xterm.js, same Chromium) uses **only** xterm's built-in debouncer.
+**This change removes the Stage-1 rAF entirely.** There is no second coalescer and no
+setting — *we don't need two.* PTY output writes straight to `terminal.write()`
+(`termwrap.doTerminalWrite`); xterm's `RenderDebouncer` is the single frame gate.
 
-This change adds `term:disablerafcoalesce`. When set, `scheduleRafWrite()` writes
-**straight to `terminal.write()`** and lets xterm own coalescing — removing our
-Stage-1 rAF. Default is unchanged behavior (coalesce on).
+## History — why it existed, and the two-step removal
 
-## Why we have the Stage-1 rAF (don't delete blindly)
+The Stage-1 rAF fixed real bugs, in a four-commit arc:
 
-Full provenance — it fixed real bugs, in four commits:
+| Commit | PR | What |
+|---|---|---|
+| `ab9c38d6` | #208 | **Introduced it.** Ink TUIs emit cursor-up + content as separate WS messages; two `terminal.write()`s snapped the viewport up-then-down = **double flash**. On **Windows 10** DWM presents each snap as a distinct frame; **on Windows 11 they coalesce within vsync (invisible).** |
+| `7f442735` | #235 | `writeInFlight` guard — a slow write (large scrollback) let a second concurrent rAF write reintroduce the flash. |
+| `5bcf503f` | #276 | ≤512 B echo **fast-path** — the rAF was taxing echo; small writes bypass it. |
+| `e58707766` | #926 | removed `writeInFlight` from the fast path — it still stalled echo during big writes ("sporadic jitter"). |
 
-| Commit | PR | Author | What |
-|---|---|---|---|
-| `ab9c38d6` | #208 (2026-03-22) | AgentA | **Introduced it.** Ink TUIs emit cursor-up + content as separate WS messages; two `terminal.write()`s snapped the viewport up-then-down = **double flash**. On **Windows 10** DWM presents each snap as a distinct frame; **on Windows 11 they coalesce within vsync (invisible).** Stage-1 rAF merges same-frame chunks into one write. |
-| `7f442735` | #235 | AgentA | Added `writeInFlight` guard — a slow write (large scrollback) let a second concurrent rAF write reintroduce the flash. |
-| `5bcf503f` | #276 | AgentA | Added the ≤512 B **fast-path** — the rAF was taxing echo; small writes bypass it. |
-| `e58707766` | #926 | AgentY | Removed `writeInFlight` from the fast path — it still stalled echo during big writes ("sporadic jitter"). |
+#235→#276→#926 was a **progressive retreat** carving the echo path back *out* of the
+coalescer because the extra frame gate kept causing latency. PR #1206 then added an
+opt-in `term:disablerafcoalesce` flag to A/B the full bypass — confirmed **"much
+better"** on Windows 11. **This change is the end of that arc:** the flag and the
+entire Stage-1 machinery are deleted. One coalescer, not two; no dead toggle.
 
-The arc #235→#276→#926 is a **progressive retreat**: each step carved the echo
-path back *out* of the coalescer because the extra frame gate kept causing
-latency. The tear-out is the logical end of that arc — but the **original Win10
-flash is the load-bearing reason it exists**, so removal must be Win10-verified.
+## What changed (this PR)
 
-## Behavior
+`frontend/app/view/term/termwrap.ts`:
+- Deleted fields `rafBuffer`, `rafPending`, `writeInFlight`, and `coalesceWrites`.
+- Deleted `RAF_BYPASS_THRESHOLD`, `scheduleRafWrite()`, and `armRaf()`.
+- `handleNewFileSubjectData` now calls `doTerminalWrite(decodedData)` directly,
+  preserving the `term-echo-render` perf mark for ≤32 B writes (closed in
+  `doTerminalWrite`'s write callback).
 
-- `term:disablerafcoalesce` absent/`false` (default): unchanged. ≤512 B echoes
-  fast-path; larger/streamed chunks buffer into our rAF, merged once per frame.
-- `term:disablerafcoalesce: true`: every PTY write goes **directly** to
-  `terminal.write()`; xterm's `RenderDebouncer` is the only frame gate.
+Setting removal (it had exactly one reader, now gone):
+- `frontend/app/view/term/term.tsx` — dropped the `coalesceWrites` option.
+- `frontend/app/view/term/termwrap.ts` — dropped `coalesceWrites` from `TermWrapOptions`.
+- `schema/settings.json`, `frontend/types/gotypes.d.ts`,
+  `agentmux-srv/src/backend/wconfig/types.rs` — removed `term:disablerafcoalesce`.
 
-Wired: `term.tsx` reads the setting → `TermWrap` `coalesceWrites` option →
-early-return branch in `scheduleRafWrite()`. Plumbed through schema, gotypes,
-and `wconfig` so the key round-trips.
+Perf marks: `term-keypress` and `term-echo-render` unchanged; `term-raf-write` is
+gone (there is no rAF write). Net **−96 lines** across 6 files.
 
-## Verification protocol (the point of the flag)
+Build verified: `npx tsc --noEmit` — no new errors (27-error pre-existing baseline
+unchanged; none in `termwrap.ts`/`term.tsx`). `cargo check -p agentmux-srv` — clean.
+`schema/settings.json` valid JSON.
 
-A/B on the **same build** (no rebuild — just edit `settings.json`, settings hot-reload):
+## ⚠️ Windows-10 verification — REQUIRED before this ships in a release
 
-### Test 1 — does the Windows-10 scroll-flash regress? (BLOCKING)
-This is the reason the coalescer exists. **Must run on a real Windows 10 machine.**
-1. Open a terminal, run an Ink TUI that redraws heavily (e.g. a Claude Code / Codex
-   session, or any full-screen `ink`/`blessed` app that emits cursor-up + content).
-2. Baseline: `term:disablerafcoalesce` unset. Note scroll stability.
-3. Tear-out: set `term:disablerafcoalesce: true`, reload, repeat the same workload.
-4. **PASS** = no viewport up/down flash in tear-out mode. **FAIL** = flash returns →
-   xterm's debouncer alone is insufficient; do NOT flip the default (consider a
-   smaller targeted merge instead of a full second rAF).
+The Stage-1 rAF existed specifically to fix the **Windows-10 DWM scroll-flash** (PR
+#208), which is invisible on Windows 11. So the Win11 "much better" result does **not**
+clear Win10. On **real Windows 10**:
 
-### Test 2 — do the typing hiccups improve?
-On both Win10 and Win11:
-1. Focus a terminal, run `node tools/tests/term-keyrepeat-hiccups.mjs --secs 18`
-   while holding a key, with the flag OFF → record VALID baseline.
-2. Set the flag ON, reload, repeat.
-3. Compare jank-frame counts (>33 ms) and the p99/max frame tail. Expect the
-   tail to shrink if the double-rAF beat was the cause.
+### Test 1 — flash regression (BLOCKING)
+1. Open a terminal, run an Ink TUI that redraws heavily (a Claude Code / Codex session,
+   or any full-screen `ink`/`blessed` app emitting cursor-up + content).
+2. Compare a build **with** this change against one **without** it (or the last release).
+3. **PASS** = no viewport up/down flash with the rAF removed. **FAIL** = flash returns →
+   xterm's debouncer alone is insufficient; do not ship; see "If it regresses" below.
+
+### Test 2 — hiccup delta (confirms the win)
+`node tools/tests/term-keyrepeat-hiccups.mjs --secs 18` (PR #1203) while holding a key,
+before vs after. Expect the >33 ms jank count and the p99/max frame tail to shrink.
 
 ### Test 3 — streaming throughput / ordering (no regression)
-`node tools/tests/bench-term-echo.mjs --stream --busy` with flag on vs off —
-confirm no new ordering violations and no echo-latency regression under load.
+`node tools/tests/bench-term-echo.mjs --stream --busy` before vs after — no new ordering
+violations, no echo-latency regression under load.
 
-## Rollout
+**Theory it passes even on Win10:** xterm's `RenderDebouncer` renders only once per
+animation frame, so the intermediate cursor-up/content viewport state should never paint
+as a separate frame even when the two writes arrive separately. The #208 flash came from
+*our* path issuing two `terminal.write()`s that each forced a viewport sync before
+xterm's debounced render; removing our coalescer leaves xterm's single debounced render
+in charge. Test 1 confirms or refutes this.
 
-If Test 1 passes on Win10 AND Tests 2–3 show improvement with no regression,
-a follow-up flips the default (or removes Stage-1 entirely). Until then this ships
-**default-off** — pure opt-in, safe for all users.
+## If the Win10 flash regresses
+
+The correct fix is **backend-side read coalescing**, NOT a second frontend rAF: in the
+PTY read loop (`agentmux-srv/src/backend/blockcontroller/shell.rs` — `spawn_blocking`,
+`PTY_READ_BUF_SIZE` 4 KiB, `handle_append_block_file(..., None)`), merge consecutive
+reads within a small window (~2–4 ms) into one `block:file` append event. That kills the
+flash at the source (the root cause per #208 is *"PTY data arrives as separate WS
+messages"*) and works on both platforms without re-introducing a per-frame beat. This
+frontend removal composes with it.

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -184,7 +184,6 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 keydownHandler: model.handleTerminalKeydown.bind(model),
                 useWebGl: !ts?.["term:disablewebgl"],
                 sendDataHandler: model.sendDataToController.bind(model),
-                coalesceWrites: !ts?.["term:disablerafcoalesce"],
             }
         );
         window.term = termWrap;

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -49,12 +49,6 @@ type TermWrapOptions = {
     keydownHandler?: (e: KeyboardEvent) => boolean;
     useWebGl?: boolean;
     sendDataHandler?: (data: string) => void;
-    // When false, bypass our own RAF write-coalescer and write straight to
-    // xterm.js, letting its built-in RenderDebouncer own frame coalescing.
-    // Removes the "double rAF" (our rAF feeding xterm's rAF). Default true
-    // (keep the Tier-3 Win10 scroll-flash fix, PR #208). Toggled by the
-    // `term:disablerafcoalesce` setting — see SPEC_TERM_DOUBLE_RAF_TEAROUT.
-    coalesceWrites?: boolean;
 };
 
 /**
@@ -90,12 +84,6 @@ export class TermWrap {
     private toDispose: TermTypes.IDisposable[] = [];
     pasteActive: boolean = false;
     lastUpdated: number;
-    private rafBuffer: Uint8Array[] = [];
-    private rafPending: boolean = false;
-    private writeInFlight: boolean = false;
-    // Stage-1 RAF coalescer toggle. true = coalesce (default, Tier-3 fix);
-    // false = write straight to xterm (double-rAF tear-out experiment).
-    private coalesceWrites: boolean = true;
     // Thaw-cycle handles — cleared in dispose() so callbacks don't fire
     // on a disposed Terminal. dispose() doesn't null `this.terminal`, so
     // a null-check guard alone isn't enough.
@@ -114,7 +102,6 @@ export class TermWrap {
         this.loaded = false;
         this.blockId = blockId;
         this.sendDataHandler = waveOptions.sendDataHandler;
-        this.coalesceWrites = waveOptions.coalesceWrites ?? true;
         this.ptyOffset = 0;
         this.dataBytesProcessed = 0;
         this.lastUpdated = Date.now();
@@ -459,7 +446,13 @@ export class TermWrap {
         } else if (msg.fileop == "append") {
             const decodedData = base64ToArray(msg.data64);
             if (this.loaded) {
-                this.scheduleRafWrite(decodedData);
+                // Write straight to xterm.js — its built-in RenderDebouncer is the
+                // single frame-coalescer (one render per animation frame). We no
+                // longer run our own RAF coalescer on top (the "double rAF" removed
+                // in SPEC_TERM_DOUBLE_RAF_TEAROUT). The ≤32B echo perf mark is
+                // started here and closed in doTerminalWrite's write callback.
+                if (decodedData.length <= 32) markStart('term-echo-render');
+                this.doTerminalWrite(decodedData, null);
             } else {
                 this.heldData.push(decodedData);
             }
@@ -469,98 +462,21 @@ export class TermWrap {
         }
     }
 
-    // Tier-3 scroll fix: RAF-batched writes with sequential drain.
+    // PTY output is written straight to xterm.js (doTerminalWrite). xterm's own
+    // RenderDebouncer is the single frame-coalescer — one render per animation
+    // frame, with dirty rows merged. We previously ran our OWN RAF write-coalescer
+    // on top of that (Stage-1 rAF: scheduleRafWrite/armRaf), a second frame gate
+    // that beat against xterm's rAF and caused uneven typing frame-pacing. Removed
+    // in SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.
     //
-    // PTY data arrives as separate WebSocket messages. Each doTerminalWrite() call
-    // triggers an xterm.js viewport sync. When Ink's cursor-up chunk and content chunk
-    // land in back-to-back messages, the viewport snaps up then back down — two flashes
-    // per render cycle, visible on Windows 10 as the DWM compositor presents each snap
-    // as a distinct frame.
-    //
-    // Buffering writes until the next animation frame coalesces same-cycle chunks into
-    // one terminal.write() call so xterm.js only updates the viewport once, to the final
-    // cursor position (back at bottom). Latency added: ≤ 16ms — imperceptible during
-    // streaming output.
-    //
-    // writeInFlight ensures no second RAF fires while a slow write (large scrollback buffer)
-    // is still in progress. Without this guard, rafPending resets before doTerminalWrite
-    // resolves, letting a concurrent write race and causing the same flash at high bufLines.
-    //
-    // Fast path: small chunks (character echo, single completions) bypass RAF entirely.
-    // The scroll-flicker pattern only occurs when Ink emits cursor-up + content as separate
-    // WebSocket messages — that only happens with large multi-chunk outputs. A single
-    // echoed character (1–4 bytes) is never split, so there is no flicker risk.
-    // Bypassing RAF here eliminates the ≤16ms echo delay (and the writeInFlight stall)
-    // that made typing feel sluggish during PTY output.
-    private static readonly RAF_BYPASS_THRESHOLD = 512; // bytes
-
-    private scheduleRafWrite(data: Uint8Array) {
-        // Double-rAF tear-out (term:disablerafcoalesce=true): bypass our Stage-1
-        // rAF coalescer entirely and write straight to xterm.js. xterm's own
-        // RenderDebouncer already coalesces same-frame writes into one render, so
-        // our extra rAF is a SECOND frame gate in series — adding latency and
-        // beating against xterm's rAF (uneven frame pacing / "hiccups"). Writing
-        // direct lets xterm own coalescing, matching how VS Code drives xterm.
-        //
-        // EXPERIMENTAL — default is coalesce=true. Our Stage-1 rAF was added to
-        // fix a real Windows-10 DWM scroll-flash with Ink TUIs (cursor-up +
-        // content arriving as separate WS messages presented as two frames; PR
-        // #208). On Windows 11 the compositor coalesces those within vsync, so
-        // the fix may be obsolete there. MUST be re-verified on Windows 10
-        // before flipping the default. See SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.
-        if (!this.coalesceWrites) {
-            if (data.length <= 32) markStart('term-echo-render');
-            this.doTerminalWrite(data, null);
-            return;
-        }
-        // Fast path: small data, nothing buffered — bypass RAF to eliminate echo delay.
-        // writeInFlight is intentionally NOT checked here: xterm.js serialises all
-        // terminal.write() calls internally, so a concurrent small write always lands
-        // after the in-flight batch without ordering issues. Removing the writeInFlight
-        // guard eliminates the extra RAF cycle (≤16ms) that was stalling echo rendering
-        // while a large PTY write was in progress, causing the sporadic keypress delays.
-        if (data.length <= TermWrap.RAF_BYPASS_THRESHOLD && this.rafBuffer.length === 0) {
-            if (data.length <= 32) markStart('term-echo-render');
-            this.doTerminalWrite(data, null);
-            return;
-        }
-        this.rafBuffer.push(data);
-        this.armRaf();
-    }
-
-    // Schedule a RAF flush if one isn't already pending and no write is in flight.
-    private armRaf() {
-        if (this.rafPending || this.writeInFlight) return;
-        this.rafPending = true;
-        requestAnimationFrame(() => {
-            this.rafPending = false;
-            if (this.rafBuffer.length === 0) return;
-            const totalLen = this.rafBuffer.reduce((n, b) => n + b.length, 0);
-            const merged = new Uint8Array(totalLen);
-            let offset = 0;
-            for (const chunk of this.rafBuffer) {
-                merged.set(chunk, offset);
-                offset += chunk.length;
-            }
-            const chunkCount = this.rafBuffer.length;
-            this.rafBuffer = [];
-            this.writeInFlight = true;
-            markStart('term-raf-write');
-            const t0 = performance.now();
-            this.doTerminalWrite(merged, null).then(() => {
-                this.writeInFlight = false;
-                const elapsed = performance.now() - t0;
-                markEnd('term-raf-write', 'done');
-                const bufLines = this.terminal.buffer.active.length;
-                if (elapsed > 4) {
-                    console.warn(`[raf-write] SLOW chunks=${chunkCount} bytes=${totalLen} elapsed=${elapsed.toFixed(1)}ms bufLines=${bufLines}`);
-                }
-                // Drain any data that arrived while the write was in progress.
-                if (this.rafBuffer.length > 0) this.armRaf();
-            });
-        });
-    }
-
+    // The Stage-1 rAF originally fixed a Windows-10 DWM scroll-flash with Ink TUIs
+    // (cursor-up + content arriving as separate WS messages presented as two
+    // frames; PR #208) — invisible on Windows 11, where the compositor coalesces
+    // within vsync. xterm's debouncer renders only once per frame, so the
+    // intermediate up/down viewport state should not paint separately even on
+    // Win10; that must be re-verified on real Windows 10 (see the spec). If the
+    // flash regresses, the fix is backend-side read coalescing (merge consecutive
+    // PTY reads into one WS message in agentmux-srv), NOT a second frontend rAF.
     doTerminalWrite(data: string | Uint8Array, setPtyOffset?: number): Promise<void> {
         const isSmall = data.length <= 32;
         let resolve: () => void = null;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1297,7 +1297,6 @@ declare global {
         "term:zoom"?: number;
         "term:theme"?: string;
         "term:disablewebgl"?: boolean;
-        "term:disablerafcoalesce"?: boolean;
         "term:localshellpath"?: string;
         "term:localshellopts"?: string[];
         "term:scrollback"?: number;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -35,10 +35,6 @@
         "term:disablewebgl": {
           "type": "boolean"
         },
-        "term:disablerafcoalesce": {
-          "type": "boolean",
-          "description": "EXPERIMENTAL. Bypass AgentMux's own RAF write-coalescer and write PTY output straight to xterm.js (which coalesces internally). Removes a redundant frame gate that can cause uneven typing frame-pacing. Default false. The coalescer originally fixed a Windows-10 DWM scroll-flash (PR #208) — verify no flash regression on Windows 10 before relying on this. See SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30."
-        },
         "term:localshellpath": {
           "type": "string"
         },


### PR DESCRIPTION
## What

Removes our **Stage-1 RAF write-coalescer** from the terminal entirely. PTY output now writes straight to `terminal.write()` and **xterm.js's own `RenderDebouncer` is the only frame-coalescer**. Also removes the opt-in `term:disablerafcoalesce` setting added in #1206 — **we don't need two coalescers or a dead toggle.** Supersedes #1206.

Tracks [#1161](https://github.com/agentmuxai/agentmux/discussions/1161); companion to the diagnostic in #1203.

## Why

The PTY→screen path ran **two `requestAnimationFrame` coalescers in series**:

```
PTY msg → [our Stage-1 rAF: scheduleRafWrite/armRaf] → terminal.write()
        → [xterm's own rAF: RenderDebouncer] → paint
```

xterm renders **at most once per animation frame** already, so ours was a second, unsynchronized frame gate that **beat against** xterm's rAF → the uneven typing frame-pacing ("not silky" hiccups): **~56 fps, frame p50 16.7 ms with a 33–50 ms tail, 0 JS long-tasks, sub-ms xterm marks** (PR #1203). Removing it was confirmed *much smoother* on Win11 via the #1206 flag; this makes it the only behavior.

## Changed

- `termwrap.ts`: deleted `rafBuffer` / `rafPending` / `writeInFlight` / `RAF_BYPASS_THRESHOLD` / `scheduleRafWrite()` / `armRaf()` and the `coalesceWrites` option. `handleNewFileSubjectData` calls `doTerminalWrite` directly (keeps the `term-echo-render` mark; `term-raf-write` is gone with the rAF).
- Removed `term:disablerafcoalesce` from `term.tsx`, `schema/settings.json`, `gotypes.d.ts`, `wconfig/types.rs`.
- Rewrote `docs/specs/SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md` for the full removal.

Net **−96 lines** (156 del / 60 ins).

## ⚠️ Windows-10 verification — REQUIRED before release

The Stage-1 rAF existed to fix a **Windows-10 DWM scroll-flash** with Ink TUIs (PR #208), invisible on Win11. So the Win11 result does **not** clear Win10. On **real Windows 10**, run an Ink TUI (Claude Code / Codex session) and confirm **no viewport up/down flash** without the rAF; also run `term-keyrepeat-hiccups.mjs` (#1203) before/after.

**Theory it passes:** xterm's debouncer renders once per frame, so the intermediate cursor-up/content viewport state shouldn't paint separately even on Win10 — the #208 flash came from *our* path forcing two viewport syncs. If it regresses, the fix is **backend read-coalescing in `shell.rs`** (merge consecutive PTY reads into one WS message), not a second frontend rAF.

## Build
- `npx tsc --noEmit`: no new errors (27 pre-existing baseline unchanged; none in termwrap.ts/term.tsx)
- `cargo check -p agentmux-srv`: clean

Changeset: `patch`.