### PR TITLE
fix(build): fingerprint AGENTMUX_BUILD_CHANNEL_DEFAULT via rustc-env (reliable channel rebake)

### DIFF
--- a/.changesets/1781088300-fix-build-bake-data-channel-via-rustc-env-so-a-channel-chang-cjkg.md
+++ b/.changesets/1781088300-fix-build-bake-data-channel-via-rustc-env-so-a-channel-chang-cjkg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): bake data channel via rustc-env so a channel change forces a rebake instead of serving a stale incremental cache

--- a/agentmux-common/build.rs
+++ b/agentmux-common/build.rs
@@ -21,4 +21,20 @@
 
 fn main() {
     println!("cargo:rerun-if-env-changed=AGENTMUX_BUILD_CHANNEL_DEFAULT");
+
+    // `rerun-if-env-changed` only re-runs THIS build script when the env
+    // changes — it does NOT, on its own, force rustc to recompile the crate
+    // whose `option_env!` reads the value (the build-script output is
+    // unchanged, so Cargo can reuse the cached object). Re-emitting the value
+    // as `rustc-env` puts it into the crate's rustc fingerprint, so a channel
+    // change (branch switch, `--fresh`) reliably forces the rebake instead of
+    // silently baking a stale channel from the incremental cache.
+    //
+    // When the env is unset (plain `cargo build`/`cargo run` for tests) we emit
+    // nothing, so `option_env!` falls back to its `"stable"` default exactly as
+    // before. The per-build LABEL is deliberately NOT tracked this way (it
+    // changes every build and would defeat incremental caching).
+    if let Ok(channel) = std::env::var("AGENTMUX_BUILD_CHANNEL_DEFAULT") {
+        println!("cargo:rustc-env=AGENTMUX_BUILD_CHANNEL_DEFAULT={channel}");
+    }
 }


### PR DESCRIPTION
## Problem

`agentmux-common/build.rs` only emitted `cargo:rerun-if-env-changed=AGENTMUX_BUILD_CHANNEL_DEFAULT`. That re-runs the build script when the env changes, but **does not by itself force rustc to recompile** the crate whose `option_env!("AGENTMUX_BUILD_CHANNEL_DEFAULT")` reads the value (`data_paths.rs`). The build-script output is unchanged, so Cargo can reuse the cached object and bake a **stale channel** from the incremental cache — the running app then writes to the wrong data dir.

The file's own comment claimed `rerun-if-env-changed` made the `option_env!` read reliable. Per cargo semantics, it doesn't.

## Fix

Re-emit the value as `cargo:rustc-env`, which puts it into the crate's **rustc fingerprint**:

```rust
if let Ok(channel) = std::env::var("AGENTMUX_BUILD_CHANNEL_DEFAULT") {
    println!("cargo:rustc-env=AGENTMUX_BUILD_CHANNEL_DEFAULT={channel}");
}
```

- A channel change (branch switch, `--fresh`) now reliably forces the rebake.
- Unchanged channels stay cached (no extra recompiles).
- Env unset (plain `cargo build`/`cargo run` for tests) → emit nothing → `option_env!` keeps its `"stable"` fallback.
- The per-build **LABEL** stays deliberately untracked (it changes every build; tracking it would defeat incremental caching).

## Verification

Building `agentmux-common` back-to-back with no `cargo clean`:

| Build | Channel | Result |
|---|---|---|
| 1 | `local-chanA` | Compiling |
| 2 | `local-chanB` | **Compiling** (rebake forced) |
| 3 | `local-chanB` | Finished in 0.14s (cached) |

## Scope note

This hardens a **latent** fragility. The 2026-06-10 `dev-portable-` symptom that surfaced it turned out to be **runtime `AGENTMUX_CHANNEL` env inheritance** (a build launched from inside an AgentMux pane inherits the parent instance's channel), not a stale compile-time bake. This PR is still the correct fix for the build-system gotcha; it just wasn't what we observed that day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)