### PR TITLE
feat(linux): Unix-socket IPC + reducer + saga coordinator on Linux (A1)

### DIFF
--- a/.changesets/1780673373-feat-linux-launcher-a1-unix-ipc.md
+++ b/.changesets/1780673373-feat-linux-launcher-a1-unix-ipc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(linux): Unix-domain-socket IPC + reducer + saga coordinator on Linux (A1)

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -58,8 +58,18 @@ pub struct LauncherIpcHandle {
     reader_task: tokio::task::JoinHandle<()>,
 }
 
-#[cfg(not(target_os = "windows"))]
-pub struct LauncherIpcHandle;
+#[cfg(unix)]
+pub struct LauncherIpcHandle {
+    /// Held purely as a keepalive; same shape as the Windows variant.
+    #[allow(dead_code)]
+    writer: Arc<Mutex<tokio::io::WriteHalf<tokio::net::UnixStream>>>,
+    /// Read-half task handle; A1.2 — the body of the reader task is
+    /// shared with the Windows path (parses HostFrame envelopes, falls
+    /// back to bare Event for legacy launchers, dispatches saga
+    /// Commands).
+    #[allow(dead_code)]
+    reader_task: tokio::task::JoinHandle<()>,
+}
 
 /// If `AGENTMUX_LAUNCHER_PIPE` is set, connect, Register as Host,
 /// and return a handle the caller (host main.rs) holds for the
@@ -295,7 +305,202 @@ pub async fn connect_to_launcher(
     })
 }
 
