### PR TITLE
feat(agent-pane): Phase 1b — shadow-populate the layout slice's expansion

### DIFF
--- a/.changesets/1780421281-feat-agent-pane-phase-1b-populate-layout-slice-expansion-fro-qx2r.md
+++ b/.changesets/1780421281-feat-agent-pane-phase-1b-populate-layout-slice-expansion-fro-qx2r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): Phase 1b — populate layout slice expansion from the live document (dev shadow)

--- a/frontend/app/store/agent-pane-layout/reducer.test.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.test.ts
@@ -252,6 +252,25 @@ describe("agent-pane-layout reducer", () => {
             expect(r.state).toBe(s);
             expect(r.events[0]).toMatchObject({ type: "command-dropped", reason: "expansion-unknown-id" });
         });
+
+        it("ExpansionResolved sets the exact value (incl. via:default, which survives a hold-expiry)", () => {
+            let s = withRow();
+            s = apply(s, { type: "ExpansionResolved", nodeId: "t", to: { open: true, via: "default" } });
+            expect(s.expansion.get("t")).toEqual({ open: true, via: "default" });
+            // a via:"default" open is NOT auto, so a hold-expiry is a no-op on it
+            const held = update(s, { type: "AutoExpandHoldExpired", nodeId: "t" });
+            expect(held.state.expansion.get("t")).toEqual({ open: true, via: "default" });
+            // resolving back to collapsed clears the key
+            s = apply(s, { type: "ExpansionResolved", nodeId: "t", to: { open: false } });
+            expect(s.expansion.has("t")).toBe(false);
+        });
+
+        it("ExpansionResolved drops for an unknown id", () => {
+            const s = withRow();
+            const r = update(s, { type: "ExpansionResolved", nodeId: "ghost", to: { open: true, via: "default" } });
+            expect(r.state).toBe(s);
+            expect(r.events[0]).toMatchObject({ type: "command-dropped", reason: "expansion-unknown-id" });
+        });
     });
 
     describe("NodesChanged — pruning by set membership", () => {

--- a/frontend/app/store/agent-pane-layout/reducer.ts
+++ b/frontend/app/store/agent-pane-layout/reducer.ts
@@ -137,6 +137,12 @@ export function update(
             };
         }
 
+        case "ExpansionResolved":
+            // Authoritative resolved value (currentExpansion already applied the
+            // per-kind precedence) — just set it. No "pin wins" guard here.
+            if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
+            return setExpansion(state, command.nodeId, command.to);
+
         case "UserExpanded":
             if (!state.idSet.has(command.nodeId)) return droppedUnknownExpansion(state);
             return setExpansion(state, command.nodeId, { open: true, via: "pin" });

--- a/frontend/app/store/agent-pane-layout/types.ts
+++ b/frontend/app/store/agent-pane-layout/types.ts
@@ -104,6 +104,12 @@ export type AgentPaneLayoutCommand =
     | { type: "UserCollapsed"; nodeId: string }
     | { type: "AutoExpandStarted"; nodeId: string }
     | { type: "AutoExpandHoldExpired"; nodeId: string }
+    // Set a row's expansion to a fully-resolved value. The Phase-1 wiring
+    // computes `currentExpansion(node, documentState)` (which already encodes
+    // the pin > auto > default precedence per kind) and pushes it here, so the
+    // slice mirrors the rendered open/closed state from one source. The
+    // semantic commands above remain for Phase-2 transient timing (the hold).
+    | { type: "ExpansionResolved"; nodeId: string; to: Expansion }
     // ── measurement ingest (normalized ÷zoom at the boundary) ───────
     | { type: "RowMeasured"; nodeId: string; state: ExpansionState; cssPx: number }
     | { type: "EstimateSet"; nodeId: string; state: ExpansionState; cssPx: number }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -212,10 +212,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         createEffect(() => {
             const nodes = agentAtoms().documentAtom[0]();
             const docState = agentAtoms().documentStateAtom[0]();
-            dispatchLayout(model.blockId, {
-                type: "NodesChanged",
-                orderedIds: nodes.map((n) => n.id),
-            });
+            const ids = nodes.map((n) => n.id);
+            dispatchLayout(model.blockId, { type: "NodesChanged", orderedIds: ids });
+            // Prune the diff cache to mirror the slice's own prune. Otherwise a
+            // node removed (slice deletes its expansion) then re-added with an
+            // unchanged resolved value is short-circuited as "unchanged" and
+            // never re-dispatched — the shadow silently diverges in exactly the
+            // prune/re-add churn case. (reagent + codex on #1239.)
+            const idSet = new Set(ids);
+            for (const k of pushed.keys()) if (!idSet.has(k)) pushed.delete(k);
             for (const node of nodes) {
                 const next = currentExpansion(node, docState);
                 const key = JSON.stringify(next);

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -23,6 +23,13 @@ import {
     registerActivity as registerAgentActivity,
     unregisterActivity as unregisterAgentActivity,
 } from "@/app/store/agentActivity";
+import {
+    dispatch as dispatchLayout,
+    registerPane as registerLayoutPane,
+    snapshot as layoutSnapshot,
+    unregisterPane as unregisterLayoutPane,
+} from "@/app/store/agent-pane-layout-store";
+import { currentExpansion } from "./virtualization/expansion-source";
 import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -187,6 +194,44 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             unregisterAgentPane(model.blockId);
             unregisterAgentActivity(model.blockId);
         });
+    }
+
+    // ── Phase 1b (DEV-ONLY shadow): populate the agent-pane-layout slice's
+    //    expansion from the live document and validate that it mirrors the
+    //    rendered open/closed state. Nothing renders FROM the slice yet
+    //    (Phase 3), so this is gated to dev — zero production cost, zero
+    //    behaviour change. The adapter pushes `currentExpansion(node, …)`
+    //    (the single per-kind source of truth, PR #1238) via
+    //    `ExpansionResolved`. See SPEC_AGENT_PANE_LAYOUT_REDUCER §6.
+    if (import.meta.env.DEV) {
+        registerLayoutPane(model.blockId, { layout: () => {}, zoom: () => {} });
+        onCleanup(() => unregisterLayoutPane(model.blockId));
+        // nodeId → JSON(Expansion) of the last value pushed, so we only
+        // dispatch genuine changes (most effect re-runs touch few rows).
+        const pushed = new Map<string, string>();
+        createEffect(() => {
+            const nodes = agentAtoms().documentAtom[0]();
+            const docState = agentAtoms().documentStateAtom[0]();
+            dispatchLayout(model.blockId, {
+                type: "NodesChanged",
+                orderedIds: nodes.map((n) => n.id),
+            });
+            for (const node of nodes) {
+                const next = currentExpansion(node, docState);
+                const key = JSON.stringify(next);
+                if (pushed.get(node.id) !== key) {
+                    pushed.set(node.id, key);
+                    dispatchLayout(model.blockId, {
+                        type: "ExpansionResolved",
+                        nodeId: node.id,
+                        to: next,
+                    });
+                }
+            }
+        });
+        // CDP validation hook (dev only): read the slice's resolved state.
+        (window as unknown as { __agentLayout?: () => unknown }).__agentLayout = () =>
+            layoutSnapshot(model.blockId);
     }
 
     // Activity log — collects per-session diagnostic entries from launch


### PR DESCRIPTION
## Summary

**Phase 1b** of the agent-pane layout state-machine (follows Phase 0 #1236, Phase 1a #1238; spec `SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md` §6).

Wires the slice to the live document via the `currentExpansion` mapper: an `agent-view` adapter dispatches `NodesChanged` + `ExpansionResolved(currentExpansion(node, documentState))` per node, so the slice's `expansion` mirrors the rendered open/closed state **from one source**.

**DEV-ONLY** (`import.meta.env.DEV`) — nothing renders *from* the slice yet (that's Phase 3), so this is pure **shadow population + validation**: zero production cost, zero behaviour change. The spec's shadow step.

## What's here
- `agent-view` dev adapter: register the layout pane + push resolved expansion, diffed (only genuine changes dispatch). Exposes `window.__agentLayout` for CDP validation.
- `ExpansionResolved` command (the slice setter the adapter pushes through; idSet-guarded; `via:"default"` survives a hold-expiry) + tests.

## Verified live (CDP)
- **Static:** 145 nodes populated; `slice.expansion` matches the DOM open/closed for **all 32 on-screen tool rows — 0 mismatches**.
- **Reactive:** pin a collapsed tool → slice `{open, via:"pin"}` + DOM expanded; unpin → slice collapsed. The adapter tracks `documentState` correctly.

## Next
- **Phase 2:** route measurement through the slice + move the two transients (3 s post-completion hold, canceled-thinking click) in.
- **Phase 3:** render positions from the slice — **where #1235 is structurally fixed** (overlap impossible by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)