### PR TITLE
fix(agent-pane): drop open/close pane animations + thicker high-contrast scrollbars + remove tool "ok" label

### DIFF
--- a/.changesets/1780468739-fix-agent-pane-remove-open-close-pane-animations-thicken-hig-sswv.md
+++ b/.changesets/1780468739-fix-agent-pane-remove-open-close-pane-animations-thicken-hig-sswv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): remove open/close pane animations, thicken high-contrast scrollbars, drop tool ok label

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -57,8 +57,8 @@ a.plain-link {
 }
 
 *::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
+    width: 14px;
+    height: 14px;
 }
 
 *::-webkit-scrollbar-track {

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -514,26 +514,6 @@
     }
 }
 
-// ── Pane reflow animation: content tracks the wrapper ───────────────────────
-// On open/close/split/rebalance the layout applies the new inner rect to
-// `.block-content` immediately (layoutModelHooks), and the `.tile-node`
-// wrapper eases to its new box. Transition the content's width/height with
-// the SAME duration + curve so the pane's body glides in lockstep instead of
-// snapping. Gated on `.tile-layout.animate`, which is OFF during a resize
-// drag (so the body follows the cursor instantly) and absent for the first
-// 150ms after mount (reveal gate). The size change drives a one-shot reflow
-// of the pane's content (xterm/CodeMirror) over the animation window.
-// See docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
-// `!important` is a deliberate essential-motion exemption (matches `.tile-node`
-// in tilelayout.scss): the pane body glides with its wrapper even under reduced
-// motion, beating the global `.prefers-reduced-motion * { transition-property:
-// none !important }` reset in app.scss. Product decision, 2026-05-29.
-.tile-layout.animate .block-content {
-    transition:
-        width var(--animation-time-s) cubic-bezier(0.2, 0, 0, 1),
-        height var(--animation-time-s) cubic-bezier(0.2, 0, 0, 1) !important;
-}
-
 // ── Per-block error boundary fallback ───────────────────────────────────────
 // Localized "this pane crashed" panel that replaces ONLY the broken pane's
 // body. Other panes in the tab + the layout chrome stay alive.

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -71,13 +71,13 @@
     padding: var(--space-1) 0;
 
     &::-webkit-scrollbar {
-        width: 6px;
+        width: 14px;
     }
     &::-webkit-scrollbar-track {
         background: transparent;
     }
     &::-webkit-scrollbar-thumb {
-        background: var(--border-color);
+        background: var(--scrollbar-thumb-color);
         border-radius: 0;
     }
 }

--- a/frontend/app/platform/pane-anim.ts
+++ b/frontend/app/platform/pane-anim.ts
@@ -1,40 +1,42 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared "a pane reflow animation is in flight" signal.
+// Shared "a pane geometry change just happened — settle native panes" signal.
 //
-// Native browser panes are real child windows (HWNDs) that CSS cannot move,
-// so they can't ride the `.tile-node` / `.block-content` CSS transitions the
-// way DOM panes do. Instead, while a reflow animation is playing, the tiling
-// layout pings `notifyPaneReflow()` (on any node geometry change that isn't a
-// resize drag), and each browser pane (`browser-view.tsx`) re-samples its
-// placeholder's live `getBoundingClientRect()` every frame and forwards it via
-// `browser_pane_resize` → `SetWindowPos`. The native window therefore tracks
-// exactly what its CSS-animating DOM placeholder is doing — one clock, no drift.
+// Native browser panes are real child windows (HWNDs) that CSS cannot move, so
+// a layout change doesn't reposition them the way it does DOM panes. On any node
+// geometry change that isn't a resize drag the tiling layout pings
+// `notifyPaneReflow()`, opening a short window during which each browser pane
+// (`browser-view.tsx`) re-samples its placeholder's live
+// `getBoundingClientRect()` and forwards it via `browser_pane_resize` →
+// `SetWindowPos`, settling the HWND onto the new rect. (The pane reflow CSS
+// animation this once tracked frame-by-frame was removed; the placeholder no
+// longer animates, so the window just covers rAF/scheduler slack before the
+// rect is final.)
 //
 // See docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
 
 import { createSignal } from "solid-js";
 
