### PR TITLE
docs(linux): catch up BUILD.md, README, cef-build guide, new linux.md operator guide

### DIFF
--- a/.changesets/1780778820-docs-linux-catch-up-build-md-readme-cef-build-guide-and-new--iq10.md
+++ b/.changesets/1780778820-docs-linux-catch-up-build-md-readme-cef-build-guide-and-new--iq10.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(linux): catch up BUILD.md, README, cef-build guide, and new linux.md operator guide

--- a/BUILD.md
+++ b/BUILD.md
@@ -48,17 +48,20 @@ These instructions cover setting up dependencies and building AgentMux from sour
 
 #### Linux
 
-1. **Install dependencies** (Debian/Ubuntu):
+AgentMux embeds Chromium via CEF — no system WebKitGTK or WebView2 required.
+
+1. **Install build tools** (Debian/Ubuntu):
    ```bash
-   sudo apt install zip libwebkit2gtk-4.1-dev \
-     build-essential curl wget file libssl-dev \
-     libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+   sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip
    ```
+   CMake and Ninja are required by `cef-dll-sys`, which builds CEF's C wrapper at compile time.
 
 2. **Install Rust**:
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
+
+> **Note — `libcef.so`:** Running on Linux requires a compatible `libcef.so`. `task package:linux` downloads the pre-built binary automatically. If you need to rebuild libcef from source (for CEF patches), see [`docs/cef-build/build-patched-libcef.md`](docs/cef-build/build-patched-libcef.md).
 
 ### Install Task
 
@@ -204,8 +207,9 @@ task dev
 
 # 5. Test changes in running app
 
-# 6. Bump version
-./bump-version.sh patch --message "Description of change"
+# 6. Add a changeset (describes your change for the release log)
+task changeset -- patch "fix(area): short description"
+# or: task changeset -- minor "feat(area): description"
 
 # 7. Commit and push
 git add -p
@@ -224,33 +228,43 @@ gh pr create --title "Feature" --body "Description"
 
 After building, you'll have:
 
+#### Windows (portable ZIP)
+
 ```
-dist/bin/
-└── agentmux-srv-{version}-windows.x64.exe       # Rust backend (sidecar)
-
-target/release/
-├── agentmux-cef.exe                              # Host
-└── agentmux-launcher.exe                         # Portable launcher
-
-~/Desktop/
-└── agentmux-{version}-x64-portable/             # Portable build
-    ├── agentmux.exe                             # Launcher
-    └── runtime/
-        ├── agentmux-{version}.exe               # Host
-        ├── agentmux-srv-{version}-windows.x64.exe  # Backend
-        ├── libcef.dll                           # CEF runtime
-        └── frontend/                            # Web UI
+~/Desktop/agentmux-{version}+g{sha}.{stamp}-x64-portable/
+├── agentmux.exe                             # Launcher (entry point)
+└── runtime/
+    ├── agentmux-{version}.exe               # CEF host
+    ├── agentmux-srv-{version}-windows.x64.exe  # Backend
+    ├── libcef.dll                           # CEF runtime
+    └── frontend/                            # Bundled web UI
 ```
 
-### Component Sizes (v0.31.0+)
+#### Linux (AppImage)
 
-| Component | Size | Purpose |
-|-----------|------|---------|
-| `agentmux.exe` (launcher) | ~325 KB | Portable launcher |
-| `agentmux-cef.exe` | ~8 MB | Host (Rust + Chromium) |
-| `agentmux-srv.exe` | ~4 MB | Rust async backend server |
-| CEF runtime (libcef + paks) | ~160 MB | Bundled Chromium |
-| **Portable ZIP** | ~156 MB | Compressed with CEF bundle |
+```
+~/Desktop/AgentMux_{version}+g{sha}.{stamp}_amd64.AppImage
+└── usr/bin/
+    ├── agentmux-launcher    # AppImage entry point (supervises srv + host)
+    ├── agentmux-cef         # CEF host binary
+    ├── agentmux-srv-{version}-linux.x64  # Backend
+    ├── libcef.so            # Chromium runtime
+    ├── libEGL.so / libGLESv2.so          # GPU abstraction
+    ├── *.pak / icudtl.dat / …            # Chromium resources
+    └── frontend/            # Bundled web UI
+```
+
+On first launch the AppImage extracts itself to `~/.local/share/agentmux/extracted/<version>/` for faster subsequent starts (~1 s vs ~3 s cold from FUSE).
+
+### Component Sizes
+
+| Component | Windows | Linux |
+|-----------|---------|-------|
+| Launcher | ~325 KB | ~325 KB |
+| CEF host | ~8 MB | ~17 MB |
+| Backend (agentmux-srv) | ~4 MB | ~4 MB |
+| CEF runtime (libcef + paks) | ~160 MB | ~620 MB |
+| **Portable build** | ~156 MB ZIP | ~220 MB AppImage |
 
 ---
 
