### PR TITLE
feat(notify): sound notifications + per-tool subliminal voice

### DIFF
--- a/.changesets/1780657891-feat-notify-sound-notifications-subsystem-with-turn-complete-9s3b.md
+++ b/.changesets/1780657891-feat-notify-sound-notifications-subsystem-with-turn-complete-9s3b.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(notify): sound notifications subsystem with turn-complete sound

--- a/.changesets/1780672640-feat-notify-per-tool-call-subliminal-tone-voice-vira.md
+++ b/.changesets/1780672640-feat-notify-per-tool-call-subliminal-tone-voice-vira.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(notify): per-tool-call subliminal tone voice

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -218,6 +218,44 @@ pub struct SettingsType {
     #[serde(rename = "voice:enabled", default, skip_serializing_if = "Option::is_none")]
     pub voice_enabled: Option<bool>,
 
+    // -- Notification sounds --
+    //
+    // Spec: docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §5.1.
+    //
+    // Master enable. Default at the UX layer is "on" — the frontend treats
+    // `undefined`/absent as enabled, so absence means sounds play. Users
+    // set this to `false` to fully silence the app.
+    #[serde(rename = "notify:sounds:enabled", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sounds_enabled: Option<bool>,
+
+    // 0.0 to 1.0; default 0.6 if unset.
+    #[serde(rename = "notify:sounds:volume", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sounds_volume: Option<f32>,
+
+    // Suppress a pane's sound when that pane is focused AND the window
+    // is in foreground. Default: true.
+    #[serde(rename = "notify:sounds:suppresswhenfocused", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sounds_suppress_when_focused: Option<bool>,
+
+    // Per-event opt-out. Absence = on (default behavior).
+    #[serde(rename = "notify:sound:agent.turn.complete", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_turn_complete: Option<bool>,
+
+    #[serde(rename = "notify:sound:agent.turn.error", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_turn_error: Option<bool>,
+
+    #[serde(rename = "notify:sound:agent.turn.interrupted", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_turn_interrupted: Option<bool>,
+
+    #[serde(rename = "notify:sound:agent.message.accepted", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_message_accepted: Option<bool>,
+
+    #[serde(rename = "notify:sound:agent.message.rejected", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_message_rejected: Option<bool>,
+
+    #[serde(rename = "notify:sound:agent.stream.stalled", default, skip_serializing_if = "Option::is_none")]
+    pub notify_sound_agent_stream_stalled: Option<bool>,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -256,6 +256,26 @@ pub struct SettingsType {
     #[serde(rename = "notify:sound:agent.stream.stalled", default, skip_serializing_if = "Option::is_none")]
     pub notify_sound_agent_stream_stalled: Option<bool>,
 
+    // -- Tool-call tones (subliminal per-tool "voice") --
+    //
+    // Spec: docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md.
+    //
+    // Master enable. Default at the UX layer is "on" — absence is on
+    // by design (see spec §7).
+    #[serde(rename = "notify:tooltones:enabled", default, skip_serializing_if = "Option::is_none")]
+    pub notify_tooltones_enabled: Option<bool>,
+
+    // Independent gain (0.0–1.0; default 0.15). Layered below the
+    // shared master gain so master kill-switches both subsystems.
+    #[serde(rename = "notify:tooltones:volume", default, skip_serializing_if = "Option::is_none")]
+    pub notify_tooltones_volume: Option<f32>,
+
+    // Scope: "all" (default) plays for every pane in every window;
+    // "focused" plays only for the focused pane in the focused window.
+    // The intermediate "window" mode is reserved for v1.5.
+    #[serde(rename = "notify:tooltones:scope", default, skip_serializing_if = "Option::is_none")]
+    pub notify_tooltones_scope: Option<String>,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md
+++ b/docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md
@@ -1,0 +1,426 @@
+# SPEC — Agent tool-call tones (subliminal "talking" voice)
+
+**Status:** Draft v1 — for review
+**Date:** 2026-06-05
+**Author:** agent2
+**Builds on:** `docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md` (v1 sound subsystem — bus, player, settings plumbing)
+
+**Related:**
+- `frontend/app/store/agent-pane-state/types.ts` (line 535 — existing `tool-started` event we hook off)
+- `frontend/app/store/agent-pane-state/reducer.ts` (line 451 — `ToolStart` arm that emits it)
+- `frontend/app/view/agent/stream-parser.ts` (line 476 — `normalizeToolName` — the canonical name set the parser surfaces to us today)
+- `frontend/app/notification/sound/` (the v1 subsystem we extend)
+- `frontend/app/store/focusManager.ts` (per-pane focus signal — central to the §3.3 scoping decision)
+- MDN — `BiquadFilterNode` lowpass + `OscillatorNode` envelope shape
+
+---
+
+## 0. TL;DR
+
+Each agent tool call (`Read`, `Write`, `Bash`, `Edit`, …) plays a tiny synthesized tone — different per tool, deterministic, ~50ms, lowpass-filtered, very quiet. The effect is an ambient "voice" texture: when the agent strings together Read → Read → Edit → Write → Bash, you hear a recognizable little phrase. Over time the user learns the phrases without consciously trying — same path as keyboard sounds, RAID-controller ticks, or a Geiger counter.
+
+**Talking, not morse.** The mapping is real — same tool always sounds the same — so it carries information, but the encoding is musical (pentatonic intervals, sine timbre) not literal (dot/dash). Pentatonic intervals can never produce a sour combination, which matters because tool calls can fire at >10 Hz during dense agent activity.
+
+**Subliminal, not background music.** Default volume is ~0.15 of master, the chain is lowpassed at ~2.5 kHz, and individual tones are 40–80 ms. Loud enough to inform "the agent is moving"; quiet enough not to compete with anything else the user is doing.
+
+**All panes by default — scope is a setting.** Tool tones are an ambient companion to *attending to the app at all*, not just to one pane. Default is `scope: "all"` so a user with two agents working in parallel hears both. Users who find the parallel chatter too dense can drop to `scope: "focused"` (only the focused pane in the focused window) — that's the single setting that turns "useful" into "useable" for a multi-agent power user. The `"focused"` mode is also the inverse of the v1 notification-sound focus rule (which *suppresses* when focused, because the user is already looking) — these are different UX surfaces and they get different defaults intentionally.
+
+---
+
+## 1. Why
+
+The agent activity log is the visual channel for "what is the agent doing?" — every Read, every Bash, every Edit shows up as a row with the tool name and a one-line summary. When the user is watching the pane, this works. When they look away for a second to type elsewhere, they lose the thread.
+
+A tiny per-call sound closes that gap as long as the user is looking AT the window. They don't have to keep their eyes on the activity log to feel the *cadence* of the work — Read-Read-Read-Bash means "looking around then ran something," Read-Edit-Read-Edit means "iterating on a file," and Bash-Bash-Bash means "this got stuck and is hammering the same thing." The user picks up patterns the way you pick up the rhythm of a colleague typing next to you.
+
+This is **distinct from** the v1 sound notifications (turn-complete, error, etc.):
+
+| | v1 notifications | tool-call tones |
+|---|---|---|
+| What it tells you | a discrete event happened | something is in progress |
+| Attention model | summons your attention | adds texture under your attention |
+| Volume | normal (0.6 default) | subliminal (~0.15 default) |
+| Focus suppression | suppress when looking at it | only play when looking at it |
+| Default | on | on (with scope and volume knobs) |
+| Frequency | seconds-to-minutes apart | up to 10–20 Hz during dense activity |
+
+We do not collapse the two — they are different UX surfaces with different defaults, different volumes, and different scope rules. They share the AudioContext and the bus, nothing else.
+
+---
+
+## 2. Non-goals
+
+- **No literal morse code, no phoneme synthesis, no TTS.** Pentatonic intervals carry plenty of information and never dissonate.
+- **No "voice themes" (major / minor / world scales).** Future surface, listed in §10 — v1 ships one curated palette.
+- **No backend-side hint stream.** The reducer already fires `tool-started` with the tool name; we read it via the multicast. No new RPC, no new event.
+- **No tool-end sound.** Doubles the rate, doesn't add information. (Tool *outcome* — error vs success — is interesting but lives in the activity log via the chunk-stream; revisit in v2 if user feedback wants it.)
+- **No per-chunk streaming sound.** Way too dense — a Bash that streams 200 lines of stdout would be a buzz, not a tone.
+- **No spatial / per-pane panning** in v1 — every pane mixes to the same mono channel. Stereo per-pane positioning is a v2 follow-up (§8.5).
+- **No spatial / stereo / panning effects** in v1 — single mono channel. Stereo per-agent panning is fun (left agent vs right agent) but adds a knob that needs design.
+- **No external asset shipping.** Synth only, per user direction. Same posture as v1.
+
+---
+
+## 3. Design — three decisions and the rest is mechanical
+
+### 3.1 The mapping: pentatonic, two-tone "syllable" per call
+
+Each tool call plays **two short tones in quick succession** (a "syllable") drawn from a pentatonic scale. Two tones because:
+- One tone is too thin to feel like speech.
+- Two tones make an interval — interval is the unit of *meaning* in this system. C→E is the Read syllable; E→C is the Write syllable; the user learns by inversion as much as by absolute pitch.
+- Two short tones at 40–80 ms each fit inside a single tool-call without colliding with the next, even at peak agent cadence.
+
+**Scale: G pentatonic** (G, A, B, D, E across two octaves). Pentatonic was chosen because:
+- No semitone clashes — any two notes sound musically compatible, even when overlapping (which they will, when tools fire faster than the coalesce window).
+- 8 distinct degrees in a 2-octave window — enough headroom to give 6–8 curated tools unique voices, plus a deterministic hash space for unknowns.
+- G base lands the syllables in the middle of human pitch perception (~390 Hz) — clear without being shrill at low volume.
+
+### 3.2 The mapping: curated for canonical tools, hashed for unknowns
+
+The canonical set (from `stream-parser.ts:478`): `Read, Edit, Write, Bash, Grep, Glob, Task, Agent`. Each gets a hand-tuned syllable that *means* what the tool does. Unknown tools (MCP-provided, agent custom, etc.) get a deterministic hash → syllable so they're consistent within a session.
+
+#### 3.2.1 Curated palette
+
+| Tool | Syllable | Why |
+|---|---|---|
+| **Read** | B4 → A4 (gentle falling 2nd) | Soft, descending — "looking." Neutral, doesn't claim attention. |
+| **Grep** | E5 → E5 (two same-pitch quick ticks) | "Search" — a question-mark feel, twin ticks for "scanning." |
+| **Glob** | D5 → E5 (paired tick, rising) | "Listing" — Grep's sibling but rising (results coming in). |
+| **Edit** | A4 → B4 → A4 (three-tone "fix") | Up-down-up — the auditory shape of a small correction. Only 3-tone tool in v1; reserved for the edit gesture because it's distinctive in conversation. |
+| **Write** | G4 → D5 (rising 5th) | Bigger interval = "creation." Confident, not loud. |
+| **Bash** | G3 → D4 (rising 5th, octave down, triangle wave) | Same musical shape as Write but darker — mechanical. Triangle gives the "machine" timbre. |
+| **Task** | D5 → G5 (rising 4th, high) | "Delegation upward" — clear and brief. |
+| **Agent** | G4 → D5 → G4 (returning 5th) | "Sub-agent dispatch" — out and back, three tones to mark importance. |
+| `Other`/unknown | hashed (see §3.2.2) | Stable across the session. |
+
+A user reading "Read Read Grep Read Edit Write Bash" hears: *falling, falling, twin-ticks, falling, three-tone-fix, rising-5th, mechanical-rising-5th*. The shape of work is audible.
+
+#### 3.2.2 Hash fallback for unknowns
+
+```ts
+function hashToolToParams(tool: string): SyllableParams {
+    // FNV-1a-ish hash for determinism + cheap to compute.
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < tool.length; i++) {
+        h = (h ^ tool.charCodeAt(i)) >>> 0;
+        h = Math.imul(h, 16777619) >>> 0;
+    }
+    // Pentatonic degree set (G major pentatonic, 2 octaves above G3).
+    // 8 entries — each tool gets two distinct degrees.
+    const DEGREES = [0, 2, 4, 7, 9, 12, 14, 16];
+    const noteAt = (i: number) => 196 * Math.pow(2, DEGREES[i % 8] / 12); // G3 base
+    return {
+        tones: [noteAt(h), noteAt(h >>> 3)],
+        durationMs: 45 + ((h >>> 6) & 0x1f), // 45–76ms
+        wave: ((h >>> 11) & 1) === 0 ? "sine" : "triangle",
+        gapMs: 12 + ((h >>> 12) & 7), // 12–19ms gap between tones
+    };
+}
+```
+
+Properties: deterministic, allocation-light, no string normalization beyond what the parser already does, no collision behavior to memorize.
+
+### 3.3 The scoping rule: `notify:tooltones:scope`
+
+Three modes, settings-driven, default `"all"`:
+
+- **`"all"` (default)** — play for every pane in every window. The user hears all active agents. This is the "I want my desktop to be a chorus of agents I can listen to" mode. Default because it's the mode that delivers the spec's core promise (a 3-agent run sounds like 3 distinct voices) without requiring any setting flip.
+- **`"window"`** — play for any pane in the *focused* window. Multi-window users who keep one foreground window per task get one window's chorus at a time. v1.5 follow-up (§8.5); not in the initial PR until we've seen actual user need.
+- **`"focused"`** — play only when the source pane is focused AND the window has OS focus. A single agent's voice; everything else silent. This is the "I'm too overwhelmed by the chorus, let me hear one at a time" knob — and it's the *opposite* of v1's notification focus-suppression rule.
+
+Default-on + `scope: "all"` does mean a user running 6 agents at once will hear all 6. That's the explicit design — it's what surfaces "the system is alive" most clearly. The pentatonic palette is bounded so 6 overlapping tools never produce a sour combination (§3.1 + §3.2). Users who find it dense have one setting flip (`scope: "focused"`) to recover quiet.
+
+---
+
+## 4. Module layout
+
+```
+frontend/app/notification/sound/
+    tool-tones.ts            # NEW — tool name → syllable params, curated + hashed
+    tool-tones-player.ts     # NEW — dedicated synth path with lowpass + indep gain
+    sound-service.ts         # MODIFIED — route `tool-started` events to the player
+    sounds.ts                # unchanged (tool tones do not use the registry — they're parametric)
+    sound-player.ts          # unchanged
+    synth-fallback.ts        # unchanged
+    sound-events.ts          # unchanged
+    index.ts                 # MODIFIED — re-export setToolTonesEnabled for tests
+```
+
+Adding a new curated tool is one entry in `tool-tones.ts`'s palette. Removing one falls back to hash. No settings change required to extend the palette.
+
+---
+
+## 5. The player chain — why a separate one
+
+The v1 `SoundPlayer` does buffer-or-synth-fallback on the shared master bus. The tool-tones path has two specific needs the master bus doesn't provide:
+
+1. **Lowpass filter.** A `BiquadFilterNode` at ~2.5 kHz cutoff smooths the attack of every tone, making the tones blend into ambient instead of poking through it. Notification sounds should NOT be lowpassed (we want them crisp); tool tones should.
+2. **Independent volume.** The user wants notifications at one level and tool tones at another (much quieter, often). Two independent gain knobs.
+
+Chain:
+
+```
+OscillatorNode → per-tone envelope (GainNode)
+              → tool-tones gain (settings-bound)
+              → BiquadFilter (lowpass ~2.5 kHz)
+              → master gain (shared with v1)
+              → AudioContext.destination
+```
+
+The master gain stays shared — turning the master to zero silences everything, which is the right semantics. The tool-tones gain layers below it.
+
+```ts
+// tool-tones-player.ts (sketch)
+export class ToolTonesPlayer {
+    private filter: BiquadFilterNode | null = null;
+    private gain: GainNode | null = null;
+    private toolGainValue = 0.15;
+    private lastFiredAt = new Map<string, number>();
+
+    attach(ctx: AudioContext, master: GainNode): void {
+        this.filter = ctx.createBiquadFilter();
+        this.filter.type = "lowpass";
+        this.filter.frequency.value = 2500;
+        this.filter.Q.value = 0.707;
+        this.gain = ctx.createGain();
+        this.gain.gain.value = this.toolGainValue;
+        this.gain.connect(this.filter).connect(master);
+    }
+
+    setVolume(v: number): void {
+        const clamped = Math.max(0, Math.min(1, v));
+        this.toolGainValue = clamped;
+        if (this.gain) this.gain.gain.value = clamped;
+    }
+
+    play(ctx: AudioContext, tool: string): void {
+        const out = this.gain;
+        if (!out) return;
+        // Coalesce: same tool fired within 30ms = drop. The number
+        // is tight on purpose; the user wants to hear "Read Read Read."
+        const now = performance.now();
+        const last = this.lastFiredAt.get(tool) ?? 0;
+        if (now - last < 30) return;
+        this.lastFiredAt.set(tool, now);
+        const p = paramsForTool(tool);
+        playSyllable(ctx, out, p);
+    }
+}
+
+function playSyllable(ctx: AudioContext, out: AudioNode, p: SyllableParams): void {
+    const startAt = ctx.currentTime;
+    p.tones.forEach((freq, i) => {
+        const osc = ctx.createOscillator();
+        const env = ctx.createGain();
+        const at = startAt + (i * (p.durationMs + p.gapMs)) / 1000;
+        osc.type = p.wave;
+        osc.frequency.setValueAtTime(freq, at);
+        env.gain.setValueAtTime(0.0001, at);
+        env.gain.exponentialRampToValueAtTime(0.4, at + 0.006);
+        env.gain.exponentialRampToValueAtTime(0.0001, at + p.durationMs / 1000);
+        osc.connect(env).connect(out);
+        osc.start(at);
+        osc.stop(at + p.durationMs / 1000 + 0.02);
+    });
+}
+```
+
+`paramsForTool` consults the curated map first; falls back to `hashToolToParams`.
+
+---
+
+## 6. Service wiring — additive to v1
+
+`sound-service.ts` already installs a single multicast listener on the agent-pane-state store. The same listener gets one more case:
+
+```ts
+case "tool-started": {
+    if (!shouldPlayToolTone(blockId)) return;
+    const ctx = player.getAudioContext();
+    if (!ctx) return; // not primed yet
+    toolTones.play(ctx, event.name);
+    return;
+}
+```
+
+`shouldPlayToolTone(blockId)` reads `notify:tooltones:enabled` (default false) + `notify:tooltones:scope` and applies the focus rule:
+
+```ts
+function shouldPlayToolTone(blockId: string): boolean {
+    if (replayMode) return false;
+    // Master notification kill-switch covers tool tones too — they share
+    // the master gain, but checking the setting up-front lets us skip
+    // the AudioContext work entirely.
+    if (getSettingsKeyAtom("notify:sounds:enabled")() === false) return false;
+    const enabled = getSettingsKeyAtom("notify:tooltones:enabled")();
+    if (enabled === false) return false; // default true — absence is on
+    const scope = getSettingsKeyAtom("notify:tooltones:scope")() ?? "all";
+    if (scope === "focused") {
+        return focusManager.blockFocusAtom() === blockId && windowFocused();
+    }
+    // "window" mode lands in v1.5 — same predicate as "all" for now.
+    return true; // "all" (or unknown — fail open to the default)
+}
+```
+
+The volume thread:
+
+```ts
+createEffect(() => {
+    const vol = getSettingsKeyAtom("notify:tooltones:volume")();
+    toolTones.setVolume(typeof vol === "number" ? vol : 0.15);
+});
+```
+
+`SoundPlayer` needs one new accessor — `getAudioContext(): AudioContext | null` — so the tool-tones player can hook into the same context. Tiny, additive.
+
+The tool-tones player is attached on first prime (chain wired up at the moment the AudioContext is created):
+
+```ts
+// Inside installSoundService(), after prime():
+toolTones.attach(player.getAudioContext()!, player.getMasterGain()!);
+```
+
+`SoundPlayer.getMasterGain(): GainNode | null` — also a tiny additive accessor.
+
+---
+
+## 7. Settings additions
+
+Mirror of the v1 plumbing — Rust struct, TS type, user template, schema:
+
+```jsonc
+// -- Notification: tool-call tones (subliminal "voice") --
+// "notify:tooltones:enabled":   true,
+// "notify:tooltones:volume":    0.15,
+// "notify:tooltones:scope":     "all",     // "all" or "focused"
+```
+
+Schema entries: `notify:tooltones:enabled` (bool, default true), `notify:tooltones:volume` (number 0–1, default 0.15), `notify:tooltones:scope` (enum `"all" | "focused"`, default `"all"`).
+
+Rust struct: three new `Option<...>` fields with the same `#[serde(rename = ...)]` pattern as v1.
+
+TypeScript `SettingsType`: three new optional keys.
+
+**Default is `enabled: true`**. The point of the feature is the cadence under everything else — having users discover it under a settings flag means most never know it's there. Risks of on-by-default (hearing fatigue, surprise on update) are mitigated by:
+- Low default volume (0.15 × master 0.6 ≈ 0.09 of full).
+- Lowpass at 2.5 kHz softens every onset.
+- v1 master `notify:sounds:enabled = false` silences tool tones too (shared chain).
+- Changelog entry calls out the new sound + how to disable it (`notify:tooltones:enabled: false`) or quiet it (`notify:tooltones:volume: 0.05`).
+
+---
+
+## 8. v1 plan — files
+
+### 8.1 Files added
+
+```
+frontend/app/notification/sound/tool-tones.ts
+frontend/app/notification/sound/tool-tones-player.ts
+frontend/app/notification/sound/__tests__/tool-tones.test.ts
+```
+
+### 8.2 Files changed
+
+| File | Change |
+|---|---|
+| `frontend/app/notification/sound/sound-player.ts` | Add `getAudioContext()` and `getMasterGain()` accessors. |
+| `frontend/app/notification/sound/sound-service.ts` | Wire `tool-started` event into `ToolTonesPlayer`; attach the player on prime; reactively thread the tool-tones volume + scope settings. |
+| `frontend/app/notification/sound/index.ts` | Re-export `__getToolTonesPlayer` for tests. |
+| `agentmux-srv/src/backend/wconfig/types.rs` | Three new `notify:tooltones:*` fields. |
+| `frontend/types/gotypes.d.ts` | Three new TS keys. |
+| `settings-template.jsonc` | Three new commented lines. |
+| `schema/settings.json` | Three new schema entries. |
+
+### 8.3 Files NOT changed
+
+- `sounds.ts` — the registry is for fixed-id sounds; tool tones are parametric.
+- `agent-pane-state-store.ts` — the multicast is already there.
+- `useAgentStream.ts` — `tool-started` already emits from the reducer.
+- `agent-pane-state/types.ts` — `tool-started.name` already carries the raw provider tool name (no `rawName` needed; see §9.6).
+- `agent-pane-state/reducer.ts` — no event-shape change.
+
+### 8.4 Test plan
+
+- **Unit (vitest):** `tool-tones.test.ts` covers:
+  - the curated palette resolves to the documented syllables (asserted on tone count, frequencies, wave shape, duration range)
+  - the hash fallback is deterministic for a given string
+  - the hash fallback never produces a frequency outside the pentatonic set
+  - `Other`-normalized tools take the hash path
+- **Unit (vitest):** `sound-service.test.ts` extension:
+  - `tool-started` plays the tone by default (no settings set) — the on-by-default contract
+  - `tool-started` does nothing when `notify:tooltones:enabled` is false
+  - `tool-started` does nothing when the v1 master `notify:sounds:enabled` is false (shared kill-switch)
+  - `tool-started` plays when scope=all regardless of focus (default behavior — both panes in a two-pane test)
+  - `tool-started` plays when scope=focused and the pane is focused (+ window focused)
+  - `tool-started` does NOT play when scope=focused and the pane is unfocused
+  - 30ms coalesce per tool — second call within the window drops
+  - Volume setting threads through to the player
+- **Manual smoke (Playwright unhelpful for audio):**
+  1. Enable, run a Claude session with multiple tools — confirm distinct sounds.
+  2. Focus a different pane in the same window — confirm silence.
+  3. Open a second window, give it focus — confirm silence from the first window.
+  4. Set scope=all, run two agents in parallel — confirm both play.
+  5. Set volume=0 — confirm silence (without disabling).
+  6. Set master notifications off — confirm tool tones also silenced (shared master).
+
+### 8.5 Out of scope, but easy v1.5 follow-ups
+
+- `scope: "window"` option (every pane in the focused window, ignore per-pane focus). Wire is in place — `shouldPlayToolTone` accepts the literal already, just treats it the same as `"all"`. Promotion is a 3-line change once the predicate is decided (tab-level focus signal exists in the layout model).
+- "Voice profile" picker (major / minor / pentatonic / wholetone) as a single string setting `notify:tooltones:scale`.
+- Stereo panning by pane position (left pane → left ear). Adds spatial information at zero cognitive cost.
+- Tool-outcome ornaments: a tiny "click up" on success vs "click down" on error appended to the syllable. Needs the tool-result event to carry success/failure — exists, would couple cleanly.
+- First-launch one-shot toast on update — "we added tool-call sounds; here's where to disable them" — if telemetry shows a wave of users disabling immediately after the release.
+
+---
+
+## 9. Resolved decisions
+
+1. **Default state of `notify:tooltones:enabled`** — **on**. The cadence is the feature; users who don't know it's there don't get it. Mitigation lives in the volume default + master kill-switch + changelog (§7).
+2. **Default scope** — **`"all"`** (every pane in every window). Users who want a quieter mode flip to `"focused"`. The middle `"window"` option is wired but treated as `"all"` for now; promoted in v1.5 (§8.5).
+3. **Default volume** — 0.15 of the master. Re-tune in v1.5 if users report it's loud at default OS volume.
+4. **Coalesce window** — 30ms per tool. Tight on purpose so Read-Read-Read sounds like three discrete syllables. If reducer storms drop legitimate signals, raise to 60ms in a quick follow-up.
+5. **Tool-ended sound** — **no**. Doubles the rate, doesn't add useful information. The next `tool-started` is the implicit "previous one finished" signal.
+6. **Raw vs normalized tool name** — *no event change needed.* Code-reading confirmed `tool-started.name` already carries the raw provider tool name (`useAgentStream.ts:554` passes `event.tool` through verbatim). The `Other` normalization happens further downstream in the document parser for the activity-log render, not at the reducer boundary. The tool-tones module hashes / matches on the raw `name` directly — MCP tools like `mcp__myserver__my_tool` each hash to their own deterministic syllable.
+
+---
+
+## 10. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Hearing fatigue during long sessions | Medium-High (on by default) | User disables, never re-enables | Low default volume (0.15 × master 0.6 ≈ 0.09 of full) + lowpass at 2.5 kHz. Master kill-switch documented. Changelog calls out volume + disable knobs. v2 follow-up: auto-fade after N minutes of continuous tool activity, or per-session diminishing returns. |
+| Tool tones mask v1 notifications | Low | Important "turn-complete" missed | They share master; tool-tones gain is layered BELOW master at 0.15 — notifications stay relatively louder. |
+| Polyphony explosion (many tools at once) | Low | Buzzing chord | Per-tool 30ms coalesce + the lowpass; pentatonic intervals don't dissonate even when overlapping. |
+| Hashed unknowns sound bad together | Low | Cacophony from MCP-heavy users | The hash output lives in the same pentatonic set as curated tools — bounded by construction. |
+| First-time users find it intrusive on update | Medium | Bad first impression | Low default volume; master kill-switch already familiar from v1; changelog highlights the new sound + the off knob. Telemetry — if disable rate spikes after release, ship a v1.1 with default-off + first-launch toast. |
+| Headphone users find it loud at default level | Medium | Discomfort | Default 0.15 is low; documented in the changelog with a "set to 0.05 if on headphones" hint. |
+| Replay mode plays the texture for every historical tool-start | Medium | Loud surprise during a replay scrub | The existing v1 `replayMode` gate covers `tool-started` too — same single check in `shouldPlayToolTone`. |
+| BiquadFilter at low cutoff on some old CEFs produces artifacts | Low | Audio glitches | Cutoff 2.5 kHz is well within stable territory; Q 0.707 (Butterworth — no resonance peak). |
+
+---
+
+## 11. Why not just one knob per tool category?
+
+A simpler design would be: "read-class tools = tone A, write-class = tone B, exec-class = tone C." Three sounds total. It's much easier to learn.
+
+We reject it because it throws away the thing that makes the system useful: the *pattern* of calls. With three sounds, Read-Edit-Read-Edit-Write sounds nearly the same as Grep-Bash-Glob-Bash-Write — both reduce to "read-write-read-write-write". Distinct per-tool syllables make the *sequence* informative. The user learns the alphabet over an afternoon — which is *exactly* the morse-code-style learning curve they asked for — and from then on every dense agent run sounds like words.
+
+Categorical mapping is a useful fallback if the curated palette feels too crowded. Easy v2 toggle: `notify:tooltones:granularity = "tool" | "category"`.
+
+---
+
+## 12. Appendix A — full curated table for reference
+
+| Tool | Tones (Hz) | Wave | Duration / tone | Gap | Notes |
+|---|---|---|---|---|---|
+| Read | B4 (494) → A4 (440) | sine | 60ms | 14ms | Gentle descending major 2nd. |
+| Grep | E5 (659) → E5 (659) | sine | 45ms | 18ms | Twin ticks, same pitch — "scanning." |
+| Glob | D5 (587) → E5 (659) | sine | 45ms | 18ms | Rising minor 2nd — "results coming." |
+| Edit | A4 (440) → B4 (494) → A4 (440) | sine | 50ms | 12ms | Three-tone up-down — the "fix" gesture. |
+| Write | G4 (392) → D5 (587) | sine | 60ms | 18ms | Rising perfect 5th — "creation." |
+| Bash | G3 (196) → D4 (294) | triangle | 70ms | 18ms | Same 5th, octave down + triangle = "machine." |
+| Task | D5 (587) → G5 (784) | sine | 55ms | 14ms | Rising 4th, high — "delegation upward." |
+| Agent | G4 (392) → D5 (587) → G4 (392) | sine | 55ms | 14ms | Out-and-back 5th — "sub-agent dispatch." |
+
+(`Other`/unknown: hashed per §3.2.2 — deterministic, pentatonic, ≤ 2 tones, sine or triangle.)

--- a/docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md
+++ b/docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md
@@ -86,7 +86,7 @@ The canonical set (from `stream-parser.ts:478`): `Read, Edit, Write, Bash, Grep,
 | **Read** | B4 → A4 (gentle falling 2nd) | Soft, descending — "looking." Neutral, doesn't claim attention. |
 | **Grep** | E5 → E5 (two same-pitch quick ticks) | "Search" — a question-mark feel, twin ticks for "scanning." |
 | **Glob** | D5 → E5 (paired tick, rising) | "Listing" — Grep's sibling but rising (results coming in). |
-| **Edit** | A4 → B4 → A4 (three-tone "fix") | Up-down-up — the auditory shape of a small correction. Only 3-tone tool in v1; reserved for the edit gesture because it's distinctive in conversation. |
+| **Edit** | A4 → B4 → A4 (three-tone "fix") | Up-down-up — the auditory shape of a small correction. Three-tone, paired with Agent to mark high-importance gestures. |
 | **Write** | G4 → D5 (rising 5th) | Bigger interval = "creation." Confident, not loud. |
 | **Bash** | G3 → D4 (rising 5th, octave down, triangle wave) | Same musical shape as Write but darker — mechanical. Triangle gives the "machine" timbre. |
 | **Task** | D5 → G5 (rising 4th, high) | "Delegation upward" — clear and brief. |

--- a/docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md
+++ b/docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md
@@ -1,0 +1,702 @@
+# SPEC — Sound notifications subsystem
+
+**Status:** Draft v1 — for review
+**Date:** 2026-06-05
+**Author:** agent2
+**First use case:** play a "ding" when the agent pane's turn completes.
+**Scope:** frontend-only (no Rust changes). Generalizes from the first use case to a registry-driven system that any pane / store / saga can opt into.
+
+**Related:**
+- `frontend/app/store/agent-pane-state/types.ts` (lines 480–605 — `AgentPaneEvent` union, source of the `turn-ended` event we react to)
+- `frontend/app/store/agent-pane-state-store.ts` (lines 78–89, 172 — current single-sink event delivery; we extend it to multicast)
+- `frontend/app/store/command-source.ts` (the global dispatch ring buffer we **do not** use; rationale in §6.2)
+- `frontend/app/store/global.ts` (lines 91, 129, 459–470 — `settingsAtom`, `notifications`, `getSettingsKeyAtom` we plug into)
+- `frontend/app/notification/usenotification.tsx` (the visual notification framework we coexist with — sound is additive, not a replacement)
+- `frontend/app/store/focusManager.ts` + `frontend/util/focusutil.ts` (pane-focus signal used to suppress sound when the user is already looking at the pane)
+- `agentmux-srv/src/backend/wconfig/types.rs` (lines 200–225 — backend settings struct we extend with the new `notify:sounds:*` keys)
+- `frontend/types/gotypes.d.ts` (lines 1287–1351 — TS counterpart of the settings struct)
+- `settings-template.jsonc` (the user-facing commented template we add a `-- Notification sounds --` section to)
+- MDN — Web Audio API best practices (informs the `AudioBufferSourceNode`-based player choice)
+- WCAG 2.2 SC 1.4.2 *Audio Control* (informs the mute / volume / per-event-disable controls)
+
+---
+
+## 0. TL;DR
+
+Add a typed sound-event bus and a small `SoundService` that subscribes to reducer events, applies user settings + suppression rules, and plays a short SFX via the Web Audio API. First wired event: `agent.turn.complete` (fired on the existing `turn-ended` reducer event, classified by `TurnOutcome` so "completed" / "stopped" / "errored" can ship as distinct sounds in v2). The system is **registry-driven** — adding a new sound elsewhere in the app is a 3-line patch to `sounds.ts` plus one `notify()` call at the emit site. No churn through the existing 4-layer reducer stack; multicast plumbing is a small, additive change to the per-slice `setEventSink` contract.
+
+The architecture choices are deliberate and small:
+
+1. **Web Audio API over `<audio>`** for short SFX (lower latency, no `cloneNode` quirks, zero allocation per playback once decoded).
+2. **Multicast event bus on top of the existing per-slice sinks** (additive — current callers keep working; no refactor of the reducer stack).
+3. **Registry-driven sound IDs** so any code path can fire a sound without touching the player.
+4. **Settings live in the same `wconfig` schema** as the rest of AgentMux — no parallel settings system.
+5. **Visual fallback via the existing `notifications` atom** so deaf / muted users still get the signal (WCAG 1.4.2).
+6. **Synthesized fallback** so the system is functional with zero shipped audio assets — the asset pack is purely a polish layer.
+
+---
+
+## 1. Why
+
+Long-horizon agent runs are exactly the workflow where the user **leaves the app focused on something else** between turns (reading a doc, in another tab, in the kitchen). Today the only "turn done" signal is the visual one inside the pane: the working spinner stops, "Worked" appears in the composer strip. If the user isn't looking at the pane, the signal is invisible.
+
+A small, ergonomic sound — *ding* when the turn finishes — closes that gap. The user can context-switch away and trust they'll be summoned back exactly when needed.
+
+Once that exists, the same hook is useful for:
+- agent error (`Done.errored`, stream stalled, submit timed out)
+- pending-message acceptance / rejection (currently silent — the amber→accent color shift in the pane is the only feedback)
+- background saga completions (package build done, deploy finished — future)
+- drone-run state changes (currently a separate slice with its own reducer/sink — the bus is slice-agnostic, so this drops in for free)
+
+We design for the general case from day one. A bespoke `playDingOnTurnEnd()` hack inside `useAgentStream` would solve the immediate ask but pay for itself zero times the next call.
+
+---
+
+## 2. Non-goals
+
+- **No sound *generation*.** v1 ships either a small CC0 asset pack or a synthesized oscillator fallback (§7.4). No DSP, no procedural composition, no theme editor.
+- **No backend sound dispatch.** The sidecar / launcher have no UI focus or audio device — sound is a renderer concern.
+- **No system tray / OS notification integration.** That is `Notification`-API territory and orthogonal — pursued in a follow-on if user feedback wants it.
+- **No multi-instance audio coordination.** Each AgentMux instance has its own renderer + AudioContext; nothing tries to dedupe "two windows both finished a turn at the same time." If the user finds this annoying, we'll add a window-leader gate later.
+- **No backwards-compat shim for the existing single-sink callers.** §6.1 keeps them working as-is; only the new bus is added.
+- **No background-music or long-form audio.** Strictly one-shot SFX.
+
+---
+
+## 3. What's in place today (verified against current `main`)
+
+### 3.1 Reducer events are already the right shape
+
+`AgentPaneEvent` (`frontend/app/store/agent-pane-state/types.ts:480–605`) is a discriminated union with stable type literals: `turn-ended`, `turn-started`, `stream-stalled`, `submit-timed-out`, `interrupt-timed-out`, `pending-accepted`, `pending-rejected`, `pending-expired`, `stream-stuck`, etc. These are **already** emitted on every state transition we'd want a sound for. The reducer is the single source of truth and the event is the audit-friendly form. We do not need a parallel "fire a sound" command; we just need a subscriber.
+
+`agent-pane-state-store.ts:172` fans every emitted event into a single global `eventSink` function (default: warn-logger). The browser, editor, and drone slices follow the same pattern. The sink slot is "last-writer-wins" with idempotent install guards — see `browser-model.ts:installEventSinkOnce` and the comment block above it. This was fine when each slice had **one** consumer (the side-effecting bridge between reducer and DOM); it becomes a problem the moment a second consumer (us) wants in.
+
+### 3.2 What does **not** carry the outcome today
+
+The `turn-ended` event payload is `{ type, statsMerged, stoppingCleared }` — no `outcome` field, even though `state.turnPhase` is by that point `{ kind: "Done", outcome, finishedAt }` (see `reducer.ts:405–432`). The sound service needs the outcome to pick the right sound (`completed` vs `stopped` vs `errored` vs `interrupted`).
+
+Two options:
+
+| | snapshot the slot to read `turnPhase.outcome` | enrich the event payload |
+|---|---|---|
+| Coupling | sound service knows about the store API (`snapshot(blockId)`) | reducer carries one more field — no extra API surface |
+| Reentrancy | safe — sink runs after state mutation (line 137 sets `slot.state = result.state` before line 172 fans events) | safe |
+| Reusability | every other consumer pays the same coupling | every consumer reads the event directly |
+| Audit | snapshot read is invisible in the dispatch ring | outcome is logged with the event in `recordDispatch` |
+
+**Recommendation: enrich the event payload.** It is a one-line type extension and a one-line reducer change, and it makes the audit ring and any future telemetry pipeline strictly better. Concretely:
+
+```ts
+// types.ts — was
+| { type: "turn-ended"; statsMerged: boolean; stoppingCleared: boolean }
+// types.ts — becomes
+| { type: "turn-ended"; outcome: TurnOutcome; statsMerged: boolean; stoppingCleared: boolean }
+```
+
+```ts
+// reducer.ts TurnEnd arm — was
+events: [{ type: "turn-ended", statsMerged: merged != null, stoppingCleared: stoppingWasSet }]
+// becomes
+events: [{ type: "turn-ended", outcome, statsMerged: merged != null, stoppingCleared: stoppingWasSet }]
+```
+
+The reducer already computes `outcome` two lines earlier (line 405). No new control flow.
+
+### 3.3 No audio infrastructure exists
+
+`/assets/`, `/public/`, `/frontend/assets/` — no `.mp3`, `.wav`, `.ogg`. No `AudioContext` / `HTMLAudioElement` / `playSound` / `howler` references in the frontend. No CEF audio flags in `agentmux-cef/src/`. The slate is clean and the design choice is unconstrained.
+
+### 3.4 Settings plumbing is already turn-key
+
+`getSettingsKeyAtom<T extends keyof SettingsType>(key)` (`global.ts:459`) returns a memoized SolidJS signal that re-renders on settings file change. Adding a new key is purely: edit `agentmux-srv/src/backend/wconfig/types.rs` + `frontend/types/gotypes.d.ts` (TS types) + `settings-template.jsonc` (the commented user-facing template). No frontend store wiring required.
+
+### 3.5 Visual notifications exist; sound is additive
+
+`atoms.notifications` + `setNotifications` (`global.ts:129`) drive the toast UI (`frontend/app/notification/notificationbubbles.tsx`). The sound service can optionally push a matching toast for any sound event when the user has muted audio or has accessibility settings on — that's our WCAG 1.4.2 visual-equivalent path. It is **not** required for v1 — the spinner stopping + "Worked" label is already a visual signal — but the hook is in place if we want belt-and-suspenders.
+
+### 3.6 Pane focus tracking exists; window focus doesn't
+
+`focusManager.blockFocusAtom()` (`focusManager.ts:11–19`) is a reactive accessor for "which blockId currently holds DOM focus." We can use this to **suppress** a sound when the originating pane is focused (the user is already watching — no audio summons needed). There is **no** existing app-level "is this window in the foreground" signal; `document.visibilityState` and `document.hasFocus()` are available but only consulted ad-hoc (one MyAgentsList refetch handler + one command-registry guard — `command-registry.ts:410`). v1 adds a small focus-state signal under `frontend/app/window/` for the sound service to read.
+
+---
+
+## 4. Design — sound notifications subsystem
+
+### 4.1 Module layout
+
+```
+frontend/app/notification/sound/
+    sounds.ts             # The registry — sound IDs + default asset + classification
+    sound-events.ts       # Typed multicast event bus + helpers
+    sound-player.ts       # Web Audio API: AudioContext owner, AudioBuffer cache, play()
+    sound-service.ts      # Orchestrator: subscribes, reads settings, suppresses, calls player
+    synth-fallback.ts     # Oscillator-based fallback when asset missing or pack disabled
+    index.ts              # Bootstrap — installed once at app init
+```
+
+Co-located with `frontend/app/notification/` because the user-mental-model of "what counts as a notification" is the same — they're going to expect to find sound settings near the existing notification settings.
+
+### 4.2 The registry — `sounds.ts`
+
+```ts
+/** Stable string IDs. Keep kebab-case; namespaced by emitting subsystem. */
+export type SoundId =
+    | "agent.turn.complete"
+    | "agent.turn.error"
+    | "agent.turn.interrupted"
+    | "agent.message.accepted"
+    | "agent.message.rejected"
+    | "agent.stream.stalled";
+
+export type SoundCategory = "success" | "info" | "warning" | "error";
+
+export interface SoundDef {
+    id: SoundId;
+    /** Default user-visible label in settings UI. */
+    label: string;
+    /** Used by the synth fallback when no asset is present. */
+    category: SoundCategory;
+    /** Path under `public/sounds/`. Optional — synth fallback kicks in if absent. */
+    asset?: string;
+    /** Setting key for per-event enable. Conventionally `notify:sound:<id>`. */
+    settingKey: keyof SettingsType;
+    /** Default volume, 0–1. Honored only if the user hasn't overridden it. */
+    defaultVolume?: number;
+    /**
+     * Coalesce window. Two firings of the same sound within this many ms
+     * play once. Default 300ms — covers double-dispatch storms during the
+     * `turn-ended` ↔ `stream-unsubscribed` race without dropping legit
+     * back-to-back signals.
+     */
+    coalesceMs?: number;
+}
+
+export const SOUNDS: Record<SoundId, SoundDef> = {
+    "agent.turn.complete": {
+        id: "agent.turn.complete",
+        label: "Agent turn completed",
+        category: "success",
+        asset: "sounds/turn-complete.ogg",
+        settingKey: "notify:sound:agent.turn.complete",
+        coalesceMs: 300,
+    },
+    // …rest defined the same way.
+};
+```
+
+The whole registry is a constant. Adding a new sound = one entry + one settings key in the schema. No imperative registration step.
+
+### 4.3 The event bus — `sound-events.ts`
+
+```ts
+export interface SoundEvent {
+    id: SoundId;
+    /** Optional: blockId of the originating pane (for focus suppression). */
+    sourceBlockId?: string;
+    /** Optional: free-form override of the default sound — alternate asset id, gain, pan. */
+    override?: { asset?: string; gain?: number };
+}
+
+type Listener = (ev: SoundEvent) => void;
+const listeners = new Set<Listener>();
+
+export function subscribeSoundEvents(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+export function notify(id: SoundId, opts?: Omit<SoundEvent, "id">): void {
+    const ev: SoundEvent = { id, ...opts };
+    for (const l of listeners) {
+        try { l(ev); } catch (e) { console.warn("[sound] listener threw", e); }
+    }
+}
+```
+
+That's the entire generalization surface. **Any code anywhere** in the frontend can call `notify("agent.turn.complete", { sourceBlockId })` and the sound service will (or won't, per settings) play it. No SolidJS coupling, no provider context, no DI graph.
+
+### 4.4 Wiring the reducer events into the bus
+
+Two integration paths, ordered cheapest-first:
+
+**Path A — explicit `notify()` at the dispatch call site** (used for v1's `turn-ended`):
+
+```ts
+// frontend/app/view/agent/useAgentStream.ts, inside finalizeTurn(), AFTER the
+// dispatchPane({ type: "TurnEnd", stats }) call:
+notify("agent.turn.complete", { sourceBlockId: blockId });
+```
+
+Pros: zero plumbing. Cons: each emit site must remember to call it, and the dispatch may be replayed in a session-replay context that **shouldn't** play sound (we only want sounds for live events).
+
+**Path B — multicast on the reducer event sink** (used for everything else):
+
+Extend `agent-pane-state-store.ts` (and any other slice we want bus integration for) so it can have N listeners in addition to the existing single sink. Minimal diff:
+
+```ts
+// agent-pane-state-store.ts — additive, no callsite changes
+const extraListeners = new Set<EventSink>();
+export function addEventListener(sink: EventSink): () => void {
+    extraListeners.add(sink);
+    return () => extraListeners.delete(sink);
+}
+// inside dispatch(), after the existing single-sink fan-out:
+for (const ev of result.events) {
+    eventSink(blockId, ev);
+    for (const l of extraListeners) {
+        try { l(blockId, ev); } catch (e) { console.warn("[pane-state] listener threw", e); }
+    }
+}
+```
+
+Sound service then installs a single listener that maps event types → `notify()` calls:
+
+```ts
+addEventListener((blockId, ev) => {
+    switch (ev.type) {
+        case "turn-ended":
+            if (ev.outcome === "completed") notify("agent.turn.complete", { sourceBlockId: blockId });
+            else if (ev.outcome === "errored") notify("agent.turn.error", { sourceBlockId: blockId });
+            else if (ev.outcome === "interrupted" || ev.outcome === "stopped")
+                notify("agent.turn.interrupted", { sourceBlockId: blockId });
+            return;
+        case "submit-timed-out":
+        case "stream-stalled":
+            notify("agent.turn.error", { sourceBlockId: blockId });
+            return;
+        case "pending-accepted":
+            notify("agent.message.accepted", { sourceBlockId: blockId });
+            return;
+        case "pending-rejected":
+            notify("agent.message.rejected", { sourceBlockId: blockId });
+            return;
+    }
+});
+```
+
+**For v1 we use Path B**, hooked off the multicast sink. It naturally covers every outcome and other future event types without per-callsite changes. Path A stays in the toolbox for "fire from a hand-coded saga, not a reducer event" cases.
+
+The `outcome` field on `turn-ended` is the only reducer change needed for this whole spec (see §3.2).
+
+### 4.5 The player — `sound-player.ts`
+
+Modeled directly on the MDN best-practices: one `AudioContext` per renderer, decoded `AudioBuffer`s per sound ID, fresh `AudioBufferSourceNode` per play. Synth fallback (`synth-fallback.ts`) runs on the same context.
+
+```ts
+class SoundPlayer {
+    private ctx: AudioContext | null = null;
+    private buffers = new Map<SoundId, AudioBuffer>();
+    private masterGain: GainNode | null = null;
+
+    /** Call inside a user gesture handler (any keydown / pointerdown in the app shell). */
+    async prime(): Promise<void> {
+        if (this.ctx) return;
+        this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+        this.masterGain = this.ctx.createGain();
+        this.masterGain.connect(this.ctx.destination);
+        await Promise.all(
+            Object.values(SOUNDS)
+                .filter((s) => s.asset)
+                .map((s) => this.loadAsset(s)),
+        );
+    }
+
+    async play(def: SoundDef, gain = 1): Promise<void> {
+        const ctx = this.ctx;
+        if (!ctx || !this.masterGain) return;
+        if (ctx.state === "suspended") await ctx.resume();
+        const buf = this.buffers.get(def.id);
+        if (buf) {
+            const src = ctx.createBufferSource();
+            src.buffer = buf;
+            const g = ctx.createGain();
+            g.gain.value = gain;
+            src.connect(g).connect(this.masterGain);
+            src.start();
+            return;
+        }
+        // Synth fallback — small, deterministic, no asset required.
+        playSynthFallback(ctx, this.masterGain, def.category, gain);
+    }
+
+    setMasterGain(value: number) {
+        if (this.masterGain) this.masterGain.gain.value = value;
+    }
+
+    private async loadAsset(def: SoundDef) {
+        try {
+            const resp = await fetch(`/${def.asset}`);
+            const bytes = await resp.arrayBuffer();
+            const buf = await this.ctx!.decodeAudioData(bytes);
+            this.buffers.set(def.id, buf);
+        } catch (e) {
+            console.warn(`[sound] failed to load asset for ${def.id}, will use synth fallback`, e);
+        }
+    }
+}
+```
+
+The synth fallback is a 4-line oscillator (`OscillatorNode` + `GainNode` with a short attack/decay envelope) per category. See `synth-fallback.ts` sketch in Appendix A.
+
+### 4.6 The orchestrator — `sound-service.ts`
+
+```ts
+const player = new SoundPlayer();
+const lastFiredAt = new Map<SoundId, number>();
+let focusedBlock: () => string | null;     // bound from focusManager
+let isWindowFocused: () => boolean;         // bound from new window-focus signal
+
+export function installSoundService() {
+    focusedBlock = focusManager.blockFocusAtom;
+    isWindowFocused = makeWindowFocusSignal();   // §4.7
+
+    // Prime AudioContext on first user gesture (autoplay policy).
+    const primeOnce = () => { player.prime(); cleanup(); };
+    const cleanup = () => {
+        document.removeEventListener("pointerdown", primeOnce, true);
+        document.removeEventListener("keydown", primeOnce, true);
+    };
+    document.addEventListener("pointerdown", primeOnce, { capture: true, once: true });
+    document.addEventListener("keydown", primeOnce, { capture: true, once: true });
+
+    // Master gain reactive to settings.
+    createEffect(() => {
+        const vol = getSettingsKeyAtom("notify:sounds:volume")() ?? 0.6;
+        player.setMasterGain(vol);
+    });
+
+    subscribeSoundEvents((ev) => {
+        if (!shouldPlay(ev)) return;
+        const def = SOUNDS[ev.id];
+        if (!def) return;
+        const now = performance.now();
+        const last = lastFiredAt.get(ev.id) ?? 0;
+        if (now - last < (def.coalesceMs ?? 300)) return;
+        lastFiredAt.set(ev.id, now);
+        player.play(def, ev.override?.gain ?? 1);
+    });
+}
+
+function shouldPlay(ev: SoundEvent): boolean {
+    if (!getSettingsKeyAtom("notify:sounds:enabled")()) return false;
+    const def = SOUNDS[ev.id];
+    const perEvent = getSettingsKeyAtom(def.settingKey)();
+    if (perEvent === false) return false;                            // explicit opt-out
+    if (perEvent == null && !defaultsOnFor(def)) return false;       // defaults-off events (none in v1)
+
+    // Focus suppression: if the originating pane is focused AND the window
+    // has OS focus, the user can already see the visual change — no need
+    // to nag them with sound.
+    const suppressWhenFocused = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")() ?? true;
+    if (suppressWhenFocused && ev.sourceBlockId
+        && focusedBlock() === ev.sourceBlockId
+        && isWindowFocused()) {
+        return false;
+    }
+    return true;
+}
+```
+
+Three knobs (master enable, master volume, suppress-when-focused), one per-event override map (`notify:sound:<id>`), and a coalesce window. That is all the policy.
+
+### 4.7 Window focus signal
+
+```ts
+// frontend/app/window/window-focus.ts
+export function makeWindowFocusSignal(): () => boolean {
+    const [focused, setFocused] = createSignal(document.hasFocus());
+    window.addEventListener("focus", () => setFocused(true));
+    window.addEventListener("blur", () => setFocused(false));
+    document.addEventListener("visibilitychange", () => setFocused(document.visibilityState === "visible" && document.hasFocus()));
+    return focused;
+}
+```
+
+Small, self-contained, no dependency on the rest of the focus manager. Used only by the sound service in v1, but the signal itself is general — surface it via `window/window-focus.ts` so future consumers can read it without reinventing.
+
+### 4.8 Bootstrap — `index.ts`
+
+```ts
+// frontend/app/notification/sound/index.ts
+export { installSoundService } from "./sound-service";
+export { notify, subscribeSoundEvents, type SoundEvent } from "./sound-events";
+export { SOUNDS, type SoundId, type SoundDef, type SoundCategory } from "./sounds";
+```
+
+`installSoundService()` is called once from `frontend/app-init.ts` after the settings atom is hydrated (so the AudioContext-prime listener is installed before the first user click) and after the agent-pane store is constructed (so we can add the multicast listener).
+
+---
+
+## 5. Settings — schema additions
+
+### 5.1 Backend struct (`agentmux-srv/src/backend/wconfig/types.rs`)
+
+Add to `SettingsType` near the existing `voice_enabled` field (~line 218):
+
+```rust
+// -- Notification sounds --
+//
+// Master switch. Default: true (sounds on). User sets to false in
+// settings.json to fully silence the app.
+#[serde(rename = "notify:sounds:enabled", default, skip_serializing_if = "Option::is_none")]
+pub notify_sounds_enabled: Option<bool>,
+
+// 0.0 to 1.0; default 0.6 if unset.
+#[serde(rename = "notify:sounds:volume", default, skip_serializing_if = "Option::is_none")]
+pub notify_sounds_volume: Option<f32>,
+
+// Suppress a pane's sound when that pane is focused AND the window is in
+// foreground. Default: true.
+#[serde(rename = "notify:sounds:suppresswhenfocused", default, skip_serializing_if = "Option::is_none")]
+pub notify_sounds_suppress_when_focused: Option<bool>,
+
+// Per-event opt-out. Absence = default (on for v1's sound set).
+#[serde(rename = "notify:sound:agent.turn.complete", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_turn_complete: Option<bool>,
+
+#[serde(rename = "notify:sound:agent.turn.error", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_turn_error: Option<bool>,
+
+#[serde(rename = "notify:sound:agent.turn.interrupted", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_turn_interrupted: Option<bool>,
+
+#[serde(rename = "notify:sound:agent.message.accepted", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_message_accepted: Option<bool>,
+
+#[serde(rename = "notify:sound:agent.message.rejected", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_message_rejected: Option<bool>,
+
+#[serde(rename = "notify:sound:agent.stream.stalled", default, skip_serializing_if = "Option::is_none")]
+pub notify_sound_agent_stream_stalled: Option<bool>,
+```
+
+### 5.2 TypeScript types (`frontend/types/gotypes.d.ts`)
+
+Mirror the above into the `SettingsType` block (~line 1287):
+
+```ts
+"notify:*"?: boolean;
+"notify:sounds:enabled"?: boolean;
+"notify:sounds:volume"?: number;
+"notify:sounds:suppresswhenfocused"?: boolean;
+"notify:sound:agent.turn.complete"?: boolean;
+"notify:sound:agent.turn.error"?: boolean;
+"notify:sound:agent.turn.interrupted"?: boolean;
+"notify:sound:agent.message.accepted"?: boolean;
+"notify:sound:agent.message.rejected"?: boolean;
+"notify:sound:agent.stream.stalled"?: boolean;
+```
+
+### 5.3 User template (`settings-template.jsonc`)
+
+Add a section after the existing dnd block:
+
+```jsonc
+// -- Notification sounds --
+// "notify:sounds:enabled":                  true,
+// "notify:sounds:volume":                   0.6,
+// "notify:sounds:suppresswhenfocused":      true,
+// "notify:sound:agent.turn.complete":       true,
+// "notify:sound:agent.turn.error":          true,
+// "notify:sound:agent.turn.interrupted":    true,
+// "notify:sound:agent.message.accepted":    true,
+// "notify:sound:agent.message.rejected":    true,
+// "notify:sound:agent.stream.stalled":      true,
+```
+
+### 5.4 JSON schema (`schema/settings.json`)
+
+Same shape — adds the keys with `type: "boolean"` / `type: "number"` and a `description` per key matching the comments above.
+
+No settings-UI work in v1. Users edit `settings.json` directly via Hamburger → Settings (same as today's settings model). A settings-UI panel is fair game for v2 once the sound set stabilizes.
+
+---
+
+## 6. Open design questions + chosen answers
+
+### 6.1 Why not just call `setEventSink` from the sound service?
+
+Because the existing `setEventSink` is "last-writer-wins" and `browser-model.ts` already owns the slot to handle `pane-clicked`. The sound service would either clobber the existing handler (silent break of the click-focus path) or have to manually re-implement the multicast itself — at which point it might as well live in the store. We do the latter, additively (§4.4 Path B). No existing single-sink call site changes.
+
+### 6.2 Why not subscribe to `dispatchRecordsAtom` instead?
+
+`command-source.ts:65` keeps a 500-entry ring buffer of every dispatch, exposed as a SolidJS signal. A naïve `createEffect(() => dispatchRecordsAtom())` listener would fire on every dispatch *anywhere in the app* — agent-document StreamFlush, agent-pane TokensIn / TokensOut delta, etc. — at the cadence of every typed character and every parsed event. The signal-write fan-out is exactly what `recordDispatch`'s `untrack` block was added to defend against (see `command-source.ts:78` and the "3000× runaway and renderer V8-stack crash" comment). Using it as a sound-event feed would mean re-walking the ring buffer per dispatch, allocating filtered arrays, and chaining a reactive effect through the most-hot dispatch paths in the app. Not viable.
+
+The multicast event-listener path is O(1) per fan-out (`for (const l of extraListeners)`), runs in the dispatch's existing critical section, and does **not** establish reactive dependencies.
+
+### 6.3 Asset format and sourcing
+
+| Format | Pros | Cons |
+|---|---|---|
+| **OGG Vorbis** | Smallest size, Apache-compatible decoders ship in CEF Chromium | None for our use case |
+| MP3 | Universal | Slightly larger, patent history is moot under modern Chromium but not great optics |
+| WAV | Zero decode cost, dead simple | 5–10× the size — bundle bloat |
+| Synth only (no assets) | Zero shipped bytes, no licensing question | Tinnier, less polished |
+
+**Recommendation:** ship OGG at 64kbps mono, target ≤200ms duration per SFX, ~3KB per file. Six sounds → ~18KB total. Tracked under `public/sounds/` (Vite copies it verbatim into the dev server and the package build). Source from CC0 packs only — short-list in Appendix B. Synth fallback (§4.5) covers the dev / unbundled case and any asset load failure.
+
+### 6.4 Per-window vs per-instance audio
+
+CEF gives each AgentMux process one renderer per top-level window. `AudioContext`s are per-renderer. If the user has two windows of the same instance, each window's sound service primes its own `AudioContext` and plays independently. If the same `turn-ended` event lands in both windows because both render the same workspace, both will play. v1 accepts this as cheap and rare (workspaces typically display in one window). If it bites, a follow-up gates by `tabAtom() === pane.tabid`.
+
+### 6.5 CEF autoplay policy quirks
+
+Chromium's autoplay policy blocks new `AudioContext`s from playing until a user gesture lands. The first-gesture prime listener in `installSoundService()` covers this. The dev server (`task dev`) opens AgentMux into a CEF window that registers a user gesture as soon as the user clicks anywhere in the chrome — typically before they could have a turn complete. Packaged builds are identical. If we somehow get a `turn-ended` before any user click (extremely unlikely — the user had to click *something* to launch the agent), we drop the sound and log it; we do not queue.
+
+### 6.6 Session-replay safety
+
+`SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md` describes a replay mode where past commands are dispatched into the reducer to rebuild state. If we're naively multicast-subscribed, replay would fire sound events for every historical `turn-ended`. Guard: the sound service's `subscribeSoundEvents` handler checks a `replayMode` flag (set by the replay infrastructure) and no-ops while it's true. Plumbing: a single `setReplayMode(bool)` export from `sound-service.ts`; replay flips it around its dispatches. Two-line patch; documented in this spec, owned by the replay infrastructure to call.
+
+### 6.7 Where does the user-facing label "Notification sounds" live?
+
+Nowhere in v1 — there is no settings UI in v1. The only user-facing strings are the comments in `settings-template.jsonc` and the `description` fields in `schema/settings.json`. A future settings panel reads `SOUNDS[id].label` for the per-event toggle row.
+
+---
+
+## 7. Concrete v1 plan — turn complete only
+
+This is the smallest end-to-end implementation. Subsequent sound events drop in by adding entries to `SOUNDS` and switch cases to the multicast listener — no further plumbing.
+
+### 7.1 Files added
+
+```
+frontend/app/notification/sound/sounds.ts
+frontend/app/notification/sound/sound-events.ts
+frontend/app/notification/sound/sound-player.ts
+frontend/app/notification/sound/sound-service.ts
+frontend/app/notification/sound/synth-fallback.ts
+frontend/app/notification/sound/index.ts
+frontend/app/notification/sound/__tests__/sound-events.test.ts
+frontend/app/notification/sound/__tests__/sound-service.test.ts
+frontend/app/window/window-focus.ts
+public/sounds/turn-complete.ogg           # CC0 — see Appendix B
+```
+
+### 7.2 Files changed
+
+| File | Change |
+|---|---|
+| `frontend/app/store/agent-pane-state/types.ts` | Add `outcome: TurnOutcome` to the `turn-ended` event variant. |
+| `frontend/app/store/agent-pane-state/reducer.ts` | Include `outcome` when emitting `turn-ended` (one-line change inside the existing TurnEnd arm). |
+| `frontend/app/store/agent-pane-state-store.ts` | Add `addEventListener(sink): () => void` (§4.4 Path B). Fan emitted events to both the single sink and the listener set. |
+| `frontend/app/store/agent-pane-state-store.test.ts` | Test the multicast: existing single-sink behavior unchanged; an added listener also receives events; unsubscribing stops delivery; a throwing listener does not break the single sink. |
+| `frontend/app-init.ts` | Call `installSoundService()` once after settings hydrate + the agent-pane store is up. |
+| `agentmux-srv/src/backend/wconfig/types.rs` | Add the 9 `notify:*` fields per §5.1. |
+| `frontend/types/gotypes.d.ts` | Mirror the type additions per §5.2. |
+| `settings-template.jsonc` | Add the "Notification sounds" section per §5.3. |
+| `schema/settings.json` | Add the same keys with type + description. |
+
+### 7.3 Files NOT changed
+
+- `useAgentStream.ts` — even though the first use case lives here, we drive the sound via the multicast off `turn-ended`. No call-site instrumentation.
+- Any other reducer / view — the bus is the integration point.
+
+### 7.4 Test plan
+
+- **Unit (vitest):** `sound-events.test.ts` covers `subscribe / notify / unsubscribe` and a throwing-listener-doesn't-break-the-rest invariant.
+- **Unit (vitest):** `sound-service.test.ts` mocks `getSettingsKeyAtom` and the player, then asserts:
+  - master-off → no play
+  - per-event-off → no play
+  - coalesce window drops a second fire within 300ms
+  - focus-suppression drops play when the source pane is focused **and** window has focus
+  - focus-suppression does **not** drop play when the pane is focused but the window is blurred
+  - volume setting threads through to `player.setMasterGain`
+- **Integration (vitest, jsdom):** `agent-pane-state-store.test.ts` extension — dispatch a `TurnEnd` from a registered slot, assert the multicast listener received an event with `type: "turn-ended"` and `outcome: "completed"`.
+- **E2E (Playwright, deferred):** turn-complete sound deferred to manual smoke since headless audio playback validation is wasteful effort. Manual smoke checklist:
+  1. With master enabled, run a Claude turn, confirm sound plays at session_end.
+  2. Focus a different pane while the agent runs → confirm sound plays.
+  3. Focus the agent pane itself → confirm sound is suppressed.
+  4. Open a second window, give it OS focus while the agent pane is focused → confirm sound plays again (window not focused).
+  5. Set `notify:sounds:enabled = false` in settings.json, save, repeat 1 → confirm silence.
+  6. Set `notify:sound:agent.turn.complete = false`, repeat → confirm silence (per-event off).
+  7. Delete the asset file before app start → confirm synth fallback plays a polite tone.
+
+### 7.5 Migration / rollout
+
+- No DB / state migration.
+- New settings keys are all `Option<…>` with `None` defaults — existing `settings.json` files are unaffected.
+- Behavior on a brand-new install: sounds are **on**. (Decision point — see §8.)
+
+---
+
+## 8. Decisions to confirm before implementing
+
+1. **Default for `notify:sounds:enabled`** — on (proposed) or off-until-opted-in?
+2. **Asset pack vs synth-only for v1** — ship a CC0 OGG pack (~18KB) or ship synth-only (zero bytes) and add the pack in v2?
+3. **Per-window dedupe** — accept v1's "both windows play" or gate to active window from day one?
+4. **Where does the `outcome` enrichment of `turn-ended` ride** — as part of this PR or as a separate prep PR? (Recommend: same PR; the change is two lines and removes the only awkward coupling in this design.)
+5. **Multicast on other slices** — `agent-document-store`, `browser-pane-state-store`, `editor-pane-state-store`, `drone-run-state-store` all have the same single-sink pattern. v1 only modifies `agent-pane-state-store`. Do we extend the others now (so future sounds drop in for free) or later (when the first one is wanted)? Recommend later — YAGNI on store API changes.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `AudioContext` never primed (autoplay block) | Low | Sound silently no-ops | Log a one-shot warning to console; user clicking anywhere primes it. |
+| Asset bundle bloat | Low | +18KB to package | OGG + mono + 64kbps + ≤200ms = bounded; checked in PR. |
+| Replay-mode regression (sound plays during session replay) | Medium until §6.6 lands | Annoying noise | §6.6 `setReplayMode(true)` gate. Test added. |
+| Multicast listener throws and crashes the dispatch | Low | Other listeners + state mutation unaffected (already happens before the fan-out) | Try/catch per listener in `dispatch()` and in `sound-events`. |
+| Multiple panes / windows all firing on one `turn-ended` | Medium | Several rapid dings | Coalesce window per sound ID (300ms default). Per-window dedupe — open question §8.3. |
+| Volume too loud on first launch | Medium | Bad first impression | Default `volume = 0.6`. Synth fallback is also gentle (sine + short envelope). |
+| CC0 asset turns out to be mis-licensed | Low | Legal | Source from a vetted CC0-only pack (Appendix B); record provenance in a `LICENSES.md` alongside the asset. |
+| User on muted speakers misses the only feedback | Always | Equivalent to today | Visual signal is already there (spinner stops, "Worked" appears). Optionally surface a passive notification toast as a belt-and-suspenders WCAG path in v2. |
+
+---
+
+## 10. Appendix A — synth fallback sketch
+
+```ts
+// frontend/app/notification/sound/synth-fallback.ts
+export function playSynthFallback(
+    ctx: AudioContext,
+    out: GainNode,
+    category: SoundCategory,
+    gain: number,
+): void {
+    const now = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    const env = ctx.createGain();
+    const params = paramsForCategory(category);
+    osc.type = params.wave;
+    osc.frequency.setValueAtTime(params.freq, now);
+    // Short attack, exponential decay — ~150ms total, polite envelope.
+    env.gain.setValueAtTime(0.0001, now);
+    env.gain.exponentialRampToValueAtTime(gain * params.peak, now + 0.01);
+    env.gain.exponentialRampToValueAtTime(0.0001, now + 0.15);
+    osc.connect(env).connect(out);
+    osc.start(now);
+    osc.stop(now + 0.16);
+}
+
+function paramsForCategory(c: SoundCategory) {
+    switch (c) {
+        case "success": return { wave: "sine" as const,     freq: 880, peak: 0.5 };
+        case "info":    return { wave: "sine" as const,     freq: 660, peak: 0.4 };
+        case "warning": return { wave: "triangle" as const, freq: 440, peak: 0.5 };
+        case "error":   return { wave: "square" as const,   freq: 220, peak: 0.4 };
+    }
+}
+```
+
+Deterministic, allocation-light, requires no assets, sounds polite.
+
+---
+
+## 11. Appendix B — CC0 asset shortlist
+
+- **Kenney UI Audio** (kenney.nl/assets/interface-sounds) — CC0, multiple short "ding" / "confirm" / "error" variants suitable for the v1 sound set.
+- **Material Sound Effects** — Google's released set under Apache 2.0; high-quality, identifiable, well-balanced.
+- **Freesound CC0 packs** — vetted per-asset CC0 dedications only (avoid Attribution licenses to keep the bundle Apache-clean).
+
+The PR will include `public/sounds/LICENSES.md` listing provenance + license for every shipped clip.
+
+---
+
+## 12. Out of scope, tracked elsewhere
+
+- Backend-originated sound events (sagas, runtime alerts) — needs a backend → frontend audio-event channel; design after sagas-execution-plan stabilizes.
+- OS-level notifications (Windows toast, macOS notification center, libnotify) — separate spec.
+- Settings UI panel for the sound controls — separate UX-driven design once the sound set stabilizes.
+- Customizable sound themes / user-supplied SFX — interesting follow-on; gate behind a "Sound theme" setting that points at a user-data-dir asset folder.
+- Per-agent / per-provider sound differentiation — drop-in via a `notify("agent.turn.complete", { override: { asset: …, gain: … } })` call from the originating site; design surface already exists.

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -894,6 +894,13 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     // clipping. See docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md.
     const { startPaneOverlayAutoService } = await import("@/app/platform/pane-overlay-auto");
     startPaneOverlayAutoService();
+
+    // Sound notifications. Subscribes to agent-pane reducer events and
+    // plays a polite SFX on turn-complete (and other configured signals).
+    // See docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md.
+    const { installSoundService } = await import("@/app/notification/sound");
+    installSoundService();
+
     tlog("TOTAL initWave", t0);
 
     // Register this window's backend ID with the CEF host so on_before_close

--- a/frontend/app/notification/sound/__tests__/sound-events.test.ts
+++ b/frontend/app/notification/sound/__tests__/sound-events.test.ts
@@ -1,0 +1,56 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetSoundListeners,
+    notify,
+    subscribeSoundEvents,
+    type SoundEvent,
+} from "../sound-events";
+
+describe("sound-events bus", () => {
+    afterEach(() => {
+        __resetSoundListeners();
+    });
+
+    it("delivers a notify() to every subscriber", () => {
+        const a = vi.fn();
+        const b = vi.fn();
+        subscribeSoundEvents(a);
+        subscribeSoundEvents(b);
+
+        notify("agent.turn.complete", { sourceBlockId: "blk-1" });
+
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).toHaveBeenCalledTimes(1);
+        const ev: SoundEvent = a.mock.calls[0][0];
+        expect(ev.id).toBe("agent.turn.complete");
+        expect(ev.sourceBlockId).toBe("blk-1");
+    });
+
+    it("unsubscribe stops delivery", () => {
+        const a = vi.fn();
+        const unsub = subscribeSoundEvents(a);
+        notify("agent.turn.complete");
+        unsub();
+        notify("agent.turn.complete");
+        expect(a).toHaveBeenCalledTimes(1);
+    });
+
+    it("a throwing listener does not poison the others", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const thrower = vi.fn(() => {
+            throw new Error("boom");
+        });
+        const good = vi.fn();
+        subscribeSoundEvents(thrower);
+        subscribeSoundEvents(good);
+
+        expect(() => notify("agent.turn.complete")).not.toThrow();
+        expect(thrower).toHaveBeenCalledTimes(1);
+        expect(good).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});

--- a/frontend/app/notification/sound/__tests__/sound-service.test.ts
+++ b/frontend/app/notification/sound/__tests__/sound-service.test.ts
@@ -1,0 +1,197 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Policy tests for the sound service — gating by settings, coalesce
+ * window, focus suppression, and replay mode. The player is not
+ * primed (no AudioContext in jsdom), so we observe `play()` calls
+ * on the player instead of measuring audio output.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Module mocks ─────────────────────────────────────────────────────
+
+const settings: Record<string, unknown> = {};
+function setSetting(key: string, value: unknown): void {
+    settings[key] = value;
+}
+function resetSettings(): void {
+    for (const k of Object.keys(settings)) delete settings[k];
+}
+
+const focusState = { focusedBlockId: null as string | null, windowFocused: true };
+
+vi.mock("@/app/store/global", () => ({
+    getSettingsKeyAtom: (key: string) => () => settings[key],
+}));
+
+vi.mock("@/app/store/focusManager", () => ({
+    focusManager: {
+        get blockFocusAtom() {
+            return () => focusState.focusedBlockId;
+        },
+    },
+}));
+
+vi.mock("@/app/window/window-focus", () => ({
+    makeWindowFocusSignal: () => () => focusState.windowFocused,
+}));
+
+// Capture the multicast listener so the test can drive reducer events
+// without registering a full pane. The sound service calls
+// `addEventListener` once during `installSoundService()`.
+let captured:
+    | ((blockId: string, event: { type: string; [k: string]: unknown }) => void)
+    | null = null;
+vi.mock("@/app/store/agent-pane-state-store", () => ({
+    addEventListener: (
+        l: (blockId: string, event: { type: string; [k: string]: unknown }) => void,
+    ) => {
+        captured = l;
+        return () => {
+            captured = null;
+        };
+    },
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────
+
+import {
+    __getSoundPlayer,
+    __resetSoundService,
+    installSoundService,
+    setReplayMode,
+} from "../sound-service";
+import { __resetSoundListeners } from "../sound-events";
+
+describe("sound-service policy", () => {
+    let playSpy: ReturnType<typeof vi.spyOn>;
+    let cleanup: () => void;
+
+    beforeEach(() => {
+        resetSettings();
+        focusState.focusedBlockId = null;
+        focusState.windowFocused = true;
+        __resetSoundService();
+        __resetSoundListeners();
+        captured = null;
+        playSpy = vi.spyOn(__getSoundPlayer(), "play").mockImplementation(() => {});
+        cleanup = installSoundService();
+    });
+
+    afterEach(() => {
+        cleanup();
+        playSpy.mockRestore();
+        setReplayMode(false);
+    });
+
+    function fireTurnEnded(blockId: string, outcome: string): void {
+        if (!captured) throw new Error("multicast listener was never installed");
+        captured(blockId, {
+            type: "turn-ended",
+            outcome,
+            statsMerged: false,
+            stoppingCleared: false,
+        });
+    }
+
+    it("plays the complete sound on outcome=completed", () => {
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.turn.complete");
+    });
+
+    it("plays the error sound on outcome=errored", () => {
+        fireTurnEnded("blk-1", "errored");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.turn.error");
+    });
+
+    it("plays the interrupted sound on outcome=stopped", () => {
+        fireTurnEnded("blk-1", "stopped");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe(
+            "agent.turn.interrupted",
+        );
+    });
+
+    it("plays the interrupted sound on outcome=interrupted", () => {
+        fireTurnEnded("blk-1", "interrupted");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe(
+            "agent.turn.interrupted",
+        );
+    });
+
+    it("master notify:sounds:enabled=false suppresses all sounds", () => {
+        setSetting("notify:sounds:enabled", false);
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("per-event setting=false suppresses just that sound", () => {
+        setSetting("notify:sound:agent.turn.complete", false);
+        fireTurnEnded("blk-1", "completed");
+        fireTurnEnded("blk-1", "errored");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.turn.error");
+    });
+
+    it("coalesces a second fire within the coalesce window", () => {
+        fireTurnEnded("blk-1", "completed");
+        fireTurnEnded("blk-1", "completed"); // within 300ms
+        expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("focus-suppression drops sound when source pane is focused AND window is focused", () => {
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = true;
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("focus-suppression does NOT drop sound when the window is blurred", () => {
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = false;
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("focus-suppression does NOT drop sound when a different pane is focused", () => {
+        focusState.focusedBlockId = "blk-OTHER";
+        focusState.windowFocused = true;
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("focus-suppression can be disabled via setting", () => {
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = true;
+        setSetting("notify:sounds:suppresswhenfocused", false);
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("replay mode drops every play", () => {
+        setReplayMode(true);
+        fireTurnEnded("blk-1", "completed");
+        expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("stream-stalled event maps to the stalled sound", () => {
+        if (!captured) throw new Error("listener not installed");
+        captured("blk-1", { type: "stream-stalled", at: 100 });
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.stream.stalled");
+    });
+
+    it("pending-accepted only fires when wasPresent=true", () => {
+        if (!captured) throw new Error("listener not installed");
+        captured("blk-1", { type: "pending-accepted", id: "m1", wasPresent: false });
+        expect(playSpy).not.toHaveBeenCalled();
+        captured("blk-1", { type: "pending-accepted", id: "m1", wasPresent: true });
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.message.accepted");
+    });
+});

--- a/frontend/app/notification/sound/__tests__/sound-service.test.ts
+++ b/frontend/app/notification/sound/__tests__/sound-service.test.ts
@@ -59,6 +59,7 @@ vi.mock("@/app/store/agent-pane-state-store", () => ({
 
 import {
     __getSoundPlayer,
+    __getToolTonesPlayer,
     __resetSoundService,
     installSoundService,
     setReplayMode,
@@ -193,5 +194,135 @@ describe("sound-service policy", () => {
         captured("blk-1", { type: "pending-accepted", id: "m1", wasPresent: true });
         expect(playSpy).toHaveBeenCalledTimes(1);
         expect((playSpy.mock.calls[0][0] as { id: string }).id).toBe("agent.message.accepted");
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Tool-tones policy — separate describe so we can stub the player as
+// "primed + attached" without affecting the notification-sound suite.
+// ──────────────────────────────────────────────────────────────────────
+describe("sound-service tool-tones policy", () => {
+    let toolPlaySpy: ReturnType<typeof vi.spyOn>;
+    let ctxSpy: ReturnType<typeof vi.spyOn>;
+    let attachedSpy: ReturnType<typeof vi.spyOn>;
+    let cleanup: () => void;
+
+    beforeEach(() => {
+        resetSettings();
+        focusState.focusedBlockId = null;
+        focusState.windowFocused = true;
+        __resetSoundService();
+        __resetSoundListeners();
+        captured = null;
+
+        // Stub the player as if it had already primed so the gate that
+        // checks `getAudioContext()` and `isAttached()` lets the call
+        // through. The actual play is then captured by the spy below.
+        const fakeCtx = { currentTime: 0 } as unknown as AudioContext;
+        ctxSpy = vi
+            .spyOn(__getSoundPlayer(), "getAudioContext")
+            .mockReturnValue(fakeCtx);
+        attachedSpy = vi
+            .spyOn(__getToolTonesPlayer(), "isAttached")
+            .mockReturnValue(true);
+        toolPlaySpy = vi
+            .spyOn(__getToolTonesPlayer(), "play")
+            .mockImplementation(() => {});
+
+        cleanup = installSoundService();
+    });
+
+    afterEach(() => {
+        cleanup();
+        ctxSpy.mockRestore();
+        attachedSpy.mockRestore();
+        toolPlaySpy.mockRestore();
+        setReplayMode(false);
+    });
+
+    function fireToolStarted(blockId: string, tool: string): void {
+        if (!captured) throw new Error("multicast listener was never installed");
+        captured(blockId, { type: "tool-started", name: tool });
+    }
+
+    it("plays the tool tone by default (no settings = on)", () => {
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).toHaveBeenCalledTimes(1);
+        expect(toolPlaySpy.mock.calls[0][1]).toBe("Read");
+    });
+
+    it("notify:tooltones:enabled=false silences", () => {
+        setSetting("notify:tooltones:enabled", false);
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("v1 master notify:sounds:enabled=false silences tool tones too", () => {
+        setSetting("notify:sounds:enabled", false);
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("scope=all plays for unfocused panes too (the default mode)", () => {
+        focusState.focusedBlockId = "blk-OTHER";
+        focusState.windowFocused = true;
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("scope=all plays when the window is blurred (default)", () => {
+        focusState.windowFocused = false;
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("scope=focused plays for the focused pane in the focused window", () => {
+        setSetting("notify:tooltones:scope", "focused");
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = true;
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("scope=focused drops calls for unfocused panes", () => {
+        setSetting("notify:tooltones:scope", "focused");
+        focusState.focusedBlockId = "blk-OTHER";
+        focusState.windowFocused = true;
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("scope=focused drops calls when the window is blurred", () => {
+        setSetting("notify:tooltones:scope", "focused");
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = false;
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("replay mode drops every tool tone", () => {
+        setReplayMode(true);
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("forwards the raw tool name (no normalization) to the player", () => {
+        fireToolStarted("blk-1", "mcp__weatherserver__get_forecast");
+        expect(toolPlaySpy).toHaveBeenCalledTimes(1);
+        expect(toolPlaySpy.mock.calls[0][1]).toBe(
+            "mcp__weatherserver__get_forecast",
+        );
+    });
+
+    it("no-op when the player is not yet primed (no audio context)", () => {
+        ctxSpy.mockReturnValueOnce(null);
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
+    });
+
+    it("no-op when the tool-tones chain is not yet attached", () => {
+        attachedSpy.mockReturnValueOnce(false);
+        fireToolStarted("blk-1", "Read");
+        expect(toolPlaySpy).not.toHaveBeenCalled();
     });
 });

--- a/frontend/app/notification/sound/__tests__/tool-tones.test.ts
+++ b/frontend/app/notification/sound/__tests__/tool-tones.test.ts
@@ -44,7 +44,7 @@ describe("tool-tones params", () => {
             expect(Math.abs(b.tones[1] - w.tones[1] / 2)).toBeLessThan(1);
         });
 
-        it("Edit is the only three-tone canonical syllable", () => {
+        it("Edit and Agent are the three-tone canonical syllables", () => {
             const threeToneCanonicals = Object.entries(curated)
                 .filter(([_, p]) => p.tones.length === 3)
                 .map(([k]) => k);

--- a/frontend/app/notification/sound/__tests__/tool-tones.test.ts
+++ b/frontend/app/notification/sound/__tests__/tool-tones.test.ts
@@ -1,0 +1,134 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    __getCurated,
+    hashToolToParams,
+    paramsForTool,
+} from "../tool-tones";
+
+describe("tool-tones params", () => {
+    describe("curated palette", () => {
+        const curated = __getCurated();
+
+        it("contains every documented canonical tool", () => {
+            for (const tool of [
+                "Read",
+                "Edit",
+                "Write",
+                "Bash",
+                "Grep",
+                "Glob",
+                "Task",
+                "Agent",
+            ]) {
+                expect(curated[tool]).toBeDefined();
+            }
+        });
+
+        it("Read = falling major 2nd (B4 → A4)", () => {
+            const r = curated["Read"];
+            expect(r.tones).toEqual([494, 440]);
+            expect(r.wave).toBe("sine");
+            expect(r.durationMs).toBe(60);
+        });
+
+        it("Bash uses triangle wave, octave below Write", () => {
+            const w = curated["Write"];
+            const b = curated["Bash"];
+            expect(b.wave).toBe("triangle");
+            // Both rise by a perfect 5th; Bash an octave below.
+            // Equal-temperament rounding leaves ~1 Hz tolerance.
+            expect(Math.abs(b.tones[0] - w.tones[0] / 2)).toBeLessThan(1);
+            expect(Math.abs(b.tones[1] - w.tones[1] / 2)).toBeLessThan(1);
+        });
+
+        it("Edit is the only three-tone canonical syllable", () => {
+            const threeToneCanonicals = Object.entries(curated)
+                .filter(([_, p]) => p.tones.length === 3)
+                .map(([k]) => k);
+            // Edit + Agent are both 3-tone syllables per Appendix A.
+            expect(threeToneCanonicals.sort()).toEqual(["Agent", "Edit"]);
+        });
+
+        it("all curated tones fall within the documented duration / gap windows", () => {
+            for (const p of Object.values(curated)) {
+                expect(p.durationMs).toBeGreaterThanOrEqual(40);
+                expect(p.durationMs).toBeLessThanOrEqual(80);
+                expect(p.gapMs).toBeGreaterThanOrEqual(10);
+                expect(p.gapMs).toBeLessThanOrEqual(24);
+            }
+        });
+    });
+
+    describe("hash fallback", () => {
+        it("is deterministic", () => {
+            const a = hashToolToParams("mcp__weatherserver__get_forecast");
+            const b = hashToolToParams("mcp__weatherserver__get_forecast");
+            expect(a).toEqual(b);
+        });
+
+        it("produces different params for different tools", () => {
+            const a = hashToolToParams("toolA");
+            const b = hashToolToParams("toolB");
+            // Same length (always 2 for hashed), but at least one
+            // frequency or wave differs. We can't assert non-equality
+            // across all hash inputs (theoretical collisions), but for
+            // these two strings the FNV-1a output diverges.
+            const same =
+                a.tones[0] === b.tones[0] &&
+                a.tones[1] === b.tones[1] &&
+                a.wave === b.wave;
+            expect(same).toBe(false);
+        });
+
+        it("only emits frequencies from the pentatonic set", () => {
+            // G3 = 196, plus the 8 pentatonic degrees up from it
+            // (0, 2, 4, 7, 9, 12, 14, 16 semitones).
+            const allowed = [0, 2, 4, 7, 9, 12, 14, 16].map((s) =>
+                196 * Math.pow(2, s / 12),
+            );
+            for (const sample of [
+                "mcp__one",
+                "foo",
+                "barbaz",
+                "WeirdTool-1",
+                "Other",
+                "",
+            ]) {
+                const p = hashToolToParams(sample);
+                for (const t of p.tones) {
+                    const close = allowed.some((a) => Math.abs(a - t) < 0.01);
+                    expect(close).toBe(true);
+                }
+            }
+        });
+
+        it("uses only sine or triangle waves", () => {
+            for (const sample of ["a", "b", "c", "d", "e", "Other", "x"]) {
+                const p = hashToolToParams(sample);
+                expect(["sine", "triangle"]).toContain(p.wave);
+            }
+        });
+    });
+
+    describe("paramsForTool", () => {
+        it("returns curated for canonical tools", () => {
+            expect(paramsForTool("Read")).toBe(__getCurated()["Read"]);
+        });
+
+        it("falls back to hash for unknown tools", () => {
+            const params = paramsForTool("mcp__unknown__tool");
+            // Hash output is always 2 tones (no curated 3-tone path).
+            expect(params.tones.length).toBe(2);
+        });
+
+        it("hashes the literal raw tool name (no normalization)", () => {
+            // "read" (lowercase) is NOT a curated key — different from "Read".
+            const lower = paramsForTool("read");
+            const canonical = paramsForTool("Read");
+            expect(lower.tones).not.toEqual(canonical.tones);
+        });
+    });
+});

--- a/frontend/app/notification/sound/index.ts
+++ b/frontend/app/notification/sound/index.ts
@@ -22,3 +22,8 @@ export {
     type SoundDef,
     type SoundCategory,
 } from "./sounds";
+export {
+    paramsForTool,
+    hashToolToParams,
+    type SyllableParams,
+} from "./tool-tones";

--- a/frontend/app/notification/sound/index.ts
+++ b/frontend/app/notification/sound/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Public entrypoint for the sound-notifications subsystem.
+ * See docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md.
+ */
+
+export {
+    installSoundService,
+    setReplayMode,
+    isReplayMode,
+} from "./sound-service";
+export {
+    notify,
+    subscribeSoundEvents,
+    type SoundEvent,
+} from "./sound-events";
+export {
+    SOUNDS,
+    type SoundId,
+    type SoundDef,
+    type SoundCategory,
+} from "./sounds";

--- a/frontend/app/notification/sound/sound-events.ts
+++ b/frontend/app/notification/sound/sound-events.ts
@@ -1,0 +1,68 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sound-event bus — typed, multicast, allocation-light.
+ *
+ * Spec: docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.3.
+ *
+ * The bus is the **only** public surface most callers ever touch:
+ *
+ *     import { notify } from "@/app/notification/sound";
+ *     notify("agent.turn.complete", { sourceBlockId });
+ *
+ * Subscribers (in practice: the sound service) call
+ * `subscribeSoundEvents` and receive every event. A subscriber that
+ * throws is isolated — it does not poison the other subscribers or
+ * the caller's stack.
+ *
+ * No SolidJS coupling — the bus is a plain Set so it can be primed
+ * during module load without a reactive root. The orchestrator
+ * (`sound-service.ts`) is where settings, focus, and player
+ * coordination live.
+ */
+
+import type { SoundId } from "./sounds";
+
+export interface SoundEvent {
+    id: SoundId;
+    /**
+     * blockId of the originating pane, if any. Used by the orchestrator
+     * to suppress sound when the source pane is focused and the window
+     * is in foreground.
+     */
+    sourceBlockId?: string;
+    /**
+     * Per-emit overrides. `gain` multiplies the master gain (0–1).
+     * `asset` lets a caller request a non-default asset (currently
+     * unused — synth-only in v1 — but the API surface is stable).
+     */
+    override?: { asset?: string; gain?: number };
+}
+
+type Listener = (ev: SoundEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribeSoundEvents(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function notify(id: SoundId, opts?: Omit<SoundEvent, "id">): void {
+    const ev: SoundEvent = { id, ...opts };
+    for (const l of listeners) {
+        try {
+            l(ev);
+        } catch (e) {
+            console.warn(`[sound] listener threw for ${id}`, e);
+        }
+    }
+}
+
+/** Test/dev helper — wipe all subscribers. Never call in production. */
+export function __resetSoundListeners(): void {
+    listeners.clear();
+}

--- a/frontend/app/notification/sound/sound-player.ts
+++ b/frontend/app/notification/sound/sound-player.ts
@@ -1,0 +1,110 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sound player — owns the AudioContext, the per-id AudioBuffer cache,
+ * and the master GainNode. One instance per renderer (the sound
+ * service holds it). Plays via `AudioBufferSourceNode` when an asset
+ * is loaded; falls back to the synth tone otherwise.
+ *
+ * Spec: SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.5.
+ *
+ * Autoplay policy: Chromium blocks new AudioContexts from playing
+ * before a user gesture. `prime()` MUST be called from inside a
+ * user-gesture event handler (typically the first pointerdown /
+ * keydown after app load — wired in `sound-service.ts`).
+ */
+
+import { playSynthFallback } from "./synth-fallback";
+import type { SoundDef } from "./sounds";
+import { SOUNDS } from "./sounds";
+
+export class SoundPlayer {
+    private ctx: AudioContext | null = null;
+    private masterGain: GainNode | null = null;
+    private buffers = new Map<string, AudioBuffer>();
+    private primed = false;
+    private masterGainValue = 0.6;
+
+    /** Whether the AudioContext has been created. */
+    isPrimed(): boolean {
+        return this.primed;
+    }
+
+    /**
+     * Initialize the AudioContext and preload assets. Idempotent.
+     * Must be invoked from a user-gesture handler under Chromium's
+     * autoplay policy.
+     */
+    async prime(): Promise<void> {
+        if (this.primed) return;
+        const Ctor =
+            (window as unknown as { AudioContext?: typeof AudioContext })
+                .AudioContext ??
+            (window as unknown as { webkitAudioContext?: typeof AudioContext })
+                .webkitAudioContext;
+        if (!Ctor) {
+            console.warn("[sound] AudioContext unavailable — sound disabled");
+            return;
+        }
+        this.ctx = new Ctor();
+        this.masterGain = this.ctx.createGain();
+        this.masterGain.gain.value = this.masterGainValue;
+        this.masterGain.connect(this.ctx.destination);
+        this.primed = true;
+        await Promise.all(
+            Object.values(SOUNDS)
+                .filter((s): s is SoundDef & { asset: string } => !!s.asset)
+                .map((s) => this.loadAsset(s.asset)),
+        );
+    }
+
+    setMasterGain(value: number): void {
+        const clamped = Math.max(0, Math.min(1, value));
+        this.masterGainValue = clamped;
+        if (this.masterGain) this.masterGain.gain.value = clamped;
+    }
+
+    /**
+     * Play the given sound definition through the master bus.
+     * No-op if the player is not yet primed. Picks the buffer path
+     * when the asset is loaded; otherwise routes to the synth fallback.
+     */
+    play(def: SoundDef, gain = 1): void {
+        const ctx = this.ctx;
+        const out = this.masterGain;
+        if (!ctx || !out) return;
+        if (ctx.state === "suspended") {
+            // A best-effort resume — the autoplay-prime path should
+            // have settled this already; if the context was suspended
+            // by an OS interruption (e.g. screen lock), resume now.
+            void ctx.resume().catch(() => {
+                /* ignore — we'll just synth-fallback */
+            });
+        }
+        const buf = def.asset ? this.buffers.get(def.asset) : undefined;
+        if (buf) {
+            const src = ctx.createBufferSource();
+            src.buffer = buf;
+            const perPlay = ctx.createGain();
+            perPlay.gain.value = Math.max(0, Math.min(1, gain));
+            src.connect(perPlay).connect(out);
+            src.start();
+            return;
+        }
+        playSynthFallback(ctx, out, def.category, gain);
+    }
+
+    private async loadAsset(asset: string): Promise<void> {
+        if (!this.ctx) return;
+        try {
+            const resp = await fetch(`/${asset}`);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const bytes = await resp.arrayBuffer();
+            const buf = await this.ctx.decodeAudioData(bytes);
+            this.buffers.set(asset, buf);
+        } catch (e) {
+            console.warn(`[sound] failed to load ${asset}; using synth fallback`, e);
+        }
+    }
+}

--- a/frontend/app/notification/sound/sound-player.ts
+++ b/frontend/app/notification/sound/sound-player.ts
@@ -32,6 +32,24 @@ export class SoundPlayer {
     }
 
     /**
+     * Direct access to the AudioContext. Returns null before `prime()`
+     * has been called. Used by sibling subsystems (e.g. the tool-tones
+     * player) to hook into the same context.
+     */
+    getAudioContext(): AudioContext | null {
+        return this.ctx;
+    }
+
+    /**
+     * Direct access to the master GainNode. Returns null before
+     * `prime()` has been called. Used by sibling subsystems to layer
+     * additional gain/filter chains below the master volume.
+     */
+    getMasterGain(): GainNode | null {
+        return this.masterGain;
+    }
+
+    /**
      * Initialize the AudioContext and preload assets. Idempotent.
      * Must be invoked from a user-gesture handler under Chromium's
      * autoplay policy.

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -148,8 +148,10 @@ function mapAgentPaneEvent(blockId: string, event: AgentPaneEvent): void {
             }
             return;
         case "submit-timed-out":
-        case "interrupt-timed-out":
             notify("agent.turn.error", { sourceBlockId: blockId });
+            return;
+        case "interrupt-timed-out":
+            notify("agent.turn.interrupted", { sourceBlockId: blockId });
             return;
         case "stream-stalled":
             notify("agent.stream.stalled", { sourceBlockId: blockId });

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -30,10 +30,12 @@ import { createEffect, createRoot } from "solid-js";
 import { notify, subscribeSoundEvents, type SoundEvent } from "./sound-events";
 import { SOUNDS, type SoundId } from "./sounds";
 import { SoundPlayer } from "./sound-player";
+import { ToolTonesPlayer } from "./tool-tones-player";
 
 let installed = false;
 let replayMode = false;
 const player = new SoundPlayer();
+const toolTones = new ToolTonesPlayer();
 const lastFiredAt = new Map<SoundId, number>();
 
 /**
@@ -63,20 +65,32 @@ export function installSoundService(): () => void {
     const windowFocused = makeWindowFocusSignal();
 
     // Prime AudioContext on the first user gesture, exactly once.
+    // After priming, hook the tool-tones chain into the same context +
+    // master gain so a single OS volume slider controls both subsystems.
     const onceOpts: AddEventListenerOptions = { capture: true, once: true };
-    const primeOnce = () => {
-        void player.prime();
+    const primeOnce = async () => {
         document.removeEventListener("pointerdown", primeOnce, true);
         document.removeEventListener("keydown", primeOnce, true);
+        await player.prime();
+        const ctx = player.getAudioContext();
+        const master = player.getMasterGain();
+        if (ctx && master && !toolTones.isAttached()) {
+            toolTones.attach(ctx, master);
+        }
     };
     document.addEventListener("pointerdown", primeOnce, onceOpts);
     document.addEventListener("keydown", primeOnce, onceOpts);
 
-    // Reactively thread the master-volume setting into the player.
+    // Reactively thread the master-volume + tool-tones-volume settings
+    // into their respective gain nodes.
     const volumeDispose = createRoot((dispose) => {
         createEffect(() => {
             const vol = getSettingsKeyAtom("notify:sounds:volume")();
             player.setMasterGain(typeof vol === "number" ? vol : 0.6);
+        });
+        createEffect(() => {
+            const vol = getSettingsKeyAtom("notify:tooltones:volume")();
+            toolTones.setVolume(typeof vol === "number" ? vol : 0.15);
         });
         return dispose;
     });
@@ -118,6 +132,9 @@ export function installSoundService(): () => void {
 
 function mapAgentPaneEvent(blockId: string, event: AgentPaneEvent): void {
     switch (event.type) {
+        case "tool-started":
+            playToolToneIfAllowed(blockId, event.name);
+            return;
         case "turn-ended":
             if (event.outcome === "completed") {
                 notify("agent.turn.complete", { sourceBlockId: blockId });
@@ -150,6 +167,39 @@ function mapAgentPaneEvent(blockId: string, event: AgentPaneEvent): void {
     }
 }
 
+/**
+ * Tool-tone playback path. Separate from the SoundEvent bus because
+ * the policy is different (on-by-default, scope-based instead of
+ * focus-suppressing) and the player is a different chain.
+ *
+ * Spec: docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md §6.
+ */
+function playToolToneIfAllowed(blockId: string, tool: string): void {
+    if (replayMode) return;
+    // v1 master kill-switch silences tool tones too (shared chain).
+    if (getSettingsKeyAtom("notify:sounds:enabled")() === false) return;
+    // Tool-tones enable; absence = default on.
+    if (getSettingsKeyAtom("notify:tooltones:enabled")() === false) return;
+    const scope = getSettingsKeyAtom("notify:tooltones:scope")() ?? "all";
+    if (scope === "focused") {
+        const windowFocused = makeWindowFocusSignal();
+        if (
+            focusManager.blockFocusAtom() !== blockId ||
+            !windowFocused()
+        ) {
+            return;
+        }
+    }
+    // "window" mode (v1.5) falls through to "all" for now; see spec §8.5.
+    const ctx = player.getAudioContext();
+    if (!ctx || !toolTones.isAttached()) return; // not primed yet
+    try {
+        toolTones.play(ctx, tool);
+    } catch (e) {
+        console.warn(`[sound] tool-tone play threw for ${tool}`, e);
+    }
+}
+
 function shouldPlay(ev: SoundEvent, windowFocused: () => boolean): boolean {
     const master = getSettingsKeyAtom("notify:sounds:enabled")();
     if (master === false) return false;
@@ -179,8 +229,13 @@ export function __resetSoundService(): void {
     installed = false;
     replayMode = false;
     lastFiredAt.clear();
+    toolTones.__resetCoalesce();
 }
 
 export function __getSoundPlayer(): SoundPlayer {
     return player;
+}
+
+export function __getToolTonesPlayer(): ToolTonesPlayer {
+    return toolTones;
 }

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sound service — the orchestrator.
+ *
+ * Spec: docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.6.
+ *
+ * Responsibilities:
+ *   1. Prime the AudioContext on the first user gesture (autoplay
+ *      policy).
+ *   2. Hold the SoundPlayer and route every sound event through it.
+ *   3. Track which agent-pane events translate to which sound IDs
+ *      (subscribed via the agent-pane-state-store multicast).
+ *   4. Apply settings gating (master enable, per-event enable,
+ *      master volume), coalesce, and focus suppression.
+ *   5. Honor replay mode so historical events don't play sound.
+ *
+ * Installed once from app-init via `installSoundService()`.
+ */
+
+import { focusManager } from "@/app/store/focusManager";
+import { getSettingsKeyAtom } from "@/app/store/global";
+import { makeWindowFocusSignal } from "@/app/window/window-focus";
+import {
+    addEventListener as addPaneListener,
+    type AgentPaneEvent,
+} from "@/app/store/agent-pane-state-store";
+import { createEffect, createRoot } from "solid-js";
+import { notify, subscribeSoundEvents, type SoundEvent } from "./sound-events";
+import { SOUNDS, type SoundId } from "./sounds";
+import { SoundPlayer } from "./sound-player";
+
+let installed = false;
+let replayMode = false;
+const player = new SoundPlayer();
+const lastFiredAt = new Map<SoundId, number>();
+
+/**
+ * Toggle replay mode. While true, the bus still receives events but
+ * the service drops every play. The session-replay infrastructure
+ * (SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md) flips this around
+ * its historical dispatches so the user doesn't hear a din of past
+ * turn-completions when scrubbing a replay.
+ */
+export function setReplayMode(value: boolean): void {
+    replayMode = value;
+}
+
+export function isReplayMode(): boolean {
+    return replayMode;
+}
+
+/**
+ * Install the sound service. Idempotent — subsequent calls no-op.
+ * Returns a cleanup function for tests; production code does not
+ * uninstall.
+ */
+export function installSoundService(): () => void {
+    if (installed) return () => undefined;
+    installed = true;
+
+    const windowFocused = makeWindowFocusSignal();
+
+    // Prime AudioContext on the first user gesture, exactly once.
+    const onceOpts: AddEventListenerOptions = { capture: true, once: true };
+    const primeOnce = () => {
+        void player.prime();
+        document.removeEventListener("pointerdown", primeOnce, true);
+        document.removeEventListener("keydown", primeOnce, true);
+    };
+    document.addEventListener("pointerdown", primeOnce, onceOpts);
+    document.addEventListener("keydown", primeOnce, onceOpts);
+
+    // Reactively thread the master-volume setting into the player.
+    const volumeDispose = createRoot((dispose) => {
+        createEffect(() => {
+            const vol = getSettingsKeyAtom("notify:sounds:volume")();
+            player.setMasterGain(typeof vol === "number" ? vol : 0.6);
+        });
+        return dispose;
+    });
+
+    // Bus → player.
+    const busUnsub = subscribeSoundEvents((ev) => {
+        if (replayMode) return;
+        if (!shouldPlay(ev, windowFocused)) return;
+        const def = SOUNDS[ev.id];
+        if (!def) return;
+        const now =
+            typeof performance !== "undefined" && performance.now
+                ? performance.now()
+                : Date.now();
+        const last = lastFiredAt.get(ev.id) ?? 0;
+        if (now - last < (def.coalesceMs ?? 300)) return;
+        lastFiredAt.set(ev.id, now);
+        try {
+            player.play(def, ev.override?.gain ?? 1);
+        } catch (e) {
+            console.warn(`[sound] play threw for ${ev.id}`, e);
+        }
+    });
+
+    // Reducer events → bus.
+    const paneUnsub = addPaneListener((blockId, event) => {
+        mapAgentPaneEvent(blockId, event);
+    });
+
+    return () => {
+        busUnsub();
+        paneUnsub();
+        volumeDispose();
+        document.removeEventListener("pointerdown", primeOnce, true);
+        document.removeEventListener("keydown", primeOnce, true);
+        installed = false;
+    };
+}
+
+function mapAgentPaneEvent(blockId: string, event: AgentPaneEvent): void {
+    switch (event.type) {
+        case "turn-ended":
+            if (event.outcome === "completed") {
+                notify("agent.turn.complete", { sourceBlockId: blockId });
+            } else if (event.outcome === "errored") {
+                notify("agent.turn.error", { sourceBlockId: blockId });
+            } else if (
+                event.outcome === "stopped" ||
+                event.outcome === "interrupted"
+            ) {
+                notify("agent.turn.interrupted", { sourceBlockId: blockId });
+            }
+            return;
+        case "submit-timed-out":
+        case "interrupt-timed-out":
+            notify("agent.turn.error", { sourceBlockId: blockId });
+            return;
+        case "stream-stalled":
+            notify("agent.stream.stalled", { sourceBlockId: blockId });
+            return;
+        case "pending-accepted":
+            if (event.wasPresent) {
+                notify("agent.message.accepted", { sourceBlockId: blockId });
+            }
+            return;
+        case "pending-rejected":
+            if (event.wasPresent) {
+                notify("agent.message.rejected", { sourceBlockId: blockId });
+            }
+            return;
+    }
+}
+
+function shouldPlay(ev: SoundEvent, windowFocused: () => boolean): boolean {
+    const master = getSettingsKeyAtom("notify:sounds:enabled")();
+    if (master === false) return false;
+    const def = SOUNDS[ev.id];
+    if (!def) return false;
+    const perEvent = getSettingsKeyAtom(def.settingKey)();
+    if (perEvent === false) return false;
+
+    const suppressRaw = getSettingsKeyAtom(
+        "notify:sounds:suppresswhenfocused",
+    )();
+    const suppressWhenFocused = suppressRaw !== false; // default true
+    if (
+        suppressWhenFocused &&
+        ev.sourceBlockId &&
+        focusManager.blockFocusAtom() === ev.sourceBlockId &&
+        windowFocused()
+    ) {
+        return false;
+    }
+    return true;
+}
+
+// ── Test helpers (NEVER call from production) ─────────────────────────
+
+export function __resetSoundService(): void {
+    installed = false;
+    replayMode = false;
+    lastFiredAt.clear();
+}
+
+export function __getSoundPlayer(): SoundPlayer {
+    return player;
+}

--- a/frontend/app/notification/sound/sounds.ts
+++ b/frontend/app/notification/sound/sounds.ts
@@ -1,0 +1,96 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sound registry — the single source of truth for every sound the app
+ * can play. Adding a new sound is one entry here plus one settings key
+ * (see SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §5).
+ *
+ * Each entry is purely declarative. The orchestrator
+ * (`sound-service.ts`) reads the registry and the user's settings to
+ * decide whether and how to play. The player (`sound-player.ts`) reads
+ * the asset path (if any) and falls back to a synthesized tone keyed
+ * on the category when the asset is missing.
+ *
+ * v1 ships **synth-only** — no asset files (`asset` left undefined on
+ * every entry). The synth fallback (§4.5 / Appendix A in the spec) is
+ * intentionally small, zero-dependency, and polite. A CC0 asset pack
+ * is a follow-up; dropping in `asset: "sounds/turn-complete.ogg"` on
+ * an entry and shipping the file under `public/sounds/` is all it
+ * takes to upgrade.
+ */
+
+export type SoundId =
+    | "agent.turn.complete"
+    | "agent.turn.error"
+    | "agent.turn.interrupted"
+    | "agent.message.accepted"
+    | "agent.message.rejected"
+    | "agent.stream.stalled";
+
+export type SoundCategory = "success" | "info" | "warning" | "error";
+
+export interface SoundDef {
+    id: SoundId;
+    /** User-visible label — surfaced by a future settings UI. */
+    label: string;
+    /** Drives the synth fallback's timbre when no asset is present. */
+    category: SoundCategory;
+    /** Path under `public/`. Optional — synth fallback covers absence. */
+    asset?: string;
+    /** Per-event enable key. Conventionally `notify:sound:<id>`. */
+    settingKey: keyof SettingsType;
+    /**
+     * Coalesce window in ms — two firings of the same sound within this
+     * window play once. Defends against double-dispatch storms during
+     * tightly-coupled reducer event sequences. 300ms is generous for
+     * "back-to-back legitimate events" but tight enough to drop the
+     * common late-`stream-unsubscribed` race after `turn-ended`.
+     */
+    coalesceMs?: number;
+}
+
+export const SOUNDS: Record<SoundId, SoundDef> = {
+    "agent.turn.complete": {
+        id: "agent.turn.complete",
+        label: "Agent turn completed",
+        category: "success",
+        settingKey: "notify:sound:agent.turn.complete",
+        coalesceMs: 300,
+    },
+    "agent.turn.error": {
+        id: "agent.turn.error",
+        label: "Agent turn errored",
+        category: "error",
+        settingKey: "notify:sound:agent.turn.error",
+        coalesceMs: 300,
+    },
+    "agent.turn.interrupted": {
+        id: "agent.turn.interrupted",
+        label: "Agent turn interrupted",
+        category: "warning",
+        settingKey: "notify:sound:agent.turn.interrupted",
+        coalesceMs: 300,
+    },
+    "agent.message.accepted": {
+        id: "agent.message.accepted",
+        label: "Pending message accepted",
+        category: "info",
+        settingKey: "notify:sound:agent.message.accepted",
+        coalesceMs: 150,
+    },
+    "agent.message.rejected": {
+        id: "agent.message.rejected",
+        label: "Pending message rejected",
+        category: "warning",
+        settingKey: "notify:sound:agent.message.rejected",
+        coalesceMs: 150,
+    },
+    "agent.stream.stalled": {
+        id: "agent.stream.stalled",
+        label: "Agent stream stalled",
+        category: "warning",
+        settingKey: "notify:sound:agent.stream.stalled",
+        coalesceMs: 1_000,
+    },
+};

--- a/frontend/app/notification/sound/synth-fallback.ts
+++ b/frontend/app/notification/sound/synth-fallback.ts
@@ -1,0 +1,91 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Synth fallback — oscillator + exponential-decay envelope per
+ * SoundCategory. Used when no asset is shipped (v1 default) or when
+ * an asset fails to load. Polite by design: ~150ms total duration,
+ * gentle attack, sub-1.0 peak gain.
+ *
+ * Spec: SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.5 + Appendix A.
+ *
+ * The whole module is allocation-light — every play creates one
+ * oscillator + one gain node, both single-use as recommended by
+ * MDN's Web Audio best practices. No shared mutable state.
+ */
+
+import type { SoundCategory } from "./sounds";
+
+interface SynthParams {
+    wave: OscillatorType;
+    freq: number;
+    /** Peak envelope gain, 0–1. Multiplied with the caller's `gain`. */
+    peak: number;
+    /** Optional second tone, played 30ms after the first for a "ding" feel. */
+    second?: { freq: number; delayMs: number };
+}
+
+function paramsFor(category: SoundCategory): SynthParams {
+    switch (category) {
+        case "success":
+            // Two-tone rising sine — "good news" interval (G5 → C6).
+            return {
+                wave: "sine",
+                freq: 784,
+                peak: 0.5,
+                second: { freq: 1046, delayMs: 70 },
+            };
+        case "info":
+            return { wave: "sine", freq: 660, peak: 0.4 };
+        case "warning":
+            return { wave: "triangle", freq: 440, peak: 0.5 };
+        case "error":
+            // Two-tone falling square — "minor concern" interval (A4 → D4).
+            return {
+                wave: "square",
+                freq: 440,
+                peak: 0.35,
+                second: { freq: 294, delayMs: 90 },
+            };
+    }
+}
+
+function playTone(
+    ctx: AudioContext,
+    out: AudioNode,
+    wave: OscillatorType,
+    freq: number,
+    peak: number,
+    startAt: number,
+): void {
+    const osc = ctx.createOscillator();
+    const env = ctx.createGain();
+    osc.type = wave;
+    osc.frequency.setValueAtTime(freq, startAt);
+    env.gain.setValueAtTime(0.0001, startAt);
+    env.gain.exponentialRampToValueAtTime(Math.max(0.0001, peak), startAt + 0.01);
+    env.gain.exponentialRampToValueAtTime(0.0001, startAt + 0.15);
+    osc.connect(env).connect(out);
+    osc.start(startAt);
+    osc.stop(startAt + 0.18);
+}
+
+/**
+ * Play a polite tone matching the category through `out`. `gain`
+ * scales the per-tone peak. Returns immediately — the audio plays
+ * asynchronously and self-disposes.
+ */
+export function playSynthFallback(
+    ctx: AudioContext,
+    out: AudioNode,
+    category: SoundCategory,
+    gain: number,
+): void {
+    const now = ctx.currentTime;
+    const p = paramsFor(category);
+    const scaledPeak = p.peak * Math.max(0, Math.min(1, gain));
+    playTone(ctx, out, p.wave, p.freq, scaledPeak, now);
+    if (p.second) {
+        playTone(ctx, out, p.wave, p.second.freq, scaledPeak, now + p.second.delayMs / 1000);
+    }
+}

--- a/frontend/app/notification/sound/tool-tones-player.ts
+++ b/frontend/app/notification/sound/tool-tones-player.ts
@@ -1,0 +1,118 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tool-tones audio player — dedicated chain with a lowpass filter
+ * and an independent gain knob, sitting below the v1 master gain.
+ *
+ * Spec: docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md §5.
+ *
+ * Chain:
+ *   per-tone OscillatorNode → per-tone envelope (GainNode)
+ *     → tool-tones gain (settings-bound)
+ *     → BiquadFilter (lowpass ~2.5 kHz)
+ *     → v1 master gain
+ *     → AudioContext.destination
+ *
+ * The lowpass softens onsets so rapid syllables blend into ambient
+ * texture rather than poking through it; the independent gain lets
+ * the user dial tool tones way down without quieting notifications.
+ *
+ * Idempotent attach — safe to call repeatedly (e.g. if the AudioContext
+ * is rebuilt). State (`lastFiredAt`) survives across attaches by
+ * design: coalesce semantics should not depend on context lifecycle.
+ */
+
+import { paramsForTool, type SyllableParams } from "./tool-tones";
+
+/** Coalesce window per tool, in ms. See spec §9.4. */
+const COALESCE_MS = 30;
+
+/** Peak envelope gain inside one tone, before the chain gain. */
+const ENVELOPE_PEAK = 0.4;
+
+export class ToolTonesPlayer {
+    private filter: BiquadFilterNode | null = null;
+    private gain: GainNode | null = null;
+    private toolGainValue = 0.15;
+    private lastFiredAt = new Map<string, number>();
+
+    /**
+     * Wire the chain into the given AudioContext and master GainNode.
+     * Idempotent — calling twice rebuilds the chain against the same
+     * (or a fresh) context.
+     */
+    attach(ctx: AudioContext, master: GainNode): void {
+        const filter = ctx.createBiquadFilter();
+        filter.type = "lowpass";
+        filter.frequency.value = 2500;
+        // Butterworth Q — no resonance peak, gentle rolloff.
+        filter.Q.value = 0.707;
+        const gain = ctx.createGain();
+        gain.gain.value = this.toolGainValue;
+        gain.connect(filter).connect(master);
+        this.filter = filter;
+        this.gain = gain;
+    }
+
+    /** True iff `attach()` has been called and the chain is wired up. */
+    isAttached(): boolean {
+        return this.gain != null;
+    }
+
+    /**
+     * Set the tool-tones independent gain (0–1). Layered below the
+     * shared master gain — turning the master to 0 silences both.
+     */
+    setVolume(value: number): void {
+        const clamped = Math.max(0, Math.min(1, value));
+        this.toolGainValue = clamped;
+        if (this.gain) this.gain.gain.value = clamped;
+    }
+
+    /**
+     * Play the syllable for `tool` through the chain. No-op if not
+     * attached. Coalesces a second fire of the same tool within
+     * `COALESCE_MS`.
+     */
+    play(ctx: AudioContext, tool: string): void {
+        const out = this.gain;
+        if (!out) return;
+        const now =
+            typeof performance !== "undefined" && performance.now
+                ? performance.now()
+                : Date.now();
+        const last = this.lastFiredAt.get(tool) ?? 0;
+        if (now - last < COALESCE_MS) return;
+        this.lastFiredAt.set(tool, now);
+        playSyllable(ctx, out, paramsForTool(tool));
+    }
+
+    /** Test/dev helper — clear the coalesce map. */
+    __resetCoalesce(): void {
+        this.lastFiredAt.clear();
+    }
+}
+
+function playSyllable(
+    ctx: AudioContext,
+    out: AudioNode,
+    p: SyllableParams,
+): void {
+    const startAt = ctx.currentTime;
+    const stepSec = (p.durationMs + p.gapMs) / 1000;
+    const toneSec = p.durationMs / 1000;
+    for (let i = 0; i < p.tones.length; i++) {
+        const at = startAt + i * stepSec;
+        const osc = ctx.createOscillator();
+        const env = ctx.createGain();
+        osc.type = p.wave;
+        osc.frequency.setValueAtTime(p.tones[i], at);
+        env.gain.setValueAtTime(0.0001, at);
+        env.gain.exponentialRampToValueAtTime(ENVELOPE_PEAK, at + 0.006);
+        env.gain.exponentialRampToValueAtTime(0.0001, at + toneSec);
+        osc.connect(env).connect(out);
+        osc.start(at);
+        osc.stop(at + toneSec + 0.02);
+    }
+}

--- a/frontend/app/notification/sound/tool-tones.ts
+++ b/frontend/app/notification/sound/tool-tones.ts
@@ -1,0 +1,136 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tool-tones parameter mapping — every tool call resolves to a short
+ * "syllable" of 1–3 tones drawn from a G major pentatonic scale.
+ *
+ * Spec: docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md §3.
+ *
+ * Design properties:
+ *  - **Deterministic.** Same tool name → same syllable, every time.
+ *    Users learn the alphabet by exposure.
+ *  - **Bounded.** All output (curated + hashed) lives in the same
+ *    pentatonic note set — no dissonance even when 6 tools overlap.
+ *  - **Lightweight.** Pure functions, no I/O, no allocation per call
+ *    beyond the returned record.
+ *  - **No state.** This module knows nothing about the AudioContext;
+ *    `tool-tones-player.ts` consumes the params and synthesizes.
+ */
+
+export interface SyllableParams {
+    /** 1–3 frequencies in Hz, played in order with `gapMs` between them. */
+    tones: number[];
+    /** Per-tone duration in ms (40–80 is the spec'd window). */
+    durationMs: number;
+    /** Silent gap between tones in ms (10–24 is the spec'd window). */
+    gapMs: number;
+    /** Oscillator wave shape. Sine for warm tones; triangle for "machine" tones. */
+    wave: OscillatorType;
+}
+
+// ─── Pentatonic scale ──────────────────────────────────────────────────
+// G major pentatonic across two octaves: G3, A3, B3, D4, E4, G4, A4, B4,
+// D5, E5, G5. All curated syllables draw from this set; the hash
+// fallback also lives inside it.
+
+const G3 = 196;
+const A3 = 220;
+const B3 = 247;
+const D4 = 294;
+const E4 = 330;
+const G4 = 392;
+const A4 = 440;
+const B4 = 494;
+const D5 = 587;
+const E5 = 659;
+const G5 = 784;
+
+/**
+ * Semitone offsets from G3 for the pentatonic notes we use in the
+ * hash fallback. Eight entries chosen so a 3-bit slice of the hash
+ * picks one cleanly.
+ */
+const PENTATONIC_DEGREES = [0, 2, 4, 7, 9, 12, 14, 16];
+
+/**
+ * Convert a pentatonic degree index (0–7) to a frequency in the G
+ * pentatonic scale, anchored at G3 (196 Hz).
+ */
+function degreeToHz(degreeIndex: number): number {
+    const semitones = PENTATONIC_DEGREES[degreeIndex % PENTATONIC_DEGREES.length];
+    return G3 * Math.pow(2, semitones / 12);
+}
+
+// ─── Curated palette ──────────────────────────────────────────────────
+// Each canonical tool gets a hand-tuned syllable that reflects its
+// semantic role. See spec §3.2.1 and Appendix A for the table.
+
+const CURATED: Record<string, SyllableParams> = {
+    // Soft, descending major-2nd — "looking."
+    Read: { tones: [B4, A4], durationMs: 60, gapMs: 14, wave: "sine" },
+    // Twin same-pitch ticks — "scanning."
+    Grep: { tones: [E5, E5], durationMs: 45, gapMs: 18, wave: "sine" },
+    // Rising minor-2nd — "results coming."
+    Glob: { tones: [D5, E5], durationMs: 45, gapMs: 18, wave: "sine" },
+    // Three-tone up-down-up — "the fix gesture."
+    Edit: { tones: [A4, B4, A4], durationMs: 50, gapMs: 12, wave: "sine" },
+    // Rising perfect-5th — "creation."
+    Write: { tones: [G4, D5], durationMs: 60, gapMs: 18, wave: "sine" },
+    // Same 5th an octave down + triangle wave — "the machine."
+    Bash: { tones: [G3, D4], durationMs: 70, gapMs: 18, wave: "triangle" },
+    // Rising 4th, high — "delegation upward."
+    Task: { tones: [D5, G5], durationMs: 55, gapMs: 14, wave: "sine" },
+    // Out-and-back 5th, three tones — "sub-agent dispatch."
+    Agent: { tones: [G4, D5, G4], durationMs: 55, gapMs: 14, wave: "sine" },
+};
+
+/**
+ * FNV-1a-like hash for deterministic, allocation-light tool-name
+ * fingerprinting. We only need ~12 bits of entropy for the syllable
+ * picks, so a single 32-bit pass is plenty.
+ */
+function hashTool(tool: string): number {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < tool.length; i++) {
+        h = (h ^ tool.charCodeAt(i)) >>> 0;
+        h = Math.imul(h, 16777619) >>> 0;
+    }
+    return h;
+}
+
+/**
+ * Hash fallback for unknown tools. Returns a syllable drawn from the
+ * pentatonic set so it never sours against curated tones, even when
+ * overlapping.
+ */
+export function hashToolToParams(tool: string): SyllableParams {
+    const h = hashTool(tool);
+    const a = h & 0x7; // 3 bits for first tone
+    const b = (h >>> 3) & 0x7; // 3 bits for second tone
+    const wave: OscillatorType = ((h >>> 6) & 1) === 0 ? "sine" : "triangle";
+    // 45–76 ms duration window
+    const durationMs = 45 + ((h >>> 7) & 0x1f);
+    // 12–19 ms gap window
+    const gapMs = 12 + ((h >>> 12) & 0x7);
+    return {
+        tones: [degreeToHz(a), degreeToHz(b)],
+        durationMs,
+        gapMs,
+        wave,
+    };
+}
+
+/**
+ * Resolve a tool name to its syllable. Curated tools hit the
+ * hand-tuned palette; everything else (MCP tools, custom providers,
+ * misspellings) is hashed.
+ */
+export function paramsForTool(tool: string): SyllableParams {
+    return CURATED[tool] ?? hashToolToParams(tool);
+}
+
+/** Test/debug helper — the immutable curated palette. */
+export function __getCurated(): Readonly<Record<string, SyllableParams>> {
+    return CURATED;
+}

--- a/frontend/app/store/agent-pane-state-store.test.ts
+++ b/frontend/app/store/agent-pane-state-store.test.ts
@@ -21,6 +21,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     __resetAllSlots,
+    __resetListeners,
+    addEventListener,
+    type AgentPaneEvent,
     type AgentPaneProjections,
     dispatch,
     dispatchIfRegistered,
@@ -43,6 +46,7 @@ function noopProj(): AgentPaneProjections {
 describe("agent-pane-state-store (cascade contracts)", () => {
     afterEach(() => {
         __resetAllSlots();
+        __resetListeners();
         setEventSink(() => {});
     });
 
@@ -184,6 +188,88 @@ describe("agent-pane-state-store (cascade contracts)", () => {
                 "Interrupting", // RequestStop while working
                 "Done", // TurnEnd
             ]);
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────
+    // Multicast event listeners — sound-notifications subsystem path.
+    // See docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.4 Path B.
+    // ────────────────────────────────────────────────────────────────
+    describe("addEventListener (multicast)", () => {
+        it("delivers every emitted event to subscribers in addition to the single sink", () => {
+            const singleSink = vi.fn();
+            const listener = vi.fn();
+            setEventSink(singleSink);
+            addEventListener(listener);
+
+            registerPane("blockX", "agentX", noopProj());
+            dispatch("blockX", { type: "InitReady", at: 100 });
+
+            // The single sink and the listener both saw the same event.
+            expect(singleSink).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(singleSink.mock.calls[0][0]).toBe("blockX");
+            expect(listener.mock.calls[0][0]).toBe("blockX");
+            expect(listener.mock.calls[0][1]).toMatchObject({ type: "init-ready" });
+        });
+
+        it("unsubscribe stops further delivery to the listener but not the sink", () => {
+            const sink = vi.fn();
+            const listener = vi.fn();
+            setEventSink(sink);
+            const unsub = addEventListener(listener);
+
+            registerPane("blockY", "agentY", noopProj());
+            dispatch("blockY", { type: "InitReady", at: 100 });
+            unsub();
+            dispatch("blockY", { type: "StreamSubscribe", at: 110 });
+
+            expect(listener).toHaveBeenCalledTimes(1); // only the first
+            expect(sink).toHaveBeenCalledTimes(2); // both
+        });
+
+        it("a throwing listener does not poison the sink or other listeners", () => {
+            const sink = vi.fn();
+            const thrower = vi.fn(() => {
+                throw new Error("listener boom");
+            });
+            const good = vi.fn();
+            setEventSink(sink);
+            addEventListener(thrower);
+            addEventListener(good);
+
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+            registerPane("blockZ", "agentZ", noopProj());
+            dispatch("blockZ", { type: "InitReady", at: 100 });
+
+            expect(sink).toHaveBeenCalledTimes(1);
+            expect(thrower).toHaveBeenCalledTimes(1);
+            expect(good).toHaveBeenCalledTimes(1);
+            expect(warn).toHaveBeenCalled();
+            warn.mockRestore();
+        });
+
+        it("turn-ended event carries the outcome for sound-notifications consumers", () => {
+            const seen: AgentPaneEvent[] = [];
+            setEventSink(() => {});
+            addEventListener((_blockId, ev) => {
+                seen.push(ev);
+            });
+
+            registerPane("blockTE", "agentTE", noopProj());
+            dispatch("blockTE", { type: "InitReady", at: 100 });
+            dispatch("blockTE", { type: "StreamSubscribe", at: 100 });
+            dispatch("blockTE", { type: "TurnStart", at: 110 });
+            dispatch("blockTE", { type: "StreamFlushObserved", addedCount: 1, at: 120 });
+            dispatch("blockTE", { type: "TurnEnd", stats: null });
+
+            const turnEnded = seen.find((e) => e.type === "turn-ended");
+            expect(turnEnded).toBeDefined();
+            expect(turnEnded).toMatchObject({
+                type: "turn-ended",
+                // Completed because no RequestStop happened.
+                outcome: "completed",
+            });
         });
     });
 });

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -89,6 +89,30 @@ export function setEventSink(sink: EventSink): void {
 }
 
 /**
+ * Additional listeners that receive a copy of every emitted event
+ * alongside the single `eventSink` above. Multiple subscribers are
+ * supported — used by the sound-notifications subsystem (see
+ * SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.4 Path B) without
+ * displacing the existing single-sink consumers in
+ * `browser-model.ts` / `editor-model.ts`. Each listener is invoked
+ * in a try/catch so a throwing subscriber cannot poison the others
+ * or the primary sink.
+ */
+const extraListeners = new Set<EventSink>();
+
+export function addEventListener(sink: EventSink): () => void {
+    extraListeners.add(sink);
+    return () => {
+        extraListeners.delete(sink);
+    };
+}
+
+/** Test helper — wipe all multicast listeners. Never call in production. */
+export function __resetListeners(): void {
+    extraListeners.clear();
+}
+
+/**
  * Register a pane. Call SYNCHRONOUSLY from the component body, before
  * any hook can dispatch. Re-registering a blockId resets the state cell
  * to initialState (useful for hot-reload).
@@ -169,7 +193,19 @@ export function dispatch(
         );
     }
 
-    for (const ev of result.events) eventSink(blockId, ev);
+    for (const ev of result.events) {
+        eventSink(blockId, ev);
+        for (const l of extraListeners) {
+            try {
+                l(blockId, ev);
+            } catch (e) {
+                console.warn(
+                    `[agent-pane-state] multicast listener threw (cmd=${command.type}, ev=${ev.type})`,
+                    e,
+                );
+            }
+        }
+    }
     recordDispatch({
         slice: "agent-pane-state",
         key: blockId,

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -101,6 +101,11 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.sessionStats).toEqual({ input_tokens: 50, output_tokens: 200 });
             expect(r.events[0]).toMatchObject({
                 type: "turn-ended",
+                // outcome is "stopped" because RequestStop put the phase
+                // into Interrupting before TurnEnd ran. Sound subsystem
+                // (SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §3.2) reads
+                // outcome directly from the event without snapshotting.
+                outcome: "stopped",
                 statsMerged: true,
                 // stoppingCleared still carries the audit signal — true
                 // iff the turn ended while in Interrupting (PR G:

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -425,6 +425,7 @@ export function update(
                 events: [
                     {
                         type: "turn-ended",
+                        outcome,
                         statsMerged: merged != null,
                         stoppingCleared: stoppingWasSet,
                     },

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -507,7 +507,22 @@ export type AgentPaneEvent =
           thresholdMs: number;
       }
     | { type: "turn-started"; at: number }
-    | { type: "turn-ended"; statsMerged: boolean; stoppingCleared: boolean }
+    | {
+          /**
+           * A turn finished and the phase transitioned to `Done`. Since
+           * the sound-notifications subsystem (SPEC_SOUND_NOTIFICATIONS_
+           * 2026_06_05.md §3.2), the event carries the outcome directly
+           * so downstream consumers (notification sounds, telemetry,
+           * future UI affordances) don't have to snapshot the slot to
+           * read it back from `state.turnPhase.outcome`. The reducer
+           * already computes `outcome` two lines earlier — this is a
+           * pure forwarding of an existing value.
+           */
+          type: "turn-ended";
+          outcome: TurnOutcome;
+          statsMerged: boolean;
+          stoppingCleared: boolean;
+      }
     | { type: "turn-reset" }
     | {
           /**

--- a/frontend/app/window/window-focus.ts
+++ b/frontend/app/window/window-focus.ts
@@ -1,0 +1,49 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Window-focus signal — reactive accessor for "is the OS window in
+ * foreground AND visible?". Used by the sound-notifications subsystem
+ * (SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §4.7) to suppress sound when
+ * the user is already looking at the originating pane in the focused
+ * window. Self-contained — the only consumer in v1 is the sound
+ * service, but the signal is intentionally general so future
+ * consumers can subscribe without re-implementing it.
+ *
+ * Combines `document.hasFocus()` (DOM focus) and
+ * `document.visibilityState === "visible"` (tab/window visibility) —
+ * both must hold for the signal to be true. A minimized window will
+ * report `document.hasFocus() === false`, and a backgrounded tab
+ * reports `visibilityState === "hidden"`.
+ */
+
+import { createSignal, type Accessor } from "solid-js";
+
+let cached: Accessor<boolean> | null = null;
+
+function compute(): boolean {
+    if (typeof document === "undefined" || typeof window === "undefined") return true;
+    return document.hasFocus() && document.visibilityState === "visible";
+}
+
+/**
+ * Returns a SolidJS accessor that reactively tracks whether the
+ * current window is OS-focused and visible. The first call wires
+ * up `focus` / `blur` / `visibilitychange` listeners; subsequent
+ * calls return the cached accessor (idempotent).
+ */
+export function makeWindowFocusSignal(): Accessor<boolean> {
+    if (cached) return cached;
+    const [focused, setFocused] = createSignal(compute());
+    const update = () => setFocused(compute());
+    window.addEventListener("focus", update);
+    window.addEventListener("blur", update);
+    document.addEventListener("visibilitychange", update);
+    cached = focused;
+    return focused;
+}
+
+/** Test/dev helper — resets the cached signal so a new one is built. */
+export function __resetWindowFocusSignal(): void {
+    cached = null;
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1342,6 +1342,16 @@ declare global {
         "conn:*"?: boolean;
         "network:lan_discovery"?: boolean;
         "voice:enabled"?: boolean;
+        "notify:*"?: boolean;
+        "notify:sounds:enabled"?: boolean;
+        "notify:sounds:volume"?: number;
+        "notify:sounds:suppresswhenfocused"?: boolean;
+        "notify:sound:agent.turn.complete"?: boolean;
+        "notify:sound:agent.turn.error"?: boolean;
+        "notify:sound:agent.turn.interrupted"?: boolean;
+        "notify:sound:agent.message.accepted"?: boolean;
+        "notify:sound:agent.message.rejected"?: boolean;
+        "notify:sound:agent.stream.stalled"?: boolean;
         "dnd:*"?: boolean;
         "dnd:enabled"?: boolean;
         "dnd:maxfilesizemb"?: number;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1352,6 +1352,9 @@ declare global {
         "notify:sound:agent.message.accepted"?: boolean;
         "notify:sound:agent.message.rejected"?: boolean;
         "notify:sound:agent.stream.stalled"?: boolean;
+        "notify:tooltones:enabled"?: boolean;
+        "notify:tooltones:volume"?: number;
+        "notify:tooltones:scope"?: "all" | "focused";
         "dnd:*"?: boolean;
         "dnd:enabled"?: boolean;
         "dnd:maxfilesizemb"?: number;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -224,6 +224,24 @@
         "notify:sound:agent.stream.stalled": {
           "type": "boolean",
           "description": "Play a sound when the agent stream stalls (diagnostic — fires before the bounded watchdog forces an exit). Default true."
+        },
+        "notify:tooltones:enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Play a subliminal synth tone for every agent tool call. Default true. See docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md."
+        },
+        "notify:tooltones:volume": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.15,
+          "description": "Independent gain for tool-call tones, 0.0 (silent) to 1.0. Layered below the shared master gain — turning the master off silences both. Default 0.15."
+        },
+        "notify:tooltones:scope": {
+          "type": "string",
+          "enum": ["all", "focused"],
+          "default": "all",
+          "description": "Which panes play tool-call tones. 'all' (default) plays for every pane in every window; 'focused' plays only for the focused pane in the focused OS window."
         }
       },
       "additionalProperties": false,

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -181,6 +181,49 @@
         "network:lan_discovery": {
           "type": "boolean",
           "description": "Enable mDNS-based discovery of other AgentMux instances on the same host and LAN. Defaults to false to avoid the Windows Firewall prompt; toggle from the HostPopover panel. See specs/lan-discovery-toggle.md."
+        },
+        "notify:*": {
+          "type": "boolean"
+        },
+        "notify:sounds:enabled": {
+          "type": "boolean",
+          "description": "Master enable for notification sounds. Default true. See docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md."
+        },
+        "notify:sounds:volume": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.6,
+          "description": "Notification sound volume, 0.0 (silent) to 1.0 (full). Default 0.6."
+        },
+        "notify:sounds:suppresswhenfocused": {
+          "type": "boolean",
+          "default": true,
+          "description": "Suppress a pane's sound when that pane is focused AND the OS window is in foreground (the user can already see the visual signal)."
+        },
+        "notify:sound:agent.turn.complete": {
+          "type": "boolean",
+          "description": "Play a sound when an agent turn completes normally. Default true."
+        },
+        "notify:sound:agent.turn.error": {
+          "type": "boolean",
+          "description": "Play a sound when an agent turn ends with an error (errored, submit-timed-out, stream-stalled). Default true."
+        },
+        "notify:sound:agent.turn.interrupted": {
+          "type": "boolean",
+          "description": "Play a sound when an agent turn is stopped or interrupted. Default true."
+        },
+        "notify:sound:agent.message.accepted": {
+          "type": "boolean",
+          "description": "Play a sound when the backend accepts a queued pending message. Default true."
+        },
+        "notify:sound:agent.message.rejected": {
+          "type": "boolean",
+          "description": "Play a sound when the backend rejects a queued pending message. Default true."
+        },
+        "notify:sound:agent.stream.stalled": {
+          "type": "boolean",
+          "description": "Play a sound when the agent stream stalls (diagnostic — fires before the bounded watchdog forces an exit). Default true."
         }
       },
       "additionalProperties": false,

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -69,6 +69,11 @@
     // "notify:sound:agent.message.rejected":    true,
     // "notify:sound:agent.stream.stalled":      true,
 
+    // -- Tool-call tones (subliminal per-tool "voice") --
+    // "notify:tooltones:enabled":               true,
+    // "notify:tooltones:volume":                0.15,
+    // "notify:tooltones:scope":                 "all",  // "all" or "focused"
+
     // -- Other --
     // "widget:icononly":           false,
     // "blockheader:showblockids": false,

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -58,6 +58,17 @@
     // "conn:wshenabled":          true,
     // "conn:askbeforewshinstall": true,
 
+    // -- Notification sounds --
+    // "notify:sounds:enabled":                  true,
+    // "notify:sounds:volume":                   0.6,
+    // "notify:sounds:suppresswhenfocused":      true,
+    // "notify:sound:agent.turn.complete":       true,
+    // "notify:sound:agent.turn.error":          true,
+    // "notify:sound:agent.turn.interrupted":    true,
+    // "notify:sound:agent.message.accepted":    true,
+    // "notify:sound:agent.message.rejected":    true,
+    // "notify:sound:agent.stream.stalled":      true,
+
     // -- Other --
     // "widget:icononly":           false,
     // "blockheader:showblockids": false,


### PR DESCRIPTION
## Summary

- **Sound notifications subsystem** (`frontend/app/notification/sound/`): plays synthesized tones on agent turn outcomes (complete, error, interrupted, stalled, message accepted/rejected). Gated by `notify:sounds:enabled` master switch, per-event settings, a 300 ms coalesce window, focus suppression (suppressed when pane is focused + window is foregrounded, per `notify:sounds:suppresswhenfocused`), and a replay-mode gate so historical session replay never emits audio.

- **Per-tool subliminal tone voice**: every `tool-started` event plays a short synth syllable — a distinct curated pattern for the 8 canonical tools (`Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `Task`, `Agent`) and an FNV-1a-hashed pentatonic fallback for any MCP / unknown tool. Routed through a lowpass BiquadFilter at 2.5 kHz so the tones are subliminal (feel the agent working without conscious distraction). Gated by `notify:tooltones:enabled`, `notify:tooltones:scope` (`all` | `focused`), and replay mode.

- **AgentPaneEvent multicast** (`agent-pane-state-store.ts`): added `addEventListener(sink)` that maintains a `Set<EventSink>` alongside the existing single-sink `setEventSink`. Backward-compatible; existing callers unchanged.

- **Settings plumbing**: 9 `notify:sounds:*` + 3 `notify:tooltones:*` keys wired through `wconfig/types.rs` → `gotypes.d.ts` → `settings-template.jsonc` → `schema/settings.json`.

- **Specs**: `docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md` and `docs/specs/SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md`.

- **Test coverage**: 165 sound tests + 41 tool-tones tests + extended store/reducer tests (all passing).

## New files

| File | Role |
|------|------|
| `frontend/app/notification/sound/sounds.ts` | Sound registry (6 SoundDefs) |
| `frontend/app/notification/sound/sound-events.ts` | Typed multicast bus |
| `frontend/app/notification/sound/sound-player.ts` | AudioContext + buffer cache + master gain |
| `frontend/app/notification/sound/synth-fallback.ts` | Two-tone oscillator envelopes per category |
| `frontend/app/notification/sound/sound-service.ts` | Orchestrator: settings, focus, coalesce, replay gate |
| `frontend/app/notification/sound/tool-tones.ts` | Curated palette + FNV-1a hash fallback |
| `frontend/app/notification/sound/tool-tones-player.ts` | ToolTonesPlayer: chain, coalesce, volume |
| `frontend/app/notification/sound/index.ts` | Public re-exports |
| `frontend/app/window/window-focus.ts` | `makeWindowFocusSignal()` accessor |

## Test plan

- [ ] Verify `npm test` passes (165 sound + 41 tool-tones + store/reducer tests)
- [ ] Open an Agent pane, run a task to completion → hear a clean two-tone chime on completion
- [ ] Deliberately cause an error → hear the error tone
- [ ] Stop an in-progress turn → hear the interrupted tone
- [ ] Watch the console during a multi-tool run → subtle subliminal pings on each tool call (Read = falling B4→A4, Bash = low triangle, etc.)
- [ ] Set `notify:tooltones:scope` to `"focused"` → tones only for the focused pane
- [ ] Set `notify:sounds:enabled` to `false` → all sounds suppressed
- [ ] Focus the agent pane, run a turn → no notification sound (focus-suppressed); tones still play
- [ ] Alt-tab away, run a turn → notification sound fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)