### PR TITLE
feat(drone): port-based drag-to-connect wiring (PR4)

### DIFF
--- a/.changesets/1780674173-feat-drone-port-based-drag-to-connect-wiring-with-typed-acyc-kwhj.md
+++ b/.changesets/1780674173-feat-drone-port-based-drag-to-connect-wiring-with-typed-acyc-kwhj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(drone): port-based drag-to-connect wiring with typed/acyclic validation

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -119,6 +119,15 @@ export class DroneViewModel implements ViewModel {
         this._canvasSize[1](size);
     };
 
+    // --- which EDGE is selected (for delete). Mutually exclusive with
+    // node selection.
+    private _selectedEdge = createSignal<string | null>(null);
+    selectedEdgeAtom: Accessor<string | null> = this._selectedEdge[0];
+    setSelectedEdge = (id: string | null): void => {
+        this._selectedEdge[1](id);
+        if (id) this._selected[1](null);
+    };
+
     // --- run state
     //
     // `_running` is the in-flight `await RunDroneCommand` flag — bound
@@ -515,6 +524,73 @@ export class DroneViewModel implements ViewModel {
 
     removeEdge(id: string): void {
         this.setDraftStore("graph", "edges", (edges) => edges.filter((e) => e.id !== id));
+        if (this.selectedEdgeAtom() === id) this.setSelectedEdge(null);
+    }
+
+    /** Validate a proposed connection before it becomes an edge:
+     *  - no self-loop,
+     *  - no duplicate (same source/handle → same target/handle),
+     *  - compatible port types (`any` matches anything),
+     *  - no cycle (keeps the graph a DAG for the executor's topo sort). */
+    canConnect(c: {
+        source: string;
+        sourceHandle?: string;
+        target: string;
+        targetHandle?: string;
+    }): boolean {
+        if (c.source === c.target) return false;
+        const graph = this.draftAtom().graph;
+        const src = graph.nodes.find((n) => n.id === c.source);
+        const dst = graph.nodes.find((n) => n.id === c.target);
+        if (!src || !dst) return false;
+        const srcH = c.sourceHandle ?? "out";
+        const dstH = c.targetHandle ?? "in";
+        if (
+            graph.edges.some(
+                (e) =>
+                    e.source === c.source &&
+                    e.target === c.target &&
+                    (e.sourceHandle ?? "out") === srcH &&
+                    (e.targetHandle ?? "in") === dstH,
+            )
+        )
+            return false;
+        const outType =
+            blockMeta(src.data.kind as BlockKind).outputs.find((h) => h.id === srcH)?.type ?? "any";
+        const inType =
+            blockMeta(dst.data.kind as BlockKind).inputs.find((h) => h.id === dstH)?.type ?? "any";
+        if (outType !== "any" && inType !== "any" && outType !== inType) return false;
+        // Cycle check: if the target can already reach the source, adding
+        // source→target would close a loop.
+        if (this.reaches(c.target, c.source)) return false;
+        return true;
+    }
+
+    /** Can `from` reach `to` by following edge direction? (iterative DFS) */
+    private reaches(from: string, to: string): boolean {
+        const edges = this.draftAtom().graph.edges;
+        const seen = new Set<string>();
+        const stack = [from];
+        while (stack.length) {
+            const cur = stack.pop() as string;
+            if (cur === to) return true;
+            if (seen.has(cur)) continue;
+            seen.add(cur);
+            for (const e of edges) if (e.source === cur) stack.push(e.target);
+        }
+        return false;
+    }
+
+    /** Validate then add an edge. Returns whether it was added. */
+    connect(c: {
+        source: string;
+        sourceHandle?: string;
+        target: string;
+        targetHandle?: string;
+    }): boolean {
+        if (!this.canConnect(c)) return false;
+        this.addEdge(c);
+        return true;
     }
 
     setName(name: string): void {

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -545,15 +545,11 @@ export class DroneViewModel implements ViewModel {
         if (!src || !dst) return false;
         const srcH = c.sourceHandle ?? "out";
         const dstH = c.targetHandle ?? "in";
-        if (
-            graph.edges.some(
-                (e) =>
-                    e.source === c.source &&
-                    e.target === c.target &&
-                    (e.sourceHandle ?? "out") === srcH &&
-                    (e.targetHandle ?? "in") === dstH,
-            )
-        )
+        // Single-input occupancy: each declared input handle takes exactly
+        // one wire, so reject a second edge into an already-wired input
+        // (this also covers exact duplicates). A multi-incoming join would
+        // require the registry to declare multiple input handles.
+        if (graph.edges.some((e) => e.target === c.target && (e.targetHandle ?? "in") === dstH))
             return false;
         const outType =
             blockMeta(src.data.kind as BlockKind).outputs.find((h) => h.id === srcH)?.type ?? "any";

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -148,6 +148,9 @@
     &:active {
         cursor: grabbing;
     }
+    &:focus {
+        outline: none; // focusable (tabindex=-1) only to scope keydown
+    }
 }
 
 // The transformed layer. A zero-size origin point at (0,0) flow-space;

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -178,6 +178,54 @@
     fill: none;
 }
 
+.drone-edge--selected {
+    stroke: var(--accent-color);
+    stroke-width: 3;
+}
+
+// Fat transparent stroke behind each edge so thin beziers are easy to
+// click. The visible edge inherits pointer-events:none from the svg.
+.drone-edge-hit {
+    stroke: transparent;
+    stroke-width: 14;
+    fill: none;
+    pointer-events: stroke;
+    cursor: pointer;
+}
+
+.drone-edge-preview {
+    stroke: var(--accent-color);
+    stroke-width: 2;
+    stroke-dasharray: 5 4;
+    fill: none;
+    pointer-events: none;
+}
+
+// ── Node ports (connection handles) ───────────────────────────────────
+
+.drone-port {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    box-sizing: border-box;
+    border-radius: 50%;
+    background: var(--secondary-text-color);
+    border: 2px solid var(--main-bg-color);
+    z-index: 2;
+}
+
+.drone-port--in {
+    left: -6px;
+}
+
+.drone-port--out {
+    right: -6px;
+    cursor: crosshair;
+    &:hover {
+        transform: scale(1.3);
+    }
+}
+
 .drone-canvas-hint {
     position: absolute;
     top: 50%;

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -131,11 +131,10 @@ const NodeChip = (p: { model: DroneViewModel; kind: BlockKind }): JSX.Element =>
 // xyflow-shaped, so we own the canvas and borrow only math where it pays
 // off. The viewport transform + pointer drag are hand-rolled (spec §3.1).
 // Supports: drag-from-bar to create, node drag, pan/zoom + fit, and
-// Shift-click wiring. See SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md.
+// port-to-port drag wiring. See SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md.
 
 const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     const m = p.model;
-    let edgeStartId: string | null = null;
     let canvasEl!: HTMLDivElement;
 
     // ── viewport transform (pan / zoom) ─────────────────────────────
@@ -218,8 +217,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         window.removeEventListener("pointermove", onNodeMove);
     };
     const onNodePointerDown = (e: PointerEvent, n: FlowNode) => {
-        // Left-button only; Shift is reserved for click-to-wire.
-        if (e.button !== 0 || e.shiftKey) return;
+        if (e.button !== 0) return; // left-button drag only
         const t = e.target as HTMLElement;
         if (t.closest(".nodrag") || t.closest(".drone-node-close")) return;
         e.stopPropagation(); // don't let the canvas start a pan
@@ -308,7 +306,15 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         sync();
         const ro = new ResizeObserver(sync);
         ro.observe(canvasEl);
-        onCleanup(() => ro.disconnect());
+        // Focus the canvas on any pointer-down within it (capture phase, so
+        // it runs even when a node/edge/port handler stops propagation) —
+        // this is what scopes the Delete/Escape keydown to this pane.
+        const focusOnDown = () => canvasEl.focus({ preventScroll: true });
+        canvasEl.addEventListener("pointerdown", focusOnDown, true);
+        onCleanup(() => {
+            ro.disconnect();
+            canvasEl.removeEventListener("pointerdown", focusOnDown, true);
+        });
     });
 
     // ── port → port connection drag ─────────────────────────────────
