### PR TITLE
fix(agent-pane): Index in ChunkList — close last replaceChild crash site (§7.4)

### DIFF
--- a/.changesets/1781088143-fix-agent-pane-replace-for-with-index-in-chunklist-to-close--tir5.md
+++ b/.changesets/1781088143-fix-agent-pane-replace-for-with-index-in-chunklist-to-close--tir5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): replace For with Index in ChunkList to close the last replaceChild crash site

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -15,7 +15,7 @@
  * ANSI parsing lands in Phase γ (perf + worker offload) per the spec.
  */
 
-import { For, Match, Show, Switch, createEffect, type JSX } from "solid-js";
+import { Index, Match, Show, Switch, createEffect, type JSX } from "solid-js";
 // `Show` retained for fallback ToolOverlayResult sub-tree.
 import type { ToolNode } from "../types";
 import { BashOutputViewer } from "./BashOutputViewer";
@@ -154,13 +154,13 @@ function ChunkList(props: ChunkListProps): JSX.Element {
             <Show when={capped().hiddenLines > 0}>
                 <OutputHiddenMarker hidden={capped().hiddenLines} noun="line" from="tail" />
             </Show>
-            <For each={capped().chunks}>
+            <Index each={capped().chunks}>
                 {(chunk) => (
-                    <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
-                        {capChars(chunk.content)}
+                    <pre class={`agent-tool-log-line ${KIND_CLASS[chunk().kind] ?? ""}`}>
+                        {capChars(chunk().content)}
                     </pre>
                 )}
-            </For>
+            </Index>
         </>
     );
 }


### PR DESCRIPTION
## Problem

`v0.43.1` still crashes with `replaceChild: node not a child` on block `aa6a64f`, even after the `<Key>→<Index>` fix from #1319. Render trail: `StreamFlushObserved (virtCount=102→103)` → `StreamUnsubscribe` (post-crash error-boundary cleanup).

The `<Index>` fix in #1319 eliminated `reconcileArrays` from the outer streaming-buffer and virtual-head containers. But a **nested `<For>`** inside `ChunkList` (ToolOverlayLog) was still reachable:

```tsx
// ToolOverlayLog.tsx — ChunkList
<For each={capped().chunks}>
    {(chunk) => <pre ...>{capChars(chunk.content)}</pre>}
</For>
```

When the `<Index>`-keyed streaming buffer shifts slot N to a **different ToolNode** (e.g. the frontier advances because the user sent a new message), `props.chunks` changes to the new node's chunk array. `mapArray` (used by `<For>`) keys by item reference — the entire incoming array is "new refs", so SolidJS calls `reconcileArrays(parent, old_pre_elements, new_pre_elements)`. If the `<Switch>` branch in `ToolOverlayLog` also changed in the same reactive batch (e.g. Match1→Match4 because the new node has no log yet), the old `<pre>` elements can already be detached before `reconcileArrays` runs → `replaceChild` throws.

This is the §7.4 crash class from `SPEC_REPLACECHILD_CRASH_FULL_ANALYSIS_AND_FIX_2026-06-06.md`, previously marked "mechanism unresolved — new diagnostic needed".

## Fix

Replace `<For>` with `<Index>` in `ChunkList`:

```tsx
<Index each={capped().chunks}>
    {(chunk) => (
        <pre class={`agent-tool-log-line ${KIND_CLASS[chunk().kind] ?? ""}`}>
            {capChars(chunk().content)}
        </pre>
    )}
</Index>
```

`<Index>` uses `indexArray` internally:
- **Same-length updates** (streaming appends within same node): slot signals update in-place → **no `reconcileArrays`**
- **Length-change updates** (new node with different chunk count): `indexArray` appends/removes from the tail only — all existing `<pre>` elements remain in their parent → **no stale DOM**

This is the same structural fix applied to `AgentDocumentVirtualList.tsx` in #1319, extended to the one remaining `<For>` in the document-rendering hot path.

## Why this is the last crash site

After this PR, there are **no remaining reactive `<For>` components** in the document rendering chain (streaming buffer → virtual head → DocumentRow → ToolBlock → ToolOverlayLog). All other `<For>` uses in the agent view are in modal/panel components outside the rendering hot path, or use static arrays.

## Test plan

- [ ] Build and launch `task package`
- [ ] Open an agent with a long conversation (150+ nodes) that has active tool streaming
- [ ] Send a new message while the tool is streaming — triggers the `virtCount` window shift that caused the crash
- [ ] Verify: no `replaceChild` error boundary, chunks continue rendering correctly in the overlay
- [ ] Verify: streaming chunks still display (no regression on ChunkList rendering)

Follow-up to #1319 — closes §7.4 of the replaceChild crash spec.