### PR TITLE
fix(auth): macOS Claude login completes — detect Keychain-stored creds

### DIFF
--- a/.changesets/1780672511-fix-auth-macos-claude-login-completes-detect-keychain-stored-kx3f.md
+++ b/.changesets/1780672511-fix-auth-macos-claude-login-completes-detect-keychain-stored-kx3f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): macOS Claude login completes — detect Keychain-stored creds

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -658,16 +658,31 @@ async fn run_cli_login_pty(
     tokio::task::spawn_blocking(move || {
         use std::io::BufRead;
         let mut reader = std::io::BufReader::new(reader);
-        let mut found: Option<String> = None;
+        // Wrap the oneshot in an Option so we send the URL exactly once and then
+        // keep reading. Before the URL: scan for it. After: keep draining and LOG
+        // every line — the CLI's `Paste code here >` prompt and, crucially, its
+        // response to the code delivered via set_provider_auth (success vs. an
+        // "invalid code" / error). Without this the host discarded that output,
+        // so a failed login was a black box. Draining also keeps the CLI from
+        // blocking on a full PTY output buffer.
+        let mut url_tx = Some(url_tx);
         let mut line = String::new();
         loop {
             line.clear();
             match reader.read_line(&mut line) {
                 Ok(0) => break, // EOF
                 Ok(_) => {
-                    if let Some(u) = extract_url(&line) {
-                        found = Some(u);
-                        break;
+                    if let Some(tx) = url_tx.take() {
+                        if let Some(u) = extract_url(&line) {
+                            let _ = tx.send(Some(u));
+                        } else {
+                            url_tx = Some(tx); // not the URL line yet
+                        }
+                    } else {
+                        let t = line.trim_end();
+                        if !t.trim().is_empty() {
+                            tracing::info!(target: "login_pty", "[login-pty] {}", t);
+                        }
                     }
                 }
                 Err(e) => {
@@ -676,9 +691,10 @@ async fn run_cli_login_pty(
                 }
             }
         }
-        let _ = url_tx.send(found);
-        // Reader is dropped here. Master keeps living in the wait task
-        // below.
+        // EOF/error before a URL was ever seen — unblock the awaiting caller.
+        if let Some(tx) = url_tx.take() {
+            let _ = tx.send(None);
+        }
     });
 
     let auth_url: Option<String> = match tokio::time::timeout(

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -323,19 +323,35 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     });
 
                     if !tokens_exist {
-                        // No credentials file or empty tokens — definitely not authenticated.
-                        tracing::info!("claude auth check: no credentials file, skipping CLI");
-                        let result = CheckCliAuthResult {
-                            authenticated: false,
-                            email: None,
-                            auth_method: None,
-                            raw_output: "no credentials found".to_string(),
-                        };
-                        return Ok(Some(serde_json::to_value(&result).unwrap()));
+                        // On macOS the Claude CLI stores credentials in the
+                        // Keychain ("Claude Safe Storage"), NOT in
+                        // .credentials.json — so a missing file does NOT mean
+                        // logged out. Fall through to `claude auth status`, which
+                        // reads the Keychain (and does so without a prompt — the
+                        // CLI owns that Keychain item). Without this, a completed
+                        // macOS login is never detected and the launch flow polls
+                        // forever ("stuck login"). On Windows/Linux the file IS
+                        // the credential store, so the fast "definitely not
+                        // authenticated" short-circuit stays correct there.
+                        #[cfg(not(target_os = "macos"))]
+                        {
+                            tracing::info!("claude auth check: no credentials file, skipping CLI");
+                            let result = CheckCliAuthResult {
+                                authenticated: false,
+                                email: None,
+                                auth_method: None,
+                                raw_output: "no credentials found".to_string(),
+                            };
+                            return Ok(Some(serde_json::to_value(&result).unwrap()));
+                        }
+                        #[cfg(target_os = "macos")]
+                        tracing::info!(
+                            "claude auth check: no credentials file — checking Keychain via CLI (macOS)"
+                        );
+                    } else {
+                        // Tokens exist on disk — validate with the CLI (10 s timeout).
+                        tracing::info!("claude auth check: credentials found, validating via CLI");
                     }
-
-                    // Tokens exist on disk — validate with the CLI (10 s timeout).
-                    tracing::info!("claude auth check: credentials found, validating via CLI");
                 }
 
                 let output = tokio::time::timeout(


### PR DESCRIPTION
## The real bug (not what it looked like)

The Claude login on macOS *always succeeded* — the browser auto-opens, you authorize, and the CLI auto-completes the **loopback happy path** (no code to paste) and stores credentials in the **macOS Keychain** (`Claude Safe Storage`), exactly as designed.

It only *looked* stuck because of a **detection** bug. `CheckCliAuth` has a fast path: "no `.credentials.json` file → **definitely** not authenticated, skip the CLI." On macOS there is **never** a credentials file (the Keychain is the store), so a completed login was never detected and the launch flow's 2s poll spun forever.

Proof from the new instrumentation:
```
[login-pty] Paste code here if prompted > Login successful.   ← CLI auto-completed
claude auth status → "loggedIn": true, asafebgi@gmail.com
creds → macOS Keychain "Claude Safe Storage"  (no .credentials.json anywhere)
```

## Fix

- **`CheckCliAuth` (agentmux-srv):** on macOS, when no credentials *file* is present, fall through to `claude auth status` (which reads the Keychain — and does so without a prompt, since the CLI owns that item) instead of returning not-authenticated. Windows/Linux keep the fast file-only short-circuit (the file *is* the store there).
- **`run_cli_login_pty` (agentmux-cef):** keep draining the login CLI's PTY *after* the URL and **log** its output as `[login-pty]`. Before, the CLI's `… > Login successful.` was discarded — a completed login was a black box. Draining also prevents the CLI blocking on a full PTY output buffer (the pipe path already drains; the PTY path didn't).

## Verification (macOS)

After a completed login + this fix:
```
claude auth check: no credentials file — checking Keychain via CLI (macOS)
[rpc-perf] checkcliauth handler=243ms        ← ran claude auth status
subprocess spawned                            ← agent launched, no login box
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)