### PR TITLE
fix(agent): stop and drop subagent file watcher on agent unregister

### DIFF
--- a/.changesets/1780650433-fix-agent-stop-and-drop-subagent-file-watcher-on-agent-unreg-veti.md
+++ b/.changesets/1780650433-fix-agent-stop-and-drop-subagent-file-watcher-on-agent-unreg-veti.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): stop and drop subagent file watcher on agent unregister

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -234,6 +234,24 @@ impl SubagentWatcher {
         });
     }
 
+    /// Stop watching an agent: drop its filesystem watcher, which closes the
+    /// debounce channel — so the processing task self-terminates on the next
+    /// `rx.recv()` returning `None`. Idempotent: a no-op if the agent isn't
+    /// currently watched.
+    ///
+    /// Without this, `watched_agents` was push-only: every distinct agent that
+    /// ever ran leaked one OS watch handle + channel + idle task for the rest of
+    /// the process lifetime, even after its pane/agent was deleted. (Session
+    /// records in `sessions` are plain data, not handles, and are left as-is.)
+    pub fn unwatch_agent(&self, agent_id: &str) {
+        let mut watched = self.watched_agents.lock().unwrap();
+        let before = watched.len();
+        watched.retain(|w| w.agent_id != agent_id);
+        if watched.len() != before {
+            tracing::info!(agent = %agent_id, "stopped watching subagent dir");
+        }
+    }
+
     /// List all subagents across all sessions (sync — safe to call from RPC dispatch).
     pub fn list_active(&self) -> Vec<SubagentInfo> {
         let sessions = self.sessions.lock().unwrap();

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -200,6 +200,9 @@ pub(super) async fn handle_reactive_unregister(
     // Also remove from cross-instance file registry.
     let data_dir = base::get_wave_data_dir();
     agent_registry::remove(&data_dir, &req.agent_id);
+    // Drop the subagent filesystem watcher (handle + channel + task) — the
+    // symmetric teardown for the watch_agent() call in the register handler.
+    state.subagent_watcher.unwatch_agent(&req.agent_id);
     Json(json!({"success": true}))
 }
 


### PR DESCRIPTION
## Problem

`SubagentWatcher.watched_agents` was **push-only**. Every distinct agent that ever ran leaked one OS filesystem-watch handle + mpsc channel + idle debounce task for the rest of the process lifetime — surviving pane/agent deletion. (MED leak in `ANALYSIS_AGENT_PANE_LIFECYCLE_LEAKS_2026-06-04.md`.)

## Fix

Add `unwatch_agent(agent_id)`:
- `watched_agents.retain(|w| w.agent_id != agent_id)` drops the `WatchedAgent`, which drops its `notify` watcher. That closes the only surviving sender on the debounce channel, so the processing task self-terminates on its next `rx.recv()` returning `None`. No manual task abort needed.
- Idempotent — a no-op if the agent isn't watched.

Wire it into **`handle_reactive_unregister`** — the exact symmetric counterpart to the `watch_agent()` call in `handle_reactive_register` (both keyed on `agent_id`, both with `state.subagent_watcher` in hand).

Session records in `sessions` are plain data (not handles), so they're left as-is — the leak was the watcher/channel/task.

## Verification
- `cargo build -p agentmux-srv --release` ✓
- Symmetric with the existing register/unregister pair, so it fires on the same lifecycle event that created the watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)