### PR TITLE
feat(agent): fork prompt for parallel sessions

### DIFF
--- a/.changesets/1781173320-fix-agent-pane-idle-send-messages-no-longer-flash-in-the-que-09vf.md
+++ b/.changesets/1781173320-fix-agent-pane-idle-send-messages-no-longer-flash-in-the-que-09vf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): idle-send messages no longer flash in the queued zone

--- a/.changesets/1781189133-feat-agent-fork-prompt-for-parallel-sessions-detect-active-p-6sqa.md
+++ b/.changesets/1781189133-feat-agent-fork-prompt-for-parallel-sessions-detect-active-p-6sqa.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): fork prompt for parallel sessions — detect active panes and offer named fork instead of silent collision

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -342,6 +342,9 @@ pub const COMMAND_LIST_RECENT_SESSIONS: &str = "listrecentsessions";
 
 // Agent definition branching
 pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
+/// Returns the suggested branch label for a fork without mutating anything.
+/// Called when the user clicks "Open new session" to pre-fill the name input.
+pub const COMMAND_FORK_AGENT_DEFINITION_SUGGEST: &str = "forkagentdefinitionsuggest";
 
 /// Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
 /// Clone a seeded template into a new user-owned agent definition with
@@ -2003,8 +2006,20 @@ pub struct CommandDeleteAgentInstanceData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandForkAgentDefinitionData {
     pub source_id: String,
+    /// When non-empty this becomes the fork's display name directly.
+    /// When empty, the handler auto-generates "Name #N".
     #[serde(default)]
     pub branch_label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandForkAgentDefinitionSuggestData {
+    pub source_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForkAgentDefinitionSuggestResult {
+    pub suggested_label: String,
 }
 
 // ====================================================================

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -57,6 +57,8 @@ use crate::backend::rpc_types::{
     CommandAgentSessionArchiveData, AgentSessionArchiveResult,
     CommandAgentSessionListArchivesData, AgentArchiveRow,
     COMMAND_FORK_AGENT_DEFINITION,
+    COMMAND_FORK_AGENT_DEFINITION_SUGGEST,
+    CommandForkAgentDefinitionSuggestData, ForkAgentDefinitionSuggestResult,
     CommandListIdentityAccountsData, CommandGetIdentityAccountData,
     CommandDeleteIdentityAccountData,
     CommandLinkAgentIdentityData, CommandUnlinkAgentIdentityData,
@@ -1892,11 +1894,13 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("forkagentdefinition: {e}"))?;
 
                 // Find the source definition by id.
-                let source = wstore
+                let all_defs = wstore
                     .agent_def_list()
-                    .map_err(|e| format!("forkagentdefinition: {e}"))?
-                    .into_iter()
+                    .map_err(|e| format!("forkagentdefinition: {e}"))?;
+                let source = all_defs
+                    .iter()
                     .find(|a| a.id == cmd.source_id)
+                    .cloned()
                     .ok_or_else(|| format!("forkagentdefinition: source not found: {}", cmd.source_id))?;
 
                 // Build a new definition that shares the source's content but
@@ -1906,20 +1910,29 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .duration_since(UNIX_EPOCH)
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
-                let branch_slug_part = if cmd.branch_label.is_empty() {
-                    "fork".to_string()
+
+                // branch_label is the fork's full display name when provided.
+                // When empty, auto-generate "Name #N" based on existing fork count.
+                let fork_name = if cmd.branch_label.is_empty() {
+                    let existing_fork_count = all_defs
+                        .iter()
+                        .filter(|a| a.parent_id == cmd.source_id && a.is_seeded == 0)
+                        .count();
+                    format!("{} #{}", source.name, existing_fork_count + 2)
                 } else {
-                    crate::backend::storage::store::derive_slug(&cmd.branch_label)
+                    cmd.branch_label.clone()
                 };
+                let branch_label = if cmd.branch_label.is_empty() {
+                    fork_name.clone()
+                } else {
+                    cmd.branch_label.clone()
+                };
+                let branch_slug_part = crate::backend::storage::store::derive_slug(&branch_label);
                 let mut fork = AgentDefinition {
                     id: uuid::Uuid::new_v4().to_string(),
                     // Empty slug → agent_def_insert derives + resolves collisions.
                     slug: format!("{}-{}", source.slug, branch_slug_part),
-                    name: if cmd.branch_label.is_empty() {
-                        format!("{} (fork)", source.name)
-                    } else {
-                        format!("{} [{}]", source.name, cmd.branch_label)
-                    },
+                    name: fork_name,
                     icon: source.icon.clone(),
                     provider: source.provider.clone(),
                     description: source.description.clone(),
@@ -1936,7 +1949,7 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     is_seeded: 0,
                     accounts: String::new(),
                     parent_id: source.id.clone(),
-                    branch_label: cmd.branch_label.clone(),
+                    branch_label: branch_label.clone(),
                     updated_at: now,
                     user_hidden: 0,
                 };
@@ -1989,6 +2002,37 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 });
 
                 Ok(Some(serde_json::to_value(&fork).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ---- Definition fork suggest (read-only — no mutation) ----
+
+    let wstore_sug = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_FORK_AGENT_DEFINITION_SUGGEST,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_sug.clone();
+            Box::pin(async move {
+                let cmd: CommandForkAgentDefinitionSuggestData = serde_json::from_value(data)
+                    .map_err(|e| format!("forkagentdefinitionsuggest: {e}"))?;
+
+                let all = wstore
+                    .agent_def_list()
+                    .map_err(|e| format!("forkagentdefinitionsuggest: {e}"))?;
+                let source = all
+                    .iter()
+                    .find(|a| a.id == cmd.source_id)
+                    .ok_or_else(|| format!("forkagentdefinitionsuggest: source not found: {}", cmd.source_id))?;
+
+                let existing_fork_count = all
+                    .iter()
+                    .filter(|a| a.parent_id == cmd.source_id && a.is_seeded == 0)
+                    .count();
+                let suggested_label = format!("{} #{}", source.name, existing_fork_count + 2);
+
+                let result = ForkAgentDefinitionSuggestResult { suggested_label };
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
             })
         }),
     );

--- a/frontend/app/store/agent-pane-registration.ts
+++ b/frontend/app/store/agent-pane-registration.ts
@@ -128,6 +128,26 @@ const paneModels = new Map<
     AgentPaneModel & { _markDisposed(): void }
 >();
 
