### PR TITLE
docs: fix one-char offset on named-pipe label in architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ws.send(JSON.stringify({
 AgentMux is a four-process desktop app. Each process owns one concern, end-to-end. See [Architecture overview](https://docs.agentmux.ai/architecture-overview/) for the full topology.
 
 ```
-┌──────────────────┐        named pipe        ┌──────────────────┐
+┌──────────────────┐         named pipe        ┌──────────────────┐
 │  agentmux-       │ ◀────────────────────────▶│  agentmux-cef    │
 │  launcher        │                          │  (the "host")    │
 │  (≈325 KB shim)  │                          │                  │


### PR DESCRIPTION
The `named pipe` label line between the two boxes was 26 chars wide while the arrow line was 27 chars — visually offset by one character. Added one space to center the label over the arrow.

Applies the same fix to agentmux-docs in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)