### PR TITLE
chore(scripts): import-agents.sh — migrate user agents across version data dirs

### DIFF
--- a/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
+++ b/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
@@ -1,5 +1,5 @@
 ---
-type: minor
+type: patch
 ---
 
-feat(app-api): agent.define — create/upsert agent definition via HTTP RPC without restart
+fix(scripts): import-agents.sh — scan version dirs for channel instead of deriving from git branch

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -13,20 +13,10 @@
 set -euo pipefail
 
 AGENTMUX_DIR="${AGENTMUX_DIR:-$HOME/.agentmux}"
-
-# Auto-detect channel from the current git branch when CHANNEL is not set.
-# The portable build channel name is: dev-portable-<branch>-<sha1(branch)[:6]>
-# where sha1 is of the branch name string itself (not the commit).
-if [ -z "${CHANNEL:-}" ]; then
-    _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
-    # Apply the same slug sanitization as scripts/package.sh BRANCH_SLUG:
-    # replace non-alphanumeric/dot/dash chars with '-', cap at 20 chars.
-    _branch_slug=$(printf '%s' "$_branch" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-20)
-    _branch_hash=$(printf '%s' "$_branch" | sha1sum | cut -c1-6 2>/dev/null \
-                   || printf '%s' "$_branch" | shasum | cut -c1-6)
-    CHANNEL="dev-portable-${_branch_slug}-${_branch_hash}"
-fi
-CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"
+CHANNEL="${CHANNEL:-}"
+# Pre-compute CHANNEL_DIR when CHANNEL is supplied via env var or --channel.
+# import_into() sets both when it auto-detects the channel.
+CHANNEL_DIR="${CHANNEL:+$AGENTMUX_DIR/channels/$CHANNEL}"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -42,6 +32,17 @@ now_ms() { printf '%s000\n' "$(date +%s)"; }
 # Find every objects.db under the agentmux dir
 all_dbs() {
     find "$AGENTMUX_DIR" -name "objects.db" 2>/dev/null | sort
+}
+
+# Scan $AGENTMUX_DIR/channels for the channel that contains a given version's
+# data dir. More robust than deriving the channel name from the current git
+# branch (which breaks after a channel rename or when the user has switched
+# branches since the build was created).
+detect_channel_for_version() {
+    local version="$1"
+    find "$AGENTMUX_DIR/channels" -maxdepth 4 \
+        -path "*/versions/$version/data/db/objects.db" 2>/dev/null | \
+        head -1 | sed -e "s|$AGENTMUX_DIR/channels/||" -e 's|/versions/.*||'
 }
 
 # ── catalog ──────────────────────────────────────────────────────────────────
@@ -80,6 +81,19 @@ catalog() {
 import_into() {
     local target_version="$1"
     local name_filter="$2"   # comma-separated names, or "" for all
+
+    # Auto-detect channel by scanning existing version dirs if not specified.
+    if [ -z "$CHANNEL" ]; then
+        CHANNEL=$(detect_channel_for_version "$target_version")
+        if [ -z "$CHANNEL" ]; then
+            echo "ERROR: No channel found containing version $target_version." >&2
+            echo "       Launch version $target_version at least once, or pass --channel." >&2
+            echo "       Available channels: $(ls "$AGENTMUX_DIR/channels/" 2>/dev/null | tr '\n' '  ')" >&2
+            exit 1
+        fi
+        CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"
+    fi
+
     local target_db="$CHANNEL_DIR/versions/$target_version/data/db/objects.db"
 
     if [ ! -f "$target_db" ]; then

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -40,7 +40,9 @@ all_dbs() {
 # branches since the build was created).
 detect_channel_for_version() {
     local version="$1"
-    find "$AGENTMUX_DIR/channels" -maxdepth 4 \
+    # Path depth from $AGENTMUX_DIR/channels:
+    #   <channel>/versions/<version>/data/db/objects.db  → 6 levels
+    find "$AGENTMUX_DIR/channels" -maxdepth 6 \
         -path "*/versions/$version/data/db/objects.db" 2>/dev/null | \
         head -1 | sed -e "s|$AGENTMUX_DIR/channels/||" -e 's|/versions/.*||'
 }
@@ -195,6 +197,20 @@ import_into() {
                 ((skipped++)) || true
                 continue
             fi
+
+            # Copy system prompt and MCP skills — the agent's behaviour config.
+            # Both tables use agent_id FK, so they must follow the def INSERT.
+            # Silent no-op when source lacks these tables (pre-v2 DBs).
+            sqlite3 "$src_win" \
+                "ATTACH '$tgt_win' AS dst;
+                 INSERT OR IGNORE INTO dst.db_agent_content (agent_id, content_type, content, updated_at)
+                 SELECT agent_id, content_type, content, updated_at
+                 FROM db_agent_content WHERE agent_id='$def_id';" 2>/dev/null || true
+            sqlite3 "$src_win" \
+                "ATTACH '$tgt_win' AS dst;
+                 INSERT OR IGNORE INTO dst.db_agent_skills (id, agent_id, name, trigger, skill_type, description, content, created_at)
+                 SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
+                 FROM db_agent_skills WHERE agent_id='$def_id';" 2>/dev/null || true
 
             # Also populate the consolidated db_agents table (schema v4+).
             # agent_def_list() and instance_list() read db_agents; skipping this


### PR DESCRIPTION
## Summary

- Adds `scripts/import-agents.sh` to migrate user-created agent definitions across the per-version data dirs that portable builds create under `channels/<channel>/versions/<v>/`
- Copies definition rows via SQLite ATTACH and creates stub `db_agent_instances` rows (status=stopped, instance_name=<agent name>) so agents appear in My Agents without a full restart — just reopen the agent pane
- Adds two spec files: window drag handle and agent fork (with corrected two-list structure)

## Problem

`data_paths.rs` version-scopes all Portable builds: `channels/<ch>/versions/<v>/data/`. Agents created in 0.43.0 are invisible in 0.43.1 and 0.43.2. `ListRecentSessionsCommand` queries instances not definitions, so inserting a definition alone isn't enough — a stub instance is required.

## Usage

```bash
scripts/import-agents.sh                        # catalog all user agents across all data dirs
scripts/import-agents.sh --to 0.43.2            # import all into target version
scripts/import-agents.sh --to 0.43.2 --name Maks,Maksi,Mopeo
```

## Test plan

- [ ] Run `--list` — shows agents from all channels and dev dirs
- [ ] Run `--to <version>` — definitions and stub instances appear in target DB
- [ ] Reopen agent pane in target build — agents visible in My Agents with stopped status
- [ ] Re-run — duplicate agents skipped, not doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)