### PR TITLE
fix(agent-pane): Phase 4 — correct zoom units (single ÷zoom at the measure boundary)

### DIFF
--- a/.changesets/1780657695-fix-agent-pane-fix-virtualized-layout-under-zoom-1-phase-4-s-odw6.md
+++ b/.changesets/1780657695-fix-agent-pane-fix-virtualized-layout-under-zoom-1-phase-4-s-odw6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): fix virtualized layout under zoom != 1 (Phase 4 - single zoom-normalize at the measure boundary)

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -75,9 +75,11 @@ export interface AgentDocumentVirtualListProps {
     onTogglePin: (id: string) => void;
     /**
      * Live per-pane zoom factor (the same value applied as CSS `zoom` on
-     * `.agent-view` in agent-view.tsx). Used to normalize the measure RO + the
-     * Scrolled / scrollToNode math into unzoomed CSS px so slice positions don't
-     * double-count zoom and overlap — see
+     * `.agent-view` in agent-view.tsx). Normalizes the SINGLE zoomed read —
+     * the measure RO's getBoundingClientRect — into unzoomed CSS px so slice
+     * positions don't double-count zoom and overlap (Phase 4). scrollTop /
+     * clientHeight / offsetTop are already unzoomed under CSS `zoom`, so they
+     * feed the slice raw — see
      * SPEC_AGENT_PANE_VIRTUALIZATION_ZOOM_OVERLAP_2026_06_01.
      * Defaults to 1 (no zoom) when not supplied.
      */
@@ -238,10 +240,10 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // The slice records scrollTop / viewport / scrollMargin / zoom and the
     // render path (windowing + prefix-sum row positions) reads them back. All
     // blockId-gated and reducer-deduped (an unchanged value returns the same
-    // state ref). Slice positions are unzoomed CSS px, so scroll + viewport
-    // are normalized by the live zoom — the same ÷zoom basis as the measure RO.
-    // (scrollTop ÷zoom under CSS `zoom` is pending CDP confirmation at zoom
-    // 0.5 / 2 per the Phase-3 plan.)
+    // state ref). Slice positions are unzoomed CSS px; scrollTop / clientHeight /
+    // offsetTop are ALSO unzoomed under the ancestor CSS `zoom` (Phase 4 —
+    // CDP-confirmed at zoom 0.5/2: ratio 1.0; only getBoundingClientRect is
+    // zoomed), so they feed the slice raw — the lone ÷zoom is at the measure RO.
     let lastScrollMarginPx = -1;
     const dispatchScrollMargin = (): void => {
         if (!props.blockId) return;
@@ -366,13 +368,13 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             }
             // Phase 3: the scroll container resizing changes the viewport the
             // slice windows against — feed it (covers hidden→visible 0→N and
-            // pane resize). blockId-gated, reducer-deduped.
+            // pane resize). blockId-gated, reducer-deduped. scrollTop / h are
+            // unzoomed CSS px (Phase 4 — only the measure RO ÷zooms).
             if (props.blockId && h > 0) {
-                const zoom = props.zoomFactor?.() ?? 1;
                 dispatchLayoutIfRegistered(props.blockId, {
                     type: "Scrolled",
-                    scrollTop: scrollRef.scrollTop / (zoom || 1),
-                    viewportPx: h / (zoom || 1),
+                    scrollTop: scrollRef.scrollTop,
+                    viewportPx: h,
                 });
             }
             wasHidden = h === 0;
@@ -401,15 +403,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         const p = partition();
         if (idx < p.splitIndex) {
             // Virtualized region — center the row from the slice's position
-            // (Step 5). row.start/height are unzoomed CSS px; convert the
-            // target back to the scroll element's zoomed scrollTop (×zoom).
+            // (Step 5). row.start/height and the scroll element's clientHeight /
+            // scrollTop are all unzoomed CSS px (Phase 4 — CSS `zoom` leaves them
+            // in layout px), so no zoom conversion is needed here.
             const v = props.layoutView?.();
             const row = v?.rows[idx];
             if (row) {
-                const zoom = props.zoomFactor?.() ?? 1;
-                const viewportPx = scrollRef.clientHeight / (zoom || 1);
+                const viewportPx = scrollRef.clientHeight;
                 const center = row.start - viewportPx / 2 + row.height / 2;
-                scrollRef.scrollTo({ top: Math.max(0, center * (zoom || 1)), behavior: "smooth" });
+                scrollRef.scrollTo({ top: Math.max(0, center), behavior: "smooth" });
             }
         } else {
             // Streaming buffer — node is mounted; query DOM and scroll directly.
@@ -424,7 +426,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
 
     // React to jump commands from the parent's useScrollToNode hook.
     // untrack the scroll so this effect depends ONLY on the command signal:
-    // scrollToNode reads layoutView / zoom / partition, all of which change on
+    // scrollToNode reads layoutView / partition, both of which change on
     // every scroll, and useScrollToNode holds the last command rather than
     // clearing it — tracking them would re-fire the jump on each scroll and pin
     // the user on the old target.
@@ -437,14 +439,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
 
-        // Phase 3: push scroll position + viewport into the slice as unzoomed
-        // CSS px. Reducer-deduped; blockId-gated.
+        // Phase 4: scrollTop / clientHeight are already unzoomed CSS px under the
+        // ancestor CSS `zoom` (CDP-confirmed: ratio 1.0 at zoom 0.5/2 — only
+        // getBoundingClientRect is zoomed), so push them raw. The lone ÷zoom is
+        // at the measure RO. Reducer-deduped; blockId-gated.
         if (props.blockId) {
-            const zoom = props.zoomFactor?.() ?? 1;
             dispatchLayoutIfRegistered(props.blockId, {
                 type: "Scrolled",
-                scrollTop: scrollTop / (zoom || 1),
-                viewportPx: clientHeight / (zoom || 1),
+                scrollTop,
+                viewportPx: clientHeight,
             });
             dispatchScrollMargin();
         }

--- a/tools/tests/ph4-zoom-probe.mjs
+++ b/tools/tests/ph4-zoom-probe.mjs
@@ -1,0 +1,94 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase 4 zoom-units probe. Injects a faithful scroll-container structure
+// (.agent-document overflow + absolute-positioned row in a tall virtualizer)
+// under a CSS `zoom` ancestor, then reads the layout properties the agent
+// pane relies on at zoom 1 / 0.5 / 2. Ratio vs zoom=1 tells us, per property:
+//   ratio ~= zoom  -> ZOOMED (device px) -> needs ÷zoom to reach unzoomed CSS px
+//   ratio ~= 1     -> UNZOOMED (CSS px)  -> ÷zoom is REDUNDANT/WRONG here
+// Settles AgentDocumentVirtualList.tsx:243 ("pending CDP confirmation").
+//
+// Usage: node tools/tests/ph4-zoom-probe.mjs [cdpPort=9223]
+import { WebSocket } from "ws";
+
+class S {
+  constructor(u) { this.u = u; this.ws = null; this.id = 1; this.p = new Map(); }
+  async connect() {
+    await new Promise((res, rej) => {
+      this.ws = new WebSocket(this.u, { perMessageDeflate: false });
+      this.ws.on("open", res); this.ws.on("error", rej);
+      this.ws.on("message", d => {
+        const m = JSON.parse(d.toString());
+        if (m.id == null) return;
+        const p = this.p.get(m.id); if (!p) return;
+        this.p.delete(m.id);
+        m.error ? p.reject(new Error(m.error.message)) : p.resolve(m.result);
+      });
+    });
+  }
+  send(method, params = {}) {
+    const id = this.id++;
+    return new Promise((res, rej) => { this.p.set(id, { resolve: res, reject: rej }); this.ws.send(JSON.stringify({ id, method, params })); });
+  }
+  close() { this.ws && this.ws.close(); }
+}
+
+const ev = async (s, e) => {
+  const r = await s.send("Runtime.evaluate", { expression: e, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails));
+  return r.result?.value;
+};
+
+const port = process.argv[2] || 9223;
+const res = await fetch(`http://127.0.0.1:${port}/json`);
+const targets = (await res.json()).filter(t => t.type === "page");
+const main = targets.find(t => !/window-pool|pool=1|devtools/.test(t.url || "")) || targets[0];
+if (!main) { console.error("no page target"); process.exit(1); }
+console.log("page:", main.title, "|", main.url);
+const s = new S(main.webSocketDebuggerUrl); await s.connect(); await s.send("Runtime.enable");
+
+const EXPR = `(() => {
+  const view = document.createElement('div');
+  view.style.cssText = 'position:fixed;left:-9999px;top:0;';
+  const doc = document.createElement('div');
+  doc.style.cssText = 'height:400px;width:600px;overflow-y:auto;position:relative;';
+  const virt = document.createElement('div');
+  virt.style.cssText = 'height:2000px;position:relative;';
+  const row = document.createElement('div');
+  row.style.cssText = 'position:absolute;top:300px;left:0;width:100%;height:100px;';
+  virt.appendChild(row); doc.appendChild(virt); view.appendChild(doc); document.body.appendChild(view);
+  const m = (z) => {
+    view.style.zoom = String(z);
+    void doc.offsetHeight;
+    doc.scrollTop = 100; void doc.scrollTop;
+    const rr = row.getBoundingClientRect();
+    const dr = doc.getBoundingClientRect();
+    return { zoom: z,
+      doc_clientHeight: doc.clientHeight,
+      doc_scrollHeight: doc.scrollHeight,
+      doc_scrollTop_set100: doc.scrollTop,
+      doc_gbcr_height: Math.round(dr.height * 100) / 100,
+      row_offsetTop: row.offsetTop,
+      row_offsetHeight: row.offsetHeight,
+      row_gbcr_height: Math.round(rr.height * 100) / 100 };
+  };
+  const out = [m(1), m(0.5), m(2)];
+  view.remove();
+  return out;
+})()`;
+
+const out = await ev(s, EXPR);
+console.log("\n=== raw ===");
+console.log(JSON.stringify(out, null, 2));
+const base = out.find(o => o.zoom === 1);
+for (const o of out) {
+  if (o.zoom === 1) continue;
+  console.log(`\n=== zoom ${o.zoom} vs 1 — ratio ~${o.zoom} => ZOOMED(÷zoom); ratio ~1 => UNZOOMED ===`);
+  for (const k of Object.keys(o)) {
+    if (k === "zoom") continue;
+    const ratio = base[k] ? o[k] / base[k] : NaN;
+    console.log(`  ${k}: ${o[k]}  (ratio ${ratio.toFixed(3)})`);
+  }
+}
+s.close();


### PR DESCRIPTION
## Phase 4 — formalize zoom (INV-2)

Completes the agent-pane layout-reducer epic (Phases 0–3 merged in #1270). The
slice operates in **unzoomed CSS px**; this PR makes the component feed it in
that unit consistently, collapsing the scattered `÷zoom` to a single boundary.

### What the measurement found

A CDP probe (`tools/tests/ph4-zoom-probe.mjs`) injects a faithful scroll
container under the ancestor CSS `zoom` and reads each property the agent pane
relies on, at zoom 0.5 / 1 / 2:

| property | ratio vs zoom 1 | unit |
|---|---|---|
| `scrollTop` (set 100 → reads 100) | 1.000 | **unzoomed** |
| `clientHeight` / `scrollHeight` | 1.000 | **unzoomed** |
| `offsetTop` / `offsetHeight` | 1.000 | **unzoomed** |
| `getBoundingClientRect().height` | 0.5 / 2.0 | **zoomed** |

So `getBoundingClientRect` (the measure RO) is the **only** zoomed read.

### The latent bug this fixes

`handleScroll`, the hidden→visible RO, and `scrollToNode` were dividing
`scrollTop`/`clientHeight` by zoom — but those are *already* unzoomed. At any
**zoom ≠ 1** the slice received a wrong `scrollTop`/`viewport` (off by a factor
of zoom) → mis-windowed rows and a mis-targeted scroll-to-node. The cutover only
exercised zoom = 1 (where `÷1` is a no-op), so it never surfaced.

### The change

Feed `scrollTop` / `clientHeight` / `offsetTop` **raw**; keep the lone `÷zoom`
at the measure RO. This is exactly the spec's *"single ÷zoom at the `RowMeasured`
boundary"* (Phase 4, INV-2). Single file: `AgentDocumentVirtualList.tsx`.

### Verification

- **Units probe** — live in cef-146, definitive (table above).
- **zoom = 1 is byte-identical** (`x / (1||1)` ≡ `x`), so the cutover's §7 live
  result (0 overlap / 0 drift) carries over unchanged; only the zoom ≠ 1 path
  differs.
- **Reducer** is zoom-invariant by construction and already unit-tested
  (`INV-2 — zoom is layout-invariant`); no reducer change here.
- **Frontend build** clean.
- ⚠️ **Not run:** the live §7 drift harness *at zoom 0.5/2* on a real pane — the
  throwaway measurement dev has no virtualized conversation to seed. The units
  probe + zoom-1-identity cover correctness; a real-session §7-at-zoom is a
  recommended final smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
