### PR TITLE
feat(app-api): agent.define — create/upsert agent definition via HTTP RPC

### DIFF
--- a/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
+++ b/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
-chore(scripts): import-agents.sh — migrate user agent definitions across version data dirs
+feat(app-api): agent.define — create/upsert agent definition via HTTP RPC without restart

--- a/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
+++ b/.changesets/1780777873-chore-scripts-import-agents-sh-migrate-user-agent-definition-50bw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(scripts): import-agents.sh — migrate user agent definitions across version data dirs

--- a/.changesets/1780810542-feat-app-api-agent-define-http-websocket-endpoint-to-create--xkpp.md
+++ b/.changesets/1780810542-feat-app-api-agent-define-http-websocket-endpoint-to-create--xkpp.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(app-api): agent.define HTTP+WebSocket endpoint to create/upsert agent definitions with system_prompt, env, and model support

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -402,6 +402,9 @@ pub const COMMAND_AGENT_KILL_PROCESS: &str = "agent.kill-process";
 /// macOS: `killpg`. Returns `AgentKillResult { ok: true }` even when
 /// there are no members (idempotent).
 pub const COMMAND_AGENT_KILL_TREE: &str = "agent.kill-tree";
+/// Create or upsert an agent definition. Broadcasts `agents:changed` on
+/// success so all open frontends refresh My Agents without a restart.
+pub const COMMAND_AGENT_DEFINE: &str = "agent.define";
 
 // App API Tier 2 — pane lifecycle commands
 pub const COMMAND_PANE_OPEN: &str = "pane.open";
@@ -795,6 +798,42 @@ pub struct AgentOpenResult {
     pub controller_type: String,
     pub status: String,
     pub created: bool,
+}
+
+/// Request for agent.define — create or upsert an agent definition.
+/// `if_exists` controls behaviour when a slug-matching definition exists:
+///   `"skip"` (default) — return existing id unchanged
+///   `"update"` — overwrite all provided non-empty fields
+///   `"error"` — fail with an error message
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentDefineData {
+    pub name: String,
+    #[serde(default)]
+    pub provider: String,
+    #[serde(default)]
+    pub icon: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub working_directory: String,
+    #[serde(default)]
+    pub shell: String,
+    #[serde(default)]
+    pub environment: String,
+    pub if_exists: Option<String>,
+    pub create_instance_stub: Option<bool>,
+}
+
+/// Response from agent.define.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentDefineResult {
+    pub definition_id: String,
+    pub slug: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_stub_id: Option<String>,
 }
 
 /// Request for pane.open — create a new pane showing the given view.

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -811,6 +811,10 @@ pub struct CommandAgentDefineData {
     pub name: String,
     #[serde(default)]
     pub provider: String,
+    /// Alternative to `provider` — inferred from model prefix.
+    /// If both are set, `provider` wins.
+    #[serde(default)]
+    pub model: String,
     #[serde(default)]
     pub icon: String,
     #[serde(default)]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -825,6 +825,10 @@ pub struct CommandAgentDefineData {
     pub shell: String,
     #[serde(default)]
     pub environment: String,
+    /// System/instruction text written to the agent's CLAUDE.md on spawn.
+    pub system_prompt: Option<String>,
+    /// Extra env vars injected at agent spawn, stored as KEY=VALUE lines.
+    pub env: Option<std::collections::HashMap<String, String>>,
     pub if_exists: Option<String>,
     pub create_instance_stub: Option<bool>,
 }

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -507,6 +507,103 @@ impl Store {
         Ok(())
     }
 
+    /// Atomic check-then-insert for `agent.define`.
+    ///
+    /// Looks up an existing user-owned definition by name (case-insensitive)
+    /// or derived slug under the SAME mutex guard that protects the INSERT —
+    /// preventing TOCTOU when two concurrent `agent.define` calls arrive for
+    /// the same name.
+    ///
+    /// Returns:
+    /// - `Ok(Some(def))` — an existing row matched; `agent` was NOT inserted.
+    /// - `Ok(None)` — no match; `agent` was inserted and `agent.slug` now
+    ///   holds the collision-resolved slug.
+    pub fn agent_def_find_or_insert(
+        &self,
+        agent: &mut AgentDefinition,
+    ) -> Result<Option<AgentDefinition>, StoreError> {
+        let name_lower = agent.name.trim().to_lowercase();
+        let derived_slug = derive_slug(agent.name.trim());
+
+        let stamped_updated_at = {
+            let conn = self.conn.lock().unwrap();
+
+            // Check under the same lock to close the TOCTOU window.
+            let mut stmt = conn.prepare(
+                "SELECT id, slug, name, icon, provider, description,
+                        working_directory, shell, provider_flags, auto_start,
+                        restart_on_crash, idle_timeout_minutes, created_at,
+                        agent_type, environment, agent_bus_id, is_seeded,
+                        accounts, parent_id, branch_label, updated_at,
+                        user_hidden
+                 FROM db_agent_definitions
+                 WHERE (lower(trim(name)) = ?1 OR slug = ?2)
+                   AND is_seeded = 0
+                 LIMIT 1",
+            )?;
+            let mut rows = stmt.query_map(
+                params![name_lower, derived_slug],
+                map_agent_definition_row,
+            )?;
+            if let Some(row) = rows.next() {
+                return Ok(Some(row?));
+            }
+            // Drop borrows on `conn` before proceeding to the insert.
+            drop(rows);
+            drop(stmt);
+
+            // Not found — insert under the same lock.
+            let base = if agent.slug.is_empty() {
+                derive_slug(&agent.name)
+            } else {
+                agent.slug.clone()
+            };
+            let mut candidate = base.clone();
+            let mut n: u32 = 2;
+            loop {
+                let count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM db_agents WHERE slug = ?1",
+                    params![candidate],
+                    |row| row.get(0),
+                )?;
+                if count == 0 {
+                    break;
+                }
+                candidate = format!("{}-{}", base, n);
+                n += 1;
+            }
+            agent.slug = candidate;
+            conn.execute(
+                "INSERT INTO db_agent_definitions
+                   (id, slug, name, icon, provider, description,
+                    working_directory, shell, provider_flags, auto_start, restart_on_crash,
+                    idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
+                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden)
+                 VALUES
+                   (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
+                    ?17, ?18, ?19, ?20, ?21, ?22)",
+                params![
+                    agent.id, agent.slug, agent.name, agent.icon, agent.provider,
+                    agent.description, agent.working_directory, agent.shell,
+                    agent.provider_flags, agent.auto_start, agent.restart_on_crash,
+                    agent.idle_timeout_minutes, agent.created_at, agent.agent_type,
+                    agent.environment, agent.agent_bus_id, agent.is_seeded,
+                    agent.accounts, agent.parent_id, agent.branch_label,
+                    agent.created_at, // updated_at = created_at for new rows
+                    agent.user_hidden,
+                ],
+            )?;
+            agent.created_at
+            // conn guard drops here; dual-write acquires the lock again below
+        };
+
+        let mut snapshot = agent.clone();
+        snapshot.updated_at = stamped_updated_at;
+        self.agents_dual_write_definition_upsert(&snapshot)?;
+
+        Ok(None)
+    }
+
     /// Set the `user_hidden` flag on a single agent definition. Phase 2
     /// of the two-tier picker (Q2 Decision Y). Returns:
     ///   `Ok(true)`  — row updated.

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -561,9 +561,13 @@ impl Store {
             };
             let mut candidate = base.clone();
             let mut n: u32 = 2;
