### PR TITLE
fix(linux): bundle CEF 148 Vulkan SwiftShader files so renderer process can start

### DIFF
--- a/.changesets/1780651010-fix-cef-148-bundle-runtime-files.md
+++ b/.changesets/1780651010-fix-cef-148-bundle-runtime-files.md
@@ -1,0 +1,22 @@
+---
+type: fix
+scope: linux
+title: Bundle CEF 148 Vulkan SwiftShader runtime files into AppImage
+---
+CEF 148 ships its software-rasterizer fallback as Vulkan SwiftShader
+(`libvk_swiftshader.so` + `vk_swiftshader_icd.json` + `libvulkan.so.1`),
+replacing the GLES-based SwiftShader path that CEF 146 used. The current
+bundle scripts don't copy these — Chromium's GPU process fails to find
+the Vulkan ICD and the renderer process crashes with SIGTRAP at GPU
+init, leaving the AppImage on a recovery screen.
+
+Also adds `headless_command_resources.pak`, a new resource bundle in
+CEF 148.
+
+Verified end-to-end:
+  task build:host && task build:backend && task build:frontend && task bundle
+  bash scripts/build-appimage-linux.sh /tmp
+  /tmp/AgentMux_0.42.0_amd64.AppImage
+  → 8 procs alive, libcef.so loaded (Chrome/148.0.7778.180), backend
+    handling RPC, renderer up, no SIGTRAP. The pre-fix AppImage from
+    yesterday SIGTRAP'd at gpu init.

--- a/.changesets/1780651010-fix-cef-148-bundle-runtime-files.md
+++ b/.changesets/1780651010-fix-cef-148-bundle-runtime-files.md
@@ -1,22 +1,5 @@
 ---
-type: fix
-scope: linux
-title: Bundle CEF 148 Vulkan SwiftShader runtime files into AppImage
+type: patch
 ---
-CEF 148 ships its software-rasterizer fallback as Vulkan SwiftShader
-(`libvk_swiftshader.so` + `vk_swiftshader_icd.json` + `libvulkan.so.1`),
-replacing the GLES-based SwiftShader path that CEF 146 used. The current
-bundle scripts don't copy these — Chromium's GPU process fails to find
-the Vulkan ICD and the renderer process crashes with SIGTRAP at GPU
-init, leaving the AppImage on a recovery screen.
 
-Also adds `headless_command_resources.pak`, a new resource bundle in
-CEF 148.
-
-Verified end-to-end:
-  task build:host && task build:backend && task build:frontend && task bundle
-  bash scripts/build-appimage-linux.sh /tmp
-  /tmp/AgentMux_0.42.0_amd64.AppImage
-  → 8 procs alive, libcef.so loaded (Chrome/148.0.7778.180), backend
-    handling RPC, renderer up, no SIGTRAP. The pre-fix AppImage from
-    yesterday SIGTRAP'd at gpu init.
+fix(linux): bundle CEF 148 Vulkan SwiftShader + headless resources so renderer process can start

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -622,6 +622,16 @@ tasks:
                 cp -f "$CEF_DIR/icudtl.dat" dist/cef/
                 cp -f "$CEF_DIR/snapshot_blob.bin" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
+                # CEF 148+ ships Vulkan SwiftShader as the software-rasterizer
+                # fallback (replacing the GLES SwiftShader path that 146 used).
+                # Chromium's GPU process loads vk_swiftshader_icd.json via
+                # VK_ICD_FILENAMES → libvk_swiftshader.so, and libvulkan.so.1
+                # is the loader. All three are required for the renderer/GPU
+                # processes to start on machines without a system Vulkan loader;
+                # missing them shows up as a renderer SIGTRAP at gpu init.
+                cp -f "$CEF_DIR/libvk_swiftshader.so" dist/cef/ 2>/dev/null || true
+                cp -f "$CEF_DIR/vk_swiftshader_icd.json" dist/cef/ 2>/dev/null || true
+                cp -f "$CEF_DIR/libvulkan.so.1" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR"/*.pak dist/cef/
                 cp -f "$CEF_DIR/locales/en-US.pak" dist/cef/locales/ 2>/dev/null || true
                 echo "✓ Bundled runtime for Linux"

