### PR TITLE
feat(drone): inline in-node parameter editing — remove right-side inspector

### DIFF
--- a/.changesets/1780692694-feat-drone-inline-in-node-parameter-editing-remove-right-sid-o6uq.md
+++ b/.changesets/1780692694-feat-drone-inline-in-node-parameter-editing-remove-right-sid-o6uq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(drone): inline in-node parameter editing — remove right-side inspector

--- a/docs/specs/SPEC_DRONE_INLINE_NODE_PARAMS_2026_06_05.md
+++ b/docs/specs/SPEC_DRONE_INLINE_NODE_PARAMS_2026_06_05.md
@@ -1,0 +1,158 @@
+# SPEC — Drone: Inline In-Node Parameter Editing
+
+- **Date:** 2026-06-05
+- **Author:** AgentX
+- **Status:** Draft / proposed
+- **Widget:** `defwidget@drone` → view `drone`
+- **Scope:** Frontend (SolidJS) — replace the right-side inspector overlay with compact in-node editing. No backend changes.
+- **Builds on:** `SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md` (merged: #1289 + #1290).
+
+---
+
+## 0. TL;DR
+
+The right-side inspector slide-over (`InspectorPanel`, `drone-view.tsx:609`) covers too much canvas. **Remove it.** Move parameter editing **into the node** as compact inline widgets, using the leading-editor pattern (ComfyUI / LiteGraph / Blender / React-Flow custom nodes): real DOM inputs in the node body, `nodrag`/`nowheel` so editing never moves the canvas, and **progressive disclosure** — a one-line summary when the node is unselected, the editable field stack when selected.
+
+Three decisions carry the design:
+
+1. **Two-state node.** Unselected → existing `nodeSummary()` one-liner. Selected → inline editable fields (the current `InspectorForm` body, restyled to fit a node).
+2. **Complex fields don't bloat the node.** Long text (agent task, API body, response template), the variables list, and the identity/memory pickers open in a **field-anchored popover** (floats over the canvas, closes on blur/Esc) — never a persistent panel. Optional power move: **double-click a node → zoom-to-node "edit mode"**.
+3. **Ports stay anchored to the header row** so a node growing taller never breaks edge attachment — no per-node re-measure needed for v1.
+
+Net result: the canvas is 100% canvas again; you edit where you look.
+
+---
+
+## 1. Problem
+
+`InspectorPanel` renders a 320px `<aside class="drone-inspector">` overlay pinned to the right (`drone-view.scss` `.drone-inspector { position:absolute; right:0; width:320px; ... }`). On a typical pane it covers a large fraction of the working area, and it spatially decouples the controls from the node being edited — the opposite of the "expansive canvas" the drone redesign set out to deliver.
+
+## 2. Current state (what moves)
+
+- **`InspectorPanel`** (`drone-view.tsx:609-636`) — the `<Show keyed>` overlay. **Delete** this and its `.drone-inspector*` styles.
+- **`InspectorForm`** (`drone-view.tsx:638-725`) — the per-kind field stack. **Relocate** its body into the node; keep the per-kind `<Show>` branches and the `update()` helper.
+- **Field editors** reused as-is (restyled compact): `Field` (`:727`), `VariablesEditor` (`:734`), `AgentRefEditor` (`:813`), `AgentResultPanel` (`:872`).
+- **Node rendering** (`drone-view.tsx:456-510`): node `<div class="drone-node">` with header (emoji + label + ×), `<div class="drone-node-body">{nodeSummary(n)}</div>`, and the input/output ports. The body becomes state-driven (summary vs fields).
+- **Ports** computed by `portFlowPos` / `portOffsetY` (`drone-view.tsx`) from a fixed top offset (`26 + …`). This already anchors ports near the header — we keep that (see §6).
+- **Selection** lives in `DroneViewModel._selected` (`selectedAtom`/`setSelected`). Drives expansion.
+
+Per-kind config (from `InspectorForm`): **Agent** = identity/memory/instance pickers + `task` textarea + last-run result; **API** = method select + url + body; **Condition** = expr; **Response** = template; **Variables** = name/value rows.
+
+## 3. Design principles (from research)
+
+- **Inline real DOM controls**, not canvas-painted — free keyboard/focus/AT support (ComfyUI uses real `<textarea>`; LiteGraph's canvas widgets are inaccessible — avoid that).
+- **Progressive disclosure** — show decision-critical info at rest; reveal editing on demand. Common fields first; advanced behind an expander.
+- **`nodrag` / `nowheel` / `nopan` discipline** — any interactive element must not drag the node, scroll-zoom the canvas, or pan it.
+- **No persistent side panel.** Room for big fields comes from on-demand **popovers** and an optional **zoom-to-node** mode.
+- **Semantic zoom / level-of-detail** — render heavy inputs only when selected and zoom ≥ threshold; cheap placeholder when zoomed out (perf + clarity).
+- **Header-anchored ports** keep edges correct as nodes grow (pragmatic 80/20 vs measure-and-recompute).
+
+## 4. Target UX
+
+### 4.1 Node states
+
+```
+ Unselected (compact)                Selected (inline edit)
+ ┌────────────────────┐              ┌────────────────────────┐
+●│ 🤖 Agent         ✕ │●           ●│ 🤖 Agent             ✕ │●
+ │ researcher · "summa…│             ├────────────────────────┤
+ └────────────────────┘             │ Identity [researcher ▾]│
+                                     │ Task  "Summarize th…" ✎│  ← click ✎ → popover
+                                     │ ▸ Advanced             │
+                                     │ ⤢ last run · $0.0021   │  ← compact result
+                                     └────────────────────────┘
+```
+
+- **Unselected:** current `nodeSummary(n)` one-liner. Unchanged behavior; cheap.
+- **Selected:** inline field stack. Fixed node width (**~248px**); height grows with content. Selecting a node expands it; clicking empty canvas / selecting another collapses it. (Selection already toggles via `setSelected`.)
+- **Pin-expanded (optional, Phase 2):** a header pin so a node stays expanded while unselected. Not required for v1.
+- **Zoom LOD:** below ~0.5 zoom, render only the title chip (no inputs), regardless of selection.
+
+### 4.2 Per-kind inline layout
+
+Fixed-width rows, label-left / control-right, ~28px tall. `Field` is reused; restyle `.drone-field` to a horizontal compact row inside nodes.
+
+| Kind | Inline (always when selected) | Behind "▸ Advanced" | Popover (click to open) |
+|---|---|---|---|
+| **Agent** 🤖 | Identity `<select>`; Task summary line + ✎ | Memory `<select>`, Instance name | **Task** prompt editor (big textarea) |
+| **API** 🌐 | Method `<select>`; URL `<input>` | Headers (kv) | **Body** editor (JSON textarea) |
+| **Condition** 🔀 | Expr `<input>` | — | — (expr is short; inline is enough) |
+| **Response** 🏁 | Template summary line + ✎ | — | **Template** editor (big textarea) |
+| **Variables** 🔢 | First 2 rows inline + "＋ n more" | — | **Variables** list editor (full `VariablesEditor`) |
+
+Rationale: short fields (method, url, identity, expr) edit fine inline; long free-text and lists escalate to a popover so the node stays compact.
+
+### 4.3 Complex-field escalation (the inspector replacement)
+
+**Field-anchored popover** is the primary mechanism. Clicking a ✎ affordance (or the summary line) opens a popover anchored to that field:
+
+- Floats **above** the canvas (`position: fixed`, anchored via the field's screen rect), generously sized (e.g. 360×220 for a prompt).
+- Contains the full editor for one field (the existing textarea / `VariablesEditor` / picker), `nodrag`+`nowheel`.
+- **Commits live** to `updateNodeData` on input (same as today); **Esc** closes (value already committed), click-outside closes.
+- Only one popover open at a time.
+
+**Optional — zoom-to-node edit mode (Phase 2):** double-click a node → `fitView` to that single node and expand every field full-size in place; Esc returns. Gives panel-level room without a panel. Nice for the Agent block.
+
+### 4.4 Inline run state
+
+`AgentResultPanel` becomes a compact, collapsible strip at the bottom of the Agent node (status dot + cost + truncated response; click to open in the same popover). During a run, the existing per-node status classes still drive the header glow.
+
+## 5. Interaction spec
+
+- **nodrag:** every inline `<input>/<select>/<textarea>/<button>` carries `nodrag` (the node-drag handler already early-returns on `.closest(".nodrag")`, `drone-view.tsx` `onNodePointerDown`). Verify selects/inputs are covered.
+- **nowheel:** any scrollable inline area (capped textarea, result strip) needs `onWheel={(e)=>e.stopPropagation()}` so the wheel scrolls content instead of zooming the canvas (the canvas `onWheel` zooms).
+- **Commit:** on `input`/`change` → `updateNodeData` (live, as today). **Enter** in single-line commits + blurs; **Esc** closes popover / blurs field.
+- **Selecting vs editing:** pressing a field selects the node (already true via capture-phase focus) and must NOT start a node drag (nodrag) or a connection.
+- **Tab order:** fields in DOM order; ensure canvas key handlers don't swallow Tab while a field is focused (the keydown handler ignores `INPUT/TEXTAREA/SELECT` targets — keep that).
+- **Ports unaffected:** port pointerdown still starts a connection; fields sit between the ports, which remain on the node edges.
+
+## 6. Node sizing + port alignment
+
+- **Width fixed** (~248px); **height auto** (grows with the selected field stack).
+- **Ports anchored to the header row.** Keep `portOffsetY` referencing the header band (top ~26px) so inputs/outputs and their bezier endpoints stay put as the body grows downward. Edges never need re-measuring. (Condition's two outputs remain stacked near the header.)
+- **Future option (not v1):** per-port DOM anchors + a measure-on-change pass (React Flow's `useUpdateNodeInternals` analog) if we later want ports aligned to specific field rows. Explicitly out of scope here.
+
+## 7. Performance
+
+- Render the **full field stack only when `selected()` and zoom ≥ ~0.5**; otherwise render the summary/title only. Caps live DOM inputs to ~one node at a time.
+- Solid's fine-grained reactivity already prevents sibling re-renders; keep field state reads scoped to the node (the store proxy per node).
+- Keep node CSS cheap (avoid heavy shadows/animations on the expanded node).
+
+## 8. Accessibility
+
+- Real `<label>` (reuse `Field`) per control; no placeholder-as-label.
+- "▸ Advanced" is a `<button aria-expanded>`; the ✎ popover trigger has an `aria-label` ("Edit task"); popover is focus-trapped and Esc-dismissible, returning focus to the trigger.
+- Tab/Shift-Tab traverse fields; canvas shortcuts don't fire while a field is focused.
+
+## 9. Component / file changes
+
+- **Remove:** `InspectorPanel` (`drone-view.tsx:609`), its render in `DroneView` (`:26`), and `.drone-inspector*` SCSS.
+- **Add:** `NodeBody` (or inline in the node `<For>`) that renders `nodeSummary` when `!selected`/zoomed-out, else `NodeFields`.
+- **Add:** `NodeFields(model, node)` — the relocated per-kind `<Show>` stack from `InspectorForm`, restyled compact; reuses `Field`, `VariablesEditor`, `AgentRefEditor`, `AgentResultPanel`.
+- **Add:** `FieldPopover` — a fixed-position editor anchored to a field rect; holds the big textarea / list / picker; `nodrag`+`nowheel`; Esc/click-outside to close.
+- **Model (`drone-model.ts`):** no new persistent state required for v1 (selection drives expansion). Optional Phase-2 `pinnedExpanded`/`collapsed` per-node flag if pinning is added → store in `node.data` so it persists.
+- **SCSS:** new `.drone-node--expanded`, `.drone-node-fields`, compact `.drone-field` (horizontal), `.drone-field-edit` (✎ button), `.drone-popover`, `.drone-node-result` (compact). Drop `.drone-inspector*`.
+- **Keep:** ports, edges, pan/zoom, wiring — untouched.
+
+## 10. Phased plan
+
+| PR | Scope |
+|---|---|
+| **1** | Remove `InspectorPanel`; render `NodeFields` inline for the selected node (all 5 kinds, simple inline controls); short fields inline, long fields as a **capped auto-grow textarea** placeholder. Header-anchored ports already work. |
+| **2** | `FieldPopover` for Task / Body / Template / Variables / pickers; ✎ affordances + summary-click; `nowheel`. Compact inline `AgentResultPanel`. |
+| **3** (opt) | Zoom-to-node edit mode (double-click); pin-expanded; "▸ Advanced" grouping; zoom LOD placeholder. |
+
+**Minimum to kill the side panel: PR 1.** PR 2 makes the heavy fields pleasant.
+
+## 11. Risks / open questions
+
+- **Agent node density** — even compact, identity + task + result is a lot. Mitigation: identity inline, task→popover, memory/instance under Advanced, result as a one-line strip. Validate live.
+- **Popover + canvas transform** — popover is screen-positioned (not inside the zoomed viewport), so it must read the field's `getBoundingClientRect()` and reposition on scroll/pan/zoom (or close on viewport change). Closing on pan/zoom is acceptable for v1.
+- **Header-anchored ports on tall nodes** — many fields make a node much taller than its single header-row of ports; visually fine (n8n-style) but confirm it reads clearly with 2 condition branches.
+- **Click-to-select vs click-to-edit** — first click selects+expands; the now-visible field takes a second click to focus. Acceptable; revisit if it feels slow.
+
+## 12. Appendix — concrete shape (research-backed)
+
+Fixed-width node (~248px), height grows. Unselected = title chip + summary line. Selected = label-left/field-right rows (~28–32px), real DOM controls, all `nodrag`; scrollable areas `nowheel`. Common fields inline; advanced behind "▸ Advanced"; long text / lists / pickers in a **field-anchored popover** (or double-click → zoom-to-node). Render full inputs only when selected + zoom ≥ 0.5. Ports stay on the header row. No persistent side panel anywhere.
+
+**References:** ComfyUI/LiteGraph inline widgets + multiline textarea; Blender geometry-node inline fields; Rete.js controls (`NoDrag`, attach-to-input); React Flow custom nodes + utility classes (`nodrag`/`nopan`/`nowheel`) + `useUpdateNodeInternals` (the measure-on-change analog we defer); n8n/cables.gl as the *panel* counter-examples (justified only for 10+ heterogeneous params / embedded code editors — not drone's blocks).

--- a/frontend/app/view/drone/block-registry.ts
+++ b/frontend/app/view/drone/block-registry.ts
@@ -1,9 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Block kind metadata — drives the NodeTypeBar chips, default block data,
-// and the InspectorPanel field schema. One source of truth shared by
-// all node components and the validators.
+// Block kind metadata — drives the NodeTypeBar chips, inline NodeFields,
+// and per-kind default data. One source of truth shared by all node
+// components and the validators.
 
 import type { BlockKind } from "./drone-types";
 

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -178,8 +178,6 @@ export class DroneViewModel implements ViewModel {
     // teardown. Codex P2 on PR #844.
     private disposed = false;
 
-    selectedNodeAtom: Accessor<FlowNode | null>;
-
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
@@ -187,11 +185,6 @@ export class DroneViewModel implements ViewModel {
         this.viewName = createMemo(() => {
             const block = this.blockAtom();
             return (block?.meta?.["frame:title"] as string) ?? this.draftAtom().name;
-        });
-        this.selectedNodeAtom = createMemo(() => {
-            const id = this.selectedAtom();
-            if (!id) return null;
-            return this.draftAtom().graph.nodes.find((n) => n.id === id) ?? null;
         });
 
         // Register the slot SYNCHRONOUSLY so the first dispatch (in

--- a/frontend/app/view/drone/drone-model.ts
+++ b/frontend/app/view/drone/drone-model.ts
@@ -96,7 +96,7 @@ export class DroneViewModel implements ViewModel {
         this.setDraftStore(reconcile(next));
     }
 
-    // --- which node is selected in the canvas (for the InspectorPanel)
+    // --- which node is selected in the canvas (drives inline NodeFields)
     private _selected = createSignal<string | null>(null);
     selectedAtom: Accessor<string | null> = this._selected[0];
     setSelected = this._selected[1];
@@ -480,7 +480,7 @@ export class DroneViewModel implements ViewModel {
     addNodeAtCenter(kind: BlockKind): FlowNode {
         const v = this.viewportAtom();
         const { w, h } = this._canvasSize[0]();
-        const cx = (w / 2 - v.x) / v.zoom - 80;
+        const cx = (w / 2 - v.x) / v.zoom - 124; // half of NODE_W (248)
         const cy = (h / 2 - v.y) / v.zoom - 30;
         return this.addNode(kind, { x: cx, y: cy });
     }

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -272,7 +272,7 @@
 
 .drone-node {
     position: absolute;
-    width: 160px;
+    width: 248px;
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 0;
@@ -322,8 +322,9 @@
     &:hover { opacity: 1; }
 }
 
-.drone-node-body {
-    padding: 6px 8px;
+// Summary line shown when the node is unselected.
+.drone-node-summary {
+    padding: 5px 8px;
     font-size: 11px;
     color: var(--secondary-text-color);
     overflow: hidden;
@@ -331,88 +332,57 @@
     white-space: nowrap;
 }
 
-// ── Inspector: right-side slide-over overlay ──────────────────────────
-
-.drone-inspector {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: 320px;
-    border-left: 1px solid var(--border-color);
-    background: var(--main-bg-color);
-    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.25);
-    overflow-y: auto;
-    padding: 8px 12px;
-    font-size: 12px;
-    z-index: 10;
-}
-
-.drone-inspector-close {
-    position: absolute;
-    top: 6px;
-    right: 8px;
-    background: transparent;
-    border: none;
-    color: var(--secondary-text-color);
-    font-size: 18px;
-    line-height: 1;
-    cursor: pointer;
-    &:hover {
-        color: var(--main-text-color);
-    }
-}
-
-.drone-inspector-empty {
-    color: var(--secondary-text-color);
-    padding: 16px 4px;
-    font-size: 11px;
-    font-style: italic;
-}
-
-.drone-inspector-form {
+// Inline field stack shown when the node is selected.
+.drone-node-fields {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 1px;
+    padding: 4px 0 4px;
+    border-top: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
 }
 
-.drone-inspector-title {
-    font-size: 14px;
-    font-weight: 500;
-    margin-bottom: -4px;
-}
-
-.drone-inspector-id {
-    font-size: 10px;
-    color: var(--secondary-text-color);
-    font-family: var(--mono-font, monospace);
-    margin-bottom: 4px;
-}
-
-.drone-field {
-    display: flex;
-    flex-direction: column;
+// Compact horizontal label + control row inside a node.
+.drone-node-field {
+    display: grid;
+    grid-template-columns: 58px 1fr;
+    align-items: center;
     gap: 4px;
+    padding: 0 6px;
+    min-height: 26px;
+    cursor: default;
 }
 
-.drone-field-label {
+.drone-node-field-label {
     font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
     color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
 }
 
 .drone-input {
-    background: var(--main-bg-color);
+    background: color-mix(in srgb, var(--main-text-color) 4%, var(--main-bg-color));
     border: 1px solid var(--border-color);
     border-radius: 0;
-    padding: 4px 8px;
+    padding: 3px 6px;
     color: inherit;
     font-family: inherit;
-    font-size: 12px;
+    font-size: 11px;
     width: 100%;
     box-sizing: border-box;
+    min-width: 0;
     &:focus { border-color: var(--accent-color); outline: none; }
+
+    // Auto-grow textarea: starts at 1 line, caps at ~5 lines, no resize handle.
+    &--grow {
+        resize: none;
+        overflow-y: auto;
+        min-height: 22px;
+        max-height: 110px; // ~5 lines at 22px
+        line-height: 1.4;
+    }
 }
 
 .drone-vars {

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -182,7 +182,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
             m.setViewport({ x: 0, y: 0, zoom: 1 });
             return;
         }
-        const NW = 180,
+        const NW = NODE_W,
             NH = 76,
             pad = 80;
         let minX = Infinity,
@@ -294,7 +294,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
         if (!kind) return;
         const p0 = screenToFlow(e.clientX, e.clientY);
         // Center the node body roughly under the cursor.
-        m.addNode(kind, { x: p0.x - 80, y: p0.y - 20 });
+        m.addNode(kind, { x: p0.x - NODE_W / 2, y: p0.y - 20 });
         setDragKind(null);
     };
 
@@ -630,11 +630,8 @@ function bezierPath(x1: number, y1: number, x2: number, y2: number): string {
 // escalation for complex fields lands in PR2.
 
 const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element => {
-    // Node kind never changes during its lifetime, so meta is stable.
-    const meta = blockMeta(p.node.data.kind as BlockKind);
     const update = (patch: Record<string, unknown>) =>
         p.model.updateNodeData(p.node.id, patch);
-    void meta; // used below in AgentRefEditor / result panel
 
     return (
         <div class="drone-node-fields">

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -23,7 +23,6 @@ export const DroneView = (props: { model: DroneViewModel }): JSX.Element => {
             <NodeTypeBar model={m} />
             <div class="drone-stage">
                 <Canvas model={m} />
-                <InspectorPanel model={m} />
                 <RunPanel model={m} />
             </div>
         </div>
@@ -150,6 +149,9 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
     const clampZoom = (z: number) => Math.min(ZMAX, Math.max(ZMIN, z));
 
     const onWheel = (e: WheelEvent) => {
+        // Let scrollable areas inside nodes (class "nowheel") scroll
+        // their content instead of zooming the canvas.
+        if ((e.target as HTMLElement | null)?.closest(".nowheel")) return;
         e.preventDefault();
         const rect = canvasEl.getBoundingClientRect();
         const mx = e.clientX - rect.left;
@@ -478,7 +480,19 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
                                         ×
                                     </button>
                                 </header>
-                                <div class="drone-node-body">{nodeSummary(n)}</div>
+                                <Show
+                                    when={selected()}
+                                    fallback={
+                                        <div class="drone-node-body drone-node-summary">
+                                            {nodeSummary(n)}
+                                        </div>
+                                    }
+                                >
+                                    <NodeFields
+                                        model={m}
+                                        node={n}
+                                    />
+                                </Show>
                                 <For each={meta.inputs}>
                                     {(h, i) => (
                                         <div
@@ -580,7 +594,7 @@ function truncate(s: string, max = 40): string {
 // helpers are the single source of truth for where a wire attaches, used
 // by both the rendered ports and the edge paths so they always line up.
 
-const NODE_W = 160;
+const NODE_W = 248;
 
 /** Vertical offset (px, node-relative) of port `idx` of `count`. */
 function portOffsetY(count: number, idx: number): number {
@@ -604,66 +618,46 @@ function bezierPath(x1: number, y1: number, x2: number, y2: number): string {
     return `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
 }
 
-// ── Inspector ─────────────────────────────────────────────────────────
+// ── NodeFields — inline in-node parameter editing ────────────────────
+//
+// Rendered inside the node body when the node is selected. Replaces the
+// old right-side InspectorPanel: no more slide-over. Every interactive
+// element carries class "nodrag" so interacting with a field never drags
+// the node or pans/zooms the canvas.
+//
+// Long text fields (task, body, template) use auto-grow textareas capped
+// at 5 lines. The Variables list stays inline here in PR1; a popover
+// escalation for complex fields lands in PR2.
 
-const InspectorPanel = (p: { model: DroneViewModel }): JSX.Element => {
-    const m = p.model;
-    // Slide-over overlay: only mounted while a node is selected, so the
-    // canvas stays full-bleed otherwise.
-    //
-    // `keyed` on the selected NODE: switching selection re-runs the child
-    // and remounts InspectorForm with the new node, so the title / fields
-    // / actions can never stay bound to a previously-selected node. The
-    // store keeps each node's proxy reference stable, so editing a field
-    // does NOT change the key (no remount → the focused input is kept) —
-    // only changing which node is selected does.
-    return (
-        <Show when={m.selectedNodeAtom()} keyed>
-            {(node) => (
-                <aside class="drone-inspector" aria-label="Inspector">
-                    <button
-                        class="drone-inspector-close"
-                        aria-label="Close inspector"
-                        onClick={() => m.setSelected(null)}
-                    >
-                        ×
-                    </button>
-                    <InspectorForm model={m} node={node} />
-                </aside>
-            )}
-        </Show>
-    );
-};
-
-const InspectorForm = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element => {
-    // The parent <Show> is keyed on the node, so this form remounts on each
-    // selection change — `p.node` is fixed for this instance's lifetime and
-    // `meta` can be computed once. (A node's kind never changes; only its
-    // data fields do, which the field bindings below read reactively.)
+const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element => {
+    // Node kind never changes during its lifetime, so meta is stable.
     const meta = blockMeta(p.node.data.kind as BlockKind);
     const update = (patch: Record<string, unknown>) =>
         p.model.updateNodeData(p.node.id, patch);
+    void meta; // used below in AgentRefEditor / result panel
 
     return (
-        <div class="drone-inspector-form">
-            <div class="drone-inspector-title">{meta.label}</div>
-            <div class="drone-inspector-id">{p.node.id}</div>
+        <div class="drone-node-fields">
             <Show when={p.node.data.kind === "agent"}>
                 <AgentRefEditor node={p.node} update={update} />
-                <Field label="Task ({{...}} interpolation supported)">
+                <NodeField label="Task">
                     <textarea
-                        class="drone-input"
-                        rows="4"
+                        class="drone-input drone-input--grow nodrag nowheel"
                         value={(p.node.data["task"] as string) ?? ""}
-                        onInput={(e) => update({ task: e.currentTarget.value })}
+                        placeholder="{{...}} interpolation supported"
+                        onInput={(e) => {
+                            update({ task: e.currentTarget.value });
+                            autoGrow(e.currentTarget);
+                        }}
+                        onFocus={(e) => autoGrow(e.currentTarget)}
                     />
-                </Field>
+                </NodeField>
                 <AgentResultPanel model={p.model} blockId={p.node.id} />
             </Show>
             <Show when={p.node.data.kind === "api"}>
-                <Field label="Method">
+                <NodeField label="Method">
                     <select
-                        class="drone-input"
+                        class="drone-input nodrag"
                         value={(p.node.data["method"] as string) ?? "GET"}
                         onChange={(e) => update({ method: e.currentTarget.value })}
                     >
@@ -673,44 +667,51 @@ const InspectorForm = (p: { model: DroneViewModel; node: FlowNode }): JSX.Elemen
                         <option>PATCH</option>
                         <option>DELETE</option>
                     </select>
-                </Field>
-                <Field label="URL">
+                </NodeField>
+                <NodeField label="URL">
                     <input
-                        class="drone-input"
+                        class="drone-input nodrag"
                         value={(p.node.data["url"] as string) ?? ""}
                         onInput={(e) => update({ url: e.currentTarget.value })}
-                        placeholder="https://example.com/{{var.endpoint}}"
+                        placeholder="https://…/{{var.path}}"
                     />
-                </Field>
-                <Field label="Body">
+                </NodeField>
+                <NodeField label="Body">
                     <textarea
-                        class="drone-input"
-                        rows="4"
+                        class="drone-input drone-input--grow nodrag nowheel"
                         value={(p.node.data["body"] as string) ?? ""}
-                        onInput={(e) => update({ body: e.currentTarget.value })}
+                        placeholder='{"key": "{{var.x}}"}'
+                        onInput={(e) => {
+                            update({ body: e.currentTarget.value });
+                            autoGrow(e.currentTarget);
+                        }}
+                        onFocus={(e) => autoGrow(e.currentTarget)}
                     />
-                </Field>
+                </NodeField>
             </Show>
             <Show when={p.node.data.kind === "condition"}>
-                <Field label="Expression (e.g. {{var.x}} > 10)">
+                <NodeField label="if">
                     <input
-                        class="drone-input"
+                        class="drone-input nodrag"
                         value={(p.node.data["expr"] as string) ?? ""}
                         onInput={(e) => update({ expr: e.currentTarget.value })}
                         placeholder="{{var.count}} > 0"
                     />
-                </Field>
+                </NodeField>
             </Show>
             <Show when={p.node.data.kind === "response"}>
-                <Field label="Template (final drone output)">
+                <NodeField label="Template">
                     <textarea
-                        class="drone-input"
-                        rows="4"
+                        class="drone-input drone-input--grow nodrag nowheel"
                         value={(p.node.data["template"] as string) ?? ""}
-                        onInput={(e) => update({ template: e.currentTarget.value })}
                         placeholder="Hello {{var.name}}!"
+                        onInput={(e) => {
+                            update({ template: e.currentTarget.value });
+                            autoGrow(e.currentTarget);
+                        }}
+                        onFocus={(e) => autoGrow(e.currentTarget)}
                     />
-                </Field>
+                </NodeField>
             </Show>
             <Show when={p.node.data.kind === "variables"}>
                 <VariablesEditor
@@ -724,12 +725,20 @@ const InspectorForm = (p: { model: DroneViewModel; node: FlowNode }): JSX.Elemen
     );
 };
 
-const Field = (p: { label: string; children: JSX.Element }): JSX.Element => (
-    <label class="drone-field">
-        <span class="drone-field-label">{p.label}</span>
+/** Compact label + control row rendered inside a node. */
+const NodeField = (p: { label: string; children: JSX.Element }): JSX.Element => (
+    <label class="drone-node-field">
+        <span class="drone-node-field-label">{p.label}</span>
         {p.children}
     </label>
 );
+
+/** Auto-grow a textarea up to a CSS max-height cap. */
+function autoGrow(el: HTMLTextAreaElement): void {
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+}
+
 
 const VariablesEditor = (p: {
     entries: Array<{ name: string; value: string }>;
@@ -744,19 +753,19 @@ const VariablesEditor = (p: {
                 {(entry, i) => (
                     <div class="drone-vars-row">
                         <input
-                            class="drone-input"
+                            class="drone-input nodrag"
                             value={entry.name}
                             onInput={(e) => update(i(), { name: e.currentTarget.value })}
                             placeholder="name"
                         />
                         <input
-                            class="drone-input"
+                            class="drone-input nodrag"
                             value={entry.value}
                             onInput={(e) => update(i(), { value: e.currentTarget.value })}
                             placeholder="value"
                         />
                         <button
-                            class="drone-btn drone-btn--small"
+                            class="drone-btn drone-btn--small nodrag"
                             onClick={() => p.onChange(p.entries.filter((_, idx) => idx !== i()))}
                         >
                             ×
@@ -765,7 +774,7 @@ const VariablesEditor = (p: {
                 )}
             </For>
             <button
-                class="drone-btn drone-btn--small"
+                class="drone-btn drone-btn--small nodrag"
                 onClick={() => p.onChange([...p.entries, { name: "", value: "" }])}
             >
                 + Add
@@ -826,38 +835,38 @@ const AgentRefEditor = (p: {
 
     return (
         <>
-            <Field label="Identity">
+            <NodeField label="Identity">
                 <select
-                    class="drone-input"
+                    class="drone-input nodrag"
                     value={ref().identityId}
                     onChange={(e) => setRef({ identityId: e.currentTarget.value })}
                 >
-                    <option value="">— Blank (ambient creds) —</option>
+                    <option value="">— blank —</option>
                     <For each={(identities() ?? []).filter((b) => !b.is_blank)}>
                         {(bundle) => <option value={bundle.id}>{bundle.name}</option>}
                     </For>
                 </select>
-            </Field>
-            <Field label="Memory">
+            </NodeField>
+            <NodeField label="Memory">
                 <select
-                    class="drone-input"
+                    class="drone-input nodrag"
                     value={ref().memoryId}
                     onChange={(e) => setRef({ memoryId: e.currentTarget.value })}
                 >
-                    <option value="">— Blank (vanilla CLI) —</option>
+                    <option value="">— blank —</option>
                     <For each={(memories() ?? []).filter((m) => !m.is_blank)}>
                         {(memory) => <option value={memory.id}>{memory.name}</option>}
                     </For>
                 </select>
-            </Field>
-            <Field label="Instance name (optional, for named-agent continuation)">
+            </NodeField>
+            <NodeField label="Instance">
                 <input
-                    class="drone-input"
+                    class="drone-input nodrag"
                     value={ref().instanceName}
                     onInput={(e) => setRef({ instanceName: e.currentTarget.value })}
-                    placeholder="leave blank for one-shot"
+                    placeholder="blank = one-shot"
                 />
-            </Field>
+            </NodeField>
         </>
     );
 };

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -483,7 +483,7 @@ const Canvas = (p: { model: DroneViewModel }): JSX.Element => {
                                 <Show
                                     when={selected()}
                                     fallback={
-                                        <div class="drone-node-body drone-node-summary">
+                                        <div class="drone-node-summary">
                                             {nodeSummary(n)}
                                         </div>
                                     }
@@ -640,6 +640,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                 <NodeField label="Task">
                     <textarea
                         class="drone-input drone-input--grow nodrag nowheel"
+                        ref={(el) => autoGrow(el)}
                         value={(p.node.data["task"] as string) ?? ""}
                         placeholder="{{...}} interpolation supported"
                         onInput={(e) => {
@@ -676,6 +677,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                 <NodeField label="Body">
                     <textarea
                         class="drone-input drone-input--grow nodrag nowheel"
+                        ref={(el) => autoGrow(el)}
                         value={(p.node.data["body"] as string) ?? ""}
                         placeholder='{"key": "{{var.x}}"}'
                         onInput={(e) => {
@@ -700,6 +702,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                 <NodeField label="Template">
                     <textarea
                         class="drone-input drone-input--grow nodrag nowheel"
+                        ref={(el) => autoGrow(el)}
                         value={(p.node.data["template"] as string) ?? ""}
                         placeholder="Hello {{var.name}}!"
                         onInput={(e) => {


### PR DESCRIPTION
## Summary

Removes the right-side inspector panel that was covering too much canvas, and moves parameter editing **inline into the node body** (see spec `docs/specs/SPEC_DRONE_INLINE_NODE_PARAMS_2026_06_05.md`).

**Two-state nodes:** unselected shows a compact one-line summary; selecting a node expands inline editable fields directly inside it — no persistent side panel anywhere.

## Changes

- **Remove** `InspectorPanel` component, its mount in `DroneView`, and all `.drone-inspector*` styles. Canvas is 100% canvas.
- **Add** `NodeFields`: per-kind field stack rendered inside the selected node — Agent (identity, memory, instance, task), API (method, url, body), Condition (expr), Response (template), Variables (name/value rows).
- **Add** `NodeField`: compact horizontal label-left / control-right row (~26px height).
- Auto-grow `textarea` for long text fields (task, body, template): capped at ~5 lines; `nowheel` so scrolling the textarea content doesn't zoom the canvas.
- `nodrag` on every control so clicking/typing never starts a node drag.
- `NODE_W` widened 160→248px for the compact field grid; updates edge x-attachment.
- Canvas `onWheel` skips `.nowheel` elements (the auto-grow textareas).
- Adds spec: `SPEC_DRONE_INLINE_NODE_PARAMS_2026_06_05.md` (PR2 = field-anchored popovers for the complex-field escalation).

## Verification

- `tsc --noEmit`: 0 drone errors, baseline unchanged.
- `npm run build`: green.
- Live (`task dev` + CDP): 3 nodes added, Agent selected → inline fields rendered, `.drone-inspector` absent, canvas 100% open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)