### PR TITLE
fix(host): gate renderer OOM recovery on system memory (Phase 1a)

### DIFF
--- a/.changesets/1780341505-fix-host-gate-renderer-oom-recovery-on-system-memory-pause-i-dkgh.md
+++ b/.changesets/1780341505-fix-host-gate-renderer-oom-recovery-on-system-memory-pause-i-dkgh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host): gate renderer OOM recovery on system memory — pause instead of false give-up

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -158,6 +158,24 @@ impl AgentMuxHandler {
         }))
     }
 
+    /// Reverse-lookup this browser's window label from the reducer's browsers
+    /// map (label → browser), by object identity. Mirrors the find-by-identity
+    /// loop in `on_before_close`. Used by the crash-recovery navigation so a
+    /// resumed *secondary* window preserves its `windowLabel` instead of
+    /// defaulting to `main` (the frontend treats a missing label as `main`,
+    /// which would re-register/route the recovered window as the wrong one).
+    /// (codex P2 on #1229.)
+    fn window_label_for(&self, browser: &mut Browser) -> Option<String> {
+        self.state
+            .list_browsers()
+            .into_iter()
+            .find(|(_, b)| {
+                let mut b = b.clone();
+                b.is_same(Some(&mut *browser)) != 0
+            })
+            .map(|(k, _)| k)
+    }
+
     fn on_title_change(&mut self, browser: Option<&mut Browser>, title: Option<&CefString>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
@@ -1448,41 +1466,51 @@ impl AgentMuxHandler {
                         let within_budget = record_memory_pause(hist, now);
                         let pauses_in_window = hist.len();
                         if within_budget {
-                            let separator = if base_url.contains('?') { "&" } else { "?" };
-                            let app_url = format!(
-                                "{}{}ipc_port={}&ipc_token={}",
-                                base_url, separator, self.ipc_port, self.state.ipc_token
-                            );
-                            tracing::warn!(
-                                target: "crash",
-                                kind = "renderer_memory_paused",
-                                browser_id = bid,
-                                commit_free_mb = commit_free,
-                                resume_floor_mb = RESUME_FLOOR_MB,
-                                pauses_in_window,
-                                "renderer OOM under low system commit — paused (NOT counted against the crash budget)",
-                            );
-                            let html = memory_paused_page(reason, error_code, commit_free, &app_url);
-                            let b64 = cef::base64_encode(Some(html.as_bytes()));
-                            let b64_str = CefString::from(&b64).to_string();
-                            let data_uri = format!("data:text/html;base64,{}", b64_str);
-                            let uri = CefString::from(data_uri.as_str());
-                            if let Some(b) = browser {
-                                if let Some(frame) = b.main_frame() {
+                            // Clone to an owned Browser (mirrors on_before_close)
+                            // for the label lookup + navigation; the original
+                            // `browser` Option stays intact for the fall-through
+                            // paths below. as_deref().cloned() borrows, not moves.
+                            if let Some(mut owned) = browser.as_deref().cloned() {
+                                let window_label = self.window_label_for(&mut owned);
+                                let app_url = recovery_navigation_url(
+                                    &base_url,
+                                    self.ipc_port,
+                                    &self.state.ipc_token,
+                                    window_label.as_deref(),
+                                );
+                                tracing::warn!(
+                                    target: "crash",
+                                    kind = "renderer_memory_paused",
+                                    browser_id = bid,
+                                    commit_free_mb = commit_free,
+                                    resume_floor_mb = RESUME_FLOOR_MB,
+                                    pauses_in_window,
+                                    window_label = window_label.as_deref().unwrap_or("<unknown>"),
+                                    "renderer OOM under low system commit — paused (NOT counted against the crash budget)",
+                                );
+                                let html = memory_paused_page(reason, error_code, commit_free, &app_url);
+                                let b64 = cef::base64_encode(Some(html.as_bytes()));
+                                let b64_str = CefString::from(&b64).to_string();
+                                let data_uri = format!("data:text/html;base64,{}", b64_str);
+                                let uri = CefString::from(data_uri.as_str());
+                                if let Some(frame) = owned.main_frame() {
                                     frame.load_url(Some(&uri));
                                 }
+                                return;
                             }
-                            return;
+                            // browser was None (unusual on this path) — fall
+                            // through to the normal crash-budget handling below.
+                        } else {
+                            tracing::error!(
+                                target: "crash",
+                                kind = "memory_pause_budget_exceeded",
+                                browser_id = bid,
+                                pauses_in_window,
+                                window_secs = MEMORY_PAUSE_WINDOW.as_secs(),
+                                "memory-pause budget exceeded (commit totally exhausted) — falling through to the give-up page",
+                            );
+                            // fall through to the crash-budget path below.
                         }
-                        tracing::error!(
-                            target: "crash",
-                            kind = "memory_pause_budget_exceeded",
-                            browser_id = bid,
-                            pauses_in_window,
-                            window_secs = MEMORY_PAUSE_WINDOW.as_secs(),
-                            "memory-pause budget exceeded (commit totally exhausted) — falling through to the give-up page",
-                        );
-                        // fall through to the crash-budget path below.
                     }
                 }
             }
@@ -1550,14 +1578,20 @@ impl AgentMuxHandler {
         // short-circuit to the "install broken" static page instead of
         // pointing the Reload button at a URL that would itself crash.
         // See docs/retro/retro-portable-rm-running-install-2026-05-28.md.
+        // Preserve the window label so the Reload button brings a recovered
+        // secondary window back as itself, not as `main` (codex P2 #1229).
+        // as_deref().cloned() borrows browser, leaving it intact for the load.
+        let recovery_label = browser
+            .as_deref()
+            .cloned()
+            .and_then(|mut owned| self.window_label_for(&mut owned));
         let app_url = match crate::commands::window::resolve_frontend_base_url(self.ipc_port) {
-            Ok(base_url) => {
-                let separator = if base_url.contains('?') { "&" } else { "?" };
-                format!(
-                    "{}{}ipc_port={}&ipc_token={}",
-                    base_url, separator, self.ipc_port, self.state.ipc_token
-                )
-            }
+            Ok(base_url) => recovery_navigation_url(
+                &base_url,
+                self.ipc_port,
+                &self.state.ipc_token,
+                recovery_label.as_deref(),
+            ),
             Err(e) => {
                 tracing::error!(
                     target: "crash",
@@ -1957,6 +1991,26 @@ setTimeout(tick, 1000);
         error_code = error_code,
         auto_close_secs = CRASH_LOOP_AUTO_CLOSE_SECS,
     )
+}
+
+/// Build the navigation URL a crash-recovery / low-memory page sends the user
+/// back to. Carries `ipc_port` + `ipc_token` and — critically — the window's
+/// `windowLabel` when known, so a recovered secondary window doesn't
+/// reinitialize as `main` (creation.rs adds the same `windowLabel` param on
+/// first load; the frontend defaults a missing label to `main`). codex P2 #1229.
+fn recovery_navigation_url(
+    base_url: &str,
+    ipc_port: u16,
+    ipc_token: &str,
+    window_label: Option<&str>,
+) -> String {
+    let sep = if base_url.contains('?') { "&" } else { "?" };
+    match window_label {
+        Some(lbl) => format!(
+            "{base_url}{sep}ipc_port={ipc_port}&ipc_token={ipc_token}&windowLabel={lbl}"
+        ),
+        None => format!("{base_url}{sep}ipc_port={ipc_port}&ipc_token={ipc_token}"),
+    }
 }
 
 /// Record a memory-pause for `now` into `hist`, pruning entries older than

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -176,6 +176,27 @@ impl AgentMuxHandler {
             .map(|(k, _)| k)
     }
 
+    /// Best navigation target for bringing a crashed window back. Prefers the
+    /// window's OWN pre-crash URL (read from its main frame before we load any
+    /// recovery page over it): it already carries every creation-time param —
+    /// `windowLabel` and, for tear-off / floating-pane windows, `workspaceId`
+    /// / `floatingPaneId` — plus the still-valid in-process `ipc_port` /
+    /// `ipc_token`, so reusing it verbatim re-projects the exact window. Falls
+    /// back to a reconstructed `?ipc_port&ipc_token&windowLabel` URL only when
+    /// the frame URL isn't a live app URL (renderer died before committing one,
+    /// or it's a prior data: recovery page). codex P2 #1229.
+    fn recovery_target_url(&self, owned: &mut Browser, base_url: &str) -> String {
+        let pre_crash = owned
+            .main_frame()
+            .map(|f| CefString::from(&f.url()).to_string())
+            .filter(|u| u.starts_with("http://127.0.0.1"));
+        if let Some(u) = pre_crash {
+            return u;
+        }
+        let label = self.window_label_for(owned);
+        recovery_navigation_url(base_url, self.ipc_port, &self.state.ipc_token, label.as_deref())
+    }
+
     fn on_title_change(&mut self, browser: Option<&mut Browser>, title: Option<&CefString>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
@@ -1471,13 +1492,7 @@ impl AgentMuxHandler {
                             // `browser` Option stays intact for the fall-through
                             // paths below. as_deref().cloned() borrows, not moves.
                             if let Some(mut owned) = browser.as_deref().cloned() {
-                                let window_label = self.window_label_for(&mut owned);
-                                let app_url = recovery_navigation_url(
-                                    &base_url,
-                                    self.ipc_port,
-                                    &self.state.ipc_token,
-                                    window_label.as_deref(),
-                                );
+                                let app_url = self.recovery_target_url(&mut owned, &base_url);
                                 tracing::warn!(
                                     target: "crash",
                                     kind = "renderer_memory_paused",
@@ -1485,7 +1500,6 @@ impl AgentMuxHandler {
                                     commit_free_mb = commit_free,
                                     resume_floor_mb = RESUME_FLOOR_MB,
                                     pauses_in_window,
-                                    window_label = window_label.as_deref().unwrap_or("<unknown>"),
                                     "renderer OOM under low system commit — paused (NOT counted against the crash budget)",
                                 );
                                 let html = memory_paused_page(reason, error_code, commit_free, &app_url);
@@ -1578,20 +1592,22 @@ impl AgentMuxHandler {
         // short-circuit to the "install broken" static page instead of
         // pointing the Reload button at a URL that would itself crash.
         // See docs/retro/retro-portable-rm-running-install-2026-05-28.md.
-        // Preserve the window label so the Reload button brings a recovered
-        // secondary window back as itself, not as `main` (codex P2 #1229).
-        // as_deref().cloned() borrows browser, leaving it intact for the load.
-        let recovery_label = browser
-            .as_deref()
-            .cloned()
-            .and_then(|mut owned| self.window_label_for(&mut owned));
+        // Reload must bring a recovered window back as ITSELF — preserving
+        // windowLabel and (for tear-off / floating-pane windows) workspaceId /
+        // floatingPaneId. recovery_target_url reuses the window's own pre-crash
+        // URL when possible. as_deref().cloned() borrows browser (a clone),
+        // leaving the original intact for the load below. (codex P2 #1229.)
+        let mut recovery_owned = browser.as_deref().cloned();
         let app_url = match crate::commands::window::resolve_frontend_base_url(self.ipc_port) {
-            Ok(base_url) => recovery_navigation_url(
-                &base_url,
-                self.ipc_port,
-                &self.state.ipc_token,
-                recovery_label.as_deref(),
-            ),
+            Ok(base_url) => match recovery_owned.as_mut() {
+                Some(owned) => self.recovery_target_url(owned, &base_url),
+                None => recovery_navigation_url(
+                    &base_url,
+                    self.ipc_port,
+                    &self.state.ipc_token,
+                    None,
+                ),
+            },
             Err(e) => {
                 tracing::error!(
                     target: "crash",

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -30,6 +30,26 @@ const CRASH_BUDGET: usize = 3;
 /// renderer that genuinely needed 2 retries to stabilise across a minute.
 const CRASH_BUDGET_WINDOW: Duration = Duration::from_secs(10);
 
+/// Commit-free (available page file) floor, in MB, below which an OOM renderer
+/// termination is treated as transient SYSTEM memory pressure rather than a
+/// broken renderer. Below this, recovery does NOT consume the wedged-slot crash
+/// budget and the browser is shown a recoverable "low memory" page instead of
+/// the give-up page. A fresh renderer's initial commit is ~100-200 MB; 512 MB
+/// leaves margin so a manual Resume doesn't instantly re-OOM.
+/// See docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md §6.B/§7.
+const RESUME_FLOOR_MB: u64 = 512;
+
+/// Backstop for the memory-pause path: if a browser enters memory-pause more
+/// than this many times within `MEMORY_PAUSE_WINDOW` — i.e. commit is so
+/// totally exhausted that even the tiny low-memory page can't render and
+/// re-fires this handler — fall through to the give-up page so we stop
+/// re-spawning a renderer that instantly dies. Deliberately more lenient than
+/// `CRASH_BUDGET`: this path is *expected* to repeat under sustained pressure,
+/// so it must not converge as fast. (Native-overlay handling of total
+/// exhaustion — rendering the paused UI without a renderer — is Phase 1b.)
+const MEMORY_PAUSE_BUDGET: usize = 5;
+const MEMORY_PAUSE_WINDOW: Duration = Duration::from_secs(30);
+
 // Phase B.9.3 — close-pool-browser task. Used by Stage 1 to defer
 // `close_browser` onto the CEF UI thread via `cef::post_task`, so
 // the call runs AFTER the current `on_before_close` unwinds.
@@ -101,6 +121,13 @@ pub struct AgentMuxHandler {
     /// window are dropped); when a browser closes cleanly its entry is
     /// removed in `on_before_close`.
     crash_history: HashMap<i32, VecDeque<Instant>>,
+    /// Per-browser ring of memory-pause timestamps (OOM under low system
+    /// commit). Separate from `crash_history` so transient system-memory
+    /// pressure never trips the wedged-slot crash budget. Bounded by
+    /// `MEMORY_PAUSE_BUDGET` within `MEMORY_PAUSE_WINDOW`; pruned in place and
+    /// removed on clean close, exactly like `crash_history`.
+    /// See docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md §6.B.
+    memory_pause_history: HashMap<i32, VecDeque<Instant>>,
 }
 
 mod handlers;
@@ -127,6 +154,7 @@ impl AgentMuxHandler {
             ipc_port,
             is_browser_pane,
             crash_history: HashMap::new(),
+            memory_pause_history: HashMap::new(),
         }))
     }
 
@@ -654,6 +682,7 @@ impl AgentMuxHandler {
         // cleanly so its budget is reset. Without this the map would
         // accumulate one stale entry per closed browser over a session.
         self.crash_history.remove(&browser.identifier());
+        self.memory_pause_history.remove(&browser.identifier());
 
         // Unregister browser from the reducer's `browsers` map and get its
         // label. Phase H.2.d — legacy `state.browsers.lock().remove` removed;
@@ -1389,6 +1418,76 @@ impl AgentMuxHandler {
             );
         }
 
+        // ── Gated renderer recovery (SPEC_GATED_RENDERER_RECOVERY §6.B) ──
+        // A renderer OOM while the system commit limit is exhausted is
+        // transient OS pressure, NOT a broken renderer — no amount of retrying
+        // helps until memory frees, and the standard 3-crashes-in-10s budget
+        // would wrongly declare "give up" on a window that is fully recoverable
+        // once commit drops. So: if the termination is PROCESS_OOM and
+        // commit-free is below RESUME_FLOOR_MB, do NOT consume the crash
+        // budget; show a recoverable "low memory" page (state is durable in
+        // srv, so Resume re-projects everything). Bounded separately by
+        // MEMORY_PAUSE_BUDGET so that *total* exhaustion — where even this tiny
+        // page can't render and re-fires the handler — still converges on the
+        // give-up page rather than looping. (Auto-resume + a renderer-free
+        // native overlay for total exhaustion are Phase 1b.)
+        if status == TerminationStatus::PROCESS_OOM {
+            let commit_free = crate::memory_heartbeat::commit_free_mb();
+            if commit_free < RESUME_FLOOR_MB {
+                if let Some(bid) = browser.as_ref().map(|b| b.identifier()) {
+                    // Resolve the live app URL up front: if the frontend assets
+                    // are unavailable that's a *different* failure (the
+                    // 2026-05-28 rm-while-running pattern), so leave the
+                    // memory-pause history untouched and fall through to the
+                    // normal path, which has the assets-missing handling.
+                    if let Ok(base_url) =
+                        crate::commands::window::resolve_frontend_base_url(self.ipc_port)
+                    {
+                        let now = Instant::now();
+                        let hist = self.memory_pause_history.entry(bid).or_default();
+                        let within_budget = record_memory_pause(hist, now);
+                        let pauses_in_window = hist.len();
+                        if within_budget {
+                            let separator = if base_url.contains('?') { "&" } else { "?" };
+                            let app_url = format!(
+                                "{}{}ipc_port={}&ipc_token={}",
+                                base_url, separator, self.ipc_port, self.state.ipc_token
+                            );
+                            tracing::warn!(
+                                target: "crash",
+                                kind = "renderer_memory_paused",
+                                browser_id = bid,
+                                commit_free_mb = commit_free,
+                                resume_floor_mb = RESUME_FLOOR_MB,
+                                pauses_in_window,
+                                "renderer OOM under low system commit — paused (NOT counted against the crash budget)",
+                            );
+                            let html = memory_paused_page(reason, error_code, commit_free, &app_url);
+                            let b64 = cef::base64_encode(Some(html.as_bytes()));
+                            let b64_str = CefString::from(&b64).to_string();
+                            let data_uri = format!("data:text/html;base64,{}", b64_str);
+                            let uri = CefString::from(data_uri.as_str());
+                            if let Some(b) = browser {
+                                if let Some(frame) = b.main_frame() {
+                                    frame.load_url(Some(&uri));
+                                }
+                            }
+                            return;
+                        }
+                        tracing::error!(
+                            target: "crash",
+                            kind = "memory_pause_budget_exceeded",
+                            browser_id = bid,
+                            pauses_in_window,
+                            window_secs = MEMORY_PAUSE_WINDOW.as_secs(),
+                            "memory-pause budget exceeded (commit totally exhausted) — falling through to the give-up page",
+                        );
+                        // fall through to the crash-budget path below.
+                    }
+                }
+            }
+        }
+
         // Crash budget — if this browser has crashed more than
         // CRASH_BUDGET times in CRASH_BUDGET_WINDOW, abandon
         // auto-recovery and load a terminal "give up" page that does
@@ -1860,4 +1959,134 @@ setTimeout(tick, 1000);
     )
 }
 
+/// Record a memory-pause for `now` into `hist`, pruning entries older than
+/// `MEMORY_PAUSE_WINDOW` first, and return whether we are still within
+/// `MEMORY_PAUSE_BUDGET`. Extracted from `on_render_process_terminated` so the
+/// bounded-recovery logic — the part that must converge on the give-up page
+/// under *total* commit exhaustion rather than loop forever — is unit-testable
+/// without a live CEF browser. (SPEC_GATED_RENDERER_RECOVERY §6.B.)
+fn record_memory_pause(hist: &mut VecDeque<Instant>, now: Instant) -> bool {
+    while hist.front().is_some_and(|t| now.duration_since(*t) > MEMORY_PAUSE_WINDOW) {
+        hist.pop_front();
+    }
+    hist.push_back(now);
+    hist.len() <= MEMORY_PAUSE_BUDGET
+}
 
+/// Low-memory "paused" page — shown when a renderer is OOM-terminated while the
+/// system commit limit is exhausted (SPEC_GATED_RENDERER_RECOVERY §6.B). Unlike
+/// the give-up page this state is RECOVERABLE: all durable state lives in the
+/// sidecar, so "Resume" navigates to the live app URL and re-projects
+/// everything — losing nothing. The Resume is manual and memory-guided: an
+/// automatic retry before commit recovers would just re-OOM, so we tell the
+/// user to free memory first (host-driven, memory-gated auto-resume is Phase
+/// 1b). `app_url` is the live frontend URL Resume navigates to (spawns a fresh
+/// renderer); it already carries the ipc_token, same as the recovery page.
+fn memory_paused_page(reason: &str, error_code: i32, commit_free_mb: u64, app_url: &str) -> String {
+    use crate::client::helpers::{html_escape, js_string_literal};
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>AgentMux — Low memory</title>
+<style>
+:root {{ color-scheme: dark; }}
+body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+       background: #1e1e2e; color: #cdd6f4;
+       display: flex; justify-content: center; align-items: center;
+       min-height: 100vh; margin: 0; padding: 24px; box-sizing: border-box; }}
+.box {{ text-align: center; max-width: 560px; padding: 36px;
+       background: #181825; border: 1px solid #313244; border-radius: 10px;
+       box-shadow: 0 8px 32px rgba(0,0,0,0.4); }}
+.icon {{ font-size: 36px; line-height: 1; margin-bottom: 12px; }}
+h1 {{ color: #f9e2af; font-size: 22px; margin: 0 0 6px 0; }}
+.reason {{ color: #a6adc8; font-size: 14px; margin: 0 0 20px 0; font-style: italic; }}
+p {{ color: #bac2de; line-height: 1.55; margin: 0 0 12px 0; font-size: 14px; }}
+strong {{ color: #f9e2af; }}
+.actions {{ display: flex; gap: 10px; justify-content: center; margin-top: 24px; flex-wrap: wrap; }}
+button {{ padding: 10px 22px; border: 1px solid #45475a; border-radius: 6px;
+         background: #313244; color: #cdd6f4; cursor: pointer;
+         font-size: 13px; font-family: inherit; }}
+button:hover {{ background: #45475a; border-color: #585b70; }}
+button.primary {{ background: #89b4fa; color: #1e1e2e; border-color: #89b4fa; font-weight: 600; }}
+button.primary:hover {{ background: #74a0f8; border-color: #74a0f8; }}
+.footer {{ color: #6c7086; font-size: 11px; margin-top: 18px; font-family: ui-monospace, monospace; }}
+</style></head>
+<body><div class="box" role="alertdialog">
+<div class="icon">⏳</div>
+<h1>Paused — system memory low</h1>
+<p class="reason">Reason: {reason_safe}</p>
+<p>This window paused because the system ran out of memory
+(only {commit_free_mb} MB of commit was free). <strong>Your work is safe</strong> —
+everything is saved in the background and will be restored exactly when this
+window resumes.</p>
+<p><strong>Free some memory first</strong> — close other AgentMux windows or
+other apps — then click Resume. Resuming before memory recovers will just
+pause again.</p>
+<div class="actions">
+<button class="primary" onclick="location.href = {app_url_js}">Resume</button>
+<button onclick="window.close()">Quit this window</button>
+</div>
+<div class="footer">error_code={error_code} · commit_free={commit_free_mb}MB</div>
+</div>
+</body></html>"#,
+        reason_safe = html_escape(reason),
+        commit_free_mb = commit_free_mb,
+        error_code = error_code,
+        app_url_js = js_string_literal(app_url),
+    )
+}
+
+
+
+#[cfg(test)]
+mod gated_recovery_tests {
+    use super::{record_memory_pause, MEMORY_PAUSE_BUDGET, MEMORY_PAUSE_WINDOW, RESUME_FLOOR_MB};
+    use std::collections::VecDeque;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn resume_floor_is_above_a_fresh_renderer_commit() {
+        // A fresh renderer commits ~100-200 MB; the floor must leave margin so
+        // a resume doesn't instantly re-OOM. Guards against an accidental
+        // shrink that would make the gate useless.
+        assert!(RESUME_FLOOR_MB >= 256, "RESUME_FLOOR_MB too low to be safe");
+    }
+
+    #[test]
+    fn within_budget_until_exceeded_then_converges() {
+        let mut hist: VecDeque<Instant> = VecDeque::new();
+        let now = Instant::now();
+        // The first MEMORY_PAUSE_BUDGET pauses stay within budget (pause path).
+        for i in 0..MEMORY_PAUSE_BUDGET {
+            assert!(
+                record_memory_pause(&mut hist, now),
+                "pause {} should be within budget",
+                i + 1
+            );
+        }
+        // The next one exceeds → falls through to the give-up path. This is the
+        // total-exhaustion convergence guarantee (no infinite memory-pause loop).
+        assert!(
+            !record_memory_pause(&mut hist, now),
+            "exceeding the budget must return false (fall through to give-up)"
+        );
+    }
+
+    #[test]
+    fn old_pauses_outside_the_window_are_pruned() {
+        let mut hist: VecDeque<Instant> = VecDeque::new();
+        let start = Instant::now();
+        // Fill the budget at t=start.
+        for _ in 0..MEMORY_PAUSE_BUDGET {
+            record_memory_pause(&mut hist, start);
+        }
+        // Later than the window: all prior entries prune, so we're within budget
+        // again — a window that recovered then hit pressure again is NOT treated
+        // as a wedged loop.
+        let later = start + MEMORY_PAUSE_WINDOW + Duration::from_secs(1);
+        assert!(
+            record_memory_pause(&mut hist, later),
+            "pauses older than the window must be pruned, resetting the budget"
+        );
+        assert_eq!(hist.len(), 1, "only the recent pause should remain");
+    }
+}

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -4,7 +4,41 @@
 // Memory heartbeat — logs system and process memory stats every 20 seconds.
 // Designed to provide forensic data for OOM / VA exhaustion crash analysis.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+/// Latest observed system commit-free (available page file) in MB. Published by
+/// the heartbeat loop and by the on-demand probe; read by the gated renderer
+/// recovery path to distinguish "OOM under system memory pressure" (transient,
+/// recoverable) from "broken renderer". `u64::MAX` until the first sample, so
+/// the gate treats an un-sampled process as having ample commit.
+///
+/// See docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md §6.A.
+static COMMIT_FREE_MB: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// On-demand synchronous probe of system commit-free (available page file), in
+/// MB. ~microsecond cost (a single `GlobalMemoryStatusEx`). Republishes the
+/// atomic so `last_commit_free_mb()` stays fresh. On non-Windows returns
+/// `u64::MAX` — commit-limit exhaustion is a Windows concern here and the
+/// recovery gate degrades to "always treat as ample" elsewhere.
+#[cfg(target_os = "windows")]
+pub fn commit_free_mb() -> u64 {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    let mut mem: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    mem.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    if unsafe { GlobalMemoryStatusEx(&mut mem) } != 0 {
+        let mb = (mem.ullAvailPageFile / (1024 * 1024)) as u64;
+        COMMIT_FREE_MB.store(mb, Ordering::Relaxed);
+        mb
+    } else {
+        COMMIT_FREE_MB.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn commit_free_mb() -> u64 {
+    u64::MAX
+}
 
 /// Spawn a background thread that logs memory stats at a fixed interval.
 /// Also refreshes the log pointer file on UTC date rollover.
@@ -102,6 +136,9 @@ fn log_memory_stats() {
         let total_virt_gb = mem.ullTotalVirtual as f64 / (1024.0 * 1024.0 * 1024.0);
         let avail_virt_gb = mem.ullAvailVirtual as f64 / (1024.0 * 1024.0 * 1024.0);
         let load_pct = mem.dwMemoryLoad;
+
+        // Publish commit-free for the gated renderer recovery path (§6.A).
+        COMMIT_FREE_MB.store((mem.ullAvailPageFile / (1024 * 1024)) as u64, Ordering::Relaxed);
 
         tracing::info!(
             target: "mem_heartbeat",

--- a/docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md
+++ b/docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md
@@ -1,6 +1,6 @@
 # Gated Renderer Recovery — Memory-Aware Crash Handling
 
-**Status:** Design — pre-implementation
+**Status:** Phase 1a implemented (PR #1229); Phases 1b/2/3 designed
 **Date:** 2026-06-01
 **Author:** AgentA
 **Tracking:** open — no PR yet

--- a/docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md
+++ b/docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md
@@ -1,0 +1,365 @@
+# Gated Renderer Recovery — Memory-Aware Crash Handling
+
+**Status:** Design — pre-implementation
+**Date:** 2026-06-01
+**Author:** AgentA
+**Tracking:** open — no PR yet
+
+---
+
+## 1. The incident
+
+On 2026-06-01 a 0.41.1 host running alongside several other AgentMux instances
+hit a Chromium renderer **OOM** termination. The host's own crash log:
+
+```
+ERROR target=crash kind="renderer_terminated" reason="out of memory" detail="Out of Memory"
+```
+
+The memory heartbeat (`agentmux-cef/src/memory_heartbeat.rs`) showed the cause
+held for **~20 minutes** before the crash:
+
+```
+avail_phys_gb=18.0     ← physical RAM fine
+avail_page_gb=0.0      ← system COMMIT LIMIT (RAM + page file) exhausted
+```
+
+Physical RAM was never the problem. The Windows **system commit limit** (87.7 GB
+of RAM + page file) was 100% committed by the aggregate of many simultaneously
+running AgentMux instances × their full Chromium process trees (GPU, network,
+storage, N renderers). When commit is pinned at zero, the next allocation in any
+renderer fails and Chromium OOM-terminates it. The host *main* process survived
+throughout (steady ~117 MB, no `LOG(FATAL)`, no exit) — only a renderer
+subprocess died.
+
+This is **not an application defect**. It is the OS being out of commit, which no
+process can allocate its way out of. The question this spec answers: *given that
+the fault is unavoidable, how do we make recovery graceful instead of a manual,
+crash-looping, sometimes-blank-screen experience?*
+
+---
+
+## 2. Current behavior (what already exists)
+
+`on_render_process_terminated` in `agentmux-cef/src/client/mod.rs:1338`
+(per `SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md`) already does a lot right:
+
+1. **Classifies** the termination: `PROCESS_OOM` → "out of memory",
+   `PROCESS_CRASHED`, `ABNORMAL_TERMINATION`.
+2. **Rate-limits** the `target=crash` log (≤1 line / 100 ms; suppressed count
+   carried forward) — from the 2026-05-28 884 MB log-spam retro.
+3. **Per-browser crash budget**: `CRASH_BUDGET = 3` crashes within
+   `CRASH_BUDGET_WINDOW = 10s` (`mod.rs:11,17`). Over budget → a terminal
+   **"give up" page** (`crash_loop_terminal_page`) that does NOT reload — breaks
+   the wedged-slot infinite loop.
+4. **Under budget** → loads an HTML **recovery page** with **Reload / Quit**
+   buttons. Reload navigates to the real app URL, which spawns a fresh renderer
+   and re-projects all state from the sidecar.
+
+State durability is already a free-ride: the renderer is **state-poor**. All
+durable state (workspaces, tabs, panes, layouts, agents, conversation history)
+lives in **srv's SQLite**, a separate process that survives renderer deaths. A
+reloaded renderer re-projects it exactly. So a renderer crash loses nothing
+*except* live renderer-only state (see §6.E).
+
+---
+
+## 3. The gap — this design misfires under *sustained* memory exhaustion
+
+The existing design is correct for a **one-off** renderer crash and for a
+**genuinely wedged** renderer slot. It misfires for the **sustained
+system-OOM** case in four specific ways:
+
+| # | Gap | Consequence |
+|---|-----|-------------|
+| G1 | The recovery page's **Reload is manual and memory-blind**. The user clicks Reload while commit is still at 0. | The fresh renderer immediately re-OOMs. White → recovery page → Reload → white → … |
+| G2 | The **crash budget conflates "OOM under pressure" with "wedged".** Three OOM re-tries in 10s (trivially hit if the user clicks Reload a few times, or if anything auto-reloads) trips the **"give up" page**. | The app declares "unrecoverable, give up" when the truth is "recoverable in ~60 s once memory frees." |
+| G3 | The recovery page **itself needs a renderer to render**. Under true commit exhaustion the data-URI recovery page's renderer may fail to start. | White screen, no recovery page at all — the worst case. |
+| G4 | Nothing is **memory-aware proactively**. The heartbeat saw `avail_page_gb=0` for 20 min and did nothing — no load-shedding, no pre-warning, no coupling to the recovery decision. Draft composer text is lost. | The crash happens that could have been avoided or softened, and unsent typed text vanishes. |
+
+---
+
+## 4. Design principle
+
+From `SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md` §1/§3 (the stability
+mandate): *"No crashes ever" = the user must never SEE a crash. Every fault
+becomes an invisible, sub-second auto-recovery — at most a flicker.* The
+supervisor is **passive, bounded, free-rides on persistence that already
+happens, and is loud about every action.**
+
+Applied here:
+
+- **We cannot allocate our way out of system OOM** — don't try. Ride it out and
+  resume. (Honest scope: from a transient spike, full recovery; from sustained
+  exhaustion, *graceful pause + auto-resume when the OS allows*, never
+  "allocate through it".)
+- **Free-ride on what exists**: the memory heartbeat already measures
+  `avail_page_gb`; srv already persists all durable state; the splash machinery
+  already proves native overlay rendering; `on_render_process_terminated`
+  already classifies OOM. This spec wires those together; it does not build a
+  new framework.
+- **Bounded**: the crash budget stays as the wedged-slot backstop. The memory
+  gate is additive, not a replacement.
+
+---
+
+## 5. The core idea
+
+Split the renderer-termination response by **whether the system is memory-starved
+right now**, measured from the heartbeat's `avail_page_gb`:
+
+```
+renderer terminated
+  ├─ status == PROCESS_OOM  AND  avail_page_gb < RESUME_FLOOR
+  │     → MEMORY-GATED PAUSE  (this is system pressure, not a broken renderer)
+  │       • does NOT consume the crash budget
+  │       • show "Paused — low system memory, resuming…" (native overlay if
+  │         the renderer can't render the HTML recovery page — §6.C)
+  │       • poll avail_page_gb; auto-reload when it recovers above RESUME_FLOOR
+  │
+  └─ otherwise  (non-OOM crash, OR OOM while memory IS available)
+        → EXISTING PATH, unchanged
+          • consume crash budget (3 / 10 s)
+          • under budget → Reload/Quit recovery page
+          • over budget  → "give up" terminal page
+```
+
+The key discrimination: **OOM-while-memory-low is the OS's fault and transient —
+it must not burn the wedged-slot budget.** OOM-while-memory-available *is* the
+renderer's fault (a genuine leak/wedge) and **must** consume the budget. This
+single distinction fixes G1 and G2 directly.
+
+---
+
+## 6. Design detail
+
+### 6.A Memory-availability signal
+
+`memory_heartbeat.rs` already computes `avail_page_gb` every 20 s. Two changes:
+
+1. Publish the latest `avail_page_gb` (and `load_pct`) to a process-wide
+   `AtomicU64` (millibytes or fixed-point) that the crash handler and the
+   load-shedder can read without blocking.
+2. On the crash path, the 20 s cadence is too coarse to gate a resume. Add an
+   **on-demand probe**: a cheap synchronous `GlobalMemoryStatusEx` call
+   (microseconds) the gated-pause loop calls directly when deciding whether to
+   resume. The heartbeat stays the background publisher; the probe is the
+   fine-grained gate.
+
+`RESUME_FLOOR` — the commit-free threshold above which it's safe to spawn a
+renderer. A renderer's initial commit is on the order of 100–200 MB; set
+`RESUME_FLOOR` with margin (e.g. **512 MB** commit-free) so the resumed renderer
+doesn't instantly re-OOM. Tunable; see §7.
+
+### 6.B OOM-gated pause (the heart of the fix)
+
+When the discrimination in §5 selects the gated-pause arm:
+
+- **Do not** push to `crash_history` (the budget deque) — this is not a
+  budget-consuming crash.
+- Enter a per-browser `MemoryPaused` state. Show the paused UI (§6.C).
+- Start (or join) a single shared **resume watcher**: a host thread that probes
+  commit-free on a short interval (e.g. 2 s) with backoff, and when it observes
+  `avail_page_gb ≥ RESUME_FLOOR` *sustained for K consecutive probes* (debounce
+  against flapping), reloads the paused browser(s) by navigating to the real app
+  URL — exactly what the existing Reload button does.
+- **Anti-flap guard**: if a browser resumes and then OOMs *again within
+  `REOOM_GUARD_WINDOW` while memory was above the floor at resume time*, that
+  resume counts as a real crash and consumes the budget — this catches a
+  genuinely broken renderer that OOMs even with headroom, so we still converge
+  on the "give up" page rather than an infinite memory-gated loop.
+
+### 6.C Paused UI — HTML page first, host-native overlay fallback (fixes G3)
+
+Two render paths, tried in order:
+
+1. **HTML paused page** (preferred): a variant of the existing recovery page
+   with no Reload button (resume is automatic) and a "Quit" button, plus
+   "Resuming automatically when memory frees." Loaded the same way
+   (`frame.load_url(data:…)`). Works when commit has *some* headroom.
+2. **Host-native overlay** (fallback): under true commit exhaustion even the
+   data-URI page's renderer can fail to start (G3). The host owns the OS window
+   and is alive, so it paints a **layered-window overlay** using the exact
+   machinery `agentmux-launcher/src/splash.rs` already uses
+   (`CreateWindowExW(WS_EX_LAYERED|WS_EX_TOPMOST|WS_EX_NOACTIVATE)` +
+   `UpdateLayeredWindow` + premultiplied DIB). No renderer required. The overlay
+   shows "Paused — system memory low. Resuming…" and is torn down when the
+   resume watcher reloads the renderer.
+
+   Detection of "the HTML page itself failed": if a browser in `MemoryPaused`
+   does not reach `on_load_end` for the paused data-URI within a short timeout,
+   escalate to the native overlay.
+
+   **Window-renderer vs browser-pane scope**: a window-level renderer OOM blanks
+   the whole window → native overlay on that window. A browser-pane child
+   renderer OOM is localized → the main window renderer is alive and can render
+   the HTML paused state in that pane's slot (no native overlay needed).
+
+### 6.D Proactive load-shedding (fixes part of G4) — Phase 2
+
+Before the OOM, when the published `avail_page_gb` crosses a **warn** threshold
+(e.g. < 1 GB commit-free), shed *our own* committed memory — the one lever we
+control:
+
+- Discard background **browser-pane** child renderers (separate processes;
+  discarding frees real commit; re-create on focus).
+- Suspend renderers of **hidden/minimized windows**.
+
+Note: panes *within* one window share that window's single renderer, so
+"freeze a background pane" frees no process — the unit of shedding is a
+**window renderer** or a **browser-pane renderer**. There is no pane-visibility
+atom today (only focus/blur listeners in `termwrap.ts:195`); Phase 2 adds the
+minimal visibility signal needed.
+
+Also surface a **non-modal** "system memory critically low — close some windows"
+hint at the warn threshold so the user can act before the cliff.
+
+### 6.E Proactive draft preservation (fixes part of G4) — Phase 3
+
+The agent composer textarea (`AgentFooter.tsx`) is **uncontrolled and
+in-renderer only** — unsent text is lost on renderer death. A reactive
+"snapshot on OOM" is **impossible**: the renderer is already dead when the host
+learns of the crash; you cannot run JS in a dead process.
+
+Therefore preservation must be **proactive**: debounced sync of composer draft
+text to srv while the user types (e.g. 500 ms idle), stored against the block.
+On renderer reload the composer rehydrates the draft from srv. Everything else
+already survives via srv; this closes the last in-renderer-only gap, making the
+recovery truly zero-loss.
+
+---
+
+## 7. Thresholds & constants (all tunable, single source)
+
+| Constant | Initial | Meaning |
+|---|---|---|
+| `RESUME_FLOOR` | 512 MB commit-free | Min headroom to spawn a renderer without instant re-OOM |
+| `WARN_FLOOR` | 1 GB commit-free | Trigger load-shedding + user hint (Phase 2) |
+| `RESUME_PROBE_INTERVAL` | 2 s | Resume-watcher poll cadence (with backoff to ~10 s) |
+| `RESUME_DEBOUNCE_K` | 3 probes | Consecutive above-floor probes before resuming (anti-flap) |
+| `REOOM_GUARD_WINDOW` | 15 s | Resume-then-OOM within this *with* headroom ⇒ counts as a real crash |
+| `DRAFT_SYNC_DEBOUNCE` | 500 ms | Composer→srv draft persistence idle (Phase 3) |
+| `CRASH_BUDGET` / `_WINDOW` | 3 / 10 s (unchanged) | Wedged-slot backstop, still applies to non-OOM + headroom-OOM |
+
+---
+
+## 8. State machine (per browser)
+
+```
+        ┌──────────┐  renderer OK
+        │  Healthy │◀───────────────────────────┐
+        └────┬─────┘                             │
+   OOM &     │     non-OOM crash, OR             │ resume watcher:
+   mem<floor │     OOM & mem≥floor               │ mem≥RESUME_FLOOR
+             │     → existing budget path        │ ×K, then load_url(app)
+             ▼                                    │
+      ┌─────────────┐                             │
+      │ MemoryPaused│─────────────────────────────┘
+      │ (no budget) │
+      └──────┬──────┘
+             │ resumed then OOM again WITH headroom (within REOOM_GUARD_WINDOW)
+             ▼
+      ┌──────────────┐  > CRASH_BUDGET in window
+      │ existing path│───────────────────────────▶ "give up" terminal page
+      └──────────────┘
+```
+
+`Healthy → (existing path) → Reload/Quit recovery page → give-up` is the
+**unchanged** legacy flow. `MemoryPaused` is the **new** arm that never reaches
+"give up" while the fault is purely system pressure.
+
+---
+
+## 9. What is explicitly unchanged / out of scope
+
+- The non-OOM crash path, the recovery page, and the crash budget for
+  wedged slots — **unchanged**.
+- The host-level crash-budget relaunch (`spawn_host_supervised`,
+  `HOST_RESTART_BUDGET`) and the GPU retry ladder (rung-2 `--disable-gpu`) in
+  the launcher — **unchanged** (different layer; this spec is renderer-level).
+- We do **not** attempt to raise the OS commit limit (system-managed; it already
+  auto-grew) or free other processes' memory (impossible).
+- Cross-process global coordination between AgentMux instances (e.g. a shared
+  total-memory budget across instances) — **out of scope**; each instance only
+  manages its own renderers.
+
+---
+
+## 10. Phasing
+
+- **Phase 1a (the discrimination — SHIPPED)** — §6.A memory signal
+  (`commit_free_mb()` + published atomic in `memory_heartbeat.rs`); §6.B the
+  OOM-vs-pressure discrimination with crash-budget **bypass** and a separate
+  `MEMORY_PAUSE_BUDGET` backstop; §6.C the **manual** recoverable "low memory"
+  paused page (Resume → re-project from srv / Quit), memory-guided so the user
+  frees memory before resuming. This stops the crash budget from falsely
+  declaring "give up" under transient system OOM, and replaces the
+  reload→re-crash→give-up experience with an honest, recoverable paused state
+  that loses nothing. Compile-verified; runtime OOM smoke pending (see §11).
+  **Highest value; shipped first.**
+- **Phase 1b (automatic + total-exhaustion)** — host-driven, memory-gated
+  **auto-resume** (`post_delayed_task` on the UI thread, probing
+  `commit_free_mb()` with `RESUME_DEBOUNCE_K` + backoff, navigating the paused
+  browser when commit recovers) so the window comes back *on its own*; plus the
+  §6.C **host-native overlay** (reusing `agentmux-launcher/src/splash.rs`'s
+  layered-window machinery) for the case where commit is so exhausted that even
+  the paused HTML page can't render. Requires a real induced-OOM smoke, so it is
+  split from 1a rather than shipped blind.
+- **Phase 2 (prevention)** — §6.D proactive load-shedding + low-memory hint.
+  Reduces how often Phase 1 is even needed.
+- **Phase 3 (zero-loss)** — §6.E proactive draft persistence to srv.
+
+---
+
+## 11. Testing
+
+- **Unit (host)**: the §5 discrimination — table-drive `(status, avail_page_gb)`
+  → `{MemoryPaused | budget-path}`; assert `MemoryPaused` does not push to
+  `crash_history`; assert resume requires K consecutive above-floor probes;
+  assert resume-then-OOM-with-headroom consumes the budget.
+- **Fault injection**: a debug command to force `on_render_process_terminated`
+  with `PROCESS_OOM` and a stubbed `avail_page_gb` provider, to exercise the
+  pause/resume loop without real memory pressure.
+- **Manual / soak**: reproduce the real condition — cap the page file small,
+  open enough panes to exhaust commit, confirm: (a) panes pause rather than
+  crash-loop, (b) the native overlay appears when the HTML page can't render,
+  (c) panes auto-resume and re-project full state when memory frees, (d) draft
+  text survives (Phase 3).
+- **Anti-flap**: oscillate `avail_page_gb` around `RESUME_FLOOR`; assert no
+  resume/OOM thrash, no budget exhaustion from the oscillation alone.
+
+---
+
+## 12. Cross-references (do not duplicate)
+
+- `SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md` — the stability mandate,
+  supervisor prime directive, host-level retry ladder. This spec is the
+  renderer-level, memory-aware refinement of §4's Chromium-children manager.
+- `SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md` — the existing recovery page +
+  crash budget this spec extends.
+- `docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md` — the GPU-process FATAL
+  cascade (6 GPU crashes → host `LOG(FATAL)` → 0x80000003 modal). Same
+  memory-exhaustion root; different subprocess. The load-shedding in §6.D also
+  reduces GPU-process pressure.
+- `docs/retro/retro-portable-rm-running-install-2026-05-28.md` — the 139k-crash
+  / 884 MB log-spam incident that motivated the rate-limit + crash budget this
+  spec preserves.
+- `docs/MEMORY_HEARTBEAT_SPEC.md` — the heartbeat this spec reads from.
+
+---
+
+## 13. Risks
+
+- **Resume too eager** → resumed renderer re-OOMs. Mitigated by `RESUME_FLOOR`
+  margin + `RESUME_DEBOUNCE_K`. If it still flaps, the anti-flap guard routes it
+  to the existing budget path so it can't loop forever.
+- **Native overlay z-order / input** — the overlay must be `WS_EX_NOACTIVATE`
+  and not steal focus or block the close button; reuse splash's exact flags.
+  Browser-pane case avoids the overlay entirely.
+- **Load-shedding visible flicker** (Phase 2) — discarding a background
+  browser-pane renderer then re-creating on focus must restore URL + scroll;
+  reuse the browser-pane lifecycle (`Closing` state machine) already specced for
+  redock.
+- **Draft sync write amplification** (Phase 3) — debounce + only persist on
+  change; draft is small text. Negligible vs the existing per-keystroke srv
+  traffic.


### PR DESCRIPTION
## Summary

Makes renderer-crash recovery **memory-aware**. A renderer OOM while the Windows system commit limit is exhausted is transient OS pressure — not a broken renderer — but the existing recovery (`SPEC_GRACEFUL_CRASH_HANDLING`) treated it like any crash:

- the **3-in-10s crash budget** falsely declared "give up" on a window that's fully recoverable once commit frees, and
- the Reload button **re-OOMs** if clicked while commit is still exhausted.

This was the 2026-06-01 incident: `avail_page_gb=0` for ~20 min (many concurrent AgentMux instances × Chromium trees), renderer OOM-terminated. The host main process survived — only a renderer died — but the recovery UX was poor.

## What changed

1. **`memory_heartbeat.rs`** — `commit_free_mb()`: an on-demand `GlobalMemoryStatusEx` probe (µs) plus a published atomic the crash path reads. Returns `u64::MAX` on non-Windows → behavior there unchanged.

2. **`on_render_process_terminated`** — when `status == PROCESS_OOM` **and** commit-free `< RESUME_FLOOR_MB` (512 MB): **do not consume the wedged-slot crash budget**. Show a recoverable "low memory" paused page — **Resume** (navigate to the live app URL → re-project all state from srv, losing nothing) / **Quit** — guided so the user frees memory first. Bounded by a separate `MEMORY_PAUSE_BUDGET` (5/30s) so *total* exhaustion (even the tiny page can't render, re-firing the handler) still converges on the existing give-up page rather than looping. **Non-OOM and OOM-with-headroom paths are unchanged.**

3. **`record_memory_pause()`** — extracted prune+budget step, **unit-tested** (3 tests: floor sanity, budget convergence, window pruning).

The key discrimination: **OOM-under-memory-pressure is the OS's fault and transient — it must not burn the wedged-slot budget; OOM-with-memory-available is the renderer's fault — it still does.**

## Why state is safe

The renderer is state-poor; the sidecar (`srv`, a separate process that survives the renderer death) holds all durable state. Resume re-projects it exactly — nothing is lost. This is the same free-ride the existing Reload uses.

## Scope / verification

- **Phase 1a (this PR):** the memory discrimination + budget bypass + manual recoverable paused page.
- **Phase 1b (follow-up):** host-driven, memory-gated **auto-resume** (`post_delayed_task` probing commit-free) so the window comes back *on its own*, plus a renderer-free **native overlay** (reusing `splash.rs`) for total exhaustion. Split out because it needs a real induced-OOM smoke.
- **Verification:** `cargo check --release -p agentmux-cef` clean (zero new warnings) + 3 unit tests pass. **Runtime OOM smoke is still pending** (inducing real commit exhaustion) — see spec §11. Flagging explicitly rather than claiming runtime-verified.

Spec: `docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` (full design incl. Phases 1b/2/3).

## Test plan
- [x] `cargo check --release -p agentmux-cef` — clean
- [x] `cargo test --release -p agentmux-cef gated_recovery` — 3/3 pass
- [ ] Runtime: induce commit exhaustion (small page file + many panes), confirm a renderer OOM shows the paused page (not give-up) and Resume re-projects state — Phase 1b smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)