@@ -321,10 +327,17 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         const p = screenToFlow(e.clientX, e.clientY);
         setConn({ ...c, x2: p.x, y2: p.y });
     };
-    const onConnUp = (e: PointerEvent) => {
+    // Tear down a connection drag — removes BOTH window listeners (the
+    // pointerup is registered `once`, but an Escape-cancel resolves before
+    // it fires, so we must remove it explicitly) and clears the preview.
+    const cancelConn = () => {
         window.removeEventListener("pointermove", onConnMove);
-        const c = conn();
+        window.removeEventListener("pointerup", onConnUp);
         setConn(null);
+    };
+    const onConnUp = (e: PointerEvent) => {
+        const c = conn();
+        cancelConn();
         if (!c) return;
         // Drop target = whatever input port is under the cursor.
         const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
@@ -350,11 +363,15 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     };
 
     // ── keyboard: delete selection · escape cancels ─────────────────
+    // Bound to the canvas element (not window) and the canvas is focused
+    // on any pointer-down within it (capture phase, below), so Delete only
+    // affects the pane the user is actually interacting with — never
+    // another drone pane's selection in the same window.
     const onKey = (e: KeyboardEvent) => {
         const tag = (e.target as HTMLElement | null)?.tagName;
         if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
         if (e.key === "Escape") {
-            setConn(null);
+            cancelConn();
             m.setSelected(null);
             m.setSelectedEdge(null);
             return;
@@ -371,63 +388,19 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
             }
         }
     };
