### PR TITLE
feat(providers): add Qwen Code provider

### DIFF
--- a/.changesets/1780445997-feat-providers-add-qwen-code-provider-vgx7.md
+++ b/.changesets/1780445997-feat-providers-add-qwen-code-provider-vgx7.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(providers): add Qwen Code provider

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -631,7 +631,8 @@ impl Controller for ShellController {
         let is_agent = agent_id_for_jekt.is_some()
             || cmd_str.to_lowercase().contains("claude")
             || cmd_str.to_lowercase().contains("codex")
-            || cmd_str.to_lowercase().contains("gemini");
+            || cmd_str.to_lowercase().contains("gemini")
+            || cmd_str.to_lowercase().contains("qwen");
 
         // Register PID and record spawn metadata.
         let spawn_ts_ms = SystemTime::now()

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -177,6 +177,37 @@ static GEMINI: ProviderConfig = ProviderConfig {
     docs_url: "https://ai.google.dev/gemini-cli",
 };
 
+// Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
+// Same stream-json headless surface, so it reuses the Gemini translator.
+// Backend is OpenAI-compatible (OPENAI_BASE_URL=https://openrouter.ai/api/v1
+// + OPENAI_API_KEY/OPENAI_MODEL), so it runs any OpenRouter model.
+static QWEN: ProviderConfig = ProviderConfig {
+    id: "qwen",
+    display_name: "Qwen Code",
+    cli_command: "qwen",
+    controller_type: ControllerType::Subprocess,
+    // -p: non-interactive; --output-format stream-json: NDJSON events;
+    // --yolo: auto-approve all tools. Mirrors GEMINI (its upstream).
+    launch_args: &["--output-format", "stream-json", "--yolo", "-p", ""],
+    persistent_launch_args: None,
+    // Docs mention --resume <id>/--continue but it's unconfirmed for the
+    // headless stream-json path; multi-turn re-runs like Codex/Kimi (None).
+    resume_flag: None,
+    session_id_field: "session_id",
+    // Gemini-CLI fork → same stream-json schema; reuse the gemini translator.
+    styled_output_format: "gemini-json",
+    // QWEN_HOME relocates the config/credentials dir (default ~/.qwen),
+    // the Qwen analogue of GEMINI_CLI_HOME — gives per-agent auth isolation.
+    auth_config_dir_env_var: "QWEN_HOME",
+    auth_dir_name: "qwen",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@qwen-code/qwen-code",
+    pinned_version: "latest",
+    icon: "feather",
+    docs_url: "https://qwenlm.github.io/qwen-code-docs",
+};
+
 static KIMI: ProviderConfig = ProviderConfig {
     id: "kimi",
     display_name: "Kimi Code CLI",
@@ -287,6 +318,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(CLAUDE.id, &CLAUDE);
     m.insert(CODEX.id, &CODEX);
     m.insert(GEMINI.id, &GEMINI);
+    m.insert(QWEN.id, &QWEN);
     m.insert(KIMI.id, &KIMI);
     m.insert(OPENCLAW.id, &OPENCLAW);
     m.insert(PI.id, &PI);
@@ -301,6 +333,8 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
     m.insert("claude_code", "claude");
     m.insert("codex-cli", "codex");
     m.insert("gemini-cli", "gemini");
+    m.insert("qwen-code", "qwen");
+    m.insert("qwen3-coder", "qwen");
     m.insert("kimi-cli", "kimi");
     m.insert("kimi_code", "kimi");
     m.insert("openclaw-cli", "openclaw");
@@ -345,7 +379,8 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
 /// Return an iterator over all registered providers in insertion order.
 pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
     // Stable canonical order matches the TypeScript PROVIDERS object order.
-    static ORDER: &[&str] = &["claude", "codex", "gemini", "kimi", "openclaw", "pi", "copilot"];
+    static ORDER: &[&str] =
+        &["claude", "codex", "gemini", "qwen", "kimi", "openclaw", "pi", "copilot"];
     ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
 }
 
@@ -362,6 +397,7 @@ mod tests {
         assert!(get_provider("gemini").is_some());
         assert!(get_provider("kimi").is_some());
         assert!(get_provider("openclaw").is_some());
+        assert!(get_provider("qwen").is_some());
     }
 
     #[test]
@@ -370,6 +406,8 @@ mod tests {
         assert_eq!(get_provider("claude_code").unwrap().id, "claude");
         assert_eq!(get_provider("codex-cli").unwrap().id, "codex");
         assert_eq!(get_provider("gemini-cli").unwrap().id, "gemini");
+        assert_eq!(get_provider("qwen-code").unwrap().id, "qwen");
+        assert_eq!(get_provider("qwen3-coder").unwrap().id, "qwen");
         assert_eq!(get_provider("kimi-cli").unwrap().id, "kimi");
         assert_eq!(get_provider("openclaw-cli").unwrap().id, "openclaw");
     }
@@ -380,11 +418,11 @@ mod tests {
     }
 
     #[test]
-    fn provider_list_has_seven_entries() {
+    fn provider_list_has_eight_entries() {
         // Update this when a provider is added or removed; a stale
         // count is the cheapest detection mechanism for accidental
         // additions.
-        assert_eq!(get_provider_list().count(), 7);
+        assert_eq!(get_provider_list().count(), 8);
     }
 
     #[test]

--- a/agentmux-srv/src/identity/auth_patterns.rs
+++ b/agentmux-srv/src/identity/auth_patterns.rs
@@ -59,7 +59,7 @@ fn is_api_key_provider(provider_id: &str) -> bool {
     // `openclaw models auth login --provider openai-codex` which emits
     // an OpenAI OAuth URL (auth.openai.com). The same `match_codex_url`
     // we use for Codex matches it.
-    matches!(provider_id, "kimi" | "pi")
+    matches!(provider_id, "kimi" | "pi" | "qwen")
 }
 
 type LineMatcher = fn(&str) -> Option<AuthPatternMatch>;
@@ -78,7 +78,7 @@ fn patterns_for(provider_id: &str) -> &'static [LineMatcher] {
         // API-key providers don't OAuth — these patterns never match.
         // Listed here so the dispatch is exhaustive and adding a new
         // provider always lands a code edit in this table.
-        "kimi" | "pi" => &[],
+        "kimi" | "pi" | "qwen" => &[],
         _ => &[],
     }
 }
