### PR TITLE
feat(container): add container schema fields to AgentDefinition (Phase 0)

### DIFF
--- a/.changesets/1781209373-feat-container-add-container-image-container-volumes-contain-liai.md
+++ b/.changesets/1781209373-feat-container-add-container-image-container-volumes-contain-liai.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(container): add container_image, container_volumes, container_name to AgentDefinition schema and RPC types (Phase 0)

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -169,6 +169,9 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
             // user explicitly hides; new template ids in re-seed are
             // force-reset to 0 below (see `reseed_if_needed`).
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -348,6 +351,9 @@ fn reseed_if_needed(
             // hidden — the `else` branch below honours that by lining
             // up against existing ids only.
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -449,6 +455,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
             user_hidden: hidden,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
     }

--- a/agentmux-srv/src/backend/agent_session.rs
+++ b/agentmux-srv/src/backend/agent_session.rs
@@ -900,6 +900,9 @@ pub fn migrate_promote_template_sessions_v1(
                 branch_label: String::new(),
                 updated_at: now,
                 user_hidden: 0,
+                container_image: template.container_image.clone(),
+                container_volumes: template.container_volumes.clone(),
+                container_name: String::new(),
             };
             if let Err(e) = wstore.agent_def_insert(&mut new_def) {
                 tracing::warn!(
@@ -1568,6 +1571,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
         def
@@ -1797,6 +1803,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: now - 2_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut user_clone).unwrap();
         // The user's clone has its OWN active conversation.
@@ -1900,6 +1909,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: now - 1_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut prior_target).unwrap();
         // Seeded `:current` has the OLDER stale snapshot the prior
@@ -1995,6 +2007,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: now - 1_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -2092,6 +2107,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: now - 1_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -2208,6 +2226,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: now - 1_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut prior_target).unwrap();
         // Realistic partial-failure shape: run 1 copied :current
@@ -2341,6 +2362,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut user_def).unwrap();
         write_session_state(&filestore, &user_def.id, br#"{"nodes":[]}"#).unwrap();

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -831,6 +831,12 @@ pub struct CommandAgentDefineData {
     pub env: Option<std::collections::HashMap<String, String>>,
     pub if_exists: Option<String>,
     pub create_instance_stub: Option<bool>,
+    /// Docker image for container-type agents. Empty string for host agents.
+    #[serde(default)]
+    pub container_image: String,
+    /// JSON array of volume mount specs. Empty array (`"[]"`) for host agents.
+    #[serde(default = "default_container_volumes")]
+    pub container_volumes: String,
 }
 
 /// Response from agent.define.
@@ -1474,6 +1480,10 @@ fn default_agent_type() -> String {
     "standalone".to_string()
 }
 
+fn default_container_volumes() -> String {
+    "[]".to_string()
+}
+
 fn default_agent_icon() -> String {
     "✦".to_string()
 }
@@ -1509,6 +1519,12 @@ pub struct CommandUpdateAgentDefinitionData {
     /// `AgentDefinition.accounts`). Written by the Agent pane's Identity tab.
     #[serde(default)]
     pub accounts: String,
+    /// Docker image for container-type agents. Empty string for host agents.
+    #[serde(default)]
+    pub container_image: String,
+    /// JSON array of volume mount specs. Empty array (`"[]"`) for host agents.
+    #[serde(default = "default_container_volumes")]
+    pub container_volumes: String,
 }
 
 /// Input for deleteagent

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -98,6 +98,22 @@ pub struct AgentDefinition {
     /// removal path is `deleteagent`, not hide.
     #[serde(default)]
     pub user_hidden: i64,
+    /// Docker image to use when `agent_type == "container"`.
+    /// e.g. `"ghcr.io/agentmuxai/agent-claude:latest"`.
+    /// Empty string for host agents. Schema v6.
+    #[serde(default)]
+    pub container_image: String,
+    /// JSON array of volume mount specs for container agents.
+    /// Each element is a string in Docker bind-mount format:
+    /// `"source:target"` or `"source:target:options"`.
+    /// Empty JSON array (`"[]"`) for host agents. Schema v6.
+    #[serde(default = "default_container_volumes")]
+    pub container_volumes: String,
+    /// Stable Docker container name managed by the server.
+    /// Set to `"agentmux-<slug>"` on first container spawn;
+    /// empty for host agents. Schema v6.
+    #[serde(default)]
+    pub container_name: String,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -131,6 +147,10 @@ pub fn derive_slug(name: &str) -> String {
 
 fn default_agent_type() -> String {
     "standalone".to_string()
+}
+
+fn default_container_volumes() -> String {
+    "[]".to_string()
 }
 
 /// Instance lifecycle status. Serialised lowercase to match the DB text.
@@ -298,7 +318,7 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
-                    user_hidden
+                    user_hidden, container_image, container_volumes, container_name
              FROM db_agent_definitions
              WHERE is_seeded = 0 AND parent_id = ?1
              ORDER BY updated_at DESC, created_at DESC",
@@ -330,7 +350,7 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
-                    user_hidden
+                    user_hidden, container_image, container_volumes, container_name
              FROM db_agent_definitions
              WHERE id = ?1",
         )?;
@@ -349,7 +369,7 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_template_id, branch_label, updated_at,
-                    user_hidden
+                    user_hidden, container_image, container_volumes, container_name
              FROM db_agents
              ORDER BY updated_at DESC, created_at ASC",
         )?;
@@ -452,9 +472,10 @@ impl Store {
             "INSERT INTO db_agent_definitions (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-             is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden)
+             is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
+             container_image, container_volumes, container_name)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21, ?22)",
+                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
             params![
                 agent.id,
                 agent.slug,
@@ -485,6 +506,9 @@ impl Store {
                 // caller-supplied value here is safe even when a stray
                 // 1 sneaks through.
                 agent.user_hidden,
+                agent.container_image,
+                agent.container_volumes,
+                agent.container_name,
             ],
         )?;
         // Persist the stamped updated_at before we leave the lock so the
