### PR TITLE
fix(history): scan AgentMux-isolated Claude homes in history browse (P1a)

### DIFF
--- a/.changesets/1781114538-fix-history-scan-agentmux-isolated-claude-homes-so-the-histo-q373.md
+++ b/.changesets/1781114538-fix-history-scan-agentmux-isolated-claude-homes-so-the-histo-q373.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(history): scan AgentMux-isolated Claude homes so the history browse surfaces agent conversations, not just global ~/.claude (history P1a)

--- a/agentmux-srv/src/backend/history/claude_adapter.rs
+++ b/agentmux-srv/src/backend/history/claude_adapter.rs
@@ -21,13 +21,13 @@ impl ClaudeHistoryAdapter {
         let mut base_dirs = Vec::new();
 
         if let Some(home) = dirs::home_dir() {
-            // User's personal Claude sessions
+            // User's personal (non-isolated) Claude sessions
             let personal = home.join(".claude").join("projects");
             if personal.is_dir() {
                 base_dirs.push(personal);
             }
 
-            // AgentMux agent sessions: ~/.config/claude-*/projects/
+            // Legacy multi-account convention: ~/.config/claude-*/projects/
             let config_dir = home.join(".config");
             if config_dir.is_dir() {
                 if let Ok(entries) = fs::read_dir(&config_dir) {
@@ -40,6 +40,32 @@ impl ClaudeHistoryAdapter {
                                 base_dirs.push(projects);
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        // AgentMux-ISOLATED Claude homes — where agents spawned by current builds
+        // actually write (AgentMux sets CLAUDE_CONFIG_DIR here at spawn time).
+        // Without these, the history browse misses every AgentMux agent
+        // conversation. See docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md.
+        //   <shared>/providers/claude/projects/              (default, account-wide)
+        //   <shared>/identities/<bundle_id>/claude/projects/ (per-identity bundles)
+        // `AGENTMUX_SHARED_DIR` is exported by the launcher; fall back to
+        // ~/.agentmux/shared so discovery still works in plain/test contexts.
+        let shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR")
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".agentmux").join("shared")));
+        if let Some(shared) = shared_dir {
+            let default_projects = shared.join("providers").join("claude").join("projects");
+            if default_projects.is_dir() {
+                base_dirs.push(default_projects);
+            }
+            if let Ok(entries) = fs::read_dir(shared.join("identities")) {
+                for entry in entries.flatten() {
+                    let projects = entry.path().join("claude").join("projects");
+                    if projects.is_dir() {
+                        base_dirs.push(projects);
                     }
                 }
             }

--- a/agentmux-srv/src/backend/history/claude_adapter.rs
+++ b/agentmux-srv/src/backend/history/claude_adapter.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Claude Code history adapter.
-//! Scans ~/.claude/projects/ and ~/.config/claude-*/projects/ for session JSONL files.
+//! Scans for session JSONL files across both the user's global Claude homes and
+//! the AgentMux-isolated homes that current agents actually write to:
+//!   - ~/.claude/projects/ and ~/.config/claude-*/projects/ (global / legacy)
+//!   - <AGENTMUX_SHARED_DIR>/providers/claude/projects/ (default isolated home)
+//!   - <AGENTMUX_SHARED_DIR>/identities/<bundle_id>/claude/projects/ (per-identity)
 
 use std::fs;
 use std::io::{BufRead, BufReader};

--- a/docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md
@@ -150,9 +150,13 @@ Impls: `claude` (`projects/<slug>/<sid>.jsonl`), `codex` (`sessions/<y>/<m>/<d>/
 | Phase | Scope | Outcome |
 |-------|-------|---------|
 | **P0** ✅ | Fix `import-agents.sh`: search `shared/providers/claude` + global, and **rehydrate** the chosen session into `$CLAUDE_CONFIG_DIR/projects/<slug>/` where resume reads (`rehydrate_claude_session`) | **DONE** — imported agents' sessions replay on resume (verified: Mopeo `4f03e3ed`, 1.1 MB, copied into the isolated home) |
-| **P1** | History store + Claude/Codex/Gemini adapters + turn-end capture + reconcile scan | Real usage durably captured & unified inside `~/.agentmux/` |
-| **P2** | `index.db` + History pane (browse/search/label/pin/restore/clear) | Organize + clear + read-only restore |
+| **P1a** ✅ | Make the **existing** `ClaudeHistoryAdapter` scan the AgentMux-isolated homes (`shared/providers/claude/projects` + `shared/identities/*/claude/projects`) | **DONE** — the existing browse (`HistoryService` → `useHistoryPagination`) now surfaces AgentMux agent conversations, not just global `~/.claude` |
+| **P1b** | Durable mirror/capture: `HistoryStore` under `shared/history/` + turn-end copy + reconcile scan; clear/delete | Histories survive provider GC; unified & agent-anchored |
+| **P1c** | Codex + Gemini `HistoryAdapter`s (scan isolated `CODEX_HOME`/`GEMINI_CLI_HOME`) | Multi-provider browse + capture |
+| **P2** | History pane UX: search/label/pin/restore/clear (RPC + `index.rs` already exist) | Organize + clear + read-only restore |
 | **P3** | ACP providers (copilot/pi/openclaw), size budget + GC, cross-machine export | Full coverage + housekeeping |
+
+> **Implementation reality (discovered 2026-06-10):** a discovery/browse layer **already exists** — `history/{adapter.rs (HistoryAdapter trait), claude_adapter.rs, index.rs (SessionIndex), mod.rs (HistoryService)}`, wired to RPC (`service.rs`) and a frontend consumer (`useHistoryPagination.ts`, `parseHistoryLines.ts`). It scanned only global `~/.claude` + `~/.config/claude-*`. P1a closes that gap; P1b/P1c/P2 build on this rather than from scratch. The trait is read-oriented (`discover_files`/`extract_meta`/`parse_file`); P1b adds the write/mirror/delete side.
 
 ---
 


### PR DESCRIPTION
## Problem

`ClaudeHistoryAdapter` scanned only `~/.claude/projects` and `~/.config/claude-*/projects`. But AgentMux spawns claude with `CLAUDE_CONFIG_DIR=~/.agentmux/shared/providers/claude`, so **agent conversations write under the isolated home** — which the adapter never scanned. The result: the existing `HistoryService` browse (wired to `useHistoryPagination` / `parseHistoryLines` in the frontend) **missed every AgentMux-spawned agent's history**, showing only global sessions.

## Fix (P1a)

`ClaudeHistoryAdapter::new()` now also scans, via the launcher-exported `AGENTMUX_SHARED_DIR` (fallback `~/.agentmux/shared`):
- `<shared>/providers/claude/projects/` — default, account-wide
- `<shared>/identities/<bundle_id>/claude/projects/` — per-identity bundles

Existing scan roots and behavior are unchanged.

## Why this is the right first increment

A discovery/browse layer **already exists** — `history/{adapter,claude_adapter,index,mod}.rs` (the `HistoryAdapter` trait + `SessionIndex` + `HistoryService`), wired to RPC and the frontend. It just wasn't looking where AgentMux writes. This change makes it user-visible immediately, and the rest of the spec (P1b durable mirror/capture + clear, P1c Codex/Gemini, P2 pane UX) builds on the same infra rather than rebuilding it.

## Verification

`cargo check -p agentmux-srv` → clean (Finished, no errors). Spec updated (`SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md`) with the corrected phasing + the "implementation reality" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)