### PR TITLE
docs: prominent early-alpha warning on README and MSIX listing

### DIFF
--- a/.changesets/1780862400-docs-early-alpha-warning-readme-and-msix.md
+++ b/.changesets/1780862400-docs-early-alpha-warning-readme-and-msix.md
@@ -1,0 +1,10 @@
+---
+type: patch
+---
+
+docs: prominent early-alpha warning at top of README and in MSIX manifest
+
+Adds a callout to the top of README.md and updates the AppxManifest
+Description so the Microsoft Store listing carries the same disclaimer.
+Canonical wording lives in
+docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+<!-- The early-alpha warning is the first content block by design — see
+docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md. Decorative logo/title
+follow below so the warning is never pushed below the fold. -->
+
+> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+>
+> **AgentMux is in early alpha.** Many features are incomplete, partially
+> broken, or change between releases without notice. Expect:
+>
+> - **Broken features** — pieces of the UI may not function, or may regress
+>   from one release to the next.
+> - **Data loss** — settings, pane layouts, and agent state may not migrate
+>   cleanly across versions. Don't store anything you can't reproduce.
+> - **Breaking changes** — config files, identity bundles, memory bundles,
+>   and the App API may change shape with no migration path during alpha.
+> - **Platform gaps** — Windows is the primary target; macOS and Linux
+>   builds lag behind and have additional known issues.
+>
+> If you hit a problem, **please file a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
+> review — it's how alpha gets to beta.
+
+---
+
 <p align="center">
   <img src="./frontend/logos/agentmux-logo-brain-alternate.svg" alt="AgentMux Logo" width="120">
 </p>

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ follow below so the warning is never pushed below the fold. -->
 > - **Platform gaps** — Windows is the primary target; macOS and Linux
 >   builds lag behind and have additional known issues.
 >
-> If you hit a problem, **please file a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
-> review — it's how alpha gets to beta.
+> If you hit a problem, **please report it as a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
 
 ---
 

--- a/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
+++ b/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
@@ -33,7 +33,7 @@ all looking at the same disclaimer.
 ## Goals
 
 - A user reading either surface immediately understands: this is alpha, things
-  break, file issues instead of leaving reviews.
+  break, and bugs should be reported as GitHub issues.
 - The two surfaces share one canonical wording — when we change one, we change
   the other.
 - The warning survives README restructuring (i.e., it's the first content
@@ -48,6 +48,17 @@ all looking at the same disclaimer.
 - Adding telemetry/feedback widgets.
 - Renaming the product or version-scheme changes.
 
+## Wording constraint — Store review policy
+
+The warning **must not** tell users to file a GitHub issue *instead of* leaving
+a review (e.g. "rather than leaving a review", "don't leave a review"). The
+Microsoft Store has a ratings/reviews-manipulation policy and copy that
+discourages reviews can trip Store certification, especially in shipped
+artifacts (`AppxManifest.xml.template` Description, Partner Center listing
+fields). Phrase the GitHub-issue ask positively: *"please report issues at
+…"* — link to the issue tracker but do not contrast it with the Store review
+flow.
+
 ---
 
 ## Canonical Warning Text
@@ -59,7 +70,7 @@ it).
 ### Short form (one line, used in Store "Short description" and any tight slot)
 
 > **Early alpha — expect bugs, broken features, and breaking changes between
-> releases. Please file issues on GitHub instead of leaving a review.**
+> releases. Please report issues at https://github.com/agentmuxai/agentmux/issues.**
 
 ### Long form (used at top of README and in Store "Description")
 
@@ -77,9 +88,8 @@ it).
 > - **Platform gaps** — Windows is the primary target; macOS and Linux
 >   builds lag behind and have additional known issues.
 >
-> If you hit a problem, **please file a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
-> review — it's how alpha gets to beta.
+> If you hit a problem, **please report it as a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
 
 ---
 
@@ -113,9 +123,8 @@ Prepend to `README.md` (at the repo root):
 > - **Platform gaps** — Windows is the primary target; macOS and Linux
 >   builds lag behind and have additional known issues.
 >
-> If you hit a problem, **please file a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
-> review — it's how alpha gets to beta.
+> If you hit a problem, **please report it as a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
 
 ---
 

--- a/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
+++ b/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
@@ -96,7 +96,7 @@ information. Decorative content should not push the warning below the fold.
 
 ### Exact edit
 