@@ -535,7 +559,7 @@ impl Store {
                         restart_on_crash, idle_timeout_minutes, created_at,
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
-                        user_hidden
+                        user_hidden, container_image, container_volumes, container_name
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
@@ -583,10 +607,11 @@ impl Store {
                    (id, slug, name, icon, provider, description,
                     working_directory, shell, provider_flags, auto_start, restart_on_crash,
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden)
+                    is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
+                    container_image, container_volumes, container_name)
                  VALUES
                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                    ?17, ?18, ?19, ?20, ?21, ?22)",
+                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
                 params![
                     agent.id, agent.slug, agent.name, agent.icon, agent.provider,
                     agent.description, agent.working_directory, agent.shell,
@@ -596,6 +621,7 @@ impl Store {
                     agent.accounts, agent.parent_id, agent.branch_label,
                     agent.created_at, // updated_at = created_at for new rows
                     agent.user_hidden,
+                    agent.container_image, agent.container_volumes, agent.container_name,
                 ],
             )?;
             agent.created_at
@@ -687,7 +713,8 @@ impl Store {
                 "UPDATE db_agent_definitions SET name=?1, icon=?2, provider=?3, description=?4,
                  working_directory=?5, shell=?6, provider_flags=?7, auto_start=?8,
                  restart_on_crash=?9, idle_timeout_minutes=?10,
-                 agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15
+                 agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
+                 container_image=?17, container_volumes=?18, container_name=?19
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -705,7 +732,10 @@ impl Store {
                     agent.agent_bus_id,
                     agent.accounts,
                     now,
-                    agent.id
+                    agent.id,
+                    agent.container_image,
+                    agent.container_volumes,
+                    agent.container_name,
                 ],
             )?
         };
@@ -1759,5 +1789,8 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
         branch_label: row.get(19)?,
         updated_at: row.get(20)?,
         user_hidden: row.get(21)?,
