### PR TITLE
fix(agent-pane): restore scroll-to-bottom when a pane returns from hidden (codex)

### DIFF
--- a/.changesets/1780500347-fix-agent-pane-restore-scroll-to-bottom-when-a-pane-returns--k2em.md
+++ b/.changesets/1780500347-fix-agent-pane-restore-scroll-to-bottom-when-a-pane-returns--k2em.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): restore scroll-to-bottom when a pane returns from hidden

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,7 +29,7 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, createMemo, createSignal, For, Index, onMount, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Index, onCleanup, onMount, type Accessor, type JSX } from "solid-js";
 import { trail } from "@/log/render-trail";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
@@ -255,6 +255,25 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
             });
         }
+    });
+
+    // Re-apply sticky-bottom on hidden → visible. An inactive tab is
+    // display:none (0×0), so the nodes()-driven scroll above is a no-op
+    // while hidden and nothing re-issues it on reactivation. Watch the
+    // container's clientHeight 0 → non-zero transition; re-scroll only
+    // when already sticky (never engages stick, so a user who scrolled
+    // up stays put).
+    onMount(() => {
+        let wasHidden = scrollRef.clientHeight === 0;
+        const ro = new ResizeObserver(() => {
+            const h = scrollRef.clientHeight;
+            if (h > 0 && wasHidden && props.viewState.stickToBottom()) {
+                scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+            }
+            wasHidden = h === 0;
+        });
+        ro.observe(scrollRef);
+        onCleanup(() => ro.disconnect());
     });
 
     // jumpToBottom: forced scroll-to-bottom that re-engages stick.


### PR DESCRIPTION
## Problem
Running 2 claude + 1 codex agents, switching tabs and returning left the **codex pane pinned at a stale scroll position** ("didn't scroll with"); the claude panes were fine. Seen live on 0.42.0 DEV.

## Root cause
Auto-follow (sticky-bottom) only re-fires on a new `nodes()` emission. An inactive tab is `display:none` (0×0), so `scrollTo(MAX)` while hidden is a **no-op**, and nothing re-issues it on reactivation. Claude kept streaming text deltas → re-glued on return. **Codex emits complete items and had gone quiet → no emission after return → stayed at the stale position.** That's why only codex did it.

## Fix
A `ResizeObserver` on the scroll container re-applies the bottom scroll on a `0 → non-zero` `clientHeight` transition (hidden→visible), **only when already sticky** — it never *engages* stick, so a user who scrolled up stays put. Deterministic (no timers).

## Verification
Typecheck clean; hot-reload didn't trip the error boundary. The full tab-switch behaviour is best confirmed live (hard to smoke deterministically).

Note: the structural fix for the underlying "unmeasured while hidden" virtualizer class is the layout-reducer work (#1235); this is the targeted fix for the missing re-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)