### PR TITLE
fix(window): collapse widget labels before tabs clip, shrink tabs when crowded

### DIFF
--- a/.changesets/1780541630-fix-window-collapse-widget-labels-then-shrink-tabs-when-the--k83i.md
+++ b/.changesets/1780541630-fix-window-collapse-widget-labels-then-shrink-tabs-when-the--k83i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): collapse widget labels then shrink tabs when the title bar is crowded

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -13,14 +13,15 @@
     // unrecoverable from the bar today, unlike editor tabs which clip).
     // Spec: specs/SPEC_WORKSPACE_TAB_SIZING_2026-05-27.md.
     // Basis ~ VS Code "fit" mode default (~240px) — enough room for
-    // ~25 chars of file/title before ellipsis. Floor at 100px keeps
-    // a crowded tab readable rather than collapsing into a pill. Cap
+    // ~25 chars of file/title before ellipsis. Floor at 56px is the
+    // thin end a crowded tab shrinks to (a few chars + ellipsis) once
+    // widget labels have collapsed, before the scroll safety-net. Cap
     // at 320px so a near-empty bar with one or two tabs still gives
     // each tab a generous ~30-char window. Editor tabs run narrower
     // (140 basis) because the editor pane itself is narrower than
     // the workspace title bar.
     --ws-tab-basis: 240px;
-    --ws-tab-min: 100px;
+    --ws-tab-min: 56px;
     --ws-tab-max: 320px;
 
     display: flex;
@@ -36,7 +37,7 @@
         display: flex;
         flex-direction: row;
         align-items: flex-end;
-        flex: 0 1 auto;
+        flex: 1 1 auto;
         min-width: 0;
         height: 100%;
         overflow-x: auto;

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -268,6 +268,9 @@ const ActionWidgets = (): JSX.Element => {
     // dropped. The collapse point still auto-tracks the widget count via the
     // mirror's measured width; this only floors the tab bar's share.
     const MIN_TAB_WIDTH = 120;
+    // Per-tab minimum readable width — mirrors `--ws-tab-min` in tabbar.scss.
+    // The collapse threshold reserves `tabCount * this`.
+    const WS_TAB_MIN_PX = 100;
 
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
@@ -309,18 +312,29 @@ const ActionWidgets = (): JSX.Element => {
         const buttons = containerRef?.parentElement?.querySelector(
             ".window-action-buttons"
         ) as HTMLElement | null;
+        const tabScroll = header.querySelector(".tab-bar-scroll") as HTMLElement | null;
         const measure = () => {
             const labeledW = mirrorRef?.offsetWidth ?? 0;
             const headerW = header.clientWidth;
             if (labeledW === 0 || headerW === 0) return;
             const buttonsW = buttons?.offsetWidth ?? 0;
-            setTooNarrow(labeledW + buttonsW + MIN_TAB_WIDTH > headerW);
+            const tabCount = tabScroll?.querySelectorAll(".tab").length ?? 0;
+            const tabsNeeded = Math.max(MIN_TAB_WIDTH, tabCount * WS_TAB_MIN_PX);
+            setTooNarrow(labeledW + buttonsW + tabsNeeded > headerW);
         };
         const ro = new ResizeObserver(measure);
         ro.observe(header);
         ro.observe(mirrorRef);
+        // Adding/removing a tab doesn't resize the header, so the ResizeObserver
+        // won't fire — watch the tab strip's child list to re-measure on a
+        // tab-count change.
+        const mo = tabScroll ? new MutationObserver(measure) : null;
+        if (mo && tabScroll) mo.observe(tabScroll, { childList: true });
         measure();
-        onCleanup(() => ro.disconnect());
+        onCleanup(() => {
+            ro.disconnect();
+            mo?.disconnect();
+        });
     });
 
     const handlePointerDown = (key: string, e: PointerEvent) => {

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -268,9 +268,12 @@ const ActionWidgets = (): JSX.Element => {
     // dropped. The collapse point still auto-tracks the widget count via the
     // mirror's measured width; this only floors the tab bar's share.
     const MIN_TAB_WIDTH = 120;
-    // Per-tab minimum readable width — mirrors `--ws-tab-min` in tabbar.scss.
-    // The collapse threshold reserves `tabCount * this`.
-    const WS_TAB_MIN_PX = 100;
+    // Per-tab COLLAPSE-TRIGGER width: widget labels drop once each open tab
+    // would fall below this. Deliberately NOT the CSS shrink floor
+    // (`--ws-tab-min`, 56px) — labels collapse first (at this comfortable
+    // width), THEN tabs shrink toward the smaller floor. Reserve =
+    // `tabCount * this`.
+    const TAB_COLLAPSE_RESERVE_PX = 100;
 
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
@@ -319,7 +322,7 @@ const ActionWidgets = (): JSX.Element => {
             if (labeledW === 0 || headerW === 0) return;
             const buttonsW = buttons?.offsetWidth ?? 0;
             const tabCount = tabScroll?.querySelectorAll(".tab").length ?? 0;
-            const tabsNeeded = Math.max(MIN_TAB_WIDTH, tabCount * WS_TAB_MIN_PX);
+            const tabsNeeded = Math.max(MIN_TAB_WIDTH, tabCount * TAB_COLLAPSE_RESERVE_PX);
             setTooNarrow(labeledW + buttonsW + tabsNeeded > headerW);
         };
         const ro = new ResizeObserver(measure);


### PR DESCRIPTION
## What

In a narrow window the tabs and the widget bar compete for width, with two responsive gaps. With 2 tabs open, the labeled widget bar (~367px) starved the tab strip to ~117px and the trailing tab was clipped *under* the widget buttons.

## Two gaps

**1. Widget labels collapsed at the wrong time.** `action-widgets.tsx` reserved a *fixed* `MIN_TAB_WIDTH = 120` for the tab strip regardless of tab count, so the collapse trigger (`labeled + buttons + 120 > header`) thought 2 tabs fit and never dropped the labels. Now it reserves `tabCount * per-tab floor`, and re-measures on tab add/remove via a `MutationObserver` (adding a tab doesn't resize the header, so the `ResizeObserver` alone wouldn't fire).

**2. Tabs couldn't get thinner.** Tabs were pinned at the `--ws-tab-min: 100px` floor while `.tab-bar-fill` (the draggable title-bar slack) grabbed the leftover, so a crowded strip *clipped* instead of shrinking. Floor lowered to `56px` (Chrome-style) and `.tab-bar-scroll` is now `flex: 1 1 auto` (was `0 1 auto`) so it reclaims the slack from the fill — tabs stay wide when there's room, shrink when crowded.

Cascade: **labels collapse -> tabs shrink -> strip scrolls**, matching Chrome's tab behavior.

## Verification (live, via CDP on a running dev instance)

| | before | after |
|---|---|---|
| widget bar | 367px labeled | 180px icon-only |
| tab strip | 117px | 305px |
| 2 tabs | trailing tab clipped | both visible, ~99px each |

- `tabbar-dnd.test.ts` — 22/22 pass (CSS-only change to the strip)
- `stylelint` clean on `tabbar.scss`
- `tsc` — 0 errors in `action-widgets.tsx` (repo gates on esbuild/Vite, not full tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)