+/** Listeners notified whenever any pane is registered or unregistered. */
+const lifecycleListeners = new Set<() => void>();
+
+/**
+ * Subscribe to pane lifecycle changes (register / unregister).
+ * Returns an unsubscribe function. Use in components that need to
+ * keep derived data (e.g. open-definition maps) in sync with the
+ * live slot set rather than relying solely on `agents:changed`.
+ */
+export function subscribeToPaneLifecycle(listener: () => void): () => void {
+    lifecycleListeners.add(listener);
+    return () => lifecycleListeners.delete(listener);
+}
+
+function notifyLifecycleListeners(): void {
+    for (const l of lifecycleListeners) {
+        try { l(); } catch { /* never let a subscriber break teardown */ }
+    }
+}
+
 /**
  * Atomically register a pane in BOTH stores. Either both succeed or
  * neither does — if the second store throws during registration, the
@@ -183,6 +203,7 @@ export function registerPane(
 
     const model = _createAgentPaneModel(blockId);
     paneModels.set(blockId, model);
+    notifyLifecycleListeners();
     return model;
 }
 
@@ -236,6 +257,7 @@ export function unregisterPane(blockId: string): void {
     } catch {
         // Best-effort — see above.
     }
+    notifyLifecycleListeners();
 }
 
 /**

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -248,4 +248,18 @@ export function __resetAllSlots(): void {
     slots.clear();
 }
 
+/**
+ * Returns a map of definition_id → blockId for all currently-open agent panes.
+ * Used by AgentPicker to detect when a definition is already open so it can
+ * show the fork prompt instead of silently reattaching.
+ */
+export function getOpenDefinitionMap(): Map<string, string> {
+    const result = new Map<string, string>();
+    for (const [blockId, slot] of slots) {
+        const defId = slot.state.streaming.agentId;
+        if (defId) result.set(defId, blockId);
+    }
+    return result;
+}
+
 export type { AgentPaneCommand, AgentPaneEvent, AgentPaneState };

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -147,7 +147,7 @@ describe("agent-pane-state reducer", () => {
         it("TurnReset clears turn-scoped state but keeps subscription + pending", () => {
             const s0 = ready(100);
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "p1",
                 text: "hello",
                 at: 105,
@@ -237,7 +237,7 @@ describe("agent-pane-state reducer", () => {
     describe("Pending message FIFO", () => {
         it("Queue then accept removes the entry", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 100,
@@ -257,7 +257,7 @@ describe("agent-pane-state reducer", () => {
 
         it("Reject removes the entry", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 100,
@@ -268,19 +268,19 @@ describe("agent-pane-state reducer", () => {
 
         it("Preserves FIFO order across multiple queues", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "a",
                 text: "1",
                 at: 100,
             }).state;
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "b",
                 text: "2",
                 at: 110,
             }).state;
             const s2 = update(s1, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "c",
                 text: "3",
                 at: 120,
@@ -483,7 +483,7 @@ describe("agent-pane-state reducer", () => {
     describe("Pending message expiry (gap 2)", () => {
         it("PendingMessageExpired removes the entry by id", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "x",
                 text: "hi",
                 at: 1_000,
@@ -512,7 +512,7 @@ describe("agent-pane-state reducer", () => {
 
         it("PendingMessageExpired after Accepted is harmless (already removed)", () => {
             const s0 = update(mk(), {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "y",
                 text: "hi",
                 at: 100,
@@ -837,7 +837,7 @@ describe("agent-pane-state reducer", () => {
             // lifecycle. PR A keeps it that way.
             const s0 = ready(100);
             const s1 = update(s0, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m1",
                 text: "hi",
                 at: 105,
@@ -846,7 +846,7 @@ describe("agent-pane-state reducer", () => {
             const s2 = update(s1, { type: "PendingMessageAccepted", id: "m1" }).state;
             expect(s2.turnPhase.kind).toBe("Idle");
             const s3 = update(s2, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m2",
                 text: "hi2",
                 at: 200,
@@ -854,7 +854,7 @@ describe("agent-pane-state reducer", () => {
             const s4 = update(s3, { type: "PendingMessageRejected", id: "m2" }).state;
             expect(s4.turnPhase.kind).toBe("Idle");
             const s5 = update(s4, {
-                type: "PendingMessageQueued",
+                type: "PendingMessageQueued", enqueuedWhileBusy: false,
                 id: "m3",
                 text: "hi3",
                 at: 300,

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -729,7 +729,12 @@ export function update(
                     ...state,
                     pending: [
                         ...state.pending,
-                        { id: command.id, text: command.text, createdAt: command.at },
+                        {
+                            id: command.id,
+                            text: command.text,
+                            createdAt: command.at,
+                            enqueuedWhileBusy: command.enqueuedWhileBusy,
+                        },
                     ],
                 },
                 events: [{ type: "pending-queued", id: command.id }],

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -434,7 +434,21 @@ export type AgentPaneCommand =
     | { type: "StreamStalled"; at: number }
 
     // ── Pending message queue (composer side) ─────────────────────
-    | { type: "PendingMessageQueued"; id: string; text: string; at: number }
+    | {
+          type: "PendingMessageQueued";
+          id: string;
+          text: string;
+          at: number;
+          /**
+           * True when the user sent this message while a turn was already
+           * in-flight (isWorking was true before TurnStart). False for
+           * idle sends. Stored on the PendingMessage entry and used by
+           * PendingMessagesPanel to gate visibility — idle-send messages
+           * must never flash in the amber queued zone.
+           * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+           */
+          enqueuedWhileBusy: boolean;
+      }
     /** Backend acknowledged the message — remove from pending. */
     | { type: "PendingMessageAccepted"; id: string }
     /** RPC failed — remove the entry so user doesn't see a ghost row. */

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1098,6 +1098,15 @@ class RpcApiType {
         return client.rpcCall("forkagentdefinition", data, opts);
     }
 
+    // command "forkagentdefinitionsuggest" [call] — read-only, no mutation
+    ForkAgentDefinitionSuggestCommand(
+        client: RpcClient,
+        data: { source_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ suggested_label: string }> {
+        return client.rpcCall("forkagentdefinitionsuggest", data, opts);
+    }
+
     // command "subprocessspawn" [call]
     SubprocessSpawnCommand(client: RpcClient, data: CommandSubprocessSpawnData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("subprocessspawn", data, opts);

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -13,6 +13,7 @@ import {
 import {
     dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,
+    snapshot as paneSnapshot,
 } from "@/app/store/agent-pane-state-store";
 import {
     registerPane as registerAgentPane,
@@ -602,8 +603,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mark turn as active when the user sends a message — TurnStart
     // also clears stale sessionStats from the prior turn.
     const handleSendMessage = (message: string): Promise<void> => {
+        // Capture working state BEFORE TurnStart so PendingMessageQueued can
+        // mark whether this message is queued behind a running turn (true) or
+        // is the message that initiated the turn (false). The panel only shows
+        // messages with enqueuedWhileBusy:true, preventing the idle-send race
+        // where the message flashed in the amber zone between Streaming
+        // promotion and agent-message-accepted. See ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+        const wasAlreadyWorking = workingFromPhase(paneSnapshot(model.blockId)?.turnPhase ?? { kind: "Idle" });
         dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
-        return commands.sendMessage(message);
+        return commands.sendMessage(message, wasAlreadyWorking);
     };
 
     // ── Startup sequence ────────────────────────────────────────────────────────
@@ -883,11 +891,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 so it sits adjacent to the messages it accelerates. */}
             <PendingMessagesPanel
                 pendingMessages={pendingMessagesAtom[0]}
-                // Hide the panel while the turn is in the Submitting transient
-                // (backend has not yet ack'd the send; pendingMessages holds
-                // the optimistic message). Every other phase — including
-                // Done.errored (stream stall) — should show the panel.
-                isSubmitting={() => agentAtoms().turnPhaseAtom[0]().kind === "Submitting"}
                 showSendNow={() =>
                     // "Send now" appears only when there is an in-flight
                     // turn that SIGINT can actually interrupt — i.e.
@@ -898,7 +901,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     // caused a brief flash on every send.
                     // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
                     isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]()) &&
-                    pendingMessagesAtom[0]().length > 0
+                    pendingMessagesAtom[0]().some((m) => m.enqueuedWhileBusy)
                 }
                 onSendImmediately={() => {
                     commands.stopAgent();

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -39,6 +39,7 @@ import { useModalLayer, type LaunchFormStateWire } from "@/element/modal-layer";
 import { getPlatform } from "@/util/platformutil";
 import { refocusNode } from "@/app/store/global";
 import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
+import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
@@ -97,8 +98,8 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const modalLayer = useModalLayer();
 
     // Reactive map of definition_id → blockId for panes currently open.
-    // Re-reads the slots map on every agents:changed event and on mount
-    // so the active badges + fork prompts reflect live state.
+    // Refreshes on pane register/unregister (via subscribeToPaneLifecycle)
+    // AND on agents:changed so newly-forked definitions also appear.
     const [openDefinitions, setOpenDefinitions] = createSignal<Map<string, string>>(new Map());
     const refreshOpenDefinitions = () => setOpenDefinitions(getOpenDefinitionMap());
     onMount(refreshOpenDefinitions);
@@ -106,7 +107,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         eventType: "agents:changed",
         handler: refreshOpenDefinitions,
     });
+    const unsubPaneLifecycle = subscribeToPaneLifecycle(refreshOpenDefinitions);
     onCleanup(unsubOpenDefs);
+    onCleanup(unsubPaneLifecycle);
 
     // Per-agent install state, keyed by agent.id.
     //   undefined = not yet checked / non-npm provider (no install needed)

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -37,6 +37,8 @@ import { ContextMenuModel } from "@/app/store/contextmenu";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { useModalLayer, type LaunchFormStateWire } from "@/element/modal-layer";
 import { getPlatform } from "@/util/platformutil";
+import { refocusNode } from "@/app/store/global";
+import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
@@ -93,6 +95,18 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const [nodejsError, setNodejsError] = createSignal<string | null>(null);
     const agents = useAgentDefinitions();
     const modalLayer = useModalLayer();
+
+    // Reactive map of definition_id → blockId for panes currently open.
+    // Re-reads the slots map on every agents:changed event and on mount
+    // so the active badges + fork prompts reflect live state.
+    const [openDefinitions, setOpenDefinitions] = createSignal<Map<string, string>>(new Map());
+    const refreshOpenDefinitions = () => setOpenDefinitions(getOpenDefinitionMap());
+    onMount(refreshOpenDefinitions);
+    const unsubOpenDefs = waveEventSubscribe({
+        eventType: "agents:changed",
+        handler: refreshOpenDefinitions,
+    });
+    onCleanup(unsubOpenDefs);
 
     // Per-agent install state, keyed by agent.id.
     //   undefined = not yet checked / non-npm provider (no install needed)
@@ -281,6 +295,34 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         } finally {
             setLaunching(null);
         }
+    };
+
+    const handleFork = async (row: RecentSessionRow, branchLabel: string): Promise<void> => {
+        const def = agents().find((a) => a.id === row.definition_id);
+        if (!def) return;
+        setLaunching(row.definition_id);
+        try {
+            const forkedDef = await RpcApi.ForkAgentDefinitionCommand(TabRpcClient, {
+                source_id: row.definition_id,
+                branch_label: branchLabel,
+            });
+            // refreshOpenDefinitions after fork so the new def won't
+            // also show as "active" before it's actually launched.
+            refreshOpenDefinitions();
+            await props.model.launchAgentDefinition(forkedDef, {
+                instanceName: branchLabel,
+                agentType: (forkedDef.agent_type as "host" | "container") || "host",
+                environment: forkedDef.agent_type === "container" ? "docker" : "local",
+                identityId: row.identity_id,
+                memoryId: row.memory_id,
+            });
+        } finally {
+            setLaunching(null);
+        }
+    };
+
+    const handleSwitchToExisting = (blockId: string): void => {
+        refocusNode(blockId);
     };
 
     // Extracted from the install branch of handleSelect so the
@@ -717,7 +759,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             current Option E session state.
                             Bottom: seeded templates, click = open the
                             create-from-template modal. */}
-                        <MyAgentsList onReattach={handleReattach} />
+                        <MyAgentsList
+                            onReattach={handleReattach}
+                            openDefinitions={openDefinitions}
+                            onFork={handleFork}
+                            onSwitchToExisting={handleSwitchToExisting}
+                        />
                         <div class="agent-picker-templates-header" data-testid="agent-templates-header">
                             <span>+ New from template</span>
                         </div>

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -29,6 +29,11 @@
  * `--continue` (and equivalents) resumes the session and the new pane's
  * `output.state.json` snapshot path picks up the conversation history
  * on render.
+ *
+ * Fork prompt (feat/agent-session-fork): when a row's definition is
+ * already open in another pane, clicking it shows an inline prompt
+ * instead of immediately reattaching. The user can either fork into a
+ * new named session or switch focus to the existing pane.
  */
 
 import {
@@ -70,11 +75,33 @@ export interface MyAgentsListProps {
     identityId?: Accessor<string | null | undefined>;
     /** Visible cap. Backend caps at 100; default is 20. */
     limit?: number;
-    /** Called when the user clicks an entry. The parent (AgentPicker)
-     *  hands this to `AgentViewModel.launchAgentDefinition` with the
-     *  continuation overrides — see "Reattach mechanism" above. */
+    /** Called when the user clicks an entry that is NOT currently open
+     *  in another pane. The parent (AgentPicker) hands this to
+     *  `AgentViewModel.launchAgentDefinition` with the continuation
+     *  overrides — see "Reattach mechanism" above. */
     onReattach: (row: RecentSessionRow) => void;
+    /**
+     * Map of definition_id → blockId for definitions currently open in
+     * another pane. When a row's definition_id is in this map, clicking
+     * the row shows the fork prompt instead of calling onReattach.
+     */
+    openDefinitions?: Accessor<Map<string, string>>;
+    /**
+     * Called after the user confirms a fork: fork has been created and
+     * the new definition should be launched. Receives the new AgentDefinition.
+     */
+    onFork?: (row: RecentSessionRow, branchLabel: string) => Promise<void>;
+    /**
+     * Called when the user clicks "Switch to existing" in the fork
+     * prompt. Receives the blockId of the already-open pane.
+     */
+    onSwitchToExisting?: (blockId: string) => void;
 }
+
+type ForkState =
+    | { kind: "idle" }
+    | { kind: "prompt" }           // showing "Open new session / Switch" buttons
+    | { kind: "naming"; label: string; loading: boolean; error: string | null }; // name input expanded
 
 export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     const filterId = createMemo(() => {
@@ -125,6 +152,82 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     const tick = setInterval(() => setNow(Date.now()), 60_000);
     onCleanup(() => clearInterval(tick));
 
+    // Fork prompt state per row (keyed by definition_id)
+    const [forkStates, setForkStates] = createSignal<Map<string, ForkState>>(new Map());
+
+    const getForkState = (definitionId: string): ForkState =>
+        forkStates().get(definitionId) ?? { kind: "idle" };
+
+    const setForkState = (definitionId: string, state: ForkState): void => {
+        setForkStates((prev) => {
+            const next = new Map(prev);
+            next.set(definitionId, state);
+            return next;
+        });
+    };
+
+    const handleRowClick = async (row: RecentSessionRow) => {
+        const openMap = props.openDefinitions?.() ?? new Map<string, string>();
+        const existingBlockId = openMap.get(row.definition_id);
+        if (existingBlockId) {
+            // Already open — show fork prompt
+            setForkState(row.definition_id, { kind: "prompt" });
+            return;
+        }
+        props.onReattach(row);
+    };
+
+    const handleOpenNewSession = async (row: RecentSessionRow) => {
+        setForkState(row.definition_id, { kind: "naming", label: "", loading: true, error: null });
+        try {
+            const result = await RpcApi.ForkAgentDefinitionSuggestCommand(TabRpcClient, {
+                source_id: row.definition_id,
+            });
+            setForkState(row.definition_id, {
+                kind: "naming",
+                label: result.suggested_label,
+                loading: false,
+                error: null,
+            });
+        } catch {
+            setForkState(row.definition_id, {
+                kind: "naming",
+                label: `${row.definition_name} #2`,
+                loading: false,
+                error: null,
+            });
+        }
+    };
+
+    const handleSwitchToExisting = (row: RecentSessionRow) => {
+        const openMap = props.openDefinitions?.() ?? new Map<string, string>();
+        const blockId = openMap.get(row.definition_id);
+        if (blockId) props.onSwitchToExisting?.(blockId);
+        setForkState(row.definition_id, { kind: "idle" });
+    };
+
+    const handleForkStart = async (row: RecentSessionRow) => {
+        const fs = getForkState(row.definition_id);
+        if (fs.kind !== "naming" || !fs.label.trim()) return;
+        const label = fs.label.trim();
+        setForkState(row.definition_id, { kind: "naming", label, loading: true, error: null });
+        try {
+            await props.onFork?.(row, label);
+            setForkState(row.definition_id, { kind: "idle" });
+        } catch (err) {
+            setForkState(row.definition_id, {
+                kind: "naming",
+                label,
+                loading: false,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    };
+
+    const handleForkCancel = (definitionId: string) => {
+        setForkState(definitionId, { kind: "idle" });
+    };
+
     // Surfacing rules:
     // - rows undefined → still loading (skeleton hint)
     // - rows []        → empty state (filter-aware copy)
@@ -155,81 +258,185 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
             >
                 <ul class="agent-recent-sessions-list">
                     <For each={rows() ?? []}>
-                        {(row) => (
-                            <li class="agent-recent-sessions-row">
-                                <button
-                                    type="button"
-                                    class="agent-recent-sessions-entry"
-                                    onClick={() => props.onReattach(row)}
-                                    aria-label={`Continue ${row.instance_name}`}
-                                    data-testid="agent-my-agents-entry"
-                                >
-                                    <ProviderLogo
-                                        provider={row.provider}
-                                        size={24}
-                                        class="agent-recent-sessions-icon"
-                                    />
-                                    <span class="agent-recent-sessions-body">
-                                        <span class="agent-recent-sessions-line1">
-                                            <span class="agent-recent-sessions-name">
-                                                {row.instance_name || row.definition_name}
+                        {(row) => {
+                            const isActive = () =>
+                                (props.openDefinitions?.() ?? new Map()).has(row.definition_id);
+                            const forkState = () => getForkState(row.definition_id);
+
+                            return (
+                                <li class="agent-recent-sessions-row">
+                                    <button
+                                        type="button"
+                                        class={`agent-recent-sessions-entry${isActive() ? " agent-recent-sessions-entry--active" : ""}`}
+                                        onClick={() => handleRowClick(row)}
+                                        aria-label={`Continue ${row.instance_name}`}
+                                        data-testid="agent-my-agents-entry"
+                                    >
+                                        <ProviderLogo
+                                            provider={row.provider}
+                                            size={24}
+                                            class="agent-recent-sessions-icon"
+                                        />
+                                        <span class="agent-recent-sessions-body">
+                                            <span class="agent-recent-sessions-line1">
+                                                <span class="agent-recent-sessions-name">
+                                                    {row.instance_name || row.definition_name}
+                                                </span>
+                                                <Show when={isActive()}>
+                                                    <span
+                                                        class="agent-active-badge"
+                                                        title="Open in another pane"
+                                                        aria-label="Active"
+                                                    />
+                                                </Show>
+                                                <span class="agent-recent-sessions-meta">
+                                                    {row.identity_name || "(ambient creds)"}
+                                                </span>
                                             </span>
-                                            <span class="agent-recent-sessions-meta">
-                                                {row.identity_name || "(ambient creds)"}
+                                            <Show
+                                                when={row.preview}
+                                                fallback={
+                                                    <span class="agent-recent-sessions-preview agent-recent-sessions-preview--empty">
+                                                        {row.has_snapshot
+                                                            ? "(no user message yet)"
+                                                            : "(no conversation snapshot)"}
+                                                    </span>
+                                                }
+                                            >
+                                                <span class="agent-recent-sessions-preview">
+                                                    {row.preview}
+                                                </span>
+                                            </Show>
+                                            <Show when={row.node_count > 0}>
+                                                <span class="agent-recent-sessions-line3">
+                                                    <span class="agent-recent-sessions-nodes">
+                                                        {row.node_count} message
+                                                        {row.node_count === 1 ? "" : "s"}
+                                                    </span>
+                                                </span>
+                                            </Show>
+                                            <span class="agent-recent-sessions-timestamps">
+                                                <Show when={row.agent_created_at > 0}>
+                                                    <span class="agent-recent-sessions-ts">
+                                                        <span class="agent-recent-sessions-ts-label">Created</span>
+                                                        <span class="agent-recent-sessions-ts-value">
+                                                            {formatRelative(now(), row.agent_created_at)}
+                                                        </span>
+                                                    </span>
+                                                </Show>
+                                                <Show when={row.started_at > 0}>
+                                                    <span class="agent-recent-sessions-ts">
+                                                        <span class="agent-recent-sessions-ts-label">Last Launch</span>
+                                                        <span class="agent-recent-sessions-ts-value">
+                                                            {formatRelative(now(), row.started_at)}
+                                                        </span>
+                                                    </span>
+                                                </Show>
+                                                <Show when={row.has_snapshot && row.started_at > 0 && row.last_active_at > row.started_at}>
+                                                    <span class="agent-recent-sessions-ts">
+                                                        <span class="agent-recent-sessions-ts-label">Last Active</span>
+                                                        <span class="agent-recent-sessions-ts-value">
+                                                            {formatRelative(now(), row.last_active_at)}
+                                                        </span>
+                                                    </span>
+                                                </Show>
                                             </span>
                                         </span>
-                                        <Show
-                                            when={row.preview}
-                                            fallback={
-                                                <span class="agent-recent-sessions-preview agent-recent-sessions-preview--empty">
-                                                    {row.has_snapshot
-                                                        ? "(no user message yet)"
-                                                        : "(no conversation snapshot)"}
-                                                </span>
-                                            }
-                                        >
-                                            <span class="agent-recent-sessions-preview">
-                                                {row.preview}
+                                    </button>
+
+                                    {/* Fork prompt — inline below the row */}
+                                    <Show when={forkState().kind !== "idle"}>
+                                        <div class="agent-fork-prompt" data-testid="agent-fork-prompt">
+                                            <span class="agent-fork-prompt-msg">
+                                                <strong>{row.instance_name || row.definition_name}</strong> is already open in another pane.
                                             </span>
-                                        </Show>
-                                        <Show when={row.node_count > 0}>
-                                            <span class="agent-recent-sessions-line3">
-                                                <span class="agent-recent-sessions-nodes">
-                                                    {row.node_count} message
-                                                    {row.node_count === 1 ? "" : "s"}
-                                                </span>
-                                            </span>
-                                        </Show>
-                                        <span class="agent-recent-sessions-timestamps">
-                                            <Show when={row.agent_created_at > 0}>
-                                                <span class="agent-recent-sessions-ts">
-                                                    <span class="agent-recent-sessions-ts-label">Created</span>
-                                                    <span class="agent-recent-sessions-ts-value">
-                                                        {formatRelative(now(), row.agent_created_at)}
-                                                    </span>
-                                                </span>
+                                            <Show when={forkState().kind === "prompt"}>
+                                                <div class="agent-fork-prompt-actions">
+                                                    <button
+                                                        type="button"
+                                                        class="agent-fork-btn agent-fork-btn--primary"
+                                                        onClick={() => handleOpenNewSession(row)}
+                                                        data-testid="agent-fork-open-new"
+                                                    >
+                                                        Open new session
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="agent-fork-btn agent-fork-btn--secondary"
+                                                        onClick={() => handleSwitchToExisting(row)}
+                                                        data-testid="agent-fork-switch"
+                                                    >
+                                                        Switch to existing
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="agent-fork-btn agent-fork-btn--ghost"
+                                                        onClick={() => handleForkCancel(row.definition_id)}
+                                                        aria-label="Cancel"
+                                                    >
+                                                        ✕
+                                                    </button>
+                                                </div>
                                             </Show>
-                                            <Show when={row.started_at > 0}>
-                                                <span class="agent-recent-sessions-ts">
-                                                    <span class="agent-recent-sessions-ts-label">Last Launch</span>
-                                                    <span class="agent-recent-sessions-ts-value">
-                                                        {formatRelative(now(), row.started_at)}
-                                                    </span>
-                                                </span>
+                                            <Show when={forkState().kind === "naming"}>
+                                                {(() => {
+                                                    const ns = forkState() as Extract<ForkState, { kind: "naming" }>;
+                                                    return (
+                                                        <div class="agent-fork-naming">
+                                                            <label class="agent-fork-label">Name for new session:</label>
+                                                            <div class="agent-fork-input-row">
+                                                                <input
+                                                                    type="text"
+                                                                    class="agent-fork-input"
+                                                                    value={ns.label}
+                                                                    disabled={ns.loading}
+                                                                    placeholder="Session name"
+                                                                    data-testid="agent-fork-name-input"
+                                                                    onInput={(e) =>
+                                                                        setForkState(row.definition_id, {
+                                                                            kind: "naming",
+                                                                            label: e.currentTarget.value,
+                                                                            loading: false,
+                                                                            error: null,
+                                                                        })
+                                                                    }
+                                                                    onKeyDown={(e) => {
+                                                                        if (e.key === "Enter") void handleForkStart(row);
+                                                                        if (e.key === "Escape") handleForkCancel(row.definition_id);
+                                                                    }}
+                                                                    // autofocus when the naming box appears
+                                                                    ref={(el) => { if (el && !ns.loading) setTimeout(() => el.focus(), 0); }}
+                                                                />
+                                                                <button
+                                                                    type="button"
+                                                                    class="agent-fork-btn agent-fork-btn--primary"
+                                                                    disabled={ns.loading || !ns.label.trim()}
+                                                                    onClick={() => handleForkStart(row)}
+                                                                    data-testid="agent-fork-start"
+                                                                >
+                                                                    {ns.loading ? "…" : "Start"}
+                                                                </button>
+                                                                <button
+                                                                    type="button"
+                                                                    class="agent-fork-btn agent-fork-btn--ghost"
+                                                                    onClick={() => handleForkCancel(row.definition_id)}
+                                                                    aria-label="Cancel"
+                                                                >
+                                                                    ✕
+                                                                </button>
+                                                            </div>
+                                                            <Show when={ns.error}>
+                                                                <span class="agent-fork-error">{ns.error}</span>
+                                                            </Show>
+                                                        </div>
+                                                    );
+                                                })()}
                                             </Show>
-                                            <Show when={row.has_snapshot && row.started_at > 0 && row.last_active_at > row.started_at}>
-                                                <span class="agent-recent-sessions-ts">
-                                                    <span class="agent-recent-sessions-ts-label">Last Active</span>
-                                                    <span class="agent-recent-sessions-ts-value">
-                                                        {formatRelative(now(), row.last_active_at)}
-                                                    </span>
-                                                </span>
-                                            </Show>
-                                        </span>
-                                    </span>
-                                </button>
-                            </li>
-                        )}
+                                        </div>
+                                    </Show>
+                                </li>
+                            );
+                        }}
                     </For>
                 </ul>
             </Show>

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -378,59 +378,55 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                     </button>
                                                 </div>
                                             </Show>
-                                            <Show when={forkState().kind === "naming"}>
-                                                {(() => {
-                                                    const ns = forkState() as Extract<ForkState, { kind: "naming" }>;
-                                                    return (
-                                                        <div class="agent-fork-naming">
-                                                            <label class="agent-fork-label">Name for new session:</label>
-                                                            <div class="agent-fork-input-row">
-                                                                <input
-                                                                    type="text"
-                                                                    class="agent-fork-input"
-                                                                    value={ns.label}
-                                                                    disabled={ns.loading}
-                                                                    placeholder="Session name"
-                                                                    data-testid="agent-fork-name-input"
-                                                                    onInput={(e) =>
-                                                                        setForkState(row.definition_id, {
-                                                                            kind: "naming",
-                                                                            label: e.currentTarget.value,
-                                                                            loading: false,
-                                                                            error: null,
-                                                                        })
-                                                                    }
-                                                                    onKeyDown={(e) => {
-                                                                        if (e.key === "Enter") void handleForkStart(row);
-                                                                        if (e.key === "Escape") handleForkCancel(row.definition_id);
-                                                                    }}
-                                                                    // autofocus when the naming box appears
-                                                                    ref={(el) => { if (el && !ns.loading) setTimeout(() => el.focus(), 0); }}
-                                                                />
-                                                                <button
-                                                                    type="button"
-                                                                    class="agent-fork-btn agent-fork-btn--primary"
-                                                                    disabled={ns.loading || !ns.label.trim()}
-                                                                    onClick={() => handleForkStart(row)}
-                                                                    data-testid="agent-fork-start"
-                                                                >
-                                                                    {ns.loading ? "…" : "Start"}
-                                                                </button>
-                                                                <button
-                                                                    type="button"
-                                                                    class="agent-fork-btn agent-fork-btn--ghost"
-                                                                    onClick={() => handleForkCancel(row.definition_id)}
-                                                                    aria-label="Cancel"
-                                                                >
-                                                                    ✕
-                                                                </button>
-                                                            </div>
-                                                            <Show when={ns.error}>
-                                                                <span class="agent-fork-error">{ns.error}</span>
-                                                            </Show>
+                                            <Show when={forkState().kind === "naming" ? (forkState() as Extract<ForkState, { kind: "naming" }>) : null}>
+                                                {(ns) => (
+                                                    <div class="agent-fork-naming">
+                                                        <label class="agent-fork-label">Name for new session:</label>
+                                                        <div class="agent-fork-input-row">
+                                                            <input
+                                                                type="text"
+                                                                class="agent-fork-input"
+                                                                value={ns().label}
+                                                                disabled={ns().loading}
+                                                                placeholder="Session name"
+                                                                data-testid="agent-fork-name-input"
+                                                                onInput={(e) =>
+                                                                    setForkState(row.definition_id, {
+                                                                        kind: "naming",
+                                                                        label: e.currentTarget.value,
+                                                                        loading: false,
+                                                                        error: null,
+                                                                    })
+                                                                }
+                                                                onKeyDown={(e) => {
+                                                                    if (e.key === "Enter") void handleForkStart(row);
+                                                                    if (e.key === "Escape") handleForkCancel(row.definition_id);
+                                                                }}
+                                                                ref={(el) => { setTimeout(() => el.focus(), 0); }}
+                                                            />
+                                                            <button
+                                                                type="button"
+                                                                class="agent-fork-btn agent-fork-btn--primary"
+                                                                disabled={ns().loading || !ns().label.trim()}
+                                                                onClick={() => handleForkStart(row)}
+                                                                data-testid="agent-fork-start"
+                                                            >
+                                                                {ns().loading ? "…" : "Start"}
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                class="agent-fork-btn agent-fork-btn--ghost"
+                                                                onClick={() => handleForkCancel(row.definition_id)}
+                                                                aria-label="Cancel"
+                                                            >
+                                                                ✕
+                                                            </button>
                                                         </div>
-                                                    );
-                                                })()}
+                                                        <Show when={ns().error}>
+                                                            <span class="agent-fork-error">{ns().error}</span>
+                                                        </Show>
+                                                    </div>
+                                                )}
                                             </Show>
                                         </div>
                                     </Show>

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -37,6 +37,7 @@
  */
 
 import {
+    createEffect,
     createMemo,
     createResource,
     createSignal,
@@ -402,7 +403,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                                     if (e.key === "Enter") void handleForkStart(row);
                                                                     if (e.key === "Escape") handleForkCancel(row.definition_id);
                                                                 }}
-                                                                ref={(el) => { setTimeout(() => el.focus(), 0); }}
+                                                                ref={(el) => { createEffect(() => { if (!ns().loading) el.focus(); }); }}
                                                             />
                                                             <button
                                                                 type="button"

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -12,20 +12,21 @@
  * into the conversation document — the color/border shift from amber to
  * accent blue is the user's visible "accepted" signal.
  *
+ * Only messages with `enqueuedWhileBusy: true` are shown — those are the
+ * ones the user sent while a turn was already running. Idle-send messages
+ * (`enqueuedWhileBusy: false`) initiated the current turn and must never
+ * appear here, regardless of phase. This closes the race where the panel
+ * would flash between Streaming promotion and agent-message-accepted.
+ * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+ *
  * See AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md.
  */
 
-import { For, Show, type Accessor, type JSX } from "solid-js";
+import { For, Show, createMemo, type Accessor, type JSX } from "solid-js";
 import type { PendingMessage } from "../state";
 
 interface PendingMessagesPanelProps {
     pendingMessages: Accessor<PendingMessage[]>;
-    /** True while the turn is in the `Submitting` transient — the backend
-     *  has not yet acknowledged the send so `pendingMessages` still holds
-     *  the optimistic message. Hide the panel during this window to avoid
-     *  a one-frame flash on every normal idle send. When absent the outer
-     *  Show is gated on `pendingMessages` length alone. */
-    isSubmitting?: Accessor<boolean>;
     /** True when the user should be offered a "Send now" shortcut —
      *  typically: a turn is running AND the queue is non-empty. */
     showSendNow?: Accessor<boolean>;
@@ -34,37 +35,45 @@ interface PendingMessagesPanelProps {
     onSendImmediately?: () => void;
 }
 
-export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => (
-    <Show when={props.pendingMessages().length > 0 && !props.isSubmitting?.()}>
-        <div class="agent-pending-zone">
-            <div class="agent-pending-header">
-                <span class="agent-spinner-dot" />
-                <span class="agent-pending-header-text">
-                    Queued — will send when the agent is idle (
-                    {props.pendingMessages().length}
-                    {props.pendingMessages().length === 1 ? " message" : " messages"})
-                </span>
-                <Show when={props.showSendNow?.()}>
-                    <button
-                        type="button"
-                        class="agent-send-immediately-btn"
-                        onClick={() => props.onSendImmediately?.()}
-                        title="Stop the current turn and process the queue now"
-                    >
-                        <span class="agent-send-immediately-icon">⏭</span>
-                        <span>Send now</span>
-                    </button>
-                </Show>
+export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => {
+    // Only surface messages that were genuinely queued behind a running turn.
+    // Idle-send messages (enqueuedWhileBusy: false) are transparent — they
+    // initiated the current turn and should never appear in this zone.
+    const queuedMessages = createMemo(() =>
+        props.pendingMessages().filter((m) => m.enqueuedWhileBusy),
+    );
+    return (
+        <Show when={queuedMessages().length > 0}>
+            <div class="agent-pending-zone">
+                <div class="agent-pending-header">
+                    <span class="agent-spinner-dot" />
+                    <span class="agent-pending-header-text">
+                        Queued — will send when the agent is idle (
+                        {queuedMessages().length}
+                        {queuedMessages().length === 1 ? " message" : " messages"})
+                    </span>
+                    <Show when={props.showSendNow?.()}>
+                        <button
+                            type="button"
+                            class="agent-send-immediately-btn"
+                            onClick={() => props.onSendImmediately?.()}
+                            title="Stop the current turn and process the queue now"
+                        >
+                            <span class="agent-send-immediately-icon">⏭</span>
+                            <span>Send now</span>
+                        </button>
+                    </Show>
+                </div>
+                <For each={queuedMessages()}>
+                    {(msg) => (
+                        <div class="agent-pending-item" data-message-id={msg.id}>
+                            <pre>{msg.text}</pre>
+                        </div>
+                    )}
+                </For>
             </div>
-            <For each={props.pendingMessages()}>
-                {(msg) => (
-                    <div class="agent-pending-item" data-message-id={msg.id}>
-                        <pre>{msg.text}</pre>
-                    </div>
-                )}
-            </For>
-        </div>
-    </Show>
-);
+        </Show>
+    );
+};
 
 PendingMessagesPanel.displayName = "PendingMessagesPanel";

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -88,8 +88,10 @@ export interface UseAgentCommandsOptions {
 }
 
 export interface UseAgentCommands {
-    /** Send a user message. Slash commands are intercepted via the registry. */
-    sendMessage: (message: string) => Promise<void>;
+    /** Send a user message. Slash commands are intercepted via the registry.
+     *  `wasAlreadyWorking` should be true when a turn was in-flight before
+     *  the caller dispatched TurnStart — drives PendingMessage.enqueuedWhileBusy. */
+    sendMessage: (message: string, wasAlreadyWorking?: boolean) => Promise<void>;
     /** Return to the agent picker by clearing the agent-identity meta keys. */
     back: () => Promise<void>;
     /**
@@ -226,7 +228,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         return registry().list(buildCommandContext());
     };
 
-    const sendMessage = async (message: string): Promise<void> => {
+    const sendMessage = async (message: string, wasAlreadyWorking = false): Promise<void> => {
         // Crash trace: this is the entry point for "user pressed send."
         // The boundary dumps this trail when a renderer fault catches —
         // see frontend/log/render-trail.ts + BlockErrorBoundary.
@@ -279,6 +281,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 id: messageId,
                 text: message,
                 at: Date.now(),
+                enqueuedWhileBusy: wasAlreadyWorking,
             },
             "user",
         );

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -108,6 +108,17 @@ export interface PendingMessage {
     id: string;
     text: string;
     createdAt: number;
+    /**
+     * True when this message was queued while a turn was already in-flight
+     * (Submitting | Streaming | Interrupting). False for messages that
+     * initiated the current turn (idle sends).
+     *
+     * The PendingMessagesPanel gates its visibility on this flag so that
+     * idle-send messages never flash in the amber queued zone — only messages
+     * genuinely sitting behind a running turn should appear there.
+     * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+     */
+    enqueuedWhileBusy: boolean;
 }
 
 /**

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -189,4 +189,156 @@
     .agent-recent-sessions-ts-value {
         font-size: 10px;
     }
+
+    // Active-pane indicator — green dot appended to the agent name
+    .agent-active-badge {
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: #34d399;
+        flex-shrink: 0;
+        align-self: center;
+        box-shadow: 0 0 4px rgba(52, 211, 153, 0.5);
+    }
+
+    .agent-recent-sessions-entry--active {
+        border-color: color-mix(in srgb, #34d399 40%, var(--border-color));
+        background: color-mix(in srgb, #34d399 4%, transparent);
+    }
+
+    // Fork prompt — inline block below the row button
+    .agent-fork-prompt {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-2) 10px;
+        border: 1px solid color-mix(in srgb, var(--accent-color) 50%, var(--border-color));
+        border-top: none;
+        background: color-mix(in srgb, var(--accent-color) 4%, transparent);
+    }
+
+    .agent-fork-prompt-msg {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        line-height: 1.4;
+    }
+
+    .agent-fork-prompt-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+    }
+
+    // Base fork button
+    .agent-fork-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 3px 10px;
+        font-size: 12px;
+        font-family: inherit;
+        border-radius: 0;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+        white-space: nowrap;
+
+        &:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--accent-color);
+            outline-offset: 1px;
+        }
+    }
+
+    .agent-fork-btn--primary {
+        background: var(--accent-color);
+        color: var(--button-color, #fff);
+        border-color: var(--accent-color);
+
+        &:not(:disabled):hover {
+            background: color-mix(in srgb, var(--accent-color) 85%, #fff);
+        }
+    }
+
+    .agent-fork-btn--secondary {
+        background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+        color: var(--main-text-color);
+        border-color: var(--border-color);
+
+        &:not(:disabled):hover {
+            background: color-mix(in srgb, var(--main-text-color) 14%, transparent);
+        }
+    }
+
+    .agent-fork-btn--ghost {
+        background: transparent;
+        color: var(--secondary-text-color);
+        border-color: transparent;
+        padding: 3px 6px;
+
+        &:not(:disabled):hover {
+            color: var(--main-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+        }
+    }
+
+    // Naming sub-section
+    .agent-fork-naming {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+    }
+
+    .agent-fork-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--secondary-text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .agent-fork-input-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .agent-fork-input {
+        flex: 1;
+        min-width: 0;
+        height: 28px;
+        padding: 0 var(--space-2);
+        font-size: 13px;
+        font-family: inherit;
+        color: var(--main-text-color);
+        background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        outline: none;
+
+        &::placeholder {
+            color: color-mix(in srgb, var(--secondary-text-color) 60%, transparent);
+        }
+
+        &:focus {
+            border-color: color-mix(in srgb, var(--accent-color) 70%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 4%, transparent);
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+
+    .agent-fork-error {
+        font-size: 11px;
+        color: var(--error-color, #f87171);
+    }
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -370,17 +370,27 @@ export function useAgentStream({
                         type: "PendingMessageAccepted",
                         id: messageId,
                     });
-                    // A new turn is now running (either the first one,
-                    // which already entered Submitting via the TurnStart
-                    // in handleSendMessage, or one drained from the
-                    // queue — in that case the previous session_end
-                    // dropped the phase to Done and nothing else flips
-                    // it back, leaving the status line stuck on "Worked"
-                    // with no running animation even though the CLI is
-                    // processing the next message).
-                    trail("agent:dispatch:TurnStart", { messageId });
-                    model.dispatchPane({ type: "TurnStart", at: Date.now() });
-                    trail("agent:dispatch:TurnStart:done", { messageId });
+                    // Queue-drain case: the prior turn ended (phase Done/Idle/
+                    // Disconnected) and the backend is now picking up the next
+                    // queued message. Re-enter Submitting so the working
+                    // animation re-activates.
+                    //
+                    // For idle sends (phase Submitting/Streaming/Interrupting),
+                    // TurnStart was already dispatched in handleSendMessage —
+                    // a second fire here regresses Streaming → Submitting and
+                    // re-arms the 30 s submit timeout unnecessarily.
+                    // See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
+                    const currentPhase = paneSnapshot(blockId)?.turnPhase;
+                    const needsTurnStart =
+                        currentPhase?.kind === "Done" ||
+                        currentPhase?.kind === "Idle" ||
+                        currentPhase?.kind === "Disconnected" ||
+                        currentPhase == null;
+                    if (needsTurnStart) {
+                        trail("agent:dispatch:TurnStart", { messageId });
+                        model.dispatchPane({ type: "TurnStart", at: Date.now() });
+                        trail("agent:dispatch:TurnStart:done", { messageId });
+                    }
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
                     // node ties back to the pending entry 1:1.


### PR DESCRIPTION
## Summary

- **Root cause**: session zones keyed on `definition_id` — opening the same agent in two panes causes both to share one `output.state.json`, clobbering each other's conversation on app restart
- **Fix**: detect collision at the picker level; surface an inline fork prompt that creates an independent definition (new zone) instead of silently reattaching

## Changes

### Backend
- `forkagentdefinitionsuggest` RPC — read-only, returns `"Name #N"` suggested label based on existing fork count under `parent_id`; called when the name input opens for instant pre-fill
- `forkagentdefinition` handler: `branch_label` is now the fork's display name directly (was `"Name [label]"`), auto-numbers as `"Name #2"` when empty

### Frontend
- `getOpenDefinitionMap()` exported from `agent-pane-state-store` — O(slots) scan returning `definition_id → blockId` for all live panes
- `ForkAgentDefinitionSuggestCommand` added to `rpc-api.ts`
- `MyAgentsList`: active badge (green dot) on rows with open definitions; inline fork prompt with **Open new session** / **Switch to existing** buttons; name input pre-filled with backend suggestion, Start disabled when empty, Enter confirms, Escape cancels
- `AgentPicker`: `openDefinitions` signal computed from pane store (refreshed on `agents:changed`); `handleFork` → `ForkAgentDefinitionCommand` + `launchAgentDefinition`; `handleSwitchToExisting` → `refocusNode`

## UX flow
```
User clicks active row
  → fork prompt appears (row stays in place)
  → "Open new session" → name input expands, pre-filled "Mopeo #2"
  → user edits / confirms → fork created → new pane opens
  → "Switch to existing" → focus jumps to the already-open pane
```

## Test plan
- [ ] Open Mopeo in two panes — second click shows fork prompt (active badge visible on first click)
- [ ] "Open new session" → name input appears pre-filled with "Mopeo #2"
- [ ] Edit name → "Start" enabled only when non-empty
- [ ] Confirm → new pane opens with a fresh conversation zone
- [ ] "Switch to existing" → focus jumps to the first pane
- [ ] Restart app → both sessions remain independent (no clobber)
- [ ] Third fork → suggested name is "Mopeo #3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)