### PR TITLE
fix(session-digest): shorten summary to 10 words or fewer

### DIFF
--- a/.changesets/1780724750-fix-session-digest-shorten-summary-to-10-words-ht15.md
+++ b/.changesets/1780724750-fix-session-digest-shorten-summary-to-10-words-ht15.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix session-digest shorten summary to 10 words

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1450,8 +1450,8 @@ fn register_session_digest(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Build the summarization prompt
                 let prompt = format!(
-                    "Summarize this AI coding session in 3-4 sentences. Focus on: what was worked on, \
-                     tools used, any errors encountered, and the current state. Be concise and factual.\n\n\
+                    "Summarize this AI coding session in 10 words or fewer. Be direct and specific. \
+                     Example: \"Fixed auth bug, added dark mode, tests passing.\"\n\n\
                      Session content (last 200 events):\n\n{}",
                     extracted
                 );


### PR DESCRIPTION
## Summary

- The session digest prompt previously asked for "3-4 sentences", producing 40–80 word summaries that were too long for a quick glance
- Changed the prompt to request ≤10 words with a concrete example: `"Fixed auth bug, added dark mode, tests passing."`
- No frontend, schema, or cache changes needed — the banner renders whatever string is returned

## Change

`agentmux-srv/src/server/app_api.rs` lines 1452–1457: prompt text only.

## Test plan

- [ ] Trigger a session digest (open a session that has been idle >1h with >20 new lines, or click the ↻ regenerate button)
- [ ] Verify the returned summary is ≤10 words
- [ ] Verify the summary is still meaningful (names a specific action, not generic)
- [ ] Verify the banner renders and dismisses correctly (no layout regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)