### PR TITLE
feat(linux): restore --features patched-libcef on CEF 148 via cef-dll-sys fork patch

### DIFF
--- a/.changesets/1780650550-feat-cef-148-patched-libcef.md
+++ b/.changesets/1780650550-feat-cef-148-patched-libcef.md
@@ -1,0 +1,26 @@
+---
+type: feat
+scope: linux
+title: Restore --features patched-libcef on CEF 148 via cef-dll-sys fork
+---
+The Linux native window-drag patch (`CefWindow::BeginWindowDrag`) lived in our
+forked CEF 146 binding (`cef-dll-sys 146.7.0+146.0.12`). When the workspace bumped to
+CEF 148 in PR #1221, `cef-dll-sys 148.3.0+148.0.9` from crates.io regenerated against
+upstream CEF 148 headers, which don't expose the patched slot — so any build with
+`--features patched-libcef` failed with `error[E0609]: no field begin_window_drag on
+_cef_window_t`. That made the feature impossible to enable, leaving Linux on a no-op
+drag implementation since the 148 bump.
+
+This PR adds a workspace `[patch.crates-io]` entry pointing `cef-dll-sys` at the
+`AgentU-asaf/cef-rs#agentmux/148-begin-window-drag` fork, which appends the
+`begin_window_drag` field to the linux_x86_64 binding (the same mechanical edit
+published in `cef-dll-sys 146.7.0+146.0.12`).
+
+Verification: `cargo build --release -p agentmux-cef --features patched-libcef`
+completes against CEF 148, and the resulting binary contains the patched-libcef
+path's runtime string (`[start_window_drag] BeginWindowDrag returned …`).
+
+Macros are unchanged: the patch transparently overrides the same crate name + version,
+so macOS and Windows builds (which don't enable `patched-libcef`) link unaffected.
+
+See SPEC §5: docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md

--- a/.changesets/1780650550-feat-cef-148-patched-libcef.md
+++ b/.changesets/1780650550-feat-cef-148-patched-libcef.md
@@ -1,26 +1,5 @@
 ---
-type: feat
-scope: linux
-title: Restore --features patched-libcef on CEF 148 via cef-dll-sys fork
+type: patch
 ---
-The Linux native window-drag patch (`CefWindow::BeginWindowDrag`) lived in our
-forked CEF 146 binding (`cef-dll-sys 146.7.0+146.0.12`). When the workspace bumped to
-CEF 148 in PR #1221, `cef-dll-sys 148.3.0+148.0.9` from crates.io regenerated against
-upstream CEF 148 headers, which don't expose the patched slot — so any build with
-`--features patched-libcef` failed with `error[E0609]: no field begin_window_drag on
-_cef_window_t`. That made the feature impossible to enable, leaving Linux on a no-op
-drag implementation since the 148 bump.
 
-This PR adds a workspace `[patch.crates-io]` entry pointing `cef-dll-sys` at the
-`AgentU-asaf/cef-rs#agentmux/148-begin-window-drag` fork, which appends the
-`begin_window_drag` field to the linux_x86_64 binding (the same mechanical edit
-published in `cef-dll-sys 146.7.0+146.0.12`).
-
-Verification: `cargo build --release -p agentmux-cef --features patched-libcef`
-completes against CEF 148, and the resulting binary contains the patched-libcef
-path's runtime string (`[start_window_drag] BeginWindowDrag returned …`).
-
-Macros are unchanged: the patch transparently overrides the same crate name + version,
-so macOS and Windows builds (which don't enable `patched-libcef`) link unaffected.
-
-See SPEC §5: docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md
+fix(linux): patch cef-dll-sys to AgentU-asaf/cef-rs fork to restore --features patched-libcef on CEF 148

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -526,8 +526,7 @@ dependencies = [
 [[package]]
 name = "cef-dll-sys"
 version = "148.3.0+148.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc364604c75169c992b3f8bc4396634bf64cfb2a4a0545cc9c7aa4eb3931057"
+source = "git+https://github.com/AgentU-asaf/cef-rs?branch=agentmux/148-begin-window-drag#515b3ac53c8b3903aeac18135473858a4d3879d2"
 dependencies = [
  "anyhow",
  "cmake",
@@ -840,8 +839,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "download-cef"
 version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c169adf067a787e1f1c58ed62906a557de85388bee4b54fb878b722ff606b113"
+source = "git+https://github.com/AgentU-asaf/cef-rs?branch=agentmux/148-begin-window-drag#515b3ac53c8b3903aeac18135473858a4d3879d2"
 dependencies = [
  "bzip2",
  "clap",
@@ -888,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1902,7 +1900,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2499,7 +2497,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2799,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2911,7 +2909,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3646,7 +3644,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "cef-dll-sys"
 version = "148.3.0+148.0.9"
-source = "git+https://github.com/AgentU-asaf/cef-rs?branch=agentmux/148-begin-window-drag#515b3ac53c8b3903aeac18135473858a4d3879d2"
+source = "git+https://github.com/AgentU-asaf/cef-rs?rev=515b3ac53c8b3903aeac18135473858a4d3879d2#515b3ac53c8b3903aeac18135473858a4d3879d2"
 dependencies = [
  "anyhow",
  "cmake",
@@ -839,7 +839,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "download-cef"
 version = "2.3.2"
-source = "git+https://github.com/AgentU-asaf/cef-rs?branch=agentmux/148-begin-window-drag#515b3ac53c8b3903aeac18135473858a4d3879d2"
+source = "git+https://github.com/AgentU-asaf/cef-rs?rev=515b3ac53c8b3903aeac18135473858a4d3879d2#515b3ac53c8b3903aeac18135473858a4d3879d2"
 dependencies = [
  "bzip2",
  "clap",
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1900,7 +1900,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2497,7 +2497,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,28 @@ lto = "thin"        # Thin LTO - parallel and much faster than full LTO
 codegen-units = 16  # Parallel codegen - uses multiple CPU cores
 strip = true
 opt-level = 2       # Still optimized, but not as aggressive as "s"
+
+# ─── CEF 148 binding patch ──────────────────────────────────────────────
+# `cef-dll-sys` 148.3.0+148.0.9 on crates.io is generated from upstream
+# CEF 148 headers, which do NOT include
+# `CefWindow::BeginWindowDrag()` (the AgentMux source patch lives in
+# `agentmuxai/cef@agentmux/7778-drag-rightclick-and-transparency`,
+# PR #3 on that repo). Without the binding-side field, our
+# `--features patched-libcef` flag fails to compile against CEF 148 on
+# Linux (`error[E0609]: no field begin_window_drag on type
+# _cef_window_t` at `agentmux-cef/src/ui_tasks.rs:215`).
+#
+# The fork at `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag`
+# (PR #1 on that fork) appends the `begin_window_drag` slot to the
+# linux_x86_64 binding — same mechanical edit that's been in published
+# `cef-dll-sys 146.7.0+146.0.12` since CEF 146. The fork's branch is
+# pinned by its commit SHA so the build is reproducible.
+#
+# Lifecycle: this `[patch.crates-io]` is temporary — when the patches
+# are upstreamed to chromiumembedded/cef and tauri-apps/cef-rs (or when
+# AgentMux's libcef build becomes the only consumer), remove this block
+# and the workspace can use the public binding directly.
+#
+# See: docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md §5
+[patch.crates-io]
+cef-dll-sys = { git = "https://github.com/AgentU-asaf/cef-rs", branch = "agentmux/148-begin-window-drag" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ opt-level = 2       # Still optimized, but not as aggressive as "s"
 #
 # See: docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md §5
 [patch.crates-io]
-cef-dll-sys = { git = "https://github.com/AgentU-asaf/cef-rs", branch = "agentmux/148-begin-window-drag" }
+cef-dll-sys = { git = "https://github.com/AgentU-asaf/cef-rs", rev = "515b3ac53c8b3903aeac18135473858a4d3879d2" }


### PR DESCRIPTION
## Summary

- PR #1221 bumped the workspace from CEF 146 → 148, which switched `cef-dll-sys` from our patched 146.7.0+146.0.12 (with the `begin_window_drag` slot on `_cef_window_t`) to upstream 148.3.0+148.0.9 (no slot).
- Result: `cargo build --features patched-libcef` has been broken on the workspace since the 148 bump, leaving Linux native window-drag silently downgraded to the no-op fallback in every AppImage shipped without the feature enabled.
- This PR adds a workspace `[patch.crates-io]` entry redirecting `cef-dll-sys` at [`AgentU-asaf/cef-rs#agentmux/148-begin-window-drag`](https://github.com/AgentU-asaf/cef-rs/pull/1), which re-applies the same mechanical edit (append `begin_window_drag` to the linux_x86_64 binding, struct size 888 → 896).

## How was this verified?

```
$ cargo build --release -p agentmux-cef --features patched-libcef
   Compiling cef-dll-sys v148.3.0+148.0.9 (https://github.com/AgentU-asaf/cef-rs?branch=agentmux%2F148-begin-window-drag)
   …
    Finished `release` profile [optimized] target(s) in 3m 28s

$ strings target/release/agentmux-cef | grep "BeginWindowDrag returned"
-[start_window_drag] BeginWindowDrag returned
```

That second grep is the key: if the no-op stub were compiled in, the string would read `patched-libcef feature disabled — native drag is a no-op` instead. The patched code path is now wired.

End-to-end (renderer up + drag interaction) is gated on §8.6 — the AppImage bundle scripts need to deploy the matching CEF 148 runtime files (paks/locales/icudtl) so the renderer process initializes. That's a separate PR.

## Companion PRs (spec §8 sequence)

- agentmuxai/cef#3 — CEF source forward-port (`agentmux/7778-drag-rightclick-and-transparency`)
- AgentU-asaf/cef-rs#1 — `cef-dll-sys` binding fork (`agentmux/148-begin-window-drag`)

## Blast radius

- macOS & Windows: unaffected. They don't enable `--features patched-libcef`, and the fork's non-Linux binding files are byte-identical to crates.io 148.3.0+148.0.9.
- CI: unaffected (no jobs build the Linux host with the feature today, since the feature was unbuildable until this PR).

## Spec

[docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md](../blob/main/docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md) §5 + §8.5

## Test plan

- [x] `cargo build --release -p agentmux-cef --features patched-libcef` compiles against CEF 148
- [x] Binary contains the `BeginWindowDrag returned` runtime string (patched path)
- [x] Default (no-feature) build still compiles unaffected on Linux
- [ ] Followup §8.6 — deploy matching CEF 148 runtime files into AppImage + smoke-test drag on Mutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)