-// A little longer than the 150ms layout animation so the per-frame sampling
-// covers the easing tail and any rAF/scheduler slack before settling.
+// Short settle window after the layout applies the new rect synchronously —
+// covers rAF/scheduler slack so the per-frame sampling lands on the final rect.
 const REFLOW_WINDOW_MS = 220;
 
-// Wall-clock instant (performance.now() ms) until which a reflow is considered
-// active. Stored in a signal so consumers can reactively start their sampling
-// loop the moment a reflow begins.
+// Wall-clock instant (performance.now() ms) until which the post-change settle
+// window is open. Stored in a signal so consumers can reactively start their
+// sampling loop the moment a change begins.
 const [animatingUntil, setAnimatingUntil] = createSignal(0);
 
-/** Called by the layout when a pane's geometry changes during an animation. */
+/** Called by the layout on a pane geometry change (open/close/split/rebalance). */
 export function notifyPaneReflow(): void {
     setAnimatingUntil(performance.now() + REFLOW_WINDOW_MS);
 }
 
 /**
- * True while a reflow is in flight. Reads the `animatingUntil` signal (so a
- * `createEffect` calling this re-runs when a reflow begins) and compares it to
- * the current time (so a per-frame loop calling this stops once the window
- * elapses).
+ * True while the post-change settle window is open. Reads the `animatingUntil`
+ * signal (so a `createEffect` calling this re-runs when a change begins) and
+ * compares it to the current time (so a per-frame loop calling this stops once
+ * the window elapses).
  */
 export function paneReflowActive(): boolean {
     return performance.now() < animatingUntil();

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -87,9 +87,9 @@
 
     /* scrollbar colors */
     --scrollbar-background-color: transparent;
-    --scrollbar-thumb-color: rgba(255, 255, 255, 0.15);
-    --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
-    --scrollbar-thumb-active-color: rgba(255, 255, 255, 0.6);
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.5);
+    --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.7);
+    --scrollbar-thumb-active-color: rgba(255, 255, 255, 0.85);
 
     --header-font: 700 11px / normal "Inter", sans-serif;
     --header-icon-size: 18px;

--- a/frontend/app/themes/catppuccin.scss
+++ b/frontend/app/themes/catppuccin.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #f38ba8;
     --button-yellow-bg: #f9e2af;
 
-    --scrollbar-thumb-color: rgba(203, 166, 247, 0.18);
+    --scrollbar-thumb-color: rgba(203, 166, 247, 0.5);
     --scrollbar-thumb-hover-color: rgba(203, 166, 247, 0.4);
 
     --term-background: #1e1e2e;

--- a/frontend/app/themes/catppuccin.scss
+++ b/frontend/app/themes/catppuccin.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #f9e2af;
 
     --scrollbar-thumb-color: rgba(203, 166, 247, 0.5);
-    --scrollbar-thumb-hover-color: rgba(203, 166, 247, 0.4);
+    --scrollbar-thumb-hover-color: rgba(203, 166, 247, 0.7);
 
     --term-background: #1e1e2e;
     --term-foreground: #cdd6f4;

--- a/frontend/app/themes/dracula.scss
+++ b/frontend/app/themes/dracula.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #f1fa8c;
 
     --scrollbar-thumb-color: rgba(189, 147, 249, 0.5);
-    --scrollbar-thumb-hover-color: rgba(189, 147, 249, 0.45);
+    --scrollbar-thumb-hover-color: rgba(189, 147, 249, 0.7);
 
     --term-background: #282a36;
     --term-foreground: #f8f8f2;

--- a/frontend/app/themes/dracula.scss
+++ b/frontend/app/themes/dracula.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #ff5555;
     --button-yellow-bg: #f1fa8c;
 
-    --scrollbar-thumb-color: rgba(189, 147, 249, 0.2);
+    --scrollbar-thumb-color: rgba(189, 147, 249, 0.5);
     --scrollbar-thumb-hover-color: rgba(189, 147, 249, 0.45);
 
     --term-background: #282a36;