+        container_image: row.get(22)?,
+        container_volumes: row.get(23)?,
+        container_name: row.get(24)?,
     })
 }

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -65,7 +65,8 @@ impl Store {
                 agent_type, agent_bus_id, accounts,
                 auto_start, restart_on_crash, idle_timeout_minutes,
                 slug, branch_label, working_directory,
-                created_at, updated_at, is_seeded, user_hidden
+                created_at, updated_at, is_seeded, user_hidden,
+                container_image, container_volumes, container_name
              ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6,
@@ -73,7 +74,8 @@ impl Store {
                 ?11, ?12, ?13,
                 ?14, ?15, ?16,
                 ?17, ?18, ?19,
-                ?20, ?21, ?22, ?23
+                ?20, ?21, ?22, ?23,
+                ?24, ?25, ?26
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -95,7 +97,10 @@ impl Store {
                 branch_label = excluded.branch_label,
                 working_directory = excluded.working_directory,
                 updated_at = excluded.updated_at,
-                is_seeded = excluded.is_seeded",
+                is_seeded = excluded.is_seeded,
+                container_image = excluded.container_image,
+                container_volumes = excluded.container_volumes,
+                container_name = excluded.container_name",
             params![
                 def.id,
                 def.name,
@@ -120,6 +125,9 @@ impl Store {
                 def.updated_at,
                 def.is_seeded,
                 def.user_hidden,
+                def.container_image,
+                def.container_volumes,
+                def.container_name,
             ],
         )?;
         Ok(())
@@ -341,7 +349,8 @@ impl Store {
                     identity_id, memory_id, working_directory, github_context,
                     instance_name,
                     created_at, updated_at, is_seeded, user_hidden,
-                    last_block_id
+                    last_block_id,
+                    container_image, container_volumes, container_name
                  ) VALUES (
                     ?1, ?2, ?3, ?4,
                     0, ?5,
@@ -352,7 +361,8 @@ impl Store {
                     ?18, ?19, ?20, ?21,
                     ?22,
                     ?23, ?24, 0, ?25,
-                    ?26
+                    ?26,
+                    ?27, ?28, ?29
                  )
                  ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
@@ -391,6 +401,9 @@ impl Store {
                     inst.created_at, // updated_at = created_at on insert
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
                     inst.block_id,
+                    def.container_image,
+                    def.container_volumes,
+                    def.container_name,
                 ],
             )
         };
@@ -625,7 +638,7 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
-                    user_hidden
+                    user_hidden, container_image, container_volumes, container_name
              FROM db_agent_definitions WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -652,6 +665,9 @@ impl Store {
                 branch_label: row.get(19)?,
                 updated_at: row.get(20)?,
                 user_hidden: row.get(21)?,
+                container_image: row.get(22)?,
+                container_volumes: row.get(23)?,
+                container_name: row.get(24)?,
             })
         });
         match result {

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -33,6 +33,10 @@ use super::error::StoreError;
 ///   v5 — db_agents.last_block_id (Phase 3c; latest launch's block, so the
 ///        consolidated read can find the session snapshot without joining
 ///        db_agent_instances)
+///   v6 — container_image / container_volumes / container_name on both
+///        db_agent_definitions and db_agents (Phase 0 of
+///        SPEC_CONTAINER_PANE_SUPPORT_2026_06_11.md; host agents default
+///        to '' / '[]' / '')
 pub const OBJECT_SCHEMA_VERSION: i64 = 6;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -33,7 +33,7 @@ use super::error::StoreError;
 ///   v5 — db_agents.last_block_id (Phase 3c; latest launch's block, so the
 ///        consolidated read can find the session snapshot without joining
 ///        db_agent_instances)
-pub const OBJECT_SCHEMA_VERSION: i64 = 5;
+pub const OBJECT_SCHEMA_VERSION: i64 = 6;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -141,7 +141,10 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             branch_label         TEXT NOT NULL DEFAULT '',
             created_at           INTEGER NOT NULL DEFAULT 0,
             updated_at           INTEGER NOT NULL DEFAULT 0,
-            user_hidden          INTEGER NOT NULL DEFAULT 0
+            user_hidden          INTEGER NOT NULL DEFAULT 0,
+            container_image      TEXT NOT NULL DEFAULT '',
+            container_volumes    TEXT NOT NULL DEFAULT '[]',
+            container_name       TEXT NOT NULL DEFAULT ''
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -330,7 +333,13 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             created_at           INTEGER NOT NULL DEFAULT 0,
             updated_at           INTEGER NOT NULL DEFAULT 0,
             is_seeded            INTEGER NOT NULL DEFAULT 0,
-            user_hidden          INTEGER NOT NULL DEFAULT 0
+            user_hidden          INTEGER NOT NULL DEFAULT 0,
+
+            -- Container support (Schema v6 / Phase 0).
+            -- Empty for host agents; populated by ContainerManager.
+            container_image      TEXT NOT NULL DEFAULT '',
+            container_volumes    TEXT NOT NULL DEFAULT '[]',
+            container_name       TEXT NOT NULL DEFAULT ''
         );
         CREATE INDEX IF NOT EXISTS idx_agents_is_template
             ON db_agents(is_template);
