### PR TITLE
refactor(agent-pane): Phase 3 — retire the TanStack virtualizer, render from the layout-reducer slice

### DIFF
--- a/.changesets/1780597099-refactor-agent-pane-retire-the-tanstack-virtualizer-render-t-o3bu.md
+++ b/.changesets/1780597099-refactor-agent-pane-retire-the-tanstack-virtualizer-render-t-o3bu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agent-pane): retire the TanStack virtualizer; render the agent pane from the layout-reducer slice (Phase 3)

--- a/docs/plans/PHASE3_LAYOUT_REDUCER_IMPL_PLAN.md
+++ b/docs/plans/PHASE3_LAYOUT_REDUCER_IMPL_PLAN.md
@@ -1,0 +1,38 @@
+# Phase 3 impl plan — slice owns positions, retire TanStack from the agent pane
+
+Issue #1235 · spec `SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md` §6 Phase 3 / §4.1-B / §11.1
+Branch builds on Phase 2 (`659f5600`). Render from the slice's pure selectors; delete TanStack.
+
+## Selectors to render from (already built + tested, Phase 0)
+`computeLayoutView(state): {rows: RowPosition[], totalSize, window:{startIndex,endIndex}}` — one O(n) pass.
+`RowPosition = {nodeId,index,start,height,end}`. **`start` INCLUDES `scrollMarginPx`; `totalSize` EXCLUDES it.**
+
+## Current wiring (truth)
+- `NodesChanged`: dispatched in `agent-view.tsx:215` but with the **FULL doc** (`nodes.map(n=>n.id)`). 🔴 must become `partition().virtualizedNodes` ids.
+- Expansion (`ExpansionResolved`) + `EstimateSet`: dispatched `agent-view.tsx:228-254` (Phase 1 done) — iterates full doc; scope to virtualized set.
+- `RowMeasured`: `AgentDocumentVirtualList.tsx:234-243` inside TanStack `measureElement` (keyed by current state). Re-home to a standalone measure RO.
+- `Scrolled` / `ScrollMarginChanged` / `ZoomChanged`: **MISSING** — wire in Phase 3.
+- Store registered with **no-op** projections (`agent-view.tsx:204`) — register real ones.
+
+## TanStack touchpoints (all in `AgentDocumentVirtualList.tsx` unless noted)
+L31 import · L182-248 `createVirtualizer` (estimateSize / scrollMargin getter / measureElement) · L337 `scrollToIndex` · L388 `getVirtualItems` (anchor capture) · L435 `getOffsetForIndex` · L471 `getTotalSize` · L476 `<For getVirtualItems>` · L488 undefined guard · L514-517 data-index dance · L524 translateY. `DocumentRow.tsx` L55/L160 `dataIndex`/`data-index`. (No `shouldMeasureDuringScroll` exists; `animateEnabled` is the streaming-buffer enter anim — orthogonal, don't touch.)
+
+## Steps (internal order; verify live via `__agentLayout()` each)
+0. **Signals/projections.** `agent-view.tsx`: replace no-op `registerLayoutPane` projection with a real `layout: setLayoutView` signal; thread `layoutView` accessor → `AgentDocumentView` → `AgentDocumentVirtualList` (mirror `zoomFactor`/`blockId`). `zoom` projection stays no-op (INV-2; CSS zoom applied at agent-view.tsx:797).
+1. **🔴 partition-scoped `NodesChanged` (critical).** MOVE the slice-feeding effect from `agent-view.tsx:206-256` INTO `AgentDocumentVirtualList` (where `partition()` lives). Dispatch `NodesChanged{orderedIds: partition().virtualizedNodes.map(n=>n.id)}` + the scoped `EstimateSet`/`ExpansionResolved` loop over `virtualizedNodes`. Keep `registerLayoutPane`/`unregisterLayoutPane` + the `__agentLayout` hook in agent-view. Gate on `props.blockId != null`; use `dispatchLayoutIfRegistered`.
+2. **Wire viewport inputs.** `handleScroll` → `Scrolled{scrollTop: scrollRef.scrollTop/zoom, viewportPx: scrollRef.clientHeight/zoom}` (÷zoom: positions are unzoomed — CONFIRM via CDP at zoom 0.5/2). `ScrollMarginChanged{px: virtualContainerRef.offsetTop}` via a RO on the container. `ZoomChanged{zoom: props.zoomFactor()}` via createEffect. **Extend the PR#1257 reactivate-RO callback to also dispatch `Scrolled` with fresh clientHeight** (viewport tracking on resize).
+3. **Render from the slice.** `const windowedRows = createMemo(() => { const v=view(); return v.window.endIndex<v.window.startIndex ? [] : v.rows.slice(v.window.startIndex, v.window.endIndex+1) })`. Container height = `view().totalSize`px. Iterate **keyed by stable `nodeId`** (`<Key by="nodeId">` / `mapArray` — NOT `<Index>` [position churn], NOT raw `<For>` [remount-every-recompute]). Row style: `position:absolute; transform: translateY(${row.start - scrollMarginValue()}px)` where `scrollMarginValue = virtualContainerRef?.offsetTop ?? 0` (first row → translateY 0). 
+4. **Measure RO (no data-index).** `measureRow(el, nodeId)`: a `ResizeObserver` (continuous re-measure — markdown/image/tool growth) → `RowMeasured{nodeId, state: inFlowState(snapshot.expansion.get(nodeId)), cssPx: gbcr.height/zoom}`. Preserve the ÷zoom + `agentPerfStore.recordEstimatorMeasurement` (dev). Store ROs in a `Map<nodeId,RO>`, disconnect on leave/unmount. `DocumentRow.tsx`: drop `dataIndex`/`data-index`; `ref` carries `measureRow`.
+5. **scrollToNode + older-history off slice.** `scrollToNode` virtualized branch → `const row = view().rows[idx]; center = row.start - clientHeight/2 + row.height/2`. Older-history capture → `view().rows[window.startIndex]` (`.start` includes margin, same basis as TanStack v3). Restore → read `computeLayoutView(snapshotLayout(blockId)!).rows[newIdx].start` (synchronous snapshot — no projection-timing dep). Keep streaming-buffer branches unchanged.
+6. **Delete TanStack.** Remove `createVirtualizer`, import, undefined guard, data-index. Drop `@tanstack/solid-virtual` from package.json + lockfile (only importer). 
+
+## MUST PRESERVE (do not break)
+Streaming buffer (`<Index>`, STREAMING_BUFFER_SIZE, sticky-frontier `partition()` memo). Sticky-bottom `createEffect` + `jumpToBottom`/`scrollToBottomRef`. **PR#1257 reactivate ResizeObserver** (hidden→visible re-scroll). `animateEnabled` gate.
+
+## Risks
+- scrollTop unit under CSS zoom (÷zoom both scrollTop+clientHeight; **CONFIRM via CDP at zoom≠1**).
+- No scroll feedback loop: rows are absolute in a fixed-height container; `Scrolled` doesn't move scrollTop. `viewsEqual` store gate + overscan=5 suppress micro-scroll re-renders.
+- onCleanup/RO scoping → use the Map<nodeId,RO> approach.
+
+## Tests / verification
+Slice tests (Phase 0) unchanged. NEW: (1) partition→slice test (`orderedIds == virtualizedNodes ids`, not full doc); (2) translateY-origin (first row → 0); (3) window slicing == rows[start..end]; (4) measure→reflow no-overlap (`start[i+1]===end[i]`); (5) ZoomChanged no-relayout. **§7 CDP churn test** (new `tools/tests/agent-layout-drift.mjs`, model on `bench-agent-keystroke.mjs`, port 9223, `__agentLayout()`): fresh reload → N expand/collapse cycles → assert **0 overlap + 0 drift** (baseline: 5 mismatches/1 overlap after 9 cycles) at zoom 0.5/1/2.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -27,6 +27,7 @@ import {
     registerPane as registerLayoutPane,
     snapshot as layoutSnapshot,
     unregisterPane as unregisterLayoutPane,
+    type LayoutView,
 } from "@/app/store/agent-pane-layout-store";
 import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
@@ -199,7 +200,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     //    scope `NodesChanged` to the virtualized region (the slice must model
     //    ONLY the prefix-summed rows, not the streaming buffer). Here we only
     //    register/unregister the per-pane slot.
-    registerLayoutPane(model.blockId, { layout: () => {}, zoom: () => {} });
+    // Phase 3 Step 0: own the derived layout-view signal the list renders
+    // from. The store recomputes computeLayoutView and calls this setter on
+    // every layout-input change (deduped by viewsEqual). `zoom` stays a no-op
+    // — INV-2: the single CSS `zoom` on `.agent-view` does the visual scaling.
+    const [layoutView, setLayoutView] = createSignal<LayoutView | null>(null);
+    registerLayoutPane(model.blockId, { layout: setLayoutView, zoom: () => {} });
     onCleanup(() => unregisterLayoutPane(model.blockId));
     // DEV-only: CDP validation hook — lets engineers run
     // `__agentLayout()` in the console to snapshot the slice state.
@@ -815,6 +821,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 registerHistoryReadyCallback={(fn) => { historyReadyFn = fn; }}
                 zoomFactor={zoomFactor}
                 blockId={model.blockId}
+                layoutView={layoutView}
             />
 
             <Show when={status.canRetry()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -24,13 +24,10 @@ import {
     unregisterActivity as unregisterAgentActivity,
 } from "@/app/store/agentActivity";
 import {
-    dispatch as dispatchLayout,
     registerPane as registerLayoutPane,
     snapshot as layoutSnapshot,
     unregisterPane as unregisterLayoutPane,
 } from "@/app/store/agent-pane-layout-store";
-import { currentExpansion } from "./virtualization/expansion-source";
-import { estimateNodeForState } from "./virtualization/renderers";
 import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -197,63 +194,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
     }
 
-    // ── Phase 2: layout slice adapter (always-on from Phase 2 onward).
-    //    Phase 1b was DEV-only shadow; Phase 2 promotes to production because
-    //    estimateSize and measureElement now read/write through the slice.
-    //    No-op projections: TanStack still owns positions (Phase 3 replaces it).
+    // ── Layout slice lifecycle. The slice is FED from
+    //    AgentDocumentVirtualList (Phase 3): it owns `partition()`, so it can
+    //    scope `NodesChanged` to the virtualized region (the slice must model
+    //    ONLY the prefix-summed rows, not the streaming buffer). Here we only
+    //    register/unregister the per-pane slot.
     registerLayoutPane(model.blockId, { layout: () => {}, zoom: () => {} });
     onCleanup(() => unregisterLayoutPane(model.blockId));
-    // nodeId → JSON(Expansion) of the last value pushed (expansion diff cache).
-    const pushed = new Map<string, string>();
-    // nodeIds for which EstimateSet has been pushed for both states. Pruned in
-    // lockstep with the slice so re-added nodes get fresh estimates.
-    const estimatesPushed = new Set<string>();
-    createEffect(() => {
-        const nodes = agentAtoms().documentAtom[0]();
-        const docState = agentAtoms().documentStateAtom[0]();
-        const ids = nodes.map((n) => n.id);
-        dispatchLayout(model.blockId, { type: "NodesChanged", orderedIds: ids });
-        // Prune diff caches to mirror the slice's own prune. Otherwise a node
-        // removed then re-added with an unchanged expansion/estimate is
-        // short-circuited as "unchanged" and never re-dispatched — the slice
-        // silently diverges. (reagent + codex on #1239.)
-        const idSet = new Set(ids);
-        for (const k of pushed.keys()) if (!idSet.has(k)) pushed.delete(k);
-        for (const k of estimatesPushed) if (!idSet.has(k)) estimatesPushed.delete(k);
-        for (const node of nodes) {
-            // Push EstimateSet for BOTH expansion states on first appearance
-            // (INV-3). The slice then has a sensible height for whichever state
-            // the row enters, so estimateSize returns the right value before
-            // measureElement settles — no stale-0 / stale-784 contamination.
-            if (!estimatesPushed.has(node.id)) {
-                estimatesPushed.add(node.id);
-                dispatchLayout(model.blockId, {
-                    type: "EstimateSet",
-                    nodeId: node.id,
-                    state: "collapsed",
-                    cssPx: estimateNodeForState(node, "collapsed", docState),
-                });
-                dispatchLayout(model.blockId, {
-                    type: "EstimateSet",
-                    nodeId: node.id,
-                    state: "expanded",
-                    cssPx: estimateNodeForState(node, "expanded", docState),
-                });
-            }
-            // ExpansionResolved: keep the slice's expansion map in sync so that
-            // measureElement can key RowMeasured to the correct state (INV-3).
-            const next = currentExpansion(node, docState);
-            const key = JSON.stringify(next);
-            if (pushed.get(node.id) !== key) {
-                pushed.set(node.id, key);
-                dispatchLayout(model.blockId, {
-                    type: "ExpansionResolved",
-                    nodeId: node.id,
-                    to: next,
-                });
-            }
-        }
-    });
     // DEV-only: CDP validation hook — lets engineers run
     // `__agentLayout()` in the console to snapshot the slice state.
     if (import.meta.env.DEV) {

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -30,6 +30,7 @@ import {
     unregisterPane as unregisterLayoutPane,
 } from "@/app/store/agent-pane-layout-store";
 import { currentExpansion } from "./virtualization/expansion-source";
+import { estimateNodeForState } from "./virtualization/renderers";
 import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -196,45 +197,66 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
     }
 
-    // ── Phase 1b (DEV-ONLY shadow): populate the agent-pane-layout slice's
-    //    expansion from the live document and validate that it mirrors the
-    //    rendered open/closed state. Nothing renders FROM the slice yet
-    //    (Phase 3), so this is gated to dev — zero production cost, zero
-    //    behaviour change. The adapter pushes `currentExpansion(node, …)`
-    //    (the single per-kind source of truth, PR #1238) via
-    //    `ExpansionResolved`. See SPEC_AGENT_PANE_LAYOUT_REDUCER §6.
-    if (import.meta.env.DEV) {
-        registerLayoutPane(model.blockId, { layout: () => {}, zoom: () => {} });
-        onCleanup(() => unregisterLayoutPane(model.blockId));
-        // nodeId → JSON(Expansion) of the last value pushed, so we only
-        // dispatch genuine changes (most effect re-runs touch few rows).
-        const pushed = new Map<string, string>();
-        createEffect(() => {
-            const nodes = agentAtoms().documentAtom[0]();
-            const docState = agentAtoms().documentStateAtom[0]();
-            const ids = nodes.map((n) => n.id);
-            dispatchLayout(model.blockId, { type: "NodesChanged", orderedIds: ids });
-            // Prune the diff cache to mirror the slice's own prune. Otherwise a
-            // node removed (slice deletes its expansion) then re-added with an
-            // unchanged resolved value is short-circuited as "unchanged" and
-            // never re-dispatched — the shadow silently diverges in exactly the
-            // prune/re-add churn case. (reagent + codex on #1239.)
-            const idSet = new Set(ids);
-            for (const k of pushed.keys()) if (!idSet.has(k)) pushed.delete(k);
-            for (const node of nodes) {
-                const next = currentExpansion(node, docState);
-                const key = JSON.stringify(next);
-                if (pushed.get(node.id) !== key) {
-                    pushed.set(node.id, key);
-                    dispatchLayout(model.blockId, {
-                        type: "ExpansionResolved",
-                        nodeId: node.id,
-                        to: next,
-                    });
-                }
+    // ── Phase 2: layout slice adapter (always-on from Phase 2 onward).
+    //    Phase 1b was DEV-only shadow; Phase 2 promotes to production because
+    //    estimateSize and measureElement now read/write through the slice.
+    //    No-op projections: TanStack still owns positions (Phase 3 replaces it).
+    registerLayoutPane(model.blockId, { layout: () => {}, zoom: () => {} });
+    onCleanup(() => unregisterLayoutPane(model.blockId));
+    // nodeId → JSON(Expansion) of the last value pushed (expansion diff cache).
+    const pushed = new Map<string, string>();
+    // nodeIds for which EstimateSet has been pushed for both states. Pruned in
+    // lockstep with the slice so re-added nodes get fresh estimates.
+    const estimatesPushed = new Set<string>();
+    createEffect(() => {
+        const nodes = agentAtoms().documentAtom[0]();
+        const docState = agentAtoms().documentStateAtom[0]();
+        const ids = nodes.map((n) => n.id);
+        dispatchLayout(model.blockId, { type: "NodesChanged", orderedIds: ids });
+        // Prune diff caches to mirror the slice's own prune. Otherwise a node
+        // removed then re-added with an unchanged expansion/estimate is
+        // short-circuited as "unchanged" and never re-dispatched — the slice
+        // silently diverges. (reagent + codex on #1239.)
+        const idSet = new Set(ids);
+        for (const k of pushed.keys()) if (!idSet.has(k)) pushed.delete(k);
+        for (const k of estimatesPushed) if (!idSet.has(k)) estimatesPushed.delete(k);
+        for (const node of nodes) {
+            // Push EstimateSet for BOTH expansion states on first appearance
+            // (INV-3). The slice then has a sensible height for whichever state
+            // the row enters, so estimateSize returns the right value before
+            // measureElement settles — no stale-0 / stale-784 contamination.
+            if (!estimatesPushed.has(node.id)) {
+                estimatesPushed.add(node.id);
+                dispatchLayout(model.blockId, {
+                    type: "EstimateSet",
+                    nodeId: node.id,
+                    state: "collapsed",
+                    cssPx: estimateNodeForState(node, "collapsed", docState),
+                });
+                dispatchLayout(model.blockId, {
+                    type: "EstimateSet",
+                    nodeId: node.id,
+                    state: "expanded",
+                    cssPx: estimateNodeForState(node, "expanded", docState),
+                });
             }
-        });
-        // CDP validation hook (dev only): read the slice's resolved state.
+            // ExpansionResolved: keep the slice's expansion map in sync so that
+            // measureElement can key RowMeasured to the correct state (INV-3).
+            const next = currentExpansion(node, docState);
+            const key = JSON.stringify(next);
+            if (pushed.get(node.id) !== key) {
+                pushed.set(node.id, key);
+                dispatchLayout(model.blockId, {
+                    type: "ExpansionResolved",
+                    nodeId: node.id,
+                    to: next,
+                });
+            }
+        }
+    });
+    // DEV-only: CDP validation hook — lets engineers run
+    // `__agentLayout()` in the console to snapshot the slice state.
+    if (import.meta.env.DEV) {
         (window as unknown as { __agentLayout?: () => unknown }).__agentLayout = () =>
             layoutSnapshot(model.blockId);
     }
@@ -845,6 +867,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 highlightNodeId={search.highlightId}
                 registerHistoryReadyCallback={(fn) => { historyReadyFn = fn; }}
                 zoomFactor={zoomFactor}
+                blockId={model.blockId}
             />
 
             <Show when={status.canRetry()}>

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -68,6 +68,12 @@ interface AgentDocumentViewProps {
      * SPEC_AGENT_PANE_VIRTUALIZATION_ZOOM_OVERLAP_2026_06_01.
      */
     zoomFactor?: Accessor<number>;
+    /**
+     * blockId for the agent-pane-layout slice (Phase 2+). When present,
+     * forwarded to AgentDocumentVirtualList so it can route estimates and
+     * measurements through the slice (INV-3).
+     */
+    blockId?: string;
 }
 
 export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element => {
@@ -141,6 +147,7 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             onToggleCollapse={toggleCollapse}
             onTogglePin={togglePin}
             zoomFactor={props.zoomFactor}
+            blockId={props.blockId}
             headerSlot={headerSlot()}
         />
     );

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -23,6 +23,7 @@ import { createSignal, onMount, Show, type Accessor, type JSX } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
+import type { LayoutView } from "@/app/store/agent-pane-layout-store";
 import { AgentDocumentVirtualList } from "../virtualization/AgentDocumentVirtualList";
 import { createAgentViewState } from "../virtualization/state";
 
@@ -74,6 +75,9 @@ interface AgentDocumentViewProps {
      * measurements through the slice (INV-3).
      */
     blockId?: string;
+    /** Derived layout view from the agent-pane-layout slice (Phase 3) —
+     *  forwarded to the list, which renders rows from its prefix-sum positions. */
+    layoutView?: Accessor<LayoutView | null>;
 }
 
 export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element => {
@@ -148,6 +152,7 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             onTogglePin={togglePin}
             zoomFactor={props.zoomFactor}
             blockId={props.blockId}
+            layoutView={props.layoutView}
             headerSlot={headerSlot()}
         />
     );

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -253,9 +253,9 @@
         // Phase A of SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md replaced
         // the portal-based overlay with this inline panel. The panel sits
         // in normal document flow underneath the summary row. Variable-
-        // height — the existing virtualizer + measureElement handles
-        // re-measurement when the panel opens/closes (§4.8 of the spec
-        // recommended option B; verified working).
+        // height — the measure RO handles re-measurement when the panel
+        // opens/closes (§4.8 of the spec recommended option B; verified
+        // working).
         //
         // Visual: indented under the summary row, with a faint accent
         // border-left to tie it visually to the running/streaming state.

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -128,7 +128,7 @@
     .agent-document-streaming-buffer {
         // Trailing nodes rendered in normal flex flow — no
         // virtualization. Always mounted so streaming token batches
-        // don't have to wait for measureElement to settle.
+        // don't have to wait for the measure RO to settle.
         display: flex;
         flex-direction: column;
         gap: 4px;

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -113,13 +113,13 @@
 
     .agent-document-virtualizer {
         // Container for the virtualized region. Children are
-        // absolute-positioned via translateY; the height equals
-        // virtualizer.getTotalSize() so the native scrollbar reflects
-        // the full virtual content.
+        // absolute-positioned via translateY; the height equals the
+        // layout slice's total (layoutView().totalSize) so the native
+        // scrollbar reflects the full virtual content.
         //
         // flex-shrink: 0 — .agent-document is a column flex container,
         // so without this the wrapper would collapse to viewport
-        // height when getTotalSize() exceeds it (codex P1 from #773).
+        // height when totalSize exceeds it (codex P1 from #773).
         position: relative;
         width: 100%;
         flex-shrink: 0;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -226,6 +226,41 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         });
     }
 
+    // ── Phase 3 Step 2: feed the layout slice's VIEWPORT inputs ─────────
+    // Shadow wiring — the slice records scrollTop / viewport / scrollMargin /
+    // zoom, but nothing renders from them until the Step-3 cutover. All
+    // blockId-gated and reducer-deduped (an unchanged value returns the same
+    // state ref). Slice positions are unzoomed CSS px, so scroll + viewport
+    // are normalized by the live zoom — the same ÷zoom basis as measureElement.
+    // (scrollTop ÷zoom under CSS `zoom` is pending CDP confirmation at zoom
+    // 0.5 / 2 per the Phase-3 plan.)
+    let lastScrollMarginPx = -1;
+    const dispatchScrollMargin = (): void => {
+        if (!props.blockId) return;
+        const px = virtualContainerRef?.offsetTop ?? 0;
+        if (px === lastScrollMarginPx) return; // skip redundant dispatches
+        lastScrollMarginPx = px;
+        dispatchLayoutIfRegistered(props.blockId, { type: "ScrollMarginChanged", px });
+    };
+    if (props.blockId) {
+        // Mirror the live zoom into the slice (INV-2: stored, never relayouts).
+        createEffect(() => {
+            const blockId = props.blockId!;
+            const zoom = props.zoomFactor?.() ?? 1;
+            dispatchLayoutIfRegistered(blockId, { type: "ZoomChanged", zoom });
+        });
+        // scrollMargin = the virtualized container's offsetTop (the header
+        // above it). Re-read on every region reflow; handleScroll + the dedup
+        // cover the header-shift cases (auth box / loading-older banner).
+        onMount(() => {
+            if (!virtualContainerRef) return;
+            dispatchScrollMargin();
+            const ro = new ResizeObserver(() => dispatchScrollMargin());
+            ro.observe(virtualContainerRef);
+            onCleanup(() => ro.disconnect());
+        });
+    }
+
     // Virtualizer over the virtualized head only — streaming buffer is
     // rendered separately as a normal flex list. Per-kind estimators
     // come from the renderer registry; measureElement settles each row
@@ -359,6 +394,17 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             if (h > 0 && wasHidden && props.viewState.stickToBottom()) {
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
             }
+            // Phase 3 Step 2 (shadow): the scroll container resizing changes the
+            // viewport the slice windows against — feed it (covers hidden→visible
+            // 0→N and pane resize). blockId-gated, reducer-deduped.
+            if (props.blockId && h > 0) {
+                const zoom = props.zoomFactor?.() ?? 1;
+                dispatchLayoutIfRegistered(props.blockId, {
+                    type: "Scrolled",
+                    scrollTop: scrollRef.scrollTop / (zoom || 1),
+                    viewportPx: h / (zoom || 1),
+                });
+            }
             wasHidden = h === 0;
         });
         ro.observe(scrollRef);
