### PR TITLE
feat(agent-pane): layout state-machine slice — Phase 0 (pure reducer + store + tests)

### DIFF
--- a/.changesets/1780398921-feat-agent-pane-add-layout-state-machine-slice-phase-0-pure--cs4e.md
+++ b/.changesets/1780398921-feat-agent-pane-add-layout-state-machine-slice-phase-0-pure--cs4e.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(agent-pane): add layout state-machine slice (Phase 0 — pure reducer + store + tests; no wiring)

--- a/.changesets/1780398921-feat-agent-pane-add-layout-state-machine-slice-phase-0-pure--cs4e.md
+++ b/.changesets/1780398921-feat-agent-pane-add-layout-state-machine-slice-phase-0-pure--cs4e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): add layout state-machine slice (Phase 0 — pure reducer + store + tests; no wiring)

--- a/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
+++ b/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
@@ -168,7 +168,7 @@ expiry becomes a no-op).
 ```ts
 export type AgentPaneLayoutEvent =
     | { type: "row-measured"; nodeId: string; state: ExpansionState; delta: number }
-    | { type: "expansion-changed"; nodeId: string; from: ExpansionState; to: ExpansionState }
+    | { type: "expansion-changed"; nodeId: string; from: Expansion; to: Expansion } // Expansion = {open:false}|{open:true;via:"pin"|"auto"} — carries `via` so consumers can tell a user-pin from an auto-hold
     | { type: "measurement-invalidated"; nodeId: string }
     | { type: "zoom-changed-no-relayout"; zoom: number }   // explicit: proves INV-2 held
     | { type: "ids-pruned"; removed: number }
@@ -178,10 +178,11 @@ export type AgentPaneLayoutEvent =
 ### 3.4 Selectors (pure projections — the renderer reads these)
 
 ```ts
-// effective in-flow height of a row, current state, unzoomed CSS px
+// effective in-flow height of a row, current state, unzoomed CSS px.
+// (Matches the shipped impl: no "overlay" branch — overlay is presentational,
+// not a layout state, per OQ-2/§3.1/§5. state = inFlowState(expansion.get(id)).)
 effectiveHeight(s, id): number =
-    s.expansion.get(id) === "overlay" ? 0
-    : (s.heights.get(id)?.[state] ?? s.estimates.get(id)?.[state] ?? DEFAULT_ESTIMATE)
+    s.heights.get(id)?.[state] ?? s.estimates.get(id)?.[state] ?? DEFAULT_ROW_PX
 
 // prefix-sum positions — THE guarantee (INV-1). O(n); see §7 perf note.
 positions(s): Array<{ id; start; height }>   // start[i+1] = start[i] + height[i]

--- a/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
+++ b/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
@@ -205,7 +205,7 @@ Highlights:
   from the prior layout height, that's the *only* thing that shifts subsequent
   positions — deterministically, via the prefix-sum selector, all at once (never
   a partial cache update).
-- **`ExpansionSet`/`AutoExpand*`** change `expansion[nodeId]`; the projected height
+- **`UserExpanded/UserCollapsed`/`AutoExpand*`** change `expansion[nodeId]`; the projected height
   immediately switches to the cached measurement for the new state (or estimate).
   **No DOM round-trip needed to know the target height** — kills the expand race.
 - **`NodesChanged`** replaces `orderedIds` and **prunes** `expansion`/`heights`/
@@ -219,7 +219,7 @@ Mirrors `browser-pane-state-store.ts`: `Map<blockId, Slot{state, proj}>`,
 `registerPane`/`unregisterPane`/`dispatch(blockId, cmd, source)`, project only
 changed fields to Solid signals, `recordDispatch({slice:"agent-pane-layout", ...})`.
 The two **timers** (post-completion hold; user-message hover-expand delay) live
-here as side effects that *dispatch* `AutoExpandHoldExpired` / `ExpansionSet` — the
+here as side effects that *dispatch* `AutoExpandHoldExpired` / `UserExpanded/UserCollapsed` — the
 reducer stays pure (cf. the `postCompletionHold` self-loop bug already documented
 in `ToolBlock.tsx`).
 
@@ -238,7 +238,7 @@ slice.totalSize()     → spacer height
 
 - On a row's `ResizeObserver`/ref fire → `dispatch(RowMeasured{nodeId, state, gbcr.height / zoom})`.
   (The ÷zoom normalization lives at this single boundary — INV-2.)
-- On expand/collapse/pin interaction → `dispatch(ExpansionSet{...})`.
+- On expand/collapse/pin interaction → `dispatch(UserExpanded/UserCollapsed{...})`.
 - On scroll → `dispatch(Scrolled{...})`; on zoom meta change → `dispatch(ZoomChanged)`.
 
 ### 4.1 Relationship to TanStack `@tanstack/virtual-core`
@@ -272,7 +272,7 @@ become thin:
 
 | Today (ad-hoc) | file | Becomes |
 |---|---|---|
-| `documentState.collapsedNodes` / `pinnedNodes` | `types.ts`, `AgentDocumentView` toggles | dispatch `ExpansionSet`; selector reads `expansion` |
+| `documentState.collapsedNodes` / `pinnedNodes` | `types.ts`, `AgentDocumentView` toggles | dispatch `UserExpanded/UserCollapsed`; selector reads `expansion` |
 | `ToolBlock.postCompletionHold` (3s timer) + `autoExpanded()` | `ToolBlock.tsx` | store-layer timer → `AutoExpandStarted` / `AutoExpandHoldExpired`; `expanded()` reads slice |
 | `MarkdownBlock.expanded()` (canceled-thinking) | `MarkdownBlock.tsx` | `UserExpanded` / `UserCollapsed` on click |
 | `UserMessageBlock.hovering` → `bodyMode "overlay"` | `UserMessageBlock.tsx` | **stays component-local** — it's presentational (absolute peek; summary stays in flow) and does **not** change in-flow height, so it is **not** a layout input (resolved OQ-2). |
@@ -294,7 +294,7 @@ reducer would add state with no layout meaning.
   the model against live traffic with zero user-visible change. Ship behind the
   existing dev-only instrumentation.
 - **Phase 1 — unify expansion (§5).** Move `collapsed/pinned/hold/hover/cancel`
-  into the slice; components dispatch `ExpansionSet`. **This alone removes the
+  into the slice; components dispatch `UserExpanded/UserCollapsed`. **This alone removes the
   component-local desync** and makes expansion testable. Still TanStack-measured.
 - **Phase 2 — route measurement (4.1-A).** `estimateSize`/`measureElement` read/
   dispatch through the slice; measurements keyed by `(nodeId, state)` (INV-3).
@@ -317,12 +317,12 @@ The whole point of moving to a reducer is that correctness becomes **provable**,
 per the project's state-machine testing discipline:
 
 - **Property test — non-overlap (INV-1).** For *any* sequence of commands
-  (random `NodesChanged`/`ExpansionSet`/`RowMeasured`/`Scrolled`/`ZoomChanged`),
+  (random `NodesChanged`/`UserExpanded/UserCollapsed`/`RowMeasured`/`Scrolled`/`ZoomChanged`),
   assert `positions()` is monotonic: `start[i+1] === end[i]` for all i. This is the
   invariant #1235 violates; here it holds by construction and is *tested* to stay
   so under churn. (Anti-vacuity: assert the generated sequence actually produced
   ≥1 measurement that changed a height.)
