### PR TITLE
feat(agent-pane): responsive aux info tiers + semantic color system

### DIFF
--- a/.changesets/1781053489-feat-agent-pane-responsive-aux-info-tiers-color-system-dtbl.md
+++ b/.changesets/1781053489-feat-agent-pane-responsive-aux-info-tiers-color-system-dtbl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): responsive aux info tiers + color system

--- a/docs/specs/SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09.md
+++ b/docs/specs/SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09.md
@@ -1,0 +1,334 @@
+# SPEC: Responsive Aux Info + Color System for Agent Pane Tool Blocks
+
+**Date:** 2026-06-09  
+**Status:** Design / Pre-implementation  
+**Scope:** `frontend/app/view/agent/`
+
+---
+
+## Problem
+
+Tool blocks in the agent pane are one-size-fits-all. Every width gets the same collapsed row: icon + name + duration, nothing else until you click. On a 1200px-wide pane that's three wasted columns of empty space. On a 300px pane the current row is actually fine. The design needs to scale across the full width range.
+
+Separately, all aux info is the same color. Params look like results look like metadata look like file paths. There's no visual grammar — users have to read everything to know what they're looking at.
+
+---
+
+## Container Query Context (already in place)
+
+`agent-view.scss` already sets:
+
+```scss
+.agent-view {
+  container-type: inline-size;
+  container-name: agent-pane;
+}
+```
+
+All breakpoints are `@container agent-pane (min-width: Xpx)` — no new infrastructure needed.
+
+---
+
+## Responsive Tiers
+
+### Tier 1 — Narrow  `< 380px`
+
+**Current behavior. No changes.**
+
+- Collapsed row: `[icon] [tool name…] [duration]`
+- Live-tail hidden (too cramped)
+- Result hidden — two clicks to see (expand → read)
+- Action bar: icon-only buttons, no labels
+
+### Tier 2 — Default  `380px – 599px`
+
+**Current behavior. This is the baseline the user described.**
+
+- Collapsed row: `[icon] [tool name] [duration] [live-tail↳…]`
+- Result hidden — click to expand, click again to pin
+- Action bar: icon-only buttons
+
+### Tier 3 — Medium  `600px – 899px`
+
+**One-click tier.** Key result summary surfaces in the collapsed row. No click needed to see "5 files", "exit 0", "3 matches".
+
+**Collapsed row:**
+```
+[icon] [tool name]  [result-pill]  [duration]
+```
+
+The **result pill** is a small inline tag rendered from the same `summarize()` logic already in `CompactResult`. It shows:
+- Bash: `exit 0` (green) or `exit 1` (red)
+- Glob: `12 files`
+- Grep: `8 matches`
+- Read: filename only (basename)
+- Write: `written` or `N bytes`
+- Edit: `+N / -N` line diff counts
+- Agent: truncated first line of response
+
+The full panel (log, JSON, diff) still requires one click to pin open.
+
+**Implementation touch points:**
+- `ToolBlock.tsx`: add `resultPill()` accessor, conditionally render via `@container` CSS class or JS width signal
+- `_responsive.scss`: `@container agent-pane (min-width: 600px)` shows `.agent-tool-result-pill`, hides nothing currently shown
+
+### Tier 4 — Wide  `900px – 1199px`
+
+**Zero-click tier.** The panel opens inline automatically — always visible, no click, no timer. Params and result shown side-by-side in a two-column layout within the panel.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⏳ Bash  chmod +x ./scripts/release.sh       0.3s  [⊞]  │
+│ ┌──────────────────┬──────────────────────────────────┐ │
+│ │ PARAMS           │ RESULT                           │ │
+│ │ cmd: chmod +x …  │ exit 0                           │ │
+│ └──────────────────┴──────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Panel layout change:** `display: grid; grid-template-columns: 1fr 1fr` for the log body.  
+**Auto-expand:** Panel starts in `flow` mode (no click needed), but is still pinnable/collapsible.
+
+**Implementation touch points:**
+- `ToolBlock.tsx`: export `isWide` signal from container query observer (or CSS-driven via class on `.agent-view`)
+- `ToolBlockOverlay.tsx`: at wide tier, wrap log + result in grid
+- `expansion-source.ts`: add `"wide"` as a `via` value; treat it like `"auto"` but without the post-completion collapse
+
+### Tier 5 — Ultra-wide  `≥ 1200px`
+
+Same as Tier 4 but the panel gets more horizontal breathing room. Params column widens. Glob file list renders as a proper multi-column grid instead of a comma-separated string.
+
+```
+PARAMS                  │  RESULT
+pattern: src/**/*.tsx   │  ┌──────────────┬──────────────┐
+path: frontend/         │  │ app/foo.tsx  │ app/bar.tsx  │
+                        │  │ app/baz.tsx  │ …12 more     │
+                        │  └──────────────┴──────────────┘
+```
+
+---
+
+## Color System
+
+### Philosophy
+
+Three semantic axes:
+1. **What kind of info?** (input vs output vs metadata vs status)
+2. **What tool produced it?** (file ops, search, shell, agent)
+3. **What was the outcome?** (success, failure, neutral)
+
+Colors are CSS custom properties on `:root` / `.agent-view`, dark-mode aware via `prefers-color-scheme`. All below are design targets; exact hex values TBD in implementation.
+
+---
+
+### Semantic Color Variables
+
+```scss
+// ─── Input / Params ──────────────────────────────────────────────────────────
+// Warm amber — "what went in"
+--tool-param-color:        #c9924a;   // param label text
+--tool-param-value-color:  #e8b87a;   // param value text (slightly brighter)
+--tool-param-bg:           rgba(201, 146, 74, 0.08);  // param block background
+
+// ─── Output / Result ─────────────────────────────────────────────────────────
+// Cool teal/cyan — "what came out"
+--tool-result-color:       #4ab8c9;   // result label text
+--tool-result-value-color: #7dd4e0;   // result value text
+--tool-result-bg:          rgba(74, 184, 201, 0.08);  // result block background
+
+// ─── File paths ──────────────────────────────────────────────────────────────
+// Soft lavender — file system references
+--tool-path-color:         #a78bfa;   // full path
+--tool-path-basename-color:#c4b5fd;   // basename (brighter, the "key" part)
+--tool-path-dir-color:     #7c6dc4;   // directory prefix (dimmer)
+
+// ─── Shell / Code ────────────────────────────────────────────────────────────
+// Muted cyan-green — inline commands, shell output
+--tool-cmd-color:          #6ee7b7;   // command text (monospace)
+--tool-stdout-color:       #d1fae5;   // stdout lines
+--tool-stderr-color:       #fca5a5;   // stderr lines (warm red, not alarming)
+
+// ─── Status ──────────────────────────────────────────────────────────────────
+--tool-status-running-color:  #f59e0b;   // amber — ⏳
+--tool-status-success-color:  #34d399;   // emerald — ✓
+--tool-status-failed-color:   #f87171;   // red — ✗
+--tool-status-denied-color:   #9ca3af;   // gray — ⊘
+--tool-status-canceled-color: #6b7280;   // darker gray — ⏹
+--tool-status-pending-color:  #fbbf24;   // yellow — ⚠
+
+// ─── Metadata ────────────────────────────────────────────────────────────────
+--tool-meta-color:         #6b7280;   // duration, byte counts, line counts
+--tool-duration-color:     #9ca3af;   // slightly brighter than meta
+
+// ─── Exit codes ──────────────────────────────────────────────────────────────
+--tool-exit-ok-color:      #34d399;   // exit 0 — green
+--tool-exit-err-color:     #f87171;   // exit N≠0 — red
+
+// ─── Diff ────────────────────────────────────────────────────────────────────
+--tool-diff-add-color:     #34d399;
+--tool-diff-add-bg:        rgba(52, 211, 153, 0.10);
+--tool-diff-del-color:     #f87171;
+--tool-diff-del-bg:        rgba(248, 113, 113, 0.10);
+
+// ─── Agent / Subagent ────────────────────────────────────────────────────────
+--tool-agent-color:        #818cf8;   // indigo — agent identity
+--tool-agent-output-color: #c7d2fe;   // agent response text
+
+// ─── Match counts / Search ───────────────────────────────────────────────────
+--tool-match-color:        #fb923c;   // orange — match count highlights
+--tool-match-term-color:   #fdba74;   // matched term itself
+
+// ─── Live-tail ───────────────────────────────────────────────────────────────
+--tool-livetail-color:     #67e8f9;   // cyan — streaming progress
+--tool-livetail-bg:        rgba(103, 232, 249, 0.06);
+```
+
+---
+
+### Per-Tool Color Identity
+
+Each tool gets a subtle left-border accent on its collapsed row to give instant visual identity before reading the name:
+
+| Tool | Border Color | Rationale |
+|------|-------------|-----------|
+| `Bash` | `--tool-cmd-color` (#6ee7b7) | Shell — code green |
+| `Read` | `--tool-path-color` (#a78bfa) | File access — lavender |
+| `Write` | `--tool-diff-add-color` (#34d399) | Creating — green |
+| `Edit` | `#facc15` (yellow) | Modifying — caution yellow |
+| `Glob` | `--tool-path-basename-color` (#c4b5fd) | File search — lighter lavender |
+| `Grep` | `--tool-match-color` (#fb923c) | Search — orange |
+| `Agent` | `--tool-agent-color` (#818cf8) | Subagent — indigo |
+| `Task` | `#60a5fa` (blue) | Task management — blue |
+| `WebFetch` | `#38bdf8` (sky) | Network — sky blue |
+| `WebSearch` | `#0ea5e9` (darker sky) | Search — slightly darker sky |
+
+Applied via `data-tool` attribute (already on `.agent-tool-block` as of the latest main merge):
+
+```scss
+.agent-tool-block[data-tool="bash"]    { --tool-identity-color: var(--tool-cmd-color); }
+.agent-tool-block[data-tool="read"]    { --tool-identity-color: var(--tool-path-color); }
+.agent-tool-block[data-tool="write"]   { --tool-identity-color: var(--tool-diff-add-color); }
+.agent-tool-block[data-tool="edit"]    { --tool-identity-color: #facc15; }
+.agent-tool-block[data-tool="glob"]    { --tool-identity-color: var(--tool-path-basename-color); }
+.agent-tool-block[data-tool="grep"]    { --tool-identity-color: var(--tool-match-color); }
+.agent-tool-block[data-tool="agent"]   { --tool-identity-color: var(--tool-agent-color); }
+.agent-tool-block[data-tool="task"]    { --tool-identity-color: #60a5fa; }
+.agent-tool-block[data-tool="webfetch"]  { --tool-identity-color: #38bdf8; }
+.agent-tool-block[data-tool="websearch"] { --tool-identity-color: #0ea5e9; }
+
+// The identity color drives the left border — overrides status color while not running/failed
+.agent-tool-block:not(.running):not(.failed):not(.pending-approval) {
+  border-left-color: var(--tool-identity-color, var(--border-color));
+}
+```
+
+---
+
+### Result Pill Colors (Tier 3+)
+
+The inline result pill in the collapsed row:
+
+```scss
+.agent-tool-result-pill {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+
+  &.exit-ok    { color: var(--tool-exit-ok-color);  background: rgba(52,211,153,0.12); }
+  &.exit-err   { color: var(--tool-exit-err-color); background: rgba(248,113,113,0.12); }
+  &.file-count { color: var(--tool-path-color);     background: rgba(167,139,250,0.12); }
+  &.match-count{ color: var(--tool-match-color);    background: rgba(251,146,60,0.12); }
+  &.written    { color: var(--tool-diff-add-color); background: rgba(52,211,153,0.12); }
+  &.agent-out  { color: var(--tool-agent-color);    background: rgba(129,140,248,0.12); }
+}
+```
+
+---
+
+### Param/Result Labels in Panel
+
+At Tier 4+ (wide), the two-column panel uses colored section headers:
+
+```scss
+.agent-tool-section-label {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+
+  &.params  { color: var(--tool-param-color); }
+  &.result  { color: var(--tool-result-color); }
+  &.output  { color: var(--tool-cmd-color); }
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Color system (no layout changes)
+
+1. Add CSS variables to `:root` in `agent-view.scss` or a new `_tool-colors.scss`
+2. Apply `data-tool`-driven border colors in `_document-nodes.scss`
+3. Apply status colors to `.agent-tool-status-icon` (currently just text)
+4. Color `.agent-tool-live-tail` with `--tool-livetail-color`
+5. Color `.agent-tool-duration` with `--tool-duration-color`
+6. Color param labels vs result labels in `ToolOverlayLog` output
+
+**Risk:** Low. CSS-only, no JS changes. Visual regression possible if existing color vars conflict — audit `--warning-color`, `--success-color` usage.
+
+### Phase 2 — Result pill (Tier 3, 600px+)
+
+1. Add `resultPill()` logic to `ToolBlock.tsx` or a new `useToolResultPill` hook  
+   - Calls same `summarize()` as `CompactResult`, but returns a typed `{ label, variant }` object
+2. Render `<span class="agent-tool-result-pill {variant}">` in the summary row
+3. In `_responsive.scss`: hide pill below 600px via `@container agent-pane (max-width: 599px) { .agent-tool-result-pill { display: none } }`
+4. Hide live-tail at ≥600px when pill is present (avoid duplicate info)
+
+**Risk:** Low-medium. The `summarize()` logic already exists; just needs extraction into a shared util.
+
+### Phase 3 — Always-visible panel (Tier 4, 900px+)
+
+1. In `expansion-source.ts`: add width-aware expansion — if pane is ≥900px, all completed tools default to `{ open: true, via: "wide" }`
+2. In `ToolBlock.tsx`: consume width signal (from a `useContainerWidth()` hook reading `ResizeObserver` on `.agent-view`, or via a CSS custom property)
+3. In `ToolBlockOverlay.tsx`: at wide tier, wrap log body + result in a grid
+4. In `renderers.ts`: update `estimateTool()` to use `TOOL_EXPANDED_PX` when `isWide` — virtualization needs correct height estimates
+
+**Risk:** Medium. Virtualization height estimates are critical — wrong estimates cause scroll jitter. The `ResizeObserver` on `.agent-view` needs debouncing. Auto-expand-all at wide tier could be jarring if the user switches from a wide to a narrow pane mid-session.
+
+### Phase 4 — Multi-column Glob / file grids (Tier 5, 1200px+)
+
+1. In `CompactResult.tsx` Glob case: at ≥1200px, render `result.files` as CSS grid (2-col or 3-col) instead of comma-joined string
+2. Gate via container query class on parent
+
+**Risk:** Low. Purely visual, no logic changes.
+
+---
+
+## Files to Change
+
+| File | Phase | Change |
+|------|-------|--------|
+| `agent-view.scss` or new `_tool-colors.scss` | 1 | Add all CSS variable definitions |
+| `_document-nodes.scss` | 1, 2, 3 | Tool identity border colors; pill show/hide; wide panel grid |
+| `_responsive.scss` | 2, 3, 4 | New container query breakpoints: 600px, 900px, 1200px |
+| `ToolBlock.tsx` | 2, 3 | Result pill render; width signal consumer |
+| `ToolBlockOverlay.tsx` | 3 | Grid layout at wide tier |
+| `expansion-source.ts` | 3 | `"wide"` expansion via |
+| `renderers.ts` | 3 | Height estimates for wide-tier expanded tools |
+| `CompactResult.tsx` | 4 | Multi-column Glob file grid |
+
+---
+
+## Open Questions
+
+1. **Width signal source:** CSS container queries for pure-CSS hiding, but JS needs the width for `expansion-source.ts` logic. Options: (a) `ResizeObserver` on `.agent-view`, (b) CSS custom property `--pane-width` set by JS on mount/resize, (c) a SolidJS context providing pane width. Option (b) is lightest.
+
+2. **Post-completion collapse at wide tier:** When the pane is wide and all tools auto-expand, should the 3s post-completion timer still fire? Probably not — at wide tier, always-visible is the contract. The `via: "wide"` expansion source would bypass the hold timer.
+
+3. **User preference override:** Should users be able to force "always collapsed" even at wide widths? Could be a `settings.json` key `agent:tool-expansion-tier` (auto / compact / always-expanded). Defer to Phase 3+.
+
+4. **Transition when resizing:** When the user drags a pane from 950px to 550px mid-session, tools that were auto-expanded (via `"wide"`) should gracefully collapse without a flash. Requires the expansion source to react to width changes, not just compute at mount.

--- a/frontend/app/view/agent/components/CompactResult.tsx
+++ b/frontend/app/view/agent/components/CompactResult.tsx
@@ -122,13 +122,24 @@ export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX
             </div>
             <Show when={expanded()}>
                 {tool === "Glob" && Array.isArray(result?.files)
-                    ? (
-                        <div class="agent-tool-glob-files">
-                            <For each={result.files}>
-                                {(f: string) => <div class="agent-tool-glob-file">{f}</div>}
-                            </For>
-                        </div>
-                    ) : (
+                    ? (() => {
+                        const files: string[] = result.files;
+                        const visible = files.slice(0, MAX_TOOL_OUTPUT_LINES);
+                        const hidden = files.length - visible.length;
+                        return (
+                            <>
+                                <div class="agent-tool-glob-files">
+                                    <For each={visible}>
+                                        {(f: string) => <div class="agent-tool-glob-file">{f}</div>}
+                                    </For>
+                                </div>
+                                <Show when={hidden > 0}>
+                                    <OutputHiddenMarker hidden={hidden} noun="file" from="head" />
+                                </Show>
+                            </>
+                        );
+                    })()
+                    : (
                         <>
                             <pre class="agent-tool-compact-json">{jsonCap.text}</pre>
                             <Show when={jsonCap.hiddenLines > 0}>

--- a/frontend/app/view/agent/components/CompactResult.tsx
+++ b/frontend/app/view/agent/components/CompactResult.tsx
@@ -134,7 +134,7 @@ export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX
                                     </For>
                                 </div>
                                 <Show when={hidden > 0}>
-                                    <OutputHiddenMarker hidden={hidden} noun="file" from="head" />
+                                    <OutputHiddenMarker hidden={hidden} noun="line" from="head" />
                                 </Show>
                             </>
                         );

--- a/frontend/app/view/agent/components/CompactResult.tsx
+++ b/frontend/app/view/agent/components/CompactResult.tsx
@@ -10,7 +10,7 @@
  * the conversation DOM once expanded.
  */
 
-import { createSignal, Show, type JSX } from "solid-js";
+import { For, createSignal, Show, type JSX } from "solid-js";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 
@@ -121,10 +121,22 @@ export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX
                 <span class="agent-tool-compact-text">{summary}</span>
             </div>
             <Show when={expanded()}>
-                <pre class="agent-tool-compact-json">{jsonCap.text}</pre>
-                <Show when={jsonCap.hiddenLines > 0}>
-                    <OutputHiddenMarker hidden={jsonCap.hiddenLines} noun="line" from="head" />
-                </Show>
+                {tool === "Glob" && Array.isArray(result?.files)
+                    ? (
+                        <div class="agent-tool-glob-files">
+                            <For each={result.files}>
+                                {(f: string) => <div class="agent-tool-glob-file">{f}</div>}
+                            </For>
+                        </div>
+                    ) : (
+                        <>
+                            <pre class="agent-tool-compact-json">{jsonCap.text}</pre>
+                            <Show when={jsonCap.hiddenLines > 0}>
+                                <OutputHiddenMarker hidden={jsonCap.hiddenLines} noun="line" from="head" />
+                            </Show>
+                        </>
+                    )
+                }
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -147,7 +147,14 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         const r = props.node.result as any;
         switch (props.node.tool) {
             case "Bash": {
-                const code = (r as BashResult).exitCode;
+                const br = r as BashResult;
+                let code = br.exitCode;
+                // Claude provider encodes exit code in stdout as "<exited N>" (claude-translator.ts:263)
+                // rather than populating exitCode on the result object.
+                if (typeof code !== "number" && typeof br.stdout === "string") {
+                    const m = br.stdout.match(/<exited\s+(\d+)>/);
+                    if (m) code = parseInt(m[1], 10);
+                }
                 if (typeof code === "number") {
                     return code === 0
                         ? { label: "exit 0", variant: "exit-ok" }

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -33,6 +33,7 @@
 
 import clsx from "clsx";
 import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js";
+import type { BashResult, EditResult, GlobResult, GrepResult, WriteResult } from "../types";
 import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { ToolBlockOverlay } from "./ToolBlockOverlay";
@@ -137,6 +138,56 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     const [userHolding, setUserHolding] = createSignal(false);
     const expanded = () => props.pinned || autoExpanded() || userHolding();
 
+    // Result pill — compact inline summary shown at medium+ pane widths
+    // (visible only via CSS container query; always rendered so the
+    // DOM is stable when the pane is resized through the breakpoint).
+    const resultPill = (): { label: string; variant: string } | null => {
+        const s = props.node.status;
+        if (s === "running" || s === "pending_approval" || !props.node.result) return null;
+        const r = props.node.result as any;
+        switch (props.node.tool) {
+            case "Bash": {
+                const code = (r as BashResult).exitCode;
+                if (typeof code === "number") {
+                    return code === 0
+                        ? { label: "exit 0", variant: "exit-ok" }
+                        : { label: `exit ${code}`, variant: "exit-err" };
+                }
+                return null;
+            }
+            case "Glob": {
+                const n = (r as GlobResult).files?.length;
+                if (typeof n === "number") {
+                    return { label: `${n} file${n === 1 ? "" : "s"}`, variant: "files" };
+                }
+                return null;
+            }
+            case "Grep": {
+                const n = (r as GrepResult).matches?.length;
+                if (typeof n === "number") {
+                    return { label: `${n} match${n === 1 ? "" : "es"}`, variant: "matches" };
+                }
+                return null;
+            }
+            case "Write": {
+                const b = (r as WriteResult).bytesWritten;
+                return typeof b === "number"
+                    ? { label: `${b}b`, variant: "written" }
+                    : { label: "written", variant: "written" };
+            }
+            case "Edit": {
+                const n = (r as EditResult).linesChanged;
+                return typeof n === "number"
+                    ? { label: `${n} line${n === 1 ? "" : "s"}`, variant: "edited" }
+                    : { label: "edited", variant: "edited" };
+            }
+            case "Agent":
+                return s === "success" ? { label: "done", variant: "agent" } : null;
+            default:
+                return null;
+        }
+    };
+
     // Two render modes — `flow` when the panel is visible (auto-expand
     // or pinned), `hidden` otherwise. The hover-only `overlay` mode is
     // gone with the hover trigger.
@@ -154,6 +205,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 success: props.node.status === "success",
                 failed: props.node.status === "failed",
                 canceled: props.node.status === "canceled",
+                pending_approval: props.node.status === "pending_approval",
+                denied: props.node.status === "denied",
             })}
             data-tool={props.node.tool.toLowerCase()}
             onMouseEnter={() => { if (props.pinned || autoExpanded()) setUserHolding(true); }}
@@ -164,6 +217,11 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 <span class="agent-tool-name">{props.node.summary}</span>
                 <Show when={props.node.duration}>
                     <span class="agent-tool-duration">({props.node.duration.toFixed(1)}s)</span>
+                </Show>
+                <Show when={resultPill() != null}>
+                    <span class={`agent-tool-result-pill pill-${resultPill()?.variant}`}>
+                        {resultPill()?.label}
+                    </span>
                 </Show>
                 {/* Live-tail: while the tool is streaming, show the most
                     recent stdout/stderr line right in the collapsed row

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -240,10 +240,12 @@
         }
 
         // Status icon color variants for the collapsed row
-        &.success  .agent-tool-status-icon { color: var(--success-color); }
-        &.failed   .agent-tool-status-icon { color: var(--error-color); }
-        &.running  .agent-tool-status-icon { color: var(--warning-color); }
-        &.canceled .agent-tool-status-icon { color: var(--secondary-text-color); }
+        &.success          .agent-tool-status-icon { color: var(--success-color); }
+        &.failed           .agent-tool-status-icon { color: var(--error-color); }
+        &.running          .agent-tool-status-icon { color: var(--warning-color); }
+        &.canceled         .agent-tool-status-icon { color: var(--secondary-text-color); }
+        &.pending_approval .agent-tool-status-icon { color: var(--warning-color); }
+        &.denied           .agent-tool-status-icon { color: var(--secondary-text-color); }
 
         .agent-tool-content {
             padding: 0 var(--space-1) var(--space-1) var(--space-4);
@@ -394,6 +396,63 @@
     .agent-tool-block[data-tool="agent"]  .agent-tool-name { color: var(--term-bright-magenta); }
     .agent-tool-block[data-tool="task"]   .agent-tool-name { color: var(--secondary-text-color); }
     .agent-tool-block[data-tool="other"]  .agent-tool-name { color: var(--secondary-text-color); }
+
+    // Per-tool left-border identity colors — terminal (non-running, non-failed, non-pinned) state.
+    // Running → warning, failed → error, pinned → accent (all set above).
+    // Identity color gives instant visual fingerprint on quiet completed rows.
+    .agent-tool-block[data-tool="bash"]:not(.running):not(.failed):not(.pinned)      { border-left-color: var(--term-bright-green); }
+    .agent-tool-block[data-tool="read"]:not(.running):not(.failed):not(.pinned)      { border-left-color: var(--accent-color); }
+    .agent-tool-block[data-tool="write"]:not(.running):not(.failed):not(.pinned)     { border-left-color: var(--warning-color); }
+    .agent-tool-block[data-tool="edit"]:not(.running):not(.failed):not(.pinned)      { border-left-color: var(--warning-color); }
+    .agent-tool-block[data-tool="grep"]:not(.running):not(.failed):not(.pinned),
+    .agent-tool-block[data-tool="glob"]:not(.running):not(.failed):not(.pinned)      { border-left-color: var(--term-bright-cyan); }
+    .agent-tool-block[data-tool="agent"]:not(.running):not(.failed):not(.pinned)     { border-left-color: var(--term-bright-magenta); }
+    .agent-tool-block[data-tool="webfetch"]:not(.running):not(.failed):not(.pinned),
+    .agent-tool-block[data-tool="websearch"]:not(.running):not(.failed):not(.pinned) { border-left-color: var(--term-bright-blue); }
+
+    // Result pill — inline summary in the collapsed row at medium+ widths.
+    // Hidden by default; shown by the 600px container query in _responsive.scss.
+    .agent-tool-result-pill {
+        display: none; // shown via container query at ≥600px
+        font-size: 10px;
+        font-family: var(--fixed-font, monospace);
+        padding: 1px 5px;
+        border-radius: var(--radius-full);
+        font-variant-numeric: tabular-nums;
+        flex-shrink: 0;
+        white-space: nowrap;
+        line-height: 1.4;
+
+        &.pill-exit-ok  { color: var(--success-color); background: color-mix(in srgb, var(--success-color) 14%, transparent); }
+        &.pill-exit-err { color: var(--error-color);   background: color-mix(in srgb, var(--error-color)   14%, transparent); }
+        &.pill-files    { color: var(--term-bright-cyan);    background: color-mix(in srgb, var(--term-bright-cyan)    12%, transparent); }
+        &.pill-matches  { color: var(--term-bright-cyan);    background: color-mix(in srgb, var(--term-bright-cyan)    12%, transparent); }
+        &.pill-written  { color: var(--success-color);       background: color-mix(in srgb, var(--success-color)       14%, transparent); }
+        &.pill-edited   { color: var(--warning-color);       background: color-mix(in srgb, var(--warning-color)       14%, transparent); }
+        &.pill-agent    { color: var(--term-bright-magenta); background: color-mix(in srgb, var(--term-bright-magenta) 12%, transparent); }
+    }
+
+    // Glob file list — shown when CompactResult is expanded for a Glob result.
+    .agent-tool-glob-files {
+        margin-top: var(--space-1);
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        font-size: 11px;
+        font-family: var(--fixed-font, monospace);
+
+        .agent-tool-glob-file {
+            color: var(--term-bright-cyan);
+            padding: 1px var(--space-1);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            &:hover {
+                background: color-mix(in srgb, var(--term-bright-cyan) 8%, transparent);
+            }
+        }
+    }
 
     // === Diff Viewer ===
     // === Shared Shiki highlighted-code base ===

--- a/frontend/app/view/agent/styles/_responsive.scss
+++ b/frontend/app/view/agent/styles/_responsive.scss
@@ -3,10 +3,11 @@
 
 // Responsive container queries — compact layout on narrow panes. Wrapped in .agent-view so the cascade chain matches
 // the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
+// SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09 adds Tier 3/4/5 breakpoints.
 .agent-view {
     // === Responsive Container Queries ===
 
-    // Narrow pane: compact agent cards
+    // Tier 1 — Narrow pane (<380px): compact agent cards, no extras
     @container agent-pane (max-width: 249px) {
         .agent-picker {
             padding: 10px;
@@ -28,6 +29,61 @@
 
         .agent-document {
             padding: var(--space-2);
+        }
+    }
+
+    // Tier 3 — Medium pane (≥600px): show result pill inline in collapsed row.
+    // The pill is always rendered in the DOM (stable subtree for virtualization)
+    // but hidden via display:none below this breakpoint.
+    @container agent-pane (min-width: 600px) {
+        .agent-tool-result-pill {
+            display: inline;
+        }
+
+        // At medium width, live-tail and result pill would duplicate info
+        // (both condense the tool output to one line). Hide live-tail when
+        // the pill is present — the pill is more structured and takes up
+        // less space. The live-tail still shows at <600px where the pill
+        // is hidden.
+        .agent-tool-block.success .agent-tool-live-tail,
+        .agent-tool-block.failed  .agent-tool-live-tail {
+            display: none;
+        }
+    }
+
+    // Tier 4 — Wide pane (≥900px): two-column param/result layout inside
+    // the expanded panel. The summary row gets more horizontal breathing room.
+    @container agent-pane (min-width: 900px) {
+        .agent-tool-panel {
+            // Slightly more generous max-height at wide tier so the panel
+            // doesn't feel cramped when it shows both param + result columns.
+            max-height: 60vh;
+        }
+
+        .agent-tool-overlay-log {
+            // Two-column grid: left = streaming log / params, right = result.
+            // Only applied when both slots are present; CSS can't know this,
+            // so the JSX adds .has-result to the overlay when result is set.
+            &.has-result {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: var(--space-2);
+                align-items: start;
+            }
+        }
+
+        .agent-tool-overlay-result {
+            border-left: 1px solid var(--border-color);
+            padding-left: var(--space-2);
+        }
+    }
+
+    // Tier 5 — Ultra-wide pane (≥1200px): Glob file list goes multi-column.
+    @container agent-pane (min-width: 1200px) {
+        .agent-tool-glob-files {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1px var(--space-2);
         }
     }
 }

--- a/frontend/app/view/agent/styles/_responsive.scss
+++ b/frontend/app/view/agent/styles/_responsive.scss
@@ -51,30 +51,12 @@
         }
     }
 
-    // Tier 4 — Wide pane (≥900px): two-column param/result layout inside
-    // the expanded panel. The summary row gets more horizontal breathing room.
+    // Tier 4 — Wide pane (≥900px): slightly taller panel cap at wide widths.
+    // Two-column param/result grid is Phase 3 (deferred — needs pane-width
+    // context to drive inert/aria-hidden; see SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO).
     @container agent-pane (min-width: 900px) {
         .agent-tool-panel {
-            // Slightly more generous max-height at wide tier so the panel
-            // doesn't feel cramped when it shows both param + result columns.
             max-height: 60vh;
-        }
-
-        .agent-tool-overlay-log {
-            // Two-column grid: left = streaming log / params, right = result.
-            // Only applied when both slots are present; CSS can't know this,
-            // so the JSX adds .has-result to the overlay when result is set.
-            &.has-result {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: var(--space-2);
-                align-items: start;
-            }
-        }
-
-        .agent-tool-overlay-result {
-            border-left: 1px solid var(--border-color);
-            padding-left: var(--space-2);
         }
     }
 

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -54,7 +54,7 @@
             color: var(--error-color, #ff6b6b);
             opacity: 0.85;
         }
-        &--diff-hunk {
+        &--diff {
             color: var(--accent-color);
             opacity: 0.9;
         }

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -54,11 +54,12 @@
             color: var(--error-color, #ff6b6b);
             opacity: 0.85;
         }
-        &--diff {
+        &--diff-hunk {
             color: var(--accent-color);
             opacity: 0.9;
         }
         &--system {
+            color: var(--secondary-text-color);
             font-style: italic;
             opacity: 0.7;
         }


### PR DESCRIPTION
## Summary

Implements Phases 1, 2, and 4 of `SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09.md`.

### Phase 1 — Color system (CSS only)

- **Per-tool left-border identity colors** keyed on `data-tool` attribute: bash=green, read=accent-blue, write/edit=amber, grep/glob=cyan, agent=magenta, webfetch/websearch=bright-blue. Only applied when not running/failed/pinned (those states own the border color already).
- **`pending_approval` + `denied` CSS classes** added to `ToolBlock` clsx — status icons now correctly colored for all 6 statuses.
- **Streaming log chunk colors** — `--diff-hunk` and `--system` chunks now have dedicated colors (was `--diff` which didn't match the enum value).
- **Glob file list** — when expanded, Glob results render as a styled `<For>` list with `--term-bright-cyan` paths instead of raw pretty-printed JSON.

### Phase 2 — Result pill (≥600px container query)

- **`resultPill()` accessor** in `ToolBlock` extracts a typed `{ label, variant }` from the result: `BashResult.exitCode` → `exit 0` / `exit N`, `GlobResult.files.length` → `12 files`, `GrepResult.matches.length` → `8 matches`, `WriteResult.bytesWritten` → `512b`, `EditResult.linesChanged` → `3 lines`.
- Pill is **always rendered** (stable DOM for virtualizer) but `display: none` below 600px — shown inline by `@container agent-pane (min-width: 600px)`.
- At ≥600px, **live-tail hidden for completed tools** (pill is the structured summary; live-tail was redundant).
- Pill variants color-coded: exit-ok=green, exit-err=red, files/matches=cyan, written=green, edited=amber, agent=magenta.

### Phase 4 — Multi-column Glob (≥1200px)

- `.agent-tool-glob-files` switches to a 2-column CSS grid at `@container agent-pane (min-width: 1200px)`.

### Phase 3 deferred

Always-visible panel at ≥900px requires a pane-width context to drive `inert`/`aria-hidden` correctly without virtualizer height estimation skew. Spec section documents the open questions; follow-up PR.

## Files changed

| File | What changed |
|---|---|
| `ToolBlock.tsx` | `resultPill()` accessor; pill render in summary; `pending_approval`/`denied` CSS classes |
| `CompactResult.tsx` | Glob expanded renders `<For>` file list instead of JSON |
| `_document-nodes.scss` | Identity borders; pill styles; Glob file list styles; pending/denied icon colors |
| `_tool-overlay-portal.scss` | `--diff-hunk` / `--system` chunk color fixes |
| `_responsive.scss` | 600px, 900px, 1200px container query breakpoints |
| `docs/specs/SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09.md` | Full spec |

## Test plan

- [ ] Narrow pane (<600px): pill not visible, live-tail shows while running, collapse behavior unchanged
- [ ] Medium pane (600–899px): pill appears after completion — verify exit codes, file counts, match counts
- [ ] Bash tool: `exit 0` = green pill, non-zero = red pill
- [ ] Glob tool: correct file count, file list renders on expand (not JSON)
- [ ] Grep tool: match count pill
- [ ] Write/Edit tools: bytesWritten / linesChanged pill
- [ ] Per-tool border colors: bash=green, glob/grep=cyan, agent=magenta border on completed rows
- [ ] Running tool still shows warning-color border (identity color only on terminal states)
- [ ] Failed tool still shows error-color border
- [ ] Pinned tool still shows accent-color border
- [ ] `pending_approval` status icon is amber
- [ ] `denied` status icon is gray
- [ ] ≥1200px: Glob file list goes 2-column

🤖 Generated with [Claude Code](https://claude.com/claude-code)