### PR TITLE
fix(tabbar): eliminate window-drag dead zone — move fill inside scroll container

### DIFF
--- a/.changesets/1780694694-fix-tabbar-move-fill-inside-scroll-so-empty-tab-bar-space-is-5ydh.md
+++ b/.changesets/1780694694-fix-tabbar-move-fill-inside-scroll-so-empty-tab-bar-space-is-5ydh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): move fill inside scroll so empty tab-bar space is draggable

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -159,17 +159,21 @@
     }
 
     .tab-bar-fill {
-        flex: 1 1 auto;
-        min-width: 0;
-        height: 100%;
+        // Lives inside .tab-bar-scroll, AFTER the tab items. Takes all space
+        // to the right of the last tab so the entire visual "empty bar" area
+        // is draggable. isInDragRegion walks UP the DOM: the fill's own
+        // data-drag-region="true" is found before the scroll container's
+        // "false", so a mousedown here starts a window drag.
+        //
         // NOTE: intentionally HTCLIENT (not -webkit-app-region: drag).
         // Chromium suppresses ALL events on drag elements before the renderer
         // sees them, so contextmenu wouldn't fire. Window drag is JS-driven
-        // (see frontend/app/hook/useWindowDrag.linux.ts) — a 4px-threshold
-        // mousedown handler sends start_window_drag IPC →
-        // CefWindow::BeginWindowDrag(), which dispatches xdg_toplevel.move
-        // (Wayland) / _NET_WM_MOVERESIZE (X11). Right-click reaches the
-        // renderer normally.
+        // (a 4px-threshold mousedown → start_window_drag IPC). Right-click
+        // reaches the renderer normally.
+        flex: 1 1 auto;
+        min-width: 0;
+        height: 100%;
+        align-self: stretch;
     }
 
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -633,9 +633,15 @@ function TabBar(props: TabBarProps): JSX.Element {
                         </>
                     )}
                 </For>
+                {/* Fill lives INSIDE the scroll container so the genuine empty
+                    space to the right of the last tab is draggable. isInDragRegion
+                    walks UP the DOM from the clicked element: the fill's own
+                    data-drag-region="true" is found before the scroll container's
+                    "false", so a click here starts a window drag. Moving it outside
+                    the scroll (as a sibling) left a dead zone — the empty interior
+                    of the scroll container looked draggable but wasn't. */}
+                <div class="tab-bar-fill" data-drag-region="true" />
             </div>
-            {/* Empty right-side space — draggable so the user can grab the window from here */}
-            <div class="tab-bar-fill" data-drag-region="true" />
         </div>
     );
 }


### PR DESCRIPTION
## Problem

Parts of the top bar could not be used to drag the window. Specifically, the empty visual space between the last tab and the action-widget buttons was NOT draggable, even though it looked like empty title bar.

## Root cause

`.tab-bar-scroll` had `flex: 1 1 auto` (grows), so it competed for space with the outer `.tab-bar-fill` sibling. Both shared the available width roughly 50/50. The empty space **inside** the scroll container (to the right of the last tab, but before the sibling fill) was inside `data-drag-region="false"` and blocked window drag.

`isInDragRegion()` walks UP the DOM from the clicked element and stops at the first `data-drag-region` attribute — hitting the scroll's `"false"` before the window-header's `"true"`.

**Before:** fill at x=863, width=777px. Dead zone: ~500px inside scroll (not draggable).

## Fix

Move `.tab-bar-fill` from a **sibling** of `.tab-bar-scroll` to a **child** of it, placed after the `<For>` tab loop.

With the fill inside the scroll, clicking it finds the fill's own `data-drag-region="true"` before the scroll container's `"false"` — drag starts correctly.

**After:** fill at x=350, width=**1290px** — the entire visual empty space after the last tab is now draggable.

## Verification

CDP scan across the header mid-line:
- x=10–250: tabs → `false` (expected)
- **x=370–1570: `tab-bar-fill=true`** (draggable — was dead zone before)
- x=1690+: action widgets → `false` (expected)

Build: ✅  No logic changes — pure DOM restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)