### PR TITLE
fix(scripts): rehydrate Claude sessions into isolated home so resume replays (history P0)

### DIFF
--- a/.changesets/1781112727-fix-scripts-import-agents-rehydrates-claude-sessions-into-th-jb9x.md
+++ b/.changesets/1781112727-fix-scripts-import-agents-rehydrates-claude-sessions-into-th-jb9x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(scripts): import-agents rehydrates Claude sessions into the isolated CLAUDE_CONFIG_DIR home so resume actually replays the conversation (history store P0)

--- a/docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md
@@ -1,0 +1,176 @@
+# SPEC: Unified Agent Conversation-History Store
+
+**Date:** 2026-06-10
+**Status:** Draft / proposal
+**Author:** AgentA
+**Related:** `agentmux-srv/src/backend/history/claude_adapter.rs`, `agentmux-srv/src/backend/agent_session.rs`, `agentmux-srv/src/backend/providers.rs`, `agentmux-common/src/data_paths.rs`, `agentmux-srv/src/server/app_api.rs`, `scripts/import-agents.sh`
+
+---
+
+## 1. Problem
+
+Conversation histories are produced and stored by each **provider CLI** (Claude Code, Codex, Gemini, Kimi, ACP providers…), each in its own on-disk layout. AgentMux does not own, unify, organize, or expose them. Symptoms:
+
+- A stopped or **imported** agent shows an **empty pane** — its prior conversation is not reconstructable by AgentMux.
+- The same logical agent's history **splinters** across many buckets (different working dirs, different portable-build paths).
+- There is **no way to browse, search, label, or clear** conversation history by agent.
+- Pre-isolation histories are **orphaned** in the user's global provider home, invisible to current builds.
+
+**Requirement (user):** entire conversation histories must be stored inside AgentMux's home, unified across all providers, with the ability to **organize and clear** them, so users always have access to full history.
+
+---
+
+## 2. Verified current state (2026-06-10)
+
+### 2.1 Provider history locations (filesystem-verified)
+
+| Provider | Native history location | Format | Resume |
+|----------|-------------------------|--------|--------|
+| **claude** | `$CLAUDE_CONFIG_DIR/projects/<cwd-slug>/<session_id>.jsonl` | NDJSON (assistant/user/tool/attachment records) | `--resume <sid>` |
+| **codex** | `$CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<id>.jsonl` | NDJSON (`session_meta` + events) | `exec resume <id>` |
+| **gemini** | `$GEMINI_CLI_HOME/history/<id>/…` | per-project dir | `-r <sid>` |
+| **kimi** | `$KIMI_SHARE_DIR/sessions/`, `…/user-history/` | sessions | none (native) |
+| **qwen** | `$QWEN_HOME/…` | stream-json | none |
+| **openclaw / pi / copilot** | `$*_HOME/…` (ACP-native) | protocol-managed | ACP session, no flag |
+
+### 2.2 AgentMux already isolates provider homes — **inside its own home**
+
+At spawn time (`app_api.rs` ~1500–1560) AgentMux sets each provider's config/home env var to:
+
+```
+~/.agentmux/shared/providers/<auth_dir_name>/        # account-wide, channel/version-independent
+# or, when an identity bundle is active:
+~/.agentmux/shared/identities/<bundle_id>/<auth_dir_name>/
+```
+
+`DataPaths::provider_auth_dir()` (`data_paths.rs:386`). **Consequence:** for agents spawned by current builds, Claude history lands at `~/.agentmux/shared/providers/claude/projects/<cwd-slug>/<sid>.jsonl` — already inside `~/.agentmux/`. (Confirmed: that dir contains real `.jsonl` transcripts for `mopeo-06103`, `maks-06103`, etc.)
+
+### 2.3 AgentMux already keeps a per-agent output store
+
+`agent_session.rs` persists, **per agent definition**, in the channel/version FileStore (`filestore.db`):
+
+```
+agent:<definition_id>:current/   → output (raw NDJSON stream) + output.state.json (UI snapshot)
+agent:<definition_id>:archive:<unix_ms>/   → archived prior sessions (up to 20)
+```
+
+This is the *rendered-output* history (used to restore the pane on mount), **per channel-version** — not account-wide, not provider-canonical, not unified or browsable.
+
+### 2.4 The three real defects
+
+1. **cwd-slug fragmentation.** History is keyed by slugified working directory. Agent cwds vary (`mopeo-06065` vs `mopeo-06103`) and **portable builds run from different Desktop paths**, so one logical agent splinters into many history buckets (observed: `C--Users-area54-Desktop-agentmux-0-43-0-…-portable`, `…0-43-1-…`, etc.).
+2. **Orphaned pre-isolation histories.** Older sessions live in **global** `~/.claude/projects/` (e.g. the 1.1 MB Mopeo `4f03e3ed` under `mopeo-06065`), outside `shared/providers/`, invisible to current resume.
+3. **No unify / organize / clear.** Heterogeneous per-provider layouts; nothing groups by agent, searches, labels, or deletes.
+
+### 2.5 Root cause of "imported agent shows no conversation"
+
+`import-agents.sh` wires an instance to a session it found in **global `~/.claude/projects/`**, but AgentMux resumes with `CLAUDE_CONFIG_DIR=~/.agentmux/shared/providers/claude`, so `claude --resume <sid>` looks under `…/shared/providers/claude/projects/<slug>/<sid>.jsonl` — which doesn't contain that file. **Location mismatch → empty pane.**
+
+---
+
+## 3. Goals / non-goals
+
+**Goals**
+- One **provider-agnostic, agent-anchored** history store inside `~/.agentmux/`, durable across channel/version/build-path churn.
+- Cover all current providers via per-provider adapters.
+- **Organize**: browse/search/label/pin by agent.
+- **Clear**: delete per-session / per-agent / bulk, freeing the provider's native files too; size budget + GC.
+- **Restore**: open a stopped/imported agent's full prior conversation read-only, without a live resume.
+- Fix resume so imported/old sessions actually replay.
+
+**Non-goals**
+- Re-implementing provider transcript formats (we normalize, we don't author).
+- Live editing of transcripts.
+- Cross-provider transcript translation (store each canonically; render uniformly).
+
+---
+
+## 4. Proposed architecture
+
+### 4.1 Store layout (account-wide)
+
+```
+~/.agentmux/shared/history/
+  index.db                                   # sqlite — organize/search/clear
+  agents/<agent_bus_id>/                      # STABLE identity, NOT cwd-slug
+    <provider>/<session_id>/
+      transcript.jsonl                        # normalized canonical copy
+      meta.json                               # provider, cwd, model, counts, ts, labels[], pinned, byte_size
+      raw/                                     # optional: byte-for-byte native copy for fidelity/debug
+```
+
+Keyed on the agent's **stable identity** (`agent_bus_id` / `definition_id`) so build-path or cwd changes never splinter it. Account-wide (mirrors the `shared/providers` precedent that fixed the auth "validate-spin" churn).
+
+### 4.2 `HistoryAdapter` trait (per provider)
+
+Extend the existing `history/claude_adapter.rs` pattern into a registry:
+
+```rust
+trait HistoryAdapter {
+    fn provider(&self) -> &'static str;
+    /// Find the native session file for (session_id, cwd) given the provider home.
+    fn locate(&self, session_id: &str, cwd: &Path, provider_home: &Path) -> Option<PathBuf>;
+    /// Normalize a native file into transcript.jsonl + Meta.
+    fn normalize(&self, native: &Path) -> Result<(NormalizedTranscript, Meta)>;
+    /// Remove the provider's native file(s) for a session (used by clear).
+    fn delete(&self, session_id: &str, cwd: &Path, provider_home: &Path) -> Result<()>;
+    /// Rehydrate a canonical transcript back into the provider home where --resume expects it.
+    fn rehydrate(&self, transcript: &Path, session_id: &str, cwd: &Path, provider_home: &Path) -> Result<()>;
+}
+```
+
+Impls: `claude` (`projects/<slug>/<sid>.jsonl`), `codex` (`sessions/<y>/<m>/<d>/rollout-*<id>.jsonl`), `gemini` (`history/<id>/`), `kimi`. ACP providers (`copilot`/`pi`/`openclaw`) expose history through the protocol, so their "adapter" captures from the **live stream** (§4.3) rather than a file.
+
+### 4.3 Capture (two sources)
+
+1. **Live tee** — AgentMux already streams provider NDJSON into `agent_session.rs` zones. On turn-end, promote the per-agent `output` into the canonical `transcript.jsonl` (append, dedup by record id). Covers ACP providers that have no file.
+2. **Reconcile** — after each turn, the adapter copies the provider's just-written native session file into the store. Catches anything the tee missed and pulls **pre-existing / orphaned** histories on first sight (scan global `~/.claude/projects` + `shared/providers/*` once, attribute to agents by cwd-slug → identity map).
+
+### 4.4 Index + organize
+
+`index.db` rows: `(agent_bus_id, provider, session_id, cwd, model, started_at, ended_at, msg_count, byte_size, preview, labels, pinned)`.
+
+**History pane** (frontend): grouped by agent, searchable (preview/labels), pin/label, and **Open** → loads `transcript.jsonl` into a **read-only document view** (reuse the agent-pane renderer). This solves "imported/stopped agent shows no conversation" without a live resume.
+
+### 4.5 Clear / GC
+
+- Delete per-session / per-agent / bulk; "older than N days" / "over X MB".
+- Deletion removes the canonical copy **and** the provider's native file (`adapter.delete`) so it frees space.
+- Size budget per `index.db` with **LRU eviction of unpinned** sessions.
+
+### 4.6 Resume correctness (the bug fix)
+
+- Make the agent **cwd deterministic per identity** so the provider slug is stable across builds.
+- On resume: if `transcript.jsonl` exists but the provider's isolated-dir copy is missing, **`adapter.rehydrate`** it into `$PROVIDER_HOME/<expected-path>` before spawning `--resume`. Minimal change that makes imported/old sessions replay.
+
+---
+
+## 5. Phasing
+
+| Phase | Scope | Outcome |
+|-------|-------|---------|
+| **P0** ✅ | Fix `import-agents.sh`: search `shared/providers/claude` + global, and **rehydrate** the chosen session into `$CLAUDE_CONFIG_DIR/projects/<slug>/` where resume reads (`rehydrate_claude_session`) | **DONE** — imported agents' sessions replay on resume (verified: Mopeo `4f03e3ed`, 1.1 MB, copied into the isolated home) |
+| **P1** | History store + Claude/Codex/Gemini adapters + turn-end capture + reconcile scan | Real usage durably captured & unified inside `~/.agentmux/` |
+| **P2** | `index.db` + History pane (browse/search/label/pin/restore/clear) | Organize + clear + read-only restore |
+| **P3** | ACP providers (copilot/pi/openclaw), size budget + GC, cross-machine export | Full coverage + housekeeping |
+
+---
+
+## 6. Open questions
+
+1. **Scope of canonical store:** account-wide `shared/history/` (survives channel/version churn — recommended) vs per-channel. *Recommendation: account-wide.*
+2. **Identity key:** `agent_bus_id` vs `definition_id` as the stable anchor (need the one that survives clone/template-promotion — see `agent_session.rs` migrations).
+3. **Raw fidelity:** keep `raw/` byte-for-byte native copies (storage cost: Claude alone is ~540 MB locally today) or normalized-only? *Lean: normalized + optional raw behind a setting.*
+4. **Capture trigger:** turn-end hook vs filesystem watcher on provider homes. *Lean: turn-end + periodic reconcile.*
+
+---
+
+## 7. Evidence appendix (for implementers)
+
+- Provider registry + resume flags + `auth_dir_name` / `auth_config_dir_env_var`: `providers.rs:98–360`.
+- Env assembly + auth-dir injection: `app_api.rs:~1500–1560`; `data_paths.rs:386`.
+- Session-id capture from stdout + hydration + resume: `subprocess.rs:322–336, 368–378, 551–656, 825–843`.
+- Per-agent output zones + archive + migrations: `agent_session.rs:120, 131, 189, 271, 453, 714`.
+- Existing read-only Claude discovery (extend this): `history/claude_adapter.rs`.
+- Observed fragmentation: `~/.agentmux/shared/providers/claude/projects/` contains per-build-path buckets (`…Desktop-agentmux-0-43-0-…-portable`, etc.).
+- Observed orphan: `~/.claude/projects/C--Users-area54--agentmux-agents-mopeo-06065/4f03e3ed-….jsonl` (1.1 MB) not present under `shared/providers/claude`.

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -49,45 +49,74 @@ all_dbs() {
 # AgentMux stores nothing of the conversation transcript in objects.db; the
 # document the agent pane renders comes from the provider CLI's own session
 # file, replayed when the agent is re-spawned with `--resume <session_id>`.
-# For Claude Code that lives at:
-#   ~/.claude/projects/<slugified-cwd>/<session_id>.jsonl   (account-wide)
+# For Claude Code that lives at <home>/projects/<slugified-cwd>/<session_id>.jsonl
 # where <slugified-cwd> is the agent's working directory with each of : \ . /
-# replaced by '-'. Agent working dirs follow the convention
-# ~/.agentmux/agents/<slug>-<id>. So to make an imported agent show its real
-# (long) conversation, we don't copy transcript bytes — we wire the instance
-# row to the existing on-disk session, and a single message resumes it.
+# replaced by '-', and <home> is whatever CLAUDE_CONFIG_DIR points at.
+#
+# IMPORTANT: AgentMux spawns claude with CLAUDE_CONFIG_DIR pointed at its OWN
+# isolated home (~/.agentmux/shared/providers/claude), so `claude --resume` reads
+# the session from THERE — not from the user's global ~/.claude. Older sessions
+# (pre-isolation) live only in the global dir. So we (a) search BOTH roots for
+# the best session, and (b) REHYDRATE the chosen session into the isolated home
+# at the slug resume expects, so a single message actually replays it.
+# (P0 of docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md.)
 CLAUDE_PROJECTS="${CLAUDE_PROJECTS:-$HOME/.claude/projects}"
+# Where AgentMux's resume actually reads from (CLAUDE_CONFIG_DIR/projects).
+SHARED_CLAUDE_PROJECTS="${SHARED_CLAUDE_PROJECTS:-$AGENTMUX_DIR/shared/providers/claude/projects}"
 AGENTS_DIR="$AGENTMUX_DIR/agents"
 
 # Slugify a working dir the way Claude Code names its project subdir.
 slugify_cwd() { printf '%s' "$1" | sed 's#[:\\./]#-#g'; }
 
 # Resolve the LARGEST Claude session for an agent slug (longest transcript →
-# best streaming/perf repro). Echoes "<session_id>\t<working_directory_win>"
+# best streaming/perf repro), searching BOTH the isolated AgentMux home and the
+# user's global ~/.claude. Echoes "<session_id>\t<working_dir_win>\t<src_jsonl>"
 # (tab-separated) or nothing if no session is found.
 best_session_for_slug() {
     local slug="$1"
     [ -n "$slug" ] || return 0
-    local best_size=0 best_sid="" best_wd=""
-    local d name wd_win cslug jf sz
+    local best_size=0 best_sid="" best_wd="" best_src=""
+    local d wd_win cslug jf sz root
     for d in "$AGENTS_DIR/$slug"-*; do
         [ -d "$d" ] || continue
         wd_win=$(win_path "$d")               # C:\Users\...\.agentmux\agents\<name>
         cslug=$(slugify_cwd "$wd_win")
-        [ -d "$CLAUDE_PROJECTS/$cslug" ] || continue
-        while IFS= read -r jf; do
-            [ -n "$jf" ] || continue
-            # `wc -c` is POSIX; `stat -c%s` is GNU-only and fails silently on
-            # BSD/macOS — that would make every size 0 and no-op the wiring.
-            sz=$(wc -c < "$jf" 2>/dev/null | tr -d '[:space:]'); sz=${sz:-0}
-            if [ "$sz" -gt "$best_size" ]; then
-                best_size=$sz
-                best_sid=$(basename "$jf" .jsonl)
-                best_wd=$wd_win
-            fi
-        done < <(find "$CLAUDE_PROJECTS/$cslug" -maxdepth 1 -name '*.jsonl' 2>/dev/null)
+        for root in "$SHARED_CLAUDE_PROJECTS" "$CLAUDE_PROJECTS"; do
+            [ -d "$root/$cslug" ] || continue
+            while IFS= read -r jf; do
+                [ -n "$jf" ] || continue
+                # `wc -c` is POSIX; `stat -c%s` is GNU-only and fails silently on
+                # BSD/macOS — that would make every size 0 and no-op the wiring.
+                sz=$(wc -c < "$jf" 2>/dev/null | tr -d '[:space:]'); sz=${sz:-0}
+                if [ "$sz" -gt "$best_size" ]; then
+                    best_size=$sz
+                    best_sid=$(basename "$jf" .jsonl)
+                    best_wd=$wd_win
+                    best_src=$jf
+                fi
+            done < <(find "$root/$cslug" -maxdepth 1 -name '*.jsonl' 2>/dev/null)
+        done
     done
-    [ -n "$best_sid" ] && printf '%s\t%s' "$best_sid" "$best_wd"
+    [ -n "$best_sid" ] && printf '%s\t%s\t%s' "$best_sid" "$best_wd" "$best_src"
+}
+
+# P0 rehydrate: copy a session transcript into AgentMux's isolated Claude home at
+# the slug `claude --resume` expects, so the conversation actually replays even
+# when the session only existed in the user's global ~/.claude (pre-isolation).
+# No-op when a copy is already present. Echoes a one-line note on success.
+rehydrate_claude_session() {
+    local sess_id="$1" work_dir="$2" src_jsonl="$3"
+    [ -n "$sess_id" ] && [ -f "$src_jsonl" ] || return 0
+    local cslug dst_dir dst
+    cslug=$(slugify_cwd "$work_dir")
+    dst_dir="$SHARED_CLAUDE_PROJECTS/$cslug"
+    dst="$dst_dir/$sess_id.jsonl"
+    # Already in the isolated home (src == dst, or a copy exists) → nothing to do.
+    [ -f "$dst" ] && return 0
+    mkdir -p "$dst_dir" 2>/dev/null || return 0
+    if cp "$src_jsonl" "$dst" 2>/dev/null; then
+        echo "        ↳ rehydrated session into shared/providers/claude (resume will find it)"
+    fi
 }
 
 # Scan $AGENTMUX_DIR/channels for the channel that contains a given version's
@@ -320,11 +349,16 @@ import_into() {
             if [ -z "$lookup_slug" ]; then
                 lookup_slug=$(printf '%s' "$agent_name" | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9_-]/-/g')
             fi
-            local resolved sess_id="" work_dir=""
+            local resolved sess_id="" work_dir="" src_jsonl=""
             resolved=$(best_session_for_slug "$lookup_slug")
             if [ -n "$resolved" ]; then
-                sess_id=$(printf '%s' "$resolved" | cut -f1)
-                work_dir=$(printf '%s' "$resolved" | cut -f2-)
+                # Tab-delimited fields; filesystem paths never contain a literal
+                # tab, so the split is unambiguous.
+                IFS=$'\t' read -r sess_id work_dir src_jsonl <<< "$resolved"
+                # P0: ensure the chosen session lives in AgentMux's isolated Claude
+                # home, which is where `claude --resume` reads — otherwise the pane
+                # stays empty even though session_id is wired.
+                rehydrate_claude_session "$sess_id" "$work_dir" "$src_jsonl"
             fi
             # SQL-escape single quotes (paths/UUIDs rarely contain them, but safe).
             local sess_sql="${sess_id//\'/\'\'}"


### PR DESCRIPTION
## Problem

Imported agents showed an **empty pane**. `import-agents.sh` wired a `session_id` it found in the user's **global** `~/.claude/projects/`, but AgentMux spawns claude with `CLAUDE_CONFIG_DIR=~/.agentmux/shared/providers/claude`, so `claude --resume <sid>` reads from the **isolated** home and never finds the global file → no replay. (Root-caused in `SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md` §2.5.)

## Fix (P0 of the history-store spec)

- `best_session_for_slug` now searches **both** the isolated home (`shared/providers/claude/projects`) and global `~/.claude/projects`, and returns the source transcript path.
- New `rehydrate_claude_session` copies the chosen transcript into `$CLAUDE_CONFIG_DIR/projects/<slug(cwd)>/<sid>.jsonl` (no-op if already there) — so a single message replays the real conversation.

## Verified

Against the running 0.44.1 channel: Mopeo's 1.1 MB session (`4f03e3ed`, previously only in global `~/.claude`) is now copied into `shared/providers/claude/projects/.../4f03e3ed.jsonl`. Agents with no session import as before (empty stub).

## Also included

The full architecture spec `docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md` — verified current state (provider isolation, cwd-slug fragmentation, orphaned pre-isolation histories), and the P1–P3 plan (per-provider `HistoryAdapter`s, turn-end capture, `index.db` + History pane, organize/clear/GC). P0 marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)