### PR TITLE
fix(gpu): SwiftShader software-GL fallback on Windows + status-bar GPU indicator

### DIFF
--- a/.changesets/1781170152-fix-gpu-bundle-swiftshader-on-windows-status-bar-gpu-indicat-0doe.md
+++ b/.changesets/1781170152-fix-gpu-bundle-swiftshader-on-windows-status-bar-gpu-indicat-0doe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(gpu): bundle SwiftShader on Windows + status-bar GPU indicator

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -536,18 +536,29 @@ tasks:
                 cp -f "$cefDir/libEGL.dll" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/libGLESv2.dll" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/d3dcompiler_47.dll" dist/cef/ 2>/dev/null || true
+                # Software-GL fallback (SwiftShader). When the HARDWARE GPU process can't
+                # initialize a GL device — virtual display adapters (Parsec, RDP/headless
+                # sessions), or broken drivers — Chromium 110+ will only fall back to
+                # SwiftShader for WebGL if these are present AND --enable-unsafe-swiftshader
+                # is set (see agentmux-cef/src/app.rs). Without them, GL is disabled entirely
+                # (gl=disabled), WebGL becomes unavailable, and xterm drops to its slower DOM
+                # renderer (no scrollbar). macOS/Linux bundles already ship SwiftShader; this
+                # restores parity on Windows. ~18 MB.
+                # See docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md.
+                cp -f "$cefDir/vk_swiftshader.dll" dist/cef/ 2>/dev/null || true
+                cp -f "$cefDir/vulkan-1.dll" dist/cef/ 2>/dev/null || true
+                cp -f "$cefDir/vk_swiftshader_icd.json" dist/cef/ 2>/dev/null || true
                 # Data files (required)
                 cp -f "$cefDir/icudtl.dat" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir"/*.pak dist/cef/ 2>/dev/null || true
                 # Locales — en-US only (saves ~18 MB)
                 [ -f "$cefDir/locales/en-US.pak" ] && cp -f "$cefDir/locales/en-US.pak" dist/cef/locales/
-                # SKIPPED (not needed, saves ~18 MB):
-                #   vk_swiftshader.dll, vulkan-1.dll, vk_swiftshader_icd.json (SwiftShader — deprecated upstream)
+                # SKIPPED (not needed):
                 #   dxil.dll, dxcompiler.dll (WebGPU — not used)
                 #   snapshot_blob.bin (removed in CEF 133+)
                 #   49 non-English locale .pak files
