### PR TITLE
fix(cef): repair inert Resume button on low-memory pause page

### DIFF
--- a/.changesets/1781012789-fix-cef-low-memory-resume-button-inert-onclick-agc1.md
+++ b/.changesets/1781012789-fix-cef-low-memory-resume-button-inert-onclick-agc1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): low-memory pause page Resume button was inert (double-quoted JS string inside a double-quoted onclick attribute) — wire it via a <script> + addEventListener so OOM-paused windows can actually resume

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -2161,11 +2161,19 @@ window resumes.</p>
 other apps — then click Resume. Resuming before memory recovers will just
 pause again.</p>
 <div class="actions">
-<button class="primary" onclick="location.href = {app_url_js}">Resume</button>
-<button onclick="window.close()">Quit this window</button>
+<button id="amx-resume" class="primary">Resume</button>
+<button id="amx-quit">Quit this window</button>
 </div>
 <div class="footer">error_code={error_code} · commit_free={commit_free_mb}MB</div>
 </div>
+<script>
+(function(){{
+  var r = document.getElementById('amx-resume');
+  if (r) r.addEventListener('click', function () {{ location.href = {app_url_js}; }});
+  var q = document.getElementById('amx-quit');
+  if (q) q.addEventListener('click', function () {{ window.close(); }});
+}})();
+</script>
 </body></html>"#,
         reason_safe = html_escape(reason),
         commit_free_mb = commit_free_mb,