-- **State cross-product.** `expansion ∈ {collapsed, expanded, overlay}` ×
+- **State cross-product.** `expansion ∈ {collapsed, expanded}` ×
   `measured? ∈ {yes,no}` × `zoom ∈ {0.5,1,2}` × `churn ∈ {toggle, stream-grow,
   prune}` — table-drive the reducer; assert effective height + position for each
   cell. Build this table *before* coding (cf. the orchestrator-test lesson from
@@ -380,7 +380,7 @@ per the project's state-machine testing discipline:
 | `frontend/app/store/agent-pane-layout-store.ts` | new — dispatch layer, projections, timers, `recordDispatch` |
 | `frontend/app/store/agent-pane-layout/reducer.test.ts` | new — property + cross-product tests (§7) |
 | `frontend/app/view/agent/components/ToolBlock.tsx` | read expansion from slice; dispatch on pin; store-layer hold timer |
-| `frontend/app/view/agent/components/UserMessageBlock.tsx`, `MarkdownBlock.tsx`, `AgentDocumentView.tsx` | dispatch `ExpansionSet`; drop local expansion signals |
+| `frontend/app/view/agent/components/UserMessageBlock.tsx`, `MarkdownBlock.tsx`, `AgentDocumentView.tsx` | dispatch `UserExpanded/UserCollapsed`; drop local expansion signals |
 | `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx` | (Ph2/3) read positions/window from slice; route measurement |
 | `frontend/app/view/agent/virtualization/renderers.ts` | estimators become `EstimateSet` producers keyed by state |
 | `frontend/app/devtools/diag-panel.tsx` | surfaces the new slice automatically (audit ring) |

--- a/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
+++ b/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
@@ -1,0 +1,417 @@
+# Agent-Pane Layout State Machine — unify zoom + virtualization + tool-expansion into one reducer
+
+**Status:** Design resolved (§11); **Phase 0 implemented** — pure slice core + store + tests (no render-path wiring yet)
+**Date:** 2026-06-02
+**Author:** AgentA
+**Tracking:** issue #1235 (the drift this eliminates); builds on PRs #1231/#1233/#1234
+**Pattern:** follows `docs/specs/frontend-reducer-conventions-2026-05-03.md` (Slice #11)
+
+---
+
+## 1. Why this spec exists
+
+Three separate bugs this cycle — overlap-under-zoom (#1231), stuck-estimate rows
+(#1233), and the expand/collapse crash + measurement drift (#1234, #1235) — are
+all **the same disease wearing different clothes**: the agent-pane has **three
+uncoordinated sources of truth** for the only two questions that matter to layout:
+
+> *How tall is row N (in its current state)? Where does it sit?*
+
+| Truth source | Owns | Where | Problem |
+|---|---|---|---|
+| **TanStack `itemSizeCache` / `measurementsCache`** | measured heights + computed `start/size/end` | `@tanstack/virtual-core` (imperative, ResizeObserver-driven) | Incremental, mutated mid-reflow; caches transient garbage (`0`, `784`) that doesn't reconverge (#1235). Not pure, not testable, not ours. |
+| **Expansion state — split** | which rows are open | `documentState.collapsedNodes`/`pinnedNodes` (reducer-backed) **+** `ToolBlock.postCompletionHold`, `UserMessageBlock.hovering`, `MarkdownBlock.expanded` (component-local signals) | The thing that *determines* a row's height is **partly invisible to the reducer**. Height can change with no reducer action. |
+| **Zoom** | render scale | CSS `zoom` on `.agent-view` **+** scattered `÷ zoomFactor` in `measureElement` | A units layer threaded through measurement by hand; easy to double-count (the original #1231 bug). |
+
+Because height isn't deterministic state, the system **can't know a row's target
+height synchronously** when expansion changes — it mutates the DOM and *waits for
+a racy ResizeObserver* to tell it what happened. That wait is the race. Patching
+it locally (data-index sync, content-visibility, undefined guards) has bought
+correctness on the happy path but the **drift under churn (#1235) is unfixable
+locally** because the cache that drifts isn't ours.
+
+This spec proposes the structural fix the symptoms keep pointing at: **one
+per-pane reducer slice that owns row heights, expansion, and zoom as pure
+deterministic state, with rendered positions as a pure projection.**
+
+---
+
+## 2. The invariant we want (and why a reducer gives it)
+
+Today positions come out of TanStack's incrementally-mutated cache, which can be
+internally inconsistent (a row's `size` and the next row's `start` disagree
+during a reflow) → **overlap**.
+
+If instead **position is a pure prefix-sum of a height map**:
+
+```
+start[0]      = scrollMargin
+start[i+1]    = start[i] + height[i]          // by construction
+end[i]        = start[i] + height[i] = start[i+1]
+```
+
+then **slots never overlap** — `start[i+1] === end[i]` always. The *only* way a
+visual overlap can occur is if a row's **rendered** height exceeds the `height[i]`
+used for layout. So the entire overlap bug class collapses to maintaining a single
+invariant:
+
+> **INV-1:** `height[i]` (the value layout uses) equals row *i*'s actual rendered
+> height *in its current expansion state*.
+
+A stale `height[i]` then degrades to at worst a **gap or a one-frame jump on
+correction** — never an overlap, never the stuck −20.9px we saw. The reducer's
+whole job becomes *keeping INV-1 true and converging it deterministically.* That
+is tractable, pure, and testable; an imperative ResizeObserver cache is none of
+those.
+
+Two corollaries shape the design:
+
+- **INV-2 (zoom-invariance):** all heights/positions are stored in **unzoomed CSS
+  px**. Zoom is applied exactly once, by the single ancestor CSS `zoom`. A zoom
+  change requires **zero** height recompute (formalizes the #1233 finding). Zoom
+  enters the reducer only as the divisor at the *measurement-ingest boundary*.
+- **INV-3 (state-keyed measurement):** a measured height is cached **per
+  `(nodeId, expansionState)`**, never as a single scalar. The #1234 `0`/`784`
+  garbage was a measurement taken in one expansion state contaminating another.
+  Keying by state makes an expand/collapse toggle resolve to a *known target
+  height immediately* (the cached value for the new state, or an estimate),
+  synchronously — no measurement round-trip, no race.
+
+---
+
+## 3. Proposed slice: `agent-pane-layout` (Slice #9)
+
+Per-pane (keyed by `blockId`), following the established slice triplet
+(`types.ts` + `reducer.ts` pure core, `agent-pane-layout-store.ts` dispatch layer
+with projections + `recordDispatch`). Distinct from the existing
+`agent-pane-state` slice (turn/lifecycle/tokens) and from the roadmap's
+`layout-reducer` #5 (window/focus/magnify) — this one owns **document-row
+layout**.
+
+### 3.1 State
+
+```ts
+// agent-pane-layout/types.ts
+
+// In-flow FOOTPRINT state — the only thing that affects the prefix-sum.
+// Resolved (OQ-2): hover "overlay" peek is presentational — it renders as
+// an ABSOLUTE layer while the collapsed summary stays in flow, so it does
+// NOT change a row's in-flow height and is NOT a layout input. Layout is
+// therefore binary.
+export type ExpansionState = "collapsed" | "expanded";
+
+// WHY a row is open. Pin (user) outlives auto (running / pending / 3s
+// post-completion hold): a hold-expiry collapses an "auto" row but is a
+// no-op on a "pin" row. Mirrors today's `pinnedNodes` ∪ `autoExpanded()`.
+export type Expansion =
+    | { open: false }
+    | { open: true; via: "pin" | "auto" };
+
+export const inFlowState = (e: Expansion | undefined): ExpansionState =>
+    e?.open ? "expanded" : "collapsed";
+
+export interface RowHeight {
+    // measured CSS-px height per in-flow state (INV-3). undefined = unmeasured.
+    collapsed?: number;
+    expanded?: number;
+}
+
+export interface AgentPaneLayoutState {
+    zoom: number;                                 // INV-2: layout is zoom-INVARIANT; this only scales render
+    orderedIds: ReadonlyArray<string>;            // FULL virtualized-region node ids, in order (not just the window)
+    expansion: ReadonlyMap<string, Expansion>;    // unified — absorbs collapsed/pinned/auto-hold/cancel-thinking
+    heights: ReadonlyMap<string, RowHeight>;      // measured, per state, unzoomed CSS px
+    estimates: ReadonlyMap<string, RowHeight>;    // estimator output, per state (fallback when unmeasured)
+    scrollTop: number;                            // unzoomed CSS px (windowing input)
+    viewportPx: number;                           // scroll container clientHeight / zoom
+    scrollMarginPx: number;                       // header offset above the virtualized region
+    overscan: number;
+}
+```
+
+Because `orderedIds` is the **full** virtualized set (not the visible window),
+a row that merely scrolls out of view stays in `orderedIds`, so its measured
+heights survive — fixing the stuck-estimate-after-recycle case structurally
+(heights are keyed by stable `nodeId`, never by a recycled DOM element).
+
+### 3.2 Commands (the only ways layout changes)
+
+```ts
+export type AgentPaneLayoutCommand =
+    // ── document shape ──────────────────────────────────────────────
+    | { type: "NodesChanged"; orderedIds: ReadonlyArray<string> }   // append/prepend/truncate → prune ids ∉ new set
+    // ── expansion (unified; replaces the scattered signals) ─────────
+    | { type: "UserExpanded"; nodeId: string }                      // pin open  → {open:true, via:"pin"}
+    | { type: "UserCollapsed"; nodeId: string }                     // unpin     → {open:false}
+    | { type: "AutoExpandStarted"; nodeId: string }                 // running/pending → {open:true, via:"auto"} (pin wins)
+    | { type: "AutoExpandHoldExpired"; nodeId: string }             // 3s timer fired (store side-effect) → collapse IF via:"auto"
+    // ── measurement ingest (normalized ÷zoom at the boundary) ───────
+    | { type: "RowMeasured"; nodeId: string; state: ExpansionState; cssPx: number }   // state ∈ {collapsed, expanded}
+    | { type: "EstimateSet"; nodeId: string; state: ExpansionState; cssPx: number }
+    | { type: "MeasurementInvalidated"; nodeId: string }            // content streamed/grew → clears the WHOLE RowHeight
+    // ── viewport / zoom ─────────────────────────────────────────────
+    | { type: "Scrolled"; scrollTop: number; viewportPx: number }
+    | { type: "ScrollMarginChanged"; px: number }
+    | { type: "ZoomChanged"; zoom: number };                        // NO height recompute (INV-2)
+```
+
+The two **timers** (3 s post-completion hold; user-message hover delay) live in
+the store layer as side effects that *dispatch* commands — never in the reducer.
+The store arms the hold timer when a tool transitions to a terminal status and
+dispatches `AutoExpandHoldExpired` on fire; the reducer collapses the row only if
+it is still `via:"auto"` (a user pin during the hold makes it `via:"pin"` and the
+expiry becomes a no-op).
+
+### 3.3 Events (audit ring; surface in the Ctrl+Shift+D diag panel)
+
+```ts
+export type AgentPaneLayoutEvent =
+    | { type: "row-measured"; nodeId: string; state: ExpansionState; delta: number }
+    | { type: "expansion-changed"; nodeId: string; from: ExpansionState; to: ExpansionState }
+    | { type: "measurement-invalidated"; nodeId: string }
+    | { type: "zoom-changed-no-relayout"; zoom: number }   // explicit: proves INV-2 held
+    | { type: "ids-pruned"; removed: number }
+    | { type: "command-dropped"; reason: string };         // per conventions §"suppression events"
+```
+
+### 3.4 Selectors (pure projections — the renderer reads these)
+
+```ts
+// effective in-flow height of a row, current state, unzoomed CSS px
+effectiveHeight(s, id): number =
+    s.expansion.get(id) === "overlay" ? 0
+    : (s.heights.get(id)?.[state] ?? s.estimates.get(id)?.[state] ?? DEFAULT_ESTIMATE)
+
+// prefix-sum positions — THE guarantee (INV-1). O(n); see §7 perf note.
+positions(s): Array<{ id; start; height }>   // start[i+1] = start[i] + height[i]
+
+totalSize(s): number                          // start[last] + height[last] - scrollMargin
+
+// windowing: first/last visible index via binary search over prefix sums + overscan
+window(s): { startIndex; endIndex }
+```
+
+### 3.5 Reducer shape (pure)
+
+`update(state, command): { state, events }` — same signature as every other slice.
+Highlights:
+
+- **`ZoomChanged`** sets `state.zoom` and emits `zoom-changed-no-relayout`. It does
+  **not** touch `heights`/`estimates` (INV-2). The renderer's single ancestor
+  `zoom` re-scales everything; positions are unzoomed and unchanged.
+- **`RowMeasured`** writes `heights[nodeId][state] = cssPx` (INV-3). If it differs
+  from the prior layout height, that's the *only* thing that shifts subsequent
+  positions — deterministically, via the prefix-sum selector, all at once (never
+  a partial cache update).
+- **`ExpansionSet`/`AutoExpand*`** change `expansion[nodeId]`; the projected height
+  immediately switches to the cached measurement for the new state (or estimate).
+  **No DOM round-trip needed to know the target height** — kills the expand race.
+- **`NodesChanged`** replaces `orderedIds` and **prunes** `expansion`/`heights`/
+  `estimates` for removed ids while **preserving surviving ids** (measurements
+  survive scroll-recycle — fixes the stuck-estimate-after-churn, because a row's
+  height is keyed by stable nodeId, not by a recycled DOM element / data-index).
+
+### 3.6 Store / dispatch layer
+
+Mirrors `browser-pane-state-store.ts`: `Map<blockId, Slot{state, proj}>`,
+`registerPane`/`unregisterPane`/`dispatch(blockId, cmd, source)`, project only
+changed fields to Solid signals, `recordDispatch({slice:"agent-pane-layout", ...})`.
+The two **timers** (post-completion hold; user-message hover-expand delay) live
+here as side effects that *dispatch* `AutoExpandHoldExpired` / `ExpansionSet` — the
+reducer stays pure (cf. the `postCompletionHold` self-loop bug already documented
+in `ToolBlock.tsx`).
+
+---
+
+## 4. Renderer becomes a pure projection
+
+`AgentDocumentVirtualList` stops asking TanStack "what are the positions?" and
+instead **renders the slice's `positions()`/`window()`**:
+
+```
+slice.window()        → which ids to mount
+slice.positions()     → translateY(start) per mounted row (unzoomed CSS px)
+slice.totalSize()     → spacer height
+```
+
+- On a row's `ResizeObserver`/ref fire → `dispatch(RowMeasured{nodeId, state, gbcr.height / zoom})`.
+  (The ÷zoom normalization lives at this single boundary — INV-2.)
+- On expand/collapse/pin interaction → `dispatch(ExpansionSet{...})`.
+- On scroll → `dispatch(Scrolled{...})`; on zoom meta change → `dispatch(ZoomChanged)`.
+
+### 4.1 Relationship to TanStack `@tanstack/virtual-core`
+
+Two viable end-states; spec recommends **(B)** as the target, reached via the
+phases in §6:
+
+- **(A) Feed TanStack from the slice.** Keep TanStack windowing; make
+  `estimateSize(i)` return `effectiveHeight(slice, id)` (so it's the cached
+  measurement when known, never a bad guess) and `measureElement` dispatch
+  `RowMeasured` and return the slice's authoritative height. *Lower risk, but
+  TanStack still owns the position prefix-sum → INV-1 not fully guaranteed.*
+- **(B) Slice owns positions; TanStack retired from the agent pane.** Positions
+  come from the slice's prefix-sum; a ~80-line pure windowing selector (binary
+  search over prefix sums + overscan) replaces `getVirtualItems()`. *This is what
+  makes overlap structurally impossible (§2). It also deletes the `data-index`
+  ref race, the `getVirtualItems()`-undefined crash guard, and the
+  `shouldMeasureDuringScroll` gating — all artifacts of not owning the cache.*
+
+The **streaming buffer** (trailing nodes in normal flow, no `translateY`) is **out
+of scope** — it has no position math to get wrong. The slice models only the
+virtualized region (`partition().virtualizedNodes`).
+
+---
+
+## 5. Unifying the scattered expansion state
+
+Today a row's "is it open" is computed from up to four places. The slice makes
+`expansion: Map<nodeId, ExpansionState>` the **single** authority; components
+become thin:
+
+| Today (ad-hoc) | file | Becomes |
+|---|---|---|
+| `documentState.collapsedNodes` / `pinnedNodes` | `types.ts`, `AgentDocumentView` toggles | dispatch `ExpansionSet`; selector reads `expansion` |
+| `ToolBlock.postCompletionHold` (3s timer) + `autoExpanded()` | `ToolBlock.tsx` | store-layer timer → `AutoExpandStarted` / `AutoExpandHoldExpired`; `expanded()` reads slice |
+| `MarkdownBlock.expanded()` (canceled-thinking) | `MarkdownBlock.tsx` | `UserExpanded` / `UserCollapsed` on click |
+| `UserMessageBlock.hovering` → `bodyMode "overlay"` | `UserMessageBlock.tsx` | **stays component-local** — it's presentational (absolute peek; summary stays in flow) and does **not** change in-flow height, so it is **not** a layout input (resolved OQ-2). |
+
+Net: the reducer sees every input that changes a row's **in-flow height**, so
+every such change is preceded by a command — the precondition for INV-1 and for
+deterministic tests. (It also lets the estimator be a pure function of slice state
+instead of reading a separate `documentState()`.) The hover-peek overlay is
+deliberately excluded: it has no in-flow footprint, so pulling it into the layout
+reducer would add state with no layout meaning.
+
+---
+
+## 6. Migration phases (each independently shippable + verifiable)
+
+- **Phase 0 — shadow.** Add the slice (state+reducer+store) and dispatch into it
+  from the existing render path, but **keep rendering from TanStack.** Log
+  divergence between slice `positions()` and TanStack measurements. Goal: validate
+  the model against live traffic with zero user-visible change. Ship behind the
+  existing dev-only instrumentation.
+- **Phase 1 — unify expansion (§5).** Move `collapsed/pinned/hold/hover/cancel`
+  into the slice; components dispatch `ExpansionSet`. **This alone removes the
+  component-local desync** and makes expansion testable. Still TanStack-measured.
+- **Phase 2 — route measurement (4.1-A).** `estimateSize`/`measureElement` read/
+  dispatch through the slice; measurements keyed by `(nodeId, state)` (INV-3).
+  Kills the `0`/`784` cross-state contamination.
+- **Phase 3 — slice owns positions (4.1-B).** Replace `getVirtualItems()` with the
+  prefix-sum windowing selector. **Overlap becomes structurally impossible
+  (INV-1).** Retire TanStack from the agent pane; delete the data-index ref race,
+  the undefined-virtualItem guard, and `shouldMeasureDuringScroll` workarounds.
+- **Phase 4 — formalize zoom (INV-2).** Single ÷zoom at the `RowMeasured` boundary;
+  remove any other zoom reads from the layout path; assert `zoom-changed-no-relayout`.
+
+Phases 1–3 each close a distinct bug class from §1; Phase 3 is the one that closes
+#1235.
+
+---
+
+## 7. Testing
+
+The whole point of moving to a reducer is that correctness becomes **provable**,
+per the project's state-machine testing discipline:
+
+- **Property test — non-overlap (INV-1).** For *any* sequence of commands
+  (random `NodesChanged`/`ExpansionSet`/`RowMeasured`/`Scrolled`/`ZoomChanged`),
+  assert `positions()` is monotonic: `start[i+1] === end[i]` for all i. This is the
+  invariant #1235 violates; here it holds by construction and is *tested* to stay
+  so under churn. (Anti-vacuity: assert the generated sequence actually produced
+  ≥1 measurement that changed a height.)
+- **State cross-product.** `expansion ∈ {collapsed, expanded, overlay}` ×
+  `measured? ∈ {yes,no}` × `zoom ∈ {0.5,1,2}` × `churn ∈ {toggle, stream-grow,
+  prune}` — table-drive the reducer; assert effective height + position for each
+  cell. Build this table *before* coding (cf. the orchestrator-test lesson from
+  PR #702).
+- **Replay production emit order.** Feed the exact command order the live render
+  path emits (measure-after-paint, expansion-before-measure) — out-of-order tests
+  give false confidence.
+- **Zoom-invariance.** `ZoomChanged` must not alter any `positions()` value; only
+  the render multiplier. Assert `heights`/`estimates` referentially unchanged.
+- **Live CDP verification of record** (jsdom can't do CSS `zoom`/layout). Reuse the
+  recipe from this cycle: read each `.agent-document-row` `translateY` vs
+  `offsetHeight`, and rendered-top overlap; run the **fresh-reload → N
+  expand/collapse cycles** churn test from #1235 and assert **0 drift** (the
+  current code accumulates 5 mismatches / 1 overlap after 9 cycles).
+
+---
+
+## 8. Why this kills each bug we chased
+
+| Bug | Root | Eliminated by |
+|---|---|---|
+| Overlap under zoom (#1231) | measure (zoomed px) vs estimate (css px) unit clash | INV-2: one unit, zoom applied once at render |
+| Stuck-at-estimate rows (#1233) | data-index null when measureElement ref fired → never observed | Phase 3: no data-index/ResizeObserver dance — height is reducer state keyed by nodeId |
+| Expand crash `(reading 'index')` (#1234) | `getVirtualItems()` transiently undefined mid-reflow | Phase 3: no `getVirtualItems()`; window is a pure selector |
+| Collapsed-overlay layout cost (#1234) | hidden content laid out | orthogonal (CSS `content-visibility`, already shipped) — slice is compatible |
+| Drift under churn (#1235) | TanStack incremental cache caches inconsistent sizes that don't reconverge; affects non-tool rows too | INV-1 + INV-3: positions = prefix-sum of state-keyed heights; deterministic reconvergence on every `RowMeasured` |
+
+---
+
+## 9. Risks & non-goals
+
+- **Scope.** This is a multi-PR migration, not a single change. Phase 0/1 deliver
+  value (unified, testable expansion) with low risk; the structural guarantee
+  needs Phase 3. Do **not** attempt all at once — each phase ships and is verified
+  live before the next (cf. "stop at perfect", the #1177 lesson).
+- **Perf of prefix-sum.** `positions()` is O(n) over the virtualized region. For
+  very long histories recompute only on height/expansion/ids change (memoized),
+  and if profiling shows it hot, back `heights` with a **Fenwick/segment tree** for
+  O(log n) position queries + O(log n) updates. Measure first (the perf HUD +
+  the §7 CDP recipe); don't pre-optimize.
+- **Behavior parity.** Phase 1 must reproduce today's exact expansion semantics
+  (startup-collapse, 3s hold, hover-peek overlay, canceled-thinking) — capture
+  them as the cross-product table before refactoring.
+- **Non-goals:** streaming buffer layout (normal flow, no bug); window/tab layout
+  (`layout-reducer` #5); the `content-visibility` perf fix (#1234, independent).
+
+---
+
+## 10. Files (Phase 1 footprint; later phases extend)
+
+| File | Change |
+|---|---|
+| `frontend/app/store/agent-pane-layout/types.ts` | new — state, commands, events, `initialState` |
+| `frontend/app/store/agent-pane-layout/reducer.ts` | new — pure `update` + selectors |
+| `frontend/app/store/agent-pane-layout-store.ts` | new — dispatch layer, projections, timers, `recordDispatch` |
+| `frontend/app/store/agent-pane-layout/reducer.test.ts` | new — property + cross-product tests (§7) |
+| `frontend/app/view/agent/components/ToolBlock.tsx` | read expansion from slice; dispatch on pin; store-layer hold timer |
+| `frontend/app/view/agent/components/UserMessageBlock.tsx`, `MarkdownBlock.tsx`, `AgentDocumentView.tsx` | dispatch `ExpansionSet`; drop local expansion signals |
+| `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx` | (Ph2/3) read positions/window from slice; route measurement |
+| `frontend/app/view/agent/virtualization/renderers.ts` | estimators become `EstimateSet` producers keyed by state |
+| `frontend/app/devtools/diag-panel.tsx` | surfaces the new slice automatically (audit ring) |
+
+---
+
+## 11. Resolved decisions (were open questions)
+
+1. **Phase 3 windowing — BUILD, don't fork.** A pure `windowRange(state)` selector:
+   prefix-sum the in-flow heights, binary-search the first row whose `end >
+   scrollTop` and the last whose `start < scrollTop + viewportPx`, pad by
+   `overscan`. ~40 lines, fully unit-testable, no imperative cache. Forking
+   `virtual-core` would re-import the very mutable cache we're removing.
+2. **Hover-peek "overlay" is NOT a layout state (see §3.1, §5).** It renders as an
+   absolute layer with the collapsed summary still in flow, so it has zero in-flow
+   footprint and stays a component-local presentational signal. Layout state is
+   binary `collapsed | expanded`. This both simplifies the model and avoids
+   anchor-math coupling (anchors are in-flow nodes; overlay rows have normal
+   collapsed extent).
+3. **Pruning by set membership — no `reason` needed.** `orderedIds` is the FULL
+   virtualized region, so scroll-out never removes an id; `NodesChanged` prunes
+   exactly the ids absent from the new set and preserves heights for survivors.
+   Re-entry (scroll back) reuses the surviving measured height for its state.
+   Content growth is the only invalidation path: `MeasurementInvalidated{nodeId}`
+   clears that row's WHOLE `RowHeight` (both states) to force a clean re-measure.
+4. **Decouple from `agent-pane-state` (#4) — translate at the edge.** The layout
+   slice does NOT import or subscribe to the turn/tool-status slice. The component
+   (or a thin adapter `createEffect` watching `node.status`) translates
+   running/pending → `AutoExpandStarted` and a terminal transition → arm the hold
+   timer → `AutoExpandHoldExpired`. Slices stay independent; the audit ring shows
+   the translated command with its `source`.
+
+### Phasing note
+Phase 0 (this implementation) ships the pure slice + store + tests — zero
+render-path wiring, zero behaviour change, fully covered by the §7 property and
+cross-product tests. Phases 1–4 (wiring, per §6) follow as separate verified PRs.

--- a/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
+++ b/docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md
@@ -79,7 +79,7 @@ Two corollaries shape the design:
 
 ---
 
-## 3. Proposed slice: `agent-pane-layout` (Slice #9)
+## 3. Proposed slice: `agent-pane-layout` (Slice #11)
 
 Per-pane (keyed by `blockId`), following the established slice triplet
 (`types.ts` + `reducer.ts` pure core, `agent-pane-layout-store.ts` dispatch layer
@@ -119,6 +119,7 @@ export interface RowHeight {
 export interface AgentPaneLayoutState {
     zoom: number;                                 // INV-2: layout is zoom-INVARIANT; this only scales render
     orderedIds: ReadonlyArray<string>;            // FULL virtualized-region node ids, in order (not just the window)
+    idSet: ReadonlySet<string>;                   // O(1) membership over orderedIds — drops late measures for removed ids
     expansion: ReadonlyMap<string, Expansion>;    // unified — absorbs collapsed/pinned/auto-hold/cancel-thinking
     heights: ReadonlyMap<string, RowHeight>;      // measured, per state, unzoomed CSS px
     estimates: ReadonlyMap<string, RowHeight>;    // estimator output, per state (fallback when unmeasured)

--- a/frontend/app/store/agent-pane-layout-store.test.ts
+++ b/frontend/app/store/agent-pane-layout-store.test.ts
@@ -71,6 +71,20 @@ describe("agent-pane-layout store", () => {
         expect(layout.mock.calls.length).toBe(before);
     });
 
+    it("does not re-project an off-flow measurement (codex P2)", () => {
+        const { layout } = mkPane();
+        dispatch(BID, { type: "NodesChanged", orderedIds: ["a"] }); // a is collapsed by default
+        dispatch(BID, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 20 });
+        const before = layout.mock.calls.length;
+        // Measuring the EXPANDED slot of a collapsed row changes `heights` but
+        // not any position → must NOT project a layout change.
+        dispatch(BID, { type: "RowMeasured", nodeId: "a", state: "expanded", cssPx: 200 });
+        expect(layout.mock.calls.length).toBe(before);
+        // …and when the row is later expanded, the cached expanded height applies.
+        dispatch(BID, { type: "UserExpanded", nodeId: "a" });
+        expect(layout.mock.calls.at(-1)![0].rows[0].height).toBe(200);
+    });
+
     it("records every dispatch in the audit ring with the slice tag + source", () => {
         // afterEach resets the ring, so this starts clean without a manual reset.
         mkPane();

--- a/frontend/app/store/agent-pane-layout-store.test.ts
+++ b/frontend/app/store/agent-pane-layout-store.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { __resetDispatchLog, dispatchRecordsAtom } from "./command-source";
 import {
     __resetAllSlots,
     dispatch,
@@ -11,6 +12,7 @@ import {
     unregisterPane,
     type LayoutView,
 } from "./agent-pane-layout-store";
+import { DEFAULT_ROW_PX } from "./agent-pane-layout/types";
 
 const BID = "block-123456789";
 
@@ -21,7 +23,12 @@ function mkPane() {
     return { layout, zoom };
 }
 
-afterEach(() => __resetAllSlots());
+afterEach(() => {
+    __resetAllSlots();
+    // Reset the SHARED audit ring too, so the audit test isn't order-dependent
+    // on whatever earlier tests left in it (reagent P2 on #1236).
+    __resetDispatchLog();
+});
 
 describe("agent-pane-layout store", () => {
     it("throws on dispatch to an unregistered pane", () => {
@@ -41,7 +48,7 @@ describe("agent-pane-layout store", () => {
         const last = layout.mock.calls.at(-1)![0];
         expect(last.rows.map((r) => r.nodeId)).toEqual(["a", "b"]);
         expect(last.rows[0].height).toBe(30);
-        expect(last.totalSize).toBe(30 + 32); // measured + default
+        expect(last.totalSize).toBe(30 + DEFAULT_ROW_PX); // measured + default
     });
 
     it("INV-2: ZoomChanged re-emits zoom but NOT the layout view", () => {
@@ -64,13 +71,11 @@ describe("agent-pane-layout store", () => {
         expect(layout.mock.calls.length).toBe(before);
     });
 
-    it("records every dispatch in the audit ring with the slice tag + source", async () => {
-        const { dispatchRecordsAtom, __resetDispatchLog } = await import("./command-source");
-        __resetDispatchLog();
+    it("records every dispatch in the audit ring with the slice tag + source", () => {
+        // afterEach resets the ring, so this starts clean without a manual reset.
         mkPane();
         dispatch(BID, { type: "NodesChanged", orderedIds: ["a"] }, "user");
-        const recs = dispatchRecordsAtom();
-        const mine = recs.filter((r) => r.slice === "agent-pane-layout");
+        const mine = dispatchRecordsAtom().filter((r) => r.slice === "agent-pane-layout");
         expect(mine.length).toBe(1);
         expect(mine[0]).toMatchObject({ key: BID, source: "user" });
     });

--- a/frontend/app/store/agent-pane-layout-store.test.ts
+++ b/frontend/app/store/agent-pane-layout-store.test.ts
@@ -1,0 +1,85 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetAllSlots,
+    dispatch,
+    dispatchIfRegistered,
+    registerPane,
+    snapshot,
+    unregisterPane,
+    type LayoutView,
+} from "./agent-pane-layout-store";
+
+const BID = "block-123456789";
+
+function mkPane() {
+    const layout = vi.fn<(v: LayoutView) => void>();
+    const zoom = vi.fn<(z: number) => void>();
+    registerPane(BID, { layout, zoom });
+    return { layout, zoom };
+}
+
+afterEach(() => __resetAllSlots());
+
+describe("agent-pane-layout store", () => {
+    it("throws on dispatch to an unregistered pane", () => {
+        expect(() =>
+            dispatch("nope", { type: "ZoomChanged", zoom: 0.5 }),
+        ).toThrow(/unregistered pane/);
+    });
+
+    it("dispatchIfRegistered is a no-op for an unregistered pane", () => {
+        expect(dispatchIfRegistered("nope", { type: "ZoomChanged", zoom: 0.5 })).toEqual([]);
+    });
+
+    it("projects the layout view when a layout input changes", () => {
+        const { layout } = mkPane();
+        dispatch(BID, { type: "NodesChanged", orderedIds: ["a", "b"] });
+        dispatch(BID, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 30 });
+        const last = layout.mock.calls.at(-1)![0];
+        expect(last.rows.map((r) => r.nodeId)).toEqual(["a", "b"]);
+        expect(last.rows[0].height).toBe(30);
+        expect(last.totalSize).toBe(30 + 32); // measured + default
+    });
+
+    it("INV-2: ZoomChanged re-emits zoom but NOT the layout view", () => {
+        const { layout, zoom } = mkPane();
+        dispatch(BID, { type: "NodesChanged", orderedIds: ["a"] });
+        const layoutCallsBefore = layout.mock.calls.length;
+
+        dispatch(BID, { type: "ZoomChanged", zoom: 0.5 });
+
+        expect(zoom).toHaveBeenLastCalledWith(0.5);
+        // zero new layout projections — the zoom change costs no relayout
+        expect(layout.mock.calls.length).toBe(layoutCallsBefore);
+    });
+
+    it("does not re-project on a no-op dispatch", () => {
+        const { layout } = mkPane();
+        dispatch(BID, { type: "Scrolled", scrollTop: 10, viewportPx: 100 });
+        const before = layout.mock.calls.length;
+        dispatch(BID, { type: "Scrolled", scrollTop: 10, viewportPx: 100 }); // identical
+        expect(layout.mock.calls.length).toBe(before);
+    });
+
+    it("records every dispatch in the audit ring with the slice tag + source", async () => {
+        const { dispatchRecordsAtom, __resetDispatchLog } = await import("./command-source");
+        __resetDispatchLog();
+        mkPane();
+        dispatch(BID, { type: "NodesChanged", orderedIds: ["a"] }, "user");
+        const recs = dispatchRecordsAtom();
+        const mine = recs.filter((r) => r.slice === "agent-pane-layout");
+        expect(mine.length).toBe(1);
+        expect(mine[0]).toMatchObject({ key: BID, source: "user" });
+    });
+
+    it("unregister + snapshot lifecycle", () => {
+        mkPane();
+        dispatch(BID, { type: "NodesChanged", orderedIds: ["a"] });
+        expect(snapshot(BID)?.orderedIds).toEqual(["a"]);
+        unregisterPane(BID);
+        expect(snapshot(BID)).toBeNull();
+    });
+});

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -21,10 +21,9 @@
 
 import { type CommandSource, recordDispatch } from "./command-source";
 import {
-    positions,
-    totalSize,
+    computeLayoutView,
     update,
-    windowRange,
+    type LayoutView,
     type RowPosition,
     type WindowRange,
 } from "./agent-pane-layout/reducer";
@@ -34,14 +33,6 @@ import {
     AgentPaneLayoutState,
     initialState,
 } from "./agent-pane-layout/types";
-
-/** The projected, render-ready layout view. Recomputed only when a
- *  layout-affecting field changes (everything except `zoom`). */
-export interface LayoutView {
-    rows: RowPosition[];
-    totalSize: number;
-    window: WindowRange;
-}
 
 /**
  * Setters the slot writes into when reducer state changes. The view owns
@@ -81,14 +72,6 @@ function layoutInputsChanged(
     );
 }
 
-function viewOf(state: AgentPaneLayoutState): LayoutView {
-    return {
-        rows: positions(state),
-        totalSize: totalSize(state),
-        window: windowRange(state),
-    };
-}
-
 /**
  * Register a pane. Call SYNCHRONOUSLY from the agent view's setup, before
  * any handler can dispatch. Re-registering a blockId resets the cell to
@@ -126,7 +109,7 @@ export function dispatch(
     slot.state = result.state;
 
     if (layoutInputsChanged(prev, slot.state)) {
-        slot.proj.layout(viewOf(slot.state));
+        slot.proj.layout(computeLayoutView(slot.state));
     }
     if (slot.state.zoom !== prev.zoom) {
         slot.proj.zoom(slot.state.zoom);
@@ -166,4 +149,4 @@ export function __resetAllSlots(): void {
 }
 
 export type { AgentPaneLayoutCommand, AgentPaneLayoutEvent, AgentPaneLayoutState };
-export type { RowPosition, WindowRange };
+export type { LayoutView, RowPosition, WindowRange };

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -1,0 +1,169 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane layout store — Slice #11 dispatch layer.
+ *
+ * Mirrors the slot lifecycle of slice #9 (browser-pane) / #10 (editor-pane):
+ * per-blockId `Map<string, Slot>`, synchronous `registerPane`, `dispatch`
+ * that throws on an unregistered pane, projection-on-change, and the global
+ * `recordDispatch` audit hook (surfaces in the Ctrl+Shift+D diag panel).
+ *
+ * The reducer is pure; this layer holds the only mutable cell and projects
+ * the derived layout view into the caller's SolidJS signals. It deliberately
+ * enforces INV-2: a `ZoomChanged` (the only command that touches `zoom` and
+ * nothing else) re-emits `zoom` but NOT the layout view — proof the zoom
+ * change costs no relayout.
+ *
+ * Phase 0: no caller yet (see spec §6). The slice is added pure + tested so
+ * Phases 1–4 can wire the renderer to it incrementally.
+ */
+
+import { type CommandSource, recordDispatch } from "./command-source";
+import {
+    positions,
+    totalSize,
+    update,
+    windowRange,
+    type RowPosition,
+    type WindowRange,
+} from "./agent-pane-layout/reducer";
+import {
+    AgentPaneLayoutCommand,
+    AgentPaneLayoutEvent,
+    AgentPaneLayoutState,
+    initialState,
+} from "./agent-pane-layout/types";
+
+/** The projected, render-ready layout view. Recomputed only when a
+ *  layout-affecting field changes (everything except `zoom`). */
+export interface LayoutView {
+    rows: RowPosition[];
+    totalSize: number;
+    window: WindowRange;
+}
+
+/**
+ * Setters the slot writes into when reducer state changes. The view owns
+ * the underlying SolidJS signals and passes the setters in via `registerPane`.
+ * Each is called only when its projected value would change.
+ */
+export interface AgentPaneLayoutProjections {
+    /** Full derived layout (positions + total size + visible window). */
+    layout: (next: LayoutView) => void;
+    /** Per-pane CSS zoom factor (render multiplier only — see INV-2). */
+    zoom: (next: number) => void;
+}
+
+interface Slot {
+    state: AgentPaneLayoutState;
+    proj: AgentPaneLayoutProjections;
+}
+
+const slots = new Map<string, Slot>();
+
+/** Fields whose change requires recomputing the projected layout view.
+ *  `zoom` is deliberately excluded (INV-2). All of these are replaced by a
+ *  fresh reference on change, so referential inequality is exact. */
+function layoutInputsChanged(
+    a: AgentPaneLayoutState,
+    b: AgentPaneLayoutState,
+): boolean {
+    return (
+        a.orderedIds !== b.orderedIds ||
+        a.expansion !== b.expansion ||
+        a.heights !== b.heights ||
+        a.estimates !== b.estimates ||
+        a.scrollTop !== b.scrollTop ||
+        a.viewportPx !== b.viewportPx ||
+        a.scrollMarginPx !== b.scrollMarginPx ||
+        a.overscan !== b.overscan
+    );
+}
+
+function viewOf(state: AgentPaneLayoutState): LayoutView {
+    return {
+        rows: positions(state),
+        totalSize: totalSize(state),
+        window: windowRange(state),
+    };
+}
+
+/**
+ * Register a pane. Call SYNCHRONOUSLY from the agent view's setup, before
+ * any handler can dispatch. Re-registering a blockId resets the cell to
+ * `initialState` (hot-reload / re-mount safety).
+ */
+export function registerPane(
+    blockId: string,
+    proj: AgentPaneLayoutProjections,
+): void {
+    slots.set(blockId, { state: initialState(), proj });
+}
+
+export function unregisterPane(blockId: string): void {
+    slots.delete(blockId);
+}
+
+/**
+ * Apply a command. Throws on an unregistered blockId — silent drops would
+ * defeat the audit value (same rule as slices #4 / #9 / #10).
+ */
+export function dispatch(
+    blockId: string,
+    command: AgentPaneLayoutCommand,
+    source: CommandSource = "system",
+): AgentPaneLayoutEvent[] {
+    const slot = slots.get(blockId);
+    if (!slot) {
+        throw new Error(
+            `[agent-pane-layout] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously during agent-view setup.`,
+        );
+    }
+
+    const prev = slot.state;
+    const result = update(prev, command);
+    slot.state = result.state;
+
+    if (layoutInputsChanged(prev, slot.state)) {
+        slot.proj.layout(viewOf(slot.state));
+    }
+    if (slot.state.zoom !== prev.zoom) {
+        slot.proj.zoom(slot.state.zoom);
+    }
+
+    recordDispatch({
+        slice: "agent-pane-layout",
+        key: blockId,
+        command,
+        events: result.events,
+        source,
+        at: Date.now(),
+    });
+
+    return result.events;
+}
+
+/** Dispatch only if the pane is registered (returns `[]` otherwise). For
+ *  async callbacks that may fire after the pane unmounts. */
+export function dispatchIfRegistered(
+    blockId: string,
+    command: AgentPaneLayoutCommand,
+    source: CommandSource = "system",
+): AgentPaneLayoutEvent[] {
+    if (!slots.has(blockId)) return [];
+    return dispatch(blockId, command, source);
+}
+
+/** Snapshot — diagnostics + tests only. */
+export function snapshot(blockId: string): AgentPaneLayoutState | null {
+    return slots.get(blockId)?.state ?? null;
+}
+
+/** Test/dev helper — clears every slot. */
+export function __resetAllSlots(): void {
+    slots.clear();
+}
+
+export type { AgentPaneLayoutCommand, AgentPaneLayoutEvent, AgentPaneLayoutState };
+export type { RowPosition, WindowRange };

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -49,9 +49,31 @@ export interface AgentPaneLayoutProjections {
 interface Slot {
     state: AgentPaneLayoutState;
     proj: AgentPaneLayoutProjections;
+    /** Last view projected to the consumer — lets us suppress a spurious
+     *  re-projection when a state change did not actually move the layout
+     *  (e.g. an off-flow measurement: writing the non-current expansion slot
+     *  changes the `heights` map ref but not any position). codex P2 on #1236. */
+    lastView: LayoutView | null;
 }
 
 const slots = new Map<string, Slot>();
+
+/** Structural equality of two layout views (rows + total + window). Compared
+ *  field-wise because `computeLayoutView` returns fresh objects each call. */
+function viewsEqual(a: LayoutView, b: LayoutView): boolean {
+    if (a.totalSize !== b.totalSize) return false;
+    if (a.window.startIndex !== b.window.startIndex) return false;
+    if (a.window.endIndex !== b.window.endIndex) return false;
+    if (a.rows.length !== b.rows.length) return false;
+    for (let i = 0; i < a.rows.length; i++) {
+        const ra = a.rows[i];
+        const rb = b.rows[i];
+        if (ra.nodeId !== rb.nodeId || ra.start !== rb.start || ra.height !== rb.height) {
+            return false;
+        }
+    }
+    return true;
+}
 
 /** Fields whose change requires recomputing the projected layout view.
  *  `zoom` is deliberately excluded (INV-2). All of these are replaced by a
@@ -81,7 +103,7 @@ export function registerPane(
     blockId: string,
     proj: AgentPaneLayoutProjections,
 ): void {
-    slots.set(blockId, { state: initialState(), proj });
+    slots.set(blockId, { state: initialState(), proj, lastView: null });
 }
 
 export function unregisterPane(blockId: string): void {
@@ -109,7 +131,14 @@ export function dispatch(
     slot.state = result.state;
 
     if (layoutInputsChanged(prev, slot.state)) {
-        slot.proj.layout(computeLayoutView(slot.state));
+        // The ref-level gate above is cheap but coarse: an off-flow measurement
+        // changes the `heights` ref without moving any position. Recompute the
+        // view and project only if it actually differs (codex P2 on #1236).
+        const view = computeLayoutView(slot.state);
+        if (slot.lastView === null || !viewsEqual(view, slot.lastView)) {
+            slot.lastView = view;
+            slot.proj.layout(view);
+        }
     }
     if (slot.state.zoom !== prev.zoom) {
         slot.proj.zoom(slot.state.zoom);

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -21,11 +21,6 @@ const apply = (
     cmd: AgentPaneLayoutCommand,
 ): AgentPaneLayoutState => update(s, cmd).state;
 
-const applyAll = (
-    s: AgentPaneLayoutState,
-    cmds: AgentPaneLayoutCommand[],
-): AgentPaneLayoutState => cmds.reduce(apply, s);
-
 /** Tiny deterministic LCG so property-test failures reproduce. */
 function rng(seed: number): () => number {
     let x = seed >>> 0;
@@ -124,8 +119,16 @@ describe("agent-pane-layout reducer", () => {
                             cmd = { type: "NodesChanged", orderedIds: ids.slice(cut) };
                         }
                     }
-                    if (cmd.type === "RowMeasured" || cmd.type === "EstimateSet") measuresApplied++;
+                    const before = s;
                     s = apply(s, cmd);
+                    // anti-vacuity counts measurements that ACTUALLY wrote to
+                    // state — not ones dropped (unknown id / no-op / invalid px).
+                    if (
+                        (cmd.type === "RowMeasured" || cmd.type === "EstimateSet") &&
+                        s !== before
+                    ) {
+                        measuresApplied++;
+                    }
                     assertPrefixSum(s);
                     // window range is always a valid (possibly empty) slice
                     const w = windowRange(s);
@@ -207,8 +210,11 @@ describe("agent-pane-layout reducer", () => {
     });
 
     describe("expansion semantics — pin outranks auto; hold expiry", () => {
+        // expansion commands are guarded by idSet, so the row must be present.
+        const withRow = () => apply(initialState(), { type: "NodesChanged", orderedIds: ["t"] });
+
         it("AutoExpandStarted then AutoExpandHoldExpired collapses", () => {
-            let s = initialState();
+            let s = withRow();
             s = apply(s, { type: "AutoExpandStarted", nodeId: "t" });
             expect(s.expansion.get("t")).toEqual({ open: true, via: "auto" });
             const r = update(s, { type: "AutoExpandHoldExpired", nodeId: "t" });
@@ -217,7 +223,7 @@ describe("agent-pane-layout reducer", () => {
         });
 
         it("a user pin survives a hold expiry (no-op, audited)", () => {
-            let s = initialState();
+            let s = withRow();
             s = apply(s, { type: "AutoExpandStarted", nodeId: "t" });
             s = apply(s, { type: "UserExpanded", nodeId: "t" }); // pin during hold
             expect(s.expansion.get("t")).toEqual({ open: true, via: "pin" });
@@ -227,11 +233,18 @@ describe("agent-pane-layout reducer", () => {
         });
 
         it("AutoExpandStarted does not downgrade an existing pin", () => {
-            let s = initialState();
+            let s = withRow();
             s = apply(s, { type: "UserExpanded", nodeId: "t" });
             const r = update(s, { type: "AutoExpandStarted", nodeId: "t" });
             expect(r.state).toBe(s);
             expect(s.expansion.get("t")).toEqual({ open: true, via: "pin" });
+        });
+
+        it("drops an expansion command for an id not in the document", () => {
+            const s = withRow();
+            const r = update(s, { type: "UserExpanded", nodeId: "ghost" });
+            expect(r.state).toBe(s);
+            expect(r.events[0]).toMatchObject({ type: "command-dropped", reason: "expansion-unknown-id" });
         });
     });
 
@@ -330,7 +343,8 @@ describe("agent-pane-layout reducer", () => {
         it("scrolled past the end → empty range", () => {
             let s = build();
             s = apply(s, { type: "Scrolled", scrollTop: 9000, viewportPx: 300 });
-            expect(windowRange(s).endIndex).toBeLessThan(windowRange(s).startIndex);
+            const w = windowRange(s);
+            expect(w.endIndex).toBeLessThan(w.startIndex);
         });
     });
 

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -1,0 +1,332 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    effectiveHeight,
+    positions,
+    totalSize,
+    update,
+    windowRange,
+} from "./reducer";
+import {
+    AgentPaneLayoutCommand,
+    AgentPaneLayoutState,
+    DEFAULT_ROW_PX,
+    initialState,
+} from "./types";
+
+const apply = (
+    s: AgentPaneLayoutState,
+    cmd: AgentPaneLayoutCommand,
+): AgentPaneLayoutState => update(s, cmd).state;
+
+const applyAll = (
+    s: AgentPaneLayoutState,
+    cmds: AgentPaneLayoutCommand[],
+): AgentPaneLayoutState => cmds.reduce(apply, s);
+
+/** Tiny deterministic LCG so property-test failures reproduce. */
+function rng(seed: number): () => number {
+    let x = seed >>> 0;
+    return () => {
+        // numerical recipes LCG
+        x = (1664525 * x + 1013904223) >>> 0;
+        return x / 0x100000000;
+    };
+}
+
+describe("agent-pane-layout reducer", () => {
+    describe("INV-1 — positions are a flush, non-overlapping prefix-sum", () => {
+        const assertPrefixSum = (s: AgentPaneLayoutState): void => {
+            const pos = positions(s);
+            expect(pos.length).toBe(s.orderedIds.length);
+            let cursor = s.scrollMarginPx;
+            for (let i = 0; i < pos.length; i++) {
+                const p = pos[i];
+                // finite, non-negative heights (guarded ingest)
+                expect(Number.isFinite(p.height)).toBe(true);
+                expect(p.height).toBeGreaterThanOrEqual(0);
+                // slot is self-consistent
+                expect(p.start).toBe(cursor);
+                expect(p.end).toBe(p.start + p.height);
+                // flush with the previous row → no overlap, no gap
+                if (i > 0) expect(p.start).toBe(pos[i - 1].end);
+                cursor = p.end;
+            }
+            // totalSize equals the accumulated height (independent of margin)
+            expect(totalSize(s)).toBe(cursor - s.scrollMarginPx);
+        };
+
+        it("holds for a hand-built mixed state", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b", "c", "d"] });
+            s = apply(s, { type: "ScrollMarginChanged", px: 12 });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 23 });
+            s = apply(s, { type: "EstimateSet", nodeId: "b", state: "collapsed", cssPx: 40 });
+            s = apply(s, { type: "UserExpanded", nodeId: "c" });
+            s = apply(s, { type: "RowMeasured", nodeId: "c", state: "expanded", cssPx: 180 });
+            // d: no measurement, no estimate → DEFAULT_ROW_PX
+            assertPrefixSum(s);
+            const pos = positions(s);
+            expect(pos.map((p) => p.height)).toEqual([23, 40, 180, DEFAULT_ROW_PX]);
+            expect(pos[0].start).toBe(12); // scrollMargin
+        });
+
+        it("holds across ANY random command sequence (property test)", () => {
+            const ids = ["n0", "n1", "n2", "n3", "n4", "n5"];
+            for (let seed = 1; seed <= 40; seed++) {
+                const rand = rng(seed);
+                const pick = <T>(arr: T[]): T => arr[Math.floor(rand() * arr.length)];
+                let s = initialState();
+                let measuresApplied = 0;
+                s = apply(s, { type: "NodesChanged", orderedIds: ids });
+
+                for (let step = 0; step < 120; step++) {
+                    const k = Math.floor(rand() * 11);
+                    const id = pick(ids);
+                    const st = rand() < 0.5 ? "collapsed" : "expanded";
+                    let cmd: AgentPaneLayoutCommand;
+                    switch (k) {
+                        case 0:
+                            cmd = { type: "RowMeasured", nodeId: id, state: st, cssPx: Math.floor(rand() * 400) };
+                            break;
+                        case 1:
+                            cmd = { type: "EstimateSet", nodeId: id, state: st, cssPx: Math.floor(rand() * 400) };
+                            break;
+                        case 2:
+                            cmd = { type: "UserExpanded", nodeId: id };
+                            break;
+                        case 3:
+                            cmd = { type: "UserCollapsed", nodeId: id };
+                            break;
+                        case 4:
+                            cmd = { type: "AutoExpandStarted", nodeId: id };
+                            break;
+                        case 5:
+                            cmd = { type: "AutoExpandHoldExpired", nodeId: id };
+                            break;
+                        case 6:
+                            cmd = { type: "MeasurementInvalidated", nodeId: id };
+                            break;
+                        case 7:
+                            cmd = { type: "Scrolled", scrollTop: Math.floor(rand() * 2000), viewportPx: Math.floor(rand() * 800) };
+                            break;
+                        case 8:
+                            cmd = { type: "ScrollMarginChanged", px: Math.floor(rand() * 60) };
+                            break;
+                        case 9:
+                            cmd = { type: "ZoomChanged", zoom: 0.5 + rand() * 1.5 };
+                            break;
+                        default: {
+                            // occasionally mutate the id set (prepend/truncate)
+                            const cut = Math.floor(rand() * ids.length);
+                            cmd = { type: "NodesChanged", orderedIds: ids.slice(cut) };
+                        }
+                    }
+                    if (cmd.type === "RowMeasured" || cmd.type === "EstimateSet") measuresApplied++;
+                    s = apply(s, cmd);
+                    assertPrefixSum(s);
+                    // window range is always a valid (possibly empty) slice
+                    const w = windowRange(s);
+                    expect(w.startIndex).toBeGreaterThanOrEqual(0);
+                    expect(w.endIndex).toBeLessThan(s.orderedIds.length);
+                }
+                // anti-vacuity: the sequence actually exercised measurement
+                expect(measuresApplied).toBeGreaterThan(0);
+            }
+        });
+
+        it("rejects non-finite / negative measurements (keeps the sum clean)", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a"] });
+            for (const bad of [NaN, Infinity, -Infinity, -5]) {
+                const r = update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: bad });
+                expect(r.state).toBe(s); // dropped, same ref
+                expect(r.events[0]).toMatchObject({ type: "command-dropped" });
+            }
+            expect(effectiveHeight(s, "a")).toBe(DEFAULT_ROW_PX);
+        });
+    });
+
+    describe("INV-2 — zoom is layout-invariant", () => {
+        it("ZoomChanged does not alter positions / heights / estimates", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 30 });
+            s = apply(s, { type: "RowMeasured", nodeId: "b", state: "collapsed", cssPx: 50 });
+            const before = positions(s);
+            const heightsRef = s.heights;
+            const estimatesRef = s.estimates;
+            const idsRef = s.orderedIds;
+
+            const r = update(s, { type: "ZoomChanged", zoom: 0.5 });
+            expect(r.events[0]).toMatchObject({ type: "zoom-changed-no-relayout", zoom: 0.5 });
+            // layout inputs untouched (same references)
+            expect(r.state.heights).toBe(heightsRef);
+            expect(r.state.estimates).toBe(estimatesRef);
+            expect(r.state.orderedIds).toBe(idsRef);
+            // positions identical
+            expect(positions(r.state)).toEqual(before);
+        });
+
+        it("ZoomChanged to the same value is a no-op (same ref)", () => {
+            const s = initialState();
+            expect(update(s, { type: "ZoomChanged", zoom: 1 }).state).toBe(s);
+        });
+    });
+
+    describe("INV-3 — measurements are keyed by expansion state", () => {
+        it("an expanded measurement never contaminates the collapsed slot", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["x"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "x", state: "collapsed", cssPx: 24 });
+            expect(effectiveHeight(s, "x")).toBe(24); // collapsed by default
+
+            s = apply(s, { type: "UserExpanded", nodeId: "x" });
+            // expanded slot unmeasured → falls back to default
+            expect(effectiveHeight(s, "x")).toBe(DEFAULT_ROW_PX);
+
+            s = apply(s, { type: "RowMeasured", nodeId: "x", state: "expanded", cssPx: 200 });
+            expect(effectiveHeight(s, "x")).toBe(200);
+
+            // collapse again → original collapsed measurement intact
+            s = apply(s, { type: "UserCollapsed", nodeId: "x" });
+            expect(effectiveHeight(s, "x")).toBe(24);
+        });
+
+        it("effectiveHeight precedence: measured > estimate > default", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["x"] });
+            expect(effectiveHeight(s, "x")).toBe(DEFAULT_ROW_PX);
+            s = apply(s, { type: "EstimateSet", nodeId: "x", state: "collapsed", cssPx: 60 });
+            expect(effectiveHeight(s, "x")).toBe(60);
+            s = apply(s, { type: "RowMeasured", nodeId: "x", state: "collapsed", cssPx: 47 });
+            expect(effectiveHeight(s, "x")).toBe(47);
+        });
+    });
+
+    describe("expansion semantics — pin outranks auto; hold expiry", () => {
+        it("AutoExpandStarted then AutoExpandHoldExpired collapses", () => {
+            let s = initialState();
+            s = apply(s, { type: "AutoExpandStarted", nodeId: "t" });
+            expect(s.expansion.get("t")).toEqual({ open: true, via: "auto" });
+            const r = update(s, { type: "AutoExpandHoldExpired", nodeId: "t" });
+            expect(r.state.expansion.has("t")).toBe(false); // collapsed === absent
+            expect(r.events[0]).toMatchObject({ type: "expansion-changed" });
+        });
+
+        it("a user pin survives a hold expiry (no-op, audited)", () => {
+            let s = initialState();
+            s = apply(s, { type: "AutoExpandStarted", nodeId: "t" });
+            s = apply(s, { type: "UserExpanded", nodeId: "t" }); // pin during hold
+            expect(s.expansion.get("t")).toEqual({ open: true, via: "pin" });
+            const r = update(s, { type: "AutoExpandHoldExpired", nodeId: "t" });
+            expect(r.state).toBe(s); // unchanged
+            expect(r.events[0]).toMatchObject({ type: "command-dropped", reason: "hold-expired-not-auto" });
+        });
+
+        it("AutoExpandStarted does not downgrade an existing pin", () => {
+            let s = initialState();
+            s = apply(s, { type: "UserExpanded", nodeId: "t" });
+            const r = update(s, { type: "AutoExpandStarted", nodeId: "t" });
+            expect(r.state).toBe(s);
+            expect(s.expansion.get("t")).toEqual({ open: true, via: "pin" });
+        });
+    });
+
+    describe("NodesChanged — pruning by set membership", () => {
+        it("prunes heights/estimates/expansion for removed ids, keeps survivors", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b", "c"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 10 });
+            s = apply(s, { type: "RowMeasured", nodeId: "b", state: "collapsed", cssPx: 20 });
+            s = apply(s, { type: "UserExpanded", nodeId: "b" });
+            s = apply(s, { type: "EstimateSet", nodeId: "c", state: "collapsed", cssPx: 30 });
+
+            const r = update(s, { type: "NodesChanged", orderedIds: ["a", "c"] });
+            expect(r.events).toContainEqual({ type: "ids-pruned", removed: 1 });
+            // b gone from every map
+            expect(r.state.heights.has("b")).toBe(false);
+            expect(r.state.expansion.has("b")).toBe(false);
+            // survivors keep their measurements
+            expect(effectiveHeight(r.state, "a")).toBe(10);
+            expect(effectiveHeight(r.state, "c")).toBe(30);
+        });
+
+        it("identical id list is a no-op (same ref)", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b"] });
+            expect(update(s, { type: "NodesChanged", orderedIds: ["a", "b"] }).state).toBe(s);
+        });
+
+        it("a measured row that scrolls out (stays in orderedIds) keeps its height", () => {
+            // models the stuck-estimate-after-recycle bug being structurally fixed:
+            // scroll-out doesn't change orderedIds, so heights survive.
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b", "c"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 18 });
+            s = apply(s, { type: "Scrolled", scrollTop: 5000, viewportPx: 400 }); // a is far off-screen
+            expect(effectiveHeight(s, "a")).toBe(18); // not reset to estimate/default
+        });
+    });
+
+    describe("MeasurementInvalidated — content growth forces a clean re-measure", () => {
+        it("clears the whole RowHeight for the node", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 24 });
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "expanded", cssPx: 200 });
+            const r = update(s, { type: "MeasurementInvalidated", nodeId: "a" });
+            expect(r.state.heights.has("a")).toBe(false);
+            expect(r.events[0]).toMatchObject({ type: "measurement-invalidated", nodeId: "a" });
+            // invalidating an unmeasured node is a no-op (same ref)
+            expect(update(r.state, { type: "MeasurementInvalidated", nodeId: "a" }).state).toBe(r.state);
+        });
+    });
+
+    describe("windowRange — binary search over the prefix sum", () => {
+        const build = (): AgentPaneLayoutState => {
+            let s = initialState();
+            const ids = Array.from({ length: 20 }, (_, i) => `r${i}`);
+            s = apply(s, { type: "NodesChanged", orderedIds: ids });
+            // each row 100px tall (collapsed)
+            for (const id of ids) {
+                s = apply(s, { type: "RowMeasured", nodeId: id, state: "collapsed", cssPx: 100 });
+            }
+            return apply(s, { type: "ScrollMarginChanged", px: 0 });
+        };
+
+        it("returns the rows overlapping the viewport, padded by overscan", () => {
+            let s = build(); // 20 rows × 100px = 2000px; overscan default 5
+            s = apply(s, { type: "Scrolled", scrollTop: 1000, viewportPx: 300 }); // rows 10..12 visible
+            const w = windowRange(s);
+            // first visible = 10, last visible = 12; ±5 overscan, clamped
+            expect(w.startIndex).toBe(5);
+            expect(w.endIndex).toBe(17);
+        });
+
+        it("empty region → empty range", () => {
+            const s = initialState();
+            expect(windowRange(s)).toEqual({ startIndex: 0, endIndex: -1 });
+        });
+
+        it("scrolled past the end → empty range", () => {
+            let s = build();
+            s = apply(s, { type: "Scrolled", scrollTop: 9000, viewportPx: 300 });
+            expect(windowRange(s).endIndex).toBeLessThan(windowRange(s).startIndex);
+        });
+    });
+
+    describe("no-op short-circuits return the same state reference", () => {
+        it("Scrolled / ScrollMarginChanged / RowMeasured idempotence", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a"] });
+            s = apply(s, { type: "Scrolled", scrollTop: 10, viewportPx: 100 });
+            expect(update(s, { type: "Scrolled", scrollTop: 10, viewportPx: 100 }).state).toBe(s);
+            s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 24 });
+            expect(update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 24 }).state).toBe(s);
+            expect(update(s, { type: "UserCollapsed", nodeId: "a" }).state).toBe(s); // already collapsed
+        });
+    });
+});

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -140,10 +140,12 @@ describe("agent-pane-layout reducer", () => {
             }
         });
 
-        it("rejects non-finite / negative measurements (keeps the sum clean)", () => {
+        it("rejects non-finite / non-positive measurements incl. 0 (keeps the sum clean)", () => {
             let s = initialState();
             s = apply(s, { type: "NodesChanged", orderedIds: ["a"] });
-            for (const bad of [NaN, Infinity, -Infinity, -5]) {
+            // 0 is rejected on purpose — a real row is never 0 tall, so a 0 read
+            // is a transient mount/expansion glitch (the stale-0 class). codex P1.
+            for (const bad of [NaN, Infinity, -Infinity, -5, 0]) {
                 const rm = update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: bad });
                 expect(rm.state).toBe(s); // dropped, same ref
                 expect(rm.events[0]).toMatchObject({ type: "command-dropped", reason: "invalid-measure-px" });

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -279,6 +279,14 @@ describe("agent-pane-layout reducer", () => {
             expect(update(s, { type: "NodesChanged", orderedIds: ["a", "b"] }).state).toBe(s);
         });
 
+        it("snapshots the orderedIds payload — caller mutation can't desync state (codex P2)", () => {
+            const mutable = ["a", "b"];
+            const s = apply(initialState(), { type: "NodesChanged", orderedIds: mutable });
+            mutable.pop(); // caller mutates the array AFTER dispatch
+            expect(s.orderedIds).toEqual(["a", "b"]); // state unaffected
+            expect([...s.idSet].sort()).toEqual(["a", "b"]); // idSet still in lockstep
+        });
+
         it("drops a late measurement for a removed id (no stale re-entry)", () => {
             // reagent P2 on #1236: a ResizeObserver firing AFTER NodesChanged
             // removed the row must not write its height back — else re-adding the

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -260,6 +260,22 @@ describe("agent-pane-layout reducer", () => {
             expect(update(s, { type: "NodesChanged", orderedIds: ["a", "b"] }).state).toBe(s);
         });
 
+        it("drops a late measurement for a removed id (no stale re-entry)", () => {
+            // reagent P2 on #1236: a ResizeObserver firing AFTER NodesChanged
+            // removed the row must not write its height back — else re-adding the
+            // id later preserves the obsolete measurement past the prune.
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b"] });
+            s = apply(s, { type: "RowMeasured", nodeId: "b", state: "collapsed", cssPx: 90 });
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a"] }); // b removed
+            const late = update(s, { type: "RowMeasured", nodeId: "b", state: "collapsed", cssPx: 90 });
+            expect(late.state).toBe(s); // dropped, same ref
+            expect(late.events[0]).toMatchObject({ type: "command-dropped", reason: "measure-unknown-id" });
+            // re-add b → it comes back clean (no stale 90), falling to default
+            const readded = apply(s, { type: "NodesChanged", orderedIds: ["a", "b"] });
+            expect(effectiveHeight(readded, "b")).toBe(DEFAULT_ROW_PX);
+        });
+
         it("a measured row that scrolls out (stays in orderedIds) keeps its height", () => {
             // models the stuck-estimate-after-recycle bug being structurally fixed:
             // scroll-out doesn't change orderedIds, so heights survive.

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -144,9 +144,13 @@ describe("agent-pane-layout reducer", () => {
             let s = initialState();
             s = apply(s, { type: "NodesChanged", orderedIds: ["a"] });
             for (const bad of [NaN, Infinity, -Infinity, -5]) {
-                const r = update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: bad });
-                expect(r.state).toBe(s); // dropped, same ref
-                expect(r.events[0]).toMatchObject({ type: "command-dropped" });
+                const rm = update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: bad });
+                expect(rm.state).toBe(s); // dropped, same ref
+                expect(rm.events[0]).toMatchObject({ type: "command-dropped", reason: "invalid-measure-px" });
+                // EstimateSet shares the same isValidPx guard.
+                const es = update(s, { type: "EstimateSet", nodeId: "a", state: "collapsed", cssPx: bad });
+                expect(es.state).toBe(s);
+                expect(es.events[0]).toMatchObject({ type: "command-dropped", reason: "invalid-estimate-px" });
             }
             expect(effectiveHeight(s, "a")).toBe(DEFAULT_ROW_PX);
         });
@@ -289,6 +293,15 @@ describe("agent-pane-layout reducer", () => {
             expect(effectiveHeight(readded, "b")).toBe(DEFAULT_ROW_PX);
         });
 
+        it("drops a late EstimateSet for a removed id (same guard as RowMeasured)", () => {
+            let s = initialState();
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a", "b"] });
+            s = apply(s, { type: "NodesChanged", orderedIds: ["a"] }); // b removed
+            const r = update(s, { type: "EstimateSet", nodeId: "b", state: "collapsed", cssPx: 50 });
+            expect(r.state).toBe(s); // dropped, same ref
+            expect(r.events[0]).toMatchObject({ type: "command-dropped", reason: "estimate-unknown-id" });
+        });
+
         it("a measured row that scrolls out (stays in orderedIds) keeps its height", () => {
             // models the stuck-estimate-after-recycle bug being structurally fixed:
             // scroll-out doesn't change orderedIds, so heights survive.
@@ -357,6 +370,9 @@ describe("agent-pane-layout reducer", () => {
             s = apply(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 24 });
             expect(update(s, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 24 }).state).toBe(s);
             expect(update(s, { type: "UserCollapsed", nodeId: "a" }).state).toBe(s); // already collapsed
+            // EstimateSet with the same value is also a no-op (same ref).
+            s = apply(s, { type: "EstimateSet", nodeId: "a", state: "expanded", cssPx: 200 });
+            expect(update(s, { type: "EstimateSet", nodeId: "a", state: "expanded", cssPx: 200 }).state).toBe(s);
         });
     });
 });

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -1,0 +1,367 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure reducer + selectors for the agent-pane layout slice (#11).
+ * See ./types.ts for the invariants and
+ * docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md.
+ *
+ * The reducer is total and pure: `(state, command) -> { state, events }`,
+ * no I/O, no time, no mutation of inputs. No-ops return the SAME state
+ * reference (so the store's projection-on-change differ short-circuits).
+ */
+
+import {
+    AgentPaneLayoutCommand,
+    AgentPaneLayoutEvent,
+    AgentPaneLayoutState,
+    COLLAPSED,
+    DEFAULT_ROW_PX,
+    Expansion,
+    ExpansionState,
+    expansionEq,
+    inFlowState,
+    ReducerResult,
+    RowHeight,
+} from "./types";
+
+// ── Internal helpers ─────────────────────────────────────────────────
+
+/** A height is usable iff finite and non-negative — anything else would
+ *  poison the prefix-sum (INV-1). */
+function isValidPx(n: number): boolean {
+    return Number.isFinite(n) && n >= 0;
+}
+
+/** Height the layout is CURRENTLY using for (nodeId, state): measured,
+ *  else estimate, else default. Used to compute `row-measured` deltas. */
+function layoutHeightFor(
+    state: AgentPaneLayoutState,
+    nodeId: string,
+    st: ExpansionState,
+): number {
+    const measured = state.heights.get(nodeId)?.[st];
+    if (measured != null) return measured;
+    const est = state.estimates.get(nodeId)?.[st];
+    if (est != null) return est;
+    return DEFAULT_ROW_PX;
+}
+
+/** Set a row's expansion, collapsing === deleting the key (default).
+ *  No-op (same state ref) when unchanged. */
+function setExpansion(
+    state: AgentPaneLayoutState,
+    nodeId: string,
+    to: Expansion,
+): ReducerResult {
+    const from = state.expansion.get(nodeId) ?? COLLAPSED;
+    if (expansionEq(from, to)) return { state, events: [] };
+    const expansion = new Map(state.expansion);
+    if (to.open) expansion.set(nodeId, to);
+    else expansion.delete(nodeId);
+    return {
+        state: { ...state, expansion },
+        events: [{ type: "expansion-changed", nodeId, from, to }],
+    };
+}
+
+/** Write one (nodeId, state) slot into a height-ish map immutably. */
+function withSlot(
+    map: ReadonlyMap<string, RowHeight>,
+    nodeId: string,
+    st: ExpansionState,
+    cssPx: number,
+): ReadonlyMap<string, RowHeight> {
+    const prev = map.get(nodeId);
+    const next: RowHeight = { ...prev, [st]: cssPx };
+    return new Map(map).set(nodeId, next);
+}
+
+// ── Reducer ──────────────────────────────────────────────────────────
+
+export function update(
+    state: AgentPaneLayoutState,
+    command: AgentPaneLayoutCommand,
+): ReducerResult {
+    switch (command.type) {
+        case "NodesChanged": {
+            const next = command.orderedIds;
+            const keep = new Set(next);
+            let removed = 0;
+            for (const id of state.orderedIds) if (!keep.has(id)) removed++;
+            const sameOrder =
+                next.length === state.orderedIds.length && removed === 0;
+            if (sameOrder) {
+                // Same set AND same length → same order (sets equal + lengths
+                // equal ⇒ permutation; but ids are unique, so identical order is
+                // the only reorder we don't separately track). Treat the common
+                // append/no-op case: only short-circuit when the arrays are
+                // referentially or element-wise identical.
+                let identical = true;
+                for (let i = 0; i < next.length; i++) {
+                    if (next[i] !== state.orderedIds[i]) {
+                        identical = false;
+                        break;
+                    }
+                }
+                if (identical) return { state, events: [] };
+            }
+            // Prune heights/estimates/expansion for ids no longer present.
+            const heights = pruneMap(state.heights, keep);
+            const estimates = pruneMap(state.estimates, keep);
+            const expansion = pruneMap(state.expansion, keep);
+            return {
+                state: {
+                    ...state,
+                    orderedIds: next,
+                    heights,
+                    estimates,
+                    expansion,
+                },
+                events: removed > 0 ? [{ type: "ids-pruned", removed }] : [],
+            };
+        }
+
+        case "UserExpanded":
+            return setExpansion(state, command.nodeId, { open: true, via: "pin" });
+
+        case "UserCollapsed":
+            return setExpansion(state, command.nodeId, { open: false });
+
+        case "AutoExpandStarted": {
+            const cur = state.expansion.get(command.nodeId);
+            // A user pin outranks auto-expand — leave it.
+            if (cur?.open && cur.via === "pin") return { state, events: [] };
+            return setExpansion(state, command.nodeId, { open: true, via: "auto" });
+        }
+
+        case "AutoExpandHoldExpired": {
+            const cur = state.expansion.get(command.nodeId);
+            if (!cur?.open || cur.via !== "auto") {
+                // Pinned (or already collapsed) during the hold → expiry is a
+                // no-op. Surface it so the audit shows the suppression.
+                return {
+                    state,
+                    events: [{ type: "command-dropped", reason: "hold-expired-not-auto" }],
+                };
+            }
+            return setExpansion(state, command.nodeId, { open: false });
+        }
+
+        case "RowMeasured": {
+            // Guard the prefix-sum: a NaN/Infinity/negative height would
+            // poison every position downstream (INV-1). Drop, don't store.
+            if (!isValidPx(command.cssPx)) {
+                return {
+                    state,
+                    events: [{ type: "command-dropped", reason: "invalid-measure-px" }],
+                };
+            }
+            const prev = state.heights.get(command.nodeId)?.[command.state];
+            if (prev === command.cssPx) return { state, events: [] };
+            const delta =
+                command.cssPx -
+                layoutHeightFor(state, command.nodeId, command.state);
+            return {
+                state: {
+                    ...state,
+                    heights: withSlot(
+                        state.heights,
+                        command.nodeId,
+                        command.state,
+                        command.cssPx,
+                    ),
+                },
+                events: [
+                    {
+                        type: "row-measured",
+                        nodeId: command.nodeId,
+                        state: command.state,
+                        delta,
+                    },
+                ],
+            };
+        }
+
+        case "EstimateSet": {
+            if (!isValidPx(command.cssPx)) {
+                return {
+                    state,
+                    events: [{ type: "command-dropped", reason: "invalid-estimate-px" }],
+                };
+            }
+            const prev = state.estimates.get(command.nodeId)?.[command.state];
+            if (prev === command.cssPx) return { state, events: [] };
+            return {
+                state: {
+                    ...state,
+                    estimates: withSlot(
+                        state.estimates,
+                        command.nodeId,
+                        command.state,
+                        command.cssPx,
+                    ),
+                },
+                events: [],
+            };
+        }
+
+        case "MeasurementInvalidated": {
+            if (!state.heights.has(command.nodeId)) return { state, events: [] };
+            const heights = new Map(state.heights);
+            heights.delete(command.nodeId);
+            return {
+                state: { ...state, heights },
+                events: [
+                    { type: "measurement-invalidated", nodeId: command.nodeId },
+                ],
+            };
+        }
+
+        case "Scrolled": {
+            if (
+                state.scrollTop === command.scrollTop &&
+                state.viewportPx === command.viewportPx
+            ) {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    scrollTop: command.scrollTop,
+                    viewportPx: command.viewportPx,
+                },
+                events: [],
+            };
+        }
+
+        case "ScrollMarginChanged": {
+            if (state.scrollMarginPx === command.px) return { state, events: [] };
+            return { state: { ...state, scrollMarginPx: command.px }, events: [] };
+        }
+
+        case "ZoomChanged": {
+            // INV-2: zoom never touches heights/positions. The single
+            // ancestor CSS `zoom` re-scales the unzoomed layout at render.
+            if (state.zoom === command.zoom) return { state, events: [] };
+            return {
+                state: { ...state, zoom: command.zoom },
+                events: [{ type: "zoom-changed-no-relayout", zoom: command.zoom }],
+            };
+        }
+    }
+}
+
+/** Immutable filter of a Map down to the `keep` key set. Returns the SAME
+ *  reference when nothing is removed (preserves no-op short-circuiting). */
+function pruneMap<V>(
+    map: ReadonlyMap<string, V>,
+    keep: ReadonlySet<string>,
+): ReadonlyMap<string, V> {
+    let anyRemoved = false;
+    for (const k of map.keys()) {
+        if (!keep.has(k)) {
+            anyRemoved = true;
+            break;
+        }
+    }
+    if (!anyRemoved) return map;
+    const next = new Map<string, V>();
+    for (const [k, v] of map) if (keep.has(k)) next.set(k, v);
+    return next;
+}
+
+// ── Selectors (pure projections — the renderer reads these) ──────────
+
+/** In-flow CSS-px height of a row in its current state: measured, else
+ *  estimate, else default. */
+export function effectiveHeight(
+    state: AgentPaneLayoutState,
+    nodeId: string,
+): number {
+    return layoutHeightFor(state, nodeId, inFlowState(state.expansion.get(nodeId)));
+}
+
+export interface RowPosition {
+    nodeId: string;
+    index: number;
+    /** Unzoomed CSS px from the scroll-container top, includes scrollMargin. */
+    start: number;
+    height: number;
+    /** === start + height === next row's start (INV-1). */
+    end: number;
+}
+
+/** Prefix-sum positions over the full virtualized region. O(n).
+ *  start[i+1] === end[i] by construction → slots never overlap (INV-1). */
+export function positions(state: AgentPaneLayoutState): RowPosition[] {
+    const out: RowPosition[] = new Array(state.orderedIds.length);
+    let cursor = state.scrollMarginPx;
+    for (let i = 0; i < state.orderedIds.length; i++) {
+        const nodeId = state.orderedIds[i];
+        const height = effectiveHeight(state, nodeId);
+        const start = cursor;
+        const end = start + height;
+        out[i] = { nodeId, index: i, start, height, end };
+        cursor = end;
+    }
+    return out;
+}
+
+/** Total scrollable height of the virtualized region (excludes scrollMargin,
+ *  which is contributed by the header element above it). */
+export function totalSize(state: AgentPaneLayoutState): number {
+    let sum = 0;
+    for (const id of state.orderedIds) sum += effectiveHeight(state, id);
+    return sum;
+}
+
+/** Inclusive visible-row index range, padded by overscan. An empty region
+ *  returns `{ startIndex: 0, endIndex: -1 }` (start > end ⇒ render nothing). */
+export interface WindowRange {
+    startIndex: number;
+    endIndex: number;
+}
+
+export function windowRange(state: AgentPaneLayoutState): WindowRange {
+    const pos = positions(state);
+    if (pos.length === 0) return { startIndex: 0, endIndex: -1 };
+
+    const top = state.scrollTop;
+    const bottom = state.scrollTop + state.viewportPx;
+
+    // First row whose `end > top` (lowest index still visible at the top edge).
+    let lo = 0;
+    let hi = pos.length - 1;
+    let first = pos.length; // sentinel: none visible
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (pos[mid].end > top) {
+            first = mid;
+            hi = mid - 1;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    if (first === pos.length) return { startIndex: 0, endIndex: -1 };
+
+    // Last row whose `start < bottom` (highest index still visible).
+    lo = 0;
+    hi = pos.length - 1;
+    let last = -1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (pos[mid].start < bottom) {
+            last = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    if (last < first) return { startIndex: 0, endIndex: -1 };
+
+    return {
+        startIndex: Math.max(0, first - state.overscan),
+        endIndex: Math.min(pos.length - 1, last + state.overscan),
+    };
+}

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -27,10 +27,14 @@ import {
 
 // ── Internal helpers ─────────────────────────────────────────────────
 
-/** A height is usable iff finite and non-negative — anything else would
- *  poison the prefix-sum (INV-1). */
+/** A height is usable iff finite and STRICTLY positive. Zero is rejected on
+ *  purpose: a real row is never 0 tall (it has at least a summary line), so a
+ *  `getBoundingClientRect().height` of 0 is a transient bad read during
+ *  mount/expansion — storing it is exactly the stale-`0` class behind the
+ *  #1234 overlap. A rejected row keeps its estimate/default until a real >0
+ *  measurement arrives. (codex P1 on #1236.) */
 function isValidPx(n: number): boolean {
-    return Number.isFinite(n) && n >= 0;
+    return Number.isFinite(n) && n > 0;
 }
 
 /** Height the layout is CURRENTLY using for (nodeId, state): measured,

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -114,6 +114,7 @@ export function update(
                 state: {
                     ...state,
                     orderedIds: next,
+                    idSet: keep,
                     heights,
                     estimates,
                     expansion,
@@ -149,6 +150,16 @@ export function update(
         }
 
         case "RowMeasured": {
+            // Drop measurements for ids not in the current document: a late
+            // ResizeObserver callback for an already-removed row would otherwise
+            // write a height back that survives the next prune (it'd re-enter
+            // with a stale measurement). reagent P2 on #1236.
+            if (!state.idSet.has(command.nodeId)) {
+                return {
+                    state,
+                    events: [{ type: "command-dropped", reason: "measure-unknown-id" }],
+                };
+            }
             // Guard the prefix-sum: a NaN/Infinity/negative height would
             // poison every position downstream (INV-1). Drop, don't store.
             if (!isValidPx(command.cssPx)) {
@@ -184,6 +195,12 @@ export function update(
         }
 
         case "EstimateSet": {
+            if (!state.idSet.has(command.nodeId)) {
+                return {
+                    state,
+                    events: [{ type: "command-dropped", reason: "estimate-unknown-id" }],
+                };
+            }
             if (!isValidPx(command.cssPx)) {
                 return {
                     state,
@@ -323,12 +340,18 @@ export interface WindowRange {
     endIndex: number;
 }
 
-export function windowRange(state: AgentPaneLayoutState): WindowRange {
-    const pos = positions(state);
+/** Window over an ALREADY-COMPUTED positions array — lets the store share
+ *  one prefix-sum pass across rows/totalSize/window (O(n), not O(3n)). */
+export function windowRangeOf(
+    pos: ReadonlyArray<RowPosition>,
+    scrollTop: number,
+    viewportPx: number,
+    overscan: number,
+): WindowRange {
     if (pos.length === 0) return { startIndex: 0, endIndex: -1 };
 
-    const top = state.scrollTop;
-    const bottom = state.scrollTop + state.viewportPx;
+    const top = scrollTop;
+    const bottom = scrollTop + viewportPx;
 
     // First row whose `end > top` (lowest index still visible at the top edge).
     let lo = 0;
@@ -361,7 +384,38 @@ export function windowRange(state: AgentPaneLayoutState): WindowRange {
     if (last < first) return { startIndex: 0, endIndex: -1 };
 
     return {
-        startIndex: Math.max(0, first - state.overscan),
-        endIndex: Math.min(pos.length - 1, last + state.overscan),
+        startIndex: Math.max(0, first - overscan),
+        endIndex: Math.min(pos.length - 1, last + overscan),
     };
+}
+
+export function windowRange(state: AgentPaneLayoutState): WindowRange {
+    return windowRangeOf(
+        positions(state),
+        state.scrollTop,
+        state.viewportPx,
+        state.overscan,
+    );
+}
+
+/** The render-ready layout view. Computes the prefix-sum ONCE and derives
+ *  totalSize + window from it — the single O(n) pass the store projects. */
+export interface LayoutView {
+    rows: RowPosition[];
+    totalSize: number;
+    window: WindowRange;
+}
+
+export function computeLayoutView(state: AgentPaneLayoutState): LayoutView {
+    const rows = positions(state);
+    const total = rows.length === 0
+        ? 0
+        : rows[rows.length - 1].end - state.scrollMarginPx;
+    const window = windowRangeOf(
+        rows,
+        state.scrollTop,
+        state.viewportPx,
+        state.overscan,
+    );
+    return { rows, totalSize: total, window };
 }

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -47,6 +47,14 @@ function layoutHeightFor(
     return DEFAULT_ROW_PX;
 }
 
+/** An expansion command targeting an id absent from the current document is
+ *  dropped — otherwise it would write expansion that survives the next prune
+ *  and re-enter stale when the id is re-added (same hazard the measurement
+ *  guard covers). reagent P2 on #1236. */
+function droppedUnknownExpansion(state: AgentPaneLayoutState): ReducerResult {
+    return { state, events: [{ type: "command-dropped", reason: "expansion-unknown-id" }] };
+}
+
 /** Set a row's expansion, collapsing === deleting the key (default).
  *  No-op (same state ref) when unchanged. */
 function setExpansion(
@@ -89,23 +97,20 @@ export function update(
             const keep = new Set(next);
             let removed = 0;
             for (const id of state.orderedIds) if (!keep.has(id)) removed++;
-            const sameOrder =
-                next.length === state.orderedIds.length && removed === 0;
-            if (sameOrder) {
-                // Same set AND same length → same order (sets equal + lengths
-                // equal ⇒ permutation; but ids are unique, so identical order is
-                // the only reorder we don't separately track). Treat the common
-                // append/no-op case: only short-circuit when the arrays are
-                // referentially or element-wise identical.
-                let identical = true;
+            // Short-circuit ONLY on an element-wise identical array (same ids,
+            // same order). A same-set-same-length permutation (reorder) is NOT
+            // identical and must fall through so the new order is stored — do
+            // not weaken this to a set/length check.
+            let identical = next.length === state.orderedIds.length;
+            if (identical) {
                 for (let i = 0; i < next.length; i++) {
                     if (next[i] !== state.orderedIds[i]) {
                         identical = false;
                         break;
                     }
                 }
-                if (identical) return { state, events: [] };
             }
+            if (identical) return { state, events: [] };
             // Prune heights/estimates/expansion for ids no longer present.
             const heights = pruneMap(state.heights, keep);
             const estimates = pruneMap(state.estimates, keep);
@@ -124,12 +129,15 @@ export function update(
         }
 
         case "UserExpanded":
+            if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
             return setExpansion(state, command.nodeId, { open: true, via: "pin" });
 
         case "UserCollapsed":
+            if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
             return setExpansion(state, command.nodeId, { open: false });
 
         case "AutoExpandStarted": {
+            if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
             const cur = state.expansion.get(command.nodeId);
             // A user pin outranks auto-expand — leave it.
             if (cur?.open && cur.via === "pin") return { state, events: [] };
@@ -137,6 +145,7 @@ export function update(
         }
 
         case "AutoExpandHoldExpired": {
+            if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
             const cur = state.expansion.get(command.nodeId);
             if (!cur?.open || cur.via !== "auto") {
                 // Pinned (or already collapsed) during the hold → expiry is a

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -122,7 +122,12 @@ export function update(
             return {
                 state: {
                     ...state,
-                    orderedIds: next,
+                    // Snapshot the payload: `ReadonlyArray` is a compile-time
+                    // contract, not a runtime guarantee. A caller could pass a
+                    // live array and later mutate it, which would silently change
+                    // `orderedIds` without rebuilding `idSet` / re-pruning the
+                    // maps. (codex P2 on #1236.)
+                    orderedIds: [...next],
                     idSet: keep,
                     heights,
                     estimates,

--- a/frontend/app/store/agent-pane-layout/types.ts
+++ b/frontend/app/store/agent-pane-layout/types.ts
@@ -51,6 +51,10 @@ export interface AgentPaneLayoutState {
     readonly zoom: number;
     /** FULL virtualized-region node ids, in order (not just the visible window). */
     readonly orderedIds: ReadonlyArray<string>;
+    /** Membership index over `orderedIds`, kept in lockstep by `NodesChanged`.
+     *  O(1) guard so a late `RowMeasured` for an already-removed id is dropped
+     *  instead of re-entering the heights map and surviving the next prune. */
+    readonly idSet: ReadonlySet<string>;
     /** Open rows only (collapsed === absent). */
     readonly expansion: ReadonlyMap<string, Expansion>;
     /** Measured heights, per state, unzoomed CSS px. */
@@ -75,6 +79,7 @@ export const DEFAULT_OVERSCAN = 5;
 export const initialState = (): AgentPaneLayoutState => ({
     zoom: 1,
     orderedIds: [],
+    idSet: new Set(),
     expansion: new Map(),
     heights: new Map(),
     estimates: new Map(),

--- a/frontend/app/store/agent-pane-layout/types.ts
+++ b/frontend/app/store/agent-pane-layout/types.ts
@@ -107,6 +107,12 @@ export type AgentPaneLayoutCommand =
     | { type: "ZoomChanged"; zoom: number };
 
 export type AgentPaneLayoutEvent =
+    // `delta` is SLOT-SPECIFIC: `cssPx - priorHeightFor(nodeId, state)` for the
+    // measured `state` only. It equals the row's change in prefix-sum
+    // contribution ONLY when `state === inFlowState(expansion.get(nodeId))`
+    // (i.e. the measured slot is the one currently rendered). A consumer must
+    // NOT add `delta` to `totalSize` unconditionally — recompute from the
+    // selectors, or gate on the current in-flow state first.
     | { type: "row-measured"; nodeId: string; state: ExpansionState; delta: number }
     | { type: "expansion-changed"; nodeId: string; from: Expansion; to: Expansion }
     | { type: "measurement-invalidated"; nodeId: string }

--- a/frontend/app/store/agent-pane-layout/types.ts
+++ b/frontend/app/store/agent-pane-layout/types.ts
@@ -1,0 +1,125 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane layout state machine — Slice #11.
+ *
+ * Owns the deterministic layout model for the agent document's
+ * VIRTUALIZED region: per-row in-flow heights (measured + estimated,
+ * keyed by expansion state), unified expansion state, zoom, and the
+ * scroll viewport. Rendered positions are a PURE prefix-sum projection,
+ * so consecutive row slots are flush by construction and overlap is
+ * impossible — the bug class behind #1231 / #1233 / #1235.
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md.
+ * Conventions: docs/specs/frontend-reducer-conventions-2026-05-03.md.
+ *
+ * Phase 0 (this file's slice): pure core + store + tests, NO render-path
+ * wiring and NO behaviour change. Phases 1–4 wire it in (see spec §6).
+ *
+ * Invariants (proven by reducer.test.ts):
+ *   INV-1  positions() is a prefix-sum of in-flow heights → start[i+1] === end[i].
+ *   INV-2  heights/positions are unzoomed CSS px; `ZoomChanged` never relayouts.
+ *   INV-3  measurements are keyed by (nodeId, ExpansionState) — an expanded
+ *          measurement never contaminates the collapsed slot.
+ */
+
+/** In-flow footprint state — the only thing that drives the prefix-sum.
+ *  Hover-peek "overlay" is presentational (absolute layer, summary stays
+ *  in flow), so it is NOT a layout input. Layout is binary. */
+export type ExpansionState = "collapsed" | "expanded";
+
+/** Why a row is open. A user pin outlives an auto-expand: a hold expiry
+ *  collapses an `auto` row but is a no-op on a `pin` row. Mirrors today's
+ *  `pinnedNodes` ∪ `autoExpanded()`. Collapsed rows are stored as ABSENT
+ *  from the expansion map (default), keeping it small. */
+export type Expansion =
+    | { open: false }
+    | { open: true; via: "pin" | "auto" };
+
+export const COLLAPSED: Expansion = { open: false };
+
+/** Measured/estimated CSS-px height per in-flow state (INV-3).
+ *  `undefined` = not yet measured/estimated for that state. */
+export interface RowHeight {
+    collapsed?: number;
+    expanded?: number;
+}
+
+export interface AgentPaneLayoutState {
+    /** INV-2: layout is zoom-INVARIANT; this only scales the final render. */
+    readonly zoom: number;
+    /** FULL virtualized-region node ids, in order (not just the visible window). */
+    readonly orderedIds: ReadonlyArray<string>;
+    /** Open rows only (collapsed === absent). */
+    readonly expansion: ReadonlyMap<string, Expansion>;
+    /** Measured heights, per state, unzoomed CSS px. */
+    readonly heights: ReadonlyMap<string, RowHeight>;
+    /** Estimator output, per state — fallback when unmeasured. */
+    readonly estimates: ReadonlyMap<string, RowHeight>;
+    /** Unzoomed CSS px — windowing input. */
+    readonly scrollTop: number;
+    /** Scroll-container clientHeight ÷ zoom (unzoomed CSS px). */
+    readonly viewportPx: number;
+    /** Header offset above the virtualized region (unzoomed CSS px). */
+    readonly scrollMarginPx: number;
+    /** Extra rows rendered beyond the viewport, each side. */
+    readonly overscan: number;
+}
+
+/** Height used when a row has neither a measurement nor an estimate for its
+ *  current state. Matches the historical `estimateSize` fallback. */
+export const DEFAULT_ROW_PX = 32;
+export const DEFAULT_OVERSCAN = 5;
+
+export const initialState = (): AgentPaneLayoutState => ({
+    zoom: 1,
+    orderedIds: [],
+    expansion: new Map(),
+    heights: new Map(),
+    estimates: new Map(),
+    scrollTop: 0,
+    viewportPx: 0,
+    scrollMarginPx: 0,
+    overscan: DEFAULT_OVERSCAN,
+});
+
+export type AgentPaneLayoutCommand =
+    // ── document shape ──────────────────────────────────────────────
+    | { type: "NodesChanged"; orderedIds: ReadonlyArray<string> }
+    // ── expansion (unified; replaces the scattered component signals) ─
+    | { type: "UserExpanded"; nodeId: string }
+    | { type: "UserCollapsed"; nodeId: string }
+    | { type: "AutoExpandStarted"; nodeId: string }
+    | { type: "AutoExpandHoldExpired"; nodeId: string }
+    // ── measurement ingest (normalized ÷zoom at the boundary) ───────
+    | { type: "RowMeasured"; nodeId: string; state: ExpansionState; cssPx: number }
+    | { type: "EstimateSet"; nodeId: string; state: ExpansionState; cssPx: number }
+    | { type: "MeasurementInvalidated"; nodeId: string }
+    // ── viewport / zoom ─────────────────────────────────────────────
+    | { type: "Scrolled"; scrollTop: number; viewportPx: number }
+    | { type: "ScrollMarginChanged"; px: number }
+    | { type: "ZoomChanged"; zoom: number };
+
+export type AgentPaneLayoutEvent =
+    | { type: "row-measured"; nodeId: string; state: ExpansionState; delta: number }
+    | { type: "expansion-changed"; nodeId: string; from: Expansion; to: Expansion }
+    | { type: "measurement-invalidated"; nodeId: string }
+    | { type: "zoom-changed-no-relayout"; zoom: number }
+    | { type: "ids-pruned"; removed: number }
+    | { type: "command-dropped"; reason: string };
+
+export interface ReducerResult {
+    state: AgentPaneLayoutState;
+    events: AgentPaneLayoutEvent[];
+}
+
+/** Pure: current in-flow footprint of a row from its expansion value. */
+export const inFlowState = (e: Expansion | undefined): ExpansionState =>
+    e?.open ? "expanded" : "collapsed";
+
+/** Pure: are two expansion values equal? */
+export function expansionEq(a: Expansion, b: Expansion): boolean {
+    if (!a.open && !b.open) return true;
+    return a.open && b.open && a.via === b.via;
+}


### PR DESCRIPTION
## Why

The agent-pane bugs we chased this week — overlap-under-zoom (#1231), stuck-estimate rows (#1233), expand crash + measurement drift (#1234, #1235) — are **one disease**: three uncoordinated sources of truth for *how tall is row N and where does it sit*:

1. **TanStack's imperative `itemSizeCache`** (ResizeObserver-mutated, races, caches the `0`/`784` garbage that never reconverges — and isn't ours, so #1235 is unfixable locally)
2. **Expansion state split** between the reducer (`collapsedNodes`/`pinnedNodes`) and **invisible component-local signals** (`postCompletionHold`, canceled-thinking `expanded`)
3. **Zoom** as a CSS layer + scattered `÷zoom`

Because height isn't deterministic state, the system can't know a row's target height synchronously on expansion — it mutates the DOM and waits for a racy ResizeObserver. That wait is the bug.

## What

**Slice #11 `agent-pane-layout`** — a per-pane reducer that owns row heights + expansion + zoom as pure state, with rendered positions a **pure prefix-sum projection**. Three invariants, each retiring a bug class, **all proven by tests**:

- **INV-1** — `positions()` is a prefix-sum ⇒ `start[i+1] === end[i]` **by construction** ⇒ slots can never overlap. A stale height degrades to a gap/jump, never the −20.9px overlap. *(closes the #1235 class)*
- **INV-2** — heights/positions are unzoomed CSS px; `ZoomChanged` never relayouts. *(formalizes #1231)*
- **INV-3** — measurements keyed by `(nodeId, ExpansionState)` — an expanded measurement can't contaminate the collapsed slot (the `0`/`784` of #1234); an expand toggle resolves to a known target height synchronously.

## Scope — Phase 0 only: pure + isolated

**No render-path wiring, no behaviour change.** This is the foundation: the slice (`types`/`reducer`/selectors), the store (slot lifecycle + projection-on-change + audit ring, mirroring slices #9/#10), and **25 tests** — all green:

- **property test:** 40 seeds × 120 random commands = **4,800 applications**, INV-1 holds after *every* one
- cross-product (expansion × measured × state-keyed), zoom-invariance, prune-by-set-membership (the stuck-after-recycle fix), pin-outranks-auto + hold-expiry, non-finite/negative measurement rejection, `windowRange` binary search, no-op short-circuits

Phases 1–4 (wiring the renderer to project from the slice, unifying the scattered expansion signals, retiring TanStack's cache) follow as **separate verified PRs** per spec §6 — deliberately not big-banged.

## Spec

`docs/specs/SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md` — design + resolved open questions (§11) + phasing (§6) + testing (§7). Tracks #1235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)