### PR TITLE
feat(container): ContainerManager with bollard Docker SDK (Phase 1)

### DIFF
--- a/.changesets/1781209707-feat-container-add-containermanager-with-bollard-docker-sdk--3e3o.md
+++ b/.changesets/1781209707-feat-container-add-containermanager-with-bollard-docker-sdk--3e3o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(container): add ContainerManager with bollard Docker SDK (Phase 1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "async-stream",
  "axum 0.7.9",
  "base64",
+ "bollard",
  "chrono",
  "clap",
  "crash-handler",
@@ -434,6 +435,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,7 +718,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -766,6 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -854,6 +911,12 @@ dependencies = [
  "thiserror 2.0.18",
  "ureq",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1142,6 +1205,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1273,6 +1342,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1393,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1452,6 +1551,17 @@ checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2025,7 +2135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -2372,6 +2482,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2700,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2814,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2834,25 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -3541,7 +3725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3554,7 +3738,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4054,7 +4238,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4085,7 +4269,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4104,7 +4288,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4244,7 +4428,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -43,6 +43,7 @@ flate2 = "1"
 sha2 = "0.10"
 hex = "0.4"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+bollard = { version = "0.18", features = ["chrono"] }
 tar = "0.4"
 tempfile = "3"
 

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -37,6 +37,10 @@ struct ContainerManagerInner {
     docker: Docker,
     /// container_name → running-state cache.
     state: Mutex<HashMap<String, ContainerState>>,
+    /// Per-container serialization lock: prevents concurrent ensure_running calls
+    /// for the same container from both seeing None and both attempting create_container
+    /// (which would fail with a 409 name-conflict on the second caller).
+    ensure_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -45,9 +49,12 @@ enum ContainerState {
     Stopped,
 }
 
-/// Exec session handles for a single turn. Contains the two async byte-streams
-/// (stdout + stderr merged into stdout, stderr empty) that Phase 2 will pipe
-/// into the block's stdin/stdout channels.
+/// Exec session handle for a single turn.
+///
+/// `output` is a bollard `StartExecResults` stream. With `tty: false` +
+/// `attach_stderr: true`, Docker multiplexes stdout and stderr as separate
+/// `LogOutput::StdOut` / `LogOutput::StdErr` frames (not merged). Phase 2
+/// should fan both into the block's output channel.
 pub struct ExecSession {
     pub output: StartExecResults,
 }
@@ -75,6 +82,7 @@ impl ContainerManager {
             inner: Arc::new(ContainerManagerInner {
                 docker,
                 state: Mutex::new(HashMap::new()),
+                ensure_locks: Mutex::new(HashMap::new()),
             }),
         })
     }
@@ -91,7 +99,9 @@ impl ContainerManager {
     /// - If it exists but stopped: starts it.
     /// - If it doesn't exist: creates and starts it.
     ///
-    /// Returns the container name (same as `container_name` in `AgentDefinition`).
+    /// Concurrent calls for the **same** `container_name` are serialized via a
+    /// per-container mutex so only one caller races Docker. Concurrent calls for
+    /// **different** containers proceed in parallel.
     pub async fn ensure_running(
         &self,
         container_name: &str,
@@ -99,13 +109,37 @@ impl ContainerManager {
         volumes: &[String],
         env_vars: &[(String, String)],
     ) -> Result<(), ContainerError> {
-        let mut state = self.inner.state.lock().await;
-        if state.get(container_name) == Some(&ContainerState::Running) {
-            return Ok(());
+        // Fast path: cache hit (no Docker round-trip needed).
+        {
+            let state = self.inner.state.lock().await;
+            if state.get(container_name) == Some(&ContainerState::Running) {
+                return Ok(());
+            }
         }
-        drop(state); // release lock before async Docker calls
 
-        // Check if container exists in Docker
+        // Acquire the per-container serialization lock before touching Docker.
+        // This closes the TOCTOU window: two concurrent callers for the same
+        // not-yet-created container both miss the cache, but the second one
+        // blocks here until the first finishes, then finds the cache warm.
+        let container_lock = {
+            let mut locks = self.inner.ensure_locks.lock().await;
+            locks.entry(container_name.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = container_lock.lock().await;
+
+        // Re-check cache after acquiring the per-container lock (another
+        // caller may have completed between the fast-path miss and here).
+        {
+            let state = self.inner.state.lock().await;
+            if state.get(container_name) == Some(&ContainerState::Running) {
+                return Ok(());
+            }
+        }
+
+        // Always query Docker rather than trusting the cache — the cache can go
+        // stale if the container is killed externally.
         let existing = self.find_container(container_name).await?;
 
         match existing {
@@ -241,7 +275,7 @@ impl ContainerManager {
         let mounts: Vec<Mount> = volumes.iter().filter_map(|spec| {
             let parts: Vec<&str> = spec.splitn(3, ':').collect();
             if parts.len() < 2 {
-                tracing::warn!(spec = spec, "ignoring malformed volume spec (expected source:target)");
+                tracing::warn!(spec = %spec, "ignoring malformed volume spec (expected source:target)");
                 return None;
             }
             let source = parts[0];

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -1,0 +1,335 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Container management for container-type agent panes (Phase 1).
+//!
+//! Manages persistent Docker containers — one per container agent. Each
+//! container runs the configured image (e.g. `ghcr.io/agentmuxai/agent-claude`)
+//! with `tini` as PID 1 and is kept alive between turns. Individual turns are
+//! executed via `docker exec -i` (no `-t` — avoids CR/LF corruption of NDJSON).
+//!
+//! Platform support (cross-platform, matches SPEC_CONTAINER_PANE_SUPPORT_2026_06_11.md):
+//!   - Windows: named pipe `//./pipe/docker_engine`
+//!   - macOS:   socket resolved via `docker context inspect` (Docker Desktop or Rancher)
+//!   - Linux:   `/var/run/docker.sock` or rootless path in XDG_RUNTIME_DIR
+//!
+//! Independence boundary: this module has no dependency on a5af/claw.
+//! Docker best practices here were researched independently.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use bollard::Docker;
+use bollard::container::{
+    Config, CreateContainerOptions, ListContainersOptions, StartContainerOptions,
+    StopContainerOptions,
+};
+use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
+use bollard::models::{HostConfig, Mount, MountTypeEnum};
+
+/// Shared container manager. Clone-on-Arc; cheap to pass around.
+#[derive(Clone)]
+pub struct ContainerManager {
+    inner: Arc<ContainerManagerInner>,
+}
+
+struct ContainerManagerInner {
+    docker: Docker,
+    /// container_name → running-state cache.
+    state: Mutex<HashMap<String, ContainerState>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ContainerState {
+    Running,
+    Stopped,
+}
+
+/// Exec session handles for a single turn. Contains the two async byte-streams
+/// (stdout + stderr merged into stdout, stderr empty) that Phase 2 will pipe
+/// into the block's stdin/stdout channels.
+pub struct ExecSession {
+    pub output: StartExecResults,
+}
+
+/// Errors from container operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ContainerError {
+    #[error("Docker API error: {0}")]
+    Docker(#[from] bollard::errors::Error),
+    #[error("Container has no id after create: {name}")]
+    NoId { name: String },
+    #[error("Docker is not available on this host: {0}")]
+    NotAvailable(String),
+}
+
+impl ContainerManager {
+    /// Connect to the local Docker daemon using environment/platform defaults.
+    ///
+    /// Honors `DOCKER_HOST` env var (e.g. for rootless or remote daemons).
+    /// On Windows connects via named pipe; on macOS/Linux via Unix socket.
+    pub fn connect() -> Result<Self, ContainerError> {
+        let docker = Docker::connect_with_local_defaults()
+            .map_err(|e| ContainerError::NotAvailable(e.to_string()))?;
+        Ok(Self {
+            inner: Arc::new(ContainerManagerInner {
+                docker,
+                state: Mutex::new(HashMap::new()),
+            }),
+        })
+    }
+
+    /// Ping the Docker daemon. Returns `Ok(())` if available.
+    pub async fn check_available(&self) -> Result<(), ContainerError> {
+        self.inner.docker.ping().await?;
+        Ok(())
+    }
+
+    /// Ensure the container for this agent is created and running.
+    ///
+    /// - If it exists and is running: no-op.
+    /// - If it exists but stopped: starts it.
+    /// - If it doesn't exist: creates and starts it.
+    ///
+    /// Returns the container name (same as `container_name` in `AgentDefinition`).
+    pub async fn ensure_running(
+        &self,
+        container_name: &str,
+        image: &str,
+        volumes: &[String],
+        env_vars: &[(String, String)],
+    ) -> Result<(), ContainerError> {
+        let mut state = self.inner.state.lock().await;
+        if state.get(container_name) == Some(&ContainerState::Running) {
+            return Ok(());
+        }
+        drop(state); // release lock before async Docker calls
+
+        // Check if container exists in Docker
+        let existing = self.find_container(container_name).await?;
+
+        match existing {
+            Some(status) if status == "running" => {
+                let mut state = self.inner.state.lock().await;
+                state.insert(container_name.to_string(), ContainerState::Running);
+            }
+            Some(_) => {
+                // Exists but stopped — start it
+                self.inner.docker
+                    .start_container(container_name, None::<StartContainerOptions<String>>)
+                    .await?;
+                let mut state = self.inner.state.lock().await;
+                state.insert(container_name.to_string(), ContainerState::Running);
+                tracing::info!(container = container_name, "restarted stopped container");
+            }
+            None => {
+                // Create and start
+                self.create_and_start(container_name, image, volumes, env_vars).await?;
+                let mut state = self.inner.state.lock().await;
+                state.insert(container_name.to_string(), ContainerState::Running);
+                tracing::info!(container = container_name, image = image, "created and started container");
+            }
+        }
+        Ok(())
+    }
+
+    /// Launch an exec session inside a running container.
+    ///
+    /// Uses `-i` (not `-t`) to avoid tty CR/LF corruption of NDJSON output.
+    /// The caller receives `ExecSession` whose `output` stream carries
+    /// multiplexed stdout/stderr for piping into the block.
+    pub async fn exec(
+        &self,
+        container_name: &str,
+        cmd: &[String],
+        working_dir: Option<&str>,
+        env_vars: &[(String, String)],
+    ) -> Result<ExecSession, ContainerError> {
+        let env: Vec<String> = env_vars.iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+
+        let exec = self.inner.docker
+            .create_exec(container_name, CreateExecOptions {
+                attach_stdin: Some(true),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                tty: Some(false), // NO tty — preserves NDJSON newlines
+                cmd: Some(cmd.iter().map(String::as_str).collect()),
+                working_dir,
+                env: if env.is_empty() { None } else { Some(env.iter().map(String::as_str).collect()) },
+                ..Default::default()
+            })
+            .await?;
+
+        let output = self.inner.docker
+            .start_exec(&exec.id, Some(StartExecOptions {
+                detach: false,
+                ..Default::default()
+            }))
+            .await?;
+
+        Ok(ExecSession { output })
+    }
+
+    /// Gracefully stop a container. Uses SIGTERM → SIGKILL after `timeout_secs`.
+    pub async fn stop(&self, container_name: &str, timeout_secs: i64) -> Result<(), ContainerError> {
+        self.inner.docker
+            .stop_container(container_name, Some(StopContainerOptions { t: timeout_secs }))
+            .await?;
+        let mut state = self.inner.state.lock().await;
+        state.insert(container_name.to_string(), ContainerState::Stopped);
+        tracing::info!(container = container_name, "stopped container");
+        Ok(())
+    }
+
+    /// Remove a container (must be stopped first or use `force = true`).
+    pub async fn remove(&self, container_name: &str, force: bool) -> Result<(), ContainerError> {
+        use bollard::container::RemoveContainerOptions;
+        self.inner.docker
+            .remove_container(container_name, Some(RemoveContainerOptions {
+                force,
+                ..Default::default()
+            }))
+            .await?;
+        let mut state = self.inner.state.lock().await;
+        state.remove(container_name);
+        tracing::info!(container = container_name, "removed container");
+        Ok(())
+    }
+
+    // ---- private helpers ----
+
+    /// Returns the container status string ("running", "exited", …) or `None` if not found.
+    async fn find_container(&self, name: &str) -> Result<Option<String>, ContainerError> {
+        let mut filters = HashMap::new();
+        filters.insert("name", vec![name]);
+        let list = self.inner.docker
+            .list_containers(Some(ListContainersOptions {
+                all: true,
+                filters,
+                ..Default::default()
+            }))
+            .await?;
+
+        // `name` filter is a prefix match — verify exact name.
+        let canonical = format!("/{name}");
+        for c in &list {
+            if let Some(names) = &c.names {
+                if names.iter().any(|n| n == &canonical) {
+                    return Ok(c.state.clone());
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    async fn create_and_start(
+        &self,
+        container_name: &str,
+        image: &str,
+        volumes: &[String],
+        env_vars: &[(String, String)],
+    ) -> Result<(), ContainerError> {
+        let env: Vec<String> = env_vars.iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+
+        // Parse volume specs: "source:target" or "source:target:options"
+        // Named volumes (no path separator in source) are treated as Docker named volumes;
+        // paths starting with / are bind mounts.
+        let mounts: Vec<Mount> = volumes.iter().filter_map(|spec| {
+            let parts: Vec<&str> = spec.splitn(3, ':').collect();
+            if parts.len() < 2 {
+                tracing::warn!(spec = spec, "ignoring malformed volume spec (expected source:target)");
+                return None;
+            }
+            let source = parts[0];
+            let target = parts[1];
+            let read_only = parts.get(2).map(|o| o.contains("ro")).unwrap_or(false);
+            let mount_type = if source.starts_with('/') || source.starts_with('~') ||
+                             source.len() > 1 && source.chars().nth(1) == Some(':') {
+                // Absolute path → bind mount
+                MountTypeEnum::BIND
+            } else {
+                // Name without path → named volume
+                MountTypeEnum::VOLUME
+            };
+            Some(Mount {
+                target: Some(target.to_string()),
+                source: Some(source.to_string()),
+                typ: Some(mount_type),
+                read_only: Some(read_only),
+                ..Default::default()
+            })
+        }).collect();
+
+        // claude-config named volume: ensure ~/.claude persists across container restarts.
+        // Using a named volume (not a host bind mount) avoids credential leakage from the
+        // host's .claude directory into the container.
+        let mut all_mounts = vec![
+            Mount {
+                target: Some("/home/agent/.claude".to_string()),
+                source: Some(format!("agentmux-claude-{container_name}")),
+                typ: Some(MountTypeEnum::VOLUME),
+                read_only: Some(false),
+                ..Default::default()
+            },
+        ];
+        all_mounts.extend(mounts);
+
+        let config: Config<String> = Config {
+            image: Some(image.to_string()),
+            env: if env.is_empty() { None } else { Some(env) },
+            // Keep container alive between turns — entrypoint keeps process running.
+            // The agent-claude image uses `tini` as PID 1 so SIGTERM routes correctly.
+            tty: Some(false),
+            open_stdin: Some(true),
+            host_config: Some(HostConfig {
+                mounts: Some(all_mounts),
+                // Security: no host network, no privileged mode.
+                network_mode: Some("bridge".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let container = self.inner.docker
+            .create_container(
+                Some(CreateContainerOptions {
+                    name: container_name,
+                    platform: None,
+                }),
+                config,
+            )
+            .await?;
+
+        let id = container.id;
+        if id.is_empty() {
+            return Err(ContainerError::NoId { name: container_name.to_string() });
+        }
+
+        self.inner.docker
+            .start_container(&id, None::<StartContainerOptions<String>>)
+            .await?;
+
+        Ok(())
+    }
+}
+
+/// Derive the stable container name for an agent from its slug.
+/// Format: `agentmux-<slug>`. Deterministic so restarts reuse the same container.
+pub fn container_name_for_slug(slug: &str) -> String {
+    format!("agentmux-{slug}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_container_name_for_slug() {
+        assert_eq!(container_name_for_slug("my-agent"), "agentmux-my-agent");
+        assert_eq!(container_name_for_slug("agent1"), "agentmux-agent1");
+    }
+}

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -35,18 +35,11 @@ pub struct ContainerManager {
 
 struct ContainerManagerInner {
     docker: Docker,
-    /// container_name → running-state cache.
-    state: Mutex<HashMap<String, ContainerState>>,
     /// Per-container serialization lock: prevents concurrent ensure_running calls
-    /// for the same container from both seeing None and both attempting create_container
-    /// (which would fail with a 409 name-conflict on the second caller).
+    /// for the same container from both seeing "not found" in Docker and both
+    /// attempting create_container (which would fail with a 409 name-conflict
+    /// on the second caller).
     ensure_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum ContainerState {
-    Running,
-    Stopped,
 }
 
 /// Exec session handle for a single turn.
@@ -81,7 +74,6 @@ impl ContainerManager {
         Ok(Self {
             inner: Arc::new(ContainerManagerInner {
                 docker,
-                state: Mutex::new(HashMap::new()),
                 ensure_locks: Mutex::new(HashMap::new()),
             }),
         })
@@ -99,9 +91,10 @@ impl ContainerManager {
     /// - If it exists but stopped: starts it.
     /// - If it doesn't exist: creates and starts it.
     ///
-    /// Concurrent calls for the **same** `container_name` are serialized via a
-    /// per-container mutex so only one caller races Docker. Concurrent calls for
-    /// **different** containers proceed in parallel.
+    /// Always queries Docker (no in-memory cache) so externally killed containers
+    /// are detected. Concurrent calls for the **same** `container_name` are
+    /// serialized via a per-container mutex. Concurrent calls for **different**
+    /// containers proceed in parallel.
     pub async fn ensure_running(
         &self,
         container_name: &str,
@@ -109,18 +102,10 @@ impl ContainerManager {
         volumes: &[String],
         env_vars: &[(String, String)],
     ) -> Result<(), ContainerError> {
-        // Fast path: cache hit (no Docker round-trip needed).
-        {
-            let state = self.inner.state.lock().await;
-            if state.get(container_name) == Some(&ContainerState::Running) {
-                return Ok(());
-            }
-        }
-
         // Acquire the per-container serialization lock before touching Docker.
-        // This closes the TOCTOU window: two concurrent callers for the same
-        // not-yet-created container both miss the cache, but the second one
-        // blocks here until the first finishes, then finds the cache warm.
+        // Concurrent callers for the same container_name queue here; once the
+        // first caller completes, the second finds the container already running
+        // via the Docker query below and returns immediately.
         let container_lock = {
             let mut locks = self.inner.ensure_locks.lock().await;
             locks.entry(container_name.to_string())
@@ -129,38 +114,26 @@ impl ContainerManager {
         };
         let _guard = container_lock.lock().await;
 
-        // Re-check cache after acquiring the per-container lock (another
-        // caller may have completed between the fast-path miss and here).
-        {
-            let state = self.inner.state.lock().await;
-            if state.get(container_name) == Some(&ContainerState::Running) {
-                return Ok(());
-            }
-        }
-
-        // Always query Docker rather than trusting the cache — the cache can go
-        // stale if the container is killed externally.
+        // Always query Docker — do not rely on an in-memory cache. The container
+        // can be stopped or removed externally (e.g. `docker rm -f`), and a
+        // stale cache entry would cause ensure_running to silently no-op while
+        // a subsequent exec call fails.
         let existing = self.find_container(container_name).await?;
 
         match existing {
             Some(status) if status == "running" => {
-                let mut state = self.inner.state.lock().await;
-                state.insert(container_name.to_string(), ContainerState::Running);
+                // Already running — nothing to do.
             }
             Some(_) => {
-                // Exists but stopped — start it
+                // Exists but stopped — start it.
                 self.inner.docker
                     .start_container(container_name, None::<StartContainerOptions<String>>)
                     .await?;
-                let mut state = self.inner.state.lock().await;
-                state.insert(container_name.to_string(), ContainerState::Running);
                 tracing::info!(container = container_name, "restarted stopped container");
             }
             None => {
-                // Create and start
+                // Create and start.
                 self.create_and_start(container_name, image, volumes, env_vars).await?;
-                let mut state = self.inner.state.lock().await;
-                state.insert(container_name.to_string(), ContainerState::Running);
                 tracing::info!(container = container_name, image = image, "created and started container");
             }
         }
@@ -211,8 +184,6 @@ impl ContainerManager {
         self.inner.docker
             .stop_container(container_name, Some(StopContainerOptions { t: timeout_secs }))
             .await?;
-        let mut state = self.inner.state.lock().await;
-        state.insert(container_name.to_string(), ContainerState::Stopped);
         tracing::info!(container = container_name, "stopped container");
         Ok(())
     }
@@ -226,8 +197,6 @@ impl ContainerManager {
                 ..Default::default()
             }))
             .await?;
-        let mut state = self.inner.state.lock().await;
-        state.remove(container_name);
         tracing::info!(container = container_name, "removed container");
         Ok(())
     }
@@ -269,24 +238,17 @@ impl ContainerManager {
             .map(|(k, v)| format!("{k}={v}"))
             .collect();
 
-        // Parse volume specs: "source:target" or "source:target:options"
-        // Named volumes (no path separator in source) are treated as Docker named volumes;
-        // paths starting with / are bind mounts.
         let mounts: Vec<Mount> = volumes.iter().filter_map(|spec| {
-            let parts: Vec<&str> = spec.splitn(3, ':').collect();
-            if parts.len() < 2 {
+            let (source, target, read_only) = parse_volume_spec(spec)?;
+            if target.is_empty() {
                 tracing::warn!(spec = %spec, "ignoring malformed volume spec (expected source:target)");
                 return None;
             }
-            let source = parts[0];
-            let target = parts[1];
-            let read_only = parts.get(2).map(|o| o.contains("ro")).unwrap_or(false);
-            let mount_type = if source.starts_with('/') || source.starts_with('~') ||
-                             source.len() > 1 && source.chars().nth(1) == Some(':') {
-                // Absolute path → bind mount
+            let mount_type = if source.starts_with('/') || source.starts_with('~')
+                || (source.len() >= 2 && source.as_bytes()[1] == b':')
+            {
                 MountTypeEnum::BIND
             } else {
-                // Name without path → named volume
                 MountTypeEnum::VOLUME
             };
             Some(Mount {
@@ -315,8 +277,9 @@ impl ContainerManager {
         let config: Config<String> = Config {
             image: Some(image.to_string()),
             env: if env.is_empty() { None } else { Some(env) },
-            // Keep container alive between turns — entrypoint keeps process running.
-            // The agent-claude image uses `tini` as PID 1 so SIGTERM routes correctly.
+            // Keep container alive between turns — idle PID 1 (`sleep infinity`
+            // via tini) stays running until `docker stop`. Agent turns run via
+            // `docker exec`, not as the PID-1 process.
             tty: Some(false),
             open_stdin: Some(true),
             host_config: Some(HostConfig {
@@ -357,6 +320,44 @@ pub fn container_name_for_slug(slug: &str) -> String {
     format!("agentmux-{slug}")
 }
 
+/// Parse a Docker volume spec into `(source, target, read_only)`.
+///
+/// Format: `source:target` or `source:target:options`.
+///
+/// Handles Windows drive-letter bind paths (e.g. `C:\Users\me\repo:/workspace:ro`)
+/// by treating the drive-letter colon (`X:`) as part of the source path, not as
+/// the source/target separator. A plain `splitn(3, ':')` would split `C:\path`
+/// into `C` and `\path`, losing the drive letter.
+///
+/// Returns `None` for malformed specs (no target separator found).
+fn parse_volume_spec(spec: &str) -> Option<(&str, &str, bool)> {
+    let bytes = spec.as_bytes();
+
+    // Detect Windows drive-letter prefix: single ASCII letter followed by ':\'  or ':/'
+    let (source, rest) = if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        // Windows path: skip the drive colon and split on the next ':'.
+        let tail = &spec[2..]; // starts at '\' or '/'
+        let pos = tail.find(':')?;
+        (&spec[..2 + pos], &tail[pos + 1..])
+    } else {
+        let pos = spec.find(':')?;
+        (&spec[..pos], &spec[pos + 1..])
+    };
+
+    // Split target from optional options.
+    let (target, options) = if let Some(pos) = rest.find(':') {
+        (&rest[..pos], &rest[pos + 1..])
+    } else {
+        (rest, "")
+    };
+
+    Some((source, target, options.contains("ro")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,5 +366,43 @@ mod tests {
     fn test_container_name_for_slug() {
         assert_eq!(container_name_for_slug("my-agent"), "agentmux-my-agent");
         assert_eq!(container_name_for_slug("agent1"), "agentmux-agent1");
+    }
+
+    #[test]
+    fn test_parse_volume_spec_unix_named() {
+        let (src, tgt, ro) = parse_volume_spec("myvolume:/data").unwrap();
+        assert_eq!(src, "myvolume");
+        assert_eq!(tgt, "/data");
+        assert!(!ro);
+    }
+
+    #[test]
+    fn test_parse_volume_spec_unix_bind_readonly() {
+        let (src, tgt, ro) = parse_volume_spec("/host/path:/container/path:ro").unwrap();
+        assert_eq!(src, "/host/path");
+        assert_eq!(tgt, "/container/path");
+        assert!(ro);
+    }
+
+    #[test]
+    fn test_parse_volume_spec_windows_bind() {
+        // Drive-letter path must not be split at the drive colon.
+        let (src, tgt, ro) = parse_volume_spec("C:\\Users\\me\\repo:/workspace").unwrap();
+        assert_eq!(src, "C:\\Users\\me\\repo");
+        assert_eq!(tgt, "/workspace");
+        assert!(!ro);
+    }
+
+    #[test]
+    fn test_parse_volume_spec_windows_bind_readonly() {
+        let (src, tgt, ro) = parse_volume_spec("C:/Users/me/repo:/workspace:ro").unwrap();
+        assert_eq!(src, "C:/Users/me/repo");
+        assert_eq!(tgt, "/workspace");
+        assert!(ro);
+    }
+
+    #[test]
+    fn test_parse_volume_spec_malformed() {
+        assert!(parse_volume_spec("nocodon").is_none());
     }
 }

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod agent_config;
 pub mod agent_session;
+pub mod container;
 pub mod blockcontroller;
 /// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).
 pub mod layout;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -538,6 +538,19 @@ async fn main() {
     // Auto-seed agent definitions on first launch (or empty DB)
     backend::agent_seed::auto_seed_on_startup(&wstore);
 
+    // Phase 0 container startup check — warn if Docker is unavailable.
+    // Container-type agent panes require Docker; host agents are unaffected.
+    // Non-fatal: server starts normally even without Docker.
+    tokio::spawn(async {
+        match backend::container::ContainerManager::connect() {
+            Ok(mgr) => match mgr.check_available().await {
+                Ok(()) => tracing::info!("Docker daemon available — container agent panes enabled"),
+                Err(e) => tracing::warn!(error = %e, "Docker daemon not reachable; container agent panes will fail to start"),
+            },
+            Err(e) => tracing::warn!(error = %e, "Docker not available; container agent panes disabled"),
+        }
+    });
+
     // Phase 3a — `db_agents` consolidation backfill. Marker-file gated
     // under the data dir; idempotent across restarts. WRITE-ONLY in
     // Phase 3a: dual-write keeps `db_agents` fresh; reads still hit


### PR DESCRIPTION
## Summary

Phase 1 of SPEC_CONTAINER_PANE_SUPPORT_2026_06_11.md — Docker runtime management.

Adds `agentmux-srv/src/backend/container.rs` with `ContainerManager`:

**Design (cross-platform, independence boundary — no claw dependency):**
- `connect()` via `Docker::connect_with_local_defaults()` — honors `DOCKER_HOST`, Windows named pipe, macOS socket, Linux `/var/run/docker.sock`
- Persistent container model (one per agent, exec per turn) — same pattern as VS Code Dev Containers
- `ensure_running()`: create+start on first use, restart stopped containers, no-op if running
- `exec()`: `docker exec -i` (no `-t`) — preserves NDJSON newlines for Claude Code output
- `stop()` / `remove()` for lifecycle management
- Named Docker volume for `/home/agent/.claude` — avoids host credential leakage, follows Anthropic recommendation
- `container_name_for_slug()` derives stable `agentmux-<slug>` names independent of claw
- Startup check in `main.rs` warns (non-fatal) if Docker unavailable
- `bollard = "0.18"` added to `Cargo.toml`

**Depends on:** PR #1350 (Phase 0 — schema fields)

## Phase sequence

| Phase | Branch | Status |
|-------|--------|--------|
| 0 — Schema | agenty/container-schema | PR #1350 |
| 1 — ContainerManager | agenty/container-manager | **this PR** |
| 2 — Spawn routing | agenty/container-spawn | next |
| 4 — Dockerfile + CI | agenty/container-image | PR #1347 |

## Test plan
- [ ] `cargo check -p agentmux-srv` compiles clean
- [ ] Server starts without Docker installed (warning logged, no crash)
- [ ] Server starts with Docker installed (ping succeeds, info logged)
- [ ] `ContainerManager::connect()` + `check_available()` returns Ok when Docker running

🤖 Generated with [Claude Code](https://claude.com/claude-code)