-Prepend to `/workspace/agentmux/README.md`:
+Prepend to `README.md` (at the repo root):
 
 ```markdown
 > ## ⚠️ EARLY ALPHA — Use At Your Own Risk

--- a/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
+++ b/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
@@ -1,0 +1,217 @@
+# SPEC: Early Alpha Warning — README & Microsoft Store Partner Center
+
+**Date:** 2026-06-05
+**Status:** Proposed
+**Owner:** TBD
+**Scope:** Top-of-README banner + Microsoft Store Partner Center listing copy
+
+---
+
+## Motivation
+
+AgentMux is publicly available (GitHub README, Microsoft Store listing) but the
+product is still in **early alpha**: significant feature surfaces are partially
+implemented, regress between releases, or are known-broken on specific
+platforms. Users arriving from the Microsoft Store in particular have no signal
+that they are installing pre-production software — the Store listing reads as a
+finished product, which produces unfair 1-star reviews and wastes the user's
+time.
+
+This spec defines a single, consistent **early-alpha warning** that lands in
+two places:
+
+1. **Top of `README.md`** in the `agentmuxai/agentmux` repo (the first thing a
+   GitHub visitor or installer-link follower sees).
+2. **Microsoft Store Partner Center listing** — both the Description and the
+   "What's new in this version" copy, so the warning is unmissable on the
+   product page *and* on every update notification.
+
+The warning must be prominent, honest, and self-consistent across both surfaces
+so that the Store reviewer, the GitHub visitor, and the installed-app user are
+all looking at the same disclaimer.
+
+## Goals
+
+- A user reading either surface immediately understands: this is alpha, things
+  break, file issues instead of leaving reviews.
+- The two surfaces share one canonical wording — when we change one, we change
+  the other.
+- The warning survives README restructuring (i.e., it's the first content
+  block, above logo niceties and badge rows if necessary).
+- The warning is reusable: the `AppxManifest.xml.template` Description field
+  references the same text.
+
+## Non-Goals
+
+- Changing the in-app UI to show an alpha banner (separate spec if we want
+  that).
+- Adding telemetry/feedback widgets.
+- Renaming the product or version-scheme changes.
+
+---
+
+## Canonical Warning Text
+
+The single source of truth lives in this spec. All other surfaces copy from
+here verbatim (or paraphrase only the Markdown/plain-text formatting around
+it).
+
+### Short form (one line, used in Store "Short description" and any tight slot)
+
+> **Early alpha — expect bugs, broken features, and breaking changes between
+> releases. Please file issues on GitHub instead of leaving a review.**
+
+### Long form (used at top of README and in Store "Description")
+
+> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+>
+> **AgentMux is in early alpha.** Many features are incomplete, partially
+> broken, or change between releases without notice. Expect:
+>
+> - **Broken features** — pieces of the UI may not function, or may regress
+>   from one release to the next.
+> - **Data loss** — settings, pane layouts, and agent state may not migrate
+>   cleanly across versions. Don't store anything you can't reproduce.
+> - **Breaking changes** — config files, identity bundles, memory bundles,
+>   and the App API may change shape with no migration path during alpha.
+> - **Platform gaps** — Windows is the primary target; macOS and Linux
+>   builds lag behind and have additional known issues.
+>
+> If you hit a problem, **please file a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
+> review — it's how alpha gets to beta.
+
+---
+
+## Surface 1 — `README.md`
+
+### Placement
+
+Insert the **Long form** warning as the very first content block, **above** the
+centered logo `<p align="center">…</p>` block, so it is the first thing visible
+both on github.com and in any tool that renders raw Markdown without centering.
+
+Rationale: the logo+title is decorative; the warning is load-bearing
+information. Decorative content should not push the warning below the fold.
+
+### Exact edit
+
+Prepend to `/workspace/agentmux/README.md`:
+
+```markdown
+> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+>
+> **AgentMux is in early alpha.** Many features are incomplete, partially
+> broken, or change between releases without notice. Expect:
+>
+> - **Broken features** — pieces of the UI may not function, or may regress
+>   from one release to the next.
+> - **Data loss** — settings, pane layouts, and agent state may not migrate
+>   cleanly across versions. Don't store anything you can't reproduce.
+> - **Breaking changes** — config files, identity bundles, memory bundles,
+>   and the App API may change shape with no migration path during alpha.
+> - **Platform gaps** — Windows is the primary target; macOS and Linux
+>   builds lag behind and have additional known issues.
+>
+> If you hit a problem, **please file a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues rather than leaving a store
+> review — it's how alpha gets to beta.
+
+---
+
+```
+
+(The trailing `---` separates the warning from the existing logo/title block.)
+
+### Acceptance
+
+- `README.md` rendered on github.com shows the warning callout *before* the
+  logo and title.
+- The warning uses GitHub's blockquote rendering (with the `>` prefix) so it
+  visually stands apart from the rest of the README.
+- No existing content is removed; everything currently in the README slides
+  down unchanged.
+
+---
+
+## Surface 2 — Microsoft Store Partner Center
+
+### Fields to update
+
+Partner Center → AgentMux → **Store listings → English (United States)** (and
+any other locales we publish):
+
+| Field | New value |
+|---|---|
+| **Short description** (≤200 chars) | Short form (see above) — prepended to existing description. |
+| **Description** (≤10 000 chars) | Long form (see above) at the very top, followed by the existing marketing copy. |
+| **What's new in this version** | Short form on its own line at the top, then the actual release notes for the version. Re-applied on every Store submission until we exit alpha. |
+
+### Submission procedure
+
+1. Sign in to Partner Center → Apps and games → AgentMux.
+2. Open the current draft submission (or create a new one if none is open).
+3. Update Store listings → English (US) per the table above.
+4. For every additional locale, replicate the same English text (we are not
+   translating during alpha).
+5. In the **Notes for certification** field, add: *"This submission adds an
+   early-alpha disclaimer to the Store listing. No package binary changes
+   versus the previous submission unless otherwise noted."*
+6. Submit for certification.
+
+### Acceptance
+
+- Store listing preview shows the long-form warning as the first paragraph of
+  the Description.
+- The Short description visible in search results contains the short-form
+  warning.
+- The "What's new" section on the product page shows the short-form warning
+  above the release notes.
+
+---
+
+## Surface 3 — `AppxManifest.xml.template` (consistency check)
+
+`packaging/msix/AppxManifest.xml.template` contains the `<Description>` element
+that Microsoft Store falls back to if the Partner Center listing field is
+empty. Update it so the two surfaces cannot drift apart:
+
+- Set `<Description>` to the **short form** warning followed by `" — "` and
+  the existing one-line product pitch.
+
+This is a belt-and-braces measure; Partner Center copy normally wins, but a
+mis-configured submission could fall back to the manifest text, and we want
+that fallback to still carry the warning.
+
+### Acceptance
+
+- Re-running `packaging/msix/generate-assets.ps1` (or whatever step renders
+  the manifest from the template) produces a manifest whose `<Description>`
+  starts with the alpha warning.
+
+---
+
+## Out-of-band: keeping the surfaces in sync
+
+When the warning text changes (e.g., when we drop "early alpha" for "beta"):
+
+1. Edit this spec's **Canonical Warning Text** section.
+2. Update `README.md` to match.
+3. Update `AppxManifest.xml.template` to match.
+4. Open a Partner Center submission with the new Store-listing copy.
+
+A future automation could lint the README and manifest against this spec's
+canonical block, but during alpha the manual review at submission time is
+adequate.
+
+---
+
+## Open questions
+
+- Do we want a matching warning on the agentmux.ai landing page? (Out of scope
+  here; flag for the website owner.)
+- Do we want an in-app first-run banner echoing the warning? Defer to a
+  follow-up spec if user-research signals it's needed.
+- Localized Store listings — do we want machine-translated warnings in the
+  other locales, or keep English everywhere during alpha? Current spec says
+  English-only for simplicity.

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -42,7 +42,7 @@
     <Application Id="AgentMux" Executable="agentmux.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         DisplayName="AgentMux"
-        Description="EARLY ALPHA — expect bugs, broken features, and breaking changes between releases. Please file issues on GitHub instead of leaving a review. Integrated agentic workflow environment — run multiple AI agents side by side."
+        Description="EARLY ALPHA — expect bugs, broken features, and breaking changes between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues. Integrated agentic workflow environment — run multiple AI agents side by side."
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -42,7 +42,7 @@
     <Application Id="AgentMux" Executable="agentmux.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         DisplayName="AgentMux"
-        Description="Integrated agentic workflow environment — run multiple AI agents side by side"
+        Description="EARLY ALPHA — expect bugs, broken features, and breaking changes between releases. Please file issues on GitHub instead of leaving a review. Integrated agentic workflow environment — run multiple AI agents side by side."
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">


### PR DESCRIPTION
## Summary
- Adds a top-of-README callout warning users that AgentMux is in early alpha (broken features, data loss, breaking changes, platform gaps) and asks them to file GitHub issues instead of leaving store reviews.
- Updates `packaging/msix/AppxManifest.xml.template` Description so the Microsoft Store listing carries the same short-form disclaimer as a fallback.
- Adds `docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md` as the single source of truth for the warning wording — README, AppxManifest, and Partner Center listing copy are all expected to track this spec.

## Out-of-band
The Microsoft Store Partner Center listing fields (Short description, Description, What's new) must be updated by the publisher per the procedure documented in the spec — that lives outside this repo, so it can't ship as part of this PR.

## Test plan
- [ ] Render README on github.com — confirm the warning blockquote appears above the logo and title.
- [ ] Run the MSIX packaging step (or inspect rendered manifest) — confirm the `Description` attribute starts with `EARLY ALPHA — …`.
- [ ] Re-read the spec and confirm wording matches both surfaces verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)