### PR TITLE
feat(drone): expansive node-graph canvas — top emoji bar, drag-to-place, pan/zoom

### DIFF
--- a/.changesets/1780670773-refactor-drone-store-backed-draft-graph-for-fine-grained-can-9crk.md
+++ b/.changesets/1780670773-refactor-drone-store-backed-draft-graph-for-fine-grained-can-9crk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(drone): store-backed draft graph for fine-grained canvas reactivity

--- a/.changesets/1780671235-feat-drone-pan-zoom-canvas-zoom-aware-node-drag-zoom-fit-con-st42.md
+++ b/.changesets/1780671235-feat-drone-pan-zoom-canvas-zoom-aware-node-drag-zoom-fit-con-st42.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(drone): pan/zoom canvas, zoom-aware node drag, zoom/fit controls

--- a/.changesets/1780671636-feat-drone-top-emoji-node-type-bar-drag-from-bar-onto-full-b-fvcw.md
+++ b/.changesets/1780671636-feat-drone-top-emoji-node-type-bar-drag-from-bar-onto-full-b-fvcw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(drone): top emoji node-type bar + drag-from-bar onto full-bleed canvas

--- a/.changesets/1780673049-fix-drone-inspector-title-tracks-selected-node-was-stale-7vu6.md
+++ b/.changesets/1780673049-fix-drone-inspector-title-tracks-selected-node-was-stale-7vu6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(drone): inspector title tracks selected node (was stale)