@@ -362,7 +362,7 @@ mod tests {
         // kimi / pi don't have OAuth flow. Even if their output includes
         // an https URL during onboarding, we don't want to misinterpret
         // it as OAuth.
-        for provider in ["kimi", "pi"] {
+        for provider in ["kimi", "pi", "qwen"] {
             let m = match_line(provider, "Get your API key at https://example.com/keys");
             assert!(m.is_none(), "provider {provider} unexpectedly matched");
         }
@@ -414,7 +414,7 @@ mod tests {
         // for kimi/pi at all. (OpenClaw moved out — see
         // openclaw_matches_openai_oauth_url; its `models auth login
         // --provider openai-codex` emits a real OAuth URL.)
-        for provider in ["kimi", "pi"] {
+        for provider in ["kimi", "pi", "qwen"] {
             let line = "Get your API key at https://example.com/auth/keys";
             assert!(match_line(provider, line).is_none(), "{provider} matched");
         }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -297,6 +297,8 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "claude" => "claude-stream-json",
                     "codex" => "codex-json",
                     "gemini" => "gemini-json",
+                    // Qwen Code is a Gemini-CLI fork → same stream-json schema.
+                    "qwen" => "gemini-json",
                     "kimi" => "kimi-stream-json",
                     _ => "claude-stream-json",
                 };

--- a/docs/specs/SPEC_ADD_PROVIDERS_QWEN_AIDER_2026_06_02.md
+++ b/docs/specs/SPEC_ADD_PROVIDERS_QWEN_AIDER_2026_06_02.md
@@ -1,0 +1,118 @@
+# SPEC: Add Qwen Code & aider as agent providers
+
+**Date:** 2026-06-02
+**Status:** Draft
+**Owner:** sidecar (`agentmux-srv/src/backend/providers.rs` + `agents/translator/`) + provider seed
+**Scope:** Register two new harness providers — **Qwen Code** and **aider** — alongside the existing Claude/Codex/Gemini/Kimi/OpenClaw/Pi/Copilot set. Both can run **OpenRouter (or any OpenAI-compatible gateway) as their LLM backend**.
+
+---
+
+## 0. Framing — harness vs. LLM gateway
+
+These are **harnesses** (agent loops), not gateways. The **LLM gateway** is OpenRouter (hosted) or LiteLLM (self-hosted); a harness points its `base_url` at the gateway:
+
+```
+harness (Qwen Code | aider | …)  →  LLM gateway (OpenRouter / LiteLLM)  →  model
+```
+
+Adding a harness here is a `ProviderConfig` entry (how to launch + auth + stream). Selecting OpenRouter as its backend is a separate per-agent config concern (identity/memory bundles) — see `SPEC_AGENT_RESEARCH_OBSERVABILITY_2026_06_02.md` §0 and the OpenRouter integration report. **This spec only adds the harnesses.**
+
+Both verified OpenAI-compatible against OpenRouter (`https://openrouter.ai/api/v1`): Qwen via `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` ([Qwen model-providers](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers/)); aider via `--model openrouter/<provider>/<model>` + `OPENROUTER_API_KEY` ([aider OpenRouter](https://aider.chat/docs/llms/openrouter.html)).
+
+---
+
+## 1. Qwen Code — clean fit ✅ (ship this)
+
+**What it is:** an open-source terminal coding agent, a **fork of Gemini CLI** ([github.com/QwenLM/qwen-code](https://github.com/QwenLM/qwen-code)). Because it's a Gemini-CLI fork, it mirrors the existing `GEMINI` `ProviderConfig` almost exactly.
+
+**Verified headless invocation** ([Headless Mode docs](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/)): `-p`/`--prompt` (non-interactive), `--output-format text|json|stream-json`, `--include-partial-messages` (requires stream-json), `--yolo` / `--approval-mode=yolo`. Install: `npm i -g @qwen-code/qwen-code@latest`; CLI command `qwen`.
+
+**OpenRouter backend** (verified): `OPENAI_API_KEY=<or-key>`, `OPENAI_BASE_URL=https://openrouter.ai/api/v1`, `OPENAI_MODEL=qwen/qwen3-coder` (or via `~/.qwen/settings.json`). Note: the Qwen OAuth free tier was discontinued 2026-04-15 — OpenRouter is now a recommended path.
+
+### 1.1 Proposed `ProviderConfig` (mirrors `GEMINI`)
+
+```rust
+static QWEN: ProviderConfig = ProviderConfig {
+    id: "qwen",
+    display_name: "Qwen Code",
+    cli_command: "qwen",
+    controller_type: ControllerType::Subprocess,
+    // Gemini-CLI fork: same stream-json headless surface.
+    launch_args: &["--output-format", "stream-json", "--yolo", "-p", ""],
+    persistent_launch_args: None,
+    resume_flag: None,              // ⚠️ VERIFY: docs mention --resume <id>/--continue; leave None until confirmed
+    session_id_field: "session_id", // ⚠️ VERIFY against actual stream-json init event
+    styled_output_format: "gemini-json", // reuse Gemini translator (fork) — ⚠️ VERIFY format identical
+    auth_config_dir_env_var: "QWEN_CODE_HOME", // ⚠️ MUST-VERIFY (see §1.2) — not documented
+    auth_dir_name: "qwen",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@qwen-code/qwen-code",
+    pinned_version: "latest",
+    icon: "feather",
+    docs_url: "https://qwenlm.github.io/qwen-code-docs",
+};
+```
+
+Registry + alias + test:
+```rust
+m.insert(QWEN.id, &QWEN);                       // in the LazyLock registry map
+m.insert("qwen-code", "qwen");                  // alias map
+m.insert("qwen3-coder", "qwen");                // alias map
+// ORDER array: add "qwen" (e.g. after "kimi")
+// test: assert get_provider("qwen").is_some() && controller_type == Subprocess
+```
+
+### 1.2 The one real blocker — config-dir isolation ⚠️
+AgentMux gives each agent an isolated config/auth dir via `auth_config_dir_env_var` (e.g. Gemini's `GEMINI_CLI_HOME` + `GEMINI_FORCE_FILE_STORAGE=true`). **Qwen Code does not document an equivalent override** (defaults to `~/.qwen`). Two agents would otherwise share `~/.qwen` — an isolation bug AgentMux explicitly avoids. **Pre-merge:** confirm one of —
+1. Qwen honors a `QWEN_*`/`QWEN_CODE_HOME` override (likely, given the fork — check source), **or**
+2. it inherits Gemini's `GEMINI_CLI_HOME`, **or**
+3. fall back to a per-agent `HOME` override (AgentMux already does this for dev isolation) + seeding `settings.json` into that dir.
+
+This is the single field that must be right before merge; everything else mirrors a proven provider.
+
+**Effort: S.** **Risk: low** (one verify item). High value — adds the entire Qwen3-Coder family + any OpenRouter model behind a structured, observable harness.
+
+---
+
+## 2. aider — poor structural fit ⚠️ (needs controller work; don't ship as a plain entry)
+
+**What it is:** a mature Python terminal coding assistant ([aider.chat](https://aider.chat/docs/)). It's excellent, but it breaks **three** core `ProviderConfig` assumptions:
+
+| Assumption (in `ProviderConfig`) | aider reality | Consequence |
+|---|---|---|
+| **Structured streaming** (`stream-json`/ACP) drives the per-provider `Translator` | aider emits **human terminal text only** — no JSON event stream ([scripting docs](https://aider.chat/docs/scripting.html)) | No rich tool-call/observability events. AgentMux would see it like a Terminal pane, not an Agent pane. |
+| **npm install** via `npm_package` | aider is **pip/uv** installed (`aider-chat`), not npm | `npm_package: ""` (like `KIMI`) works as a signal, but auto-install path differs |
+| **Prompt written to stdin** | aider takes the prompt as an **arg** (`--message`/`-m`) or `--message-file`, not stdin | The current Subprocess launcher (prompt→stdin) doesn't fit; needs arg/file injection |
+
+**Verified non-interactive use:** `aider --message "…" --yes --no-stream --no-auto-commits <file>` ([scripting](https://aider.chat/docs/scripting.html)); OpenRouter via `--model openrouter/<provider>/<model>` + `OPENROUTER_API_KEY`, or generic `OPENAI_API_BASE`+`OPENAI_API_KEY`+`--model openai/<name>` ([openai-compat](https://aider.chat/docs/llms/openai-compat.html)).
+
+### 2.1 Options
+- **Option A — Text/terminal-class provider (degraded observability).** Add a `ControllerType` path that runs aider as a subprocess, passes the prompt via `--message`, captures raw stdout (a `styled_output_format: "text"` passthrough with no structured Translator). aider still *works* (edits + commits files), but AgentMux can't surface tool calls — it's "watch the terminal," not "watch the agent." Requires: an arg-prompt launch path + a no-op/text translator + a non-npm install note.
+- **Option B — Defer.** Add aider only once a generic **text-translator** + **arg-prompt launcher** + **pip-install** path exist (useful for any non-structured CLI, not just aider).
+
+### 2.2 Recommendation
+**Defer aider to its own PR (Option A as the target).** Adding it as a normal `ProviderConfig` now would either silently break (stdin prompt) or present a broken Agent pane (no events). It's worth doing — but it's *launcher/controller* work, not a registry line. Track as a follow-up: "Text-class (non-streaming) provider support → enables aider, and any OpenAI-compatible REPL CLI."
+
+---
+
+## 3. Changes & sequencing
+
+| PR | Change | Effort | Risk |
+|---|---|---|---|
+| **1** | Add `QWEN` to `providers.rs` (registry + alias + ORDER + test); reuse `gemini-json` translator; confirm §1.2 config-dir isolation | **S** | low (1 verify item) |
+| **2** (later) | `ControllerType` text/non-stream path + arg-prompt launcher + pip-install support → add **aider** (Option A) | **M–L** | med (launcher surface) |
+
+Both: add a changeset (`task changeset -- minor "feat(providers): add Qwen Code"`), **not** a `bump` (AgentMux uses changesets in feature PRs).
+
+---
+
+## 4. Pre-merge verify checklist (Qwen)
+- [ ] **Config-dir isolation env var** (§1.2) — the only blocker.
+- [ ] `resume_flag` — does `qwen` accept `--resume <id>` / `--continue`? (set or keep `None`)
+- [ ] `session_id_field` — confirm the field name in the stream-json init event.
+- [ ] Translator — confirm Qwen's `stream-json` is byte-compatible with Gemini's (`gemini-json`); if not, add a `qwen` translator.
+- [ ] `icon` is cosmetic; pick a final glyph.
+
+## Sources
+Qwen: [README/install](https://github.com/QwenLM/qwen-code) · [headless mode](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/) · [model-providers (OpenRouter)](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers/). aider: [docs](https://aider.chat/docs/) · [scripting](https://aider.chat/docs/scripting.html) · [OpenRouter](https://aider.chat/docs/llms/openrouter.html) · [OpenAI-compatible](https://aider.chat/docs/llms/openai-compat.html). OpenRouter OpenAI-compat base_url verified in `reports/openrouter-agentmux-integration-2026-06-02.md`.

--- a/frontend/app/view/agent-def/agent-def-constants.ts
+++ b/frontend/app/view/agent-def/agent-def-constants.ts
@@ -5,6 +5,7 @@ export const PROVIDERS = [
     { id: "claude", label: "Claude Code", cmd: "claude --output-format stream-json" },
     { id: "codex", label: "Codex CLI", cmd: "codex --full-auto" },
     { id: "gemini", label: "Gemini CLI", cmd: "gemini --yolo" },
+    { id: "qwen", label: "Qwen Code", cmd: "qwen --output-format stream-json --yolo" },
     { id: "kimi", label: "Kimi Code CLI", cmd: "kimi --print --output-format stream-json" },
     { id: "openclaw", label: "OpenClaw", cmd: "openclaw acp" },
     { id: "pi", label: "Pi", cmd: "pi --json" },

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -71,8 +71,9 @@ export function buildRuntimeArgs(
     }
 
     // Apply permission mode
-    if (providerId === "kimi" || providerId === "gemini") {
-        // Kimi and Gemini only support --yolo (bypass) vs no flag (default)
+    if (providerId === "kimi" || providerId === "gemini" || providerId === "qwen") {
+        // Kimi, Gemini, and Qwen (a Gemini-CLI fork) only support --yolo
+        // (bypass) vs no flag (default) — not --permission-mode / --dangerously-skip-permissions
         if (config.permissionMode !== "default") {
             args.push("--yolo");
         }

--- a/frontend/app/view/agent/defaults/cli-catalog.ts
+++ b/frontend/app/view/agent/defaults/cli-catalog.ts
@@ -87,6 +87,20 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         containerImage: "agentmux/gemini:latest",
     },
     {
+        provider: "qwen",
+        displayName: "Qwen Code",
+        icon: "❖",
+        blurb: "Alibaba's open-source coding agent",
+        primaryContextFile: "QWEN.md",
+        mcpSupport: "stdio+http",
+        popoverMarkdown:
+            "Alibaba's open-source coding agent (a fork of Gemini CLI) tuned for the Qwen3-Coder models. Runs on any OpenAI-compatible endpoint — point it at OpenRouter and use a huge range of models with a single key. Good when you want broad open-model coverage or a low-cost backend.",
+        hostSupported: true,
+        // No agentmux/qwen container image is built yet — host-only for now.
+        // Flip to true + add containerImage once the image ships.
+        containerSupported: false,
+    },
+    {
         provider: "kimi",
         displayName: "Kimi Code",
         icon: "◈",

--- a/frontend/app/view/agent/providers/index.test.ts
+++ b/frontend/app/view/agent/providers/index.test.ts
@@ -12,7 +12,7 @@ import type { ProviderDefinition } from "./index";
 //     SPEC_OPENCLAW_AGENT_2026_05_17.md §4), pi (api-key). Both
 //     `outputFormat: "acp"`.
 const OAUTH_CLI_IDS = ["claude", "codex", "gemini"] as const;
-const API_KEY_CLI_IDS = ["kimi"] as const;
+const API_KEY_CLI_IDS = ["kimi", "qwen"] as const;
 const ACP_IDS = ["openclaw", "pi"] as const;
 // ACP sub-partition by auth type. Kept separate from the unified
 // `ACP_IDS` so the "ACP providers use the ACP output format"

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -190,8 +190,13 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
     // OPENAI_BASE_URL=https://openrouter.ai/api/v1 + OPENAI_API_KEY (+ OPENAI_MODEL)
     // to run any OpenRouter model. The Qwen OAuth free tier was retired
     // (2026-04-15), so this is treated as api-key.
-    // NOTE: authCheck/authLogin below are provisional — the intended path is
-    // an env-injected key from the identity bundle, not an interactive CLI login.
+    // Auth: the intended path is an env-injected key from the identity bundle
+    // (OPENAI_API_KEY/OPENROUTER_API_KEY), not an interactive CLI login. We use
+    // the Gemini-parent `auth status`/`auth` convention for the check/login:
+    // `auth status` fails-closed (prompts for auth) rather than reporting a
+    // false positive the way `--version` would (checkcliauth treats any
+    // non-JSON zero exit as authenticated — cli_handlers.rs). A deeper fix
+    // would validate the bound env key directly in the api-key flow.
     qwen: {
         id: "qwen",
         displayName: "Qwen Code",
@@ -201,7 +206,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         outputFormat: "raw",
         styledOutputFormat: "gemini-json",
         authType: "api-key",
-        authCheckCommand: ["--version"],
+        authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth"],
         npmPackage: "@qwen-code/qwen-code",
         pinnedVersion: "latest",

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -184,6 +184,38 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
+    // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
+    // Same stream-json headless surface → reuses the gemini translator
+    // (styledOutputFormat "gemini-json"). Backend is OpenAI-compatible: set
+    // OPENAI_BASE_URL=https://openrouter.ai/api/v1 + OPENAI_API_KEY (+ OPENAI_MODEL)
+    // to run any OpenRouter model. The Qwen OAuth free tier was retired
+    // (2026-04-15), so this is treated as api-key.
+    // NOTE: authCheck/authLogin below are provisional — the intended path is
+    // an env-injected key from the identity bundle, not an interactive CLI login.
+    qwen: {
+        id: "qwen",
+        displayName: "Qwen Code",
+        cliCommand: "qwen",
+        defaultArgs: [],
+        styledArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
+        outputFormat: "raw",
+        styledOutputFormat: "gemini-json",
+        authType: "api-key",
+        authCheckCommand: ["--version"],
+        authLoginCommand: ["auth"],
+        npmPackage: "@qwen-code/qwen-code",
+        pinnedVersion: "latest",
+        docsUrl: "https://qwenlm.github.io/qwen-code-docs",
+        windowsInstallCommand: "npm install -g @qwen-code/qwen-code",
+        unixInstallCommand: "npm install -g @qwen-code/qwen-code",
+        icon: "feather",
+        authConfigDirEnvVar: "QWEN_HOME",
+        authDirName: "qwen",
+        launchArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
+        resumeFlag: null,
+        sessionIdField: "session_id",
+        controllerType: "subprocess",
+    },
     // OpenClaw — model-agnostic personal AI assistant from openclaw.ai.
     // We launch its `openclaw acp` bridge: speaks ACP over stdio (our
     // side) and forwards turns to OpenClaw's local Gateway daemon over
@@ -335,6 +367,8 @@ const PROVIDER_ALIASES: Record<string, string> = {
     "claude_code": "claude",
     "codex-cli": "codex",
     "gemini-cli": "gemini",
+    "qwen-code": "qwen",
+    "qwen3-coder": "qwen",
     "kimi-cli": "kimi",
     "kimi_code": "kimi",
     "openclaw-cli": "openclaw",

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -218,6 +218,7 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                     <option value="claude">Claude Code</option>
                                     <option value="codex">Codex CLI</option>
                                     <option value="gemini">Gemini CLI</option>
+                                    <option value="qwen">Qwen Code</option>
                                 </select>
                             </label>
 


### PR DESCRIPTION
## What

Adds **Qwen Code** as an agent provider, registered in both places:
- `agentmux-srv/src/backend/providers.rs` (sidecar registry)
- `frontend/app/view/agent/providers/index.ts` (frontend registry)

## Why / how it works

Qwen Code is a **fork of Gemini CLI**, so it mirrors the existing `GEMINI` provider almost exactly:
- Same headless surface: `-p` / `--output-format stream-json` / `--yolo`
- **Reuses the Gemini translator** (`styledOutputFormat: "gemini-json"`) — no new translator needed
- **OpenAI-compatible backend** → runs any OpenRouter model via `OPENAI_BASE_URL=https://openrouter.ai/api/v1` + `OPENAI_API_KEY`/`OPENAI_MODEL`
- Per-agent auth isolation via **`QWEN_HOME`** (the Qwen analogue of `GEMINI_CLI_HOME`; verified to relocate `~/.qwen`)
- npm `@qwen-code/qwen-code`, CLI `qwen`, api-key auth
- Aliases: `qwen-code`, `qwen3-coder`

This is the harness × LLM-gateway model in action: **Qwen Code is the harness; OpenRouter is the gateway/backend.**

## Tests (run locally)
- `cargo test -p agentmux-srv backend::providers` → **10 pass** (incl. provider-count 7→8 + alias resolution)
- providers vitest → **25 pass** (incl. the all-providers-have-required-fields sweep over `qwen`)
- `cargo check -p agentmux-srv` → clean (pre-existing warnings only)

## Provisional / to verify (flagged in the spec)
- `authCheckCommand` / `authLoginCommand` are provisional — the intended auth path is an **env-injected key from the identity bundle**, not an interactive CLI login.
- `resume_flag` left `None` (Qwen docs mention `--resume`/`--continue` but it's unconfirmed for the stream-json path).
- The `gemini-json` translator reuse assumes Qwen's stream-json is byte-identical to Gemini's.

## Not included — aider (intentionally deferred)
**aider** breaks three provider assumptions (no structured/stream output, pip-not-npm install, prompt-via-arg not stdin) and needs a non-streaming controller path, not just a registry entry. Full analysis + recommendation are in the spec.

**Spec:** `docs/specs/SPEC_ADD_PROVIDERS_QWEN_AIDER_2026_06_02.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
