### PR TITLE
revert(arch): restore the original architecture SVG from PR #1258

### DIFF
--- a/.changesets/1780569218-revert-arch-restore-the-original-architecture-svg-from-pr-12-0v19.md
+++ b/.changesets/1780569218-revert-arch-restore-the-original-architecture-svg-from-pr-12-0v19.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+revert(arch): restore the original architecture SVG from PR #1258 (the one that renders dark on GitHub dark theme) — undoes the readability fixes from #1264 that made it permanently light

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ws.send(JSON.stringify({
 AgentMux is a four-process desktop app. Each process owns one concern, end-to-end. See [Architecture overview](https://docs.agentmux.ai/architecture-overview/) for the full topology.
 
 <p align="center">
-  <img src="./assets/architecture.svg" alt="AgentMux four-process architecture: agentmux-launcher (×1 per (channel, version) — single-instance lock keyed on hash(data_dir + version), per the I1 isolation invariant) spawns agentmux-cef (×1 per launcher) and agentmux-srv (×1 per launcher, dynamic port). Host embeds Chromium 148 via CEF (×1 main renderer + ×N per browser pane). The SolidJS frontend runs in the main renderer and talks to srv over WebSocket. Multiple AgentMux instances can run side-by-side, each (channel, version) with its own full stack." width="860">
+  <img src="./assets/architecture.svg" alt="AgentMux four-process architecture: agentmux-launcher (×1 per channel, single-instance lock) spawns agentmux-cef (×1 per launcher) and agentmux-srv (×1 per launcher, dynamic port). Host embeds Chromium 148 via CEF (×1 main renderer + ×N per browser pane). The SolidJS frontend runs in the main renderer and talks to srv over WebSocket. Multiple AgentMux instances can run side-by-side, each with its own full stack keyed on data-dir channel." width="860">
 </p>
 
 | Process | Crate | Role |

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16">
   <title>AgentMux four-process architecture</title>
-  <desc>agentmux-launcher (1 per (channel, version) pair, enforced via single-instance named-pipe lock keyed on hash(data_dir + version)) spawns agentmux-cef (1 per launcher) and agentmux-srv (1 per launcher, dynamic port). The host embeds Chromium 148 via CEF (1 main renderer + N renderer subprocesses, one per browser pane). The main renderer loads the SolidJS frontend, which talks to the srv sidecar over a WebSocket. Multiple AgentMux instances may run side-by-side; each (channel, version) pair gets its own complete 4-process stack.</desc>
+  <desc>agentmux-launcher (1 per channel, enforced via single-instance named-pipe lock) spawns agentmux-cef (1 per launcher) and agentmux-srv (1 per launcher, dynamic port). The host embeds Chromium 148 via CEF (1 main renderer + N renderer subprocesses, one per browser pane). The main renderer loads the SolidJS frontend, which talks to the srv sidecar over a WebSocket. Multiple AgentMux instances may run side-by-side; each gets its own complete 4-process stack keyed on data-dir channel.</desc>
 
   <defs>
     <style>
-      .surface   { fill: #fafbfc; stroke: none; }
       .box       { fill: #ffffff; stroke: #8168d3; stroke-width: 1.5; rx: 10; ry: 10; }
       .box-alt   { fill: #ffffff; stroke: #419fe0; stroke-width: 1.5; rx: 10; ry: 10; }
       .sidecar   { fill: #ffffff; stroke: #5e8fd9; stroke-width: 1.5; rx: 10; ry: 10; }
@@ -23,6 +22,13 @@
       .bullet      { font-size: 14px; fill: #44444c; }
       .legend      { font-size: 12px; fill: #6a6a72; font-style: italic; }
 
+      @media (prefers-color-scheme: dark) {
+        .box, .box-alt, .sidecar { fill: #1a1a1e; }
+        .title  { fill: #f0f0f5; }
+        .sub, .bullet, .edge-label { fill: #b8b8c2; }
+        .legend { fill: #9090a0; }
+        .edge   { stroke: #6a6a78; }
+      }
     </style>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#8b8b95"/>
@@ -32,15 +38,12 @@
     </marker>
   </defs>
 
-  <!-- Surface — explicit light background so the SVG renders consistently on both light/dark backgrounds (GitHub dark mode, Starlight dark theme, etc.) -->
-  <rect class="surface" x="0" y="0" width="960" height="600"/>
-
   <!-- Row 1: launcher (left) -->
   <g>
     <rect class="box" x="40" y="40" width="280" height="110"/>
     <text class="title" x="180" y="72" text-anchor="middle">agentmux-launcher</text>
     <text class="sub"   x="180" y="96" text-anchor="middle">~325 KB shim · spawns host + srv</text>
-    <text class="card"  x="180" y="125" text-anchor="middle">×1 per (channel, version)</text>
+    <text class="card"  x="180" y="125" text-anchor="middle">×1 per channel</text>
     <text class="sub"   x="180" y="142" text-anchor="middle" style="font-size:12px;">(single-instance via named-pipe lock)</text>
   </g>
 
@@ -95,7 +98,8 @@
   <path class="edge" d="M780,440 L780,490" marker-end="url(#arrow)"/>
   <text class="edge-label" x="790" y="468">websocket</text>
 
-  <!-- Legend / multiplicity note. Split onto two lines so the text never overflows the viewBox. -->
-  <text class="legend" x="480" y="14" text-anchor="middle">Multiple AgentMux instances can run side-by-side —</text>
-  <text class="legend" x="480" y="28" text-anchor="middle">each (channel, version) gets its own full 4-process stack.</text>
+  <!-- Legend / multiplicity note -->
+  <text class="legend" x="480" y="20" text-anchor="middle">
+    Multiple AgentMux instances can run side-by-side — each gets its own full 4-process stack, keyed on data-dir channel (version / branch / --fresh).
+  </text>
 </svg>


### PR DESCRIPTION
## Summary

Per user direction: the original architecture SVG (PR #1258, before #1264's readability fixes) was preferred — it renders dark on GitHub's dark theme via \`prefers-color-scheme\`, which is the canonical README viewing context. The light-surface variant landed in #1264 looked off.

This PR restores \`assets/architecture.svg\` and the \`README.md\` alt-text to exactly the PR #1258 state (commit 5fbe100a).

What gets reverted from #1264:
- The \`.surface\` rect (light #fafbfc background panel).
- The 2-line legend (back to a single line — slight viewBox overflow is the trade-off for the original aesthetic).
- \`×1 per (channel, version)\` → \`×1 per channel\` in the launcher box.
- The README alt-text wording.

Acknowledged trade-offs (intentional):
- The single-line legend slightly clips at both ends in some viewers.
- Docs site (Starlight) loads the SVG via \`<img>\`, so the OS-scheme media query may not match the user's Starlight theme toggle.
- \`×1 per channel\` is broader than the v0.41.1 single-instance domain (which is per (channel, version) per the I1 invariant). This is a cosmetic mismatch with the body text on the docs site that we'll handle separately.

## Test plan
- [ ] README renders the diagram dark on GitHub's dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)