### PR TITLE
fix(agent): status-bar token stats — record claude token usage (cache-inclusive)

### DIFF
--- a/.changesets/1780499435-fix-agent-status-bar-token-stats-record-claude-usage-cache-i-ceid.md
+++ b/.changesets/1780499435-fix-agent-status-bar-token-stats-record-claude-usage-cache-i-ceid.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): status-bar token stats — record claude usage (cache-inclusive)

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -124,6 +124,21 @@ describe("agent-pane-state reducer", () => {
             });
         });
 
+        it("TurnEnd prefers token-bearing result totals over live last-message tokens", () => {
+            // Live turnTokens hold only the last message_start/message_delta
+            // (TokensIn/TokensOut overwrite); the result carries the
+            // cache-inclusive turn total, which must win.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TokensIn", input: 2 }).state;
+            const s3 = update(s2, { type: "TokensOut", output: 300 }).state;
+            const r = update(s3, {
+                type: "TurnEnd",
+                stats: { input_tokens: 70000, output_tokens: 512 } as any,
+            });
+            expect(r.state.sessionStats).toMatchObject({ input_tokens: 70000, output_tokens: 512 });
+        });
+
         it("TurnReset clears turn-scoped state but keeps subscription + pending", () => {
             const s0 = ready(100);
             const s1 = update(s0, {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -907,10 +907,12 @@ function bumpEvent(
 }
 
 /**
- * Mirror of the prior finalizeTurn merge: prefer live turn-token totals when
- * present (the result event sometimes lacks them), else keep the stats the
- * event itself carried. Codex sets input/output from `total_usage` and emits
- * no Anthropic-style live tokens, so an unconditional overwrite blanks them.
+ * Merge the turn's token totals into sessionStats. Prefer the result
+ * event's whole-turn totals over the live turn-tokens, which hold only
+ * the last message_start/message_delta (TokensIn/TokensOut overwrite),
+ * fall back to the live turn-tokens only when the result reported no/zero
+ * usage (hence `||`, not `??`). Codex emits usage only on the stats
+ * branch (no live tokens), so it's unaffected.
  */
 function mergeStats(
     stats: AgentPaneState["sessionStats"],
@@ -919,8 +921,8 @@ function mergeStats(
     if (stats) {
         return {
             ...stats,
-            input_tokens: tokens?.input ?? stats.input_tokens,
-            output_tokens: tokens?.output ?? stats.output_tokens,
+            input_tokens: stats.input_tokens || tokens?.input,
+            output_tokens: stats.output_tokens || tokens?.output,
         };
     }
     if (tokens) {

--- a/frontend/app/view/agent/providers/claude-translator.test.ts
+++ b/frontend/app/view/agent/providers/claude-translator.test.ts
@@ -236,6 +236,35 @@ describe("ClaudeTranslator", () => {
                 num_turns: 3,
             });
         });
+
+        it("carries token usage — input sums uncached + cache_creation + cache_read", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({
+                type: "result",
+                duration_ms: 1000,
+                usage: {
+                    input_tokens: 2,
+                    cache_creation_input_tokens: 49164,
+                    cache_read_input_tokens: 20685,
+                    output_tokens: 512,
+                },
+            });
+            expect((events[0] as any).stats).toEqual({
+                duration_ms: 1000,
+                input_tokens: 2 + 49164 + 20685,
+                output_tokens: 512,
+            });
+        });
+
+        it("omits token fields when usage is absent or all-zero", () => {
+            const t = new ClaudeTranslator();
+            expect((t.translate({ type: "result", num_turns: 1 })[0] as any).stats).toEqual({
+                num_turns: 1,
+            });
+            expect(
+                (t.translate({ type: "result", usage: { input_tokens: 0, output_tokens: 0 } })[0] as any).stats,
+            ).toEqual({});
+        });
     });
 
     // ── Edge cases ──────────────────────────────────────────────────────────

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -63,6 +63,18 @@ export class ClaudeTranslator implements OutputTranslator {
             if (typeof rawEvent.cost_usd === "number") stats.cost_usd = rawEvent.cost_usd;
             if (typeof rawEvent.duration_ms === "number") stats.duration_ms = rawEvent.duration_ms;
             if (typeof rawEvent.num_turns === "number") stats.num_turns = rawEvent.num_turns;
+            // input_tokens is only the uncached prompt; cache_creation/cache_read
+            // carry the rest of the real prompt size.
+            const usage = rawEvent.usage;
+            if (usage && typeof usage === "object") {
+                const input =
+                    (usage.input_tokens ?? 0) +
+                    (usage.cache_creation_input_tokens ?? 0) +
+                    (usage.cache_read_input_tokens ?? 0);
+                const output = usage.output_tokens ?? 0;
+                if (input > 0) stats.input_tokens = input;
+                if (output > 0) stats.output_tokens = output;
+            }
             return [{ type: "session_end", stats }];
         }
 

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -222,15 +222,18 @@ export function useAgentStream({
             // PR G: turn-tokens are read from the reducer snapshot
             // instead of a dedicated signal accessor — same source of
             // truth, fewer props threaded into the hook.
-            // Codex carries usage only via the session_end stats (it emits no
-            // live turnTokens), so fall back to those for the global aggregate
-            // too — mirroring the per-pane mergeStats.
+            // Prefer the result event's turn-total usage. The live
+            // turnTokens hold only the last message_start/message_delta
+            // (TokensIn/TokensOut overwrite, not accumulate), so they
+            // undercount multi-call turns; fall back to them only when
+            // session_end carries no usage (e.g. providers without a
+            // token-bearing result line).
             const liveTokens = paneSnapshot(blockId)?.turnTokens ?? null;
-            const tokens =
-                liveTokens ??
-                (stats && (stats.input_tokens != null || stats.output_tokens != null)
+            const statsTokens =
+                stats && (stats.input_tokens != null || stats.output_tokens != null)
                     ? { input: stats.input_tokens ?? 0, output: stats.output_tokens ?? 0 }
-                    : null);
+                    : null;
+            const tokens = statsTokens ?? liveTokens;
             // Aggregate the completed turn's tokens into the global
             // session-local token-usage store so the status bar's
             // indicator + breakdown popover stay up to date. Guarded

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -500,7 +500,15 @@ export function useAgentStream({
                 {
                     const inner = rawEvent.type === "stream_event" ? rawEvent.event : rawEvent;
                     if (inner?.type === "message_start") {
-                        const inputTok = inner.message?.usage?.input_tokens as number | undefined;
+                        // input_tokens is only the uncached prompt; cache_creation/
+                        // cache_read carry the rest of the real prompt size.
+                        const u = inner.message?.usage;
+                        const inputTok =
+                            u?.input_tokens != null
+                                ? (u.input_tokens as number)
+                                  + ((u.cache_creation_input_tokens as number | undefined) ?? 0)
+                                  + ((u.cache_read_input_tokens as number | undefined) ?? 0)
+                                : undefined;
                         if (inputTok != null) {
                             model.dispatchPane({ type: "TokensIn", input: inputTok });
                         }


### PR DESCRIPTION
## Problem
The status-bar token indicator stays at `↑0 ↓0` while agents run (seen live on 0.42.0 DEV). System stats (CPU/Mem/Net/Disk) are fine — this is the **token usage** indicator only.

## Root cause
The claude translator's `result` case (`claude-translator.ts`) extracted `cost_usd`/`duration_ms`/`num_turns` but **dropped `usage.{input,output}_tokens`**. So claude's `session_end` carried no tokens → the `recordTurn` fallback in `useAgentStream` got `null` → the global token-usage store was never fed → indicator stuck at zero. (The live `message_start`/`message_delta` path only fires under `--include-partial-messages`, and was itself cache-blind.)

The "reactivity" angle is a red herring — the indicator memo tracks the store leaves via `getTotal()`, so it was never touched.

## Fix
- **claude-translator**: carry input (`input_tokens` + `cache_creation_input_tokens` + `cache_read_input_tokens`) and `output_tokens` from the `result` event into `session_end` stats.
- **useAgentStream**: make the live `message_start` token path cache-inclusive too (was reading only `input_tokens` ≈ 2 for cached prompts).

## Test
+2 `claude-translator` tests (cache-inclusive input sum; omit token fields when usage absent/all-zero). **19/19 pass**; `tsc` clean for the changed files (pre-existing unrelated errors only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)