### PR TITLE
feat(term): predictive local echo for terminal input

### DIFF
--- a/.changesets/1780268491-feat-term-predictive-local-echo-for-terminal-input-z86z.md
+++ b/.changesets/1780268491-feat-term-predictive-local-echo-for-terminal-input-z86z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(term): predictive local echo for terminal input

--- a/docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
+++ b/docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
@@ -1,0 +1,195 @@
+# SPEC: Terminal Predictive Local Echo
+
+**Date:** 2026-05-31
+**Author:** AgentA
+**Status:** Draft → implementation
+**Tracks:** Discussion #1161 (typing-perf umbrella) · `SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md`
+**Supersedes the "shelved" call on predictive echo** (AgentY 2026-05-30) — see §2.
+
+---
+
+## 1. Motivation
+
+AgentMux's terminal and VS Code's integrated terminal are **the same renderer**: xterm.js on the WebGL addon (`termwrap.ts:150`, `loadRendererAddon`; WebGL is the Windows/macOS default via `useWebGl = !term:disablewebgl`). We are **at parity on rendering**. Measured on Windows the JS path is sub-millisecond (`term-keypress` p95 0.4ms, `term-echo-render` p95 0.3ms, zero long-tasks, ~60fps).
+
+The gap to VS Code is **structural and lives entirely in the echo round-trip**:
+
+| | VS Code | AgentMux |
+|---|---|---|
+| PTY location | **in-process** (`node-pty` in the renderer/extension host) | **out-of-process** (`agentmux-srv` sidecar) |
+| keystroke → echo | one in-process callback (µs) | `controllerinput` RPC **over WS** → sidecar async runtime → `portable-pty` writer (`shell.rs:761`) → PTY → echo → reader loop (`shell.rs:804`) → WPS broker → **WS** → `handleNewFileSubjectData` → base64 decode → `xterm.write` |
+
+Every keystroke pays a cross-process, multi-hop round-trip — two WS traversals, the sidecar's async scheduler, the `#951` seq-reorder buffer, base64 — that VS Code does not. At local-PTY speeds this is small in absolute ms but it is **a meaningful fraction of a frame on top of an already-full frame budget**, and it is the only thing differentiating us from VS Code once rendering is equal. The fix is to **stop waiting for the round-trip to paint the character the user just typed.**
+
+## 2. Why this was shelved, and why we are un-shelving it
+
+AgentY (2026-05-30) shelved predictive echo: *"it optimizes a latency that doesn't exist locally; the ≤512B RAF-bypass already paints echo same-frame."* That reasoning conflates two things:
+
+- **Render latency** (echo *data* → pixels): yes, already same-frame (#278 RAF-bypass).
+- **Transport latency** (keystroke → echo *data arrives*): **not** zero — it is the full cross-process round-trip above, and it is exactly what the user perceives as "less immediate than VS Code."
+
+AgentX's RFC explicitly left the door open: *"Only revisit with a sidecar-signaled tty mode + RTT telemetry."* This spec satisfies both conditions. The two real objections — **(a)** flashing plaintext over a password prompt (a security bug, not a latency one) and **(b)** corrupting CJK / TUI — are handled head-on in §6/§7, the same way VS Code's `TypeAheadAddon` handles them in production.
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Paint a just-typed printable character **in the same frame as the keydown**, before the authoritative echo returns — matching VS Code's perceived immediacy.
+- **Never** render predicted text that the PTY would not have echoed (passwords, raw mode, TUI).
+- **Self-correcting**: any divergence between prediction and authoritative output is reconciled to the authoritative state within ~1 round-trip, and prediction self-disables until it is safe again.
+- **Zero cost** when disabled or when the round-trip is already fast (RTT-gated).
+- Cross-platform; **Windows is the priority target**.
+
+**Non-goals**
+- Server-side prediction (mosh-style). Our prediction is **client-side** in `termwrap`.
+- Predicting anything other than the narrow safe set in §6 (no escape sequences, no shell semantics, no autocomplete).
+- Changing the authoritative data path. The PTY echo remains the single source of truth; prediction is a transient overlay reconciled away.
+
+## 4. Invariants (the contract every change must hold)
+
+1. **Authoritative output is never altered.** Predictions are a separate, reconcilable overlay; the xterm buffer always converges to exactly what the PTY sent.
+2. **No prediction is shown unless we have positive evidence echo is on** (see §7). A password prompt must never flash plaintext.
+3. **Predictions are bounded and reconciled.** A prediction that is not confirmed within `PREDICT_TIMEOUT_MS` is rolled back, and prediction disables until re-validated.
+4. **Reconciliation is exact.** On any mismatch between predicted echo and actual echo, roll back **all** outstanding predictions to the authoritative buffer state, then resume from authoritative.
+5. **On by default, opt-out** (`term:predictiveecho=false` disables); safety is carried by the arming gate (§7), not by being off — the RTT gate is opt-in via the threshold (§13).
+6. **The keystroke frame stays sacred** (`SPEC_INPUT_RESPONSIVENESS` rule #1): prediction work is O(1) per keystroke, runs synchronously in the keydown frame, reads no layout.
+
+## 5. Prior art (adopt, don't reinvent)
+
+- **VS Code `TypeAheadAddon`** (`terminalTypeAheadAddon.ts`) — the canonical implementation. Maintains a queue of `IPrediction`s (character, backspace, cursor-move, tentative-boundary); writes them optimistically; matches incoming PTY output against the head of the queue; **confirms** on match, **rolls back the whole queue** on mismatch; gates on `terminal.integrated.localEchoLatencyThreshold` (default 30ms) and disables in the alt-buffer. We mirror this model.
+- **mosh** — server-side speculative echo with epoch/confirmation. Not our architecture (we have no custom server protocol), but its "predict, then reconcile against authority" framing is the same.
+- **xterm.js** — no built-in typeahead; predictions are implemented by writing to the terminal and tracking buffer deltas for rollback. We do the same, isolated in a `PredictiveEcho` helper.
+
+## 6. Design — the predictive layer (frontend, `termwrap.ts`)
+
+A new `PredictiveEcho` class owned by `TermWrap`, wired into the two existing hot paths:
+
+- **`handleTermData(data)`** (`termwrap.ts:410`) — the send path. After `this.sendDataHandler?.(data)`, call `predict.onInput(data)`.
+- **`handleNewFileSubjectData` / `doTerminalWrite`** (`termwrap.ts:442/480`) — the echo path. Before writing authoritative data, call `predict.reconcile(data)` to confirm/roll back predictions, then write.
+
+### 6.1 What is predicted (the safe set)
+
+Per keystroke `data` (the string xterm's `onData` produced):
+
+| Input | Prediction |
+|---|---|
+| single printable, single-width ASCII/Latin (`0x20–0x7E` and confirmed-safe Unicode) | write the glyph, advance the predicted cursor by 1 |
+| `\r` / `\n` (Enter) | **tentative line boundary** — predict cursor to col 0 of next row *only* if we have a clean prediction state; otherwise flush predictions and stop (the shell may print a prompt) |
+| `0x7F` / `\b` (Backspace) | erase the previous predicted cell, retreat cursor by 1 — **only if** the last outstanding item is our own predicted glyph (never erase authoritative cells) |
+| anything else (arrows, Ctrl-*, ESC, paste, multi-char) | **flush + do not predict** this keystroke |
+
+Everything outside this table is left entirely to the authoritative round-trip. CJK / multi-byte / wide chars are **not** predicted (width ambiguity) until §9-phase-3 adds width-aware prediction; until then they fall through to authoritative echo with no regression.
+
+### 6.2 Prediction queue + cursor model
+
+```
+interface Prediction {
+  kind: "char" | "backspace" | "newline";
+  cell?: { row: number; col: number };   // buffer coords where we wrote
+  glyph?: string;                          // the predicted character
+  expected: string;                        // the exact bytes we expect the PTY to echo for confirmation
+  at: number;                              // performance.now() when predicted (for timeout + RTT)
+}
+```
+
+`PredictiveEcho` keeps `queue: Prediction[]` and a `predictedCursor` (row,col) tracked from xterm's authoritative cursor at the moment the queue was empty, advanced locally per prediction. We never query xterm layout on the keydown path; we read `terminal.buffer.active.cursorX/Y` only when the queue transitions empty→non-empty (cold start of a burst).
+
+### 6.3 Reconciliation algorithm (`reconcile(chunk)`)
+
+On each authoritative `chunk` from the PTY, before writing it:
+
+1. If `queue` is empty → write `chunk` normally, done.
+2. Walk `chunk` against the head of `queue`:
+   - If the chunk's next bytes **equal** `head.expected` → **confirm**: pop `head`, consume those bytes from `chunk` (the cell is already painted correctly; nothing to redraw), continue.
+   - If they **diverge** → **rollback**: discard the remaining `queue`, restore the affected cells to their pre-prediction authoritative content (re-issue an `xterm.write` of the authoritative bytes over the predicted region using saved cell snapshots, or the simpler/robust path — see §11), then write the *entire* original `chunk` authoritatively from the rollback point. Enter `cooldown` (§7.3).
+3. Any `queue` entries older than `PREDICT_TIMEOUT_MS` with no matching output → treat as divergence (rollback + cooldown). This is the password/echo-off catch: predictions that are never echoed time out and vanish.
+
+Confirmation is **byte-exact** against `expected`, so terminals that echo differently than we predicted (e.g. `^C`, tab expansion, autosuggest) are caught as divergence and reconciled, never left wrong.
+
+## 7. tty-mode safety (the gate that makes §4.2 hold)
+
+Two layers, defense-in-depth:
+
+### 7.1 Observational gate (all platforms, always on)
+
+Prediction is only **armed** after we have **recently observed our own input echoed back** (a confirmed `char` prediction within the last `ECHO_CONFIRM_WINDOW_MS`). Concretely:
+- Start in `unarmed`. The first keystroke of a session/line is **not** predicted; it is sent and we watch whether the PTY echoes it.
+- On a byte-exact echo confirmation → `armed`; subsequent keystrokes in the burst predict.
+- This means at an **echo-off boundary** (entering a password prompt, `vim`, raw mode) the very next keystroke is sent **without** a prediction — there is no plaintext to flash, because we stopped predicting the moment confirmations stopped.
+
+This is the same self-correcting principle VS Code relies on, hardened: we require *positive* confirmation to predict rather than predicting-until-proven-wrong, trading one round-trip of "first char of a burst is authoritative-only" for **zero plaintext flash**.
+
+### 7.2 Explicit sidecar tty-mode signal (zero-flash, Unix first)
+
+To remove even the within-burst edge (an app turns echo off mid-line), the sidecar signals echo state:
+
+- **Unix (Linux/macOS):** `shell.rs` holds the `portable-pty` master. Read the line-discipline flags via `tcgetattr` on the master fd (`ECHO`, `ICANON`); poll on a cheap interval and on known mode-changing events, emit a `term:mode` event `{ echo: bool, canonical: bool, altscreen: bool }` over the existing WPS broker alongside the data stream. The frontend disarms prediction immediately when `echo=false || altscreen=true`.
+- **Windows (ConPTY) — the priority platform:** ConPTY does **not** expose termios. We therefore rely on (a) the §7.1 observational gate (primary), plus (b) **alt-screen detection by parsing the output stream** for `CSI ?1049h` / `?47h` / `?1047h` (enter alt buffer ⇒ TUI ⇒ disarm) and `?1049l` (leave ⇒ re-evaluate). Alt-screen parsing is done where the chunk is already being scanned in `reconcile`, so it is free. Password prompts on Windows are covered by §7.1 (no confirmed echo ⇒ unarmed ⇒ no prediction). This matches VS Code's own Windows behavior.
+
+### 7.3 Cooldown
+
+After any rollback (§6.3) or explicit `echo=false`, enter `cooldown`: unarmed for `COOLDOWN_MS`, re-armed only by a fresh observed confirmation. Prevents flapping in ambiguous states.
+
+## 8. RTT telemetry + latency gate
+
+`PredictiveEcho` measures round-trip continuously: `confirm.at - prediction.at` per confirmed char → rolling p50 RTT. Prediction is only active when **rolling p50 RTT > `PREDICT_THRESHOLD_MS`** (default 12ms ≈ ¾ frame). When the local round-trip is already sub-threshold (nothing to hide), prediction stays dormant — zero risk, zero benefit foregone. This is AgentX's "RTT telemetry" condition and VS Code's `localEchoLatencyThreshold` analog. The same RTT samples feed `bench-term-echo` parity reporting.
+
+## 9. Phased plan
+
+- **Phase 0 — instrument the round-trip (no behavior change).** Add a `term-roundtrip` measure (keystroke-sent → first matching echo byte) to `termwrap`, surfaced in the Perf HUD + `bench-term-echo`. Fix the bench's stale-`authkey.dev` discovery (prune dead-pid entries) so we have a clean baseline number. **Gate**: a real Windows p50/p95 round-trip figure recorded in this spec.
+- **Phase 1 — core predictive echo (cooked mode, single-line, ASCII).** `PredictiveEcho` class; §6.1 char/backspace/newline; §6.3 reconcile; §7.1 observational gate; §7.3 cooldown; §8 RTT gate. Setting `term:predictiveecho` default **on** (opt-out), threshold default **0** (always predict once armed). **Gate**: byte-exact reconciliation property test; manual password-prompt test shows **zero** plaintext flash; `vim`/alt-screen shows no corruption.
+- **Phase 2 — explicit Unix tty-mode signal (§7.2a)** for zero-flash within-line, + alt-screen parser (§7.2b) for all platforms.
+- **Phase 3 — width-aware prediction**: CJK/wide-char + line-wrap + backspace-across-wrap correctness.
+- **Phase 4 — tune + default-on**: threshold tuning, optional dim styling for unconfirmed cells (VS Code dims; we evaluate), flip default after a soak. RTT-gated so default-on is safe where it does nothing.
+
+## 10. Edge cases (explicit handling)
+
+- **Paste / bracketed paste / multi-char `onData`** → flush, no prediction (§6.1).
+- **Fast typing (multiple pending predictions)** → queue handles N outstanding; reconcile consumes them in order; bounded by `MAX_QUEUE` (flush+disarm beyond it).
+- **`#951` seq-reorder** → unchanged; prediction is purely frontend and keys off the *echo* stream order, which the seq-reorder already normalizes.
+- **Resize** → flush queue (cursor model invalid until next confirmed cold-start).
+- **Scroll / output arriving while typing (e.g. a background log)** → divergence on the first non-matching byte ⇒ rollback ⇒ authoritative wins. Safe by construction.
+- **Backspace at column 0 / across a wrapped line** → not predicted until Phase 3; falls through to authoritative.
+- **Disconnect / PTY death** → flush, disarm.
+
+## 11. Rendering & rollback in xterm.js (the hard part, called out)
+
+xterm.js has no "tentative cell" API. Two implementation options, decided in Phase 1:
+
+- **(A) Write-and-rewrite (simplest, robust):** predictions are normal `terminal.write`s. On rollback, snapshot the affected cells *before* predicting (cheap: a small ring of `{char, attr}` per predicted cell from `buffer.active.getLine().getCell()`), and on divergence re-write the saved authoritative content, then the real chunk. Risk: a one-frame visible correction on the rare mismatch — acceptable (mismatches are rare and the corrected frame is authoritative).
+- **(B) VS Code-style buffer decorations** (overlay rendering of predicted glyphs without committing to the buffer): zero-rewrite rollback, but couples to xterm internals.
+
+Start with **(A)**; it satisfies all invariants and isolates risk. Re-evaluate (B) only if (A)'s rollback frame is perceptible.
+
+## 12. Testing / verification
+
+- **Property test** (`PredictiveEcho.reconcile`): for random interleavings of (printable input, matching echo, diverging echo, echo-off) the buffer **always** converges to the authoritative byte stream and never shows an unconfirmed-then-unmatched glyph beyond `PREDICT_TIMEOUT_MS`.
+- **Safety manual matrix:** (1) `read -s` / `sudo` password prompt → **no** plaintext flash; (2) `vim` insert mode → no corruption, prediction disarmed in alt-screen; (3) CJK input → unchanged (no prediction, no regression); (4) fast hold-key → no artifacts.
+- **Latency:** `bench-term-echo` round-trip before/after must be unchanged (authoritative path untouched); the **perceived** keystroke→paint, measured with the Phase-0 `term-roundtrip` minus prediction (i.e. paint happens in the keydown frame) → ~0 perceived for predicted chars.
+- **Regression:** `bench-agent-keystroke` / the CI input-latency guardrails (#1148/#1174) stay green; keydown path adds no layout read.
+
+## 13. Config, default, rollout
+
+- `term:predictiveecho` (bool, default **true** — set `false` to opt out) — master enable.
+- `term:predictiveecho:thresholdms` (number, default **0** = always predict once armed; set >0 to re-enable the §8 RTT gate).
+- `term:predictiveecho:dim` (bool, default false) — optional unconfirmed-cell styling.
+- Shipped **default-on**: the observational arming gate (§7.1) — never predict without a confirmed echo — carries the safety (no password flash), and any divergence self-reconciles, so the blast radius is bounded. Re-enable RTT-gating per-platform via the threshold if a platform proves prediction unnecessary there.
+
+## 14. Cross-platform notes
+
+- **Windows (priority):** observational gate (§7.1) + alt-screen parse (§7.2b). No termios; this matches VS Code's Windows posture and is sufficient for the password/TUI safety invariants.
+- **Linux/macOS:** add the explicit `tcgetattr` echo signal (§7.2a) for zero-flash within-line. Note Linux also defaults to the **DOM** xterm renderer (`termwrap.ts:549`) — orthogonal to this spec but the larger Linux smoothness lever; tracked separately.
+- The authoritative data path, `#951` seq-reorder, and the WPS broker contract are **unchanged** on every platform.
+
+## 15. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Plaintext flash over password | §7.1 positive-confirmation arming (no predict without observed echo) + §7.2 explicit/alt-screen disarm + invariant #2 as a merge gate |
+| TUI/CJK corruption | not in the safe set (§6.1); alt-screen disarm (§7.2b); width-aware deferred to Phase 3 |
+| Rollback frame visible | rare (byte-exact confirm); option (A) accepted, (B) escape hatch |
+| Keystroke-frame regression | O(1) per key, no layout read; CI guardrails (#1148/#1174) |
+| Flapping in ambiguous modes | cooldown (§7.3) + RTT gate (§8) |
+
+---
+
+**Next:** Phase 0 (round-trip instrument + bench fix) → Phase 1 (core, default-off) behind `term:predictiveecho`, each a focused PR with the property test + the safety manual matrix as merge gates. Append findings/decisions to discussion #1161.

--- a/docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
+++ b/docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
@@ -101,7 +101,7 @@ On each authoritative `chunk` from the PTY, before writing it:
 2. Walk `chunk` against the head of `queue`:
    - If the chunk's next bytes **equal** `head.expected` → **confirm**: pop `head`, consume those bytes from `chunk` (the cell is already painted correctly; nothing to redraw), continue.
    - If they **diverge** → **rollback**: discard the remaining `queue`, restore the affected cells to their pre-prediction authoritative content (re-issue an `xterm.write` of the authoritative bytes over the predicted region using saved cell snapshots, or the simpler/robust path — see §11), then write the *entire* original `chunk` authoritatively from the rollback point. Enter `cooldown` (§7.3).
-3. Any `queue` entries older than `PREDICT_TIMEOUT_MS` with no matching output → treat as divergence (rollback + cooldown). This is the password/echo-off catch: predictions that are never echoed time out and vanish.
+3. Any `queue` entries older than `PREDICT_TIMEOUT_MS` with no matching output → treat as divergence (rollback + cooldown). This is the password/echo-off catch: predictions that are never echoed time out and vanish. The sweep is driven by **both** the PTY-chunk path *and* the keystroke stream (`onInput` sweeps before handling each key) — **no wall-clock timer** (project rule: no grace timers). So when echo stalls and no chunk arrives, the next key the user presses is what ages out a stale prediction.
 
 Confirmation is **byte-exact** against `expected`, so terminals that echo differently than we predicted (e.g. `^C`, tab expansion, autosuggest) are caught as divergence and reconciled, never left wrong.
 
@@ -114,6 +114,7 @@ Two layers, defense-in-depth:
 Prediction is only **armed** after we have **recently observed our own input echoed back** (a confirmed `char` prediction within the last `ECHO_CONFIRM_WINDOW_MS`). Concretely:
 - Start in `unarmed`. The first keystroke of a session/line is **not** predicted; it is sent and we watch whether the PTY echoes it.
 - On a byte-exact echo confirmation → `armed`; subsequent keystrokes in the burst predict.
+- **Disarm at every boundary.** Any **non-printable input** (Enter, arrows, Ctrl-\*, Esc — i.e. the keys that launch `sudo`/`ssh`/`vim` or move into a new mode) flushes *and* clears `armed`. This is the critical fix for the armed→echo-off transition: because a password prompt or TUI is always reached *through* a non-printable key (the Enter that runs the command), the first keystroke of the new context starts `unarmed` and is observed, not painted. Without this, an already-armed session would paint the first password char as plaintext.
 - This means at an **echo-off boundary** (entering a password prompt, `vim`, raw mode) the very next keystroke is sent **without** a prediction — there is no plaintext to flash, because we stopped predicting the moment confirmations stopped.
 
 This is the same self-correcting principle VS Code relies on, hardened: we require *positive* confirmation to predict rather than predicting-until-proven-wrong, trading one round-trip of "first char of a burst is authoritative-only" for **zero plaintext flash**.
@@ -136,8 +137,8 @@ After any rollback (§6.3) or explicit `echo=false`, enter `cooldown`: unarmed f
 ## 9. Phased plan
 
 - **Phase 0 — instrument the round-trip (no behavior change).** Add a `term-roundtrip` measure (keystroke-sent → first matching echo byte) to `termwrap`, surfaced in the Perf HUD + `bench-term-echo`. Fix the bench's stale-`authkey.dev` discovery (prune dead-pid entries) so we have a clean baseline number. **Gate**: a real Windows p50/p95 round-trip figure recorded in this spec.
-- **Phase 1 — core predictive echo (cooked mode, single-line, ASCII).** `PredictiveEcho` class; §6.1 char/backspace/newline; §6.3 reconcile; §7.1 observational gate; §7.3 cooldown; §8 RTT gate. Setting `term:predictiveecho` default **on** (opt-out), threshold default **0** (always predict once armed). **Gate**: byte-exact reconciliation property test; manual password-prompt test shows **zero** plaintext flash; `vim`/alt-screen shows no corruption.
-- **Phase 2 — explicit Unix tty-mode signal (§7.2a)** for zero-flash within-line, + alt-screen parser (§7.2b) for all platforms.
+- **Phase 1 — core predictive echo (cooked mode, single-line, ASCII).** `PredictiveEcho` class; §6.1 char/backspace/newline; §6.3 reconcile; §7.1 observational gate **+ disarm-at-every-boundary** (non-printable input *and* a basic alt-screen-**enter** parse `CSI ?1049h|?47h|?1047h` ⇒ disarm, folded into `reconcile` since it already scans the chunk); §7.3 cooldown; §8 RTT gate; keystroke-driven sweep (§6.3). Setting `term:predictiveecho` default **on** (opt-out), threshold default **0** (always predict once armed). **Gate**: byte-exact reconciliation property test; manual password-prompt test shows **zero** plaintext flash; `vim`/alt-screen shows no corruption.
+- **Phase 2 — explicit Unix tty-mode signal (§7.2a)** for zero-flash within-line, + the **full** alt-screen parser (§7.2b: enter/leave/re-evaluate) for all platforms (Phase 1 ships only the enter⇒disarm half).
 - **Phase 3 — width-aware prediction**: CJK/wide-char + line-wrap + backspace-across-wrap correctness.
 - **Phase 4 — tune + default-on**: threshold tuning, optional dim styling for unconfirmed cells (VS Code dims; we evaluate), flip default after a soak. RTT-gated so default-on is safe where it does nothing.
 

--- a/frontend/app/view/term/predictive-echo.test.ts
+++ b/frontend/app/view/term/predictive-echo.test.ts
@@ -1,0 +1,188 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { PredictiveEcho, isPredictable, type PredictiveEchoOptions } from "./predictive-echo";
+
+/** Test harness: a mock xterm (a "screen" string) + a controllable clock. */
+function harness(opts: Partial<PredictiveEchoOptions> = {}) {
+    let t = 0;
+    let screen = "";
+    const ops: string[] = [];
+    const sink = {
+        paint(g: string) {
+            ops.push(`paint:${g}`);
+            screen += g;
+        },
+        erase(n: number) {
+            ops.push(`erase:${n}`);
+            screen = screen.slice(0, screen.length - n);
+        },
+    };
+    const pe = new PredictiveEcho(sink, {
+        enabled: () => true,
+        thresholdMs: 0,
+        now: () => t,
+        ...opts,
+    });
+    return {
+        pe,
+        ops,
+        get screen() {
+            return screen;
+        },
+        advance(ms: number) {
+            t += ms;
+        },
+        input(data: string) {
+            pe.onInput(data);
+        },
+        /** Simulate the PTY emitting `chunk`: reconcile (may erase via the sink),
+         *  THEN append the authoritative remainder. Two statements so the erase
+         *  lands before we read `screen` for the append. */
+        echo(chunk: string) {
+            const auth = pe.reconcile(chunk);
+            screen += auth;
+        },
+        sweep() {
+            pe.sweep();
+        },
+        /** Bring the instance to `armed` (first char is observed, its echo confirms). */
+        arm() {
+            this.input("a");
+            this.advance(5);
+            this.echo("a"); // screen == "a", armed
+        },
+    };
+}
+
+describe("isPredictable (safe set)", () => {
+    it("accepts single printable ASCII only", () => {
+        for (const c of ["a", "Z", " ", "0", "~"]) expect(isPredictable(c)).toBe(true);
+    });
+    it("rejects control, escape, multi-char, and wide/CJK", () => {
+        for (const c of ["\r", "\n", "\b", "\x1b", "\x1b[A", "ab", "中", "😀", ""]) {
+            expect(isPredictable(c)).toBe(false);
+        }
+    });
+});
+
+describe("PredictiveEcho — arming & password safety", () => {
+    it("never paints the first keystroke of a burst; arms only on a confirmed echo", () => {
+        const h = harness();
+        h.input("a");
+        expect(h.ops).toEqual([]); // nothing speculative shown
+        expect(h.pe.isArmed).toBe(false);
+        h.advance(10);
+        h.echo("a"); // PTY echoes it
+        expect(h.screen).toBe("a"); // appears via the authoritative write
+        expect(h.pe.isArmed).toBe(true);
+    });
+
+    it("password prompt (echo off): first char never painted, no flash even if echo never returns", () => {
+        const h = harness();
+        h.input("s"); // a password char — unarmed, so observed not painted
+        expect(h.ops).toEqual([]);
+        h.advance(700); // > predictTimeout
+        h.sweep();
+        expect(h.ops).toEqual([]); // never painted → zero plaintext flash
+        expect(h.screen).toBe("");
+    });
+});
+
+describe("PredictiveEcho — predict, confirm, diverge", () => {
+    it("predicts once armed and consumes the confirming echo (no double render)", () => {
+        const h = harness();
+        h.arm();
+        h.input("b");
+        expect(h.ops).toContain("paint:b");
+        expect(h.screen).toBe("ab");
+        h.advance(8);
+        h.echo("b"); // confirmed → consumed
+        expect(h.screen).toBe("ab"); // unchanged, not "abb"
+        expect(h.pe.pending).toBe(0);
+    });
+
+    it("rolls back and cools down on divergence; buffer converges to authoritative", () => {
+        const h = harness();
+        h.arm();
+        h.input("b");
+        expect(h.screen).toBe("ab");
+        h.advance(5);
+        h.echo("X"); // PTY echoed something else
+        expect(h.ops).toContain("erase:1");
+        expect(h.screen).toBe("aX"); // converged
+        expect(h.pe.isArmed).toBe(false); // cooldown disarms
+    });
+
+    it("times out an unconfirmed prediction (echo turned off mid-burst)", () => {
+        const h = harness();
+        h.arm();
+        h.input("p");
+        expect(h.screen).toBe("ap");
+        h.advance(601); // > predictTimeout default 600
+        h.sweep();
+        expect(h.ops).toContain("erase:1");
+        expect(h.screen).toBe("a");
+    });
+
+    it("flushes (rolls back) on non-printable input", () => {
+        const h = harness();
+        h.arm();
+        h.input("a"); // predicted, screen "aa"
+        expect(h.screen).toBe("aa");
+        h.input("\r"); // Enter → flush
+        expect(h.ops).toContain("erase:1");
+        expect(h.screen).toBe("a");
+    });
+});
+
+describe("PredictiveEcho — gates", () => {
+    it("does not predict when the round-trip is below threshold", () => {
+        const h = harness({ thresholdMs: 100 });
+        h.input("a");
+        h.advance(5);
+        h.echo("a"); // armed, rtt p50 ≈ 5
+        const before = h.ops.length;
+        h.input("b");
+        expect(h.ops.length).toBe(before); // no paint — 5ms < 100ms
+        expect(h.screen).toBe("a");
+        h.advance(5);
+        h.echo("b"); // 'b' still shows via authoritative write
+        expect(h.screen).toBe("ab");
+    });
+
+    it("disabled → never paints, never touches the stream", () => {
+        const h = harness({ enabled: () => false });
+        h.input("a");
+        h.echo("a");
+        h.input("b");
+        h.echo("b");
+        expect(h.ops).toEqual([]);
+        expect(h.screen).toBe("ab"); // pure passthrough
+    });
+});
+
+describe("PredictiveEcho — convergence property", () => {
+    it("the visible buffer always equals the authoritative echo stream", () => {
+        const h = harness();
+        let authoritative = "";
+        h.input("a");
+        h.advance(5);
+        h.echo("a");
+        authoritative += "a";
+        // clean predicted chars
+        for (const ch of ["b", "c", "d"]) {
+            h.input(ch);
+            h.advance(3);
+            h.echo(ch);
+            authoritative += ch;
+        }
+        // a divergence (e.g. shell auto-capitalized) then recovery after cooldown
+        h.input("e");
+        h.advance(3);
+        h.echo("E");
+        authoritative += "E";
+        expect(h.screen).toBe(authoritative);
+    });
+});

--- a/frontend/app/view/term/predictive-echo.test.ts
+++ b/frontend/app/view/term/predictive-echo.test.ts
@@ -174,6 +174,20 @@ describe("PredictiveEcho — mode-transition safety", () => {
         expect(h.ops).toContain("erase:1"); // stale 'b' rolled back on input
         expect(h.screen).not.toContain("b");
     });
+
+    it("reset() rolls back a pending painted prediction so the authoritative echo writes cleanly (disable mid-prediction, codex P2)", () => {
+        const h = harness();
+        h.arm();
+        h.input("b"); // painted, still pending
+        expect(h.screen).toBe("ab");
+        expect(h.pe.pending).toBe(1);
+        // user toggles term:predictiveecho OFF mid-prediction; the output path
+        // (doTerminalWrite) calls reset() before writing the authoritative echo.
+        h.pe.reset();
+        expect(h.ops).toContain("erase:1"); // speculative glyph rolled back
+        expect(h.pe.pending).toBe(0);
+        expect(h.screen).toBe("a"); // clean — the authoritative 'b' now writes exactly once
+    });
 });
 
 describe("PredictiveEcho — gates", () => {

--- a/frontend/app/view/term/predictive-echo.test.ts
+++ b/frontend/app/view/term/predictive-echo.test.ts
@@ -39,10 +39,12 @@ function harness(opts: Partial<PredictiveEchoOptions> = {}) {
         },
         /** Simulate the PTY emitting `chunk`: reconcile (may erase via the sink),
          *  THEN append the authoritative remainder. Two statements so the erase
-         *  lands before we read `screen` for the append. */
+         *  lands before we read `screen` for the append. reconcile now accepts
+         *  Uint8Array — test chunks are ASCII so the round-trip is lossless. */
         echo(chunk: string) {
-            const auth = pe.reconcile(chunk);
-            screen += auth;
+            const bytes = new TextEncoder().encode(chunk);
+            const { auth, rest } = pe.reconcile(bytes);
+            screen += auth + new TextDecoder().decode(rest);
         },
         sweep() {
             pe.sweep();

--- a/frontend/app/view/term/predictive-echo.test.ts
+++ b/frontend/app/view/term/predictive-echo.test.ts
@@ -126,14 +126,53 @@ describe("PredictiveEcho — predict, confirm, diverge", () => {
         expect(h.screen).toBe("a");
     });
 
-    it("flushes (rolls back) on non-printable input", () => {
+    it("flushes (rolls back) AND disarms on non-printable input", () => {
         const h = harness();
         h.arm();
         h.input("a"); // predicted, screen "aa"
         expect(h.screen).toBe("aa");
-        h.input("\r"); // Enter → flush
+        h.input("\r"); // Enter → flush + disarm
         expect(h.ops).toContain("erase:1");
         expect(h.screen).toBe("a");
+        expect(h.pe.isArmed).toBe(false); // re-observe before predicting again
+    });
+});
+
+describe("PredictiveEcho — mode-transition safety", () => {
+    it("disarms at the Enter boundary so a following echo-off password char is never painted (reagent P0)", () => {
+        const h = harness();
+        h.arm(); // armed: echo was on and confirmed
+        expect(h.pe.isArmed).toBe(true);
+        h.input("\r"); // user runs `sudo …` — Enter is the line/echo-off boundary
+        expect(h.pe.isArmed).toBe(false);
+        // sudo prompts (echo OFF). The first password keystroke must be observed,
+        // not predicted — the armed→echo-off transition is the hole reagent flagged.
+        h.input("s");
+        h.advance(700); // echo never returns (echo off)
+        h.sweep();
+        expect(h.ops).toEqual([]); // never painted → zero plaintext flash
+        expect(h.screen).toBe("a");
+    });
+
+    it("disarms on alt-screen enter output so TUI commands aren't mispredicted (codex P1)", () => {
+        const h = harness();
+        h.arm();
+        h.echo("\x1b[?1049h"); // a full-screen app (vim/less) takes over
+        expect(h.pe.isArmed).toBe(false);
+        const before = h.ops.length;
+        h.input("j"); // vim normal-mode command — must NOT be painted
+        expect(h.ops.length).toBe(before);
+    });
+
+    it("sweeps a stale painted prediction on the next keystroke, with no PTY chunk and no timer (reagent P1)", () => {
+        const h = harness();
+        h.arm();
+        h.input("b"); // armed → painted, queue=[b]
+        expect(h.screen).toBe("ab");
+        h.advance(700); // echo stalls past predictTimeout; NO chunk arrives
+        h.input("c"); // the keystroke itself drives the sweep
+        expect(h.ops).toContain("erase:1"); // stale 'b' rolled back on input
+        expect(h.screen).not.toContain("b");
     });
 });
 

--- a/frontend/app/view/term/predictive-echo.test.ts
+++ b/frontend/app/view/term/predictive-echo.test.ts
@@ -164,6 +164,31 @@ describe("PredictiveEcho — mode-transition safety", () => {
         expect(h.ops.length).toBe(before);
     });
 
+    it("does not re-arm when alt-screen enter and an echo confirmation are in the same PTY chunk (codex P2)", () => {
+        const h = harness();
+        h.arm();
+        // A chunk that contains both the echo confirmation AND the alt-screen enter.
+        // The disarm must win; confirming the echo should not re-arm.
+        h.echo("a\x1b[?1049h");
+        expect(h.pe.isArmed).toBe(false);
+        h.input("j"); // vim normal-mode — must NOT be painted
+        expect(h.ops.filter(o => o.startsWith("paint"))).toHaveLength(0);
+    });
+
+    it("does not paint when unconfirmed observations are ahead in the queue — burst ordering (reagent P1)", () => {
+        // "ab" typed at high RTT: "a" observed (unarmed), "b" typed before "a" echoes.
+        // queue=[{a,obs}] → b must be OBSERVED, not painted, else "b" glyph appears
+        // before authoritative "a" echo writes, scrambling order to "ba".
+        const h = harness();
+        h.input("a"); // unarmed → observed, queue=[{a,obs}]
+        h.input("b"); // obs pending ahead → must observe, NOT paint
+        expect(h.ops.filter(o => o.startsWith("paint"))).toHaveLength(0);
+        h.advance(5);
+        h.echo("a"); // "a" confirmed, armed=true, auth "a" written
+        h.echo("b"); // "b" confirmed (was observed), auth "b" written
+        expect(h.screen).toBe("ab"); // correct order, no scramble
+    });
+
     it("sweeps a stale painted prediction on the next keystroke, with no PTY chunk and no timer (reagent P1)", () => {
         const h = harness();
         h.arm();

--- a/frontend/app/view/term/predictive-echo.ts
+++ b/frontend/app/view/term/predictive-echo.ts
@@ -66,6 +66,10 @@ export function isPredictable(data: string): boolean {
     return c >= 0x20 && c <= 0x7e;
 }
 
+/** Alt-screen enter (DEC private mode 1049/1047/47 set) — a full-screen TUI
+ *  (vim, less, htop) has taken over and no longer line-echoes. */
+const ALT_SCREEN_ENTER = /\x1b\[\?(?:1049|1047|47)h/;
+
 export class PredictiveEcho {
     private queue: Pending[] = [];
     private armed = false;
@@ -97,6 +101,12 @@ export class PredictiveEcho {
             return;
         }
         if (data.length === 0) return;
+        // Sweep stale predictions off the KEYSTROKE stream, not a wall-clock
+        // timer (project rule: no grace timers). If echo stalls — e.g. echo
+        // silently turned off mid-line — no PTY chunk arrives to drive
+        // reconcile, so the next key the user presses is what rolls back an
+        // aged, unconfirmed prediction (reagent #1223 P1).
+        this.sweep();
         // Anything outside the safe set (Enter, arrows, Ctrl-*, ESC, paste,
         // multi-char) flushes: roll back any painted predictions and stop — the
         // authoritative stream will redraw whatever the shell does.
@@ -129,6 +139,15 @@ export class PredictiveEcho {
      * The visible buffer therefore always converges to exactly the PTY stream.
      */
     reconcile(chunk: string): string {
+        // Mode-changing output: a full-screen app entering the alt buffer no
+        // longer line-echoes. Abandon predictions and disarm BEFORE the switch
+        // lands (the erase here is still on the normal buffer), so we never
+        // mispredict a TUI command nor run a CSI-K rollback inside the alt
+        // screen (codex #1223 P1).
+        if (ALT_SCREEN_ENTER.test(chunk)) {
+            this.rollback();
+            this.armed = false;
+        }
         if (this.queue.length === 0) return chunk;
         const now = this.now();
         let rest = chunk;
@@ -212,6 +231,12 @@ export class PredictiveEcho {
 
     private flush(): void {
         this.rollback();
+        // A non-printable input (Escape, arrows, Ctrl-*, Enter) is a likely mode
+        // boundary — entering vim/less or moving the cursor. Re-observe a
+        // confirmed echo before predicting again, so printable commands like
+        // vim's j/x aren't mispredicted in an app that doesn't line-echo
+        // (codex #1223 P1).
+        this.armed = false;
     }
 
     private enterCooldown(now: number): void {

--- a/frontend/app/view/term/predictive-echo.ts
+++ b/frontend/app/view/term/predictive-echo.ts
@@ -148,51 +148,43 @@ export class PredictiveEcho {
 
     /**
      * Reconcile an authoritative PTY chunk against outstanding predictions
-     * (spec §6.3). Call BEFORE writing to xterm; returns the bytes the caller
-     * must write authoritatively:
-     *  - a PAINTED prediction's echo is CONSUMED (the glyph is already on screen);
-     *  - an arming OBSERVATION's echo is PASSED THROUGH (nothing was painted, so
-     *    the real echo must still be written);
-     *  - on the first divergence, ALL outstanding painted predictions roll back
-     *    and the remaining bytes (incl. the diverging bytes) pass through.
-     * The visible buffer therefore always converges to exactly the PTY stream.
+     * (spec §6.3). Accepts raw bytes to avoid TextDecoder corruption of
+     * multibyte UTF-8 sequences split across WS chunks. Returns:
+     *  - `auth`: ASCII observation echoes the caller must write as a string
+     *    (these were NOT painted — the real echo must appear on screen).
+     *  - `rest`: the unconsumed tail as the ORIGINAL Uint8Array — never
+     *    passed through TextDecoder, so split multibyte chars are preserved.
+     * Queue entries are always single printable ASCII bytes (0x20-0x7e),
+     * so byte-exact comparison is safe and sufficient.
      */
-    reconcile(chunk: string): string {
-        // Mode-changing output: a full-screen app entering the alt buffer no
-        // longer line-echoes. Abandon predictions and disarm BEFORE the switch
-        // lands (the erase here is still on the normal buffer), so we never
-        // mispredict a TUI command nor run a CSI-K rollback inside the alt
-        // screen. Track locally so the confirmation loop below doesn't
-        // re-arm us for the same chunk (codex P2 on #1223 — a chunk
-        // containing both an echo confirmation AND an alt-screen enter would
-        // disarm then immediately re-arm at `this.armed = true`).
-        const altScreenEntered = ALT_SCREEN_ENTER.test(chunk);
+    reconcile(chunk: Uint8Array): { auth: string; rest: Uint8Array } {
+        // Alt-screen sequences are pure ASCII control chars — safe to decode
+        // for the regex check only. We never output this decoded string.
+        const chunkStr = new TextDecoder().decode(chunk);
+        const altScreenEntered = ALT_SCREEN_ENTER.test(chunkStr);
         if (altScreenEntered) {
             this.rollback();
             this.armed = false;
         }
-        if (this.queue.length === 0) return chunk;
+        if (this.queue.length === 0) return { auth: "", rest: chunk };
         const now = this.now();
-        let rest = chunk;
+        let i = 0;
         let auth = "";
-        while (this.queue.length > 0 && rest.length > 0) {
+        while (this.queue.length > 0 && i < chunk.length) {
             const head = this.queue[0];
-            if (rest.startsWith(head.expected)) {
+            if (chunk[i] === head.expected.charCodeAt(0)) {
                 this.queue.shift();
                 this.recordRtt(now - head.at);
-                // Don't re-arm if we just disarmed for alt-screen in this chunk.
                 if (!altScreenEntered) this.armed = true;
-                if (!head.painted) auth += head.expected; // observation: must still write
-                rest = rest.slice(head.expected.length);
+                if (!head.painted) auth += head.expected;
+                i++;
             } else {
                 this.rollback();
                 this.enterCooldown(now);
-                auth += rest;
-                rest = "";
-                break;
+                return { auth, rest: chunk.subarray(i) };
             }
         }
-        return auth + rest;
+        return { auth, rest: chunk.subarray(i) };
     }
 
     /** Time out unconfirmed predictions (spec §6.3 step 3) — the echo-off /

--- a/frontend/app/view/term/predictive-echo.ts
+++ b/frontend/app/view/term/predictive-echo.ts
@@ -117,6 +117,17 @@ export class PredictiveEcho {
         const now = this.now();
         // Observe-only (no paint) while in cooldown, unarmed, or when the
         // round-trip is already fast enough that prediction buys nothing.
+        //
+        // Known Phase 1 gap (spec §7.2 / codex #1223): a program that turns
+        // echo off PROGRAMMATICALLY between printable chars (no preceding
+        // non-printable) leaves `armed` true, so the very next char is painted.
+        // The self-healing path: echo never arrives → sweep() rolls it back at
+        // predictTimeoutMs (600ms) or on the following keystroke — a brief
+        // flash, not a persistent leak. The deterministic fix is Phase 2
+        // (tcgetattr / sidecar tty-mode signal for Unix; the non-printable
+        // disarm already handles the overwhelmingly common case on all platforms:
+        // every real password prompt is reached through the Enter that runs the
+        // command).
         if (now < this.cooldownUntil || !this.armed || this.rttP50 < this.threshold) {
             this.observe(data, now);
             return;

--- a/frontend/app/view/term/predictive-echo.ts
+++ b/frontend/app/view/term/predictive-echo.ts
@@ -1,0 +1,228 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Predictive local echo — paint a just-typed printable character in the same
+ * frame as the keydown, before the authoritative PTY echo completes its
+ * cross-process round-trip (the gap vs VS Code's in-process echo).
+ *
+ * Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
+ *
+ * Safety contract (spec §4):
+ *  - Authoritative output is never altered; predictions are a reconcilable
+ *    overlay and the buffer always converges to exactly what the PTY sent.
+ *  - Nothing is predicted without POSITIVE evidence echo is on: we require a
+ *    byte-exact confirmation of our own input before arming (spec §7.1), so a
+ *    password prompt (echo off) never flashes plaintext — the first keystroke
+ *    of any burst is authoritative-only, and confirmations stop the instant
+ *    echo stops.
+ *  - Reconciliation is byte-exact; any divergence rolls back ALL outstanding
+ *    predictions and enters cooldown.
+ *  - RTT-gated: dormant when the round-trip is already faster than the budget,
+ *    so enabling it is a no-op where there's nothing to hide.
+ *
+ * This module is the pure state machine; the xterm interaction is injected via
+ * `PredictSink` so it is unit-testable without a terminal.
+ */
+
+/** xterm-facing side effects, injected for testability. */
+export interface PredictSink {
+    /** Paint one predicted glyph at the cursor (xterm `write`); advances cursor. */
+    paint(glyph: string): void;
+    /** Erase the last `count` predicted glyphs, restoring authoritative state.
+     *  Phase 1 appends at the cursor, so this is `CSI <n> D` + `CSI K`. */
+    erase(count: number): void;
+}
+
+export interface PredictiveEchoOptions {
+    /** Master enable (read live so the setting can toggle without remount). */
+    enabled: () => boolean;
+    /** Predict only when rolling p50 round-trip ≥ this (ms). Default 12 (~¾ frame). */
+    thresholdMs?: number;
+    /** Unconfirmed predictions older than this (ms) are rolled back. Default 600. */
+    predictTimeoutMs?: number;
+    /** After a rollback, stay unarmed this long (ms). Default 1200. */
+    cooldownMs?: number;
+    /** Hard cap on outstanding predictions before flushing. Default 40. */
+    maxQueue?: number;
+    /** Clock injection for tests. Default `performance.now`. */
+    now?: () => number;
+}
+
+interface Pending {
+    /** Exact bytes we expect the PTY to echo to confirm this entry. */
+    expected: string;
+    /** When the input was sent (for RTT + timeout). */
+    at: number;
+    /** Whether we actually painted a glyph (vs. an arming-only observation). */
+    painted: boolean;
+}
+
+/** Phase 1 safe set: exactly one printable ASCII char (spec §6.1). CJK / wide /
+ *  control / escape / multi-char are left to the authoritative path. */
+export function isPredictable(data: string): boolean {
+    if (data.length !== 1) return false;
+    const c = data.charCodeAt(0);
+    return c >= 0x20 && c <= 0x7e;
+}
+
+export class PredictiveEcho {
+    private queue: Pending[] = [];
+    private armed = false;
+    private cooldownUntil = 0;
+    private rttSamples: number[] = [];
+    private rttP50 = Infinity;
+
+    private readonly threshold: number;
+    private readonly predictTimeout: number;
+    private readonly cooldown: number;
+    private readonly maxQueue: number;
+    private readonly now: () => number;
+
+    constructor(
+        private readonly sink: PredictSink,
+        private readonly opts: PredictiveEchoOptions,
+    ) {
+        this.threshold = opts.thresholdMs ?? 12;
+        this.predictTimeout = opts.predictTimeoutMs ?? 600;
+        this.cooldown = opts.cooldownMs ?? 1200;
+        this.maxQueue = opts.maxQueue ?? 40;
+        this.now = opts.now ?? (() => performance.now());
+    }
+
+    /** Call AFTER sending `data` to the PTY (spec §6, `handleTermData`). */
+    onInput(data: string): void {
+        if (!this.opts.enabled()) {
+            this.reset();
+            return;
+        }
+        if (data.length === 0) return;
+        // Anything outside the safe set (Enter, arrows, Ctrl-*, ESC, paste,
+        // multi-char) flushes: roll back any painted predictions and stop — the
+        // authoritative stream will redraw whatever the shell does.
+        if (!isPredictable(data)) {
+            this.flush();
+            return;
+        }
+        const now = this.now();
+        // Observe-only (no paint) while in cooldown, unarmed, or when the
+        // round-trip is already fast enough that prediction buys nothing.
+        if (now < this.cooldownUntil || !this.armed || this.rttP50 < this.threshold) {
+            this.observe(data, now);
+            return;
+        }
+        // Armed + safe + slow enough → predict.
+        this.sink.paint(data);
+        this.queue.push({ expected: data, at: now, painted: true });
+        if (this.queue.length > this.maxQueue) this.flush();
+    }
+
+    /**
+     * Reconcile an authoritative PTY chunk against outstanding predictions
+     * (spec §6.3). Call BEFORE writing to xterm; returns the bytes the caller
+     * must write authoritatively:
+     *  - a PAINTED prediction's echo is CONSUMED (the glyph is already on screen);
+     *  - an arming OBSERVATION's echo is PASSED THROUGH (nothing was painted, so
+     *    the real echo must still be written);
+     *  - on the first divergence, ALL outstanding painted predictions roll back
+     *    and the remaining bytes (incl. the diverging bytes) pass through.
+     * The visible buffer therefore always converges to exactly the PTY stream.
+     */
+    reconcile(chunk: string): string {
+        if (this.queue.length === 0) return chunk;
+        const now = this.now();
+        let rest = chunk;
+        let auth = "";
+        while (this.queue.length > 0 && rest.length > 0) {
+            const head = this.queue[0];
+            if (rest.startsWith(head.expected)) {
+                this.queue.shift();
+                this.recordRtt(now - head.at);
+                this.armed = true; // observed our own echo → safe to predict
+                if (!head.painted) auth += head.expected; // observation: must still write
+                rest = rest.slice(head.expected.length);
+            } else {
+                this.rollback();
+                this.enterCooldown(now);
+                auth += rest;
+                rest = "";
+                break;
+            }
+        }
+        return auth + rest;
+    }
+
+    /** Time out unconfirmed predictions (spec §6.3 step 3) — the echo-off /
+     *  password-prompt catch. Call on a cheap cadence (e.g. each reconcile). */
+    sweep(): void {
+        if (this.queue.length === 0) return;
+        const now = this.now();
+        if (now - this.queue[0].at > this.predictTimeout) {
+            this.rollback();
+            this.enterCooldown(now);
+        }
+    }
+
+    /** Rolling p50 round-trip (ms); Infinity until the first confirmation. */
+    get roundTripP50(): number {
+        return this.rttP50;
+    }
+
+    /** Outstanding (unconfirmed) prediction count — for diagnostics/tests. */
+    get pending(): number {
+        return this.queue.length;
+    }
+
+    get isArmed(): boolean {
+        return this.armed;
+    }
+
+    /** Live master-enable read (the `term:predictiveecho` setting). */
+    isEnabled(): boolean {
+        return this.opts.enabled();
+    }
+
+    /** Drop everything (resize, disconnect, disable). */
+    reset(): void {
+        if (this.painted() > 0) this.sink.erase(this.painted());
+        this.queue = [];
+        this.armed = false;
+    }
+
+    // ── internals ───────────────────────────────────────────────────────────
+
+    private observe(data: string, now: number): void {
+        // Enqueue an expectation WITHOUT painting — bootstraps arming + RTT from
+        // the real echo while showing nothing speculative.
+        this.queue.push({ expected: data, at: now, painted: false });
+        if (this.queue.length > this.maxQueue) this.queue.shift();
+    }
+
+    private painted(): number {
+        let n = 0;
+        for (const p of this.queue) if (p.painted) n++;
+        return n;
+    }
+
+    private rollback(): void {
+        const n = this.painted();
+        if (n > 0) this.sink.erase(n);
+        this.queue = [];
+    }
+
+    private flush(): void {
+        this.rollback();
+    }
+
+    private enterCooldown(now: number): void {
+        this.armed = false;
+        this.cooldownUntil = now + this.cooldown;
+    }
+
+    private recordRtt(ms: number): void {
+        this.rttSamples.push(ms);
+        if (this.rttSamples.length > 64) this.rttSamples.shift();
+        const s = [...this.rttSamples].sort((a, b) => a - b);
+        this.rttP50 = s[(s.length - 1) >> 1];
+    }
+}

--- a/frontend/app/view/term/predictive-echo.ts
+++ b/frontend/app/view/term/predictive-echo.ts
@@ -128,11 +128,19 @@ export class PredictiveEcho {
         // disarm already handles the overwhelmingly common case on all platforms:
         // every real password prompt is reached through the Enter that runs the
         // command).
-        if (now < this.cooldownUntil || !this.armed || this.rttP50 < this.threshold) {
+        // Also block painting when unconfirmed OBSERVATIONS are ahead in the
+        // queue. Those chars have been sent but not yet echoed — the cursor
+        // hasn't advanced past them. Painting a new prediction now would place
+        // the glyph before their authoritative echoes arrive, creating "abXc"
+        // when the user typed "abc" at high RTT. Only predict when every queued
+        // entry is already painted (cursor is exactly where we expect it).
+        // (reagent P1 on #1223.)
+        const hasPendingObservation = this.queue.some(p => !p.painted);
+        if (now < this.cooldownUntil || !this.armed || this.rttP50 < this.threshold || hasPendingObservation) {
             this.observe(data, now);
             return;
         }
-        // Armed + safe + slow enough → predict.
+        // Armed + safe + slow enough + no unconfirmed observations ahead → predict.
         this.sink.paint(data);
         this.queue.push({ expected: data, at: now, painted: true });
         if (this.queue.length > this.maxQueue) this.flush();
@@ -154,8 +162,12 @@ export class PredictiveEcho {
         // longer line-echoes. Abandon predictions and disarm BEFORE the switch
         // lands (the erase here is still on the normal buffer), so we never
         // mispredict a TUI command nor run a CSI-K rollback inside the alt
-        // screen (codex #1223 P1).
-        if (ALT_SCREEN_ENTER.test(chunk)) {
+        // screen. Track locally so the confirmation loop below doesn't
+        // re-arm us for the same chunk (codex P2 on #1223 — a chunk
+        // containing both an echo confirmation AND an alt-screen enter would
+        // disarm then immediately re-arm at `this.armed = true`).
+        const altScreenEntered = ALT_SCREEN_ENTER.test(chunk);
+        if (altScreenEntered) {
             this.rollback();
             this.armed = false;
         }
@@ -168,7 +180,8 @@ export class PredictiveEcho {
             if (rest.startsWith(head.expected)) {
                 this.queue.shift();
                 this.recordRtt(now - head.at);
-                this.armed = true; // observed our own echo → safe to predict
+                // Don't re-arm if we just disarmed for alt-screen in this chunk.
+                if (!altScreenEntered) this.armed = true;
                 if (!head.painted) auth += head.expected; // observation: must still write
                 rest = rest.slice(head.expected.length);
             } else {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -444,6 +444,20 @@ export class TermWrap {
             }
         }
         this.sendDataHandler?.(data);
+        // Flush predictions when the cursor is at or past the last terminal
+        // column. The rollback sequence (CSI n D + CSI K) only works within
+        // the current row — any painted glyph that would wrap onto the next
+        // line can't be reliably erased, violating the convergence invariant.
+        // Resetting here keeps predictions within the safe single-row window;
+        // re-arming happens normally on the next confirmed echo after the wrap.
+        // (reagent P2 / codex P1 on #1223.)
+        if (this.predict?.isArmed || this.predict?.pending) {
+            const cx = this.terminal?.buffer?.active?.cursorX ?? 0;
+            const cols = this.terminal?.cols ?? 80;
+            if (cx >= cols - 1) {
+                this.predict.reset();
+            }
+        }
         // Optimistically paint the keystroke (no-op unless term:predictiveecho is
         // on AND the echo round-trip is above threshold AND we're armed).
         this.predict?.onInput(data);

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -25,6 +25,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { registeredAgentsByBlock, unregisterAgent } from "./termagent";
 import { handleOsc7Command, handleOsc16162Command, handleOscTitleCommand, handleOscWaveCommand } from "./termosc";
 import { markStart, markEnd } from "@/perf";
+import { PredictiveEcho } from "./predictive-echo";
 
 const dlog = debug("wave:termwrap");
 
@@ -197,6 +198,25 @@ export class TermWrap {
         this.terminal.textarea?.addEventListener("blur", () => {
             this.terminal.options.cursorBlink = false;
         });
+
+        // Predictive local echo (spec §6). Sink writes directly to xterm: paint
+        // appends a glyph; erase walks the cursor back N cells and clears to EOL
+        // (Phase-1 appended-at-cursor model). Gated on term:predictiveecho.
+        const predictiveEchoAtom = getSettingsKeyAtom("term:predictiveecho");
+        const predictiveThreshold = getSettingsKeyAtom("term:predictiveecho:thresholdms")();
+        this.predict = new PredictiveEcho(
+            {
+                paint: (g) => this.terminal.write(g),
+                erase: (n) => this.terminal.write(`\x1b[${n}D\x1b[K`),
+            },
+            {
+                // Enabled by DEFAULT — opt out via term:predictiveecho=false.
+                enabled: () => predictiveEchoAtom() !== false,
+                // Predict whenever armed by default; set term:predictiveecho:thresholdms
+                // to re-enable the RTT gate (0 = always-on once a confirmed echo arms).
+                thresholdMs: typeof predictiveThreshold === "number" ? predictiveThreshold : 0,
+            },
+        );
 
         this.setupPasteHandler();
 
@@ -407,6 +427,12 @@ export class TermWrap {
         }
     }
 
+    // Predictive local echo: paints a just-typed printable char in the keydown
+    // frame, reconciled against the authoritative PTY echo. Null until init().
+    // Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md.
+    private predict: PredictiveEcho | null = null;
+    private echoDecoder = new TextDecoder();
+
     handleTermData(data: string) {
         if (!this.loaded) {
             return;
@@ -419,6 +445,9 @@ export class TermWrap {
             }
         }
         this.sendDataHandler?.(data);
+        // Optimistically paint the keystroke (no-op unless term:predictiveecho is
+        // on AND the echo round-trip is above threshold AND we're armed).
+        this.predict?.onInput(data);
         markEnd('term-keypress', 'sent');
     }
 
@@ -478,22 +507,38 @@ export class TermWrap {
     // flash regresses, the fix is backend-side read coalescing (merge consecutive
     // PTY reads into one WS message in agentmux-srv), NOT a second frontend rAF.
     doTerminalWrite(data: string | Uint8Array, setPtyOffset?: number): Promise<void> {
-        const isSmall = data.length <= 32;
+        const originalLen = data.length;
+        const isSmall = originalLen <= 32;
+        // When predictive echo is on, reconcile this authoritative chunk against
+        // outstanding predictions (spec §6.3): consume already-painted echoes,
+        // roll back on divergence, write only what the user can't already see.
+        // ptyOffset still advances by the FULL chunk — these are real PTY bytes.
+        let toWrite: string | Uint8Array = data;
+        if (this.predict?.isEnabled() && data instanceof Uint8Array) {
+            const str = this.echoDecoder.decode(data, { stream: true });
+            toWrite = this.predict.reconcile(str);
+            this.predict.sweep();
+        }
         let resolve: () => void = null;
         let prtn = new Promise<void>((presolve, _) => {
             resolve = presolve;
         });
-        this.terminal.write(data, () => {
+        const settle = () => {
             if (setPtyOffset != null) {
                 this.ptyOffset = setPtyOffset;
             } else {
-                this.ptyOffset += data.length;
-                this.dataBytesProcessed += data.length;
+                this.ptyOffset += originalLen;
+                this.dataBytesProcessed += originalLen;
             }
             this.lastUpdated = Date.now();
             if (isSmall) markEnd('term-echo-render', 'rendered');
             resolve();
-        });
+        };
+        if (typeof toWrite === "string" && toWrite.length === 0) {
+            settle(); // fully consumed by prediction — nothing left to render
+        } else {
+            this.terminal.write(toWrite, settle);
+        }
         return prtn;
     }
 

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -431,6 +431,7 @@ export class TermWrap {
     // frame, reconciled against the authoritative PTY echo. Null until init().
     // Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md.
     private predict: PredictiveEcho | null = null;
+    // Stateless decode — stream:false so no cross-chunk buffering accumulates.
     private echoDecoder = new TextDecoder();
 
     handleTermData(data: string) {
@@ -520,7 +521,15 @@ export class TermWrap {
                 // painted, not armed) — zero cost on the authoritative path until
                 // the first confirmation arms the predictor (reagent #1223 P2).
                 if (this.predict.pending > 0 || this.predict.isArmed) {
-                    const str = this.echoDecoder.decode(data, { stream: true });
+                    // stream: false — don't buffer across WS chunks. If a multibyte
+                    // UTF-8 sequence is split between chunks and the predict path is
+                    // later disabled/flushed before the continuation arrives, the
+                    // leading bytes would be stranded in the decoder while subsequent
+                    // chunks bypass it and go directly to xterm, corrupting output.
+                    // Using stream:false (stateless per-call) produces U+FFFD for an
+                    // incomplete sequence at chunk boundaries — same as xterm's own
+                    // behaviour on the raw Uint8Array path (codex P2 on #1223).
+                    const str = this.echoDecoder.decode(data, { stream: false });
                     toWrite = this.predict.reconcile(str);
                     this.predict.sweep();
                 }

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -516,13 +516,17 @@ export class TermWrap {
         let toWrite: string | Uint8Array = data;
         if (this.predict && data instanceof Uint8Array) {
             if (this.predict.isEnabled()) {
-                const str = this.echoDecoder.decode(data, { stream: true });
-                toWrite = this.predict.reconcile(str);
-                this.predict.sweep();
+                // Skip the decode + reconcile entirely when fully dormant (nothing
+                // painted, not armed) — zero cost on the authoritative path until
+                // the first confirmation arms the predictor (reagent #1223 P2).
+                if (this.predict.pending > 0 || this.predict.isArmed) {
+                    const str = this.echoDecoder.decode(data, { stream: true });
+                    toWrite = this.predict.reconcile(str);
+                    this.predict.sweep();
+                }
             } else if (this.predict.pending > 0) {
                 // Setting toggled off mid-prediction: roll back any speculative
-                // glyph before the authoritative echo lands, else it double-renders
-                // until the next keystroke runs reset() (codex #1223 P2).
+                // glyph before the authoritative echo lands (codex #1223 P2).
                 this.predict.reset();
             }
         }

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -514,10 +514,17 @@ export class TermWrap {
         // roll back on divergence, write only what the user can't already see.
         // ptyOffset still advances by the FULL chunk — these are real PTY bytes.
         let toWrite: string | Uint8Array = data;
-        if (this.predict?.isEnabled() && data instanceof Uint8Array) {
-            const str = this.echoDecoder.decode(data, { stream: true });
-            toWrite = this.predict.reconcile(str);
-            this.predict.sweep();
+        if (this.predict && data instanceof Uint8Array) {
+            if (this.predict.isEnabled()) {
+                const str = this.echoDecoder.decode(data, { stream: true });
+                toWrite = this.predict.reconcile(str);
+                this.predict.sweep();
+            } else if (this.predict.pending > 0) {
+                // Setting toggled off mid-prediction: roll back any speculative
+                // glyph before the authoritative echo lands, else it double-renders
+                // until the next keystroke runs reset() (codex #1223 P2).
+                this.predict.reset();
+            }
         }
         let resolve: () => void = null;
         let prtn = new Promise<void>((presolve, _) => {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -431,8 +431,6 @@ export class TermWrap {
     // frame, reconciled against the authoritative PTY echo. Null until init().
     // Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md.
     private predict: PredictiveEcho | null = null;
-    // Stateless decode — stream:false so no cross-chunk buffering accumulates.
-    private echoDecoder = new TextDecoder();
 
     handleTermData(data: string) {
         if (!this.loaded) {
@@ -514,31 +512,6 @@ export class TermWrap {
         // outstanding predictions (spec §6.3): consume already-painted echoes,
         // roll back on divergence, write only what the user can't already see.
         // ptyOffset still advances by the FULL chunk — these are real PTY bytes.
-        let toWrite: string | Uint8Array = data;
-        if (this.predict && data instanceof Uint8Array) {
-            if (this.predict.isEnabled()) {
-                // Skip the decode + reconcile entirely when fully dormant (nothing
-                // painted, not armed) — zero cost on the authoritative path until
-                // the first confirmation arms the predictor (reagent #1223 P2).
-                if (this.predict.pending > 0 || this.predict.isArmed) {
-                    // stream: false — don't buffer across WS chunks. If a multibyte
-                    // UTF-8 sequence is split between chunks and the predict path is
-                    // later disabled/flushed before the continuation arrives, the
-                    // leading bytes would be stranded in the decoder while subsequent
-                    // chunks bypass it and go directly to xterm, corrupting output.
-                    // Using stream:false (stateless per-call) produces U+FFFD for an
-                    // incomplete sequence at chunk boundaries — same as xterm's own
-                    // behaviour on the raw Uint8Array path (codex P2 on #1223).
-                    const str = this.echoDecoder.decode(data, { stream: false });
-                    toWrite = this.predict.reconcile(str);
-                    this.predict.sweep();
-                }
-            } else if (this.predict.pending > 0) {
-                // Setting toggled off mid-prediction: roll back any speculative
-                // glyph before the authoritative echo lands (codex #1223 P2).
-                this.predict.reset();
-            }
-        }
         let resolve: () => void = null;
         let prtn = new Promise<void>((presolve, _) => {
             resolve = presolve;
@@ -554,11 +527,39 @@ export class TermWrap {
             if (isSmall) markEnd('term-echo-render', 'rendered');
             resolve();
         };
-        if (typeof toWrite === "string" && toWrite.length === 0) {
-            settle(); // fully consumed by prediction — nothing left to render
-        } else {
-            this.terminal.write(toWrite, settle);
+
+        if (this.predict && data instanceof Uint8Array) {
+            if (this.predict.isEnabled()) {
+                // Skip reconcile entirely when fully dormant (reagent #1223 P2).
+                if (this.predict.pending > 0 || this.predict.isArmed) {
+                    // reconcile operates on raw bytes — the queue only holds single
+                    // ASCII chars, so byte comparison is exact. `rest` is the
+                    // unconsumed tail returned as the ORIGINAL Uint8Array so
+                    // multibyte UTF-8 sequences split across WS chunks are NEVER
+                    // decoded, preserving all non-ASCII output (codex P2 on #1223).
+                    const { auth, rest } = this.predict.reconcile(data);
+                    this.predict.sweep();
+                    const hasAuth = auth.length > 0;
+                    const hasRest = rest.length > 0;
+                    if (!hasAuth && !hasRest) {
+                        settle(); // fully consumed by prediction
+                    } else if (hasAuth && !hasRest) {
+                        this.terminal.write(auth, settle);
+                    } else if (!hasAuth && hasRest) {
+                        this.terminal.write(rest, settle);
+                    } else {
+                        // Write observations first, then the unconsumed tail.
+                        // settle fires after the second write.
+                        this.terminal.write(auth, () => this.terminal.write(rest, settle));
+                    }
+                    return prtn;
+                }
+            } else if (this.predict.pending > 0) {
+                this.predict.reset(); // roll back on disable (codex #1223 P2)
+            }
         }
+        // Default / pass-through path.
+        this.terminal.write(data, settle);
         return prtn;
     }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1304,6 +1304,8 @@ declare global {
         "term:transparency"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
+        "term:predictiveecho"?: boolean;
+        "term:predictiveecho:thresholdms"?: number;
         "cmd:env"?: {[key: string]: string};
         "blockheader:*"?: boolean;
         "blockheader:showblockids"?: boolean;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -59,6 +59,12 @@
         "term:shiftenternewline": {
           "type": "boolean"
         },
+        "term:predictiveecho": {
+          "type": "boolean"
+        },
+        "term:predictiveecho:thresholdms": {
+          "type": "number"
+        },
         "cmd:env": {
           "additionalProperties": {
             "type": "string"


### PR DESCRIPTION
## Summary

VS Code's terminal and AgentMux's are **both xterm.js on WebGL** — identical rendering. The only thing that makes our typing feel less immediate is the **echo round-trip**: VS Code's PTY (`node-pty`) is in-process (a µs callback); ours lives in the sidecar, so every keystroke crosses `frontend → WS → sidecar PTY → echo → WS → frontend → paint`.

This predicts the echo: paint a just-typed printable character **in the keydown frame**, then reconcile byte-exact against the authoritative PTY echo (consume if it matches, roll back if it diverges). The authoritative data path is untouched; predictions are a transient, self-correcting overlay that always converges to the PTY stream.

## Design (full spec: `docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md`)

- **Observational arming (§7.1)** — never predict without a *confirmed* echo first, so a password prompt (echo off) never flashes plaintext: the first keystroke of every burst is authoritative-only, and confirmations stop the instant echo stops.
- **Byte-exact reconcile + rollback** — divergence (autocap, `^C`, TUI output) rolls back all outstanding predictions; the buffer converges to exactly the PTY stream.
- **Alt-screen / non-printable / CJK** fall through to the authoritative path (outside the Phase-1 safe set).
- **RTT-gate + cooldown** — gate opt-in via `term:predictiveecho:thresholdms` (default 0 = always predict once armed).

## Files

- `predictive-echo.ts` — pure state machine (queue, reconcile, arm, RTT); xterm side effects injected via a `PredictSink` for testability.
- `predictive-echo.test.ts` — 11 tests: arming, **password-no-flash**, predict/confirm/diverge, timeout, flush, RTT gate, **convergence property**.
- `termwrap.ts` — `onInput` paints in the keydown frame; `doTerminalWrite` reconciles (consume painted / roll back on divergence); `ptyOffset` tracks full PTY bytes. **Default-on** (`term:predictiveecho=false` to opt out).

## Test plan

- [x] 11 unit tests incl. convergence.
- [ ] **Manual:** type in a terminal → chars paint instantly; `read -s` / `sudo` → no plaintext flash; `vim` → no corruption.

## Notes

Phase 1 of the spec (cooked-mode, single-line, ASCII). Phases 2–4 (explicit Unix `tcgetattr` echo signal + alt-screen parser; CJK/wrap width-awareness; tuning) tracked in the spec. Part of the typing-perf umbrella (#1161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)