### PR TITLE
fix(my-agents): repair missing definitions + add Created/Last Launch/Last Active metadata

### DIFF
--- a/.changesets/1780984725-fix-my-agents-repair-missing-definitions-in-db-agents-add-cr-hkin.md
+++ b/.changesets/1780984725-fix-my-agents-repair-missing-definitions-in-db-agents-add-cr-hkin.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(my-agents): repair missing definitions in db_agents; add Created/Last Launch/Last Active timestamps to My Agents cards

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1968,6 +1968,12 @@ pub struct RecentSessionRow {
     /// block. False when the snapshot doesn't exist yet (no preview)
     /// or the block_id_hint was empty.
     pub has_snapshot: bool,
+    /// When the agent definition was first created (ms since epoch).
+    /// Shown as "Created" in the My Agents card.
+    pub agent_created_at: i64,
+    /// When this instance was last launched (ms since epoch).
+    /// Shown as "Last Launch" in the My Agents card.
+    pub started_at: i64,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/backend/storage/agents_consolidate.rs
+++ b/agentmux-srv/src/backend/storage/agents_consolidate.rs
@@ -447,7 +447,7 @@ pub fn run_consolidate_migration(
 /// inserts at most) and is idempotent via `INSERT OR IGNORE`.
 ///
 /// Returns the number of definitions inserted.
-pub fn repair_def_gaps(conn: &Connection) -> Result<usize, StoreError> {
+pub fn repair_def_gaps(conn: &mut Connection) -> Result<usize, StoreError> {
     // Find every db_agent_definitions row that has no matching id in
     // db_agents.  These were written between Phase 3a marker creation and
     // Phase 3b dual-write landing.
@@ -498,6 +498,11 @@ pub fn repair_def_gaps(conn: &Connection) -> Result<usize, StoreError> {
         .collect::<Result<Vec<_>, _>>()?;
     drop(stmt);
 
+    if missing.is_empty() {
+        return Ok(0);
+    }
+
+    let tx = conn.transaction()?;
     let mut inserted = 0usize;
     for (
         id, name, icon, provider, description, working_directory, shell,
@@ -512,7 +517,7 @@ pub fn repair_def_gaps(conn: &Connection) -> Result<usize, StoreError> {
         } else {
             parent_id.clone()
         };
-        let affected = conn.execute(
+        let affected = tx.execute(
             "INSERT OR IGNORE INTO db_agents (
                 id, name, icon, description,
                 is_template, parent_template_id,
@@ -554,6 +559,7 @@ pub fn repair_def_gaps(conn: &Connection) -> Result<usize, StoreError> {
             inserted += 1;
         }
     }
+    tx.commit()?;
 
     if inserted > 0 {
         info!(

--- a/agentmux-srv/src/backend/storage/agents_consolidate.rs
+++ b/agentmux-srv/src/backend/storage/agents_consolidate.rs
@@ -433,6 +433,138 @@ pub fn run_consolidate_migration(
     Ok(stats)
 }
 
+/// Delta repair: backfill any `db_agent_definitions` rows that are
+/// missing from `db_agents`.
+///
+/// This closes a gap the one-shot consolidation migration cannot cover:
+/// agents defined after the marker file was written (and before Phase 3b
+/// dual-write landed) live only in `db_agent_definitions`.  Phase 3b
+/// readers look exclusively at `db_agents`, so those agents are invisible
+/// — no icon, no reattach, "clicking does nothing".
+///
+/// Unlike `run_consolidate_migration`, this is **not** marker-gated.  It
+/// runs on every startup (cheap — one indexed LEFT JOIN + a handful of
+/// inserts at most) and is idempotent via `INSERT OR IGNORE`.
+///
+/// Returns the number of definitions inserted.
+pub fn repair_def_gaps(conn: &Connection) -> Result<usize, StoreError> {
+    // Find every db_agent_definitions row that has no matching id in
+    // db_agents.  These were written between Phase 3a marker creation and
+    // Phase 3b dual-write landing.
+    let mut stmt = conn.prepare(
+        "SELECT d.id, d.name, d.icon, d.provider, d.description,
+                d.working_directory, d.shell, d.provider_flags, d.auto_start,
+                d.restart_on_crash, d.idle_timeout_minutes, d.created_at,
+                d.agent_type, d.environment, d.agent_bus_id, d.is_seeded,
+                d.accounts, d.parent_id, d.branch_label, d.updated_at,
+                d.slug, d.user_hidden
+         FROM db_agent_definitions d
+         LEFT JOIN db_agents a ON a.id = d.id
+         WHERE a.id IS NULL",
+    )?;
+
+    #[allow(clippy::type_complexity)]
+    let missing: Vec<(
+        String, String, String, String, String, String, String, String,
+        i64, i64, i64, i64, String, String, String, i64, String, String,
+        String, i64, String, i64,
+    )> = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,   // id
+                row.get::<_, String>(1)?,   // name
+                row.get::<_, String>(2)?,   // icon
+                row.get::<_, String>(3)?,   // provider
+                row.get::<_, String>(4)?,   // description
+                row.get::<_, String>(5)?,   // working_directory
+                row.get::<_, String>(6)?,   // shell
+                row.get::<_, String>(7)?,   // provider_flags
+                row.get::<_, i64>(8)?,      // auto_start
+                row.get::<_, i64>(9)?,      // restart_on_crash
+                row.get::<_, i64>(10)?,     // idle_timeout_minutes
+                row.get::<_, i64>(11)?,     // created_at
+                row.get::<_, String>(12)?,  // agent_type
+                row.get::<_, String>(13)?,  // environment
+                row.get::<_, String>(14)?,  // agent_bus_id
+                row.get::<_, i64>(15)?,     // is_seeded
+                row.get::<_, String>(16)?,  // accounts
+                row.get::<_, String>(17)?,  // parent_id
+                row.get::<_, String>(18)?,  // branch_label
+                row.get::<_, i64>(19)?,     // updated_at
+                row.get::<_, String>(20)?,  // slug
+                row.get::<_, i64>(21)?,     // user_hidden
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    drop(stmt);
+
+    let mut inserted = 0usize;
+    for (
+        id, name, icon, provider, description, working_directory, shell,
+        provider_flags, auto_start, restart_on_crash, idle_timeout_minutes,
+        created_at, agent_type, environment, agent_bus_id, is_seeded,
+        accounts, parent_id, branch_label, updated_at, slug, user_hidden,
+    ) in &missing
+    {
+        let is_template = if *is_seeded == 1 { 1_i64 } else { 0_i64 };
+        let parent_template_id = if *is_seeded == 1 {
+            String::new()
+        } else {
+            parent_id.clone()
+        };
+        let affected = conn.execute(
+            "INSERT OR IGNORE INTO db_agents (
+                id, name, icon, description,
+                is_template, parent_template_id,
+                provider, provider_flags, shell, environment,
+                agent_type, agent_bus_id, accounts,
+                auto_start, restart_on_crash, idle_timeout_minutes,
+                slug, branch_label,
+                identity_id, memory_id, working_directory, github_context,
+                instance_name,
+                created_at, updated_at, is_seeded, user_hidden
+             ) VALUES (
+                ?1, ?2, ?3, ?4,
+                ?5, ?6,
+                ?7, ?8, ?9, ?10,
+                ?11, ?12, ?13,
+                ?14, ?15, ?16,
+                ?17, ?18,
+                '', '', ?19, '',
+                '',
+                ?20, ?21, ?22, ?23
+             )",
+            params![
+                id, name, icon, description,
+                is_template, parent_template_id,
+                provider, provider_flags, shell, environment,
+                agent_type, agent_bus_id, accounts,
+                auto_start, restart_on_crash, idle_timeout_minutes,
+                slug, branch_label,
+                working_directory,
+                created_at, updated_at, is_seeded, user_hidden,
+            ],
+        )?;
+        if affected > 0 {
+            warn!(
+                def_id = %id,
+                name = %name,
+                "agents_consolidate: gap-repair inserted missing definition into db_agents"
+            );
+            inserted += 1;
+        }
+    }
+
+    if inserted > 0 {
+        info!(
+            count = inserted,
+            "agents_consolidate: gap-repair complete — definitions backfilled"
+        );
+    }
+
+    Ok(inserted)
+}
+
 /// Snapshot of one `db_agent_definitions` row, narrow projection
 /// matching what the backfill needs.
 struct DefRow {

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -73,8 +73,8 @@ impl Store {
     /// `db_agents`.  Not marker-gated — runs cheaply on every startup.
     /// See `agents_consolidate::repair_def_gaps` for details.
     pub fn repair_agent_def_gaps(&self) -> Result<usize, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        super::agents_consolidate::repair_def_gaps(&conn)
+        let mut conn = self.conn.lock().unwrap();
+        super::agents_consolidate::repair_def_gaps(&mut *conn)
     }
 
     fn configure_and_migrate(conn: Connection) -> Result<Self, StoreError> {

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -69,6 +69,14 @@ impl Store {
         super::agents_consolidate::run_consolidate_migration(&mut conn, data_dir)
     }
 
+    /// Backfill any `db_agent_definitions` rows that are missing from
+    /// `db_agents`.  Not marker-gated — runs cheaply on every startup.
+    /// See `agents_consolidate::repair_def_gaps` for details.
+    pub fn repair_agent_def_gaps(&self) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        super::agents_consolidate::repair_def_gaps(&conn)
+    }
+
     fn configure_and_migrate(conn: Connection) -> Result<Self, StoreError> {
         conn.execute_batch(
             // `foreign_keys=ON` is per-connection and defaults to OFF in

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -569,6 +569,19 @@ async fn main() {
         }
     }
 
+    // Gap-repair: backfill definitions written after the Phase 3a marker
+    // but before Phase 3b dual-write (they exist in db_agent_definitions
+    // but not in db_agents, making them invisible to Phase 3b readers).
+    match wstore.repair_agent_def_gaps() {
+        Ok(0) => {}
+        Ok(n) => {
+            tracing::info!(count = n, "agents_consolidate: gap-repair backfilled missing definitions");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "agents_consolidate: gap-repair failed (non-fatal)");
+        }
+    }
+
     // Event infrastructure
     let event_bus = Arc::new(EventBus::new());
     let broker = Arc::new(Broker::new());

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1855,6 +1855,8 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         node_count,
                         last_active_at,
                         has_snapshot,
+                        agent_created_at: def.map(|d| d.created_at).unwrap_or(0),
+                        started_at: inst.started_at,
                     });
                 }
 

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -62,6 +62,8 @@ const makeRow = (overrides: Partial<RecentSessionRow> = {}): RecentSessionRow =>
     node_count: 12,
     last_active_at: Date.now() - 60_000,
     has_snapshot: true,
+    agent_created_at: Date.now() - 7_776_000_000,
+    started_at: Date.now() - 3_600_000,
     ...overrides,
 });
 

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -192,19 +192,14 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                 {row.preview}
                                             </span>
                                         </Show>
-                                        <span class="agent-recent-sessions-line3">
-                                            <Show when={row.node_count > 0}>
+                                        <Show when={row.node_count > 0}>
+                                            <span class="agent-recent-sessions-line3">
                                                 <span class="agent-recent-sessions-nodes">
                                                     {row.node_count} message
                                                     {row.node_count === 1 ? "" : "s"}
                                                 </span>
-                                            </Show>
-                                            <Show when={row.last_active_at > 0}>
-                                                <span class="agent-recent-sessions-when">
-                                                    {formatRelative(now(), row.last_active_at)}
-                                                </span>
-                                            </Show>
-                                        </span>
+                                            </span>
+                                        </Show>
                                         <span class="agent-recent-sessions-timestamps">
                                             <Show when={row.agent_created_at > 0}>
                                                 <span class="agent-recent-sessions-ts">

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -205,6 +205,32 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                 </span>
                                             </Show>
                                         </span>
+                                        <span class="agent-recent-sessions-timestamps">
+                                            <Show when={row.agent_created_at > 0}>
+                                                <span class="agent-recent-sessions-ts">
+                                                    <span class="agent-recent-sessions-ts-label">Created</span>
+                                                    <span class="agent-recent-sessions-ts-value">
+                                                        {formatRelative(now(), row.agent_created_at)}
+                                                    </span>
+                                                </span>
+                                            </Show>
+                                            <Show when={row.started_at > 0}>
+                                                <span class="agent-recent-sessions-ts">
+                                                    <span class="agent-recent-sessions-ts-label">Last Launch</span>
+                                                    <span class="agent-recent-sessions-ts-value">
+                                                        {formatRelative(now(), row.started_at)}
+                                                    </span>
+                                                </span>
+                                            </Show>
+                                            <Show when={row.has_snapshot && row.last_active_at > row.started_at}>
+                                                <span class="agent-recent-sessions-ts">
+                                                    <span class="agent-recent-sessions-ts-label">Last Active</span>
+                                                    <span class="agent-recent-sessions-ts-value">
+                                                        {formatRelative(now(), row.last_active_at)}
+                                                    </span>
+                                                </span>
+                                            </Show>
+                                        </span>
                                     </span>
                                 </button>
                             </li>

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -217,7 +217,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                     </span>
                                                 </span>
                                             </Show>
-                                            <Show when={row.has_snapshot && row.last_active_at > row.started_at}>
+                                            <Show when={row.has_snapshot && row.started_at > 0 && row.last_active_at > row.started_at}>
                                                 <span class="agent-recent-sessions-ts">
                                                     <span class="agent-recent-sessions-ts-label">Last Active</span>
                                                     <span class="agent-recent-sessions-ts-value">

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -161,4 +161,32 @@
     .agent-recent-sessions-nodes {
         // Numeric "12 messages" stays inline with timestamp.
     }
+
+    .agent-recent-sessions-timestamps {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-1) var(--space-3);
+        margin-top: 2px;
+    }
+
+    .agent-recent-sessions-ts {
+        display: flex;
+        gap: 3px;
+        align-items: baseline;
+        font-size: 10px;
+        color: color-mix(in srgb, var(--secondary-text-color) 60%, transparent);
+        font-variant-numeric: tabular-nums;
+    }
+
+    .agent-recent-sessions-ts-label {
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        font-size: 9px;
+        font-weight: 600;
+        opacity: 0.75;
+    }
+
+    .agent-recent-sessions-ts-value {
+        font-size: 10px;
+    }
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -530,6 +530,10 @@ declare global {
         node_count: number;
         last_active_at: number;
         has_snapshot: boolean;
+        /** When the agent definition was first created (ms epoch). */
+        agent_created_at: number;
+        /** When this instance was most recently launched (ms epoch). */
+        started_at: number;
     };
 
     // AgentContent


### PR DESCRIPTION
## Summary

- **Bug fix**: My Agents cards show blank icon, no snapshot, and clicking does nothing — caused by agent definitions living only in `db_agent_definitions` and not in `db_agents` (written between Phase 3a marker write and Phase 3b dual-write landing). New `repair_def_gaps()` runs on every startup: one indexed LEFT JOIN finds the gap, `INSERT OR IGNORE` fills it. Not marker-gated; idempotent.
- **Feature**: My Agents cards now show three metadata timestamps — **Created**, **Last Launch**, **Last Active** — populated from `def.created_at`, `inst.started_at`, and the existing `last_active_at` (filestore modts). New fields `agent_created_at` + `started_at` added to `RecentSessionRow`.

## Test plan

- [ ] Build + launch — no regression on My Agents cards that already work
- [ ] On a store with agents pre-dating Phase 3b dual-write: launch → `repair_def_gaps` log line fires → agent cards show icon + snapshot + click works
- [ ] My Agents cards show Created / Last Launch / Last Active labels under the preview
- [ ] Agent with no snapshot shows Created + Last Launch (no Last Active — gated on `has_snapshot && last_active_at > started_at`)
- [ ] `cargo check` clean; frontend tsc no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)