### PR TITLE
feat(statusbar): GPU status indicator — enabled/disabled + driver info

### DIFF
--- a/.changesets/1781171432-feat-statusbar-gpu-status-indicator-enabled-disabled-driver--bp14.md
+++ b/.changesets/1781171432-feat-statusbar-gpu-status-indicator-enabled-disabled-driver--bp14.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): GPU status indicator — enabled/disabled + driver info

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -1,9 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, backendDeathInfoAtom, getApi, setBackendStatusAtom } from "@/store/global";
+import { atoms, backendDeathInfoAtom, getApi, setBackendStatusAtom, termRendererAtom } from "@/store/global";
 import { setRestartInProgress } from "@/store/backendStatus";
 import { waveEventSubscribe } from "@/app/store/wps";
+import { getGpuInfo } from "@/util/gpuutil";
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 
 function pad2(n: number): string {
@@ -18,6 +19,17 @@ function formatUptime(secs: number): string {
     if (d > 0) return `${d}:${pad2(h)}:${pad2(m)}:${pad2(s)}`;
     if (h > 0) return `${h}:${pad2(m)}:${pad2(s)}`;
     return `${m}:${pad2(s)}`;
+}
+
+function gpuColor(c: ReturnType<typeof getGpuInfo>["classification"]): string {
+    switch (c) {
+        case "hardware":
+            return "var(--accent-color)";
+        case "software":
+            return "var(--warning-color)";
+        default:
+            return "var(--error-color)";
+    }
 }
 
 const BackendStatus = (): JSX.Element => {
@@ -47,6 +59,7 @@ const BackendStatus = (): JSX.Element => {
         version: string;
     } | null>(null);
     let popoverRef!: HTMLDivElement;
+    const gpu = getGpuInfo(); // WebGL/GPU capability — static for the renderer process
 
     // Fetch started_at when backend becomes running
     createEffect(() => {
@@ -177,6 +190,47 @@ const BackendStatus = (): JSX.Element => {
                             <div class="status-bar-popover-row">
                                 <span class="status-bar-popover-label">Version</span>
                                 <span>{backendInfo().version}</span>
+                            </div>
+                        </Show>
+                        {/* GPU / WebGL rendering — enabled/disabled + driver info.
+                            Surfaces the silent DOM-renderer fallback when the GPU
+                            process is unavailable. */}
+                        <div class="status-bar-popover-divider" />
+                        <div class="status-bar-popover-section-title">GPU</div>
+                        <div class="status-bar-popover-row">
+                            <span class="status-bar-popover-label">Status</span>
+                            <span style={{ color: gpuColor(gpu.classification) }}>
+                                {gpu.classification === "unavailable"
+                                    ? "Disabled"
+                                    : gpu.classification === "software"
+                                        ? "Enabled (software)"
+                                        : "Enabled (hardware)"}
+                            </span>
+                        </div>
+                        <Show when={gpu.webgl}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">WebGL</span>
+                                <span>{gpu.webgl2 ? "2.0" : "1.0"}</span>
+                            </div>
+                        </Show>
+                        <Show when={gpu.renderer}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Driver</span>
+                                <span class="status-bar-popover-mono">{gpu.renderer}</span>
+                            </div>
+                        </Show>
+                        <Show when={gpu.vendor}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Vendor</span>
+                                <span class="status-bar-popover-mono">{gpu.vendor}</span>
+                            </div>
+                        </Show>
+                        <Show when={termRendererAtom() != null}>
+                            <div class="status-bar-popover-row">
+                                <span class="status-bar-popover-label">Terminal</span>
+                                <span style={{ color: termRendererAtom() === "webgl" ? "var(--accent-color)" : "var(--warning-color)" }}>
+                                    {termRendererAtom() === "webgl" ? "WebGL (GPU)" : "DOM (software)"}
+                                </span>
                             </div>
                         </Show>
                         <Show when={backendStatus() === "crashed" && backendDeathInfoAtom() != null}>

--- a/frontend/app/statusbar/GpuStatus.tsx
+++ b/frontend/app/statusbar/GpuStatus.tsx
@@ -28,22 +28,24 @@ const GpuStatus = (): JSX.Element => {
         const termPart = term ? ` · terminal: ${term.toUpperCase()}` : "";
         switch (info.classification) {
             case "hardware":
-                return `GPU: hardware accelerated${rend}${termPart}`;
+                return `Graphics: hardware accelerated${rend}${termPart}`;
             case "software":
-                return `GPU: software rendering (SwiftShader)${rend}${termPart}`;
+                return `Graphics: software rendering${rend}${termPart}`;
             default:
-                return `GPU: unavailable — WebGL disabled, terminals use the DOM renderer${termPart}`;
+                return `Graphics: GPU disabled — WebGL unavailable, terminals use the DOM renderer${termPart}`;
         }
     };
 
+    // Labeled "GFX" (graphics-acceleration state) to distinguish from SystemStats'
+    // "GPU {n}%" (utilization) sitting in the same bar.
     return (
         <span
             class="stat-mono stat-gpu-mode"
             style={{ color: color() }}
             data-tip={tip()}
-            aria-label="GPU rendering status"
+            aria-label="Graphics acceleration status"
         >
-            GPU {gpuClassBadge(info.classification)}
+            GFX {gpuClassBadge(info.classification)}
         </span>
     );
 };

--- a/frontend/app/statusbar/GpuStatus.tsx
+++ b/frontend/app/statusbar/GpuStatus.tsx
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { termRendererAtom } from "@/store/global";
+import { getGpuInfo, gpuClassBadge } from "@/util/gpuutil";
+import { type JSX } from "solid-js";
+
+// Compact bottom-left status-bar line for GPU/WebGL state (enabled/disabled).
+// Driver detail lives in the BackendStatus popover (click the uptime). The probe
+// is in gpuutil.ts.
+const GpuStatus = (): JSX.Element => {
+    const info = getGpuInfo();
+
+    const color = () => {
+        switch (info.classification) {
+            case "hardware":
+                return "var(--secondary-text-color)";
+            case "software":
+                return "var(--warning-color)";
+            default:
+                return "var(--error-color)";
+        }
+    };
+
+    const tip = () => {
+        const term = termRendererAtom();
+        const rend = info.renderer ? ` — ${info.renderer}` : "";
+        const termPart = term ? ` · terminal: ${term.toUpperCase()}` : "";
+        switch (info.classification) {
+            case "hardware":
+                return `GPU: hardware accelerated${rend}${termPart}`;
+            case "software":
+                return `GPU: software rendering (SwiftShader)${rend}${termPart}`;
+            default:
+                return `GPU: unavailable — WebGL disabled, terminals use the DOM renderer${termPart}`;
+        }
+    };
+
+    return (
+        <span
+            class="stat-mono stat-gpu-mode"
+            style={{ color: color() }}
+            data-tip={tip()}
+            aria-label="GPU rendering status"
+        >
+            GPU {gpuClassBadge(info.classification)}
+        </span>
+    );
+};
+
+GpuStatus.displayName = "GpuStatus";
+
+export { GpuStatus };

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -302,6 +302,14 @@
         opacity: 0.4;
     }
 
+    .status-bar-popover-section-title {
+        text-transform: uppercase;
+        font-size: 0.85em;
+        letter-spacing: 0.05em;
+        opacity: 0.5;
+        padding: var(--space-0-5) 0;
+    }
+
     /* Toggle switch used in the LAN discovery row.
        Spec: specs/lan-discovery-toggle.md */
     .status-bar-toggle {

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -5,6 +5,7 @@ import { getApi, windowCountAtom, backendStatusAtom, isDev } from "@/store/globa
 import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
+import { GpuStatus } from "./GpuStatus";
 import { HostPopover } from "./HostPopover";
 import { InstancePanel } from "./InstancePanel";
 import { SystemStats } from "./SystemStats";
@@ -56,6 +57,8 @@ const StatusBar = (): JSX.Element => {
                 <BackendStatus />
                 <span class="stat-separator">|</span>
                 <SystemStats />
+                <span class="stat-separator">|</span>
+                <GpuStatus />
             </div>
             <div class="status-bar-center" />
             <div class="status-bar-right">

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -106,6 +106,12 @@ export const [controlShiftDelayAtom, setControlShiftDelayAtom] = createSignal(fa
 export const [updaterStatusAtom, setUpdaterStatusAtom] = createSignal<UpdaterStatus>("up-to-date");
 export const [updaterVersionAtom, setUpdaterVersionAtom] = createSignal<string | null>(null);
 
+// Which renderer the most recently-mounted terminal actually loaded: "webgl"
+// (GPU-accelerated, xterm WebglAddon) or "dom" (software fallback when WebGL is
+// unavailable). Set by TermWrap.loadRendererAddon; read by the status-bar GPU
+// indicator. null until the first terminal mounts.
+export const [termRendererAtom, setTermRendererAtom] = createSignal<"webgl" | "dom" | null>(null);
+
 export const reducedMotionSetting = createMemo(() => settingsAtom()?.["window:reducedmotion"]);
 export const [reducedMotionSystemPreference, setReducedMotionSystemPreference] = createSignal(false);
 

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -5,7 +5,7 @@ import { getFileSubject } from "@/app/store/wps";
 import { sendWSCommand } from "@/app/store/ws";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS, atoms, fetchWaveFile, getSettingsKeyAtom, openLink } from "@/app/store/global";
+import { WOS, atoms, fetchWaveFile, getSettingsKeyAtom, openLink, setTermRendererAtom } from "@/app/store/global";
 import * as services from "@/app/store/services";
 import { PLATFORM, PlatformLinux, PlatformMacOS, PlatformWindows } from "@/util/platformutil";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
@@ -632,6 +632,7 @@ export class TermWrap {
                 console.log("linux: using DOM renderer (WebKitGTK WebGL workaround)");
                 loggedWebGL = true;
             }
+            setTermRendererAtom("dom"); // surfaces in the status-bar GPU indicator
             return; // DOM renderer is the default when no renderer addon is loaded
         }
         if (WebGLSupported && useWebGl) {
@@ -641,21 +642,27 @@ export class TermWrap {
                     webglAddon.onContextLoss(() => {
                         webglAddon.dispose();
                         console.warn("WebGL context lost, falling back to DOM renderer");
+                        setTermRendererAtom("dom"); // GPU context lost → DOM fallback
                         // DOM renderer is active by default when no addon is loaded
                     })
                 );
                 this.terminal.loadAddon(webglAddon);
+                setTermRendererAtom("webgl");
                 if (!loggedWebGL) {
                     console.log("loaded webgl renderer!");
                     loggedWebGL = true;
                 }
             } catch (e) {
                 console.warn("WebGL renderer unavailable, using DOM renderer:", e);
+                setTermRendererAtom("dom");
                 if (!loggedWebGL) {
                     console.log("loaded DOM renderer (webgl fallback)!");
                     loggedWebGL = true;
                 }
             }
+        } else {
+            // WebGL unsupported (GPU disabled) or disabled by setting — DOM renderer.
+            setTermRendererAtom("dom");
         }
     }
 

--- a/frontend/util/gpuutil.ts
+++ b/frontend/util/gpuutil.ts
@@ -61,6 +61,11 @@ function probe(): GpuInfo {
                 vendor = gl.getParameter(gl.VENDOR) as string;
                 renderer = gl.getParameter(gl.RENDERER) as string;
             }
+            // Release the probe context immediately. Chromium caps live WebGL
+            // contexts per page (~16) and evicts the oldest; holding this one for
+            // the renderer's lifetime would steal a slot from xterm's WebGL
+            // terminals. We only needed it to read the capability params.
+            gl.getExtension("WEBGL_lose_context")?.loseContext();
         }
     } catch {
         // leave defaults → classified "unavailable"

--- a/frontend/util/gpuutil.ts
+++ b/frontend/util/gpuutil.ts
@@ -1,0 +1,87 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// GPU / WebGL capability probe. Runs in the renderer with a throwaway <canvas>;
+// safe to call anywhere and cached after the first call.
+//
+// Why this exists: when Chromium's GPU process can't initialize a hardware GL
+// device, it disables GL and WebGL becomes unavailable — xterm then silently
+// falls back to its slower DOM renderer. This probe drives the status-bar GPU
+// indicator so that degraded state is visible (enabled/disabled + which GL
+// renderer/driver is actually in use) rather than silent.
+
+export type GpuClass = "hardware" | "software" | "unavailable";
+
+export type GpuInfo = {
+    webgl: boolean;
+    webgl2: boolean;
+    vendor: string | null; // unmasked GL vendor, when WEBGL_debug_renderer_info is available
+    renderer: string | null; // unmasked GL renderer (e.g. "ANGLE (NVIDIA ...)" or "SwiftShader")
+    classification: GpuClass;
+};
+
+// Substrings (lowercased) that mark a software/virtual GL backend rather than a
+// real GPU. SwiftShader is Chromium's software rasterizer; llvmpipe is Mesa's;
+// "Microsoft Basic Render" / "basic render driver" is the Windows fallback.
+const SOFTWARE_MARKERS = [
+    "swiftshader",
+    "software",
+    "llvmpipe",
+    "microsoft basic render",
+    "basic render driver",
+    "disabled",
+];
+
+function classify(supported: boolean, renderer: string | null): GpuClass {
+    if (!supported) return "unavailable";
+    const r = (renderer ?? "").toLowerCase();
+    if (SOFTWARE_MARKERS.some((m) => r.includes(m))) return "software";
+    return "hardware";
+}
+
+let cached: GpuInfo | undefined;
+
+function probe(): GpuInfo {
+    let webgl = false;
+    let webgl2 = false;
+    let vendor: string | null = null;
+    let renderer: string | null = null;
+    try {
+        const canvas = document.createElement("canvas");
+        const gl2 = canvas.getContext("webgl2") as WebGL2RenderingContext | null;
+        const gl = (gl2 ?? canvas.getContext("webgl")) as WebGLRenderingContext | null;
+        webgl2 = !!gl2;
+        webgl = !!gl;
+        if (gl) {
+            const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+            if (dbg) {
+                vendor = gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) as string;
+                renderer = gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) as string;
+            } else {
+                vendor = gl.getParameter(gl.VENDOR) as string;
+                renderer = gl.getParameter(gl.RENDERER) as string;
+            }
+        }
+    } catch {
+        // leave defaults → classified "unavailable"
+    }
+    return { webgl, webgl2, vendor, renderer, classification: classify(webgl, renderer) };
+}
+
+/** WebGL/GPU capability of the renderer process. Cached after first call. */
+export function getGpuInfo(): GpuInfo {
+    if (cached === undefined) cached = probe();
+    return cached;
+}
+
+/** Compact status-bar badge text, e.g. "HW" / "SW" / "off". */
+export function gpuClassBadge(c: GpuClass): string {
+    switch (c) {
+        case "hardware":
+            return "HW";
+        case "software":
+            return "SW";
+        default:
+            return "off";
+    }
+}