--- a/frontend/app/themes/gruvbox.scss
+++ b/frontend/app/themes/gruvbox.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #cc241d;
     --button-yellow-bg: #d79921;
 
-    --scrollbar-thumb-color: rgba(215, 153, 33, 0.2);
+    --scrollbar-thumb-color: rgba(215, 153, 33, 0.5);
     --scrollbar-thumb-hover-color: rgba(215, 153, 33, 0.45);
 
     --term-background: #282828;

--- a/frontend/app/themes/gruvbox.scss
+++ b/frontend/app/themes/gruvbox.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #d79921;
 
     --scrollbar-thumb-color: rgba(215, 153, 33, 0.5);
-    --scrollbar-thumb-hover-color: rgba(215, 153, 33, 0.45);
+    --scrollbar-thumb-hover-color: rgba(215, 153, 33, 0.7);
 
     --term-background: #282828;
     --term-foreground: #ebdbb2;

--- a/frontend/app/themes/high-contrast.scss
+++ b/frontend/app/themes/high-contrast.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: rgb(255, 200, 0);
 
     --scrollbar-thumb-color: rgba(255, 255, 255, 0.5);
-    --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.6);
+    --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.7);
 
     --term-background: #000000;
     --term-foreground: #ffffff;

--- a/frontend/app/themes/high-contrast.scss
+++ b/frontend/app/themes/high-contrast.scss
@@ -36,7 +36,7 @@
     --button-red-bg: rgb(255, 60, 60);
     --button-yellow-bg: rgb(255, 200, 0);
 
-    --scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.5);
     --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.6);
 
     --term-background: #000000;

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -29,7 +29,7 @@
     --button-grey-hover-bg: rgba(100, 160, 255, 0.12);
     --button-grey-border-color: rgba(100, 140, 255, 0.18);
 
-    --scrollbar-thumb-color: rgba(100, 160, 255, 0.18);
+    --scrollbar-thumb-color: rgba(100, 160, 255, 0.5);
     --scrollbar-thumb-hover-color: rgba(100, 160, 255, 0.4);
 
     --term-background: #060810;

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -30,7 +30,7 @@
     --button-grey-border-color: rgba(100, 140, 255, 0.18);
 
     --scrollbar-thumb-color: rgba(100, 160, 255, 0.5);
-    --scrollbar-thumb-hover-color: rgba(100, 160, 255, 0.4);
+    --scrollbar-thumb-hover-color: rgba(100, 160, 255, 0.7);
 
     --term-background: #060810;
     --term-foreground: #c8d0e8;

--- a/frontend/app/themes/monokai.scss
+++ b/frontend/app/themes/monokai.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #f92672;
     --button-yellow-bg: #e6db74;
 
-    --scrollbar-thumb-color: rgba(255, 255, 255, 0.15);
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.5);
     --scrollbar-thumb-hover-color: rgba(166, 226, 46, 0.4);
 
     --term-background: #272822;

--- a/frontend/app/themes/monokai.scss
+++ b/frontend/app/themes/monokai.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #e6db74;
 
     --scrollbar-thumb-color: rgba(255, 255, 255, 0.5);
-    --scrollbar-thumb-hover-color: rgba(166, 226, 46, 0.4);
+    --scrollbar-thumb-hover-color: rgba(166, 226, 46, 0.7);
 
     --term-background: #272822;
     --term-foreground: #f8f8f2;

--- a/frontend/app/themes/nord.scss
+++ b/frontend/app/themes/nord.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #bf616a;
     --button-yellow-bg: #ebcb8b;
 
-    --scrollbar-thumb-color: rgba(136, 192, 208, 0.2);
+    --scrollbar-thumb-color: rgba(136, 192, 208, 0.5);
     --scrollbar-thumb-hover-color: rgba(136, 192, 208, 0.45);
 
     --term-background: #2e3440;