@@ -313,7 +327,7 @@ ls -lh dist/bin/agentmux-srv-*
 
 **Fix (Linux):**
 ```bash
-sudo apt install libwebkit2gtk-4.1-dev build-essential libssl-dev
+sudo apt install cmake ninja-build build-essential libssl-dev
 ```
 
 ### Issue: Frontend not loading in dev mode
@@ -361,8 +375,8 @@ Artifacts are uploaded to GitHub Releases on tagged commits.
 ### Local Release Build
 
 ```bash
-# 1. Bump version
-./bump-version.sh patch --message "v0.31.x release"
+# 1. Add a changeset
+task changeset -- patch "fix(scope): description"
 
 # 2. Rebuild Rust binaries
 task build:backend
@@ -396,8 +410,10 @@ git push origin main --tags
 
 ### Linux
 
-- Uses **DEB** (Debian/Ubuntu) and **AppImage** (universal)
-- WebKitGTK required: `libwebkit2gtk-4.1-dev`
+- **AppImage** (universal) and **DEB** (Debian/Ubuntu) produced by CI.
+- CEF bundles Chromium — no system WebKitGTK required.
+- Default display: **XWayland** (`--ozone-platform=x11`). Set `AGENTMUX_OZONE_PLATFORM=wayland` for native Wayland (experimental).
+- Window drag and right-click on title-bar require the patched `libcef.so` (included in all release AppImages). See `docs/cef-build/build-patched-libcef.md`.
 
 ---
 
@@ -442,6 +458,6 @@ npm run build:prod
 | **Build host** | `task build:host` |
 | **Bundle runtime** | `task bundle` |
 | **Portable ZIP** | `task package` |
-| **Bump version** | `./bump-version.sh patch` |
+| **Add changeset** | `task changeset -- patch "description"` |
 | **Run tests** | `npm test` |
 | **Verify versions** | `bump verify` |

--- a/BUILD.md
+++ b/BUILD.md
@@ -336,8 +336,8 @@ sudo apt install cmake ninja-build build-essential libssl-dev
 
 **Fix:**
 ```bash
-# Check if port 1420 is in use
-netstat -ano | grep :1420
+# Check if port 5173 is in use
+netstat -ano | grep :5173
 
 # Clear and reinstall
 rm -rf node_modules package-lock.json

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 Platform-specific:
 - **Windows:** Visual Studio Build Tools (CMake + Ninja ship with VS, but Ninja must be on PATH — see CLAUDE.md)
 - **macOS:** Xcode Command Line Tools, `brew install cmake ninja`
-- **Linux:** Build essentials, `apt install cmake ninja-build`
+- **Linux:** `apt install cmake ninja-build build-essential` — CEF bundles Chromium, no WebKitGTK required. See [`docs/linux.md`](docs/linux.md) for the full Linux operator guide.
 
 ### Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,12 @@
 
 Project documentation organized by type.
 
-| Directory | Purpose |
-|-----------|---------|
+| Path | Purpose |
+|------|---------|
+| [`linux.md`](linux.md) | Linux operator guide — AppImage structure, display server, logging, diagnostics, known limitations |
 | `analysis/` | Technical analysis, audits, benchmarks, root cause investigations |
 | `api/` | User-facing API guides (start with `api/getting-started.md`) |
+| `cef-build/` | Guides for building the patched `libcef.so` from source |
 | `investigations/` | Active bug investigations with reproduction steps |
 | `reports/` | Session reports, handoff notes, bug fix summaries |
 | `research/` | Research into technologies, approaches, and design options |

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -9,14 +9,19 @@
 
 ## What this libcef contains that upstream's doesn't
 
