### PR TITLE
feat(error-pane): copy-on-highlight with Copied tooltip

### DIFF
--- a/.changesets/1780692933-feat-error-pane-copy-on-highlight-with-cursor-tooltip-bpip.md
+++ b/.changesets/1780692933-feat-error-pane-copy-on-highlight-with-cursor-tooltip-bpip.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(error-pane): copy-on-highlight with cursor tooltip

--- a/.changesets/1780724458-fix-error-pane-copy-on-highlight-with-tooltip-and-full-heigh-a4a2.md
+++ b/.changesets/1780724458-fix-error-pane-copy-on-highlight-with-tooltip-and-full-heigh-a4a2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(error-pane): copy-on-highlight with tooltip and full-height stack

--- a/frontend/app/block/BlockErrorBoundary.tsx
+++ b/frontend/app/block/BlockErrorBoundary.tsx
@@ -25,6 +25,7 @@
 import { invokeCommand } from "@/app/platform/ipc";
 import { resolveStack, resolveStackSync, type ResolveStatus } from "@/log/source-map-resolver";
 import { getTrail } from "@/log/render-trail";
+import { writeText as ipcWriteText } from "@/util/clipboard";
 import { ErrorBoundary as SolidErrorBoundary, createSignal, Show } from "solid-js";
 import type { JSX } from "solid-js";
 
