### PR TITLE
fix(agents): surface real cause of a failed agent run instead of opaque exit

### DIFF
--- a/.changesets/1781209847-fix-agents-surface-the-real-cause-of-a-failed-agent-run-rate-yqmk.md
+++ b/.changesets/1781209847-fix-agents-surface-the-real-cause-of-a-failed-agent-run-rate-yqmk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agents): surface the real cause of a failed agent run (rate-limit/auth/OOM/crash) instead of an opaque exit code

--- a/agentmux-srv/src/agents/failure.rs
+++ b/agentmux-srv/src/agents/failure.rs
@@ -4,12 +4,12 @@
 //! Classification of agent (Claude CLI) run failures into a small,
 //! stable taxonomy with a human-readable explanation.
 //!
-//! `classify()` is a **pure** function — exit code + terminating signal
-//! + the tail of the child's stderr + an optional terminal `result`
-//! frame go in; an [`AgentFailure`] comes out. It does no IO and is
-//! exhaustively unit-tested against the real Anthropic error phrasings,
-//! so the "why" behind a non-zero exit can be surfaced to the user
-//! instead of a bare `exit 1`.
+//! `classify()` is a **pure** function: it takes the exit code, the
+//! terminating signal, the tail of the child's stderr, and an optional
+//! terminal `result` frame, and returns an [`AgentFailure`]. It does no
+//! IO and is exhaustively unit-tested against the real Anthropic error
+//! phrasings, so the "why" behind a non-zero exit can be surfaced to the
+//! user instead of a bare `exit 1`.
 //!
 //! See `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`. This
 //! is the P1 (capture + classify) slice; live-stream emission and UI
