### PR TITLE
perf(cef): enable EarlyEstablishGpuChannel + EstablishGpuChannelAsync

### DIFF
--- a/.changesets/1780305472-perf-cef-gpu-channel-flags-v674.md
+++ b/.changesets/1780305472-perf-cef-gpu-channel-flags-v674.md
@@ -1,0 +1,35 @@
+---
+type: patch
+---
+
+perf(cef): enable EarlyEstablishGpuChannel + EstablishGpuChannelAsync
+
+Adds `--enable-features=EarlyEstablishGpuChannel,EstablishGpuChannelAsync`
+to the CEF browser-process command line in
+`AgentMuxApp::on_before_command_line_processing`. Both features ship
+enabled in stable Chrome on Linux and are explicitly set by VSCode's
+Electron (confirmed via `/proc/<pid>/cmdline` on a running VSCode); CEF
+does not enable them by default.
+
+They (a) request the GPU process channel before the renderer's first
+paint instead of synchronously on first paint and (b) treat the channel
+establishment as non-blocking, which lets the compositor start producing
+frames against the GPU process sooner.
+
+## Empirical impact (Linux Chromium-Ozone-Wayland, 10 panes, 12 s held key)
+
+Measured via `scripts/capture-trace-ipv6.cjs`:
+
+| | Before | After |
+|---|---|---|
+| `BeginMainFrame` avg | 39.1 ms | **35.7 ms** (-9 %) |
+| `BeginMainFrame` count | 12 | 12 (unchanged) |
+| Frame cadence | ~1 Hz | ~1 Hz (unchanged) |
+| `LayerTreeHostImpl::DidNotProduceFrame` | 66 | 60 |
+
+Small per-frame win (~3 ms / frame). The Wayland frame-production stall
+that holds the cadence at ~1 Hz under sysinfo invalidation is a separate
+problem (the renderer rejects 60+ Mutter `BeginFrame` requests as
+`DidNotProduceFrame` because xterm.js WebGL canvas writes don't surface
+as page-level dirtiness). Tracked separately; this PR is just the
+matching VSCode flag set so we're not unnecessarily off-default.

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -356,6 +356,53 @@ wrap_app! {
                 let val = CefString::from("CalculateNativeWinOcclusion");
                 cmd.append_switch_with_value(Some(&key), Some(&val));
 
+                // ── GPU channel + frame-production tuning ─────────────────────
+                // Symptom this addresses (Linux Chromium-Ozone-Wayland on
+                // Mutter): the compositor receives ~6 Hz `BeginFrame` signals
+                // from Mutter but responds `DidNotProduceFrame` 89 % of the
+                // time. `BeginMainFrame` only fires at the sysinfo-status-bar
+                // invalidation cadence (~1 Hz). Result: xterm.js
+                // `requestAnimationFrame` callbacks (including predictive
+                // local echo's render path, #1223) are gated on those 1 Hz
+                // frames, so a held key visibly lags up to a second behind
+                // the keypress.
+                //
+                // VSCode (Electron, same Chromium codebase) does NOT have
+                // this stall on the same hardware and compositor. Its
+                // renderer + utility processes ship with:
+                //
+                //   --enable-features=EarlyEstablishGpuChannel,
+                //                     EstablishGpuChannelAsync
+                //
+                // confirmed via `/proc/<pid>/cmdline` on a running VSCode +
+                // documented in Chromium's `chrome/browser/about_flags.cc`.
+                // Both features ship enabled in stable Chrome on Linux; CEF
+                // does not enable them by default. They (a) request the GPU
+                // process channel before the renderer's first paint instead
+                // of synchronously on first paint and (b) treat the channel
+                // establishment as non-blocking, which lets the compositor
+                // start producing frames against the GPU process sooner and
+                // without serialising on the channel handshake.
+                //
+                // Hypothesis: the synchronous + late channel establishment
+                // contributes to the `DidNotProduceFrame` storm on Wayland
+                // here. Confirming empirically: trace with
+                // `scripts/capture-trace-ipv6.cjs`, look at
+                // `ProxyMain::BeginMainFrame` cadence and the
+                // `cc::Scheduler::SendDidNotProduceFrame` count before/after.
+                //
+                // Spec: docs/specs/SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md
+                //       (host-side complement — predictive echo is renderer-
+                //       side; this is the upstream frame-production fix).
+                let gpu_features_key = CefString::from("enable-features");
+                let gpu_features_val = CefString::from(
+                    "EarlyEstablishGpuChannel,EstablishGpuChannelAsync",
+                );
+                cmd.append_switch_with_value(
+                    Some(&gpu_features_key),
+                    Some(&gpu_features_val),
+                );
+
                 // Initial background color, ARGB hex. alpha=00 → fully
                 // transparent → first-frame paint is alpha-aware so the
                 // CSS body background's rgba() composes with the desktop


### PR DESCRIPTION
## Summary

Adds `--enable-features=EarlyEstablishGpuChannel,EstablishGpuChannelAsync` to the CEF browser-process command line. Both ship enabled in stable Chrome on Linux and are explicitly set by VSCode's Electron (confirmed via `/proc/<pid>/cmdline` on a running VSCode on the same machine); CEF does not enable them by default.

`EarlyEstablishGpuChannel` requests the GPU process channel before the renderer's first paint instead of synchronously on first paint; `EstablishGpuChannelAsync` treats establishment as non-blocking. Together they let the compositor start producing frames against the GPU process sooner.

## Empirical impact (Linux Chromium-Ozone-Wayland, 10 panes, 12 s held key)

Captured via `scripts/capture-trace-ipv6.cjs`:

| | Before | After |
|---|---|---|
| `BeginMainFrame` avg | 39.1 ms | **35.7 ms** (-9%) |
| `BeginMainFrame` count | 12 | 12 (unchanged) |
| Frame cadence | ~1 Hz | ~1 Hz (unchanged) |
| `LayerTreeHostImpl::DidNotProduceFrame` | 66 | 60 |

Small per-frame win (~3 ms / frame). The Wayland frame-production stall that holds the cadence at ~1 Hz under sysinfo invalidation is a separate problem — the renderer rejects 60+ Mutter `BeginFrame` requests as `DidNotProduceFrame` because xterm.js WebGL canvas writes don't surface as page-level dirtiness. Predictive echo (#1223) writes to xterm's internal buffer instantly, but the render-to-pixels step is gated on those 1 Hz frames.

**This PR is not the typing-latency silver bullet — it's the matching VSCode flag set so we're not unnecessarily off-default while we investigate the real fix.**

## Test plan

- [ ] `task build:host` succeeds (✅ verified locally)
- [ ] App launches; renderer/utility subprocesses show `--enable-features=EarlyEstablishGpuChannel,EstablishGpuChannelAsync` in `/proc/<pid>/cmdline`
- [ ] `scripts/capture-trace-ipv6.cjs` reports no new errors
- [ ] No GPU process / WebGL regressions in normal workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)