### PR TITLE
fix(auth): seed isolated claude creds from global to stop the validate spin

### DIFF
--- a/.changesets/1780668404-fix-auth-seed-isolated-claude-creds-from-global-to-stop-the--8asi.md
+++ b/.changesets/1780668404-fix-auth-seed-isolated-claude-creds-from-global-to-stop-the--8asi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): seed isolated claude creds from global to stop the validate spin

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -334,6 +334,34 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         return Ok(Some(serde_json::to_value(&result).unwrap()));
                     }
 
+                    // Bootstrap the isolated CLAUDE_CONFIG_DIR from the global login.
+                    // Phase 2 (and the spawned agent) validate against the isolated dir;
+                    // if the tokens were found only in the global ~/.claude fallback above
+                    // but the isolated dir is empty, phase 2 reports loggedIn:false forever
+                    // — credentials "found" yet "not logged in", an unrecoverable spin.
+                    // Copy the global credentials in once so an existing login works
+                    // per-instance without a re-login. Only when the isolated file is
+                    // ABSENT, so a real per-instance login still wins (multi-account stays
+                    // isolated).
+                    if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
+                        let iso = format!("{}/.credentials.json", config_dir);
+                        let global = format!("{}/.claude/.credentials.json", home);
+                        if !std::path::Path::new(&iso).exists()
+                            && std::path::Path::new(&global).exists()
+                        {
+                            match std::fs::create_dir_all(config_dir)
+                                .and_then(|_| std::fs::copy(&global, &iso))
+                            {
+                                Ok(_) => tracing::info!(
+                                    "claude auth: seeded isolated CLAUDE_CONFIG_DIR from global ~/.claude"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    "claude auth: failed to seed isolated creds from global: {e}"
+                                ),
+                            }
+                        }
+                    }
+
                     // Tokens exist on disk — validate with the CLI (10 s timeout).
                     tracing::info!("claude auth check: credentials found, validating via CLI");
                 }

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -339,22 +339,31 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // if the tokens were found only in the global ~/.claude fallback above
                     // but the isolated dir is empty, phase 2 reports loggedIn:false forever
                     // — credentials "found" yet "not logged in", an unrecoverable spin.
-                    // Copy the global credentials in once so an existing login works
-                    // per-instance without a re-login. Only when the isolated file is
-                    // ABSENT, so a real per-instance login still wins (multi-account stays
-                    // isolated).
+                    // Copy the global credentials in once, gated on a first-run sentinel:
+                    // after a deliberate `claude auth logout` / account switch in this
+                    // instance the creds file is absent again but the sentinel remains, so
+                    // we never silently reseed the global account over the user's logout —
+                    // per-instance / multi-account isolation stays intact.
                     if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
                         let iso = format!("{}/.credentials.json", config_dir);
+                        let seeded = format!("{}/.agentmux-cred-seeded", config_dir);
                         let global = format!("{}/.claude/.credentials.json", home);
                         if !std::path::Path::new(&iso).exists()
+                            && !std::path::Path::new(&seeded).exists()
                             && std::path::Path::new(&global).exists()
                         {
                             match std::fs::create_dir_all(config_dir)
                                 .and_then(|_| std::fs::copy(&global, &iso))
                             {
-                                Ok(_) => tracing::info!(
-                                    "claude auth: seeded isolated CLAUDE_CONFIG_DIR from global ~/.claude"
-                                ),
+                                Ok(_) => {
+                                    let _ = std::fs::write(
+                                        &seeded,
+                                        b"seeded from global ~/.claude on first run\n",
+                                    );
+                                    tracing::info!(
+                                        "claude auth: seeded isolated CLAUDE_CONFIG_DIR from global ~/.claude (first run)"
+                                    );
+                                }
                                 Err(e) => tracing::warn!(
                                     "claude auth: failed to seed isolated creds from global: {e}"
                                 ),


### PR DESCRIPTION
## The bug

Creating an agent leaves it stuck "not authenticated" forever, CPU pinned and
login timing out — even though `claude` is logged in globally.

Logs show the two-phase claude auth check (SPEC_AUTH_CHECK_FALSE_POSITIVE):
- **Phase 1** finds credentials in EITHER the isolated `CLAUDE_CONFIG_DIR` **or**
  the global `~/.claude` fallback (`cli_handlers.rs:304-323`).
- **Phase 2** runs `claude auth status --json` against ONLY the isolated
  `CLAUDE_CONFIG_DIR`.

On a fresh instance the isolated dir is empty but the user is logged in
globally → Phase 1 says "found", Phase 2 says `loggedIn: false`. The frontend
re-polls every ~2s, each poll re-spawns the CLI (the **CPU churn**), and
`run_cli_login` PTY-times-out at **15s**. An unrecoverable "found-but-not-
logged-in" spin — credentials present, never recognized.

## The fix

When tokens were found via the global fallback but the isolated dir has no
`.credentials.json`, copy the global file in **once**. Phase 2 then validates a
populated dir, and the spawned agent (same dir) authenticates too. Only copies
when **absent** → a real per-instance login still wins, so multi-account
isolation is preserved.

## Verification

Mechanism validated **live** against the bundled CLI (v2.1.160):

| `CLAUDE_CONFIG_DIR` | `claude auth status --json` |
|---|---|
| seeded (global creds copied in) | `loggedIn: true` |
| empty (current fresh-instance state) | `loggedIn: false` |

`cargo check -p agentmux-srv` clean. End-to-end relaunch verification next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