--- a/docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md
+++ b/docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md
@@ -1,0 +1,429 @@
+# SPEC — Drone Canvas: Expansive Node-Graph Editor
+
+- **Date:** 2026-06-05
+- **Author:** AgentX
+- **Status:** Draft / proposed
+- **Widget:** `defwidget@drone` → view `drone` (pinned)
+- **Scope:** Frontend (SolidJS) canvas rewrite + small backend touch-ups. Backend execution engine is **out of scope** (Phase-1 complete).
+- **Related:** `SPEC_RENAME_WORKFLOWS_TO_DRONE_2026_05_18.md`, `SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md`, `REPORT_DRONE_VS_WORKFLOW_ENGINE_2026_05_08.md`
+- **Tracking:** GitHub **issue #753** (RFC: Workflows pane — Sim-modeled DAG executor) and **discussion #832** (Workflows pane — long-term tracking thread). ⚠️ **Both have drifted from the shipped code — see §0.1.**
+
+### 0.1 Relationship to the existing RFC (#753) — this spec supersedes two stale decisions
+
+The feature is tracked by **issue #753** + **discussion #832**, but the RFC predates the code as shipped and is wrong on two points this spec corrects:
+
+1. **Naming.** #753 proposes renaming Drone → "Workflows" with code under `frontend/app/view/workflows/`. That was **reversed** by `SPEC_RENAME_WORKFLOWS_TO_DRONE_2026_05_18.md` (dated *after* the RFC); the widget is `defwidget@drone` and the code lives in `frontend/app/view/drone/`. This spec uses the shipped names.
+2. **Canvas library.** #753's headline decision (§2 Q1) was "drop the ~750-LOC custom canvas, adopt `solid-flow` (miguelsalesvieira/solid-flow)." The team **did not** do this — a custom SVG canvas shipped instead. Independent research (2026-06-05) confirms `miguelsalesvieira/solid-flow` is **abandoned since 2022** (v1.0.4, Oct 2022; different non-xyflow API), and the alternative `@dschz/solid-flow` is a single-maintainer v0.1.x alpha. So the team's instinct to keep a custom canvas was correct. §3 here formalizes that: **build custom, borrow `@xyflow/system` for the d3/geometry math + `@dagrejs/dagre` for layout.**
+
+Everything else in #753 (5-block taxonomy, Mustache `{{...}}` interpolation, Agent-block-references-identity, SQLite run history, validator rules) **matches the shipped backend** and stands. Recommend posting this spec under discussion #832 and adding a correcting note to #753 rather than opening a new tracking issue.
+
+---
+
+## 0. TL;DR
+
+The drone pane today is a 3-column form (left palette · cramped SVG canvas · right inspector) where **you cannot drag nodes, pan, zoom, or drag from the palette** — so it reads as broken. The backend DAG engine behind it is already complete and solid.
+
+This spec rebuilds the *frontend canvas* into the requested experience:
+
+> **A horizontal node-type bar at the top (emoji + name chips), and the entire rest of the pane is one expansive DAG canvas.** You drag node-types down from the bar onto the canvas, wire nodes together by dragging between ports, pan/zoom freely, and the inspector + run state appear as overlays so they never eat canvas space.
+
+**Architecture decision:** **build out the existing custom SolidJS SVG/HTML canvas** rather than adopt a library. There is *no* production-grade SolidJS flow library (React Flow is React-only; the one Solid port is a bus-factor-1 alpha). We borrow only the framework-agnostic hard-math pieces: **`@xyflow/system`** (pan/zoom via d3, edge-path geometry, connection hit-testing) and **`@dagrejs/dagre`** (auto-layout). Everything else is Solid code we own — which suits the team's "control + minimal deps" bias and reuses the model/backend that are *already* xyflow-shaped.
+
+---
+
+## 1. Current state (ground truth)
+
+### 1.1 Frontend — `frontend/app/view/drone/`
+
+| File | Role | State |
+|---|---|---|
+| `drone.tsx` | Barrel; assigns `DroneView` to `DroneViewModel.prototype.viewComponent` | OK |
+| `drone-view.tsx` | The whole UI: `Toolbar`, `BlockPalette`, `Canvas`, `InspectorPanel`, `RunPanel` | **The rewrite target** |
+| `drone-model.ts` | `DroneViewModel` — draft graph state + RPC + run-state subscription | Mostly reusable; needs store migration + new mutations |
+| `block-registry.ts` | Per-kind metadata (label, color, icon, defaultData, handles) | Reusable; add `emoji` |
+| `drone-types.ts` | `FlowNode`, `FlowEdge`, `DroneGraph`, `DroneDefinition`, `DroneViewport` | Reusable (already xyflow-shaped) |
+| `drone-view.scss` | Styles | Largely rewritten |
+| `store/drone-run-state/*` | Reducer slice #10 — live run state (status, blockResults) | Reusable as-is |
+
+**Layout today** (`drone-view.tsx:16-29`): `Toolbar` (header) → `drone-body` = **`BlockPalette` (left aside) · `Canvas` (center) · `InspectorPanel` (right aside)** → `RunPanel` (footer). Three columns + two horizontal bars = the canvas is the *smallest* region, the opposite of the vision.
+
+**What the canvas can do today** (`drone-view.tsx:130-242`):
+- ✅ Add node — **click** a palette item → node spawns at `{80 + rand·60, 80 + rand·60}` (`drone-view.tsx:90`). Nodes stack near the origin.
+- ✅ Select node — click → `setSelected`; inspector edits work.
+- ✅ Remove node — `×` on node header.
+- ✅ Wire — **shift-click source then shift-click target** (`drone-view.tsx:136-174`); Condition branch handle auto-assigned by order (1st edge `true`, 2nd `false`).
+- ✅ Edges rendered as straight `<line>` with hard-coded offsets (`x1 = src.x+80, y1 = src.y+28`, `drone-view.tsx:190-196`).
+- ❌ **No node dragging** — `moveNode()` exists (`drone-model.ts:447`) but **no pointer handlers are wired**. This is the #1 "nothing works" symptom.
+- ❌ **No pan / zoom** — `viewport` is stored but never applied to a transform.
+- ❌ **No drag-from-palette** — explicitly deferred ("Phase 2 will use drag + drop", `drone-view.tsx:87`).
+- ❌ **No port handles** — wiring is whole-node→whole-node; no visible ports, no typed validation, no drag-to-connect.
+- ❌ **No edge delete / select**, no multi-select, no undo/redo, no fit-view, no minimap, no auto-layout.
+- ❌ **No emoji** — `icon` is an unused FontAwesome class string; palette shows a colored dot only.
+- ⚠️ `AgentRefEditor` references types `IdentityBundle` / `Memory` that may be missing from `gotypes` (`drone-view.tsx:467-470`) — verify during the rewrite.
+
+**State shape** (`drone-model.ts:74`): the entire draft is one `createSignal<DroneDefinition>`, mutated by **spread-copying the whole graph** on every change (`addNode`/`moveNode`/etc., `drone-model.ts:409-472`). Under Solid this means *every* node-position change replaces the array and re-runs the whole nodes `<For>` — fine at 5 nodes, janky at 50, and fatal for smooth dragging. **Migrate to `createStore` with path mutations** (§9).
+
+### 1.2 Backend — `agentmux-srv/src/drone/` (complete, do not rewrite)
+
+- **Model:** `DroneDefinition { id, name, description, graph: {nodes: FlowNode[], edges: FlowEdge[]}, viewport: {x,y,zoom}, created_at, updated_at }`. `FlowNode { id, position:{x,y}, data: JSON, node_type }`. `FlowEdge { id, source, target, sourceHandle?, targetHandle? }` — **camelCase handles on the wire** (`types.rs`, `#[serde(rename_all="camelCase")]`). This is the xyflow shape verbatim.
+- **Engine:** Kahn topological layering, sequential per-layer execution, `{{block_id.field}}` / `{{var.name}}` / `{{env.AGENTMUX_DR_*}}` interpolation, Condition branch-pruning gated on edge `sourceHandle ∈ {"true","false"}`. SSRF-guarded API block.
+- **RPC (WSH, no REST):** `listdrones() · getdrone(id) · upsertdrone(DroneDefinition) → normalized · deletedrone(id) · rundrone(drone_id) → {run_id} · listdroneruns(drone_id, limit?)`. **There is no per-node / per-edge / per-viewport delta API by design — the frontend owns the graph and upserts the whole `DroneDefinition`.**
+- **Live run state:** subscribe to broker event `dronerun:<run_id>`; events `run_started · block_started · block_done · block_error · run_done · run_failed` (snake_case `kind` tag). Already wired through slice #10.
+
+**Node taxonomy (canonical — the top bar's contents):** `agent`, `condition`, `api`, `response`, `variables`. Phase-2 engine adds `function`, `loop`, `parallel`, `router`, `subdrone` (reserve UI slots, don't build).
+
+---
+
+## 2. Vision & target UX
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  [Untitled Drone ▾]            🔢 Variables  🤖 Agent  🌐 API  🔀 Condition │  ← node-type bar
+│                                🏁 Response          🔍search   ⟳ Tidy  ▶ Run │     (drag chips down)
+├─────────────────────────────────────────────────────────────────────────┤
+│ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · │
+│ · · · · ┌──────────┐ · · · · · · · · · · · · · · · · · · · · · · · · · · · │
+│ · · · · │🤖 Agent  ●─────────●┌──────────┐· · · · · · · · · · · · · · · · │
+│ · · · · │ researcher│         │🔀 Condition│ ──true──●┌──────────┐· · · · · │
+│ · · · · └──────────┘         │ {{x}} > 0  │          │🏁 Response│· · · · · │
+│ · · · · · · · · · · · · · · · └──────────┘ ──false─● └──────────┘· · · · · │
+│ · · · · · · · · · · · · ·  (infinite, pannable, zoomable canvas) · · · · · │
+│ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ┌────┐│
+│ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · │mini││
+│  [�――●――]  ⊕ ⊖ ⤢                                          (overlays) └────┘│
+└─────────────────────────────────────────────────────────────────────────┘
+        ▲ controls (bottom-left)              ▲ inspector slides in from right when a node is selected
+```
+
+**Principles**
+
+1. **Canvas is the product.** Top bar is the only permanent chrome. Inspector and run-log are **overlays** (slide-over / collapsible drawer) that float above the canvas, never columns that shrink it.
+2. **Node types live at the top, horizontal, emoji + name.** They are **draggable chips** (drag onto canvas to create) *and* clickable (click drops at viewport center) for accessibility.
+3. **Direct manipulation.** Drag nodes; drag from a port to another port to wire; box-select; delete; pan with space/middle-drag; zoom with wheel; "Tidy" auto-lays-out.
+4. **Live execution is on the canvas.** During a run, nodes glow by status (pending/running/done/error/skipped); the run panel is a thin overlay, not a footer.
+
+---
+
+## 3. Architecture decision
+
+### 3.1 Decision: build the custom Solid canvas; borrow only hard-math libs
+
+| Concern | Decision | Why |
+|---|---|---|
+| Flow framework | **None.** Build custom. | No production-grade SolidJS flow lib exists. React Flow is React-only. `@dschz/solid-flow` is v0.1.x, 44★, single maintainer, pinned to an old `@xyflow/system`. Adopting it = inheriting an alpha + a rewrite of working code. |
+| Pan / zoom | **Borrow `@xyflow/system`** (`XYPanZoom`, d3-zoom under the hood) | Hardest thing to hand-roll correctly (transform origin, wheel/pinch, bounds). Proven; Solid-consumable (the alpha port proves the wiring). |
+| Edge geometry | **Borrow `@xyflow/system`** (`getBezierPath`, `getSmoothStepPath`) | ~50 lines of bezier we'd otherwise own and get subtly wrong. |
+| Connection hit-test / validation | **Borrow `@xyflow/system`** (`XYHandle`) *or hand-roll* | Optional; can hand-roll handle hit-testing if we want zero coupling. |
+| Coord transforms (screen↔flow) | **Borrow** `pointToRendererPoint` / `rendererPointToPoint` | The math behind `screenToFlowPosition`. Needed for drag-from-palette drops. |
+| Auto-layout ("Tidy") | **Borrow `@dagrejs/dagre`** (rank dir `LR`) | Framework-agnostic; feed nodes/edges, get x/y, write back to the store. Add `elkjs` only if we later need ports/orthogonal routing. |
+| Node render, ports, drag, selection, inspector, run overlay | **Hand-roll in Solid** | Our domain UI; where Solid's fine-grained reactivity shines. |
+
+**Net new deps:** `@xyflow/system` (pin exact version — it's `0.0.x`, internally scoped, treat minor bumps as breaking) and `@dagrejs/dagre`. *Escape hatch:* if `@xyflow/system`'s instability bites, depend on raw `d3-zoom` and copy the 2–3 path/transform functions — they're small and stable.
+
+### 3.2 Rejected alternatives
+
+- **Adopt `@dschz/solid-flow`** — alpha, bus-factor 1, pinned-old core, forces a component-model rewrite. Keep it as a *reference implementation* only.
+- **Adopt React Flow** — impossible; the app is SolidJS (`solid-js ^1.9.11`), no React anywhere.
+- **Keep pure hand-rolled (no `@xyflow/system`)** — viable, but re-deriving d3-zoom semantics and bezier math is avoidable risk; borrow the math, own the UI.
+- **Swap the whole frontend to React for React Flow** — absurd cost; rejected.
+
+---
+
+## 4. Node taxonomy & emoji design (the top bar)
+
+Add an `emoji` field to `BlockKindMeta` (`block-registry.ts`). Keep `color` (used for the header strip + handle accents) and `icon` (drop the unused FA string or repurpose for the overflow menu).
+
+| Kind | Emoji | Label | Color | Inputs | Outputs | One-liner |
+|---|---|---|---|---|---|---|
+| `variables` | 🔢 | Variables | `#a855f7` | — | `out` | Declare drone-scope `{{var.*}}` |
+| `agent` | 🤖 | Agent | `#3b82f6` | `in` | `out` | Run an agent with a task prompt |
+| `api` | 🌐 | API | `#10b981` | `in` | `out` | HTTP request (`{{...}}` in url/headers/body) |
+| `condition` | 🔀 | Condition | `#eab308` | `in` | `true`,`false` | Branch on a boolean expression |
+| `response` | 🏁 | Response | `#ef4444` | `in` | — | Terminal output (exactly one) |
+
+**Reserved (Phase-2 engine; show greyed/"coming soon" or omit):** `function` 🧩 · `loop` 🔁 · `parallel` 🪢 · `router` 🧭 · `subdrone` 🛸.
+
+Emoji rendering: plain Unicode in a `<span class="chip-emoji">` — no icon font, no asset pipeline, renders identically in the CEF webview. Provide an `aria-label` per chip (e.g. `aria-label="Agent node — drag onto canvas"`).
+
+---
+
+## 5. Target layout & component tree
+
+```
+<DronePane>                         // root; CSS grid: [topbar] / [canvas]   (full-bleed)
+ ├─ <NodeTypeBar model>             // the horizontal emoji-chip palette (replaces BlockPalette aside)
+ │   ├─ <DroneTitle/>               // name field + New/Save/Open menu (left)
+ │   ├─ <NodeChip kind> × N         // draggable + clickable emoji chips (center, horizontal, wraps)
+ │   ├─ <NodeSearch/>               // fuzzy filter when catalog grows (Cmd-K style, optional Phase 2)
+ │   └─ <CanvasActions/>            // Tidy (dagre) · Fit · Run  (right)
+ └─ <Canvas model>                  // fills 100% of the area under the bar
+     ├─ <svg class="dr-viewport">   // single <g transform> = pan/zoom; ALL graph content inside
+     │   ├─ <Background/>           // dot grid (re-rendered cheaply on zoom)
+     │   ├─ <EdgeLayer>             // <For edges> → <EdgePath> (bezier/smoothstep)
+     │   ├─ <ConnectionPreview/>    // live wire while dragging from a port
+     │   └─ <NodeLayer>             // <For nodes> → <DroneNode> (HTML in <foreignObject> OR overlaid div layer)
+     ├─ <Controls/>                 // zoom +/- , fit, lock  (bottom-left overlay)
+     ├─ <MiniMap/>                  // bottom-right overlay (Phase 2)
+     ├─ <InspectorDrawer model>     // slide-over from right; shown when selectedNode != null
+     └─ <RunOverlay model>          // thin collapsible run-log; live status; bottom overlay
+```
+
+**Rendering choice — HTML node layer over SVG edge layer (recommended).** Render edges in one `<svg>` and nodes as absolutely-positioned `<div>`s in a sibling layer that shares the *same* pan/zoom transform. Reason: rich node bodies (inputs, selects, textareas, the AgentRef pickers) are far easier and more accessible as HTML than `<foreignObject>`, and HTML inputs inside `<foreignObject>` have known focus/caret quirks in Chromium. Both layers are wrapped by one transformed container so they stay aligned. (This is exactly how React Flow renders.)
+
+---
+
+## 6. Interaction specifications
+
+### 6.1 Node-type bar (top)
+
+- Horizontal flex row, wraps to a second line on narrow widths; chips are `draggable`.
+- **Chip = `<button draggable>` with `🤖 Agent`**. `onDragStart` sets the dragged kind into a small module-level signal (don't rely on `dataTransfer.getData` during `dragover` — it's write-only there) **and** `e.dataTransfer.setData("application/x-drone-kind", kind)` as a fallback.
+- **Click** (no drag) → `addNode(kind, centerOfViewport())` so keyboard/non-drag users can still build.
+- Accessibility: `role="button"`, `tabindex=0`, Enter/Space = click-add, `aria-label` includes "drag onto canvas".
+- Search (Phase 2): filter chips by fuzzy match; later a `Cmd-K` command palette and "double-click empty canvas → searchable add menu".
+
+### 6.2 Drag-from-bar → drop-on-canvas
+
+Canonical recipe adapted to Solid:
+
+```tsx
+// module scope
+const [dragKind, setDragKind] = createSignal<BlockKind | null>(null);
+
+// NodeChip
+<button draggable
+  onDragStart={(e) => { setDragKind(kind);
+    e.dataTransfer!.effectAllowed = "copy";
+    e.dataTransfer!.setData("application/x-drone-kind", kind); }}
+  onDragEnd={() => setDragKind(null)}>
+  <span class="chip-emoji">{meta.emoji}</span><span>{meta.label}</span>
+</button>
+
+// Canvas
+const onDragOver = (e: DragEvent) => { e.preventDefault(); e.dataTransfer!.dropEffect = "copy"; };
+const onDrop = (e: DragEvent) => {
+  e.preventDefault();
+  const kind = dragKind() ?? (e.dataTransfer!.getData("application/x-drone-kind") as BlockKind);
+  if (!kind) return;
+  const pos = screenToFlow({ x: e.clientX, y: e.clientY });   // uses @xyflow/system transform + canvas rect
+  m.addNode(kind, pos);
+};
+```
+
+`screenToFlow` = invert the current `{x, y, zoom}` viewport relative to the canvas bounding rect (or `rendererPointToPoint` from `@xyflow/system`). **Use `clientX/clientY`, not `screenX/screenY`.**
+
+### 6.3 Node rendering (`<DroneNode>`)
+
+```
+┌───────────────────────────┐
+●in  │ 🤖  Agent          ✕ │   header: emoji + label + (color strip) + close
+     ├───────────────────────┤
+     │ researcher · "summari…│   body: nodeSummary(node)  (existing helper)
+     └───────────────────────┘ ●out
+                               (Condition: ●true / ●false stacked on the right)
+```
+
+- Header strip tinted with `--block-color`; emoji in a `.dr-node__emoji`.
+- **Ports = `<Handle>`-equivalent dots** on left (inputs) / right (outputs), positioned from `meta.inputs/outputs`. Each port carries `{nodeId, handleId, kind, dataType}`.
+- During a run, node gets a status class (`is-running` pulse, `is-done` green, `is-error` red, `is-skipped` dim) driven by slice #10 `blockResults` / `status`.
+- Body inputs that shouldn't start a node-drag get `class="nodrag"` (the drag handler ignores `pointerdown` originating inside `.nodrag`).
+- `memo` is **not** needed (Solid doesn't re-render); correctness comes from store granularity (§9).
+
+### 6.4 Wiring (drag-to-connect, typed, acyclic)
+
+- **Initiate:** `pointerdown` on an **output** port → start a connection; render `<ConnectionPreview>` (bezier from port to cursor) following `pointermove`; `pointerup` over an **input** port → commit `addEdge`.
+- **Typed validation** (`isValidConnection`): reject if
+  - source === target (no self-loop),
+  - target handle already satisfied where single-input semantics apply,
+  - **type mismatch** (compare `outputs[h].type` vs `inputs[h].type`; `any` matches all),
+  - **would create a cycle** (walk existing edges; reject if `target` can already reach `source` — preserves DAG-ness for the topological engine).
+- **Condition branches:** dragging from the `true` / `false` output sets `sourceHandle` explicitly — replaces today's fragile "first edge = true, second = false" ordering hack (`drone-view.tsx:142-171`). Color the two ports (green `true`, grey `false`) and label on hover.
+- **Edge select + delete:** click an edge → select (thicken/highlight); `Delete`/`Backspace` → `removeEdge`. Right-click → context menu (delete, for Condition: "swap branch").
+- Keep **shift-click-to-connect** as a secondary affordance (accessibility / no-drag).
+
+### 6.5 Node drag (in zoomed space)
+
+- `pointerdown` on node header (not `.nodrag`) → `setPointerCapture`; record start cursor + node origin.
+- `pointermove` → `moveNode(id, origin + (cursorΔ / zoom))` — **divide client delta by zoom** so drag tracks the cursor at any zoom level. Snap to grid (`Math.round(p / 16) * 16`) when snap is on.
+- `pointerup` → release capture; mark draft dirty → debounced autosave (§9.3).
+- Multi-select drag: move all selected nodes by the same delta.
+
+### 6.6 Pan / zoom / fit / background / minimap
+
+- **Pan:** space-drag or middle-mouse-drag or two-finger; updates the `viewport` store `{x,y}` only → one transform attribute changes, **zero** node bindings re-run (Solid win).
+- **Zoom:** wheel (zoom toward cursor) and `+`/`-` controls; clamp `zoom ∈ [0.2, 2.5]`.
+- **Fit-view:** compute bbox of all nodes → center + zoom to fit with padding. Bound to a Controls button and `⇧1`.
+- **Background:** dot grid via a tiled SVG `<pattern>` whose transform follows the viewport (cheap; no per-dot nodes).
+- **MiniMap (Phase 2):** scaled bbox render + draggable viewport rect, bottom-right overlay.
+
+### 6.7 Selection, delete, multi-select, clipboard, undo/redo, shortcuts
+
+- **Select:** click node/edge; shift-click to add; **box-select** by dragging on empty canvas.
+- **Delete:** `Delete`/`Backspace` removes selected nodes (cascade their edges) + selected edges.
+- **Copy/paste** (Phase 2): `⌘C`/`⌘V` duplicate selected nodes with offset + rewired internal edges + fresh ids.
+- **Undo/redo** (Phase 2): snapshot the graph store on each committed mutation into a bounded past/future stack; `⌘Z` / `⌘⇧Z`. (Debounce drag into one snapshot per gesture.)
+- **Shortcut table:**
+
+| Keys | Action |
+|---|---|
+| `Del` / `Backspace` | Delete selection |
+| `Space`+drag / middle-drag | Pan |
+| Wheel / `⌘`+wheel | Zoom |
+| `⇧1` | Fit view |
+| `⌘A` | Select all |
+| `⌘Z` / `⌘⇧Z` | Undo / redo (Phase 2) |
+| `⌘C` / `⌘V` | Copy / paste (Phase 2) |
+| `Esc` | Cancel connection / clear selection |
+| `⌘S` | Force save |
+
+### 6.8 Inspector as a slide-over
+
+- When `selectedNodeAtom()` is non-null, slide a panel in from the right **over** the canvas (≈360px, translucent backdrop edge), with the existing `InspectorForm` content (agent/api/condition/response/variables editors + `AgentResultPanel`).
+- Pin/unpin toggle; closing deselects. Never a permanent column.
+- Verify `ListIdentityBundlesCommand` / `ListMemoriesCommand` + `IdentityBundle` / `Memory` types exist; fix imports if `gotypes` lacks them (`drone-view.tsx:467-470`).
+
+### 6.9 Run overlay & live execution
+
+- Run from the top bar (validation gate unchanged: ≥1 node, exactly one Response).
+- During a run, drive node status classes from slice #10 (`BlockStarted`→running, `BlockDone`→done, `BlockError`→error; pruned branches→skipped). Edges on the active path animate (dash-flow).
+- Run-log overlay (bottom, collapsible): per-run rows (`status · id · output/error`) — today's `RunPanel`, restyled as an overlay drawer, plus a per-node "last result" already in the inspector.
+
+### 6.10 Auto-layout ("Tidy")
+
+- Button in the top bar → run `@dagrejs/dagre` (`rankdir: "LR"`, sensible `nodesep`/`ranksep`) over current nodes/edges using measured node sizes → write resulting `x/y` back via `moveNode` (batched in one store update) → `fitView`. Animate transition (CSS transform) for polish.
+
+---
+
+## 7. Backend touchpoints (small)
+
+The engine and RPC are complete. Only persistence ergonomics need attention:
+
+1. **Viewport + positions persist through `upsertdrone`** — no new endpoint required. The frontend autosaves the whole `DroneDefinition` (debounced) on graph/viewport change.
+2. **(Optional, nice-to-have) `update_drone_viewport(id, viewport)` lightweight RPC** to avoid rewriting the whole graph row on every pan/zoom. *Defer unless autosave write volume proves to be a problem* — Phase-1 contract is whole-graph upsert, and a debounce makes the cost negligible.
+3. **(Optional) Orphaned-run recovery** — on server start, mark stale `running` rows as `interrupted` (already noted as a TODO in `drone_handlers.rs`). Out of scope for this spec; file separately.
+
+No schema changes. No engine changes.
+
+---
+
+## 8. State model migration (the key correctness/perf change)
+
+### 8.1 `createSignal<DroneDefinition>` → `createStore`
+
+Today every mutation spreads the whole graph (`drone-model.ts:417-472`), so Solid sees a brand-new `nodes` array each time and re-runs the entire `<For>`. Replace with a Solid store so each node/field is independently reactive:
+
+```ts
+import { createStore, produce, reconcile } from "solid-js/store";
+
+const [draft, setDraft] = createStore<DroneDefinition>(BLANK_DRONE());
+
+// move ONE node — touches only that node's transform binding:
+moveNode(id, pos) { setDraft("graph", "nodes", n => n.id === id, "position", pos); }
+updateNodeData(id, patch) { setDraft("graph", "nodes", n => n.id === id, "data", d => ({ ...d, ...patch })); }
+addNode(node)   { setDraft("graph", "nodes", ns => [...ns, node]); }   // add still appends; <For> keys by id
+removeNode(id)  { setDraft(produce(d => {
+  d.graph.nodes = d.graph.nodes.filter(n => n.id !== id);
+  d.graph.edges = d.graph.edges.filter(e => e.source !== id && e.target !== id);
+})); }
+// backend → canvas without nuking DOM:
+loadDrone(wf)   { setDraft(reconcile(wf, { key: "id" })); }
+```
+
+Expose accessors so the rest of the codebase is unaffected (`draftAtom()` can stay as a thin getter returning `draft`). `selectedNodeAtom` becomes a store path read.
+
+### 8.2 Viewport store (isolated from nodes)
+
+Keep `viewport` either as its own `createSignal<{x,y,zoom}>` or a store slice, applied as the single `<g transform>` on the viewport container. Panning/zooming must **not** touch any node binding.
+
+### 8.3 Debounced autosave
+
+- After any committed graph/viewport mutation, schedule a debounced (~800ms) `upsertdrone(draft)`; coalesce rapid drags into one write. Optimistic local state; on failure surface via `errorAtom` and retry.
+- Drag gestures: write to the store live (for render), but only mark dirty / schedule autosave on `pointerup`.
+
+### 8.4 Solid perf rules (replacing React's "memo everything")
+
+Solid doesn't re-render components, so the perf model is *reactive granularity*:
+- `createStore` for nodes/edges (above); never a signal holding the array.
+- `<For>` keyed by node id; stable references via path mutation (no array spreads on hot paths).
+- `reconcile` when replacing graph data from the backend.
+- One viewport transform outside the node loop.
+- Per-edge `createMemo` reading only its two endpoints' positions → moving a node recomputes only incident edges.
+- Pointer-capture drag writing straight to the store; no global listeners.
+- For >~1–2k nodes (unlikely near-term): viewport-bbox `createMemo` cull before `<For>`.
+
+---
+
+## 9. Phased implementation plan
+
+Each phase is an independently shippable PR (changesets workflow — `task changeset -- ...`, **no manual version bump**).
+
+| PR | Title | Deliverable | Unblocks "nothing works" |
+|---|---|---|---|
+| **1** | Canvas store migration | `createSignal<DroneDefinition>` → `createStore`; path mutations; `reconcile` on load. No UX change yet. | Foundation |
+| **2** | Pan/zoom + node drag | Add `@xyflow/system`; viewport transform; wheel-zoom; pointer-capture node drag (zoom-aware); Controls (zoom/fit). | **Drag + navigate works** ✅ |
+| **3** | Top node-type bar + drag-from-bar | Replace `BlockPalette` aside with `<NodeTypeBar>` (emoji chips); HTML5 DnD drop → `screenToFlow` → `addNode`; click-to-center fallback; add `emoji` to registry. | **Layout matches vision; intuitive add** ✅ |
+| **4** | Ports + drag-to-connect + typed/acyclic validation | Visible handles; connection preview; `isValidConnection` (type + cycle); explicit Condition branch handles; edge select/delete. | **Real wiring** ✅ |
+| **5** | Inspector slide-over + run overlay + node run-state | Move inspector to overlay drawer; run-log overlay; live node status glow + animated active edges. | Expansive canvas; live feedback |
+| **6** | Auto-layout + polish | `@dagrejs/dagre` "Tidy"; bezier/smoothstep edges; dot-grid background; debounced autosave; a11y pass. | Pro feel |
+| **7** (opt) | MiniMap · undo/redo · copy-paste · search/Cmd-K | Power-user features. | — |
+
+**Minimum to kill "nothing works": PRs 1–3** (store + pan/zoom + drag + top bar with drag-drop). PR-4 makes it genuinely useful.
+
+## 10. File-level change map
+
+- `frontend/app/view/drone/block-registry.ts` — add `emoji` to `BlockKindMeta` + each entry; (drop unused `icon` or repurpose).
+- `frontend/app/view/drone/drone-model.ts` — `createSignal`→`createStore`; rewrite `addNode/removeNode/updateNodeData/moveNode/addEdge/removeEdge` as path mutations; `reconcile` in `openDrone/newDrone/save`; add `setViewport`, dirty/autosave scheduler, `isValidConnection`, `addNodeAtCenter`, multi-select state.
+- `frontend/app/view/drone/drone-view.tsx` — **split** into:
+  - `node-type-bar.tsx` (`<NodeTypeBar>`, `<NodeChip>`)
+  - `canvas.tsx` (`<Canvas>`, `<NodeLayer>`, `<EdgeLayer>`, `<DroneNode>`, `<Handle>`, `<ConnectionPreview>`, `<Background>`, `<Controls>`, `<MiniMap>`)
+  - `inspector-drawer.tsx` (existing `InspectorForm`/editors moved here)
+  - `run-overlay.tsx` (existing `RunPanel` restyled)
+  - `drone-view.tsx` becomes the thin `<DronePane>` shell (grid: topbar / canvas).
+- `frontend/app/view/drone/canvas-geometry.ts` (new) — `screenToFlow`, `flowToScreen`, bbox/fit math, dagre adapter, `@xyflow/system` wrappers.
+- `frontend/app/view/drone/drone-view.scss` — rewrite to full-bleed grid + overlays + node/handle/edge styles.
+- `package.json` — add `@xyflow/system` (pinned exact) + `@dagrejs/dagre`.
+- **No backend changes** (optional viewport RPC tracked separately).
+
+## 11. Testing
+
+- **Unit (vitest):** store mutations (add/remove/move/connect cascade), `isValidConnection` (self-loop, type mismatch, **cycle rejection**), `screenToFlow` round-trip at various zoom/pan, dagre adapter writes valid coords, Condition branch-handle assignment.
+- **Component:** drag-from-chip creates a node at the drop point; node drag updates position by `Δ/zoom`; edge connect/delete; inspector opens on select.
+- **E2E (`e2e/`):** open drone widget → drag Agent + Condition + Response from bar → wire them → Run → assert live status classes + run-log row. Reuses backend RPC end-to-end.
+- **Perf smoke:** 100-node graph stays smooth on drag/pan in the CEF webview (profile: dragging one node updates only that node + incident edges).
+
+## 12. Risks & open questions
+
+- **`@xyflow/system` is `0.0.x` / internally scoped** → pin exact; wrap all usage behind `canvas-geometry.ts` so a breaking bump is a one-file fix; escape hatch = raw `d3-zoom` + copied path math.
+- **HTML-over-SVG alignment** under zoom — both layers must share the identical transform; cover with a round-trip test.
+- **`gotypes` missing `IdentityBundle`/`Memory`** — verify in PR-1; regenerate/declare if absent.
+- **Autosave write volume** on pan/zoom — debounce; revisit optional viewport RPC only if measured cost warrants.
+- **Emoji rendering consistency** in CEF — verify the chosen glyphs render across the bundled Chromium; swap any that fall back to tofu.
+- **Reserved Phase-2 node types** — show as disabled or omit; don't half-wire engine-less kinds.
+
+## 13. Appendix
+
+**Dependencies to add**
+```jsonc
+"@xyflow/system": "0.0.77",   // EXACT pin — vendored math: XYPanZoom, edge paths, coord transforms
+"@dagrejs/dagre": "^3.0.0"     // auto-layout (LR) for "Tidy"
+```
+
+**`BlockKindMeta` addition**
+```ts
+export interface BlockKindMeta {
+  kind: BlockKind;
+  emoji: string;          // NEW — top-bar chip + node header
+  label: string;
+  description: string;
+  color: string;          // header strip + handle accent
+  defaultData: Record<string, unknown>;
+  inputs: BlockHandleSpec[];
+  outputs: BlockHandleSpec[];
+}
+// variables 🔢 · agent 🤖 · api 🌐 · condition 🔀 · response 🏁
+```
+
+**Canonical references**
+- Existing: `drone-view.tsx`, `drone-model.ts`, `block-registry.ts`, `drone-types.ts`, `store/drone-run-state/*`; backend `agentmux-srv/src/drone/*`, `server/drone_handlers.rs`.
+- External: `@xyflow/system` source (`packages/system/src/xypanzoom`, `xyhandle`, `utils`), `@dagrejs/dagre` README, React Flow drag-and-drop / validation / custom-node guides (as conceptual reference — APIs are React, patterns are portable), SolidJS stores + fine-grained reactivity docs.
+```

--- a/frontend/app/view/drone/block-registry.ts
+++ b/frontend/app/view/drone/block-registry.ts
@@ -16,11 +16,13 @@ export interface BlockHandleSpec {
 
 export interface BlockKindMeta {
     kind: BlockKind;
+    /** Unicode emoji shown on the top-bar chip + the node header. */
+    emoji: string;
     label: string;
     description: string;
     /** Hex color for the node header strip. */
     color: string;
-    /** FontAwesome-class icon string (used by the canvas + palette). */
+    /** FontAwesome-class icon string (legacy; superseded by `emoji`). */
     icon: string;
     /** Default per-kind data fields the node ships with. */
     defaultData: Record<string, unknown>;
@@ -32,6 +34,7 @@ export interface BlockKindMeta {
 export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     variables: {
         kind: "variables",
+        emoji: "🔢",
         label: "Variables",
         description: "Declare drone-scope variables. Read via {{var.name}}.",
         color: "#a855f7",
@@ -44,6 +47,7 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     },
     agent: {
         kind: "agent",
+        emoji: "🤖",
         label: "Agent",
         description: "Run an agent with a per-call task prompt.",
         color: "#3b82f6",
@@ -64,6 +68,7 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     },
     api: {
         kind: "api",
+        emoji: "🌐",
         label: "API",
         description: "Make an HTTP request. Headers and body support {{...}}.",
         color: "#10b981",
@@ -79,6 +84,7 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     },
     condition: {
         kind: "condition",
+        emoji: "🔀",
         label: "Condition",
         description: "Boolean expression. Output `result` is true / false.",
         color: "#eab308",
@@ -94,6 +100,7 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     },
     response: {
         kind: "response",
+        emoji: "🏁",
         label: "Response",
         description: "Terminal output. Exactly one per drone.",
         color: "#ef4444",

--- a/frontend/app/view/drone/block-registry.ts
+++ b/frontend/app/view/drone/block-registry.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Block kind metadata — drives the BlockPalette, default block data,
+// Block kind metadata — drives the NodeTypeBar chips, default block data,
 // and the InspectorPanel field schema. One source of truth shared by
 // all node components and the validators.
 
@@ -113,7 +113,7 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     },
 };
 
-/** Stable list for the BlockPalette — palette order is rendering order. */
+/** Stable list for the NodeTypeBar — chip order is rendering order. */
 export const BLOCK_KINDS: BlockKind[] = [
     "variables",
     "agent",

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -26,6 +26,7 @@ import {
 import { waveEventSubscribe } from "@/app/store/wps";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
+import { createStore, produce, reconcile, type SetStoreFunction } from "solid-js/store";
 
 import { blockMeta } from "./block-registry";
 import {
@@ -71,9 +72,28 @@ export class DroneViewModel implements ViewModel {
     setList = this._list[1];
 
     // --- the drone currently open in the canvas (a draft until saved)
-    private _draft = createSignal<DroneDefinition>(BLANK_DRONE());
-    draftAtom: Accessor<DroneDefinition> = this._draft[0];
-    setDraft = this._draft[1];
+    //
+    // Backed by a Solid STORE, not a signal. A signal holding the whole
+    // DroneDefinition replaces the object on every edit, so any reader
+    // of `graph.nodes` re-runs — fatal for smooth node dragging at 50+
+    // nodes. A store proxies each node/field independently, so moving
+    // one node touches only that node's `position` binding. See
+    // SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md §8.
+    private _draftStore = createStore<DroneDefinition>(BLANK_DRONE());
+    private draft: DroneDefinition = this._draftStore[0];
+    private setDraftStore: SetStoreFunction<DroneDefinition> = this._draftStore[1];
+
+    // Stable accessor — the rest of the codebase keeps calling
+    // `m.draftAtom()`. Returns the live store proxy; property reads on
+    // it (`.graph.nodes`) stay fine-grained inside a tracking scope.
+    draftAtom: Accessor<DroneDefinition> = () => this.draft;
+
+    /** Replace the entire draft (load / new / post-save normalize).
+     *  Uses `reconcile` (keyed on node/edge `id`) so surviving DOM nodes
+     *  and edges are diffed in place rather than torn down + rebuilt. */
+    private setDraft(next: DroneDefinition): void {
+        this.setDraftStore(reconcile(next));
+    }
 
     // --- which node is selected in the canvas (for the InspectorPanel)
     private _selected = createSignal<string | null>(null);
@@ -414,65 +434,55 @@ export class DroneViewModel implements ViewModel {
             data: { kind, ...meta.defaultData },
             type: kind,
         };
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: { ...prev.graph, nodes: [...prev.graph.nodes, node] },
-        }));
+        // Append keeps `<For>`'s keying intact (new id → new row); the
+        // existing node DOM is untouched.
+        this.setDraftStore("graph", "nodes", (nodes) => [...nodes, node]);
         return node;
     }
 
     removeNode(id: string): void {
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: {
-                nodes: prev.graph.nodes.filter((n) => n.id !== id),
-                edges: prev.graph.edges.filter((e) => e.source !== id && e.target !== id),
-            },
-        }));
+        // `produce` for the two-array cascade (drop the node + its edges)
+        // in one granular transaction.
+        this.setDraftStore(
+            produce((d) => {
+                d.graph.nodes = d.graph.nodes.filter((n) => n.id !== id);
+                d.graph.edges = d.graph.edges.filter(
+                    (e) => e.source !== id && e.target !== id,
+                );
+            }),
+        );
         if (this.selectedAtom() === id) this.setSelected(null);
     }
 
     updateNodeData(id: string, patch: Record<string, unknown>): void {
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: {
-                ...prev.graph,
-                nodes: prev.graph.nodes.map((n) =>
-                    n.id === id ? { ...n, data: { ...n.data, ...patch } } : n,
-                ),
-            },
-        }));
+        // Path mutation: touches only the matched node's `data` binding.
+        this.setDraftStore(
+            "graph",
+            "nodes",
+            (n) => n.id === id,
+            "data",
+            (data) => ({ ...data, ...patch }),
+        );
     }
 
     moveNode(id: string, position: { x: number; y: number }): void {
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: {
-                ...prev.graph,
-                nodes: prev.graph.nodes.map((n) =>
-                    n.id === id ? { ...n, position } : n,
-                ),
-            },
-        }));
+        // The hot path during a drag — updates ONLY this node's
+        // `position`, so its `<For>` row's transform binding re-runs and
+        // nothing else does. This is the whole point of the store.
+        this.setDraftStore("graph", "nodes", (n) => n.id === id, "position", position);
     }
 
     addEdge(edge: Omit<FlowEdge, "id">): void {
         const e: FlowEdge = { id: `e_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`, ...edge };
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: { ...prev.graph, edges: [...prev.graph.edges, e] },
-        }));
+        this.setDraftStore("graph", "edges", (edges) => [...edges, e]);
     }
 
     removeEdge(id: string): void {
-        this.setDraft((prev) => ({
-            ...prev,
-            graph: { ...prev.graph, edges: prev.graph.edges.filter((e) => e.id !== id) },
-        }));
+        this.setDraftStore("graph", "edges", (edges) => edges.filter((e) => e.id !== id));
     }
 
     setName(name: string): void {
-        this.setDraft((prev) => ({ ...prev, name }));
+        this.setDraftStore("name", name);
     }
 
     /** Validation surface read by the Toolbar before enabling Run. */

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -111,6 +111,14 @@ export class DroneViewModel implements ViewModel {
         this._viewport[1]((v) => ({ ...v, ...patch }));
     };
 
+    // --- canvas pixel size, kept current by the Canvas via a
+    // ResizeObserver. Used to place a node at the visible center when a
+    // top-bar chip is clicked (the no-drag fallback).
+    private _canvasSize = createSignal<{ w: number; h: number }>({ w: 0, h: 0 });
+    setCanvasSize = (size: { w: number; h: number }): void => {
+        this._canvasSize[1](size);
+    };
+
     // --- run state
     //
     // `_running` is the in-flight `await RunDroneCommand` flag — bound
@@ -454,6 +462,18 @@ export class DroneViewModel implements ViewModel {
         // existing node DOM is untouched.
         this.setDraftStore("graph", "nodes", (nodes) => [...nodes, node]);
         return node;
+    }
+
+    /** Add a node at the center of the currently visible canvas — the
+     *  click-a-chip (no-drag) fallback. Inverts the viewport transform
+     *  for the screen-center point, then offsets to roughly center the
+     *  node body under that point. */
+    addNodeAtCenter(kind: BlockKind): FlowNode {
+        const v = this.viewportAtom();
+        const { w, h } = this._canvasSize[0]();
+        const cx = (w / 2 - v.x) / v.zoom - 80;
+        const cy = (h / 2 - v.y) / v.zoom - 30;
+        return this.addNode(kind, { x: cx, y: cy });
     }
 
     removeNode(id: string): void {

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -38,6 +38,7 @@ import {
     type DroneDefinition,
     type DroneGraph,
     type DroneRun,
+    type DroneViewport,
 } from "./drone-types";
 
 const BLANK_DRONE = (): DroneDefinition => ({
@@ -99,6 +100,16 @@ export class DroneViewModel implements ViewModel {
     private _selected = createSignal<string | null>(null);
     selectedAtom: Accessor<string | null> = this._selected[0];
     setSelected = this._selected[1];
+
+    // --- canvas viewport (pan + zoom). Deliberately SEPARATE from the
+    // draft store: panning/zooming updates only this one transform, so
+    // it never re-runs a node binding. Synced into draft.viewport at
+    // save time (so it persists). See spec §8.2.
+    private _viewport = createSignal<DroneViewport>(defaultViewport());
+    viewportAtom: Accessor<DroneViewport> = this._viewport[0];
+    setViewport = (patch: Partial<DroneViewport>): void => {
+        this._viewport[1]((v) => ({ ...v, ...patch }));
+    };
 
     // --- run state
     //
@@ -213,6 +224,7 @@ export class DroneViewModel implements ViewModel {
             if (wf) {
                 this.setDraft(wf);
                 this.setSelected(null);
+                this.setViewport(wf.viewport ?? defaultViewport());
                 this.dispatchIfAlive({ type: "Reset" }, "user");
                 await this.refreshRuns(id);
             }
@@ -225,6 +237,7 @@ export class DroneViewModel implements ViewModel {
     newDrone(): void {
         this.setDraft(BLANK_DRONE());
         this.setSelected(null);
+        this.setViewport(defaultViewport());
         this.setRuns([]);
         this.dispatchIfAlive({ type: "Reset" }, "user");
         if (this.activeRunUnsub) {
@@ -235,6 +248,9 @@ export class DroneViewModel implements ViewModel {
 
     /** Persist the current draft. Returns the saved id. */
     async save(): Promise<string | null> {
+        // Fold the live canvas viewport into the draft store so it
+        // persists with the graph.
+        this.setDraftStore("viewport", { ...this.viewportAtom() });
         const wf = this.draftAtom();
         try {
             const saved = await RpcApi.UpsertDroneCommand(TabRpcClient, wf);

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -122,7 +122,7 @@ export class DroneViewModel implements ViewModel {
     // --- run state
     //
     // `_running` is the in-flight `await RunDroneCommand` flag — bound
-    // to the Toolbar's button disable. It's a UI thing, separate from the
+    // to the NodeTypeBar's Run button disable. It's a UI thing, separate from the
     // slot's `status` (which is "idle"|"running"|"done"|"failed", folded
     // from `dronerun:<id>` events). Keeping it in the view.
     private _running = createSignal<boolean>(false);
@@ -521,7 +521,7 @@ export class DroneViewModel implements ViewModel {
         this.setDraftStore("name", name);
     }
 
-    /** Validation surface read by the Toolbar before enabling Run. */
+    /** Validation surface read by the NodeTypeBar before enabling Run. */
     validate(): { ok: boolean; errors: string[] } {
         const errors: string[] = [];
         const graph = this.draftAtom().graph;

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -154,14 +154,33 @@
 .drone-canvas {
     position: absolute;
     inset: 0;
-    overflow: auto;
+    overflow: hidden;
+    touch-action: none; // we own pan/zoom via pointer + wheel
+    cursor: grab;
+    &:active {
+        cursor: grabbing;
+    }
+}
+
+// The transformed layer. A zero-size origin point at (0,0) flow-space;
+// all nodes + edges are positioned absolutely in flow coordinates and
+// this single transform pans/zooms the whole graph at once.
+.drone-viewport {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    will-change: transform;
 }
 
 .drone-canvas-edges {
     position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    overflow: visible; // lines drawn at flow coords must not clip
     pointer-events: none;
 }
 
@@ -173,12 +192,43 @@
 
 .drone-canvas-hint {
     position: absolute;
-    bottom: 8px;
-    left: 8px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 360px;
+    text-align: center;
+    line-height: 1.6;
     color: var(--secondary-text-color);
-    font-size: 10px;
-    opacity: 0.7;
+    font-size: 12px;
+    opacity: 0.8;
     pointer-events: none;
+}
+
+.drone-controls {
+    position: absolute;
+    left: 8px;
+    bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    z-index: 5;
+}
+
+.drone-ctrl {
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    color: inherit;
+    cursor: pointer;
+    font-size: 15px;
+    line-height: 1;
+    &:hover {
+        background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+    }
 }
 
 .drone-node {
@@ -188,8 +238,12 @@
     border: 1px solid var(--border-color);
     border-radius: 0;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-    cursor: pointer;
+    cursor: grab;
+    user-select: none;
     transition: border-color 80ms ease;
+    &:active {
+        cursor: grabbing;
+    }
     &--selected {
         border-color: var(--accent-color);
         box-shadow: 0 0 0 1px var(--accent-color);
@@ -199,13 +253,22 @@
 .drone-node-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 6px;
     padding: 4px 8px;
     background: var(--block-color, var(--accent-color));
     color: white;
     border-radius: 0;
     font-size: 11px;
     font-weight: 500;
+}
+
+.drone-node-emoji {
+    font-size: 13px;
+    line-height: 1;
+}
+
+.drone-node-label {
+    flex: 1;
 }
 
 .drone-node-close {

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -12,22 +12,27 @@
     overflow: hidden;
 }
 
-.drone-toolbar {
+// ── Top node-type bar ─────────────────────────────────────────────────
+
+.drone-bar {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 8px 12px;
+    padding: 6px 12px;
     border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
     position: relative;
+    flex-wrap: wrap;
 }
 
-.drone-toolbar-name {
-    flex: 1;
+.drone-bar-name {
+    width: 160px;
+    flex-shrink: 0;
     background: transparent;
     border: 1px solid transparent;
     color: inherit;
     font-size: 14px;
+    font-weight: 500;
     padding: 4px 8px;
     border-radius: 0;
     &:focus, &:hover {
@@ -36,9 +41,52 @@
     }
 }
 
-.drone-toolbar-actions {
+.drone-bar-types {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    flex-wrap: wrap;
+    min-width: 0;
+}
+
+.drone-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 8px;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--block-color, var(--accent-color));
+    border-radius: 0;
+    color: inherit;
+    cursor: grab;
+    font-size: 12px;
+    white-space: nowrap;
+    user-select: none;
+    &:hover {
+        background: color-mix(in srgb, var(--block-color) 12%, transparent);
+        border-color: var(--block-color, var(--border-color));
+    }
+    &:active {
+        cursor: grabbing;
+    }
+}
+
+.drone-chip-emoji {
+    font-size: 14px;
+    line-height: 1;
+}
+
+.drone-chip-label {
+    font-weight: 500;
+}
+
+.drone-bar-actions {
     display: flex;
     gap: 6px;
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 .drone-btn {
@@ -75,72 +123,12 @@
     z-index: 5;
 }
 
-.drone-body {
-    display: grid;
-    grid-template-columns: 200px 1fr 280px;
+// ── Stage: everything below the bar is canvas ─────────────────────────
+
+.drone-stage {
+    position: relative;
     flex: 1;
     min-height: 0;
-}
-
-.drone-palette {
-    border-right: 1px solid var(--border-color);
-    padding: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    overflow-y: auto;
-}
-
-.drone-palette-title {
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--secondary-text-color);
-    padding: 4px;
-}
-
-.drone-palette-section {
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--secondary-text-color);
-    padding: 8px 4px 4px;
-    border-top: 1px solid var(--border-color);
-    margin-top: 4px;
-}
-
-.drone-palette-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 8px;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 0;
-    cursor: pointer;
-    color: inherit;
-    text-align: left;
-    font-size: 12px;
-    &:hover {
-        border-color: var(--border-color);
-        background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
-    }
-    &--drone {
-        font-style: italic;
-        opacity: 0.85;
-    }
-}
-
-.drone-palette-item-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--block-color, var(--accent-color));
-    flex-shrink: 0;
-}
-
-.drone-canvas-wrap {
-    position: relative;
     overflow: hidden;
     background: color-mix(in srgb, var(--main-text-color) 2%, var(--main-bg-color));
     background-image: radial-gradient(
@@ -211,7 +199,7 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
-    z-index: 5;
+    z-index: 12; // above the run-log overlay so zoom stays reachable
 }
 
 .drone-ctrl {
@@ -292,11 +280,36 @@
     white-space: nowrap;
 }
 
+// ── Inspector: right-side slide-over overlay ──────────────────────────
+
 .drone-inspector {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 320px;
     border-left: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.25);
     overflow-y: auto;
     padding: 8px 12px;
     font-size: 12px;
+    z-index: 10;
+}
+
+.drone-inspector-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    color: var(--secondary-text-color);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    &:hover {
+        color: var(--main-text-color);
+    }
 }
 
 .drone-inspector-empty {
@@ -363,13 +376,19 @@
     gap: 4px;
 }
 
+// ── Run log: bottom overlay drawer ────────────────────────────────────
+
 .drone-runpanel {
-    border-top: 1px solid var(--border-color);
-    flex-shrink: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
     max-height: 180px;
     display: flex;
     flex-direction: column;
-    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    border-top: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 6%, var(--main-bg-color));
+    z-index: 8;
 }
 
 .drone-runpanel-title {

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -35,7 +35,7 @@ DroneView.displayName = "DroneView";
 // ── Top node-type bar ─────────────────────────────────────────────────
 //
 // The only permanent chrome. Left: drone name + open/new/save/run.
-// Center: the horizontal palette of draggable emoji node-type chips.
+// Center: the horizontal row of draggable emoji node-type chips.
 // Everything below this bar is canvas.
 
 const NodeTypeBar = (p: { model: DroneViewModel }): JSX.Element => {
@@ -514,16 +514,17 @@ const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
 };
 
 const InspectorForm = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element => {
-    // Reactive: the same InspectorForm instance is reused as the selection
-    // changes (the <Show> stays truthy), so `meta` must re-read p.node —
-    // a computed-once const would show the first-selected node's label.
-    const meta = () => blockMeta(p.node.data.kind as BlockKind);
+    // The parent <Show> is keyed on the node, so this form remounts on each
+    // selection change — `p.node` is fixed for this instance's lifetime and
+    // `meta` can be computed once. (A node's kind never changes; only its
+    // data fields do, which the field bindings below read reactively.)
+    const meta = blockMeta(p.node.data.kind as BlockKind);
     const update = (patch: Record<string, unknown>) =>
         p.model.updateNodeData(p.node.id, patch);
 
     return (
         <div class="drone-inspector-form">
-            <div class="drone-inspector-title">{meta().label}</div>
+            <div class="drone-inspector-title">{meta.label}</div>
             <div class="drone-inspector-id">{p.node.id}</div>
             <Show when={p.node.data.kind === "agent"}>
                 <AgentRefEditor node={p.node} update={update} />

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -125,13 +125,13 @@ const NodeChip = (p: { model: DroneViewModel; kind: BlockKind }): JSX.Element =>
 
 // ── Canvas ────────────────────────────────────────────────────────────
 //
-// Phase 1 ships a minimal SVG-based canvas instead of the full
-// `@dschz/solid-flow` integration. Rationale: the xyflow runtime expects
-// SolidJS reactive primitives wired through a `<SolidFlow>` provider
-// component which conflicts with our existing Solid root setup; the
-// integration spike is its own follow-up. This canvas covers the demo
-// path (drop nodes, click to select, draw edges by clicking source then
-// target). The Phase 1 PR-4 polish issue tracks the swap.
+// A custom SolidJS SVG/HTML canvas (NOT a flow library). There is no
+// production-grade SolidJS flow lib — React Flow is React-only and the one
+// Solid port is a single-maintainer alpha — and the model is already
+// xyflow-shaped, so we own the canvas and borrow only math where it pays
+// off. The viewport transform + pointer drag are hand-rolled (spec §3.1).
+// Supports: drag-from-bar to create, node drag, pan/zoom + fit, and
+// Shift-click wiring. See SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md.
 
 const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
@@ -488,8 +488,15 @@ const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
     // Slide-over overlay: only mounted while a node is selected, so the
     // canvas stays full-bleed otherwise.
+    //
+    // `keyed` on the selected NODE: switching selection re-runs the child
+    // and remounts InspectorForm with the new node, so the title / fields
+    // / actions can never stay bound to a previously-selected node. The
+    // store keeps each node's proxy reference stable, so editing a field
+    // does NOT change the key (no remount → the focused input is kept) —
+    // only changing which node is selected does.
     return (
-        <Show when={m.selectedNodeAtom()}>
+        <Show when={m.selectedNodeAtom()} keyed>
             {(node) => (
                 <aside class="drone-inspector" aria-label="Inspector">
                     <button
@@ -499,7 +506,7 @@ const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
                     >
                         ×
                     </button>
-                    <InspectorForm model={m} node={node()} />
+                    <InspectorForm model={m} node={node} />
                 </aside>
             )}
         </Show>

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createResource, For, onCleanup, Show, type JSX } from "solid-js";
+import { createResource, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -10,41 +10,68 @@ import type { DroneViewModel } from "./drone-model";
 import type { BlockKind, FlowNode } from "./drone-types";
 import "./drone-view.scss";
 
+// Transient global: which node-kind is being dragged from the top bar.
+// Read by the Canvas's drop handler. Drag is inherently app-global, so a
+// module-level signal is fine even with multiple drone panes open.
+const [dragKind, setDragKind] = createSignal<BlockKind | null>(null);
+
 export const DroneView = (props: { model: DroneViewModel }): JSX.Element => {
     const m = props.model;
 
     return (
         <div class="drone-pane">
-            <Toolbar model={m} />
-            <div class="drone-body">
-                <BlockPalette model={m} />
-                <div class="drone-canvas-wrap">
-                    <Canvas model={m} />
-                </div>
+            <NodeTypeBar model={m} />
+            <div class="drone-stage">
+                <Canvas model={m} />
                 <InspectorPanel model={m} />
+                <RunPanel model={m} />
             </div>
-            <RunPanel model={m} />
         </div>
     );
 };
 
 DroneView.displayName = "DroneView";
 
-// ── Toolbar ───────────────────────────────────────────────────────────
+// ── Top node-type bar ─────────────────────────────────────────────────
+//
+// The only permanent chrome. Left: drone name + open/new/save/run.
+// Center: the horizontal palette of draggable emoji node-type chips.
+// Everything below this bar is canvas.
 
-const Toolbar = (p: { model: DroneViewModel }): JSX.Element => {
+const NodeTypeBar = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
     const validation = () => m.validate();
     return (
-        <header class="drone-toolbar">
+        <header class="drone-bar">
             <input
-                class="drone-toolbar-name"
+                class="drone-bar-name"
                 value={m.draftAtom().name}
                 onInput={(e) => m.setName(e.currentTarget.value)}
                 placeholder="Untitled Drone"
                 aria-label="Drone name"
             />
-            <div class="drone-toolbar-actions">
+
+            <div class="drone-bar-types" role="toolbar" aria-label="Node types">
+                <For each={BLOCK_KINDS}>{(kind) => <NodeChip model={m} kind={kind} />}</For>
+            </div>
+
+            <div class="drone-bar-actions">
+                <Show when={m.listAtom().length > 0}>
+                    <select
+                        class="drone-btn"
+                        aria-label="Open saved drone"
+                        onChange={(e) => {
+                            const id = e.currentTarget.value;
+                            if (id) void m.openDrone(id);
+                            e.currentTarget.value = "";
+                        }}
+                    >
+                        <option value="">Open…</option>
+                        <For each={m.listAtom()}>
+                            {(wf) => <option value={wf.id}>{wf.name}</option>}
+                        </For>
+                    </select>
+                </Show>
                 <button class="drone-btn" onClick={() => m.newDrone()}>
                     New
                 </button>
@@ -57,9 +84,10 @@ const Toolbar = (p: { model: DroneViewModel }): JSX.Element => {
                     title={validation().errors.join(" · ")}
                     onClick={() => void m.run()}
                 >
-                    {m.runningAtom() ? "Running…" : "Run"}
+                    {m.runningAtom() ? "Running…" : "▶ Run"}
                 </button>
             </div>
+
             <Show when={m.errorAtom()}>
                 <div class="drone-error" role="alert">
                     {m.errorAtom()}
@@ -69,51 +97,29 @@ const Toolbar = (p: { model: DroneViewModel }): JSX.Element => {
     );
 };
 
-// ── Block palette ─────────────────────────────────────────────────────
-
-const BlockPalette = (p: { model: DroneViewModel }): JSX.Element => {
-    const m = p.model;
+const NodeChip = (p: { model: DroneViewModel; kind: BlockKind }): JSX.Element => {
+    const meta = blockMeta(p.kind);
     return (
-        <aside class="drone-palette" aria-label="Block palette">
-            <div class="drone-palette-title">Blocks</div>
-            <For each={BLOCK_KINDS}>
-                {(kind) => {
-                    const meta = blockMeta(kind);
-                    return (
-                        <button
-                            class="drone-palette-item"
-                            style={{ "--block-color": meta.color }}
-                            onClick={() => {
-                                // Naive placement — Phase 2 will use drag + drop
-                                // with cursor coords. For now, drop near origin
-                                // with a small random offset so adds don't stack.
-                                m.addNode(kind, {
-                                    x: 80 + Math.random() * 60,
-                                    y: 80 + Math.random() * 60,
-                                });
-                            }}
-                            title={meta.description}
-                        >
-                            <span class="drone-palette-item-dot" />
-                            <span class="drone-palette-item-label">{meta.label}</span>
-                        </button>
-                    );
-                }}
-            </For>
-            <Show when={m.listAtom().length > 0}>
-                <div class="drone-palette-section">Saved drones</div>
-                <For each={m.listAtom()}>
-                    {(wf) => (
-                        <button
-                            class="drone-palette-item drone-palette-item--drone"
-                            onClick={() => void m.openDrone(wf.id)}
-                        >
-                            <span class="drone-palette-item-label">{wf.name}</span>
-                        </button>
-                    )}
-                </For>
-            </Show>
-        </aside>
+        <button
+            class="drone-chip"
+            style={{ "--block-color": meta.color }}
+            draggable={true}
+            title={meta.description}
+            aria-label={`${meta.label} node — drag onto the canvas, or click to add`}
+            onDragStart={(e) => {
+                setDragKind(p.kind);
+                if (e.dataTransfer) {
+                    e.dataTransfer.effectAllowed = "copy";
+                    // Fallback channel in case the signal is cleared.
+                    e.dataTransfer.setData("application/x-drone-kind", p.kind);
+                }
+            }}
+            onDragEnd={() => setDragKind(null)}
+            onClick={() => p.model.addNodeAtCenter(p.kind)}
+        >
+            <span class="drone-chip-emoji">{meta.emoji}</span>
+            <span class="drone-chip-label">{meta.label}</span>
+        </button>
     );
 };
 
@@ -265,6 +271,45 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         window.removeEventListener("pointermove", onPanMove);
     });
 
+    // ── drag-from-bar → drop-on-canvas ──────────────────────────────
+    const screenToFlow = (clientX: number, clientY: number) => {
+        const rect = canvasEl.getBoundingClientRect();
+        const v = m.viewportAtom();
+        return {
+            x: (clientX - rect.left - v.x) / v.zoom,
+            y: (clientY - rect.top - v.y) / v.zoom,
+        };
+    };
+    const onDragOver = (e: DragEvent) => {
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDrop = (e: DragEvent) => {
+        e.preventDefault();
+        const kind =
+            dragKind() ??
+            (e.dataTransfer?.getData("application/x-drone-kind") as BlockKind | undefined) ??
+            null;
+        if (!kind) return;
+        const p0 = screenToFlow(e.clientX, e.clientY);
+        // Center the node body roughly under the cursor.
+        m.addNode(kind, { x: p0.x - 80, y: p0.y - 20 });
+        setDragKind(null);
+    };
+
+    // Keep the model's canvas pixel size current so a chip-click can
+    // place a node at the visible center.
+    onMount(() => {
+        const sync = () => {
+            const r = canvasEl.getBoundingClientRect();
+            m.setCanvasSize({ w: r.width, h: r.height });
+        };
+        sync();
+        const ro = new ResizeObserver(sync);
+        ro.observe(canvasEl);
+        onCleanup(() => ro.disconnect());
+    });
+
     const onNodeClick = (e: MouseEvent, n: FlowNode) => {
         e.stopPropagation();
         if (e.shiftKey) {
@@ -316,6 +361,8 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
             ref={canvasEl}
             onWheel={onWheel}
             onPointerDown={onCanvasPointerDown}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
         >
             <div class="drone-viewport" style={vpStyle()}>
                 <svg class="drone-canvas-edges" aria-hidden="true">
@@ -358,6 +405,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
                                 onClick={(e) => onNodeClick(e, n)}
                             >
                                 <header class="drone-node-header">
+                                    <span class="drone-node-emoji">{meta.emoji}</span>
                                     <span class="drone-node-label">{meta.label}</span>
                                     <button
                                         class="drone-node-close"
@@ -438,17 +486,23 @@ function truncate(s: string, max = 40): string {
 
 const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
+    // Slide-over overlay: only mounted while a node is selected, so the
+    // canvas stays full-bleed otherwise.
     return (
-        <aside class="drone-inspector" aria-label="Inspector">
-            <Show
-                when={m.selectedNodeAtom()}
-                fallback={
-                    <div class="drone-inspector-empty">Select a block to edit.</div>
-                }
-            >
-                {(node) => <InspectorForm model={m} node={node()} />}
-            </Show>
-        </aside>
+        <Show when={m.selectedNodeAtom()}>
+            {(node) => (
+                <aside class="drone-inspector" aria-label="Inspector">
+                    <button
+                        class="drone-inspector-close"
+                        aria-label="Close inspector"
+                        onClick={() => m.setSelected(null)}
+                    >
+                        ×
+                    </button>
+                    <InspectorForm model={m} node={node()} />
+                </aside>
+            )}
+        </Show>
     );
 };
 
@@ -717,40 +771,44 @@ const AgentResultPanel = (p: {
 
 const RunPanel = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
+    // Bottom overlay drawer — only present when there's something to
+    // show, so the empty canvas stays clean.
     return (
-        <footer class="drone-runpanel">
-            <div class="drone-runpanel-title">
-                Runs
-                <Show when={m.activeRunIdAtom()}>
-                    <span class="drone-runpanel-active">
-                        active: {m.activeRunIdAtom()?.slice(0, 8)}
-                    </span>
-                </Show>
-            </div>
-            <div class="drone-runpanel-list">
-                <Show
-                    when={m.runsAtom().length > 0}
-                    fallback={<div class="drone-runpanel-empty">No runs yet.</div>}
-                >
-                    <For each={m.runsAtom()}>
-                        {(r) => (
-                            <div
-                                class="drone-runpanel-row"
-                                classList={{
-                                    "drone-runpanel-row--ok": r.status === "done",
-                                    "drone-runpanel-row--err": r.status === "failed",
-                                }}
-                            >
-                                <span class="drone-runpanel-status">{r.status}</span>
-                                <span class="drone-runpanel-id">{r.id.slice(0, 8)}</span>
-                                <span class="drone-runpanel-output">
-                                    {r.error ? r.error : r.output}
-                                </span>
-                            </div>
-                        )}
-                    </For>
-                </Show>
-            </div>
-        </footer>
+        <Show when={m.runsAtom().length > 0 || m.activeRunIdAtom()}>
+            <footer class="drone-runpanel">
+                <div class="drone-runpanel-title">
+                    Runs
+                    <Show when={m.activeRunIdAtom()}>
+                        <span class="drone-runpanel-active">
+                            active: {m.activeRunIdAtom()?.slice(0, 8)}
+                        </span>
+                    </Show>
+                </div>
+                <div class="drone-runpanel-list">
+                    <Show
+                        when={m.runsAtom().length > 0}
+                        fallback={<div class="drone-runpanel-empty">No runs yet.</div>}
+                    >
+                        <For each={m.runsAtom()}>
+                            {(r) => (
+                                <div
+                                    class="drone-runpanel-row"
+                                    classList={{
+                                        "drone-runpanel-row--ok": r.status === "done",
+                                        "drone-runpanel-row--err": r.status === "failed",
+                                    }}
+                                >
+                                    <span class="drone-runpanel-status">{r.status}</span>
+                                    <span class="drone-runpanel-id">{r.id.slice(0, 8)}</span>
+                                    <span class="drone-runpanel-output">
+                                        {r.error ? r.error : r.output}
+                                    </span>
+                                </div>
+                            )}
+                        </For>
+                    </Show>
+                </div>
+            </footer>
+        </Show>
     );
 };

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -507,13 +507,16 @@ const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
 };
 
 const InspectorForm = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element => {
-    const meta = blockMeta(p.node.data.kind as BlockKind);
+    // Reactive: the same InspectorForm instance is reused as the selection
+    // changes (the <Show> stays truthy), so `meta` must re-read p.node —
+    // a computed-once const would show the first-selected node's label.
+    const meta = () => blockMeta(p.node.data.kind as BlockKind);
     const update = (patch: Record<string, unknown>) =>
         p.model.updateNodeData(p.node.id, patch);
 
     return (
         <div class="drone-inspector-form">
-            <div class="drone-inspector-title">{meta.label}</div>
+            <div class="drone-inspector-title">{meta().label}</div>
             <div class="drone-inspector-id">{p.node.id}</div>
             <Show when={p.node.data.kind === "agent"}>
                 <AgentRefEditor node={p.node} update={update} />

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createResource, For, Show, type JSX } from "solid-js";
+import { createResource, For, onCleanup, Show, type JSX } from "solid-js";
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -130,6 +130,140 @@ const BlockPalette = (p: { model: DroneViewModel }): JSX.Element => {
 const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
     let edgeStartId: string | null = null;
+    let canvasEl!: HTMLDivElement;
+
+    // ── viewport transform (pan / zoom) ─────────────────────────────
+    const vpStyle = () => {
+        const v = m.viewportAtom();
+        return {
+            transform: `translate(${v.x}px, ${v.y}px) scale(${v.zoom})`,
+            "transform-origin": "0 0",
+        };
+    };
+    const ZMIN = 0.2,
+        ZMAX = 2.5;
+    const clampZoom = (z: number) => Math.min(ZMAX, Math.max(ZMIN, z));
+
+    const onWheel = (e: WheelEvent) => {
+        e.preventDefault();
+        const rect = canvasEl.getBoundingClientRect();
+        const mx = e.clientX - rect.left;
+        const my = e.clientY - rect.top;
+        const v = m.viewportAtom();
+        const zoom = clampZoom(v.zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+        // Anchor the flow-point under the cursor so zoom feels natural.
+        const fx = (mx - v.x) / v.zoom;
+        const fy = (my - v.y) / v.zoom;
+        m.setViewport({ zoom, x: mx - fx * zoom, y: my - fy * zoom });
+    };
+
+    const zoomByCenter = (factor: number) => {
+        const rect = canvasEl.getBoundingClientRect();
+        const cx = rect.width / 2,
+            cy = rect.height / 2;
+        const v = m.viewportAtom();
+        const zoom = clampZoom(v.zoom * factor);
+        const fx = (cx - v.x) / v.zoom;
+        const fy = (cy - v.y) / v.zoom;
+        m.setViewport({ zoom, x: cx - fx * zoom, y: cy - fy * zoom });
+    };
+
+    const fitView = () => {
+        const nodes = m.draftAtom().graph.nodes;
+        const rect = canvasEl.getBoundingClientRect();
+        if (nodes.length === 0) {
+            m.setViewport({ x: 0, y: 0, zoom: 1 });
+            return;
+        }
+        const NW = 180,
+            NH = 76,
+            pad = 80;
+        let minX = Infinity,
+            minY = Infinity,
+            maxX = -Infinity,
+            maxY = -Infinity;
+        for (const n of nodes) {
+            minX = Math.min(minX, n.position.x);
+            minY = Math.min(minY, n.position.y);
+            maxX = Math.max(maxX, n.position.x + NW);
+            maxY = Math.max(maxY, n.position.y + NH);
+        }
+        const w = maxX - minX || 1,
+            h = maxY - minY || 1;
+        const zoom = clampZoom(Math.min((rect.width - pad) / w, (rect.height - pad) / h));
+        m.setViewport({
+            zoom,
+            x: rect.width / 2 - (minX + w / 2) * zoom,
+            y: rect.height / 2 - (minY + h / 2) * zoom,
+        });
+    };
+
+    // ── node drag (zoom-aware: divide client delta by zoom) ─────────
+    let drag: { id: string; sx: number; sy: number; ox: number; oy: number; zoom: number } | null =
+        null;
+    const onNodeMove = (e: PointerEvent) => {
+        if (!drag) return;
+        const dx = (e.clientX - drag.sx) / drag.zoom;
+        const dy = (e.clientY - drag.sy) / drag.zoom;
+        m.moveNode(drag.id, { x: drag.ox + dx, y: drag.oy + dy });
+    };
+    const onNodeUp = () => {
+        drag = null;
+        window.removeEventListener("pointermove", onNodeMove);
+    };
+    const onNodePointerDown = (e: PointerEvent, n: FlowNode) => {
+        // Left-button only; Shift is reserved for click-to-wire.
+        if (e.button !== 0 || e.shiftKey) return;
+        const t = e.target as HTMLElement;
+        if (t.closest(".nodrag") || t.closest(".drone-node-close")) return;
+        e.stopPropagation(); // don't let the canvas start a pan
+        m.setSelected(n.id);
+        drag = {
+            id: n.id,
+            sx: e.clientX,
+            sy: e.clientY,
+            ox: n.position.x,
+            oy: n.position.y,
+            zoom: m.viewportAtom().zoom,
+        };
+        window.addEventListener("pointermove", onNodeMove);
+        window.addEventListener("pointerup", onNodeUp, { once: true });
+    };
+
+    // ── canvas pan (drag empty background or middle-mouse) ──────────
+    let pan: { sx: number; sy: number; ox: number; oy: number; moved: boolean } | null = null;
+    const onPanMove = (e: PointerEvent) => {
+        if (!pan) return;
+        const dx = e.clientX - pan.sx,
+            dy = e.clientY - pan.sy;
+        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) pan.moved = true;
+        m.setViewport({ x: pan.ox + dx, y: pan.oy + dy });
+    };
+    const onPanUp = () => {
+        // A background press that never moved is a click → deselect.
+        if (pan && !pan.moved) m.setSelected(null);
+        pan = null;
+        window.removeEventListener("pointermove", onPanMove);
+    };
+    const isBackground = (t: HTMLElement) =>
+        t === canvasEl ||
+        t.classList.contains("drone-viewport") ||
+        t.classList.contains("drone-canvas-edges") ||
+        t.tagName.toLowerCase() === "svg";
+    const onCanvasPointerDown = (e: PointerEvent) => {
+        const t = e.target as HTMLElement;
+        if (e.button === 1 || (e.button === 0 && isBackground(t))) {
+            const v = m.viewportAtom();
+            pan = { sx: e.clientX, sy: e.clientY, ox: v.x, oy: v.y, moved: false };
+            window.addEventListener("pointermove", onPanMove);
+            window.addEventListener("pointerup", onPanUp, { once: true });
+        }
+    };
+
+    onCleanup(() => {
+        window.removeEventListener("pointermove", onNodeMove);
+        window.removeEventListener("pointermove", onPanMove);
+    });
 
     const onNodeClick = (e: MouseEvent, n: FlowNode) => {
         e.stopPropagation();
@@ -177,65 +311,95 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     };
 
     return (
-        <div class="drone-canvas" onClick={() => m.setSelected(null)}>
-            <svg class="drone-canvas-edges" aria-hidden="true">
-                <For each={m.draftAtom().graph.edges}>
-                    {(edge) => {
-                        const src = () =>
-                            m.draftAtom().graph.nodes.find((n) => n.id === edge.source);
-                        const dst = () =>
-                            m.draftAtom().graph.nodes.find((n) => n.id === edge.target);
+        <div
+            class="drone-canvas"
+            ref={canvasEl}
+            onWheel={onWheel}
+            onPointerDown={onCanvasPointerDown}
+        >
+            <div class="drone-viewport" style={vpStyle()}>
+                <svg class="drone-canvas-edges" aria-hidden="true">
+                    <For each={m.draftAtom().graph.edges}>
+                        {(edge) => {
+                            const src = () =>
+                                m.draftAtom().graph.nodes.find((n) => n.id === edge.source);
+                            const dst = () =>
+                                m.draftAtom().graph.nodes.find((n) => n.id === edge.target);
+                            return (
+                                <Show when={src() && dst()}>
+                                    <line
+                                        class="drone-edge"
+                                        x1={src()!.position.x + 80}
+                                        y1={src()!.position.y + 28}
+                                        x2={dst()!.position.x}
+                                        y2={dst()!.position.y + 28}
+                                    />
+                                </Show>
+                            );
+                        }}
+                    </For>
+                </svg>
+                <For each={m.draftAtom().graph.nodes}>
+                    {(n) => {
+                        const meta = blockMeta(n.data.kind as BlockKind);
+                        const selected = () => m.selectedAtom() === n.id;
                         return (
-                            <Show when={src() && dst()}>
-                                <line
-                                    class="drone-edge"
-                                    x1={src()!.position.x + 80}
-                                    y1={src()!.position.y + 28}
-                                    x2={dst()!.position.x}
-                                    y2={dst()!.position.y + 28}
-                                />
-                            </Show>
+                            <div
+                                class="drone-node"
+                                classList={{
+                                    "drone-node--selected": selected(),
+                                }}
+                                style={{
+                                    left: `${n.position.x}px`,
+                                    top: `${n.position.y}px`,
+                                    "--block-color": meta.color,
+                                }}
+                                onPointerDown={(e) => onNodePointerDown(e, n)}
+                                onClick={(e) => onNodeClick(e, n)}
+                            >
+                                <header class="drone-node-header">
+                                    <span class="drone-node-label">{meta.label}</span>
+                                    <button
+                                        class="drone-node-close"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            m.removeNode(n.id);
+                                        }}
+                                        aria-label="Remove block"
+                                    >
+                                        ×
+                                    </button>
+                                </header>
+                                <div class="drone-node-body">{nodeSummary(n)}</div>
+                            </div>
                         );
                     }}
                 </For>
-            </svg>
-            <For each={m.draftAtom().graph.nodes}>
-                {(n) => {
-                    const meta = blockMeta(n.data.kind as BlockKind);
-                    const selected = () => m.selectedAtom() === n.id;
-                    return (
-                        <div
-                            class="drone-node"
-                            classList={{
-                                "drone-node--selected": selected(),
-                            }}
-                            style={{
-                                left: `${n.position.x}px`,
-                                top: `${n.position.y}px`,
-                                "--block-color": meta.color,
-                            }}
-                            onClick={(e) => onNodeClick(e, n)}
-                        >
-                            <header class="drone-node-header">
-                                <span class="drone-node-label">{meta.label}</span>
-                                <button
-                                    class="drone-node-close"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        m.removeNode(n.id);
-                                    }}
-                                    aria-label="Remove block"
-                                >
-                                    ×
-                                </button>
-                            </header>
-                            <div class="drone-node-body">{nodeSummary(n)}</div>
-                        </div>
-                    );
-                }}
-            </For>
-            <div class="drone-canvas-hint">
-                Click to add blocks · Shift-click two nodes to connect them
+            </div>
+            <Show when={m.draftAtom().graph.nodes.length === 0}>
+                <div class="drone-canvas-hint">
+                    Drag a block from the top bar onto the canvas · drag nodes to move ·
+                    scroll to zoom · drag the canvas to pan · Shift-click two nodes to wire
+                </div>
+            </Show>
+            <div class="drone-controls">
+                <button
+                    class="drone-ctrl"
+                    title="Zoom in"
+                    onClick={() => zoomByCenter(1.2)}
+                >
+                    +
+                </button>
+                <button
+                    class="drone-ctrl"
+                    title="Zoom out"
+                    onClick={() => zoomByCenter(1 / 1.2)}
+                >
+                    −
+                </button>
+                <button class="drone-ctrl" title="Fit view" onClick={fitView}>
+                    ⤢
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Rebuilds the **Drone** pane's frontend canvas into the intended experience: a horizontal **emoji node-type bar** at the top, and everything below is one **expansive DAG canvas** — drag node-types down to create nodes, drag nodes around, wire them, pan/zoom. The backend DAG engine was already complete; this is a frontend-only canvas rebuild (plus the spec).

Before: click-to-add at a random spot, **no node drag, no pan/zoom, no drag-from-palette**, palette stuck in a left column — the pane read as broken. After: direct-manipulation canvas that owns the screen.

Implements PRs 1–3 of `docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md`.

## What's in here

- **Spec** — `docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md` (research + 7-PR plan; supersedes the stale `solid-flow`/rename decisions in #753 — see spec §0.1).
- **PR1 — store migration** (`refactor`): the draft graph moves from a single `createSignal<DroneDefinition>` (whole-object replace on every edit → every node row re-runs) to a Solid `createStore` with path mutations + `reconcile` on load. Foundation for smooth dragging; public API unchanged.
- **PR2 — pan/zoom + node drag** (`feat`): viewport `{x,y,zoom}` in its own signal (isolated from the node store, so pan/zoom never re-runs a node binding; folded into `draft.viewport` at save). Wheel-zoom anchored to cursor; +/−/fit controls; pointer-capture node drag with delta ÷ zoom; pan via empty-canvas/middle drag.
- **PR3 — top emoji bar + drag-from-bar** (`feat`): `emoji` added per block kind (🔢 Variables · 🤖 Agent · 🌐 API · 🔀 Condition · 🏁 Response); `NodeTypeBar` replaces the left palette + toolbar; drag a chip → `screenToFlow(cursor)` → node at the drop point (click-to-center fallback). Inspector → right slide-over overlay; run log → bottom overlay — canvas stays full-bleed.
- **fix** — inspector title now tracks the selected node (was showing the first-selected node's label due to a computed-once `meta`; found via the live run).

## Architecture decision

Build out the **custom SolidJS canvas** rather than adopt a library: there is no production-grade SolidJS flow lib (React Flow is React-only; the one Solid port is a single-maintainer alpha pinned to an old `@xyflow/system`). The viewport/drag math is **hand-rolled** (spec §3.1 escape hatch) — zero new deps for this PR. `@xyflow/system` (edge geometry) + `@dagrejs/dagre` (auto-layout) are deferred to later PRs where they earn their keep.

## Verification

- `tsc --noEmit`: **0 errors in `view/drone` / `store/drone`** (project baseline unchanged).
- `npm run build` (Vite/Solid/SCSS): green.
- Drone unit tests: **26/26 pass**.
- **Live run** (`task dev`, driven via CDP): opened the Drone widget, dragged 🤖 Agent → 🔀 Condition → 🏁 Response onto the canvas, wired them, pan/zoom + inspector overlay all work. (The inspector-title bug above was caught here and fixed.)

## Not in this PR

Real port-based **drag-to-connect wiring** with typed/acyclic validation + edge select/delete is **PR4** (follow-up). Current wiring is shift-click-two-nodes, preserved from the prior canvas.

## Refs

- Spec: `docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md`
- Tracking: #753 (RFC), discussion #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