--- a/frontend/app/themes/nord.scss
+++ b/frontend/app/themes/nord.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #ebcb8b;
 
     --scrollbar-thumb-color: rgba(136, 192, 208, 0.5);
-    --scrollbar-thumb-hover-color: rgba(136, 192, 208, 0.45);
+    --scrollbar-thumb-hover-color: rgba(136, 192, 208, 0.7);
 
     --term-background: #2e3440;
     --term-foreground: #d8dee9;

--- a/frontend/app/themes/tokyo-night.scss
+++ b/frontend/app/themes/tokyo-night.scss
@@ -36,7 +36,7 @@
     --button-red-bg: #f7768e;
     --button-yellow-bg: #e0af68;
 
-    --scrollbar-thumb-color: rgba(122, 162, 247, 0.18);
+    --scrollbar-thumb-color: rgba(122, 162, 247, 0.5);
     --scrollbar-thumb-hover-color: rgba(122, 162, 247, 0.4);
 
     --term-background: #1a1b2e;

--- a/frontend/app/themes/tokyo-night.scss
+++ b/frontend/app/themes/tokyo-night.scss
@@ -37,7 +37,7 @@
     --button-yellow-bg: #e0af68;
 
     --scrollbar-thumb-color: rgba(122, 162, 247, 0.5);
-    --scrollbar-thumb-hover-color: rgba(122, 162, 247, 0.4);
+    --scrollbar-thumb-hover-color: rgba(122, 162, 247, 0.7);
 
     --term-background: #1a1b2e;
     --term-foreground: #c0caf5;

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -18,7 +18,9 @@
  * simplified: the status icon, tool name, summary, and duration are on
  * the collapsed row above, so the header carries only the status label.
  * The on-hover timestamp slot was later removed. The header is omitted
