### PR TITLE
fix(bashwrap): collapse lone CR so spinner animations don't bleed as multiple lines

### DIFF
--- a/.changesets/1781172595-feat-agent-pane-persistent-shell-node-shellnode-type-reducer-wiiq.md
+++ b/.changesets/1781172595-feat-agent-pane-persistent-shell-node-shellnode-type-reducer-wiiq.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): persistent shell node — ShellNode type, reducer, PersistentShellBlock component and styles (Phase 1 frontend skeleton)

--- a/.changesets/1781208279-fix-bashwrap-collapse-lone-cr-sequences-so-spinner-animation-n1j4.md
+++ b/.changesets/1781208279-fix-bashwrap-collapse-lone-cr-sequences-so-spinner-animation-n1j4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(bashwrap): collapse lone CR sequences so spinner animations don't render as one line per frame

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -704,10 +704,11 @@ fn strip_dsr(chunk: &mut Vec<u8>) {
 ///    Git Bash on every command).
 ///
 /// 3. **Lone control chars** — `\r` (carriage return without
-///    newline), `\x07` (bell), `\x08` (backspace). We strip `\r`
-///    when it immediately precedes `\n` (CRLF → LF for the chunk
-///    list); other `\r` we keep as-is for now since simple progress
-///    bars use it.
+///    newline), `\x07` (bell), `\x08` (backspace). CRLF → LF for
+///    the chunk list. Lone `\r` collapses the current visual line
+///    (truncate `out` back to after the last `\n`), simulating
+///    carriage-return overwrite so spinner animations don't leak as
+///    one line per frame when rendered in a `<pre>`.
 ///
 /// Things we DON'T handle yet (Phase γ territory):
 /// - Alt-screen apps (`\x1b[?1049h`) — left in the stream.
@@ -778,9 +779,22 @@ fn strip_ansi(chunk: &mut Vec<u8>) {
             i += 1;
             continue;
         }
-        if b == b'\r' && i + 1 < chunk.len() && chunk[i + 1] == b'\n' {
-            // CRLF → LF (matches what bash sends after every line on
-            // a PTY; the chunk list expects LF only).
+        if b == b'\r' {
+            if i + 1 < chunk.len() && chunk[i + 1] == b'\n' {
+                // CRLF → LF: drop the \r, keep the \n on the next pass.
+                i += 1;
+                continue;
+            }
+            // Lone \r: simulate carriage-return by discarding the current
+            // line's content in `out` (truncate back to after the last \n).
+            // This collapses spinner/progress animations — each frame
+            // overwrites the previous one — instead of leaking them as
+            // separate lines when the frontend renders the chunk in a <pre>.
+            if let Some(last_nl) = out.iter().rposition(|&b| b == b'\n') {
+                out.truncate(last_nl + 1);
+            } else {
+                out.clear();
+            }
             i += 1;
             continue;
         }

--- a/docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md
+++ b/docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md
@@ -1,0 +1,461 @@
+# SPEC: Persistent Shell Node in the Agent Pane
+
+**Date:** 2026-06-11  
+**Status:** Draft  
+**Scope:** New `ShellNode` document node type + `PersistentShellBlock` UI component + `agentmux-mcp` `Shell` tool
+
+---
+
+## 1. Problem
+
+Long-running processes (build systems, dev servers, watchers, REPL sessions) cannot be represented in the agent conversation today. The `Bash` tool — intercepted by `agentmux-bashwrap` — blocks the entire tool call until the process exits. If the process never exits (e.g. `task dev`, `npm run watch`), the tool call hangs indefinitely and the agent is frozen.
+
+Two downstream failures:
+
+1. **Build progress is invisible.** The agent cannot stream compilation output live to the user while also continuing the conversation.  
+2. **No persistent session.** Each Bash call is isolated — no PTY state, no environment carry-over, no way to send input to a running process.
+
+The existing `term` widget (xterm.js) solves this for *manually-operated* terminals, but agents cannot open or interact with a terminal widget programmatically.
+
+---
+
+## 2. Goals
+
+- Agents can launch long-running processes that appear as a **compact, colored, named row** in the conversation document.
+- The row expands inline (click-to-reveal) to show the full **live-log** — the same streaming chunk renderer already used by `ToolBlock`.
+- The agent can continue the conversation immediately after launching; the process runs independently.
+- Processes can be **stopped** (agent-initiated or user-initiated via the UI).
+- The representation is **efficient**: one row per shell in the DOM regardless of how much output has streamed.
+- Color encodes status at a glance without expanding.
+
+---
+
+## 3. Non-Goals
+
+- Full interactive PTY (keyboard input from the agent pane UI). The shell row is **read-only** from the UI; the agent can send input via a follow-up tool call.
+- Replacing the existing `term` widget for human-operated terminals.
+- Persistence across app restarts (session-scoped only, same as ToolStreamingLog today).
+
+---
+
+## 4. User-Visible Behavior
+
+### 4.1 Collapsed state (default)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ⟩  task dev                    [running 0:42]  ↳ Compiling… │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **Left border**: colored by status (§6.3).
+- **Icon** `⟩`: shell sigil (distinct from tool status icons `⏳ ✓ ✗`).
+- **Label**: command or user-supplied `title` prop.
+- **Elapsed timer**: counts up from spawn while running; freezes on exit.
+- **Live-tail**: last output line, same mechanic as `ToolBlock`'s live-tail.
+- **Stop button** `■`: visible on hover while status is `running`; sends SIGTERM.
+
+### 4.2 Expanded state (click to toggle)
+
+Inline panel below the row — identical layout to `ToolBlockOverlay`:
+- Header: command + exit code (if done) + timestamp.
+- Scrollable log body: `ToolOverlayLog`-compatible chunk list (stdout in foreground, stderr in red, system lines in muted italic).
+- Cap: same `MAX_TOOL_OUTPUT_LINES = 1000` rendering cap, `OutputHiddenMarker` for overflow.
+- No action bar (no bookmark, no open-in-pane, Phase 2 concern).
+
+### 4.3 Terminal states
+
+| Exit | Border color | Icon | Tail |
+|------|--------------|------|------|
+| Running | `--term-bright-green` | `⟩` | last line |
+| Exited 0 | `--accent-color` (dim) | `✓` | last line |
+| Exited non-0 | `--error-color` | `✗` | last line |
+| Stopped by agent/user | `--secondary-text-color` | `■` | last line |
+
+---
+
+## 5. Architecture
+
+### 5.1 Overview
+
+```
+Agent calls Shell(cmd, cwd?, title?)
+        │
+        ▼
+agentmux-mcp (new binary)
+  ├─ POST /agentmux/shell/create  → srv creates ShellController
+  ├─ receives shell_id
+  └─ returns { shell_id } to Claude immediately (non-blocking)
+
+agentmux-srv ShellController
+  ├─ spawns PTY subprocess
+  ├─ reads PTY output line-by-line
+  └─ publishes WPS event "shell_chunk" scoped to block:<block_id>
+       { shell_id, kind, content, timestamp, exit_code? }
+
+Frontend (useAgentStream.ts)
+  ├─ subscribes "shell_chunk" scope block:<id>
+  ├─ dispatches ShellNodeCreate on first chunk for a new shell_id
+  ├─ dispatches ShellChunkAppend per line
+  └─ dispatches ShellStatusUpdate on exit
+
+DocumentRow routes ShellNode → <PersistentShellBlock>
+```
+
+### 5.2 New `agentmux-mcp` binary
+
+New workspace member `agentmux-mcp/` (referenced in `.mcp.json` but not yet built).
+
+**Exposed tools:**
+
+| Tool | Purpose |
+|------|---------|
+| `Shell(cmd, cwd?, title?, env?)` | Start a persistent shell, returns `shell_id` |
+| `ShellInput(shell_id, text)` | Send text to stdin of a running shell |
+| `ShellStop(shell_id, signal?)` | Send SIGTERM/SIGKILL |
+| `ShellStatus(shell_id)` | Query current status + last N lines |
+
+`Shell` is the primary tool. The others are follow-on Phase 2 items (see §10).
+
+**`Shell` tool contract:**
+```json
+{
+  "name": "Shell",
+  "description": "Start a long-running shell process. Returns immediately with a shell_id. Output streams live in the conversation. Use for build systems, watchers, dev servers.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "cmd":   { "type": "string", "description": "Command to run" },
+      "cwd":   { "type": "string", "description": "Working directory" },
+      "title": { "type": "string", "description": "Display label (defaults to cmd)" },
+      "env":   { "type": "object", "description": "Extra environment variables" }
+    },
+    "required": ["cmd"]
+  }
+}
+```
+
+**Implementation sketch (Rust):**
+- Reads `AGENTMUX_AGENT_ID`, `AGENTMUX_LOCAL_URL`, `AGENTMUX_AUTH_KEY`, `AGENTMUX_AGENT_BUS_ID` from env.
+- POSTs `{ agent_id, cmd, cwd, title, env }` to `agentmux-srv` via `POST /api/v1/shell/create`.
+- Receives `{ shell_id }` synchronously.
+- Emits `StructuredOutput({ shell_id })` and exits.
+
+### 5.3 Backend: shell/create endpoint + ShellController
+
+**New HTTP route:** `POST /api/v1/shell/create`  
+**Handler** in `agentmux-srv/src/server/app_api.rs` (alongside existing pane.open handler ~line 773):
+
+```rust
+async fn handle_shell_create(
+    State(srv): State<Arc<ServerState>>,
+    Json(req): Json<ShellCreateRequest>,
+) -> Json<ShellCreateResponse>
+```
+
+- Generates a `shell_id` (UUID).
+- Emits a `ShellNodeCreate` WPS event to `block:<agent_block_id>` immediately (so frontend creates the row before output arrives).
+- Spawns a `ShellController` (already exists in `blockcontroller/shell.rs`) wired to publish **`shell_chunk`** WPS events (not `blockfile` events) to scope `block:<agent_block_id>`.
+- Returns `{ shell_id }`.
+
+**WPS event: `shell_chunk`**
+```json
+{
+  "event": "shell_chunk",
+  "scopes": ["block:<agent_block_id>"],
+  "persist": 1024,
+  "data": {
+    "shell_id": "<uuid>",
+    "op": "chunk" | "exit",
+    "kind": "stdout" | "stderr" | "system",
+    "content": "...",
+    "timestamp": 1234567890,
+    "exit_code": 0
+  }
+}
+```
+
+**WPS event: `shell_node_create`**
+```json
+{
+  "event": "shell_node_create",
+  "scopes": ["block:<agent_block_id>"],
+  "persist": 1,
+  "data": {
+    "shell_id": "<uuid>",
+    "cmd": "task dev",
+    "cwd": "/workspace/agentmux",
+    "title": "task dev",
+    "timestamp": 1234567890
+  }
+}
+```
+
+### 5.4 Frontend: new types
+
+**`frontend/app/view/agent/types.ts`** — add `ShellNode`:
+
+```typescript
+export interface ShellNode {
+    type: "shell";
+    id: string;               // shell_id
+    cmd: string;
+    title: string;
+    cwd?: string;
+    status: "running" | "exited-ok" | "exited-err" | "stopped";
+    exitCode?: number;
+    spawnedAt: number;        // Unix ms
+    exitedAt?: number;        // Unix ms
+    log: ToolStreamingLog;    // reuse exact same type
+}
+```
+
+`DocumentNode` union gets `| ShellNode`.
+
+### 5.5 Frontend: store commands
+
+**`frontend/app/store/agent-document/types.ts`** — add:
+
+```typescript
+| { type: "ShellNodeCreate"; node: ShellNode }
+| { type: "ShellChunkAppend"; shellId: string; chunk: ToolLogChunk }
+| { type: "ShellStatusUpdate"; shellId: string; status: ShellNode["status"]; exitCode?: number; exitedAt: number }
+```
+
+Reducer in `agent-document-store.ts`:
+- `ShellNodeCreate`: appends `ShellNode` to `nodes`, registers in `nodeIdSet`.
+- `ShellChunkAppend`: finds ShellNode by id, immutably appends chunk to `log.chunks`.
+- `ShellStatusUpdate`: updates `status`, `exitCode`, `exitedAt`, sets `log.open = false`.
+
+### 5.6 Frontend: stream subscription
+
+**`useAgentStream.ts`** — alongside existing `tool_chunk` subscription, add:
+
+```typescript
+waveEventSubscribe({
+    eventType: "shell_node_create",
+    scope: `block:${blockId}`,
+    handler: (ev) => {
+        const { shell_id, cmd, title, cwd, timestamp } = ev.data;
+        pendingShellCreates.push({ shell_id, cmd, title, cwd, timestamp });
+        scheduleFlush();
+    }
+});
+
+waveEventSubscribe({
+    eventType: "shell_chunk",
+    scope: `block:${blockId}`,
+    handler: (ev) => {
+        const { shell_id, op, kind, content, timestamp, exit_code } = ev.data;
+        if (op === "chunk") {
+            pendingShellChunks.push({ shellId: shell_id, chunk: { kind, content, timestamp } });
+        } else if (op === "exit") {
+            pendingShellExits.push({ shellId: shell_id, exitCode: exit_code, exitedAt: timestamp });
+        }
+        scheduleFlush();
+    }
+});
+```
+
+Flush dispatches `ShellNodeCreate` first, then `ShellChunkAppend`, then `ShellStatusUpdate` — same ordering guarantee as existing tool_chunk batch.
+
+### 5.7 Frontend: routing
+
+**`DocumentRow.tsx`** — add branch:
+
+```tsx
+<Show when={props.node().type === "shell"}>
+    <PersistentShellBlock
+        node={props.node() as ShellNode}
+        pinned={documentState.pinnedNodes.has(props.node().id)}
+        onTogglePin={() => togglePin(props.node().id)}
+    />
+</Show>
+```
+
+### 5.8 Frontend: `<PersistentShellBlock>` component
+
+New file: `frontend/app/view/agent/components/PersistentShellBlock.tsx`
+
+**Collapsed row (always rendered):**
+```tsx
+<div class={clsx("agent-shell-block", {
+    "running": status === "running",
+    "exited-ok": status === "exited-ok",
+    "exited-err": status === "exited-err",
+    "stopped": status === "stopped",
+    "expanded": expanded(),
+    "collapsed": !expanded(),
+})} onClick={onTogglePin}>
+    <span class="agent-shell-sigil">⟩</span>
+    <span class="agent-shell-title">{props.node.title}</span>
+    <span class="agent-shell-elapsed">[{elapsed()}]</span>
+    <Show when={lastLine()}>
+        <span class="agent-shell-live-tail">↳ {lastLine()}</span>
+    </Show>
+    <Show when={props.node.status === "running"}>
+        <button class="agent-shell-stop" onClick={handleStop} title="Stop">■</button>
+    </Show>
+</div>
+```
+
+**Elapsed timer:** `createEffect` + `setInterval(1000)` while `status === "running"`. Shows `M:SS` format. Clears on exit.
+
+**Expanded panel:** `<Show when={expanded()}>` renders `<ToolBlockOverlay>` with the ShellNode's log passed in — reuse the existing overlay without modification (it operates on the `log` field, not the node type).
+
+**`lastLine()`:** `createMemo` returning the last chunk's content (trimmed).
+
+---
+
+## 6. Visual Design
+
+### 6.1 Component anatomy
+
+```
+╔════════════════════════════════════════════════════════════╗
+║ ║ ⟩  task dev                 [running 1:23]  ↳ Linking… ║
+╚════════════════════════════════════════════════════════════╝
+  ▲
+  left border (4px, status color)
+```
+
+### 6.2 Collapsed row layout
+
+| Slot | Element | Notes |
+|------|---------|-------|
+| left border | 4px solid (status color) | same mechanic as `.agent-tool-block` |
+| sigil | `⟩` | monospace, `--accent-color` while running |
+| title | `props.node.title` | truncated with ellipsis |
+| elapsed | `[M:SS]` | right-aligned, `--secondary-text-color` |
+| live-tail | `↳ last line` | hidden below 400px container width |
+| stop button | `■` | hover-reveal only, right edge |
+
+### 6.3 Status colors (left border)
+
+Applied via CSS class on `.agent-shell-block` using the same `data-tool`-style approach:
+
+```scss
+.agent-shell-block {
+    &.running  { border-left-color: var(--term-bright-green); }
+    &.exited-ok { border-left-color: var(--accent-color); opacity: 0.7; }
+    &.exited-err { border-left-color: var(--error-color); }
+    &.stopped  { border-left-color: var(--secondary-text-color); opacity: 0.6; }
+}
+```
+
+Running state also gets a subtle left-border pulse animation (CSS keyframe, same period as the existing spinner animations):
+
+```scss
+&.running {
+    animation: shell-running-pulse 2s ease-in-out infinite;
+}
+@keyframes shell-running-pulse {
+    0%, 100% { border-left-color: var(--term-bright-green); }
+    50%       { border-left-color: color-mix(in srgb, var(--term-bright-green) 40%, transparent); }
+}
+```
+
+### 6.4 Expanded panel
+
+Reuses `.agent-tool-panel` layout and `ToolOverlayLog` rendering exactly. No new SCSS required for the panel body — only the collapsed row needs new styles.
+
+### 6.5 Container query breakpoints
+
+Follows the Tier 3/4/5 breakpoints from `SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09`:
+
+| Container width | Change |
+|----------------|--------|
+| < 400px | Hide live-tail |
+| ≥ 600px | Show elapsed timer |
+| ≥ 900px | Show stop button without requiring hover |
+
+---
+
+## 7. `agentmux-bashwrap` integration (Phase 2)
+
+Currently, the `PreToolUse` hook rewrites **all** Bash calls through `agentmux-bashwrap exec`. Phase 1 introduces the explicit `Shell` tool. Phase 2 adds **auto-promotion**: if bashwrap detects a command that's still running after a threshold (e.g. 30s), it can:
+
+1. Detach the process into a new ShellController.
+2. Publish a `shell_node_create` event retroactively.
+3. Return from the tool call immediately with a message: `"Process promoted to persistent shell <shell_id>. Continuing in background."`.
+
+This is optional; the explicit `Shell` tool is the primary interface.
+
+---
+
+## 8. Files to Create / Modify
+
+### New files
+| File | Purpose |
+|------|---------|
+| `agentmux-mcp/` | New workspace member — MCP server binary |
+| `agentmux-mcp/src/main.rs` | Tool definitions + HTTP client to srv |
+| `agentmux-mcp/Cargo.toml` | Crate manifest |
+| `frontend/app/view/agent/components/PersistentShellBlock.tsx` | Collapsed row + overlay wiring |
+| `frontend/app/view/agent/styles/_shell-node.scss` | Shell-specific CSS |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/types.ts` | Add `ShellNode` to `DocumentNode` union |
+| `frontend/app/store/agent-document/types.ts` | Add `ShellNodeCreate`, `ShellChunkAppend`, `ShellStatusUpdate` commands |
+| `frontend/app/store/agent-document-store.ts` | Reducer cases for new commands |
+| `frontend/app/view/agent/virtualization/DocumentRow.tsx` | Add `<Show>` branch for `shell` type |
+| `frontend/app/view/agent/useAgentStream.ts` | Add `shell_node_create` + `shell_chunk` subscriptions |
+| `frontend/app/view/agent/styles/index.scss` | Import `_shell-node.scss` |
+| `agentmux-srv/src/server/app_api.rs` | Add `POST /api/v1/shell/create` handler |
+| `agentmux-srv/src/backend/rpc_types.rs` | Add `ShellCreateRequest` / `ShellCreateResponse` |
+| `agentmux-srv/src/backend/blockcontroller/shell.rs` | Add `shell_chunk` WPS publication mode (alongside existing `blockfile` model) |
+| `Cargo.toml` (workspace) | Add `agentmux-mcp` member |
+| `Taskfile.yml` | Add `build:mcp` + `task dev` dependency |
+
+---
+
+## 9. Implementation Phases
+
+### Phase 1 — Frontend skeleton (no backend wiring)
+- Add `ShellNode` type to `types.ts`.
+- Add store commands + reducer stubs.
+- Add `<PersistentShellBlock>` component with mock data.
+- Wire `DocumentRow.tsx` router.
+- Ship `_shell-node.scss` styles.
+- **Deliverable:** Hardcoded ShellNode renders correctly in all states.
+
+### Phase 2 — Backend + MCP tool
+- Implement `agentmux-mcp` workspace member with `Shell` tool.
+- Add `POST /api/v1/shell/create` to agentmux-srv.
+- Wire `ShellController` to publish `shell_chunk` WPS events.
+- Wire `useAgentStream.ts` subscriptions.
+- **Deliverable:** Agent can call `Shell("task dev")` and see live build progress in the conversation.
+
+### Phase 3 — Input + lifecycle tools
+- `ShellInput(shell_id, text)` — send stdin.
+- `ShellStop(shell_id)` — SIGTERM.
+- `ShellStatus(shell_id)` — query.
+- Stop button in UI wired to `ShellStop`.
+- **Deliverable:** Full interactive shell lifecycle from agent.
+
+### Phase 4 — Bashwrap auto-promotion (optional)
+- Detect long-running Bash calls and auto-promote to ShellNode.
+- Configurable timeout threshold.
+
+---
+
+## 10. Open Questions
+
+1. **Output durability**: Should shell output persist across app restarts? Today `ToolStreamingLog` is session-only. If yes, wire into `FileStore` (like the existing `term` widget). If no, WPS replay buffer (1024 events) is sufficient.
+
+2. **Multiple shells per agent**: Should the agent be able to run multiple concurrent persistent shells? Architecture supports it (each has its own `shell_id`), but UX for managing several shells in one conversation needs design.
+
+3. **Shell vs. PTY**: Phase 1 uses a non-interactive PTY (no stdin). Phase 3 adds stdin. Full interactive PTY (xterm.js rendering) is out of scope — use the `term` widget for that.
+
+4. **Changeset type**: Phase 1 is `minor` (new feature, non-breaking). Phase 2+ are `minor` each. No breaking changes to existing document schema (additive `| ShellNode`).
+
+---
+
+## 11. Relation to Existing Work
+
+- **`SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09`** — ShellBlock uses the same container query breakpoints (Tier 2–5). Result pill concept (§600px) maps to elapsed timer + exit code pill.
+- **`SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28`** — ShellBlock follows the same pin-to-expand model (no hover-expand). The `userHolding` anti-collapse guard from PR #1320 should be applied to ShellBlock.
+- **`SPEC_TOOL_OUTPUT_CAP_2026_05_30`** — same `MAX_TOOL_OUTPUT_LINES` cap applies to shell log rendering.
+- **`RETRO_REPLACECHILD_CRASH_2026-06-06`** — ShellChunkAppend must be dispatched inside `batch()` alongside ShellNodeCreate to avoid the same reconciler race that affected tool_chunk.

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -13,7 +13,7 @@
  * on every mount. Issue #728 gap 4.
  */
 
-import type { DocumentNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
+import type { DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
 import {
     AgentDocumentCommand,
     AgentDocumentState,
@@ -106,6 +106,12 @@ function scrubOrphanedInProgress(
             // spinner" goal. Codex + reagent P2 on PR #1104.
             const closedLog = n.log != null ? { ...n.log, open: false } : n.log;
             next[i] = { ...n, status: "canceled", log: closedLog };
+            toolsCanceled++;
+            continue;
+        }
+        if (n.type === "shell" && n.status === "running") {
+            if (!next) next = nodes.slice();
+            next[i] = { ...n, status: "stopped", log: { ...n.log, open: false } };
             toolsCanceled++;
             continue;
         }
@@ -474,6 +480,48 @@ export function update(
                     { type: "truncate-applied", reason: command.reason, clearedCount: cleared },
                 ],
             };
+        }
+
+        case "ShellNodeCreate": {
+            if (state.nodeIdSet.has(command.node.id)) {
+                return { state, events: [] };
+            }
+            const nextSet = new Set(state.nodeIdSet);
+            nextSet.add(command.node.id);
+            return {
+                state: { ...state, nodes: [...state.nodes, command.node], nodeIdSet: nextSet },
+                events: [{ type: "stream-flushed", appended: 1, updated: 0, updateDropped: 0 }],
+            };
+        }
+
+        case "ShellChunkAppend": {
+            const idx = state.nodes.findIndex((n) => n.type === "shell" && n.id === command.shellId);
+            if (idx === -1) return { state, events: [] };
+            const shell = state.nodes[idx] as ShellNode;
+            const existingChunks = shell.log.chunks;
+            if (isDuplicate(existingChunks, command.chunk)) return { state, events: [] };
+            const nextLog: ToolStreamingLog = {
+                chunks: [...existingChunks, command.chunk],
+                open: shell.log.open,
+            };
+            const nextNodes = state.nodes.slice();
+            nextNodes[idx] = { ...shell, log: nextLog };
+            return { state: { ...state, nodes: nextNodes }, events: [] };
+        }
+
+        case "ShellStatusUpdate": {
+            const idx = state.nodes.findIndex((n) => n.type === "shell" && n.id === command.shellId);
+            if (idx === -1) return { state, events: [] };
+            const shell = state.nodes[idx] as ShellNode;
+            const nextNodes = state.nodes.slice();
+            nextNodes[idx] = {
+                ...shell,
+                status: command.status,
+                exitCode: command.exitCode,
+                exitedAt: command.exitedAt,
+                log: { ...shell.log, open: false },
+            };
+            return { state: { ...state, nodes: nextNodes }, events: [] };
         }
 
         case "UserClear": {

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -490,7 +490,7 @@ export function update(
             nextSet.add(command.node.id);
             return {
                 state: { ...state, nodes: [...state.nodes, command.node], nodeIdSet: nextSet },
-                events: [{ type: "stream-flushed", appended: 1, updated: 0, updateDropped: 0 }],
+                events: [{ type: "stream-flushed", appendedNew: 1, collidedAndUpdated: 0, updateApplied: 0, updateDropped: 0 }],
             };
         }
 

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -111,7 +111,7 @@ function scrubOrphanedInProgress(
         }
         if (n.type === "shell" && n.status === "running") {
             if (!next) next = nodes.slice();
-            next[i] = { ...n, status: "stopped", log: { ...n.log, open: false } };
+            next[i] = { ...n, status: "stopped", exitedAt: at, log: { ...n.log, open: false } };
             toolsCanceled++;
             continue;
         }

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -517,7 +517,7 @@ export function update(
             nextNodes[idx] = {
                 ...shell,
                 status: command.status,
-                exitCode: command.exitCode,
+                exitCode: command.exitCode ?? shell.exitCode,
                 exitedAt: command.exitedAt,
                 log: { ...shell.log, open: false },
             };

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -10,7 +10,7 @@
  * and produces typed Events for audit. Pure function, no I/O.
  */
 
-import type { DocumentNode, ToolLogChunk } from "../../view/agent/types";
+import type { DocumentNode, ShellNode, ToolLogChunk } from "../../view/agent/types";
 
 export type SessionPhase = "loading-history" | "active" | "ended";
 
@@ -98,6 +98,12 @@ export type AgentDocumentCommand =
      * SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.3.
      */
     | { type: "ToolChunkAppend"; toolId: string; chunk: ToolLogChunk }
+    /** Create a new ShellNode in the document (fired on shell_node_create WPS event). */
+    | { type: "ShellNodeCreate"; node: ShellNode }
+    /** Append a streaming chunk to a ShellNode's live-log. */
+    | { type: "ShellChunkAppend"; shellId: string; chunk: ToolLogChunk }
+    /** Update a ShellNode's terminal status (exit, stop). */
+    | { type: "ShellStatusUpdate"; shellId: string; status: ShellNode["status"]; exitCode?: number; exitedAt: number }
     /**
      * Backend `fileop=truncate` arrived on the file subject. The reducer
      * decides whether to honor (initialization, legitimate clear) or

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -32,6 +32,7 @@
 @use "styles/auth-overlay";
 @use "styles/responsive";
 @use "styles/decision-panel";
+@use "styles/shell-node";
 
 .agent-view {
     container-type: inline-size;

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -13,7 +13,7 @@
 
 import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
-import { MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChunksByLines, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import type { ShellNode, ToolLogChunk } from "../types";
 
@@ -74,15 +74,13 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
 
     const expanded = () => props.pinned;
 
-    // Cap chunks for rendering — same limit as tool log
-    const visibleChunks = createMemo((): ToolLogChunk[] => {
-        const chunks = props.node.log.chunks;
-        if (chunks.length <= MAX_TOOL_OUTPUT_LINES) return chunks as ToolLogChunk[];
-        return chunks.slice(chunks.length - MAX_TOOL_OUTPUT_LINES) as ToolLogChunk[];
-    });
-    const hiddenCount = createMemo(() =>
-        Math.max(0, props.node.log.chunks.length - MAX_TOOL_OUTPUT_LINES)
+    // Cap by rendered lines (not chunk count) — a single chunk can contain
+    // thousands of newlines and bypass a naive array-slice cap.
+    const capped = createMemo(() =>
+        capChunksByLines(props.node.log.chunks as ToolLogChunk[], MAX_TOOL_OUTPUT_LINES, "tail")
     );
+    const visibleChunks = () => capped().chunks;
+    const hiddenCount = () => capped().hiddenLines;
 
     return (
         <div

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -13,7 +13,7 @@
 
 import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
-import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import type { ShellNode, ToolLogChunk } from "../types";
 

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -13,7 +13,7 @@
 
 import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
-import { capChunksByLines, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import type { ShellNode, ToolLogChunk } from "../types";
 
@@ -74,10 +74,11 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
 
     const expanded = () => props.pinned;
 
-    // Cap by rendered lines (not chunk count) — a single chunk can contain
-    // thousands of newlines and bypass a naive array-slice cap.
+    // createChunkCapper tracks total lines incrementally and returns hiddenLines.
+    // Using capChunksByLines directly only returns keptLines (no hidden count).
+    const chunkCap = createChunkCapper(MAX_TOOL_OUTPUT_LINES);
     const capped = createMemo(() =>
-        capChunksByLines(props.node.log.chunks as ToolLogChunk[], MAX_TOOL_OUTPUT_LINES, "tail")
+        chunkCap(props.node.log.chunks as ToolLogChunk[])
     );
     const visibleChunks = () => capped().chunks;
     const hiddenCount = () => capped().hiddenLines;
@@ -126,7 +127,7 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
                         <For each={visibleChunks()}>
                             {(chunk) => (
                                 <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
-                                    {chunk.content}
+                                    {capChars(chunk.content)}
                                 </pre>
                             )}
                         </For>

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -1,0 +1,145 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PersistentShellBlock — compact document row for a long-running shell process.
+ *
+ * Displays as a single colored line in the conversation (status color on the
+ * left border, sigil, title, elapsed timer, live-tail of last output).
+ * Click toggles an inline log panel showing all streamed output.
+ *
+ * Spec: docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md
+ */
+
+import clsx from "clsx";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import type { ShellNode, ToolLogChunk } from "../types";
+
+interface PersistentShellBlockProps {
+    node: ShellNode;
+    pinned: boolean;
+    onTogglePin: () => void;
+}
+
+const KIND_CLASS: Record<string, string> = {
+    stdout: "agent-tool-log-line--stdout",
+    stderr: "agent-tool-log-line--stderr",
+    system: "agent-tool-log-line--system",
+};
+
+function formatElapsed(ms: number): string {
+    const totalSec = Math.floor(ms / 1000);
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Element => {
+    const [now, setNow] = createSignal(Date.now());
+
+    createEffect(() => {
+        if (props.node.status !== "running") return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    const elapsed = createMemo(() => {
+        const end = props.node.exitedAt ?? now();
+        return formatElapsed(end - props.node.spawnedAt);
+    });
+
+    const lastLine = createMemo((): string | undefined => {
+        const chunks = props.node.log.chunks;
+        if (!chunks.length) return undefined;
+        // Walk from the end to find the last non-empty stdout/stderr line
+        for (let i = chunks.length - 1; i >= 0; i--) {
+            const c = chunks[i];
+            if ((c.kind === "stdout" || c.kind === "stderr") && c.content.trim()) {
+                return c.content.trim();
+            }
+        }
+        return undefined;
+    });
+
+    const statusSigil = createMemo(() => {
+        switch (props.node.status) {
+            case "running": return "⟩";
+            case "exited-ok": return "✓";
+            case "exited-err": return "✗";
+            case "stopped": return "■";
+        }
+    });
+
+    const expanded = () => props.pinned;
+
+    // Cap chunks for rendering — same limit as tool log
+    const visibleChunks = createMemo((): ToolLogChunk[] => {
+        const chunks = props.node.log.chunks;
+        if (chunks.length <= MAX_TOOL_OUTPUT_LINES) return chunks as ToolLogChunk[];
+        return chunks.slice(chunks.length - MAX_TOOL_OUTPUT_LINES) as ToolLogChunk[];
+    });
+    const hiddenCount = createMemo(() =>
+        Math.max(0, props.node.log.chunks.length - MAX_TOOL_OUTPUT_LINES)
+    );
+
+    return (
+        <div
+            class={clsx("agent-shell-block", {
+                "running": props.node.status === "running",
+                "exited-ok": props.node.status === "exited-ok",
+                "exited-err": props.node.status === "exited-err",
+                "stopped": props.node.status === "stopped",
+                "expanded": expanded(),
+                "collapsed": !expanded(),
+            })}
+        >
+            <div class="agent-shell-summary" onClick={props.onTogglePin}>
+                <span class="agent-shell-sigil">{statusSigil()}</span>
+                <span class="agent-shell-title">{props.node.title}</span>
+                <span class="agent-shell-elapsed">[{elapsed()}]</span>
+                <Show when={lastLine()}>
+                    <span class="agent-shell-live-tail">↳ {lastLine()}</span>
+                </Show>
+            </div>
+            <div
+                class={clsx("agent-tool-panel", {
+                    "agent-tool-panel--hidden": !expanded(),
+                    "agent-tool-panel--flow": expanded(),
+                })}
+                inert={!expanded()}
+                aria-hidden={!expanded()}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div class="agent-tool-overlay">
+                    <div class="agent-tool-overlay-header">
+                        <span class="agent-shell-header-cmd">{props.node.cmd}</span>
+                        <Show when={props.node.exitCode !== undefined}>
+                            <span class="agent-tool-overlay-status-label">
+                                exit {props.node.exitCode}
+                            </span>
+                        </Show>
+                    </div>
+                    <div class="agent-tool-overlay-log">
+                        <Show when={hiddenCount() > 0}>
+                            <OutputHiddenMarker hidden={hiddenCount()} noun="line" from="tail" />
+                        </Show>
+                        <For each={visibleChunks()}>
+                            {(chunk) => (
+                                <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
+                                    {chunk.content}
+                                </pre>
+                            )}
+                        </For>
+                        <Show when={props.node.log.open}>
+                            <div class="agent-shell-streaming-indicator" />
+                        </Show>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+PersistentShellBlock.displayName = "PersistentShellBlock";

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -39,8 +39,11 @@ function formatElapsed(ms: number): string {
 export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Element => {
     const [now, setNow] = createSignal(Date.now());
 
+    // Gate the interval on the status memo, not props.node, so chunk appends
+    // don't tear down and recreate the timer on every streamed line.
+    const isRunning = createMemo(() => props.node.status === "running");
     createEffect(() => {
-        if (props.node.status !== "running") return;
+        if (!isRunning()) return;
         const id = setInterval(() => setNow(Date.now()), 1000);
         onCleanup(() => clearInterval(id));
     });

--- a/frontend/app/view/agent/hooks/useBookmarks.ts
+++ b/frontend/app/view/agent/hooks/useBookmarks.ts
@@ -73,6 +73,7 @@ function nodePreview(node: DocumentNode): string {
         case "agent_message": raw = node.summary || node.message; break;
         case "section":       raw = node.title; break;
         case "subagent_link": raw = node.slug || node.subagentId; break;
+        case "shell":         raw = node.title || node.cmd; break;
     }
     return raw.replace(/\s+/g, " ").trim().slice(0, 80);
 }

--- a/frontend/app/view/agent/hooks/useInSessionSearch.ts
+++ b/frontend/app/view/agent/hooks/useInSessionSearch.ts
@@ -67,6 +67,7 @@ function nodeSearchText(node: DocumentNode): string {
         case "tool":          return node.tool + " " + JSON.stringify(node.params ?? {});
         case "section":       return node.title;
         case "subagent_link": return node.slug + " " + node.subagentId;
+        case "shell":         return node.cmd + " " + node.title;
         default:              return "";
     }
 }

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -1,0 +1,113 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Persistent shell node — compact colored row + inline log panel.
+// Spec: docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md
+
+.agent-shell-block {
+    position: relative;
+    border-left: 4px solid var(--border-color);
+    transition: border-left-color 0.2s ease;
+
+    // Status colors
+    &.running    { border-left-color: var(--term-bright-green); }
+    &.exited-ok  { border-left-color: var(--accent-color); opacity: 0.8; }
+    &.exited-err { border-left-color: var(--error-color, #ff6b6b); }
+    &.stopped    { border-left-color: var(--secondary-text-color); opacity: 0.6; }
+
+    // Running pulse — draws attention to an active long-running process
+    &.running {
+        animation: shell-running-pulse 2s ease-in-out infinite;
+    }
+}
+
+@keyframes shell-running-pulse {
+    0%, 100% { border-left-color: var(--term-bright-green); }
+    50%       { border-left-color: color-mix(in srgb, var(--term-bright-green) 35%, transparent); }
+}
+
+.agent-shell-summary {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    cursor: pointer;
+    user-select: none;
+    min-height: 24px;
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+    }
+}
+
+.agent-shell-sigil {
+    flex: 0 0 auto;
+    font-size: 12px;
+    width: 14px;
+    text-align: center;
+
+    .running &    { color: var(--term-bright-green); }
+    .exited-ok &  { color: var(--accent-color); }
+    .exited-err & { color: var(--error-color, #ff6b6b); }
+    .stopped &    { color: var(--secondary-text-color); }
+}
+
+.agent-shell-title {
+    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 40%;
+}
+
+.agent-shell-elapsed {
+    flex: 0 0 auto;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+}
+
+.agent-shell-live-tail {
+    flex: 1 1 0;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0.75;
+    min-width: 0;
+}
+
+.agent-shell-header-cmd {
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+// Pulsing cursor shown while the shell is still streaming
+.agent-shell-streaming-indicator {
+    display: inline-block;
+    width: 6px;
+    height: 12px;
+    background: var(--term-bright-green);
+    margin-left: 2px;
+    vertical-align: text-bottom;
+    animation: shell-cursor-blink 1s step-end infinite;
+}
+
+@keyframes shell-cursor-blink {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0; }
+}
+
+// Responsive: hide live-tail on narrow panes
+@container agent-pane (max-width: 399px) {
+    .agent-shell-live-tail {
+        display: none;
+    }
+}

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -52,7 +52,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode | ShellNode;
 
 /**
  * Raw markdown text block
@@ -303,6 +303,29 @@ export interface SubagentLinkNode {
     status: "active" | "completed";
     model: string | null;
     timestamp?: number; // Unix ms
+}
+
+/**
+ * Persistent shell — a long-running process launched by the agent via the
+ * Shell tool (agentmux-mcp). Lives in the document as a single compact row
+ * that expands inline to show the live-log.
+ *
+ * Unlike ToolNode, a ShellNode is not tied to a tool-call lifecycle —
+ * the shell runs independently after the Shell tool returns.
+ *
+ * Spec: docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md
+ */
+export interface ShellNode {
+    type: "shell";
+    id: string;
+    cmd: string;
+    title: string;
+    cwd?: string;
+    status: "running" | "exited-ok" | "exited-err" | "stopped";
+    exitCode?: number;
+    spawnedAt: number;   // Unix ms
+    exitedAt?: number;   // Unix ms
+    log: ToolStreamingLog;
 }
 
 /**

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -20,9 +20,10 @@ import { AgentMessageBlock } from "../components/AgentMessageBlock";
 import { MarkdownBlock } from "../components/MarkdownBlock";
 import { NodeHoverStrip } from "../components/NodeHoverStrip";
 import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
+import { PersistentShellBlock } from "../components/PersistentShellBlock";
 import { ToolBlock } from "../components/ToolBlock";
 import { UserMessageBlock } from "../components/UserMessageBlock";
-import type { DocumentNode, DocumentState, SubagentLinkNode, UserMessageNode } from "../types";
+import type { DocumentNode, DocumentState, ShellNode, SubagentLinkNode, UserMessageNode } from "../types";
 import { markRowMount } from "./perf-probe";
 
 export interface DocumentRowProps {
@@ -256,6 +257,13 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                 <SubagentLinkBlock
                     node={props.node() as Extract<DocumentNode, { type: "subagent_link" }>}
                     onClick={props.onSubagentClick ?? (() => { })}
+                />
+            </Show>
+            <Show when={props.node() && props.node().type === "shell"}>
+                <PersistentShellBlock
+                    node={props.node() as ShellNode}
+                    pinned={props.documentState().pinnedNodes.has(props.node().id)}
+                    onTogglePin={() => props.onTogglePin(props.node().id)}
                 />
             </Show>
             <Show when={props.node() && props.node().type === "section"}>

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -58,6 +58,7 @@ export interface DocumentRowProps {
 // to begin with). Codex P2 on PR #1020.
 const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
     "tool",
+    "shell",
     "agent_message",
     "section",
 ]);
@@ -84,13 +85,13 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
     const isExpanded = (): boolean => {
         const n = props.node();
         const state = props.documentState();
-        if (n.type === "tool") return state.pinnedNodes.has(n.id);
+        if (n.type === "tool" || n.type === "shell") return state.pinnedNodes.has(n.id);
         return !state.collapsedNodes.has(n.id);
     };
 
     const onExpand = (): void => {
         const n = props.node();
-        if (n.type === "tool") props.onTogglePin(n.id);
+        if (n.type === "tool" || n.type === "shell") props.onTogglePin(n.id);
         else props.onToggleCollapse(n.id);
     };
 

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -84,9 +84,9 @@ export function currentExpansion(
             return OPEN_DEFAULT;
 
         case "shell":
-            // Mirrors tool: pin wins; a running shell is auto-expanded.
+            // Pin-to-expand only: unlike tools, a running shell stays collapsed
+            // by default (spec §11). Only a pin opens it.
             if (state.pinnedNodes.has(node.id)) return { open: true, via: "pin" };
-            if (node.status === "running") return { open: true, via: "auto" };
             return CLOSED;
     }
 }

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -82,5 +82,11 @@ export function currentExpansion(
 
         case "subagent_link":
             return OPEN_DEFAULT;
+
+        case "shell":
+            // Mirrors tool: pin wins; a running shell is auto-expanded.
+            if (state.pinnedNodes.has(node.id)) return { open: true, via: "pin" };
+            if (node.status === "running") return { open: true, via: "auto" };
+            return CLOSED;
     }
 }

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -19,6 +19,7 @@ import type {
     DocumentState,
     MarkdownNode,
     SectionNode,
+    ShellNode,
     SubagentLinkNode,
     ToolNode,
     UserMessageNode,
@@ -162,6 +163,13 @@ export function estimateSubagentLink(_node: SubagentLinkNode): number {
     return SUBAGENT_LINK_PX;
 }
 
+const SHELL_COLLAPSED_PX = 32;
+const SHELL_EXPANDED_PX = 200;
+
+export function estimateShell(node: ShellNode, state: DocumentState): number {
+    return state.pinnedNodes.has(node.id) ? SHELL_EXPANDED_PX : SHELL_COLLAPSED_PX;
+}
+
 /** Per-kind streaming capability — straightforward map. */
 export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     markdown: true,
@@ -170,6 +178,7 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     tool: false,
     user_message: false,
     subagent_link: false,
+    shell: false,
 };
 
 // ── Registry factory ────────────────────────────────────────────────────────
@@ -181,6 +190,7 @@ export interface RendererComponents {
     AgentMessage: Component<{ node: AgentMessageNode; state: DocumentState }>;
     UserMessage: Component<{ node: UserMessageNode; state: DocumentState }>;
     SubagentLink: Component<{ node: SubagentLinkNode; state: DocumentState }>;
+    Shell: Component<{ node: ShellNode; state: DocumentState }>;
 }
 
 /**
@@ -220,6 +230,11 @@ export function buildRendererRegistry(components: RendererComponents): NodeRende
             estimatedSize: estimateSubagentLink,
             isStreamingCapable: STREAMING_CAPABLE.subagent_link,
         },
+        shell: {
+            component: components.Shell,
+            estimatedSize: estimateShell,
+            isStreamingCapable: STREAMING_CAPABLE.shell,
+        },
     };
 }
 
@@ -236,6 +251,7 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "agent_message": return estimateAgentMessage(node, state);
         case "user_message": return estimateUserMessage(node, state);
         case "subagent_link": return estimateSubagentLink(node);
+        case "shell": return estimateShell(node, state);
     }
 }
 
@@ -272,6 +288,7 @@ export function estimateNodeForState(
                     ? COLLAPSED_MESSAGE_PX
                     : estimateTextHeight(node.content);
             case "subagent_link": return SUBAGENT_LINK_PX;
+            case "shell":         return SHELL_COLLAPSED_PX;
         }
     }
     // expanded
@@ -282,5 +299,6 @@ export function estimateNodeForState(
         case "section":       return SECTION_PX;
         case "markdown":      return estimateTextHeight(node.content);
         case "subagent_link": return SUBAGENT_LINK_PX;
+        case "shell":         return SHELL_EXPANDED_PX;
     }
 }


### PR DESCRIPTION
## Summary

- Spinner/progress animations that use `\r` to overwrite the current line were rendering as one line per frame in the agent pane's `<pre>` log view. HTML normalizes bare `\r` to a line break, so each animation frame appeared on its own line.
- Fix: in `strip_ansi` (PTY path), a lone `\r` now truncates the current visual line in the output buffer back to after the last `\n`, simulating what a real terminal does (cursor to column 0, next write overwrites).
- CRLF (`\r\n`) handling is unchanged.

## Test plan

- [ ] Run a command that uses a spinner (e.g. `npm install`, a Python `tqdm` bar, or `printf 'frame1\rframe2\rfinal\n'`) in an agent pane — only the final frame should appear in the log, not one line per frame.
- [ ] Confirm normal multi-line output (with `\n`) is unaffected.
- [ ] Confirm CRLF output is still normalized to LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)