### PR TITLE
fix(floating-pane): dwell + velocity gate prevents accidental redock on transit

### DIFF
--- a/.changesets/1780886557-fix-floating-pane-dwell-velocity-gate-redock-transit-7k9x.md
+++ b/.changesets/1780886557-fix-floating-pane-dwell-velocity-gate-redock-transit-7k9x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): dwell + velocity gate prevents accidental redock on fast transit

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -451,14 +451,26 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // may arrive before or after DOM mouseup (separate CEF IPC channels).
                 // If ended arrives first: hoverArmed is still true and wins.
                 // If mouseup arrives first: pendingRedockArmed carries it for ended.
-                pendingRedockArmed = hoverArmed;
+                // Point-in-time fallback: if user held still over a target until the
+                // dwell threshold elapsed but no further hover-state event fired to set
+                // hoverArmed, check the wall-clock directly at mouseup time.
+                const nowMs = performance.now();
+                pendingRedockArmed = hoverArmed ||
+                    (dwellCurrentHoverTarget !== null &&
+                     dwellHoverTargetFirstSeenAt !== null &&
+                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 pendingRedockCoords = { x: e.screenX, y: e.screenY };
             } else if (hasMoved) {
                 // Non-Windows: on macOS the JS-driven path fires mousemove+mouseup
                 // normally. On Linux, BeginWindowDrag may deliver them. Only
                 // attempt redock if the dwell gate armed and motion confirmed.
-                const armed = hoverArmed;
+                // Point-in-time fallback: if cursor went slow REDOCK_DWELL_MS ago and
+                // then held still (no more mousemove events), fire redock at release;
+                // tryRedockAtCursorInner handles the no-target case gracefully.
+                const nowMs = performance.now();
+                const armed = hoverArmed ||
+                    (dwellSlowSince !== null && nowMs - dwellSlowSince >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
             }
@@ -522,7 +534,16 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // this event can arrive before or after DOM mouseup (separate CEF IPC
                 // channels). Before mouseup: hoverArmed is still true. After mouseup:
                 // onMouseUp already moved it to pendingRedockArmed.
-                const armedAtEnd = pendingRedockArmed || hoverArmed;
+                // Point-in-time fallback: if the user held still over a target until
+                // the dwell elapsed but no event fired to set hoverArmed (or mouseup
+                // raced ahead and set pendingRedockArmed via the fallback there), the
+                // wall-clock check here covers the window_drag_ended ordering leg.
+                const nowMs = performance.now();
+                const armedAtEnd = pendingRedockArmed || hoverArmed ||
+                    (dwellCurrentHoverTarget !== null &&
+                     dwellHoverTargetFirstSeenAt !== null &&
+                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
+                    (dwellSlowSince !== null && nowMs - dwellSlowSince >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 pendingRedockArmed = false;
                 // Always clear hover — safety net for non-Windows where onMouseUp
@@ -674,11 +695,12 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 }).then((res) => {
                     const newTarget = res?.target_label ?? null;
                     if (newTarget !== dwellLastArmedTarget) {
-                        // Target changed — disarm. Don't reset dwellSlowSince: the
-                        // cursor has already qualified for ≥180ms, so the new target
-                        // will arm on the very next throttled IPC that returns the
-                        // same label rather than requiring a fresh 180ms wait.
+                        // Target changed — disarm and restart the dwell clock.
+                        // Preserving dwellSlowSince would let a slow transit across an
+                        // intermediate window pre-satisfy the 180ms dwell for the
+                        // destination, bypassing the gate (codex P2).
                         dwellLastArmedTarget = newTarget;
+                        dwellSlowSince = null;
                         if (hoverArmed) {
                             hoverArmed = false;
                             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -681,6 +681,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     if (velocity > REDOCK_VELOCITY_PX_PER_S) {
                         dwellSlowSince = null;
                         dwellLastArmedTarget = null;
+                        dwellCurrentConfirmedAt = null;
                         if (hoverArmed) {
                             hoverArmed = false;
                             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -469,7 +469,14 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 pendingRedockArmed = hoverArmed ||
                     (dwellCurrentHoverTarget !== null &&
                      dwellHoverTargetFirstSeenAt !== null &&
-                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS);
+                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
+                    // Hold-still after fast entry: velocity gate preserved the target
+                    // but cleared the timer; cursor then stopped so no slow event
+                    // restarted it. Check time-since-last-event as dwell proxy.
+                    (dwellCurrentHoverTarget !== null &&
+                     dwellHoverTargetFirstSeenAt === null &&
+                     dwellWinLastSampleAt > 0 &&
+                     nowMs - dwellWinLastSampleAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 pendingRedockCoords = { x: e.screenX, y: e.screenY };
             } else if (hasMoved) {
@@ -561,6 +568,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     (dwellCurrentHoverTarget !== null &&
                      dwellHoverTargetFirstSeenAt !== null &&
                      nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
+                    // Hold-still after fast entry (Windows): same fallback as onMouseUp.
+                    (dwellCurrentHoverTarget !== null &&
+                     dwellHoverTargetFirstSeenAt === null &&
+                     dwellWinLastSampleAt > 0 &&
+                     nowMs - dwellWinLastSampleAt >= REDOCK_DWELL_MS) ||
                     (dwellCurrentConfirmedAt !== null &&
                      nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
@@ -619,10 +631,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                             const velocity = dt > 0 ? Math.sqrt(dx * dx + dy * dy) / (dt / 1000) : 0;
                             if (velocity > REDOCK_VELOCITY_PX_PER_S) {
                                 // Moving fast — reset dwell clock and disarm.
-                                // If the overlay was showing (hoverArmed), clear it so the
-                                // dock indicator disappears immediately on fast movement,
-                                // matching the non-Windows path (line 671).
-                                dwellCurrentHoverTarget = null;
+                                // Preserve dwellCurrentHoverTarget (don't null it) so that
+                                // if the cursor slows or stops over the same target the
+                                // dwell timer can restart (codex P2 fix). Only the timer
+                                // is cleared; the target identity is kept.
+                                dwellCurrentHoverTarget = newTarget;
                                 dwellHoverTargetFirstSeenAt = null;
                                 hoverArmed = false;
                                 invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
@@ -644,6 +657,10 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         const wasArmed = hoverArmed;
                         hoverArmed = false;
                         if (wasArmed) invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                    } else if (newTarget !== null && dwellHoverTargetFirstSeenAt === null) {
+                        // Velocity gate preserved the target but cleared the timer.
+                        // Cursor has now slowed on the same target — restart dwell clock.
+                        dwellHoverTargetFirstSeenAt = now;
                     } else if (
                         newTarget !== null &&
                         dwellHoverTargetFirstSeenAt !== null &&
@@ -723,19 +740,25 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     if (capturedSessionId !== dragSessionId) return;
                     const newTarget = res?.target_label ?? null;
                     if (newTarget !== dwellLastArmedTarget) {
-                        // Target changed — disarm and restart both dwell clocks.
-                        // dwellSlowSince reset prevents a slow transit across an
-                        // intermediate window from pre-satisfying the dwell for the
-                        // destination (codex P2). dwellCurrentConfirmedAt records when
-                        // this target was first confirmed so the mouseup fallback can
-                        // check "180ms since first confirmation" rather than "180ms
-                        // since any slow motion" (prevents desktop-transit false arm).
+                        // Target changed — disarm old target and restart both dwell
+                        // clocks. dwellSlowSince reset prevents a slow transit across
+                        // an intermediate window from pre-satisfying the dwell for the
+                        // destination. dwellCurrentConfirmedAt records when this target
+                        // was first confirmed so the mouseup fallback uses "180ms since
+                        // first confirmation" (prevents desktop-transit false arm).
                         dwellLastArmedTarget = newTarget;
                         dwellCurrentConfirmedAt = newTarget !== null ? performance.now() : null;
                         dwellSlowSince = null;
                         if (hoverArmed) {
                             hoverArmed = false;
                             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                        }
+                        // IPC returned a confirmed non-null target — the backend has
+                        // already broadcast the dock indicator. Arm immediately so
+                        // the velocity gate (line 692) can clear it on fast escape
+                        // and mouseup can dock on release.
+                        if (newTarget !== null) {
+                            hoverArmed = true;
                         }
                     } else if (newTarget !== null) {
                         hoverArmed = true;

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -191,6 +191,10 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // Non-Windows: wall-clock time when IPC first confirmed the current target.
         // Used as fallback when cursor holds still after first confirmation (no 2nd IPC).
         let dwellCurrentConfirmedAt: number | null = null;
+        // Non-Windows: true once update_floating_redock_hover returned a non-null target
+        // (indicator is showing on the backend). Separate from hoverArmed so the velocity
+        // gate can clear the indicator even before the full dwell interval has elapsed.
+        let indicatorShowing = false;
         // Per-target dwell (Windows): driven by floating-redock:hover-state events.
         let dwellCurrentHoverTarget: string | null = null;
         let dwellHoverTargetFirstSeenAt: number | null = null;
@@ -395,6 +399,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 dwellSlowSince = null;
                 dwellLastArmedTarget = null;
                 dwellCurrentConfirmedAt = null;
+                indicatorShowing = false;
                 dwellCurrentHoverTarget = null;
                 dwellHoverTargetFirstSeenAt = null;
                 dwellWinLastSampleAt = 0;
@@ -442,6 +447,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dwellSlowSince = null;
             dwellLastArmedTarget = null;
             dwellCurrentConfirmedAt = null;
+            indicatorShowing = false;
             dwellCurrentHoverTarget = null;
             dwellHoverTargetFirstSeenAt = null;
             dwellWinLastSampleAt = 0;
@@ -491,6 +497,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     (dwellCurrentConfirmedAt !== null &&
                      nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
+                indicatorShowing = false;
                 if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
             }
         };
@@ -527,6 +534,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     dwellSlowSince = null;
                     dwellLastArmedTarget = null;
                     dwellCurrentConfirmedAt = null;
+                    indicatorShowing = false;
                     dwellCurrentHoverTarget = null;
                     dwellHoverTargetFirstSeenAt = null;
                     dwellLastMoveSampleAt = 0;
@@ -576,6 +584,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     (dwellCurrentConfirmedAt !== null &&
                      nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
+                indicatorShowing = false;
                 pendingRedockArmed = false;
                 // Always clear hover — safety net for non-Windows where onMouseUp
                 // may not have fired (BeginWindowDrag absorbs the release).
@@ -710,8 +719,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         dwellSlowSince = null;
                         dwellLastArmedTarget = null;
                         dwellCurrentConfirmedAt = null;
-                        if (hoverArmed) {
+                        if (hoverArmed || indicatorShowing) {
                             hoverArmed = false;
+                            indicatorShowing = false;
                             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                         }
                         dwellLastMoveSampleAt = now;
@@ -749,18 +759,17 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         dwellLastArmedTarget = newTarget;
                         dwellCurrentConfirmedAt = newTarget !== null ? performance.now() : null;
                         dwellSlowSince = null;
-                        if (hoverArmed) {
+                        if (hoverArmed || indicatorShowing) {
                             hoverArmed = false;
+                            indicatorShowing = false;
                             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                         }
-                        // IPC returned a confirmed non-null target — the backend has
-                        // already broadcast the dock indicator. Arm immediately so
-                        // the velocity gate (line 692) can clear it on fast escape
-                        // and mouseup can dock on release.
-                        if (newTarget !== null) {
-                            hoverArmed = true;
-                        }
+                        // Backend has now broadcast the indicator for the new target.
+                        // Mark it showing so the velocity gate can clear it on fast
+                        // escape. hoverArmed stays false — full dwell still required.
+                        indicatorShowing = newTarget !== null;
                     } else if (newTarget !== null) {
+                        indicatorShowing = true;
                         hoverArmed = true;
                     }
                 }).catch(() => {});

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -187,6 +187,10 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // Per-target dwell (Windows): driven by floating-redock:hover-state events.
         let dwellCurrentHoverTarget: string | null = null;
         let dwellHoverTargetFirstSeenAt: number | null = null;
+        // Velocity sampling for Windows (hover-state events carry cursor_x/y).
+        let dwellWinLastSampleAt = 0;
+        let dwellWinLastSampleX = 0;
+        let dwellWinLastSampleY = 0;
         // redockInProgress is a signal at component scope (above this onMount)
         // so createEffect re-runs when it changes.
         // Sentinel for the listenEvent .then() race: if the component unmounts
@@ -384,6 +388,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 dwellLastArmedTarget = null;
                 dwellCurrentHoverTarget = null;
                 dwellHoverTargetFirstSeenAt = null;
+                dwellWinLastSampleAt = 0;
+                dwellWinLastSampleX = 0;
+                dwellWinLastSampleY = 0;
                 invokeCommand<{ x: number; y: number }>("get_window_position", { label })
                     .then((pos) => {
                         if (myId !== macMouseDownId) return;
@@ -427,6 +434,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dwellLastArmedTarget = null;
             dwellCurrentHoverTarget = null;
             dwellHoverTargetFirstSeenAt = null;
+            dwellWinLastSampleAt = 0;
+            dwellWinLastSampleX = 0;
+            dwellWinLastSampleY = 0;
         };
 
         const onMouseUp = (e: MouseEvent) => {
@@ -485,6 +495,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     dwellLastArmedTarget = null;
                     dwellCurrentHoverTarget = null;
                     dwellHoverTargetFirstSeenAt = null;
+                    dwellWinLastSampleAt = 0;
+                    dwellWinLastSampleX = 0;
+                    dwellWinLastSampleY = 0;
                 }
             },
         );
@@ -535,17 +548,52 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             },
         );
 
-        // On Windows, Win32BeginMoveTask emits `floating-redock:hover-state` as
-        // the dragged window transits. The dwell gate arms once the same target
-        // window has been reported for REDOCK_DWELL_MS ms continuously.
+        // On Windows, Win32BeginMoveTask emits `floating-redock:hover-state` at
+        // 50 ms with cursor_x/cursor_y (physical px). Both gates apply:
+        // 1. Velocity: compute CSS-px/s from successive event positions; if
+        //    > REDOCK_VELOCITY_PX_PER_S reset dwell clock and disarm.
+        // 2. Dwell: arm only after the same target has been seen continuously for
+        //    REDOCK_DWELL_MS ms (checked after the velocity gate passes).
         let stopHoverStateListener: (() => void) = () => {};
         if (isWindows()) {
-            stopHoverStateListener = safeListenEvent<{ target_label?: string | null }>(
+            stopHoverStateListener = safeListenEvent<{
+                target_label?: string | null;
+                cursor_x?: number;
+                cursor_y?: number;
+            }>(
                 "floating-redock:hover-state",
                 (ev) => {
                     if (!dragging) return;
                     const newTarget = ev.target_label ?? null;
                     const now = performance.now();
+                    // Velocity gate: cursor_x/cursor_y are physical px — divide by
+                    // posScale() to get CSS px (1 DIP on non-HiDPI, 0.5 CSS on 2×).
+                    if (typeof ev.cursor_x === "number" && typeof ev.cursor_y === "number") {
+                        const scale = posScale();
+                        const cssCurX = ev.cursor_x / scale;
+                        const cssCurY = ev.cursor_y / scale;
+                        if (dwellWinLastSampleAt > 0) {
+                            const dt = now - dwellWinLastSampleAt;
+                            const dx = cssCurX - dwellWinLastSampleX;
+                            const dy = cssCurY - dwellWinLastSampleY;
+                            const velocity = dt > 0 ? Math.sqrt(dx * dx + dy * dy) / (dt / 1000) : 0;
+                            if (velocity > REDOCK_VELOCITY_PX_PER_S) {
+                                // Moving fast — reset dwell clock, disarm, skip target check.
+                                dwellCurrentHoverTarget = null;
+                                dwellHoverTargetFirstSeenAt = null;
+                                hoverArmed = false;
+                                dwellWinLastSampleAt = now;
+                                dwellWinLastSampleX = cssCurX;
+                                dwellWinLastSampleY = cssCurY;
+                                return;
+                            }
+                        }
+                        dwellWinLastSampleAt = now;
+                        dwellWinLastSampleX = cssCurX;
+                        dwellWinLastSampleY = cssCurY;
+                    }
+                    // Dwell gate: arm only after seeing the same non-null target for
+                    // REDOCK_DWELL_MS ms. Target change resets the clock.
                     if (newTarget !== dwellCurrentHoverTarget) {
                         dwellCurrentHoverTarget = newTarget;
                         dwellHoverTargetFirstSeenAt = newTarget !== null ? now : null;

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -489,15 +489,34 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // Non-Windows: on macOS the JS-driven path fires mousemove+mouseup
                 // normally. On Linux, BeginWindowDrag may deliver them. Only
                 // attempt redock if the dwell gate armed and motion confirmed.
-                // Point-in-time fallback: if cursor went slow REDOCK_DWELL_MS ago and
-                // then held still (no more mousemove events), fire redock at release;
-                // tryRedockAtCursorInner handles the no-target case gracefully.
+                // Arm conditions (any one suffices):
+                // 1. hoverArmed: second IPC confirmed same target (full dwell cycle).
+                // 2. indicatorShowing: first IPC confirmed target after dwell;
+                //    cursor held still so no second IPC fired.
+                // 3. dwellSlowSince elapsed: cursor slowed and stopped before the
+                //    IPC could fire (stopped during the slow-motion window before
+                //    REDOCK_DWELL_MS); tryRedockAtCursorInner handles no-target.
+                // 4. dwellCurrentConfirmedAt elapsed: belt-and-suspenders for any
+                //    path where the target was confirmed but hoverArmed wasn't set.
                 const nowMs = performance.now();
                 const armed = hoverArmed ||
+                    indicatorShowing ||
+                    (dwellSlowSince !== null &&
+                     nowMs - dwellSlowSince >= REDOCK_DWELL_MS) ||
                     (dwellCurrentConfirmedAt !== null &&
                      nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
+                // Invalidate in-flight IPC .then() so it cannot re-arm hoverArmed
+                // after this mouseup has already consumed and cleared the state
+                // (reagent P1 — stale IPC re-arm → spurious window_drag_ended dock).
+                dragSessionId += 1;
                 hoverArmed = false;
                 indicatorShowing = false;
+                // Clear non-Windows dwell state so window_drag_ended (Linux race)
+                // cannot see stale dwellCurrentConfirmedAt and fire a second
+                // tryRedockAtCursor on the already-redocked block (reagent P1).
+                dwellCurrentConfirmedAt = null;
+                dwellCurrentHoverTarget = null;
+                dwellHoverTargetFirstSeenAt = null;
                 if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
             }
         };
@@ -573,6 +592,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // wall-clock check here covers the window_drag_ended ordering leg.
                 const nowMs = performance.now();
                 const armedAtEnd = pendingRedockArmed || hoverArmed ||
+                    // Non-Windows: indicatorShowing means IPC confirmed target after dwell.
+                    indicatorShowing ||
                     (dwellCurrentHoverTarget !== null &&
                      dwellHoverTargetFirstSeenAt !== null &&
                      nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -599,10 +599,18 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                             const dy = cssCurY - dwellWinLastSampleY;
                             const velocity = dt > 0 ? Math.sqrt(dx * dx + dy * dy) / (dt / 1000) : 0;
                             if (velocity > REDOCK_VELOCITY_PX_PER_S) {
-                                // Moving fast — reset dwell clock, disarm, skip target check.
+                                // Moving fast — reset dwell clock and disarm.
+                                // If the overlay was showing (hoverArmed), clear it so the
+                                // dock indicator disappears immediately on fast movement,
+                                // matching the non-Windows path (line 671).
                                 dwellCurrentHoverTarget = null;
                                 dwellHoverTargetFirstSeenAt = null;
-                                hoverArmed = false;
+                                if (hoverArmed) {
+                                    hoverArmed = false;
+                                    invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                                } else {
+                                    hoverArmed = false;
+                                }
                                 dwellWinLastSampleAt = now;
                                 dwellWinLastSampleX = cssCurX;
                                 dwellWinLastSampleY = cssCurY;

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -165,6 +165,28 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         let macSetPosInFlight = false;
         let macPendingPos: { x: number; y: number } | null = null;
         let macMouseDownId = 0;
+        // Dwell + velocity gate: prevents accidental redock when the cursor
+        // transits over another window at speed. Arms hover only after the cursor
+        // stays near the same target window for REDOCK_DWELL_MS ms at
+        // ≤ REDOCK_VELOCITY_PX_PER_S CSS-px/s. All vars hoisted to drag scope so
+        // a second drag never inherits state from the first.
+        const REDOCK_DWELL_MS = 180;
+        const REDOCK_VELOCITY_PX_PER_S = 400;
+        let hoverArmed = false;
+        // Preserves arm state across the Windows mouseup/window_drag_ended race:
+        // onMouseUp sets pendingRedockArmed=hoverArmed before clearing hoverArmed,
+        // so window_drag_ended can safely use either flag.
+        let pendingRedockArmed = false;
+        // Velocity sampling state (non-Windows mousemove path).
+        let dwellLastMoveSampleAt = 0;
+        let dwellLastMoveSampleX = 0;
+        let dwellLastMoveSampleY = 0;
+        let dwellSlowSince: number | null = null;
+        // Per-target dwell (non-Windows): reset arming when IPC returns a new target.
+        let dwellLastArmedTarget: string | null = null;
+        // Per-target dwell (Windows): driven by floating-redock:hover-state events.
+        let dwellCurrentHoverTarget: string | null = null;
+        let dwellHoverTargetFirstSeenAt: number | null = null;
         // redockInProgress is a signal at component scope (above this onMount)
         // so createEffect re-runs when it changes.
         // Sentinel for the listenEvent .then() race: if the component unmounts
@@ -353,6 +375,15 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 macLatestScreenY = e.screenY;
                 hasMoved = false;
                 pendingRedockCoords = null;
+                hoverArmed = false;
+                pendingRedockArmed = false;
+                dwellLastMoveSampleAt = 0;
+                dwellLastMoveSampleX = 0;
+                dwellLastMoveSampleY = 0;
+                dwellSlowSince = null;
+                dwellLastArmedTarget = null;
+                dwellCurrentHoverTarget = null;
+                dwellHoverTargetFirstSeenAt = null;
                 invokeCommand<{ x: number; y: number }>("get_window_position", { label })
                     .then((pos) => {
                         if (myId !== macMouseDownId) return;
@@ -387,6 +418,15 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dragging = true;
             hasMoved = false;
             pendingRedockCoords = null;
+            hoverArmed = false;
+            pendingRedockArmed = false;
+            dwellLastMoveSampleAt = 0;
+            dwellLastMoveSampleX = 0;
+            dwellLastMoveSampleY = 0;
+            dwellSlowSince = null;
+            dwellLastArmedTarget = null;
+            dwellCurrentHoverTarget = null;
+            dwellHoverTargetFirstSeenAt = null;
         };
 
         const onMouseUp = (e: MouseEvent) => {
@@ -397,15 +437,20 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dragging = false;
             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
             if (isWindows()) {
-                // On Windows: save coords; window_drag_ended carries
-                // cursor_x/cursor_y from the host (physical px) and drives
-                // tryRedockAtCursor — no ordering race with this event.
+                // On Windows: preserve arm state before clearing — window_drag_ended
+                // may arrive before or after DOM mouseup (separate CEF IPC channels).
+                // If ended arrives first: hoverArmed is still true and wins.
+                // If mouseup arrives first: pendingRedockArmed carries it for ended.
+                pendingRedockArmed = hoverArmed;
+                hoverArmed = false;
                 pendingRedockCoords = { x: e.screenX, y: e.screenY };
             } else if (hasMoved) {
                 // Non-Windows: on macOS the JS-driven path fires mousemove+mouseup
                 // normally. On Linux, BeginWindowDrag may deliver them. Only
-                // attempt redock if onMouseMove confirmed actual motion.
-                void tryRedockAtCursor(e.screenX, e.screenY);
+                // attempt redock if the dwell gate armed and motion confirmed.
+                const armed = hoverArmed;
+                hoverArmed = false;
+                if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
             }
         };
 
@@ -434,6 +479,12 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     dragging = false;
                     hasMoved = false;
                     pendingRedockCoords = null;
+                    hoverArmed = false;
+                    pendingRedockArmed = false;
+                    dwellSlowSince = null;
+                    dwellLastArmedTarget = null;
+                    dwellCurrentHoverTarget = null;
+                    dwellHoverTargetFirstSeenAt = null;
                 }
             },
         );
@@ -454,10 +505,17 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             (ev) => {
                 if (!ev.label || ev.label !== label) return;
                 dragging = false;
+                // Capture arm state before clearing — handles the Windows race where
+                // this event can arrive before or after DOM mouseup (separate CEF IPC
+                // channels). Before mouseup: hoverArmed is still true. After mouseup:
+                // onMouseUp already moved it to pendingRedockArmed.
+                const armedAtEnd = pendingRedockArmed || hoverArmed;
+                hoverArmed = false;
+                pendingRedockArmed = false;
                 // Always clear hover — safety net for non-Windows where onMouseUp
                 // may not have fired (BeginWindowDrag absorbs the release).
                 invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                if (ev.moved && !cleaned) {
+                if (ev.moved && !cleaned && armedAtEnd) {
                     // Prefer host-provided cursor coords (physical px → CSS px via
                     // posScale). On Windows these are always present. On non-Windows
                     // fall back to pendingRedockCoords saved by onMouseUp if the OS
@@ -476,6 +534,32 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 }
             },
         );
+
+        // On Windows, Win32BeginMoveTask emits `floating-redock:hover-state` as
+        // the dragged window transits. The dwell gate arms once the same target
+        // window has been reported for REDOCK_DWELL_MS ms continuously.
+        let stopHoverStateListener: (() => void) = () => {};
+        if (isWindows()) {
+            stopHoverStateListener = safeListenEvent<{ target_label?: string | null }>(
+                "floating-redock:hover-state",
+                (ev) => {
+                    if (!dragging) return;
+                    const newTarget = ev.target_label ?? null;
+                    const now = performance.now();
+                    if (newTarget !== dwellCurrentHoverTarget) {
+                        dwellCurrentHoverTarget = newTarget;
+                        dwellHoverTargetFirstSeenAt = newTarget !== null ? now : null;
+                        hoverArmed = false;
+                    } else if (
+                        newTarget !== null &&
+                        dwellHoverTargetFirstSeenAt !== null &&
+                        now - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS
+                    ) {
+                        hoverArmed = true;
+                    }
+                },
+            );
+        }
 
         // On macOS/Linux, BeginWindowDrag may still deliver mousemove to the
         // renderer (F3 verification pending). Keep the hover emit here for
@@ -505,15 +589,55 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     );
                 }
                 const now = performance.now();
+                // Velocity gate: measure cursor speed since the last sample.
+                const dt = now - dwellLastMoveSampleAt;
+                const dx = e.screenX - dwellLastMoveSampleX;
+                const dy = e.screenY - dwellLastMoveSampleY;
+                if (dwellLastMoveSampleAt > 0 && dt > 0) {
+                    const velocity = Math.sqrt(dx * dx + dy * dy) / (dt / 1000);
+                    if (velocity > REDOCK_VELOCITY_PX_PER_S) {
+                        dwellSlowSince = null;
+                        dwellLastArmedTarget = null;
+                        if (hoverArmed) {
+                            hoverArmed = false;
+                            invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                        }
+                        dwellLastMoveSampleAt = now;
+                        dwellLastMoveSampleX = e.screenX;
+                        dwellLastMoveSampleY = e.screenY;
+                        return;
+                    }
+                }
+                dwellLastMoveSampleAt = now;
+                dwellLastMoveSampleX = e.screenX;
+                dwellLastMoveSampleY = e.screenY;
+                if (dwellSlowSince === null) dwellSlowSince = now;
+                if (now - dwellSlowSince < REDOCK_DWELL_MS) return;
+                // Cursor has been slow for REDOCK_DWELL_MS — throttle IPC calls.
                 if (now - lastHoverAt < HOVER_THROTTLE_MS) return;
                 lastHoverAt = now;
                 const scale = posScale();
                 const sourceLabel = windowLabel();
                 if (!sourceLabel) return;
-                invokeCommand("update_floating_redock_hover", {
+                invokeCommand<{ target_label?: string | null }>("update_floating_redock_hover", {
                     source_label: sourceLabel,
                     x: Math.round(e.screenX * scale),
                     y: Math.round(e.screenY * scale),
+                }).then((res) => {
+                    const newTarget = res?.target_label ?? null;
+                    if (newTarget !== dwellLastArmedTarget) {
+                        // Target changed — disarm. Don't reset dwellSlowSince: the
+                        // cursor has already qualified for ≥180ms, so the new target
+                        // will arm on the very next throttled IPC that returns the
+                        // same label rather than requiring a fresh 180ms wait.
+                        dwellLastArmedTarget = newTarget;
+                        if (hoverArmed) {
+                            hoverArmed = false;
+                            invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                        }
+                    } else if (newTarget !== null) {
+                        hoverArmed = true;
+                    }
                 }).catch(() => {});
             };
             document.addEventListener("mousemove", onMouseMove);
@@ -644,6 +768,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             document.removeEventListener("mouseup", onMouseUp, true);
             stopCancelListener();
             stopEndedListener();
+            stopHoverStateListener();
             unlistenMouseMove?.();
         });
     });

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -165,6 +165,10 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         let macSetPosInFlight = false;
         let macPendingPos: { x: number; y: number } | null = null;
         let macMouseDownId = 0;
+        // Per-drag session counter: incremented on every drag start and on cancel.
+        // Guards the update_floating_redock_hover IPC .then() against stale responses
+        // from a prior drag session arriving during a new drag (or after a cancel).
+        let dragSessionId = 0;
         // Dwell + velocity gate: prevents accidental redock when the cursor
         // transits over another window at speed. Arms hover only after the cursor
         // stays near the same target window for REDOCK_DWELL_MS ms at
@@ -375,6 +379,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // isn't available in dev builds. Use JS-driven get/set_window_position
                 // polling instead (restores the pre-PR #1276 macOS behaviour).
                 macMouseDownId += 1;
+                dragSessionId += 1;
                 const myId = macMouseDownId;
                 macClickScreenX = e.screenX;
                 macClickScreenY = e.screenY;
@@ -442,6 +447,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dwellWinLastSampleAt = 0;
             dwellWinLastSampleX = 0;
             dwellWinLastSampleY = 0;
+            dragSessionId += 1;
         };
 
         const onMouseUp = (e: MouseEvent) => {
@@ -504,6 +510,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             "window_drag_cancelled",
             (ev) => {
                 if (!ev.label || ev.label === label) {
+                    if (isMacOS()) macMouseDownId += 1;
+                    dragSessionId += 1;
                     dragging = false;
                     hasMoved = false;
                     pendingRedockCoords = null;
@@ -514,6 +522,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     dwellCurrentConfirmedAt = null;
                     dwellCurrentHoverTarget = null;
                     dwellHoverTargetFirstSeenAt = null;
+                    dwellLastMoveSampleAt = 0;
+                    dwellLastMoveSampleX = 0;
+                    dwellLastMoveSampleY = 0;
                     dwellWinLastSampleAt = 0;
                     dwellWinLastSampleX = 0;
                     dwellWinLastSampleY = 0;
@@ -703,11 +714,13 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 const scale = posScale();
                 const sourceLabel = windowLabel();
                 if (!sourceLabel) return;
+                const capturedSessionId = dragSessionId;
                 invokeCommand<{ target_label?: string | null }>("update_floating_redock_hover", {
                     source_label: sourceLabel,
                     x: Math.round(e.screenX * scale),
                     y: Math.round(e.screenY * scale),
                 }).then((res) => {
+                    if (capturedSessionId !== dragSessionId) return;
                     const newTarget = res?.target_label ?? null;
                     if (newTarget !== dwellLastArmedTarget) {
                         // Target changed — disarm and restart both dwell clocks.

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -491,16 +491,16 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // attempt redock if the dwell gate armed and motion confirmed.
                 // Arm conditions (any one suffices):
                 // 1. hoverArmed: second IPC confirmed same target (full dwell cycle).
-                // 2. indicatorShowing: first IPC confirmed target after dwell;
-                //    cursor held still so no second IPC fired.
-                // 3. dwellSlowSince elapsed: cursor slowed and stopped before the
-                //    IPC could fire (stopped during the slow-motion window before
-                //    REDOCK_DWELL_MS); tryRedockAtCursorInner handles no-target.
-                // 4. dwellCurrentConfirmedAt elapsed: belt-and-suspenders for any
-                //    path where the target was confirmed but hoverArmed wasn't set.
+                // 2. dwellSlowSince elapsed: cursor slowed and stopped before
+                //    the IPC could fire (stopped during the slow-motion window);
+                //    tryRedockAtCursorInner handles the no-target case gracefully.
+                // 3. dwellCurrentConfirmedAt elapsed: first IPC confirmed the target;
+                //    user has now held still over it for a full REDOCK_DWELL_MS.
+                //    (indicatorShowing intentionally excluded — arming on first IPC
+                //    confirmation lets slow desktop transits dock without per-target
+                //    dwell; dwellCurrentConfirmedAt is the spec-correct check.)
                 const nowMs = performance.now();
                 const armed = hoverArmed ||
-                    indicatorShowing ||
                     (dwellSlowSince !== null &&
                      nowMs - dwellSlowSince >= REDOCK_DWELL_MS) ||
                     (dwellCurrentConfirmedAt !== null &&
@@ -592,8 +592,6 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // wall-clock check here covers the window_drag_ended ordering leg.
                 const nowMs = performance.now();
                 const armedAtEnd = pendingRedockArmed || hoverArmed ||
-                    // Non-Windows: indicatorShowing means IPC confirmed target after dwell.
-                    indicatorShowing ||
                     (dwellCurrentHoverTarget !== null &&
                      dwellHoverTargetFirstSeenAt !== null &&
                      nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -184,6 +184,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         let dwellSlowSince: number | null = null;
         // Per-target dwell (non-Windows): reset arming when IPC returns a new target.
         let dwellLastArmedTarget: string | null = null;
+        // Non-Windows: wall-clock time when IPC first confirmed the current target.
+        // Used as fallback when cursor holds still after first confirmation (no 2nd IPC).
+        let dwellCurrentConfirmedAt: number | null = null;
         // Per-target dwell (Windows): driven by floating-redock:hover-state events.
         let dwellCurrentHoverTarget: string | null = null;
         let dwellHoverTargetFirstSeenAt: number | null = null;
@@ -386,6 +389,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 dwellLastMoveSampleY = 0;
                 dwellSlowSince = null;
                 dwellLastArmedTarget = null;
+                dwellCurrentConfirmedAt = null;
                 dwellCurrentHoverTarget = null;
                 dwellHoverTargetFirstSeenAt = null;
                 dwellWinLastSampleAt = 0;
@@ -432,6 +436,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dwellLastMoveSampleY = 0;
             dwellSlowSince = null;
             dwellLastArmedTarget = null;
+            dwellCurrentConfirmedAt = null;
             dwellCurrentHoverTarget = null;
             dwellHoverTargetFirstSeenAt = null;
             dwellWinLastSampleAt = 0;
@@ -470,7 +475,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // tryRedockAtCursorInner handles the no-target case gracefully.
                 const nowMs = performance.now();
                 const armed = hoverArmed ||
-                    (dwellSlowSince !== null && nowMs - dwellSlowSince >= REDOCK_DWELL_MS);
+                    (dwellCurrentConfirmedAt !== null &&
+                     nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
             }
@@ -505,6 +511,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     pendingRedockArmed = false;
                     dwellSlowSince = null;
                     dwellLastArmedTarget = null;
+                    dwellCurrentConfirmedAt = null;
                     dwellCurrentHoverTarget = null;
                     dwellHoverTargetFirstSeenAt = null;
                     dwellWinLastSampleAt = 0;
@@ -543,7 +550,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     (dwellCurrentHoverTarget !== null &&
                      dwellHoverTargetFirstSeenAt !== null &&
                      nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
-                    (dwellSlowSince !== null && nowMs - dwellSlowSince >= REDOCK_DWELL_MS);
+                    (dwellCurrentConfirmedAt !== null &&
+                     nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
                 hoverArmed = false;
                 pendingRedockArmed = false;
                 // Always clear hover — safety net for non-Windows where onMouseUp
@@ -605,12 +613,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                                 // matching the non-Windows path (line 671).
                                 dwellCurrentHoverTarget = null;
                                 dwellHoverTargetFirstSeenAt = null;
-                                if (hoverArmed) {
-                                    hoverArmed = false;
-                                    invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                                } else {
-                                    hoverArmed = false;
-                                }
+                                hoverArmed = false;
+                                invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                                 dwellWinLastSampleAt = now;
                                 dwellWinLastSampleX = cssCurX;
                                 dwellWinLastSampleY = cssCurY;
@@ -626,7 +630,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     if (newTarget !== dwellCurrentHoverTarget) {
                         dwellCurrentHoverTarget = newTarget;
                         dwellHoverTargetFirstSeenAt = newTarget !== null ? now : null;
+                        const wasArmed = hoverArmed;
                         hoverArmed = false;
+                        if (wasArmed) invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                     } else if (
                         newTarget !== null &&
                         dwellHoverTargetFirstSeenAt !== null &&
@@ -703,11 +709,15 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 }).then((res) => {
                     const newTarget = res?.target_label ?? null;
                     if (newTarget !== dwellLastArmedTarget) {
-                        // Target changed — disarm and restart the dwell clock.
-                        // Preserving dwellSlowSince would let a slow transit across an
-                        // intermediate window pre-satisfy the 180ms dwell for the
-                        // destination, bypassing the gate (codex P2).
+                        // Target changed — disarm and restart both dwell clocks.
+                        // dwellSlowSince reset prevents a slow transit across an
+                        // intermediate window from pre-satisfying the dwell for the
+                        // destination (codex P2). dwellCurrentConfirmedAt records when
+                        // this target was first confirmed so the mouseup fallback can
+                        // check "180ms since first confirmation" rather than "180ms
+                        // since any slow motion" (prevents desktop-transit false arm).
                         dwellLastArmedTarget = newTarget;
+                        dwellCurrentConfirmedAt = newTarget !== null ? performance.now() : null;
                         dwellSlowSince = null;
                         if (hoverArmed) {
                             hoverArmed = false;


### PR DESCRIPTION
## Problem

When dragging a floating pane across the screen, the cursor frequently *transits* over another AgentMux window on its way somewhere else. The dock indicator appears the instant the cursor enters, and if the user releases the mouse during that transit — even unintentionally — the pane docks.

User report (2026-06-03):
> "Sometimes when dragging the pane over a main window, I don't want it to dock, but it immediately does."

Root cause: every `mousemove` during a drag pushes `update_floating_redock_hover` (throttled only at 50 ms cadence), and `tryRedockAtCursor` on `mouseup` commits unconditionally on cursor-over-window — no intent gate.

## Approach

Researched industry patterns: dwell-time delay (Baymard, Windows hover default), velocity gate (USPTO 11163428), and explicit compass widgets (VS Code, Infragistics, Telerik, Dockview). Chose **dwell + velocity** — composes naturally, no new UI affordances. Compass widget is the natural next step if this proves insufficient.

## Change (single file: `frontend/app/workspace/floating-pane-workspace.tsx`)

Two-stage commitment:

1. **Armed**: dock indicator only appears after the cursor has been moving slowly (≤ 400 CSS-px/s) for ≥ 180 ms.
2. **Committed**: `mouseup` invokes `tryRedockAtCursor` *only if armed at release time*.

Velocity is sampled per-mousemove from the previous sample. Exceeding threshold resets the dwell timer and immediately fires `clear_floating_redock_hover` if the indicator was visible. Returning to slow motion restarts dwell from scratch.

### Tuning (local constants — easy to revisit)

- `REDOCK_DWELL_MS = 180` — below Windows' 400 ms hover default because drag-aiming feels more deliberate than passive hover.
- `REDOCK_VELOCITY_PX_PER_S = 400` — relaxed aim ≈ 100 px / 250 ms (= 400 px/s); transit drags hit 1500+ px/s.

## Behavior matrix

| User action | Old | New |
|---|---|---|
| Drag fast across main window → release elsewhere | Indicator flashes briefly | No indicator |
| Drag fast across main window → accidentally release while over it | **Docks** (the reported bug) | No dock — floater stays put |
| Drag slowly to aim → ~200 ms → release | Indicator + dock | Indicator + dock (unchanged) |
| Drag slowly to aim → see indicator → change mind, drag fast away | Indicator persists | Indicator clears within 1 frame |

## Spec

`docs/specs/SPEC_FLOATING_REDOCK_DWELL_2026-06-03.md` — full research summary (VS Code, Infragistics, Telerik, Baymard, Dockview), design rationale, behavior matrix, known limitations, and future work (compass widget, telemetry).

## Test plan

- [ ] Drag a floating pane *fast* across a main window and release while still over it → floater stays at drop position, no dock.
- [ ] Drag a floating pane slowly toward a main window, hold ~200 ms → indicator appears → release → docks correctly.
- [ ] Begin slow drag → indicator appears → speed up and drag away → indicator clears immediately; release elsewhere → no dock.
- [ ] Multiple floating panes open: redock target resolution still picks the correct window (no regression on existing Phase 4a behavior).
- [ ] No regression in non-redock floating-pane drag (window follows cursor, edge resize, double-click maximize all still work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)