-1. **`CefWindow::BeginWindowDrag()`** — appended to the `_cef_window_t` C struct, called via raw FFI by `agentmux-cef/src/ui_tasks.rs::StartWindowDragTask` to dispatch `xdg_toplevel.move` (Wayland) / `_NET_WM_MOVERESIZE` (X11) on the user's left-click drag of the title-bar area. Without this, AgentMux PR #663's drag IPC is a no-op.
-2. **Transparency broadening** — Chad Nelson's `SetBackgroundOpaque(false)` IPC support extended to views-hosted browsers. Foundation for future Wayland window transparency. Not yet user-visible.
+1. **`CefWindow::BeginWindowDrag()`** — appended to the `_cef_window_t` C struct, called via raw FFI by `agentmux-cef/src/ui_tasks.rs::StartWindowDragTask` to dispatch `xdg_toplevel.move` (Wayland) / `_NET_WM_MOVERESIZE` (X11/XWayland) on the user's left-click drag of the title-bar area.
+2. **Right-click passthrough on HTCAPTION** — lets right-clicks on the drag region reach the renderer (for the pane-header context menu).
+3. **Transparency broadening** — deferred `SetBackgroundOpaque(false)` + WebContents transparency cascade. Foundation for Wayland window transparency. Root cause identified (views::SolidBackground / kColorPrimaryBackground); fix in progress.
 
-Both patches live in the AgentMux fork of CEF:
-- **Repo:** https://github.com/a5af/cef
-- **Branch:** `agentmux/7680-drag-rightclick-and-transparency`
-- **Base:** Chromium 146.0.7680.179
-- **HEAD:** `5ab41b6` at last build (2026-05-01)
+Patches live in the AgentMux fork of CEF:
+- **Repo:** https://github.com/agentmuxai/cef (canonical) / https://github.com/a5af/cef (personal fork, kept in sync)
+- **Branch:** `agentmux/7778-drag-rightclick-and-transparency`
+- **Base:** Chromium 148 (CEF branch 7778)
+- **HEAD:** `c87bca497` ("views: deferred top-level transparent bg + observer cleanup")
+- **Rust binding:** `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` — adds `begin_window_drag` field to `_cef_window_t` in the linux_x86_64 binding
+- **Workspace patch in `Cargo.toml`:** `[patch.crates-io] cef-dll-sys = { git = "…AgentU-asaf/cef-rs", rev = "515b3ac5…" }`
+
+> **Annotation history:** `BeginWindowDrag` was annotated `added=14600` on the old CEF 146 branch, then briefly changed to `added=NEXT` during the 148 port (this caused a CppToC type-tag mismatch making all drags silently no-op), then corrected to `added=14800`. The current branch has the correct `added=14800` annotation.
 
 ---
 
@@ -50,7 +55,7 @@ wget https://bitbucket.org/chromiumembedded/cef/raw/master/tools/automate/automa
 # First sync (downloads chromium ~99 GB, takes hours)
 python3 automate-git.py \
   --download-dir=$(pwd) \
-  --branch=7680 \
+  --branch=7778 \
   --no-distrib \
   --no-build
 ```
@@ -59,9 +64,9 @@ python3 automate-git.py \
 
 ```bash
 cd ~/cef-build/chromium_git/cef
