### PR TITLE
fix(linux/macos): floater & secondary windows honor window:transparent

### DIFF
--- a/.changesets/1780986440-fix-linux-floater-secondary-windows-honor-window-transparent-zwbl.md
+++ b/.changesets/1780986440-fix-linux-floater-secondary-windows-honor-window-transparent-zwbl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux): floater & secondary windows honor window:transparent (were opaque-black by construction)

--- a/.changesets/1780986440-fix-linux-floater-secondary-windows-honor-window-transparent-zwbl.md
+++ b/.changesets/1780986440-fix-linux-floater-secondary-windows-honor-window-transparent-zwbl.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(linux): floater & secondary windows honor window:transparent (were opaque-black by construction)
+fix(linux/macos): floater & secondary windows honor window:transparent (were opaque-black by construction)

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -793,7 +793,21 @@ wrap_task! {
             tracing::info!(label = %self.label, "[create-window] task entered UI thread");
 
             let settings = BrowserSettings {
-                background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
+                // ARGB alpha=0 → transparent, mirroring the MAIN window
+                // (app.rs:679) and the global CefSettings.background_color
+                // (main.rs). CreateWindowTask builds every secondary window
+                // on Linux/macOS — additional windows AND floating-pane
+                // tear-offs (open_floating_pane_window routes here on
+                // non-Windows; the dedicated post_create_floating_window is
+                // Windows-only). Previously hard-coded 0xFF000000 (opaque
+                // black), which (a) overrode the transparent global default
+                // and (b) gated OFF the BrowserViewImpl transparency cascade
+                // (it only fires when default_background_color_ is
+                // transparent — see cef/libcef/browser/views/browser_view_impl.cc
+                // WebContentsCreated). Result: floaters/secondary windows were
+                // fully opaque even when window:transparent=true. 0x00000000
+                // lets them inherit the same transparency path as main.
+                background_color: 0x00000000,
                 ..Default::default()
             };
             let cef_url = CefString::from(self.url.as_str());


### PR DESCRIPTION
## Symptom
With `window:transparent: true`, the **main** window is translucent but **floating tear-off windows and additional windows are fully opaque** on Linux/macOS.

## Root cause (verified against the patched CEF source)
`CreateWindowTask` (`agentmux-cef/src/ui_tasks.rs`) builds every secondary window on non-Windows — additional windows *and* floating-pane tear-offs (`open_floating_pane_window` routes through `post_create_window` on non-Windows; the dedicated `post_create_floating_window` is Windows-only). It hard-coded:

```rust
BrowserSettings { background_color: 0xFF000000, .. }  // opaque black
```

In the patched libcef, `CefBrowserViewImpl` sets `default_background_color_` from `CefContext::GetBackgroundColor(&settings, STATE_ENABLED)` (`browser_view_impl.cc:535`), which honors the **per-browser** `BrowserSettings.background_color`. The transparency cascade in `WebContentsCreated` — `SetPageBaseBackgroundColor(TRANSPARENT)` + `RWHView::SetBackgroundColor → SetBackgroundOpaque(false)` — is gated on `SkColorGetA(default_background_color_) == SK_AlphaTRANSPARENT` (line 257).

So the opaque-black value (a) overrode the transparent global `CefSettings.background_color` default and (b) gated the cascade **off** → secondary windows opaque. The main window already uses `0x00000000` (`app.rs:679`) and is transparent.

## Fix
Set `CreateWindowTask`'s `BrowserSettings.background_color = 0x00000000`, mirroring the main window. Secondary/floating windows now inherit the same transparency path.

Confirmed via live inspection: the floater I inspected (`windowLabel: floating-…`) composited over an opaque base, consistent with the gate being off.

## Scope
This fixes the **per-window opaque-base** bug (floaters/secondary windows). The deeper **renderer-side "multi-layer pane interior"** partial-opacity on the *main* window (promoted cc layers) is a separate, known CEF-compositor issue — documented but not addressed here. macOS additionally needs its CEF framework rebuilt with the transparency patches (regressed in the 146→148 bump); that's a builder/CI change, not this PR.

## Test
- [ ] Linux: `window:transparent: true`, tear off a pane → floater is translucent (was opaque)
- [ ] Linux: open an additional window → translucent
- [ ] Main window unaffected; non-transparent (`window:transparent: false`) windows still opaque

🤖 Generated with [Claude Code](https://claude.com/claude-code)