-                echo "✓ Bundled runtime to dist/cef/ (optimized: GPU kept, SwiftShader/WebGPU/extra locales stripped)"
+                echo "✓ Bundled runtime to dist/cef/ (GPU + SwiftShader fallback kept, WebGPU/extra locales stripped)"
 
     bundle:darwin:
         internal: true

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -623,6 +623,20 @@ wrap_app! {
                 // the app in a zombie white-screen state on GPU context loss with
                 // no recovery path. Removed in v0.33.66.
 
+                // Permit SwiftShader as a software-GL fallback. Chromium 110+
+                // removed the automatic SwiftShader fallback for WebGL and gated
+                // it behind this switch. Without it, when the hardware GPU process
+                // can't initialize a GL device — virtual display adapters (Parsec,
+                // RDP/headless), broken drivers — Chromium disables GL entirely
+                // (gl=disabled), WebGL becomes unavailable, and xterm drops to its
+                // slower DOM renderer (no scrollbar). With this switch + the bundled
+                // vk_swiftshader.dll / vulkan-1.dll (Taskfile bundle:windows), GL
+                // degrades to software instead, keeping WebGL and the xterm WebGL
+                // renderer working. Hardware GL is still preferred when available,
+                // so this is a fallback only — no perf cost on healthy machines.
+                // See docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md.
+                cmd.append_switch(Some(&CefString::from("enable-unsafe-swiftshader")));
+
                 // NOTE: `--renderer-process-limit=1` was previously set here to
                 // protect against DevTools popups spawning extra renderers under
                 // an Alloy-mode assumption. The current Linux CEF build is NOT

--- a/docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md
+++ b/docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md
@@ -1,0 +1,177 @@
+# Root-Cause Analysis: WebGL Unavailable in AgentMux (GPU process disabled)
+
+**Status:** Complete — evidence-backed via CDP + CEF logs + system inventory
+**Author:** AgentX
+**Date:** 2026-06-10
+**Fix:** `agentx/gpu-swiftshader-fallback-and-status` (this PR)
+
+---
+
+## 1. Summary
+
+WebGL is unavailable in AgentMux on this machine because **Chromium's GPU process
+crashes at initialization and, after 3 crashes, Chromium disables the GPU entirely**
+(`gl=disabled, angle=none`). xterm then falls back to the DOM renderer, which in xterm v6
+has no native scrollbar (scroll is wheel-only).
+
+Two independent causes combine:
+
+1. **Environmental trigger:** a **Parsec Virtual Display Adapter** is installed alongside
+   the real GPUs. Chromium's GPU process cannot bring up a hardware D3D11/GL device in that
+   display context and aborts with `STATUS_BREAKPOINT` (`0x80000003`) at ~130 ms init.
+2. **AgentMux contributing factor:** the Windows bundle step **strips SwiftShader**
+   (`vk_swiftshader.dll`, `vulkan-1.dll`), so there is **no software-GL fallback**. Chromium
+   goes straight from "hardware GPU crashed" to "GPU fully off." (Linux/macOS bundles keep
+   SwiftShader — see Taskfile.yml.)
+
+It is **not** dev-specific, **not** a feature branch, and **not** a CEF version mismatch: the
+downloaded **portable v0.44.0** build shows the identical disabled state, and `libcef.dll`
+is correctly `148.0.9 / chromium-148.0.7778.180` (matches the host).
+
+---
+
+## 2. Evidence
+
+### 2.1 GPU is off (both dev :9223 and portable :9222)
+
+`SystemInfo.getInfo` → `featureStatus` on **both** running builds:
+
+```
+opengl: disabled_off    webgl: disabled_off    webgpu: disabled_off
+gpu_compositing: disabled_software    2d_canvas: disabled_software
+glImplementationParts: "(gl=disabled,angle=none)"   glRenderer/Vendor/Version: "Disabled"
+processCrashCount: 3    driverBugWorkarounds: []
+```
+
+Page-side: `canvas.getContext('webgl'|'webgl2'|'experimental-webgl')` all return null with
+`"...GL_VENDOR = Disabled, GL_RENDERER = Disabled... ErrorMessage = BindToCurrentSequence failed"`.
+
+### 2.2 The GPU process crash sequence (dev CEF debug log)
+
+`~/.agentmux/dev/<branch>/<hash>/logs/cef-debug.log`:
+
+```
+123048.292  ERROR gpu_process_host.cc:999  GPU process exited unexpectedly: exit_code=-2147483645
+123048.292  WARN  gpu_process_host.cc:1441 The GPU process has crashed 1 time(s)
+123048.468  ...                              exit_code=-2147483645  → crashed 2 time(s)
+123048.646  ...                              exit_code=-2147483645  → crashed 3 time(s)
+123048.726  ERROR gpu_channel_manager.cc:927 ContextResult::kFatalFailure:
+                                             Failed to create shared context for virtualization.
+```
+
+- `exit_code=-2147483645` = `0x80000003` = **STATUS_BREAKPOINT** — a Chromium CHECK/DCHECK or
+  `__debugbreak()`, i.e. the process *loaded fine* then asserted during GL/D3D init (init
+  times 132/133/0 ms). A missing DLL would be `0xC0000135` (DLL_NOT_FOUND), which this is not.
+- Same exit code recurs historically across versions in the launcher log (v0.38, v0.39,
+  v0.42) → a persistent, environment-level condition, not a one-off.
+
+### 2.3 The machine has a virtual display adapter
+
+`Win32_VideoController`:
+
+| Adapter | Driver | Note |
+|---|---|---|
+| **Parsec Virtual Display Adapter** | 0.45.0.0 (2024) | virtual display (remote streaming) |
+| AMD Radeon(TM) Graphics | 32.0.21043.5001 (2026) | iGPU |
+| NVIDIA GeForce RTX 3060 | 32.0.15.9186 (2026) | dGPU |
+
+`SessionName=Console`, `SessionId=1`. Parsec's virtual adapter is the well-known trigger for
+Chromium/Electron GPU-process crashes: when the GPU process targets the virtual display's
+adapter, hardware D3D11 device creation fails and (in this CEF build) trips a CHECK →
+`STATUS_BREAKPOINT`. Repeated 3× → Chromium's "GPU process keeps crashing" policy disables
+the GPU for the session.
+
+### 2.4 No software fallback is bundled (the AgentMux factor)
+
+Dev runtime (`dist/cef-dev/runtime`) **and** the downloaded portable runtime both contain
+`libcef.dll`, `libEGL.dll`, `libGLESv2.dll`, `d3dcompiler_47.dll` — but **not**
+`vk_swiftshader.dll` / `vulkan-1.dll`.
+
+`Taskfile.yml` bundle step (Windows branch) explicitly stripped them; the Linux/macOS
+branches deliberately keep SwiftShader "so GPU processes start on machines without a system
+Vulkan loader." So on Windows there was nothing for Chromium to fall back to once the
+hardware GPU process died → `webgl: disabled_off` (not `disabled_software`).
+
+---
+
+## 3. Causal chain
+
+```
+Parsec Virtual Display Adapter is the GPU/display context
+        ↓
+Chromium GPU process can't create a hardware D3D11/GL device → CHECK fail (STATUS_BREAKPOINT)
+        ↓
+GPU process crashes 3× in ~350 ms → Chromium disables GPU for the session (gl=disabled)
+        ↓
+No SwiftShader bundled on Windows → no software-GL fallback → webgl: disabled_off
+        ↓
+xterm WebglAddon can't load → DOM renderer
+        ↓
+xterm v6 DOM renderer has no native viewport scrollbar → wheel-only scroll
+```
+
+---
+
+## 4. Fix (this PR)
+
+### 4.1 Bundle SwiftShader on Windows + enable it
+
+- `Taskfile.yml` `bundle:windows` now copies `vk_swiftshader.dll`, `vulkan-1.dll`,
+  `vk_swiftshader_icd.json` into `dist/cef/` (parity with macOS/Linux).
+- `agentmux-cef/src/app.rs` appends `--enable-unsafe-swiftshader`. Chromium 110+ gates the
+  SwiftShader-for-WebGL fallback behind this switch; without it, even with the DLLs present,
+  `getContext('webgl')` returns null once hardware GPU is off. Hardware GL is still preferred
+  when available — this is a fallback only, no cost on healthy machines.
+
+Result: a hardware-GPU failure degrades to **software WebGL** instead of disabling WebGL
+outright — the xterm WebGL renderer (and its native scrollbar) keep working on
+virtual-display / headless / broken-driver machines, exactly the remote-agent environments
+AgentMux runs in.
+
+### 4.2 Make the degraded state visible (this PR)
+
+A status-bar GPU indicator (`frontend/util/gpuutil.ts`, `frontend/app/statusbar/GpuStatus.tsx`)
+shows `GPU HW/SW/off` in the bottom-left, and the BackendStatus popover (click the uptime)
+gains a GPU section: WebGL class, unmasked renderer/vendor, and the terminal's actual renderer
+(WebGL vs DOM, via `termRendererAtom` set in `termwrap.ts`). So the fallback is observable
+rather than silent.
+
+### 4.3 Environmental note (no code)
+
+The hardware GPU process should also initialize when the session is driven by a real display
+adapter (physical monitor on the console) rather than the Parsec virtual display; disabling
+the Parsec Virtual Display Adapter in Device Manager typically lets Chromium's GPU process
+start. 4.1 is what makes AgentMux *resilient* to it regardless.
+
+### 4.4 Not a fix
+
+- Bumping drivers — both real GPUs already have 2026 drivers; the trigger is the virtual
+  adapter / display context.
+- The launcher's `--disable-gpu` ladder — host-crash-level; it did **not** fire (host cmdline
+  was just `--url=...`); the GPU *process* crashes are Chromium-internal.
+
+---
+
+## 5. Impact
+
+Until this fix, **every terminal on an affected machine uses the xterm DOM renderer**: slower
+for large/fast output, and **no visible scrollbar** (wheel-only). The companion scrollbar-gap
+fix stands on its own; restoring WebGL via §4.1 (or a visible DOM-renderer scrollbar) is the
+complete story.
+
+---
+
+## 6. Appendix: how to re-verify
+
+```
+# GPU feature status of any running build (dev 9223 / portable 9222):
+curl -s http://127.0.0.1:9223/json/version > ver.json
+node scripts/cdp-featurestatus.mjs ver.json
+
+# GPU crash sequence:
+grep -aE 'GPU process|ContextResult|shared context' \
+  ~/.agentmux/dev/<branch>/<hash>/logs/cef-debug.log
+
+# Adapters:
+pwsh -NoProfile -Command "Get-CimInstance Win32_VideoController | Format-List Name,DriverVersion"
+```

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -1,9 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, backendDeathInfoAtom, getApi, setBackendStatusAtom } from "@/store/global";
+import { atoms, backendDeathInfoAtom, getApi, setBackendStatusAtom, termRendererAtom } from "@/store/global";
 import { setRestartInProgress } from "@/store/backendStatus";
 import { waveEventSubscribe } from "@/app/store/wps";