- * while running — the body's "Thinking…" spinner already conveys that.
+ * while running (the body's "Thinking…" spinner conveys that) and on
+ * success (the collapsed row already shows the outcome) — so it appears
+ * only for failed / denied / canceled / awaiting-approval statuses.
  */
 
 import { type JSX } from "solid-js";

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -48,7 +48,12 @@ export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (
     <div class="agent-tool-overlay" data-node-id={props.node.id}>
         <div
             class="agent-tool-overlay-header"
-            style={{ display: props.node.status === "running" ? "none" : "" }}
+            style={{
+                display:
+                    props.node.status === "running" || props.node.status === "success"
+                        ? "none"
+                        : "",
+            }}
         >
             <span class="agent-tool-overlay-status-label">
                 {STATUS_LABEL[props.node.status]}

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -156,15 +156,15 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
         registerPaneRect(model.blockId, paneRectCss());
     };
 
-    // Per-frame tracking during a pane reflow animation.
+    // Native browser-pane HWND settle on a layout change.
     //
-    // DOM panes ride the `.tile-node` / `.block-content` CSS transitions, but
-    // a native browser-pane HWND can't be moved by CSS — so while a reflow is
-    // in flight we re-sample this pane's (CSS-animating) placeholder rect every
-    // frame and push it to the host. `syncPosition` dedupes, so frames with no
-    // change are free. The native window thus tracks its DOM placeholder
-    // exactly (one clock, no drift). Reduced-motion users skip this — the
-    // layout snaps and the ResizeObserver/poll sends the final rect.
+    // A native browser-pane HWND can't be moved by CSS. On a pane geometry
+    // change `notifyPaneReflow()` opens a short window during which we re-sample
+    // this pane's placeholder rect per frame and push it to the host
+    // (`syncPosition` dedupes, so unchanged frames are free). The pane reflow CSS
+    // animation has since been removed, so the placeholder no longer animates —
+    // this now just settles the HWND onto the final rect; the ResizeObserver/poll
+    // is the steady-state path.
     // See docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
     let reflowRAF: number | null = null;
     const sampleReflowFrame = () => {
@@ -172,18 +172,17 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
         if (paneReflowActive()) {
             reflowRAF = requestAnimationFrame(sampleReflowFrame);
         } else {
-            // One final settle frame so the HWND lands exactly on the
-            // post-animation rect even if the last tick fired slightly early.
+            // One final settle frame so the HWND lands exactly on the final
+            // rect even if the last tick fired slightly early.
             reflowRAF = null;
             syncPosition();
         }
     };
     createEffect(() => {
-        // `paneReflowActive()` reads the shared `animatingUntil` signal, so
-        // this effect re-runs the instant a reflow begins. Pane reflow is
-        // treated as essential motion (see tilelayout.scss), so this tracks
-        // regardless of the reduced-motion preference — keeping the native
-        // browser-pane window in lockstep with the animating DOM panes.
+        // `paneReflowActive()` reads the shared `animatingUntil` signal, so this
+        // effect re-runs the instant a pane geometry change opens the settle
+        // window; the per-frame loop then re-syncs the native browser-pane HWND
+        // onto the new placeholder rect.
         if (paneReflowActive() && reflowRAF == null) {
             reflowRAF = requestAnimationFrame(sampleReflowFrame);
         }

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -18,10 +18,10 @@
     min-width: 0;
 
     &::-webkit-scrollbar {
-        width: 4px;
+        width: 14px;
     }
     &::-webkit-scrollbar-thumb {
-        background: var(--border-color);
+        background: var(--scrollbar-thumb-color);
         border-radius: 0;
     }
 }

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -49,10 +49,10 @@
     padding: var(--space-2) var(--space-3);
 
     &::-webkit-scrollbar {
-        width: 4px;
+        width: 14px;
     }
     &::-webkit-scrollbar-thumb {
-        background: var(--border-color);
+        background: var(--scrollbar-thumb-color);
         border-radius: 0;
     }
 }

--- a/frontend/app/view/identity/styles/_form-overlay.scss
+++ b/frontend/app/view/identity/styles/_form-overlay.scss
@@ -58,10 +58,10 @@
     gap: var(--space-2);
 
     &::-webkit-scrollbar {
-        width: 4px;
+        width: 14px;
     }
     &::-webkit-scrollbar-thumb {
-        background: var(--border-color);
+        background: var(--scrollbar-thumb-color);
         border-radius: 0;
     }
 }

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -159,8 +159,8 @@
 
         .xterm-viewport {
             &::-webkit-scrollbar {
-                width: 6px;
-                height: 6px;
+                width: 14px;
+                height: 14px;
             }
 
             &::-webkit-scrollbar-track {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -591,17 +591,18 @@ export class TermWrap {
 
     // FitAddon v0.11.0 subtracts `overviewRuler.width || 14` from available width
     // whenever scrollback > 0. We don't use the overview ruler or Monaco-style scrollbar —
-    // our CSS webkit scrollbar is 6px and overlaps the content. This corrects for the
-    // discrepancy so the terminal fills the pane correctly.
+    // our CSS webkit scrollbar is now 14px (term.scss .xterm-viewport). With the
+    // scrollbar matching FitAddon's 14px reservation the correction is currently 0,
+    // but the constants remain so a future width change re-derives it automatically.
     //
     // FITADDON_SCROLLBAR_ASSUMPTION: the width FitAddon reserves for the right-side
     // scrollbar/overview ruler when no overviewRuler is configured (hardcoded in addon-fit.js).
     // CSS_SCROLLBAR_WIDTH: our actual webkit scrollbar width (term.scss .xterm-viewport).
     // If either value changes, update both constants to match.
     private static readonly FITADDON_SCROLLBAR_ASSUMPTION = 14; // px — FitAddon's `overviewRuler.width || 14`
-    private static readonly CSS_SCROLLBAR_WIDTH = 6;            // px — our webkit scrollbar (term.scss)
+    private static readonly CSS_SCROLLBAR_WIDTH = 14;           // px — our webkit scrollbar (term.scss)
     private static readonly FIT_WIDTH_CORRECTION =
-        TermWrap.FITADDON_SCROLLBAR_ASSUMPTION - TermWrap.CSS_SCROLLBAR_WIDTH; // = 8px
+        TermWrap.FITADDON_SCROLLBAR_ASSUMPTION - TermWrap.CSS_SCROLLBAR_WIDTH; // = 0px
 
     private customFit() {
         const dims = this.fitAddon.proposeDimensions();

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -341,12 +341,11 @@ const DisplayNode = (props: DisplayNodeProps) => {
     let leafRef: HTMLDivElement | undefined;
     const addlProps = () => nodeModel.additionalProps();
 
-    // Ping the shared reflow signal whenever this node's geometry changes
-    // while animations are live (i.e. not during the first-paint reveal gate
-    // and not during a resize drag). Native browser panes read the signal to
-    // drive per-frame SetWindowPos so their HWND glides in lockstep with the
-    // CSS-animating DOM. DOM panes need nothing here — they ride the CSS
-    // transitions directly. See SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
+    // Ping the shared settle signal whenever this node's geometry changes
+    // outside the first-paint reveal gate and a resize drag. Native browser
+    // panes read the signal to re-sample + SetWindowPos their HWND onto the new
+    // rect. (The CSS reflow animation this once tracked was removed; DOM panes
+    // just take the new rect directly.) See SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
     let prevGeomKey: string | undefined;
     createEffect(() => {
         const t = addlProps()?.transform as JSX.CSSProperties | undefined;

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -100,16 +100,13 @@ import {
     computeSpiralOrder,
 } from "./layoutGeometry";
 
-// Duration (seconds) of the pane reflow animation that plays on
-// open/close/split/rebalance. Drives the `--animation-time-s` CSS custom
-// property consumed by the `.tile-node` wrapper transition AND the
-// `.block-content` size transition (block.scss). Browser panes track this
-// window by re-sampling their rect per frame (browser-view.tsx). The inner
-// rect is applied immediately (see layoutModelHooks) so both wrapper and
-// content transition from old→new in lockstep. 0.15s matches the file's
-// reveal-gate and placeholder timings. Honors prefers-reduced-motion (CSS
-// overrides + the layoutModelHooks instant path). See
-// docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
+// Duration (seconds) backing the `--animation-time-s` CSS custom property.
+// The pane reflow transition it used to drive (the `.tile-node` wrapper +
+// `.block-content` size transitions over `.tile-layout.animate`) was removed —
+// pane open/close/split is now instant — so the property now only delays the
+// resize-line hover reveal (tilelayout.scss). 0.15s matches the file's
+// reveal-gate and placeholder timings.
+// See docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
 const DefaultAnimationTimeS = 0.15;
 
 export class LayoutModel {

--- a/frontend/layout/lib/layoutModelHooks.ts
+++ b/frontend/layout/lib/layoutModelHooks.ts
@@ -108,13 +108,11 @@ export function useDebouncedNodeInnerRect(nodeModel: NodeModel): () => CSSProper
         // `animationTimeS`, which held the pane CONTENT at its old size for
         // the whole animation and then snapped it — so only the empty
         // wrapper box eased while the visible content popped at the end
-        // (the "panes jerk into place" report). The reflow animation now
-        // lives in CSS: the inner rect changes old→new right now, and the
-        // `.block-content` size transition (block.scss, gated on
-        // `.tile-layout.animate`) animates it in lockstep with the
-        // `.tile-node` wrapper. During a resize drag `.animate` is off, so
-        // the content follows the cursor instantly with no transition —
-        // same as before. Reduced-motion zeroes the CSS transition.
+        // (the "panes jerk into place" report). The inner rect now changes
+        // old→new immediately in every case; the CSS reflow transition that
+        // used to ease the `.block-content` / `.tile-node` size over
+        // `.tile-layout.animate` was removed, so pane open/close/resize is
+        // instant.
         // See docs/specs/SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
         clearInnerRectDebounce();
         setInnerRect(nodeInnerRect as any);

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -162,26 +162,6 @@
     }
 
     &.animate {
-        // `.tile-node` inline styles include width/height alongside
-        // transform — pane split/close/rebalance needs all three
-        // animated for the resize to be smooth. Codex P2 on PR #829.
-        .tile-node {
-            // ease-out (fast start, gentle settle) reads better than linear
-            // for a discrete open/close reflow. The same curve is used by the
-            // `.block-content` size transition (block.scss) so wrapper and
-            // content stay visually in sync.
-            //
-            // `!important` is a DELIBERATE essential-motion exemption: pane
-            // open/close/split is a spatial cue (where did my pane go?), not
-            // decoration, so it animates even when the user prefers reduced
-            // motion. The global accessibility reset in app.scss
-            // (`.prefers-reduced-motion * { transition-property: none !important }`)
-            // would otherwise kill it; a higher-specificity `!important` rule
-            // beats that blanket. Product decision, 2026-05-29.
-            transition-duration: var(--animation-time-s) !important;
-            transition-timing-function: cubic-bezier(0.2, 0, 0, 1) !important;
-            transition-property: width, height, transform !important;
-        }
         // `.placeholder-sizer` only changes transform during drag-move
         // (width/height are set once per zone change and snap instantly
         // — that's the whole point of the two-div split). Use a
@@ -246,12 +226,10 @@
     }
 
     // NOTE — no `prefers-reduced-motion` suppression here by design.
-    // Pane reflow (`.tile-node`, `.block-content`) and the drag-rearrange
-    // glide (`.placeholder-sizer`) are treated as ESSENTIAL spatial motion
-    // and animate regardless of the reduced-motion preference — see the
-    // `!important` exemptions above. The inner `.placeholder` opacity/scale
-    // fade is decorative and intentionally left subject to the global
-    // accessibility reset in app.scss (no `!important`), so it still snaps
-    // for reduced-motion users while the position glide survives.
-    // Product decision, 2026-05-29.
+    // The drag-rearrange glide (`.placeholder-sizer`) is treated as ESSENTIAL
+    // spatial motion and animates regardless of the reduced-motion preference —
+    // see the `!important` exemption above. The inner `.placeholder`
+    // opacity/scale fade is decorative and intentionally left subject to the
+    // global accessibility reset in app.scss (no `!important`), so it still
+    // snaps for reduced-motion users while the position glide survives.
 }

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -173,9 +173,9 @@
         // the whole point of the two-div split. 120ms matches the
         // inner `.placeholder` opacity/scale transitions so the
         // visual response is uniform across enter / drag-move / exit.
-        // `!important`: same essential-motion exemption as `.tile-node` above —
-        // the drag-rearrange placeholder glide is a spatial cue and must beat
-        // the global reduced-motion reset.
+        // `!important`: the drag-rearrange placeholder glide is essential spatial
+        // motion (a cue, not decoration), so it must beat the global
+        // reduced-motion reset in app.scss.
         .placeholder-sizer {
             transition: transform 120ms ease-out !important;
         }


### PR DESCRIPTION
Agent-pane UX polish (three independent, mostly CSS-only changes). Verified live via HMR.

## 1. Remove pane open/close animations (keep drop-zone ghosts)
The `.tile-layout.animate` reflow transition on `.tile-node` (width/height/transform) and its `.block-content` content-half are removed, so pane **open/close/split/rebalance is instant**. The drag-rearrange **drop-zone ghost** glide/fade (`.placeholder-sizer` / `.placeholder`) is **kept**. Resize was already exempt (`.animate` is off while resizing). The native-pane reflow sampling (`pane-anim.ts`) is left in place — it now samples a static final rect, so native browser panes simply jump to position with everything else.

## 2. Thicker, high-contrast scrollbars (all of them)
- Width **4px → 14px** globally (`app.scss`); xterm **6px → 14px** (`term.scss`).
- Thumb rest-alpha raised to **0.5** (high-contrast) on the default theme + all 8 named themes (catppuccin, dracula, gruvbox, high-contrast, midnight, monokai, nord, tokyo-night). Was 0.15–0.3 — nearly invisible.

## 3. Drop the tool "ok" label
The tool-overlay header no longer shows the `success → "ok"` status label (it conveyed nothing on a successful tool). `failed` / `denied` / `canceled` / `awaiting approval` labels are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