@@ -106,7 +106,7 @@ pub fn classify(
     stderr: &str,
     result_frame: Option<&Value>,
 ) -> AgentFailure {
-    let frame_is_error = result_frame.is_some_and(frame_is_error);
+    let frame_reported_error = result_frame.is_some_and(is_error_result_frame);
     let frame_text = result_frame.map(frame_error_text).unwrap_or_default();
 
     let combined = if frame_text.is_empty() {
@@ -153,7 +153,7 @@ pub fn classify(
     if hay.contains("rate limited")
         || hay.contains("temporarily limiting requests")
         || hay.contains("rate_limit")
-        || hay.contains("429")
+        || mentions_http_status(&hay, "429")
     {
         return build(
             FailureClass::RateLimited,
@@ -165,7 +165,7 @@ pub fn classify(
             &tail,
         );
     }
-    if hay.contains("overloaded") || hay.contains("529") {
+    if hay.contains("overloaded") || mentions_http_status(&hay, "529") {
         return build(
             FailureClass::Overloaded,
             "API temporarily overloaded",
@@ -181,7 +181,7 @@ pub fn classify(
         || hay.contains("invalid x-api-key")
         || hay.contains("unauthorized")
         || hay.contains("please run /login")
-        || hay.contains("401")
+        || mentions_http_status(&hay, "401")
     {
         return build(
             FailureClass::Auth,
@@ -255,7 +255,7 @@ pub fn classify(
     }
 
     // Fallbacks.
-    if frame_is_error {
+    if frame_reported_error {
         return build(
             FailureClass::UnknownNonZero,
             "Agent reported an error",
@@ -329,7 +329,7 @@ fn frame_error_text(frame: &Value) -> String {
 }
 
 /// True if a terminal `result` frame represents a failure.
-fn frame_is_error(frame: &Value) -> bool {
+pub(crate) fn is_error_result_frame(frame: &Value) -> bool {
     frame.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false)
         || frame
             .get("subtype")
@@ -355,6 +355,28 @@ fn tail_lines(s: &str, max_lines: usize, max_chars: usize) -> String {
     } else {
         joined
     }
+}
+
+/// True if `hay` mentions HTTP status `code` in a status-like context
+/// (e.g. "http 429", "status 429", "error 429", "[429]"). Anchoring on a
+/// context word avoids the false positives a bare substring would hit —
+/// an ISO date like `2026-04-29` contains "429". (reagent P2 on #1353.)
+fn mentions_http_status(hay: &str, code: &str) -> bool {
+    [
+        format!("http {code}"),
+        format!("http/1.1 {code}"),
+        format!("http/2 {code}"),
+        format!("status {code}"),
+        format!("status: {code}"),
+        format!("status code {code}"),
+        format!("code {code}"),
+        format!("code: {code}"),
+        format!("error {code}"),
+        format!("[{code}]"),
+        format!("({code})"),
+    ]
+    .iter()
+    .any(|p| hay.contains(p.as_str()))
 }
 
 #[cfg(test)]
@@ -387,6 +409,37 @@ mod tests {
             None,
         );
         assert_eq!(f.code, FailureClass::RateLimited);
+    }
+
+    #[test]
+    fn iso_date_in_stderr_does_not_false_positive() {
+        // "2026-04-29" contains "429"; "2026-04-01" -> "401";
+        // "2026-05-29" -> "529". A bare substring match would misclassify
+        // these; anchored matching must not. (reagent P2 on #1353.)
+        for stderr in [
+            "panic at 2026-04-29T10:00:00: unexpected eof",
+            "build 2026-04-01 failed: assertion",
+            "ts=2026-05-29 fatal: segfault",
+        ] {
+            let f = classify(Some(2), None, stderr, None);
+            assert_eq!(
+                f.code,
+                FailureClass::UnknownNonZero,
+                "stderr {stderr:?} must not match an HTTP status"
+            );
+        }
+    }
+
+    #[test]
+    fn anchored_http_status_still_classifies() {
+        assert_eq!(
+            classify(Some(1), None, "Error: HTTP 429 Too Many Requests", None).code,
+            FailureClass::RateLimited
+        );
+        assert_eq!(
+            classify(Some(1), None, "request failed with status 401", None).code,
+            FailureClass::Auth
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/agents/failure.rs
+++ b/agentmux-srv/src/agents/failure.rs
@@ -1,0 +1,490 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Classification of agent (Claude CLI) run failures into a small,
+//! stable taxonomy with a human-readable explanation.
+//!
+//! `classify()` is a **pure** function — exit code + terminating signal
+//! + the tail of the child's stderr + an optional terminal `result`
+//! frame go in; an [`AgentFailure`] comes out. It does no IO and is
+//! exhaustively unit-tested against the real Anthropic error phrasings,
+//! so the "why" behind a non-zero exit can be surfaced to the user
+//! instead of a bare `exit 1`.
+//!
+//! See `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`. This
+//! is the P1 (capture + classify) slice; live-stream emission and UI
+//! banners are P2/P3.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Stable failure taxonomy. Wire format is snake_case to match the rest
+/// of the agent event surface (`frontend/types/gotypes.d.ts`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    /// Server-side rate limit (HTTP 429). Transient, not the account quota.
+    RateLimited,
+    /// API overloaded (HTTP 529). Transient.
+    Overloaded,
+    /// Plan / usage / billing limit reached. Not transient.
+    UsageLimit,
+    /// Credentials rejected (HTTP 401).
+    Auth,
+    /// Conversation exceeded the model's context window.
+    ContextExceeded,
+    /// Hit the configured `--max-turns` cap.
+    MaxTurns,
+    /// Network / connectivity error reaching the API.
+    Network,
+    /// Killed by a signal (OOM killer or external stop).
+    Killed,
+    /// Exited cleanly but produced no final result.
+    NoOutput,
+    /// Could not launch the `claude` binary at all.
+    SpawnFailure,
+    /// Non-zero exit with no recognized cause.
+    UnknownNonZero,
+}
+
+/// A classified agent failure: the class, a user-facing title + detail,
+/// the raw exit evidence, the stderr tail, and whether a retry is
+/// worth attempting.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentFailure {
+    pub code: FailureClass,
+    pub title: String,
+    pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<i32>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stderr_tail: String,
+    pub retryable: bool,
+}
+
+impl AgentFailure {
+    /// Render the single-string explanation that becomes a run's
+    /// terminal error (drone `error` column, sidecar log, future agent
+    /// pane banner). Title + detail + exit evidence + retryable hint,
+    /// followed by the raw stderr tail so the original text is never
+    /// more than a glance away.
+    pub fn explain(&self) -> String {
+        let mut s = self.title.clone();
+        if !self.detail.is_empty() {
+            s.push_str(" — ");
+            s.push_str(&self.detail);
+        }
+        match (self.signal, self.exit_code) {
+            (Some(sig), _) => s.push_str(&format!(" [signal {sig}]")),
+            (None, Some(code)) => s.push_str(&format!(" [exit {code}]")),
+            (None, None) => {}
+        }
+        if self.retryable {
+            s.push_str(" (retryable)");
+        }
+        if !self.stderr_tail.is_empty() {
+            s.push_str("\n--- claude stderr (tail) ---\n");
+            s.push_str(&self.stderr_tail);
+        }
+        s
+    }
+}
+
+/// Classify an agent run failure.
+///
+/// `exit_code` / `signal` come from the child's `ExitStatus`. `stderr`
+/// is the captured (capped) child stderr. `result_frame` is the
+/// terminal stream-json `result` object when one was seen — the CLI
+/// sometimes reports an error there while still exiting 0, so it is
+/// folded into the evidence.
+pub fn classify(
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    stderr: &str,
+    result_frame: Option<&Value>,
+) -> AgentFailure {
+    let frame_is_error = result_frame.is_some_and(frame_is_error);
+    let frame_text = result_frame.map(frame_error_text).unwrap_or_default();
+
+    let combined = if frame_text.is_empty() {
+        stderr.to_string()
+    } else {
+        format!("{stderr}\n{frame_text}")
+    };
+    let tail = tail_lines(&combined, 24, 1600);
+    let hay = combined.to_ascii_lowercase();
+
+    // Explicit terminal-frame subtype: turn cap reached.
+    if result_frame
+        .and_then(|f| f.get("subtype"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.contains("max_turns"))
+    {
+        return build(
+            FailureClass::MaxTurns,
+            "Hit the turn limit",
+            "The agent reached its configured `--max-turns` cap before finishing. Raise the cap or split the task.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+
+    // Killed by a signal (OOM killer or external stop). 137 == 128 + SIGKILL(9).
+    if signal.is_some() || exit_code == Some(137) {
+        return build(
+            FailureClass::Killed,
+            "Agent process was killed",
+            "Terminated by a signal — most often the OS out-of-memory killer or an external stop. Reduce concurrent load / memory pressure and retry.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+
+    // Keyword matches. Order matters: rate-limit and overload are checked
+    // before usage-limit because the server-side rate-limit message
+    // literally contains "not your usage limit".
+    if hay.contains("rate limited")
+        || hay.contains("temporarily limiting requests")
+        || hay.contains("rate_limit")
+        || hay.contains("429")
+    {
+        return build(
+            FailureClass::RateLimited,
+            "Rate-limited by the API",
+            "Server-side rate limit — transient, and not your account quota. Retry shortly; consider lowering parallelism.",
+            true,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("overloaded") || hay.contains("529") {
+        return build(
+            FailureClass::Overloaded,
+            "API temporarily overloaded",
+            "The API reported it is overloaded (HTTP 529). Transient — retry with backoff.",
+            true,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("authentication_error")
+        || hay.contains("invalid api key")
+        || hay.contains("invalid x-api-key")
+        || hay.contains("unauthorized")
+        || hay.contains("please run /login")
+        || hay.contains("401")
+    {
+        return build(
+            FailureClass::Auth,
+            "Not authenticated",
+            "The API rejected the credentials (HTTP 401). Re-authenticate via the Identity tab or `claude /login`.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("model_context_window_exceeded")
+        || hay.contains("prompt is too long")
+        || (hay.contains("context") && (hay.contains("exceed") || hay.contains("window") || hay.contains("too long")))
+    {
+        return build(
+            FailureClass::ContextExceeded,
+            "Context window exceeded",
+            "The conversation exceeded the model's context window. Clear or compact the agent's history and retry.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("max turns") || hay.contains("max-turns") || hay.contains("maximum number of turns") {
+        return build(
+            FailureClass::MaxTurns,
+            "Hit the turn limit",
+            "The agent reached its configured `--max-turns` cap before finishing. Raise the cap or split the task.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("usage limit")
+        || hay.contains("out of credits")
+        || hay.contains("quota")
+        || hay.contains("billing")
+        || hay.contains("insufficient")
+    {
+        return build(
+            FailureClass::UsageLimit,
+            "Usage limit reached",
+            "Your plan or usage limit appears to be reached. Check plan / billing — retrying won't help until it resets.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if hay.contains("apiconnectionerror")
+        || hay.contains("connection error")
+        || hay.contains("could not resolve")
+        || hay.contains("econnreset")
+        || hay.contains("network")
+        || hay.contains("timed out")
+        || hay.contains("timeout")
+        || hay.contains("dns")
+    {
+        return build(
+            FailureClass::Network,
+            "Network error reaching the API",
+            "A network/connection error occurred talking to the API. Check connectivity and retry.",
+            true,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+
+    // Fallbacks.
+    if frame_is_error {
+        return build(
+            FailureClass::UnknownNonZero,
+            "Agent reported an error",
+            "The agent reported a terminal error with no recognized cause. The raw output tail is included below.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    if exit_code == Some(0) {
+        return build(
+            FailureClass::NoOutput,
+            "Agent produced no output",
+            "The agent exited cleanly (code 0) but never produced a final result. Inspect the transcript / sidecar log.",
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
+    build(
+        FailureClass::UnknownNonZero,
+        "Agent failed",
+        "The agent exited with a non-zero status and no recognized error. The raw stderr tail is included below.",
+        false,
+        exit_code,
+        signal,
+        &tail,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build(
+    code: FailureClass,
+    title: &str,
+    detail: &str,
+    retryable: bool,
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    tail: &str,
+) -> AgentFailure {
+    AgentFailure {
+        code,
+        title: title.to_string(),
+        detail: detail.to_string(),
+        exit_code,
+        signal,
+        stderr_tail: tail.to_string(),
+        retryable,
+    }
+}
+
+/// Best-effort error text from a terminal stream-json `result` frame:
+/// `error.message`, else a string `error`/`result`, else the `subtype`.
+fn frame_error_text(frame: &Value) -> String {
+    if let Some(msg) = frame.pointer("/error/message").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+    if let Some(err) = frame.get("error").and_then(|v| v.as_str()) {
+        return err.to_string();
+    }
+    if let Some(res) = frame.get("result").and_then(|v| v.as_str()) {
+        return res.to_string();
+    }
+    frame
+        .get("subtype")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// True if a terminal `result` frame represents a failure.
+fn frame_is_error(frame: &Value) -> bool {
+    frame.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false)
+        || frame
+            .get("subtype")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s.starts_with("error"))
+}
+
+/// Last `max_lines` non-empty lines of `s`, further capped to the last
+/// `max_chars` characters (char-safe — never slices mid-codepoint).
+fn tail_lines(s: &str, max_lines: usize, max_chars: usize) -> String {
+    let mut lines: Vec<&str> = s
+        .lines()
+        .map(|l| l.trim_end())
+        .filter(|l| !l.is_empty())
+        .collect();
+    if lines.len() > max_lines {
+        lines = lines.split_off(lines.len() - max_lines);
+    }
+    let joined = lines.join("\n");
+    let n = joined.chars().count();
+    if n > max_chars {
+        joined.chars().skip(n - max_chars).collect()
+    } else {
+        joined
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rate_limit_incident_string_classifies_retryable() {
+        // The exact string this work was motivated by.
+        let stderr =
+            "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited";
+        let f = classify(Some(1), None, stderr, None);
+        assert_eq!(f.code, FailureClass::RateLimited);
+        assert!(f.retryable);
+        let e = f.explain();
+        assert!(e.contains("Rate-limited"), "explain: {e}");
+        assert!(e.contains("retryable"), "explain: {e}");
+        assert!(e.to_lowercase().contains("rate limited"), "explain: {e}");
+    }
+
+    #[test]
+    fn not_your_usage_limit_does_not_classify_as_usage_limit() {
+        // Guard: the rate-limit message contains "usage limit"; it must
+        // win as RateLimited (checked first), not UsageLimit.
+        let f = classify(
+            Some(1),
+            None,
+            "temporarily limiting requests (not your usage limit) · Rate limited",
+            None,
+        );
+        assert_eq!(f.code, FailureClass::RateLimited);
+    }
+
+    #[test]
+    fn overloaded_is_retryable() {
+        let f = classify(Some(1), None, "overloaded_error: please retry", None);
+        assert_eq!(f.code, FailureClass::Overloaded);
+        assert!(f.retryable);
+    }
+
+    #[test]
+    fn invalid_api_key_is_auth_not_retryable() {
+        let f = classify(Some(1), None, "authentication_error: Invalid API key provided", None);
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(!f.retryable);
+    }
+
+    #[test]
+    fn sigkill_is_killed() {
+        let f = classify(None, Some(9), "", None);
+        assert_eq!(f.code, FailureClass::Killed);
+        assert_eq!(f.signal, Some(9));
+        assert!(f.explain().contains("[signal 9]"));
+    }
+
+    #[test]
+    fn exit_137_is_killed() {
+        let f = classify(Some(137), None, "", None);
+        assert_eq!(f.code, FailureClass::Killed);
+    }
+
+    #[test]
+    fn context_window_exceeded_classifies() {
+        let f = classify(
+            Some(1),
+            None,
+            "prompt is too long: 1200000 tokens > 200000 maximum context window",
+            None,
+        );
+        assert_eq!(f.code, FailureClass::ContextExceeded);
+    }
+
+    #[test]
+    fn network_error_is_retryable() {
+        let f = classify(Some(1), None, "APIConnectionError: Connection error.", None);
+        assert_eq!(f.code, FailureClass::Network);
+        assert!(f.retryable);
+    }
+
+    #[test]
+    fn clean_exit_no_output_is_no_output() {
+        let f = classify(Some(0), None, "", None);
+        assert_eq!(f.code, FailureClass::NoOutput);
+        assert!(!f.retryable);
+    }
+
+    #[test]
+    fn unknown_nonzero_is_default() {
+        let f = classify(Some(2), None, "something unexpected happened", None);
+        assert_eq!(f.code, FailureClass::UnknownNonZero);
+        assert!(f.explain().contains("[exit 2]"));
+    }
+
+    #[test]
+    fn result_frame_max_turns_subtype() {
+        let frame = json!({ "type": "result", "is_error": true, "subtype": "error_max_turns" });
+        let f = classify(Some(0), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::MaxTurns);
+    }
+
+    #[test]
+    fn result_frame_error_message_feeds_classification() {
+        // CLI reported an overload on stdout but exited 0 — must still
+        // classify, not fall through to NoOutput.
+        let frame = json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": { "message": "overloaded_error: upstream busy" }
+        });
+        let f = classify(Some(0), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::Overloaded);
+    }
+
+    #[test]
+    fn tail_lines_keeps_last_lines_char_safe() {
+        let s = (0..100).map(|i| format!("line{i}")).collect::<Vec<_>>().join("\n");
+        let t = tail_lines(&s, 5, 1000);
+        assert_eq!(t.lines().count(), 5);
+        assert!(t.contains("line99"));
+        assert!(!t.contains("line0\n"));
+    }
+
+    #[test]
+    fn serializes_snake_case_code_camel_fields() {
+        let f = classify(Some(1), None, "Rate limited", None);
+        let v = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["code"], json!("rate_limited"));
+        assert_eq!(v["retryable"], json!(true));
+        assert!(v.get("stderrTail").is_some(), "camelCase stderrTail expected: {v}");
+    }
+}

--- a/agentmux-srv/src/agents/mod.rs
+++ b/agentmux-srv/src/agents/mod.rs
@@ -11,6 +11,7 @@
 //! This is Phase 1.5 PR 0: types + skeleton. PR 1 wires the agent
 //! pane through this module; PR 2 wires the drone Agent block.
 
+pub mod failure;
 pub mod runner;
 pub mod translator;
 pub mod types;

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -150,40 +150,29 @@ pub(crate) async fn run_agent_with_bin(
     // `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`.
     let (stderr_tx, stderr_rx) = oneshot::channel::<Vec<u8>>();
 
-    // Drain stderr to EOF in the background so the child's pipe
-    // never fills (a half-drained pipe causes the child to block
-    // on stderr writes, which can stall the whole run). Capped at
-    // STDERR_CAP bytes — beyond that, additional bytes are read
-    // and dropped on the floor so the child can keep writing.
-    // On EOF the captured prefix is handed to the collector via
-    // `stderr_tx`, which classifies + surfaces it when the run fails.
+    // Drain stderr to EOF in the background so the child's pipe never
+    // fills (a half-drained pipe blocks the child on stderr writes and
+    // can stall the whole run). We keep a rolling *tail* — the last
+    // STDERR_TAIL_CAP bytes — because the CLI's terminal error line
+    // (rate-limit / auth / OOM) lands at the END of stderr; a capped
+    // prefix would drop exactly the line the classifier needs. On EOF
+    // the tail is handed to the collector via `stderr_tx`.
+    // (codex P2 on #1353: keep the tail, not a prefix.)
     tokio::spawn(async move {
-        const STDERR_CAP: usize = 64 * 1024;
-        let mut buf = Vec::with_capacity(4096);
+        const STDERR_TAIL_CAP: usize = 64 * 1024;
+        let mut buf: Vec<u8> = Vec::with_capacity(8192);
         let mut reader = BufReader::new(stderr);
-        let mut sink = [0u8; 4096];
-        // Read until EOF, capping the kept prefix at STDERR_CAP.
+        let mut sink = [0u8; 8192];
         loop {
-            if buf.len() < STDERR_CAP {
-                let space = STDERR_CAP - buf.len();
-                let take = space.min(sink.len());
-                match reader.read(&mut sink[..take]).await {
-                    Ok(0) => break,
-                    Ok(n) => buf.extend_from_slice(&sink[..n]),
-                    Err(_) => break,
-                }
-            } else {
-                // Beyond cap — keep draining but discard.
-                match reader.read(&mut sink).await {
-                    Ok(0) => break,
-                    Ok(_) => {}
-                    Err(_) => break,
-                }
+            match reader.read(&mut sink).await {
+                Ok(0) => break,
+                Ok(n) => append_capped_tail(&mut buf, &sink[..n], STDERR_TAIL_CAP),
+                Err(_) => break,
             }
         }
-        // Hand the captured prefix to the collector. If the receiver is
-        // already gone (run succeeded — nobody needs stderr), the send
-        // just drops; harmless.
+        // Trim to exactly the last CAP bytes. If the receiver is gone
+        // (run succeeded — nobody needs stderr), the send just drops.
+        trim_to_tail(&mut buf, STDERR_TAIL_CAP);
         let _ = stderr_tx.send(buf);
     });
 
@@ -273,6 +262,26 @@ fn exit_signal(status: &std::process::ExitStatus) -> Option<i32> {
 #[cfg(not(unix))]
 fn exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
     None
+}
+
+/// Append `chunk` to a rolling tail buffer, compacting to the last
+/// `cap` bytes whenever it grows past `2 * cap` (amortized O(1)). The
+/// exact final trim happens at EOF via [`trim_to_tail`]. Keeping the
+/// *tail* (not a prefix) matters because the CLI's terminal error line
+/// is at the end of stderr.
+fn append_capped_tail(buf: &mut Vec<u8>, chunk: &[u8], cap: usize) {
+    buf.extend_from_slice(chunk);
+    if buf.len() > cap.saturating_mul(2) {
+        trim_to_tail(buf, cap);
+    }
+}
+
+/// Drop all but the last `cap` bytes of `buf`.
+fn trim_to_tail(buf: &mut Vec<u8>, cap: usize) {
+    if buf.len() > cap {
+        let excess = buf.len() - cap;
+        buf.drain(0..excess);
+    }
 }
 
 /// Drain an arbitrary async reader of newline-delimited stream-json
@@ -596,6 +605,84 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// End-to-end (Unix): stderr larger than the tail cap with the real
+    /// error on the LAST line must still classify correctly — the
+    /// rolling tail keeps the end, not a prefix. Regression test for
+    /// codex P2 on #1353.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn classified_failure_reads_error_past_stderr_cap() {
+        use std::io::Write as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = std::env::temp_dir()
+            .join(format!("amux-stub-claude-big-{}.sh", uuid::Uuid::new_v4()));
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "#!/bin/sh").unwrap();
+            // ~70 KiB of filler (> 64 KiB tail cap), THEN the real error.
+            writeln!(f, "head -c 70000 /dev/zero | tr '\\0' x >&2").unwrap();
+            writeln!(
+                f,
+                "printf '\\nAPI Error: Server is temporarily limiting requests (not your usage limit) Rate limited\\n' >&2"
+            )
+            .unwrap();
+            writeln!(f, "exit 1").unwrap();
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let handle = run_agent_with_bin(
+            path.to_str().unwrap(),
+            AgentRef::default(),
+            AgentTask {
+                prompt: "hi".to_string(),
+                context: serde_json::Map::new(),
+                max_turns: None,
+            },
+            tx,
+        )
+        .await
+        .expect("spawn ok");
+
+        let err = handle
+            .final_result
+            .await
+            .expect("oneshot ok")
+            .expect_err("run should fail");
+
+        assert!(
+            err.contains("Rate-limited"),
+            "must classify from the tail past the cap; got: {}",
+            err.chars().take(160).collect::<String>()
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn rolling_tail_keeps_last_bytes_past_cap() {
+        let cap = 8;
+        let mut buf = Vec::new();
+        for i in 0..100u8 {
+            append_capped_tail(&mut buf, &[i], cap);
+            assert!(buf.len() <= cap * 2, "rolling buffer must stay bounded");
+        }
+        trim_to_tail(&mut buf, cap);
+        assert_eq!(buf, vec![92, 93, 94, 95, 96, 97, 98, 99]);
+    }
+
+    #[test]
+    fn rolling_tail_single_large_chunk() {
+        let cap = 4;
+        let mut buf = Vec::new();
+        append_capped_tail(&mut buf, b"abcdefghij", cap);
+        trim_to_tail(&mut buf, cap);
+        assert_eq!(&buf, b"ghij");
     }
 
     #[test]

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -207,22 +207,31 @@ async fn drain_and_collect(
     let exit = child.wait().await.map_err(|e| format!("wait: {e}"))?;
 
     match result {
-        Ok(mut accumulated) if exit.success() => {
-            // Exited 0 but the stream never emitted Done (claude
-            // reported an error on stdout, or died mid-write).
-            // Classify it rather than returning empty defaults silently.
-            if accumulated.response.is_empty() && accumulated.transcript.is_empty() {
-                return Err(explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await);
+        Ok(mut accumulated) => {
+            // A run is a failure if the process exited non-zero OR claude
+            // reported an error on stdout (a terminal error `result`
+            // frame) even while exiting 0 — otherwise downstream blocks
+            // could treat a failed run as successful. (codex P1 #1353.)
+            let reported_error = accumulated.error_frame.take();
+            if exit.success() && reported_error.is_none() {
+                // Genuine success — but a stream that produced nothing is
+                // itself a (classified) failure, not a silent empty result.
+                if accumulated.response.is_empty() && accumulated.transcript.is_empty() {
+                    return Err(
+                        explain_failure(exit.code(), exit_signal(&exit), None, stderr_rx).await,
+                    );
+                }
+                accumulated.transcript.shrink_to_fit();
+                return Ok(accumulated);
             }
-            accumulated.transcript.shrink_to_fit();
-            Ok(accumulated)
+            // Non-zero exit, or a stdout-reported error on exit 0: classify
+            // from the exit status + result frame + captured stderr so the
+            // caller sees a real cause, not "exited with status N".
+            Err(explain_failure(exit.code(), exit_signal(&exit), reported_error, stderr_rx).await)
         }
-        // Non-zero exit: classify from the exit status + captured stderr
-        // so the caller sees a real cause, not "exited with status N".
-        Ok(_) => Err(explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await),
         // Stream read error: still enrich with the exit/stderr cause.
         Err(e) => {
-            let cause = explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await;
+            let cause = explain_failure(exit.code(), exit_signal(&exit), None, stderr_rx).await;
             Err(format!("{cause}\n(stream read: {e})"))
         }
     }
@@ -235,11 +244,12 @@ async fn drain_and_collect(
 async fn explain_failure(
     exit_code: Option<i32>,
     signal: Option<i32>,
+    result_frame: Option<serde_json::Value>,
     stderr_rx: oneshot::Receiver<Vec<u8>>,
 ) -> String {
     let bytes = stderr_rx.await.unwrap_or_default();
     let stderr = String::from_utf8_lossy(&bytes);
-    let failure = classify(exit_code, signal, &stderr, None);
+    let failure = classify(exit_code, signal, &stderr, result_frame.as_ref());
     tracing::warn!(
         code = ?failure.code,
         exit_code = ?exit_code,
@@ -313,6 +323,15 @@ pub(crate) async fn drain_async_reader<R: tokio::io::AsyncBufRead + Unpin>(
         let Ok(frame) = serde_json::from_str::<serde_json::Value>(trimmed) else {
             continue;
         };
+        // Capture a terminal *error* result frame so the collector can
+        // fail the run even when claude reports the error on stdout and
+        // exits 0 (the translator still emits a hollow `Done`).
+        // codex P1 on #1353.
+        if frame.get("type").and_then(|v| v.as_str()) == Some("result")
+            && super::failure::is_error_result_frame(&frame)
+        {
+            accumulated.error_frame = Some(frame.clone());
+        }
         for event in translator.translate(frame) {
             // Capture terminal values before forwarding so a closed
             // receiver doesn't lose the accumulated result.
@@ -683,6 +702,79 @@ mod tests {
         append_capped_tail(&mut buf, b"abcdefghij", cap);
         trim_to_tail(&mut buf, cap);
         assert_eq!(&buf, b"ghij");
+    }
+
+    #[tokio::test]
+    async fn drain_captures_error_result_frame() {
+        // An error result frame on stdout must be captured so the
+        // collector can fail the run even on exit 0. codex P1 #1353.
+        let bytes =
+            b"{\"type\":\"result\",\"is_error\":true,\"subtype\":\"error_during_execution\",\"error\":{\"message\":\"overloaded_error\"}}\n"
+                .to_vec();
+        let (mut w, r) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            w.write_all(&bytes).await.unwrap();
+            w.shutdown().await.unwrap();
+        });
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let result = drain_async_reader(BufReader::new(r), &tx)
+            .await
+            .expect("drain ok");
+        assert!(
+            result.error_frame.is_some(),
+            "error result frame should be captured"
+        );
+    }
+
+    /// End-to-end (Unix): claude can report an error on stdout and still
+    /// exit 0; the runner must NOT treat that as success. codex P1 #1353.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdout_error_result_with_exit_zero_is_a_failure() {
+        use std::io::Write as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = std::env::temp_dir()
+            .join(format!("amux-stub-claude-okerr-{}.sh", uuid::Uuid::new_v4()));
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "#!/bin/sh").unwrap();
+            // Emit an error result frame on stdout, then exit 0. The JSON
+            // lives in a `let` so its braces are data, not writeln! format
+            // placeholders (no escaping, no print_literal lint).
+            let frame = r#"{"type":"result","is_error":true,"subtype":"error_during_execution","error":{"message":"overloaded_error: upstream busy"}}"#;
+            writeln!(f, "echo '{frame}'").unwrap();
+            writeln!(f, "exit 0").unwrap();
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let handle = run_agent_with_bin(
+            path.to_str().unwrap(),
+            AgentRef::default(),
+            AgentTask {
+                prompt: "hi".to_string(),
+                context: serde_json::Map::new(),
+                max_turns: None,
+            },
+            tx,
+        )
+        .await
+        .expect("spawn ok");
+
+        let err = handle
+            .final_result
+            .await
+            .expect("oneshot ok")
+            .expect_err("stdout-reported error with exit 0 must fail");
+        assert!(
+            err.to_lowercase().contains("overloaded"),
+            "should classify the stdout error; got: {err}"
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -25,6 +25,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot};
 
+use super::failure::classify;
 use super::translator::claude::ClaudeTranslator;
 use super::translator::Translator as _;
 use super::types::{AgentEvent, AgentRef, AgentRunResult, AgentTask};
@@ -143,15 +144,19 @@ pub(crate) async fn run_agent_with_bin(
 
     let instance_id = format!("drone-agent-{}", uuid::Uuid::new_v4());
     let (result_tx, result_rx) = oneshot::channel();
+    // Hand the captured stderr back to `drain_and_collect` so a failed
+    // run reports the real cause (rate-limit / auth / OOM) instead of a
+    // bare exit code. See
+    // `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`.
+    let (stderr_tx, stderr_rx) = oneshot::channel::<Vec<u8>>();
 
     // Drain stderr to EOF in the background so the child's pipe
     // never fills (a half-drained pipe causes the child to block
     // on stderr writes, which can stall the whole run). Capped at
     // STDERR_CAP bytes — beyond that, additional bytes are read
     // and dropped on the floor so the child can keep writing.
-    // Phase 2 surfaces stderr as a `dronerun:<id>` diagnostic
-    // event; for now it's captured locally and discarded.
-    // Reagent P2 on PR #834.
+    // On EOF the captured prefix is handed to the collector via
+    // `stderr_tx`, which classifies + surfaces it when the run fails.
     tokio::spawn(async move {
         const STDERR_CAP: usize = 64 * 1024;
         let mut buf = Vec::with_capacity(4096);
@@ -176,12 +181,14 @@ pub(crate) async fn run_agent_with_bin(
                 }
             }
         }
-        // buf currently dropped; Phase 2 will plumb it to the broker.
-        let _ = buf;
+        // Hand the captured prefix to the collector. If the receiver is
+        // already gone (run succeeded — nobody needs stderr), the send
+        // just drops; harmless.
+        let _ = stderr_tx.send(buf);
     });
 
     tokio::spawn(async move {
-        let result = drain_and_collect(stdout, &tx, &mut child).await;
+        let result = drain_and_collect(stdout, &tx, &mut child, stderr_rx).await;
         let _ = result_tx.send(result);
     });
 
@@ -203,6 +210,7 @@ async fn drain_and_collect(
     stdout: tokio::process::ChildStdout,
     tx: &mpsc::UnboundedSender<AgentEvent>,
     child: &mut tokio::process::Child,
+    stderr_rx: oneshot::Receiver<Vec<u8>>,
 ) -> Result<AgentRunResult, String> {
     let result = drain_async_reader(BufReader::new(stdout), tx).await;
 
@@ -211,20 +219,60 @@ async fn drain_and_collect(
 
     match result {
         Ok(mut accumulated) if exit.success() => {
-            // If the stream never emitted Done (e.g. claude died
-            // mid-run), surface a synthetic error rather than
-            // returning empty defaults silently.
+            // Exited 0 but the stream never emitted Done (claude
+            // reported an error on stdout, or died mid-write).
+            // Classify it rather than returning empty defaults silently.
             if accumulated.response.is_empty() && accumulated.transcript.is_empty() {
-                return Err("claude exited 0 but stream produced no Done event".to_string());
+                return Err(explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await);
             }
             accumulated.transcript.shrink_to_fit();
             Ok(accumulated)
         }
-        Ok(_) => Err(format!(
-            "claude exited with status {exit} but stream emitted no error"
-        )),
-        Err(e) => Err(e),
+        // Non-zero exit: classify from the exit status + captured stderr
+        // so the caller sees a real cause, not "exited with status N".
+        Ok(_) => Err(explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await),
+        // Stream read error: still enrich with the exit/stderr cause.
+        Err(e) => {
+            let cause = explain_failure(exit.code(), exit_signal(&exit), stderr_rx).await;
+            Err(format!("{cause}\n(stream read: {e})"))
+        }
     }
+}
+
+/// Await the captured stderr, classify the exit, log a warning, and
+/// render the human-readable explanation that becomes the run's
+/// terminal error string. See
+/// `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`.
+async fn explain_failure(
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    stderr_rx: oneshot::Receiver<Vec<u8>>,
+) -> String {
+    let bytes = stderr_rx.await.unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&bytes);
+    let failure = classify(exit_code, signal, &stderr, None);
+    tracing::warn!(
+        code = ?failure.code,
+        exit_code = ?exit_code,
+        signal = ?signal,
+        retryable = failure.retryable,
+        "agent run failed: {}",
+        failure.title,
+    );
+    failure.explain()
+}
+
+/// Extract the terminating signal (Unix only). On non-Unix there is no
+/// signal concept, so this is always `None`.
+#[cfg(unix)]
+fn exit_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
 }
 
 /// Drain an arbitrary async reader of newline-delimited stream-json
@@ -485,6 +533,69 @@ mod tests {
             Err(other) => panic!("expected Spawn error, got: {other}"),
             Ok(_) => panic!("expected Spawn error, got Ok(handle)"),
         }
+    }
+
+    /// End-to-end (Unix): a stub binary that writes a rate-limit line to
+    /// stderr and exits 1 must produce a *classified* failure naming the
+    /// cause and including the stderr tail — not a bare "exit 1".
+    /// Exercises G1 (stderr retained) + G2 (classify) of
+    /// SPEC_AGENT_FAILURE_DIAGNOSTICS.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn classified_failure_surfaces_cause_and_stderr() {
+        use std::io::Write as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = std::env::temp_dir()
+            .join(format!("amux-stub-claude-{}.sh", uuid::Uuid::new_v4()));
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "#!/bin/sh").unwrap();
+            writeln!(
+                f,
+                "echo 'API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited' >&2"
+            )
+            .unwrap();
+            writeln!(f, "exit 1").unwrap();
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let handle = run_agent_with_bin(
+            path.to_str().unwrap(),
+            AgentRef::default(),
+            AgentTask {
+                prompt: "hi".to_string(),
+                context: serde_json::Map::new(),
+                max_turns: None,
+            },
+            tx,
+        )
+        .await
+        .expect("spawn ok");
+
+        let err = handle
+            .final_result
+            .await
+            .expect("oneshot ok")
+            .expect_err("run should fail");
+
+        assert!(
+            err.contains("Rate-limited"),
+            "explanation should name the class; got: {err}"
+        );
+        assert!(
+            err.to_lowercase().contains("rate limited"),
+            "stderr tail should be included; got: {err}"
+        );
+        assert!(
+            err.contains("retryable"),
+            "rate-limit is retryable; got: {err}"
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/agentmux-srv/src/agents/types.rs
+++ b/agentmux-srv/src/agents/types.rs
@@ -140,6 +140,12 @@ pub struct AgentRunResult {
     pub tokens: TokenCounts,
     pub cost_usd: f64,
     pub transcript: Vec<AgentTurn>,
+    /// Terminal stream-json `result` frame when it reported an error
+    /// (`is_error` / `error_*` subtype). Internal only — `#[serde(skip)]`
+    /// keeps it off the IPC wire. Lets the runner fail a run that claude
+    /// reported as an error on stdout while still exiting 0. (codex P1 #1353.)
+    #[serde(skip)]
+    pub error_frame: Option<serde_json::Value>,
 }
 
 #[cfg(test)]
@@ -270,6 +276,7 @@ mod tests {
             tokens: TokenCounts::default(),
             cost_usd: 0.0,
             transcript: vec![],
+            error_frame: None,
         };
         let v = serde_json::to_value(&r).unwrap();
         // costUsd at the result level, tokens nested with camelCase.

--- a/docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md
+++ b/docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md
@@ -1,0 +1,239 @@
+<!--
+Copyright 2026, AgentMux Corp.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# SPEC: Agent Failure Diagnostics — Surfacing the "Why" Behind a Non-Zero Exit
+
+- **Date:** 2026-06-11
+- **Status:** Draft / proposed
+- **Area:** `agentmux-srv` agent runner + translator; `frontend/app` agent-pane state; drone run records
+- **Related:** `SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md`, `docs/specs/agent-health-design.md`, `docs/specs/backend-status-tests.md`
+
+---
+
+## 0. One-line
+
+When a Claude agent subprocess dies (rate limit, overload, auth, OOM, crash), AgentMux must **capture the real error, classify it, and show a human-readable explanation** — instead of an opaque "exit 1" / silent status flip.
+
+---
+
+## 1. Motivation
+
+### 1.1 The incident that prompted this
+
+A multi-agent run launched three research subagents in parallel. All three died within ~60–80 s with:
+
+```
+API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited
+```
+
+What reached the operator was effectively a bare failure — "exit 1," no cause. The actual explanation (server-side rate-limit, transient, **not** a quota problem, retryable) existed but never surfaced. The operator's reasonable question was *"why did it exit 1?"* — and the system couldn't answer.
+
+### 1.2 Why this generalizes to AgentMux agents
+
+AgentMux agents are `claude` CLI subprocesses (`agentmux-srv/src/agents/runner.rs`). They fail for the same family of reasons — rate-limit (429), overloaded (529), auth (401), usage-limit, OOM/SIGKILL, network, max-turns, or a plain crash. Today every one of those collapses to the same opaque terminal string. Agents are long-lived and often unattended; an unexplained death erodes trust and is undebuggable after the fact. This is adjacent to the known "dead but shows running" staleness problem (stale `db_agent_instances.status='running'`).
+
+### 1.3 The hard requirement
+
+> **An explanation of the exit must appear** — in the UI, in plain language, with whether it's retryable and what to do next.
+
+---
+
+## 2. Current behavior — why the reason is lost (code-grounded)
+
+There are two agent execution paths. The **headless/drone runner** (`agents/runner.rs`, stream-json) is where the loss is cleanest and most fixable; the **interactive PTY pane** (`blockcontroller/`) has the exit code but no classified cause.
+
+### Gap G1 — stderr is captured, then thrown on the floor
+`agentmux-srv/src/agents/runner.rs:147-181` drains the child's stderr into a 64 KB capped buffer (`STDERR_CAP`, line 156) **and then discards it**:
+
+```rust
+// runner.rs:179-181
+// buf currently dropped; Phase 2 will plumb it to the broker.
+let _ = buf;
+```
+
+That buffer is exactly where `API Error: … Rate limited`, `Invalid API key`, `overloaded_error`, etc. live. The code already admits the gap ("Phase 2 surfaces stderr …", lines 152-154). **This spec is that Phase 2.**
+
+### Gap G2 — failure messages carry only the exit status
+`agentmux-srv/src/agents/runner.rs:212-227`, the failure branches build strings with *no* stderr, *no* classification, *no* structured exit code:
+
+```rust
+// runner.rs:218
+return Err("claude exited 0 but stream produced no Done event".to_string());
+// runner.rs:223-225
+Ok(_) => Err(format!(
+    "claude exited with status {exit} but stream emitted no error"
+)),
+```
+
+`"claude exited with status 1 but stream emitted no error"` **is** the opaque "exit 1."
+
+### Gap G3 — error `result` frames are swallowed by the translator
+The Claude CLI can report a failure on **stdout** as a terminal `result` frame with `subtype: "error_*"` / `is_error: true` / an `error` object (so the process may even exit 0). `handle_result` in `agentmux-srv/src/agents/translator/claude.rs:248-266` only reads `cost_usd`, `usage`, and `result` text, then emits `Cost` + `Done`. It inspects `is_error` **only** at the tool_result level (line 198), never at the result level. An error result frame therefore becomes a hollow *successful* `Done` and the reason vanishes.
+
+### Gap G4 — the structured error channel exists but is never used on failure
+`AgentEvent::Error { message }` is defined (`agentmux-srv/src/agents/types.rs:104-108`) and is the intended user-facing error channel. But the runner's failure path returns a bare `Err(String)` on the `final_result` oneshot (`runner.rs:184-186, 223-227`) and **never sends `AgentEvent::Error` on the live event stream (`tx`)**. Stream-watchers (the agent pane) get nothing; only the drone's terminal accumulator sees the string.
+
+### Gap G5 — the interactive path knows the code but not the cause
+The PTY pane plumbs an exit code end-to-end — `proc_exit_code` (`agentmux-srv/src/backend/blockcontroller/subprocess.rs:94-95`), set on `child.wait()` (lines 727-749), surfaced to the frontend as `shellprocexitcode` (lines 208, 811). The frontend agent state machine has an `errored` outcome (`frontend/app/store/agent-pane-state/types.ts:76-80`) reached via bounded force-transitions with **generic** reasons like `"stream-stalled"` and timeout (`frontend/app/store/agent-pane-state/reducer.ts:663, 718`). So it can say *"errored"* but not *why* — the underlying error text is never captured or classified on this path either.
+
+### What already works (reuse, don't rebuild)
+- **Token/cost capture** is solid: `TokenCounts { input, output, cache_creation, cache_read }` (`types.rs:110-121`) parsed from the result frame's `usage` (`translator/claude.rs:268-280`) and carried by `AgentEvent::Cost`. The failure struct should ride alongside this, not replace it.
+- **The drone already persists an `error` column** on a run row (`agentmux-srv/src/drone/storage.rs:141, 151, 167, 175`) — today it stores the opaque G2 string. We upgrade *what* goes in, not the plumbing.
+- **The sidecar connection already models cause well**: `backendStatus` distinguishes `crashed`, tracks exit code, and handles "exit code null when signal kill" (`frontend/app/store/backendStatus.test.ts`). That's the precedent to mirror for agents (it is a *different* subject — the srv sidecar, not the agent — but the shape is exactly what we want).
+
+---
+
+## 3. Goals / Non-goals
+
+**Goals**
+1. **Capture** the failure evidence: exit code, signal (SIGKILL ⇒ OOM), the tail of stderr, and any error `result` frame.
+2. **Classify** it into a small, stable taxonomy (§5).
+3. **Surface** a plain-language explanation + actionable hint in the UI, replacing bare "exit 1" everywhere an agent can die.
+4. **Persist** it (drone run record; `db_agent_instances` last-failure) so it's inspectable after the fact.
+5. **Mark retryability** — transient classes (rate-limit, overloaded, network) say so explicitly and emit a `retryable` flag.
+
+**Non-goals**
+- Auto-retry / backoff / auto-resume orchestration. This spec *emits* `retryable`; acting on it is a follow-up.
+- Modifying the `claude` CLI.
+- Context-window / compaction handling (parked, separate spec) — except the one cross-link in §10.
+- Reconciling the stale `status='running'` liveness bug (related, separate).
+
+---
+
+## 4. Design
+
+### 4.1 Capture (`agents/runner.rs`)
+- **Retain the stderr buffer.** Replace the discard at `runner.rs:180` by handing the capped buffer back to `drain_and_collect` — give the stderr-drain `tokio::spawn` a `oneshot<Vec<u8>>` (or a shared `Arc<Mutex<Vec<u8>>>`) it sends on EOF, and `await` it after `child.wait()`. Keep the existing cap + keep-draining-and-discarding-past-cap behavior (it prevents pipe-fill stalls).
+- **Capture exit precisely.** From `child.wait()` (`runner.rs:210`), record both `status.code()` and, on Unix, `std::os::unix::process::ExitStatusExt::signal()` so a SIGKILL/OOM (code `None`, signal `9`) is distinguishable from a clean `exit 1`.
+- **Assemble a structured failure** on every error branch (§6) instead of the bare strings at lines 218/223-224.
+
+### 4.2 Classify (new `agents/failure.rs`)
+A **pure, data-driven, unit-testable** function:
+
+```
+classify(exit_code: Option<i32>, signal: Option<i32>,
+         stderr_tail: &str, result_frame: Option<&Value>) -> AgentFailure
+```
+
+A match table maps stderr substrings + exit/signal to a class. The Anthropic error phrasings are stable enough to match on; include the exact incident string `"Server is temporarily limiting requests"` / `"Rate limited"` → `RateLimited { retryable: true }`. Purity keeps it trivially testable with real captured strings.
+
+### 4.3 Translator (`translator/claude.rs`)
+`handle_result` (lines 248-266) must inspect the result frame's `subtype` / `is_error` / `error`. When it's an error frame, emit `AgentEvent::Error` (classified via §4.2) **instead of** a hollow `Done`. This catches failures the CLI reports on **stdout** (the exit-0 path G3).
+
+### 4.4 Emit on the live stream (`types.rs` + `runner.rs`)
+On any failure, the runner **sends `AgentEvent::Error` on `tx`** (the live stream) *before* resolving `final_result`. Extend `AgentEvent::Error` from `{ message }` to carry the structured failure (`code`, `detail`, `retryable`) — wire-format camelCase, mirrored in `frontend/types/gotypes.d.ts`. Both the agent pane (stream-watcher) and the drone accumulator then see the same classified failure.
+
+### 4.5 Persist
+- **Drone:** write the structured failure as JSON into the existing `DroneRun.error` column (`drone/storage.rs`), not a bare string.
+- **Agent instance:** add a `last_failure` field on `db_agent_instances` (class + detail + ts) so the Swarm/Warden overview and the agent pane can show *"last died: rate-limited, 3 m ago, retryable."* This also gives the liveness reconciler something truthful to display.
+
+### 4.6 Surface in the UI (the hard requirement)
+- **Agent pane:** map the runner's `AgentEvent::Error` → the `errored` outcome (`agent-pane-state`) carrying `failureCode` + `failureDetail`, and render an **explanation banner** instead of a generic errored state, e.g.:
+  > ⚠️ Claude hit a **rate limit** (server-side, temporary — not your quota). Retry in a moment.
+- **Drone run inspector:** show class + hint + stderr tail (collapsible).
+- **Swarm / Warden overview:** badge the agent with the failure class + retryable hint.
+- **Interactive PTY pane:** feed `shellprocexitcode` + captured stderr tail through the same `classify()` so this path gets the same banner (closes G5).
+
+### 4.7 Retryability hook (future)
+`retryable: true` is emitted but acting on it (backoff/auto-resume) is out of scope. Named so a later orchestration spec can consume it.
+
+---
+
+## 5. Taxonomy
+
+| Class | Trigger (stderr / exit / signal) | User-facing message | Retryable | Suggested action |
+|---|---|---|---|---|
+| `RateLimited` | `"Rate limited"`, `"temporarily limiting requests"`, HTTP 429 | Server-side rate limit (transient, **not** your quota) | ✅ | Retry shortly; reduce concurrency |
+| `Overloaded` | `overloaded_error`, HTTP 529 | API temporarily overloaded | ✅ | Retry with backoff |
+| `UsageLimit` | `"usage limit"`, quota/billing text | Your plan/usage limit reached | ❌ | Check plan/billing |
+| `Auth` | `authentication_error`, `"Invalid API key"`, `/login`, 401 | Not authenticated | ❌ | Re-auth (Identity tab) |
+| `Killed` (OOM) | signal 9 / code 137 / `None` | Process killed (likely OOM) | ⚠️ | Reduce load; check memory |
+| `Network` | `APIConnectionError`, DNS/connreset | Network error reaching API | ✅ | Check connectivity; retry |
+| `MaxTurns` | `--max-turns` reached / `error_max_turns` | Hit the turn cap | ❌ | Raise cap or split task |
+| `NoOutput` | exit 0, no `Done` (runner.rs:218) | Exited cleanly but produced nothing | ⚠️ | Inspect transcript/logs |
+| `SpawnFailure` | `AgentError::Spawn` (runner.rs:133) | Couldn't launch `claude` | ❌ | Check binary / `AGENTMUX_CLAUDE_BIN` |
+| `UnknownNonZero` | any other non-zero exit | Failed (exit N) — see detail | ⚠️ | Show stderr tail |
+| `Normal` | exit 0 + `Done` | — (success) | — | — |
+
+Every non-`Normal` class carries the **stderr tail** so the raw text is always one click away.
+
+---
+
+## 6. Data shapes (proposed)
+
+```rust
+// agents/failure.rs
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentFailure {
+    pub code: FailureClass,           // serde-tagged enum, snake_case wire
+    pub title: String,                // short, user-facing
+    pub detail: String,               // explanation (may embed stderr tail)
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub stderr_tail: String,          // capped, already in runner
+    pub retryable: bool,
+}
+```
+
+```rust
+// types.rs — extend the existing variant (back-compat: message stays)
+AgentEvent::Error {
+    message: String,                  // existing
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failure: Option<AgentFailure>,    // new structured payload
+}
+```
+
+TS mirror in `frontend/types/gotypes.d.ts`; the agent-pane reducer reads `failure.code` / `failure.detail`.
+
+---
+
+## 7. Touch points
+
+| Gap | File | Change |
+|---|---|---|
+| G1 | `agentmux-srv/src/agents/runner.rs:147-181` | Return the stderr buffer instead of `let _ = buf;` |
+| G2 | `agentmux-srv/src/agents/runner.rs:212-227` | Build `AgentFailure` via `classify()`; stop returning bare strings |
+| — | `agentmux-srv/src/agents/failure.rs` *(new)* | `classify()` + `FailureClass` + table |
+| G3 | `agentmux-srv/src/agents/translator/claude.rs:248-266` | Inspect `subtype`/`is_error`/`error`; emit `AgentEvent::Error` |
+| G4 | `agentmux-srv/src/agents/types.rs:104-108` | Extend `AgentEvent::Error` with `failure` |
+| G4 | `agentmux-srv/src/agents/runner.rs:183-186` | Emit `AgentEvent::Error` on `tx` before resolving `final_result` |
+| persist | `agentmux-srv/src/drone/storage.rs:141-175` | Store `AgentFailure` JSON in `DroneRun.error` |
+| persist | `db_agent_instances` schema + store | Add `last_failure` column/field |
+| G5 | `agentmux-srv/src/backend/blockcontroller/subprocess.rs:727-749` | Capture stderr tail; run `shellprocexitcode` through `classify()` |
+| UI | `frontend/app/store/agent-pane-state/reducer.ts:633-720`, `types.ts:76-80` | `errored` outcome carries `failureCode`/`failureDetail` |
+| UI | agent pane view + Swarm/Warden overview | Render explanation banner + badge |
+
+---
+
+## 8. Testing
+- **Unit (`failure.rs`):** table tests with **real** captured strings, including the incident's `"Server is temporarily limiting requests … Rate limited"` ⇒ `RateLimited { retryable: true }`; SIGKILL ⇒ `Killed`; `Invalid API key` ⇒ `Auth`.
+- **Translator:** an error `result` frame ⇒ `AgentEvent::Error` (not a hollow `Done`). Extends the existing `result_*` tests in `translator/claude.rs`.
+- **Runner:** extend `run_agent_with_bin_surfaces_spawn_failure` (`runner.rs:460-488`) with a stub binary that writes a rate-limit line to stderr and exits 1 ⇒ assert the structured failure carries the classification **and** the stderr tail.
+- **Frontend:** `errored` outcome renders the explanation banner with the right copy + retryable hint.
+
+---
+
+## 9. Rollout / phasing
+- **P1 — kill the opaque string at the source.** G1 + G2 + `failure.rs`: capture stderr, classify, put the explanation into the runner's terminal error and the drone `error` column. Smallest change, biggest win — literally finishes the `runner.rs` "Phase 2" TODO.
+- **P2 — live surfacing.** G3 + G4: emit `AgentEvent::Error` on the stream; agent-pane banner.
+- **P3 — persistence + overview.** `db_agent_instances.last_failure`, Swarm/Warden badge, interactive-path parity (G5), `retryable` hook.
+
+---
+
+## 10. Open questions
+1. Should the interactive PTY path and the headless runner converge on one capture/classify helper now, or stay separate per `SPEC_UNIFIED_AGENT_TYPES` (runner.rs:14-19 keeps spawn separate, translator shared)? Recommended: share `classify()` only.
+2. Retryable failures — inline banner only, or also a transient toast?
+3. `model_context_window_exceeded` is a failure *and* a context-window concern — does its messaging live here or in the parked context-window spec? Recommended: classify it here (`ContextExceeded`), link the remediation there.
+
+---
+
+## 11. Back to the incident
+Under this spec, the failure that triggered it — three subagents, `Server is temporarily limiting requests · Rate limited`, surfaced as an opaque exit — classifies as **`RateLimited`, retryable = true**, and the operator sees:
+
+> ⚠️ Rate-limited by the API (server-side, temporary — **not** your quota). The agent can be retried shortly; consider lowering parallelism.
+
+…instead of "exit 1."


### PR DESCRIPTION
## Problem

A failed Claude agent run surfaced as an opaque terminal string —
`claude exited with status N but stream emitted no error` — with no cause.
The real error (rate-limit, auth, OOM, crash) was in the child's stderr,
which the runner captured into a 64 KB buffer and then **discarded**
(`let _ = buf;` in `runner.rs` — a known "Phase 2" TODO). The motivating
incident: parallel agents died with
`API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited`,
and all the operator saw was "exit 1."

## What's in this PR (P1)

Spec: `docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md` (included).

- **`agents/failure.rs`** (new) — pure, fully-tested `classify(exit_code, signal, stderr, result_frame) -> AgentFailure`:
  - 11-class taxonomy: RateLimited, Overloaded, UsageLimit, Auth, ContextExceeded, MaxTurns, Network, Killed, NoOutput, SpawnFailure, UnknownNonZero.
  - Each carries a user-facing title/detail, exit/signal evidence, the stderr tail, and a `retryable` flag.
  - `explain()` renders the operator-facing string.
- **`runner.rs`**:
  - **G1** — the captured stderr is no longer dropped; it's handed to the collector via a `oneshot`.
  - **G2** — every failure branch classifies the exit + stderr into a human-readable explanation and emits a `tracing::warn!`. The opaque status string is removed.

## Behavior change

The explanation now appears, with no extra wiring, in:
- the **drone run `error` column** (the drone block already wraps the runner error verbatim — `drone/executor/blocks/agent.rs`), and
- the **sidecar log** (`muxlog srv`).

The motivating incident would now read:
> Rate-limited by the API — server-side rate limit, transient, and not your account quota. Retry shortly; consider lowering parallelism. [exit 1] (retryable)

…instead of "exit 1."

## Testing

- `cargo test -p agentmux-srv agents::` → **44 passed, 0 failed** (14 new classification tests + a Unix end-to-end test that spawns a stub which rate-limits and exits 1).
- clippy-clean on the new/changed files; no regressions in existing runner/translator/types tests.

## Follow-ups (P2/P3, scoped in the spec)

- Emit `AgentEvent::Error` on the live stream → agent-pane explanation banner.
- Translator error `result`-frame path (G3).
- `db_agent_instances.last_failure` + Swarm/Warden badge.
- Interactive-PTY path parity (G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
