### PR TITLE
fix(auth): provider auth in one shared, instance-independent dir (kills the validate-spin)

### DIFF
--- a/.changesets/1780675514-fix-auth-shared-provider-auth-dir-restore-the-validate-the-d-3zgu.md
+++ b/.changesets/1780675514-fix-auth-shared-provider-auth-dir-restore-the-validate-the-d-3zgu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): shared provider auth dir; restore the validate-the-dir-you-run-in invariant

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -100,13 +100,21 @@ pub fn ensure_auth_dir(
         ));
     }
 
-    let config_dir = state.version_config_dir.lock();
-    let config_dir = config_dir
+    // The DEFAULT provider auth/config dir lives under the account-wide, version-
+    // and channel-independent shared root (`~/.agentmux/shared/providers/<provider>/`),
+    // NOT the per-channel config dir. One login is shared across every instance /
+    // channel / version — the structural fix for the per-channel validate-spin
+    // regression (docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md).
+    // The per-identity bundle override (identity_handlers) still wins for explicit
+    // multi-account. `user_home_dir` is the AgentMux root (`~/.agentmux/`).
+    let home = state.user_home_dir.lock();
+    let home = home
         .as_ref()
-        .ok_or_else(|| "Config dir not initialized yet".to_string())?;
+        .ok_or_else(|| "Home dir not initialized yet".to_string())?;
 
-    let auth_dir = std::path::PathBuf::from(config_dir)
-        .join("auth")
+    let auth_dir = std::path::PathBuf::from(home)
+        .join("shared")
+        .join("providers")
         .join(provider_id);
     std::fs::create_dir_all(&auth_dir)
         .map_err(|e| format!("Failed to create auth dir for {}: {}", provider_id, e))?;

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -77,7 +77,10 @@ pub fn get_user_home_dir(state: &Arc<AppState>) -> Result<serde_json::Value, Str
 }
 
 /// Ensure a provider auth directory exists and return its absolute path.
