### PR TITLE
fix(auth): single-flight login CLI lifecycle (supersede-kill + timeout reaper)

### DIFF
--- a/.changesets/1780650174-fix-auth-single-flight-login-cli-lifecycle-supersede-kill-ti-io8v.md
+++ b/.changesets/1780650174-fix-auth-single-flight-login-cli-lifecycle-supersede-kill-ti-io8v.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): single-flight login CLI lifecycle — supersede-kill + timeout reaper

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -363,6 +363,13 @@ impl CliLoginStdin {
     }
 }
 
+/// Hard cap on how long a login CLI may sit at its paste prompt before the
+/// reaper kills it. Slightly longer than the frontend's 5-minute auth poll so
+/// the frontend (which also reaps on completion/cancel) wins normal cases;
+/// this is the backstop for a login whose frontend driver vanished (e.g. the
+/// pane was closed without its cleanup firing).
+const LOGIN_REAP_TIMEOUT_SECS: u64 = 6 * 60;
+
 /// Spawn a CLI auth login flow.
 pub async fn run_cli_login(
     state: Arc<AppState>,
@@ -408,8 +415,19 @@ pub async fn run_cli_login(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    // Supersede any in-progress login so we never accumulate orphaned
+    // `auth login` children (one per attempt — the confirmed leak). cancel_cli_login
+    // kills both transports (pipe oneshot + PTY kill-by-PID) and is idempotent —
+    // a no-op when nothing is in flight. We then bump the generation so this
+    // attempt's reaper can tell itself apart from the one we just superseded.
+    let _ = cancel_cli_login(&state);
+    let generation = state
+        .cli_login_generation
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        + 1;
+
     if requires_tty {
-        return run_cli_login_pty(state, cli_path, login_args, auth_env).await;
+        return run_cli_login_pty(state, cli_path, login_args, auth_env, generation).await;
     }
 
     let mut cmd = make_cli_cmd(&cli_path);
@@ -531,9 +549,20 @@ pub async fn run_cli_login(
                 tracing::info!("run_cli_login: cancel signal received, killing child");
                 let _ = child.kill().await;
             }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(LOGIN_REAP_TIMEOUT_SECS)) => {
+                tracing::warn!("run_cli_login: login timed out, killing child");
+                let _ = child.kill().await;
+            }
         }
-        // Clear the stored stdin handle once the process is done.
-        *state_for_cleanup.cli_login_stdin.lock() = None;
+        // Clear the stored stdin handle once the process is done — but only if a
+        // newer login hasn't superseded us and repopulated the slot.
+        if state_for_cleanup
+            .cli_login_generation
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == generation
+        {
+            *state_for_cleanup.cli_login_stdin.lock() = None;
+        }
     });
 
     Ok(serde_json::json!({ "auth_url": auth_url }))
@@ -559,6 +588,7 @@ async fn run_cli_login_pty(
     cli_path: String,
     login_args: Vec<String>,
     auth_env: std::collections::HashMap<String, String>,
+    generation: u64,
 ) -> Result<serde_json::Value, String> {
     use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
@@ -677,20 +707,49 @@ async fn run_cli_login_pty(
     let state_for_cleanup = state.clone();
     tokio::task::spawn_blocking(move || {
         let mut child = child;
-        match child.wait() {
-            Ok(status) => tracing::info!(
-                exit_code = ?status.exit_code(),
-                "run_cli_login_pty: child exited"
-            ),
-            Err(e) => tracing::warn!(
-                error = %e,
-                "run_cli_login_pty: child wait error"
-            ),
+        // Poll for exit with a hard timeout. The previous blocking wait() could
+        // only end when the child self-exited, so an abandoned login (user never
+        // pastes, or completes OAuth out-of-band) sat at the paste prompt
+        // forever — the confirmed process leak.
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(LOGIN_REAP_TIMEOUT_SECS);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    tracing::info!(
+                        exit_code = ?status.exit_code(),
+                        "run_cli_login_pty: child exited"
+                    );
+                    break;
+                }
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        tracing::warn!("run_cli_login_pty: login timed out, killing child");
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "run_cli_login_pty: child wait error");
+                    break;
+                }
+            }
         }
-        // pair drops here, after child.wait() returns
+        // pair drops here, after the child reaps (ConPTY lifetime contract).
         drop(pair);
