### PR TITLE
fix(agent-pane): gate send-now zone on an interruptible turn

### DIFF
--- a/.changesets/1780246791-fix-agent-pane-gate-send-now-zone-on-an-interruptible-turn-091f.md
+++ b/.changesets/1780246791-fix-agent-pane-gate-send-now-zone-on-an-interruptible-turn-091f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): gate send-now zone on an interruptible turn

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -822,6 +822,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 so it sits adjacent to the messages it accelerates. */}
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
+                interruptibleTurn={() =>
+                    isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]())
+                }
                 showSendNow={() =>
                     // "Send now" appears only when there is an in-flight
                     // turn that SIGINT can actually interrupt — i.e.

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -26,10 +26,15 @@ interface PendingMessagesPanelProps {
     /** Fires when the user clicks "Send now". Caller is expected to
      *  SIGINT the running turn so the queued messages drain. */
     onSendImmediately?: () => void;
+    /** True when a CLI turn is genuinely in flight (Streaming/Interrupting)
+     *  — i.e. there's a running turn to queue behind. Gates the whole zone
+     *  so the optimistic-enqueue transient during `Submitting` (every idle
+     *  send) no longer flashes the "Queued" box. Shown when absent. */
+    interruptibleTurn?: Accessor<boolean>;
 }
 
 export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => (
-    <Show when={props.pendingMessages().length > 0}>
+    <Show when={props.pendingMessages().length > 0 && (props.interruptibleTurn?.() ?? true)}>
         <div class="agent-pending-zone">
             <div class="agent-pending-header">
                 <span class="agent-spinner-dot" />


### PR DESCRIPTION
## Summary

The queued-messages zone (`PendingMessagesPanel`) rendered whenever `pendingMessages()` was non-empty. But during the **`Submitting`** phase of every idle send, the message is optimistically enqueued for a frame before the turn starts — so the **"Queued" box flashed on every normal send**, with no running turn to queue behind.

## Fix

Gate the whole zone on a genuinely **interruptible** turn (`Streaming` / `Interrupting`) via a new `interruptibleTurn` accessor (`isInterruptibleTurn(turnPhase)`) — so the zone only appears when there's actually a running turn the queued messages sit behind. Defaults to shown when the prop is absent (back-compat).

## Test plan

- [ ] Send a message while the agent is **idle** → no "Queued" flash.
- [ ] Send while a turn is **streaming** → queued zone + "Send now" appear as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)