-/// Auth dirs are version-isolated under the version-specific config dir.
+/// The DEFAULT provider auth lives in the account-wide, version- and
+/// channel-independent `~/.agentmux/shared/providers/<provider>/` — the
+/// per-identity bundle override (identity_handlers) still wins for explicit
+/// multi-account.
 pub fn ensure_auth_dir(
     state: &Arc<AppState>,
     args: &serde_json::Value,

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -372,6 +372,20 @@ impl DataPaths {
     pub fn identity_dir(&self, bundle_id: &str) -> Option<PathBuf> {
         sanitize_path_segment(bundle_id).map(|safe| self.identities_dir().join(safe))
     }
+
+    /// `~/.agentmux/shared/providers/<auth_dir_name>/` — the DEFAULT provider
+    /// config + auth dir. Lives under `shared_dir`, so it is account-wide,
+    /// version-independent, AND channel-independent: every instance / channel /
+    /// version logs in ONCE and shares it. This is the structural fix for the
+    /// per-channel "validate-spin" regression — there is no empty-per-instance
+    /// auth dir to spin on. The per-identity override (`identity_dir`) still
+    /// takes precedence for explicit multi-account bundles. `auth_dir_name`
+    /// comes from the static provider registry (e.g. "claude"), never user
+    /// input. Retro:
+    /// `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`.
+    pub fn provider_auth_dir(&self, auth_dir_name: &str) -> PathBuf {
+        self.shared_dir.join("providers").join(auth_dir_name)
+    }
 }
 
 /// `~/.agentmux/` root, or the test override via
@@ -896,6 +910,39 @@ mod tests {
             assert_eq!(p.identity_dir("foo*bar"), None);
             assert_eq!(p.identity_dir("foo?bar"), None);
             assert_eq!(p.identity_dir("with\0nul"), None);
+        });
+    }
+
+    #[test]
+    fn provider_auth_dir_is_shared_and_channel_independent() {
+        // The DEFAULT provider auth lives under shared_dir, so it resolves to the
+        // SAME path regardless of channel / version / mode — the structural fix
+        // for the per-channel "validate-spin" regression. It must NOT live under
+        // the per-channel config dir (which is where the regression put it).
+        // Retro: docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md
+        with_home_override(|_root| {
+            clear_channel_env();
+            let installed = DataPaths::resolve("0.42.0", &RuntimeMode::Installed).unwrap();
+            let dev = DataPaths::resolve(
+                "0.42.0",
+                &RuntimeMode::Dev { branch: "some-branch".into(), clone_id: None },
+            )
+            .unwrap();
+
+            let a = installed.provider_auth_dir("claude");
+            assert_eq!(
+                a,
+                dev.provider_auth_dir("claude"),
+                "provider auth dir must not vary by channel / mode (instance-independent)"
+            );
+            assert!(
+                a.ends_with("shared/providers/claude"),
+                "provider auth dir must live under shared/providers/: {a:?}"
+            );
+            assert!(
+                !a.starts_with(&installed.config_dir),
+                "provider auth dir must NOT be under the per-channel config dir"
+            );
         });
     }
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -58,7 +58,10 @@ pub struct ProviderConfig {
     /// Environment variable that redirects the provider's config / auth
     /// directory, e.g. `"CLAUDE_CONFIG_DIR"`.
     pub auth_config_dir_env_var: &'static str,
-    /// Sub-directory name under `{dataDir}/auth/`, e.g. `"claude"`.
+    /// Sub-directory name for this provider's auth/config dir, e.g. `"claude"`.
+    /// Resolved under `shared/providers/<name>/` (the default, account-wide and
+    /// instance-independent) and `shared/identities/<bundle>/<name>/` (per-identity)
+    /// — see `DataPaths::provider_auth_dir` and `identity_dir`.
     pub auth_dir_name: &'static str,
     /// Extra environment variables required for auth isolation.
     /// Each entry is a `(key, value)` pair.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -270,8 +270,14 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // Falls back to ~/.agentmux/config for non-portable installs.
                 let config_home = std::env::var("AGENTMUX_CONFIG_HOME")
                     .unwrap_or_else(|_| format!("{}/.agentmux/config", home));
-                // Auth dir
-                let auth_dir = format!("{}/auth/{}", config_home, provider.auth_dir_name);
+                // Auth dir — the DEFAULT provider auth lives in the shared,
+                // instance/channel/version-independent providers area so a single
+                // login is shared everywhere (the structural fix for the per-channel
+                // validate-spin regression). The per-identity bundle override
+                // (identity_handlers) still wins for explicit multi-account.
+                let auth_dir = agentmux_common::DataPaths::from_env()
+                    .map(|p| p.provider_auth_dir(provider.auth_dir_name).to_string_lossy().into_owned())
+                    .unwrap_or_else(|| format!("{}/.agentmux/shared/providers/{}", home, provider.auth_dir_name));
                 let _ = std::fs::create_dir_all(&auth_dir);
                 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
                 for (k, v) in provider.auth_extra_env {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -301,30 +301,77 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         .or_else(|_| std::env::var("USERPROFILE"))
                         .unwrap_or_default();
 
-                    // Build candidate paths: isolated dir first, then global ~/.claude/
-                    let mut creds_candidates: Vec<String> = Vec::new();
+                    // First-run bootstrap of the SHARED provider auth dir
+                    // (~/.agentmux/shared/providers/claude). It is account-wide, so the
+                    // user's existing global ~/.claude login is imported into it ONCE,
+                    // gated on a sentinel so a later `claude auth logout` in this provider
+                    // space sticks. This is a one-time bootstrap of the single shared
+                    // auth, NOT per-instance reseeding. Retro:
+                    // docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md
                     if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
-                        creds_candidates.push(format!("{}/.credentials.json", config_dir));
-                    }
-                    creds_candidates.push(format!("{}/.claude/.credentials.json", home));
-
-                    let tokens_exist = creds_candidates.iter().any(|p| {
-                        if let Ok(content) = std::fs::read_to_string(p) {
-                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                                let oauth = json.get("claudeAiOauth");
-                                let has_token = oauth.and_then(|o| o.get("accessToken"))
-                                    .and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false);
-                                let has_refresh = oauth.and_then(|o| o.get("refreshToken"))
-                                    .and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false);
-                                return has_token || has_refresh;
+                        let iso = format!("{}/.credentials.json", config_dir);
+                        let seeded = format!("{}/.agentmux-cred-seeded", config_dir);
+                        let global = format!("{}/.claude/.credentials.json", home);
+                        if !std::path::Path::new(&iso).exists()
+                            && !std::path::Path::new(&seeded).exists()
+                            && std::path::Path::new(&global).exists()
+                        {
+                            match std::fs::create_dir_all(config_dir)
+                                .and_then(|_| std::fs::copy(&global, &iso))
+                            {
+                                Ok(_) => {
+                                    let _ = std::fs::write(
+                                        &seeded,
+                                        b"imported from global ~/.claude on first run\n",
+                                    );
+                                    tracing::info!(
+                                        "claude auth: imported global ~/.claude into shared provider dir (first run)"
+                                    );
+                                }
+                                Err(e) => tracing::warn!(
+                                    "claude auth: failed to import global creds into shared provider dir: {e}"
+                                ),
                             }
                         }
-                        false
-                    });
+                    }
+
+                    // §4 INVARIANT (provider-auth-isolation.md): validate the SAME dir
+                    // the agent runs in — the isolated CLAUDE_CONFIG_DIR if set, else
+                    // global ~/.claude. NEVER "isolated OR global": that "check global /
+                    // run isolated" split is the validate-spin regression's root cause
+                    // (phase 2 below runs `claude auth status --json` against this exact
+                    // dir, so phase 1 must check the same one).
+                    let creds_path = cmd
+                        .auth_env
+                        .get("CLAUDE_CONFIG_DIR")
+                        .map(|d| format!("{}/.credentials.json", d))
+                        .unwrap_or_else(|| format!("{}/.claude/.credentials.json", home));
+
+                    let tokens_exist = match std::fs::read_to_string(&creds_path) {
+                        Ok(content) => serde_json::from_str::<serde_json::Value>(&content)
+                            .ok()
+                            .map(|json| {
+                                let oauth = json.get("claudeAiOauth");
+                                let has_token = oauth
+                                    .and_then(|o| o.get("accessToken"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| !s.is_empty())
+                                    .unwrap_or(false);
+                                let has_refresh = oauth
+                                    .and_then(|o| o.get("refreshToken"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| !s.is_empty())
+                                    .unwrap_or(false);
+                                has_token || has_refresh
+                            })
+                            .unwrap_or(false),
+                        Err(_) => false,
+                    };
 
                     if !tokens_exist {
-                        // No credentials file or empty tokens — definitely not authenticated.
-                        tracing::info!("claude auth check: no credentials file, skipping CLI");
+                        // No credentials in the dir the agent will run in — not
+                        // authenticated. Fast path: no CLI spawn, so no spin.
+                        tracing::info!("claude auth check: no credentials in provider dir, skipping CLI");
                         let result = CheckCliAuthResult {
                             authenticated: false,
                             email: None,
@@ -334,7 +381,7 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         return Ok(Some(serde_json::to_value(&result).unwrap()));
                     }
 
-                    // Tokens exist on disk — validate with the CLI (10 s timeout).
+                    // Tokens exist in the provider dir — validate with the CLI (10 s timeout).
                     tracing::info!("claude auth check: credentials found, validating via CLI");
                 }
 

--- a/docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md
+++ b/docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md
@@ -1,0 +1,139 @@
+# Retro: How Provider Auth Isolation Regressed Into the "Validate-Spin" Bug
+
+**Date:** 2026-06-05
+**Author:** AgentA
+**Trigger:** A freshly-created agent never authenticates — UI stuck "not
+authenticated", CPU pinned ~100%, manual login times out at 15 s, "already
+logged in but it won't take." User: *"but this was already working before … we
+had set this up."* They're right. This is a **regression**, and the original
+design **predicted the exact failure**.
+
+---
+
+## TL;DR
+
+Provider auth was designed (2026-03-21) to live in **one version-shared dir**
+(`~/.agentmux/instances/v{version}/auth/{provider}/`) with a single rule: *the
+auth check must validate the SAME dir the agent uses.* Two later changes broke
+that rule:
+
+1. **#850** added a two-phase auth check whose phase 1 **falls back to the
+   global `~/.claude`** — the precise "check global / run isolated" split the
+   spec's §4 warned against.
+2. **#1027 (channels)** re-rooted config (and with it, auth) from a
+   version-shared dir to a **per-channel / per-data-dir** dir.
+
+Per-instance empty auth dir (from #1027) + global-fallback check (from #850) =
+"credentials found, but loggedIn:false, forever" → a 2 s CLI re-spawn spin. The
+fix is to return to the spec's own *"Future: shared"* mode, generalized to the
+user's directive: **every provider is a pinned unit, independent of installed
+instances.**
+
+---
+
+## What we set up (the design that worked)
+
+`docs/specs/provider-auth-isolation.md` — **2026-03-21**:
+
+- Auth dir = `~/.agentmux/instances/v{version}/auth/{provider}/`, keyed on the
+  **AgentMux version** and **shared across all agents/data-dirs of that
+  version** (§"Shared vs Per-Agent Auth"). Log in once per version → every agent
+  uses it silently.
+- **§4 "Auth Check — Use Isolated Dir" (the prophecy):**
+  > The `CheckCliAuth` command must pass the auth dir env var when running
+  > `claude auth status --json`. **Otherwise the check passes (using personal
+  > `~/.claude/`) but the subprocess fails (using the isolated empty dir).**
+
+That single invariant — *check the dir you run in* — is the whole ballgame. It
+was written down. It was then violated from two directions.
+
+---
+
+## Evolution timeline
+
+| Date | PR / Spec | Change | Effect on auth dir |
+|------|-----------|--------|--------------------|
+| 2026-03-21 | `provider-auth-isolation.md` | Design: version-shared auth at `instances/v{ver}/auth/{provider}`; §4 invariant | **Intended: shared per version** |
+| 2026-05-14 | #850 `feat(auth): AuthFlowController (PR B-2)` | Implements `auth_config_dir_env_var` + the **two-phase** `CheckCliAuth`: phase 1 "creds exist?" falls back to **global `~/.claude`**, phase 2 validates the **isolated** `CLAUDE_CONFIG_DIR` via `claude auth status --json` | Check can now pass on global while the agent runs isolated — **violates §4** |
+| 2026-05-22 | #978–#982 OAuth Identity Bundles | Per-**identity** isolation (`identity_dir(bundle)/…`, per-bundle `CLAUDE_CONFIG_DIR` override) for deliberate multi-account | Adds a legitimate second isolation layer (keep this) |
+| 2026-05-24 | #1027 `feat(common): channels` (`SPEC_DATA_CHANNELS`) | Data/config move to **per-channel** dirs (`~/.agentmux/channels/<channel>/config/…`); dev mode → `~/.agentmux/dev/<branch>/…` | **Auth root silently moves from version-shared → per-channel / per-data-dir** |
+| 2026-06-05 | — | Fresh dev-branch / channel + a globally-authed user: phase 1 finds global creds, phase 2 validates the empty isolated dir → `loggedIn:false` forever | **The spin surfaces** |
+
+---
+
+## Root causes (two, compounding)
+
+1. **The global fallback re-introduced the §4 hazard (#850).** To avoid a
+   *false-positive* (a file-only check passing on stale/expired tokens — see
+   `SPEC_AUTH_CHECK_FALSE_POSITIVE`), phase 1 was made to accept creds from
+   *either* the isolated dir *or* global `~/.claude`. But phase 2 still validates
+   only the isolated dir. That is exactly "check global / run isolated" — the
+   thing §4 said never to do. On a populated dir it's harmless; on an **empty**
+   one it loops.
+
+2. **Channels re-rooted auth per-instance (#1027).** The 2026-03-21 design put
+   auth in a **version-shared** dir. Channels keyed `config_dir` (and therefore
+   `config_dir/auth/<provider>`) on the **channel / data-dir**. Every dev branch,
+   every portable channel, every `--fresh` build now starts with its **own empty
+   auth dir** — multiplying the §4 hazard from "once per version" to "once per
+   channel/branch/build." This is the same root as the recurring "where did my
+   agents go?" confusion: per-data-dir isolation makes fresh instances look
+   wiped. (See `feedback_dev_instance_empty_session_panic`.)
+
+Neither change is "wrong" in isolation — the false-positive fix is real, channels
+are a good model. They **combined** into a non-recoverable state because nothing
+re-checked §4's invariant when the auth root moved.
+
+---
+
+## Symptom cluster (all one bug)
+
+- `CheckCliAuth` every ~2 s, each "credentials found, validating via CLI", never
+  settling → constant CLI re-spawn = **CPU ~100%**.
+- `run_cli_login` PTY **15 s timeout** (can't write the isolated dir fast enough
+  / OAuth never completes against an empty dir).
+- "Trying to login but it says already logged in" (global is logged in; the
+  isolated dir the agent uses is not).
+
+Full diagnosis: `reference_claude_auth_validate_spin`.
+
+---
+
+## Lessons
+
+1. **A written invariant is worthless if nothing re-checks it when the ground
+   moves.** §4 ("check the dir you run in") was correct and explicit. It was
+   broken twice — once by a feature that *needed* a fallback (#850), once by a
+   feature that *moved the dir* (#1027). A test that asserts "the dir CheckCliAuth
+   validates == the dir the agent's `CLAUDE_CONFIG_DIR` points at" would have
+   failed at both PRs.
+2. **"Found" and "logged in" are different states; never let one satisfy a poll
+   that waits on the other.** The frontend polled on "logged in" while the
+   backend answered "found-somewhere" → an unrecoverable spin. (cf. the reducer
+   principle: every state needs a forward edge.)
+3. **Per-instance isolation of a thing the user owns globally is an
+   anti-pattern.** Auth, like the CLI binary, is a *provider* property, not an
+   *instance* property. The CLI was already version-shared; auth drifted to
+   per-instance and nobody noticed until channels multiplied it.
+
+---
+
+## Fix direction (where this goes)
+
+The user's directive — **"every provider's requirements is a pinned version,
+completely independent from the installed instances"** — is precisely the spec's
+own *"Future: Version-to-Version Auth Migration → shared"* mode (§"Future"),
+generalized one step further (independent of *version* too, not just data-dir):
+
+- A provider = a **pinned** unit (CLI + config + auth) at a location independent
+  of every channel / data-dir / AgentMux version (e.g.
+  `~/.agentmux/providers/<provider>/`). Instances **reference** it.
+- The empty-per-instance dir that the §4 hazard needs **cannot exist** → the spin
+  is impossible by construction, and the global-vs-isolated dilemma dissolves.
+- The per-**identity** bundle layer (#978–#982) stays for deliberate
+  multi-account — that isolation is intentional and explicit.
+- Pin `pinned_version` (claude is `"latest"` today — not actually pinned).
+
+Tracked in `project_provider_pinned_independent`. The earlier "seed isolated
+creds from global" patch (PR #1283, closed) treated the symptom; this retro is
+why we're doing the structural fix instead.

--- a/docs/specs/SPEC_PROVIDER_PINNED_AUTH_2026_06_05.md
+++ b/docs/specs/SPEC_PROVIDER_PINNED_AUTH_2026_06_05.md
@@ -1,0 +1,90 @@
+# Spec: Provider-Pinned, Instance-Independent Auth
+
+**Status:** Implementing
+**Author:** AgentA
+**Date:** 2026-06-05
+**Supersedes:** `provider-auth-isolation.md` (2026-03-21, "per-version" model)
+**Retro:** `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`
+
+---
+
+## Principle
+
+> *Every provider's requirements is a pinned version, completely independent
+> from the installed instances.* — directive, 2026-06-05
+
+A provider (claude, codex, gemini, …) is a **first-class, version-pinned unit**:
+its CLI binary, config, **and credentials** live in **one** place that does not
+depend on, and is not duplicated by, any installed AgentMux instance / channel /
+version. Instances **reference** a provider; they never get their own
+isolated/recreated copy of its auth.
+
+## Why (the regression this fixes)
+
+The 2026-03-21 design shared auth per *version* (`instances/v{ver}/auth/…`) with
+a stated invariant (§4): *the auth check must validate the same dir the agent
+runs in.* Two later changes broke it:
+
+- **#850** added a two-phase `CheckCliAuth` whose phase 1 falls back to global
+  `~/.claude` while phase 2 validates the isolated dir → "check global / run
+  isolated", the §4 hazard.
+- **#1027 (channels)** re-rooted config (hence auth) to **per-channel /
+  per-data-dir** dirs.
+
+Together: a fresh channel/branch/build starts with an **empty** isolated auth
+dir; phase 1 finds global creds, phase 2 validates the empty dir → `loggedIn:false`
+forever → a 2 s CLI re-spawn **spin** (CPU pinned, 15 s login timeouts). Full
+timeline in the retro.
+
+## The model
+
+```
+~/.agentmux/
+  shared/                         ← account-wide, version- & channel-independent
+    providers/<provider>/         ← DEFAULT provider auth/config (NEW; CLAUDE_CONFIG_DIR, …)
+    identities/<bundle>/<provider> ← explicit per-identity multi-account (unchanged)
+  instances/v<ver>/cli/<provider> ← pinned CLI binary (already version-shared)
+```
+
+- **Single source of truth:** `DataPaths::provider_auth_dir(auth_dir_name)` →
+  `shared_dir/providers/<auth_dir_name>`. Every site resolves through it (or the
+  equivalent `<home>/shared/providers/<provider>` in cef).
+- **§4 restored:** `CheckCliAuth` validates **only** the dir the agent runs in
+  (the isolated `CLAUDE_CONFIG_DIR` if set, else global `~/.claude`) — **never**
+  "isolated OR global". Phase 2 runs `claude auth status --json` against the same
+  dir phase 1 checks.
+- **One-time bootstrap:** when the shared provider dir is empty and the user has
+  an existing global `~/.claude` login, import it **once**, gated on a
+  `.agentmux-cred-seeded` sentinel so a later `claude auth logout` in the provider
+  space sticks. This bootstraps the *single shared* dir — it is **not**
+  per-instance reseeding.
+- **Per-identity layer preserved:** `identity_dir(bundle)/<provider>` still
+  overrides `CLAUDE_CONFIG_DIR` for deliberate multi-account bundles.
+
+## Behaviour matrix
+
+| State | Result |
+|-------|--------|
+| Fresh instance/channel, user logged in globally | Import once → authed; **shared everywhere**, no spin |
+| Already authed (shared dir populated) | authed; no CLI spin |
+| Logged out in the provider space (sentinel present) | stays not-authed → user logs in; logout **sticks** |
+| Never authed anywhere | not-authed (fast, no CLI spawn) → log in once |
+
+## Change surface (this PR)
+
+- `agentmux-common/src/data_paths.rs` — `provider_auth_dir()` + contract test
+  (`provider_auth_dir_is_shared_and_channel_independent`).
+- `agentmux-cef/src/commands/platform.rs` — `ensure_auth_dir` → shared providers dir.
+- `agentmux-srv/src/server/app_api.rs` — agent env `CLAUDE_CONFIG_DIR` → shared providers dir.
+- `agentmux-srv/src/server/cli_handlers.rs` — §4 fix (drop global fallback) + one-time import.
+
+## Follow-ups (not in this PR)
+
+1. **Pin the CLI version** — `providers.rs` `pinned_version` is `"latest"` for
+   claude; pin to a concrete version (e.g. `2.1.160`) per provider.
+2. **Migration sweep** — old per-channel `config/auth/<provider>` dirs are
+   orphaned; the import covers the common (globally-authed) case, but a one-time
+   move of an existing per-channel login into the shared dir would avoid a
+   re-login for users with no global `~/.claude`.
+3. **§4 integration test** — assert the dir `CheckCliAuth` validates equals the
+   `CLAUDE_CONFIG_DIR` the agent is spawned with (cross-module).

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -413,10 +413,11 @@ export class AgentViewModel implements ViewModel {
         // GIT_CONFIG_GLOBAL is intentionally not set: we use the 4 identity
         // env vars above which git always honours, avoiding any path-handling edge cases.
 
-        // Provider auth isolation: shared per-version auth dir (not per-agent)
-        // Each AgentMux version gets its own auth space via the Tauri app data dir,
-        // which already includes the version in its identifier (ai.agentmux.app.vX-Y-Z).
-        // Skip if provider has no isolated auth dir configured (e.g. Claude uses ~/.claude/ globally).
+        // Provider auth: the default lives in the account-wide, version- and
+        // channel-independent shared dir (~/.agentmux/shared/providers/<provider>/),
+        // resolved by ensureAuthDir → ensure_auth_dir; one login is shared across
+        // every instance / channel / version. Skip the env var only for providers
+        // with no isolated auth dir configured.
         if (provider.authConfigDirEnvVar) {
             const authDir = await getApi().ensureAuthDir(provider.id);
             envVars[provider.authConfigDirEnvVar] = authDir;


### PR DESCRIPTION
## The bug (a regression)

A fresh agent never authenticates — UI stuck "not authenticated", CPU pinned
~100%, login times out at 15s — even though `claude` is logged in. Full
evolution: `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`.

**Root cause — two compounding changes.** The original design
(`provider-auth-isolation.md`, 2026-03-21) shared provider auth per *version*
with a stated invariant (§4: *validate the dir the agent runs in*). Then:
- **#850** added a two-phase `CheckCliAuth` whose phase 1 falls back to global
  `~/.claude` while phase 2 validates only the isolated dir → "check global / run
  isolated", the §4 hazard.
- **#1027 (channels)** re-rooted config (hence auth) to **per-channel** dirs.

→ a fresh channel / branch / build starts with an **empty** isolated auth dir;
phase 1 finds global creds, phase 2 validates the empty dir → `loggedIn:false`
forever → a 2 s CLI re-spawn spin.

## The fix — providers are pinned + instance-independent

- Root the **default** provider auth at `~/.agentmux/shared/providers/<provider>/`
  (`DataPaths::provider_auth_dir`) — account-wide, version/channel-independent,
  like the CLI. One login shared everywhere → the empty-per-instance dir cannot
  exist by construction.
- **Restore §4** in `CheckCliAuth`: validate the **same dir the agent runs in**
  (`CLAUDE_CONFIG_DIR` if set, else global) — never "isolated OR global".
- **One-time import** of an existing global login into the shared dir,
  sentinel-gated so a `logout` sticks (a single shared bootstrap, **not**
  per-instance reseeding).
- Per-identity bundle override (multi-account) unchanged.

## Verification

- `cargo check -p agentmux-srv` clean; the **`provider_auth_dir` contract test
  passes** (channel/mode-independent, never under `config_dir`).
- The import → CLI-validates → authed mechanism was empirically confirmed earlier
  (seeded `CLAUDE_CONFIG_DIR` → `loggedIn:true`); this PR only changes *which* dir.
- The cef change is a one-line re-point of the proven `version_config_dir`
  pattern (confirmed field + type). ⚠️ The **local full build** hit the known
  CEF-download / Defender rename race (env, not code) — **CI builds it clean**; a
  full GUI smoke is pending the env.

Spec: `docs/specs/SPEC_PROVIDER_PINNED_AUTH_2026_06_05.md`. Supersedes the closed
band-aid #1283. Follow-ups (in the spec): pin `pinned_version`, migration sweep,
cross-module §4 integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