--- a/scripts/build-appimage-linux.sh
+++ b/scripts/build-appimage-linux.sh
@@ -90,7 +90,9 @@ cp "dist/bin/agentmux-srv-${VERSION}-linux.x64" "$APPDIR/usr/bin/"
 # --- 4. CEF runtime (libcef.so, GL libs, paks, snapshots, sandbox) ---
 for f in libcef.so libEGL.so libGLESv2.so chrome-sandbox chrome_crashpad_handler \
          icudtl.dat snapshot_blob.bin v8_context_snapshot.bin \
-         chrome_100_percent.pak chrome_200_percent.pak resources.pak; do
+         chrome_100_percent.pak chrome_200_percent.pak resources.pak \
+         headless_command_resources.pak \
+         libvk_swiftshader.so vk_swiftshader_icd.json libvulkan.so.1; do
     if [ -f "dist/cef/$f" ]; then
         cp "dist/cef/$f" "$APPDIR/usr/bin/"
     fi
@@ -101,7 +103,8 @@ done
 # debugging in dist/cef/ but huge for distribution. `strip` removes the local
 # (non-dynamic) symbol table but keeps .dynsym so dlopen + relocations still
 # work; saves ~210MB on libcef.so alone (~33% AppImage reduction).
-for so in libcef.so libEGL.so libGLESv2.so; do
+# libvk_swiftshader.so + libvulkan.so.1 added for CEF 148 — same treatment.
+for so in libcef.so libEGL.so libGLESv2.so libvk_swiftshader.so libvulkan.so.1; do
     if [ -f "$APPDIR/usr/bin/$so" ]; then
         strip "$APPDIR/usr/bin/$so"
     fi


### PR DESCRIPTION
## Summary

CEF 148 changed its software-rasterizer fallback from GLES SwiftShader to **Vulkan SwiftShader** (`libvk_swiftshader.so` + `vk_swiftshader_icd.json` + `libvulkan.so.1`). The current Linux bundle scripts don't copy those files. Without them, Chromium's GPU process can't find the Vulkan ICD at init, the renderer SIGTRAPs ~600ms after host start, and the AppImage lands on the recovery screen.

CEF 148 also added `headless_command_resources.pak` to the resource set.

This PR teaches `Taskfile.yml::bundle:linux` and `scripts/build-appimage-linux.sh` to copy the four new files alongside the existing GL/snapshot/icudtl set.

## Verification

```
task build:host && task build:backend && task build:frontend && task bundle
bash scripts/build-appimage-linux.sh /tmp
/tmp/AgentMux_0.42.0_amd64.AppImage
```

Result at +18s:
- 8 procs alive (main + GPU + utility + zygote + 2× renderer + 2× sidecar)
- libcef.so mapped: `Chrome/148.0.7778.180`
- Backend serving RPC (`object.GetObject`, `command=listrecentsessions`, etc.)
- Renderer firing focus events, agent cards rendering, no SIGTRAP
- Strip pass works: libcef.so 629 MB → 434 MB

The pre-fix AppImage from yesterday SIGTRAP'd at GPU init within ~600ms with the same libcef.so.

## Why no `--features patched-libcef` in the test build

This PR was smoke-tested with `cargo build --release -p agentmux-cef` (default features) because the workspace `[patch.crates-io]` required to compile `--features patched-libcef` on CEF 148 lives in independent PR #1272 (§8.5). The bundle-script logic exercised here doesn't depend on that feature — it's purely about CEF runtime file presence.

Once both this PR + #1272 land, `task package:linux` produces an AppImage with native window-drag fully restored on Mutter/Wayland.

## Blast radius

- Linux only. The macOS bundle path (`bundle:darwin`) is untouched.
- New `cp -f … 2>/dev/null || true` lines mean missing files don't break older CEF builds — the runtime stays backward-compatible with CEF 146 if someone bisects against a CEF 146 build dir.

## Spec

docs/specs/SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md §8.6

## Test plan

- [x] CEF 148 AppImage launches + renderer comes up + backend serves RPC (verified on this machine)
- [x] Bundle picks up new files when `~/cef-build/.../Release_GN_x64` is the source
- [ ] CI bundle:linux runs against either the cef-dll-sys cached path or the explicit `AGENTMUX_CEF_RUNTIME_DIR` env override

🤖 Generated with [Claude Code](https://claude.com/claude-code)