### PR TITLE
feat(agent-pane): hold expanded tool on hover; expand Glob results by default

### DIFF
--- a/.changesets/1781046953-fix-agent-pane-hold-expanded-tool-on-hover-expand-glob-resul-n6gb.md
+++ b/.changesets/1781046953-fix-agent-pane-hold-expanded-tool-on-hover-expand-glob-resul-n6gb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): hold expanded tool on hover; expand Glob results by default

--- a/docs/specs/SPEC_TOOL_BLOCK_INTERACTION_HOLD_AND_GLOB_EXPAND_2026_06_09.md
+++ b/docs/specs/SPEC_TOOL_BLOCK_INTERACTION_HOLD_AND_GLOB_EXPAND_2026_06_09.md
@@ -1,0 +1,66 @@
+# SPEC: Tool Block Interaction Hold + Glob Auto-Expand
+
+**Date:** 2026-06-09  
+**Status:** Implemented  
+**Files changed:**
+- `frontend/app/view/agent/components/ToolBlock.tsx`
+- `frontend/app/view/agent/components/CompactResult.tsx`
+
+---
+
+## Problem
+
+### 1. Post-completion collapse interrupts active reading
+
+When a tool completes, `ToolBlock` holds the panel open for `POST_COMPLETION_HOLD_MS` (3s) then collapses. If the user's mouse is inside the block while the timer fires — actively reading the output — the panel collapses under them with no way to prevent it short of clicking to pin.
+
+### 2. Glob results always start collapsed
+
+`CompactResult` initializes with `createSignal(false)` for all tools. Glob results are therefore collapsed by default, showing only a one-line path summary. Users must click the chevron to see the full file list every time — high friction for a result that is almost always worth reading in full.
+
+---
+
+## Changes
+
+### ToolBlock.tsx — interaction hold
+
+Added a `userHolding` signal that latches when the user's mouse enters an already-expanded block, and clears on mouse leave.
+
+```ts
+const [userHolding, setUserHolding] = createSignal(false);
+const expanded = () => props.pinned || autoExpanded() || userHolding();
+```
+
+Mouse handlers on the outer `agent-tool-block` div:
+
+```tsx
+onMouseEnter={() => { if (props.pinned || autoExpanded()) setUserHolding(true); }}
+onMouseLeave={() => setUserHolding(false)}
+```
+
+**Behavior:**
+- Mouse enters while block is auto-expanded (running / post-completion hold) → `userHolding` latches true. Post-completion timer can now fire and clear `autoExpanded` without collapsing the block.
+- Mouse leaves → `userHolding` clears → block collapses normally.
+- Mouse enters a *collapsed* block → guard (`props.pinned || autoExpanded()`) is false → `userHolding` stays false → no change. Hover-to-peek remains removed per `SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md`.
+
+**Not affected:** pin behavior, the post-completion timer itself, or any keyboard/a11y path.
+
+### CompactResult.tsx — Glob default expanded
+
+```ts
+// Before
+const [expanded, setExpanded] = createSignal(false);
+
+// After
+const [expanded, setExpanded] = createSignal(tool === "Glob");
+```
+
+Glob results render with the full file list visible on mount. All other tools remain collapsed by default. The toggle chevron still works — users can collapse a Glob result manually.
+
+---
+
+## Design notes
+
+- The `userHolding` guard on mouse-enter (`if (props.pinned || autoExpanded())`) is intentional: it prevents hover from opening an already-collapsed tool. This preserves the consolidation from `SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md` — collapsed tools stay collapsed on hover.
+- `userHolding` is not persisted in `documentState.pinnedNodes`. It is a transient, per-mount interaction signal. If the component unmounts and remounts (virtualization scroll-off), the block starts fresh with no hold. This is acceptable — the user can re-hover or click to pin.
+- Glob default-expand applies at the `CompactResult` level, so it takes effect wherever `CompactResult` is used with `tool="Glob"` (currently only `ToolOverlayLog.tsx`).

--- a/frontend/app/view/agent/components/CompactResult.tsx
+++ b/frontend/app/view/agent/components/CompactResult.tsx
@@ -98,7 +98,7 @@ function shortPath(p: string): string {
 }
 
 export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX.Element => {
-    const [expanded, setExpanded] = createSignal(false);
+    const [expanded, setExpanded] = createSignal(tool === "Glob");
 
     const summary = summarize(tool, params, result);
     const fullJson = result != null ? JSON.stringify(result, null, 2) : "";

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -130,7 +130,12 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // expand. The user-visible "three popups on hover" (browser title
     // tooltip + larger log panel + fast expand/collapse animation)
     // collapsed into a single in-flow panel.
-    const expanded = () => props.pinned || autoExpanded();
+    //
+    // Exception: if the user's mouse is inside an already-expanded block,
+    // we hold it open until they leave so the post-completion timer can't
+    // collapse it mid-read.
+    const [userHolding, setUserHolding] = createSignal(false);
+    const expanded = () => props.pinned || autoExpanded() || userHolding();
 
     // Two render modes — `flow` when the panel is visible (auto-expand
     // or pinned), `hidden` otherwise. The hover-only `overlay` mode is
@@ -151,6 +156,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 canceled: props.node.status === "canceled",
             })}
             data-tool={props.node.tool.toLowerCase()}
+            onMouseEnter={() => { if (props.pinned || autoExpanded()) setUserHolding(true); }}
+            onMouseLeave={() => setUserHolding(false)}
         >
             <div class="agent-tool-summary" onClick={props.onTogglePin}>
                 <span class="agent-tool-status-icon">{statusIcon()}</span>


### PR DESCRIPTION
## Summary

- **Interaction hold**: When a tool block is auto-expanded (running or post-completion hold) and the user's mouse enters it, the block stays open until they leave — the post-completion timer can no longer collapse it mid-read. Hover on already-collapsed tools is unchanged (no peek, per `SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28`).
- **Glob auto-expand**: Glob tool results now start expanded so the full file list is visible immediately without requiring a chevron click.

## Files changed

- `frontend/app/view/agent/components/ToolBlock.tsx` — `userHolding` signal latched on `mouseEnter` while `autoExpanded() || pinned`, cleared on `mouseLeave`; included in `expanded()` guard
- `frontend/app/view/agent/components/CompactResult.tsx` — `createSignal(tool === "Glob")` instead of `createSignal(false)`
- `docs/specs/SPEC_TOOL_BLOCK_INTERACTION_HOLD_AND_GLOB_EXPAND_2026_06_09.md` — spec documenting both changes

## Test plan

- [ ] Run a tool call, let it complete — hover inside the block while the 3s hold is counting down, confirm it stays open after the timer fires, confirm it collapses when mouse leaves
- [ ] Hover over a collapsed (already-completed) tool — confirm it does NOT open (hover-to-peek still disabled)
- [ ] Trigger a Glob tool call — confirm file list is expanded on arrival without clicking
- [ ] Click the Glob chevron — confirm it can still be manually collapsed
- [ ] Pin a tool block — confirm pin still overrides everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)