-    onMount(() => {
-        window.addEventListener("keydown", onKey);
-        onCleanup(() => window.removeEventListener("keydown", onKey));
+    onCleanup(() => {
+        window.removeEventListener("pointermove", onConnMove);
+        window.removeEventListener("pointerup", onConnUp);
     });
-    onCleanup(() => window.removeEventListener("pointermove", onConnMove));
-
-    const onNodeClick = (e: MouseEvent, n: FlowNode) => {
-        e.stopPropagation();
-        if (e.shiftKey) {
-            // Shift-click toggles edge-draw mode.
-            if (edgeStartId == null) {
-                edgeStartId = n.id;
-                return;
-            }
-            if (edgeStartId !== n.id) {
-                // For edges sourced from a Condition block, auto-assign
-                // the branch handle by edge-order: first connection =
-                // "true" branch, second = "false". The executor's
-                // branch-pruning logic (engine.rs `edge_is_active`)
-                // gates on this handle, so without it BOTH branches
-                // run and fire API/agent side effects on the path
-                // that should have been skipped. Phase 1 trades
-                // discoverability for simplicity; Phase 2 / canvas
-                // polish PR introduces a UI affordance (color, label,
-                // right-click "swap branches"). See codex review on
-                // PR #755.
-                const srcId = edgeStartId;
-                const srcNode = m
-                    .draftAtom()
-                    .graph.nodes.find((x) => x.id === srcId);
-                const isCondition =
-                    (srcNode?.data?.kind as string | undefined) === "condition";
-                let sourceHandle: string | undefined;
-                if (isCondition) {
-                    const existing = m
-                        .draftAtom()
-                        .graph.edges.filter((edge) => edge.source === srcId);
-                    sourceHandle = existing.length === 0 ? "true" : "false";
-                }
-                m.addEdge({
-                    source: srcId,
-                    target: n.id,
-                    ...(sourceHandle ? { sourceHandle } : {}),
-                });
-            }
-            edgeStartId = null;
-            return;
-        }
-        m.setSelected(n.id);
-    };
 
     return (
         <div
             class="drone-canvas"
             ref={canvasEl}
+            tabindex={-1}
             onWheel={onWheel}
             onPointerDown={onCanvasPointerDown}
+            onKeyDown={onKey}
             onDragOver={onDragOver}
             onDrop={onDrop}
         >
@@ -490,7 +463,6 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
                                     "--block-color": meta.color,
                                 }}
                                 onPointerDown={(e) => onNodePointerDown(e, n)}
-                                onClick={(e) => onNodeClick(e, n)}
                             >
                                 <header class="drone-node-header">
                                     <span class="drone-node-emoji">{meta.emoji}</span>

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -224,6 +224,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         if (t.closest(".nodrag") || t.closest(".drone-node-close")) return;
         e.stopPropagation(); // don't let the canvas start a pan
         m.setSelected(n.id);
+        m.setSelectedEdge(null);
         drag = {
             id: n.id,
             sx: e.clientX,
@@ -310,6 +311,72 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         onCleanup(() => ro.disconnect());
     });
 
