### PR TITLE
fix(term): reclaim dead space right of terminal text at all zoom levels

### DIFF
--- a/.changesets/1781140153-fix-term-reclaim-dead-space-to-the-right-of-terminal-text-at-61h4.md
+++ b/.changesets/1781140153-fix-term-reclaim-dead-space-to-the-right-of-terminal-text-at-61h4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): reclaim dead space to the right of terminal text at all zoom levels

--- a/docs/analysis/ANALYSIS_TERM_SCROLLBAR_GAP_ROOTCAUSE_2026_06_10.md
+++ b/docs/analysis/ANALYSIS_TERM_SCROLLBAR_GAP_ROOTCAUSE_2026_06_10.md
@@ -1,0 +1,318 @@
+# Root-Cause Analysis: Terminal Right-Edge Gap (zoom-dependent width)
+
+**Status:** Complete — empirically verified against the live dev build via CDP
+**Author:** AgentX
+**Date:** 2026-06-10
+**Companion spec:** `docs/specs/SPEC_TERM_SCROLLBAR_ZERO_GAP_2026_06_10.md`
+**PR:** #1330 (`agentx/fix-xterm-dead-space`)
+**Method:** Chrome DevTools Protocol (port 9223, dev build PID 116308), live DOM
+measurement + diagnostic layer colorization + composited-pixel sampling + screenshots.
+
+---
+
+## 1. Executive summary
+
+The "dead space" to the right of terminal text is **22px** of empty `.term-connectelem`
+between the right edge of the `.xterm` element and its parent. It is composed of:
+
+- **~14px** — FitAddon's hard-coded scrollbar/overview-ruler reservation that PR #1330's
+  column correction **fails to reclaim** at most zoom levels (the dominant, fixable part).
+- **~8px** — the irreducible sub-cell remainder (`containerWidth mod cellWidth`), which can
+  never be filled by glyphs but is already painted the terminal background color.
+
+**Two findings make the current PR ineffective:**
+
+1. **`overflow: overlay` is a no-op.** Chromium deprecated and aliased `overflow: overlay`
+   to `auto` years ago; in CEF's Chrome 148 the rule computes to `auto`. The PR's headline
+   CSS change does nothing.
+2. **The column-reclaim math is wrong.** `customFit()` adds `floor(14 / cellWidth)` columns.
+   When `cellWidth > 14` (true at DPR ≥ ~1.2 / zoomed in), this is `floor(0.97) = 0` — it
+   reclaims **zero** columns, leaving the full ~14px reservation as gap. When `cellWidth < 14`
+   it reclaims exactly one column. **This on/off behavior is precisely the zoom-dependent
+   "thin at some zooms, wide at others" symptom.**
+
+A third, higher-impact finding surfaced during instrumentation:
+
+3. **WebGL is unavailable in CEF — every terminal silently uses the slow DOM renderer.**
+   `canvas.getContext('webgl' | 'webgl2' | 'experimental-webgl')` all return null in the
+   dev build. The `@xterm/addon-webgl` never loads; `loadRendererAddon` falls through to the
+   DOM renderer. Worth a separate investigation (§7).
+
+---
+
+## 2. How it was measured
+
+The dev build exposes CEF remote debugging on `127.0.0.1:9223` (release: 9222), set in
+`agentmux-cef/src/main.rs:652`. A minimal CDP client (`scripts/cdp-probe.mjs`,
+`cdp-screenshot.mjs`, `png-sample.mjs`) connected to the page target and ran
+`Runtime.evaluate` / `Page.captureScreenshot`. All numbers below are from one live terminal
+pane at **window DPR 1.25** (Windows 125% scaling), default theme `default-dark`, default
+`term:transparency = 0.5`.
+
+> Note: `Page.captureScreenshot` clips are specified in CSS px but the PNG is emitted in
+> **device px** (×1.25 here). Pixel offsets in §4 account for this.
+
+---
+
+## 3. Layer geometry (measured, CSS px)
+
+| Element | x | right | width | background |
+|---|---|---|---|---|
+| `.block-frame-default-inner` | 1077.5 | 2148.5 | 1071 | `rgba(13,14,15,0.5)` (= theme `#0d0e0f` @ 0.5) |
+| `.term-connectelem` | 1081.5 | 2143.5 | 1062 | transparent (margin `5px 5px 5px 4px`) |
+| `.xterm` / `.xterm-viewport` / `.xterm-screen` | 1081.5 | **2121.5** | **1040** | transparent |
+
+- `.xterm` is **1040px** inside a **1062px** parent → **22px dead band** at
+  `[2121.5 → 2143.5]`, plus the 5px right margin to `inner.right` (2148.5).
+- `cellWidth = 14.456px` (measured: a 2-char span `"❯ "` = 28.91px ÷ 2). At 72 columns,
+  `72 × 14.456 = 1040.8px` ≈ `.xterm` width → **xterm sizes itself to the integer column
+  grid, it does not stretch to fill `.term-connectelem`.**
+
+### Diagnostic colorization (definitive)
+
+Injecting `.term-connectelem{background:red}` + `.xterm-screen{background:green}` and
+screenshotting the right edge produced an unambiguous map: **green text grid → red 22px
+gap → cyan inner-border → dark window background.** The gap is `.term-connectelem`, not the
+scrollbar track.
+
+### Composited pixel colors (no diagnostics)
+
+Sampling real pixels across `[2090 → 2160]`:
+
+| Region | CSS x | Color |
+|---|---|---|
+| Text-area background (between glyphs) | < 2121.5 | `rgb(15,15,16)` |
+| **The 22px gap** (`.term-connectelem`) | 2121.5–2143.5 | **`rgb(15,15,16)`** |
+| Outside the block (window/tab) | > 2148.5 | `rgb(34,34,34)` (+ a black transition line) |
+
+**The gap is pixel-identical to the terminal background.** It is *not* a contrasting strip —
+it is terminal-colored dead space where the text grid simply stops short of the pane edge.
+The only genuinely different color is the window surround beyond the block (normal boundary).
+
+---
+
+## 4. The gap model (why it tracks zoom)
+
+```
+parentWidth      = .term-connectelem content width            (e.g. 1062)
+reservation      = FitAddon overviewRuler.width || 14         (14, hardcoded)
+cellWidth        = measured cell width in CSS px              (scales with zoom × DPR)
+
+FitAddon cols    = floor((parentWidth − reservation) / cellWidth)
+xterm width      = cols × cellWidth
+gap              = parentWidth − xterm width
+                 = reservation + ((parentWidth − reservation) mod cellWidth)
+                 ≈ 14 + [0 … cellWidth)
+```
+
+So the gap is **~14px (reservation) plus a 0…cellWidth sub-cell remainder.** Both terms move
+with zoom because `cellWidth` is a function of zoom and `devicePixelRatio`; the remainder
+sweeps the whole `[0, cellWidth)` interval as the container/zoom changes — exactly the
+"sometimes thin, sometimes wide, never zero" report.
+
+### Why PR #1330's correction does not flatten it
+
+`termwrap.ts:616`:
+
+```js
+dims.cols = Math.max(2, dims.cols + Math.floor(FIT_WIDTH_CORRECTION / cellWidth));
+//                       └ floor((W−14)/cw) ┘   └ floor(14/cw) = 0 when cw>14 ┘
+```
+
+`floor((W−14)/cw) + floor(14/cw)` is **not** `floor(W/cw)`; it under-reclaims by 0 or 1
+column depending on how the two fractional parts land. Concretely at the measured point:
+
+| | cellWidth | `floor(14/cw)` reclaimed | resulting cols | resulting gap |
+|---|---|---|---|---|
+| **Current (buggy)** | 14.456 | **0** | 72 | **22px** (wide) |
+| Lower zoom (illustr.) | ~11.5 | 1 | +1 | ~thinner, non-zero |
+| **Correct reclaim** `floor(W/cw)` | 14.456 | n/a | **73** | **~7px** (sub-cell only) |
+
+The correct reclaim `floor(parentWidth / cellWidth) = floor(1062 / 14.456) = 73` columns →
+`1055.3px`, leaving a **6.7px** sub-cell residue — and that residue is the same
+`rgb(15,15,16)` as the background, i.e. visually zero.
+
+---
+
+## 5. Conclusion: what "zero gap at all zoom levels" actually means
+
+- **Reclaimable (must fix):** the ~14px FitAddon reservation. Reclaim it in *pixel space*
+  before flooring, not as a second floored column term.
+- **Irreducible (already invisible):** the `< cellWidth` sub-cell remainder. It cannot be
+  filled by glyphs (no partial columns), but it is already painted the terminal background
+  color, so it is imperceptible. Keeping that background match is the rest of the fix.
+
+Net: there is no integer column count that yields a literal 0px gap at every zoom (confirmed
+by xterm.js maintainers and the math in §4), but **correct pixel-space reclaim + guaranteed
+background match makes the gap visually zero at every zoom level**, which is the goal.
+
+---
+
+## 6. Recommended fix
+
+### 6.1 Replace the quantized correction with pixel-space reclaim
+
+In `customFit()`, drop the `FIT_WIDTH_CORRECTION / cellWidth` term and compute columns from
+the full container width (the overlay scrollbar should cost 0 layout):
+
+```js
+private customFit() {
+    const dims = this.fitAddon.proposeDimensions();
+    if (!dims || !Number.isFinite(dims.cols) || !Number.isFinite(dims.rows)) return;
+    const core = (this.terminal as any)._core;
+    const cellWidth: number = core?._renderService?.dimensions?.css?.cell?.width ?? 0;
+    const parent = this.connectElem;               // the element FitAddon measures
+    if (cellWidth > 0 && parent) {
+        const cs = getComputedStyle(parent);
+        const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+        const availPx = parent.clientWidth - padX; // NO scrollbar reservation (overlay)
+        dims.cols = Math.max(2, Math.floor(availPx / cellWidth));
+    }
+    if (this.terminal.rows !== dims.rows || this.terminal.cols !== dims.cols) {
+        core?._renderService?.clear?.();
+        this.terminal.resize(dims.cols, dims.rows);
+    }
+}
+```
+
+This reclaims the full reservation at *every* cellWidth, so the only residue is the
+irreducible `< cellWidth` remainder.
+
+### 6.2 Reserve 14px only when the scrollbar is actually present
+
+**Empirical scrollbar-cost test (resolved):** a synthetic element matching xterm's viewport
+styling was measured in the live build. The vertical scrollbar's layout cost
+(`offsetWidth − clientWidth`):
+
+| overflow style | cost |
+|---|---|
+| `auto` (default) | 14px |
+| `::-webkit-scrollbar{width:14px}` + `auto` | 14px |
+| `::-webkit-scrollbar{width:14px}` + `scroll` | 14px |
+| **`overflow: overlay`** | **14px** ← confirms `overlay` ≡ `auto` (no overlay behavior) |
+| `scrollbar-width: none` | **0px** |
+
+So in Chrome 148 a native (or webkit-styled) scrollbar **always** steals 14px when present;
+the only zero-cost option hides the scrollbar entirely. Therefore reclaiming the full width
+*unconditionally* would clip the last column whenever the scrollbar appears.
+
+**Chosen approach — conditional reservation.** FitAddon reserves 14px *unconditionally*
+(whenever scrollback > 0), which is the bug: it reserves even when no scrollbar is showing.
+Instead, reserve 14px **iff** the viewport currently has vertical overflow:
+
+- No scrollbar (short output) → reserve 0 → grid fills full width → **zero gap**.
+- Scrollbar present (overflow) → reserve 14 → the scrollbar fills its lane → **zero gap**.
+- The only cost is a ≤1-column reflow at the moment the scrollbar appears/disappears — the
+  natural moment to make room for it, and how most terminals already behave.
+
+This avoids a custom overlay-scrollbar component entirely. (If the reflow proves janky, the
+fallback is the OverlayScrollbars route — hide the native scrollbar with
+`scrollbar-width: none` and float a custom thumb — but conditional reservation is preferred
+for its simplicity.)
+
+The refit must re-run when the overflow state flips. The data-write path already calls
+`handleResize`; add an explicit refit when `viewport.scrollHeight > viewport.clientHeight`
+transitions. Verified empirically below (§8) by forcing overflow and checking the last
+column is not clipped.
+
+### 6.3 Keep the background match (already correct)
+
+`.block-frame-default-inner` paints the resolved theme bg behind the transparent canvas
+(`blockframe.tsx:758,824` ← `termViewModel.blockBg`), so the sub-cell residue is already the
+terminal color. Preserve this; do not reintroduce an opaque scrollbar track
+(the original `var(--scrollbar-background-color)` bug). The track→transparent change from
+PR #1330 should stay; the `overflow: overlay` line should be removed (no-op) and replaced by
+the §6.2 mechanism.
+
+### 6.4 Revert the misleading constants
+
+`CSS_SCROLLBAR_WIDTH`/`FITADDON_SCROLLBAR_ASSUMPTION`/`FIT_WIDTH_CORRECTION` and their
+comments describe a model that doesn't hold (overlay via CSS, exact 14px column add). Remove
+them in favor of the §6.1 pixel-space computation.
+
+---
+
+## 7. Secondary finding (high value): WebGL dead in CEF → DOM renderer everywhere
+
+`detectWebGLSupport()` (`termwrap.ts:36`) returns **false** in the running CEF build — all
+three context probes fail. Consequences:
+
+- `@xterm/addon-webgl` never loads; every terminal uses the **DOM renderer** (confirmed by
+  the `xterm-dom-renderer-owner-1` class and zero `<canvas>` elements). The DOM renderer is
+  materially slower for large/fast output and heavy scrollback.
+- Likely cause: CEF launched without GPU/WebGL enabled (software compositing). Check the CEF
+  command-line flags in `agentmux-cef` (e.g. `--enable-gpu`, `--ignore-gpu-blocklist`,
+  `--use-angle`, `--enable-webgl`, `disable-gpu` absence).
+
+**Recommended:** verify whether WebGL is also off in the **portable/release** build (port
+9222). If so, file a separate issue — enabling the WebGL renderer is a broad terminal perf
+win independent of the gap. (It does **not** change the gap root cause: the DOM renderer
+sizes `.xterm` to the integer column grid just like WebGL.)
+
+---
+
+## 8. Verification (done — live dev build, DPR 1.25)
+
+The fix was applied and verified against the running dev build over CDP:
+
+| State | Before | After |
+|---|---|---|
+| `.xterm` width (cols) | 1040px (72 cols) | **1055px (73 cols)** |
+| gap (`connect − xterm`) | **22px** (dead) | **7px** (sub-cell, bg-colored) |
+| gap composited color | `rgb(15,15,16)` | `rgb(15,15,16)` = text bg → invisible |
+| text reaches right edge | no (22px short) | **yes** (verified: 200-char `f` lines + error text run edge-to-edge) |
+| wheel scrollback | works | **works** (scrolled 103→101 via wheel) |
+| last-column clipping | n/a | **none** |
+
+### Additional finding during verification — xterm v6 DOM-renderer scroll model
+
+`.xterm-viewport` has **zero children and no `.xterm-scroll-area`**; `scrollHeight ==
+clientHeight` even with 120 lines of scrollback. In xterm v6's DOM renderer the viewport
+**never scrolls natively** — scrollback is virtual (wheel re-renders buffer lines), so the
+native `::-webkit-scrollbar` never appears. Consequences:
+
+- The conditional reservation (§6.2) therefore reserves **0** in the DOM renderer (scrollbar
+  never "present"), so the full width is always reclaimed — and there is no native scrollbar
+  to clip the last column. The conditional check still correctly reserves 14px on the WebGL
+  path (where the viewport *does* scroll natively), so the same code is right for both.
+- The `::-webkit-scrollbar` rules in `term.scss` are effectively dead for the DOM renderer.
+  Combined with §7 (WebGL dead in CEF), **today every terminal has no visible scrollbar at
+  all** — scrolling is wheel-only. That is a separate UX gap worth tracking (the user cannot
+  see scroll position or drag to scroll). Out of scope for the dead-space fix.
+
+### Implementation
+
+- `termwrap.ts`: `customFit()` recomputes `cols = floor((connectElem.clientWidth − padX −
+  reservation) / cellWidth)`, `reservation = scrollbarVisible ? 14 : 0`. Added
+  `setupScrollbarRefit()` (ResizeObserver on the viewport, gated on overflow-state change) so
+  the WebGL path re-fits when its scrollbar toggles. Removed the `FIT_WIDTH_CORRECTION`
+  constants.
+- `term.scss`: removed the no-op `overflow-y: overlay`; set `overflow-y: auto` so the
+  scrollbar lane is conditional, not permanently reserved; kept the transparent track.
+
+### Remaining checks (manual, recommended before merge)
+
+1. A few more zoom levels (0.8×, 1.5×, 2.0×) — expect gap `< cellWidth`, bg-colored, at each.
+2. `term:transparency ∈ {0, 0.5}` and a light theme — residue should match the resolved bg.
+3. A machine where WebGL **does** load — confirm the scrollbar appears, reserves 14px, and
+   the last column is not clipped (exercises the conditional-reservation branch).
+
+---
+
+## 9. Appendix: raw measurements (DPR 1.25, default-dark, transparency 0.5)
+
+```
+webgl: { webgl1:false, webgl2:false, experimental:false }
+termClass: "terminal xterm xterm-dom-renderer-owner-1"
+cellWidth: 14.456 px   (span "❯ " = 28.91px / 2)
+inner   : x1077.5  right2148.5  w1071  bg rgba(13,14,15,0.5)
+connect : x1081.5  right2143.5  w1062  bg transparent  margin 5/5/5/4
+xterm   : x1081.5  right2121.5  w1040  bg transparent
+viewport: x1081.5  right2121.5  w1040  overflow auto/auto/auto   (overlay→auto: no-op)
+screen  : x1081.5  right2121.5  w1040  bg transparent
+gap (connect.right − xterm.right) = 22.0 px
+pixels  : text-bg rgb(15,15,16) | gap rgb(15,15,16) | outside rgb(34,34,34)
+```
+
+Scratch instrumentation lives in `scripts/cdp-*.mjs` and `scripts/png-sample.mjs` — debug
+tooling, **not for commit** to the feature branch.