-#[cfg(not(target_os = "windows"))]
+/// A1.2 — Unix-domain-socket variant. Mirrors the Windows path above:
+/// connect → Register → spawn drain task → spawn reader task → return
+/// handle. Protocol on the wire is identical (newline-delimited JSON
+/// `Command` / `Event` / `HostFrame`) so the launcher's
+/// `handle_connection` generic body serves both transports unchanged.
+///
+/// Env var name: reuses `AGENTMUX_LAUNCHER_PIPE` even though the
+/// underlying resource is a Unix-domain socket. Lets the 17 host-side
+/// `report_*` call sites in this file stay platform-agnostic. The
+/// launcher's `spawn_host_unix` exports the socket path under this
+/// name (see `agentmux-launcher/src/main.rs::run_unix`).
+#[cfg(unix)]
+pub async fn connect_to_launcher(
+    state: std::sync::Arc<crate::state::AppState>,
+) -> Option<LauncherIpcHandle> {
+    use tokio::net::UnixStream;
+
+    let sock_path = match std::env::var("AGENTMUX_LAUNCHER_PIPE") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            tracing::info!(
+                "AGENTMUX_LAUNCHER_PIPE unset — running without launcher IPC (dev mode)"
+            );
+            return None;
+        }
+    };
+
+    let stream = match UnixStream::connect(&sock_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                "[launcher-ipc] failed to connect {}: {} — continuing without launcher IPC",
+                sock_path,
+                e
+            );
+            return None;
+        }
+    };
+    tracing::info!("[launcher-ipc] connected to {}", sock_path);
+
+    let (read_half, write_half) = tokio::io::split(stream);
+    let writer = Arc::new(Mutex::new(write_half));
+
+    // Send Register FIRST — same race-avoidance discipline as the
+    // Windows path: COMMAND_TX is only published after Register
+    // flushes successfully.
+    let register = Command::Register {
+        kind: ClientKind::Host,
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let mut buf = match serde_json::to_vec(&register) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(
+                "[launcher-ipc] failed to serialize Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+    };
+    buf.push(b'\n');
+    {
+        let mut w = writer.lock().await;
+        if let Err(e) = w.write_all(&buf).await {
+            tracing::error!(
+                "[launcher-ipc] failed to send Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+        if let Err(e) = w.flush().await {
+            tracing::error!(
+                "[launcher-ipc] failed to flush Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+    }
+
+    // Outbound command drain task — same shape as Windows variant.
+    let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+    if COMMAND_TX.set(tx).is_err() {
+        tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
+    }
+    let writer_for_drain = Arc::clone(&writer);
+    tokio::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            let mut buf = match serde_json::to_vec(&cmd) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("[launcher-ipc] failed to serialize {:?}: {}", cmd, e);
+                    continue;
+                }
+            };
+            buf.push(b'\n');
+            let mut w = writer_for_drain.lock().await;
+            if let Err(e) = w.write_all(&buf).await {
+                tracing::warn!(
+                    "[launcher-ipc] write failed for {:?}: {} — dropping further commands",
+                    cmd, e
+                );
+                return;
+            }
+            if let Err(e) = w.flush().await {
+                tracing::warn!("[launcher-ipc] flush failed: {}", e);
+                return;
+            }
+        }
+    });
+
+    // Reader task — identical body to the Windows variant.
+    let state_for_reader = std::sync::Arc::clone(&state);
+    let saga_lru = std::sync::Arc::new(parking_lot::Mutex::new(
+        crate::saga_dispatch::SagaIdempotencyLru::with_default_cap(),
+    ));
+    let reply_tx = COMMAND_TX
+        .get()
+        .expect("COMMAND_TX set before reader task spawn")
+        .clone();
+    let saga_runner = std::sync::Arc::new(crate::saga_dispatch::LiveActionRunner {
+        state: std::sync::Arc::clone(&state),
+    });
+    let reader_task = tokio::spawn(async move {
+        let reader = BufReader::new(read_half);
+        let mut lines = reader.lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) if line.trim().is_empty() => continue,
+                Ok(Some(line)) => {
+                    match serde_json::from_str::<HostFrame>(&line) {
+                        Ok(HostFrame::Event(event)) => {
+                            tracing::info!("[launcher-ipc] received event: {:?}", event);
+                            apply_event_to_shadow(&state_for_reader, &event);
+                        }
+                        Ok(HostFrame::Command(cmd)) => {
+                            tracing::info!(
+                                "[launcher-ipc] received saga command: {:?}",
+                                cmd
+                            );
+                            let outcome = crate::saga_dispatch::dispatch_host_command(
+                                &cmd,
+                                saga_runner.as_ref(),
+                                &saga_lru,
+                                &reply_tx,
+                            );
+                            tracing::debug!(
+                                "[launcher-ipc] saga command outcome: {:?}",
+                                outcome
+                            );
+                        }
+                        Err(_envelope_err) => {
+                            match serde_json::from_str::<Event>(&line) {
+                                Ok(event) => {
+                                    tracing::info!(
+                                        "[launcher-ipc] received event (legacy bare-Event): {:?}",
+                                        event
+                                    );
+                                    apply_event_to_shadow(&state_for_reader, &event);
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "[launcher-ipc] could not parse line as HostFrame or Event ({}): {}",
+                                        e,
+                                        line
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("[launcher-ipc] launcher socket EOF — connection closed");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("[launcher-ipc] read error: {}", e);
+                    return;
+                }
+            }
+        }
+    });
+
+    Some(LauncherIpcHandle {
+        writer,
+        reader_task,
+    })
+}
+
+/// Non-Windows + non-Unix fallback (e.g., WASM if we ever ship it). Should be
+/// unreachable in practice — every Tier-1 platform we ship is either Windows
+/// or Unix.
+#[cfg(not(any(target_os = "windows", unix)))]
+pub struct LauncherIpcHandle;
+
+#[cfg(not(any(target_os = "windows", unix)))]
 pub async fn connect_to_launcher(
     _state: std::sync::Arc<crate::state::AppState>,
 ) -> Option<LauncherIpcHandle> {

--- a/agentmux-cef/src/parent_process.rs
+++ b/agentmux-cef/src/parent_process.rs
@@ -61,14 +61,26 @@ pub fn parent_is_agentmux_launcher() -> Option<bool> {
 
 #[cfg(not(target_os = "windows"))]
 pub fn parent_is_agentmux_launcher() -> Option<bool> {
-    // The launcher now drives srv + host on macOS/Linux dev too (Phase 1,
-    // SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30), but the launcher↔host
-    // IPC pipe is still deferred to Phase 2 — so there is no IPC parent-
-    // identity check to perform here yet. (The host's srv-adoption decision
-    // uses a separate, direct getppid == AGENTMUX_LAUNCHER_PID check in
-    // main.rs::launcher_is_genuine_parent.) Return None and let the path-
-    // based guard decide until the Unix IPC transport lands.
-    None
+    // A1 (SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md §4) wires
+    // the Unix-socket IPC; the launcher exports its pid in
+    // `AGENTMUX_LAUNCHER_PID` for any host child it spawns directly
+    // (`spawn_host_unix` at agentmux-launcher/src/main.rs:411). If our
+    // getppid matches that env-stamped pid, the launcher IS our parent
+    // and we should attempt the launcher-IPC connect — even in dev
+    // builds where `is_dev_build_exe` would otherwise short-circuit it.
+    //
+    // Without this check, `task dev` on Linux/macOS would skip the
+    // launcher IPC even though `run_unix` has the socket up — leaving
+    // the 17 `report_*` hooks no-opping in dev. (Codex P2 on PR #1288.)
+    let stamped: u32 = match std::env::var("AGENTMUX_LAUNCHER_PID")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+    {
+        Some(p) => p,
+        None => return None, // No stamp → fall through to path-based guard
+    };
+    let our_ppid = unsafe { libc::getppid() } as u32;
+    Some(our_ppid == stamped)
 }
 
 /// Walk the Toolhelp32 process snapshot in a single pass to:

--- a/agentmux-cef/src/saga_dispatch.rs
+++ b/agentmux-cef/src/saga_dispatch.rs
@@ -322,12 +322,13 @@ fn build_and_run_report<R: SagaActionRunner>(
 // Wraps real host code paths. Kept thin so the test runner can
 // substitute deterministic stubs without pulling in CEF.
 
-#[cfg(target_os = "windows")]
+// (A1.2 — gate removed; body is platform-neutral and the Unix IPC
+// client now also needs it. The original gate was defensive because
+// the only caller was Windows-only.)
 pub struct LiveActionRunner {
     pub state: Arc<crate::state::AppState>,
 }
 
-#[cfg(target_os = "windows")]
 impl SagaActionRunner for LiveActionRunner {
     fn spawn_pool_window(&self) -> String {
         // Fire the real spawn. The host's existing

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -82,11 +82,25 @@ pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
 ///      a systemd user manager. UID in the path so users can't
 ///      collide.
 ///
-/// The directory is created on first call (idempotent). On the rare
-/// failure path (read-only `/tmp`, exotic chroot) we fall back to
-/// `/tmp` with the launcher pid as a discriminator. That fallback
-/// is intentionally non-strict — the caller's bind will fail and
-/// the launcher exits cleanly with a clear error.
+/// Security (codex P1 + reagent P1 on #1288). The `/tmp` fallback path
+/// is reachable by every local user. The resolver must close every
+/// TOCTOU window:
+///
+///   * If the dir doesn't exist, create it NON-RECURSIVELY (so a race
+///     between our stat and our create fails with `AlreadyExists`,
+///     not silently succeeds the way `create_dir_all` would).
+///   * Immediately after a successful create, RE-STAT and verify
+///     ownership + mode. A `create_dir(0700)` syscall under a 0022
+///     umask still produces a 0700 dir; this re-stat is belt-and-
+///     suspenders against the unlikely case where the dir we just
+///     created has been replaced by an attacker between mkdir and
+///     re-stat.
+///   * If the dir already exists, `symlink_metadata` (NOT `metadata`
+///     — we must not follow symlinks) and refuse to proceed unless
+///     it's a real directory owned by our uid with mode masking 0700.
+///   * Refusal = `std::process::exit(2)` with a clear error. We do
+///     NOT try to recover by picking a different path; that would
+///     enlarge the trust boundary.
 #[cfg(unix)]
 pub fn ipc_socket_dir() -> std::path::PathBuf {
     use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
@@ -159,24 +173,61 @@ pub fn ipc_socket_dir() -> std::path::PathBuf {
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Atomically create with mode 0700. `DirBuilder::mode(0700)`
-            // applies via mkdir(2)'s `mode` arg under our umask, so the
-            // directory's actual perms are the requested mode masked by
-            // the umask. We set the mode explicitly via `set_permissions`
-            // immediately after creation as a belt + suspenders against
-            // any inherited umask quirk.
+            // Non-recursive create with mode 0700. `recursive(true)`
+            // (= create_dir_all semantics) would return Ok even if an
+            // attacker pre-created the directory in the race window
+            // between our `symlink_metadata` NotFound and this call —
+            // we'd then bind our socket inside attacker-controlled
+            // space, exactly the squatting attack this resolver is
+            // here to prevent. Non-recursive create fails with
+            // `AlreadyExists` in that race; we treat it as fatal.
+            //
+            // For the XDG path (`$XDG_RUNTIME_DIR/agentmux`), the
+            // parent (`/run/user/{uid}`) is created by systemd-logind
+            // and always exists. For the `/tmp` fallback, `/tmp` is
+            // a standard system directory and always exists. So a
+            // non-recursive create is safe; it only fails when the
+            // parent is missing (which is itself a sign something
+            // weird is going on and we should abort).
             let mut builder = std::fs::DirBuilder::new();
-            builder.recursive(true).mode(0o700);
-            if let Err(e) = builder.create(&dir) {
+            builder.recursive(false).mode(0o700);
+            if let Err(create_err) = builder.create(&dir) {
                 eprintln!(
-                    "AgentMux refusing to start: failed to create IPC socket dir {}: {}.",
+                    "AgentMux refusing to start: failed to create IPC socket dir {} (mode 0700, non-recursive): {}.",
                     dir.display(),
-                    e
+                    create_err
                 );
                 std::process::exit(2);
             }
-            use std::os::unix::fs::PermissionsExt as _;
-            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+            // Belt-and-suspenders post-create verification. The mkdir(2)
+            // syscall is atomic, so the dir we just created is OURS at
+            // this instant. Re-stat anyway to defend against any future
+            // refactor that loosens the create flags.
+            let post_meta = match std::fs::symlink_metadata(&dir) {
+                Ok(m) => m,
+                Err(stat_err) => {
+                    eprintln!(
+                        "AgentMux refusing to start: post-create stat of {} failed: {}.",
+                        dir.display(),
+                        stat_err
+                    );
+                    std::process::exit(2);
+                }
+            };
+            if !post_meta.file_type().is_dir()
+                || post_meta.file_type().is_symlink()
+                || post_meta.uid() != our_uid
+                || post_meta.mode() & 0o077 != 0
+            {
+                eprintln!(
+                    "AgentMux refusing to start: IPC socket dir {} failed post-create verification (uid={}, mode={:o}, symlink={}).",
+                    dir.display(),
+                    post_meta.uid(),
+                    post_meta.mode() & 0o777,
+                    post_meta.file_type().is_symlink()
+                );
+                std::process::exit(2);
+            }
         }
         Err(e) => {
             eprintln!(

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -170,51 +170,56 @@ pub fn ensure_ipc_socket_dir() -> std::path::PathBuf {
     //   3. On refusal, abort the launcher with a clear error rather
     //      than continuing to bind in an unsafe location.
     let our_uid = unsafe { libc::getuid() };
-    match std::fs::symlink_metadata(&dir) {
-        Ok(meta) => {
-            let file_type = meta.file_type();
-            if file_type.is_symlink() {
+
+    // Validate an existing directory (whether we found it via the
+    // initial stat or via a same-user-race AlreadyExists from create).
+    // Returns Ok on safe-to-use, exits(2) with a clear error otherwise.
+    // Side-effect: tightens mode to 0700 if it's looser.
+    let validate_existing = |meta: std::fs::Metadata| {
+        let file_type = meta.file_type();
+        if file_type.is_symlink() {
+            eprintln!(
+                "AgentMux refusing to start: IPC socket dir {} is a symlink (potential squatting attack).",
+                dir.display()
+            );
+            std::process::exit(2);
+        }
+        if !file_type.is_dir() {
+            eprintln!(
+                "AgentMux refusing to start: IPC socket path {} exists but is not a directory.",
+                dir.display()
+            );
+            std::process::exit(2);
+        }
+        if meta.uid() != our_uid {
+            eprintln!(
+                "AgentMux refusing to start: IPC socket dir {} is owned by uid {}, not our uid {} (potential squatting attack).",
+                dir.display(),
+                meta.uid(),
+                our_uid
+            );
+            std::process::exit(2);
+        }
+        let mode = meta.mode() & 0o777;
+        if mode & 0o077 != 0 {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) = std::fs::set_permissions(
+                &dir,
+                std::fs::Permissions::from_mode(0o700),
+            ) {
                 eprintln!(
-                    "AgentMux refusing to start: IPC socket dir {} is a symlink (potential squatting attack).",
-                    dir.display()
-                );
-                std::process::exit(2);
-            }
-            if !file_type.is_dir() {
-                eprintln!(
-                    "AgentMux refusing to start: IPC socket path {} exists but is not a directory.",
-                    dir.display()
-                );
-                std::process::exit(2);
-            }
-            if meta.uid() != our_uid {
-                eprintln!(
-                    "AgentMux refusing to start: IPC socket dir {} is owned by uid {}, not our uid {} (potential squatting attack).",
+                    "AgentMux refusing to start: IPC socket dir {} has mode {:o} (group/other accessible) and chmod 0700 failed: {}.",
                     dir.display(),
-                    meta.uid(),
-                    our_uid
+                    mode,
+                    e
                 );
                 std::process::exit(2);
-            }
-            // Tighten mode if it's looser than 0700. Use the chmod
-            // (rather than a fresh create) so we never widen perms.
-            let mode = meta.mode() & 0o777;
-            if mode & 0o077 != 0 {
-                use std::os::unix::fs::PermissionsExt as _;
-                if let Err(e) = std::fs::set_permissions(
-                    &dir,
-                    std::fs::Permissions::from_mode(0o700),
-                ) {
-                    eprintln!(
-                        "AgentMux refusing to start: IPC socket dir {} has mode {:o} (group/other accessible) and chmod 0700 failed: {}.",
-                        dir.display(),
-                        mode,
-                        e
-                    );
-                    std::process::exit(2);
-                }
             }
         }
+    };
+
+    match std::fs::symlink_metadata(&dir) {
+        Ok(meta) => validate_existing(meta),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // Non-recursive create with mode 0700. `recursive(true)`
             // (= create_dir_all semantics) would return Ok even if an
@@ -234,42 +239,55 @@ pub fn ensure_ipc_socket_dir() -> std::path::PathBuf {
             // weird is going on and we should abort).
             let mut builder = std::fs::DirBuilder::new();
             builder.recursive(false).mode(0o700);
-            if let Err(create_err) = builder.create(&dir) {
-                eprintln!(
-                    "AgentMux refusing to start: failed to create IPC socket dir {} (mode 0700, non-recursive): {}.",
-                    dir.display(),
-                    create_err
-                );
-                std::process::exit(2);
-            }
-            // Belt-and-suspenders post-create verification. The mkdir(2)
-            // syscall is atomic, so the dir we just created is OURS at
-            // this instant. Re-stat anyway to defend against any future
-            // refactor that loosens the create flags.
-            let post_meta = match std::fs::symlink_metadata(&dir) {
-                Ok(m) => m,
-                Err(stat_err) => {
+            match builder.create(&dir) {
+                Ok(()) => {
+                    // Belt-and-suspenders post-create verification.
+                    // mkdir(2) is atomic; the dir we just created is
+                    // OURS at this instant. Re-stat to defend against
+                    // any future refactor that loosens the flags.
+                    match std::fs::symlink_metadata(&dir) {
+                        Ok(m) => validate_existing(m),
+                        Err(stat_err) => {
+                            eprintln!(
+                                "AgentMux refusing to start: post-create stat of {} failed: {}.",
+                                dir.display(),
+                                stat_err
+                            );
+                            std::process::exit(2);
+                        }
+                    }
+                }
+                Err(create_err)
+                    if create_err.kind() == std::io::ErrorKind::AlreadyExists =>
+                {
+                    // Legitimate same-user race (codex P2 on PR #1288):
+                    // a concurrent launcher created the dir between our
+                    // initial NotFound and this create. NOT necessarily
+                    // a squatting attack — re-stat + run the same
+                    // owner/mode/symlink validation we'd run on a
+                    // pre-existing dir. If validation passes, the
+                    // concurrent launcher created a safe dir for us
+                    // both and we can proceed.
+                    match std::fs::symlink_metadata(&dir) {
+                        Ok(m) => validate_existing(m),
+                        Err(stat_err) => {
+                            eprintln!(
+                                "AgentMux refusing to start: re-stat after AlreadyExists race on {} failed: {}.",
+                                dir.display(),
+                                stat_err
+                            );
+                            std::process::exit(2);
+                        }
+                    }
+                }
+                Err(create_err) => {
                     eprintln!(
-                        "AgentMux refusing to start: post-create stat of {} failed: {}.",
+                        "AgentMux refusing to start: failed to create IPC socket dir {} (mode 0700, non-recursive): {}.",
                         dir.display(),
-                        stat_err
+                        create_err
                     );
                     std::process::exit(2);
                 }
-            };
-            if !post_meta.file_type().is_dir()
-                || post_meta.file_type().is_symlink()
-                || post_meta.uid() != our_uid
-                || post_meta.mode() & 0o077 != 0
-            {
-                eprintln!(
-                    "AgentMux refusing to start: IPC socket dir {} failed post-create verification (uid={}, mode={:o}, symlink={}).",
-                    dir.display(),
-                    post_meta.uid(),
-                    post_meta.mode() & 0o777,
-                    post_meta.file_type().is_symlink()
-                );
-                std::process::exit(2);
             }
         }
         Err(e) => {

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -89,6 +89,8 @@ pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
 /// the launcher exits cleanly with a clear error.
 #[cfg(unix)]
 pub fn ipc_socket_dir() -> std::path::PathBuf {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+
     let dir = if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
         let mut p = std::path::PathBuf::from(runtime);
         p.push("agentmux");
@@ -97,21 +99,94 @@ pub fn ipc_socket_dir() -> std::path::PathBuf {
         let uid = unsafe { libc::getuid() };
         std::path::PathBuf::from(format!("/tmp/agentmux-{}", uid))
     };
-    // Best-effort mkdir + chmod 0700. Errors (EEXIST is fine, anything
-    // else is rare and the bind will surface a clear error).
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        if e.kind() != std::io::ErrorKind::AlreadyExists {
-            crate::log(&format!(
-                "[ipc] WARN: failed to create socket dir {}: {} — bind may fail",
+
+    // Security (codex P1 on PR #1288): the /tmp fallback is reachable
+    // by any local user. If an attacker pre-creates the path with a
+    // permissive mode, the naive `create_dir_all` + best-effort chmod
+    // pattern silently lets us bind the launcher socket inside an
+    // attacker-controlled directory, where they can connect as the
+    // first IPC client and impersonate the host. Defense:
+    //   1. Create the directory atomically with mode 0700.
+    //   2. If the directory already exists, stat it and refuse to
+    //      proceed unless: (a) it's a real directory (not a symlink),
+    //      (b) it's owned by the current uid, (c) its mode masks 0700.
+    //   3. On refusal, abort the launcher with a clear error rather
+    //      than continuing to bind in an unsafe location.
+    let our_uid = unsafe { libc::getuid() };
+    match std::fs::symlink_metadata(&dir) {
+        Ok(meta) => {
+            let file_type = meta.file_type();
+            if file_type.is_symlink() {
+                eprintln!(
+                    "AgentMux refusing to start: IPC socket dir {} is a symlink (potential squatting attack).",
+                    dir.display()
+                );
+                std::process::exit(2);
+            }
+            if !file_type.is_dir() {
+                eprintln!(
+                    "AgentMux refusing to start: IPC socket path {} exists but is not a directory.",
+                    dir.display()
+                );
+                std::process::exit(2);
+            }
+            if meta.uid() != our_uid {
+                eprintln!(
+                    "AgentMux refusing to start: IPC socket dir {} is owned by uid {}, not our uid {} (potential squatting attack).",
+                    dir.display(),
+                    meta.uid(),
+                    our_uid
+                );
+                std::process::exit(2);
+            }
+            // Tighten mode if it's looser than 0700. Use the chmod
+            // (rather than a fresh create) so we never widen perms.
+            let mode = meta.mode() & 0o777;
+            if mode & 0o077 != 0 {
+                use std::os::unix::fs::PermissionsExt as _;
+                if let Err(e) = std::fs::set_permissions(
+                    &dir,
+                    std::fs::Permissions::from_mode(0o700),
+                ) {
+                    eprintln!(
+                        "AgentMux refusing to start: IPC socket dir {} has mode {:o} (group/other accessible) and chmod 0700 failed: {}.",
+                        dir.display(),
+                        mode,
+                        e
+                    );
+                    std::process::exit(2);
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Atomically create with mode 0700. `DirBuilder::mode(0700)`
+            // applies via mkdir(2)'s `mode` arg under our umask, so the
+            // directory's actual perms are the requested mode masked by
+            // the umask. We set the mode explicitly via `set_permissions`
+            // immediately after creation as a belt + suspenders against
+            // any inherited umask quirk.
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true).mode(0o700);
+            if let Err(e) = builder.create(&dir) {
+                eprintln!(
+                    "AgentMux refusing to start: failed to create IPC socket dir {}: {}.",
+                    dir.display(),
+                    e
+                );
+                std::process::exit(2);
+            }
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+        Err(e) => {
+            eprintln!(
+                "AgentMux refusing to start: failed to stat IPC socket dir {}: {}.",
                 dir.display(),
                 e
-            ));
+            );
+            std::process::exit(2);
         }
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
-    }
+
     dir
 }

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -25,23 +25,93 @@ pub mod server;
 // the launcher's public surface honest.
 pub use server::run_ipc_server;
 
-/// Construct the named-pipe path for a given data-dir hash.
-/// Format: `\\.\pipe\agentmux-{hash16}\command`.
+/// Construct the IPC endpoint path for a given data-dir hash.
+///
+/// Windows: a named-pipe path `\\.\pipe\agentmux-{hash16}\command`.
+/// Unix:    a Unix-domain-socket path under `$XDG_RUNTIME_DIR/agentmux/`
+///          (fallback `/tmp/agentmux-{uid}/`), file name
+///          `{hash16}.sock`. The directory is created with 0700 perms
+///          and ownership = the user, so cross-user squatting in `/tmp`
+///          can't happen.
 ///
 /// Per-data-dir scoping preserves multi-instance support per
 /// `CLAUDE.md`: different portable folders / installed versions
-/// → different data dirs → different hashes → distinct pipes.
-/// Two launchers pointing at the SAME data dir will collide on
-/// the pipe name, which is also the single-instance signal
-/// Phase B.6 relies on.
+/// → different data dirs → different hashes → distinct endpoints.
+/// Two launchers pointing at the SAME data dir collide at bind time,
+/// which is also the single-instance signal Phase B.6 / A1.6 use.
+#[cfg(target_os = "windows")]
 pub fn pipe_name(data_dir_hash16: &str) -> String {
     format!("\\\\.\\pipe\\agentmux-{}\\command", data_dir_hash16)
+}
+
+#[cfg(unix)]
+pub fn pipe_name(data_dir_hash16: &str) -> String {
+    format!(
+        "{}/{}.sock",
+        ipc_socket_dir().display(),
+        data_dir_hash16
+    )
 }
 
 /// Phase E.1b — srv-side pipe path. Same data-dir hash as the
 /// launcher pipe (multi-instance scoping is identical), different
 /// leaf name. Both pipes coexist; subscribers connect to whichever
 /// reducer they need.
+#[cfg(target_os = "windows")]
 pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
     format!("\\\\.\\pipe\\agentmux-{}\\srv-command", data_dir_hash16)
+}
+
+#[cfg(unix)]
+pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
+    format!(
+        "{}/{}-srv.sock",
+        ipc_socket_dir().display(),
+        data_dir_hash16
+    )
+}
+
+/// Directory under which all launcher Unix sockets live. Created with
+/// 0700 perms so cross-user squatting can't happen.
+///
+/// Resolution order (A1.1 of SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_
+/// 2026_06_05):
+///   1. `$XDG_RUNTIME_DIR/agentmux/` — preferred; tmpfs, per-user,
+///      automatically cleaned up by systemd-logind on session end.
+///   2. `/tmp/agentmux-{uid}/` — fallback for environments without
+///      a systemd user manager. UID in the path so users can't
+///      collide.
+///
+/// The directory is created on first call (idempotent). On the rare
+/// failure path (read-only `/tmp`, exotic chroot) we fall back to
+/// `/tmp` with the launcher pid as a discriminator. That fallback
+/// is intentionally non-strict — the caller's bind will fail and
+/// the launcher exits cleanly with a clear error.
+#[cfg(unix)]
+pub fn ipc_socket_dir() -> std::path::PathBuf {
+    let dir = if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let mut p = std::path::PathBuf::from(runtime);
+        p.push("agentmux");
+        p
+    } else {
+        let uid = unsafe { libc::getuid() };
+        std::path::PathBuf::from(format!("/tmp/agentmux-{}", uid))
+    };
+    // Best-effort mkdir + chmod 0700. Errors (EEXIST is fine, anything
+    // else is rare and the bind will surface a clear error).
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            crate::log(&format!(
+                "[ipc] WARN: failed to create socket dir {}: {} — bind may fail",
+                dir.display(),
+                e
+            ));
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
+    dir
 }

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -46,9 +46,20 @@ pub fn pipe_name(data_dir_hash16: &str) -> String {
 
 #[cfg(unix)]
 pub fn pipe_name(data_dir_hash16: &str) -> String {
+    // PURE — no filesystem mutation. `ipc_socket_dir_path` returns
+    // the path string without creating or validating the directory.
+    // Callers that need the directory to actually exist + be safe
+    // (only the launcher's startup path needs that) must call
+    // `ensure_ipc_socket_dir()` separately before binding/connecting.
+    //
+    // Reagent P2 on PR #1288: pipe_name on Windows is a pure string
+    // formatter; making the Unix variant filesystem-mutating + able
+    // to std::process::exit was a footgun for any future read-only
+    // inspector (e.g. the planned Linux `--diag` port) that calls
+    // pipe_name purely to locate the socket.
     format!(
         "{}/{}.sock",
-        ipc_socket_dir().display(),
+        ipc_socket_dir_path().display(),
         data_dir_hash16
     )
 }
@@ -64,11 +75,32 @@ pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
 
 #[cfg(unix)]
 pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
+    // PURE — see comment on `pipe_name` above.
     format!(
         "{}/{}-srv.sock",
-        ipc_socket_dir().display(),
+        ipc_socket_dir_path().display(),
         data_dir_hash16
     )
+}
+
+/// Pure computation of the IPC socket directory path. No I/O, no
+/// process-exit. Used by `pipe_name` / `srv_pipe_name` so they
+/// behave like their Windows counterparts (pure string formatters).
+///
+/// Resolution order (A1.1 of SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_
+/// 2026_06_05):
+///   1. `$XDG_RUNTIME_DIR/agentmux/` — preferred.
+///   2. `/tmp/agentmux-{uid}/` — fallback.
+#[cfg(unix)]
+pub fn ipc_socket_dir_path() -> std::path::PathBuf {
+    if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let mut p = std::path::PathBuf::from(runtime);
+        p.push("agentmux");
+        p
+    } else {
+        let uid = unsafe { libc::getuid() };
+        std::path::PathBuf::from(format!("/tmp/agentmux-{}", uid))
+    }
 }
 
 /// Directory under which all launcher Unix sockets live. Created with
@@ -101,18 +133,29 @@ pub fn srv_pipe_name(data_dir_hash16: &str) -> String {
 ///   * Refusal = `std::process::exit(2)` with a clear error. We do
 ///     NOT try to recover by picking a different path; that would
 ///     enlarge the trust boundary.
+/// Ensure the IPC socket directory exists with safe ownership + mode.
+///
+/// This is the SIDE-EFFECTING half of the path/ensure split — callers
+/// that need the directory to actually exist (only the launcher's
+/// startup path) call this BEFORE binding/connecting. Read-only
+/// inspectors (e.g. future `--diag` tools) use `ipc_socket_dir_path`
+/// directly and never reach this code.
+///
+/// Returns the validated directory path on success. Calls
+/// `std::process::exit(2)` on any verification failure — we do NOT
+/// recover by picking a different path; that would enlarge the trust
+/// boundary.
+///
+/// (Reagent P2 on PR #1288: previously this logic was inside the
+/// `ipc_socket_dir` function which `pipe_name` called, making
+/// `pipe_name` a filesystem-mutating + process-exiting function on
+/// Unix while it's a pure string formatter on Windows. Split into a
+/// pure `ipc_socket_dir_path` + this ensure-step.)
 #[cfg(unix)]
-pub fn ipc_socket_dir() -> std::path::PathBuf {
+pub fn ensure_ipc_socket_dir() -> std::path::PathBuf {
     use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
 
-    let dir = if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
-        let mut p = std::path::PathBuf::from(runtime);
-        p.push("agentmux");
-        p
-    } else {
-        let uid = unsafe { libc::getuid() };
-        std::path::PathBuf::from(format!("/tmp/agentmux-{}", uid))
-    };
+    let dir = ipc_socket_dir_path();
 
     // Security (codex P1 on PR #1288): the /tmp fallback is reachable
     // by any local user. If an attacker pre-creates the path with a

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -172,16 +172,57 @@ pub fn run_ipc_server(
     })
 }
 
-#[cfg(not(target_os = "windows"))]
+/// Unix counterpart of `bind_first_pipe_instance`: bind a Unix
+/// domain socket. The bind is the single-instance signal — a second
+/// launcher pointing at the same socket path gets `EADDRINUSE`. Caller
+/// is responsible for unlinking a stale socket file first (see the
+/// `connect → ECONNREFUSED → unlink → bind` pattern in `main.rs::run_unix`).
+///
+/// A1.1 of SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.
+#[cfg(unix)]
+pub fn bind_first_unix_socket(socket_path: &str) -> std::io::Result<tokio::net::UnixListener> {
+    tokio::net::UnixListener::bind(socket_path)
+}
+
+/// Run the Unix-domain-socket IPC server until cancelled (or task panics).
+///
+/// Mirrors the Windows accept loop above. The protocol on the wire is
+/// identical (newline-delimited JSON `Command` / `Event`) so
+/// `handle_connection` is shared between platforms via generics.
+///
+/// The listener is passed in pre-bound by the caller so a collision
+/// (a second launcher pointing at the same data dir) can be surfaced
+/// synchronously before any children spawn. (Same Phase B.6 contract
+/// as the Windows path.)
+#[cfg(unix)]
 pub fn run_ipc_server(
-    _pipe_name: String,
-    _ctx: ServerCtx,
+    socket_path: String,
+    listener: tokio::net::UnixListener,
+    ctx: ServerCtx,
 ) -> tokio::task::JoinHandle<()> {
-    // Non-Windows: pipe IPC isn't built yet. Phase 7 of the broader
-    // tear-off cross-platform work (separate spec) will add Unix
-    // domain socket support. For now return an immediately-finished
-    // task so the caller can hold a handle uniformly.
-    tokio::spawn(async {})
+    tokio::spawn(async move {
+        let ctx = Arc::new(ctx);
+        crate::log(&format!("[ipc] server starting on {}", socket_path));
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, _addr)) => {
+                    tokio::spawn(handle_connection(stream, Arc::clone(&ctx)));
+                }
+                Err(e) => {
+                    // Transient accept errors (EMFILE, ENFILE, ECONNABORTED)
+                    // shouldn't kill the server — log and continue. A
+                    // permanent error (e.g. listener fd closed) keeps
+                    // returning the same error indefinitely; we'd burn CPU
+                    // logging it. Yield to the runtime so the supervisor
+                    // has a chance to abort us if the launcher is shutting
+                    // down. (Mirrors Win32 accept-loop hygiene from above.)
+                    crate::log(&format!("[ipc] accept error: {} — continuing", e));
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    })
 }
 
 /// Drive one connection: read newline-delimited JSON Commands,
@@ -199,8 +240,16 @@ pub fn run_ipc_server(
 /// direct writes are reserved for "response-to-this-client-only"
 /// errors (parse failure, register-first violation). (codex P1
 /// PR #605.)
-#[cfg(target_os = "windows")]
-async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
+// (gate removed — platform-neutral body, accessible from cfg(unix) too — A1.1)
+//
+// Generic over the duplex stream type so the same body serves Windows
+// `NamedPipeServer` and Unix `tokio::net::UnixStream` without code
+// duplication. Bounds are what `tokio::io::split` + `Box<dyn AsyncWrite>`
+// need: AsyncRead + AsyncWrite + Unpin + Send + 'static.
+async fn handle_connection<S>(stream: S, ctx: Arc<ServerCtx>)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
     let (read_half, write_half) = tokio::io::split(stream);
     // CPD-2 — wrap the writer in the HostPipe-compatible
     // `Arc<Mutex<Box<dyn AsyncWrite + Unpin + Send>>>` shape so the
@@ -589,7 +638,7 @@ static NEXT_CONN_ID: std::sync::atomic::AtomicU64 =
 /// Without this, the reducer's process record stays Running and a
 /// reconnect from the same live PID hits AlreadyRegistered.
 /// (codex P1 #610.)
-#[cfg(target_os = "windows")]
+// (gate removed — platform-neutral body, accessible from cfg(unix) too — A1.1)
 async fn dispatch_synthetic_goodbye(
     ctx: &Arc<ServerCtx>,
     conn_id: u64,
@@ -637,7 +686,7 @@ fn launcher_start_ms() -> u64 {
 /// Enforce the "first message must be Register" invariant. Returns
 /// `Some(Event::Error)` if the command violates the contract; the
 /// caller sends it and closes the connection.
-#[cfg(target_os = "windows")]
+// (gate removed — platform-neutral body, accessible from cfg(unix) too — A1.1)
 async fn enforce_register_first(
     cmd: &Command,
     registered_kind: &Option<ClientKind>,
@@ -922,7 +971,7 @@ fn patch_launcher_identity(event: Event, ctx: &Arc<ServerCtx>) -> Event {
 /// `Event` JSON to preserve backwards compat with existing host
 /// versions that haven't adopted the envelope yet — CPD-1 lands the
 /// host-side schema migration.
-#[cfg(target_os = "windows")]
+// (gate removed — platform-neutral body, accessible from cfg(unix) too — A1.1)
 async fn send_event_shared(
     writer: &crate::host_pipe::SharedWriter,
     event: Event,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -204,21 +204,40 @@ pub fn run_ipc_server(
         let ctx = Arc::new(ctx);
         crate::log(&format!("[ipc] server starting on {}", socket_path));
 
+        // Backoff state — guard against a persistent accept error
+        // (e.g. EMFILE/ENFILE under fd exhaustion, EBADF if the
+        // listener fd is closed out from under us) spinning a hot
+        // loop and flooding the launcher log. Reagent P2 on PR #1288.
+        const MAX_CONSECUTIVE_ACCEPT_ERRORS: u32 = 32;
+        let mut consecutive_errors: u32 = 0;
+
         loop {
             match listener.accept().await {
                 Ok((stream, _addr)) => {
+                    consecutive_errors = 0;
                     tokio::spawn(handle_connection(stream, Arc::clone(&ctx)));
                 }
                 Err(e) => {
-                    // Transient accept errors (EMFILE, ENFILE, ECONNABORTED)
-                    // shouldn't kill the server — log and continue. A
-                    // permanent error (e.g. listener fd closed) keeps
-                    // returning the same error indefinitely; we'd burn CPU
-                    // logging it. Yield to the runtime so the supervisor
-                    // has a chance to abort us if the launcher is shutting
-                    // down. (Mirrors Win32 accept-loop hygiene from above.)
-                    crate::log(&format!("[ipc] accept error: {} — continuing", e));
-                    tokio::task::yield_now().await;
+                    consecutive_errors = consecutive_errors.saturating_add(1);
+                    if consecutive_errors >= MAX_CONSECUTIVE_ACCEPT_ERRORS {
+                        crate::log(&format!(
+                            "[ipc] FATAL: {} consecutive accept errors (last: {}); listener appears permanently broken — stopping IPC server",
+                            consecutive_errors, e
+                        ));
+                        return;
+                    }
+                    // Exponential backoff capped at 1s: 1ms → 2ms → 4ms
+                    // → … → 1024ms → 1024ms. Keeps EMFILE/ENFILE
+                    // recovery responsive (most descriptor pressure
+                    // clears in microseconds) without hot-spinning a
+                    // CPU core on a truly broken listener.
+                    let backoff_ms = 1u64 << consecutive_errors.min(10);
+                    let backoff = std::time::Duration::from_millis(backoff_ms.min(1024));
+                    crate::log(&format!(
+                        "[ipc] accept error #{}: {} — backing off {:?}",
+                        consecutive_errors, e, backoff
+                    ));
+                    tokio::time::sleep(backoff).await;
                 }
             }
         }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -487,18 +487,33 @@ async fn next_signal(s: &mut Option<tokio::signal::unix::Signal>) {
     }
 }
 
-/// Unix (macOS/Linux) main flow, Phase 1: resolve paths → spawn srv →
-/// spawn host with srv endpoints in env → supervised wait → cleanup.
+/// Unix (macOS/Linux) main flow: resolve paths → bind launcher IPC
+/// socket (single-instance signal) → set up reducer / event log / saga
+/// coordinator / IPC server → spawn srv → spawn host with srv endpoints
+/// AND the launcher socket path in env → supervised wait → cleanup.
+///
+/// As of A1 (SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md §4)
+/// the launcher's window/pool/instance reducer + durable saga
+/// coordinator are now live on Linux. The 17 host-side `report_*` IPC
+/// calls reach the reducer; the saga log persists at
+/// `<data-dir>/db/launcher-sagas.db`; second-instance launches are
+/// detected via socket-bind contention.
 ///
 /// Differs from `run_windows` only where the OS forces it:
-///   * No Job Object — children inherit the launcher's process group, so
-///     a terminal Ctrl+C (SIGINT to the foreground group) already reaches
-///     host + srv directly. We additionally install SIGINT/SIGTERM
-///     handlers so `kill <launcher-pid>` (signal to the launcher alone)
-///     also tears the tree down deterministically.
-///   * No named-pipe IPC yet (Phase 2): srv is launched WITHOUT an
-///     AGENTMUX_SRV_PIPE_PATH, so it skips binding its IPC pipe — exactly
-///     as in today's `task dev` direct-invoke mode.
+///   * No Job Object — A0 (`PR_SET_PDEATHSIG` in `spawn_host_unix` and
+///     `srv_spawner`) gives the equivalent kernel-side reap when the
+///     launcher dies abnormally. Terminal Ctrl+C reaches the process
+///     group; explicit SIGINT/SIGTERM handlers cover the
+///     `kill <launcher-pid>` case.
+///   * Unix-domain-socket IPC (A1) instead of named pipes; protocol on
+///     the wire is identical (newline-delimited JSON Command/Event).
+///     The launcher-side server uses `tokio::net::UnixListener`; the
+///     host-side client uses `tokio::net::UnixStream`. See
+///     `ipc::server::run_ipc_server` (Unix arm) and
+///     `agentmux-cef/src/launcher_ipc.rs::connect_to_launcher` (Unix arm).
+///   * srv-side IPC is still skipped on Linux (srv is launched with an
+///     empty `srv_pipe_path`); follow-up PR will bring srv's Unix
+///     socket online too.
 ///   * Cleanup is SIGTERM-then-SIGKILL (we own the reap) rather than
 ///     KILL_ON_JOB_CLOSE.
 ///

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -745,9 +745,10 @@ async fn run_unix(
     let _srv_stdin_keepalive = srv_child.stdin.take();
 
     // 3. Spawn the host with srv endpoints in env.
-    let dir_hash_unix = hash::data_dir_hash16(&paths.data_dir, version);
+    // dir_hash was computed once above for socket_path; reuse it here
+    // instead of re-hashing the same paths.data_dir + version.
     let mut host_env = paths.common.to_env_vars();
-    host_env.push(("AGENTMUX_IPC_HASH", std::ffi::OsString::from(&dir_hash_unix)));
+    host_env.push(("AGENTMUX_IPC_HASH", std::ffi::OsString::from(&dir_hash)));
     // A1.3 — IPC env handshake. Tell the host where to find the
     // launcher socket. The env var name `AGENTMUX_LAUNCHER_PIPE` is
     // reused from the Windows side even though the underlying resource

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -487,6 +487,152 @@ async fn next_signal(s: &mut Option<tokio::signal::unix::Signal>) {
     }
 }
 
+/// Bind the launcher's IPC socket with single-instance enforcement +
+/// crash-safe stale-socket recovery, serialized across concurrent
+/// launchers via `flock(2)`.
+///
+/// Returns a bound `UnixListener` on success. Calls `std::process::exit`
+/// on:
+///   * second-instance detection (exit code 0)
+///   * a hard bind failure that isn't `EADDRINUSE` (exit code 2)
+///   * unable to acquire the recovery lock (exit code 2)
+///
+/// Why the lockfile (codex P1 + reagent P1 on PR #1288): see the call-
+/// site comment. Two-launcher concurrent stale-cleanup would otherwise
+/// produce two live launchers for one data dir.
+#[cfg(not(target_os = "windows"))]
+fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
+    use std::os::unix::io::AsRawFd as _;
+
+    // Fast path: bind without contention.
+    match ipc::server::bind_first_unix_socket(socket_path) {
+        Ok(l) => return l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => { /* slow path below */ }
+        Err(e) => {
+            log(&format!("FATAL: bind {} failed: {}", socket_path, e));
+            eprintln!(
+                "AgentMux failed to start: could not bind IPC socket.\n\nSocket: {}\nError: {}",
+                socket_path, e
+            );
+            std::process::exit(2);
+        }
+    }
+
+    // Slow path: contention. Acquire the recovery lock so only one
+    // launcher at a time does the connect-probe + unlink + rebind.
+    let lock_path = format!("{}.lock", socket_path);
+    let lock_file = match std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            log(&format!(
+                "FATAL: could not open recovery lockfile {}: {}",
+                lock_path, e
+            ));
+            eprintln!(
+                "AgentMux failed to start: could not open IPC recovery lockfile.\n\nLockfile: {}\nError: {}",
+                lock_path, e
+            );
+            std::process::exit(2);
+        }
+    };
+    // Block until we have the lock — another launcher's recovery
+    // window is bounded by a single bind + a single connect-probe;
+    // we won't wait long. flock(2) is auto-released on close (when
+    // the OS reaps the launcher process), so a SIGKILL'd holder
+    // doesn't leak the lock.
+    if unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        let errno = std::io::Error::last_os_error();
+        log(&format!(
+            "FATAL: flock({}, LOCK_EX) failed: {}",
+            lock_path, errno
+        ));
+        eprintln!(
+            "AgentMux failed to start: could not acquire IPC recovery lock.\n\nLockfile: {}\nError: {}",
+            lock_path, errno
+        );
+        std::process::exit(2);
+    }
+
+    // Retry the bind under the lock — another launcher may have
+    // already cleaned up the stale file while we were waiting on
+    // flock, leaving us free to bind directly.
+    match ipc::server::bind_first_unix_socket(socket_path) {
+        Ok(l) => return l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => { /* probe below */ }
+        Err(e) => {
+            log(&format!(
+                "FATAL: post-lock bind {} failed: {}",
+                socket_path, e
+            ));
+            eprintln!(
+                "AgentMux failed to start: post-lock IPC bind failed.\n\nSocket: {}\nError: {}",
+                socket_path, e
+            );
+            std::process::exit(2);
+        }
+    }
+
+    // Disambiguate: is the existing socket a real running launcher,
+    // or a stale file?
+    match std::os::unix::net::UnixStream::connect(socket_path) {
+        Ok(_) => {
+            // Real second-instance. Exit cleanly so the existing
+            // launcher's window gets focus (Phase-2 arg-forwarding
+            // is a separate PR).
+            eprintln!(
+                "AgentMux is already running for this data directory.\n\nSocket: {}",
+                socket_path
+            );
+            log(&format!(
+                "[ipc] second-instance detected — existing launcher owns {}",
+                socket_path
+            ));
+            std::process::exit(0);
+        }
+        Err(connect_err)
+            if connect_err.kind() == std::io::ErrorKind::ConnectionRefused
+                || connect_err.raw_os_error() == Some(libc::ENOENT) =>
+        {
+            // Stale socket file from a crashed launcher. Unlink and
+            // rebind — under the lock, no other launcher can race us.
+            log(&format!(
+                "[ipc] stale socket file at {} — unlinking and rebinding (under recovery lock)",
+                socket_path
+            ));
+            let _ = std::fs::remove_file(socket_path);
+            match ipc::server::bind_first_unix_socket(socket_path) {
+                Ok(l) => l,
+                Err(retry_e) => {
+                    log(&format!(
+                        "FATAL: bind retry after stale-socket unlink failed: {}",
+                        retry_e
+                    ));
+                    eprintln!(
+                        "AgentMux failed to start: IPC rebind after stale cleanup failed.\n\nSocket: {}\nError: {}",
+                        socket_path, retry_e
+                    );
+                    std::process::exit(2);
+                }
+            }
+        }
+        Err(other) => {
+            log(&format!(
+                "[ipc] AddrInUse but connect probe failed in an unexpected way: {} — \
+                 treating as second instance and exiting cleanly",
+                other
+            ));
+            std::process::exit(0);
+        }
+    }
+    // `lock_file` drops here; flock auto-released on close.
+}
+
 /// Unix (macOS/Linux) main flow: resolve paths → bind launcher IPC
 /// socket (single-instance signal) → set up reducer / event log / saga
 /// coordinator / IPC server → spawn srv → spawn host with srv endpoints
@@ -578,70 +724,32 @@ async fn run_unix(
 
     // Single-instance handshake (A1.6). The bind is the authoritative
     // signal: a second launcher pointing at the same data dir gets
-    // `EADDRINUSE`. Handle stale-socket cleanup with the canonical
-    // pattern: `connect → ECONNREFUSED → unlink → bind`.
-    let first_socket = match ipc::server::bind_first_unix_socket(&socket_path) {
-        Ok(l) => l,
-        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-            // Could be a real running launcher OR a stale socket file
-            // left over from a crash. Try to connect to disambiguate.
-            match std::os::unix::net::UnixStream::connect(&socket_path) {
-                Ok(_) => {
-                    // Another launcher is listening — second-instance
-                    // case. Exit cleanly so the existing instance's
-                    // window gets focus (Phase-2 will forward args via
-                    // a Command frame; today we just exit).
-                    eprintln!(
-                        "AgentMux is already running for this data directory.\n\nSocket: {}",
-                        socket_path
-                    );
-                    log(&format!(
-                        "[ipc] second-instance detected — existing launcher owns {}",
-                        socket_path
-                    ));
-                    std::process::exit(0);
-                }
-                Err(connect_err)
-                    if connect_err.kind() == std::io::ErrorKind::ConnectionRefused
-                        || connect_err.raw_os_error() == Some(libc::ENOENT) =>
-                {
-                    // Stale socket file from a crashed launcher. Unlink
-                    // and retry the bind.
-                    log(&format!(
-                        "[ipc] stale socket file at {} — unlinking and rebinding",
-                        socket_path
-                    ));
-                    let _ = std::fs::remove_file(&socket_path);
-                    match ipc::server::bind_first_unix_socket(&socket_path) {
-                        Ok(l) => l,
-                        Err(retry_e) => {
-                            log(&format!(
-                                "FATAL: bind retry after stale-socket unlink failed: {}",
-                                retry_e
-                            ));
-                            std::process::exit(2);
-                        }
-                    }
-                }
-                Err(other) => {
-                    log(&format!(
-                        "[ipc] AddrInUse but connect probe failed in an unexpected way: {} — \
-                         treating as second instance and exiting cleanly",
-                        other
-                    ));
-                    std::process::exit(0);
-                }
-            }
-        }
-        Err(e) => {
-            log(&format!("FATAL: bind {} failed: {}", socket_path, e));
-            eprintln!(
-                "AgentMux failed to start: could not bind IPC socket.\n\nSocket: {}\nError: {}",
-                socket_path, e
-            );
-            std::process::exit(2);
-        }
-    };
+    // `EADDRINUSE`. The Windows path enjoys atomic `first_pipe_
+    // instance(true)`; Unix bind isn't atomic with respect to stale-
+    // file recovery, so we serialize that recovery via an `flock(2)`
+    // lockfile (codex P1 + reagent P1 on PR #1288).
+    //
+    // Concurrent-cleanup race the lockfile defends against:
+    //   1. Stale socket file remains from a crashed prior launcher.
+    //   2. Launcher A and B start concurrently. Both `bind` returns
+    //      EADDRINUSE because the file exists.
+    //   3. Without the lock: both A and B `connect` → ECONNREFUSED
+    //      (no listener on the stale file), both `unlink`, both
+    //      `bind` succeeds → two live launchers for one data dir,
+    //      and B's `unlink` may have removed A's freshly-bound
+    //      socket file before B bound its own.
+    //   4. With the lock: A holds the lock → does probe + unlink +
+    //      rebind atomically. B blocks on the lock. When A releases,
+    //      B's retry-bind sees A's running listener (file exists) and
+    //      B's `connect` succeeds → B exits cleanly as second
+    //      instance. No double-recovery.
+    //
+    // The lockfile lives next to the socket as `<socket>.lock`. It is
+    // intentionally NOT removed on clean shutdown — the inode is
+    // tiny, and leaving it lets the next launcher reuse it without a
+    // create-race. (Stale-lock-file scenarios are bounded: flock(2)
+    // is auto-released on process exit even for SIGKILL.)
+    let first_socket = bind_socket_with_recovery(&socket_path);
 
     // Broadcast bus for reducer-emitted events. Same capacity (1024)
     // and rationale as the Windows path.

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -600,7 +600,15 @@ fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
                 || connect_err.raw_os_error() == Some(libc::ENOENT) =>
         {
             // Stale socket file from a crashed launcher. Unlink and
-            // rebind — under the lock, no other launcher can race us.
+            // rebind. The lock serializes us against other launchers
+            // ALSO doing recovery, but it does NOT block a fresh
+            // launcher taking the fast-path bind() above — that
+            // launcher is lock-free and can win the socket in the
+            // microsecond window between our `remove_file` and our
+            // `bind`. If that happens, AddrInUse means a real
+            // launcher just claimed the socket and WE are now the
+            // losing second instance, not a failed start.
+            // (Reagent P2 on PR #1288.)
             log(&format!(
                 "[ipc] stale socket file at {} — unlinking and rebinding (under recovery lock)",
                 socket_path
@@ -608,6 +616,17 @@ fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
             let _ = std::fs::remove_file(socket_path);
             match ipc::server::bind_first_unix_socket(socket_path) {
                 Ok(l) => l,
+                Err(retry_e) if retry_e.kind() == std::io::ErrorKind::AddrInUse => {
+                    eprintln!(
+                        "AgentMux is already running for this data directory.\n\nSocket: {}",
+                        socket_path
+                    );
+                    log(&format!(
+                        "[ipc] post-recovery bind lost the race to a fresh launcher on {} — exiting as second instance",
+                        socket_path
+                    ));
+                    std::process::exit(0);
+                }
                 Err(retry_e) => {
                     log(&format!(
                         "FATAL: bind retry after stale-socket unlink failed: {}",

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -538,9 +538,196 @@ async fn run_unix(
         std::process::exit(1);
     }
 
-    // 2. Spawn srv. Empty pipe path → srv skips its IPC bind (Phase 2
-    //    wires the Unix-socket transport). spawn_srv is already
-    //    Unix-clean (the job_handle param is #[cfg(windows)]).
+    // -----------------------------------------------------------------
+    // A1.1 — IPC server setup on Linux (the wire is up). Mirrors the
+    // Windows path at the equivalent point in `run_windows`. Once this
+    // lands the host's 17 `report_*` IPC calls reach the (already
+    // platform-neutral) reducer, the window-pool / single-instance /
+    // instance-numbering logic activates, sagas get persisted to the
+    // launcher_saga.db SQLite log, and `--diag sagas` reads something
+    // useful.
+    //
+    // Spec: docs/specs/SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md §4
+    // -----------------------------------------------------------------
+
+    // Compute the socket path from a data-dir hash + version, identical
+    // scoping rule to the Windows pipe namespace.
+    let dir_hash = hash::data_dir_hash16(&paths.data_dir, version);
+    let socket_path = ipc::pipe_name(&dir_hash);
+    log(&format!(
+        "launcher IPC socket = {} (data_dir={} version={})",
+        socket_path,
+        paths.data_dir.display(),
+        version
+    ));
+
+    // Single-instance handshake (A1.6). The bind is the authoritative
+    // signal: a second launcher pointing at the same data dir gets
+    // `EADDRINUSE`. Handle stale-socket cleanup with the canonical
+    // pattern: `connect → ECONNREFUSED → unlink → bind`.
+    let first_socket = match ipc::server::bind_first_unix_socket(&socket_path) {
+        Ok(l) => l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            // Could be a real running launcher OR a stale socket file
+            // left over from a crash. Try to connect to disambiguate.
+            match std::os::unix::net::UnixStream::connect(&socket_path) {
+                Ok(_) => {
+                    // Another launcher is listening — second-instance
+                    // case. Exit cleanly so the existing instance's
+                    // window gets focus (Phase-2 will forward args via
+                    // a Command frame; today we just exit).
+                    eprintln!(
+                        "AgentMux is already running for this data directory.\n\nSocket: {}",
+                        socket_path
+                    );
+                    log(&format!(
+                        "[ipc] second-instance detected — existing launcher owns {}",
+                        socket_path
+                    ));
+                    std::process::exit(0);
+                }
+                Err(connect_err)
+                    if connect_err.kind() == std::io::ErrorKind::ConnectionRefused
+                        || connect_err.raw_os_error() == Some(libc::ENOENT) =>
+                {
+                    // Stale socket file from a crashed launcher. Unlink
+                    // and retry the bind.
+                    log(&format!(
+                        "[ipc] stale socket file at {} — unlinking and rebinding",
+                        socket_path
+                    ));
+                    let _ = std::fs::remove_file(&socket_path);
+                    match ipc::server::bind_first_unix_socket(&socket_path) {
+                        Ok(l) => l,
+                        Err(retry_e) => {
+                            log(&format!(
+                                "FATAL: bind retry after stale-socket unlink failed: {}",
+                                retry_e
+                            ));
+                            std::process::exit(2);
+                        }
+                    }
+                }
+                Err(other) => {
+                    log(&format!(
+                        "[ipc] AddrInUse but connect probe failed in an unexpected way: {} — \
+                         treating as second instance and exiting cleanly",
+                        other
+                    ));
+                    std::process::exit(0);
+                }
+            }
+        }
+        Err(e) => {
+            log(&format!("FATAL: bind {} failed: {}", socket_path, e));
+            eprintln!(
+                "AgentMux failed to start: could not bind IPC socket.\n\nSocket: {}\nError: {}",
+                socket_path, e
+            );
+            std::process::exit(2);
+        }
+    };
+
+    // Broadcast bus for reducer-emitted events. Same capacity (1024)
+    // and rationale as the Windows path.
+    let (events_tx, _) =
+        tokio::sync::broadcast::channel::<agentmux_common::ipc::Event>(1024);
+
+    // Event log: in-memory ring + disk persistence at
+    // <data-dir>/launcher-events.log. Disk writer task spawned next.
+    let log_disk_path = paths.data_dir.join("launcher-events.log");
+    let event_log = std::sync::Arc::new(event_log::EventLog::new(Some(log_disk_path)));
+    let event_log_for_writer = std::sync::Arc::clone(&event_log);
+    let disk_writer_rx = events_tx.subscribe();
+    tokio::spawn(event_log::run_disk_writer(
+        event_log_for_writer,
+        disk_writer_rx,
+    ));
+
+    // Canonical state shared between IPC server + saga coordinator.
+    let state = std::sync::Arc::new(tokio::sync::Mutex::new(state::State::default()));
+
+    // Durable saga log at <data-dir>/db/launcher-sagas.db.
+    let saga_log_path = data_dir::launcher_saga_log_path(&paths.data_dir);
+    let saga_log = match saga::LauncherSagaLog::open(&saga_log_path) {
+        Ok(l) => std::sync::Arc::new(l),
+        Err(e) => {
+            log(&format!(
+                "FATAL: failed to open launcher saga log at {:?}: {}",
+                saga_log_path, e
+            ));
+            std::process::exit(2);
+        }
+    };
+
+    // Startup recovery walker: mark any saga left running from a prior
+    // crashed run as failed_compensation. Must run BEFORE coordinator
+    // spawn (LSD-3).
+    if let Err(e) = saga::compensate_unresolved_launcher_sagas(&saga_log).await {
+        log(&format!(
+            "[saga-recovery] WARN: walker failed: {} — coordinator will still spawn",
+            e
+        ));
+    }
+
+    // Startup retention vacuum (LSD-4).
+    let retention_days = config::load_saga_retention_days(&paths.user_home_dir, |w| log(w));
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days);
+    match saga_log.vacuum_older_than(cutoff) {
+        Ok(removed) => log(&format!(
+            "[saga-log] vacuumed {} sagas older than {} (retention {} days)",
+            removed, cutoff, retention_days
+        )),
+        Err(e) => log(&format!("[saga-log] WARN: vacuum failed: {}", e)),
+    }
+
+    // Host pipe wrapper for saga-issued Commands → host. The IPC
+    // server's per-connection handler installs the host's writer once
+    // the host registers (see ipc/server.rs handle_connection's
+    // ClientKind::Host branch).
+    let host_pipe = std::sync::Arc::new(host_pipe::HostPipe::new(
+        events_tx.clone(),
+        std::sync::Arc::clone(&state),
+    ));
+
+    // Saga coordinator. Same construction + error handling as the
+    // Windows path; the coordinator itself is platform-neutral.
+    let saga_coord_inner =
+        saga::SagaCoordinator::new(events_tx.clone(), std::sync::Arc::clone(&state))
+            .with_log(std::sync::Arc::clone(&saga_log))
+            .unwrap_or_else(|e| {
+                log(&format!(
+                    "[main] FATAL: failed to seed saga_id allocator: {}",
+                    e
+                ));
+                std::process::exit(1);
+            })
+            .with_host_pipe(std::sync::Arc::clone(&host_pipe));
+    let saga_coord = std::sync::Arc::new(saga_coord_inner);
+    let saga_rx = events_tx.subscribe();
+    tokio::spawn(saga::run_coordinator(
+        std::sync::Arc::clone(&saga_coord),
+        saga_rx,
+    ));
+
+    let _ipc_handle = ipc::run_ipc_server(
+        socket_path.clone(),
+        first_socket,
+        ipc::server::ServerCtx {
+            launcher_pid: std::process::id(),
+            launcher_version: env!("CARGO_PKG_VERSION").to_string(),
+            state,
+            events_tx,
+            event_log,
+            host_pipe: std::sync::Arc::clone(&host_pipe),
+        },
+    );
+    log(&format!("IPC server started on {}", socket_path));
+
+    // 2. Spawn srv. The srv pipe path is the launcher-owned socket
+    //    path scope (srv will gain its own Unix-socket bind in a
+    //    follow-up; for now we still pass an empty string so srv's
+    //    Windows-only IPC code stays disabled).
     let srv_pipe_path = String::new();
     let (srv_result, mut srv_child) =
         match srv_spawner::spawn_srv(launcher_exe_dir, &paths, &srv_pipe_path).await {
@@ -561,6 +748,26 @@ async fn run_unix(
     let dir_hash_unix = hash::data_dir_hash16(&paths.data_dir, version);
     let mut host_env = paths.common.to_env_vars();
     host_env.push(("AGENTMUX_IPC_HASH", std::ffi::OsString::from(&dir_hash_unix)));
+    // A1.3 — IPC env handshake. Tell the host where to find the
+    // launcher socket. The env var name `AGENTMUX_LAUNCHER_PIPE` is
+    // reused from the Windows side even though the underlying resource
+    // is a Unix-domain socket — keeps the 17 `report_*` call sites in
+    // `agentmux-cef/src/launcher_ipc.rs` unchanged and avoids touching
+    // the host's connect-on-startup code in `agentmux-cef/src/app.rs`.
+    host_env.push((
+        "AGENTMUX_LAUNCHER_PIPE",
+        std::ffi::OsString::from(&socket_path),
+    ));
+    // AGENTMUX_HOME = the host's runtime directory (siblings of the
+    // host binary — libcef.so, paks, locales, etc). Mirrors the
+    // Windows path so the host's asset-resolution code finds its
+    // co-located data without searching $PATH-like fallbacks.
+    if let Some(host_runtime) = real_exe.parent() {
+        host_env.push((
+            "AGENTMUX_HOME",
+            std::ffi::OsString::from(host_runtime),
+        ));
+    }
     let mut host_child = match spawn_host_unix(real_exe, args, &srv_result, &host_env, false) {
         Some(c) => c,
         None => {

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -731,7 +731,11 @@ async fn run_unix(
     // -----------------------------------------------------------------
 
     // Compute the socket path from a data-dir hash + version, identical
-    // scoping rule to the Windows pipe namespace.
+    // scoping rule to the Windows pipe namespace. `pipe_name` is now
+    // pure on both platforms — the side-effecting ensure step lives
+    // in `ensure_ipc_socket_dir` and is invoked separately below so
+    // that any future read-only inspector (e.g. a Linux `--diag`
+    // port) can call `pipe_name` without mutating the filesystem.
     let dir_hash = hash::data_dir_hash16(&paths.data_dir, version);
     let socket_path = ipc::pipe_name(&dir_hash);
     log(&format!(
@@ -740,6 +744,10 @@ async fn run_unix(
         paths.data_dir.display(),
         version
     ));
+    // Ensure the socket dir exists with safe ownership/perms BEFORE
+    // any bind attempts. This may call std::process::exit(2) on a
+    // hostile-dir-on-disk scenario (cross-user squatting attack).
+    let _ = ipc::ensure_ipc_socket_dir();
 
     // Single-instance handshake (A1.6). The bind is the authoritative
     // signal: a second launcher pointing at the same data dir gets


### PR DESCRIPTION
## Summary

A1 of [SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md](../blob/main/docs/specs/SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md). Follow-up to #1286 (A0).

Before this PR, the launcher's reducer + durable saga coordinator (already platform-neutral in `agentmux-launcher/src/state.rs`, `src/reducer/`, `src/saga/`) were dormant on Linux because the only transport that drives them was a no-op stub:

- `agentmux-launcher/src/ipc/server.rs:175-185`: non-Windows `run_ipc_server` was literally `tokio::spawn(async {})`
- `agentmux-cef/src/launcher_ipc.rs:298-303`: non-Windows `connect_to_launcher` returned `None`
- `agentmux-launcher/src/main.rs::spawn_host_unix`: didn't export `AGENTMUX_LAUNCHER_PIPE`

This PR makes the wire come up:

| Sub-step | What it does | LOC |
|---|---|---|
| **A1.1** | `handle_connection` made generic over duplex streams; Unix `run_ipc_server` + `bind_first_unix_socket` mirror the Windows accept loop; `pipe_name`/`srv_pipe_name` get `cfg(unix)` arms; `run_unix` in main.rs gets the full IPC + saga setup that `run_windows` already had (incl. single-instance handshake via `connect → ECONNREFUSED → unlink → bind`) | ~290 |
| **A1.2** | Host-side `connect_to_launcher` Unix variant mirrors the Windows path line for line via `tokio::net::UnixStream`. `saga_dispatch::LiveActionRunner` ungated (body was already platform-neutral) | ~200 |
| **A1.3** | `spawn_host_unix` exports `AGENTMUX_LAUNCHER_PIPE` (the socket path) and `AGENTMUX_HOME` | ~20 |

## Smoke-test result

Verified end-to-end on this machine:

```
[launcher-ipc] connected to /run/user/1000/agentmux/<hash>.sock
[launcher-ipc] received event: ProcessSpawned { pid, kind: Host }
[launcher-ipc] received event: LifecyclePhaseChanged { from: Starting, to: Running }
[launcher-ipc] received event: Registered { client_id: 1, launcher_pid }
[host-reducer] event="BrowserRegistered" label=main version=1
[launcher-ipc] received event: WindowOpened { label: "main", kind: FullInstance }
[launcher-ipc] received event: WindowInstanceAssigned { label: "main", num: 1 }
```

- ✅ Socket bound at `$XDG_RUNTIME_DIR/agentmux/<hash>.sock` under a 0700 dir
- ✅ Host `connect_to_launcher` succeeds; Register accepted by the reducer (`client_id: 1`)
- ✅ Window pool reducer driving — BrowserRegistered → WindowOpened sequence
- ✅ **Instance numbering working** (`num: 1` — first thing the user actually sees)
- ✅ Saga log written at `<data-dir>/db/launcher-sagas.db` with the documented schema
- ✅ A0's `PR_SET_PDEATHSIG` reap still works (kill -9 launcher → host + srv reaped within 200ms)
- ✅ Second-instance launch: connect-probe succeeds → second launcher exits cleanly without spawning a second host

## What's NOT in this PR

- **srv-side Unix-socket IPC** — srv still skips its IPC bind on Linux. Launcher passes empty `srv_pipe_path` to spawn_srv. Separate follow-up.
- **A1.4 (pre_exec supervision parity)** — landed in A0 (#1286) already
- **A1.5 (cgroup-v2 hardening)** — deferred per spec
- **A1.6 (arg forwarding from second instance)** — second instance exits cleanly today; forwarding the args via a Command is a separate small PR
- **B (splash_linux.rs)** — independent workstream

## Blast radius

- **Linux/Unix gains**: full reducer + saga + window-pool + instance-numbering machinery activates. Single-instance enforcement comes online via socket-bind.
- **Windows**: unchanged behaviorally. Code changes:
  - `handle_connection` is now generic — same type-erased monomorphization in the Windows path
  - 4 helper functions lose their `#[cfg(target_os = "windows")]` gate (bodies were always neutral)
  - `LiveActionRunner` loses its Windows gate
  - **No semantic changes to the Windows path; the diff is type-discipline, not behavior**
- **macOS**: gets the same wire since `cfg(unix)` covers both. Will need its own `spawn_host_macos` env-export change to actually use it (separate PR — macOS launcher work is owned by SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31).

## Spec

`docs/specs/SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md` §4 — added in #1286.

## Test plan

- [x] `cargo build --release -p agentmux-launcher && cargo build --release -p agentmux-cef` both pass
- [x] AppImage launches, host's `connect_to_launcher` connects to the Unix socket
- [x] Register accepted, reducer events flow back to host via `apply_event_to_shadow`
- [x] Instance numbering assigns `num: 1`
- [x] Saga log written to `db/launcher-sagas.db`
- [x] A0 process-tree reap (`PR_SET_PDEATHSIG`) still works on top of A1
- [x] Second-instance launch returns cleanly without spawning a duplicate host
- [ ] Reagent + Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)