+    // ── port → port connection drag ─────────────────────────────────
+    const [conn, setConn] = createSignal<
+        { sourceId: string; sourceHandle: string; x1: number; y1: number; x2: number; y2: number } | null
+    >(null);
+    const onConnMove = (e: PointerEvent) => {
+        const c = conn();
+        if (!c) return;
+        const p = screenToFlow(e.clientX, e.clientY);
+        setConn({ ...c, x2: p.x, y2: p.y });
+    };
+    const onConnUp = (e: PointerEvent) => {
+        window.removeEventListener("pointermove", onConnMove);
+        const c = conn();
+        setConn(null);
+        if (!c) return;
+        // Drop target = whatever input port is under the cursor.
+        const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+        const port = el?.closest(".drone-port--in") as HTMLElement | null;
+        if (port?.dataset.node) {
+            m.connect({
+                source: c.sourceId,
+                sourceHandle: c.sourceHandle,
+                target: port.dataset.node,
+                targetHandle: port.dataset.handle ?? "in",
+            });
+        }
+    };
+    const startConn = (e: PointerEvent, nodeId: string, handleId: string) => {
+        if (e.button !== 0) return;
+        e.stopPropagation(); // don't start a node drag
+        const node = m.draftAtom().graph.nodes.find((n) => n.id === nodeId);
+        if (!node) return;
+        const sp = portFlowPos(node, "out", handleId);
+        setConn({ sourceId: nodeId, sourceHandle: handleId, x1: sp.x, y1: sp.y, x2: sp.x, y2: sp.y });
+        window.addEventListener("pointermove", onConnMove);
+        window.addEventListener("pointerup", onConnUp, { once: true });
+    };
+
+    // ── keyboard: delete selection · escape cancels ─────────────────
+    const onKey = (e: KeyboardEvent) => {
+        const tag = (e.target as HTMLElement | null)?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        if (e.key === "Escape") {
+            setConn(null);
+            m.setSelected(null);
+            m.setSelectedEdge(null);
+            return;
+        }
+        if (e.key === "Delete" || e.key === "Backspace") {
+            const edgeId = m.selectedEdgeAtom();
+            const nodeId = m.selectedAtom();
+            if (edgeId) {
+                m.removeEdge(edgeId);
+                e.preventDefault();
+            } else if (nodeId) {
+                m.removeNode(nodeId);
+                e.preventDefault();
+            }
+        }
+    };
+    onMount(() => {
+        window.addEventListener("keydown", onKey);
+        onCleanup(() => window.removeEventListener("keydown", onKey));
+    });
+    onCleanup(() => window.removeEventListener("pointermove", onConnMove));
+
     const onNodeClick = (e: MouseEvent, n: FlowNode) => {
         e.stopPropagation();
         if (e.shiftKey) {
@@ -365,26 +432,47 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
             onDrop={onDrop}
         >
             <div class="drone-viewport" style={vpStyle()}>
-                <svg class="drone-canvas-edges" aria-hidden="true">
+                <svg class="drone-canvas-edges">
                     <For each={m.draftAtom().graph.edges}>
                         {(edge) => {
                             const src = () =>
                                 m.draftAtom().graph.nodes.find((n) => n.id === edge.source);
                             const dst = () =>
                                 m.draftAtom().graph.nodes.find((n) => n.id === edge.target);
+                            const d = () => {
+                                const a = portFlowPos(src()!, "out", edge.sourceHandle ?? "out");
+                                const b = portFlowPos(dst()!, "in", edge.targetHandle ?? "in");
+                                return bezierPath(a.x, a.y, b.x, b.y);
+                            };
                             return (
                                 <Show when={src() && dst()}>
-                                    <line
+                                    <path
+                                        class="drone-edge-hit"
+                                        d={d()}
+                                        onPointerDown={(e) => {
+                                            e.stopPropagation();
+                                            m.setSelectedEdge(edge.id);
+                                        }}
+                                    />
+                                    <path
                                         class="drone-edge"
-                                        x1={src()!.position.x + 80}
-                                        y1={src()!.position.y + 28}
-                                        x2={dst()!.position.x}
-                                        y2={dst()!.position.y + 28}
+                                        classList={{
+                                            "drone-edge--selected": m.selectedEdgeAtom() === edge.id,
+                                        }}
+                                        d={d()}
                                     />
                                 </Show>
                             );
                         }}
                     </For>
+                    <Show when={conn()}>
+                        {(c) => (
+                            <path
+                                class="drone-edge-preview"
+                                d={bezierPath(c().x1, c().y1, c().x2, c().y2)}
+                            />
+                        )}
+                    </Show>
                 </svg>
                 <For each={m.draftAtom().graph.nodes}>
                     {(n) => {
@@ -419,6 +507,37 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
                                     </button>
                                 </header>
                                 <div class="drone-node-body">{nodeSummary(n)}</div>
+                                <For each={meta.inputs}>
+                                    {(h, i) => (
+                                        <div
+                                            class="drone-port drone-port--in nodrag"
+                                            data-node={n.id}
+                                            data-handle={h.id}
+                                            title={`input: ${h.label}`}
+                                            style={{ top: `${portOffsetY(meta.inputs.length, i()) - 6}px` }}
+                                        />
+                                    )}
+                                </For>
+                                <For each={meta.outputs}>
+                                    {(h, i) => (
+                                        <div
+                                            class="drone-port drone-port--out nodrag"
+                                            data-node={n.id}
+                                            data-handle={h.id}
+                                            title={`output: ${h.label}`}
+                                            style={{
+                                                top: `${portOffsetY(meta.outputs.length, i()) - 6}px`,
+                                                background:
+                                                    h.id === "true"
+                                                        ? "#10b981"
+                                                        : h.id === "false"
+                                                          ? "#6b7280"
+                                                          : meta.color,
+                                            }}
+                                            onPointerDown={(e) => startConn(e, n.id, h.id)}
+                                        />
+                                    )}
+                                </For>
                             </div>
                         );
                     }}
@@ -427,7 +546,8 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
             <Show when={m.draftAtom().graph.nodes.length === 0}>
                 <div class="drone-canvas-hint">
                     Drag a block from the top bar onto the canvas · drag nodes to move ·
-                    scroll to zoom · drag the canvas to pan · Shift-click two nodes to wire
+                    drag a right port → a left port to wire · scroll to zoom · drag the
+                    canvas to pan · Del removes the selection
                 </div>
             </Show>
             <div class="drone-controls">
@@ -480,6 +600,36 @@ function nodeSummary(n: FlowNode): string {
 
 function truncate(s: string, max = 40): string {
     return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+// ── Port + edge geometry ──────────────────────────────────────────────
+// Node body is NODE_W wide; ports sit on the left (inputs) and right
+// (outputs) edges, distributed vertically around the header. These
+// helpers are the single source of truth for where a wire attaches, used
+// by both the rendered ports and the edge paths so they always line up.
+
+const NODE_W = 160;
+
+/** Vertical offset (px, node-relative) of port `idx` of `count`. */
+function portOffsetY(count: number, idx: number): number {
+    return 26 + (idx - (count - 1) / 2) * 20;
+}
+
+/** Flow-space center of a node's port. */
+function portFlowPos(node: FlowNode, side: "in" | "out", handleId: string): { x: number; y: number } {
+    const meta = blockMeta(node.data.kind as BlockKind);
+    const list = side === "out" ? meta.outputs : meta.inputs;
+    const idx = Math.max(0, list.findIndex((h) => h.id === handleId));
+    return {
+        x: side === "out" ? node.position.x + NODE_W : node.position.x,
+        y: node.position.y + portOffsetY(list.length, idx),
+    };
+}
+
+/** Horizontal cubic bezier between two points (left→right flow). */
+function bezierPath(x1: number, y1: number, x2: number, y2: number): string {
+    const dx = Math.max(40, Math.abs(x2 - x1) * 0.5);
+    return `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
 }
 
 // ── Inspector ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR4 of the drone canvas (follows #1289). Replaces the shift-click wiring with real **ports + drag-to-connect**, so the DAG is buildable mouse-only.

## What changed

- **Visible port handles** on every node — inputs on the left edge, outputs on the right, positioned from the registry's `inputs`/`outputs`. Condition shows its two outputs color-coded (**green `true` / grey `false`**); the branch handle is now set by *which port you drag from*, replacing the fragile "first edge = true, second = false" ordering heuristic.
- **Drag-to-connect**: press an output port → a live **bezier preview** follows the cursor → release over an input port to connect (drop target resolved via `elementFromPoint`).
- **Validated connections** (`model.canConnect` / `connect`): rejects self-loops, duplicate edges, incompatible port types (`any` matches all), and **cycles** (keeps the graph a DAG for the topo executor).
- **Bezier edges** attached at port centers, each with a fat invisible hit-path so thin wires are easy to select. Click selects; **Delete/Backspace** removes the selected edge or node; **Escape** cancels a connection / clears selection.
- Node ↔ edge selection are mutually exclusive.

## Verification

- `tsc --noEmit`: 0 errors in `view/drone` / `store/drone`.
- `npm run build`: green.
- **Live run** (`task dev` + CDP): dragged Agent→Condition and Condition's **`true`** port→Response by ports; 2 edges created, branch port honored, bezier wires attach at the ports. Edge select + Delete confirmed.

## Refs

- Spec §6.4: `docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md`
- Tracking: #753, discussion #832 · follows #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
