### PR TITLE
chore: release v0.44.1

### DIFF
--- a/.changesets/1781012789-fix-cef-low-memory-resume-button-inert-onclick-agc1.md
+++ b/.changesets/1781012789-fix-cef-low-memory-resume-button-inert-onclick-agc1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): low-memory pause page Resume button was inert (double-quoted JS string inside a double-quoted onclick attribute) — wire it via a <script> + addEventListener so OOM-paused windows can actually resume

--- a/.changesets/1781093156-fix-agent-pane-replace-remaining-index-with-key-in-virt-list-vxq9.md
+++ b/.changesets/1781093156-fix-agent-pane-replace-remaining-index-with-key-in-virt-list-vxq9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): replace remaining <Index> with <Key> in virt list and <For> with <Index> in DiffViewer to close replaceChild crash class (#1326)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.44.0"
+version = "0.44.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,11 @@
 # AgentMux Version History
 
+## 0.44.1 — 2026-06-10
+
+- fix(cef): low-memory pause page Resume button was inert (double-quoted JS string inside a double-quoted onclick attribute) — wire it via a <script> + addEventListener so OOM-paused windows can actually resume
+- fix(agent-pane): replace remaining <Index> with <Key> in virt list and <For> with <Index> in DiffViewer to close replaceChild crash class (#1326)
+
+
 ## 0.44.0 — 2026-06-10
 
 - perf(pane-focus): skip updateTree for FocusNode + drop diag console.logs
@@ -1067,6 +1073,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.44.0 | 2026-06-10 | 163.9 MiB | 349.8 MiB | |
 | 0.38.13 | 2026-05-26 | 164.8 MiB | 346.2 MiB | |
 | 0.38.11 | 2026-05-26 | 164.8 MiB | 346.1 MiB | |
 | 0.38.10 | 2026-05-26 | 164.8 MiB | 346.1 MiB | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.44.0",
+      "version": "0.44.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release v0.44.1 (patch) — consumes #1327 (replaceChild crash class fix, closes #1326) + #1316 (low-memory Resume button). Produced by task release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)