### PR DESCRIPTION
## What

A bottom-left **status-bar GPU indicator** so the rendering path is visible instead of silent. When Chromium's GPU process is unavailable, WebGL is disabled and xterm silently falls back to its slower DOM renderer (no scrollbar); this makes that state observable.

This is the **first step** toward VS-Code-style robust GPU operation. Hardware-GPU steering (ANGLE D3D11 / high-performance preference) and driver-info-while-disabled are the follow-up.

## Changes (frontend-only — no backend/CEF changes)

- **`frontend/util/gpuutil.ts`** — cached WebGL probe → `hardware` / `software` / `unavailable`, plus the unmasked GL **renderer + vendor**. The renderer string is the GPU model + D3D driver version (same as `chrome://gpu`'s `glRenderer`, e.g. `ANGLE (NVIDIA RTX 3060 … D3D11-32.0.15.9186)`).
- **`statusbar/GpuStatus.tsx`** — compact bottom-left line `GPU HW/SW/off` (green / amber / red) with a detail tooltip.
- **`BackendStatus` popover** (click the uptime) gains a **GPU section**: Status (Enabled hardware / Enabled software / Disabled), WebGL version, **Driver** (renderer), Vendor, and the terminal's actual renderer (WebGL vs DOM).
- **`termwrap.ts`** records the chosen renderer via a new global `termRendererAtom`.

## Why it matters

On a machine where the GPU process can't start, every terminal silently uses the DOM renderer. Today there's no way to see that from the UI. Evidence that this is real (same machine, same Chromium 148):

| | AgentMux (CEF) | VS Code (Electron) |
|---|---|---|
| webgl | `disabled_off` | `enabled` |
| glRenderer | `Disabled` | `ANGLE (NVIDIA RTX 3060 … D3D11)` |

The indicator makes this immediately visible.

## Verification

- ✅ `tsc --noEmit` clean (no errors in changed files)
- ⏳ Live visual check pending a clean isolated dev run (frontend-only; mirrors the existing `BackendStatus`/`SystemStats` patterns)

## Test plan

- [ ] On a healthy-GPU machine: status bar shows `GPU HW`; popover shows Status = Enabled (hardware) + Driver/Vendor + Terminal = WebGL (GPU)
- [ ] On a machine with the GPU disabled: shows `GPU off`; popover shows Status = Disabled + Terminal = DOM (software)
- [ ] Click the uptime → GPU section renders; tooltip on the line shows the renderer