@@ -406,6 +452,18 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     const handleScroll = (): void => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
+
+        // Phase 3 Step 2 (shadow): push scroll position + viewport into the
+        // slice as unzoomed CSS px. Reducer-deduped; blockId-gated.
+        if (props.blockId) {
+            const zoom = props.zoomFactor?.() ?? 1;
+            dispatchLayoutIfRegistered(props.blockId, {
+                type: "Scrolled",
+                scrollTop: scrollTop / (zoom || 1),
+                viewportPx: clientHeight / (zoom || 1),
+            });
+            dispatchScrollMargin();
+        }
 
         // Engage stick when user scrolls back near bottom; disengage
         // otherwise. Engaging clears any captured headAnchor (atomic).

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,8 +29,9 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, createMemo, createSignal, For, Index, onCleanup, onMount, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, Index, onCleanup, onMount, Show, type Accessor, type JSX } from "solid-js";
 import { trail } from "@/log/render-trail";
+import { Key } from "@solid-primitives/keyed";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import { agentPerfStore, startAgentLayoutShiftObserver } from "./perf-probe";
@@ -48,6 +49,7 @@ import {
     dispatchIfRegistered as dispatchLayoutIfRegistered,
     snapshot as snapshotLayout,
     type LayoutView,
+    type RowPosition,
 } from "@/app/store/agent-pane-layout-store";
 import { effectiveHeight } from "@/app/store/agent-pane-layout/reducer";
 import { inFlowState } from "@/app/store/agent-pane-layout/types";