@@ -148,6 +149,7 @@ function BlockErrorFallback(props: {
 }): JSX.Element {
     const [stackOpen, setStackOpen] = createSignal(false);
     const [copiedPos, setCopiedPos] = createSignal<{ x: number; y: number } | null>(null);
+    let fadeTimer: ReturnType<typeof setTimeout> | null = null;
     const errName = () => props.error?.name ?? "Error";
     const errMessage = () => props.error?.message ?? String(props.error);
     const errStack = () => props.error?.stack ?? "";
@@ -156,23 +158,24 @@ function BlockErrorFallback(props: {
     // Copy-on-highlight: when the user releases the mouse with a non-empty
     // selection inside the error pane, copy to clipboard and show a brief
     // "Copied" tooltip near the cursor. Uses execCommand as primary path
-    // (synchronous, no permission issues in CEF) with clipboard API fallback.
+    // (synchronous, no permission issues in CEF) with IPC writeText fallback.
     const handleMouseUp = (e: MouseEvent): void => {
         const sel = window.getSelection();
         const text = sel?.toString().trim();
         if (!text) return;
         const pos = { x: e.clientX, y: e.clientY };
         const show = (): void => {
+            if (fadeTimer) clearTimeout(fadeTimer);
             setCopiedPos(pos);
-            setTimeout(() => setCopiedPos(null), 1500);
+            fadeTimer = setTimeout(() => setCopiedPos(null), 1500);
         };
         // execCommand is synchronous and works reliably in CEF within a user gesture.
         try {
             const ok = document.execCommand("copy");
             if (ok) { show(); return; }
         } catch (_) { /* fall through */ }
-        // Fallback to async clipboard API.
-        void navigator.clipboard.writeText(text).then(show).catch(() => {});
+        // Fallback: route through CEF IPC (navigator.clipboard is blocked in CEF).
+        void ipcWriteText(text).then(show).catch(() => {});
     };
 
     return (

--- a/frontend/app/block/BlockErrorBoundary.tsx
+++ b/frontend/app/block/BlockErrorBoundary.tsx
@@ -161,7 +161,8 @@ function BlockErrorFallback(props: {
     // (synchronous, no permission issues in CEF) with IPC writeText fallback.
     const handleMouseUp = (e: MouseEvent): void => {
         const sel = window.getSelection();
-        const text = sel?.toString().trim();
+        const raw = sel?.toString() ?? "";
+        const text = raw.trim();
         if (!text) return;
         const pos = { x: e.clientX, y: e.clientY };
         const show = (): void => {
@@ -175,7 +176,8 @@ function BlockErrorFallback(props: {
             if (ok) { show(); return; }
         } catch (_) { /* fall through */ }
         // Fallback: route through CEF IPC (navigator.clipboard is blocked in CEF).
-        void ipcWriteText(text).then(show).catch(() => {});
+        // Use raw (untrimmed) to match what execCommand would have copied.
+        void ipcWriteText(raw).then(show).catch(() => {});
     };
 
     return (
@@ -229,11 +231,11 @@ function BlockErrorFallback(props: {
                     </button>
                 </Show>
             </div>
-            <Show when={copiedPos()}>
+            <Show when={copiedPos()} keyed>
                 {(pos) => (
                     <div
                         class="block-error-fallback-copied"
-                        style={{ left: `${pos().x + 12}px`, top: `${pos().y - 28}px` }}
+                        style={{ left: `${pos.x + 12}px`, top: `${pos.y - 28}px` }}
                     >
                         Copied
                     </div>

--- a/frontend/app/block/BlockErrorBoundary.tsx
+++ b/frontend/app/block/BlockErrorBoundary.tsx
@@ -147,13 +147,36 @@ function BlockErrorFallback(props: {
     onClose?: () => void;
 }): JSX.Element {
     const [stackOpen, setStackOpen] = createSignal(false);
+    const [copiedPos, setCopiedPos] = createSignal<{ x: number; y: number } | null>(null);
     const errName = () => props.error?.name ?? "Error";
     const errMessage = () => props.error?.message ?? String(props.error);
     const errStack = () => props.error?.stack ?? "";
     const shortId = () => props.blockId.substring(0, 7);
 
+    // Copy-on-highlight: when the user releases the mouse with a non-empty
+    // selection inside the error pane, copy to clipboard and show a brief
+    // "Copied" tooltip near the cursor. Uses execCommand as primary path
+    // (synchronous, no permission issues in CEF) with clipboard API fallback.
+    const handleMouseUp = (e: MouseEvent): void => {
+        const sel = window.getSelection();
+        const text = sel?.toString().trim();
+        if (!text) return;
+        const pos = { x: e.clientX, y: e.clientY };
+        const show = (): void => {
+            setCopiedPos(pos);
+            setTimeout(() => setCopiedPos(null), 1500);
+        };
+        // execCommand is synchronous and works reliably in CEF within a user gesture.
+        try {
+            const ok = document.execCommand("copy");
+            if (ok) { show(); return; }
+        } catch (_) { /* fall through */ }
+        // Fallback to async clipboard API.
+        void navigator.clipboard.writeText(text).then(show).catch(() => {});
+    };
+
     return (
-        <div class="block-error-fallback" role="alert" data-testid="block-error-fallback">
+        <div class="block-error-fallback" role="alert" data-testid="block-error-fallback" onMouseUp={handleMouseUp}>
             <div class="block-error-fallback-header">
                 <i class="fa-sharp fa-solid fa-triangle-exclamation block-error-fallback-icon" aria-hidden="true" />
                 <div class="block-error-fallback-title">This pane crashed</div>
@@ -203,6 +226,16 @@ function BlockErrorFallback(props: {
                     </button>
                 </Show>
             </div>
+            <Show when={copiedPos()}>
+                {(pos) => (
+                    <div
+                        class="block-error-fallback-copied"
+                        style={{ left: `${pos().x + 12}px`, top: `${pos().y - 28}px` }}
+                    >
+                        Copied
+                    </div>
+                )}
+            </Show>
         </div>
     );
 }

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -555,6 +555,7 @@
         display: flex;
         flex-direction: column;
         gap: var(--space-2);
+        flex: 1;
         min-height: 0;
     }
 
@@ -594,7 +595,8 @@
 
     .block-error-fallback-stack {
         margin: 0;
-        max-height: 220px;
+        flex: 1;
+        min-height: 0;
         overflow: auto;
         font-family: var(--fixed-font);
         font-size: var(--text-xs);
@@ -603,6 +605,29 @@
         border-radius: var(--radius-sm);
         white-space: pre-wrap;
         word-break: break-word;
+    }
+
+    // Copy-on-highlight tooltip — appears near the cursor for 1.5s after the
+    // user releases a text selection in the error pane.
+    .block-error-fallback-copied {
+        position: fixed;
+        pointer-events: none;
+        background: var(--main-bg-color);
+        border: 1px solid var(--border-color);
+        color: var(--secondary-text-color);
+        font-size: var(--text-xs);
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+        white-space: nowrap;
+        z-index: 9999;
+        animation: block-error-copied-fade 1.5s ease forwards;
+    }
+
+    @keyframes block-error-copied-fade {
+        0%   { opacity: 1; }
+        70%  { opacity: 1; }
+        100% { opacity: 0; }
     }
 
     .block-error-fallback-footer {


### PR DESCRIPTION
## Problem

Clicking the Copy button in the error pane doesn't work — it pastes old clipboard data. The actual error text can't be easily copied.

## Change

Single `onMouseUp` listener on the error fallback container: when the user releases with a non-empty text selection, copy to clipboard instantly and show a small **"Copied"** tooltip near the cursor that fades out over 1.5 s.

No button to click. No extra step. The selection itself is the copy action.

## Files

- `BlockErrorBoundary.tsx` — `handleMouseUp`, `copiedPos` signal, tooltip `<Show>`
- `block.scss` — `.block-error-fallback-copied` (fixed-position, pointer-events:none, fade animation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)