@@ -2179,11 +2187,39 @@ pause again.</p>
 #[cfg(test)]
 mod gated_recovery_tests {
     use super::{
-        record_memory_pause, url_on_origin, MEMORY_PAUSE_BUDGET, MEMORY_PAUSE_WINDOW,
-        RESUME_FLOOR_MB,
+        memory_paused_page, record_memory_pause, url_on_origin, MEMORY_PAUSE_BUDGET,
+        MEMORY_PAUSE_WINDOW, RESUME_FLOOR_MB,
     };
     use std::collections::VecDeque;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn memory_paused_page_resume_button_has_working_handler() {
+        // Regression for the inert-Resume bug: js_string_literal() returns a
+        // DOUBLE-quoted JS string and is a <script>-context literal; embedding it
+        // in a double-quoted onclick="..." attribute terminated the attribute
+        // early, so Resume did nothing and the window wedged. The handler must be
+        // wired in a <script> block instead.
+        let url = "http://127.0.0.1:63627/?ipc_port=63627&ipc_token=abc";
+        let html = memory_paused_page("out of memory", -1, 100, url);
+
+        // The broken antipattern must be gone.
+        assert!(
+            !html.contains("onclick=\"location.href"),
+            "Resume must not use an inline onclick with a double-quoted URL"
+        );
+        // The handler is attached by id via addEventListener.
+        assert!(html.contains("addEventListener"), "handler should use addEventListener");
+        assert!(html.contains("id=\"amx-resume\""), "Resume button needs its id");
+        // The app URL must appear as a valid JS string literal in script context
+        // (js_string_literal escapes & -> \\u0026 and wraps in double quotes).
+        assert!(
+            html.contains(
+                "location.href = \"http://127.0.0.1:63627/?ipc_port=63627\\u0026ipc_token=abc\""
+            ),
+            "Resume must navigate to the app URL as a valid JS string literal"
+        );
+    }
 
     #[test]
     fn url_on_origin_matches_only_real_same_origin_urls() {

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -160,6 +160,16 @@ fn resolve_host_runtime_dir() -> Result<PathBuf, FrontendUrlError> {
 /// path" (the missing asset path is shown so the user knows what to
 /// reinstall).
 pub(crate) fn assets_missing_data_url(err: &FrontendUrlError) -> String {
+    let html = assets_missing_html(err);
+    let b64 = cef::base64_encode(Some(html.as_bytes()));
+    let b64_str = cef::CefString::from(&b64).to_string();
+    format!("data:text/html;base64,{}", b64_str)
+}
+
+/// HTML for the broken-install error page. Split out from
+/// `assets_missing_data_url` so the button wiring is unit-testable without
+/// CEF / base64 round-tripping.
+fn assets_missing_html(err: &FrontendUrlError) -> String {
     let (reason, detail) = match err {
         FrontendUrlError::ExeUnresolvable(e) => (
             "Could not determine the install directory".to_string(),
@@ -170,7 +180,7 @@ pub(crate) fn assets_missing_data_url(err: &FrontendUrlError) -> String {
             format!("Expected at: {}", checked_path.display()),
         ),
     };
-    let html = format!(
+    format!(
         r#"<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><title>AgentMux — Install broken</title>
 <style>
@@ -203,16 +213,24 @@ button:hover {{ background: #45475a; border-color: #585b70; }}
 <p>Reinstall AgentMux from a fresh portable ZIP to recover. Your saved
 sessions and agent state are in <code>~/.agentmux/</code> and are unaffected.</p>
 <div class="actions">
-<button onclick="navigator.clipboard &amp;&amp; navigator.clipboard.writeText({detail_js})">Copy path</button>
-<button onclick="window.close()">Quit</button>
-</div></div></body></html>"#,
+<button id="amx-copy">Copy path</button>
+<button id="amx-quit">Quit</button>
+</div></div>
+<script>
+(function(){{
+  var c = document.getElementById('amx-copy');
+  if (c) c.addEventListener('click', function () {{
+    if (navigator.clipboard) navigator.clipboard.writeText({detail_js});
+  }});
+  var q = document.getElementById('amx-quit');
+  if (q) q.addEventListener('click', function () {{ window.close(); }});
+}})();
+</script>
+</body></html>"#,
         reason_safe = html_escape(&reason),
         detail_safe = html_escape(&detail),
         detail_js = js_string_literal(&detail),
-    );
-    let b64 = cef::base64_encode(Some(html.as_bytes()));
-    let b64_str = cef::CefString::from(&b64).to_string();
-    format!("data:text/html;base64,{}", b64_str)
+    )
 }
 
 /// Open a new full AgentMux instance (status-bar version click, Ctrl+Shift+N,
@@ -375,4 +393,35 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
         }
     }
     (1200, 800)
+}
+
+#[cfg(test)]
+mod assets_missing_tests {
+    use super::{assets_missing_html, FrontendUrlError};
+    use std::path::PathBuf;
+
+    #[test]
+    fn copy_path_button_has_working_handler() {
+        // Regression: js_string_literal() returns a DOUBLE-quoted JS string;
+        // dropping it into a double-quoted onclick="..." attribute terminated
+        // the attribute early, leaving the "Copy path" button inert. The
+        // handler must be wired in a <script> block instead.
+        let err = FrontendUrlError::AssetsMissing {
+            checked_path: PathBuf::from("MISSING_ASSETS"),
+        };
+        let html = assets_missing_html(&err);
+
+        assert!(
+            !html.contains("onclick=\"navigator.clipboard"),
+            "Copy path must not use an inline onclick with a double-quoted literal"
+        );
+        assert!(html.contains("addEventListener"), "handler should use addEventListener");
+        assert!(html.contains("id=\"amx-copy\""), "Copy button needs its id");
+        // The detail string is emitted as a valid JS string literal in script
+        // context (js_string_literal wraps in double quotes).
+        assert!(
+            html.contains("writeText(\"Expected at: MISSING_ASSETS\")"),
+            "Copy path must writeText the detail as a valid JS string literal"
+        );
+    }
 }

--- a/docs/recovery/FIX_MEMORY_PAUSE_RESUME_BUTTON_2026_06_09.md
+++ b/docs/recovery/FIX_MEMORY_PAUSE_RESUME_BUTTON_2026_06_09.md
@@ -1,0 +1,102 @@
+# Fix — Low-memory "Resume" button is inert (HTML quoting bug)
+
+**Status:** P0 fix implemented (this PR); P1 (auto-resume) designed below as follow-up
+**Date:** 2026-06-09
+**Author:** AgentC
+**Related:** `docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` (Phase 1b)
+
+---
+
+## 1. Symptom
+
+A long-lived AgentMux window (v0.42.0, ~4 days uptime) was OOM-paused after the *host*
+hit 99% commit-limit exhaustion, showing the gated-recovery **"Paused — system memory low"**
+page. Clicking **Resume did nothing**, even after system memory was freed — the window was
+permanently wedged. Recovery required an operator to drive the renderer back to the app URL
+over the Chrome DevTools Protocol (`Page.navigate` on `:9222`).
+
+## 2. Root cause — malformed `onclick`
+
+`memory_paused_page()` (`agentmux-cef/src/client/mod.rs`) builds the Resume button as:
+
+```rust
+<button class="primary" onclick="location.href = {app_url_js}">Resume</button>
+```
+
+`app_url_js = js_string_literal(app_url)` (`agentmux-cef/src/client/helpers.rs`) returns a
+**double-quoted** JS string and is documented as a `<script>`-context literal (it escapes
+`<`/`>`/`&` to defend against `</script>` injection). Dropped into a **double-quoted HTML
+attribute**, the quotes collide and the rendered markup is:
+
+```html
+<button class="primary" onclick="location.href = "http://127.0.0.1:63627/?ipc_port=63627&ipc_token=…">Resume</button>
+```
+
+The attribute terminates at the second `"` (before `http`), leaving `onclick="location.href = "`
+(a no-op) and turning the URL into stray markup. **The click runs nothing.** The target URL is
+valid — the app's pre-warmed pool windows load from the same origin successfully.
+
+Consequence: the gated-recovery pause page has **never** been resumable via its button. Anyone
+who hits a low-memory renderer OOM is wedged until the process is killed.
+
+## 3. The fix (P0 — this PR)
+
+Use `js_string_literal` in the context it's built for — a `<script>` block — instead of an
+inline HTML attribute. The handler is attached by element id via `addEventListener`:
+
+```rust
+<button id="amx-resume" class="primary">Resume</button>
+<button id="amx-quit">Quit this window</button>
+...
+<script>
+(function(){
+  var r = document.getElementById('amx-resume');
+  if (r) r.addEventListener('click', function () { location.href = {app_url_js}; });
+  var q = document.getElementById('amx-quit');
+  if (q) q.addEventListener('click', function () { window.close(); });
+})();
+</script>
+```
+
+This is quoting-safe (the literal lives in script context, exactly what its `<`/`&`
+escaping is for) and keeps the same UX.
+
+**Regression test** (pure string, no CEF runtime): `memory_paused_page_resume_button_has_working_handler`
+asserts the inert `onclick="location.href` antipattern is gone, the URL appears as a valid JS
+string literal (`location.href = "http://…&…"`), and the handler is wired via
+`addEventListener`.
+
+> Audit note: confirm the normal crash-recovery and "give-up" pages don't construct buttons the
+> same way (they appear to use different markup, but worth a glance during review).
+
+## 4. Follow-up (P1 — memory-gated auto-resume, separate PR)
+
+P0 restores the *manual* one-click path. Full automation — so no human/agent is ever needed —
+is SPEC_GATED_RENDERER_RECOVERY **Phase 1b**, and the codebase already has every piece:
+
+- **Track paused windows by label** (not by Browser handle). Per `ui_tasks.rs`'s rule
+  ("don't pass Browser/Window across threads — pass `Arc<AppState>` and look up on the UI
+  thread"), record `{window_label → recovery_url}` in `AppState` when `memory_paused_page` is
+  shown (in `on_render_process_terminated`, which already has `self.state` and resolves the
+  label). Clear the entry in `on_before_close` / on successful resume.
+- **Trigger from the memory heartbeat.** `memory_heartbeat.rs` already runs a 20 s loop and
+  publishes `COMMIT_FREE_MB` via `commit_free_mb()`. When the paused set is non-empty **and**
+  commit-free has stayed above a resume threshold for N consecutive samples (hysteresis — e.g.
+  `≥ 2 × RESUME_FLOOR_MB` for 2–3 samples to avoid flapping), post a UI task per paused label.
+- **Resume on the UI thread** by reusing the existing pattern: look up the browser with
+  `state.get_browser(label)` and navigate via a `DeferredLoadUrlTask`-style task to the stored
+  recovery URL.
+- **Bounding:** reuse `MEMORY_PAUSE_BUDGET` / `MEMORY_PAUSE_WINDOW` convergence so a window that
+  immediately re-OOMs still falls through to the give-up page instead of looping.
+
+Wiring requires passing `Arc<AppState>` to the heartbeat (or a small dedicated resume subsystem
+holding it) and a host build to validate the threading — hence a separate PR.
+
+### Other layers (tracked elsewhere, not code in these PRs)
+- **Proactive shedding:** release the pre-warmed window pool under rising commit pressure before
+  the OS OOM-kills a live renderer.
+- **Renderer-free paused overlay:** render the paused state natively so the recovery UI itself
+  can't be OOM-killed under total exhaustion (also Phase 1b).
+- **System-level:** the real trigger was host-wide commit exhaustion from a long-uptime driver
+  leak + accumulated stale instances — a commit watchdog and stale-instance reaping belong at the
+  launcher/OS layer, independent of this page.

--- a/docs/recovery/FIX_MEMORY_PAUSE_RESUME_BUTTON_2026_06_09.md
+++ b/docs/recovery/FIX_MEMORY_PAUSE_RESUME_BUTTON_2026_06_09.md
@@ -66,8 +66,17 @@ asserts the inert `onclick="location.href` antipattern is gone, the URL appears 
 string literal (`location.href = "http://…&…"`), and the handler is wired via
 `addEventListener`.
 
-> Audit note: confirm the normal crash-recovery and "give-up" pages don't construct buttons the
-> same way (they appear to use different markup, but worth a glance during review).
+### Same bug, second instance (also fixed in this PR)
+
+ReAgent review flagged the identical pattern on the **broken-install error page**:
+`assets_missing_data_url()` in `agentmux-cef/src/commands/window/creation.rs` put
+`js_string_literal(&detail)` into a double-quoted `onclick="navigator.clipboard && …writeText(…)"`,
+making the **"Copy path"** button permanently inert. Fixed the same way — extracted a testable
+`assets_missing_html()`, moved the handlers into a `<script>` block via `addEventListener`, and
+added `copy_path_button_has_working_handler`.
+
+Both data:-page buttons in the CEF host are now wired in script context; no remaining
+`onclick="…{js_string_literal}…"` attribute call sites.
 
 ## 4. Follow-up (P1 — memory-gated auto-resume, separate PR)
 


### PR DESCRIPTION
## Problem

A long-lived AgentMux window was OOM-paused (host hit 99% commit-limit exhaustion) and showed the gated-recovery **"Paused — system memory low"** page. **Clicking Resume did nothing**, even after memory was freed — the window was permanently wedged. Recovery required driving the renderer back to the app URL by hand over the Chrome DevTools Protocol.

## Root cause

`memory_paused_page()` (`agentmux-cef/src/client/mod.rs`) built the button as:

```rust
<button class="primary" onclick="location.href = {app_url_js}">Resume</button>
```

`js_string_literal()` returns a **double-quoted** JS string and is a `<script>`-context literal (it escapes `<`/`>`/`&` for `</script>` defense). Dropped into a **double-quoted `onclick="…"` attribute**, the quotes collide — the attribute terminates at the first inner quote, leaving `onclick="location.href = "` (a no-op) and turning the URL into stray markup:

```html
<button class="primary" onclick="location.href = "http://127.0.0.1:63627/?ipc_port=63627&ipc_token=…">Resume</button>
```

So the gated-recovery pause page has **never** been resumable via its button — any low-memory renderer OOM wedges the window until the process is killed.

## Fix

Attach the handlers in a `<script>` block via `addEventListener` (the context `js_string_literal` is designed for), keyed by button id. Same UX, quoting-safe. Adds a pure-string regression test (`memory_paused_page_resume_button_has_working_handler`) asserting the inert `onclick="location.href` antipattern is gone and the URL is emitted as a valid JS literal.

## Test

`cargo test -p agentmux-cef gated_recovery_tests` → 5 passed (incl. the new test). `cargo check -p agentmux-cef --tests` clean.

## Scope / follow-up

This restores the **manual** one-click recovery. Memory-gated **auto-resume** (so no human/agent is ever needed) is SPEC_GATED_RENDERER_RECOVERY **Phase 1b** — fully specified in `docs/recovery/FIX_MEMORY_PAUSE_RESUME_BUTTON_2026_06_09.md`, to land as a separate PR (it needs `Arc<AppState>` wiring into the memory heartbeat + a host build to validate threading).

> Review note: worth a glance that the crash-recovery / give-up pages don't construct buttons the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)