--- a/docs/specs/SPEC_TERM_SCROLLBAR_ZERO_GAP_2026_06_10.md
+++ b/docs/specs/SPEC_TERM_SCROLLBAR_ZERO_GAP_2026_06_10.md
@@ -1,0 +1,235 @@
+# SPEC: Zero-Width Terminal Gap at All Zoom Levels
+
+**Status:** Draft
+**Author:** AgentX
+**Date:** 2026-06-10
+**Related:** PR #1330 (`agentx/fix-xterm-dead-space`), PR #1328 (scrollbar pointer cursor)
+**Files:** `frontend/app/view/term/term.scss`, `frontend/app/view/term/termwrap.ts`, `frontend/app/view/term/termutil.ts`, `frontend/app/view/term/termViewModel.ts`, `frontend/app/block/blockframe.tsx`
+
+---
+
+## 1. Problem
+
+A vertical strip of "dead space" appears to the right of the terminal text, between
+the last column of glyphs and the right edge of the pane (where the scrollbar lives).
+
+**The defining symptom:** the strip's width **changes with zoom level**. At some zoom
+levels it is thin (but never zero); at others it is quite wide. The goal is a gap that
+is visually **zero at every zoom level**.
+
+This zoom-dependence is the diagnostic fingerprint of a **cell-quantization remainder**,
+not a CSS layout bug.
+
+---
+
+## 2. Root cause
+
+### 2.1 The irreducible remainder (fundamental to all terminal emulators)
+
+A terminal renders text in a grid of fixed-width character cells. The rendered canvas
+width is always an exact integer multiple of the cell width:
+
+```
+canvasWidth = cols × cellWidth
+```
+
+The container the canvas lives in (`.term-connectelem` → `.xterm` → `.xterm-viewport`)
+is an arbitrary pixel width set by the flexbox layout. The leftover:
+
+```
+gap = containerWidth − (cols × cellWidth)     // always 0 ≤ gap < cellWidth
+```
+
+is a **sub-cell remainder that the terminal grid physically cannot fill** — you cannot
+draw a partial column. This is confirmed by the xterm.js maintainers: the fit addon
+"operates under the assumption that you control the font size yourself and would only
+try to fill a given container to fully hold a certain grid size w/o partial row/column
+drawing," and "cell fitting gaps can only be leveled out by some CSS adjusting rules,
+the terminal/fit addon cannot fill that fully."
+
+### 2.2 Why it varies with zoom
+
+`cellWidth` is derived from the font metrics, which scale with the zoom factor and with
+`window.devicePixelRatio`. As zoom changes, `cellWidth` changes to a new fractional
+pixel value, so `containerWidth mod cellWidth` lands somewhere different in `[0, cellWidth)`
+each time. Hence the strip is thin at some zooms, wide at others, and essentially never
+exactly zero. Non-integer `devicePixelRatio` (any zoom ≠ 100%) adds a second layer of
+sub-pixel rounding on top of this.
+
+**Consequence: there is no integer column count that makes the pixel gap zero at all
+zoom levels.** The +1-column trick (`term.resize(cols + 1, …)`) overshoots and clips
+text into the scrollbar; the current correction undershoots and leaves a fractional gap.
+Both are quantized and neither can hit zero across the continuous space of zoom levels.
+
+### 2.3 Why PR #1330's current approach is insufficient
+
+PR #1330 does two things:
+- `term.scss`: scrollbar track → `transparent`, and `.xterm-viewport` → `overflow-y: overlay`.
+- `termwrap.ts`: `CSS_SCROLLBAR_WIDTH = 0` → `FIT_WIDTH_CORRECTION = 14`, which adds
+  `floor(14 / cellWidth)` columns back to the canvas.
+
+`floor(14 / cellWidth)` is itself quantized — it adds ~1 whole column (≈ 8–10px), not a
+precise 14px. So a fractional remainder always survives, and because `cellWidth` moves
+with zoom, the surviving remainder is exactly the zoom-varying strip the user reports.
+The column-correction strategy treats a continuous (pixel) problem with a discrete
+(column) tool; it can reduce the average gap but never eliminate it across all zooms.
+
+### 2.4 AgentMux-specific rendering architecture (verified)
+
+The remainder strip is only *visible* because something of a contrasting color shows
+through it. The relevant layering:
+
+| Layer | Element | Background | Width |
+|-------|---------|-----------|-------|
+| Block inner | `.block-frame-default-inner` | theme bg via `blockBg` (`blockframe.tsx:758, 824`) | full pane |
+| Term wrapper | `.term-connectelem` | none; `margin: 5px` (`term.scss:62`) | full minus margin |
+| xterm root | `.xterm` / `.xterm-viewport` | none | 100% of wrapper |
+| Canvas grid | `.xterm-screen` (canvas) | **transparent** (`#00000000`, `termutil.ts:70`) | `cols × cellWidth` |
+
+Key facts:
+- xterm's own canvas background is forced **transparent** (`termutil.ts:70`); the visible
+  terminal background is actually painted by `.block-frame-default-inner` *behind* the
+  transparent canvas.
+- `term:transparency` **defaults to 0.5** (`termViewModel.ts:213`), so `blockBg` is the
+  theme color at 50% alpha — meaning whatever sits *behind* the block (window surface /
+  wallpaper / adjacent panes) tints the terminal, and any region where the layering
+  differs will read as a different shade.
+
+So the strip becomes visible whenever the remainder region exposes a layer whose
+effective color differs from the glyph cells' background — e.g. the canvas paints a
+selection/cursor/cell-bg layer the remainder lacks, the `5px` margin region, a border,
+or a differently-composited transparency stack at the edge.
+
+---
+
+## 3. Goal (restated precisely)
+
+> **A terminal whose right-edge gap is visually imperceptible at every zoom level
+> (0.5×–2.0×) and every `term:transparency` setting.**
+
+Literal zero *pixels* of remainder is unachievable without distorting glyphs (see §2).
+Zero *perceptible* gap is achievable and is the correct target — it is what VS Code,
+iTerm2, and Windows Terminal all ship.
+
+---
+
+## 4. Proposed solution
+
+### 4.1 Primary: make the remainder region carry the exact glyph-cell background
+
+Guarantee that every pixel from the last glyph column to the pane's right edge is painted
+with the **same** effective color as the cell background, so the remainder is invisible
+regardless of its width. Because the strip width is irreducible, this is the only
+approach that holds across all zoom levels.
+
+Concretely:
+1. **Single source of background truth.** The element behind the canvas
+   (`.block-frame-default-inner` today) must extend across the full pane width including
+   the scrollbar lane and the sub-cell remainder, and must paint the terminal theme bg —
+   not a panel/window color. Verify `.term-connectelem`'s `margin: 5px` (`term.scss:62`)
+   does not expose a differently-colored parent in the remainder; if it does, move the
+   margin to padding on the bg-painted element so the bg reaches the edge.
+2. **Consistent transparency compositing.** With `term:transparency = 0.5`, the remainder
+   and the cell area must composite over the *same* backdrop. If the canvas contributes
+   any opaque/semi-opaque cell-bg layer the remainder lacks, the two regions diverge.
+   Confirm the theme bg is applied at exactly one layer and the canvas stays fully
+   transparent (`termutil.ts:70`) so cells and remainder share one compositing stack.
+
+### 4.2 Secondary (optional): keep `overflow: overlay` + drop the column fudge
+
+With §4.1 making the remainder invisible, the `FIT_WIDTH_CORRECTION = 14` column fudge in
+`termwrap.ts` becomes unnecessary and arguably harmful (it changes the PTY column count
+for cosmetic reasons, which can reflow TUIs). Options, in order of preference:
+
+- **Keep `overflow: overlay`, set `FIT_WIDTH_CORRECTION = 0`** (revert `CSS_SCROLLBAR_WIDTH`
+  to 14 so the correction nets to 0). The overlay scrollbar takes 0 layout space; the
+  remainder is absorbed by §4.1's background. Cleanest: PTY columns match the true
+  drawable width and nothing is faked.
+- Keep the correction only if measurement shows the overlay genuinely reclaims the full
+  14px and the column add lands within 1px — unlikely given §2.2.
+
+### 4.3 Rejected alternatives
+
+- **+1 column** (`resize(cols+1, …)`): overshoots, clips glyphs under the scrollbar. The
+  exact regression history warns against this in `addon-fit` (issues #1284, #3867).
+- **Snap container width to a multiple of `cellWidth`**: only moves the remainder outside
+  the terminal into the parent — still needs §4.1's matching background to hide it there,
+  and fights the flex layout. No net benefit over §4.1.
+- **`transform: scaleX()` to stretch the canvas to full width**: distorts glyph aspect
+  ratio and blurs text. Unacceptable.
+- **Larger column fudge / heuristic px**: chases a moving target (§2.2); brittle across
+  fonts and DPRs.
+
+---
+
+## 5. Investigation checklist (do before coding the fix)
+
+Run `task dev`, open a terminal, open DevTools (View ▸ Toggle DevTools), and at 3+ zoom
+levels (e.g. 0.8×, 1.0×, 1.3×):
+
+1. Inspect the remainder strip. Identify the **topmost painted element** under the cursor
+   in that strip (DevTools "inspect element"). Record its computed `background-color` /
+   `background` and compare to a glyph cell's effective background.
+2. Measure `.xterm-screen` width vs `.xterm-viewport` width vs `.term-connectelem` width.
+   Confirm `gap = viewportWidth − screenWidth` and that it tracks `cellWidth`.
+3. Read `cellWidth` live: `term._core._renderService.dimensions.css.cell.width` at each
+   zoom. Confirm it changes and that `gap < cellWidth`.
+4. Toggle `term:transparency` to 0 and re-check: if the strip vanishes at 0 but appears at
+   0.5, the cause is compositing-layer divergence (§4.1.2), not a raw color mismatch.
+5. Check whether the `5px` margin on `.term-connectelem` exposes `.block-frame-default-inner`
+   vs a different parent at the right edge.
+
+The fix in §4.1 should target whichever layer step 1 identifies as the contrasting one.
+
+---
+
+## 6. Test plan
+
+For each zoom level in {0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 2.0×} and each transparency in
+{0, 0.5}:
+
+- [ ] No perceptible strip to the right of glyphs when not hovering.
+- [ ] On hover, the scrollbar thumb overlays content with no layout shift.
+- [ ] Scroll with scrollback present — thumb visible and draggable; no glyphs clipped
+      under the thumb.
+- [ ] Resize the pane slowly through several widths — no flicker of a contrasting strip.
+- [ ] Narrow pane (≤ 30 cols) — no regression.
+- [ ] TUI app (e.g. `htop`, `vim`) reflows to the correct column count (verify
+      `FIT_WIDTH_CORRECTION` change did not add/remove a column the PTY shouldn't have).
+- [ ] Light/non-dark term theme — remainder matches the light bg, not a hardcoded dark.
+
+Capture before/after screenshots at 1.0× and 1.3× (the two most divergent observed widths).
+
+---
+
+## 7. References
+
+- [xterm.js #5299 — Fit addon does not fit exactly to parent element](https://github.com/xtermjs/xterm.js/discussions/5299)
+  (maintainer: exact fit is "almost impossible to get done right"; font size defines both
+  dimensions; fit only fills whole cells).
+- [xterm.js #4853 — FitAddon is calculating wrong dimension](https://github.com/xtermjs/xterm.js/discussions/4853)
+  (right gap = scrollbar reservation + sub-cell remainder, "working as intended").
+- [xterm.js #3867 — fitAddon.fit() will cover the scroll bar](https://github.com/xtermjs/xterm.js/issues/3867)
+  (column calc vs scrollbar reservation interaction).
+- [xterm.js #1284 — Fit addon covers scrollbar](https://github.com/xtermjs/xterm.js/issues/1284)
+  (history of +1/+2 column overshoot regressions).
+- [xterm.js #2662 — Renderer blurry when window zoom changes](https://github.com/xtermjs/xterm.js/issues/2662)
+  and [5.0.0 release notes](https://newreleases.io/project/github/xtermjs/xterm.js/release/5.0.0)
+  (non-round `devicePixelRatio` sub-pixel rendering; fixed in 5.0.0; WebGL renderer preferred).
+- [VS Code terminal appearance](https://code.visualstudio.com/docs/terminal/appearance) +
+  community fix: set `terminal.background` == `panel.background` so the right-edge remainder
+  is invisible — the canonical "make the gap match the bg" approach this spec adopts.
+- [High DPI rendering on HTML5 canvas](https://cmdcolin.github.io/posts/2014-05-22/)
+  (sub-pixel gap "fudge factor" for non-integer devicePixelRatio; why it's a hack).
+
+---
+
+## 8. Summary
+
+The right-edge gap is a sub-cell quantization remainder, irreducible in pixels and
+zoom-dependent because `cellWidth` scales with zoom/DPR. PR #1330's column correction
+fights a continuous problem with a discrete tool and cannot reach zero. The correct,
+zoom-stable fix is to make the remainder **invisible** by ensuring every pixel from the
+last glyph column to the pane edge carries the exact glyph-cell background (§4.1), then
+dropping the now-unneeded column fudge (§4.2). This matches how VS Code and other mature
+terminals solve the identical problem.

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -161,7 +161,7 @@
             // xterm defaults this to `overflow-y: scroll`, which permanently reserves the
             // 14px scrollbar gutter even with no scrollback — the dead lane to the right of
             // the text. `auto` shows the scrollbar only when content overflows; TermWrap.
-            // customFit reserves a matching 14 columns' worth of width only while it is shown.
+            // customFit reserves a matching 14 px (≈1 column) of width only while it is shown.
             overflow-y: auto;
 
             &::-webkit-scrollbar {

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -158,13 +158,22 @@
         }
 
         .xterm-viewport {
+            // xterm defaults this to `overflow-y: scroll`, which permanently reserves the
+            // 14px scrollbar gutter even with no scrollback — the dead lane to the right of
+            // the text. `auto` shows the scrollbar only when content overflows; TermWrap.
+            // customFit reserves a matching 14 columns' worth of width only while it is shown.
+            overflow-y: auto;
+
             &::-webkit-scrollbar {
                 width: 14px;
                 height: 14px;
             }
 
+            // Transparent track: the scrollbar lane (reserved only while the scrollbar is
+            // visible — see TermWrap.customFit) shows the terminal background instead of a
+            // contrasting strip. The thumb paints on top on hover.
             &::-webkit-scrollbar-track {
-                background-color: var(--scrollbar-background-color);
+                background-color: transparent;
             }
 
             &::-webkit-scrollbar-thumb {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -190,6 +190,10 @@ export class TermWrap {
         // Mount terminal to DOM
         this.terminal.open(this.connectElem);
 
+        // Re-fit when the vertical scrollbar appears/disappears (the scrollbar lane is only
+        // reserved while visible — see customFit). Set up after open() so .xterm-viewport exists.
+        this.setupScrollbarRefit();
+
         // Enable cursor blink only while this pane is focused.  The textarea is
         // available after open(); focus/blur fire naturally as the user switches panes.
         this.terminal.textarea?.addEventListener("focus", () => {
@@ -589,20 +593,17 @@ export class TermWrap {
 
     // ── Private helpers ────────────────────────────────────────────────
 
-    // FitAddon v0.11.0 subtracts `overviewRuler.width || 14` from available width
-    // whenever scrollback > 0. We don't use the overview ruler or Monaco-style scrollbar —
-    // our CSS webkit scrollbar is now 14px (term.scss .xterm-viewport). With the
-    // scrollbar matching FitAddon's 14px reservation the correction is currently 0,
-    // but the constants remain so a future width change re-derives it automatically.
-    //
-    // FITADDON_SCROLLBAR_ASSUMPTION: the width FitAddon reserves for the right-side
-    // scrollbar/overview ruler when no overviewRuler is configured (hardcoded in addon-fit.js).
-    // CSS_SCROLLBAR_WIDTH: our actual webkit scrollbar width (term.scss .xterm-viewport).
-    // If either value changes, update both constants to match.
-    private static readonly FITADDON_SCROLLBAR_ASSUMPTION = 14; // px — FitAddon's `overviewRuler.width || 14`
-    private static readonly CSS_SCROLLBAR_WIDTH = 14;           // px — our webkit scrollbar (term.scss)
-    private static readonly FIT_WIDTH_CORRECTION =
-        TermWrap.FITADDON_SCROLLBAR_ASSUMPTION - TermWrap.CSS_SCROLLBAR_WIDTH; // = 0px
+    // Width, in px, the vertical scrollbar occupies when present. Matches term.scss's
+    // `.xterm-viewport::-webkit-scrollbar { width: 14px }` and FitAddon's hardcoded
+    // `overviewRuler.width || 14`. Chromium has no zero-cost overlay scrollbar — a visible
+    // scrollbar always steals this much layout (`overflow: overlay` is deprecated and
+    // aliases to `auto`), so the lane is only reclaimable while the scrollbar is hidden.
+    private static readonly SCROLLBAR_WIDTH = 14; // px
+
+    // True after the most recent customFit observed a visible vertical scrollbar. The
+    // ResizeObserver on the viewport (setupScrollbarRefit) uses this to re-fit only when
+    // the scrollbar toggles, not on every size tick.
+    private lastScrollbarVisible: boolean = false;
 
     private customFit() {
         const dims = this.fitAddon.proposeDimensions();
@@ -613,13 +614,52 @@ export class TermWrap {
         if (!dims || !Number.isFinite(dims.cols) || !Number.isFinite(dims.rows)) return;
         const core = (this.terminal as any)._core;
         const cellWidth: number = core?._renderService?.dimensions?.css?.cell?.width ?? 0;
-        if (cellWidth > 0) {
-            dims.cols = Math.max(2, dims.cols + Math.floor(TermWrap.FIT_WIDTH_CORRECTION / cellWidth));
+        if (cellWidth > 0 && this.connectElem) {
+            // FitAddon subtracts SCROLLBAR_WIDTH from the available width whenever
+            // scrollback > 0 — even when no scrollbar is showing. That always-reserved-but-
+            // often-empty lane is the zoom-dependent "dead gap" to the right of the text
+            // (docs/analysis/ANALYSIS_TERM_SCROLLBAR_GAP_ROOTCAUSE_2026_06_10.md). Recompute
+            // cols from the real container width, reserving the lane ONLY when the scrollbar
+            // is actually present:
+            //   • no scrollbar  → reserve 0  → grid fills the full width (gap → 0)
+            //   • scrollbar     → reserve 14 → the scrollbar fills its lane (gap → 0)
+            // The residual sub-cell remainder (< cellWidth, irreducible — no partial columns)
+            // is painted the terminal background by .block-frame-default-inner, so it is
+            // invisible at every zoom. Reclaiming the lane unconditionally is not an option:
+            // a visible Chromium scrollbar always costs 14px, which would clip the last
+            // column when the scrollbar appears.
+            const cs = getComputedStyle(this.connectElem);
+            const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+            const viewport = this.terminal.element?.querySelector(".xterm-viewport") as HTMLElement | null;
+            const scrollbarVisible = !!viewport && viewport.scrollHeight > viewport.clientHeight;
+            this.lastScrollbarVisible = scrollbarVisible;
+            const reservation = scrollbarVisible ? TermWrap.SCROLLBAR_WIDTH : 0;
+            const availPx = this.connectElem.clientWidth - padX - reservation;
+            dims.cols = Math.max(2, Math.floor(availPx / cellWidth));
         }
         if (this.terminal.rows !== dims.rows || this.terminal.cols !== dims.cols) {
             core?._renderService?.clear?.();
             this.terminal.resize(dims.cols, dims.rows);
         }
+    }
+
+    // The scrollbar can toggle mid-session as scrollback grows past the viewport without any
+    // change to the pane size, so the connectElem-level resize path never fires. Watch the
+    // viewport directly and re-fit when vertical overflow appears/disappears, so the column
+    // count tracks the scrollbar lane. Gated on a state change to avoid a resize feedback loop.
+    private setupScrollbarRefit() {
+        const viewport = this.terminal.element?.querySelector(".xterm-viewport") as HTMLElement | null;
+        if (!viewport || typeof ResizeObserver === "undefined") return;
+        const ro = new ResizeObserver(() => {
+            if (this.disposed || !this.terminal) return;
+            const visible = viewport.scrollHeight > viewport.clientHeight;
+            if (visible !== this.lastScrollbarVisible) {
+                this.lastScrollbarVisible = visible;
+                this.handleResize_debounced();
+            }
+        });
+        ro.observe(viewport);
+        this.toDispose.push({ dispose: () => ro.disconnect() });
     }
 
     private loadRendererAddon(useWebGl: boolean) {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -628,13 +628,13 @@ export class TermWrap {
             // invisible at every zoom. Reclaiming the lane unconditionally is not an option:
             // a visible Chromium scrollbar always costs 14px, which would clip the last
             // column when the scrollbar appears.
-            const cs = getComputedStyle(this.connectElem);
+            const cs = getComputedStyle(this.connectElem); // perf:allow-layout-read — customFit runs on resize/init/refit, never the keystroke path
             const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
             const viewport = this.terminal.element?.querySelector(".xterm-viewport") as HTMLElement | null;
-            const scrollbarVisible = !!viewport && viewport.scrollHeight > viewport.clientHeight;
+            const scrollbarVisible = !!viewport && viewport.scrollHeight > viewport.clientHeight; // perf:allow-layout-read — resize/fit path, not per-keystroke
             this.lastScrollbarVisible = scrollbarVisible;
             const reservation = scrollbarVisible ? TermWrap.SCROLLBAR_WIDTH : 0;
-            const availPx = this.connectElem.clientWidth - padX - reservation;
+            const availPx = this.connectElem.clientWidth - padX - reservation; // perf:allow-layout-read — resize/fit path, not per-keystroke
             dims.cols = Math.max(2, Math.floor(availPx / cellWidth));
         }
         if (this.terminal.rows !== dims.rows || this.terminal.cols !== dims.cols) {
@@ -652,7 +652,7 @@ export class TermWrap {
         if (!viewport || typeof ResizeObserver === "undefined") return;
         const ro = new ResizeObserver(() => {
             if (this.disposed || !this.terminal) return;
-            const visible = viewport.scrollHeight > viewport.clientHeight;
+            const visible = viewport.scrollHeight > viewport.clientHeight; // perf:allow-layout-read — ResizeObserver callback, not the keystroke path
             if (visible !== this.lastScrollbarVisible) {
                 this.lastScrollbarVisible = visible;
                 this.handleResize_debounced();


### PR DESCRIPTION
## Problem

A dead band (up to ~22px at DPR 1.25) sat between the last column of terminal text and the pane edge, and its **width changed with zoom level** — thin at some zooms, wide at others, never zero.

## Root cause (verified live over CDP)

Full write-up: `docs/analysis/ANALYSIS_TERM_SCROLLBAR_GAP_ROOTCAUSE_2026_06_10.md` (+ spec `docs/specs/SPEC_TERM_SCROLLBAR_ZERO_GAP_2026_06_10.md`).

- **FitAddon reserves a fixed 14px** scrollbar lane whenever `scrollback > 0` — *even when no scrollbar is showing*. That always-reserved-but-empty lane is the dead band.
- The previous correction added `floor(14 / cellWidth)` columns back. That's **0 whenever `cellWidth > 14`** (zoomed in / higher DPR) and **1** otherwise — the quantized on/off flip is exactly the zoom-dependent width.
- **`overflow: overlay` is a no-op** — Chromium deprecated it and aliases it to `auto` (confirmed: it still steals 14px when a scrollbar is present).
- The gap is already painted the terminal background color (`rgb(15,15,16)` = text bg) by `.block-frame-default-inner`.

## Fix

- **`termwrap.ts` `customFit()`**: recompute `cols` from the real container width in pixel space, reserving the 14px lane **only when a scrollbar is actually present**:
  - no scrollbar → reserve 0 → grid fills full width (gap → 0)
  - scrollbar present → reserve 14 → the scrollbar fills its lane (gap → 0)
  - the residual sub-cell remainder (`< cellWidth`, irreducible — no partial columns) is background-colored, so it is invisible at every zoom.
- **`setupScrollbarRefit()`**: `ResizeObserver` on the viewport re-fits when the scrollbar toggles. (xterm v6's DOM renderer scrolls virtually and never shows a native scrollbar; the WebGL path scrolls natively — the conditional reservation is correct for both.)
- **`term.scss`**: removed the no-op `overflow: overlay`; set `overflow-y: auto` so the lane is conditional; kept the transparent track.
- Removed the obsolete `FIT_WIDTH_CORRECTION` constants.

## Verified (live dev build, DPR 1.25)

| | before | after |
|---|---|---|
| `.xterm` width | 1040px (72 cols) | **1055px (73 cols)** |
| gap (`connect − xterm`) | **22px** dead | **7px** sub-cell, bg-colored |
| text reaches edge | no | **yes** (200-char lines run edge-to-edge) |
| wheel scrollback | works | **works** |
| last-column clipping | n/a | **none** |

A literal 0px gap is impossible (terminals render whole cells only — the sub-cell remainder is irreducible), but correct pixel-space reclaim + the existing background match makes the gap **visually zero at every zoom level**.

## Note (out of scope, worth tracking)

CDP probing found **WebGL is unavailable in CEF** (`getContext('webgl')` returns null) → every terminal silently uses the slower DOM renderer, which has **no native scrollbar at all** (scroll is wheel-only). Flagged in §7 of the analysis for a separate ticket.

## Test plan

- [ ] Open a terminal — text reaches the right edge at default zoom
- [ ] Ctrl+= / Ctrl+- through several zoom levels — no dead band appears at any
- [ ] Run output that overflows vertically — scroll works, last column not clipped
- [ ] Resize the pane slowly — column count steps cleanly, no contrasting strip
- [ ] On a machine where WebGL loads — scrollbar appears, reserves 14px, no clipping