@@ -573,6 +575,75 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         }
     };
 
+    // ── Phase 3 Step 3+4: render from the slice + a standalone measure RO ──
+    // Rows render from the slice's prefix-sum positions (computeLayoutView →
+    // the layoutView signal), keyed by stable nodeId so the fresh RowPosition
+    // objects each recompute produces don't remount rows. Heights come from a
+    // single ResizeObserver that dispatches RowMeasured keyed by (nodeId,
+    // state) — replacing measureElement + the data-index dance. The virtualizer
+    // stays instantiated for scrollToNode / older-history until Step 5.
+
+    // The visible rows, sliced from the slice's full positions array. Empty
+    // window (endIndex < startIndex) → render nothing.
+    const windowedRows = createMemo<RowPosition[]>(() => {
+        const v = props.layoutView?.();
+        if (!v || v.window.endIndex < v.window.startIndex) return [];
+        return v.rows.slice(v.window.startIndex, v.window.endIndex + 1);
+    });
+
+    // nodeId → live DocumentNode for the virtualized partition, so a row
+    // renders the CURRENT node at its id (streaming updates propagate without
+    // remount). A windowed row whose node isn't in the partition this frame is
+    // skipped — the same recoverable drop the old getVirtualItems guard did.
+    const nodeById = createMemo(() => {
+        const m = new Map<string, DocumentNode>();
+        for (const n of partition().virtualizedNodes) m.set(n.id, n);
+        return m;
+    });
+
+    // One measure RO for all virtualized rows; el→nodeId lets the callback
+    // dispatch RowMeasured keyed by the row's current in-flow state, ÷zoom to
+    // stay in unzoomed CSS px (INV-2/3). Rows observe on mount, unobserve on
+    // unmount (the Key child's onCleanup).
+    const elNodeId = new WeakMap<Element, string>();
+    const measureRO = typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver((entries) => {
+            const blockId = props.blockId;
+            if (!blockId) return;
+            const zoom = props.zoomFactor?.() ?? 1;
+            const snap = snapshotLayout(blockId);
+            const nodes = nodeById();
+            for (const entry of entries) {
+                const nodeId = elNodeId.get(entry.target);
+                if (!nodeId) continue;
+                const cssPx = entry.target.getBoundingClientRect().height / (zoom || 1);
+                const node = nodes.get(nodeId);
+                if (node) {
+                    agentPerfStore.recordEstimatorMeasurement(
+                        node.type,
+                        estimateNode(node, props.documentState()),
+                        cssPx,
+                    );
+                }
+                dispatchLayoutIfRegistered(blockId, {
+                    type: "RowMeasured",
+                    nodeId,
+                    state: inFlowState(snap?.expansion.get(nodeId)),
+                    cssPx,
+                });
+            }
+        })
+        : undefined;
+    onCleanup(() => measureRO?.disconnect());
+    const observeRow = (el: HTMLElement, nodeId: string): void => {
+        elNodeId.set(el, nodeId);
+        measureRO?.observe(el);
+    };
+    const unobserveRow = (el: HTMLElement): void => {
+        measureRO?.unobserve(el);
+        elNodeId.delete(el);
+    };
+
     // Render: scroll container holds the optional header, the
     // virtualized head, and the streaming buffer. headerSlot offsets
     // the virtualizer; scrollMargin (above) handles that automatically.
@@ -584,65 +655,48 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 ref={(el) => { virtualContainerRef = el; }}
                 class="agent-document-virtualizer"
                 style={{
-                    height: `${virtualizer.getTotalSize()}px`,
+                    height: `${props.layoutView?.()?.totalSize ?? 0}px`,
                     position: "relative",
                     width: "100%",
                 }}
             >
-                <For each={virtualizer.getVirtualItems()}>
-                    {(virtualItem) => {
-                        // Defensive: during the reflow that follows a tool
-                        // expand/collapse height change, getVirtualItems() can
-                        // transiently yield an undefined entry. Without this
-                        // guard the `virtualItem.index` reads below throw
-                        // "Cannot read properties of undefined (reading 'index')"
-                        // *during render*, which the agent-pane error boundary
-                        // catches by tearing down the ENTIRE virtualized list.
-                        // Dropping one transient row for a frame is recoverable;
-                        // crashing the list is not. (Observed live under rapid
-                        // expand/collapse churn.)
-                        if (!virtualItem) return null;
-                        const nodeAccessor = (): DocumentNode => {
-                            return partition().virtualizedNodes[virtualItem.index];
-                        };
+                <Key each={windowedRows()} by={(r) => r.nodeId}>
+                    {(row) => {
+                        let rowEl: HTMLElement | undefined;
+                        // The live node at this row's id; skip a frame if it's
+                        // momentarily absent from the partition (recoverable,
+                        // like the old getVirtualItems undefined guard).
+                        const node = (): DocumentNode | undefined => nodeById().get(row().nodeId);
+                        onCleanup(() => { if (rowEl) unobserveRow(rowEl); });
                         return (
-                            <DocumentRow
-                                node={nodeAccessor}
-                                documentState={props.documentState}
-                                bookmarkedNodeIds={props.bookmarkedNodeIds}
-                                onBookmark={props.onBookmark}
-                                onSubagentClick={props.onSubagentClick}
-                                highlightNodeId={props.highlightNodeId}
-                                onToggleCollapse={props.onToggleCollapse}
-                                onTogglePin={props.onTogglePin}
-                                // data-index is also bound reactively below
-                                // (dataIndex prop), but that binding is a Solid
-                                // render-effect that RACES this ref callback. If
-                                // the ref wins, TanStack's measureElement reads a
-                                // null data-index and returns *before*
-                                // observer.observe(node) — so the row is never
-                                // observed and stays pinned at estimateSize
-                                // forever, overlapping its neighbors. Setting the
-                                // attribute synchronously here, right before
-                                // measureElement, closes that race. Verified via
-                                // live CDP: rows mounting on the losing side of
-                                // the race were stuck at the 32px estimate.
-                                ref={(el) => {
-                                    el.setAttribute("data-index", String(virtualItem.index));
-                                    virtualizer.measureElement(el);
-                                }}
-                                dataIndex={virtualItem.index}
-                                style={{
-                                    position: "absolute",
-                                    top: "0",
-                                    left: "0",
-                                    width: "100%",
-                                    transform: `translateY(${virtualItem.start - (virtualContainerRef?.offsetTop ?? 0)}px)`,
-                                }}
-                            />
+                            <Show when={node()}>
+                                {(n) => (
+                                    <DocumentRow
+                                        node={n}
+                                        documentState={props.documentState}
+                                        bookmarkedNodeIds={props.bookmarkedNodeIds}
+                                        onBookmark={props.onBookmark}
+                                        onSubagentClick={props.onSubagentClick}
+                                        highlightNodeId={props.highlightNodeId}
+                                        onToggleCollapse={props.onToggleCollapse}
+                                        onTogglePin={props.onTogglePin}
+                                        // Step 4: ref carries the measure RO
+                                        // (keyed by nodeId), not measureElement —
+                                        // no data-index, no measure race.
+                                        ref={(el) => { rowEl = el; observeRow(el, row().nodeId); }}
+                                        style={{
+                                            position: "absolute",
+                                            top: "0",
+                                            left: "0",
+                                            width: "100%",
+                                            transform: `translateY(${row().start - (virtualContainerRef?.offsetTop ?? 0)}px)`,
+                                        }}
+                                    />
+                                )}
+                            </Show>
                         );
                     }}
-                </For>
+                </Key>
             </div>
 
             {/* Streaming buffer — always-mounted trailing nodes.

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -28,7 +28,7 @@
  * the state into the DOM but never reads it back.
  */
 
-import { createEffect, createMemo, createSignal, Index, onCleanup, onMount, Show, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, Index, onCleanup, onMount, Show, untrack, type Accessor, type JSX } from "solid-js";
 import { trail } from "@/log/render-trail";
 import { Key } from "@solid-primitives/keyed";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -266,15 +266,33 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             const ro = new ResizeObserver(() => dispatchScrollMargin());
             ro.observe(virtualContainerRef);
             // The header (auth box / loading-older banner) sits ABOVE the
-            // container; toggling it changes the container's offsetTop WITHOUT
-            // resizing the container itself, so the RO above never fires for it.
-            // Watch scrollRef's direct children for the header add/remove and
-            // re-read scrollMargin then — keeps the slice's scrollMarginPx in
-            // sync with offsetTop for the render path, windowing, and
-            // scroll-to-node (which all subtract the current offsetTop).
-            const mo = new MutationObserver(() => dispatchScrollMargin());
+            // container; it shifts the container's offsetTop WITHOUT resizing
+            // the container itself, so the RO above never fires for it. The
+            // header moves offsetTop two ways, and we watch both:
+            //   • add/remove (a Show toggles the banner/auth box) → childList
+            //     on scrollRef.
+            //   • internal resize (AuthUrlBox grows when its paste-result
+            //     appears inside the existing box) → no childList mutation, so
+            //     a ResizeObserver on the header element itself catches it.
+            // headerRO observes only the 0-2 header elements that precede the
+            // container (never the virtualized rows), so there's no scroll-time
+            // reflow storm. Keeping scrollMarginPx in sync matters because row
+            // starts include it while the render path, windowing, and
+            // scroll-to-node subtract the live offsetTop.
+            const headerRO = new ResizeObserver(() => dispatchScrollMargin());
+            const observeHeaders = (): void => {
+                for (const child of Array.from(scrollRef.children)) {
+                    if (child === virtualContainerRef) break;
+                    headerRO.observe(child); // idempotent per element
+                }
+            };
+            observeHeaders();
+            const mo = new MutationObserver(() => {
+                dispatchScrollMargin();
+                observeHeaders();
+            });
             mo.observe(scrollRef, { childList: true });
-            onCleanup(() => { ro.disconnect(); mo.disconnect(); });
+            onCleanup(() => { ro.disconnect(); headerRO.disconnect(); mo.disconnect(); });
         });
     }
 
