### PR TITLE
fix(gemini): stop Claude-model leak + map turn-end to session_end (2 of 3)

### DIFF
--- a/.changesets/1780487171-fix-gemini-stop-claude-model-leak-map-turn-end-to-session-en-4w34.md
+++ b/.changesets/1780487171-fix-gemini-stop-claude-model-leak-map-turn-end-to-session-en-4w34.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(gemini): stop Claude model leak + map turn-end to session_end

--- a/docs/analysis/GEMINI_PROVIDER_ISSUES_2026_06_02.md
+++ b/docs/analysis/GEMINI_PROVIDER_ISSUES_2026_06_02.md
@@ -1,0 +1,100 @@
+# Gemini provider — auth loop + two latent codex-class bugs
+
+**Date:** 2026-06-02
+**Status:** diagnosed; fixes proposed (2 quick code fixes + 1 deeper auth-orchestration fix)
+**Area:** agent provider auth orchestration (`cli_handlers`) + arg construction + output translation
+
+A Gemini agent pane "doesn't do anything once loaded and never logged in." Three
+distinct issues; the **auth loop is the live blocker**, the other two are the same
+classes already fixed for codex in `CODEX_AGENT_LAUNCH_DOA_2026_06_02.md`.
+
+---
+
+## Issue 1 (LIVE BLOCKER): expired token + auth check loops without escalating to login
+
+### Symptom
+Opening the gemini pane does nothing; no browser login ever opens.
+
+### Evidence (dev instance)
+- `~/.gemini/oauth_creds.json` token is **expired ~70 days**:
+  `expiry_date = 1774444778400` (≈ Mar 25) vs now `1780469278000` (Jun 3).
+- The srv log shows `cli_handlers: CheckCliAuth` repeating **every ~7 s,
+  indefinitely** (06:40 → 06:44+ and still going).
+- **No `run_cli_login` and no `subprocess spawned` for gemini** in the session —
+  only the CheckCliAuth poll. (Codex, by contrast, fired
+  `run_cli_login: spawned (pipes), browser should open` and then spawned.)
+
+### Root cause
+The auth orchestration polls the provider's `authCheckCommand`
+(`gemini auth status`) but, when the check keeps failing (expired/missing token),
+**never escalates to the provider's `authLoginCommand` (`gemini auth login`).**
+It loops on the check forever instead of triggering login. So the user is never
+prompted and the agent never spawns.
+
+### Fix (deeper — auth-launch orchestration)
+In the `cli_handlers` / agent-launch auth flow: when `CheckCliAuth` returns
+not-authenticated (or after N failed polls), trigger `run_cli_login` with the
+provider's `authLoginCommand` instead of re-polling. Confirm whether codex's
+working path special-cases something gemini misses (codex *did* escalate).
+Needs a focused read of the auth-flow state machine.
+
+### Immediate unblock (no code change)
+Re-authenticate gemini interactively: `gemini auth login` (refreshes the token).
+The pane then gets past the check loop.
+
+---
+
+## Issue 2 (latent): `--model sonnet` leak — Claude model passed to gemini
+
+`buildRuntimeArgs` still includes `gemini` in `supportsModel`, so it appends
+`--model <ModelChoice>` where `ModelChoice = opus|sonnet|haiku` are **Claude**
+names. Gemini needs a gemini model (e.g. `gemini-2.5-pro`).
+
+**Fix:** mirror the codex fix — drop `gemini` from `supportsModel` (let gemini use
+its own configured default) or insert a real gemini model. `buildRuntimeArgs.ts`
+line ~85. This is the sibling already flagged in the codex analysis doc.
+
+---
+
+## Issue 3 (latent): translator drops the turn boundary → stuck spinner
+
+`gemini-translator.ts:34` returns `[]` for `result` (gemini's turn-end event:
+`{"type":"result","status":"success","stats":{...}}`), treating it as a
+no-content lifecycle event. So the conversation reducer never receives
+`session_end` → never leaves the `Streaming` phase → **the working spinner never
+stops** — identical to the codex bug.
+
+Ordering is **not** affected here: gemini streams incremental `message` deltas
+that the stream-parser accumulates (unlike codex's complete items), so it has no
+out-of-order problem.
+
+**Fix:** map `result` → `session_end` carrying `stats`, mirroring
+`claude-translator.ts:60-66` and the codex fix. Sketch:
+
+```ts
+case "result": {
+    const stats: SessionStats = {};
+    const s = rawEvent.stats;
+    if (s && typeof s === "object") {
+        if (typeof s.input_tokens === "number") stats.input_tokens = s.input_tokens;
+        if (typeof s.output_tokens === "number") stats.output_tokens = s.output_tokens;
+    }
+    return [{ type: "session_end", stats }];
+}
+```
+(Remove `result` from the dropped-lifecycle `case "init":` group; keep `init` dropped.)
+
+---
+
+## Suggested sequencing
+
+1. **Issues 2 + 3** — quick, mechanical, mirror the merged codex fixes; ship as a
+   small `fix(gemini)` PR with `gemini-translator` + `buildRuntimeArgs` tests.
+2. **Issue 1** — the auth-escalation orchestration fix; bigger, needs the
+   auth-flow read. Until it lands, expired-token gemini panes require a manual
+   `gemini auth login`.
+
+## Verification
+After re-auth + fixes: gemini pane launches (browser login on expired token),
+runs on a gemini model (no `--model sonnet`), and the spinner stops when
+`result` arrives.

--- a/frontend/app/view/agent/buildRuntimeArgs.test.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.test.ts
@@ -69,11 +69,14 @@ describe("buildRuntimeArgs", () => {
         });
     });
 
