### PR TITLE
fix(agent-pane): idle-send messages no longer flash in queued zone

### DIFF
--- a/.changesets/1781173320-fix-agent-pane-idle-send-messages-no-longer-flash-in-the-que-09vf.md
+++ b/.changesets/1781173320-fix-agent-pane-idle-send-messages-no-longer-flash-in-the-que-09vf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): idle-send messages no longer flash in the queued zone

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -147,7 +147,7 @@ describe("agent-pane-state reducer", () => {
         it("TurnReset clears turn-scoped state but keeps subscription + pending", () => {
             const s0 = ready(100);
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "p1",
                 text: "hello",
                 at: 105,
@@ -237,7 +237,7 @@ describe("agent-pane-state reducer", () => {
     describe("Pending message FIFO", () => {
         it("Queue then accept removes the entry", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 100,
@@ -257,7 +257,7 @@ describe("agent-pane-state reducer", () => {
 
         it("Reject removes the entry", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 100,
@@ -268,19 +268,19 @@ describe("agent-pane-state reducer", () => {
 
         it("Preserves FIFO order across multiple queues", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "a",
                 text: "1",
                 at: 100,
             }).state;
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "b",
                 text: "2",
                 at: 110,
             }).state;
             const s2 = update(s1, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "c",
                 text: "3",
                 at: 120,
@@ -483,7 +483,7 @@ describe("agent-pane-state reducer", () => {
     describe("Pending message expiry (gap 2)", () => {
         it("PendingMessageExpired removes the entry by id", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "x",
                 text: "hi",
                 at: 1_000,
@@ -512,7 +512,7 @@ describe("agent-pane-state reducer", () => {
 
         it("PendingMessageExpired after Accepted is harmless (already removed)", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "y",
                 text: "hi",
                 at: 100,
@@ -837,7 +837,7 @@ describe("agent-pane-state reducer", () => {
             // lifecycle. PR A keeps it that way.
             const s0 = ready(100);
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 105,
@@ -846,7 +846,7 @@ describe("agent-pane-state reducer", () => {
             const s2 = update(s1, { type: "PendingMessageAccepted", id: "m1" }).state;
             expect(s2.turnPhase.kind).toBe("Idle");
             const s3 = update(s2, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m2",
                 text: "hi2",
                 at: 200,
@@ -854,7 +854,7 @@ describe("agent-pane-state reducer", () => {
             const s4 = update(s3, { type: "PendingMessageRejected", id: "m2" }).state;
             expect(s4.turnPhase.kind).toBe("Idle");
             const s5 = update(s4, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m3",
                 text: "hi3",
                 at: 300,

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -729,7 +729,12 @@ export function update(
                     ...state,
                     pending: [
                         ...state.pending,
-                        { id: command.id, text: command.text, createdAt: command.at },
+                        {
+                            id: command.id,
+                            text: command.text,
+                            createdAt: command.at,
+                            enqueuedWhileBusy: command.enqueuedWhileBusy,
+                        },
                     ],
                 },
                 events: [{ type: "pending-queued", id: command.id }],

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -434,7 +434,21 @@ export type AgentPaneCommand =
     | { type: "StreamStalled"; at: number }
 
     // ── Pending message queue (composer side) ─────────────────────
-    | { type: "PendingMessageQueued"; id: string; text: string; at: number }
+    | {
+          type: "PendingMessageQueued";
+          id: string;
+          text: string;
+          at: number;
+          /**
+           * True when the user sent this message while a turn was already
+           * in-flight (isWorking was true before TurnStart). False for
+           * idle sends. Stored on the PendingMessage entry and used by
+           * PendingMessagesPanel to gate visibility — idle-send messages
+           * must never flash in the amber queued zone.
+           * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+           */
+          enqueuedWhileBusy: boolean;
+      }
     /** Backend acknowledged the message — remove from pending. */
     | { type: "PendingMessageAccepted"; id: string }
     /** RPC failed — remove the entry so user doesn't see a ghost row. */

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -13,6 +13,7 @@ import {
 import {
     dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,
+    snapshot as paneSnapshot,
 } from "@/app/store/agent-pane-state-store";
 import {
     registerPane as registerAgentPane,
@@ -602,8 +603,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mark turn as active when the user sends a message — TurnStart
     // also clears stale sessionStats from the prior turn.
     const handleSendMessage = (message: string): Promise<void> => {
+        // Capture working state BEFORE TurnStart so PendingMessageQueued can
+        // mark whether this message is queued behind a running turn (true) or
+        // is the message that initiated the turn (false). The panel only shows
+        // messages with enqueuedWhileBusy:true, preventing the idle-send race
+        // where the message flashed in the amber zone between Streaming
+        // promotion and agent-message-accepted. See ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+        const wasAlreadyWorking = workingFromPhase(paneSnapshot(model.blockId)?.turnPhase ?? { kind: "Idle" });
         dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
-        return commands.sendMessage(message);
+        return commands.sendMessage(message, wasAlreadyWorking);
     };
 
     // ── Startup sequence ────────────────────────────────────────────────────────
@@ -883,11 +891,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 so it sits adjacent to the messages it accelerates. */}
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
-                // Hide the panel while the turn is in the Submitting transient
-                // (backend has not yet ack'd the send; pendingMessages holds
-                // the optimistic message). Every other phase — including
-                // Done.errored (stream stall) — should show the panel.
-                isSubmitting={() => agentAtoms().turnPhaseAtom[0]().kind === "Submitting"}
                 showSendNow={() =>
                     // "Send now" appears only when there is an in-flight
                     // turn that SIGINT can actually interrupt — i.e.
@@ -898,7 +901,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     // caused a brief flash on every send.
                     // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
                     isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]()) &&
-                    pendingMessagesAtom[0]().length > 0
+                    pendingMessagesAtom[0]().some((m) => m.enqueuedWhileBusy)
                 }
                 onSendImmediately={() => {
                     commands.stopAgent();

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -12,20 +12,21 @@
  * into the conversation document — the color/border shift from amber to
  * accent blue is the user's visible "accepted" signal.
  *
+ * Only messages with `enqueuedWhileBusy: true` are shown — those are the
+ * ones the user sent while a turn was already running. Idle-send messages
+ * (`enqueuedWhileBusy: false`) initiated the current turn and must never
+ * appear here, regardless of phase. This closes the race where the panel
+ * would flash between Streaming promotion and agent-message-accepted.
+ * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+ *
  * See AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md.
  */
 
-import { For, Show, type Accessor, type JSX } from "solid-js";
+import { For, Show, createMemo, type Accessor, type JSX } from "solid-js";
 import type { PendingMessage } from "../state";
 
 interface PendingMessagesPanelProps {
     pendingMessages: Accessor<PendingMessage[]>;
-    /** True while the turn is in the `Submitting` transient — the backend
-     *  has not yet acknowledged the send so `pendingMessages` still holds
-     *  the optimistic message. Hide the panel during this window to avoid
-     *  a one-frame flash on every normal idle send. When absent the outer
-     *  Show is gated on `pendingMessages` length alone. */
-    isSubmitting?: Accessor<boolean>;
     /** True when the user should be offered a "Send now" shortcut —
      *  typically: a turn is running AND the queue is non-empty. */
     showSendNow?: Accessor<boolean>;
@@ -34,37 +35,45 @@ interface PendingMessagesPanelProps {
     onSendImmediately?: () => void;
 }
 
-export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => (
-    <Show when={props.pendingMessages().length > 0 && !props.isSubmitting?.()}>
-        <div class="agent-pending-zone">
-            <div class="agent-pending-header">
-                <span class="agent-spinner-dot" />
-                <span class="agent-pending-header-text">
-                    Queued — will send when the agent is idle (
-                    {props.pendingMessages().length}
-                    {props.pendingMessages().length === 1 ? " message" : " messages"})
-                </span>
-                <Show when={props.showSendNow?.()}>
-                    <button
-                        type="button"
-                        class="agent-send-immediately-btn"
-                        onClick={() => props.onSendImmediately?.()}
-                        title="Stop the current turn and process the queue now"
-                    >
-                        <span class="agent-send-immediately-icon">⏭</span>
-                        <span>Send now</span>
-                    </button>
-                </Show>
+export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => {
+    // Only surface messages that were genuinely queued behind a running turn.
+    // Idle-send messages (enqueuedWhileBusy: false) are transparent — they
+    // initiated the current turn and should never appear in this zone.
+    const queuedMessages = createMemo(() =>
+        props.pendingMessages().filter((m) => m.enqueuedWhileBusy),
+    );
+    return (
+        <Show when={queuedMessages().length > 0}>
+            <div class="agent-pending-zone">
+                <div class="agent-pending-header">
+                    <span class="agent-spinner-dot" />
+                    <span class="agent-pending-header-text">
+                        Queued — will send when the agent is idle (
+                        {queuedMessages().length}
+                        {queuedMessages().length === 1 ? " message" : " messages"})
+                    </span>
+                    <Show when={props.showSendNow?.()}>
+                        <button
+                            type="button"
+                            class="agent-send-immediately-btn"
+                            onClick={() => props.onSendImmediately?.()}
+                            title="Stop the current turn and process the queue now"
+                        >
+                            <span class="agent-send-immediately-icon">⏭</span>
+                            <span>Send now</span>
+                        </button>
+                    </Show>
+                </div>
+                <For each={queuedMessages()}>
+                    {(msg) => (
+                        <div class="agent-pending-item" data-message-id={msg.id}>
+                            <pre>{msg.text}</pre>
+                        </div>
+                    )}
+                </For>
             </div>
-            <For each={props.pendingMessages()}>
-                {(msg) => (
-                    <div class="agent-pending-item" data-message-id={msg.id}>
-                        <pre>{msg.text}</pre>
-                    </div>
-                )}
-            </For>
-        </div>
-    </Show>
-);
+        </Show>
+    );
+};
 
 PendingMessagesPanel.displayName = "PendingMessagesPanel";

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -88,8 +88,10 @@ export interface UseAgentCommandsOptions {
 }
 
 export interface UseAgentCommands {
-    /** Send a user message. Slash commands are intercepted via the registry. */
-    sendMessage: (message: string) => Promise<void>;
+    /** Send a user message. Slash commands are intercepted via the registry.
+     *  `wasAlreadyWorking` should be true when a turn was in-flight before
+     *  the caller dispatched TurnStart — drives PendingMessage.enqueuedWhileBusy. */
+    sendMessage: (message: string, wasAlreadyWorking?: boolean) => Promise<void>;
     /** Return to the agent picker by clearing the agent-identity meta keys. */
     back: () => Promise<void>;
     /**
@@ -226,7 +228,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         return registry().list(buildCommandContext());
     };
 
-    const sendMessage = async (message: string): Promise<void> => {
+    const sendMessage = async (message: string, wasAlreadyWorking = false): Promise<void> => {
         // Crash trace: this is the entry point for "user pressed send."
         // The boundary dumps this trail when a renderer fault catches —
         // see frontend/log/render-trail.ts + BlockErrorBoundary.
@@ -279,6 +281,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 id: messageId,
                 text: message,
                 at: Date.now(),
+                enqueuedWhileBusy: wasAlreadyWorking,
             },
             "user",
         );

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -108,6 +108,17 @@ export interface PendingMessage {
     id: string;
     text: string;
     createdAt: number;
+    /**
+     * True when this message was queued while a turn was already in-flight
+     * (Submitting | Streaming | Interrupting). False for messages that
+     * initiated the current turn (idle sends).
+     *
+     * The PendingMessagesPanel gates its visibility on this flag so that
+     * idle-send messages never flash in the amber queued zone — only messages
+     * genuinely sitting behind a running turn should appear there.
+     * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+     */
+    enqueuedWhileBusy: boolean;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -370,17 +370,27 @@ export function useAgentStream({
                         type: "PendingMessageAccepted",
                         id: messageId,
                     });
-                    // A new turn is now running (either the first one,
-                    // which already entered Submitting via the TurnStart
-                    // in handleSendMessage, or one drained from the
-                    // queue — in that case the previous session_end
-                    // dropped the phase to Done and nothing else flips
-                    // it back, leaving the status line stuck on "Worked"
-                    // with no running animation even though the CLI is
-                    // processing the next message).
-                    trail("agent:dispatch:TurnStart", { messageId });
-                    model.dispatchPane({ type: "TurnStart", at: Date.now() });
-                    trail("agent:dispatch:TurnStart:done", { messageId });
+                    // Queue-drain case: the prior turn ended (phase Done/Idle/
+                    // Disconnected) and the backend is now picking up the next
+                    // queued message. Re-enter Submitting so the working
+                    // animation re-activates.
+                    //
+                    // For idle sends (phase Submitting/Streaming/Interrupting),
+                    // TurnStart was already dispatched in handleSendMessage —
+                    // a second fire here regresses Streaming → Submitting and
+                    // re-arms the 30 s submit timeout unnecessarily.
+                    // See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+                    const currentPhase = paneSnapshot(blockId)?.turnPhase;
+                    const needsTurnStart =
+                        currentPhase?.kind === "Done" ||
+                        currentPhase?.kind === "Idle" ||
+                        currentPhase?.kind === "Disconnected" ||
+                        currentPhase == null;
+                    if (needsTurnStart) {
+                        trail("agent:dispatch:TurnStart", { messageId });
+                        model.dispatchPane({ type: "TurnStart", at: Date.now() });
+                        trail("agent:dispatch:TurnStart:done", { messageId });
+                    }
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
                     // node ties back to the pending entry 1:1.


### PR DESCRIPTION
## Summary

- **Bug 1 — pending panel flash**: When a user sent a message from idle, the message briefly appeared in the amber \"Queued\" panel between the phase promoting `Submitting → Streaming` and `agent-message-accepted` clearing the pending queue. This was the same race that the `ANALYSIS_SEND_NOW_FLASH_2026_05_28.md` fix addressed for `Submitting`, but it also existed one phase later.
- **Bug 2 — spurious double TurnStart**: `useAgentStream` unconditionally dispatched a second `TurnStart` on every `agent-message-accepted`. For idle sends, the phase was already `Streaming` — the second dispatch regressed it back to `Submitting`, re-armed the 30s submit timeout, and caused a brief working-indicator glitch before the next stream event re-promoted.

## Changes

**`PendingMessage` / `PendingMessageQueued` — new `enqueuedWhileBusy` field**  
`handleSendMessage` captures `isWorking` before dispatching `TurnStart` and threads it through `sendMessage` → `PendingMessageQueued`. Messages sent from idle get `enqueuedWhileBusy: false`; messages sent while a turn was running get `true`.

**`PendingMessagesPanel` — filter to `enqueuedWhileBusy` messages only**  
The panel now derives a `queuedMessages` memo filtering to only `enqueuedWhileBusy: true` entries and gates its visibility on that list. Idle-send messages are transparent regardless of phase — no more flash. The `isSubmitting` prop (previous workaround) is removed as redundant.

**`useAgentStream` — conditional `TurnStart` on `agent-message-accepted`**  
`TurnStart` is now only dispatched when the current phase is `Done | Idle | Disconnected` (the queue-drain case). When phase is `Submitting | Streaming | Interrupting`, the turn was already started by `handleSendMessage` — the second dispatch is skipped.

## Test plan

- [ ] Send a message from idle — message should appear directly in conversation, never in the amber queued zone
- [ ] Send a second message while the agent is actively streaming — message should appear in the queued zone with the amber style, then move to conversation when accepted
- [ ] \"Send now\" button still appears only when a message is genuinely queued behind a running turn
- [ ] All 138 reducer tests pass (`npm test frontend/app/store/agent-pane-state/reducer.test.ts`)

Full analysis: `docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md` (see also the analysis file in the mopeo agent workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)