### PR TITLE
feat(macos): standard notarized DMG — CEF 148, patched renderer, launcher splash, lean packaging

### DIFF
--- a/.changesets/1780159576-feat-macos-package-macos-signed-app-dmg-with-cef-helper-app-i709.md
+++ b/.changesets/1780159576-feat-macos-package-macos-signed-app-dmg-with-cef-helper-app-i709.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(macos): package:macos — signed .app/.dmg with CEF Helper app

--- a/.changesets/1780224165-feat-macos-patched-cef-148-framework-per-type-helpers-fix-th-ko6e.md
+++ b/.changesets/1780224165-feat-macos-patched-cef-148-framework-per-type-helpers-fix-th-ko6e.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(macos): patched CEF 148 framework + per-type helpers fix the renderer on macOS 26

--- a/.changesets/1780248067-fix-macos-lean-notarized-dmg-ulmo-lzma-strip-locale-trim-167-re5q.md
+++ b/.changesets/1780248067-fix-macos-lean-notarized-dmg-ulmo-lzma-strip-locale-trim-167-re5q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): lean notarized DMG (ULMO/LZMA + strip + locale trim) — 167MB

--- a/.changesets/1780253873-feat-macos-launcher-owned-instant-splash-launcher-as-package-cfts.md
+++ b/.changesets/1780253873-feat-macos-launcher-owned-instant-splash-launcher-as-package-cfts.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(macos): launcher-owned instant splash + launcher as packaged entry point

--- a/.changesets/1780269738-fix-cef-guard-createwindowtask-against-null-client-crbrowser-q9m4.md
+++ b/.changesets/1780269738-fix-cef-guard-createwindowtask-against-null-client-crbrowser-q9m4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): guard CreateWindowTask against null client (CrBrowserMain SIGABRT on multi-window tear-off)

--- a/.changesets/1780305968-fix-macos-stop-sigabrt-on-window-close-try-close-browser-vs--p131.md
+++ b/.changesets/1780305968-fix-macos-stop-sigabrt-on-window-close-try-close-browser-vs--p131.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): stop SIGABRT on window close (try_close_browser vs window.close); bundle schema; drop dead per-type helpers

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ nul
 
 # Claude Code agent session state — worktrees, logs, todos, etc.
 .claude/
+
+# macOS packaging build artifact (signed .app — never commit)
+build/AgentMux.app/
+build/AgentMux.AppDir/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "146.7.0+146.0.12"
+version = "148.3.0+148.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09c05112b644e85d58f9e1bf7d62bc5a21a806a92129d4ed750d8cc9479abff"
+checksum = "a920bb7b8ff94c3abe487df2a7234d8fb8226369d97296a12ac863a15c168d59"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "146.7.0+146.0.12"
+version = "148.3.0+148.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693e287c4fe19ba5ed6f478bed66b1d367b06fbce904eeffafb8359a40dab24b"
+checksum = "0fc364604c75169c992b3f8bc4396634bf64cfb2a4a0545cc9c7aa4eb3931057"
 dependencies = [
  "anyhow",
  "cmake",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,10 +111,21 @@ tasks:
             - pwsh -File scripts/package-msix.ps1 {{.CLI_ARGS}}
 
     package:macos:
-        desc: "[TODO] Package the application for macOS."
+        desc: >-
+            Package the application as a signed macOS .app + .dmg (Developer ID,
+            hardened runtime). Output to ~/Desktop by default. Notarization is
+            attempted via the `notarytool` keychain profile and degrades to a
+            signed-only DMG if it's unavailable (see scripts/package-macos.sh and
+            docs/macos-signing.md). Set NOTARIZE=0 to skip notarization.
         platforms: [darwin]
+        deps:
+            - build:host
+            - build:backend
+            - build:frontend
+            - copy:schema
         cmds:
-            - echo "macOS packaging not yet implemented."
+            - task: bundle
+            - bash scripts/package-macos.sh {{.CLI_ARGS}}
 
     package:linux:
         desc: Package the application as a portable AppImage (Linux). Output to ~/Desktop by default.

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -30,7 +30,7 @@ resources_path = "resources"
 
 [dependencies]
 agentmux-common = { path = "../agentmux-common" }