+            // Use db_agents (not db_agent_definitions) to match agent_def_insert
+            // at line 440: db_agents surfaces template-instance projection rows
+            // that have no db_agent_definitions entry, making this a strict
+            // superset check that prevents slug collisions in the consolidated table.
             loop {
                 let count: i64 = conn.query_row(
-                    "SELECT COUNT(*) FROM db_agent_definitions WHERE slug = ?1",
+                    "SELECT COUNT(*) FROM db_agents WHERE slug = ?1",
                     params![candidate],
                     |row| row.get(0),
                 )?;

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -539,6 +539,7 @@ impl Store {
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
+                 ORDER BY CASE WHEN lower(trim(name)) = ?1 THEN 0 ELSE 1 END
                  LIMIT 1",
             )?;
             let mut rows = stmt.query_map(

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -563,7 +563,7 @@ impl Store {
             let mut n: u32 = 2;
             loop {
                 let count: i64 = conn.query_row(
-                    "SELECT COUNT(*) FROM db_agents WHERE slug = ?1",
+                    "SELECT COUNT(*) FROM db_agent_definitions WHERE slug = ?1",
                     params![candidate],
                     |row| row.get(0),
                 )?;

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -561,10 +561,10 @@ impl Store {
             };
             let mut candidate = base.clone();
             let mut n: u32 = 2;
-            // Use db_agents (not db_agent_definitions) to match agent_def_insert
-            // at line 440: db_agents surfaces template-instance projection rows
-            // that have no db_agent_definitions entry, making this a strict
-            // superset check that prevents slug collisions in the consolidated table.
+            // Query db_agents (the superset view) for slug uniqueness — matches
+            // agent_def_insert at line 440. Template-instance projections add rows to
+            // db_agents without a corresponding db_agent_definitions entry; checking
+            // only db_agent_definitions would miss those slugs and allow collisions.
             loop {
                 let count: i64 = conn.query_row(
                     "SELECT COUNT(*) FROM db_agents WHERE slug = ?1",

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -64,7 +64,7 @@ impl Store {
                 provider, provider_flags, shell, environment,
                 agent_type, agent_bus_id, accounts,
                 auto_start, restart_on_crash, idle_timeout_minutes,
-                slug, branch_label,
+                slug, branch_label, working_directory,
                 created_at, updated_at, is_seeded, user_hidden
              ) VALUES (
                 ?1, ?2, ?3, ?4,
@@ -72,8 +72,8 @@ impl Store {
                 ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13,
                 ?14, ?15, ?16,
-                ?17, ?18,
-                ?19, ?20, ?21, ?22
+                ?17, ?18, ?19,
+                ?20, ?21, ?22, ?23
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -93,6 +93,7 @@ impl Store {
                 idle_timeout_minutes = excluded.idle_timeout_minutes,
                 slug = excluded.slug,
                 branch_label = excluded.branch_label,
+                working_directory = excluded.working_directory,
                 updated_at = excluded.updated_at,
                 is_seeded = excluded.is_seeded",
             params![
@@ -114,6 +115,7 @@ impl Store {
                 def.idle_timeout_minutes,
                 def.slug,
                 def.branch_label,
+                def.working_directory,
                 def.created_at,
                 def.updated_at,
                 def.is_seeded,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1847,17 +1847,24 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .unwrap_or_default()
                     .as_millis() as i64;
 
-                // Resolve the slug the new name would get, then look for a
-                // matching user-owned definition.
-                let slug_candidate = derive_slug(&cmd.name);
+                // Look up an existing user-owned definition by name (case-insensitive).
+                // We cannot use derive_slug() for the lookup because agent_def_insert
+                // collision-resolves slugs against ALL existing rows (including seeded
+                // templates), so a prior call with name "Codex CLI" may have been stored
+                // as slug "codex-cli-2" when "codex-cli" was already taken by a template.
+                // Matching on the display name avoids that drift and keeps the call
+                // idempotent regardless of what slug was assigned at insert time.
+                let name_lower = cmd.name.trim().to_lowercase();
                 let all_defs = wstore.agent_def_list()
                     .map_err(|e| format!("agent.define: list defs: {e}"))?;
-                let existing = all_defs.iter().find(|d| d.slug == slug_candidate && d.is_seeded == 0);
+                let existing = all_defs.iter().find(|d| {
+                    d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower
+                });
 
                 if let Some(def) = existing {
                     match if_exists {
                         "skip" => {
-                            tracing::info!(slug = %slug_candidate, "agent.define: skipped (exists)");
+                            tracing::info!(id = %def.id, slug = %def.slug, "agent.define: skipped (exists)");
                             return Ok(Some(serde_json::to_value(&AgentDefineResult {
                                 definition_id: def.id.clone(),
                                 slug: def.slug.clone(),
@@ -1867,8 +1874,8 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         }
                         "error" => {
                             return Err(format!(
-                                "agent.define: definition with slug '{}' already exists (if_exists=error)",
-                                slug_candidate
+                                "agent.define: definition '{}' already exists (if_exists=error)",
+                                cmd.name.trim()
                             ));
                         }
                         "update" => {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1819,6 +1819,49 @@ fn write_agent_config_files(
 }
 
 // ---------------------------------------------------------------------------
+// agent.define helpers
+// ---------------------------------------------------------------------------
+
+/// Create a stub AgentInstance for a definition, idempotently.
+///
+/// The stub id is deterministically derived from the definition id so that
+/// calling this function multiple times for the same definition is a no-op
+/// rather than accumulating duplicate stopped rows in My Agents.
+fn make_stub_idempotent(
+    wstore: &crate::backend::storage::store::Store,
+    def_id: &str,
+    name: &str,
+    now: i64,
+) -> Result<String, String> {
+    let stub_id = format!("si-{}", def_id.replace('-', ""));
+    let inst = AgentInstance {
+        id: stub_id.clone(),
+        definition_id: def_id.to_string(),
+        parent_instance_id: String::new(),
+        block_id: String::new(),
+        session_id: String::new(),
+        status: "stopped".to_string(),
+        github_context: String::new(),
+        started_at: now,
+        ended_at: 0,
+        created_at: now,
+        identity_id: String::new(),
+        memory_id: String::new(),
+        instance_name: name.to_string(),
+        working_directory: String::new(),
+        display_hidden: false,
+    };
+    match wstore.instance_create(&inst) {
+        Ok(_) => Ok(stub_id),
+        Err(e) if e.to_string().contains("UNIQUE constraint") => {
+            // Stub already exists — deterministic id makes this idempotent
+            Ok(stub_id)
+        }
+        Err(e) => Err(format!("agent.define: create stub instance: {e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // agent.define
 // ---------------------------------------------------------------------------
 
@@ -1854,12 +1897,24 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // as slug "codex-cli-2" when "codex-cli" was already taken by a template.
                 // Matching on the display name avoids that drift and keeps the call
                 // idempotent regardless of what slug was assigned at insert time.
+                //
+                // agent_def_list() reads from db_agents, which includes both real
+                // definition rows AND template-instance projections (rows whose id matches
+                // an AgentInstance id, not an AgentDefinition id). We verify each
+                // candidate via agent_def_get() — which queries db_agent_definitions
+                // directly — so instance projections are correctly ignored.
                 let name_lower = cmd.name.trim().to_lowercase();
                 let all_defs = wstore.agent_def_list()
                     .map_err(|e| format!("agent.define: list defs: {e}"))?;
-                let existing = all_defs.iter().find(|d| {
-                    d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower
-                });
+                let existing: Option<AgentDefinition> = {
+                    let candidate = all_defs.iter()
+                        .find(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower);
+                    match candidate {
+                        Some(c) => wstore.agent_def_get(&c.id)
+                            .map_err(|e| format!("agent.define: lookup: {e}"))?,
+                        None => None,
+                    }
+                };
 
                 if let Some(def) = existing {
                     match if_exists {
@@ -1892,27 +1947,9 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             wstore.agent_def_update(&mut updated)
                                 .map_err(|e| format!("agent.define: update: {e}"))?;
                             let stub_id = if create_stub {
-                                let id = format!("stub-{}", uuid::Uuid::new_v4().to_string().replace('-', "").chars().take(12).collect::<String>());
-                                let inst = AgentInstance {
-                                    id: id.clone(),
-                                    definition_id: updated.id.clone(),
-                                    parent_instance_id: String::new(),
-                                    block_id: String::new(),
-                                    session_id: String::new(),
-                                    status: "stopped".to_string(),
-                                    github_context: String::new(),
-                                    started_at: now,
-                                    ended_at: 0,
-                                    created_at: now,
-                                    identity_id: String::new(),
-                                    memory_id: String::new(),
-                                    instance_name: updated.name.clone(),
-                                    working_directory: String::new(),
-                                    display_hidden: false,
-                                };
-                                wstore.instance_create(&inst)
-                                    .map_err(|e| format!("agent.define: create stub instance: {e}"))?;
-                                Some(id)
+                                Some(make_stub_idempotent(
+                                    &wstore, &updated.id, &updated.name, now,
+                                )?)
                             } else {
                                 None
                             };
@@ -1966,27 +2003,9 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("agent.define: insert def: {e}"))?;
 
                 let stub_id = if create_stub {
-                    let id = format!("stub-{}", uuid::Uuid::new_v4().to_string().replace('-', "").chars().take(12).collect::<String>());
-                    let inst = AgentInstance {
-                        id: id.clone(),
-                        definition_id: def.id.clone(),
-                        parent_instance_id: String::new(),
-                        block_id: String::new(),
-                        session_id: String::new(),
-                        status: "stopped".to_string(),
-                        github_context: String::new(),
-                        started_at: now,
-                        ended_at: 0,
-                        created_at: now,
-                        identity_id: String::new(),
-                        memory_id: String::new(),
-                        instance_name: cmd.name.clone(),
-                        working_directory: String::new(),
-                        display_hidden: false,
-                    };
-                    wstore.instance_create(&inst)
-                        .map_err(|e| format!("agent.define: create stub instance: {e}"))?;
-                    Some(id)
+                    Some(make_stub_idempotent(
+                        &wstore, &def.id, &def.name, now,
+                    )?)
                 } else {
                     None
                 };

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2018,8 +2018,8 @@ pub(crate) async fn agent_define_core(
             "update" => {
                 let mut updated = existing.clone();
                 // provider was already validated/defaulted above; only
-                // overwrite if the caller explicitly supplied one.
-                if !cmd.provider.is_empty() { updated.provider = provider.clone(); }
+                // overwrite if the caller explicitly supplied a provider or model.
+                if !cmd.provider.is_empty() || !cmd.model.is_empty() { updated.provider = provider.clone(); }
                 if !cmd.icon.is_empty()     { updated.icon = cmd.icon.clone(); }
                 if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
                 if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2065,18 +2065,10 @@ pub(crate) async fn agent_define_core(
     }
 
     // Fresh insert — def.slug is now set by agent_def_find_or_insert.
-    // Broadcast agents:changed before the stub creation: the definition is
-    // already committed, so broadcasting immediately is correct. If the stub
-    // create fails (a real DB error, not the expected UNIQUE no-op), we log
-    // a warning and return success with instance_stub_id = None rather than
-    // returning an error for an already-committed definition.
-    broker.publish(crate::backend::wps::WaveEvent {
-        event: "agents:changed".to_string(),
-        scopes: vec![],
-        sender: String::new(),
-        persist: 0,
-        data: None,
-    });
+    // Create the stub first so that listeners handling agents:changed can
+    // immediately find the new agent via ListRecentSessionsCommand. The
+    // definition is already committed; a stub failure is non-fatal (log +
+    // continue) and we still broadcast so callers see the new definition.
     let stub_id = if create_stub {
         match make_stub_idempotent(&wstore, &def.id, &def.name, now) {
             Ok((id, _new)) => Some(id),
@@ -2088,6 +2080,13 @@ pub(crate) async fn agent_define_core(
     } else {
         None
     };
+    broker.publish(crate::backend::wps::WaveEvent {
+        event: "agents:changed".to_string(),
+        scopes: vec![],
+        sender: String::new(),
+        persist: 0,
+        data: None,
+    });
 
     tracing::info!(
         id = %def.id,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1828,21 +1828,23 @@ fn write_agent_config_files(
 /// calling this function multiple times for the same definition is a no-op
 /// rather than accumulating duplicate stopped rows in My Agents.
 /// Infer a provider slug from a model name prefix.
-/// Callers should still validate the result via `providers::get_provider`.
+/// Only maps prefixes that correspond to a registered provider slug.
+/// Callers must still validate the result via `providers::get_provider`.
 fn infer_provider_from_model(model: &str) -> String {
     let m = model.to_lowercase();
     if m.starts_with("claude") {
         "claude".to_string()
-    } else if m.starts_with("gpt") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") {
-        "openai".to_string()
     } else if m.starts_with("gemini") {
         "gemini".to_string()
     } else if m.starts_with("codex") {
         "codex".to_string()
     } else if m.starts_with("qwen") {
         "qwen".to_string()
+    } else if m.starts_with("kimi") {
+        "kimi".to_string()
     } else {
-        // Unknown prefix — return as-is; get_provider will reject it.
+        // Unknown prefix — return as-is; get_provider will reject it with
+        // a "cannot infer provider" error so callers know to set provider explicitly.
         model.to_string()
     }
 }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1882,6 +1882,19 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     return Err("agent.define: name is required".to_string());
                 }
 
+                // Validate / default the provider so we never persist an
+                // unknown value that would cause agent.open to fail later.
+                let provider = if cmd.provider.is_empty() {
+                    "claude".to_string()
+                } else if providers::get_provider(&cmd.provider).is_none() {
+                    return Err(format!(
+                        "agent.define: unknown provider '{}'; valid: claude, codex, gemini, qwen, kimi, openclaw, pi, copilot",
+                        cmd.provider
+                    ));
+                } else {
+                    cmd.provider.clone()
+                };
+
                 let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
                 let create_stub = cmd.create_instance_stub.unwrap_or(true);
 
@@ -1935,7 +1948,9 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         }
                         "update" => {
                             let mut updated = def.clone();
-                            if !cmd.provider.is_empty() { updated.provider = cmd.provider; }
+                            // provider was already validated/defaulted above; only
+                            // overwrite if the caller explicitly supplied one.
+                            if !cmd.provider.is_empty() { updated.provider = provider.clone(); }
                             if !cmd.icon.is_empty()     { updated.icon = cmd.icon; }
                             if !cmd.description.is_empty() { updated.description = cmd.description; }
                             if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory; }
@@ -1980,7 +1995,7 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     slug: String::new(), // agent_def_insert derives + collision-resolves
                     name: cmd.name.clone(),
                     icon: cmd.icon,
-                    provider: cmd.provider,
+                    provider,  // validated / defaulted above
                     description: cmd.description,
                     working_directory: cmd.working_directory,
                     shell: cmd.shell,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,7 +18,7 @@ use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
-use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance};
+use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance, derive_slug};
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -1910,12 +1910,22 @@ pub(crate) async fn agent_define_core(
     // an AgentInstance id, not an AgentDefinition id). We iterate ALL same-name
     // candidates and call agent_def_get() — which queries db_agent_definitions
     // directly — skipping projections (None) until we find a real definition.
+    //
+    // We also check by derived slug as a fallback so that two names that
+    // normalise to the same slug ("Senior Dev" and "Senior-Dev" both → "senior_dev")
+    // find the same existing definition instead of creating a duplicate.
     let name_lower = cmd.name.trim().to_lowercase();
+    let derived_slug = derive_slug(cmd.name.trim());
     let all_defs = wstore.agent_def_list()
         .map_err(|e| format!("agent.define: list defs: {e}"))?;
     let existing: Option<AgentDefinition> = {
         let mut found = None;
-        for c in all_defs.iter().filter(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower) {
+        // Primary: exact name match (case-insensitive).
+        // Secondary: slug match (catches formatting variants of the same name).
+        for c in all_defs.iter().filter(|d| {
+            d.is_seeded == 0 &&
+            (d.name.trim().to_lowercase() == name_lower || d.slug == derived_slug)
+        }) {
             match wstore.agent_def_get(&c.id)
                 .map_err(|e| format!("agent.define: lookup: {e}"))? {
                 Some(def) => { found = Some(def); break; }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -245,13 +245,17 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // 6. Build metadata
                 let controller_type = provider.controller_type_str();
                 let is_persistent = controller_type == "persistent";
-                let cli_args: Vec<String> = if is_persistent {
+                let mut cli_args: Vec<String> = if is_persistent {
                     provider.persistent_launch_args
                         .unwrap_or(provider.launch_args)
                         .iter().map(|s| s.to_string()).collect()
                 } else {
                     provider.launch_args.iter().map(|s| s.to_string()).collect()
                 };
+                // Append definition-level flags (e.g. --model <value>) stored in provider_flags.
+                if !agent.provider_flags.is_empty() {
+                    cli_args.extend(agent.provider_flags.split_whitespace().map(str::to_string));
+                }
 
                 let agent_slug = agent.name.to_lowercase()
                     .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
@@ -283,6 +287,19 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
+                }
+                // Merge env vars from the definition's persisted env content blob (KEY=VALUE lines).
+                // Provider/auth entries inserted above take precedence; definition-level vars
+                // are merged after so they can extend (but not override) the auth env.
+                if let Ok(Some(env_blob)) = wstore.agent_content_get(&agent.id, "env") {
+                    for line in env_blob.content.lines() {
+                        if let Some((k, v)) = line.split_once('=') {
+                            let k = k.trim();
+                            if !k.is_empty() && !env_vars.contains_key(k) {
+                                env_vars.insert(k.to_string(), json!(v));
+                            }
+                        }
+                    }
                 }
                 // Agent identity
                 env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("{}/gh-{}", config_home, agent_slug)));

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1989,8 +1989,11 @@ pub(crate) async fn agent_define_core(
                 if !cmd.environment.is_empty() { updated.environment = cmd.environment.clone(); }
                 // name update intentionally omitted — the slug is immutable;
                 // renaming would create a slug mismatch. Use updateagent for renames.
-                wstore.agent_def_update(&mut updated)
+                let did_update = wstore.agent_def_update(&mut updated)
                     .map_err(|e| format!("agent.define: update: {e}"))?;
+                if !did_update {
+                    return Err("agent.define: update: row was deleted between find and update".to_string());
+                }
                 let stub_id = if create_stub {
                     match make_stub_idempotent(&wstore, &updated.id, &updated.name, now) {
                         Ok((id, _new)) => Some(id),

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,7 +18,7 @@ use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
-use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance};
+use crate::backend::storage::store::{Store, AgentContent, AgentDefinition, AgentInstance};
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -1891,6 +1891,46 @@ fn make_stub_idempotent(
 
 /// Core logic for the `agent.define` command, shared by the WebSocket RPC
 /// handler and the HTTP service dispatch (`("agent", "define")` in service.rs).
+/// Persist `system_prompt` and `env` content blobs for a freshly created or
+/// updated agent definition.  Errors are logged but not propagated — the
+/// definition row is already committed and the caller has already published
+/// `agents:changed`, so a content-write failure must not abort the response.
+fn persist_define_content(
+    wstore: &Store,
+    agent_id: &str,
+    cmd: &CommandAgentDefineData,
+    now: i64,
+) {
+    if let Some(prompt) = &cmd.system_prompt {
+        if !prompt.is_empty() {
+            if let Err(e) = wstore.agent_content_set(&AgentContent {
+                agent_id: agent_id.to_string(),
+                content_type: "agentmd".to_string(),
+                content: prompt.clone(),
+                updated_at: now,
+            }) {
+                tracing::warn!(agent_id, err = %e, "agent.define: failed to persist system_prompt (non-fatal)");
+            }
+        }
+    }
+    if let Some(env_map) = &cmd.env {
+        if !env_map.is_empty() {
+            let content = env_map.iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if let Err(e) = wstore.agent_content_set(&AgentContent {
+                agent_id: agent_id.to_string(),
+                content_type: "env".to_string(),
+                content,
+                updated_at: now,
+            }) {
+                tracing::warn!(agent_id, err = %e, "agent.define: failed to persist env (non-fatal)");
+            }
+        }
+    }
+}
+
 pub(crate) async fn agent_define_core(
     wstore: Arc<Store>,
     broker: Arc<crate::backend::wps::Broker>,
@@ -2043,6 +2083,7 @@ pub(crate) async fn agent_define_core(
                 if !did_update {
                     return Err("agent.define: update: row was deleted between find and update".to_string());
                 }
+                persist_define_content(&wstore, &updated.id, &cmd, now);
                 let stub_id = if create_stub {
                     match make_stub_idempotent(&wstore, &updated.id, &updated.name, now) {
                         Ok((id, _new)) => Some(id),
@@ -2098,6 +2139,7 @@ pub(crate) async fn agent_define_core(
         persist: 0,
         data: None,
     });
+    persist_define_content(&wstore, &def.id, &cmd, now);
 
     tracing::info!(
         id = %def.id,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,7 +18,7 @@ use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
-use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance, derive_slug};
+use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance};
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -1891,6 +1891,31 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             // mismatch. Use updateagent for renames.
                             wstore.agent_def_update(&mut updated)
                                 .map_err(|e| format!("agent.define: update: {e}"))?;
+                            let stub_id = if create_stub {
+                                let id = format!("stub-{}", uuid::Uuid::new_v4().to_string().replace('-', "").chars().take(12).collect::<String>());
+                                let inst = AgentInstance {
+                                    id: id.clone(),
+                                    definition_id: updated.id.clone(),
+                                    parent_instance_id: String::new(),
+                                    block_id: String::new(),
+                                    session_id: String::new(),
+                                    status: "stopped".to_string(),
+                                    github_context: String::new(),
+                                    started_at: now,
+                                    ended_at: 0,
+                                    created_at: now,
+                                    identity_id: String::new(),
+                                    memory_id: String::new(),
+                                    instance_name: updated.name.clone(),
+                                    working_directory: String::new(),
+                                    display_hidden: false,
+                                };
+                                wstore.instance_create(&inst)
+                                    .map_err(|e| format!("agent.define: create stub instance: {e}"))?;
+                                Some(id)
+                            } else {
+                                None
+                            };
                             broker.publish(crate::backend::wps::WaveEvent {
                                 event: "agents:changed".to_string(),
                                 scopes: vec![],
@@ -1898,12 +1923,12 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 persist: 0,
                                 data: None,
                             });
-                            tracing::info!(id = %updated.id, slug = %updated.slug, "agent.define: updated");
+                            tracing::info!(id = %updated.id, slug = %updated.slug, stub = stub_id.is_some(), "agent.define: updated");
                             return Ok(Some(serde_json::to_value(&AgentDefineResult {
                                 definition_id: updated.id.clone(),
                                 slug: updated.slug.clone(),
                                 action: "updated".to_string(),
-                                instance_stub_id: None,
+                                instance_stub_id: stub_id,
                             }).unwrap()));
                         }
                         other => {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1865,6 +1865,183 @@ fn make_stub_idempotent(
 // agent.define
 // ---------------------------------------------------------------------------
 
+/// Core logic for the `agent.define` command, shared by the WebSocket RPC
+/// handler and the HTTP service dispatch (`("agent", "define")` in service.rs).
+pub(crate) async fn agent_define_core(
+    wstore: Arc<Store>,
+    broker: Arc<crate::backend::wps::Broker>,
+    cmd: CommandAgentDefineData,
+) -> Result<AgentDefineResult, String> {
+    if cmd.name.trim().is_empty() {
+        return Err("agent.define: name is required".to_string());
+    }
+
+    // Validate / default the provider so we never persist an
+    // unknown value that would cause agent.open to fail later.
+    let provider = if cmd.provider.is_empty() {
+        "claude".to_string()
+    } else if providers::get_provider(&cmd.provider).is_none() {
+        return Err(format!(
+            "agent.define: unknown provider '{}'; valid: claude, codex, gemini, qwen, kimi, openclaw, pi, copilot",
+            cmd.provider
+        ));
+    } else {
+        cmd.provider.clone()
+    };
+
+    let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
+    let create_stub = cmd.create_instance_stub.unwrap_or(true);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    // Look up an existing user-owned definition by name (case-insensitive).
+    // We cannot use derive_slug() for the lookup because agent_def_insert
+    // collision-resolves slugs against ALL existing rows (including seeded
+    // templates), so a prior call with name "Codex CLI" may have been stored
+    // as slug "codex-cli-2" when "codex-cli" was already taken by a template.
+    // Matching on the display name avoids that drift and keeps the call
+    // idempotent regardless of what slug was assigned at insert time.
+    //
+    // agent_def_list() reads from db_agents, which includes both real
+    // definition rows AND template-instance projections (rows whose id matches
+    // an AgentInstance id, not an AgentDefinition id). We verify each
+    // candidate via agent_def_get() — which queries db_agent_definitions
+    // directly — so instance projections are correctly ignored.
+    let name_lower = cmd.name.trim().to_lowercase();
+    let all_defs = wstore.agent_def_list()
+        .map_err(|e| format!("agent.define: list defs: {e}"))?;
+    let existing: Option<AgentDefinition> = {
+        let candidate = all_defs.iter()
+            .find(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower);
+        match candidate {
+            Some(c) => wstore.agent_def_get(&c.id)
+                .map_err(|e| format!("agent.define: lookup: {e}"))?,
+            None => None,
+        }
+    };
+
+    if let Some(def) = existing {
+        match if_exists {
+            "skip" => {
+                tracing::info!(id = %def.id, slug = %def.slug, "agent.define: skipped (exists)");
+                return Ok(AgentDefineResult {
+                    definition_id: def.id.clone(),
+                    slug: def.slug.clone(),
+                    action: "skipped".to_string(),
+                    instance_stub_id: None,
+                });
+            }
+            "error" => {
+                return Err(format!(
+                    "agent.define: definition '{}' already exists (if_exists=error)",
+                    cmd.name.trim()
+                ));
+            }
+            "update" => {
+                let mut updated = def.clone();
+                // provider was already validated/defaulted above; only
+                // overwrite if the caller explicitly supplied one.
+                if !cmd.provider.is_empty() { updated.provider = provider.clone(); }
+                if !cmd.icon.is_empty()     { updated.icon = cmd.icon; }
+                if !cmd.description.is_empty() { updated.description = cmd.description; }
+                if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory; }
+                if !cmd.shell.is_empty()    { updated.shell = cmd.shell; }
+                if !cmd.environment.is_empty() { updated.environment = cmd.environment; }
+                // name update intentionally omitted — the slug
+                // is immutable, so renaming would create a slug
+                // mismatch. Use updateagent for renames.
+                wstore.agent_def_update(&mut updated)
+                    .map_err(|e| format!("agent.define: update: {e}"))?;
+                let stub_id = if create_stub {
+                    Some(make_stub_idempotent(
+                        &wstore, &updated.id, &updated.name, now,
+                    )?)
+                } else {
+                    None
+                };
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "agents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                tracing::info!(id = %updated.id, slug = %updated.slug, stub = stub_id.is_some(), "agent.define: updated");
+                return Ok(AgentDefineResult {
+                    definition_id: updated.id.clone(),
+                    slug: updated.slug.clone(),
+                    action: "updated".to_string(),
+                    instance_stub_id: stub_id,
+                });
+            }
+            other => {
+                return Err(format!("agent.define: unknown if_exists value '{other}'"));
+            }
+        }
+    }
+
+    // No existing definition — create.
+    let mut def = AgentDefinition {
+        id: uuid::Uuid::new_v4().to_string(),
+        slug: String::new(), // agent_def_insert derives + collision-resolves
+        name: cmd.name.clone(),
+        icon: cmd.icon,
+        provider,  // validated / defaulted above
+        description: cmd.description,
+        working_directory: cmd.working_directory,
+        shell: cmd.shell,
+        environment: cmd.environment,
+        provider_flags: String::new(),
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: now,
+        agent_type: "agent".to_string(),
+        agent_bus_id: String::new(),
+        is_seeded: 0,
+        accounts: String::new(),
+        parent_id: String::new(),
+        branch_label: String::new(),
+        updated_at: now,
+        user_hidden: 0,
+    };
+    wstore.agent_def_insert(&mut def)
+        .map_err(|e| format!("agent.define: insert def: {e}"))?;
+
+    let stub_id = if create_stub {
+        Some(make_stub_idempotent(
+            &wstore, &def.id, &def.name, now,
+        )?)
+    } else {
+        None
+    };
+
+    broker.publish(crate::backend::wps::WaveEvent {
+        event: "agents:changed".to_string(),
+        scopes: vec![],
+        sender: String::new(),
+        persist: 0,
+        data: None,
+    });
+
+    tracing::info!(
+        id = %def.id,
+        slug = %def.slug,
+        stub = stub_id.is_some(),
+        "agent.define: created"
+    );
+
+    Ok(AgentDefineResult {
+        definition_id: def.id.clone(),
+        slug: def.slug.clone(),
+        action: "created".to_string(),
+        instance_stub_id: stub_id,
+    })
+}
+
 fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
@@ -1877,175 +2054,8 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandAgentDefineData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.define: {e}"))?;
-
-                if cmd.name.trim().is_empty() {
-                    return Err("agent.define: name is required".to_string());
-                }
-
-                // Validate / default the provider so we never persist an
-                // unknown value that would cause agent.open to fail later.
-                let provider = if cmd.provider.is_empty() {
-                    "claude".to_string()
-                } else if providers::get_provider(&cmd.provider).is_none() {
-                    return Err(format!(
-                        "agent.define: unknown provider '{}'; valid: claude, codex, gemini, qwen, kimi, openclaw, pi, copilot",
-                        cmd.provider
-                    ));
-                } else {
-                    cmd.provider.clone()
-                };
-
-                let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
-                let create_stub = cmd.create_instance_stub.unwrap_or(true);
-
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as i64;
-
-                // Look up an existing user-owned definition by name (case-insensitive).
-                // We cannot use derive_slug() for the lookup because agent_def_insert
-                // collision-resolves slugs against ALL existing rows (including seeded
-                // templates), so a prior call with name "Codex CLI" may have been stored
-                // as slug "codex-cli-2" when "codex-cli" was already taken by a template.
-                // Matching on the display name avoids that drift and keeps the call
-                // idempotent regardless of what slug was assigned at insert time.
-                //
-                // agent_def_list() reads from db_agents, which includes both real
-                // definition rows AND template-instance projections (rows whose id matches
-                // an AgentInstance id, not an AgentDefinition id). We verify each
-                // candidate via agent_def_get() — which queries db_agent_definitions
-                // directly — so instance projections are correctly ignored.
-                let name_lower = cmd.name.trim().to_lowercase();
-                let all_defs = wstore.agent_def_list()
-                    .map_err(|e| format!("agent.define: list defs: {e}"))?;
-                let existing: Option<AgentDefinition> = {
-                    let candidate = all_defs.iter()
-                        .find(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower);
-                    match candidate {
-                        Some(c) => wstore.agent_def_get(&c.id)
-                            .map_err(|e| format!("agent.define: lookup: {e}"))?,
-                        None => None,
-                    }
-                };
-
-                if let Some(def) = existing {
-                    match if_exists {
-                        "skip" => {
-                            tracing::info!(id = %def.id, slug = %def.slug, "agent.define: skipped (exists)");
-                            return Ok(Some(serde_json::to_value(&AgentDefineResult {
-                                definition_id: def.id.clone(),
-                                slug: def.slug.clone(),
-                                action: "skipped".to_string(),
-                                instance_stub_id: None,
-                            }).unwrap()));
-                        }
-                        "error" => {
-                            return Err(format!(
-                                "agent.define: definition '{}' already exists (if_exists=error)",
-                                cmd.name.trim()
-                            ));
-                        }
-                        "update" => {
-                            let mut updated = def.clone();
-                            // provider was already validated/defaulted above; only
-                            // overwrite if the caller explicitly supplied one.
-                            if !cmd.provider.is_empty() { updated.provider = provider.clone(); }
-                            if !cmd.icon.is_empty()     { updated.icon = cmd.icon; }
-                            if !cmd.description.is_empty() { updated.description = cmd.description; }
-                            if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory; }
-                            if !cmd.shell.is_empty()    { updated.shell = cmd.shell; }
-                            if !cmd.environment.is_empty() { updated.environment = cmd.environment; }
-                            // name update intentionally omitted — the slug
-                            // is immutable, so renaming would create a slug
-                            // mismatch. Use updateagent for renames.
-                            wstore.agent_def_update(&mut updated)
-                                .map_err(|e| format!("agent.define: update: {e}"))?;
-                            let stub_id = if create_stub {
-                                Some(make_stub_idempotent(
-                                    &wstore, &updated.id, &updated.name, now,
-                                )?)
-                            } else {
-                                None
-                            };
-                            broker.publish(crate::backend::wps::WaveEvent {
-                                event: "agents:changed".to_string(),
-                                scopes: vec![],
-                                sender: String::new(),
-                                persist: 0,
-                                data: None,
-                            });
-                            tracing::info!(id = %updated.id, slug = %updated.slug, stub = stub_id.is_some(), "agent.define: updated");
-                            return Ok(Some(serde_json::to_value(&AgentDefineResult {
-                                definition_id: updated.id.clone(),
-                                slug: updated.slug.clone(),
-                                action: "updated".to_string(),
-                                instance_stub_id: stub_id,
-                            }).unwrap()));
-                        }
-                        other => {
-                            return Err(format!("agent.define: unknown if_exists value '{other}'"));
-                        }
-                    }
-                }
-
-                // No existing definition — create.
-                let mut def = AgentDefinition {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    slug: String::new(), // agent_def_insert derives + collision-resolves
-                    name: cmd.name.clone(),
-                    icon: cmd.icon,
-                    provider,  // validated / defaulted above
-                    description: cmd.description,
-                    working_directory: cmd.working_directory,
-                    shell: cmd.shell,
-                    environment: cmd.environment,
-                    provider_flags: String::new(),
-                    auto_start: 0,
-                    restart_on_crash: 0,
-                    idle_timeout_minutes: 0,
-                    created_at: now,
-                    agent_type: "agent".to_string(),
-                    agent_bus_id: String::new(),
-                    is_seeded: 0,
-                    accounts: String::new(),
-                    parent_id: String::new(),
-                    branch_label: String::new(),
-                    updated_at: now,
-                    user_hidden: 0,
-                };
-                wstore.agent_def_insert(&mut def)
-                    .map_err(|e| format!("agent.define: insert def: {e}"))?;
-
-                let stub_id = if create_stub {
-                    Some(make_stub_idempotent(
-                        &wstore, &def.id, &def.name, now,
-                    )?)
-                } else {
-                    None
-                };
-
-                broker.publish(crate::backend::wps::WaveEvent {
-                    event: "agents:changed".to_string(),
-                    scopes: vec![],
-                    sender: String::new(),
-                    persist: 0,
-                    data: None,
-                });
-
-                tracing::info!(
-                    id = %def.id,
-                    slug = %def.slug,
-                    stub = stub_id.is_some(),
-                    "agent.define: created"
-                );
-
-                Ok(Some(serde_json::to_value(&AgentDefineResult {
-                    definition_id: def.id.clone(),
-                    slug: def.slug.clone(),
-                    action: "created".to_string(),
-                    instance_stub_id: stub_id,
-                }).unwrap()))
+                agent_define_core(wstore, broker, cmd).await
+                    .map(|r| Some(serde_json::to_value(&r).unwrap()))
             })
         }),
     );

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2087,7 +2087,13 @@ pub(crate) async fn agent_define_core(
                 if !cmd.provider.is_empty() || !cmd.model.is_empty() { updated.provider = provider.clone(); }
                 // Persist the model as a CLI flag so the agent launches with
                 // the requested model rather than the provider default.
-                if !cmd.model.is_empty() { updated.provider_flags = format!("--model {}", cmd.model); }
+                // If the provider changes but no model is supplied, clear stale
+                // flags from the old provider so the new provider's default is used.
+                if !cmd.model.is_empty() {
+                    updated.provider_flags = format!("--model {}", cmd.model);
+                } else if !cmd.provider.is_empty() {
+                    updated.provider_flags = String::new();
+                }
                 if !cmd.icon.is_empty()     { updated.icon = cmd.icon.clone(); }
                 if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
                 if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1827,6 +1827,26 @@ fn write_agent_config_files(
 /// The stub id is deterministically derived from the definition id so that
 /// calling this function multiple times for the same definition is a no-op
 /// rather than accumulating duplicate stopped rows in My Agents.
+/// Infer a provider slug from a model name prefix.
+/// Callers should still validate the result via `providers::get_provider`.
+fn infer_provider_from_model(model: &str) -> String {
+    let m = model.to_lowercase();
+    if m.starts_with("claude") {
+        "claude".to_string()
+    } else if m.starts_with("gpt") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") {
+        "openai".to_string()
+    } else if m.starts_with("gemini") {
+        "gemini".to_string()
+    } else if m.starts_with("codex") {
+        "codex".to_string()
+    } else if m.starts_with("qwen") {
+        "qwen".to_string()
+    } else {
+        // Unknown prefix — return as-is; get_provider will reject it.
+        model.to_string()
+    }
+}
+
 /// Returns `(stub_id, newly_inserted)`. `newly_inserted = false` when the
 /// UNIQUE constraint fires (stub already existed); callers use this to avoid
 /// broadcasting `agents:changed` on no-op calls.
@@ -1878,20 +1898,38 @@ pub(crate) async fn agent_define_core(
         return Err("agent.define: name is required".to_string());
     }
 
-    // Validate / default the provider so we never persist an
-    // unknown value that would cause agent.open to fail later.
-    let provider = if cmd.provider.is_empty() {
-        "claude".to_string()
-    } else if providers::get_provider(&cmd.provider).is_none() {
+    // Validate if_exists early so a typo is caught even for new definitions,
+    // not only when a matching definition already exists.
+    let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
+    if !matches!(if_exists, "skip" | "update" | "error") {
         return Err(format!(
-            "agent.define: unknown provider '{}'; valid: claude, codex, gemini, qwen, kimi, openclaw, pi, copilot",
-            cmd.provider
+            "agent.define: unknown if_exists value '{if_exists}'; valid: skip, update, error"
         ));
-    } else {
+    }
+
+    // Resolve provider: explicit `provider` wins; fall back to inference from
+    // `model` prefix; default to "claude" when neither is supplied.
+    let provider = if !cmd.provider.is_empty() {
+        if providers::get_provider(&cmd.provider).is_none() {
+            return Err(format!(
+                "agent.define: unknown provider '{}'; valid: claude, codex, gemini, qwen, kimi, openclaw, pi, copilot",
+                cmd.provider
+            ));
+        }
         cmd.provider.clone()
+    } else if !cmd.model.is_empty() {
+        let inferred = infer_provider_from_model(&cmd.model);
+        if providers::get_provider(&inferred).is_none() {
+            return Err(format!(
+                "agent.define: cannot infer provider from model '{}'; set provider explicitly",
+                cmd.model
+            ));
+        }
+        inferred
+    } else {
+        "claude".to_string()
     };
 
-    let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
     let create_stub = cmd.create_instance_stub.unwrap_or(true);
 
     let now = std::time::SystemTime::now()

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1907,31 +1907,51 @@ pub(crate) async fn agent_define_core(
     //
     // agent_def_list() reads from db_agents, which includes both real
     // definition rows AND template-instance projections (rows whose id matches
-    // an AgentInstance id, not an AgentDefinition id). We verify each
-    // candidate via agent_def_get() — which queries db_agent_definitions
-    // directly — so instance projections are correctly ignored.
+    // an AgentInstance id, not an AgentDefinition id). We iterate ALL same-name
+    // candidates and call agent_def_get() — which queries db_agent_definitions
+    // directly — skipping projections (None) until we find a real definition.
     let name_lower = cmd.name.trim().to_lowercase();
     let all_defs = wstore.agent_def_list()
         .map_err(|e| format!("agent.define: list defs: {e}"))?;
     let existing: Option<AgentDefinition> = {
-        let candidate = all_defs.iter()
-            .find(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower);
-        match candidate {
-            Some(c) => wstore.agent_def_get(&c.id)
-                .map_err(|e| format!("agent.define: lookup: {e}"))?,
-            None => None,
+        let mut found = None;
+        for c in all_defs.iter().filter(|d| d.is_seeded == 0 && d.name.trim().to_lowercase() == name_lower) {
+            match wstore.agent_def_get(&c.id)
+                .map_err(|e| format!("agent.define: lookup: {e}"))? {
+                Some(def) => { found = Some(def); break; }
+                None => continue, // projection row — skip and keep searching
+            }
         }
+        found
     };
 
     if let Some(def) = existing {
         match if_exists {
             "skip" => {
-                tracing::info!(id = %def.id, slug = %def.slug, "agent.define: skipped (exists)");
+                // Still honor create_instance_stub on skip: the definition may
+                // have been created without a stub (e.g. create_instance_stub=false
+                // or imported via another path). A subsequent idempotent call with
+                // create_instance_stub=true should make it visible in My Agents.
+                let stub_id = if create_stub {
+                    Some(make_stub_idempotent(&wstore, &def.id, &def.name, now)?)
+                } else {
+                    None
+                };
+                if stub_id.is_some() {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "agents:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                tracing::info!(id = %def.id, slug = %def.slug, stub = stub_id.is_some(), "agent.define: skipped (exists)");
                 return Ok(AgentDefineResult {
                     definition_id: def.id.clone(),
                     slug: def.slug.clone(),
                     action: "skipped".to_string(),
-                    instance_stub_id: None,
+                    instance_stub_id: stub_id,
                 });
             }
             "error" => {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,7 +18,7 @@ use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
-use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance, derive_slug};
+use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance};
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -1827,12 +1827,15 @@ fn write_agent_config_files(
 /// The stub id is deterministically derived from the definition id so that
 /// calling this function multiple times for the same definition is a no-op
 /// rather than accumulating duplicate stopped rows in My Agents.
+/// Returns `(stub_id, newly_inserted)`. `newly_inserted = false` when the
+/// UNIQUE constraint fires (stub already existed); callers use this to avoid
+/// broadcasting `agents:changed` on no-op calls.
 fn make_stub_idempotent(
     wstore: &crate::backend::storage::store::Store,
     def_id: &str,
     name: &str,
     now: i64,
-) -> Result<String, String> {
+) -> Result<(String, bool), String> {
     let stub_id = format!("si-{}", def_id.replace('-', ""));
     let inst = AgentInstance {
         id: stub_id.clone(),
@@ -1852,10 +1855,9 @@ fn make_stub_idempotent(
         display_hidden: false,
     };
     match wstore.instance_create(&inst) {
-        Ok(_) => Ok(stub_id),
+        Ok(_) => Ok((stub_id, true)),
         Err(e) if e.to_string().contains("UNIQUE constraint") => {
-            // Stub already exists — deterministic id makes this idempotent
-            Ok(stub_id)
+            Ok((stub_id, false)) // stub already existed — idempotent
         }
         Err(e) => Err(format!("agent.define: create stub instance: {e}")),
     }
@@ -1897,57 +1899,62 @@ pub(crate) async fn agent_define_core(
         .unwrap_or_default()
         .as_millis() as i64;
 
-    // Look up an existing user-owned definition by name (case-insensitive).
-    // We cannot use derive_slug() for the lookup because agent_def_insert
-    // collision-resolves slugs against ALL existing rows (including seeded
-    // templates), so a prior call with name "Codex CLI" may have been stored
-    // as slug "codex-cli-2" when "codex-cli" was already taken by a template.
-    // Matching on the display name avoids that drift and keeps the call
-    // idempotent regardless of what slug was assigned at insert time.
-    //
-    // agent_def_list() reads from db_agents, which includes both real
-    // definition rows AND template-instance projections (rows whose id matches
-    // an AgentInstance id, not an AgentDefinition id). We iterate ALL same-name
-    // candidates and call agent_def_get() — which queries db_agent_definitions
-    // directly — skipping projections (None) until we find a real definition.
-    //
-    // We also check by derived slug as a fallback so that two names that
-    // normalise to the same slug ("Senior Dev" and "Senior-Dev" both → "senior_dev")
-    // find the same existing definition instead of creating a duplicate.
-    let name_lower = cmd.name.trim().to_lowercase();
-    let derived_slug = derive_slug(cmd.name.trim());
-    let all_defs = wstore.agent_def_list()
-        .map_err(|e| format!("agent.define: list defs: {e}"))?;
-    let existing: Option<AgentDefinition> = {
-        let mut found = None;
-        // Primary: exact name match (case-insensitive).
-        // Secondary: slug match (catches formatting variants of the same name).
-        for c in all_defs.iter().filter(|d| {
-            d.is_seeded == 0 &&
-            (d.name.trim().to_lowercase() == name_lower || d.slug == derived_slug)
-        }) {
-            match wstore.agent_def_get(&c.id)
-                .map_err(|e| format!("agent.define: lookup: {e}"))? {
-                Some(def) => { found = Some(def); break; }
-                None => continue, // projection row — skip and keep searching
-            }
-        }
-        found
+    // Build the new definition struct up-front so agent_def_find_or_insert
+    // can use it as both the lookup key and the insert payload.
+    // agent_def_find_or_insert holds a single mutex guard for the check +
+    // conditional insert — closing the TOCTOU window between list and insert.
+    let mut def = AgentDefinition {
+        id: uuid::Uuid::new_v4().to_string(),
+        slug: String::new(), // resolved by agent_def_find_or_insert
+        name: cmd.name.clone(),
+        icon: cmd.icon.clone(),
+        provider: provider.clone(),
+        description: cmd.description.clone(),
+        working_directory: cmd.working_directory.clone(),
+        shell: cmd.shell.clone(),
+        environment: cmd.environment.clone(),
+        provider_flags: String::new(),
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: now,
+        agent_type: "host".to_string(), // matches every other user-owned definition
+        agent_bus_id: String::new(),
+        is_seeded: 0,
+        accounts: String::new(),
+        parent_id: String::new(),
+        branch_label: String::new(),
+        updated_at: now,
+        user_hidden: 0,
     };
 
-    if let Some(def) = existing {
+    // Atomic check-then-insert.
+    // Returns Some(existing) if a row matched by name/slug already exists;
+    // None if the row was freshly inserted (def.slug now holds resolved slug).
+    let existing_opt = wstore.agent_def_find_or_insert(&mut def)
+        .map_err(|e| format!("agent.define: find_or_insert: {e}"))?;
+
+    if let Some(existing) = existing_opt {
+        // A definition with this name/slug already exists — apply if_exists policy.
         match if_exists {
             "skip" => {
-                // Still honor create_instance_stub on skip: the definition may
-                // have been created without a stub (e.g. create_instance_stub=false
-                // or imported via another path). A subsequent idempotent call with
-                // create_instance_stub=true should make it visible in My Agents.
-                let stub_id = if create_stub {
-                    Some(make_stub_idempotent(&wstore, &def.id, &def.name, now)?)
+                // Honor create_instance_stub even on skip: a definition that was
+                // created with create_instance_stub=false (or imported via another
+                // path) might not have a stub yet; a subsequent idempotent call
+                // with create_instance_stub=true should make it visible in My Agents.
+                // Only fire agents:changed when the stub was actually newly inserted.
+                let (stub_id, stub_new) = if create_stub {
+                    match make_stub_idempotent(&wstore, &existing.id, &existing.name, now) {
+                        Ok((id, new)) => (Some(id), new),
+                        Err(e) => {
+                            tracing::warn!(id = %existing.id, err = %e, "agent.define: skip stub failed (non-fatal)");
+                            (None, false)
+                        }
+                    }
                 } else {
-                    None
+                    (None, false)
                 };
-                if stub_id.is_some() {
+                if stub_new {
                     broker.publish(crate::backend::wps::WaveEvent {
                         event: "agents:changed".to_string(),
                         scopes: vec![],
@@ -1956,10 +1963,10 @@ pub(crate) async fn agent_define_core(
                         data: None,
                     });
                 }
-                tracing::info!(id = %def.id, slug = %def.slug, stub = stub_id.is_some(), "agent.define: skipped (exists)");
+                tracing::info!(id = %existing.id, slug = %existing.slug, stub = stub_id.is_some(), "agent.define: skipped (exists)");
                 return Ok(AgentDefineResult {
-                    definition_id: def.id.clone(),
-                    slug: def.slug.clone(),
+                    definition_id: existing.id.clone(),
+                    slug: existing.slug.clone(),
                     action: "skipped".to_string(),
                     instance_stub_id: stub_id,
                 });
@@ -1971,24 +1978,27 @@ pub(crate) async fn agent_define_core(
                 ));
             }
             "update" => {
-                let mut updated = def.clone();
+                let mut updated = existing.clone();
                 // provider was already validated/defaulted above; only
                 // overwrite if the caller explicitly supplied one.
                 if !cmd.provider.is_empty() { updated.provider = provider.clone(); }
-                if !cmd.icon.is_empty()     { updated.icon = cmd.icon; }
-                if !cmd.description.is_empty() { updated.description = cmd.description; }
-                if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory; }
-                if !cmd.shell.is_empty()    { updated.shell = cmd.shell; }
-                if !cmd.environment.is_empty() { updated.environment = cmd.environment; }
-                // name update intentionally omitted — the slug
-                // is immutable, so renaming would create a slug
-                // mismatch. Use updateagent for renames.
+                if !cmd.icon.is_empty()     { updated.icon = cmd.icon.clone(); }
+                if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
+                if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }
+                if !cmd.shell.is_empty()    { updated.shell = cmd.shell.clone(); }
+                if !cmd.environment.is_empty() { updated.environment = cmd.environment.clone(); }
+                // name update intentionally omitted — the slug is immutable;
+                // renaming would create a slug mismatch. Use updateagent for renames.
                 wstore.agent_def_update(&mut updated)
                     .map_err(|e| format!("agent.define: update: {e}"))?;
                 let stub_id = if create_stub {
-                    Some(make_stub_idempotent(
-                        &wstore, &updated.id, &updated.name, now,
-                    )?)
+                    match make_stub_idempotent(&wstore, &updated.id, &updated.name, now) {
+                        Ok((id, _new)) => Some(id),
+                        Err(e) => {
+                            tracing::warn!(id = %updated.id, err = %e, "agent.define: update stub failed (non-fatal)");
+                            None
+                        }
+                    }
                 } else {
                     None
                 };
@@ -2013,42 +2023,12 @@ pub(crate) async fn agent_define_core(
         }
     }
 
-    // No existing definition — create.
-    let mut def = AgentDefinition {
-        id: uuid::Uuid::new_v4().to_string(),
-        slug: String::new(), // agent_def_insert derives + collision-resolves
-        name: cmd.name.clone(),
-        icon: cmd.icon,
-        provider,  // validated / defaulted above
-        description: cmd.description,
-        working_directory: cmd.working_directory,
-        shell: cmd.shell,
-        environment: cmd.environment,
-        provider_flags: String::new(),
-        auto_start: 0,
-        restart_on_crash: 0,
-        idle_timeout_minutes: 0,
-        created_at: now,
-        agent_type: "agent".to_string(),
-        agent_bus_id: String::new(),
-        is_seeded: 0,
-        accounts: String::new(),
-        parent_id: String::new(),
-        branch_label: String::new(),
-        updated_at: now,
-        user_hidden: 0,
-    };
-    wstore.agent_def_insert(&mut def)
-        .map_err(|e| format!("agent.define: insert def: {e}"))?;
-
-    let stub_id = if create_stub {
-        Some(make_stub_idempotent(
-            &wstore, &def.id, &def.name, now,
-        )?)
-    } else {
-        None
-    };
-
+    // Fresh insert — def.slug is now set by agent_def_find_or_insert.
+    // Broadcast agents:changed before the stub creation: the definition is
+    // already committed, so broadcasting immediately is correct. If the stub
+    // create fails (a real DB error, not the expected UNIQUE no-op), we log
+    // a warning and return success with instance_stub_id = None rather than
+    // returning an error for an already-committed definition.
     broker.publish(crate::backend::wps::WaveEvent {
         event: "agents:changed".to_string(),
         scopes: vec![],
@@ -2056,6 +2036,17 @@ pub(crate) async fn agent_define_core(
         persist: 0,
         data: None,
     });
+    let stub_id = if create_stub {
+        match make_stub_idempotent(&wstore, &def.id, &def.name, now) {
+            Ok((id, _new)) => Some(id),
+            Err(e) => {
+                tracing::warn!(id = %def.id, err = %e, "agent.define: stub failed (definition committed, non-fatal)");
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     tracing::info!(
         id = %def.id,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1953,7 +1953,13 @@ pub(crate) async fn agent_define_core(
         working_directory: cmd.working_directory.clone(),
         shell: cmd.shell.clone(),
         environment: cmd.environment.clone(),
-        provider_flags: String::new(),
+        // Persist the requested model as a CLI flag so the agent launches
+        // with the specified model rather than the provider default.
+        provider_flags: if cmd.model.is_empty() {
+            String::new()
+        } else {
+            format!("--model {}", cmd.model)
+        },
         auto_start: 0,
         restart_on_crash: 0,
         idle_timeout_minutes: 0,
@@ -2022,6 +2028,9 @@ pub(crate) async fn agent_define_core(
                 // provider was already validated/defaulted above; only
                 // overwrite if the caller explicitly supplied a provider or model.
                 if !cmd.provider.is_empty() || !cmd.model.is_empty() { updated.provider = provider.clone(); }
+                // Persist the model as a CLI flag so the agent launches with
+                // the requested model rather than the provider default.
+                if !cmd.model.is_empty() { updated.provider_flags = format!("--model {}", cmd.model); }
                 if !cmd.icon.is_empty()     { updated.icon = cmd.icon.clone(); }
                 if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
                 if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,7 +18,7 @@ use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
-use crate::backend::storage::store::Store;
+use crate::backend::storage::store::{Store, AgentDefinition, AgentInstance, derive_slug};
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -35,6 +35,7 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_tracked_blocks(engine, state);
     register_agent_kill_process(engine, state);
     register_agent_kill_tree(engine, state);
+    register_agent_define(engine, state);
     register_pane_open(engine, state);
     register_blockfile_line_count(engine, state);
     register_blockfile_read_range(engine, state);
@@ -1815,5 +1816,172 @@ fn write_agent_config_files(
     );
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// agent.define
+// ---------------------------------------------------------------------------
+
+fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_DEFINE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentDefineData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.define: {e}"))?;
+
+                if cmd.name.trim().is_empty() {
+                    return Err("agent.define: name is required".to_string());
+                }
+
+                let if_exists = cmd.if_exists.as_deref().unwrap_or("skip");
+                let create_stub = cmd.create_instance_stub.unwrap_or(true);
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64;
+
+                // Resolve the slug the new name would get, then look for a
+                // matching user-owned definition.
+                let slug_candidate = derive_slug(&cmd.name);
+                let all_defs = wstore.agent_def_list()
+                    .map_err(|e| format!("agent.define: list defs: {e}"))?;
+                let existing = all_defs.iter().find(|d| d.slug == slug_candidate && d.is_seeded == 0);
+
+                if let Some(def) = existing {
+                    match if_exists {
+                        "skip" => {
+                            tracing::info!(slug = %slug_candidate, "agent.define: skipped (exists)");
+                            return Ok(Some(serde_json::to_value(&AgentDefineResult {
+                                definition_id: def.id.clone(),
+                                slug: def.slug.clone(),
+                                action: "skipped".to_string(),
+                                instance_stub_id: None,
+                            }).unwrap()));
+                        }
+                        "error" => {
+                            return Err(format!(
+                                "agent.define: definition with slug '{}' already exists (if_exists=error)",
+                                slug_candidate
+                            ));
+                        }
+                        "update" => {
+                            let mut updated = def.clone();
+                            if !cmd.provider.is_empty() { updated.provider = cmd.provider; }
+                            if !cmd.icon.is_empty()     { updated.icon = cmd.icon; }
+                            if !cmd.description.is_empty() { updated.description = cmd.description; }
+                            if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory; }
+                            if !cmd.shell.is_empty()    { updated.shell = cmd.shell; }
+                            if !cmd.environment.is_empty() { updated.environment = cmd.environment; }
+                            // name update intentionally omitted — the slug
+                            // is immutable, so renaming would create a slug
+                            // mismatch. Use updateagent for renames.
+                            wstore.agent_def_update(&mut updated)
+                                .map_err(|e| format!("agent.define: update: {e}"))?;
+                            broker.publish(crate::backend::wps::WaveEvent {
+                                event: "agents:changed".to_string(),
+                                scopes: vec![],
+                                sender: String::new(),
+                                persist: 0,
+                                data: None,
+                            });
+                            tracing::info!(id = %updated.id, slug = %updated.slug, "agent.define: updated");
+                            return Ok(Some(serde_json::to_value(&AgentDefineResult {
+                                definition_id: updated.id.clone(),
+                                slug: updated.slug.clone(),
+                                action: "updated".to_string(),
+                                instance_stub_id: None,
+                            }).unwrap()));
+                        }
+                        other => {
+                            return Err(format!("agent.define: unknown if_exists value '{other}'"));
+                        }
+                    }
+                }
+
+                // No existing definition — create.
+                let mut def = AgentDefinition {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    slug: String::new(), // agent_def_insert derives + collision-resolves
+                    name: cmd.name.clone(),
+                    icon: cmd.icon,
+                    provider: cmd.provider,
+                    description: cmd.description,
+                    working_directory: cmd.working_directory,
+                    shell: cmd.shell,
+                    environment: cmd.environment,
+                    provider_flags: String::new(),
+                    auto_start: 0,
+                    restart_on_crash: 0,
+                    idle_timeout_minutes: 0,
+                    created_at: now,
+                    agent_type: "agent".to_string(),
+                    agent_bus_id: String::new(),
+                    is_seeded: 0,
+                    accounts: String::new(),
+                    parent_id: String::new(),
+                    branch_label: String::new(),
+                    updated_at: now,
+                    user_hidden: 0,
+                };
+                wstore.agent_def_insert(&mut def)
+                    .map_err(|e| format!("agent.define: insert def: {e}"))?;
+
+                let stub_id = if create_stub {
+                    let id = format!("stub-{}", uuid::Uuid::new_v4().to_string().replace('-', "").chars().take(12).collect::<String>());
+                    let inst = AgentInstance {
+                        id: id.clone(),
+                        definition_id: def.id.clone(),
+                        parent_instance_id: String::new(),
+                        block_id: String::new(),
+                        session_id: String::new(),
+                        status: "stopped".to_string(),
+                        github_context: String::new(),
+                        started_at: now,
+                        ended_at: 0,
+                        created_at: now,
+                        identity_id: String::new(),
+                        memory_id: String::new(),
+                        instance_name: cmd.name.clone(),
+                        working_directory: String::new(),
+                        display_hidden: false,
+                    };
+                    wstore.instance_create(&inst)
+                        .map_err(|e| format!("agent.define: create stub instance: {e}"))?;
+                    Some(id)
+                } else {
+                    None
+                };
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "agents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+
+                tracing::info!(
+                    id = %def.id,
+                    slug = %def.slug,
+                    stub = stub_id.is_some(),
+                    "agent.define: created"
+                );
+
+                Ok(Some(serde_json::to_value(&AgentDefineResult {
+                    definition_id: def.id.clone(),
+                    slug: def.slug.clone(),
+                    action: "created".to_string(),
+                    instance_stub_id: stub_id,
+                }).unwrap()))
+            })
+        }),
+    );
 }
 

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2286,7 +2286,7 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     Err(e) => return WebReturnType::error(e),
                 };
             match super::app_api::agent_define_core(state.wstore.clone(), state.broker.clone(), data).await {
-                Ok(result) => WebReturnType::success(serde_json::to_value(&result).unwrap()),
+                Ok(result) => WebReturnType::success(serde_json::to_value(&result).unwrap_or_default()),
                 Err(e) => WebReturnType::error(e),
             }
         }

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2278,6 +2278,19 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             WebReturnType::success_empty()
         }
 
+        // ---- App API (also reachable via WebSocket RPC in app_api.rs) ----
+        ("agent", "define") => {
+            let data: crate::backend::rpc_types::CommandAgentDefineData =
+                match service::get_arg(args, 0) {
+                    Ok(v) => v,
+                    Err(e) => return WebReturnType::error(e),
+                };
+            match super::app_api::agent_define_core(state.wstore.clone(), state.broker.clone(), data).await {
+                Ok(result) => WebReturnType::success(serde_json::to_value(&result).unwrap()),
+                Err(e) => WebReturnType::error(e),
+            }
+        }
+
         _ => WebReturnType::error(format!(
             "unknown service method: {}.{}",
             call.service, call.method

--- a/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
+++ b/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
@@ -45,17 +45,13 @@ This is the **robust, restart-free alternative** to `scripts/import-agents.sh`.
 The token is stripped from the sidecar's own environment at startup and injected only into
 agent subprocesses — it never leaks to child processes that agents spawn.
 
-**HTTP envelope** (`WebCallType` — matches all other `/agentmux/service` calls):
+**HTTP request body** — use `WebCallType` (matches every other `/agentmux/service` call):
 ```json
-{ "service": "agent", "method": "define", "args": [{ ... }] }
+{ "service": "agent", "method": "define", "args": [{ "name": "...", "provider": "claude" }] }
 ```
 
-**WebSocket envelope** (`WshRpc` — for the WebSocket `/ws` path):
-```json
-{ "command": "agent.define", "reqid": "<uuid-v4>", "data": { ... } }
-```
-
-Both routes call the same `agent_define_core` handler and return equivalent results.
+Both the HTTP path and the WebSocket (`wscommand: "rpc"`) path call the same
+`agent_define_core` handler. For in-pane curl scripts, always use the HTTP shape above.
 
 ---
 
@@ -215,11 +211,10 @@ Expected response:
 }
 ```
 
-> **Note on envelope format:** The HTTP `/agentmux/service` endpoint uses the
-> `WebCallType` envelope (`service` + `method` + `args[]`), which matches all other
-> AgentMux HTTP service calls. The WebSocket path uses the `WshRpc` envelope
-> (`command` + `reqid` + `data`). Both routes call the same `agent_define_core`
-> handler and return equivalent results.
+> **Note on envelope format:** The HTTP `/agentmux/service` endpoint uses
+> `{"service":"agent","method":"define","args":[{...}]}` — the same `WebCallType`
+> shape as every other service call. Both the HTTP path and the WebSocket RPC path
+> call the same `agent_define_core` handler and produce equivalent results.
 
 The agent appears in My Agents on all open frontends within ~100ms (broadcast roundtrip),
 without any restart.

--- a/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
+++ b/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
@@ -21,7 +21,7 @@ The endpoint completes the "agent-driven self-configuration" loop:
 ```
 Agent reads  AGENTMUX_LOCAL_URL + AGENTMUX_AUTH_KEY
          ↓
-POST /agentmux/service  { "command": "agent.define", ... }
+POST /agentmux/service  {"service":"agent","method":"define","args":[{...}]}
          ↓
 Sidecar inserts/updates db_agent_definitions
          ↓
@@ -45,14 +45,17 @@ This is the **robust, restart-free alternative** to `scripts/import-agents.sh`.
 The token is stripped from the sidecar's own environment at startup and injected only into
 agent subprocesses — it never leaks to child processes that agents spawn.
 
-RPC envelope (same as all Tier 1 commands):
+**HTTP envelope** (`WebCallType` — matches all other `/agentmux/service` calls):
 ```json
-{
-  "command": "agent.define",
-  "reqid": "<uuid-v4>",
-  "data": { ... }
-}
+{ "service": "agent", "method": "define", "args": [{ ... }] }
 ```
+
+**WebSocket envelope** (`WshRpc` — for the WebSocket `/ws` path):
+```json
+{ "command": "agent.define", "reqid": "<uuid-v4>", "data": { ... } }
+```
+
+Both routes call the same `agent_define_core` handler and return equivalent results.
 
 ---
 

--- a/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
+++ b/docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md
@@ -1,0 +1,345 @@
+# SPEC: App API — `agent.define` (Import / Upsert Agent Definition)
+
+**Status:** Draft  
+**Date:** 2026-06-06  
+**Author:** AgentA  
+**Tier:** 1 extension (same auth + transport as existing `agent.open`)  
+**Tracking:** Discussion #1205 (app API long-term thread)  
+**Related:** `docs/specs/app-api-extension.md`, `docs/specs/app-api-status.md`
+
+---
+
+## 1. Purpose
+
+Allow any process — including a Claude agent running inside an AgentMux pane — to **create
+or update an agent definition** via the HTTP/WebSocket app API, without requiring:
+- direct SQLite access, or
+- an application restart for the definition to become visible.
+
+The endpoint completes the "agent-driven self-configuration" loop:
+
+```
+Agent reads  AGENTMUX_LOCAL_URL + AGENTMUX_AUTH_KEY
+         ↓
+POST /agentmux/service  { "command": "agent.define", ... }
+         ↓
+Sidecar inserts/updates db_agent_definitions
+         ↓
+Broadcast agents:changed  →  all frontends refresh My Agents instantly
+```
+
+This is the **robust, restart-free alternative** to `scripts/import-agents.sh`.
+
+---
+
+## 2. Transport & Auth (unchanged from existing Tier 1)
+
+| Property | Value |
+|---|---|
+| HTTP endpoint | `POST http://<AGENTMUX_LOCAL_URL>/agentmux/service` |
+| WebSocket endpoint | `ws://<AGENTMUX_LOCAL_URL>/ws?authkey=<token>` |
+| Auth header (HTTP) | `X-AuthKey: <token>` |
+| Auth query param (WS) | `authkey=<token>` |
+| Token source | `AGENTMUX_AUTH_KEY` env var (injected at agent spawn time) |
+
+The token is stripped from the sidecar's own environment at startup and injected only into
+agent subprocesses — it never leaks to child processes that agents spawn.
+
+RPC envelope (same as all Tier 1 commands):
+```json
+{
+  "command": "agent.define",
+  "reqid": "<uuid-v4>",
+  "data": { ... }
+}
+```
+
+---
+
+## 3. Request Shape
+
+```typescript
+interface AgentDefineRequest {
+  // Required
+  name: string;                    // Display name ("Maks", "Senior Dev")
+
+  // Identity — one of these must be set
+  provider?: string;               // "claude" | "openai" | "gemini" | "codex" | ...
+  model?: string;                  // e.g. "claude-sonnet-4-6" (provider inferred if omitted)
+
+  // Optional configuration — all fields mirror db_agent_definitions columns
+  system_prompt?: string;          // System/instruction text
+  working_directory?: string;      // Absolute path; "" = auto-allocate
+  shell?: string;                  // Shell override, e.g. "/bin/bash"
+  icon?: string;                   // Emoji or short string used as avatar
+  env?: Record<string, string>;    // Extra env vars to inject at agent spawn
+
+  // Import behaviour
+  if_exists?: "skip" | "update" | "error";   // Default: "skip"
+  //   "skip"   — if a definition with the same slug already exists, return its id; no update
+  //   "update" — overwrite all provided fields on the existing definition
+  //   "error"  — return error if a definition with the same slug exists
+
+  // Definition metadata
+  is_seeded?: 0 | 1;               // Default: 0 (user-owned, appears in My Agents)
+  parent_id?: string;              // id of the definition this was forked from
+
+  // Instance stub — controls whether a My Agents row appears immediately
+  create_instance_stub?: boolean;  // Default: true
+  //   true  → insert a stopped AgentInstance row so the agent appears in My Agents right away
+  //   false → definition is created but won't appear in My Agents until first launch
+}
+```
+
+### 3.1 Slug derivation
+
+The backend derives a **slug** from `name` to detect duplicates across calls:
+- Lowercase, whitespace → `_`, strip non-`[a-z0-9_]` chars
+- Examples: `"Maks"` → `"maks"`, `"Senior Dev"` → `"senior_dev"`
+- Slug uniqueness is checked across all user-owned (`is_seeded=0`) definitions only
+
+---
+
+## 4. Response Shape
+
+**Success (HTTP 200):**
+
+```typescript
+interface AgentDefineResponse {
+  ok: true;
+  definition_id: string;
+  slug: string;
+  action: "created" | "updated" | "skipped";  // What actually happened
+  instance_stub_id?: string;                   // Set when create_instance_stub=true + action=created
+}
+```
+
+**Error (HTTP 200 with error envelope, following existing Tier 1 pattern):**
+
+```typescript
+interface AgentDefineError {
+  ok: false;
+  error: string;
+  code:
+    | "UNKNOWN_PROVIDER"    // provider string not in the registered provider set
+    | "MISSING_IDENTITY"    // neither provider nor model was given
+    | "MISSING_NAME"        // name was empty or whitespace-only
+    | "ALREADY_EXISTS"      // if_exists="error" and slug already registered
+    | "INVALID_FIELD"       // a field value failed validation (details in error string)
+    | "INTERNAL";
+}
+```
+
+---
+
+## 5. Behaviour
+
+### 5.1 On `action = "created"` (new definition)
+
+1. Generate a new UUID for `definition_id`.
+2. Insert row into `db_agent_definitions` with all supplied fields; fill defaults:
+   - `is_seeded = 0`
+   - `created_at = now_ms()`
+   - `working_directory = ""` if not supplied (app allocates on first launch)
+3. If `create_instance_stub = true` (default): insert a stub `db_agent_instances` row:
+   - `status = "stopped"`
+   - `instance_name = <name>`
+   - `display_hidden = 0`
+   - `definition_id = <new_definition_id>`
+   - `started_at = now_ms()`, `ended_at = 0`
+4. Broadcast `agents:changed` to all connected WebSocket clients.
+   - All open `AgentPicker` frontends refresh `useAgentDefinitions()` and `MyAgentsList`
+     immediately — no restart required.
+5. Return `AgentDefineResponse { action: "created", ... }`.
+
+### 5.2 On `action = "updated"` (`if_exists="update"`, slug found)
+
+1. Look up existing definition by slug.
+2. Update only the fields present in the request (treat missing fields as "no change").
+3. Broadcast `agents:changed`.
+4. Return `AgentDefineResponse { action: "updated", definition_id: existing_id }`.
+
+### 5.3 On `action = "skipped"` (`if_exists="skip"`, slug found)
+
+1. Look up existing definition by slug.
+2. No DB write.
+3. No broadcast.
+4. Return `AgentDefineResponse { action: "skipped", definition_id: existing_id }`.
+
+### 5.4 `agents:changed` broadcast
+
+The broadcast is the same message the backend already emits on `AgentDefinitionForkCommand`
+and other definition mutations. The frontend's `useAgentDefinitions()` hook — already
+subscribed — will re-fetch and update signals. No frontend changes needed.
+
+---
+
+## 6. Example — Agent calling from inside a pane
+
+A Claude agent running in an AgentMux pane can drive this via `curl` (already available
+in the pane's shell):
+
+```bash
+#!/usr/bin/env bash
+# Create a new agent definition and see it appear in My Agents immediately.
+# The HTTP endpoint uses the WebCallType envelope: service + method + args[].
+
+curl -s -X POST "$AGENTMUX_LOCAL_URL/agentmux/service" \
+  -H "Content-Type: application/json" \
+  -H "X-AuthKey: $AGENTMUX_AUTH_KEY" \
+  -d '{
+    "service": "agent",
+    "method": "define",
+    "args": [{
+      "name": "Refactor Agent",
+      "provider": "claude",
+      "working_directory": "/c/Systems/agentmux",
+      "if_exists": "skip"
+    }]
+  }'
+```
+
+Expected response:
+```json
+{
+  "success": true,
+  "data": {
+    "definition_id": "a1b2c3d4-...",
+    "slug": "refactor_agent",
+    "action": "created",
+    "instance_stub_id": "si-a1b2c3d4..."
+  }
+}
+```
+
+> **Note on envelope format:** The HTTP `/agentmux/service` endpoint uses the
+> `WebCallType` envelope (`service` + `method` + `args[]`), which matches all other
+> AgentMux HTTP service calls. The WebSocket path uses the `WshRpc` envelope
+> (`command` + `reqid` + `data`). Both routes call the same `agent_define_core`
+> handler and return equivalent results.
+
+The agent appears in My Agents on all open frontends within ~100ms (broadcast roundtrip),
+without any restart.
+
+---
+
+## 7. `amux` CLI integration (when amux ships)
+
+```bash
+# Idiomatic CLI form (amux — planned, see app-api-status.md)
+amux agent define \
+  --name "Refactor Agent" \
+  --provider claude \
+  --model claude-sonnet-4-6 \
+  --system-prompt "You are a senior Rust engineer." \
+  --workdir /c/Systems/agentmux \
+  --if-exists skip
+
+# Batch import from a JSON file
+amux agent define --file agents.json
+```
+
+The `amux` CLI is the long-term preferred interface; `curl` is the stable fallback while
+`amux` is in development.
+
+---
+
+## 8. Batch import (single call, multiple definitions)
+
+To avoid multiple round-trips when importing many agents, the endpoint accepts an array:
+
+```typescript
+// Alternative request shape: array at top level
+type AgentDefineBatchRequest = AgentDefineRequest[];
+
+// Response when batch:
+interface AgentDefineBatchResponse {
+  ok: true;
+  results: Array<AgentDefineResponse | AgentDefineError>;
+  // agents:changed broadcast fires ONCE after all inserts (not per-item)
+}
+```
+
+The endpoint detects array vs object by checking the `data` field type. A single
+`agents:changed` broadcast covers all items in the batch.
+
+---
+
+## 9. Backend implementation — key files
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/server/app_api.rs` | Add `handle_agent_define()` function; register under `COMMAND_AGENT_DEFINE` |
+| `agentmux-srv/src/backend/rpc_types.rs` | Add `pub const COMMAND_AGENT_DEFINE: &str = "agent.define";` |
+| `agentmux-srv/src/backend/storage/agents.rs` | Add `upsert_agent_definition(conn, data, if_exists) -> Result<AgentDefineResult>` |
+| `frontend/types/gotypes.d.ts` | No change needed (response is JSON, not a typed frontend RPC) |
+
+### 9.1 Slug uniqueness query
+
+```sql
+SELECT id FROM db_agent_definitions
+WHERE lower(replace(name, ' ', '_')) = ?
+  AND is_seeded = 0
+LIMIT 1;
+```
+
+### 9.2 Instance stub insert (mirrors import-agents.sh)
+
+```rust
+conn.execute(
+    "INSERT OR IGNORE INTO db_agent_instances
+       (id, definition_id, parent_instance_id, block_id, session_id,
+        status, github_context, identity_id, memory_id, instance_name,
+        working_directory, display_hidden, started_at, ended_at, created_at)
+     VALUES
+       (?1, ?2, '', '', '', 'stopped', '', '', '', ?3, '', 0, ?4, 0, ?4)",
+    params![stub_id, definition_id, name, now_ms],
+)?;
+```
+
+### 9.3 Broadcast
+
+Re-use the existing broadcast helper already called by `AgentDefinitionForkCommand`:
+```rust
+broadcast_agents_changed(&state).await;
+```
+
+---
+
+## 10. Fit within the Tier taxonomy
+
+From `docs/specs/app-api-extension.md`:
+
+| Tier | Scope | This endpoint |
+|---|---|---|
+| 1 | Core agent/pane lifecycle over existing RPC | ✅ Yes — definition management is agent lifecycle |
+| 2 | File/editor integration | No |
+| 3 | UI state (tab, focus, layout) | No |
+| 4 | Auth, identity, secrets | No |
+| 5 | MCP / plugin host | No |
+
+`agent.define` is a natural Tier 1 extension alongside `agent.open`. It completes the
+create-before-open flow: an agent can call `agent.define` to register itself, then
+`agent.open` to spawn a fresh instance of the definition in a new pane.
+
+---
+
+## 11. Security constraints (unchanged from existing Tier 1)
+
+- Requires valid `X-AuthKey` — not accessible to processes outside AgentMux.
+- Only operates on user-owned definitions (`is_seeded=0`). Seeded templates cannot
+  be created or modified via this endpoint.
+- `working_directory` is stored as-is; validation (path-traversal, sandbox) is the same
+  as `agent.open` (existing behaviour).
+- No rate limit beyond what the RPC engine already applies.
+
+---
+
+## 12. Open questions
+
+| # | Question | Default |
+|---|----------|---------|
+| 1 | Should `update` action create a stub instance if one doesn't exist yet? | Yes — same as `created` |
+| 2 | Should `name` be the uniqueness key, or should callers pass an explicit `slug`? | `name`-derived slug; caller can pass `slug` override |
+| 3 | Should the batch form accept a NDJSON stream for very large imports? | Out of scope for v1 |
+| 4 | Should `agent.define` also trigger a one-time allocation of `working_directory` if ""? | No — allocate lazily at `agent.open` time (existing behaviour) |

--- a/docs/specs/SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md
+++ b/docs/specs/SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md
@@ -1,0 +1,329 @@
+# SPEC: Multi-Session Agent Fork
+
+**Status:** Draft  
+**Date:** 2026-06-06  
+**Author:** AgentA  
+**Based on:** Code introspection of actual implementation (see §2)
+
+---
+
+## 1. Problem
+
+When a user has an active agent session running and opens the same agent definition
+again from the agent pane picker, there is no mechanism to run it as an independent
+parallel session. The current session-zone model keys on `definition_id`, so a second
+open of the same definition reattaches to the same conversation rather than starting a
+fresh parallel one.
+
+Users want to run the same agent configuration concurrently on different tasks — e.g.
+two independent coding tasks using the same "Senior Dev" agent — each with an isolated
+working directory and independent conversation history.
+
+---
+
+## 2. Actual Architecture (code-verified)
+
+### 2.1 The Agent Pane Picker Has Two Lists
+
+**File:** `frontend/app/view/agent/components/AgentPicker.tsx`
+
+**List A — My Agents (session instances)**  
+Component: `MyAgentsList` (`frontend/app/view/agent/components/MyAgentsList.tsx`)  
+Data: `ListRecentSessionsCommand` → `RecentSessionRow[]`  
+Each row represents a **session instance** — an `AgentInstance` (concrete run) joined with
+its definition. A single definition with two past runs appears as **two rows** (truly
+per-instance, not per-definition). Clicking a row calls `onReattach(row)` →
+`launchAgentDefinition({ continueOfInstanceId: row.instance_id })`.
+
+**List B — Agent definitions (seeded, "+ New from template")**  
+Rendered directly in `AgentPicker.tsx` as a card grid below the "+" header.  
+Data: `ListAgentDefinitionsCommand({ is_seeded: 1 })` → `AgentDefinition[]`  
+These are seeded agent definitions (blueprints — "Claude Code", "Codex CLI", etc.).
+Clicking opens the create-from-template modal, which calls `AgentDefCreateFromTemplateCommand`
+to create a NEW user-owned definition (`is_seeded=0`, `parent_id = template.id`), then
+launches it fresh. Seeded definitions never appear in List A (they have no session instances).
+
+### 2.2 Core Types (from `frontend/types/gotypes.d.ts`)
+
+```typescript
+// Blueprint / template
+type AgentDefinition = {
+    id: string;
+    name: string;
+    is_seeded: number;        // 1=template, 0=user-owned
+    parent_id?: string;       // Forked-from definition id (v6+)
+    branch_label?: string;    // Fork branch label (v6+)
+    working_directory: string;
+    provider: string;
+    // ...model, tools, env, etc.
+};
+
+// A concrete run/session
+type AgentInstance = {
+    id: string;
+    definition_id: string;    // FK → AgentDefinition
+    parent_instance_id?: string;
+    block_id?: string;        // UI pane this instance lives in
+    session_id?: string;      // CLI session id (for --resume)
+    status: string;           // "running" | "paused" | "stopped" | "crashed" | "detached"
+    instance_name?: string;   // User-visible label
+    working_directory?: string;
+    identity_id?: string;
+    memory_id?: string;
+    // ...
+};
+
+// Combined view for List A
+type RecentSessionRow = {
+    instance_id: string;
+    instance_name: string;
+    definition_id: string;
+    definition_name: string;
+    working_directory: string;
+    preview: string;           // Last user message text
+    node_count: number;
+    last_active_at: number;
+    has_snapshot: boolean;
+    // ...identity, memory fields
+};
+```
+
+### 2.3 Session Zone Model (Option E)
+
+Session state (conversation snapshot) is stored in a **zone keyed on `definition_id`**:
+
+```
+agent:<definition_id>:current/output.state.json   ← UI snapshot (for restore)
+agent:<definition_id>:current/output              ← raw NDJSON stream (crash recovery)
+agent:<definition_id>:archive:<unix_ms>/...       ← archived past sessions
+```
+
+**This is the critical constraint:** one active session zone per definition. A second
+pane opening the same `definition_id` reads the same zone — no isolation.
+
+### 2.4 No "Already Running" Detection Today
+
+There is no check in `launchAgentDefinition()` (`agent-model.ts:276`) or anywhere in
+the picker for whether a definition already has an active `AgentInstance`. Two panes
+can silently reattach to the same session zone.
+
+---
+
+## 3. Proposed Solution: Definition Fork
+
+### 3.1 Core Insight
+
+The session zone is keyed on `definition_id`. The cleanest path to session isolation —
+without restructuring the entire zone model — is to give each parallel run its **own
+definition copy** (`is_seeded=0`, `parent_id` = original). The existing
+`parent_id`/`branch_label` fields on `AgentDefinition` were added for exactly this
+purpose (v6+) but never wired to a user-facing flow.
+
+Each forked definition:
+- Gets a new `definition_id` (new session zone key)
+- Inherits all config from the parent (system prompt, model, tools)
+- Gets an auto-incremented `branch_label` ("Senior Dev #2", "Senior Dev #3")
+- Gets its own `working_directory` (separate workspace)
+- Has `is_seeded=0` so it appears in List A (My Agents) as a new session instance after first run
+
+### 3.2 When Fork Is Triggered
+
+**Trigger point:** User clicks a `RecentSessionRow` in List A (My Agents) while that
+definition already has an active instance in another open pane (block).
+
+Detection in `launchAgentDefinition()` (`agent-model.ts`):
+1. Query WOS for all open blocks with `view: "agent"` and `meta.agentId === definition_id`
+2. If any such block exists and the instance's status is `"running"` → show fork prompt
+
+**Fork prompt** (inline, non-modal, appears below the row in List A):
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ "Senior Dev" is already open in another pane.            │
+│                                                          │
+│  [Open new session]    [Switch to existing]              │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **"Open new session"** → fork flow (§3.3)
+- **"Switch to existing"** → focus the pane that already has the agent open
+
+### 3.3 Fork Flow
+
+```
+User clicks "Open new session"
+  │
+  ├─ 1. Backend: AgentDefinitionForkCommand({ source_id, branch_label })
+  │      - Creates new AgentDefinition row:
+  │          id = new UUID
+  │          parent_id = source_id
+  │          branch_label = auto-generated (§3.4)
+  │          is_seeded = 0
+  │          working_directory = auto-allocate new dir
+  │          (all other fields copied from source)
+  │      - Returns: new_definition_id
+  │
+  ├─ 2. Frontend: launchAgentDefinition({ definitionId: new_definition_id })
+  │      - Normal launch flow: allocate workdir, spawn CLI, create AgentInstance
+  │      - New session zone: agent:<new_definition_id>:current/...
+  │
+  └─ 3. List A (MyAgentsList) auto-refreshes via `agents:changed` broadcast
+         - New fork appears as its own row with branch_label as display name
+```
+
+### 3.4 Auto-Naming
+
+The `branch_label` for a fork is assigned by the backend at creation time:
+
+```
+parent definition name: "Senior Dev"
+existing non-archived fork count under parent_id: N
+
+  N=0 (no prior forks): branch_label = "Senior Dev #2"
+  N=1:                  branch_label = "Senior Dev #3"
+  ...
+```
+
+The original definition keeps its original name ("Senior Dev"). Only forks get the
+`#N` suffix. Users can rename any definition from its context menu; the `branch_label`
+is then overwritten with the user's choice.
+
+### 3.5 Workspace Isolation
+
+Each fork gets its own working directory. Options:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| New dir under parent's workspace root: `<parent_workdir>/forks/<branch_label>/` | Easy to find related forks | Requires parent to have a workdir set |
+| Fresh auto-allocated dir (same as new agent): `~/.agentmux/workspaces/<new_def_id>/` | Always works, clean isolation | Disconnected from parent |
+
+**Default:** fresh auto-allocated dir (Option B). Users who want sibling forks can
+configure workdir manually after creation. A `"Copy working directory contents"` checkbox
+in the fork prompt (optional) lets users seed the new workspace from the parent's current
+files.
+
+---
+
+## 4. UX Changes
+
+### 4.1 List A — My Agents (session instances)
+
+Each `RecentSessionRow` gets a context menu (right-click / "..." button on hover):
+- **Fork → New session** — triggers §3.2 flow
+- **Rename** — edit `instance_name`
+- **Archive** — soft-delete (hides from list)
+- **Open in new pane** — same as click but forces new pane
+
+Forked sessions appear as their own rows in List A. They are visually linked to their
+parent by showing the `parent_id`'s name in small text below the row name (e.g.
+`fork of Senior Dev`) — only visible on hover to reduce noise.
+
+### 4.2 List B — Agent definitions (seeded)
+
+No change to List B. Seeded definitions (`is_seeded=1`) never have session instances
+and always create a fresh user-owned definition. Their existing flow is already "create
+new definition + launch."
+
+### 4.3 "Already Open" Indicator
+
+If a session instance is currently open in another pane, its row in List A shows a small
+"active" badge (green dot / running indicator). This gives the user visual awareness
+before clicking.
+
+---
+
+## 5. Backend Changes
+
+### 5.1 New RPC: `AgentDefinitionForkCommand`
+
+```rust
+pub struct AgentDefinitionForkCommand {
+    pub source_id: String,
+    pub branch_label: Option<String>,  // None → auto-generate
+    pub copy_workdir_contents: bool,   // false → empty new workdir
+}
+
+pub struct AgentDefinitionForkResponse {
+    pub definition_id: String,
+    pub branch_label: String,
+    pub working_directory: String,
+}
+```
+
+Handler in `agent_handlers.rs`:
+1. Load source definition
+2. Compute next branch_label (count non-archived forks with `parent_id = source_id`)
+3. Insert new `db_agent_definitions` row (copy + new id + parent_id + branch_label)
+4. Auto-allocate working_directory if `copy_workdir_contents=false`
+5. If `copy_workdir_contents=true`: `fs::copy_dir(source.working_directory, new_dir)`
+6. Broadcast `agents:changed`
+7. Return response
+
+### 5.2 "Active Instance" Query
+
+New helper in `storage/agents.rs`:
+
+```rust
+pub fn definition_active_instance(
+    conn: &Connection,
+    definition_id: &str,
+) -> Option<AgentInstance>;
+```
+
+Returns the most recent instance with `definition_id = ?` and `status IN ("running",
+"paused")`. Used by the frontend detection in §3.2 via a new lightweight RPC, or
+by the frontend querying WOS directly for open agent blocks.
+
+### 5.3 No Session Zone Changes
+
+The session zone model (§2.3) is unchanged. Forks get new `definition_id`s, so they
+naturally get new zones (`agent:<new_def_id>:current`) without any refactoring of
+the zone machinery.
+
+---
+
+## 6. Migration / Backwards Compatibility
+
+- No DB migration needed for the fork flow itself — `parent_id` and `branch_label`
+  columns already exist on `db_agent_definitions` (added in v6+).
+- Existing agents are unaffected; they have `parent_id = NULL` and `branch_label = NULL`.
+- `ListRecentSessionsCommand` already returns all user-owned instances; forks appear
+  automatically once created.
+
+---
+
+## 7. Out of Scope (Follow-ups)
+
+- **Conversation branching:** forking mid-conversation to explore two different reply
+  paths (requires per-instance session zones, larger refactor)
+- **Fork tree visualization:** showing the parent → fork → fork tree in the picker UI
+- **Auto-fork setting:** per-definition toggle to always fork on open without prompting
+- **Merge/sync:** syncing changes between fork and parent (out of scope, complex)
+- **Session zone refactor to per-instance:** decouples zones from definitions entirely;
+  would enable branching but is a large separate project
+
+---
+
+## 8. Open Questions
+
+| # | Question | Default |
+|---|----------|---------|
+| 1 | Should fork prompt also appear when opening via template cards? | No — templates always create fresh; no ambiguity |
+| 2 | Should the "Copy working directory contents" checkbox default to on or off? | Off — isolated by default, user opts in to copying |
+| 3 | Should forked definitions be editable (change model, system prompt) independently of parent? | Yes — they are independent definitions after fork |
+| 4 | Where does the "active in another pane" detection live — WOS query in frontend, or a backend RPC? | WOS query in frontend (already has block state) |
+| 5 | Should the fork prompt appear on a session-instance row click (List A), or only in the context menu? | On click when active instance detected; context menu for explicit fork regardless |
+
+---
+
+## 9. Key Files
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/components/MyAgentsList.tsx` | Add context menu, active-instance badge, fork prompt inline UI |
+| `frontend/app/view/agent/agent-model.ts:276` | Add active-instance detection in `launchAgentDefinition()` |
+| `frontend/app/view/agent/components/AgentPicker.tsx` | Pass active-instance map to MyAgentsList |
+| `agentmux-srv/src/server/agent_handlers.rs` | Add `AgentDefinitionForkCommand` handler |
+| `agentmux-srv/src/backend/storage/agents.rs` | Add `definition_active_instance()` helper |
+| `frontend/types/gotypes.d.ts` | Add `AgentDefinitionForkCommand` / `AgentDefinitionForkResponse` types |
+| `frontend/app/view/agent/rpc-api.ts` | Add `AgentDefinitionForkCommand` RPC wrapper |

--- a/docs/specs/SPEC_WINDOW_DRAG_HANDLE_2026_06_06.md
+++ b/docs/specs/SPEC_WINDOW_DRAG_HANDLE_2026_06_06.md
@@ -1,0 +1,157 @@
+# SPEC: Always-visible window drag handle (grip) in the tab bar
+
+**Status:** Draft
+**Date:** 2026-06-06
+**Author:** AgentA
+
+---
+
+## 1. Problem
+
+On Windows/Linux the entire tab bar is technically a drag region, but the only
+reliably empty draggable space is `tab-bar-fill` — the slack area to the right
+of the last tab. When the tab bar is full, `tab-bar-fill` shrinks to zero and
+there is nowhere to grab the window without closing or moving a tab.
+
+The hamburger (`<HamburgerMenu>`) sits at the far left but its element has
+`data-drag-region="false"` (it's a button). The window is effectively
+un-draggable with a full tab strip.
+
+---
+
+## 2. Solution: fixed-width grip handle between hamburger and tabs
+
+Insert a `<WindowDragHandle>` component immediately after `<HamburgerMenu>` in
+the tab bar, to the LEFT of the tab scroll container. The handle:
+
+- is **always present** and always the same size regardless of tab count
+- shows a **grip icon** (⠿ — see §3) as a visual affordance
+- carries `data-drag-region="true"` so the existing win32/linux drag hook picks
+  it up with zero extra logic
+- is **non-interactive** beyond drag: no click action, no menu, no tooltip
+
+On macOS the handle is **not rendered** — the traffic light area + the native
+window header already covers this, and the macOS drag hook uses a different
+mechanism (WebView-level `data-drag-region` → OS HTCAPTION).
+
+---
+
+## 3. Grip icon
+
+Unicode **⠿** (U+283F, Braille pattern dots-1-2-3-4-5-6) renders as a tight
+2×3 dot grid and is the conventional "grip" glyph in monospace/icon contexts.
+If the chosen font renders it too small or off-center, fall back to a small
+inline SVG (two columns of three dots, 2px diameter, 3px vertical gap, 5px
+column gap).
+
+The icon color: `var(--color-secondary-text)` at 50% opacity (subdued but
+readable), brightening to 70% on hover over the handle.
+
+---
+
+## 4. Size and hit target
+
+| Property | Value |
+|---|---|
+| Width | 20px |
+| Height | 100% of `.tab-bar` (inherits flex align-stretch) |
+| Min hit target | 20 × 28px (meets WCAG 2.5.8 minimum) |
+| Cursor | `grab` (→ `grabbing` while held, via CSS `:active`) |
+| Padding | 0 4px (icon centered) |
+
+The handle sits between the hamburger button and the `.tab-bar-scroll`
+container. It does not push tabs; the flex layout of `.tab-bar` absorbs it as a
+fixed-width flex item.
+
+---
+
+## 5. Technical implementation
+
+### 5.1 Component
+
+New file: `frontend/app/window/WindowDragHandle.tsx`
+
+```tsx
+// Renders only on Windows and Linux; returns null on macOS.
+// data-drag-region="true" hooks into the existing useWindowDrag hook
+// (win32: native move loop via start_window_drag IPC; linux: JS-driven).
+export function WindowDragHandle(): JSX.Element {
+    if (isMacOS()) return null;
+    return (
+        <div class="window-drag-handle" data-drag-region="true" aria-hidden="true">
+            ⠿
+        </div>
+    );
+}
+```
+
+### 5.2 Tab bar insertion
+
+`frontend/app/tab/tabbar.tsx` — inside the `<Show when={!isMacOS()}>` block,
+after `<HamburgerMenu />`:
+
+```tsx
+<Show when={!isMacOS()}>
+    <HamburgerMenu />
+    <WindowDragHandle />  {/* ← new */}
+</Show>
+```
+
+### 5.3 CSS
+
+```css
+.window-drag-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    flex-shrink: 0;
+    cursor: grab;
+    color: var(--color-secondary-text);
+    opacity: 0.5;
+    font-size: 14px;
+    user-select: none;
+}
+
+.window-drag-handle:hover  { opacity: 0.7; }
+.window-drag-handle:active { cursor: grabbing; }
+```
+
+### 5.4 Drag machinery — no changes needed
+
+`useWindowDrag.win32.ts`: `isInDragRegion()` walks up the DOM looking for
+`data-drag-region`. The handle's own attribute (`"true"`) is found immediately —
+no changes to the hook. The native move loop fires exactly as it does for
+`tab-bar-fill`.
+
+`useWindowDrag.linux.ts`: same attribute-walk logic, same result.
+
+---
+
+## 6. Platform matrix
+
+| Platform | Rendered | Drag mechanism |
+|---|---|---|
+| Windows | Yes | `data-drag-region` → `start_window_drag` IPC → native move loop (SetCapture) |
+| Linux | Yes | `data-drag-region` → JS-driven `set_window_position` per-move |
+| macOS | No | Traffic lights + macOS WebView drag handle the window |
+
+---
+
+## 7. Open questions / out of scope
+
+| # | Question | Default |
+|---|---|---|
+| 1 | Show on floater windows too? | Yes — same component, same region; floaters already have their own drag header but consistency doesn't hurt |
+| 2 | Reduce opacity when maximized (dragging a maximized window unmaximizes it)? | No change for now; existing behavior on `tab-bar-fill` is the same |
+| 3 | RTL layout — does the handle move to the right of the hamburger (now on the right)? | Out of scope; RTL not currently supported |
+
+---
+
+## 8. Key files
+
+| File | Change |
+|---|---|
+| `frontend/app/window/WindowDragHandle.tsx` | New component |
+| `frontend/app/tab/tabbar.tsx` | Insert `<WindowDragHandle />` after `<HamburgerMenu />` |
+| `frontend/app/styles/tabbar.css` (or equivalent) | `.window-drag-handle` styles |

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -44,6 +44,7 @@ import {
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { ProviderLogo } from "@/element/ProviderLogo";
 
 /** ms epoch → human-readable relative timestamp. Centralized here +
@@ -108,6 +109,14 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     };
     document.addEventListener("visibilitychange", onVisible);
     onCleanup(() => document.removeEventListener("visibilitychange", onVisible));
+
+    // Refetch when a new agent definition is created (e.g. via agent.define)
+    // so the stub instance appears immediately without needing a restart.
+    const unsubAgents = waveEventSubscribe({
+        eventType: "agents:changed",
+        handler: () => void refetch(),
+    });
+    onCleanup(unsubAgents);
 
     // The Date.now() snapshot updates every minute so "5m ago" rolls
     // forward without the user having to re-render. createSignal ticks

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -116,6 +116,23 @@ import_into() {
 
         local src_win; src_win=$(win_path "$src_db")
 
+        # Detect which newer columns exist in the source schema so the SELECT
+        # does not fail on older AgentMux databases that lack them.
+        local _src_cols; _src_cols=$(sqlite3 "$src_win" \
+            "SELECT group_concat(name) FROM pragma_table_info('db_agent_definitions');" \
+            2>/dev/null || echo "")
+        local _col_updated_at _col_user_hidden
+        if echo "$_src_cols" | grep -qw "updated_at"; then
+            _col_updated_at="updated_at"
+        else
+            _col_updated_at="created_at"
+        fi
+        if echo "$_src_cols" | grep -qw "user_hidden"; then
+            _col_user_hidden="user_hidden"
+        else
+            _col_user_hidden="0"
+        fi
+
         while IFS=$'\x01' read -r def_id agent_name; do
             # Escape single-quotes for safe SQL interpolation (e.g. "Bob's Agent" → "Bob''s Agent")
             local safe_name="${agent_name//\'/\'\'}"
@@ -132,6 +149,8 @@ import_into() {
             # Copy definition row (always required).
             # Explicit column list avoids INSERT/SELECT * schema-mismatch failures
             # when importing across versions with different db_agent_definitions schemas.
+            # Uses detected column names so source DBs lacking updated_at/user_hidden
+            # fall back to created_at/0 rather than aborting the import.
             sqlite3 "$src_win" \
                 "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agent_definitions
@@ -143,8 +162,22 @@ import_into() {
                     id, slug, name, icon, provider, description,
                     working_directory, shell, provider_flags, auto_start, restart_on_crash,
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden
+                    is_seeded, accounts, parent_id, branch_label,
+                    ${_col_updated_at}, ${_col_user_hidden}
                  FROM db_agent_definitions WHERE id='$def_id';"
+
+            # Verify the definition was actually inserted.
+            # db_agent_definitions has a UNIQUE index on slug — an INSERT OR IGNORE
+            # silently skips when the target already has a different agent with the
+            # same slug. Creating a stub for a missing definition would leave a
+            # broken My Agents entry, so abort this agent if the row didn't land.
+            local def_landed; def_landed=$(db_query "$target_db" \
+                "SELECT count(*) FROM db_agent_definitions WHERE id='$def_id';")
+            if [ "${def_landed:-0}" -eq 0 ]; then
+                echo "  SKIP  $agent_name (slug conflict in target — definition not imported)"
+                ((skipped++)) || true
+                continue
+            fi
 
             # Also populate the consolidated db_agents table (schema v4+).
             # agent_def_list() and instance_list() read db_agents; skipping this
@@ -168,7 +201,7 @@ import_into() {
                    agent_type, agent_bus_id, accounts,
                    auto_start, restart_on_crash, idle_timeout_minutes,
                    slug, branch_label,
-                   created_at, updated_at, is_seeded, user_hidden
+                   created_at, ${_col_updated_at}, is_seeded, ${_col_user_hidden}
                  FROM db_agent_definitions WHERE id='$def_id';" 2>/dev/null || true
 
             # Create a stub instance so the agent appears in My Agents

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -106,13 +106,15 @@ import_into() {
             where="is_seeded=0"
         fi
 
+        # Use char(1) (ASCII unit-separator) instead of '|' so agent names that
+        # contain a pipe character don't corrupt the field split.
         agents=$(db_query "$src_db" \
-            "SELECT id, name FROM db_agent_definitions WHERE $where;" 2>/dev/null)
+            "SELECT id||char(1)||name FROM db_agent_definitions WHERE $where;" 2>/dev/null)
         [ -z "$agents" ] && continue
 
         local src_win; src_win=$(win_path "$src_db")
 
-        while IFS='|' read -r def_id agent_name; do
+        while IFS=$'\x01' read -r def_id agent_name; do
             # Escape single-quotes for safe SQL interpolation (e.g. "Bob's Agent" → "Bob''s Agent")
             local safe_name="${agent_name//\'/\'\'}"
 

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -19,9 +19,12 @@ AGENTMUX_DIR="${AGENTMUX_DIR:-$HOME/.agentmux}"
 # where sha1 is of the branch name string itself (not the commit).
 if [ -z "${CHANNEL:-}" ]; then
     _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+    # Apply the same slug sanitization as scripts/package.sh BRANCH_SLUG:
+    # replace non-alphanumeric/dot/dash chars with '-', cap at 20 chars.
+    _branch_slug=$(printf '%s' "$_branch" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-20)
     _branch_hash=$(printf '%s' "$_branch" | sha1sum | cut -c1-6 2>/dev/null \
                    || printf '%s' "$_branch" | shasum | cut -c1-6)
-    CHANNEL="dev-portable-${_branch}-${_branch_hash}"
+    CHANNEL="dev-portable-${_branch_slug}-${_branch_hash}"
 fi
 CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"
 
@@ -218,6 +221,15 @@ import_into() {
                    ('$stub_id', '$def_id', '', '', '', 'stopped',
                     '', '', '', '$safe_name',
                     '', 0, $ts, 0, $ts);"
+
+            # Mirror instance_name into db_agents so Phase-3b readers
+            # (which read db_agents directly) see the agent name immediately,
+            # matching what agents_dual_write_instance_create does on the
+            # Rust path when a stub is created for a user-clone definition.
+            sqlite3 "$tgt_win" \
+                "UPDATE db_agents SET instance_name='$safe_name', updated_at=$ts
+                 WHERE id='$def_id'
+                   AND (instance_name IS NULL OR instance_name='');" 2>/dev/null || true
 
             echo "  OK    $agent_name"
             ((imported++)) || true

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -98,6 +98,9 @@ import_into() {
         local src_win; src_win=$(win_path "$src_db")
 
         while IFS='|' read -r def_id agent_name; do
+            # Escape single-quotes for safe SQL interpolation (e.g. "Bob's Agent" → "Bob''s Agent")
+            local safe_name="${agent_name//\'/\'\'}"
+
             # Skip if definition already present
             exists=$(db_query "$target_db" \
                 "SELECT count(*) FROM db_agent_definitions WHERE id='$def_id';")
@@ -123,7 +126,7 @@ import_into() {
                     working_directory, display_hidden, started_at, ended_at, created_at)
                  VALUES
                    ('$stub_id', '$def_id', '', '', '', 'stopped',
-                    '', '', '', '$agent_name',
+                    '', '', '', '$safe_name',
                     '', 0, $ts, 0, $ts);"
 
             echo "  OK    $agent_name"

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# import-agents.sh — copy user-created agent definitions into a target version DB
+# and create stub session instances so they appear in My Agents without a restart.
+#
+# Usage:
+#   scripts/import-agents.sh                        # catalog all agents across all DBs
+#   scripts/import-agents.sh --to 0.43.2            # import all user agents into version
+#   scripts/import-agents.sh --to 0.43.2 --name Maks,Maksi
+#
+# After running, reopen the agent pane in the target build (no full restart needed).
+# The agents appear in My Agents with status "stopped", ready to launch.
+
+set -euo pipefail
+
+AGENTMUX_DIR="${AGENTMUX_DIR:-$HOME/.agentmux}"
+CHANNEL="${CHANNEL:-dev-portable-main-b28b7a}"
+CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+db_query() { sqlite3 "$1" "$2" 2>/dev/null; }
+
+# sqlite3 ATTACH fails on long POSIX paths on Windows; convert to Win32
+win_path() { cygpath -w "$1" 2>/dev/null || echo "$1"; }
+
+# ms-epoch timestamp
+now_ms() { date +%s%3N; }
+
+# Find every objects.db under the agentmux dir
+all_dbs() {
+    find "$AGENTMUX_DIR" -name "objects.db" 2>/dev/null | sort
+}
+
+# ── catalog ──────────────────────────────────────────────────────────────────
+
+catalog() {
+    echo ""
+    echo "User-created agents across all data dirs:"
+    echo "──────────────────────────────────────────────────────────"
+    printf "%-20s %-12s %-10s %s\n" "NAME" "PROVIDER" "VERSION" "SOURCE"
+    echo "──────────────────────────────────────────────────────────"
+    while IFS= read -r db; do
+        result=$(db_query "$db" \
+            "SELECT name, provider FROM db_agent_definitions WHERE is_seeded=0 ORDER BY name;")
+        [ -z "$result" ] && continue
+        label=$(echo "$db" | sed \
+            -e "s|$AGENTMUX_DIR/||" \
+            -e 's|/data/db/objects\.db||' \
+            -e 's|channels/||' \
+            -e 's|versions/||')
+        version=$(echo "$label" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+        version="${version:-dev}"
+        while IFS='|' read -r name provider; do
+            printf "%-20s %-12s %-10s %s\n" "$name" "$provider" "$version" "$label"
+        done <<< "$result"
+    done < <(all_dbs)
+    echo ""
+    echo "Run with --to <version> to import into that version."
+    echo "Example: scripts/import-agents.sh --to 0.43.2"
+    echo "         scripts/import-agents.sh --to 0.43.2 --name Maks,Maksi"
+}
+
+# ── import ───────────────────────────────────────────────────────────────────
+
+import_into() {
+    local target_version="$1"
+    local name_filter="$2"   # comma-separated names, or "" for all
+    local target_db="$CHANNEL_DIR/versions/$target_version/data/db/objects.db"
+
+    if [ ! -f "$target_db" ]; then
+        echo "ERROR: Target DB not found: $target_db" >&2
+        echo "       Build and launch version $target_version at least once first." >&2
+        exit 1
+    fi
+
+    local tgt_win; tgt_win=$(win_path "$target_db")
+    local ts; ts=$(now_ms)
+    local imported=0 skipped=0
+
+    echo "Target: $target_db"
+    echo ""
+
+    while IFS= read -r src_db; do
+        [ "$src_db" = "$target_db" ] && continue
+
+        if [ -n "$name_filter" ]; then
+            names_in=$(echo "$name_filter" | tr ',' '\n' | \
+                awk '{printf "%s'\''%s'\''", (NR>1?",":""), $0}')
+            where="is_seeded=0 AND name IN ($names_in)"
+        else
+            where="is_seeded=0"
+        fi
+
+        agents=$(db_query "$src_db" \
+            "SELECT id, name FROM db_agent_definitions WHERE $where;" 2>/dev/null)
+        [ -z "$agents" ] && continue
+
+        local src_win; src_win=$(win_path "$src_db")
+
+        while IFS='|' read -r def_id agent_name; do
+            # Skip if definition already present
+            exists=$(db_query "$target_db" \
+                "SELECT count(*) FROM db_agent_definitions WHERE id='$def_id';")
+            if [ "$exists" -gt 0 ]; then
+                echo "  SKIP  $agent_name (already in target)"
+                ((skipped++)) || true
+                continue
+            fi
+
+            # Copy definition
+            sqlite3 "$src_win" \
+                "ATTACH '$tgt_win' AS dst;
+                 INSERT OR IGNORE INTO dst.db_agent_definitions
+                 SELECT * FROM db_agent_definitions WHERE id='$def_id';"
+
+            # Create a stub instance so the agent appears in My Agents
+            # (ListRecentSessionsCommand queries instances, not definitions)
+            local stub_id="stub-$(echo "$def_id" | tr -dc 'a-z0-9' | head -c8)-01"
+            sqlite3 "$tgt_win" \
+                "INSERT OR IGNORE INTO db_agent_instances
+                   (id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, identity_id, memory_id, instance_name,
+                    working_directory, display_hidden, started_at, ended_at, created_at)
+                 VALUES
+                   ('$stub_id', '$def_id', '', '', '', 'stopped',
+                    '', '', '', '$agent_name',
+                    '', 0, $ts, 0, $ts);"
+
+            echo "  OK    $agent_name"
+            ((imported++)) || true
+        done <<< "$agents"
+    done < <(all_dbs)
+
+    echo ""
+    echo "Imported: $imported  Skipped: $skipped"
+    [ "$imported" -gt 0 ] && \
+        echo "Reopen the agent pane in the $target_version build to see the changes."
+}
+
+# ── arg parsing ──────────────────────────────────────────────────────────────
+
+TARGET_VERSION=""
+NAME_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --to)      TARGET_VERSION="$2"; shift 2 ;;
+        --name)    NAME_FILTER="$2";    shift 2 ;;
+        --channel) CHANNEL="$2"; CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -n "$TARGET_VERSION" ]; then
+    import_into "$TARGET_VERSION" "$NAME_FILTER"
+else
+    catalog
+fi

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -70,6 +70,9 @@ import_into() {
     if [ ! -f "$target_db" ]; then
         echo "ERROR: Target DB not found: $target_db" >&2
         echo "       Build and launch version $target_version at least once first." >&2
+        echo "" >&2
+        echo "       If you're using a different channel, pass --channel <name>." >&2
+        echo "       Available channels: $(ls "$AGENTMUX_DIR/channels/" 2>/dev/null | tr '\n' '  ')" >&2
         exit 1
     fi
 
@@ -84,7 +87,9 @@ import_into() {
         [ "$src_db" = "$target_db" ] && continue
 
         if [ -n "$name_filter" ]; then
+            # Escape apostrophes in each name before building the SQL IN list.
             names_in=$(echo "$name_filter" | tr ',' '\n' | \
+                sed "s/'/''/g" | \
                 awk '{printf "%s'\''%s'\''", (NR>1?",":""), $0}')
             where="is_seeded=0 AND name IN ($names_in)"
         else
@@ -117,8 +122,10 @@ import_into() {
                  SELECT * FROM db_agent_definitions WHERE id='$def_id';"
 
             # Create a stub instance so the agent appears in My Agents
-            # (ListRecentSessionsCommand queries instances, not definitions)
-            local stub_id="stub-$(echo "$def_id" | tr -dc 'a-z0-9' | head -c8)-01"
+            # (ListRecentSessionsCommand queries instances, not definitions).
+            # Derive stub_id from the full def_id (UUID, globally unique) so
+            # repeated imports are idempotent and INSERT OR IGNORE is safe.
+            local stub_id="si-$(echo "$def_id" | tr -d '-')"
             sqlite3 "$tgt_win" \
                 "INSERT OR IGNORE INTO db_agent_instances
                    (id, definition_id, parent_instance_id, block_id, session_id,

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -126,10 +126,21 @@ import_into() {
             fi
 
             # Copy definition row (always required).
+            # Explicit column list avoids INSERT/SELECT * schema-mismatch failures
+            # when importing across versions with different db_agent_definitions schemas.
             sqlite3 "$src_win" \
                 "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agent_definitions
-                   SELECT * FROM db_agent_definitions WHERE id='$def_id';"
+                   (id, slug, name, icon, provider, description,
+                    working_directory, shell, provider_flags, auto_start, restart_on_crash,
+                    idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
+                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden)
+                 SELECT
+                    id, slug, name, icon, provider, description,
+                    working_directory, shell, provider_flags, auto_start, restart_on_crash,
+                    idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
+                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden
+                 FROM db_agent_definitions WHERE id='$def_id';"
 
             # Also populate the consolidated db_agents table (schema v4+).
             # agent_def_list() and instance_list() read db_agents; skipping this

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -125,15 +125,19 @@ import_into() {
                 continue
             fi
 
-            # Copy definition into the legacy table AND the consolidated
-            # db_agents table (present in schema v4+). Readers such as
-            # agent_def_list() and instance_list() use db_agents; skipping
-            # the dual-write leaves the agent invisible to the running app
-            # even though it's in db_agent_definitions.
+            # Copy definition row (always required).
             sqlite3 "$src_win" \
                 "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agent_definitions
-                   SELECT * FROM db_agent_definitions WHERE id='$def_id';
+                   SELECT * FROM db_agent_definitions WHERE id='$def_id';"
+
+            # Also populate the consolidated db_agents table (schema v4+).
+            # agent_def_list() and instance_list() read db_agents; skipping this
+            # write leaves the agent invisible to the running app even though the
+            # definition row is present. Silent no-op on pre-v4 targets where the
+            # table does not exist yet.
+            sqlite3 "$src_win" \
+                "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agents
                    (id, name, icon, description,
                     is_template, parent_template_id,
@@ -150,11 +154,7 @@ import_into() {
                    auto_start, restart_on_crash, idle_timeout_minutes,
                    slug, branch_label,
                    created_at, updated_at, is_seeded, user_hidden
-                 FROM db_agent_definitions WHERE id='$def_id';" 2>/dev/null || \
-            sqlite3 "$src_win" \
-                "ATTACH '$tgt_win' AS dst;
-                 INSERT OR IGNORE INTO dst.db_agent_definitions
-                 SELECT * FROM db_agent_definitions WHERE id='$def_id';"
+                 FROM db_agent_definitions WHERE id='$def_id';" 2>/dev/null || true
 
             # Create a stub instance so the agent appears in My Agents
             # (ListRecentSessionsCommand queries instances, not definitions).

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -32,8 +32,9 @@ db_query() { sqlite3 "$1" "$2" 2>/dev/null; }
 # sqlite3 ATTACH fails on long POSIX paths on Windows; convert to Win32
 win_path() { cygpath -w "$1" 2>/dev/null || echo "$1"; }
 
-# ms-epoch timestamp
-now_ms() { date +%s%3N; }
+# ms-epoch timestamp — uses epoch seconds × 1000; %N is a GNU extension and
+# is not available on macOS/BSD, so we avoid it for portability.
+now_ms() { printf '%s000\n' "$(date +%s)"; }
 
 # Find every objects.db under the agentmux dir
 all_dbs() {
@@ -136,7 +137,7 @@ import_into() {
                  INSERT OR IGNORE INTO dst.db_agents
                    (id, name, icon, description,
                     is_template, parent_template_id,
-                    provider, provider_flags, shell, environment,
+                    provider, provider_flags, shell, environment, working_directory,
                     agent_type, agent_bus_id, accounts,
                     auto_start, restart_on_crash, idle_timeout_minutes,
                     slug, branch_label,
@@ -144,7 +145,7 @@ import_into() {
                  SELECT
                    id, name, icon, description,
                    0,  parent_id,
-                   provider, provider_flags, shell, environment,
+                   provider, provider_flags, shell, environment, working_directory,
                    agent_type, agent_bus_id, accounts,
                    auto_start, restart_on_crash, idle_timeout_minutes,
                    slug, branch_label,

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -50,8 +50,10 @@ catalog() {
     printf "%-20s %-12s %-10s %s\n" "NAME" "PROVIDER" "VERSION" "SOURCE"
     echo "──────────────────────────────────────────────────────────"
     while IFS= read -r db; do
+        # Use char(1) (ASCII unit-separator) as column delimiter so agent
+        # names containing '|' don't corrupt the field split.
         result=$(db_query "$db" \
-            "SELECT name, provider FROM db_agent_definitions WHERE is_seeded=0 ORDER BY name;")
+            "SELECT name||char(1)||provider FROM db_agent_definitions WHERE is_seeded=0 ORDER BY name;")
         [ -z "$result" ] && continue
         label=$(echo "$db" | sed \
             -e "s|$AGENTMUX_DIR/||" \
@@ -60,7 +62,7 @@ catalog() {
             -e 's|versions/||')
         version=$(echo "$label" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
         version="${version:-dev}"
-        while IFS='|' read -r name provider; do
+        while IFS=$'\x01' read -r name provider; do
             printf "%-20s %-12s %-10s %s\n" "$name" "$provider" "$version" "$label"
         done <<< "$result"
     done < <(all_dbs)

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -13,7 +13,16 @@
 set -euo pipefail
 
 AGENTMUX_DIR="${AGENTMUX_DIR:-$HOME/.agentmux}"
-CHANNEL="${CHANNEL:-dev-portable-main-b28b7a}"
+
+# Auto-detect channel from the current git branch when CHANNEL is not set.
+# The portable build channel name is: dev-portable-<branch>-<sha1(branch)[:6]>
+# where sha1 is of the branch name string itself (not the commit).
+if [ -z "${CHANNEL:-}" ]; then
+    _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+    _branch_hash=$(printf '%s' "$_branch" | sha1sum | cut -c1-6 2>/dev/null \
+                   || printf '%s' "$_branch" | shasum | cut -c1-6)
+    CHANNEL="dev-portable-${_branch}-${_branch_hash}"
+fi
 CHANNEL_DIR="$AGENTMUX_DIR/channels/$CHANNEL"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -115,7 +124,32 @@ import_into() {
                 continue
             fi
 
-            # Copy definition
+            # Copy definition into the legacy table AND the consolidated
+            # db_agents table (present in schema v4+). Readers such as
+            # agent_def_list() and instance_list() use db_agents; skipping
+            # the dual-write leaves the agent invisible to the running app
+            # even though it's in db_agent_definitions.
+            sqlite3 "$src_win" \
+                "ATTACH '$tgt_win' AS dst;
+                 INSERT OR IGNORE INTO dst.db_agent_definitions
+                   SELECT * FROM db_agent_definitions WHERE id='$def_id';
+                 INSERT OR IGNORE INTO dst.db_agents
+                   (id, name, icon, description,
+                    is_template, parent_template_id,
+                    provider, provider_flags, shell, environment,
+                    agent_type, agent_bus_id, accounts,
+                    auto_start, restart_on_crash, idle_timeout_minutes,
+                    slug, branch_label,
+                    created_at, updated_at, is_seeded, user_hidden)
+                 SELECT
+                   id, name, icon, description,
+                   0,  parent_id,
+                   provider, provider_flags, shell, environment,
+                   agent_type, agent_bus_id, accounts,
+                   auto_start, restart_on_crash, idle_timeout_minutes,
+                   slug, branch_label,
+                   created_at, updated_at, is_seeded, user_hidden
+                 FROM db_agent_definitions WHERE id='$def_id';" 2>/dev/null || \
             sqlite3 "$src_win" \
                 "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agent_definitions


### PR DESCRIPTION
## Summary

- Adds `agent.define` to the app HTTP/WebSocket API (Tier 1, same `X-AuthKey` auth as `agent.open`)
- A process running inside an AgentMux pane can now POST to `/agentmux/service` to register a new agent definition and see it appear in My Agents **without a restart** (~100ms roundtrip via `agents:changed` broadcast)
- Three `if_exists` modes: `"skip"` (default, idempotent), `"update"`, `"error"`
- `create_instance_stub: true` (default) creates a stopped `AgentInstance` row so the agent appears in **My Agents** immediately

## Key files

| File | Change |
|---|---|
| `agentmux-srv/src/backend/rpc_types.rs` | `COMMAND_AGENT_DEFINE` + `CommandAgentDefineData` + `AgentDefineResult` |
| `agentmux-srv/src/server/app_api.rs` | `agent_define_core()` pub(crate); WebSocket RPC handler |
| `agentmux-srv/src/server/service.rs` | `("agent", "define")` dispatch on HTTP `/agentmux/service` |
| `docs/specs/SPEC_APP_API_AGENT_DEFINE_2026_06_06.md` | Full spec |
| `scripts/import-agents.sh` | Portable `now_ms()`; `working_directory` in `db_agents` INSERT; explicit column list |

## Usage (curl)

The HTTP endpoint uses `WebCallType` (`service` + `method` + `args[]`):

```bash
curl -s -X POST "$AGENTMUX_LOCAL_URL/agentmux/service" \
  -H "Content-Type: application/json" \
  -H "X-AuthKey: $AGENTMUX_AUTH_KEY" \
  -d '{"service":"agent","method":"define","args":[{"name":"Refactor Agent","provider":"claude","if_exists":"skip"}]}'
```

Response: `{"success":true,"data":{"definition_id":"...","slug":"refactor_agent","action":"created","instance_stub_id":"si-..."}}`

The WebSocket path uses the WshRpc envelope (`command` + `reqid` + `data`); both routes call the same `agent_define_core` handler.

## Test plan
- [ ] `cargo check -p agentmux-srv` clean
- [ ] curl with new agent name → appears in My Agents within ~100ms
- [ ] curl again same name + `if_exists:"skip"` → same id, no duplicate
- [ ] `if_exists:"update"` → fields updated
- [ ] `if_exists:"error"` → error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)