### PR TITLE
perf: drop sysinfo cascade-diagnostic instrumentation (ac70ff59 cleanup)

### DIFF
--- a/.changesets/1780247983-perf-drop-sysinfo-cascade-diag-instrumentation-332b.md
+++ b/.changesets/1780247983-perf-drop-sysinfo-cascade-diag-instrumentation-332b.md
@@ -1,0 +1,31 @@
+---
+type: patch
+---
+
+perf: drop sysinfo cascade-diagnostic instrumentation
+
+Commit ac70ff59 (2026-05-28) added temporary diagnostic instrumentation to
+the sysinfo broadcast hot path — two `tracing::warn!` calls in
+`Broker::publish` (one per missing-client branch, one per zero-routes
+sysinfo branch) and two per-tick `console.log("[fe] sysinfo:* handler …")`
+emits in the status-bar widgets (`SystemStats`, `BackendStatus`). All four
+were tagged "Remove once the cascade root cause lands."
+
+The cascade root cause has since landed. The diag is no longer needed and
+is shipping in production builds, where:
+
+- The two FE `console.log` calls fire every sysinfo tick (~1 Hz × 2
+  widgets) → routed through CEF's console→host bridge → synchronous
+  `tracing::info!` → disk. Locally measured at ~70k `[fe] sysinfo:*` lines
+  per day in the host log on Linux. Each emit also rides the main thread's
+  IPC bridge, adding noise to the input-first hot path.
+- The two backend `tracing::warn!` calls fire from inside the broker
+  mutex, with `event.scopes` formatted as `?` debug on every sysinfo
+  publish whose route lookup is empty.
+
+This commit removes all four diagnostics. The widget bodies revert to the
+shape they had pre-ac70ff59 (no diagnostic logging around the reactive
+setStats / setUptimeSecs calls). The broker's `client is None` arm
+becomes a plain early return; the zero-routes branch is deleted entirely.
+
+Net: 1 insertion / 29 deletions across 3 files.

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -315,26 +315,10 @@ impl Broker {
 
         let client = match &inner.client {
             Some(c) => c,
-            None => {
-                // Diagnostic for agent-pane cascade freeze (2026-05-28):
-                // if the bridge gets dropped, every publish silently no-ops.
-                tracing::warn!(target: "wps-diag", event = %event.event,
-                    "broker.publish: client is None — no delivery");
-                return;
-            }
+            None => return,
         };
 
         let route_ids = Self::get_matching_routes(&inner, &event);
-        // Diagnostic for agent-pane cascade freeze (2026-05-28): if sysinfo
-        // is published but no routes match, the status-bar widgets will
-        // freeze. Pair with `[fe] sysinfo:* handler` console logs to
-        // distinguish broker-drop from FE-scheduler-stall. Remove once
-        // the cascade root cause lands.
-        if route_ids.is_empty() && event.event == "sysinfo" {
-            tracing::warn!(target: "wps-diag",
-                scopes = ?event.scopes,
-                "broker.publish: 0 routes for sysinfo event");
-        }
         for route_id in route_ids {
             client.send_event(&route_id, event.clone());
         }

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -64,20 +64,12 @@ const BackendStatus = (): JSX.Element => {
     // Drive uptime from sysinfo event timestamp so all windows update in sync.
     // The backend broadcasts sysinfo with a server-side ts (ms epoch); all windows
     // receive the same ts and compute the same integer, eliminating phase drift.
-    //
-    // Diagnostic instrumentation (2026-05-28): the per-agent-pane cascade
-    // crash has been observed to leave this widget's value frozen until a
-    // sysinfo widget pane is opened. The console.log distinguishes:
-    //   - log silent + DOM frozen  → backend stopped delivering (broker drop)
-    //   - log fires + DOM frozen   → SolidJS scheduler / render-effect stuck
-    // Remove once the cascade root cause lands.
     onMount(() => {
         const unsub = waveEventSubscribe({
             eventType: "sysinfo",
             scope: "local",
             handler: (event) => {
                 const ts: number | undefined = (event as WaveEvent)?.data?.ts;
-                console.log("[fe] sysinfo:BackendStatus handler ts=", ts);
                 const start = startedAt();
                 if (ts != null && start != null) {
                     setUptimeSecs(Math.floor((ts - start) / 1000));

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -44,16 +44,12 @@ function memColor(used: number, total: number): string {
 const SystemStats = (): JSX.Element => {
     const [stats, setStats] = createSignal<SysStats | null>(null);
 
-    // Diagnostic instrumentation (2026-05-28): pairs with BackendStatus
-    // to confirm whether the agent-pane cascade freeze is broker-side
-    // (handler silent) or scheduler-side (handler fires, DOM stays stale).
     onMount(() => {
         const unsub = waveEventSubscribe({
             eventType: "sysinfo",
             scope: "local",
             handler: (event) => {
                 const vals = (event as WaveEvent)?.data?.values;
-                console.log("[fe] sysinfo:SystemStats handler vals=", vals != null);
                 if (vals == null) return;
                 setStats({
                     cpu: vals["cpu"] ?? 0,


### PR DESCRIPTION
## Summary

Removes the four diagnostic instrumentations added in #ac70ff59 (2026-05-28) explicitly tagged *"Remove once the cascade root cause lands."* The cascade root cause has since landed; the diag is no longer needed and is shipping in production.

**Removed:**
- `agentmux-srv/src/backend/wps.rs` — two `tracing::warn!` calls in `Broker::publish` (no-client and zero-routes-for-sysinfo branches).
- `frontend/app/statusbar/SystemStats.tsx` — per-tick `console.log("[fe] sysinfo:SystemStats handler vals=", ...)`.
- `frontend/app/statusbar/BackendStatus.tsx` — per-tick `console.log("[fe] sysinfo:BackendStatus handler ts=", ...)`.

## Why this matters (Linux esp.)

Each FE `console.log` rides the CEF console→host bridge → synchronous `tracing::info!` → disk. Two widgets × ~1 Hz sysinfo tick = ~70k `[fe] sysinfo:*` host-log lines per day measured locally. Plus IPC overhead on the input-first path. The backend `warn!`s additionally fire inside the broker mutex with `event.scopes` debug-formatted per zero-route sysinfo publish.

Net: **1 insertion / 29 deletions across 3 files.** Widget bodies revert to their pre-ac70ff59 shape; broker's `client is None` arm becomes a plain early return; the zero-routes branch is deleted entirely.

## Test plan

- [ ] `task build:backend` succeeds (Rust changes)
- [ ] `task build:frontend` succeeds (TS changes)
- [ ] Launch local build; `muxlog host` shows no `[fe] sysinfo:*` lines
- [ ] Status-bar widgets (CPU/MEM/uptime) still update once per second visually
- [ ] No `wps-diag` `warn!` lines in `muxlog srv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)