-cef = { version = "146", default-features = false, features = ["build-util"] }
+cef = { version = "148", default-features = false, features = ["build-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -352,48 +352,42 @@ wrap_app! {
         ) {
             if let Some(cmd) = command_line {
                 // Prevent empty browser on visibility change (CEF #3638).
+                //
+                // Also disable MediaRouter: Chromium's Cast/DIAL device
+                // discovery probes the local network (mDNS/SSDP), which trips
+                // the macOS "AgentMux would like to find devices on your local
+                // network" prompt at launch. AgentMux never casts, so this is
+                // pure overhead — disabling it keeps the app off the local
+                // network entirely unless the user explicitly turns on LAN
+                // instance discovery (`network:lan_discovery`, off by default
+                // and lazily started). See feedback_no_os_notices_at_launch.
+                // Disabled features (comma-joined; one switch — a second
+                // --disable-features would override the first):
+                //   CalculateNativeWinOcclusion — empty browser on visibility (CEF #3638)
+                //   MediaRouter                  — Cast/DIAL local-network discovery (TCC prompt)
+                //   PreconnectToSearch           — Chromium warms the default search engine
+                //                                  (Google) at startup → www/accounts.google.com
+                //   AutofillServerCommunication  — Autofill field-metadata downloads
+                //                                  → content-autofill.googleapis.com
+                // The last two were the actual Google QUIC traffic observed via
+                // net-log; AgentMux makes no such calls itself.
                 let key = CefString::from("disable-features");
-                let val = CefString::from("CalculateNativeWinOcclusion");
+                // MachPortRendezvous{Validate,Enforce}PeerRequirements: Chromium's
+                // Mach-port peer code-sign validation. Our self-reexec CEF Helper
+                // fails it on macOS 26 (process_requirement.cc -67030), so the
+                // rendezvous denies the renderer its ports → crash-loop. The
+                // browser reads this policy from the runtime FeatureList and
+                // propagates it to children via env var, so disabling both here
+                // forces kNoValidation everywhere. (Earlier attempts used the
+                // wrong feature name.) Acceptable for a local single-user app.
+                let val = CefString::from(
+                    "CalculateNativeWinOcclusion,MediaRouter,PreconnectToSearch,\
+                     AutofillServerCommunication,MachPortRendezvousValidatePeerRequirements,\
+                     MachPortRendezvousEnforcePeerRequirements",
+                );
                 cmd.append_switch_with_value(Some(&key), Some(&val));
 
                 // ── GPU channel + frame-production tuning ─────────────────────
-                // Symptom this addresses (Linux Chromium-Ozone-Wayland on
-                // Mutter): the compositor receives ~6 Hz `BeginFrame` signals
-                // from Mutter but responds `DidNotProduceFrame` 89 % of the
-                // time. `BeginMainFrame` only fires at the sysinfo-status-bar
-                // invalidation cadence (~1 Hz). Result: xterm.js
-                // `requestAnimationFrame` callbacks (including predictive
-                // local echo's render path, #1223) are gated on those 1 Hz
-                // frames, so a held key visibly lags up to a second behind
-                // the keypress.
-                //
-                // VSCode (Electron, same Chromium codebase) does NOT have
-                // this stall on the same hardware and compositor. Its
-                // renderer + utility processes ship with:
-                //
-                //   --enable-features=EarlyEstablishGpuChannel,
-                //                     EstablishGpuChannelAsync
-                //
-                // confirmed via `/proc/<pid>/cmdline` on a running VSCode +
-                // documented in Chromium's `chrome/browser/about_flags.cc`.
-                // Both features ship enabled in stable Chrome on Linux; CEF
-                // does not enable them by default. They (a) request the GPU
-                // process channel before the renderer's first paint instead
-                // of synchronously on first paint and (b) treat the channel
-                // establishment as non-blocking, which lets the compositor
-                // start producing frames against the GPU process sooner and
-                // without serialising on the channel handshake.
-                //
-                // Hypothesis: the synchronous + late channel establishment
-                // contributes to the `DidNotProduceFrame` storm on Wayland
-                // here. Confirming empirically: trace with
-                // `scripts/capture-trace-ipv6.cjs`, look at
-                // `ProxyMain::BeginMainFrame` cadence and the
-                // `cc::Scheduler::SendDidNotProduceFrame` count before/after.
-                //
-                // Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
-                //       (host-side complement — predictive echo is renderer-
-                //       side; this is the upstream frame-production fix).
                 let gpu_features_key = CefString::from("enable-features");
                 let gpu_features_val = CefString::from(
                     "EarlyEstablishGpuChannel,EstablishGpuChannelAsync",
@@ -402,6 +396,19 @@ wrap_app! {
                     Some(&gpu_features_key),
                     Some(&gpu_features_val),
                 );
+
+                // Stop Chromium's background phone-home — the QUIC connections
+                // to Google (1e100.net) that an embedded CEF app neither needs
+                // nor should make. `disable-background-networking` covers most
+                // background subsystems; the rest get an explicit switch because
+                // Chromium leaves them on otherwise.
+                cmd.append_switch(Some(&CefString::from("disable-background-networking")));
+                cmd.append_switch(Some(&CefString::from("disable-component-update")));
+                cmd.append_switch(Some(&CefString::from("disable-domain-reliability")));
+                cmd.append_switch(Some(&CefString::from("disable-field-trial-config")));
+                let vurl = CefString::from("variations-server-url");
+                let vempty = CefString::from("");
+                cmd.append_switch_with_value(Some(&vurl), Some(&vempty));
 
                 // Initial background color, ARGB hex. alpha=00 → fully
                 // transparent → first-frame paint is alpha-aware so the

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -126,8 +126,10 @@ wrap_window_delegate! {
                 return 1;
             };
             if let Some(browser) = browser_view.browser() {
-                let browser_host = browser.host().expect("BrowserHost is None");
-                browser_host.try_close_browser()
+                match browser.host() {
+                    Some(host) => host.try_close_browser(),
+                    None => 1, // no host yet (pre-init teardown) — allow close
+                }
             } else {
                 1
             }
@@ -372,14 +374,13 @@ wrap_app! {
                 // The last two were the actual Google QUIC traffic observed via
                 // net-log; AgentMux makes no such calls itself.
                 let key = CefString::from("disable-features");
-                // MachPortRendezvous{Validate,Enforce}PeerRequirements: Chromium's
-                // Mach-port peer code-sign validation. Our self-reexec CEF Helper
-                // fails it on macOS 26 (process_requirement.cc -67030), so the
-                // rendezvous denies the renderer its ports → crash-loop. The
-                // browser reads this policy from the runtime FeatureList and
-                // propagates it to children via env var, so disabling both here
-                // forces kNoValidation everywhere. (Earlier attempts used the
-                // wrong feature name.) Acceptable for a local single-user app.
+                // MachPortRendezvous{Validate,Enforce}PeerRequirements: belt-and-
+                // suspenders flags kept for defence in depth. NOTE: the actual fix
+                // for the macOS-26 renderer crash (-67030 / errSecCSReqFailed) is
+                // the source patch in docs/cef-patches/ (GetPeerValidationPolicy →
+                // kNoValidation) — the policy is read before FeatureList init so
+                // this runtime flag cannot apply in time and is NOT the load-bearing
+                // mechanism. Do not remove the patch thinking these flags cover it.
                 let val = CefString::from(
                     "CalculateNativeWinOcclusion,MediaRouter,PreconnectToSearch,\
                      AutofillServerCommunication,MachPortRendezvousValidatePeerRequirements,\

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -327,7 +327,10 @@ impl AgentMuxHandler {
     fn on_after_created(&mut self, browser: Option<&mut Browser>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
-        let browser = browser.cloned().expect("Browser is None");
+        let Some(browser) = browser.cloned() else {
+            tracing::error!("[on_after_created] browser is None — skipping registration");
+            return;
+        };
         tracing::info!("Browser created (total: {})", self.browser_list.len() + 1);
 
         // Phase 1 diagnostic tracing — find the exact line that silences the
@@ -715,7 +718,14 @@ impl AgentMuxHandler {
         );
         dlog(&format!("on_before_close fired; browser_list.len()={}", self.browser_list.len()));
 
-        let mut browser = browser.cloned().expect("Browser is None");
+        let Some(mut browser) = browser.cloned() else {
+            // CEF can pass None during emergency teardown (e.g. process
+            // shutdown while a browser is still closing). Log and bail —
+            // a panic here SIGABRTs CrBrowserMain, which the launcher
+            // mistakes for a crash and relaunches the app.
+            tracing::error!("[on_before_close] browser is None — skipping close logic");
+            return;
+        };
 
         // Drop any crash-history entry for this browser — it's closing
         // cleanly so its budget is reset. Without this the map would

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1237,6 +1237,21 @@ impl AgentMuxHandler {
             }
         }
 
+        // macOS analogue of the Win32 splash signal: the launcher owns the
+        // native splash (see agentmux-launcher/src/splash_mac.rs) and passes a
+        // ready-file path via AGENTMUX_SPLASH_READY_FILE. Creating the file is
+        // the cross-process "first frame painted" signal the launcher polls for
+        // before tearing the splash down. Fire-and-forget; absent var => no
+        // launcher splash (e.g. dev:standalone), so this is a no-op.
+        #[cfg(target_os = "macos")]
+        {
+            if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
+                if !path.is_empty() {
+                    let _ = std::fs::write(&path, b"ready");
+                }
+            }
+        }
+
         // Show window via CEF Views API after content paints.
         // All windows (main + secondary) now use CEF Views.
         let mut browser_cloned = browser.cloned();

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -77,6 +77,43 @@ fn suppress_os_crash_dialogs() {
 #[cfg(not(target_os = "windows"))]
 fn suppress_os_crash_dialogs() {}
 
+/// Resolve CEF's `browser_subprocess_path` (the executable CEF spawns for
+/// renderer / GPU / utility processes).
+///
+/// On a packaged macOS `.app`, return the dedicated `AgentMux Helper`
+/// executable inside `Contents/Frameworks/AgentMux Helper.app` — re-execing
+/// the main bundle binary for subprocesses is rejected by the macOS process
+/// model (every child would inherit the main bundle's identity), which makes
+/// the renderers crash-loop. When no Helper.app is present (dev: a bare binary
+/// with no bundle) fall back to the current exe — self-reexec works there.
+/// Windows/Linux always use the current exe (self-reexec is fine off-bundle).
+#[cfg(target_os = "macos")]
+fn resolve_browser_subprocess_path() -> String {
+    let exe = std::env::current_exe().unwrap();
+    // exe = AgentMux.app/Contents/MacOS/agentmux-cef
+    // → AgentMux.app/Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/AgentMux Helper
+    if let Some(contents) = exe.parent().and_then(|macos| macos.parent()) {
+        let helper = contents
+            .join("Frameworks")
+            .join("AgentMux Helper.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("AgentMux Helper");
+        if helper.exists() {
+            return helper.to_string_lossy().into_owned();
+        }
+    }
+    exe.to_string_lossy().into_owned()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resolve_browser_subprocess_path() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_owned()))
+        .unwrap_or_default()
+}
+
 /// True when a launcher is THIS host's actual parent process this run.
 ///
 /// The launcher (which spawns the host directly) stamps
@@ -159,8 +196,18 @@ fn main() {
     // macOS: load the CEF framework library explicitly.
     #[cfg(target_os = "macos")]
     let _library = {
-        let loader =
-            library_loader::LibraryLoader::new(&std::env::current_exe().unwrap(), false);
+        let exe = std::env::current_exe().unwrap();
+        // Inside a packaged .app, renderer/GPU/utility subprocesses run as the
+        // bundled "AgentMux Helper" at
+        // …/Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/AgentMux Helper
+        // — 4 levels below the framework — so it must resolve the framework via
+        // the deeper `../../../../Frameworks/…` path (helper=true). The main
+        // host (Contents/MacOS/) and the bare dev binary use `../Frameworks/…`
+        // (helper=false). Detect the helper by its exe path; the main bundle
+        // binary is never under Contents/Frameworks/. See
+        // docs/specs/SPEC_MACOS_PACKAGING_2026_05_30.md.
+        let is_helper = exe.to_string_lossy().contains(".app/Contents/Frameworks/");
+        let loader = library_loader::LibraryLoader::new(&exe, is_helper);
         assert!(loader.load(), "Failed to load CEF framework");
         loader
     };
@@ -629,10 +676,14 @@ fn main() {
         framework_dir_path: framework_dir,
         log_file: cef_log_file,
         log_severity: LogSeverity::INFO,
-        // CEF subprocess (renderer, GPU) uses the same exe
-        browser_subprocess_path: CefString::from(
-            std::env::current_exe().unwrap().to_str().unwrap_or("")
-        ),
+        // CEF subprocess (renderer, GPU, utility) executable. On a packaged
+        // macOS .app this is the dedicated "AgentMux Helper" (distinct bundle
+        // id, LSUIElement) — re-execing the main bundle binary is rejected by
+        // the macOS process model and the renderers crash-loop. In dev (bare
+        // binary, no Helper.app) and on Windows/Linux it's the current exe
+        // (self-reexec, which works there). See
+        // docs/specs/SPEC_MACOS_PACKAGING_2026_05_30.md.
+        browser_subprocess_path: CefString::from(resolve_browser_subprocess_path().as_str()),
         ..Default::default()
     };
 

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -697,28 +697,45 @@ wrap_task! {
             };
             let cef_url = CefString::from(self.url.as_str());
 
-            // Get client from an existing TOP-LEVEL browser. Cannot use
-            // `first_browser()` here: that does `HashMap::iter().next()`
-            // over the full browsers map, which includes pane browsers.
-            // Pane browsers have `is_browser_pane=true` on their client.
-            // If we inherited that, the new window's `on_load_end` would
-            // take the pane early-return branch (client/mod.rs:954) and
-            // never call `window.show()` — backend reports success
-            // (status panel updates) but no OS window appears. Filter on
-            // label prefix: top-level labels are `window-…` (per
-            // client/mod.rs:218), panes are `browser-pane-…`.
+            // Get client from an existing TOP-LEVEL browser.
+            // Use list_top_level_browsers() rather than list_browsers() +
+            // manual filter — the dedicated helper already excludes pane
+            // browsers (kind: Pane{..}), removing the label-prefix heuristic.
+            //
+            // GUARD: if no top-level browser is alive at this point (race
+            // between window close → UnregisterBrowser and this task being
+            // posted, or all windows closing during a multi-window tear-off),
+            // bail early rather than passing None to browser_view_create.
+            // CEF's C++ layer CHECK-fails on a null client → SIGABRT on
+            // CrBrowserMain. A graceful return here lets the launcher's crash-
+            // budget supervisor retry (with --disable-gpu) only on real CEF
+            // faults, not on this transient race.
             let client = self
                 .state
-                .list_browsers()
+                .list_top_level_browsers()
                 .into_iter()
-                .find(|(label, _)| !label.starts_with("browser-pane-"))
-                .and_then(|(_, b)| b.host().map(|h| h.client()));
+                .find_map(|(_, b)| {
+                    b.host().and_then(|h| h.client())
+                });
             tracing::info!(
                 label = %self.label,
                 elapsed_us = t0.elapsed().as_micros() as u64,
                 client_found = client.is_some(),
                 "[create-window] got client"
             );
+
+            let mut client_ref = match client {
+                Some(c) => c,
+                None => {
+                    tracing::error!(
+                        label = %self.label,
+                        elapsed_us = t0.elapsed().as_micros() as u64,
+                        "[create-window] no live top-level browser to clone client from \
+                         (all windows closing?) — aborting window creation"
+                    );
+                    return;
+                }
+            };
 
             let mut request_context = crate::commands::create_isolated_request_context(
                 &self.state, &self.label,
@@ -728,13 +745,11 @@ wrap_task! {
                 elapsed_us = t0.elapsed().as_micros() as u64,
                 "[create-window] request_context resolved"
             );
-
-            let mut client_ref = client.flatten();
             let mut bv_delegate = crate::app::AgentMuxBrowserViewDelegate::new(
                 RuntimeStyle::ALLOY,
             );
             let browser_view = browser_view_create(
-                client_ref.as_mut(),
+                Some(&mut client_ref),
                 Some(&cef_url),
                 Some(&settings),
                 None,

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -61,8 +61,16 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
-            if let Some(window) = get_window_on_ui(&self.state, &self.label) {
-                window.close();
+            // Use try_close_browser rather than window.close() — the latter
+            // calls Widget::Close directly, which CHECKs !on_call_stack_ and
+            // aborts if the widget is already being destroyed (e.g. the OS
+            // sent windowShouldClose on macOS while our close_window IPC task
+            // was already queued). try_close_browser goes through do_close
+            // which sets is_closing and is idempotent on re-entry.
+            if let Some(mut browser) = self.state.get_browser(&self.label) {
+                if let Some(host) = browser.host() {
+                    host.try_close_browser();
+                }
             }
         }
     }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -85,11 +85,19 @@ fn main() {
         std::thread::Builder::new()
             .name("launcher-supervisor".into())
             .spawn(|| {
-                tokio::runtime::Runtime::new()
-                    .expect("failed to build Tokio runtime")
-                    .block_on(launcher_main());
-                // Supervisor finished (host exited / fatal) — end the process;
-                // this unblocks the parked main thread and tears the splash down.
+                // Catch panics so a supervisor crash always exits the process
+                // rather than leaving the main-thread AppKit runloop spinning
+                // as an invisible orphan.
+                let result = std::panic::catch_unwind(|| {
+                    tokio::runtime::Runtime::new()
+                        .expect("failed to build Tokio runtime")
+                        .block_on(launcher_main());
+                });
+                if result.is_err() {
+                    eprintln!("AgentMux launcher supervisor panicked — exiting");
+                    std::process::exit(1);
+                }
+                // Supervisor finished cleanly (host exited / fatal).
                 std::process::exit(0);
             })
             .expect("failed to spawn launcher supervisor thread");

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -34,6 +34,8 @@ mod reducer;
 mod saga;
 #[cfg(target_os = "windows")]
 mod splash;
+#[cfg(target_os = "macos")]
+mod splash_mac;
 mod srv_spawner;
 mod state;
 mod wrr;
@@ -70,9 +72,37 @@ fn suppress_os_crash_dialogs() {}
 /// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
 fn main() {
     suppress_os_crash_dialogs();
-    tokio::runtime::Runtime::new()
-        .expect("failed to build Tokio runtime")
-        .block_on(launcher_main());
+
+    // macOS: paint the splash FIRST, on the main thread, before any heavy work
+    // — this is the whole reason the splash lives in the small fast launcher
+    // rather than the slow CEF host. AppKit must own the main thread, so the
+    // srv+host supervisor (`launcher_main`) runs on a worker thread with its
+    // own Tokio runtime; the splash pumps a CoreFoundation runloop on main
+    // until the host signals first paint. See `splash_mac`.
+    #[cfg(target_os = "macos")]
+    {
+        let splash = splash_mac::Splash::show();
+        std::thread::Builder::new()
+            .name("launcher-supervisor".into())
+            .spawn(|| {
+                tokio::runtime::Runtime::new()
+                    .expect("failed to build Tokio runtime")
+                    .block_on(launcher_main());
+                // Supervisor finished (host exited / fatal) — end the process;
+                // this unblocks the parked main thread and tears the splash down.
+                std::process::exit(0);
+            })
+            .expect("failed to spawn launcher supervisor thread");
+        splash.run_until_dismissed(); // pumps the runloop, then parks forever
+        return;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        tokio::runtime::Runtime::new()
+            .expect("failed to build Tokio runtime")
+            .block_on(launcher_main());
+    }
 }
 
 async fn launcher_main() {

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -1,0 +1,364 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Native macOS startup splash, owned by the **launcher** — the macOS analogue
+//! of the Win32 `splash.rs`, matching its look and effects:
+//!
+//! * a solid **dark backdrop** (RGB 26,26,31) with the brain logo centered on
+//!   it (Win32 paints an opaque dark DIB; here a layer-backed `NSView`);
+//! * the brain **pulses** (alpha fades in 0→1 over 200 ms, then a 1.1 Hz sine
+//!   between ~0.73 and 1.0 — the backdrop stays solid);
+//! * on first host frame the whole splash **fades out** (~160 ms) then leaves.
+//!
+//! Why the launcher and not the host: the launcher is a tiny binary up in
+//! milliseconds, whereas `agentmux-cef` *is* the multi-second CEF load. This is
+//! the only place a splash can paint *before* CEF initializes. The launcher
+//! shows it in its own process (no AppKit/CEF runloop conflict); the host owns
+//! its own runloop in the child process.
+//!
+//! Raw Objective-C runtime FFI (same approach as `agentmux-cef/src/main.rs`) so
+//! the launcher pulls in no heavy new deps — `NSImage` decodes the bundled PNG.
+//!
+//! Dismiss protocol: `show()` sets `AGENTMUX_SPLASH_READY_FILE`; the host
+//! inherits it and `write`s the file the moment CEF paints its first frame (see
+//! `agentmux-cef/src/client/mod.rs`). `run_until_dismissed()` pumps a
+//! CoreFoundation runloop on the main thread, animating the pulse and polling
+//! for that file (with a safety timeout), then fades out and orders the window
+//! away — and keeps the runloop turning afterward so the removal actually
+//! flushes (the supervisor thread owns process lifetime).
+
+#![cfg(target_os = "macos")]
+
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+// The brain logo (transparent PNG). NSImage decodes it natively at runtime.
+static BRAIN_PNG: &[u8] = include_bytes!("../resources/brain.png");
+
+const BRAIN_PX: f64 = 150.0; // displayed brain size
+const PAD_PX: f64 = 35.0; // backdrop padding around the brain
+const SPLASH_PX: f64 = BRAIN_PX + PAD_PX * 2.0; // 220×220 dark card
+const CORNER_RADIUS: f64 = 16.0;
+
+// Backdrop color — matches the Win32 splash's BG (R=0x1A, G=0x1A, B=0x1F).
+const BG_R: f64 = 26.0 / 255.0;
+const BG_G: f64 = 26.0 / 255.0;
+const BG_B: f64 = 31.0 / 255.0;
+
+/// Safety net: if the host never signals (crash before first paint), tear the
+/// splash down anyway so it can't get stuck on screen.
+const DISMISS_TIMEOUT: Duration = Duration::from_secs(10);
+const FADE_OUT: f64 = 0.16; // seconds
+
+#[allow(non_camel_case_types)]
+type id = *mut std::ffi::c_void;
+type Class = *const std::ffi::c_void;
+type SEL = *const std::ffi::c_void;
+
+const NIL: id = std::ptr::null_mut();
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CGPoint {
+    x: f64,
+    y: f64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CGSize {
+    width: f64,
+    height: f64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CGRect {
+    origin: CGPoint,
+    size: CGSize,
+}
+
+type CFStringRef = *const std::ffi::c_void;
+
+#[link(name = "AppKit", kind = "framework")]
+#[link(name = "Foundation", kind = "framework")]
+#[link(name = "CoreFoundation", kind = "framework")]
+#[link(name = "QuartzCore", kind = "framework")]
+#[link(name = "objc")]
+extern "C" {
+    fn objc_getClass(name: *const c_char) -> Class;
+    fn sel_registerName(name: *const c_char) -> SEL;
+    fn objc_msgSend();
+    static kCFRunLoopDefaultMode: CFStringRef;
+    fn CFRunLoopRunInMode(mode: CFStringRef, seconds: f64, return_after_source_handled: u8) -> i32;
+}
+
+#[inline]
+unsafe fn class(name: &[u8]) -> id {
+    // Cast Class (*const) to id (*mut) so it can be a `send` receiver — both
+    // are just pointers to ObjC objects as far as objc_msgSend is concerned.
+    objc_getClass(name.as_ptr() as *const c_char) as id
+}
+#[inline]
+unsafe fn sel(name: &[u8]) -> SEL {
+    sel_registerName(name.as_ptr() as *const c_char)
+}
+
+#[inline]
+unsafe fn send(recv: id, s: SEL) -> id {
+    let f: extern "C" fn(id, SEL) -> id = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s)
+}
+#[inline]
+unsafe fn send_void(recv: id, s: SEL) {
+    let f: extern "C" fn(id, SEL) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s)
+}
+#[inline]
+unsafe fn send_id(recv: id, s: SEL, a: id) -> id {
+    let f: extern "C" fn(id, SEL, id) -> id = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+#[inline]
+unsafe fn send_void_id(recv: id, s: SEL, a: id) {
+    let f: extern "C" fn(id, SEL, id) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+#[inline]
+unsafe fn send_void_bool(recv: id, s: SEL, a: u8) {
+    let f: extern "C" fn(id, SEL, u8) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+#[inline]
+unsafe fn send_void_i64(recv: id, s: SEL, a: i64) {
+    let f: extern "C" fn(id, SEL, i64) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+#[inline]
+unsafe fn send_void_f64(recv: id, s: SEL, a: f64) {
+    let f: extern "C" fn(id, SEL, f64) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+
+/// A live splash window plus the path the host touches when it's ready.
+pub struct Splash {
+    window: id,
+    image_view: id,
+    ready_file: PathBuf,
+}
+
+impl Splash {
+    /// Create the `AGENTMUX_SPLASH_READY_FILE` env path and the window, paint
+    /// it, and return the handle. MUST be called on the process main thread,
+    /// before the supervisor thread spawns the host (so the host inherits the
+    /// env var).
+    pub fn show() -> Splash {
+        let ready_file =
+            std::env::temp_dir().join(format!("agentmux-splash-ready-{}", std::process::id()));
+        let _ = std::fs::remove_file(&ready_file);
+        // Inherited by the host spawned later on the supervisor thread.
+        std::env::set_var("AGENTMUX_SPLASH_READY_FILE", &ready_file);
+
+        let (window, image_view) = unsafe { build_window() };
+        Splash {
+            window,
+            image_view,
+            ready_file,
+        }
+    }
+
+    /// Pump the splash runloop on the main thread: animate the brain pulse, and
+    /// once the host signals first paint (ready-file appears) — or the safety
+    /// timeout elapses — fade the whole splash out and order it away. Then keep
+    /// the runloop turning (so the removal flushes) until the supervisor thread
+    /// exits the process.
+    pub fn run_until_dismissed(self) {
+        let start = Instant::now();
+        let mut fade_start: Option<Instant> = None;
+
+        loop {
+            unsafe {
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.016, 0);
+            }
+            let t = start.elapsed().as_secs_f64();
+
+            // Brain pulse: fade in 0→1 over 200 ms, then 1.1 Hz sine 0.73..1.0
+            // (the Win32 splash pulses 160..220/255 ≈ the same band).
+            let brain_alpha = if t < 0.2 {
+                t / 0.2
+            } else {
+                let pulse = ((t - 0.2) * std::f64::consts::TAU * 1.1).sin() * 0.5 + 0.5;
+                0.73 + pulse * 0.27
+            };
+            unsafe {
+                send_void_f64(self.image_view, sel(b"setAlphaValue:\0"), brain_alpha);
+            }
+
+            // Trigger the fade-out once the host is ready (or we time out).
+            if fade_start.is_none()
+                && (self.ready_file.exists() || start.elapsed() > DISMISS_TIMEOUT)
+            {
+                fade_start = Some(Instant::now());
+                let _ = std::fs::remove_file(&self.ready_file);
+            }
+
+            if let Some(f0) = fade_start {
+                let p = (f0.elapsed().as_secs_f64() / FADE_OUT).min(1.0);
+                unsafe {
+                    send_void_f64(self.window, sel(b"setAlphaValue:\0"), 1.0 - p);
+                }
+                if p >= 1.0 {
+                    unsafe {
+                        send_void_id(self.window, sel(b"orderOut:\0"), NIL);
+                    }
+                    break;
+                }
+            }
+
+            std::thread::sleep(Duration::from_millis(8));
+        }
+
+        // Keep pumping so the order-out flushes and AppKit stays sane. The
+        // supervisor thread owns process lifetime and `process::exit`s when the
+        // host exits, which ends this loop with the process.
+        loop {
+            unsafe {
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.2, 0);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+/// Build the splash window: a dark rounded backdrop with the brain centered on
+/// it. Returns (window, image_view) — the image_view's alpha is pulsed.
+unsafe fn build_window() -> (id, id) {
+    // NSApplication, as an accessory app: no Dock tile (the host sets .regular
+    // and owns the single tile). Accessory == 1.
+    let app = send(class(b"NSApplication\0"), sel(b"sharedApplication\0"));
+    {
+        let f: extern "C" fn(id, SEL, i64) -> u8 = std::mem::transmute(objc_msgSend as *const ());
+        f(app, sel(b"setActivationPolicy:\0"), 1);
+    }
+
+    // NSImage from the embedded PNG bytes via NSData.
+    let data = {
+        let f: extern "C" fn(id, SEL, *const std::ffi::c_void, usize) -> id =
+            std::mem::transmute(objc_msgSend as *const ());
+        f(
+            class(b"NSData\0"),
+            sel(b"dataWithBytes:length:\0"),
+            BRAIN_PNG.as_ptr() as *const std::ffi::c_void,
+            BRAIN_PNG.len(),
+        )
+    };
+    let image = send_id(
+        send(class(b"NSImage\0"), sel(b"alloc\0")),
+        sel(b"initWithData:\0"),
+        data,
+    );
+
+    // Center on the main screen.
+    let screen = send(class(b"NSScreen\0"), sel(b"mainScreen\0"));
+    let screen_frame: CGRect = {
+        let f: extern "C" fn(id, SEL) -> CGRect = std::mem::transmute(objc_msgSend as *const ());
+        f(screen, sel(b"frame\0"))
+    };
+    let x = screen_frame.origin.x + (screen_frame.size.width - SPLASH_PX) / 2.0;
+    let y = screen_frame.origin.y + (screen_frame.size.height - SPLASH_PX) / 2.0;
+    let win_rect = CGRect {
+        origin: CGPoint { x, y },
+        size: CGSize {
+            width: SPLASH_PX,
+            height: SPLASH_PX,
+        },
+    };
+
+    // NSWindow: borderless (styleMask 0), buffered (backing 2), defer NO.
+    let window = {
+        let win = send(class(b"NSWindow\0"), sel(b"alloc\0"));
+        let f: extern "C" fn(id, SEL, CGRect, u64, u64, u8) -> id =
+            std::mem::transmute(objc_msgSend as *const ());
+        f(
+            win,
+            sel(b"initWithContentRect:styleMask:backing:defer:\0"),
+            win_rect,
+            0,
+            2,
+            0,
+        )
+    };
+    // The window itself is transparent; the dark card is the contentView's
+    // layer (so we get rounded corners + a shadow around the card).
+    send_void_bool(window, sel(b"setOpaque:\0"), 0);
+    let clear = send(class(b"NSColor\0"), sel(b"clearColor\0"));
+    send_void_id(window, sel(b"setBackgroundColor:\0"), clear);
+    send_void_bool(window, sel(b"setHasShadow:\0"), 1);
+    send_void_i64(window, sel(b"setLevel:\0"), 25); // NSStatusWindowLevel
+    send_void_bool(window, sel(b"setIgnoresMouseEvents:\0"), 1);
+
+    // Backdrop: layer-backed NSView filling the window, dark fill + rounded.
+    let local = CGRect {
+        origin: CGPoint { x: 0.0, y: 0.0 },
+        size: CGSize {
+            width: SPLASH_PX,
+            height: SPLASH_PX,
+        },
+    };
+    let backdrop = {
+        let v = send(class(b"NSView\0"), sel(b"alloc\0"));
+        let f: extern "C" fn(id, SEL, CGRect) -> id = std::mem::transmute(objc_msgSend as *const ());
+        f(v, sel(b"initWithFrame:\0"), local)
+    };
+    send_void_bool(backdrop, sel(b"setWantsLayer:\0"), 1);
+    let layer = send(backdrop, sel(b"layer\0"));
+    // CGColorRef from NSColor (colorWithSRGBRed:green:blue:alpha:).
+    let bg_color = {
+        let f: extern "C" fn(id, SEL, f64, f64, f64, f64) -> id =
+            std::mem::transmute(objc_msgSend as *const ());
+        f(
+            class(b"NSColor\0"),
+            sel(b"colorWithSRGBRed:green:blue:alpha:\0"),
+            BG_R,
+            BG_G,
+            BG_B,
+            1.0,
+        )
+    };
+    let bg_cgcolor = send(bg_color, sel(b"CGColor\0"));
+    send_void_id(layer, sel(b"setBackgroundColor:\0"), bg_cgcolor);
+    send_void_f64(layer, sel(b"setCornerRadius:\0"), CORNER_RADIUS);
+    send_void_bool(layer, sel(b"setMasksToBounds:\0"), 1);
+
+    // Brain image view centered on the backdrop, proportional scaling.
+    let brain_rect = CGRect {
+        origin: CGPoint {
+            x: PAD_PX,
+            y: PAD_PX,
+        },
+        size: CGSize {
+            width: BRAIN_PX,
+            height: BRAIN_PX,
+        },
+    };
+    let image_view = {
+        let iv = send(class(b"NSImageView\0"), sel(b"alloc\0"));
+        let f: extern "C" fn(id, SEL, CGRect) -> id = std::mem::transmute(objc_msgSend as *const ());
+        f(iv, sel(b"initWithFrame:\0"), brain_rect)
+    };
+    send_void_id(image_view, sel(b"setImage:\0"), image);
+    {
+        // NSImageScaleProportionallyUpOrDown == 3
+        let f: extern "C" fn(id, SEL, u64) = std::mem::transmute(objc_msgSend as *const ());
+        f(image_view, sel(b"setImageScaling:\0"), 3);
+    }
+    send_void_f64(image_view, sel(b"setAlphaValue:\0"), 0.0); // fades in
+
+    send_void_id(backdrop, sel(b"addSubview:\0"), image_view);
+    send_void_id(window, sel(b"setContentView:\0"), backdrop);
+
+    // Bring the app + window up immediately.
+    send_void(app, sel(b"finishLaunching\0"));
+    send_void_bool(app, sel(b"activateIgnoringOtherApps:\0"), 1);
+    send_void_id(window, sel(b"orderFrontRegardless\0"), NIL);
+    (window, image_view)
+}

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -158,7 +158,18 @@ impl Splash {
         // Inherited by the host spawned later on the supervisor thread.
         std::env::set_var("AGENTMUX_SPLASH_READY_FILE", &ready_file);
 
-        let (window, image_view) = unsafe { build_window() };
+        // NSAutoreleasePool ensures autoreleased objects (NSData, NSImage,
+        // NSColor, NSWindow, NSView) created in build_window() are drained
+        // before we return. Without it, the pool from the thread's implicit
+        // NSApplication runloop hasn't been set up yet and autorelease
+        // messages queue to a nil pool — leaking on pre-macOS-12 targets.
+        let (window, image_view) = unsafe {
+            let pool = send(class(b"NSAutoreleasePool\0"), sel(b"alloc\0"));
+            let pool = send(pool, sel(b"init\0"));
+            let result = build_window();
+            send_void(pool, sel(b"drain\0"));
+            result
+        };
         Splash {
             window,
             image_view,
@@ -235,10 +246,7 @@ unsafe fn build_window() -> (id, id) {
     // NSApplication, as an accessory app: no Dock tile (the host sets .regular
     // and owns the single tile). Accessory == 1.
     let app = send(class(b"NSApplication\0"), sel(b"sharedApplication\0"));
-    {
-        let f: extern "C" fn(id, SEL, i64) -> u8 = std::mem::transmute(objc_msgSend as *const ());
-        f(app, sel(b"setActivationPolicy:\0"), 1);
-    }
+    send_void_i64(app, sel(b"setActivationPolicy:\0"), 1);
 
     // NSImage from the embedded PNG bytes via NSData.
     let data = {

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -359,6 +359,6 @@ unsafe fn build_window() -> (id, id) {
     // Bring the app + window up immediately.
     send_void(app, sel(b"finishLaunching\0"));
     send_void_bool(app, sel(b"activateIgnoringOtherApps:\0"), 1);
-    send_void_id(window, sel(b"orderFrontRegardless\0"), NIL);
+    send_void(window, sel(b"orderFrontRegardless\0"));
     (window, image_view)
 }

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for CEF/Chromium under the hardened runtime: V8 JIT writes +
+         executes code pages, so it needs JIT + unsigned-executable-memory, and
+         CEF dlopen's the framework + GL dylibs (disable library validation). -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+
+    <!-- we add the following entitlements so that *CLI* applications can request/use these features.  this matches iTerm's permission set -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/cef-patches/README.md
+++ b/docs/cef-patches/README.md
@@ -1,0 +1,77 @@
+# Patched CEF framework for macOS 26 (process_requirement / renderer crash)
+
+## The problem
+
+On **macOS 26 (Tahoe)**, a signed, packaged AgentMux `.app` crash-looped its **renderer**
+subprocess. cef-debug logged:
+
+```
+process_requirement.cc:165 Unable to derive validation category for current process.
+  Signature validation … failed … Error -67030 (errSecCSReqFailed)
+```
+
+Chromium's **Mach-port rendezvous** validates that subprocesses satisfy a code-signing
+`ProcessRequirement` before handing them their IPC ports. Our self-reexec CEF helper fails that
+check on macOS 26, so the rendezvous **denies the renderer its ports** → the renderer can't connect
+→ crash-loop. Notarization, stapling (app + helper), entitlement changes, and the runtime
+`--disable-features=MachPortRendezvous*` flag all **failed** to fix it — the policy is read before
+the FeatureList initializes, so the runtime flag never applies.
+
+## The fix (two parts)
+
+1. **Patched CEF framework** — `agentmux_disable_mach_rendezvous_validation.patch` forces
+   `base/apple/mach_port_rendezvous_mac.cc::GetPeerValidationPolicy()` to return `kNoValidation`,
+   disabling the peer validation at the source (the only place it reliably applies). Acceptable for
+   a local single-user desktop app (the check is anti-injection hardening; AgentMux's threat model
+   doesn't require it — same class of tradeoff as the OSCrypt switches).
+2. **Per-type helper apps** — the from-source CEF framework uses CEF's standard macOS layout:
+   renderer/GPU/utility run as `AgentMux Helper (<Type>).app` (Renderer/GPU/Plugin/Alloy + generic).
+   `scripts/package-macos.sh` now creates all five.
+
+Result: the signed + **notarized** `.app` launches with a **working, stable renderer** and a live UI.
+
+## How to rebuild the framework
+
+```bash
+# 1. depot_tools + automate-git (CEF branch 7778 = Chromium 148.0.7778, matches the `cef` crate)
+mkdir -p ~/cef-build && cd ~/cef-build
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+curl -o code/automate-git.py https://raw.githubusercontent.com/agentmuxai/cef/master/tools/automate/automate-git.py
+export PATH="$PWD/depot_tools:$PATH"
+export GN_DEFINES="is_official_build=false is_debug=false symbol_level=1"
+python3 code/automate-git.py --download-dir=$PWD/chromium --depot-tools-dir=$PWD/depot_tools \
+  --branch=7778 --arm64-build --no-debug-build --no-build --no-distrib
+
+# 2. apply the patch
+cd chromium/chromium/src
+git apply <agentmux>/docs/cef-patches/agentmux_disable_mach_rendezvous_validation.patch
+
+# 3. generate + build (just the framework)
+cd cef && GN_DEFINES="is_official_build=false is_debug=false symbol_level=1 target_cpu=\"arm64\"" \
+  ./cef_create_projects.sh && cd ..
+ninja -C out/Release_GN_arm64 -j8 cef_framework
+# → out/Release_GN_arm64/Chromium Embedded Framework.framework
+
+# 4. use it from AgentMux
+export AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$PWD/out/Release_GN_arm64
+cd <agentmux> && task package:macos     # bundles the PATCHED framework, signs, notarizes, staples
+```
+
+## ⚠️ Metal caveat (important for a SHIP build)
+
+This first framework was built with **`angle_enable_metal=false`** to bypass a broken Xcode-26 Metal
+toolchain (`xcodebuild -downloadComponent MetalToolchain` fails on an outdated DVTDownloads from the
+old Command Line Tools). The app **works** (ANGLE falls back to CGL/SwiftShader), but the GPU is not
+Metal-accelerated.
+
+**For a production framework with Metal:**
+```bash
+sudo softwareupdate -i 'Command Line Tools for Xcode 26.5'   # fixes the Metal toolchain
+# then remove angle_enable_metal=false from out/Release_GN_arm64/args.gn, re-gen, rebuild.
+```
+
+## Fork persistence
+
+The patch is staged at `src/cef/patch/patches/agentmux_process_requirement.patch`. To make builds
+reproducible, push it to `agentmuxai/cef` as a branch (e.g. `agentmux/7778-process-requirement`)
++ register in `cef/patch/patch.cfg`, so `cef_create_projects.sh` applies it automatically.

--- a/docs/cef-patches/README.md
+++ b/docs/cef-patches/README.md
@@ -57,18 +57,25 @@ export AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$PWD/out/Release_GN_arm64
 cd <agentmux> && task package:macos     # bundles the PATCHED framework, signs, notarizes, staples
 ```
 
-## ⚠️ Metal caveat (important for a SHIP build)
+## Metal (resolved — framework is Metal-accelerated)
 
-This first framework was built with **`angle_enable_metal=false`** to bypass a broken Xcode-26 Metal
-toolchain (`xcodebuild -downloadComponent MetalToolchain` fails on an outdated DVTDownloads from the
-old Command Line Tools). The app **works** (ANGLE falls back to CGL/SwiftShader), but the GPU is not
-Metal-accelerated.
+The framework is built **with Metal enabled** (`angle_enable_metal=true`, the default) — verified at
+runtime: the GPU process loads `Metal.framework` + `AGXMetalG14G` via ANGLE-Metal (hardware accel).
 
-**For a production framework with Metal:**
+Getting Metal to build required a one-time Xcode-26 toolchain repair. Xcode 26 ships the Metal
+compiler as a *separate* downloadable component, and `xcodebuild -downloadComponent MetalToolchain`
+was broken by a stale `DVTDownloads.framework` (old `XcodeSystemResources` pkg) whose missing symbol
+crashed the download plugin. Fix (run once, with sudo):
+
 ```bash
-sudo softwareupdate -i 'Command Line Tools for Xcode 26.5'   # fixes the Metal toolchain
-# then remove angle_enable_metal=false from out/Release_GN_arm64/args.gn, re-gen, rebuild.
+sudo installer -pkg /Applications/Xcode.app/Contents/Resources/Packages/XcodeSystemResources.pkg -target /
+xcodebuild -downloadComponent MetalToolchain
+xcrun metal --version   # confirm
 ```
+
+(The first framework was a stopgap built with `angle_enable_metal=false` → CGL/SwiftShader; once the
+toolchain was repaired we removed that arg, re-ran `gn gen`, and did an incremental rebuild — only
+the ANGLE-Metal objects + `.air` shaders + the `libcef` relink, ~minutes.)
 
 ## Fork persistence
 

--- a/docs/cef-patches/agentmux_disable_mach_rendezvous_validation.patch
+++ b/docs/cef-patches/agentmux_disable_mach_rendezvous_validation.patch
@@ -1,0 +1,34 @@
+diff --git a/base/apple/mach_port_rendezvous_mac.cc b/base/apple/mach_port_rendezvous_mac.cc
+index 42c732389886b..111d2119cd0cc 100644
+--- a/base/apple/mach_port_rendezvous_mac.cc
++++ b/base/apple/mach_port_rendezvous_mac.cc
+@@ -405,14 +405,21 @@ GetPeerValidationPolicyFromEnvironment() {
+ }
+ 
+ MachPortRendezvousPeerValidationPolicy GetPeerValidationPolicy() {
+-  if (base::FeatureList::GetInstance()) {
+-    return GetPeerValidationPolicyFromFeatureList();
+-  }
+-
+-  // In child processes, MachPortRendezvousClient is used during feature list
+-  // initialization so the validation policy is passed via an environment
+-  // variable.
+-  return GetPeerValidationPolicyFromEnvironment();
++  // AgentMux patch: force kNoValidation. AgentMux's self-reexec CEF helper
++  // fails Chromium's Mach-port peer process_requirement check on macOS 26
++  // (process_requirement.cc -67030 / errSecCSReqFailed), so the rendezvous
++  // denies the renderer its ports -> renderer crash-loop. The runtime
++  // --disable-features path does not apply early enough (rendezvous runs
++  // before the FeatureList is ready), so disable it at the source. Acceptable
++  // for a local single-user desktop app.
++  //
++  // Evaluate the original resolution to keep the helpers referenced (avoids
++  // -Wunused-function), but ignore the result.
++  MachPortRendezvousPeerValidationPolicy original =
++      base::FeatureList::GetInstance() ? GetPeerValidationPolicyFromFeatureList()
++                                       : GetPeerValidationPolicyFromEnvironment();
++  (void)original;
++  return MachPortRendezvousPeerValidationPolicy::kNoValidation;
+ }
+ 
+ }  // namespace

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,180 +1,131 @@
 # macOS Code Signing & Notarization
 
-This document covers how to sign and notarize AgentMux DMGs for direct distribution.
+How to build, sign, and notarize the AgentMux macOS app for direct distribution.
 
-Credential details (Apple ID, Team ID, keychain profile, certificate name) are kept in the
-private [agentmux-builder](https://github.com/agentmuxai/agentmux-builder) repo.
+The app is a **CEF (Chromium Embedded Framework)** desktop app — 100% Rust, no Tauri/Electron.
+`task package:macos` (`scripts/package-macos.sh`) does the full build + sign + (attempted)
+notarize in one command; this doc explains what it does and how to set up credentials.
+
+Credential details (Apple ID, Team ID, certificate name) are also kept in the private
+[agentmux-builder](https://github.com/agentmuxai/agentmux-builder) repo.
 
 ---
 
 ## Prerequisites
 
-- A **Developer ID Application** certificate installed in your login Keychain
-- An **app-specific password** stored as a `notarytool` Keychain profile (see agentmux-builder docs)
-- `xcrun notarytool` — ships with Xcode Command Line Tools
+- A **Developer ID Application** certificate in your login Keychain
+  (`security find-identity -v -p codesigning` should list a
+  `Developer ID Application: <Your Name> (<TEAMID>)` entry). The packager
+  auto-detects it; the team's actual identity details live in the private
+  `agentmux-builder` repo — never hardcode them here.
+- An **app-specific password** stored as a `notarytool` Keychain profile (one-time, below).
+- Xcode Command Line Tools (`codesign`, `xcrun notarytool`, `iconutil`, `sips`, `hdiutil`).
 
 ---
 
-## One-Time Setup: Store Notarization Credentials
-
-Run once to save credentials to the Keychain:
+## One-Time: Store Notarization Credentials
 
 ```bash
 xcrun notarytool store-credentials "notarytool" \
   --apple-id "<your-apple-id>" \
   --password "<app-specific-password>" \
-  --team-id "<your-team-id>"
+  --team-id  "<your-team-id>"
 ```
 
-App-specific passwords are generated at [appleid.apple.com](https://appleid.apple.com) →
-Sign-In & Security → App-Specific Passwords. Format: `xxxx-xxxx-xxxx-xxxx`.
+App-specific passwords: [appleid.apple.com](https://appleid.apple.com) → Sign-In & Security →
+App-Specific Passwords (format `xxxx-xxxx-xxxx-xxxx`). After this, reference the profile by
+name; the raw password is never needed again.
 
-Once stored, reference credentials by profile name in all subsequent calls — the raw
-password is never needed again.
+> **Apple Developer Program agreement.** Notarization requires an in-effect program license
+> agreement. If `notarytool` returns `HTTP 403 — "A required agreement is missing or has
+> expired"`, sign the updated agreement at [appstoreconnect.apple.com](https://appstoreconnect.apple.com)
+> before retrying. Signing still works without it; only notarization is gated.
 
 ---
 
-## Signing Workflow
-
-Run after `task package:macos` has built the `.app` and initial DMG.
-
-### 1. Sign all binaries inside the .app
-
-The `.app` bundle contains multiple Mach-O executables. Each must be individually signed
-with `--options runtime` (hardened runtime) before notarization will accept them.
+## Build + Sign + Notarize (one command)
 
 ```bash
-APP=target/release/bundle/macos/AgentMux.app
-VERSION=$(node -p "require('./package.json').version")
-CERT="<your-developer-id-cert-name>"   # e.g. "Developer ID Application: Name (TEAMID)"
-
-# Sign resource binaries first
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/Resources/binaries/bin/wsh-${VERSION}-darwin.arm64"
-
-# Sign MacOS binaries
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/MacOS/agentmuxsrv-rs"
-
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/MacOS/wsh"
-
-# Re-seal the .app bundle
-codesign --deep --force --options runtime --sign "$CERT" "$APP"
+task package:macos          # → ~/Desktop/AgentMux_<VERSION>_arm64.dmg
+# task package:macos -- /some/out/dir     # alternate output dir
+# NOTARIZE=0 task package:macos           # signed-only, skip notarization
 ```
 
-> **Why sign individually before `--deep`?** `--deep` seals nested content — signing
-> individual binaries first ensures their signatures are included in the bundle seal.
+`task package:macos` runs `build:host`, `build:backend`, `build:frontend`, `bundle`, then
+`scripts/package-macos.sh`, which:
 
-### 2. Re-create and sign the DMG
+1. **Assembles `AgentMux.app`.** The host resolves everything relative to its own binary
+   (`current_exe().parent()`), so the layout needs no Rust changes:
 
-The DMG must be rebuilt from the signed `.app`. Signing the pre-existing DMG won't work
-because it was created before the binaries were signed.
+   ```
+   AgentMux.app/Contents/
+     Info.plist
+     MacOS/
+       agentmux-cef                          ← host (re-execs itself for renderer/gpu;
+                                                no Helper.app needed, --no-sandbox)
+       agentmux-srv-<VERSION>-darwin.arm64    ← backend sidecar (resolve_backend_binary)
+       frontend/                              ← bundled UI (resolve_frontend_base_url)
+       *.dylib + vk_swiftshader_icd.json      ← GL libs (Chromium DIR_MODULE = exe dir)
+     Frameworks/
+       Chromium Embedded Framework.framework  ← cef-rs ../Frameworks lookup
+     Resources/
+       AgentMux.icns                          ← generated from the 512px logo PNG
+   ```
+
+2. **Signs inside-out** with `--options runtime` (hardened runtime), deepest first — the GL
+   dylibs, the framework's `Libraries/*.dylib`, the framework bundle, the `agentmux-srv`
+   backend, the host, then the `.app` bundle. The backend + host + app get
+   `build/entitlements.mac.plist` (CEF JIT + CLI feature access). Signing each Mach-O before
+   sealing the bundle is required for notarization to accept them.
+
+3. **Builds + signs the DMG** (with an `/Applications` drag-target symlink).
+
+4. **Notarizes + staples** via the `notarytool` profile. If notarization is unavailable
+   (e.g. the 403 above), it emits a **signed-but-un-notarized** DMG and warns — Gatekeeper
+   then needs a right-click → Open on first launch on other Macs until a notarized build ships.
+
+---
+
+## Verify
 
 ```bash
-OUT=target/release/bundle/macos/AgentMux_${VERSION}_aarch64.dmg
-
-hdiutil create -volname "AgentMux-${VERSION}" -srcfolder "$APP" -ov -format UDZO "$OUT"
-codesign --force --sign "$CERT" "$OUT"
+DMG=~/Desktop/AgentMux_<VERSION>_arm64.dmg
+codesign -dv --verbose=2 "$DMG"                 # Authority should be your Developer ID
+spctl --assess --type open --context context:primary-signature -v "$DMG"
+# Notarized: "source=Notarized Developer ID".  Signed-only: spctl rejects (expected until notarized).
 ```
 
-### 3. Notarize
+If notarization status is `Invalid`, fetch the log:
 
-```bash
-xcrun notarytool submit "$OUT" --keychain-profile "notarytool" --wait
-```
-
-Expected output when successful:
-```
-status: Accepted
-```
-
-If status is `Invalid`, fetch the rejection log:
 ```bash
 xcrun notarytool log <submission-id> --keychain-profile "notarytool"
 ```
 
-Common rejection reasons:
-| Error | Fix |
-|-------|-----|
-| `The binary is not signed with a valid Developer ID certificate` | Sign each binary individually (step 1) |
-| `The signature does not include a secure timestamp` | Add `--options runtime` to codesign |
-| `The executable does not have the hardened runtime enabled` | Add `--options runtime` to codesign |
-
-### 4. Staple
-
-Attach the notarization ticket to the DMG so Gatekeeper works offline:
-
-```bash
-xcrun stapler staple "$OUT"
-# Expected: "The staple and validate action worked!"
-```
-
-### 5. Verify
-
-```bash
-spctl --assess --type open --context context:primary-signature -v "$OUT"
-# Expected: "source=Notarized Developer ID"
-```
+| Rejection | Fix |
+|-----------|-----|
+| binary not signed with a valid Developer ID | a nested Mach-O was missed — re-run the packager |
+| signature lacks a secure timestamp | ensure `--timestamp` (the packager passes it) |
+| hardened runtime not enabled | ensure `--options runtime` (the packager passes it) |
 
 ---
 
-## Upload to GitHub Release
+## Upload to the GitHub Release
 
 ```bash
-cp "$OUT" ~/Desktop/
-gh release upload "v${VERSION}" ~/Desktop/AgentMux_${VERSION}_aarch64.dmg --clobber
-```
-
----
-
-## Full Script
-
-```bash
-#!/bin/bash
-set -e
-
-APP=target/release/bundle/macos/AgentMux.app
-VERSION=$(node -p "require('./package.json').version")
-OUT=target/release/bundle/macos/AgentMux_${VERSION}_aarch64.dmg
-CERT="<your-developer-id-cert-name>"
-
-echo "==> Signing binaries..."
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/Resources/binaries/bin/wsh-${VERSION}-darwin.arm64"
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/MacOS/agentmuxsrv-rs"
-codesign --force --options runtime --sign "$CERT" \
-  "$APP/Contents/MacOS/wsh"
-codesign --deep --force --options runtime --sign "$CERT" "$APP"
-
-echo "==> Creating and signing DMG..."
-hdiutil create -volname "AgentMux-${VERSION}" -srcfolder "$APP" -ov -format UDZO "$OUT"
-codesign --force --sign "$CERT" "$OUT"
-
-echo "==> Notarizing..."
-xcrun notarytool submit "$OUT" --keychain-profile "notarytool" --wait
-
-echo "==> Stapling..."
-xcrun stapler staple "$OUT"
-
-echo "==> Done: $OUT"
+gh release upload "v<VERSION>" ~/Desktop/AgentMux_<VERSION>_arm64.dmg --clobber
 ```
 
 ---
 
 ## CI / Automated Signing
 
-The [agentmux-builder](https://github.com/agentmuxai/agentmux-builder) workflow handles
-signing automatically using GitHub Actions secrets. See `agentmux-builder` for the secret
-names required and how the CI pipeline maps to these steps.
-
----
+The [agentmux-builder](https://github.com/agentmuxai/agentmux-builder) repo is intended to host
+the automated signing pipeline; it currently lags the CEF migration (see the build-cleanup
+tracking issue in the main repo).
 
 ## Notes
 
 - Notarization typically takes 1–3 minutes. If it stalls >15 min, check
   [Apple's developer status page](https://developer.apple.com/system-status/).
-- This flow is for **direct distribution** (outside the App Store). Mac App Store
-  distribution requires a different certificate type, provisioning profiles, and App
-  Sandbox entitlements — see `docs/macos-appstore.md` if that work is ever pursued.
+- This is **direct distribution** (outside the App Store). Mac App Store distribution needs a
+  different certificate type, provisioning profiles, and App Sandbox entitlements.

--- a/docs/specs/SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31.md
+++ b/docs/specs/SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31.md
@@ -1,0 +1,229 @@
+# SPEC: Launcher in packaged macOS builds + restore the splash + tear-off crash
+
+**Date:** 2026-05-31
+**Repo state:** branch `agenta/cef-148-bump` (CEF 148 patched framework, notarized DMG #1221), base `main` @ v0.40.x
+**Author:** AgentO-asaf (driven by Claude)
+**Status:** Spec — ready to implement (phased)
+**Motivated by:** a SIGABRT crash tearing off a pane from a 2nd window on the packaged macOS DMG, and the absence of the startup splash.
+**Builds on:** [`SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30.md`](./SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30.md) (launcher in macOS **dev**), [`SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`](./SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md), [`SPEC_MACOS_PACKAGING_2026_05_30.md`](./SPEC_MACOS_PACKAGING_2026_05_30.md), [`SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md`](./SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md).
+
+---
+
+## 0. TL;DR
+
+1. **The owner is right: the launcher is essential**, not just a splash host. The launcher owns a **window/pool/instance reducer + a durable saga coordinator** (`agentmux-launcher/src/reducer/`, `src/saga/`). The host talks to it over IPC (`agentmux-cef/src/launcher_ipc.rs`); when the launcher is absent, **every `report_*` call silently no-ops** and the window-pool / tear-off / instance-numbering / supervision machinery runs degraded and untested.
+2. **Packaged macOS bundles only the host** (`scripts/package-macos.sh`, `CFBundleExecutable = agentmux-cef`). No launcher → no single-instance enforcement, no srv supervision (orphan-prone), no saga coordination, no instance numbering, weaker tear-off path. **This is the architectural gap to close.**
+3. **The splash MUST be launcher-owned and instant.** The whole point of the tiny launcher is that it is up in milliseconds and can paint a splash *before* the multi-second CEF host load. A host-owned splash is rejected: by the time `agentmux-cef` reaches `main`, the delay the user is staring at has already elapsed. The Win32 splash (`agentmux-launcher/src/splash.rs`, `#![cfg(target_os = "windows")]`) is a layered Win32 window and can't be reused — macOS needs a **new native AppKit splash in the launcher**. This makes "the launcher is the macOS entry point" a **hard prerequisite** for the splash.
+4. **The tear-off crash is a separate, host-side bug** that must be root-caused with symbols. It is *plausibly aggravated* by the missing launcher (the pooled tear-off path is launcher-coordinated; without it the host falls back to the less-tested cold `CreateWindowTask` path) but that is **not yet proven**. Treat crash-hardening as its own workstream.
+
+Workstreams: **(A) bundle the launcher as the macOS entry point** — split into **A0** (entry point + instant splash, the priority slice) and **A1/A2** (full single-instance + saga-IPC parity); **(C) root-cause + harden the tear-off crash**. (The former "Workstream B / native splash" is folded into A0, since the splash *requires* the launcher to be the entry point.)
+
+---
+
+## 1. The crash (evidence)
+
+macOS crash report `~/Library/Logs/DiagnosticReports/agentmux-cef-2026-05-31-111746.ips`:
+
+```
+proc:        agentmux-cef  (/Volumes/VOLUME/AgentMux.app/Contents/MacOS/agentmux-cef)   ← the DMG build
+exception:   EXC_CRASH (SIGABRT)
+asi:         libsystem_c.dylib: "abort() called"
+crashed thread 0: CrBrowserMain
+  abort
+  Chromium Embedded Framework  (+0x7aca000 …)   ← all frames in CEF, symbols stripped
+```
+
+Repro: open a 2nd window, drag-tear a pane → `abort()` on the **browser-main thread inside CEF**, during window/view creation.
+
+**Symbolication is blocked** because the packaged framework was stripped for the lean DMG (PR #1221). The unstripped from-source framework exists at `~/cef-build/chromium/chromium/src/out/Release_GN_arm64/`, but `symbol_level=1` yields no usable `atos` debug map. **Action (C0): produce a symbolized repro** — see §4.
+
+What we *can* say: a `SIGABRT` on `CrBrowserMain` is a deliberate `abort()` — a Chromium `CHECK`/`DCHECK`, or a Rust `panic!`/`unwrap`/`expect` inside a CEF callback (which aborts the process). The suspect host code is the window-creation path that runs during tear-off (§4).
+
+---
+
+## 2. Rigorous findings — what the launcher owns, and what breaks without it
+
+> Investigated against the **real** repo `/Users/asafebgi/Workspace/agentmux` (an earlier analysis used a stale April-18 checkout at `~/agentmux` and wrongly concluded "the launcher does nothing" — disregard that).
+
+### 2.1 Precise state-ownership map (correcting the mental model)
+
+The owner's phrasing — "the reducer keeps track of panes and state" — spans **two distinct reducers**:
+
+| State | Owner (source of truth) | Notes |
+|---|---|---|
+| **Pane layout within a window** (splits, the tile tree) | **Frontend** `LayoutModel` (SolidJS reducer) + **srv** (persisted WaveObject) | Not launcher-owned. Survives launcher absence. |
+| **Windows, the window pool, instance numbers, HWND↔label links, process lifecycle** | **Launcher** `reducer/` + `saga/` (with a **host-side mirror** via IPC) | **This** is launcher-owned and is what degrades without the launcher. |
+
+So the launcher is essential for the **window/pool/instance** layer, not the **intra-window pane tree**. Both are "panes and state" colloquially; the distinction matters for what the crash and the fix touch.
+
+### 2.2 Launcher reducer + sagas (`agentmux-launcher/src/`)
+
+- **`reducer/{mod,window,pool,connection}.rs`** — owns a read-only **mirror of top-level windows**, the **pool inventory** (unpromoted pre-warmed windows), the **authoritative instance registry** (per-label monotonic numbering), backend-window-id map, and process lifecycle records. Actions: `Register`, `ReportWindow{Opened,Closed}`, `ReportPoolWindow{Added,Removed,Promoted}`, `ReportHwnd*` (WRR drift observability), `ReportHostCounts` (drift check), etc.
+- **`saga/{mod,pool_respawn,window_cleanup,recovery}.rs`** + **`saga/log/`** — a Tokio multi-step coordinator with **per-saga deadline timers** and a **durable SQLite log** (`SPEC_LAUNCHER_SAGA_DURABILITY`). Two production sagas:
+  - **`pool_respawn_on_promote`** — on tear-off (a pool window is promoted), issue `SpawnPoolWindow` to the host and wait for the refill. Keeps the pre-warm pool topped up *atomically*, bracketed by `SagaStarted`/`SagaCompleted` the renderer buffers on.
+  - **`window_cleanup_cascade`** — on window close, issue `ReapPanes` + `DrainPoolIfLast` to the host and await echoes (30 s deadline).
+  - **`recovery`** — on launcher startup, re-run unresolved sagas from the durable log.
+
+### 2.3 Host ↔ launcher IPC and the silent-no-op fallback
+
+`agentmux-cef/src/launcher_ipc.rs:78` gates the entire IPC layer on the `AGENTMUX_LAUNCHER_PIPE` env var:
+
+```rust
+let pipe_path = match std::env::var("AGENTMUX_LAUNCHER_PIPE") {
+    Ok(p) if !p.is_empty() => p,
+    _ => { /* "AGENTMUX_LAUNCHER_PIPE unset — running without launcher IPC" */ return None; }
+};
+```
+
+When unset, `COMMAND_TX` (`OnceLock`, line 37) is never set, so **every `report_window_opened` / `report_pool_window_promoted` / `report_hwnd_opened` becomes a silent no-op**. The host keeps running, but the launcher mirror, the pool sagas, instance numbering, and WRR drift detection all go dark.
+
+### 2.4 The window pool & tear-off: pooled (launcher-coordinated) vs cold (direct)
+
+- **Pooled path** (normal tear-off): `commands/drag.rs::open_window_at_position` → `commands/window_pool.rs::promote_pool_window` → pops a pre-warmed window and fires **6+ launcher reports** (`report_pool_window_removed/promoted`, `report_window_opened`, `report_hwnd_opened`, `compute_and_report_host_counts`). The `pool_respawn` saga then refills.
+- **Cold path** (pool empty, or pooling unavailable): falls back to `ui_tasks.rs::CreateWindowTask::execute` (≈ lines 672–766) — direct `browser_view_create` + `window_create_top_level`, no pool, no saga.
+
+**Without the launcher**, the pooled reports no-op and there is **no `pool_respawn` saga to refill the pool**. The pool drains and subsequent tear-offs hit the **cold `CreateWindowTask` path** — which is exactly the suspect crash site (§4) and the least macOS-tested path.
+
+### 2.5 Current state by platform
+
+| | Single-instance | srv lifecycle | Saga/reducer IPC | Splash |
+|---|---|---|---|---|
+| **Windows (packaged & dev)** | Launcher named-pipe bind | Launcher-spawned sibling, Job Object J0 `KILL_ON_JOB_CLOSE`, crash-budget retry | Wired (named pipe) | Win32 splash |
+| **macOS dev** (`task dev`, run_unix, PR #1193) | Chromium process-singleton (host) | **Launcher**-spawned, process-group containment | **NOT wired yet** — Unix socket is Phase 2 of the dev spec; `run_unix` comment: *"wires the Unix-socket transport"* (future). `launcher_ipc` still no-ops. | none |
+| **macOS packaged** (the DMG) | Chromium process-singleton (host) | **Host**-spawned (`sidecar.rs`); **orphan-prone** if host crashes | **Absent** (no launcher bundled) | none |
+
+So packaged macOS is the most degraded: no launcher at all. Even dev lacks the saga IPC until Phase 2 lands.
+
+### 2.6 What packaged macOS loses without the launcher (impact table)
+
+| Lost capability | Source | User-visible impact |
+|---|---|---|
+| **Window instance numbering** | `launcher/reducer/window.rs` | 2nd+ windows have no instance id → InstancePanel labels incomplete |
+| **Pool refill saga + bracket** | `saga/pool_respawn.rs` | Pool drains; tear-offs fall to the cold path (crash-suspect); renderer never sees refill brackets |
+| **HWND↔label / WRR drift detection** | `window_pool.rs` reports | Torn-off windows can't be matched on close → false "orphan" tracking |
+| **Durable saga recovery** | `saga/log/`, `saga/recovery.rs` | A crash mid-tear-off leaves stale pool windows with no recovery breadcrumb |
+| **srv supervision + containment** | `launcher main.rs` Job Object / process group | Host crash orphans srv → stale srv can corrupt the next instance's data dir |
+| **Crash-budget retry ladder** (`--disable-gpu` rungs) | `launcher main.rs::spawn_host_supervised` | Cascading GPU crashes don't auto-fall-back |
+| **Single-instance owned by a supervisor** | `launcher ipc/server.rs` + `data_dir.rs` | Second launch races on the data dir instead of forwarding `open_new_window` |
+
+**Verdict:** the launcher is required for correct, supervised multi-window behavior on macOS. Shipping the host standalone is the root architectural defect behind the fragile tear-off, regardless of whether it is the *direct* SIGABRT cause.
+
+---
+
+## 3. Workstream A — bundle the launcher as the macOS entry point
+
+Goal: packaged macOS runs `agentmux-launcher` as `CFBundleExecutable`. It paints the splash **instantly** (A0), then supervises srv + host exactly like Windows, with single-instance + saga/reducer IPC wired (A1/A2). This is the **packaging + Phase-2/3 completion** that `SPEC_LAUNCHER_MACOS_DEV_INTEGRATION` explicitly deferred ("unblocks a future `task package:macos`").
+
+### A0 — PRIORITY SLICE: launcher as entry point + instant splash
+
+The minimal change that delivers the splash the user wants, without waiting on full IPC parity. The launcher already spawns srv + host on Unix (`run_unix`, landed PR #1193); A0 makes it the *bundled entry point* and gives it an AppKit splash.
+
+**A0.1 — Native AppKit splash (`agentmux-launcher/src/splash_mac.rs`, `#[cfg(target_os = "macos")]`).**
+- The **first thing** `main()` does on macOS — before `run_unix`, before srv/host spawn, before any heavy work — is create a minimal `NSApplication`, a **borderless transparent `NSWindow`** centered on the main screen showing the AgentMux brain logo (reuse the BGRA logo already compiled in `build.rs`), and `orderFront`. Target: pixels on screen in **< 100 ms** from app launch.
+- **No main-thread/CEF conflict:** the launcher is a *separate process* from the CEF host. The launcher owns a tiny AppKit runloop only for the splash; the host owns its own `NSApplication`/CEF runloop in its child process. (This is exactly how the Win32 splash already works — separate launcher process, host is a child.)
+- **No duplicate Dock tile:** the launcher runs as an **accessory app** (activation policy `.accessory` / `LSUIElement`-equivalent) so the splash gets no Dock tile; the host sets `.regular` (existing `set_macos_activation_policy_regular`) and owns the one Dock tile. Validate the Dock tile appears once, from the host.
+- **Threading:** AppKit must run on the launcher's main thread. Spawn srv/host supervision (`run_unix`, Tokio) on a background thread (or pump the AppKit runloop alongside Tokio) so the splash stays responsive while the host loads.
+
+**A0.2 — Dismiss protocol.** Generalize the Win32 `AGENTMUX_SPLASH_EVENT` signal to a cross-platform one. Minimal macOS mechanism (no full saga IPC needed yet): the host signals "first frame painted" and the launcher closes the splash + terminates its splash runloop. Options, simplest first:
+  1. **stdout/pipe token** — launcher already owns the host child; host prints a `SPLASH-READY` line on first paint, launcher watches the child's stdout. Zero new transport.
+  2. Unix-domain datagram to a path passed via env (`AGENTMUX_SPLASH_SOCK`).
+  - Add a **safety timeout** (e.g. 8 s) and **dismiss-on-host-window-visible** fallback so a missed signal never leaves the splash stuck.
+  - Generalize the host hook in `agentmux-cef/src/client/mod.rs` (today Win32-only `OpenEventW`/`SetEvent`) to emit the chosen macOS signal on first `on_paint`/first window shown.
+
+**A0.3 — Packaging.** Bundle `agentmux-launcher` (see A.2 layout), set `CFBundleExecutable = agentmux-launcher`, sign it inside-out (launcher last), re-notarize + staple. A0 does **not** require the Unix socket / flock work — the launcher can spawn srv+host via the existing `run_unix` path with the splash on top.
+
+**A0 acceptance:**
+- [ ] Double-clicking the DMG shows the splash within ~100 ms, before any window.
+- [ ] Splash dismisses on host first frame; never stuck (timeout + window-visible fallback verified).
+- [ ] Exactly one Dock tile, owned by the host.
+- [ ] srv is launcher-spawned (supervision parity gained for free); quit reaps the tree.
+- [ ] DMG re-notarized + stapled, `spctl` = Notarized Developer ID.
+- [ ] No new OS permission prompts (per the "no notices unless user-initiated" constraint).
+
+### A1/A2 — full single-instance + saga-IPC parity (follow-on)
+The dev spec's Phase 1 (launcher supervises srv+host on macOS) has landed (`run_unix`). **Phase 2 (single-instance `flock` + Unix-socket IPC, `AGENTMUX_LAUNCHER_SOCK`)** and **Phase 3 (supervision parity + host parent-death backstop)** complete the reducer/saga coordination — without them the window/pool/instance machinery still no-ops even with the launcher present.
+
+- Add the Unix-socket transport (`ipc/unix_socket.rs`); have the host connect when `AGENTMUX_LAUNCHER_SOCK` is set. **Update `launcher_ipc.rs` to honor `AGENTMUX_LAUNCHER_SOCK` (Unix) in addition to `AGENTMUX_LAUNCHER_PIPE` (Windows)** — today it only checks the pipe var, so the host can never connect on macOS.
+- `flock(<data-dir>/launcher.lock)` single-instance + forward `open_new_window` to the running instance.
+- `setpgid` + `killpg`-on-exit containment; host parent-death watcher as backstop.
+
+### A.2 Bundle layout
+Extend `scripts/package-macos.sh` so the `.app` is launcher-rooted:
+
+```
+AgentMux.app/Contents/
+  MacOS/
+    agentmux-launcher              ← CFBundleExecutable (NEW)
+    agentmux-cef                   ← host (no longer the entry point)
+    agentmux-srv-<ver>-darwin.arm64
+    *.dylib (GL libs), frontend/   ← as today
+  Frameworks/Chromium Embedded Framework.framework
+  Info.plist                       ← CFBundleExecutable = agentmux-launcher
+```
+
+- Build `agentmux-launcher` for darwin (`cargo build -p agentmux-launcher`; today `build:host:darwin` builds only `-p agentmux-cef`).
+- The launcher resolves host + srv as **siblings in `Contents/MacOS/`** (not a `runtime/` subdir — packaged layout differs from dev's `dist/cef-dev/runtime/`). Confirm the host's `../Frameworks` framework lookup still resolves with the host at `Contents/MacOS/agentmux-cef` (it does — `Contents/MacOS/../Frameworks`). **This is the layout subtlety; pin it (Open Q1).**
+- **Signing:** all five helper apps + host + srv + launcher + dylibs + framework signed inside-out, launcher signed last; entitlements unchanged; re-notarize/staple. The launcher is just another Mach-O in the bundle.
+- **Self-spawn guard:** the launcher already refuses to spawn if the resolved host == its own path (`main.rs`). Keep, since both now live in `Contents/MacOS/`.
+
+### A.3 Acceptance (A)
+- [ ] Packaged `.app` launches `agentmux-launcher`; window comes up identically.
+- [ ] Logs show launcher supervising: srv ESTART adopted by host (`use_launcher_endpoints`), host spawned with `AGENTMUX_BACKEND_*` + `AGENTMUX_LAUNCHER_SOCK`.
+- [ ] `launcher_ipc` **connects** (no "running without launcher IPC" line); `report_*` reach the launcher; instance numbering works for the 2nd window.
+- [ ] Quit → srv + host + renderers reaped, no orphan srv.
+- [ ] Second launch on same data dir → forwards `open_new_window`, exits.
+- [ ] Pool refill saga runs on macOS (tear-off keeps the pool topped up); durable log + recovery work.
+- [ ] DMG re-notarized + stapled; `spctl` = Notarized Developer ID. Size budget honored (launcher binary is small).
+- [ ] Windows unchanged.
+
+---
+
+## 4. Workstream C — root-cause + harden the tear-off crash
+
+Independent of A (the crash must be fixed even with the launcher, since the cold path still exists).
+
+- **C0 — symbolized repro (blocking).** Rebuild/keep an **unstripped framework or a `.dSYM`** (bump `symbol_level=2` for a debug framework, or `dsymutil` the binary) and re-run the tear-off repro to get a real stack. Alternatively run the **prebuilt official cef-dll-sys framework** (which has downloadable symbols) to bisect whether the crash is specific to our patched 148 build or general to the host multi-window path. Until C0, the rest is hypothesis.
+- **C1 — harden `CreateWindowTask::execute` (`ui_tasks.rs` ≈710–759).** It selects a client from the first non-pane browser and, if none exists, calls `browser_view_create(None, …)` / `window_create_top_level` anyway. Add an explicit guard: if no live top-level client/browser context is available (all closing / mid-teardown), **bail with a logged error instead of proceeding into CEF** — and verify whether CEF actually tolerates a `None` client here on macOS 26 (it may `CHECK`).
+- **C2 — audit `unwrap`/`expect`/`panic!`/`assert!` on the multi-window + tear-off path** (`commands/drag.rs`, `commands/window_pool.rs`, `client/mod.rs` `on_after_created`/`on_before_close`, `ui_tasks.rs`). A panic in any CEF callback aborts on `CrBrowserMain` exactly as observed. Convert hot-path panics to recoverable errors.
+- **C3 — macOS multi-window maturity gaps.** Several macOS branches are stubs vs full Windows impls: monitor work-area, tear-off hit-test, focus. Cross-reference `SPEC_MACOS_TEAROFF_STABILITY_2026_05_29.md`; fill the gaps the 2nd-window tear-off path hits.
+- **C4 — does the launcher fix it?** After A, re-test: with the pool kept warm by the `pool_respawn` saga, does the cold path (and the crash) stop being reached? If the crash persists with the launcher, it is purely host-side (C1/C2/C3). Record the result.
+
+### Acceptance (C)
+- [ ] Symbolized stack identifies the exact abort.
+- [ ] Open 2nd window + tear-off pane, repeated 20×, no abort (with **and** without the launcher).
+- [ ] No `unwrap`/`expect` reachable on the tear-off hot path.
+
+---
+
+## 5. Splash — folded into A0 (launcher-owned)
+
+The splash is **not a separate workstream** — it is the payload of **A0** (§3). The owner's requirement settles the long-open "splash owner" question decisively: it must be the **launcher**, because the launcher is the only process up early enough to paint *before* CEF loads. A host-owned splash is rejected (the host *is* the slow part). See **A0.1/A0.2** for the AppKit design and dismiss protocol. The dev spec §3.6 ("skip splash on Unix") is **superseded** for packaged macOS.
+
+---
+
+## 6. Sequencing & risks
+
+**Recommended order:**
+1. **A0** — launcher as macOS entry point + instant AppKit splash (delivers the splash the owner is asking for; gains srv supervision for free). Ship as its own PR + re-notarized DMG.
+2. **C0/C1/C2** — symbolize and harden the tear-off crash (independent; the cold `CreateWindowTask` path exists regardless of the launcher).
+3. **A1/A2** — single-instance (`flock`) + Unix-socket saga-IPC, so the window/pool/instance reducer actually coordinates on macOS.
+4. **C4** — confirm the warm pool (now refilled by the `pool_respawn` saga) keeps tear-off off the crash path.
+
+| Risk | Mitigation |
+|---|---|
+| Launcher AppKit splash + Tokio supervision on one process | Splash on the launcher main thread; run `run_unix` supervision on a background thread / pump both runloops. Launcher and host are separate processes, so no conflict with CEF's runloop |
+| Duplicate Dock tile (launcher + host) | Launcher = `.accessory` (no tile); host = `.regular` (one tile). Verify there's exactly one |
+| Splash never dismissed (missed host signal) | Safety timeout (~8 s) + dismiss-on-host-window-visible fallback |
+| `../Frameworks` lookup breaks under launcher-rooted bundle | Host stays at `Contents/MacOS/agentmux-cef`; `../Frameworks` already resolves — smoke-test first (Open Q1) |
+| Adding the launcher regresses notarization/Gatekeeper | Sign inside-out, launcher last; re-run full `spctl`/`stapler` checks |
+| Crash is in our patched CEF 148, not host logic | C0 bisect against the official prebuilt framework |
+
+## 7. Open questions
+1. **Framework placement** under the launcher-rooted bundle — confirm `Contents/MacOS/../Frameworks` resolves with the host as a sibling of the launcher (expected yes).
+2. **Splash dismiss transport for A0** — host-stdout token (simplest, no new transport) vs a dedicated `AGENTMUX_SPLASH_SOCK` datagram. Start with stdout token; revisit if A1/A2's Unix socket lands first.
+3. **AppKit crate** — what the launcher already pulls in for macOS GUI (objc2 / cocoa / raw `objc`); pick the lightest path to an `NSWindow` + image view to keep the launcher tiny and fast.
+4. **Is the SIGABRT in our patched framework or generic?** — resolve via C0 before investing in C1/C3.
+5. **Linux** — A1/A2's Unix code (flock, Unix socket, process group) is shared; Linux splash is out of scope for now (no instant-splash requirement stated).
+
+## 8. Decision
+The launcher is **not optional** on macOS, and the splash **must** live in it. Ship **A0** first (launcher as the packaged entry point with an instant native splash) as the priority — it directly answers "we need it right away." Then harden the crash (C), then complete single-instance + saga-IPC parity (A1/A2) so the window/pool/saga reducer coordinates on macOS. The host-owned-splash fallback is dropped per the owner's instant-splash requirement.

--- a/docs/specs/SPEC_MACOS_PACKAGING_2026_05_30.md
+++ b/docs/specs/SPEC_MACOS_PACKAGING_2026_05_30.md
@@ -1,0 +1,153 @@
+# Spec: macOS packaging — signed, launchable `AgentMux.app` / `.dmg`
+
+**Date:** 2026-05-30
+**Status:** Spec → implementation (phased)
+**Related:** `docs/macos-signing.md`, `docs/retro/retro-macos-keychain-prompt-2026-05-30.md`,
+`docs/specs/SPEC_MACOS_CEF_FRAMEWORK_BUNDLING_2026_05_28.md` (framework bundling — done),
+`docs/specs/SPEC_SUPPRESS_OS_CREDENTIAL_PROMPTS_2026_05_30.md` (keychain prompt — done, #1208).
+
+## Goal
+
+`task package:macos` produces a **signed, launchable** `AgentMux.app` (and `.dmg`) on Apple Silicon —
+the app opens its window and renders the UI — ready for Developer-ID distribution (notarization gated
+separately on the Apple account agreement).
+
+This implements the long-deferred `package:macos` TODO. Framework bundling (`bundle:darwin`) and dev
+launch already work; the keychain-prompt blocker is fixed (#1208). Two pieces remain: the **packaging
+pipeline** (assemble + sign + DMG) and the **CEF subprocess model** (Helper apps).
+
+## Background / findings
+
+A first-cut packaging script assembles a valid, Developer-ID-signed `.app` that passes
+`codesign --verify --deep --strict`, and (post-#1208) the **browser process launches**: the host log
+shows `Browser created`, window registration, message loop entry, Dock tile, and icon. **But the
+renderer/GPU subprocesses crash-loop** (hundreds of crashes in seconds → crash-budget abort → the
+"Window stopped recovering" page). This persists even **ad-hoc-signed without hardened runtime**, so it
+is **structural**, not a signing/entitlements problem.
+
+Root cause: the host sets `browser_subprocess_path = current_exe()` and re-execs **its own bundle
+binary** for renderer/GPU/utility. That works for the bare dev binary but **not** inside a signed `.app`:
+every subprocess inherits the main bundle's identity (`CFBundleIdentifier ai.agentmux.cef`, a *regular*
+foreground app), which the macOS process/Mach model rejects — the standard reason CEF macOS apps ship
+dedicated **Helper.app** bundles for subprocesses.
+
+## Design
+
+### Part A — Bundle layout (mostly implemented)
+
+```
+AgentMux.app/Contents/
+  Info.plist                              CFBundleIdentifier ai.agentmux.cef
+  MacOS/
+    agentmux-cef                          host (CFBundleExecutable)
+    agentmux-srv-<VERSION>-darwin.arm64   backend (sidecar::resolve_backend_binary)
+    frontend → ../Resources/frontend      symlink (host's current_exe()/frontend lookup;
+                                          real tree under Resources/ so codesign seals it)
+    *.dylib                               GL libs (Chromium DIR_MODULE = exe dir)
+  Frameworks/
+    Chromium Embedded Framework.framework
+    AgentMux Helper.app/                  ← NEW (Part B)
+      Contents/
+        Info.plist                        CFBundleIdentifier ai.agentmux.cef.helper, LSUIElement=1
+        MacOS/
+          AgentMux Helper                 copy of agentmux-cef
+          *.dylib                         GL libs (the GPU helper's DIR_MODULE = its own exe dir)
+  Resources/
+    AgentMux.icns
+    frontend/…
+```
+
+Notes:
+- The host self-reexecs for subprocesses ONLY in dev (bare binary). In the `.app`, subprocesses run the
+  Helper.
+- Resources (frontend, icns) live under `Contents/Resources/`; only executables/dylibs go under
+  `MacOS/` (codesign rejects resource trees under `MacOS/`). The `frontend` symlink bridges the host's
+  `current_exe()/frontend` lookup with no Rust change.
+- `vk_swiftshader_icd.json` is omitted (non-code file codesign rejects under `MacOS/`; SwiftShader-Vulkan
+  software fallback only — not needed with hardware GL). If ever required, place under Resources with a
+  `library_path` pointing back at `MacOS/`.
+
+### Part B — CEF Helper app (the launch fix)
+
+1. **Packaging:** create `Contents/Frameworks/AgentMux Helper.app` with:
+   - `Contents/MacOS/AgentMux Helper` = a copy of `agentmux-cef`.
+   - `Contents/MacOS/*.dylib` = the GL libs (the GPU helper resolves them via its own DIR_MODULE).
+   - `Contents/Info.plist`: `CFBundleIdentifier = ai.agentmux.cef.helper`, `CFBundleExecutable =
+     AgentMux Helper`, `LSUIElement = true`, `CFBundlePackageType = APPL`.
+   - Signed with hardened runtime + `build/entitlements.mac.plist` (the renderer's V8 needs
+     allow-jit / unsigned-executable-memory; disable-library-validation lets it load the framework).
+   - A single helper suffices because all subprocess types share one entitlement set (Chromium permits
+     one helper when entitlements don't vary per type).
+
+2. **Rust (macOS-gated, no Windows change) — `agentmux-cef/src/main.rs`:**
+   - `browser_subprocess_path`: when running inside an `.app` (a sibling
+     `…/Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/AgentMux Helper` exists), point CEF at it;
+     else fall back to `current_exe()` (dev). Gated `#[cfg(target_os = "macos")]`; Windows/Linux keep
+     `current_exe()` verbatim.
+   - `LibraryLoader`: the helper executable lives 4 levels deeper than the main exe, so it must resolve
+     the framework with `helper = true` (`…/../../../../Frameworks/…`) instead of `false`
+     (`…/../Frameworks/…`). Detect via the exe path containing `.app/Contents/Frameworks/` →
+     `helper = true`. The main host + dev binary stay `helper = false`.
+
+   Both are net-additive, macOS-cfg-gated branches around values that are currently `current_exe()`/
+   `false` — no shared type/state change (avoids the #1192 Windows-compile failure mode).
+
+### Part C — Signing pipeline (implemented)
+
+Inside-out, deepest first, `--options runtime --timestamp`: GL dylibs → framework `Libraries/*.dylib` →
+framework bundle → **Helper.app** (its dylibs, then the helper exe, then the helper bundle) → srv → host
+→ the `.app`. Backend/host/helper/app get `build/entitlements.mac.plist`. Cert auto-detected from the
+keychain (`security find-identity`; never hardcode identity — `MACOS_SIGN_CERT` override; details in the
+private `agentmux-builder`).
+
+### Part D — DMG + notarization (implemented; notarization gated externally)
+
+DMG with an `/Applications` symlink; signed. Notarize via the `notarytool` keychain profile and staple;
+degrade to a signed-only DMG if notarization is unavailable. **External blocker:** the Apple Developer
+program agreement is expired (`notarytool` HTTP 403) — must be re-signed at appstoreconnect.apple.com
+before any notarization succeeds.
+
+## Phasing & PRs
+
+- **PR 1 — packaging pipeline + this spec.** `task package:macos` + `scripts/package-macos.sh`
+  (assemble Parts A/C/D) + `docs/macos-signing.md` refresh + the `entitlements` comment + `.gitignore`
+  for the build artifact. Produces a valid **signed** DMG. (App not yet launchable — Part B follows;
+  documented in the PR + this spec.)
+- **PR 2 — CEF Helper app (Part B).** The macOS-gated Rust change + the packaging script emitting +
+  signing the Helper.app. **Acceptance:** the signed `.app` opens its window and a renderer subprocess
+  **survives** (no crash-loop); `lsappinfo` shows it Foreground with a Dock tile.
+- **External:** re-sign the Apple agreement → notarize + staple → upload the DMG to the release.
+
+## Verification (Part B acceptance)
+
+1. `task package:macos`; `open build/AgentMux.app`.
+2. A `--type=renderer` subprocess stays alive >15 s; `count windows` ≥ 1; UI renders.
+3. Host log: no `crash budget exceeded`; `Browser created` followed by a live renderer.
+4. No OS credential prompt (already fixed, #1208).
+
+## Findings update (2026-05-30, post-implementation)
+
+Parts A/B/C/D implemented and tested on the signed `.app`:
+
+- **Part B works for 5/6 subprocess types.** With the Helper app + `browser_subprocess_path` +
+  helper-aware `LibraryLoader`, the GPU / network / utility / service / storage subprocesses now run
+  as the stable `AgentMux Helper` (verified via `ps`: 3+ live `AgentMux Helper --type=…`), and no
+  longer crash-loop. The browser launches, creates its window, sets the Dock tile, and serves the
+  frontend. Signatures are valid: `codesign --verify --deep --strict` passes; browser + helper share
+  Team `7Z3Z4B37QJ` with hardened runtime.
+- **The renderer is gated on notarization.** It still won't stay up, but the cause is NOT a crash —
+  `cef-debug.log` shows `base/mac/process_requirement.cc: Unable to derive validation category for
+  current process. Signature validation … failed … Code=-67030` (`errSecCSReqFailed`). Chromium
+  validates that subprocesses are legitimately signed; on macOS 26 that derivation requires a
+  **fully-trusted** signature. `spctl --assess` reports `rejected — source=Unnotarized Developer ID`.
+  So the renderer process-requirement check fails **only because the build isn't notarized**.
+- **Conclusion:** the implementation is complete. A fully-launching macOS app needs **notarization**,
+  which is blocked on the Apple Developer program agreement (`notarytool` HTTP 403 — re-sign at
+  appstoreconnect.apple.com). Once notarized + stapled, the renderer process-requirement check should
+  pass. (If a non-notarized dev launch is needed before then, investigate a Chromium
+  `--disable-features=…` switch for the process-requirement enforcement — not pursued here to avoid
+  shipping a speculative flag.)
+
+## Out of scope
+
+Intel (x86_64) slice, Mac App Store distribution, per-type helper entitlements, auto-update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.41.0",
+      "version": "0.41.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.40.1",
+      "version": "0.41.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.41.1",
+  "version": "0.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.41.1",
+      "version": "0.40.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -164,7 +164,7 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
@@ -1042,7 +1042,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,7 +1058,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,7 +1074,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1093,7 +1090,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,7 +1106,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,7 +1122,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,7 +1138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,7 +1154,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,7 +1170,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,7 +1186,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,7 +1202,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1229,7 +1218,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,7 +1234,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1263,7 +1250,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,7 +1266,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,7 +1282,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1314,7 +1298,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,7 +1314,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,7 +1330,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1365,7 +1346,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,7 +1362,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,7 +1378,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,7 +1394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,7 +1410,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,7 +1426,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,7 +1442,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1695,6 +1669,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1912,7 +1898,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1952,7 +1937,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,7 +1957,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,7 +1977,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2015,7 +1997,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2036,7 +2017,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,7 +2037,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,7 +2057,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,7 +2077,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2120,7 +2097,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2141,7 +2117,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2162,7 +2137,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2183,7 +2157,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,7 +2177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,7 +2256,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,7 +2269,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2312,7 +2282,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2326,7 +2295,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2340,7 +2308,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2354,7 +2321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2368,7 +2334,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,7 +2347,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2396,7 +2360,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,7 +2373,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2424,7 +2386,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,7 +2399,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,7 +2412,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,7 +2425,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,7 +2438,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,7 +2451,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2508,7 +2464,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2522,7 +2477,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2536,7 +2490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2550,7 +2503,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,7 +2516,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2578,7 +2529,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,7 +2542,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,7 +2555,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2620,7 +2568,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3461,7 +3408,7 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
@@ -3481,7 +3428,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
@@ -3943,7 +3890,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4581,7 +4528,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4800,6 +4747,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4991,7 +4946,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5204,7 +5159,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -5850,7 +5805,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5976,7 +5931,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6341,7 +6296,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6458,7 +6412,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6504,7 +6457,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7187,7 +7140,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7232,7 +7185,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7349,7 +7302,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7369,7 +7322,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7560,7 +7513,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7796,7 +7749,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7829,7 +7782,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7850,7 +7802,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7871,7 +7822,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7892,7 +7842,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7913,7 +7862,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7934,7 +7882,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7955,7 +7902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7976,7 +7922,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7997,7 +7942,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8018,7 +7962,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8039,7 +7982,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8104,6 +8046,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9314,7 +9269,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9371,7 +9326,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9421,7 +9375,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9723,7 +9676,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9769,7 +9721,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10039,6 +9990,19 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -10050,7 +10014,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10064,7 +10028,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -10379,7 +10343,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10445,7 +10409,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10547,7 +10510,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10760,6 +10723,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -10939,7 +10925,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -11483,6 +11469,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11573,7 +11587,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11802,7 +11815,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11822,7 +11835,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11904,7 +11916,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -12135,7 +12147,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -12302,7 +12313,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12319,7 +12329,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12336,7 +12345,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12353,7 +12361,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12370,7 +12377,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12387,7 +12393,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12404,7 +12409,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12421,7 +12425,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12438,7 +12441,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12455,7 +12457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12472,7 +12473,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12489,7 +12489,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12506,7 +12505,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12523,7 +12521,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12540,7 +12537,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12557,7 +12553,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12574,7 +12569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12591,7 +12585,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12608,7 +12601,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12625,7 +12617,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12642,7 +12633,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12659,7 +12649,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12676,7 +12665,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12693,7 +12681,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12710,7 +12697,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12727,7 +12713,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12741,7 +12726,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12783,7 +12767,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Build AgentMux as a signed macOS .app + .dmg (Developer ID, hardened runtime).
+#
+# Usage:  bash scripts/package-macos.sh [output-dir]   (output-dir defaults to ~/Desktop)
+#
+# Prerequisites (the `task package:macos` deps run these for you):
+#   task build:host      → dist/cef/agentmux-cef
+#   task build:backend   → dist/bin/agentmux-srv-<VERSION>-darwin.arm64
+#   task build:frontend  → dist/frontend/index.html
+#   task bundle          → dist/Frameworks/Chromium Embedded Framework.framework + GL libs in dist/cef/
+#
+# Bundle layout. The host resolves everything RELATIVE TO ITS OWN BINARY
+# (current_exe().parent()), so this needs ZERO Rust changes — it mirrors the
+# Linux AppImage's "next to the binary" convention, mapped onto .app dirs:
+#
+#   AgentMux.app/Contents/
+#     Info.plist
+#     MacOS/
+#       agentmux-cef                          ← host (CFBundleExecutable; re-execs
+#                                                itself for renderer/gpu subprocesses)
+#       agentmux-srv-<VERSION>-darwin.arm64   ← backend (sidecar::resolve_backend_binary)
+#       frontend/                             ← bundled UI (resolve_frontend_base_url)
+#       *.dylib + vk_swiftshader_icd.json     ← GL libs (Chromium DIR_MODULE = exe dir)
+#     Frameworks/
+#       Chromium Embedded Framework.framework ← cef-rs ../Frameworks/... lookup +
+#                                                CefSettings framework_dir_path
+#     Resources/
+#       AgentMux.icns
+#
+# Signing/notarization: each Mach-O is signed inside-out with --options runtime.
+# Notarization is ATTEMPTED via the `notarytool` keychain profile; if it fails
+# (e.g. an expired Apple Developer agreement → HTTP 403) the script still emits a
+# SIGNED — but un-notarized — DMG and warns. Gatekeeper will then require a
+# right-click→Open on first launch on other Macs until the build is notarized.
+#   NOTARIZE=0            skip notarization entirely (signed-only)
+#   NOTARY_PROFILE=name   keychain profile name (default: notarytool)
+#   MACOS_SIGN_CERT="..." override the Developer ID cert name
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="$(node -p "require('./package.json').version")"
+ARCH="arm64"   # Apple Silicon; cef-dll-sys resolves the aarch64 framework
+OUTDIR="${1:-$HOME/Desktop}"
+APP="$REPO_ROOT/build/AgentMux.app"
+DMG="$OUTDIR/AgentMux_${VERSION}_${ARCH}.dmg"
+# Resolve the Developer ID cert from the keychain — never hardcode the signing
+# identity (name + team id) in the public repo. Override with MACOS_SIGN_CERT.
+# Credential/identity details live in the private agentmux-builder repo.
+CERT="${MACOS_SIGN_CERT:-$(security find-identity -v -p codesigning 2>/dev/null \
+        | awk -F'"' '/Developer ID Application/ {print $2; exit}')}"
+[ -n "$CERT" ] || { echo "❌ No 'Developer ID Application' identity in the keychain (and MACOS_SIGN_CERT unset)." >&2; exit 1; }
+ENTITLEMENTS="$REPO_ROOT/build/entitlements.mac.plist"
+BUNDLE_ID="ai.agentmux.cef"
+NOTARIZE="${NOTARIZE:-1}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-notarytool}"
+SRV="dist/bin/agentmux-srv-${VERSION}-darwin.${ARCH}"
+
+require() { [ -e "$1" ] || { echo "❌ missing required artifact: $1 — run the build steps first" >&2; exit 1; }; }
+require dist/cef/agentmux-cef
+require "$SRV"
+require dist/frontend/index.html
+require "dist/Frameworks/Chromium Embedded Framework.framework"
+[ -f "$ENTITLEMENTS" ] || { echo "❌ missing entitlements: $ENTITLEMENTS" >&2; exit 1; }
+
+echo "==> Assembling AgentMux.app v$VERSION ($ARCH)"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" "$APP/Contents/Resources"
+
+cp dist/cef/agentmux-cef "$APP/Contents/MacOS/agentmux-cef"
+cp "$SRV" "$APP/Contents/MacOS/$(basename "$SRV")"
+
+# Frontend is a tree of resource files (HTML/CSS/fonts), NOT code. codesign
+# only allows executables under Contents/MacOS/ — a resource dir there breaks
+# the bundle seal ("In subcomponent: …/frontend/…css"). So the real files live
+# in Contents/Resources/frontend (sealed automatically as bundle resources),
+# and a relative symlink at Contents/MacOS/frontend keeps the host's
+# `current_exe().parent()/frontend` lookup working with no Rust change.
+cp -R dist/frontend "$APP/Contents/Resources/frontend"
+ln -s "../Resources/frontend" "$APP/Contents/MacOS/frontend"
+
+# GL libs next to the host exe (Chromium DIR_MODULE = exe dir). These are
+# Mach-O dylibs, so codesign signs them as nested code — fine under MacOS/.
+# NOTE: vk_swiftshader_icd.json (the SwiftShader Vulkan ICD manifest) is
+# intentionally NOT copied: it's a non-code JSON file, which codesign refuses
+# to seal under Contents/MacOS/, and it's only the software-Vulkan fallback —
+# not needed with hardware GL (libGLESv2/libEGL). If a future build must ship
+# it, place it in Resources/ with a library_path that points back at MacOS/.
+shopt -s nullglob
+for f in dist/cef/*.dylib; do cp "$f" "$APP/Contents/MacOS/"; done
+shopt -u nullglob
+
+# CEF framework — ditto preserves the Versions/Current symlink chain the loader follows.
+ditto "dist/Frameworks/Chromium Embedded Framework.framework" \
+      "$APP/Contents/Frameworks/Chromium Embedded Framework.framework"
+
+# CEF Helper app — renderer/GPU/utility subprocesses run as this dedicated
+# helper (distinct bundle id, LSUIElement) instead of re-execing the main
+# bundle binary, which the macOS process model rejects (→ renderer crash-loop).
+# The host points CEF's browser_subprocess_path at it (see
+# main.rs::resolve_browser_subprocess_path). One helper suffices because all
+# subprocess types share one entitlement set.
+HELPER_APP="$APP/Contents/Frameworks/AgentMux Helper.app"
+mkdir -p "$HELPER_APP/Contents/MacOS"
+cp dist/cef/agentmux-cef "$HELPER_APP/Contents/MacOS/AgentMux Helper"
+# GL libs next to the helper exe too — the GPU subprocess resolves them via its
+# own DIR_MODULE (= the helper's MacOS dir).
+shopt -s nullglob
+for f in dist/cef/*.dylib; do cp "$f" "$HELPER_APP/Contents/MacOS/"; done
+shopt -u nullglob
+cat > "$HELPER_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>AgentMux Helper</string>
+    <key>CFBundleDisplayName</key><string>AgentMux Helper</string>
+    <key>CFBundleExecutable</key><string>AgentMux Helper</string>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}.helper</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
+    <key>LSUIElement</key><true/>
+    <key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>
+PLIST
+
+# Icon: build AgentMux.icns from the 512px PNG (the normal AgentMux logo, same
+# source the Dock icon + Linux taskbar use).
+echo "==> Generating AgentMux.icns"
+SRC_PNG="assets/linux/icons/hicolor/512x512/apps/agentmux.png"
+require "$SRC_PNG"
+ICONSET="$(mktemp -d)/AgentMux.iconset"; mkdir -p "$ICONSET"
+for s in 16 32 64 128 256 512; do
+  sips -z "$s" "$s" "$SRC_PNG" --out "$ICONSET/icon_${s}x${s}.png" >/dev/null
+  d=$((s * 2)); sips -z "$d" "$d" "$SRC_PNG" --out "$ICONSET/icon_${s}x${s}@2x.png" >/dev/null
+done
+iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AgentMux.icns"
+
+# Info.plist
+cat > "$APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>AgentMux</string>
+    <key>CFBundleDisplayName</key><string>AgentMux</string>
+    <key>CFBundleExecutable</key><string>agentmux-cef</string>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleIconFile</key><string>AgentMux</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
+    <key>NSHighResolutionCapable</key><true/>
+    <key>NSPrincipalClass</key><string>NSApplication</string>
+    <key>LSApplicationCategoryType</key><string>public.app-category.developer-tools</string>
+</dict>
+</plist>
+PLIST
+
+echo "==> Signing inside-out (Developer ID: $CERT)"
+SIGN=(codesign --force --timestamp --options runtime --sign "$CERT")
+FW="$APP/Contents/Frameworks/Chromium Embedded Framework.framework"
+
+# 1. GL dylibs next to the exe (plain libraries — no entitlements).
+shopt -s nullglob
+for dy in "$APP/Contents/MacOS/"*.dylib; do "${SIGN[@]}" "$dy"; done
+# 2. Framework's nested dylibs, then the framework bundle itself.
+for dy in "$FW/Libraries/"*.dylib; do "${SIGN[@]}" "$dy"; done
+# 3. Helper app: its GL dylibs → helper exe (entitlements: the renderer's V8
+#    JIT + framework dlopen) → helper bundle. Signed before the outer .app so
+#    its signature is included in the bundle seal.
+for dy in "$HELPER_APP/Contents/MacOS/"*.dylib; do "${SIGN[@]}" "$dy"; done
+shopt -u nullglob
+"${SIGN[@]}" "$FW"
+"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$HELPER_APP/Contents/MacOS/AgentMux Helper"
+"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$HELPER_APP"
+# 4. Backend + host get the app entitlements (CLI feature access + CEF JIT).
+"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/$(basename "$SRV")"
+"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/agentmux-cef"
+# 5. Seal the .app bundle last (everything nested is already signed).
+"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP"
+
+echo "==> Verifying signature"
+codesign --verify --deep --strict --verbose=2 "$APP"
+
+echo "==> Creating DMG"
+mkdir -p "$OUTDIR"
+rm -f "$DMG"
+STAGE="$(mktemp -d)/dmg"; mkdir -p "$STAGE"
+ditto "$APP" "$STAGE/AgentMux.app"
+ln -s /Applications "$STAGE/Applications"
+hdiutil create -volname "AgentMux ${VERSION}" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
+codesign --force --timestamp --sign "$CERT" "$DMG"
+
+NOTARIZED=0
+if [ "$NOTARIZE" = "1" ]; then
+    echo "==> Notarizing (keychain profile: $NOTARY_PROFILE)"
+    if xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait 2>&1 \
+         | tee /tmp/agentmux-notary.log | grep -q "status: Accepted"; then
+        xcrun stapler staple "$DMG"
+        NOTARIZED=1
+        echo "✓ Notarized + stapled"
+    else
+        echo "⚠ Notarization FAILED or unavailable — emitting a SIGNED-ONLY DMG."
+        echo "  Log: /tmp/agentmux-notary.log"
+        echo "  Most likely the Apple Developer program license agreement needs"
+        echo "  re-signing at https://appstoreconnect.apple.com (notarytool returns"
+        echo "  HTTP 403 'a required agreement is missing or has expired')."
+    fi
+else
+    echo "==> Skipping notarization (NOTARIZE=0)"
+fi
+
+echo ""
+if [ "$NOTARIZED" = "1" ]; then
+    echo "✓ Built SIGNED + NOTARIZED DMG: $DMG"
+else
+    echo "✓ Built SIGNED (not notarized) DMG: $DMG"
+fi
+codesign -dv --verbose=2 "$DMG" 2>&1 | grep -E "Authority=|TeamIdentifier=" | head -3 || true
+ls -lh "$DMG"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -112,9 +112,14 @@ for i in "${!HELPER_NAMES[@]}"; do
     ha="$APP/Contents/Frameworks/${hn}.app"
     mkdir -p "$ha/Contents/MacOS"
     cp dist/cef/agentmux-cef "$ha/Contents/MacOS/${hn}"
-    # GL libs next to each helper exe (the GPU subprocess resolves them via its
-    # own DIR_MODULE = the helper's MacOS dir).
-    for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done
+    # GL libs ONLY next to the GPU helper (the GPU subprocess resolves them via
+    # its DIR_MODULE) + the generic helper as a fallback. The renderer/plugin/
+    # alloy helpers never touch GL, so copying ~45MB of GL libs (mostly
+    # libvk_swiftshader) into each of them is pure bloat.
+    case "$hn" in
+        "AgentMux Helper"|"AgentMux Helper (GPU)")
+            for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done ;;
+    esac
     cat > "$ha/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -173,9 +178,40 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
+FW="$APP/Contents/Frameworks/Chromium Embedded Framework.framework"
+
+# Strip debug/local symbols from every Mach-O BEFORE signing (a from-source
+# CEF build with symbol_level=1 leaves ~240MB of symbols in libcef alone).
+# `strip -S -x` removes debug info + local symbols while keeping the exported
+# (global) symbols that cef-rs's loader needs. Halves the framework; the GL
+# dylibs and the host/helper copies shrink too. Must run before codesign (it
+# would otherwise invalidate the signature).
+echo "==> Stripping symbols (lean build)"
+strip -S -x "$FW/Versions/A/Chromium Embedded Framework" 2>/dev/null || true
+shopt -s nullglob
+for dy in "$FW/Versions/A/Libraries/"*.dylib \
+          "$APP/Contents/MacOS/"*.dylib \
+          "$APP/Contents/MacOS/agentmux-cef" \
+          "$APP/Contents/Frameworks/"*Helper*.app/Contents/MacOS/*.dylib \
+          "$APP/Contents/Frameworks/"*Helper*.app/Contents/MacOS/"AgentMux Helper"*; do
+    strip -S -x "$dy" 2>/dev/null || true
+done
+shopt -u nullglob
+# Trim non-English locales (~52MB of locale.pak across ~200 languages). These
+# are only Chromium's built-in UI strings (context menus, etc.) — AgentMux's UI
+# is its own bundled frontend. Chromium falls back to en for any locale whose
+# .pak is absent, so keeping en* is safe and standard for size-conscious builds.
+LOCDIR="$FW/Versions/A/Resources"
+for lp in "$LOCDIR"/*.lproj; do
+    case "$(basename "$lp")" in
+        en.lproj|en_*.lproj|en-*.lproj) ;;
+        *) rm -rf "$lp" ;;
+    esac
+done
+echo "  framework now: $(du -sh "$FW" 2>/dev/null | awk '{print $1}')  (locales trimmed to en*)"
+
 echo "==> Signing inside-out (Developer ID: $CERT)"
 SIGN=(codesign --force --timestamp --options runtime --sign "$CERT")
-FW="$APP/Contents/Frameworks/Chromium Embedded Framework.framework"
 
 # 1. GL dylibs next to the exe (plain libraries — no entitlements).
 shopt -s nullglob

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -94,6 +94,13 @@ cp dist/cef/agentmux-launcher "$APP/Contents/MacOS/agentmux-launcher"
 cp -R dist/frontend "$APP/Contents/Resources/frontend"
 ln -s "../Resources/frontend" "$APP/Contents/MacOS/frontend"
 
+# Strip .js.map source maps for release DMGs (~28 MB saved). Matches the
+# STRIP_MAPS logic in scripts/package.sh (#1226). Set STRIP_MAPS=0 to keep.
+if [ "${STRIP_MAPS:-1}" = "1" ]; then
+    find "$APP/Contents/Resources/frontend" -name "*.map" -delete
+    echo "  stripped .map files from frontend"
+fi
+
 # Schema files (JSON) — srv resolves these from AGENTMUX_APP_PATH/schema
 # which is Contents/MacOS/ (the host exe's parent directory). Resource files
 # cannot live under Contents/MacOS/ without breaking the bundle seal, so

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -123,17 +123,16 @@ ditto "dist/Frameworks/Chromium Embedded Framework.framework" \
 # the macOS process model accepts them instead of re-execing the main bundle.
 # (The patched CEF framework additionally disables the Mach-port peer
 # process_requirement validation that failed on macOS 26 — the deeper fix.)
-# Two helpers are needed:
-# 1. "AgentMux Helper"         — the subprocess binary CEF spawns for all
-#    renderer/GPU/utility processes. resolve_browser_subprocess_path()
-#    (agentmux-cef/src/main.rs) points browser_subprocess_path here; the
-#    per-type variants (GPU/Plugin/Renderer/Alloy) are NOT used because we
-#    set an explicit subprocess path rather than relying on CEF's name-based
-#    discovery.
-# 2. "AgentMux Helper (Alerts)" — spawned by Chromium's native notification
-#    alert service; without it posix_spawnp retries forever.
-HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (Alerts)")
-HELPER_IDS=("helper" "helper.alerts")
+# The patched from-source CEF 148 framework spawns renderer/GPU/utility
+# subprocesses as per-type named helpers (Renderer/GPU/Plugin/Alloy) regardless
+# of browser_subprocess_path — it derives the path from the bundle name directly.
+# All six variants are required:
+#   Generic  — fallback + resolve_browser_subprocess_path() target
+#   Renderer / GPU / Plugin / Alloy — spawned by the patched CEF 148 framework
+#   Alerts   — Chromium's native notification service
+HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (GPU)" "AgentMux Helper (Plugin)" \
+              "AgentMux Helper (Renderer)" "AgentMux Helper (Alloy)" "AgentMux Helper (Alerts)")
+HELPER_IDS=("helper" "helper.gpu" "helper.plugin" "helper.renderer" "helper.alloy" "helper.alerts")
 HELPER_APPS=()
 shopt -s nullglob
 for i in "${!HELPER_NAMES[@]}"; do
@@ -141,12 +140,13 @@ for i in "${!HELPER_NAMES[@]}"; do
     ha="$APP/Contents/Frameworks/${hn}.app"
     mkdir -p "$ha/Contents/MacOS"
     cp dist/cef/agentmux-cef "$ha/Contents/MacOS/${hn}"
-    # GL libs go next to the generic helper only — GPU/renderer processes
-    # resolve dylibs via their DIR_MODULE (= this helper's MacOS dir).
-    # The Alerts helper never touches GL.
-    if [ "$hn" = "AgentMux Helper" ]; then
-        for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done
-    fi
+    # GL libs next to generic + GPU helpers only — the GPU subprocess resolves
+    # them via its DIR_MODULE; the generic helper needs them as a fallback.
+    # Renderer/Plugin/Alloy/Alerts never touch GL.
+    case "$hn" in
+        "AgentMux Helper"|"AgentMux Helper (GPU)")
+            for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done ;;
+    esac
     cat > "$ha/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -141,14 +141,12 @@ for i in "${!HELPER_NAMES[@]}"; do
     ha="$APP/Contents/Frameworks/${hn}.app"
     mkdir -p "$ha/Contents/MacOS"
     cp dist/cef/agentmux-cef "$ha/Contents/MacOS/${hn}"
-    # GL libs ONLY next to the GPU helper (the GPU subprocess resolves them via
-    # its DIR_MODULE) + the generic helper as a fallback. The renderer/plugin/
-    # alloy helpers never touch GL, so copying ~45MB of GL libs (mostly
-    # libvk_swiftshader) into each of them is pure bloat.
-    case "$hn" in
-        "AgentMux Helper"|"AgentMux Helper (GPU)")
-            for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done ;;
-    esac
+    # GL libs go next to the generic helper only — GPU/renderer processes
+    # resolve dylibs via their DIR_MODULE (= this helper's MacOS dir).
+    # The Alerts helper never touches GL.
+    if [ "$hn" = "AgentMux Helper" ]; then
+        for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done
+    fi
     cat > "$ha/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -95,29 +95,35 @@ shopt -u nullglob
 ditto "dist/Frameworks/Chromium Embedded Framework.framework" \
       "$APP/Contents/Frameworks/Chromium Embedded Framework.framework"
 
-# CEF Helper app — renderer/GPU/utility subprocesses run as this dedicated
-# helper (distinct bundle id, LSUIElement) instead of re-execing the main
-# bundle binary, which the macOS process model rejects (→ renderer crash-loop).
-# The host points CEF's browser_subprocess_path at it (see
-# main.rs::resolve_browser_subprocess_path). One helper suffices because all
-# subprocess types share one entitlement set.
-HELPER_APP="$APP/Contents/Frameworks/AgentMux Helper.app"
-mkdir -p "$HELPER_APP/Contents/MacOS"
-cp dist/cef/agentmux-cef "$HELPER_APP/Contents/MacOS/AgentMux Helper"
-# GL libs next to the helper exe too — the GPU subprocess resolves them via its
-# own DIR_MODULE (= the helper's MacOS dir).
+# CEF Helper apps — on macOS, Chromium launches renderer/GPU/utility
+# subprocesses as the standard per-type helper apps named "<App> Helper (<Type>)"
+# (CEF's canonical macOS layout). Each is a copy of the host binary (which
+# handles --type subprocess mode), with a distinct bundle id + LSUIElement, so
+# the macOS process model accepts them instead of re-execing the main bundle.
+# (The patched CEF framework additionally disables the Mach-port peer
+# process_requirement validation that failed on macOS 26 — the deeper fix.)
+HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (GPU)" "AgentMux Helper (Plugin)" \
+              "AgentMux Helper (Renderer)" "AgentMux Helper (Alloy)")
+HELPER_IDS=("helper" "helper.gpu" "helper.plugin" "helper.renderer" "helper.alloy")
+HELPER_APPS=()
 shopt -s nullglob
-for f in dist/cef/*.dylib; do cp "$f" "$HELPER_APP/Contents/MacOS/"; done
-shopt -u nullglob
-cat > "$HELPER_APP/Contents/Info.plist" <<PLIST
+for i in "${!HELPER_NAMES[@]}"; do
+    hn="${HELPER_NAMES[$i]}"
+    ha="$APP/Contents/Frameworks/${hn}.app"
+    mkdir -p "$ha/Contents/MacOS"
+    cp dist/cef/agentmux-cef "$ha/Contents/MacOS/${hn}"
+    # GL libs next to each helper exe (the GPU subprocess resolves them via its
+    # own DIR_MODULE = the helper's MacOS dir).
+    for f in dist/cef/*.dylib; do cp "$f" "$ha/Contents/MacOS/"; done
+    cat > "$ha/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleName</key><string>AgentMux Helper</string>
-    <key>CFBundleDisplayName</key><string>AgentMux Helper</string>
-    <key>CFBundleExecutable</key><string>AgentMux Helper</string>
-    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}.helper</string>
+    <key>CFBundleName</key><string>${hn}</string>
+    <key>CFBundleDisplayName</key><string>${hn}</string>
+    <key>CFBundleExecutable</key><string>${hn}</string>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}.${HELPER_IDS[$i]}</string>
     <key>CFBundleVersion</key><string>${VERSION}</string>
     <key>CFBundleShortVersionString</key><string>${VERSION}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
@@ -128,6 +134,9 @@ cat > "$HELPER_APP/Contents/Info.plist" <<PLIST
 </dict>
 </plist>
 PLIST
+    HELPER_APPS+=("$ha")
+done
+shopt -u nullglob
 
 # Icon: build AgentMux.icns from the 512px PNG (the normal AgentMux logo, same
 # source the Dock icon + Linux taskbar use).
@@ -173,14 +182,18 @@ shopt -s nullglob
 for dy in "$APP/Contents/MacOS/"*.dylib; do "${SIGN[@]}" "$dy"; done
 # 2. Framework's nested dylibs, then the framework bundle itself.
 for dy in "$FW/Libraries/"*.dylib; do "${SIGN[@]}" "$dy"; done
-# 3. Helper app: its GL dylibs → helper exe (entitlements: the renderer's V8
-#    JIT + framework dlopen) → helper bundle. Signed before the outer .app so
-#    its signature is included in the bundle seal.
-for dy in "$HELPER_APP/Contents/MacOS/"*.dylib; do "${SIGN[@]}" "$dy"; done
+# 3. Each Helper app: its GL dylibs → helper exe (entitlements: the renderer's
+#    V8 JIT + framework dlopen) → helper bundle. Signed before the outer .app so
+#    the signatures are included in the bundle seal.
+for ha in "${HELPER_APPS[@]}"; do
+    for dy in "$ha/Contents/MacOS/"*.dylib; do "${SIGN[@]}" "$dy"; done
+done
 shopt -u nullglob
 "${SIGN[@]}" "$FW"
-"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$HELPER_APP/Contents/MacOS/AgentMux Helper"
-"${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$HELPER_APP"
+for ha in "${HELPER_APPS[@]}"; do
+    "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$ha/Contents/MacOS/$(basename "$ha" .app)"
+    "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$ha"
+done
 # 4. Backend + host get the app entitlements (CLI feature access + CEF JIT).
 "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/$(basename "$SRV")"
 "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/agentmux-cef"
@@ -202,17 +215,22 @@ codesign --force --timestamp --sign "$CERT" "$DMG"
 NOTARIZED=0
 if [ "$NOTARIZE" = "1" ]; then
     echo "==> Notarizing (keychain profile: $NOTARY_PROFILE)"
-    if xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait 2>&1 \
-         | tee /tmp/agentmux-notary.log | grep -q "status: Accepted"; then
+    # Capture the full output FIRST, then inspect — do NOT pipe into `grep -q`.
+    # `grep -q` exits on the first match (the mid-stream "Current status:
+    # Accepted"), which SIGPIPEs notarytool; under `set -o pipefail` that makes
+    # the whole pipeline non-zero and the success branch is skipped even though
+    # Apple accepted the submission (notarized-but-not-stapled). `|| true` keeps
+    # set -e from aborting if notarytool exits non-zero.
+    notary_out="$(xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait 2>&1 || true)"
+    printf '%s\n' "$notary_out" > /tmp/agentmux-notary.log
+    if printf '%s\n' "$notary_out" | grep -q "status: Accepted"; then
         xcrun stapler staple "$DMG"
         NOTARIZED=1
         echo "✓ Notarized + stapled"
     else
-        echo "⚠ Notarization FAILED or unavailable — emitting a SIGNED-ONLY DMG."
-        echo "  Log: /tmp/agentmux-notary.log"
-        echo "  Most likely the Apple Developer program license agreement needs"
-        echo "  re-signing at https://appstoreconnect.apple.com (notarytool returns"
-        echo "  HTTP 403 'a required agreement is missing or has expired')."
+        echo "⚠ Notarization not accepted — emitting a SIGNED-ONLY DMG. Log: /tmp/agentmux-notary.log"
+        echo "  If this is an agreement issue, re-sign at https://appstoreconnect.apple.com"
+        echo "  (notarytool returns HTTP 403 'a required agreement is missing or has expired')."
     fi
 else
     echo "==> Skipping notarization (NOTARIZE=0)"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -16,8 +16,11 @@
 #   AgentMux.app/Contents/
 #     Info.plist
 #     MacOS/
-#       agentmux-cef                          ← host (CFBundleExecutable; re-execs
-#                                                itself for renderer/gpu subprocesses)
+#       agentmux-launcher                     ← CFBundleExecutable: tiny binary
+#                                                that paints the splash instantly,
+#                                                then spawns + supervises srv + host
+#       agentmux-cef                          ← host (spawned by the launcher;
+#                                                re-execs for renderer/gpu helpers)
 #       agentmux-srv-<VERSION>-darwin.arm64   ← backend (sidecar::resolve_backend_binary)
 #       frontend/                             ← bundled UI (resolve_frontend_base_url)
 #       *.dylib + vk_swiftshader_icd.json     ← GL libs (Chromium DIR_MODULE = exe dir)
@@ -59,6 +62,7 @@ SRV="dist/bin/agentmux-srv-${VERSION}-darwin.${ARCH}"
 
 require() { [ -e "$1" ] || { echo "❌ missing required artifact: $1 — run the build steps first" >&2; exit 1; }; }
 require dist/cef/agentmux-cef
+require dist/cef/agentmux-launcher
 require "$SRV"
 require dist/frontend/index.html
 require "dist/Frameworks/Chromium Embedded Framework.framework"
@@ -70,6 +74,15 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" "$APP/Contents/Resourc
 
 cp dist/cef/agentmux-cef "$APP/Contents/MacOS/agentmux-cef"
 cp "$SRV" "$APP/Contents/MacOS/$(basename "$SRV")"
+
+# The LAUNCHER is the bundle entry point (CFBundleExecutable below): a tiny,
+# fast binary that paints the native splash INSTANTLY — before the multi-second
+# CEF host load — then spawns + supervises srv and the host (run_unix). The host
+# stays a sibling under MacOS/, so its current_exe()-relative resolution of
+# frontend/srv/../Frameworks and its Dock tile are byte-identical to the
+# host-as-entry-point build. The launcher runs as an accessory (no Dock tile of
+# its own); the host sets the regular policy and owns the one tile.
+cp dist/cef/agentmux-launcher "$APP/Contents/MacOS/agentmux-launcher"
 
 # Frontend is a tree of resource files (HTML/CSS/fonts), NOT code. codesign
 # only allows executables under Contents/MacOS/ — a resource dir there breaks
@@ -102,9 +115,12 @@ ditto "dist/Frameworks/Chromium Embedded Framework.framework" \
 # the macOS process model accepts them instead of re-execing the main bundle.
 # (The patched CEF framework additionally disables the Mach-port peer
 # process_requirement validation that failed on macOS 26 — the deeper fix.)
+# CEF 148 / Chromium also spawns an "(Alerts)" helper for the native
+# notification (alert) service; without it the framework retries
+# posix_spawnp forever ("No such file or directory"). Ship all six.
 HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (GPU)" "AgentMux Helper (Plugin)" \
-              "AgentMux Helper (Renderer)" "AgentMux Helper (Alloy)")
-HELPER_IDS=("helper" "helper.gpu" "helper.plugin" "helper.renderer" "helper.alloy")
+              "AgentMux Helper (Renderer)" "AgentMux Helper (Alloy)" "AgentMux Helper (Alerts)")
+HELPER_IDS=("helper" "helper.gpu" "helper.plugin" "helper.renderer" "helper.alloy" "helper.alerts")
 HELPER_APPS=()
 shopt -s nullglob
 for i in "${!HELPER_NAMES[@]}"; do
@@ -163,7 +179,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 <dict>
     <key>CFBundleName</key><string>AgentMux</string>
     <key>CFBundleDisplayName</key><string>AgentMux</string>
-    <key>CFBundleExecutable</key><string>agentmux-cef</string>
+    <key>CFBundleExecutable</key><string>agentmux-launcher</string>
     <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
     <key>CFBundleVersion</key><string>${VERSION}</string>
     <key>CFBundleShortVersionString</key><string>${VERSION}</string>
@@ -192,6 +208,7 @@ shopt -s nullglob
 for dy in "$FW/Versions/A/Libraries/"*.dylib \
           "$APP/Contents/MacOS/"*.dylib \
           "$APP/Contents/MacOS/agentmux-cef" \
+          "$APP/Contents/MacOS/agentmux-launcher" \
           "$APP/Contents/Frameworks/"*Helper*.app/Contents/MacOS/*.dylib \
           "$APP/Contents/Frameworks/"*Helper*.app/Contents/MacOS/"AgentMux Helper"*; do
     strip -S -x "$dy" 2>/dev/null || true
@@ -231,9 +248,13 @@ for ha in "${HELPER_APPS[@]}"; do
     "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$ha"
 done
 # 4. Backend + host get the app entitlements (CLI feature access + CEF JIT).
+#    The host is now NESTED code (the launcher is CFBundleExecutable), so it must
+#    be signed here, before the bundle seal.
 "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/$(basename "$SRV")"
 "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP/Contents/MacOS/agentmux-cef"
-# 5. Seal the .app bundle last (everything nested is already signed).
+# 5. Seal the .app bundle last. codesign signs the main executable
+#    (agentmux-launcher) as part of sealing; pass the entitlements so the
+#    launcher is hardened-runtime signed identically to the host.
 "${SIGN[@]}" --entitlements "$ENTITLEMENTS" "$APP"
 
 echo "==> Verifying signature"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -278,7 +278,10 @@ OSA
     sync
     hdiutil detach "$RWMNT" >/dev/null 2>&1 || true
 fi
-hdiutil convert "$RW" -format UDZO -o "$DMG" >/dev/null
+# ULMO (LZMA) compression — LZMA-class like Linux's SquashFS AppImage, vs the
+# default UDZO (zlib) which left the DMG ~50% larger. Requires macOS 10.15+ to
+# mount (we target 11+, so fine). On this build: UDZO 248MB -> ULMO 167MB.
+hdiutil convert "$RW" -format ULMO -o "$DMG" >/dev/null
 rm -f "$RW"
 codesign --force --timestamp --sign "$CERT" "$DMG"
 

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -203,13 +203,47 @@ done
 echo "==> Verifying signature"
 codesign --verify --deep --strict --verbose=2 "$APP"
 
-echo "==> Creating DMG"
+echo "==> Creating DMG (icon-view drag-to-install layout)"
 mkdir -p "$OUTDIR"
 rm -f "$DMG"
+DMG_VOL="AgentMux"
 STAGE="$(mktemp -d)/dmg"; mkdir -p "$STAGE"
 ditto "$APP" "$STAGE/AgentMux.app"
 ln -s /Applications "$STAGE/Applications"
-hdiutil create -volname "AgentMux ${VERSION}" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
+# Build a READ-WRITE DMG first so we can set the Finder window (icon view, the
+# AgentMux app icon on the left + an /Applications drop-target on the right —
+# the standard drag-to-install UX), then compress it read-only. Without this a
+# plain DMG opens in whatever view Finder last used (list/column), showing the
+# bundle as folders. Falls back to a plain DMG if Finder automation is
+# unavailable (headless / no TCC grant).
+RW="$(mktemp -u).dmg"
+hdiutil create -volname "$DMG_VOL" -srcfolder "$STAGE" -ov -format UDRW -fs HFS+ "$RW" >/dev/null
+RWMNT="$(hdiutil attach "$RW" -nobrowse -noautoopen 2>/dev/null | sed -n 's/.*\(\/Volumes\/.*\)/\1/p' | tail -1)"
+if [ -n "$RWMNT" ]; then
+    osascript >/dev/null 2>&1 <<OSA || echo "  ⚠ Finder layout skipped (automation unavailable) — DMG uses default view"
+tell application "Finder"
+    tell disk "$DMG_VOL"
+        open
+        set current view of container window to icon view
+        set toolbar visible of container window to false
+        set statusbar visible of container window to false
+        set the bounds of container window to {300, 150, 880, 520}
+        set vopts to the icon view options of container window
+        set arrangement of vopts to not arranged
+        set icon size of vopts to 128
+        set position of item "AgentMux.app" of container window to {150, 195}
+        set position of item "Applications" of container window to {430, 195}
+        update without registering applications
+        delay 1
+        close
+    end tell
+end tell
+OSA
+    sync
+    hdiutil detach "$RWMNT" >/dev/null 2>&1 || true
+fi
+hdiutil convert "$RW" -format UDZO -o "$DMG" >/dev/null
+rm -f "$RW"
 codesign --force --timestamp --sign "$CERT" "$DMG"
 
 NOTARIZED=0

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -65,6 +65,7 @@ require dist/cef/agentmux-cef
 require dist/cef/agentmux-launcher
 require "$SRV"
 require dist/frontend/index.html
+require dist/schema/settings.json
 require "dist/Frameworks/Chromium Embedded Framework.framework"
 [ -f "$ENTITLEMENTS" ] || { echo "❌ missing entitlements: $ENTITLEMENTS" >&2; exit 1; }
 
@@ -93,6 +94,13 @@ cp dist/cef/agentmux-launcher "$APP/Contents/MacOS/agentmux-launcher"
 cp -R dist/frontend "$APP/Contents/Resources/frontend"
 ln -s "../Resources/frontend" "$APP/Contents/MacOS/frontend"
 
+# Schema files (JSON) — srv resolves these from AGENTMUX_APP_PATH/schema
+# which is Contents/MacOS/ (the host exe's parent directory). Resource files
+# cannot live under Contents/MacOS/ without breaking the bundle seal, so
+# place them in Resources/schema and symlink like frontend.
+cp -R dist/schema "$APP/Contents/Resources/schema"
+ln -s "../Resources/schema" "$APP/Contents/MacOS/schema"
+
 # GL libs next to the host exe (Chromium DIR_MODULE = exe dir). These are
 # Mach-O dylibs, so codesign signs them as nested code — fine under MacOS/.
 # NOTE: vk_swiftshader_icd.json (the SwiftShader Vulkan ICD manifest) is
@@ -115,12 +123,17 @@ ditto "dist/Frameworks/Chromium Embedded Framework.framework" \
 # the macOS process model accepts them instead of re-execing the main bundle.
 # (The patched CEF framework additionally disables the Mach-port peer
 # process_requirement validation that failed on macOS 26 — the deeper fix.)
-# CEF 148 / Chromium also spawns an "(Alerts)" helper for the native
-# notification (alert) service; without it the framework retries
-# posix_spawnp forever ("No such file or directory"). Ship all six.
-HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (GPU)" "AgentMux Helper (Plugin)" \
-              "AgentMux Helper (Renderer)" "AgentMux Helper (Alloy)" "AgentMux Helper (Alerts)")
-HELPER_IDS=("helper" "helper.gpu" "helper.plugin" "helper.renderer" "helper.alloy" "helper.alerts")
+# Two helpers are needed:
+# 1. "AgentMux Helper"         — the subprocess binary CEF spawns for all
+#    renderer/GPU/utility processes. resolve_browser_subprocess_path()
+#    (agentmux-cef/src/main.rs) points browser_subprocess_path here; the
+#    per-type variants (GPU/Plugin/Renderer/Alloy) are NOT used because we
+#    set an explicit subprocess path rather than relying on CEF's name-based
+#    discovery.
+# 2. "AgentMux Helper (Alerts)" — spawned by Chromium's native notification
+#    alert service; without it posix_spawnp retries forever.
+HELPER_NAMES=("AgentMux Helper" "AgentMux Helper (Alerts)")
+HELPER_IDS=("helper" "helper.alerts")
 HELPER_APPS=()
 shopt -s nullglob
 for i in "${!HELPER_NAMES[@]}"; do


### PR DESCRIPTION
Produces a **standard, double-clickable, notarized macOS DMG** for AgentMux on macOS 26 (Tahoe). Consolidates all macOS packaging tooling plus two stability fixes.

## What's in here

### CEF 148 + renderer fix
- **CEF 146 → 148 bump** (Chromium 148.0.7778) — cross-platform code update, compiles clean on all platforms.
- **Patched CEF 148 framework fixes the macOS-26 renderer crash.** The signed/packaged renderer crash-looped with `process_requirement.cc … Error -67030`. Fixed at source: `GetPeerValidationPolicy() → kNoValidation` (`docs/cef-patches/`). Framework is **Metal-accelerated** (ANGLE-Metal / AGXMetal verified at runtime).
- **Per-type helper apps** — CEF 148 requires all six variants: Renderer/GPU/Plugin/Alloy/generic + **Alerts** (CEF 148 spawns an alert-service helper; its absence caused endless `posix_spawnp` retries and crash-loops). `package-macos.sh` creates and signs all six.

### Launcher-owned instant splash (A0)
- **`agentmux-launcher` is now `CFBundleExecutable`** — the entry point of the packaged `.app`. The launcher is a tiny binary up in milliseconds; it paints the native splash *before* CEF loads, then spawns + supervises srv and the host (`run_unix`).
- **`splash_mac.rs`** — native AppKit splash (raw ObjC FFI, no new deps): dark rounded card (RGB 26,26,31, matching the Win32 splash) with the brain logo pulsing (fade-in → 1.1 Hz sine), fades out on host first-frame signal. Runs on the main thread; Tokio supervisor runs on a worker thread.
- **Host dismiss signal** (`client/mod.rs`) — touches `AGENTMUX_SPLASH_READY_FILE` (inherited by the host via env) on first CEF paint; launcher polls it and fades the splash out.
- Also gains the **launcher-supervised srv model** on macOS: srv survives a host crash.

### Crash fix — `CreateWindowTask` null-client guard
- **Root cause:** tearing off a pane with a 2nd window open could SIGABRT (`CrBrowserMain`). `CreateWindowTask::execute()` selected a client via `list_browsers()` + label-prefix heuristic; if concurrent `on_before_close → UnregisterBrowser` raced the snapshot, `client = None` → `browser_view_create(None, …)` → CEF C++ `CHECK` → abort.
- **Fix:** switch to `list_top_level_browsers()` (the proper reducer helper, filters by `kind: TopLevel`) and add an explicit early-return guard if no live client is found — log an error and bail before calling CEF, instead of crashing the process.

### Lean DMG — ~169 MB
- `strip -S -x` on libcef + all dylibs/helper binaries (564 → 321 MB framework)
- Dedup helper GL libs (only GPU + generic carry them)
- Trim Chromium locales → en* only (−52 MB)
- **ULMO (LZMA) compression** — same compression class as Linux's SquashFS AppImage; was 248 MB with UDZO (zlib)
- Icon-view drag-to-install DMG layout (AgentMux.app + /Applications alias)
- Cert auto-detected from keychain (no hardcoded identity in public repo)

## Verified
- `spctl -a -t open` → **accepted, source=Notarized Developer ID**
- `xcrun stapler validate` → ticket stapled  
- All six helper apps present and signed
- Splash appears instantly on launch, dismisses on first frame
- One Dock tile (host), no duplicate (launcher runs as accessory)
- Host stable from `/Applications` — no crash-loop, no `--disable-gpu` degradation
- `CreateWindowTask` guard tested: no SIGABRT on multi-window tear-off

## Notes
- **Run from `/Applications`, not the mounted DMG.** Chromium's `code_sign_clone` needs a same-device writable path; launching from the DMG volume causes cross-device errors and a crash-loop.
- Workstream A1/A2 (Unix socket IPC for full launcher reducer/saga coordination on macOS) is a follow-on PR — the null-client guard is the immediate stability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)