### PR TITLE
fix(package): copy SwiftShader DLLs into portable runtime (follow-up to #1344)

### DIFF
--- a/.changesets/1781196402-fix-package-copy-swiftshader-dlls-into-portable-runtime-foll-5c45.md
+++ b/.changesets/1781196402-fix-package-copy-swiftshader-dlls-into-portable-runtime-foll-5c45.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(package): copy SwiftShader DLLs into portable runtime (follow-up to #1344)

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -134,6 +134,10 @@ cp dist/cef/v8_context_snapshot.bin "$PORTABLE/runtime/" 2>/dev/null || true
 
 # GPU support
 cp dist/cef/libEGL.dll dist/cef/libGLESv2.dll dist/cef/d3dcompiler_47.dll "$PORTABLE/runtime/" 2>/dev/null || true
+# Software-GL fallback (SwiftShader) — must reach runtime/ too, not just dist/cef.
+# Without these the GPU degrades to the disabled DOM renderer when hardware GL
+# can't boot. Paired with --enable-unsafe-swiftshader (app.rs) + the bundle step.
+cp dist/cef/vk_swiftshader.dll dist/cef/vulkan-1.dll dist/cef/vk_swiftshader_icd.json "$PORTABLE/runtime/" 2>/dev/null || true
 
 # Resource paks
 cp dist/cef/chrome_100_percent.pak dist/cef/chrome_200_percent.pak dist/cef/resources.pak "$PORTABLE/runtime/" 2>/dev/null || true


### PR DESCRIPTION
Follow-up to #1344. That PR's Taskfile bundle step copies `vk_swiftshader.dll` / `vulkan-1.dll` / `vk_swiftshader_icd.json` into `dist/cef`, but `scripts/package-portable.sh` has its **own** explicit GPU-DLL copy list (`libEGL`/`libGLESv2`/`d3dcompiler`) that didn't include SwiftShader — so the portable's `runtime/` shipped **without** it and the software-GL fallback never reached users.

**Caught by building from main and inspecting the artifact:** SwiftShader DLLs were present in `dist/cef/` but missing from `runtime/`. This adds the runtime copy.

## Test plan
- [ ] `task package` → confirm `vk_swiftshader.dll` + `vulkan-1.dll` + `vk_swiftshader_icd.json` are in the portable's `runtime/` (not just `dist/cef/`)