@@ -384,10 +393,20 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
     //     Defaults to '' for existing rows; the dual-write populates it on
     //     the next launch/continuation. Read side (3b.1b) treats '' as
     //     "no snapshot" (same as the current empty-block_id fallback).
+    // v6: Container support (Phase 0 of SPEC_CONTAINER_PANE_SUPPORT_2026_06_11.md).
+    //     container_image / container_volumes / container_name on both tables.
+    //     Host-agent rows default to '', '[]', '' respectively — ContainerManager
+    //     populates them on first container spawn.
     for stmt in &[
         "ALTER TABLE db_agent_definitions ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE db_agent_definitions ADD COLUMN user_hidden INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE db_agents ADD COLUMN last_block_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_definitions ADD COLUMN container_image TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_definitions ADD COLUMN container_volumes TEXT NOT NULL DEFAULT '[]'",
+        "ALTER TABLE db_agent_definitions ADD COLUMN container_name TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agents ADD COLUMN container_image TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agents ADD COLUMN container_volumes TEXT NOT NULL DEFAULT '[]'",
+        "ALTER TABLE db_agents ADD COLUMN container_name TEXT NOT NULL DEFAULT ''",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -835,6 +835,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -898,6 +901,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -956,6 +962,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         }
     }
 
@@ -2740,6 +2749,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         // db_agents row exists, projected as template.
@@ -2776,6 +2788,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-cloned def has is_seeded=0 + parent_id pointing at template.
@@ -2818,6 +2833,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         def.name = "New Name".to_string();
@@ -2854,6 +2872,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         assert_eq!(count_agents(&store, "id = 'tpl-del'"), 1);
@@ -2888,6 +2909,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -2970,6 +2994,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -3061,6 +3088,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -3114,6 +3144,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -3165,6 +3198,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl_a).unwrap();
         let mut tpl_b = tpl_a.clone();
@@ -3228,6 +3264,9 @@ mod tests {
                 branch_label: String::new(),
                 updated_at: 1000,
                 user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
             };
             store.agent_def_insert(&mut d).unwrap();
         }
