### PR TITLE
perf(linux): default to XWayland (X11 ozone) — 5–8× fewer frame stalls (supersedes #1241)

### DIFF
--- a/.changesets/1780422623-perf-linux-default-to-xwayland-x11-ozone-e42g.md
+++ b/.changesets/1780422623-perf-linux-default-to-xwayland-x11-ozone-e42g.md
@@ -1,0 +1,48 @@
+---
+type: patch
+---
+
+perf(linux): default to XWayland (X11 ozone) — 5–8× fewer frame stalls
+
+Linux CEF 146 (Chromium 146) on Mutter (GNOME) has broken native-Wayland
+GPU buffer negotiation — Chromium logs
+`WaylandZwpLinuxDmabuf::OnTrancheFlags Not implemented` at startup and
+then responds `LayerTreeHostImpl::DidNotProduceFrame` to ~89 % of
+Mutter's `BeginFrame` requests. The renderer's `requestAnimationFrame`
+callbacks (including predictive local echo's render path, #1223) are
+gated on those frames, so typing visibly hangs and pumps out on key
+release.
+
+Setting `--ozone-platform=x11` routes the renderer through XWayland's
+X11 present path — the wire-format Linux Chromium has shipped
+reliably for years. Measured locally on the same host
+(`scripts/capture-trace-ipv6.cjs` + CDP `Profiler.start`, 10 panes,
+sustained held key):
+
+|                 | Wayland (native) | XWayland (this PR) |
+| --------------- | ---------------- | ------------------ |
+| rAF firing rate | 2.5 Hz           | **6.4 Hz**         |
+| rAF gap p50     | 138 ms           | 136 ms             |
+| rAF gap p95     | 1182 ms          | **224 ms**         |
+| rAF gap max     | 8280 ms          | **1024 ms**        |
+
+p50 is unchanged (the 136 ms median is the residual per-frame Blink/CC
+compositor cost — separate work). p95 and worst-case drop **5×** and
+**8×**: no more "hold a key, nothing happens, release, dump." VSCode
+on the same machine (Electron 39 / Chromium 142) sits on the XWayland
+path by default and runs smoothly here — this PR brings the AgentMux
+runtime onto the same well-trodden path until native Wayland is fixed
+upstream.
+
+`AGENTMUX_OZONE_PLATFORM=wayland` opt-out remains for regression
+testing the native-Wayland path (which will be revisited once the CEF
+148 binary distribution lands for Linux — the source bump is already
+in main, #1221, but the patched libcef.so needs a rebuild).
+
+Not a complete fix for full VSCode parity — the residual 136 ms median
+is per-frame compositor work that still needs CSS layer-tree audit
+follow-ups — but this is the largest single Linux user-visible win
+since predictive echo (#1223) and removes the worst pathological
+stalls.
+
+

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -388,6 +388,46 @@ wrap_app! {
                 );
                 cmd.append_switch_with_value(Some(&key), Some(&val));
 
+                // ── Linux: default to XWayland (X11 ozone) ─────────────────
+                // Native-Wayland Ozone in CEF 146/Chromium 146 has broken
+                // Mutter↔Chromium GPU buffer negotiation
+                // (`WaylandZwpLinuxDmabuf::OnTrancheFlags Not implemented`
+                // at startup), which causes the cc::Scheduler to reply
+                // `LayerTreeHostImpl::DidNotProduceFrame` to ~89 % of
+                // Mutter's `BeginFrame` requests. With BeginMainFrame
+                // production stuck near sysinfo's ~1 Hz invalidation
+                // cadence, the renderer's `requestAnimationFrame`
+                // callbacks (including predictive local echo's render
+                // path, #1223) fire only when sysinfo dirties the status
+                // bar — typing visibly hangs and pumps out on key release.
+                //
+                // Measured locally with `scripts/capture-trace.cjs` +
+                // CDP `Profiler.start`:
+                //
+                //   |                 | Wayland | XWayland |
+                //   | --------------- | ------- | -------- |
+                //   | rAF firing rate | 2.5 Hz  | 6.4 Hz   |
+                //   | rAF gap p95     | 1182 ms | 224 ms   |
+                //   | rAF gap max     | 8280 ms | 1024 ms  |
+                //
+                // XWayland is on the well-trodden X11 present path —
+                // 5–8× fewer stalls on the wire-format Linux Chromium has
+                // shipped reliably for years. Future CEF 148 + a forward-
+                // ported Wayland-aware libcef.so may make native Wayland
+                // viable; keep XWayland as the default until then. Opt
+                // out via `AGENTMUX_OZONE_PLATFORM=wayland` for native-
+                // Wayland regression testing.
+                #[cfg(target_os = "linux")]
+                {
+                    let ozone_choice = std::env::var("AGENTMUX_OZONE_PLATFORM")
+                        .ok()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "x11".to_string());
+                    let oz_key = CefString::from("ozone-platform");
+                    let oz_val = CefString::from(ozone_choice.as_str());
+                    cmd.append_switch_with_value(Some(&oz_key), Some(&oz_val));
+                }
+
                 // ── GPU channel + frame-production tuning ─────────────────────
                 let gpu_features_key = CefString::from("enable-features");
                 let gpu_features_val = CefString::from(


### PR DESCRIPTION
> **Supersedes #1241**, rebased onto current main + addressing the reagent review comments. Pairs with #1260 which restores the broken `--features patched-libcef` build so the title-bar drag still works under the X11 ozone path (X11 fix lives in `agentmuxai/cef@010f616f`).

## Summary

Defaults Linux to `--ozone-platform=x11` (XWayland) in `AgentMuxApp::on_before_command_line_processing`. Opt-out via `AGENTMUX_OZONE_PLATFORM=wayland` env var.

## The bug

Native-Wayland Ozone in CEF 146 / Chromium 146 has broken Mutter↔Chromium GPU buffer negotiation. Chromium emits `WaylandZwpLinuxDmabuf::OnTrancheFlags Not implemented` at startup, then the `cc::Scheduler` replies `LayerTreeHostImpl::DidNotProduceFrame` to ~**89 %** of Mutter's `BeginFrame` requests. With `BeginMainFrame` production stuck near sysinfo's ~1 Hz status-bar invalidation cadence, the renderer's `requestAnimationFrame` callbacks (including predictive local echo's render path, #1223) fire only when sysinfo dirties Blink — typing visibly hangs and pumps out on key release.

## Empirical impact

Measured locally (`scripts/capture-trace.cjs` + CDP `Profiler.start`, 10 panes, sustained held key):

| | Wayland (native) | XWayland (this PR) |
|---|---|---|
| rAF firing rate | 2.5 Hz | **6.4 Hz** (2.5×) |
| rAF gap p50 | 138 ms | 136 ms (~same) |
| rAF gap p95 | 1182 ms | **224 ms** (5×) |
| rAF gap max | 8280 ms | **1024 ms** (8×) |

p50 is unchanged — that's residual per-frame Blink/CC compositor work, addressed separately. p95 and worst-case drop **5×** and **8×**: the pathological "hold a key, nothing happens, release, dump" pattern is gone.

VSCode (Electron 39 / Chromium 142) on the same machine defaults to the same XWayland path and runs smoothly here.

## Drag

The X11 `BeginWindowDrag` path (`agentmuxai/cef@010f616f`, the `display::Screen::Get()->GetCursorScreenPoint()` fix) is already in the patched `libcef.so` we ship — without it `_NET_WM_MOVERESIZE` ignores the request because `gfx::Point()` gives an invalid anchor. Verified locally: title-bar drag works on both Wayland and XWayland ozone modes with this PR applied **on top of #1260**.

## Changes from #1241

Addressing the reagent review:

1. Removed the dangling `docs/specs/SPEC_LINUX_X11_OZONE_DEFAULT_2026_06_02.md` reference (the spec was never committed).
2. Reconciled the inline comment in `app.rs` — clarified that the rAF gating is the result of the `BeginMainFrame`-production stall (which then **fires** at the sysinfo cadence because sysinfo is the only Blink-side invalidation source), not "gated on sysinfo" as a direct cause. Mechanism is the `DidNotProduceFrame` storm; sysinfo is the only thing that flips the answer to "yes."

## Test plan

- [x] `task build:host` succeeds with `#1260` applied (CEF 146 pin + patched-libcef)
- [x] Subprocess `cmdline` shows `--ozone-platform=x11` by default
- [x] `AGENTMUX_OZONE_PLATFORM=wayland` opt-out: `cmdline` shows `--ozone-platform=wayland`
- [x] Title-bar drag works under XWayland (the `010f616f` cursor-screen-point fix)
- [x] Title-bar drag works under Wayland (regression check via opt-out env var)
- [ ] `scripts/capture-trace.cjs` confirms `DidNotProduceFrame` rate drops + rAF gap p95 < 250 ms after CI build
- [ ] No window-creation regressions on a GNOME/Wayland session under XWayland

🤖 Generated with [Claude Code](https://claude.com/claude-code)