### PR TITLE
fix(agent-pane): HMR-safe useProcessCount RPC guard (DEV crash)

### DIFF
--- a/.changesets/1780499728-fix-agent-pane-hmr-safe-useprocesscount-rpc-guard-buw5.md
+++ b/.changesets/1780499728-fix-agent-pane-hmr-safe-useprocesscount-rpc-guard-buw5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): HMR-safe useProcessCount RPC guard

--- a/frontend/app/view/agent/hooks/useProcessCount.ts
+++ b/frontend/app/view/agent/hooks/useProcessCount.ts
@@ -59,15 +59,21 @@ export function useProcessCount(blockId: string): Accessor<number> {
         // a tiny transient window.
         // Silently tolerate RPC failure — older backends without the
         // command fall back to delta-only mode and still converge.
-        void RpcApi.AgentProcessListCommand(TabRpcClient, { block_id: blockId })
-            .then((res) => {
-                setCount(Math.max(0, res.processes.length + deltaSincePreSeed));
-                seeded = true;
-            })
-            .catch(() => {
-                setCount(Math.max(0, deltaSincePreSeed));
-                seeded = true;
-            });
+        if (!TabRpcClient) {
+            // Client may be unbound this early; seed from buffered deltas only.
+            setCount(Math.max(0, deltaSincePreSeed));
+            seeded = true;
+        } else {
+            void RpcApi.AgentProcessListCommand(TabRpcClient, { block_id: blockId })
+                .then((res) => {
+                    setCount(Math.max(0, res.processes.length + deltaSincePreSeed));
+                    seeded = true;
+                })
+                .catch(() => {
+                    setCount(Math.max(0, deltaSincePreSeed));
+                    seeded = true;
+                });
+        }
 
         onCleanup(() => {
             unsubAdded?.();


### PR DESCRIPTION
## Problem
The block-error-boundary trips in DEV with `TypeError: Cannot read properties of undefined (reading 'rpcCall')` at `useProcessCount.ts` → `AgentProcessListCommand`, on agent-pane re-mount (e.g. after a tab switch). Recovers on reload.

## Root cause
`useProcessCount` fires `RpcApi.AgentProcessListCommand(TabRpcClient, …)` **synchronously in `onMount`**. Under a Vite HMR module re-eval, `rpc-util.ts` re-runs `let TabRpcClient` (→ `undefined`) without `initWshrpc()` re-binding it. The undefined client throws synchronously during argument evaluation — before the Promise exists — so the existing `.catch()` can't catch it, and it escapes to the error boundary. **DEV/HMR-only**; production builds have no HMR, so this can't happen there. Worth fixing as the unguarded `onMount` RPC is a latent fragility.

## Fix
Guard `TabRpcClient` before the call; when unbound, seed from buffered deltas only (the same fallback `.catch()` already provides). Kept as `if/else` (not early `return`) so `onCleanup` still registers — an early return would leak the two WPS subscriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)