### PR TITLE
fix(a11y): don't freeze loading spinners under prefers-reduced-motion

### DIFF
--- a/.changesets/1780689507-fix-a11y-keep-loading-spinners-spinning-under-reduced-motion-cnr6.md
+++ b/.changesets/1780689507-fix-a11y-keep-loading-spinners-spinning-under-reduced-motion-cnr6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(a11y): keep loading spinners spinning under reduced-motion (macOS)

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -78,9 +78,15 @@
 }
 
 @include mixins.respect-reduced-motion {
+    // Loading spinners are FUNCTIONAL "agent is working" indicators — never
+    // freeze them under reduced motion. A stuck spinner reads as a hung app,
+    // which is worse for everyone (motion-sensitive users included: they then
+    // can't tell it's busy). A small continuous rotate is low vestibular risk;
+    // keep it spinning, just slower/gentler. reduced-motion targets decorative
+    // / large-translation motion, not essential status indicators.
     .agent-composer-strip-spinner,
     .agent-composer-strip-spinner--decelerating {
-        animation: none;
+        animation-duration: 2.4s;
     }
 }
 

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -47,8 +47,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+    // Functional loading indicator (and already a discrete flip, not a
+    // continuous spin) — keep it moving, gentler, rather than freezing it.
     .agent-install-modal-spinner {
-        animation: none;
+        animation-duration: 3.2s;
     }
 }
 


### PR DESCRIPTION
## Symptom

On macOS the loading spinner is **stuck/frozen**; on Windows it spins fine.

## Cause (not platform code — an OS setting + an over-eager rule)

macOS "Reduce Motion" (Accessibility → Display) was **on** (`defaults read com.apple.universalaccess reduceMotion` → `1`), which sets `prefers-reduced-motion: reduce`. Two spinners then disable themselves:
- `_composer-strip.scss` — the agent "working" spinner, via `@include mixins.respect-reduced-motion { … animation: none }`
- `_install-modal.scss` — `@media (prefers-reduced-motion: reduce) { .agent-install-modal-spinner { animation: none } }`

It "works on Windows" only because Reduce Motion is off there. Nothing platform-specific in the code.

## Fix

A **frozen loading indicator reads as a hung app** — worse for everyone, and *especially* for motion-sensitive users, who then can't tell it's busy. Loading spinners are **functional status indicators**, not decorative motion (a small continuous rotate is low vestibular risk), so they now **keep spinning under reduced motion, just slower/gentler** (2.4s / 3.2s) instead of freezing.

Genuinely decorative animations (modal entrance/exit in `modal-layer.scss`, message-enter in `_document.scss`) **stay suppressed** under reduced motion — only the loading spinners are exempted.

SCSS-only; hot-reloads. Verify with macOS Reduce Motion **on**: the agent spinner now rotates (gently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)