### PR TITLE
fix(macos): move hamburger to far-right of title bar; mirror right-anchored menus

### DIFF
--- a/.changesets/1780494809-fix-macos-move-hamburger-menu-to-far-right-of-title-bar-mirr-dk4i.md
+++ b/.changesets/1780494809-fix-macos-move-hamburger-menu-to-far-right-of-title-bar-mirr-dk4i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): move hamburger menu to far-right of title bar; mirror right-anchored menus

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -62,6 +62,44 @@
     }
 }
 
+// Mirrored layout for right-anchored (left-opening) menus — e.g. the macOS
+// far-right hamburger. Items run right-to-left: icon on the right, label
+// right-aligned, shortcut/chevron on the left, and the submenu chevron flips
+// to point LEFT (the direction the submenu opens). Best practice for
+// edge-anchored menus; scoped to .menu--mirrored so standard menus are
+// unaffected. See window/hamburger-menu.tsx + the `mirrored` prop on FlyoutMenu.
+.menu--mirrored {
+    align-items: flex-end;
+
+    .menu-item {
+        flex-direction: row-reverse;
+
+        .label {
+            text-align: right;
+        }
+
+        // Icon moves to the right edge of the row.
+        .menu-item-icon {
+            margin-right: 0;
+            margin-left: var(--space-1);
+        }
+
+        // Keyboard shortcut hints are dropped in the mirrored menu — on the
+        // left, next to the right-aligned labels, they read awkwardly.
+        .menu-item-shortcut {
+            display: none;
+        }
+
+        // Chevron moves to the left and mirrors to point left (▶ → ◀),
+        // matching the direction the submenu opens.
+        > .fa-chevron-right {
+            margin-left: 0;
+            margin-right: var(--space-1);
+            transform: scaleX(-1);
+        }
+    }
+}
+
 .menu-divider {
     height: 1px;
     background-color: rgba(255, 255, 255, 0.1);

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -26,6 +26,16 @@ type MenuProps = {
     items: MenuItem[];
     className?: string;
     placement?: Placement;
+    /**
+     * Mirror the menu for a right-anchored (left-opening) placement: items are
+     * laid out right-to-left (icon on the right, label right-aligned, chevron
+     * on the left pointing left) and submenus prefer to open to the LEFT.
+     * Use for menus anchored to the right edge (e.g. the macOS far-right
+     * hamburger). Best practice for edge-anchored menus — the disclosure arrow
+     * points the same way the submenu actually opens. Default off; every other
+     * menu keeps the standard left-to-right layout.
+     */
+    mirrored?: boolean;
     onOpenChange?: (isOpen: boolean) => void;
     children?: JSX.Element;
     renderMenu?: (subMenu: JSX.Element, props: any) => JSX.Element;
@@ -167,7 +177,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
             <Show when={isOpen()}>
                 <Portal>
                     <div
-                        class={clsx("menu", props.className)}
+                        class={clsx("menu", props.className, { "menu--mirrored": props.mirrored })}
                         ref={registerFloating}
                         style={floatingStyle()}
                         data-pane-overlay
@@ -232,6 +242,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
                                                 handleOnClick={handleOnClick}
                                                 renderMenu={props.renderMenu}
                                                 renderMenuItem={props.renderMenuItem}
+                                                mirrored={props.mirrored}
                                             />
                                         </Show>
                                     </>
@@ -267,6 +278,7 @@ type SubMenuProps = {
     handleOnClick: (e: MouseEvent, item: MenuItem) => void;
     renderMenu?: (subMenu: JSX.Element, props: any) => JSX.Element;
     renderMenuItem?: (item: MenuItem, props: any) => JSX.Element;
+    mirrored?: boolean;
 };
 
 const SubMenu = (props: SubMenuProps): JSX.Element => {
@@ -287,8 +299,14 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             const update = async () => {
                 const cur = position();
                 if (!cur) return;
+                // Mirrored (right-anchored) menus prefer to open submenus to
+                // the LEFT; flip() still sends them right if there's no room.
+                // Standard menus prefer right, flipping left near the edge.
                 const computed = await computeMenuPosition(
-                    { anchor: cur.anchorRect, placement: "right-start" },
+                    {
+                        anchor: cur.anchorRect,
+                        placement: props.mirrored ? "left-start" : "right-start",
+                    },
                     el,
                 );
                 setSubStyle(styleToString(computed.style));
@@ -311,7 +329,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
     const subMenu = (
         <div
             ref={registerSubMenu}
-            class="menu sub-menu"
+            class={clsx("menu sub-menu", { "menu--mirrored": props.mirrored })}
             style={subStyle()}
             data-pane-overlay
         >
@@ -375,6 +393,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                                     handleOnClick={props.handleOnClick}
                                     renderMenu={props.renderMenu}
                                     renderMenuItem={props.renderMenuItem}
+                                    mirrored={props.mirrored}
                                 />
                             </Show>
                         </>

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -93,35 +93,9 @@
         }
     }
 
-    .hamburger-btn {
-        flex-shrink: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 28px;
-        height: 27px;
-        padding: 0;
-        background: transparent;
-        border: none;
-        color: var(--accent-color);
-        -webkit-app-region: no-drag;
-        cursor: pointer;
-        align-self: center;
-
-        &:hover {
-            color: color-mix(in srgb, var(--accent-color), white 25%);
-        }
-
-        // Inline SVG (replaces fa-bars icon font). Icon fonts rasterize
-        // each glyph independently at the zoomed size; tiny sub-pixel
-        // boundary differences caused one of the three hamburger bars
-        // to render thinner than the other two, with a different bar
-        // affected at each zoom level. SVG rectangles fill uniformly
-        // and scale predictably with parent zoom.
-        svg {
-            display: block;
-        }
-    }
+    // .hamburger-btn styles moved to window/hamburger-menu.scss (top-level,
+    // un-nested) when the menu was extracted into <HamburgerMenu> — on macOS
+    // the button renders in the window header, outside .tab-bar.
 
     // --- Drag-and-drop wrapper for each tab ---
     // Wrapper floor MUST match the inner `.tab` floor. With

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -1,21 +1,14 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, createTab, getApi, setActiveTab, settingsAtom } from "@/store/global";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
-import { THEME_OPTIONS } from "@/app/menu/base-menus";
-import { FlyoutMenu } from "@/app/element/flyoutmenu";
-import { invokeCommand } from "@/app/platform/ipc";
+import { atoms, getApi, setActiveTab } from "@/store/global";
 import { fireAndForget } from "@/util/util";
-import { openModal } from "@/app/store/modalmodel";
-import { CommandPaletteModal } from "@/app/modals/command-palette";
-import { openBundleManager } from "@/app/modals/bundle-manager-modal";
 import { isMacOS } from "@/util/platformutil";
+import { HamburgerMenu } from "@/app/window/hamburger-menu";
 import { getTabGrabOffset } from "./tab-grab-offset";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { createMemo, For, onCleanup, onMount, Show } from "solid-js";
+import { For, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import { ObjectService, WorkspaceService } from "../store/services";
 import { makeORef, getObjectValue } from "../store/wos";
@@ -602,148 +595,15 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     const activeIndex = () => tabIds().indexOf(activeTabId());
 
-    const tabBarMenuItems = createMemo((): MenuItem[] => {
-        const settings = settingsAtom() ?? ({} as any);
-
-        const currentTheme = (settings["window:theme"] as string) || "default";
-        const themeSubItems: MenuItem[] = THEME_OPTIONS.map((opt) => ({
-            label: opt.label,
-            checked: currentTheme === opt.id,
-            onClick: () => {
-                fireAndForget(() =>
-                    RpcApi.SetConfigCommand(TabRpcClient, { "window:theme": opt.id } as any),
-                );
-            },
-        }));
-
-        const rawOpacity = (settings["window:opacity"] as number) ?? 0.8;
-        const isTransparent = (settings["window:transparent"] as boolean) ?? false;
-        const effectiveOpacity = isTransparent ? rawOpacity : 1.0;
-        const opacityStep = Math.round(effectiveOpacity * 20) / 20;
-        const opacitySubItems: MenuItem[] = [];
-        for (let pct = 100; pct >= 35; pct -= 5) {
-            const value = pct / 100;
-            opacitySubItems.push({
-                label: `${pct}%`,
-                checked: Math.abs(value - opacityStep) < 0.001,
-                onClick: () => {
-                    fireAndForget(() =>
-                        value < 1.0
-                            ? RpcApi.SetConfigCommand(TabRpcClient, {
-                                  "window:opacity": value,
-                                  "window:transparent": true,
-                              } as any)
-                            : RpcApi.SetConfigCommand(TabRpcClient, {
-                                  "window:opacity": 1.0,
-                                  "window:transparent": false,
-                              } as any),
-                    );
-                },
-            });
-        }
-
-        const mac = isMacOS();
-        const kbd = (m: string, w: string) => (mac ? m : w);
-
-        return [
-            {
-                label: "New Tab",
-                icon: "plus",
-                shortcut: kbd("⌘T", "Ctrl+T"),
-                onClick: () => createTab(),
-            },
-            { label: "", divider: true },
-            {
-                label: "New Window",
-                icon: "window-restore",
-                shortcut: kbd("⌘⇧N", "Ctrl+Shift+N"),
-                onClick: () => getApi().openNewWindow().catch(console.error),
-            },
-            { label: "", divider: true },
-            {
-                label: "Theme",
-                icon: "palette",
-                subItems: themeSubItems,
-            },
-            {
-                label: "Opacity",
-                icon: "circle-half-stroke",
-                subItems: opacitySubItems,
-            },
-            { label: "", divider: true },
-            {
-                label: "Settings",
-                icon: "cog",
-                onClick: () =>
-                    fireAndForget(async () => {
-                        const path = await invokeCommand<string>("ensure_settings_file");
-                        await invokeCommand("open_in_editor", { path });
-                    }),
-            },
-            {
-                label: "Command Palette",
-                icon: "magnifying-glass",
-                shortcut: kbd("⌘P", "Ctrl+P"),
-                onClick: () => openModal(CommandPaletteModal),
-            },
-            {
-                // Bundle-management PR 4 (Feature 2) — the app-wide
-                // Identity & Memory bundle manager. Opens the manager
-                // modal here when the app-wide singleton is free; when it
-                // is held in another window, focuses that window instead
-                // (the persistent "open elsewhere" banner stays the
-                // durable affordance). See SPEC_BUNDLE_MANAGEMENT §3.
-                label: "Identity & Memory",
-                icon: "id-card",
-                onClick: () => openBundleManager(),
-            },
-            {
-                label: "DevTools",
-                icon: "code",
-                onClick: () => getApi().toggleDevtools(),
-            },
-            {
-                label: "Online Docs",
-                icon: "book",
-                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
-            },
-            { label: "", divider: true },
-            {
-                label: "Exit",
-                icon: "right-from-bracket",
-                onClick: () => fireAndForget(() => invokeCommand("close_window", {})),
-            },
-        ];
-    });
-
     return (
         <div class="tab-bar" {...dragProps}>
-            <FlyoutMenu
-                items={tabBarMenuItems()}
-                placement="bottom-start"
-            >
-                <button class="hamburger-btn" title="Menu" data-drag-region="false">
-                    {/*
-                     * Inline SVG with three filled rects instead of
-                     * `fa fa-bars`. Icon-font glyphs rasterized one of
-                     * the three lines on a fractional pixel boundary at
-                     * different chrome zoom levels, making it noticeably
-                     * thinner — and the affected line shifted as zoom
-                     * changed. Filled rects scale uniformly with the
-                     * parent's CSS zoom, no rasterization unevenness.
-                     */}
-                    <svg
-                        width="26"
-                        height="22"
-                        viewBox="0 0 26 22"
-                        fill="currentColor"
-                    >
-                        <rect x="2" y="3" width="22" height="3" rx="1" />
-                        <rect x="2" y="10" width="22" height="3" rx="1" />
-                        <rect x="2" y="17" width="22" height="3" rx="1" />
-                    </svg>
-                </button>
-            </FlyoutMenu>
+            {/* Windows/Linux: hamburger sits at the LEFT of the tab strip.
+                On macOS it's rendered at the far right of the window header
+                instead (see window-header.tsx) so it clears the native
+                traffic-light controls. */}
+            <Show when={!isMacOS()}>
+                <HamburgerMenu />
+            </Show>
             <div ref={tabBarScrollRef!} class="tab-bar-scroll" data-drag-region="false">
                 <For each={tabIds()}>
                     {(tabId, i) => (

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -1,0 +1,45 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hamburger (☰) button. Top-level (un-nested) so the same rule applies
+// whether the button is rendered inside `.tab-bar` (Windows/Linux) or as a
+// direct child of `.window-header` (macOS far-right). Moved here from
+// tabbar.scss when the menu was extracted into <HamburgerMenu>.
+
+.hamburger-btn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 27px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: var(--accent-color);
+    -webkit-app-region: no-drag;
+    cursor: pointer;
+    align-self: center;
+
+    &:hover {
+        color: color-mix(in srgb, var(--accent-color), white 25%);
+    }
+
+    // Inline SVG (replaces fa-bars icon font). Icon fonts rasterize
+    // each glyph independently at the zoomed size; tiny sub-pixel
+    // boundary differences caused one of the three hamburger bars
+    // to render thinner than the other two, with a different bar
+    // affected at each zoom level. SVG rectangles fill uniformly
+    // and scale predictably with parent zoom.
+    svg {
+        display: block;
+    }
+
+    // macOS: pinned to the far right of the title bar, after the action
+    // widgets. Add breathing room so it doesn't sit flush against the
+    // window's right frame.
+    &--right {
+        margin-left: 4px;
+        margin-right: 8px;
+    }
+}

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -1,0 +1,184 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The app/overflow (hamburger ☰) menu. Extracted from TabBar so it can be
+// rendered in two places depending on platform:
+//   * Windows / Linux — at the LEFT of the tab strip (default position),
+//     clear of the right-side caption buttons.
+//   * macOS — at the FAR RIGHT of the window header, after the action
+//     widgets, so it doesn't crowd the native traffic-light controls on
+//     the left. See window-header.tsx.
+//
+// Every menu action resolves to a module-level store/RPC primitive, so the
+// component is fully self-contained (no TabBar state coupling).
+
+import { createTab, getApi, settingsAtom } from "@/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { THEME_OPTIONS } from "@/app/menu/base-menus";
+import { FlyoutMenu } from "@/app/element/flyoutmenu";
+import { invokeCommand } from "@/app/platform/ipc";
+import { fireAndForget } from "@/util/util";
+import { openModal } from "@/app/store/modalmodel";
+import { CommandPaletteModal } from "@/app/modals/command-palette";
+import { openBundleManager } from "@/app/modals/bundle-manager-modal";
+import { isMacOS } from "@/util/platformutil";
+import { createMemo, type JSX } from "solid-js";
+import "./hamburger-menu.scss";
+
+interface HamburgerMenuProps {
+    /**
+     * Where the button sits in the header. "left" (default) opens the
+     * flyout aligned to the left edge; "right" (macOS far-right) opens it
+     * aligned to the right edge so it can't overflow off the window frame.
+     */
+    position?: "left" | "right";
+}
+
+export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
+    const menuItems = createMemo((): MenuItem[] => {
+        const settings = settingsAtom() ?? ({} as any);
+
+        const currentTheme = (settings["window:theme"] as string) || "default";
+        const themeSubItems: MenuItem[] = THEME_OPTIONS.map((opt) => ({
+            label: opt.label,
+            checked: currentTheme === opt.id,
+            onClick: () => {
+                fireAndForget(() =>
+                    RpcApi.SetConfigCommand(TabRpcClient, { "window:theme": opt.id } as any),
+                );
+            },
+        }));
+
+        const rawOpacity = (settings["window:opacity"] as number) ?? 0.8;
+        const isTransparent = (settings["window:transparent"] as boolean) ?? false;
+        const effectiveOpacity = isTransparent ? rawOpacity : 1.0;
+        const opacityStep = Math.round(effectiveOpacity * 20) / 20;
+        const opacitySubItems: MenuItem[] = [];
+        for (let pct = 100; pct >= 35; pct -= 5) {
+            const value = pct / 100;
+            opacitySubItems.push({
+                label: `${pct}%`,
+                checked: Math.abs(value - opacityStep) < 0.001,
+                onClick: () => {
+                    fireAndForget(() =>
+                        value < 1.0
+                            ? RpcApi.SetConfigCommand(TabRpcClient, {
+                                  "window:opacity": value,
+                                  "window:transparent": true,
+                              } as any)
+                            : RpcApi.SetConfigCommand(TabRpcClient, {
+                                  "window:opacity": 1.0,
+                                  "window:transparent": false,
+                              } as any),
+                    );
+                },
+            });
+        }
+
+        const mac = isMacOS();
+        const kbd = (m: string, w: string) => (mac ? m : w);
+
+        return [
+            {
+                label: "New Tab",
+                icon: "plus",
+                shortcut: kbd("⌘T", "Ctrl+T"),
+                onClick: () => createTab(),
+            },
+            { label: "", divider: true },
+            {
+                label: "New Window",
+                icon: "window-restore",
+                shortcut: kbd("⌘⇧N", "Ctrl+Shift+N"),
+                onClick: () => getApi().openNewWindow().catch(console.error),
+            },
+            { label: "", divider: true },
+            {
+                label: "Theme",
+                icon: "palette",
+                subItems: themeSubItems,
+            },
+            {
+                label: "Opacity",
+                icon: "circle-half-stroke",
+                subItems: opacitySubItems,
+            },
+            { label: "", divider: true },
+            {
+                label: "Settings",
+                icon: "cog",
+                onClick: () =>
+                    fireAndForget(async () => {
+                        const path = await invokeCommand<string>("ensure_settings_file");
+                        await invokeCommand("open_in_editor", { path });
+                    }),
+            },
+            {
+                label: "Command Palette",
+                icon: "magnifying-glass",
+                shortcut: kbd("⌘P", "Ctrl+P"),
+                onClick: () => openModal(CommandPaletteModal),
+            },
+            {
+                // Bundle-management PR 4 (Feature 2) — the app-wide
+                // Identity & Memory bundle manager. Opens the manager
+                // modal here when the app-wide singleton is free; when it
+                // is held in another window, focuses that window instead
+                // (the persistent "open elsewhere" banner stays the
+                // durable affordance). See SPEC_BUNDLE_MANAGEMENT §3.
+                label: "Identity & Memory",
+                icon: "id-card",
+                onClick: () => openBundleManager(),
+            },
+            {
+                label: "DevTools",
+                icon: "code",
+                onClick: () => getApi().toggleDevtools(),
+            },
+            {
+                label: "Online Docs",
+                icon: "book",
+                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
+            },
+            { label: "", divider: true },
+            {
+                label: "Exit",
+                icon: "right-from-bracket",
+                onClick: () => fireAndForget(() => invokeCommand("close_window", {})),
+            },
+        ];
+    });
+
+    const atRight = (): boolean => props.position === "right";
+
+    return (
+        <FlyoutMenu
+            items={menuItems()}
+            placement={atRight() ? "bottom-end" : "bottom-start"}
+            mirrored={atRight()}
+        >
+            <button
+                class="hamburger-btn"
+                classList={{ "hamburger-btn--right": atRight() }}
+                title="Menu"
+                data-drag-region="false"
+            >
+                {/*
+                 * Inline SVG with three filled rects instead of
+                 * `fa fa-bars`. Icon-font glyphs rasterized one of
+                 * the three lines on a fractional pixel boundary at
+                 * different chrome zoom levels, making it noticeably
+                 * thinner — and the affected line shifted as zoom
+                 * changed. Filled rects scale uniformly with the
+                 * parent's CSS zoom, no rasterization unevenness.
+                 */}
+                <svg width="26" height="22" viewBox="0 0 26 22" fill="currentColor">
+                    <rect x="2" y="3" width="22" height="3" rx="1" />
+                    <rect x="2" y="10" width="22" height="3" rx="1" />
+                    <rect x="2" y="17" width="22" height="3" rx="1" />
+                </svg>
+            </button>
+        </FlyoutMenu>
+    );
+}

--- a/frontend/app/window/window-header.tsx
+++ b/frontend/app/window/window-header.tsx
@@ -10,6 +10,9 @@ import { type JSX } from "solid-js";
 import { createTabBarMenu } from "@/app/menu/base-menus";
 import { SystemStatus } from "@/app/window/system-status";
 import { WindowControlsLeft } from "@/app/window/window-controls.platform";
+import { HamburgerMenu } from "@/app/window/hamburger-menu";
+import { isMacOS } from "@/util/platformutil";
+import { Show } from "solid-js";
 import "./window-header.platform.scss";
 
 
@@ -46,6 +49,14 @@ const WindowHeader = (props: WindowHeaderProps): JSX.Element => {
             <TabBar workspace={props.workspace} />
 
             <SystemStatus />
+
+            {/* macOS: the hamburger lives at the far right of the header,
+                after the action widgets — the native traffic-light controls
+                occupy the left, so a left-side hamburger crowds them. On
+                Windows/Linux it stays in the tab strip (see TabBar). */}
+            <Show when={isMacOS()}>
+                <HamburgerMenu position="right" />
+            </Show>
         </div>
     );
 };


### PR DESCRIPTION
## Problem
On macOS the native traffic-light controls sit at the top-left of the window, so the hamburger (☰) menu — the first item in the tab strip — crowded them and looked off.

## Change
Move the hamburger to the **far right** of the window header (after the action widgets), matching the Chrome top-right overflow-menu convention. Windows/Linux keep it on the **left**, clear of their right-side caption buttons.

- **Extract `<HamburgerMenu>`** (`window/hamburger-menu.tsx` + `.scss`) — a self-contained component carrying the menu logic from `TabBar`. Every action was already a module-level store/RPC call, so it lifted out with zero TabBar coupling. Rendered in the tab strip on Win/Linux; in the header far-right on macOS (`window-header.tsx`, gated on `isMacOS()`).
- **`mirrored` mode on `FlyoutMenu`** for right-anchored (left-opening) placement:
  - items lay out right-to-left (icon right, label right-aligned),
  - submenus prefer to open **left** (`left-start`; `flip()` still sends them right if there's no room),
  - the disclosure chevron flips to point **left**, matching the direction the submenu actually opens,
  - keyboard-shortcut hints are dropped in the mirrored menu.
  - Scoped to `.menu--mirrored` (the macOS far-right hamburger only) — every other menu keeps the standard left-to-right layout.

## Best-practice basis
Edge-anchored menus should open submenus toward available space, with the disclosure arrow following the open direction ([Drupal nice_menus](https://www.drupal.org/project/nice_menus/issues/737730), [WP Astra](https://wpastra.com/docs/submenu-opening/)); right-aligned menus are a standard pattern ([Bootstrap `dropdown-menu-end`](https://getbootstrap.com/docs/5.0/components/dropdowns/)). Content mirroring is kept opt-in and macOS-right-only since native macOS/Chrome menus keep text left-aligned even when right-anchored.

## Testing
- `task dev` on macOS, verified live via HMR: hamburger at far-right, items mirrored, Theme/Opacity submenus cascade left with left-pointing arrows, no shortcut hints.
- Frontend type-check clean for all touched files.
- No behavior change on Windows/Linux (hamburger stays left, non-mirrored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)