### PR TITLE
fix(gpu): bundle SwiftShader software-GL fallback on Windows

### DIFF
--- a/.changesets/1781194353-fix-gpu-bundle-swiftshader-software-gl-fallback-on-windows-zfgh.md
+++ b/.changesets/1781194353-fix-gpu-bundle-swiftshader-software-gl-fallback-on-windows-zfgh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(gpu): bundle SwiftShader software-GL fallback on Windows

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -536,18 +536,29 @@ tasks:
                 cp -f "$cefDir/libEGL.dll" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/libGLESv2.dll" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/d3dcompiler_47.dll" dist/cef/ 2>/dev/null || true
+                # Software-GL fallback (SwiftShader, ~6 MB). When the HARDWARE GPU process
+                # can't boot, Chromium falls back to SwiftShader for WebGL ONLY if these are
+                # present AND --enable-unsafe-swiftshader is set (app.rs). Without them, the
+                # software-GL fallback also fails ("crashed too many times with software GL")
+                # and Chromium disables GL entirely → WebGL unavailable → xterm drops to its
+                # slower DOM renderer (no scrollbar). This is the current Windows failure mode
+                # (GPU process STATUS_BREAKPOINTs at init — see issue / the DCHECK-build root
+                # cause). macOS/Linux bundles already ship SwiftShader; this restores parity.
+                # SAFETY NET ONLY — hardware GL is still preferred when it boots.
+                cp -f "$cefDir/vk_swiftshader.dll" dist/cef/ 2>/dev/null || true
+                cp -f "$cefDir/vulkan-1.dll" dist/cef/ 2>/dev/null || true
+                cp -f "$cefDir/vk_swiftshader_icd.json" dist/cef/ 2>/dev/null || true
                 # Data files (required)
                 cp -f "$cefDir/icudtl.dat" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
                 cp -f "$cefDir"/*.pak dist/cef/ 2>/dev/null || true
                 # Locales — en-US only (saves ~18 MB)
                 [ -f "$cefDir/locales/en-US.pak" ] && cp -f "$cefDir/locales/en-US.pak" dist/cef/locales/
-                # SKIPPED (not needed, saves ~18 MB):
-                #   vk_swiftshader.dll, vulkan-1.dll, vk_swiftshader_icd.json (SwiftShader — deprecated upstream)
+                # SKIPPED (not needed):
                 #   dxil.dll, dxcompiler.dll (WebGPU — not used)
                 #   snapshot_blob.bin (removed in CEF 133+)
                 #   49 non-English locale .pak files
-                echo "✓ Bundled runtime to dist/cef/ (optimized: GPU kept, SwiftShader/WebGPU/extra locales stripped)"
+                echo "✓ Bundled runtime to dist/cef/ (GPU + SwiftShader software fallback kept; WebGPU/extra locales stripped)"
 
     bundle:darwin:
         internal: true

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -623,6 +623,18 @@ wrap_app! {
                 // the app in a zombie white-screen state on GPU context loss with
                 // no recovery path. Removed in v0.33.66.
 
+                // Software-GL safety net. Chromium 110+ gates the SwiftShader
+                // fallback for WebGL behind this switch. When the hardware GPU
+                // process can't boot (e.g. the Windows STATUS_BREAKPOINT-at-init
+                // crash from the DCHECK-enabled libcef build, or any driver/virtual-
+                // display failure), this + the bundled vk_swiftshader.dll/vulkan-1.dll
+                // (Taskfile bundle) let GL degrade to *software* WebGL instead of
+                // being disabled entirely — keeping the xterm WebGL renderer (and its
+                // scrollbar) working. Hardware GL is still preferred when available,
+                // so there is no cost on healthy machines. This is a fallback only;
+                // the real fix is an official (DCHECK-off) Windows libcef build.
+                cmd.append_switch(Some(&CefString::from("enable-unsafe-swiftshader")));
+
                 // NOTE: `--renderer-process-limit=1` was previously set here to
                 // protect against DevTools popups spawning extra renderers under
                 // an Alloy-mode assumption. The current Linux CEF build is NOT

--- a/docs/analysis/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md
+++ b/docs/analysis/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md
@@ -1,0 +1,125 @@
+# Root-Cause Analysis: Windows GPU Disabled (CEF GPU-process STATUS_BREAKPOINT)
+
+**Status:** Complete — empirically verified (CDP `SystemInfo`/`chrome://gpu`, CEF logs, A/B build, VS Code comparison)
+**Author:** AgentX
+**Date:** 2026-06-11
+**This PR:** SwiftShader software-GL safety net (`agentx/gpu-hardware-fix`)
+**Real fix (separate):** an official (DCHECK-off) Windows `libcef` build in `agentmuxai/cef` — filed as an issue.
+
+---
+
+## 1. Summary
+
+On Windows, AgentMux's GPU is fully disabled (`gl=disabled`, `webgl: disabled_off`): the
+Chromium **GPU process crashes with `STATUS_BREAKPOINT` (`0x80000003`) ×3 at GPU
+shared-context init**, falls to software GL, which also fails (no SwiftShader bundled), so
+Chromium disables all GPU → every terminal uses the slow xterm **DOM renderer** (no
+scrollbar).
+
+**Root cause:** the `agentmuxai/cef` fork's **Windows `libcef.dll` is a non-official /
+DCHECK-enabled build.** A `DCHECK`/`CHECK` in the GPU's context-virtualization init fires as
+a fatal `int3` — which **upstream release Chrome (VS Code) and AgentMux's macOS build both
+survive** on the same machine.
+
+**This is NOT** transparency (disproven by A/B), **NOT** adapter selection (NVIDIA is
+correctly chosen and is fully capable), and **NOT** AMD-switchable (false on this box).
+
+---
+
+## 2. Evidence
+
+### 2.1 The hardware GPU is fully capable
+
+`chrome://gpu` Hardware-GPU profile (scraped from a running portable):
+`GPU0 = NVIDIA RTX 3060 *ACTIVE*`, `GL_RENDERER: ANGLE (NVIDIA … Direct3D11)`,
+`(gl=egl-angle, angle=d3d11)`, Skia GaneshGL, **init 192 ms**, WebGL: *Hardware accelerated*.
+So NVIDIA D3D11 works when the GPU process boots.
+
+### 2.2 The crash
+
+```
+GpuProcessHost: GPU process exited unexpectedly: exit_code=-2147483645  (0x80000003 STATUS_BREAKPOINT) ×3
+ContextResult::kFatalFailure: Failed to create shared context for virtualization.
+GPU process was unable to boot: GPU process crashed too many times with software GL.  → Disabled: all
+```
+
+`STATUS_BREAKPOINT` = a `DCHECK`/`CHECK` `int3` *inside* the GPU process during GL/D3D
+context creation (init ~134–192 ms, before it can log the GL detail).
+
+### 2.3 It's a non-official (DCHECK-enabled) build
+
+AgentMux's `cef-debug.log` prints **full source paths + line numbers** —
+`gpu\ipc\service\gpu_channel_manager.cc:927`, `components\viz\service\main\viz_main_impl.cc:190`.
+**Official/release Chrome strips these.** Their presence ⇒ `is_official_build=false` and/or
+`dcheck_always_on=true`, which leaves DCHECKs live. VS Code (official Chrome) on the same
+machine does not crash and uses NVIDIA D3D11.
+
+### 2.4 Transparency ruled out (A/B)
+
+Built an opaque variant (`background_color = 0xFF222222` in main.rs/app.rs/ui_tasks.rs) and
+launched it on a **virgin data dir**. Result: **identical** crash — 3× `STATUS_BREAKPOINT`
+at "create shared context for virtualization." So the translucent surface is not the trigger.
+
+### 2.5 Other negatives
+
+- **High-performance GPU preference** (`UserGpuPreferences = GpuPreference=2`) on the host exe
+  did **not** fix it — the portable still crashed 3×.
+- **AMD switchable: false**, **Optimus: false** — adapter selection correctly targets NVIDIA;
+  not a switchable-graphics `disable_d3d11` issue.
+
+### 2.6 Why macOS works but Windows doesn't
+
+macOS GPU is enabled in the latest fork build. Either the macOS `libcef` is built official
+(DCHECK-off) while Windows isn't, or the firing DCHECK isn't hit on macOS's ANGLE-Metal
+backend vs Windows's ANGLE-D3D11. Either way it is the **Windows fork build** that differs.
+
+---
+
+## 3. The fix
+
+### 3.1 Real fix (separate — `agentmuxai/cef` build): official Windows libcef
+
+Build the Windows `libcef` from the fork with **`is_official_build=true`** (or at minimum
+`dcheck_always_on=false` + `is_debug=false`) — matching a release Chrome build and the macOS
+build. That compiles out the firing DCHECK; the GPU process then initializes NVIDIA D3D11
+normally (§2.1). Re-point the `cef-rs` download (`AgentU-asaf/cef-rs`) at the new binary and
+rebuild AgentMux. **Filed as an issue on `agentmuxai/cef`.**
+
+### 3.2 This PR — SwiftShader software-GL safety net
+
+Independent of the build fix, ensure a hardware-GPU failure degrades to **software WebGL**
+instead of fully-disabled DOM rendering:
+
+- `Taskfile.yml` `bundle:windows` ships `vk_swiftshader.dll`, `vulkan-1.dll`,
+  `vk_swiftshader_icd.json` (~6 MB; parity with macOS/Linux, which already bundle it).
+- `agentmux-cef/src/app.rs` adds `--enable-unsafe-swiftshader` (Chromium 110+ gates the
+  SwiftShader WebGL fallback behind it).
+
+With both, when the GPU process can't boot, Chromium settles on SwiftShader (software WebGL)
+instead of `crashed too many times with software GL → disable all`. **Software is CPU-bound
+and not the goal** — hardware via §3.1 is — but it removes the "fully-disabled DOM-renderer"
+cliff and keeps the xterm WebGL renderer + scrollbar working. Hardware GL is still preferred
+when it boots, so there is no cost on healthy machines.
+
+### 3.3 Further hardening (not in this PR — tracked from CRASH_GPU_PROCESS_FATAL_2026_05_20)
+
+`--disable-gpu-process-crash-limit`, launcher relaunch with `--disable-gpu` after repeated
+crashes, `SetErrorMode(SEM_NOGPFAULTERRORBOX)`, launcher supervision + state restore — so
+*any* GPU fault becomes invisible recovery.
+
+---
+
+## 4. Re-verify
+
+```
+# GPU feature status of a running build (dev 9223 / release 9222):
+curl -s http://127.0.0.1:9223/json/version > ver.json
+node scripts/cdp-featurestatus.mjs ver.json     # expect webgl: enabled / disabled_software (net) — not disabled_off
+
+# Crash signature in the CEF log:
+grep -aE 'GPU process|STATUS_BREAKPOINT|shared context' \
+  ~/.agentmux/channels/stable/versions/<v>/logs/cef-debug.log
+
+# Build-flavor tell (non-official leaves source paths in log messages):
+grep -aE '\.cc:[0-9]+\]' <cef-debug.log>     # present ⇒ non-official build
+```


### PR DESCRIPTION
## Problem

On Windows the GPU is **fully disabled** (`gl=disabled`, `webgl: disabled_off`). The CEF GPU process crashes `STATUS_BREAKPOINT` ×3 at "create shared context for virtualization", falls to software GL, which **also** fails (no SwiftShader bundled), so Chromium disables all GPU → every terminal uses the slow xterm **DOM renderer** (no scrollbar).

Full diagnosis: `docs/analysis/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md`.

**Root cause** (the real hardware fix, *separate*): the `agentmuxai/cef` fork's **Windows `libcef.dll` is a non-official / DCHECK-enabled build** — a `DCHECK` in GPU context init fires as a fatal `int3`, which upstream release Chrome (VS Code) and AgentMux's **macOS** build both survive on the same machine. Evidence: the CEF log prints full source paths/line numbers (`gpu_channel_manager.cc:927`) which official Chrome strips. Filed as an issue on `agentmuxai/cef` (build Windows libcef with `is_official_build=true`). **Ruled out:** transparency (opaque A/B crashes identically), adapter selection (NVIDIA correctly chosen, fully capable — `chrome://gpu` Hardware profile init 192ms), AMD-switchable (false).

## This PR — the software-GL safety net

So a hardware-GPU failure degrades to **software WebGL** instead of the fully-disabled cliff:
- **`Taskfile.yml` `bundle:windows`** ships `vk_swiftshader.dll`, `vulkan-1.dll`, `vk_swiftshader_icd.json` (**~6 MB**; parity with macOS/Linux which already bundle it).
- **`app.rs`** adds `--enable-unsafe-swiftshader` (Chromium 110+ gates the SwiftShader WebGL fallback behind it).

With both, when the GPU process can't boot, Chromium settles on SwiftShader (software WebGL) instead of `crashed too many times with software GL → disable all`. Keeps the xterm WebGL renderer + scrollbar working.

**Not the end goal** — software is CPU-bound; hardware (the official libcef build) is. But this removes the disabled-DOM-renderer cliff, and **hardware GL is still preferred when it boots, so there is no cost on healthy machines.**

## Verification
- ✅ `cargo check -p agentmux-cef` compiles
- ✅ SwiftShader DLLs present in the CEF runtime to bundle (~6.1 MB → ~3 MB in the ZIP)
- ⏳ Runtime "software WebGL kicks in" confirmation pending (needs the build; or validates naturally once the official-libcef fix lands and hardware works)

## Test plan
- [ ] `task package` → confirm `vk_swiftshader.dll` + `vulkan-1.dll` in `runtime/`
- [ ] On a machine where the hardware GPU process can't boot → terminals render via software WebGL (status bar `GFX SW`, scrollbar present) instead of `GFX off`
- [ ] On a healthy-GPU machine → hardware path unchanged (`GFX HW`), no regression

## Follow-ups (tracked, not here)
- **Real fix:** official (DCHECK-off) Windows `libcef` build in `agentmuxai/cef`.
- Stability roadmap from `CRASH_GPU_PROCESS_FATAL_2026_05_20.md`: `--disable-gpu-process-crash-limit`, launcher relaunch w/ `--disable-gpu`, `SetErrorMode`, launcher supervision + restore.