-        *state_for_cleanup.cli_login_stdin.lock() = None;
-        *state_for_cleanup.cli_login_pty_pid.lock() = None;
+        // Only clear the slots if we still own them — a newer login may have
+        // superseded us and repopulated them; clearing would strand the new
+        // login's stdin handle (the "stuck login" bug).
+        if state_for_cleanup
+            .cli_login_generation
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == generation
+        {
+            *state_for_cleanup.cli_login_stdin.lock() = None;
+            *state_for_cleanup.cli_login_pty_pid.lock() = None;
+        }
     });
 
     Ok(serde_json::json!({ "auth_url": auth_url }))

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -564,6 +564,15 @@ pub struct AppState {
     /// pasted token. See `commands::platform::CliLoginStdin`.
     pub cli_login_stdin: Mutex<Option<crate::commands::platform::CliLoginStdin>>,
 
+    /// Monotonic login-attempt counter. `run_cli_login` bumps it on every
+    /// attempt. A login's reaper task captures the value at spawn and only
+    /// clears the shared `cli_login_*` slots if it still matches — so a
+    /// SUPERSEDED login (whose child is killed by the next attempt) cannot
+    /// null out the slots the new attempt just repopulated. Clearing the new
+    /// login's stdin handle out from under it is exactly the "stuck login"
+    /// bug, where the pasted code has nowhere to be delivered.
+    pub cli_login_generation: std::sync::atomic::AtomicU64,
+
     /// IPC HTTP server port
     pub ipc_port: Mutex<u16>,
 
@@ -825,6 +834,7 @@ impl Default for AppState {
             cli_login_cancel: Mutex::new(None),
             cli_login_pty_pid: Mutex::new(None),
             cli_login_stdin: Mutex::new(None),
+            cli_login_generation: std::sync::atomic::AtomicU64::new(0),
             ipc_port: Mutex::new(0),
             ipc_token: uuid::Uuid::new_v4().to_string(),
             // browsers field removed in H.2.e — see comment near struct decl.

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -237,6 +237,12 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             }
             setLoginWaiting(false);
 
+            // Reap the login CLI now the attempt has concluded (success,
+            // timeout, or cancel). On manual-paste success the child self-exits;
+            // if creds appeared without a paste it would otherwise linger at the
+            // prompt. cancelCliLogin is idempotent and host-side.
+            getApi().cancelCliLogin().catch(() => {});
+
             // Always clear auth URL after the login attempt
             setAuthUrl(null);
 
@@ -260,6 +266,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             }
         } catch (err: any) {
             setLoginWaiting(false);
+            getApi().cancelCliLogin().catch(() => {});
             setAuthUrl(null);
             log("auth", `login failed: ${err?.message ?? String(err)}`, "error");
             log("auth", `run: ${provider.cliCommand} ${provider.authLoginCommand.join(" ")}`, "warn");

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -142,10 +142,13 @@ export function useAgentControllerStatus(
     // SolidJS owner context that called useAgentControllerStatus — the
     // agent presentation view's component scope.
     onCleanup(() => {
-        if (loginWaiting()) {
-            loginCancelled = true;
-            getApi().cancelCliLogin().catch(() => {});
-        }
+        // Cancel unconditionally. The login CLI can already be spawned during
+        // the window between runCliLogin() and setLoginWaiting(true) flipping
+        // true, so gating on loginWaiting() can leave the child orphaned if the
+        // pane closes inside that window. cancelCliLogin is idempotent and
+        // swallows errors, so calling it when no login is in flight is safe.
+        loginCancelled = true;
+        getApi().cancelCliLogin().catch(() => {});
     });
 
     return {


### PR DESCRIPTION
## Problem (confirmed live leak)

The `claude auth login` CLI runs under a PTY and is *designed* to stay alive at the `Paste code here >` prompt. But the login lifecycle had three gaps:

1. **No supersede-kill** — `run_cli_login`/`run_cli_login_pty` spawned a fresh child on every attempt without killing the previous one.
2. **Lost handle** — the stored `cli_login_pty_pid` was overwritten on each attempt, so older children became permanently unkillable via `cancel_cli_login`.
3. **No timeout reaper** — the PTY reaper only exited when the child self-exited.

Result: abandoned/superseded logins accumulated as orphaned `node` processes. Caught two live `claude auth login` children at once during the audit. (See `ANALYSIS_AGENT_PANE_LIFECYCLE_LEAKS_2026-06-04.md`.)

## Fix

- **Supersede:** `run_cli_login` now `cancel_cli_login(&state)`s any in-progress login before spawning.
- **Generation guard** (`AppState.cli_login_generation`, `AtomicU64`): each attempt bumps it; a superseded login's reaper clears the shared `cli_login_*` slots **only if it still owns the current generation**. This is the subtle part — without it, the old reaper (when its killed child finally dies) would null out the *new* login's stdin handle, stranding the pasted code (the "stuck login" symptom).
- **Timeout reaper:** both transports kill the child after `LOGIN_REAP_TIMEOUT_SECS` (6 min, just past the frontend's 5-min poll) if it never completes. The PTY path polls `try_wait()` instead of a blocking `wait()`.
- **Frontend:** reaps the CLI when the attempt concludes (`launch-flow.ts`, success/timeout/error) and **unconditionally** on pane unmount (`useAgentControllerStatus.ts`) — closing the window between `runCliLogin()` and `setLoginWaiting(true)` where a close could orphan the child.

Three independent reap triggers now exist: supersede, frontend completion/unmount, backend timeout.

## Verification

- `cargo build -p agentmux-cef --release` ✓ (warning-clean for the touched code)
- `npx tsc --noEmit` ✓ for `launch-flow.ts` + `useAgentControllerStatus.ts`
- Repro to confirm post-merge: trigger login → trigger a second login → assert exactly one `claude auth login` PID survives; close pane mid-login → child gone ≤1s; complete a real login → `.credentials.json` written, "Logged in as …" fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)