### PR TITLE
fix(cef): pin Cargo to CEF 146 until 7778 drag/right-click/transparency patches are forward-ported

### DIFF
--- a/.changesets/1780541435-fix-cef-pin-146-until-7778-port-yo56.md
+++ b/.changesets/1780541435-fix-cef-pin-146-until-7778-port-yo56.md
@@ -1,0 +1,61 @@
+---
+type: patch
+---
+
+fix(cef): pin Cargo to CEF 146 until 7778 drag/right-click/transparency patches are forward-ported
+
+PR #1221 (CEF 146 → 148 source bump) inadvertently broke
+`build:host:linux` because the agentmux patches that add
+`_cef_window_t::begin_window_drag` (the source code addition behind
+`StartWindowDragTask` for native Wayland/X11 window drag) only exist on
+the `agentmuxai/cef@agentmux/7680-drag-rightclick-and-transparency`
+branch — they have not been forward-ported to the
+`agentmuxai/cef@agentmux/7778-…` branch yet.
+
+Consequences observed locally:
+
+- `cargo build --release -p agentmux-cef --features patched-libcef`
+  fails at `ui_tasks.rs:215` with
+  `error[E0609]: no field begin_window_drag on type _cef_window_t`,
+  because the cef-dll-sys 148 binding lacks the field.
+- To get a green build, the Linux Taskfile path has been silently
+  building **without** `--features patched-libcef`, which compiles the
+  `#[cfg(not(feature = "patched-libcef"))]` no-op branch — every
+  `start_window_drag` IPC then warns "patched-libcef feature disabled
+  — native drag is a no-op." Title-bar drag silently does nothing on
+  every Linux build since the bump, regardless of ozone platform.
+
+This pin restores the previous state: CEF 146 with the patched
+binding, `--features patched-libcef` compiles, and the existing
+patched `libcef.so` (built from
+`agentmuxai/cef@agentmux/7680-drag-rightclick-and-transparency` via
+`scripts/resolve-cef-runtime.sh`) is the matching runtime.
+
+This is **explicitly temporary**. The proper fix is two PRs:
+
+1. New branch `agentmuxai/cef@agentmux/7778-drag-rightclick-and-transparency`
+   cherry-picking these commits onto upstream `7778`:
+   - `af485ed2` views: Add `CefWindow::BeginWindowDrag()`
+   - `010f616f` views: PR review — pass actual cursor screen point
+     (the X11 fix; without it `_NET_WM_MOVERESIZE` ignores the
+     request)
+   - `130af663` views: Annotate API version
+   - `41802fe6` Patch A: right-clicks on HTCAPTION fall through to renderer
+   - `b921ffe1` Support transparent window in Views framework
+   - The five `views: …transparency cascade…` follow-ups
+2. `cef-dll-sys` 148 binding adds the `begin_window_drag` field.
+
+Once both land and a CEF 148 `libcef.so` is rebuilt and bundled,
+Cargo can move back to `"148"`.
+
+macOS and Windows tasks are unaffected: macOS builds CEF 148 from
+`agentmuxai/cef@agentmux/7778-process-requirement` (which has only the
+macOS-26 patch, no drag patch); Windows doesn't use
+`--features patched-libcef` (native drag goes through a different
+Windows-specific path).
+
+Local validation: with this pin, `task build:host` succeeds, the
+resulting host binary contains the `BeginWindowDrag returned` info
+string (not the disabled-feature warn string), and title-bar drag
+works on both Wayland and X11 ozone modes against the existing CEF
+146 `libcef.so`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "148.3.0+148.0.9"
+version = "146.7.0+146.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a920bb7b8ff94c3abe487df2a7234d8fb8226369d97296a12ac863a15c168d59"
+checksum = "d09c05112b644e85d58f9e1bf7d62bc5a21a806a92129d4ed750d8cc9479abff"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "148.3.0+148.0.9"
+version = "146.7.0+146.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc364604c75169c992b3f8bc4396634bf64cfb2a4a0545cc9c7aa4eb3931057"
+checksum = "693e287c4fe19ba5ed6f478bed66b1d367b06fbce904eeffafb8359a40dab24b"
 dependencies = [
  "anyhow",
  "cmake",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -30,7 +30,7 @@ resources_path = "resources"
 
 [dependencies]
 agentmux-common = { path = "../agentmux-common" }
-cef = { version = "148", default-features = false, features = ["build-util"] }
+cef = { version = "146", default-features = false, features = ["build-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
## Summary

PR #1221 (CEF 146 → 148 source bump) inadvertently broke `build:host:linux` because the agentmux patches that add `_cef_window_t::begin_window_drag` (the source code addition behind `StartWindowDragTask` for native Wayland/X11 window drag) **only exist on the `agentmuxai/cef@agentmux/7680-drag-rightclick-and-transparency` branch** — they have not been forward-ported to the `agentmux/7778-…` branch yet.

## What happened

- `cargo build --release -p agentmux-cef --features patched-libcef` fails at `ui_tasks.rs:215` with `error[E0609]: no field begin_window_drag on type _cef_window_t` (the cef-dll-sys 148 binding lacks the field).
- The Linux Taskfile path has been silently building **without** `--features patched-libcef` since the bump, which compiles the `#[cfg(not(feature = "patched-libcef"))]` no-op branch. Every `start_window_drag` IPC since then warns "patched-libcef feature disabled — native drag is a no-op."
- **Title-bar drag has silently been broken on every Linux AppImage built since #1221 was merged**, regardless of ozone platform.

## What this PR does

Pins `cef = "146"` in `agentmux-cef/Cargo.toml` + refreshes `Cargo.lock` accordingly. With this pin, the patched cef-dll-sys 146 binding (which has `begin_window_drag`) is used, `--features patched-libcef` compiles, and the existing patched `libcef.so` (built from `agentmuxai/cef@agentmux/7680-drag-rightclick-and-transparency` via `scripts/resolve-cef-runtime.sh`) is the matching runtime.

**Explicitly temporary.** The proper fix is two follow-up PRs:

1. New branch `agentmuxai/cef@agentmux/7778-drag-rightclick-and-transparency` cherry-picking these commits onto upstream `7778`:
   - `af485ed2` `views: Add CefWindow::BeginWindowDrag()`
   - `010f616f` `views: PR review on BeginWindowDrag` (the X11 fix using `display::Screen::Get()->GetCursorScreenPoint()` — without this `_NET_WM_MOVERESIZE` ignores the drag request because `gfx::Point()` gives an invalid anchor)
   - `130af663` `views: Annotate CefWindow::BeginWindowDrag with added=14600`
   - `41802fe6` `Patch A: Let right-clicks on HTCAPTION fall through to renderer`
   - `b921ffe1` `Support transparent window in Views framework`
   - The five `views: …transparency cascade…` follow-ups
2. `cef-dll-sys` 148 binding adds the `begin_window_drag` field at the end of `_cef_window_t`.

Once both land and a CEF 148 `libcef.so` is rebuilt and bundled (the multi-hour `~/cef-build` step), Cargo can move back to `"148"`.

## Platforms

- **macOS, Windows: unaffected.** macOS already builds CEF 148 from `agentmuxai/cef@agentmux/7778-process-requirement` (which has only the macOS-26 patch, no drag patch); Windows doesn't use `--features patched-libcef` (native drag goes through `SetWindowsHookEx` + `WM_NCHITTEST`).
- **Linux: restored.** `task build:host` produces a host binary that calls the native `BeginWindowDrag` slot in libcef.so; title-bar drag works on both Wayland and X11 ozone modes.

## Test plan

- [x] `cargo build --release -p agentmux-cef --features patched-libcef` succeeds (verified locally on this branch)
- [x] Resulting host binary `strings` shows `BeginWindowDrag returned` info string (the patched path) — **not** `patched-libcef feature disabled` (the no-op path)
- [x] Title-bar drag works on Wayland default
- [x] Title-bar drag works with `--ozone-platform=x11` (validates the `010f616f` X11 cursor-screen-point fix)
- [ ] CI build:host:linux green
- [ ] macOS and Windows tasks build clean (no Cargo resolver fights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)