-git remote add a5af https://github.com/a5af/cef.git
-git fetch a5af agentmux/7680-drag-rightclick-and-transparency
-git checkout a5af/agentmux/7680-drag-rightclick-and-transparency
+git remote add agentmuxai https://github.com/agentmuxai/cef.git
+git fetch agentmuxai agentmux/7778-drag-rightclick-and-transparency
+git checkout agentmuxai/agentmux/7778-drag-rightclick-and-transparency
 
 # Mirror to the chromium-side cef checkout
 rsync -a --delete --exclude=.git ~/cef-build/chromium_git/cef/ ~/cef-build/chromium_git/chromium/src/cef/

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -47,7 +47,7 @@ muxlog host '\[fe\]'           # frontend-only lines
 muxlog host cat                # full host log (not tailed)
 ```
 
-The launcher writes an append-only JSONL event log to `<data-dir>/data/launcher-events.log` (crash forensics — one JSON object per line). The saga journal is a separate SQLite database at `<data-dir>/data/db/launcher-sagas.db` — that is what `--diag sagas` reads.
+The launcher writes an append-only JSONL event log to `~/.agentmux/channels/<ch>/versions/<v>/data/launcher-events.log` (crash forensics — one JSON object per line). The saga journal is a separate SQLite database at `~/.agentmux/channels/<ch>/versions/<v>/data/db/launcher-sagas.db` — that is what `--diag sagas` reads.
 
 `$AGENTMUX_LOG_DIR` inside AgentMux terminals points to `~/.agentmux/logs/` (stable channel) or `~/.agentmux-dev/logs/` (dev builds). The host log lives in the per-instance data dir; a pointer file (`current-host-v<v>.path`) in the shared logs dir lets `muxlog host` resolve it automatically.
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,92 @@
+# Linux — operator guide
+
+## AppImage structure
+
+The AppImage entry point is the **launcher** (since v0.42.x, A0 / PR #1286). When you run the AppImage:
+
+1. `AppRun` → `usr/bin/linux-apprun.sh`
+2. On first launch, the script extracts itself to `~/.local/share/agentmux/extracted/<version>/` (~2–3 s one-time). Subsequent launches re-exec from the cache (~1 s).
+3. `linux-apprun.sh` execs `usr/bin/agentmux-launcher`
+4. The launcher spawns `agentmux-srv` (backend) and `agentmux-cef` (CEF host) as a supervised process group via `PR_SET_PDEATHSIG`
+5. The launcher binds a Unix-socket IPC server; the host connects and reports window lifecycle events
+6. The host opens the main window and loads the frontend from the embedded `usr/bin/frontend/`
+
+**AppImage contents:**
+
+```
+usr/bin/
+├── agentmux-launcher              # AppRun entry point — supervises srv + host
+├── agentmux-cef                   # CEF host binary
+├── agentmux-srv-{version}-linux.x64  # Rust async backend
+├── libcef.so                      # Chromium runtime (~613 MB stripped)
+├── libEGL.so / libGLESv2.so       # GPU abstraction
+├── *.pak / icudtl.dat / …         # Chromium resources
+└── frontend/                      # Bundled web UI
+```
+
+## Display server
+
+By default, AgentMux uses **XWayland** (`--ozone-platform=x11`) under any Wayland compositor (Mutter, KWin, etc.). This default provides the best frame-rate consistency across GPU configurations (5–8× fewer stalls than native Wayland on the tested hardware/driver set).
+
+Set `AGENTMUX_OZONE_PLATFORM=wayland` to use native Wayland (`xdg_toplevel`). This is experimental.
+
+## Window drag
+
+Title-bar drag and floating-pane header drag use `CefWindow::BeginWindowDrag()` — a native AgentMux patch that dispatches `xdg_toplevel.move` (Wayland) or `_NET_WM_MOVERESIZE` (X11/XWayland). The patched `libcef.so` must be present (all release AppImages include it).
+
+Dev builds compile with `--features patched-libcef` automatically via `task build:host:linux`.
+
+See [`docs/cef-build/build-patched-libcef.md`](cef-build/build-patched-libcef.md) for building libcef from source.
+
+## Log access
+
+```bash
+muxlog host                    # tail the CEF host log ([fe] lines = frontend)
+muxlog srv                     # tail the backend sidecar log
+muxlog host '\[fe\]'           # frontend-only lines
+muxlog host cat                # full host log (not tailed)
+```
+
+The launcher writes an append-only JSONL event log to `<data-dir>/data/launcher-events.log` (crash forensics — one JSON object per line). The saga journal is a separate SQLite database at `<data-dir>/data/db/launcher-sagas.db` — that is what `--diag sagas` reads.
+
+`$AGENTMUX_LOG_DIR` inside AgentMux terminals points to `~/.agentmux/logs/` (stable channel) or `~/.agentmux-dev/logs/` (dev builds). The host log lives in the per-instance data dir; a pointer file (`current-host-v<v>.path`) in the shared logs dir lets `muxlog host` resolve it automatically.
+
+## Launcher diagnostics
+
+The launcher runs the full reducer + saga coordinator on Linux (since v0.42.x A1 / PR #1288 — same as Windows). Offline diagnostic commands (no running instance required):
+
+```bash
+./AgentMux_*.AppImage --diag sagas   # dump the saga journal (SQLite log of lifecycle events)
+```
+
+:::note[Windows-only diagnostics]
+`--diag wrr` (window/pool/reducer state) and `--diag srv` (live sidecar query) are Windows-only today — the Unix-domain-socket IPC client for these tools is not yet implemented. See [Platform support](/internals/platform-support/).
+:::
+
+## Remote debugging
+
+The CEF host starts a remote debugger on port 9222 (release builds) or 9223 (dev builds). Connect from a Chromium-based browser:
+
+1. Start AgentMux
+2. Open `chrome://inspect` in another Chromium browser
+3. Under "Remote Target", click "Configure…" and add `localhost:9222` (release builds) or `localhost:9223` (dev builds via `task dev`)
+4. The AgentMux renderer process appears under "Remote Target"
+
+## Single-instance enforcement
+
+The launcher enforces single-instance per `(data_dir, version)` pair via a Unix domain socket. Socket location:
+
+- Primary: `$XDG_RUNTIME_DIR/agentmux/{hash16}.sock`
+- Fallback (no `$XDG_RUNTIME_DIR`): `/tmp/agentmux-{uid}/{hash16}.sock`
+
+Opening a second instance sends an `open_new_window` command to the running launcher and exits immediately.
+
+## Known limitations (as of v0.43.x)
+
+| Feature | Status |
+|---|---|
+| Splash screen | Not yet implemented (Windows + macOS have native splash screens) |
+| Window transparency | Under investigation — root cause identified (views::SolidBackground), fix blocked on Mutter wl_surface visibility without opaque base pixel |
+| Native Wayland (non-XWayland) | Experimental; set `AGENTMUX_OZONE_PLATFORM=wayland` |
+| Linux .deb package | Produced by CI builder (`agentmuxai/agentmux-builder`) only, not by `task package:linux` |
+| Owned-window floaters (`transient-for` + destroy-with-parent) | Phase B, not yet implemented — floaters open as independent top-level windows |