+import { getGpuInfo, gpuClassLabel } from "@/util/gpuutil";
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 
 function pad2(n: number): string {
@@ -18,6 +19,17 @@ function formatUptime(secs: number): string {
     if (d > 0) return `${d}:${pad2(h)}:${pad2(m)}:${pad2(s)}`;
     if (h > 0) return `${h}:${pad2(m)}:${pad2(s)}`;
     return `${m}:${pad2(s)}`;
+}
+
+function gpuColor(c: ReturnType<typeof getGpuInfo>["classification"]): string {
+    switch (c) {
+        case "hardware":
+            return "var(--accent-color)";
+        case "software":
+            return "var(--warning-color)";
+        default:
+            return "var(--error-color)";
+    }
 }
 
 const BackendStatus = (): JSX.Element => {
@@ -47,6 +59,7 @@ const BackendStatus = (): JSX.Element => {
         version: string;
     } | null>(null);
     let popoverRef!: HTMLDivElement;
+    const gpu = getGpuInfo(); // WebGL/GPU capability — static for the renderer process
 
     // Fetch started_at when backend becomes running
     createEffect(() => {
@@ -177,6 +190,38 @@ const BackendStatus = (): JSX.Element => {
                             <div class="status-bar-popover-row">
                                 <span class="status-bar-popover-label">Version</span>
                                 <span>{backendInfo().version}</span>
+                            </div>
+                        </Show>
+                        {/* GPU / WebGL rendering — surfaces silent software/DOM fallback
+                            (e.g. virtual display adapters disabling the GPU). See
+                            docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md */}
+                        <div class="status-bar-popover-divider" />
+                        <div class="status-bar-popover-section-title">GPU</div>
+                        <div class="status-bar-popover-row">
+                            <span class="status-bar-popover-label">WebGL</span>
+                            <span style={{ color: gpuColor(gpu.classification) }}>
+                                {gpuClassLabel(gpu.classification)}
+                                {gpu.webgl ? (gpu.webgl2 ? " (WebGL2)" : " (WebGL1)") : ""}
+                            </span>
+                        </div>
+                        <Show when={gpu.renderer}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Renderer</span>
+                                <span class="status-bar-popover-mono">{gpu.renderer}</span>
+                            </div>
+                        </Show>
+                        <Show when={gpu.vendor}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Vendor</span>
+                                <span class="status-bar-popover-mono">{gpu.vendor}</span>
+                            </div>
+                        </Show>
+                        <Show when={termRendererAtom() != null}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Terminal</span>
+                                <span style={{ color: termRendererAtom() === "webgl" ? "var(--accent-color)" : "var(--warning-color)" }}>
+                                    {termRendererAtom() === "webgl" ? "WebGL (GPU)" : "DOM (software)"}
+                                </span>
                             </div>
                         </Show>
                         <Show when={backendStatus() === "crashed" && backendDeathInfoAtom() != null}>

--- a/frontend/app/statusbar/GpuStatus.tsx
+++ b/frontend/app/statusbar/GpuStatus.tsx
@@ -1,0 +1,54 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { termRendererAtom } from "@/store/global";
+import { getGpuInfo, gpuClassBadge } from "@/util/gpuutil";
+import { type JSX } from "solid-js";
+
+// Compact bottom-left status-bar line for GPU/WebGL state. Detail lives in the
+// BackendStatus popover (click the uptime). See gpuutil.ts for the probe and
+// docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md for why this
+// matters (silent DOM-renderer fallback when the GPU process can't start).
+const GpuStatus = (): JSX.Element => {
+    const info = getGpuInfo();
+
+    const color = () => {
+        switch (info.classification) {
+            case "hardware":
+                return "var(--secondary-text-color)";
+            case "software":
+                return "var(--warning-color)";
+            default:
+                return "var(--error-color)";
+        }
+    };
+
+    const tip = () => {
+        const term = termRendererAtom();
+        const rend = info.renderer ? ` — ${info.renderer}` : "";
+        const termPart = term ? ` · terminal: ${term.toUpperCase()}` : "";
+        switch (info.classification) {
+            case "hardware":
+                return `GPU: hardware accelerated${rend}${termPart}`;
+            case "software":
+                return `GPU: software rendering (SwiftShader)${rend}${termPart}`;
+            default:
+                return `GPU: unavailable — WebGL disabled, terminals use the DOM renderer${termPart}`;
+        }
+    };
+
+    return (
+        <span
+            class="stat-mono stat-gpu-mode"
+            style={{ color: color() }}
+            data-tip={tip()}
+            aria-label="GPU rendering status"
+        >
+            GPU {gpuClassBadge(info.classification)}
+        </span>
+    );
+};
+
+GpuStatus.displayName = "GpuStatus";
+
+export { GpuStatus };

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -302,6 +302,14 @@
         opacity: 0.4;
     }
 
+    .status-bar-popover-section-title {
+        text-transform: uppercase;
+        font-size: 0.85em;
+        letter-spacing: 0.05em;
+        opacity: 0.5;
+        padding: var(--space-0-5) 0;
+    }
+
     /* Toggle switch used in the LAN discovery row.
        Spec: specs/lan-discovery-toggle.md */
     .status-bar-toggle {

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -5,6 +5,7 @@ import { getApi, windowCountAtom, backendStatusAtom, isDev } from "@/store/globa
 import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
+import { GpuStatus } from "./GpuStatus";
 import { HostPopover } from "./HostPopover";
 import { InstancePanel } from "./InstancePanel";
 import { SystemStats } from "./SystemStats";
@@ -56,6 +57,8 @@ const StatusBar = (): JSX.Element => {
                 <BackendStatus />
                 <span class="stat-separator">|</span>
                 <SystemStats />
+                <span class="stat-separator">|</span>
+                <GpuStatus />
             </div>
             <div class="status-bar-center" />
             <div class="status-bar-right">

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -106,6 +106,12 @@ export const [controlShiftDelayAtom, setControlShiftDelayAtom] = createSignal(fa
 export const [updaterStatusAtom, setUpdaterStatusAtom] = createSignal<UpdaterStatus>("up-to-date");
 export const [updaterVersionAtom, setUpdaterVersionAtom] = createSignal<string | null>(null);
 
+// Which renderer the most recently-mounted terminal actually loaded: "webgl"
+// (GPU-accelerated, xterm WebglAddon) or "dom" (software fallback when WebGL is
+// unavailable). Set by TermWrap.loadRendererAddon; read by the status-bar GPU
+// indicator. null until the first terminal mounts.
+export const [termRendererAtom, setTermRendererAtom] = createSignal<"webgl" | "dom" | null>(null);
+
 export const reducedMotionSetting = createMemo(() => settingsAtom()?.["window:reducedmotion"]);
 export const [reducedMotionSystemPreference, setReducedMotionSystemPreference] = createSignal(false);
 

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -5,7 +5,7 @@ import { getFileSubject } from "@/app/store/wps";
 import { sendWSCommand } from "@/app/store/ws";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS, atoms, fetchWaveFile, getSettingsKeyAtom, openLink } from "@/app/store/global";
+import { WOS, atoms, fetchWaveFile, getSettingsKeyAtom, openLink, setTermRendererAtom } from "@/app/store/global";
 import * as services from "@/app/store/services";
 import { PLATFORM, PlatformLinux, PlatformMacOS, PlatformWindows } from "@/util/platformutil";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
@@ -632,6 +632,7 @@ export class TermWrap {
                 console.log("linux: using DOM renderer (WebKitGTK WebGL workaround)");
                 loggedWebGL = true;
             }
+            setTermRendererAtom("dom"); // surfaces in the status-bar GPU indicator
             return; // DOM renderer is the default when no renderer addon is loaded
         }
         if (WebGLSupported && useWebGl) {
@@ -641,21 +642,27 @@ export class TermWrap {
                     webglAddon.onContextLoss(() => {
                         webglAddon.dispose();
                         console.warn("WebGL context lost, falling back to DOM renderer");
+                        setTermRendererAtom("dom"); // GPU context lost → DOM fallback
                         // DOM renderer is active by default when no addon is loaded
                     })
                 );
                 this.terminal.loadAddon(webglAddon);
+                setTermRendererAtom("webgl");
                 if (!loggedWebGL) {
                     console.log("loaded webgl renderer!");
                     loggedWebGL = true;
                 }
             } catch (e) {
                 console.warn("WebGL renderer unavailable, using DOM renderer:", e);
+                setTermRendererAtom("dom");
                 if (!loggedWebGL) {
                     console.log("loaded DOM renderer (webgl fallback)!");
                     loggedWebGL = true;
                 }
             }
+        } else {
+            // WebGL unsupported (GPU disabled) or disabled by setting — DOM renderer.
+            setTermRendererAtom("dom");
         }
     }
 

--- a/frontend/util/gpuutil.ts
+++ b/frontend/util/gpuutil.ts
@@ -1,0 +1,100 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// GPU / WebGL capability probe. Runs in the renderer with a throwaway <canvas>;
+// safe to call anywhere and cached after the first call.
+//
+// Why this exists: when Chromium's GPU process can't initialize a hardware GL
+// device (virtual display adapters such as Parsec, headless/RDP sessions, broken
+// drivers) it disables GL entirely and WebGL becomes unavailable — xterm then
+// falls back to its slower DOM renderer (no scrollbar). This probe surfaces that
+// state for the status bar so the degraded mode is visible rather than silent.
+// See docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md.
+
+export type GpuClass = "hardware" | "software" | "unavailable";
+
+export type GpuInfo = {
+    webgl: boolean;
+    webgl2: boolean;
+    vendor: string | null; // unmasked GL vendor, when WEBGL_debug_renderer_info is available
+    renderer: string | null; // unmasked GL renderer (e.g. "ANGLE (NVIDIA ...)" or "SwiftShader")
+    classification: GpuClass;
+};
+
+// Substrings (lowercased) that mark a software/virtual GL backend rather than a
+// real GPU. SwiftShader is Chromium's software rasterizer; llvmpipe is Mesa's;
+// "Microsoft Basic Render" / "basic render driver" is the Windows fallback.
+const SOFTWARE_MARKERS = [
+    "swiftshader",
+    "software",
+    "llvmpipe",
+    "microsoft basic render",
+    "basic render driver",
+    "disabled",
+];
+
+function classify(supported: boolean, renderer: string | null): GpuClass {
+    if (!supported) return "unavailable";
+    const r = (renderer ?? "").toLowerCase();
+    if (SOFTWARE_MARKERS.some((m) => r.includes(m))) return "software";
+    return "hardware";
+}
+
+let cached: GpuInfo | undefined;
+
+function probe(): GpuInfo {
+    let webgl = false;
+    let webgl2 = false;
+    let vendor: string | null = null;
+    let renderer: string | null = null;
+    try {
+        const canvas = document.createElement("canvas");
+        const gl2 = canvas.getContext("webgl2") as WebGL2RenderingContext | null;
+        const gl = (gl2 ?? canvas.getContext("webgl")) as WebGLRenderingContext | null;
+        webgl2 = !!gl2;
+        webgl = !!gl;
+        if (gl) {
+            const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+            if (dbg) {
+                vendor = gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) as string;
+                renderer = gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) as string;
+            } else {
+                vendor = gl.getParameter(gl.VENDOR) as string;
+                renderer = gl.getParameter(gl.RENDERER) as string;
+            }
+        }
+    } catch {
+        // leave defaults → classified "unavailable"
+    }
+    return { webgl, webgl2, vendor, renderer, classification: classify(webgl, renderer) };
+}
+
+/** WebGL/GPU capability of the renderer process. Cached after first call. */
+export function getGpuInfo(): GpuInfo {
+    if (cached === undefined) cached = probe();
+    return cached;
+}
+
+/** Short human label for a GPU classification. */
+export function gpuClassLabel(c: GpuClass): string {
+    switch (c) {
+        case "hardware":
+            return "Hardware";
+        case "software":
+            return "Software";
+        default:
+            return "Unavailable";
+    }
+}
+
+/** Compact status-bar badge text, e.g. "HW" / "SW" / "off". */
+export function gpuClassBadge(c: GpuClass): string {
+    switch (c) {
+        case "hardware":
+            return "HW";
+        case "software":
+            return "SW";
+        default:
+            return "off";
+    }
+}


### PR DESCRIPTION
## Problem

When Chromium's hardware GPU process can't initialize a GL device — **virtual display adapters (Parsec, RDP/headless), or broken drivers** — it crashes at init, and after 3 crashes Chromium disables GL entirely (`gl=disabled`). WebGL becomes unavailable and xterm **silently** falls back to its slower DOM renderer, which in xterm v6 has **no scrollbar** (wheel-only).

Full evidence-backed root cause (CDP `SystemInfo`, CEF debug log, `Win32_VideoController`): `docs/analysis/ANALYSIS_WEBGL_GPU_DISABLED_ROOTCAUSE_2026_06_10.md`. Confirmed on this machine across **both** the dev build and the downloaded portable v0.44.0 — it's environment + bundle, not a version mismatch (`libcef.dll` is correctly 148.0.9).

The AgentMux-side contributing factor: the **Windows bundle stripped SwiftShader**, so there was no software-GL fallback (macOS/Linux bundles keep it). Chromium went straight from "hardware GPU crashed" → "GPU fully off."

## GPU fix

- **`Taskfile.yml` `bundle:windows`** now ships `vk_swiftshader.dll`, `vulkan-1.dll`, `vk_swiftshader_icd.json` (parity with macOS/Linux). ~18 MB.
- **`agentmux-cef/src/app.rs`** appends `--enable-unsafe-swiftshader`. Chromium 110+ gates the SwiftShader-for-WebGL fallback behind this switch; without it, even with the DLLs present, `getContext('webgl')` returns null once hardware GPU is off. Hardware GL is still preferred when available → **fallback only, no cost on healthy machines**.

Net: a hardware-GPU failure degrades to **software WebGL** instead of disabling it — the xterm WebGL renderer (and its scrollbar) keep working on virtual-display / headless / broken-driver machines (the remote-agent environments AgentMux runs in).

## Make the degraded state visible

- **`frontend/util/gpuutil.ts`** — cached WebGL probe → `hardware` / `software` / `unavailable` + unmasked renderer/vendor.
- **`statusbar/GpuStatus.tsx`** — bottom-left `GPU HW/SW/off` line (color-coded) with a detail tooltip.
- **`BackendStatus` popover** (click the uptime / "time-up") gains a **GPU section**: WebGL class, renderer, vendor, and the terminal's actual renderer (WebGL vs DOM).
- **`termwrap.ts`** records the chosen renderer via a new global `termRendererAtom`.

## Verification

- ✅ Frontend typechecks (`tsc --noEmit`, no errors in changed files)
- ✅ `cargo check -p agentmux-cef` compiles
- ✅ SwiftShader DLLs present in the CEF runtime source, so the bundle copy is real (not a silent no-op)
- ⏳ End-to-end "WebGL returns under Parsec" needs a clean rebuild + relaunch (manual — the running dev instance is on another branch). Expected: `SystemInfo` `webgl` flips from `disabled_off` to software, status bar shows `GPU SW`.

## Test plan

- [ ] Build a Windows portable (`task package`) — confirm `vk_swiftshader.dll` + `vulkan-1.dll` are in `runtime/`
- [ ] Launch on a machine with a virtual display adapter (or after a GPU-process crash) — terminals render via WebGL (software), scrollbar present; status bar shows `GPU SW`
- [ ] On a healthy GPU machine — status bar shows `GPU HW`, hardware path unchanged (no perf regression)
- [ ] Click the uptime in the status bar — GPU section shows WebGL class / renderer / vendor / terminal renderer