### PR TITLE
fix(agent-pane): keep tool body visible during collapse animation (content-visibility allow-discrete)

### DIFF
--- a/.changesets/1780409073-fix-agent-pane-keep-tool-body-visible-during-collapse-animat-a45m.md
+++ b/.changesets/1780409073-fix-agent-pane-keep-tool-body-visible-during-collapse-animat-a45m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): keep tool body visible during collapse animation (content-visibility allow-discrete)

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -287,7 +287,13 @@
                 max-height 120ms cubic-bezier(0.4, 0, 0.2, 1),
                 padding 120ms cubic-bezier(0.4, 0, 0.2, 1),
                 margin 120ms cubic-bezier(0.4, 0, 0.2, 1),
-                opacity 100ms ease-out;
+                opacity 100ms ease-out,
+                // `content-visibility` is discrete; `allow-discrete` lets it
+                // animate with the collapse — it flips to `hidden` at the END of
+                // the close (body stays rendered through the 120ms shrink) and to
+                // visible at the START of the open. Without it the body pops out
+                // the instant `--hidden` is added. (Chromium 117+.)
+                content-visibility 120ms allow-discrete;
 
             &--hidden {
                 max-height: 0;


### PR DESCRIPTION
## Summary

Follow-up to #1234 — addresses a **codex P2 that was posted on #1234 but not caught before merge** (my review monitor was reading codex's issue-comment summary, not its inline review findings; now fixed).

#1234 added `content-visibility: hidden` to `.agent-tool-panel--hidden` for the ~10× zoom-reflow win. But `content-visibility` is a **discrete** property and wasn't part of the transition, so Chromium stops rendering the descendants the instant `--hidden` is applied — the tool output **pops out at the start of every auto-collapse / unpin** instead of staying visible through the documented 120 ms fade/shrink.

## Fix

Add `content-visibility 120ms allow-discrete` to the panel transition. The discrete flip then happens at the **end** of the close (body stays rendered through the shrink) and the **start** of the open. (Chromium 117+; the bundled CEF supports it.)

## Verified live (CDP)

| moment | `content-visibility` |
|---|---|
| collapsed steady-state | `hidden` (perf win intact — contained) |
| **collapse + 50ms (mid-transition)** | **`visible`** ✅ (was instantly `hidden` before) |
| collapse + 170ms (after 120ms) | `hidden` |

The zoom-reflow perf win from #1234 is unchanged — collapsed steady-state is still `content-visibility: hidden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)