@@ -3266,6 +3305,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-clone DEF of that template (Phase 1 created this).
@@ -3336,6 +3378,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 1000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let mut clone = AgentDefinition {

--- a/agentmux-srv/src/identity/migration.rs
+++ b/agentmux-srv/src/identity/migration.rs
@@ -654,6 +654,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -772,6 +775,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -846,6 +852,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         let inst = crate::backend::storage::store::AgentInstance {

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -758,6 +758,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -832,6 +835,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -919,6 +925,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -961,6 +970,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1047,6 +1059,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1128,6 +1143,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1293,6 +1311,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1379,6 +1400,9 @@ mod tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -251,8 +251,13 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // (`agentdefhide` / `agentdefunhide`). Phase 2 of
                     // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
                     user_hidden: old.user_hidden,
-                    container_image: cmd.container_image,
-                    container_volumes: cmd.container_volumes,
+                    // Preserve existing container config when the caller omits the field
+                    // (cmd.container_image defaults to "" via #[serde(default)]). Callers
+                    // that only update name/icon/etc. (AgentDefForm) don't carry container
+                    // fields, so falling back to old values prevents silently wiping a
+                    // container agent's image and volumes — same guard as `accounts` above.
+                    container_image: if cmd.container_image.is_empty() { old.container_image.clone() } else { cmd.container_image },
+                    container_volumes: if cmd.container_volumes == "[]" { old.container_volumes.clone() } else { cmd.container_volumes },
                     // container_name is server-managed; preserve the existing value.
                     container_name: old.container_name.clone(),
                 };

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -177,6 +177,9 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     branch_label: String::new(),
                     updated_at: now,
                     user_hidden: 0,
+                    container_image: String::new(),
+                    container_volumes: "[]".to_string(),
+                    container_name: String::new(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -248,6 +251,10 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // (`agentdefhide` / `agentdefunhide`). Phase 2 of
                     // SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md.
                     user_hidden: old.user_hidden,
+                    container_image: cmd.container_image,
+                    container_volumes: cmd.container_volumes,
+                    // container_name is server-managed; preserve the existing value.
+                    container_name: old.container_name.clone(),
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -387,6 +394,11 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // (Q2 Decision Y) — hide applies only to seeded
                     // templates, never to user-owned agents.
                     user_hidden: 0,
+                    // Inherit container config from template so container-type
+                    // templates propagate their image to user-cloned agents.
+                    container_image: template.container_image.clone(),
+                    container_volumes: template.container_volumes.clone(),
+                    container_name: String::new(),
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -829,6 +841,9 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     branch_label: String::new(),
                     updated_at: now,
                     user_hidden: 0,
+                    container_image: String::new(),
+                    container_volumes: "[]".to_string(),
+                    container_name: String::new(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -961,6 +976,9 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         branch_label: String::new(),
                         updated_at: now,
                         user_hidden: 0,
+                        container_image: String::new(),
+                        container_volumes: "[]".to_string(),
+                        container_name: String::new(),
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {
@@ -1939,6 +1957,11 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     branch_label: cmd.branch_label.clone(),
                     updated_at: now,
                     user_hidden: 0,
+                    // Forks inherit container config from source so forked container agents
+                    // retain their image and volumes.
+                    container_image: source.container_image.clone(),
+                    container_volumes: source.container_volumes.clone(),
+                    container_name: String::new(),
                 };
                 wstore
                     .agent_def_insert(&mut fork)
@@ -2769,6 +2792,9 @@ mod recent_sessions_tests {
             branch_label: String::new(),
             updated_at: 0,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         let mut def_mut = def.clone();
         wstore.agent_def_insert(&mut def_mut).unwrap();
@@ -3039,6 +3065,9 @@ mod recent_sessions_tests {
             branch_label: String::new(),
             updated_at: 1_700_000_000_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut tpl).unwrap();
 
@@ -3065,6 +3094,9 @@ mod recent_sessions_tests {
             branch_label: String::new(),
             updated_at: 1_700_000_001_000,
             user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
         };
         wstore.agent_def_insert(&mut user_a).unwrap();
 

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2029,6 +2029,9 @@ pub(crate) async fn agent_define_core(
         branch_label: String::new(),
         updated_at: now,
         user_hidden: 0,
+        container_image: cmd.container_image.clone(),
+        container_volumes: cmd.container_volumes.clone(),
+        container_name: String::new(), // assigned by ContainerManager on first spawn
     };
 
     // Atomic check-then-insert.


### PR DESCRIPTION
## Summary

Phase 0 of SPEC_CONTAINER_PANE_SUPPORT_2026_06_11.md — schema foundation for container-type agent panes.

- Adds container_image, container_volumes, container_name to AgentDefinition struct
- Updates all storage SELECT/INSERT/UPDATE queries (db_agent_definitions + db_agents)
- Updates dual_write.rs upsert and instance_create helpers
- Adds 6 idempotent ALTER TABLE migrations (3 per table), bumps OBJECT_SCHEMA_VERSION 5→6
- Adds fresh-database CREATE TABLE columns to both tables
- Extends CommandAgentDefineData and CommandUpdateAgentDefinitionData RPC types
- container_name is server-managed only (never accepted from clients)
- All host-agent rows default to '', '[]', '' — no data loss on existing databases

Independence boundary: AgentMux and claw are fully independent. No Docker runtime code in this phase.

## Phase sequence

| Phase | Branch | Status |
|-------|--------|--------|
| 0 — Schema | agenty/container-schema | this PR |
| 1 — ContainerManager | agenty/container-manager | next |
| 2 — Spawn routing | agenty/container-spawn | after Phase 1 |
| 4 — Dockerfile + CI | agenty/container-image | open (#1347) |

## Test plan
- [ ] cargo build -p agentmux-srv passes
- [ ] cargo test --no-run compiles clean
- [ ] Existing agent definitions survive migration (columns default to ''/'/[]'/'')
- [ ] agent.define with no container fields creates host agent with empty container fields
- [ ] updateagent preserves container_name and accepts container_image/container_volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)