### PR TITLE
fix(css): pointer cursor on all scrollbar thumbs

### DIFF
--- a/.changesets/1781106676-fix-css-pointer-cursor-on-all-scrollbar-thumbs-global-webkit-vtew.md
+++ b/.changesets/1781106676-fix-css-pointer-cursor-on-all-scrollbar-thumbs-global-webkit-vtew.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(css): pointer cursor on all scrollbar thumbs — global WebKit, xterm, OverlayScrollbars, Monaco

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -66,6 +66,7 @@ a.plain-link {
 }
 
 *::-webkit-scrollbar-thumb {
+    cursor: pointer;
     background-color: var(--scrollbar-thumb-color);
     border-radius: 0;
     margin: 0 1px 0 1px;
@@ -97,6 +98,10 @@ a.plain-link {
     --os-handle-bg: var(--scrollbar-thumb-color);
     --os-handle-bg-hover: var(--scrollbar-thumb-hover-color);
     --os-handle-bg-active: var(--scrollbar-thumb-active-color);
+}
+
+.os-scrollbar-handle {
+    cursor: pointer;
 }
 
 .scrollbar-hide-until-hover {

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -168,6 +168,7 @@
             }
 
             &::-webkit-scrollbar-thumb {
+                cursor: pointer;
                 display: none;
                 background-color: var(--scrollbar-thumb-color);
                 border-radius: 0;

--- a/frontend/tailwindsetup.css
+++ b/frontend/tailwindsetup.css
@@ -81,6 +81,7 @@ svg [aria-label="tip"] g path {
 
 /* Monaco editor scrollbar styling */
 .monaco-editor .slider {
+    cursor: pointer;
     background: rgba(255, 255, 255, 0.4);
     border-radius: 0;
     transition: background 0.2s ease;


### PR DESCRIPTION
## Summary

`cursor: pointer` was missing from every scrollbar in the app. Four targeted additions:

| Fix | File | Surfaces covered |
|-----|------|-----------------|
| A — global WebKit thumb | `app.scss` | agent-document, modal, agent-picker, card-settings, identity-assignments, block-error-fallback, warden, flash-error, markdown code blocks, all future scrollables |
| B — xterm-viewport thumb | `term.scss` | Terminal pane (overrides global, needs its own rule) |
| C — `.os-scrollbar-handle` | `app.scss` | Markdown content + TOC (OverlayScrollbars library) |
| D — `.monaco-editor .slider` | `tailwindsetup.css` | Monaco editor scrollbar |

All changes are WebKit/Chromium-only — appropriate since AgentMux is a CEF app. Firefox scrollbar cursor is OS-controlled with no CSS hook.

Full audit: `docs/analysis/ANALYSIS_SCROLLBAR_CURSOR_AUDIT_2026_06_10.md`

## Test plan
- [ ] Hover over scrollbars in agent pane — cursor changes to pointer
- [ ] Hover over terminal scrollbar — cursor changes to pointer  
- [ ] Hover over markdown panel scrollbar — cursor changes to pointer
- [ ] Hover over Monaco editor scrollbar — cursor changes to pointer
- [ ] Hover over modal scrollbar — cursor changes to pointer