@@ -405,9 +423,14 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     };
 
     // React to jump commands from the parent's useScrollToNode hook.
+    // untrack the scroll so this effect depends ONLY on the command signal:
+    // scrollToNode reads layoutView / zoom / partition, all of which change on
+    // every scroll, and useScrollToNode holds the last command rather than
+    // clearing it — tracking them would re-fire the jump on each scroll and pin
+    // the user on the old target.
     createEffect(() => {
         const cmd = props.scrollCommand?.();
-        if (cmd) scrollToNode(cmd.nodeId);
+        if (cmd) untrack(() => scrollToNode(cmd.nodeId));
     });
 
     const handleScroll = (): void => {

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -28,7 +28,6 @@
  * the state into the DOM but never reads it back.
  */
 
-import { createVirtualizer } from "@tanstack/solid-virtual";
 import { createEffect, createMemo, createSignal, Index, onCleanup, onMount, Show, type Accessor, type JSX } from "solid-js";
 import { trail } from "@/log/render-trail";
 import { Key } from "@solid-primitives/keyed";
@@ -51,7 +50,7 @@ import {
     type LayoutView,
     type RowPosition,
 } from "@/app/store/agent-pane-layout-store";
-import { effectiveHeight } from "@/app/store/agent-pane-layout/reducer";
+import { computeLayoutView } from "@/app/store/agent-pane-layout/reducer";
 import { inFlowState } from "@/app/store/agent-pane-layout/types";
 import {
     initialStickyFrontierId,
@@ -270,77 +269,12 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         });
     }
 
-    // Virtualizer over the virtualized head only — streaming buffer is
-    // rendered separately as a normal flex list. Per-kind estimators
-    // come from the renderer registry; measureElement settles each row
-    // to actual height after first paint.
-    const virtualizer = createVirtualizer({
-        get count() { return partition().virtualizedNodes.length; },
-        getScrollElement: () => scrollRef,
-        estimateSize: (index) => {
-            const node = partition().virtualizedNodes[index];
-            if (!node) return 32;
-            // Phase 2: prefer the slice's effective height (measured > estimate >
-            // DEFAULT_ROW_PX) over the direct per-kind estimator. This is the core
-            // INV-3 fix: when a row switches expansion state the slice immediately
-            // returns the cached height for the NEW state instead of the wrong-state
-            // value TanStack would have kept in its cache.
-            if (props.blockId) {
-                const s = snapshotLayout(props.blockId);
-                if (s) return effectiveHeight(s, node.id);
-            }
-            return estimateNode(node, props.documentState());
-        },
-        overscan: 5,
-        getItemKey: (index) => partition().virtualizedNodes[index]?.id ?? index,
-        // scrollMargin: any content rendered above the virtualizer
-        // container (loading-older banner, auth-url box from the
-        // parent) shifts the virtual coordinate system. Read offsetTop
-        // as a getter so it's evaluated each tick.
-        get scrollMargin() {
-            return virtualContainerRef?.offsetTop ?? 0;
-        },
-        // Phase 3 perf probe: validate the per-kind estimator against
-        // the measured size after every measurement. The HUD surfaces
-        // any kind whose miss-rate stays high so we recalibrate.
-        // No-op in production builds (agentPerfStore short-circuits).
-        measureElement: (element) => {
-            // Normalize OUT the per-pane CSS `zoom`: getBoundingClientRect is
-            // zoom-scaled (verified cef-146: css×zoom), but estimateSize returns
-            // fixed unzoomed CSS px. Without this, the two units disagree at
-            // zoom≠1 and the cumulative translateY offsets double-count zoom →
-            // rows overlap (zoom<1) or gap (zoom>1). Dividing by the live zoom
-            // factor keeps the virtualizer entirely in zoom-independent CSS px.
-            // SPEC_AGENT_PANE_VIRTUALIZATION_ZOOM_OVERLAP_2026_06_01 §4.1.
-            const zoom = props.zoomFactor?.() ?? 1;
-            const measured = element.getBoundingClientRect().height / (zoom || 1);
-            const indexAttr = element.getAttribute("data-index");
-            if (indexAttr != null) {
-                const idx = Number(indexAttr);
-                const node = partition().virtualizedNodes[idx];
-                if (node) {
-                    const estimated = estimateNode(node, props.documentState());
-                    agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
-                    // Phase 2: dispatch RowMeasured keyed by the row's CURRENT
-                    // expansion state (INV-3 — an expanded measurement must land in
-                    // the expanded slot, not the collapsed slot, and vice versa).
-                    // `dispatchLayoutIfRegistered` is a no-op if the pane isn't
-                    // wired (e.g. during tests), so this is always-safe.
-                    if (props.blockId) {
-                        const s = snapshotLayout(props.blockId);
-                        const expState = inFlowState(s?.expansion.get(node.id));
-                        dispatchLayoutIfRegistered(props.blockId, {
-                            type: "RowMeasured",
-                            nodeId: node.id,
-                            state: expState,
-                            cssPx: measured,
-                        });
-                    }
-                }
-            }
-            return measured;
-        },
-    });
+    // Phase 3 Step 6: the TanStack virtualizer is gone. Positions, windowing,
+    // and measurement now come entirely from the agent-pane-layout slice
+    // (rendered above from layoutView + the measure RO). Heights are keyed by
+    // (nodeId, state) in the slice, so a row that scrolls out and back keeps
+    // its measured height — the recycle-stale-estimate class is gone by
+    // construction, and prefix-sum positions make overlap impossible (INV-1).
 
     // Layout-shift observer scoped to .agent-document. Idempotent —
     // subsequent mounts are no-ops. Production: short-circuits.