--- a/docs/specs/SPEC_LINUX_DOCS_UPDATE_2026_06_06.md
+++ b/docs/specs/SPEC_LINUX_DOCS_UPDATE_2026_06_06.md
@@ -1,0 +1,276 @@
+# SPEC — Linux documentation catch-up
+
+**Date:** 2026-06-06
+**Author:** AgentU
+**Status:** Ready to implement
+**Scope:** `BUILD.md`, `README.md`, new `docs/linux.md`
+**Motivated by:** ~4 major Linux milestones (CEF migration, AppImage launcher, Unix-socket IPC, X11 ozone default, native window drag) shipped since the Linux docs were last updated. Docs still describe the old WebKitGTK/Tauri architecture.
+
+---
+
+## 0. Audit summary — what is wrong today
+
+### BUILD.md
+
+| Location | Wrong | Correct |
+|---|---|---|
+| Line 53 — Linux prerequisites | `apt install zip libwebkit2gtk-4.1-dev … libayatana-appindicator3-dev librsvg2-dev` | CEF build: `cmake ninja-build zip build-essential` + CEF's own `install-build-deps.sh`. `libwebkit2gtk` is gone — CEF bundles Chromium. |
+| Lines 314–316 — "Fix (Linux)" troubleshooting | "missing libwebkit2gtk" fix | Obsolete. CEF has no WebKitGTK dep. Remove. |
+| Lines 397–400 — Platform notes Linux | "Uses DEB and AppImage. WebKitGTK required." | CEF runtime bundled in AppImage; no system-level WebKitGTK. Remove that line. |
+| Lines 228–253 — Build output tree + component sizes | Windows-only (`dist/cef-dev/`, `.exe`) | Add Linux AppImage tree; update component sizes. |
+| Dev workflow step 6 | `./bump-version.sh patch` | `task changeset -- patch "..."` (changesets RFC #857). |
+
+### README.md
+
+| Location | Wrong / missing |
+|---|---|
+| §Build commands | `task package:linux` correct, but missing context on CEF build prerequisites. |
+| Nowhere | X11 ozone default (XWayland), opt-out to native Wayland via `AGENTMUX_OZONE_PLATFORM=wayland`. |
+| Nowhere | Launcher is the AppImage entry point (A0, #1286). The host is no longer `exec`'d directly. |
+| Nowhere | Linux limitations: no native splash yet; transparency not yet working (CEF Wayland transparency under investigation). |
+| Nowhere | `patched-libcef` requirement: window drag, right-click-on-title-bar, and eventual transparency require the `agentmux/7778-drag-rightclick-and-transparency` build of `libcef.so`. Pre-built binaries ship with it; dev builds use `task build:host:linux`. |
+
+### docs/cef-build/build-patched-libcef.md
+
+Out of date — still references CEF 146 (`agentmux/7680-drag-rightclick-and-transparency`) and the old a5af/cef fork. Current state:
+- CEF 148 (Chromium 148)
+- Branch `agentmuxai/cef@agentmux/7778-drag-rightclick-and-transparency`
+- Key fix: `BeginWindowDrag` annotation corrected to `added=14800` (was `added=NEXT`; the NEXT tag caused CppToC type-tag mismatch → silent drag no-op)
+- Binding: `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` (patched `cef-dll-sys`)
+
+---
+
+## 1. BUILD.md changes
+
+### 1.1 Replace Linux prerequisites (lines 49–67)
+
+Replace:
+```markdown
+#### Linux
+
+1. **Install dependencies** (Debian/Ubuntu):
+   ```bash
+   sudo apt install zip libwebkit2gtk-4.1-dev \
+     build-essential curl wget file libssl-dev \
+     libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+   ```
+```
+
+With:
+```markdown
+#### Linux
+
+AgentMux embeds Chromium via CEF — no system WebView2 or WebKitGTK required.
+
+1. **Install build tools** (Debian/Ubuntu):
+   ```bash
+   sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip
+   ```
+   CMake and Ninja are required by `cef-dll-sys` (builds CEF's C wrapper at compile time).
+
+2. **Install Rust**:
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+> **Note — `libcef.so`:** Running on Linux requires a compatible `libcef.so`. `task package:linux` builds the AppImage with the pre-built binary from the CI artifact store. If you need to rebuild libcef for CEF patches (window drag, transparency), see [`docs/cef-build/build-patched-libcef.md`](docs/cef-build/build-patched-libcef.md).
+```
+
+### 1.2 Add Linux build output tree to §Architecture
+
+After the Windows `dist/cef-dev/` tree, add:
+
+```markdown
+#### Linux (AppImage)
+
+```
+~/Desktop/
+└── AgentMux_<version>+g<sha>[.dirty].<stamp>_amd64.AppImage   # Self-contained AppImage
+    └── usr/bin/
+        ├── agentmux-launcher   # AppImage entry point (since A0, #1286)
+        ├── agentmux            # CEF host
+        ├── agentmux-srv-*.x64  # Rust async backend
+        ├── libcef.so           # Chromium runtime (~613 MB stripped)
+        └── *.pak / icudtl.dat / …  # Chromium resources
+```
+
+The launcher (`agentmux-launcher`) is the AppImage entry point. `AppRun` → `linux-apprun.sh` execs the launcher; the launcher spawns `agentmux-srv` and `agentmux` (the CEF host). On Linux, the launcher provides PR_SET_PDEATHSIG–based process supervision; the full Window/saga coordinator (A1, #1288) drives the same reducer as Windows via Unix-socket IPC.
+```
+
+### 1.3 Update component sizes table
+
+Add a Linux row or note:
+
+```markdown
+| Component | Windows | Linux |
+|-----------|---------|-------|
+| Launcher | ~325 KB | ~325 KB |
+| Host (agentmux / agentmux-cef) | ~8 MB | ~17 MB (includes `custom-protocol` feature) |
+| Backend (agentmux-srv) | ~4 MB | ~4 MB |
+| CEF runtime (libcef + paks) | ~160 MB | ~620 MB (libcef.so ~613 MB stripped) |
+| **AppImage / ZIP** | ~156 MB | ~220 MB |
+```
+
+### 1.4 Remove stale "Fix (Linux)" section
+
+Lines 314–316 reference `libwebkit2gtk-4.1-dev` as the fix for a rendering issue. This no longer applies. Delete the paragraph. If there's a replacement for common CEF startup issues, see §Known issues below.
+
+### 1.5 Update Linux platform notes
+
+Replace (lines 397–400):
+```markdown
+### Linux
+
+- Uses **DEB** (Debian/Ubuntu) and **AppImage** (universal)
+- WebKitGTK required: `libwebkit2gtk-4.1-dev`
+```
+
+With:
+```markdown
+### Linux
+
+- **AppImage** (universal) and **DEB** (Debian/Ubuntu) produced by CI.
+- CEF bundles Chromium — no system WebView2/WebKitGTK required.
+- Default display backend: **X11 via XWayland** (`--ozone-platform=x11`). Override with `AGENTMUX_OZONE_PLATFORM=wayland` for native Wayland (experimental).
+- Window drag, right-click on title-bar, and future transparency features require the patched `libcef.so` (bundled in all release AppImages). See `docs/cef-build/build-patched-libcef.md`.
+```
+
+### 1.6 Update dev workflow step 6 (version bump)
+
+Replace:
+```bash
+./bump-version.sh patch --message "Description of change"
+```
+
+With:
+```bash
+task changeset -- patch "fix(area): description"
+# or: task changeset -- minor "feat(area): description"
+```
+
+---
+
+## 2. README.md additions
+
+### 2.1 Linux-specific callout in §Getting started / §Build
+
+Add after the `task package:linux` entry:
+
+```markdown
+**Linux prerequisites:** `cmake ninja-build build-essential` (for the CEF C wrapper). See [BUILD.md](BUILD.md#linux) for full instructions.
+```
+
+### 2.2 Linux limitations section
+
+Add a new `### Linux` subsection under §Platform notes or §Known limitations:
+
+```markdown
+### Linux
+
+- **Display:** Runs on XWayland by default (`--ozone-platform=x11`). Set `AGENTMUX_OZONE_PLATFORM=wayland` for native Wayland.
+- **Splash screen:** Not yet implemented on Linux (Windows and macOS have native splash screens).
+- **Window transparency:** Under active development. The CEF Wayland transparency root cause is identified (views::SolidBackground / kColorPrimaryBackground); a fix is blocked on Mutter surface visibility behavior without an opaque base pixel.
+- **Window drag:** Requires the patched `libcef.so`. All release AppImages include it. Dev builds: `task build:host:linux` uses `--features patched-libcef`.
+```
+
+---
+
+## 3. Update docs/cef-build/build-patched-libcef.md
+
+The doc currently describes a CEF 146 build on the `a5af/cef` fork. Update:
+
+**§What this libcef contains:** Same two items (BeginWindowDrag + transparency), but note:
+- BeginWindowDrag annotation is `added=14800` (was `added=14600` on the 146 branch, briefly `added=NEXT` during the 148 port — the NEXT tag caused `CefWindow_14800_CppToC::Get()` type-tag mismatch, silently dropping all drags).
+
+**§Repos/branches (replace entirely):**
+```markdown
+- **CEF source:** `agentmuxai/cef@agentmux/7778-drag-rightclick-and-transparency` (base: Chromium 148 / CEF 7778)
+- **Rust binding:** `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` — adds `begin_window_drag` field to `_cef_window_t` in the linux_x86_64 binding
+- **Workspace patch:** `[patch.crates-io] cef-dll-sys = { git = "…AgentU-asaf/cef-rs", rev = "515b3ac5…" }` in `Cargo.toml`
+```
+
+**§HEAD:** Remove old `5ab41b6` SHA; note current HEAD is `47e94db7a` ("Change BeginWindowDrag annotation from added=NEXT to added=14800").
+
+**§Build steps:** CEF 148 build command is the same (`automate-git.py --branch 7778 …`); update the branch name.
+
+---
+
+## 4. New doc: docs/linux.md
+
+Create a Linux-specific operator guide covering what isn't in BUILD.md or README.md. Content:
+
+```markdown
+# Linux — operator guide
+
+## AppImage structure
+
+The AppImage entry point is the **launcher** (since v0.42.x, A0). When you `chmod +x AgentMux_*.AppImage && ./AgentMux_*.AppImage`:
+
+1. `AppRun` → `usr/bin/linux-apprun.sh`
+2. `linux-apprun.sh` → `exec usr/bin/agentmux-launcher`
+3. Launcher spawns `agentmux-srv` (backend) and `agentmux` (CEF host) as a supervised process group
+4. Launcher registers a Unix-socket IPC server; host connects and reports window lifecycle events
+5. Host opens the main window and loads the frontend from the embedded `dist/frontend`
+
+## Display server
+
+By default, the app uses **XWayland** (`--ozone-platform=x11`) under any Wayland compositor (Mutter, KWin, etc.). This maximises compat and avoids frame-stall regressions seen with the `wayland` platform on some GPU configurations.
+
+Set `AGENTMUX_OZONE_PLATFORM=wayland` in the environment to use native Wayland (`xdg_toplevel`). This is experimental and not tested against all compositors.
+
+## Window drag
+
+Title-bar drag and floating-pane header drag use `CefWindow::BeginWindowDrag()` — a native AgentMux patch that dispatches `xdg_toplevel.move` (Wayland) or `_NET_WM_MOVERESIZE` (X11/XWayland). The AgentMux-forked `libcef.so` must be present (all release builds include it). Dev builds compile with `--features patched-libcef` automatically via `task build:host:linux`.
+
+## Log access
+
+```bash
+muxlog host          # tail the CEF host log ([fe] lines = frontend)
+muxlog srv           # tail the backend sidecar log
+muxlog host cat      # full host log
+cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"   # launcher log
+```
+
+`$AGENTMUX_LOG_DIR` = `~/.agentmux/logs/` for stable channel, `~/.agentmux-dev/logs/` for dev builds.
+
+## Launcher IPC diagnostics
+
+The launcher runs the full reducer + saga coordinator (same as Windows, since v0.42.x A1). Diagnostic output:
+
+```bash
+./AgentMux_*.AppImage --diag sagas      # dump the saga journal (SQLite)
+./AgentMux_*.AppImage --diag state      # dump the current reducer state
+```
+
+## Remote debugging
+
+```bash
+AGENTMUX_CEF_ARGS="--remote-debugging-port=9222" ./AgentMux_*.AppImage
+# open chrome://inspect in a Chromium browser
+```
+
+## Single-instance enforcement
+
+The launcher enforces single-instance per (data-dir, version) pair via a Unix domain socket at `$XDG_RUNTIME_DIR/agentmux/<hash16>.sock` (fallback: `/tmp/agentmux-<uid>/<hash16>.sock`). Opening a second instance sends an `open_new_window` command to the running launcher and exits.
+
+## Known Linux limitations (as of v0.42.x)
+
+| Feature | Status |
+|---|---|
+| Splash screen | Not yet implemented (Windows + macOS have it) |
+| Window transparency | Under investigation — CEF Wayland surface visibility without opaque base pixel |
+| Native Wayland (non-XWayland) | Experimental; set `AGENTMUX_OZONE_PLATFORM=wayland` |
+| Linux deb package | Produced by CI builder (`agentmuxai/agentmux-builder`) only |
+| macOS-style owned-window floaters (`transient-for` + `destroy-with-parent`) | Phase B, not yet implemented |
+```
+
+---
+
+## 5. Implementation order
+
+1. `BUILD.md` — fix the three active wrong sections (prerequisites, Linux platform notes, version workflow)
+2. `README.md` — add Linux prerequisites callout + limitations section
+3. `docs/cef-build/build-patched-libcef.md` — update CEF 146 → 148 and fix the annotation history
+4. `docs/linux.md` — create new operator guide (content in §4 above, adjust prose as needed)
+
+Items 1–2 are the highest visibility (public-facing). Items 3–4 are internal / maintainer-facing.

--- a/docs/specs/SPEC_LINUX_DOCS_UPDATE_2026_06_06.md
+++ b/docs/specs/SPEC_LINUX_DOCS_UPDATE_2026_06_06.md
@@ -238,16 +238,14 @@ cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"   # launcher log
 The launcher runs the full reducer + saga coordinator (same as Windows, since v0.42.x A1). Diagnostic output:
 
 ```bash
-./AgentMux_*.AppImage --diag sagas      # dump the saga journal (SQLite)
-./AgentMux_*.AppImage --diag state      # dump the current reducer state
+./AgentMux_*.AppImage --diag sagas   # dump the saga journal (cross-platform)
+# --diag wrr and --diag srv are Windows-only (Phase 7 will add Unix socket parity)
 ```
 
 ## Remote debugging
 
-```bash
-AGENTMUX_CEF_ARGS="--remote-debugging-port=9222" ./AgentMux_*.AppImage
-# open chrome://inspect in a Chromium browser
-```
+The CEF host starts a remote debugger automatically on port 9222 (release) or 9223 (`task dev`).
+Open `chrome://inspect` in a Chromium browser and add `localhost:9222` (or `9223`) as a target.
 
 ## Single-instance enforcement
 


### PR DESCRIPTION
## Summary

Linux docs were ~4 milestones behind. All claims verified against the code before writing.

**BUILD.md**
- Prerequisites: removed stale WebKitGTK deps (`libwebkit2gtk-4.1-dev` etc.), replaced with correct CEF deps (`cmake ninja-build build-essential`)
- Troubleshooting Fix(Linux): same package fix
- §Build Output: added Linux AppImage tree alongside the Windows tree; updated component sizes to include Linux column
- Linux platform notes: removed "WebKitGTK required"; added XWayland default + `AGENTMUX_OZONE_PLATFORM` opt-out; patched libcef.so note
- Dev workflow step 6: replaced `./bump-version.sh patch` with `task changeset`

**README.md**
- Linux prerequisites: replaced WebKit mention with correct CEF deps, linked to `docs/linux.md`

**docs/cef-build/build-patched-libcef.md**
- Updated CEF 146 → 148, branch `7680` → `7778`, repo `a5af/cef` → `agentmuxai/cef`
- Expanded §What this libcef contains: added right-click passthrough, deferred transparency, annotation history (`added=NEXT` bug that caused silent drag no-op)
- Updated automate-git.py `--branch` and `git checkout` target

**docs/linux.md** (new)
- AppImage structure and launch flow (AppRun → linux-apprun.sh → launcher → srv + host)
- Extract-once cache (`~/.local/share/agentmux/extracted/<version>/`)
- Display server / `AGENTMUX_OZONE_PLATFORM`
- Window drag and patched libcef.so
- Log access (`muxlog host/srv`)
- Launcher diagnostics (`--diag sagas/wrr/srv`) — verified in `agentmux-launcher/src/main.rs`
- Remote debugging (port 9222 release / 9223 dev) — verified in `agentmux-cef/src/main.rs:652`
- Single-instance socket path (`$XDG_RUNTIME_DIR/agentmux/{hash16}.sock`) — verified in `agentmux-launcher/src/ipc/mod.rs`
- Known limitations table (splash, transparency, native Wayland, deb, owned-window floaters)

**docs/README.md**
- Added `linux.md` and `cef-build/` to the index table

🤖 Generated with [Claude Code](https://claude.com/claude-code)