-    describe("gemini (unchanged)", () => {
-        it("uses --yolo for a non-default permission mode, never the Claude bypass flag", () => {
+    describe("gemini", () => {
+        it("uses --yolo for a non-default mode; no Claude bypass flag and no Claude --model", () => {
             const out = buildRuntimeArgs(["--output-format", "stream-json", "-p", ""], cfg(), "gemini");
             expect(out).toContain("--yolo");
             expect(out).not.toContain("--dangerously-skip-permissions");
+            // gemini no longer receives the Claude-named ModelChoice (it rejects it)
+            expect(out).not.toContain("--model");
+            expect(out).not.toContain("sonnet");
         });
 
         it("no --yolo when the permission mode is default", () => {

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -92,9 +92,11 @@ export function buildRuntimeArgs(
         args.push(...permFlags);
     }
 
-    // --model: claude + gemini use the Claude-named ModelChoice. Codex is handled
-    // separately below (its own gpt-5.x namespace). --effort: claude only.
-    const supportsModel = !providerId || providerId === "claude" || providerId === "gemini";
+    // --model: claude only. ModelChoice values (opus/sonnet/haiku) are Claude
+    // model names; codex (handled below) and gemini use their own model
+    // namespaces, so a Claude name is rejected. gemini falls back to its CLI
+    // default until a per-provider model list lands. --effort: claude only.
+    const supportsModel = !providerId || providerId === "claude";
     if (supportsModel) {
         args.push("--model", config.model);
     }

--- a/frontend/app/view/agent/providers/gemini-translator.test.ts
+++ b/frontend/app/view/agent/providers/gemini-translator.test.ts
@@ -6,11 +6,21 @@ import { GeminiTranslator } from "./gemini-translator";
 
 describe("GeminiTranslator", () => {
     describe("turn boundary → session_end (fixes the never-stopping spinner)", () => {
-        it("maps result to session_end, carrying stats tokens", () => {
+        it("maps a success result to session_end, carrying stats tokens", () => {
             const t = new GeminiTranslator();
             expect(
                 t.translate({ type: "result", status: "success", stats: { input_tokens: 800, output_tokens: 210 } }),
             ).toEqual([{ type: "session_end", stats: { input_tokens: 800, output_tokens: 210 } }]);
+        });
+
+        it("a non-success result surfaces the error before session_end", () => {
+            const t = new GeminiTranslator();
+            expect(
+                t.translate({ type: "result", status: "error", error: { message: "quota exceeded" } }),
+            ).toEqual([
+                { type: "text", content: "**Error:** quota exceeded" },
+                { type: "session_end", stats: {} },
+            ]);
         });
 
         it("session_end with empty stats when stats are absent or partial", () => {

--- a/frontend/app/view/agent/providers/gemini-translator.test.ts
+++ b/frontend/app/view/agent/providers/gemini-translator.test.ts
@@ -1,0 +1,47 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { GeminiTranslator } from "./gemini-translator";
+
+describe("GeminiTranslator", () => {
+    describe("turn boundary → session_end (fixes the never-stopping spinner)", () => {
+        it("maps result to session_end, carrying stats tokens", () => {
+            const t = new GeminiTranslator();
+            expect(
+                t.translate({ type: "result", status: "success", stats: { input_tokens: 800, output_tokens: 210 } }),
+            ).toEqual([{ type: "session_end", stats: { input_tokens: 800, output_tokens: 210 } }]);
+        });
+
+        it("session_end with empty stats when stats are absent or partial", () => {
+            const t = new GeminiTranslator();
+            expect(t.translate({ type: "result" })).toEqual([{ type: "session_end", stats: {} }]);
+            expect(t.translate({ type: "result", stats: { input_tokens: 5 } })).toEqual([
+                { type: "session_end", stats: { input_tokens: 5 } },
+            ]);
+        });
+
+        it("init is still a no-content lifecycle event", () => {
+            const t = new GeminiTranslator();
+            expect(t.translate({ type: "init", model: "gemini-2.5-pro" })).toEqual([]);
+        });
+    });
+
+    describe("content unchanged by the fix", () => {
+        it("assistant message delta → text", () => {
+            const t = new GeminiTranslator();
+            expect(t.translate({ type: "message", role: "assistant", content: "hi" })).toEqual([
+                { type: "text", content: "hi" },
+            ]);
+            // user-role messages are not surfaced
+            expect(t.translate({ type: "message", role: "user", content: "x" })).toEqual([]);
+        });
+
+        it("tool_use → tool_call", () => {
+            const t = new GeminiTranslator();
+            expect(
+                t.translate({ type: "tool_use", tool_name: "Bash", tool_id: "t1", parameters: { cmd: "ls" } }),
+            ).toEqual([{ type: "tool_call", tool: "Bash", id: "t1", params: { cmd: "ls" } }]);
+        });
+    });
+});

--- a/frontend/app/view/agent/providers/gemini-translator.ts
+++ b/frontend/app/view/agent/providers/gemini-translator.ts
@@ -38,13 +38,23 @@ export class GeminiTranslator implements OutputTranslator {
                 // Gemini's turn-end → the provider-agnostic `session_end` the
                 // conversation reducer uses to finalize the turn (which stops the
                 // working spinner). Mirrors the claude/codex translators.
+                const out: StreamEvent[] = [];
+                // A non-"success" result surfaces its error first, like the codex
+                // turn.failed case — otherwise it stops the spinner silently and
+                // reads as a success.
+                if (rawEvent.status && rawEvent.status !== "success") {
+                    const msg: string =
+                        rawEvent.error?.message ?? rawEvent.error ?? rawEvent.message ?? `gemini turn ${rawEvent.status}`;
+                    out.push({ type: "text", content: `**Error:** ${msg}` });
+                }
                 const stats: SessionStats = {};
                 const s = rawEvent.stats;
                 if (s && typeof s === "object") {
                     if (typeof s.input_tokens === "number") stats.input_tokens = s.input_tokens;
                     if (typeof s.output_tokens === "number") stats.output_tokens = s.output_tokens;
                 }
-                return [{ type: "session_end", stats }];
+                out.push({ type: "session_end", stats });
+                return out;
             }
 
             case "message": {

--- a/frontend/app/view/agent/providers/gemini-translator.ts
+++ b/frontend/app/view/agent/providers/gemini-translator.ts
@@ -1,7 +1,7 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { SessionStats, StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
 import type { OutputTranslator } from "./translator";
 
 /**
@@ -31,9 +31,21 @@ export class GeminiTranslator implements OutputTranslator {
 
         switch (type) {
             case "init":
-            case "result":
-                // Lifecycle events — no display content
+                // Lifecycle event — no display content
                 return [];
+
+            case "result": {
+                // Gemini's turn-end → the provider-agnostic `session_end` the
+                // conversation reducer uses to finalize the turn (which stops the
+                // working spinner). Mirrors the claude/codex translators.
+                const stats: SessionStats = {};
+                const s = rawEvent.stats;
+                if (s && typeof s === "object") {
+                    if (typeof s.input_tokens === "number") stats.input_tokens = s.input_tokens;
+                    if (typeof s.output_tokens === "number") stats.output_tokens = s.output_tokens;
+                }
+                return [{ type: "session_end", stats }];
+            }
 
             case "message": {
                 if (rawEvent.role !== "assistant") return [];


### PR DESCRIPTION
Fixes **2 of the 3** gemini provider issues. Issue 1 — an auth-escalation loop — is the **live blocker** and is bigger; it's tracked in the analysis doc for a separate fix.

## Issue 2 — `--model sonnet` leak (`buildRuntimeArgs.ts`)
gemini was in `supportsModel`, so it received `--model sonnet` — a Claude model gemini rejects. Removed gemini from `supportsModel`; it now uses its CLI default. (Per-provider gemini model selection is a follow-up.)

## Issue 3 — translator drops the turn boundary (`gemini-translator.ts`)
`result` (gemini's turn-end: `{"type":"result","status":"success","stats":{…}}`) was returned as `[]` (a lifecycle event), so the reducer never received `session_end` → the working spinner never stopped. Now mapped to `session_end` with stats — same class as the merged codex fix.

## Not in this PR — issue 1 (live blocker)
The gemini pane "does nothing / never logs in" because the stored OAuth token is expired (~Mar 25) and the auth orchestration loops on `CheckCliAuth` without ever escalating to `gemini auth login`. That's a `cli_handlers` auth-flow fix (bigger) — see `docs/analysis/GEMINI_PROVIDER_ISSUES_2026_06_02.md`. Until it lands, an expired-token gemini pane needs a manual `gemini auth login`.

## Tests
- `gemini-translator.test.ts` — `result` → `session_end`; `init` still dropped; content unchanged.
- `buildRuntimeArgs.test.ts` — gemini no longer gets `--model`/`sonnet`.
- 11/11 green.

Note: gemini's exact `result.stats` field names are unverified (the auth blocker prevents live testing) — the fix reads `input_tokens`/`output_tokens`; the spinner-stop (the primary fix) works regardless of the stats shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