@@ -439,8 +373,17 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (idx < 0) return;
         const p = partition();
         if (idx < p.splitIndex) {
-            // Virtualized region — virtualizer handles ensure-visible + scroll.
-            virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
+            // Virtualized region — center the row from the slice's position
+            // (Step 5). row.start/height are unzoomed CSS px; convert the
+            // target back to the scroll element's zoomed scrollTop (×zoom).
+            const v = props.layoutView?.();
+            const row = v?.rows[idx];
+            if (row) {
+                const zoom = props.zoomFactor?.() ?? 1;
+                const viewportPx = scrollRef.clientHeight / (zoom || 1);
+                const center = row.start - viewportPx / 2 + row.height / 2;
+                scrollRef.scrollTo({ top: Math.max(0, center * (zoom || 1)), behavior: "smooth" });
+            }
         } else {
             // Streaming buffer — node is mounted; query DOM and scroll directly.
             const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
@@ -503,12 +446,18 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             //      is empty, so fall back to the streaming buffer's
             //      first node via DOM. This is the common initial-
             //      pagination case (codex P2 on #784).
-            const items = virtualizer.getVirtualItems();
+            // Step 5: anchor on the topmost visible row from the slice's
+            // window (row.start includes scrollMargin — same basis as the old
+            // TanStack v3 virtualItem.start).
+            const v = props.layoutView?.();
+            const topRow = v && v.window.endIndex >= v.window.startIndex
+                ? v.rows[v.window.startIndex]
+                : undefined;
             let anchorId: string | null = null;
             let anchorOffsetPx = 0;
-            if (items.length > 0) {
-                anchorId = partition().virtualizedNodes[items[0].index]?.id ?? null;
-                anchorOffsetPx = items[0].start;
+            if (topRow) {
+                anchorId = topRow.nodeId;
+                anchorOffsetPx = topRow.start;
             } else if (partition().streamingNodes.length > 0) {
                 anchorId = partition().streamingNodes[0].id;
                 const el = scrollRef.querySelector(
@@ -547,12 +496,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                         if (newIdx >= 0) {
                             const newP = partition();
                             if (newIdx < newP.splitIndex) {
-                                // Still virtualized — recompute via virtualizer's offsetForIndex.
-                                // The returned offset already includes scrollMargin in v3,
-                                // so don't add virtualContainerRef.offsetTop again.
-                                const offset = virtualizer.getOffsetForIndex(newIdx, "start");
+                                // Still virtualized — read the new offset from a
+                                // FRESH slice snapshot (the prepend shifted every
+                                // position). Synchronous, so no projection-timing
+                                // dependency. start includes scrollMargin — same
+                                // basis as the captured anchorOffsetPx.
+                                const snap = props.blockId ? snapshotLayout(props.blockId) : null;
+                                const offset = snap ? computeLayoutView(snap).rows[newIdx]?.start : undefined;
                                 if (offset != null) {
-                                    const target = restoreScrollFromAnchor(anchor, offset[0]);
+                                    const target = restoreScrollFromAnchor(anchor, offset);
                                     scrollRef.scrollTo({ top: target, behavior: "auto" });
                                 }
                             } else {

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -44,6 +44,12 @@ import { DocumentRow } from "./DocumentRow";
 import { estimateNode } from "./renderers";
 import type { AgentViewState } from "./state";
 import {
+    dispatchIfRegistered as dispatchLayoutIfRegistered,
+    snapshot as snapshotLayout,
+} from "@/app/store/agent-pane-layout-store";
+import { effectiveHeight } from "@/app/store/agent-pane-layout/reducer";
+import { inFlowState } from "@/app/store/agent-pane-layout/types";
+import {
     initialStickyFrontierId,
     partitionForVirtualization,
     STREAMING_BUFFER_SIZE,
@@ -79,6 +85,13 @@ export interface AgentDocumentVirtualListProps {
      * via scrollMargin (read from virtualContainerRef.offsetTop).
      */
     headerSlot?: JSX.Element;
+    /**
+     * blockId for the agent-pane-layout slice (Phase 2+). When present,
+     * `estimateSize` reads `effectiveHeight` from the slice (measured >
+     * estimate > default) and `measureElement` dispatches `RowMeasured`
+     * keyed by the row's current expansion state (INV-3).
+     */
+    blockId?: string;
 }
 
 export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): JSX.Element {
@@ -171,7 +184,17 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         getScrollElement: () => scrollRef,
         estimateSize: (index) => {
             const node = partition().virtualizedNodes[index];
-            return node ? estimateNode(node, props.documentState()) : 32;
+            if (!node) return 32;
+            // Phase 2: prefer the slice's effective height (measured > estimate >
+            // DEFAULT_ROW_PX) over the direct per-kind estimator. This is the core
+            // INV-3 fix: when a row switches expansion state the slice immediately
+            // returns the cached height for the NEW state instead of the wrong-state
+            // value TanStack would have kept in its cache.
+            if (props.blockId) {
+                const s = snapshotLayout(props.blockId);
+                if (s) return effectiveHeight(s, node.id);
+            }
+            return estimateNode(node, props.documentState());
         },
         overscan: 5,
         getItemKey: (index) => partition().virtualizedNodes[index]?.id ?? index,
@@ -203,6 +226,21 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 if (node) {
                     const estimated = estimateNode(node, props.documentState());
                     agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
+                    // Phase 2: dispatch RowMeasured keyed by the row's CURRENT
+                    // expansion state (INV-3 — an expanded measurement must land in
+                    // the expanded slot, not the collapsed slot, and vice versa).
+                    // `dispatchLayoutIfRegistered` is a no-op if the pane isn't
+                    // wired (e.g. during tests), so this is always-safe.
+                    if (props.blockId) {
+                        const s = snapshotLayout(props.blockId);
+                        const expState = inFlowState(s?.expansion.get(node.id));
+                        dispatchLayoutIfRegistered(props.blockId, {
+                            type: "RowMeasured",
+                            nodeId: node.id,
+                            state: expState,
+                            cssPx: measured,
+                        });
+                    }
                 }
             }
             return measured;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -47,6 +47,7 @@ import type { AgentViewState } from "./state";
 import {
     dispatchIfRegistered as dispatchLayoutIfRegistered,
     snapshot as snapshotLayout,
+    type LayoutView,
 } from "@/app/store/agent-pane-layout-store";
 import { effectiveHeight } from "@/app/store/agent-pane-layout/reducer";
 import { inFlowState } from "@/app/store/agent-pane-layout/types";
@@ -93,6 +94,12 @@ export interface AgentDocumentVirtualListProps {
      * keyed by the row's current expansion state (INV-3).
      */
     blockId?: string;
+    /**
+     * Derived layout view from the agent-pane-layout slice (Phase 3). When
+     * present, rows render from `layoutView().rows` (prefix-sum positions)
+     * instead of TanStack's virtual items.
+     */
+    layoutView?: Accessor<LayoutView | null>;
 }
 
 export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): JSX.Element {

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -10,10 +10,10 @@
  *
  *  ┌─ scrollRef (.agent-document) ─────────────────────────┐
  *  │  ┌─ virtualized region ─────────────────────────────┐ │
- *  │  │  height = virtualizer.getTotalSize()             │ │
+ *  │  │  height = layoutView().totalSize (slice)         │ │
  *  │  │  position: relative                              │ │
  *  │  │  rows: position: absolute, translateY(start)     │ │
- *  │  │  measureElement on each row                      │ │
+ *  │  │  measure ResizeObserver on each row              │ │
  *  │  └──────────────────────────────────────────────────┘ │
  *  │  ┌─ streaming buffer ───────────────────────────────┐ │
  *  │  │  trailing N nodes, normal flex flow              │ │
@@ -75,9 +75,10 @@ export interface AgentDocumentVirtualListProps {
     onTogglePin: (id: string) => void;
     /**
      * Live per-pane zoom factor (the same value applied as CSS `zoom` on
-     * `.agent-view` in agent-view.tsx). Used to normalize `measureElement`
-     * into unzoomed CSS px so virtualizer row offsets don't double-count zoom
-     * and overlap — see SPEC_AGENT_PANE_VIRTUALIZATION_ZOOM_OVERLAP_2026_06_01.
+     * `.agent-view` in agent-view.tsx). Used to normalize the measure RO + the
+     * Scrolled / scrollToNode math into unzoomed CSS px so slice positions don't
+     * double-count zoom and overlap — see
+     * SPEC_AGENT_PANE_VIRTUALIZATION_ZOOM_OVERLAP_2026_06_01.
      * Defaults to 1 (no zoom) when not supplied.
      */
     zoomFactor?: Accessor<number>;
@@ -89,10 +90,10 @@ export interface AgentDocumentVirtualListProps {
      */
     headerSlot?: JSX.Element;
     /**
-     * blockId for the agent-pane-layout slice (Phase 2+). When present,
-     * `estimateSize` reads `effectiveHeight` from the slice (measured >
-     * estimate > default) and `measureElement` dispatches `RowMeasured`
-     * keyed by the row's current expansion state (INV-3).
+     * blockId for the agent-pane-layout slice. When present, the list feeds the
+     * slice (nodes / estimates / expansion / viewport / measurements) and the
+     * measure RO dispatches `RowMeasured` keyed by the row's current expansion
+     * state (INV-3). Required for the slice-driven render path (Phase 3).
      */
     blockId?: string;
     /**
@@ -138,12 +139,11 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // defer), so they cascade regardless. (reagent P1 on #1212.)
     const [animateEnabled, setAnimateEnabled] = createSignal(false);
 
-    // Memoized — partition is read inside virtualizer's reactive
-    // count getter, estimateSize, getItemKey, the streaming buffer
-    // <For>, and each virtual item's nodeAccessor. Without
-    // createMemo, every read re-slices the document (O(n)) on every
-    // token of streaming, defeating the streaming buffer's purpose.
-    // (reagent P1 on #784.)
+    // Memoized — partition is read inside the slice-feeding effect,
+    // nodeById, scrollToNode / older-history, and the streaming buffer
+    // <Index>. Without createMemo, every read re-slices the document
+    // (O(n)) on every token of streaming, defeating the streaming
+    // buffer's purpose. (reagent P1 on #784.)
     const partition = createMemo(() => {
         const nodes = props.viewState.nodes();
 
@@ -364,9 +364,9 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     if (props.scrollToBottomRef) props.scrollToBottomRef(jumpToBottom);
 
     // scrollToNode: jump the named node into view. Disengages stick
-    // (user wants to stay where they jumped). Routes through the
-    // virtualizer if the target is in the virtualized head, else uses
-    // the streaming buffer's natural DOM offset.
+    // (user wants to stay where they jumped). Uses the slice's row
+    // position if the target is in the virtualized head, else the
+    // streaming buffer's natural DOM offset.
     const scrollToNode = (nodeId: string): void => {
         if (!scrollRef) return;
         const idx = props.viewState.indexOf(nodeId);
@@ -437,18 +437,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             !(props.loadingOlder?.())
         ) {
             // Capture anchor from the topmost visible node. Two cases:
-            //   1) Document is large enough to virtualize → use the
-            //      topmost virtual item. Note: in TanStack Virtual v3
-            //      `virtualItem.start` ALREADY includes scrollMargin
-            //      so we read it directly without re-adding the margin.
+            //   1) Document is large enough to virtualize → anchor on the
+            //      topmost visible row from the slice's window. row.start
+            //      already includes scrollMargin, so it's read directly
+            //      without re-adding the margin (same basis as the old
+            //      TanStack v3 virtualItem.start).
             //   2) Document fits entirely in the streaming buffer
-            //      (≤ STREAMING_BUFFER_SIZE nodes) → getVirtualItems()
-            //      is empty, so fall back to the streaming buffer's
-            //      first node via DOM. This is the common initial-
-            //      pagination case (codex P2 on #784).
-            // Step 5: anchor on the topmost visible row from the slice's
-            // window (row.start includes scrollMargin — same basis as the old
-            // TanStack v3 virtualItem.start).
+            //      (≤ STREAMING_BUFFER_SIZE nodes) → the window is empty, so
+            //      fall back to the streaming buffer's first node via DOM.
+            //      This is the common initial-pagination case (codex P2 #784).
             const v = props.layoutView?.();
             const topRow = v && v.window.endIndex >= v.window.startIndex
                 ? v.rows[v.window.startIndex]
@@ -485,10 +482,9 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                     // `partitionForVirtualization()` here would use a
                     // count-based split that ignores the sticky
                     // frontier, so an anchor that's actually in the
-                    // streaming buffer could be classified as
-                    // virtualized, then `getOffsetForIndex(newIdx)`
-                    // would be called with an index past the
-                    // virtualizer's count and the restore would
+                    // streaming buffer could be misclassified as
+                    // virtualized and read a slice row index past the
+                    // virtualized region, and the restore would
                     // silently fail. Codex P2 on PR #1101.
                     const anchor = props.viewState.headAnchor();
                     if (anchor != null && scrollRef) {
@@ -532,8 +528,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // the layoutView signal), keyed by stable nodeId so the fresh RowPosition
     // objects each recompute produces don't remount rows. Heights come from a
     // single ResizeObserver that dispatches RowMeasured keyed by (nodeId,
-    // state) — replacing measureElement + the data-index dance. The virtualizer
-    // stays instantiated for scrollToNode / older-history until Step 5.
+    // state) — replacing measureElement + the data-index dance.
 
     // The visible rows, sliced from the slice's full positions array. Empty
     // window (endIndex < startIndex) → render nothing.
@@ -598,7 +593,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
 
     // Render: scroll container holds the optional header, the
     // virtualized head, and the streaming buffer. headerSlot offsets
-    // the virtualizer; scrollMargin (above) handles that automatically.
+    // the rows; the slice's scrollMargin (fed above) accounts for it.
     return (
         <div class="agent-document" ref={scrollRef} onScroll={handleScroll}>
             {props.headerSlot}

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -265,7 +265,16 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             dispatchScrollMargin();
             const ro = new ResizeObserver(() => dispatchScrollMargin());
             ro.observe(virtualContainerRef);
-            onCleanup(() => ro.disconnect());
+            // The header (auth box / loading-older banner) sits ABOVE the
+            // container; toggling it changes the container's offsetTop WITHOUT
+            // resizing the container itself, so the RO above never fires for it.
+            // Watch scrollRef's direct children for the header add/remove and
+            // re-read scrollMargin then — keeps the slice's scrollMarginPx in
+            // sync with offsetTop for the render path, windowing, and
+            // scroll-to-node (which all subtract the current offsetTop).
+            const mo = new MutationObserver(() => dispatchScrollMargin());
+            mo.observe(scrollRef, { childList: true });
+            onCleanup(() => { ro.disconnect(); mo.disconnect(); });
         });
     }
 

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -234,12 +234,12 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         });
     }
 
-    // ── Phase 3 Step 2: feed the layout slice's VIEWPORT inputs ─────────
-    // Shadow wiring — the slice records scrollTop / viewport / scrollMargin /
-    // zoom, but nothing renders from them until the Step-3 cutover. All
+    // ── Phase 3: feed the layout slice's VIEWPORT inputs ────────────────
+    // The slice records scrollTop / viewport / scrollMargin / zoom and the
+    // render path (windowing + prefix-sum row positions) reads them back. All
     // blockId-gated and reducer-deduped (an unchanged value returns the same
     // state ref). Slice positions are unzoomed CSS px, so scroll + viewport
-    // are normalized by the live zoom — the same ÷zoom basis as measureElement.
+    // are normalized by the live zoom — the same ÷zoom basis as the measure RO.
     // (scrollTop ÷zoom under CSS `zoom` is pending CDP confirmation at zoom
     // 0.5 / 2 per the Phase-3 plan.)
     let lastScrollMarginPx = -1;
@@ -346,9 +346,9 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             if (h > 0 && wasHidden && props.viewState.stickToBottom()) {
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
             }
-            // Phase 3 Step 2 (shadow): the scroll container resizing changes the
-            // viewport the slice windows against — feed it (covers hidden→visible
-            // 0→N and pane resize). blockId-gated, reducer-deduped.
+            // Phase 3: the scroll container resizing changes the viewport the
+            // slice windows against — feed it (covers hidden→visible 0→N and
+            // pane resize). blockId-gated, reducer-deduped.
             if (props.blockId && h > 0) {
                 const zoom = props.zoomFactor?.() ?? 1;
                 dispatchLayoutIfRegistered(props.blockId, {
@@ -414,8 +414,8 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
 
-        // Phase 3 Step 2 (shadow): push scroll position + viewport into the
-        // slice as unzoomed CSS px. Reducer-deduped; blockId-gated.
+        // Phase 3: push scroll position + viewport into the slice as unzoomed
+        // CSS px. Reducer-deduped; blockId-gated.
         if (props.blockId) {
             const zoom = props.zoomFactor?.() ?? 1;
             dispatchLayoutIfRegistered(props.blockId, {

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -41,7 +41,8 @@ import {
     restoreScrollFromAnchor,
 } from "./anchor";
 import { DocumentRow } from "./DocumentRow";
-import { estimateNode } from "./renderers";
+import { estimateNode, estimateNodeForState } from "./renderers";
+import { currentExpansion } from "./expansion-source";
 import type { AgentViewState } from "./state";
 import {
     dispatchIfRegistered as dispatchLayoutIfRegistered,
@@ -174,6 +175,56 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         });
         return result;
     });
+
+    // Phase 3: feed the layout slice from the VIRTUALIZED partition only.
+    // The slice models the prefix-summed region; the streaming buffer is
+    // normal-flow and out of scope. Dispatches NodesChanged + per-node
+    // EstimateSet (both states, INV-3) + ExpansionResolved so positions /
+    // effectiveHeight are authoritative. No-op when blockId is absent.
+    if (props.blockId) {
+        // nodeId → JSON(Expansion) last pushed (expansion diff cache).
+        const pushedExpansion = new Map<string, string>();
+        // nodeIds with EstimateSet pushed for both states; pruned in lockstep
+        // with the slice so a removed-then-re-added node gets fresh values.
+        const estimatesPushed = new Set<string>();
+        createEffect(() => {
+            const blockId = props.blockId!;
+            const vnodes = partition().virtualizedNodes;
+            const docState = props.documentState();
+            const ids = vnodes.map((n) => n.id);
+            dispatchLayoutIfRegistered(blockId, { type: "NodesChanged", orderedIds: ids });
+            const idSet = new Set(ids);
+            for (const k of pushedExpansion.keys()) if (!idSet.has(k)) pushedExpansion.delete(k);
+            for (const k of estimatesPushed) if (!idSet.has(k)) estimatesPushed.delete(k);
+            for (const node of vnodes) {
+                if (!estimatesPushed.has(node.id)) {
+                    estimatesPushed.add(node.id);
+                    dispatchLayoutIfRegistered(blockId, {
+                        type: "EstimateSet",
+                        nodeId: node.id,
+                        state: "collapsed",
+                        cssPx: estimateNodeForState(node, "collapsed", docState),
+                    });
+                    dispatchLayoutIfRegistered(blockId, {
+                        type: "EstimateSet",
+                        nodeId: node.id,
+                        state: "expanded",
+                        cssPx: estimateNodeForState(node, "expanded", docState),
+                    });
+                }
+                const next = currentExpansion(node, docState);
+                const key = JSON.stringify(next);
+                if (pushedExpansion.get(node.id) !== key) {
+                    pushedExpansion.set(node.id, key);
+                    dispatchLayoutIfRegistered(blockId, {
+                        type: "ExpansionResolved",
+                        nodeId: node.id,
+                        to: next,
+                    });
+                }
+            }
+        });
+    }
 
     // Virtualizer over the virtualized head only — streaming buffer is
     // rendered separately as a normal flex list. Per-kind estimators

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -43,16 +43,9 @@ export interface DocumentRowProps {
      *  passes absolute positioning + translateY; streaming parent
      *  passes nothing (normal flow). */
     style?: JSX.CSSProperties;
-    /** Ref forwarded to the wrapper element. Virtualized parent
-     *  passes virtualizer.measureElement; streaming parent omits. */
+    /** Ref forwarded to the wrapper element. Virtualized parent passes the
+     *  measure-RO observer (keyed by nodeId); streaming parent omits. */
     ref?: (el: HTMLElement) => void;
-    /**
-     * Virtual item index — set as `data-index` on the wrapper. TanStack
-     * Virtual's measureElement requires this attribute to match
-     * measurements back to virtual items. Streaming parent omits.
-     * (codex P1 on #784.)
-     */
-    dataIndex?: number;
 }
 
 // Kinds whose hover-strip surfaces an Expand/Collapse control.
@@ -157,7 +150,6 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 "agent-node-search-match": isSearchMatch(),
             }}
             data-node-id={props.node().id}
-            data-index={props.dataIndex}
             tabindex="0"
             onKeyDown={handleRowKey}
             onContextMenu={handleContextMenu}

--- a/frontend/app/view/agent/virtualization/renderers.test.ts
+++ b/frontend/app/view/agent/virtualization/renderers.test.ts
@@ -15,6 +15,7 @@ import {
     estimateAgentMessage,
     estimateMarkdown,
     estimateNode,
+    estimateNodeForState,
     estimateSection,
     estimateSubagentLink,
     estimateTextHeight,
@@ -252,6 +253,94 @@ describe("estimateNode dispatch", () => {
         expect(estimateNode(am, state)).toBe(estimateAgentMessage(am, state));
         expect(estimateNode(um, state)).toBe(estimateUserMessage(um, state));
         expect(estimateNode(sl, state)).toBe(estimateSubagentLink(sl));
+    });
+});
+
+describe("estimateNodeForState (Phase 2 — INV-3 per-state estimates)", () => {
+    const state = baseDocState();
+
+    it("tool: collapsed → 32, expanded → 200", () => {
+        const node: ToolNode = {
+            type: "tool", id: "t1", tool: "Bash", params: { command: "ls" },
+            status: "success", collapsed: true, summary: "Bash ls",
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(32);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(200);
+    });
+
+    it("agent_message: collapsed → 32, expanded → text height", () => {
+        const node: AgentMessageNode = {
+            type: "agent_message", id: "am1", from: "a", to: "b",
+            message: "a".repeat(160), method: "mux", direction: "incoming",
+            timestamp: 0, collapsed: false, summary: "S",
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(32);
+        // 160 chars → 2 lines × 24 = 48
+        expect(estimateNodeForState(node, "expanded", state)).toBe(48);
+    });
+
+    it("section: both states → same fixed height (no in-flow difference)", () => {
+        const node: SectionNode = {
+            type: "section", id: "s1", level: 1, title: "H",
+            collapsible: false, collapsed: false,
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(48);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(48);
+    });
+
+    it("user_message (normal): both states → text height (not collapsible)", () => {
+        const node: UserMessageNode = { type: "user_message", id: "um1", message: "hi", timestamp: 0 };
+        // Normal user messages are never collapsed (only startup payloads are).
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(32);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(32);
+    });
+
+    it("user_message (startup): collapsed → 32, expanded → text height", () => {
+        const node: UserMessageNode = {
+            type: "user_message", id: "um2", message: "hi", timestamp: 0, isStartup: true,
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(32);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(32);
+    });
+
+    it("markdown (normal): collapsed → text height (not canceled), expanded → text height", () => {
+        const node: MarkdownNode = { type: "markdown", id: "m1", content: "a".repeat(160) };
+        // Non-canceled markdown is open by default; collapsed estimate = full text height.
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(48); // 2 lines × 24
+        expect(estimateNodeForState(node, "expanded", state)).toBe(48);
+    });
+
+    it("markdown (canceled-thinking): collapsed → 32 (summary), expanded → text height", () => {
+        const node: MarkdownNode = {
+            type: "markdown", id: "m2", content: "a".repeat(160),
+            metadata: { canceled: true },
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(32);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(48);
+    });
+
+    it("subagent_link: both states → fixed height", () => {
+        const node: SubagentLinkNode = {
+            type: "subagent_link", id: "sl1", subagentId: "x", slug: "y",
+            parentAgent: "p", sessionId: "s", status: "active", model: null,
+        };
+        expect(estimateNodeForState(node, "collapsed", state)).toBe(56);
+        expect(estimateNodeForState(node, "expanded", state)).toBe(56);
+    });
+
+    it("ignores DocumentState entirely — document collapse/pin signals don't affect per-state estimates", () => {
+        const tool: ToolNode = {
+            type: "tool", id: "t2", tool: "Read", params: { file_path: "x" },
+            status: "success", collapsed: true, summary: "Read x",
+        };
+        const pinned = baseDocState();
+        pinned.pinnedNodes.add("t2");
+        // estimateNodeForState for "collapsed" is always 32 regardless of pin state.
+        expect(estimateNodeForState(tool, "collapsed", pinned)).toBe(32);
+        expect(estimateNodeForState(tool, "expanded", pinned)).toBe(200);
+        // Same result with no pin — it's purely state-driven.
+        expect(estimateNodeForState(tool, "collapsed", state)).toBe(32);
+        expect(estimateNodeForState(tool, "expanded", state)).toBe(200);
     });
 });
 

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -238,3 +238,48 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "subagent_link": return estimateSubagentLink(node);
     }
 }
+
+/**
+ * Per-state height estimate for a given node, independent of the
+ * document's current open/collapsed signals. Used by the Phase-2 adapter
+ * to push `EstimateSet` for BOTH expansion states when a node first enters
+ * the layout slice (INV-3: measurements are keyed by (nodeId, state), so
+ * the slice needs an estimate for each state before measureElement settles).
+ *
+ * Intentionally does not receive `DocumentState` — the whole point is to
+ * give a size for the GIVEN state, not the rendered state. `_docState` is
+ * accepted only for call-site symmetry with `estimateNode`.
+ */
+export function estimateNodeForState(
+    node: DocumentNode,
+    expansionState: "collapsed" | "expanded",
+    _docState: DocumentState,
+): number {
+    if (expansionState === "collapsed") {
+        switch (node.type) {
+            case "tool":          return TOOL_COLLAPSED_PX;
+            case "agent_message": return COLLAPSED_MESSAGE_PX;
+            case "user_message":
+                // Startup messages collapse; normal user input doesn't.
+                return node.isStartup
+                    ? COLLAPSED_MESSAGE_PX
+                    : estimateUnwrappedTextHeight(node.message);
+            case "section":       return SECTION_PX;
+            case "markdown":
+                // Canceled-thinking collapses; normal markdown stays full.
+                return node.metadata?.canceled
+                    ? COLLAPSED_MESSAGE_PX
+                    : estimateTextHeight(node.content);
+            case "subagent_link": return SUBAGENT_LINK_PX;
+        }
+    }
+    // expanded
+    switch (node.type) {
+        case "tool":          return TOOL_EXPANDED_PX;
+        case "agent_message": return estimateTextHeight(node.message);
+        case "user_message":  return estimateUnwrappedTextHeight(node.message);
+        case "section":       return SECTION_PX;
+        case "markdown":      return estimateTextHeight(node.content);
+        case "subagent_link": return SUBAGENT_LINK_PX;
+    }
+}

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -34,7 +34,7 @@ export interface NodeKindRenderer<K extends NodeKind = NodeKind> {
      *  reactively (no destructuring) so prop changes propagate. */
     component: Component<{ node: NodeOf<K>; state: DocumentState }>;
     /**
-     * Initial height estimate in pixels. Used until measureElement
+     * Initial height estimate in pixels. Used until the measure RO
      * settles each row to its real size. Should be close to the p50
      * actual height for the kind — Phase 3's perf probe surfaces
      * estimator misses > 30% in the dev HUD so we can recalibrate.
@@ -92,8 +92,8 @@ export function estimateTextHeight(
  * `_document-nodes.scss`, so the char-count heuristic in
  * `estimateTextHeight` would over-allocate for long URLs / paths
  * (300-char URL → 4 estimated lines vs 1 actual line) and cause
- * blank gaps / scroll jumps in the virtualized list until
- * measureElement caught up. Codex P2 round 4 on PR #1020.
+ * blank gaps / scroll jumps in the virtualized list until the
+ * measure RO caught up. Codex P2 round 4 on PR #1020.
  */
 export function estimateUnwrappedTextHeight(
     content: string,
@@ -241,10 +241,11 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
 
 /**
  * Per-state height estimate for a given node, independent of the
- * document's current open/collapsed signals. Used by the Phase-2 adapter
- * to push `EstimateSet` for BOTH expansion states when a node first enters
- * the layout slice (INV-3: measurements are keyed by (nodeId, state), so
- * the slice needs an estimate for each state before measureElement settles).
+ * document's current open/collapsed signals. Used by the layout
+ * slice-feeding effect to push `EstimateSet` for BOTH expansion states when a
+ * node first enters the slice (INV-3: measurements are keyed by (nodeId,
+ * state), so the slice needs an estimate for each state until the measure RO
+ * settles a real height for it).
  *
  * Intentionally does not receive `DocumentState` — the whole point is to
  * give a size for the GIVEN state, not the rendered state. `_docState` is

--- a/tools/tests/agent-layout-drift.mjs
+++ b/tools/tests/agent-layout-drift.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// agent-layout-drift.mjs — Phase 3 layout-reducer drift / overlap verifier.
+//
+// Drives N expand/collapse cycles on a VIRTUALIZED agent pane via CDP and
+// asserts, after every cycle, that the rendered rows are flush and never
+// overlap — the user-visible form of INV-1 (positions are a prefix-sum, so
+// start[i+1] === end[i] by construction). This is the integration check the
+// pure reducer property test (INV-1) can't make: that the SLICE's positions
+// match what the browser actually paints.
+//
+// Models the CDP harness on bench-agent-keystroke.mjs.
+//
+// Spec: SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02 §7. Closes the verification
+// leg of #1235. Pre-Phase-3 baseline (TanStack): ~5 mismatches / 1 overlap
+// after 9 expand/collapse cycles. Target: 0 overlap, max |gap| ≤ tolerance.
+//
+// ⚠ Prereq: AgentMux running (CDP 127.0.0.1:9223) with an agent pane whose
+// history EXCEEDS the streaming buffer, so `.agent-document-virtualizer` holds
+// ≥ 2 rows. Fresh panes freeze the sticky-frontier at node 0 (empty virtualized
+// head) and do NOT exercise Phase 3 — load older history first.
+
+import { WebSocket } from "ws";
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const getArg = (n, d) => { const i = args.indexOf(n); return i !== -1 ? args[i + 1] : d; };
+const hasFlag = (n) => args.includes(n);
+if (hasFlag("--help")) {
+    console.log(`node tools/tests/agent-layout-drift.mjs [options]
+  --cdp-port <port>     CEF debug port (default 9223)
+  --cycles <n>          Expand/collapse cycles (default 12)
+  --toggles <n>         Rows toggled per cycle (default 6)
+  --tolerance-px <n>    Max allowed |gap| between consecutive rows (default 1.5)
+  --inter-ms <ms>       Pause after each toggle for reflow (default 120)
+  --no-cleanup          Leave toggles applied (default: restore)
+  --help`);
+    process.exit(0);
+}
+const CDP_PORT = parseInt(getArg("--cdp-port", "9223"), 10);
+const CYCLES = parseInt(getArg("--cycles", "12"), 10);
+const TOGGLES = parseInt(getArg("--toggles", "6"), 10);
+const TOL = parseFloat(getArg("--tolerance-px", "1.5"));
+const INTER_MS = parseInt(getArg("--inter-ms", "120"), 10);
+
+// ── CDP session (minimal client, from bench-agent-keystroke.mjs) ─────────────
+class CdpSession {
+    constructor(wsUrl) { this.wsUrl = wsUrl; this.ws = null; this.nextId = 1; this.pending = new Map(); }
+    async connect() {
+        await new Promise((resolve, reject) => {
+            this.ws = new WebSocket(this.wsUrl, { perMessageDeflate: false, maxPayload: 64 * 1024 * 1024 });
+            this.ws.on("open", resolve);
+            this.ws.on("error", reject);
+            this.ws.on("message", (d) => this.onMessage(d));
+            this.ws.on("close", () => { for (const { reject } of this.pending.values()) reject(new Error("CDP closed")); this.pending.clear(); });
+        });
+    }
+    onMessage(data) {
+        const msg = JSON.parse(data.toString());
+        if (msg.id == null) return;
+        const p = this.pending.get(msg.id);
+        if (!p) return;
+        this.pending.delete(msg.id);
+        msg.error ? p.reject(new Error(`CDP ${msg.error.code}: ${msg.error.message}`)) : p.resolve(msg.result);
+    }
+    async send(method, params = {}) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => { this.pending.set(id, { resolve, reject }); this.ws.send(JSON.stringify({ id, method, params })); });
+    }
+    close() { if (this.ws) { this.ws.close(); this.ws = null; } }
+}
+
+async function evaluate(session, expression, awaitPromise = false) {
+    const res = await session.send("Runtime.evaluate", { expression, awaitPromise, returnByValue: true });
+    if (res.exceptionDetails) throw new Error(`evaluate: ${res.exceptionDetails.text}`);
+    return res.result?.value;
+}
+
+// Pick the workspace page (not a warm-pool window): the main page's URL has no
+// windowLabel=window-pool / pool param.
+async function findWorkspaceTarget(port) {
+    const res = await fetch(`http://127.0.0.1:${port}/json`).catch((e) => { throw new Error(`CDP :${port} unreachable: ${e.message} — is AgentMux running?`); });
+    const targets = (await res.json()).filter((t) => t.type === "page");
+    const main = targets.find((t) => !/window-pool|pool=1/.test(t.url || "")) || targets[0];
+    if (!main) throw new Error(`no page targets on :${port}`);
+    return main;
+}
+
+// ── DOM probe: rendered-row gaps in the virtualized container ────────────────
+// Returns { n, overlaps, maxAbsGap, worst:[{a,b,gap}], err }.
+const PROBE = `
+(() => {
+  const c = document.querySelector('.agent-document-virtualizer');
+  if (!c) return { err: 'no .agent-document-virtualizer' };
+  const rows = [...c.querySelectorAll('.agent-document-row')];
+  if (rows.length < 2) return { err: 'virtualized region has < 2 rows — need a long-history pane', n: rows.length };
+  const r = rows.map(el => { const b = el.getBoundingClientRect(); return { id: el.getAttribute('data-node-id'), top: b.top, bottom: b.bottom }; })
+               .sort((a,b) => a.top - b.top);
+  let overlaps = 0, maxAbsGap = 0; const worst = [];
+  for (let i = 1; i < r.length; i++) {
+    const gap = r[i].top - r[i-1].bottom;          // 0 == flush; <0 == overlap
+    if (gap < 0) overlaps++;
+    if (Math.abs(gap) > maxAbsGap) maxAbsGap = Math.abs(gap);
+    if (Math.abs(gap) > 1.0) worst.push({ a: r[i-1].id, b: r[i].id, gap: +gap.toFixed(2) });
+  }
+  worst.sort((x,y) => Math.abs(y.gap) - Math.abs(x.gap));
+  return { n: r.length, overlaps, maxAbsGap: +maxAbsGap.toFixed(2), worst: worst.slice(0, 5) };
+})()`;
+
+// Toggle expansion on up to `count` virtualized rows by focusing each and
+// pressing 'e' (DocumentRow.handleRowKey maps 'e' → onExpand for the
+// expandable kinds: tool / agent_message / section). Returns the ids toggled.
+async function toggleRows(session, count) {
+    const ids = await evaluate(session, `
+      (() => {
+        const c = document.querySelector('.agent-document-virtualizer');
+        if (!c) return [];
+        const rows = [...c.querySelectorAll('.agent-document-row[tabindex]')];
+        const picked = [];
+        for (let i = 0; i < rows.length && picked.length < ${count}; i += Math.max(1, Math.floor(rows.length / ${count}))) {
+          rows[i].focus();
+          rows[i].dispatchEvent(new KeyboardEvent('keydown', { key: 'e', bubbles: true }));
+          picked.push(rows[i].getAttribute('data-node-id'));
+        }
+        return picked;
+      })()`);
+    return ids || [];
+}
+
+const fmt = (n) => (n == null ? "—" : `${n}`);
+
+async function main() {
+    console.log(`agent-layout-drift: CDP 127.0.0.1:${CDP_PORT}, ${CYCLES} cycles × ${TOGGLES} toggles, tol ${TOL}px`);
+    const target = await findWorkspaceTarget(CDP_PORT);
+    console.log(`  page: ${target.title || "(no title)"}`);
+    const session = new CdpSession(target.webSocketDebuggerUrl);
+    await session.connect();
+    await session.send("Runtime.enable");
+
+    // Fresh reload so we start from a known render (spec §7: "fresh reload → …").
+    await session.send("Page.enable").catch(() => {});
+    await session.send("Page.reload", { ignoreCache: false }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 2500)); // let history + first paint settle
+
+    const base = await evaluate(session, PROBE);
+    if (base.err) throw new Error(`${base.err} (n=${fmt(base.n)})`);
+    console.log(`  baseline: ${base.n} rows, ${base.overlaps} overlap, maxAbsGap ${base.maxAbsGap}px`);
+
+    let worstOverlaps = base.overlaps, worstGap = base.maxAbsGap, worstDetail = base.worst;
+    for (let cy = 1; cy <= CYCLES; cy++) {
+        await toggleRows(session, TOGGLES);
+        await new Promise((r) => setTimeout(r, INTER_MS));
+        const p = await evaluate(session, PROBE);
+        if (p.err) { console.log(`  cycle ${cy}: ${p.err}`); continue; }
+        if (p.overlaps > worstOverlaps) { worstOverlaps = p.overlaps; worstDetail = p.worst; }
+        if (p.maxAbsGap > worstGap) worstGap = p.maxAbsGap;
+        console.log(`  cycle ${cy.toString().padStart(2)}: ${p.n} rows, overlaps ${p.overlaps}, maxAbsGap ${p.maxAbsGap}px`);
+    }
+
+    session.close();
+    console.log("─".repeat(60));
+    console.log(`worst over ${CYCLES} cycles: overlaps=${worstOverlaps}, maxAbsGap=${worstGap}px (tolerance ${TOL})`);
+    if (worstDetail?.length) console.log(`  worst gaps: ${JSON.stringify(worstDetail)}`);
+
+    const pass = worstOverlaps === 0 && worstGap <= TOL;
+    console.log(pass ? "\n✓ PASS — 0 overlap, rows flush within tolerance" : "\n✗ FAIL — overlap or drift exceeded tolerance");
+    process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => { console.error(`\nagent-layout-drift: ${err.message}`); process.exit(2); });

--- a/tools/tests/agent-layout-drift.mjs
+++ b/tools/tests/agent-layout-drift.mjs
@@ -11,16 +11,12 @@
 // pure reducer property test (INV-1) can't make: that the SLICE's positions
 // match what the browser actually paints.
 //
-// Models the CDP harness on bench-agent-keystroke.mjs.
+// Models the CDP harness on bench-agent-keystroke.mjs. Spec: §7 of
+// SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02. Closes the verification leg of #1235.
 //
-// Spec: SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02 §7. Closes the verification
-// leg of #1235. Pre-Phase-3 baseline (TanStack): ~5 mismatches / 1 overlap
-// after 9 expand/collapse cycles. Target: 0 overlap, max |gap| ≤ tolerance.
-//
-// ⚠ Prereq: AgentMux running (CDP 127.0.0.1:9223) with an agent pane whose
-// history EXCEEDS the streaming buffer, so `.agent-document-virtualizer` holds
-// ≥ 2 rows. Fresh panes freeze the sticky-frontier at node 0 (empty virtualized
-// head) and do NOT exercise Phase 3 — load older history first.
+// ⚠ A FRESH/reloaded pane is all-streaming (sticky-frontier frozen at node 0,
+// empty virtualized head). The harness pages in older history (scroll-to-top →
+// onLoadOlder) until the virtualized region is non-empty, THEN runs the cycles.
 
 import { WebSocket } from "ws";
 
@@ -34,16 +30,18 @@ if (hasFlag("--help")) {
   --cycles <n>          Expand/collapse cycles (default 12)
   --toggles <n>         Rows toggled per cycle (default 6)
   --tolerance-px <n>    Max allowed |gap| between consecutive rows (default 1.5)
-  --inter-ms <ms>       Pause after each toggle for reflow (default 120)
-  --no-cleanup          Leave toggles applied (default: restore)
-  --help`);
+  --seed-scrolls <n>    Max scroll-to-top passes to page in history (default 30)
+  --inter-ms <ms>       Pause after each toggle for reflow (default 140)
+  --no-reload           Skip the initial Page.reload`);
     process.exit(0);
 }
 const CDP_PORT = parseInt(getArg("--cdp-port", "9223"), 10);
 const CYCLES = parseInt(getArg("--cycles", "12"), 10);
 const TOGGLES = parseInt(getArg("--toggles", "6"), 10);
 const TOL = parseFloat(getArg("--tolerance-px", "1.5"));
-const INTER_MS = parseInt(getArg("--inter-ms", "120"), 10);
+const SEED_SCROLLS = parseInt(getArg("--seed-scrolls", "30"), 10);
+const INTER_MS = parseInt(getArg("--inter-ms", "140"), 10);
+const NO_RELOAD = hasFlag("--no-reload");
 
 // ── CDP session (minimal client, from bench-agent-keystroke.mjs) ─────────────
 class CdpSession {
@@ -78,8 +76,6 @@ async function evaluate(session, expression, awaitPromise = false) {
     return res.result?.value;
 }
 
-// Pick the workspace page (not a warm-pool window): the main page's URL has no
-// windowLabel=window-pool / pool param.
 async function findWorkspaceTarget(port) {
     const res = await fetch(`http://127.0.0.1:${port}/json`).catch((e) => { throw new Error(`CDP :${port} unreachable: ${e.message} — is AgentMux running?`); });
     const targets = (await res.json()).filter((t) => t.type === "page");
@@ -88,48 +84,73 @@ async function findWorkspaceTarget(port) {
     return main;
 }
 
-// ── DOM probe: rendered-row gaps in the virtualized container ────────────────
-// Returns { n, overlaps, maxAbsGap, worst:[{a,b,gap}], err }.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── DOM probe ────────────────────────────────────────────────────────────────
+// { n (virtualized rows), streaming, panes, overlaps, maxAbsGap, worst, err }
 const PROBE = `
 (() => {
   const c = document.querySelector('.agent-document-virtualizer');
-  if (!c) return { err: 'no .agent-document-virtualizer' };
+  const panes = document.querySelectorAll('.agent-document').length;
+  const streaming = document.querySelectorAll('.agent-document-streaming-buffer .agent-document-row').length;
+  const base = { panes, streaming };
+  if (!c) return { ...base, err: 'no .agent-document-virtualizer' };
   const rows = [...c.querySelectorAll('.agent-document-row')];
-  if (rows.length < 2) return { err: 'virtualized region has < 2 rows — need a long-history pane', n: rows.length };
+  if (rows.length < 2) return { ...base, n: rows.length, err: 'virtualized region < 2 rows' };
   const r = rows.map(el => { const b = el.getBoundingClientRect(); return { id: el.getAttribute('data-node-id'), top: b.top, bottom: b.bottom }; })
                .sort((a,b) => a.top - b.top);
   let overlaps = 0, maxAbsGap = 0; const worst = [];
   for (let i = 1; i < r.length; i++) {
-    const gap = r[i].top - r[i-1].bottom;          // 0 == flush; <0 == overlap
+    const gap = r[i].top - r[i-1].bottom;
     if (gap < 0) overlaps++;
     if (Math.abs(gap) > maxAbsGap) maxAbsGap = Math.abs(gap);
     if (Math.abs(gap) > 1.0) worst.push({ a: r[i-1].id, b: r[i].id, gap: +gap.toFixed(2) });
   }
   worst.sort((x,y) => Math.abs(y.gap) - Math.abs(x.gap));
-  return { n: r.length, overlaps, maxAbsGap: +maxAbsGap.toFixed(2), worst: worst.slice(0, 5) };
+  return { ...base, n: r.length, overlaps, maxAbsGap: +maxAbsGap.toFixed(2), worst: worst.slice(0, 5) };
 })()`;
 
-// Toggle expansion on up to `count` virtualized rows by focusing each and
-// pressing 'e' (DocumentRow.handleRowKey maps 'e' → onExpand for the
-// expandable kinds: tool / agent_message / section). Returns the ids toggled.
-async function toggleRows(session, count) {
-    const ids = await evaluate(session, `
-      (() => {
-        const c = document.querySelector('.agent-document-virtualizer');
-        if (!c) return [];
-        const rows = [...c.querySelectorAll('.agent-document-row[tabindex]')];
-        const picked = [];
-        for (let i = 0; i < rows.length && picked.length < ${count}; i += Math.max(1, Math.floor(rows.length / ${count}))) {
-          rows[i].focus();
-          rows[i].dispatchEvent(new KeyboardEvent('keydown', { key: 'e', bubbles: true }));
-          picked.push(rows[i].getAttribute('data-node-id'));
-        }
-        return picked;
-      })()`);
-    return ids || [];
+// Scroll the agent document to the top to trigger onLoadOlder, paging older
+// history into the virtualized region. Repeat until it stops growing or we
+// have a healthy number of virtualized rows.
+async function seedHistory(session) {
+    let prev = -1, stable = 0;
+    for (let i = 0; i < SEED_SCROLLS; i++) {
+        const s = await evaluate(session, `
+          (() => {
+            const doc = document.querySelector('.agent-document');
+            if (!doc) return { v: -1 };
+            doc.scrollTop = 0;
+            doc.dispatchEvent(new Event('scroll'));
+            const c = document.querySelector('.agent-document-virtualizer');
+            return { v: c ? c.querySelectorAll('.agent-document-row').length : 0 };
+          })()`);
+        if (s.v < 0) return -1;
+        if (s.v >= 8) return s.v;                 // plenty to exercise overlap
+        if (s.v === prev) { if (++stable >= 3) return s.v; } else stable = 0;
+        prev = s.v;
+        await sleep(450);                          // let onLoadOlder fetch + prepend + restore
+    }
+    return prev;
 }
 
 const fmt = (n) => (n == null ? "—" : `${n}`);
+
+async function toggleRows(session, count) {
+    return evaluate(session, `
+      (() => {
+        const c = document.querySelector('.agent-document-virtualizer');
+        if (!c) return 0;
+        const rows = [...c.querySelectorAll('.agent-document-row[tabindex]')];
+        let n = 0;
+        for (let i = 0; i < rows.length && n < ${count}; i += Math.max(1, Math.floor(rows.length / ${count}))) {
+          rows[i].focus();
+          rows[i].dispatchEvent(new KeyboardEvent('keydown', { key: 'e', bubbles: true }));
+          n++;
+        }
+        return n;
+      })()`);
+}
 
 async function main() {
     console.log(`agent-layout-drift: CDP 127.0.0.1:${CDP_PORT}, ${CYCLES} cycles × ${TOGGLES} toggles, tol ${TOL}px`);
@@ -138,32 +159,47 @@ async function main() {
     const session = new CdpSession(target.webSocketDebuggerUrl);
     await session.connect();
     await session.send("Runtime.enable");
-
-    // Fresh reload so we start from a known render (spec §7: "fresh reload → …").
     await session.send("Page.enable").catch(() => {});
-    await session.send("Page.reload", { ignoreCache: false }).catch(() => {});
-    await new Promise((r) => setTimeout(r, 2500)); // let history + first paint settle
 
-    const base = await evaluate(session, PROBE);
-    if (base.err) throw new Error(`${base.err} (n=${fmt(base.n)})`);
-    console.log(`  baseline: ${base.n} rows, ${base.overlaps} overlap, maxAbsGap ${base.maxAbsGap}px`);
+    if (!NO_RELOAD) {
+        await session.send("Page.reload", { ignoreCache: false }).catch(() => {});
+        await sleep(3000);
+    }
 
-    let worstOverlaps = base.overlaps, worstGap = base.maxAbsGap, worstDetail = base.worst;
+    let p = await evaluate(session, PROBE);
+    console.log(`  post-reload: panes=${fmt(p.panes)} streaming=${fmt(p.streaming)} virtualized=${fmt(p.n)}${p.err ? " (" + p.err + ")" : ""}`);
+
+    if (p.err || (p.n ?? 0) < 2) {
+        console.log(`  paging in older history (≤${SEED_SCROLLS} scroll passes)...`);
+        const seeded = await seedHistory(session);
+        await sleep(300);
+        p = await evaluate(session, PROBE);
+        console.log(`  after seeding: virtualized=${fmt(p.n)} (seedHistory→${fmt(seeded)})`);
+    }
+
+    if (p.err || (p.n ?? 0) < 2) {
+        session.close();
+        console.error(`\n✗ INCONCLUSIVE: couldn't populate the virtualized region (panes=${fmt(p.panes)} streaming=${fmt(p.streaming)} virtualized=${fmt(p.n)}). This pane has no virtualizable history — open/seed a long-history agent pane.`);
+        process.exit(3);
+    }
+
+    console.log(`  baseline: ${p.n} virtualized rows, ${p.overlaps} overlap, maxAbsGap ${p.maxAbsGap}px`);
+    let worstOverlaps = p.overlaps, worstGap = p.maxAbsGap, worstDetail = p.worst;
+
     for (let cy = 1; cy <= CYCLES; cy++) {
         await toggleRows(session, TOGGLES);
-        await new Promise((r) => setTimeout(r, INTER_MS));
-        const p = await evaluate(session, PROBE);
-        if (p.err) { console.log(`  cycle ${cy}: ${p.err}`); continue; }
-        if (p.overlaps > worstOverlaps) { worstOverlaps = p.overlaps; worstDetail = p.worst; }
-        if (p.maxAbsGap > worstGap) worstGap = p.maxAbsGap;
-        console.log(`  cycle ${cy.toString().padStart(2)}: ${p.n} rows, overlaps ${p.overlaps}, maxAbsGap ${p.maxAbsGap}px`);
+        await sleep(INTER_MS);
+        const q = await evaluate(session, PROBE);
+        if (q.err) { console.log(`  cycle ${cy}: ${q.err} (re-seeding)`); await seedHistory(session); continue; }
+        if (q.overlaps > worstOverlaps) { worstOverlaps = q.overlaps; worstDetail = q.worst; }
+        if (q.maxAbsGap > worstGap) worstGap = q.maxAbsGap;
+        console.log(`  cycle ${cy.toString().padStart(2)}: ${q.n} rows, overlaps ${q.overlaps}, maxAbsGap ${q.maxAbsGap}px`);
     }
 
     session.close();
     console.log("─".repeat(60));
     console.log(`worst over ${CYCLES} cycles: overlaps=${worstOverlaps}, maxAbsGap=${worstGap}px (tolerance ${TOL})`);
     if (worstDetail?.length) console.log(`  worst gaps: ${JSON.stringify(worstDetail)}`);
-
     const pass = worstOverlaps === 0 && worstGap <= TOL;
     console.log(pass ? "\n✓ PASS — 0 overlap, rows flush within tolerance" : "\n✗ FAIL — overlap or drift exceeded tolerance");
     process.exit(pass ? 0 : 1);


### PR DESCRIPTION
## Phase 3 — retire the TanStack virtualizer; render the agent pane from the layout-reducer slice

Completes the agent-pane layout-reducer migration (spec `SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02`, plan `docs/plans/PHASE3_LAYOUT_REDUCER_IMPL_PLAN.md`). **Closes #1235.**

### Why
The agent-pane overlap / stuck-row / reconcile-crash bugs (#1231 / #1233 / #1234 / #1235) share one root cause: **three uncoordinated sources of truth** for row height & position — TanStack's imperative `itemSizeCache` (races, not ours → #1235 unfixable locally), expansion split between the reducer and component signals, and zoom as scattered `÷zoom`. Slice #11 (`agent-pane-layout`, merged Phase 0) made height/expansion/zoom **pure deterministic state**, with positions as a prefix-sum projection — `start[i+1] === end[i]` ⇒ overlap impossible by construction (INV-1). This PR flips the agent pane to **render from that slice** and deletes TanStack.

### What
Built on the (previously unmerged) Phase 2, rebased onto latest main:

- **Step 0** — promote the no-op `layout` projection to a real `setLayoutView` signal, threaded agent-view → `AgentDocumentView` → list.
- **Step 2** — viewport inputs (`Scrolled` / `ScrollMarginChanged` / `ZoomChanged`) fed into the slice (reducer-deduped, `blockId`-gated).
- **Step 3+4** — rows render from `computeLayoutView().rows` (prefix-sum positions), keyed by stable `nodeId` via `@solid-primitives/keyed` `<Key>` so the fresh `RowPosition` objects each recompute produces don't remount. Heights come from a single measure `ResizeObserver` dispatching `RowMeasured` keyed by `(nodeId, state)` — `measureElement` and the `data-index` race are gone.
- **Step 5** — `scrollToNode` + older-history capture/restore read positions from the slice (`layoutView` for capture, a fresh `computeLayoutView` snapshot for restore) — **same unzoomed-offset basis** as the old `virtualItem.start`, so the anchor math is unchanged.
- **Step 6** — `createVirtualizer` + the `@tanstack/solid-virtual` import deleted.

Preserved untouched: the streaming buffer (`<Index>`, sticky-frontier), sticky-bottom + `jumpToBottom`, the PR #1257 reactivate-RO, the `animateEnabled` gate.

### Verification
- `tsc --noEmit`: **clean** (no new errors; total unchanged at the pre-existing baseline).
- `task build:frontend`: **green** (incl. the bash `input-handler-layout` / `menu-positioning` pre-checks).
- Unit: **67/67** slice + renderer tests pass — INV-1 prefix-sum **property test** (random command sequences ⇒ no overlap), INV-2 zoom-no-relayout, INV-3 state-keyed measurement, `windowRange` binary search.
- **⏳ Live §7 CDP drift-test is PENDING and is a hard merge gate** — fresh reload → N expand/collapse cycles ⇒ assert **0 overlap + 0 drift** at zoom 0.5 / 1 / 2. It needs a running instance, and the dev port was occupied when this PR was opened. **Do not merge until it passes.** It confirms the two runtime unknowns: the `scrollTop ÷zoom` basis under CSS `zoom` (affects *windowing* only, not positions) and the measure-RO → re-projection → re-render cycle.

### Follow-ups (deliberately out of scope)
- Drop `@tanstack/solid-virtual` from `package.json` + lockfile (now unused; kept here to avoid a lockfile-regen churn that has historically dropped peer deps).
- Phase 4 — formalize zoom (single `÷zoom` at the `RowMeasured` boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
