### PR TITLE
fix(agent): own tool_chunk sub at body scope; drop dead detached login spawn

### DIFF
--- a/.changesets/1780650869-fix-agent-own-tool-chunk-sub-at-body-scope-drop-dead-detache-68hs.md
+++ b/.changesets/1780650869-fix-agent-own-tool-chunk-sub-at-body-scope-drop-dead-detache-68hs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): own tool_chunk sub at body scope; drop dead detached login spawn

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -400,22 +400,11 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("runclilogin: {e}"))?;
                 tracing::info!(cli = %cmd.cli_path, args = ?cmd.login_args, "RunCliLogin");
 
-                // Spawn the login process. On most platforms it opens the browser
-                // automatically and writes the URL to stderr. On Windows, stderr is
-                // block-buffered when piped so we can't reliably read it in real-time.
-                // Strategy: inherit stdout/stderr so the CLI can open the browser normally,
-                // then return immediately — the frontend polls auth status until done.
-                let mut child = make_cli_cmd(&cmd.cli_path)
-                    .args(&cmd.login_args)
-                    .envs(&cmd.auth_env)
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                    .map_err(|e| format!("failed to spawn login: {e}"))?;
-
-                // Keep child alive in background — it waits for the user to complete OAuth
-                tokio::spawn(async move { let _ = child.wait().await; });
-
+                // Dead path: the active login flow is the CEF host IPC
+                // `run_cli_login`, which owns the child's lifecycle (supersede-kill
+                // + timeout reaper). This srv-side variant previously spawned a
+                // DETACHED, unkillable `auth login` child here — a process leak if
+                // ever invoked. It has no live caller; do NOT spawn.
                 let result = RunCliLoginResult { auth_url: None, raw_output: String::new() };
                 Ok(Some(serde_json::to_value(&result).unwrap()))
             })

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -158,6 +158,12 @@ export function useAgentStream({
         },
     });
 
+    // Own the tool_chunk subscription at body scope so it is torn down even if
+    // onMount early-returns (e.g. enabled:false). Its only other teardown lives
+    // inside onMount's onCleanup, which is skipped on early-return — so without
+    // this the global handler would leak one per mount.
+    onCleanup(() => { try { blockChunkUnsub(); } catch { /* ignore */ } });
+
     function flushPendingNodes() {
         flushRafId = null;
         if (pendingNew.length === 0 && pendingUpdates.length === 0) return;
@@ -590,8 +596,9 @@ export function useAgentStream({
         onCleanup(() => {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
-            // Tear down the per-block tool_chunk subscription.
-            try { blockChunkUnsub(); } catch { /* ignore */ }
+            // (the tool_chunk subscription is torn down by its own body-scope
+            // onCleanup registered where blockChunkUnsub is created — so it is
+            // cleaned up even when this onMount early-returns.)
             // StreamUnsubscribe transitions a working turn into the
             // Disconnected phase (so a crash or exit without
             // session_end doesn't leave "Working…" stuck).


### PR DESCRIPTION
Two MED lifecycle-leak fixes from `ANALYSIS_AGENT_PANE_LIFECYCLE_LEAKS_2026-06-04.md`.

## 1. `useAgentStream` — `tool_chunk` subscription torn down even on early-return
The per-block `tool_chunk` WPS subscription (`blockChunkUnsub`) is created at **hook-body** scope, but its only teardown lived inside `onMount`'s `onCleanup` — which is **skipped** when `onMount` early-returns (`if (!enabled || !blockId) return;`). So a mount with `enabled:false`/empty `blockId` would leak one global handler per mount (latent today: the sole caller hardcodes `enabled:true`).

Fix: register the teardown at **body scope** (where the subscription is created), and drop the now-redundant call from the `onMount` cleanup.

## 2. `cli_handlers` `runclilogin` — remove the dead detached-spawn
This srv-side login handler has **no live caller** (the active path is the CEF host IPC `run_cli_login`). It spawned a **detached, unkillable** `claude auth login` child via `tokio::spawn(async { child.wait().await })` — zero cancellation, zero timeout. Removed the spawn so it can't orphan a login process if ever wired up. `make_cli_cmd`/`RunCliLoginResult` stay used elsewhere → no unused-symbol warnings.

## Verification
- `npx tsc --noEmit` ✓ (useAgentStream)
- `cargo build -p agentmux-srv --release` ✓ (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)