### PR TITLE
fix(gpu): embed supportedOS manifest so the GPU process can initialize on Windows

### DIFF
--- a/.changesets/1781212885-fix-gpu-embed-supportedos-manifest-so-windows-reports-the-tr-x1e7.md
+++ b/.changesets/1781212885-fix-gpu-embed-supportedos-manifest-so-windows-reports-the-tr-x1e7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(gpu): embed supportedOS manifest so Windows reports the true OS version — fixes GPU process crash

--- a/agentmux-cef/build.rs
+++ b/agentmux-cef/build.rs
@@ -1,6 +1,33 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+// Windows application manifest. The `supportedOS` GUIDs (Vista, 7, 8, 8.1,
+// 10/11) make Windows report the true OS version to the process instead of
+// capping at 6.2 — required for correct Chromium GPU initialization. Mirrors
+// the manifest Electron embeds. `asInvoker` preserves winres's default UAC
+// behavior (no elevation prompt).
+#[cfg(target_os = "windows")]
+const WINDOWS_APP_MANIFEST: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+"#;
+
 fn main() {
     // No `cargo:rerun-if-changed` directives by design: emitting any of them
     // disables Cargo's default "rerun build.rs when any package file changes".
@@ -52,6 +79,17 @@ fn main() {
         if icon_path.exists() {
             res.set_icon(icon_path.to_str().unwrap());
         }
+        // Embed an application manifest declaring supportedOS for Win7→Win10/11.
+        // Without it the exe is "unmanifested": Windows lies about its version and
+        // reports 6.2 (Windows 8) via GetVersionEx — which sends Chromium's GPU
+        // init down OS-version-gated paths (DirectComposition / D3D feature
+        // detection / driver workarounds) that CHECK-crash the GPU process at
+        // "create shared context for virtualization" on modern Win11/multi-GPU/
+        // virtual-display hardware. chrome://gpu showed `Windows NT 6.2.9200`
+        // before this; Electron/VS Code ship the same manifest and report 10.0.
+        // The GPU process runs as THIS exe (agentmux-cef.exe --type=gpu-process),
+        // so its manifest is what determines the reported OS version.
+        res.set_manifest(WINDOWS_APP_MANIFEST);
         res.compile().expect("winres compile failed");
     }
 }

--- a/agentmux-launcher/build.rs
+++ b/agentmux-launcher/build.rs
@@ -1,6 +1,32 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+// Same supportedOS manifest as the host (agentmux-cef/build.rs) — the launcher
+// is the top-level exe and child processes can inherit OS-version behavior, so
+// keep both manifested to report the true Windows version. See the host
+// build.rs for the GPU-init rationale.
+#[cfg(target_os = "windows")]
+const WINDOWS_APP_MANIFEST: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+"#;
+
 fn main() {
     // AGENTMUX_BUILD_LABEL is injected by package.sh and includes a per-build
     // timestamp stamp. Tracking it here forces a recompile of agentmux-launcher
@@ -22,6 +48,7 @@ fn main() {
         if icon_path.exists() {
             res.set_icon(icon_path.to_str().unwrap());
         }
+        res.set_manifest(WINDOWS_APP_MANIFEST);
         res.compile().expect("winres compile failed");
 
         // Decode the brain logo PNG (transparent background, 256×256) to


### PR DESCRIPTION
## The real fix for Windows GPU being disabled

**Root cause:** `agentmux-cef.exe` and `agentmux-launcher.exe` shipped **without a Windows application manifest** declaring `supportedOS`. Windows version-lies to unmanifested exes — `GetVersionEx` reports **6.2 (Windows 8)** on a Windows 11 box. `chrome://gpu` confirmed it: `Operating system: Windows NT 6.2.9200`.

Chromium's GPU init is **OS-version-gated** (DirectComposition, D3D feature detection, driver-bug workarounds). Fed a fake "Windows 8", the GPU process took a path that `CHECK`-crashed (`STATUS_BREAKPOINT`) at "create shared context for virtualization" on this Win11 / multi-GPU / Parsec-virtual-display hardware → 3 crashes → Chromium disabled GL → xterm DOM renderer (no scrollbar, `GFX off`).

**Why VS Code works on the identical machine:** Electron embeds exactly this manifest and reports the true OS, so its GPU process initializes hardware NVIDIA D3D11. (Thanks to @a5af for pointing at VS Code — that's what cracked it.)

## Fix
`winres` now embeds an app manifest with `supportedOS` GUIDs (Win7→Win10/11) + `asInvoker` (preserves prior UAC behavior) on **both** the host and the launcher. The GPU process runs as `agentmux-cef.exe`, so its manifest is what determines the reported OS.

## Verified — packaged build, virgin data dir

| | before | after |
|---|---|---|
| OS reported | `Windows NT 6.2.9200` | **`Windows NT 10.0`** |
| GPU-process crashes | 3 (every launch) | **0** |
| `shared context` failure | yes | **none** |
| GPU process `--use-gl` | `disabled` | **(none → default hardware path)** |

## Corrects earlier wrong analysis
My prior conclusions (custom/DCHECK libcef build; transparency) were **wrong** — the Windows `libcef.dll` is the stock official CEF 148.0.9 release (pulled from `cef-builds.spotifycdn.com`). The problem was purely the missing exe manifest. Issue #1345 and the related analysis doc should be corrected/closed.

## Supersedes / reframes
- The SwiftShader bundle (#1344/#1346) stays as general robustness, but **isn't needed for this** — hardware GPU now works.
- The conditional-SwiftShader-fallback idea is moot for this machine.

## Test plan
- [ ] `task package`; launch on a Win11 machine → `chrome://gpu` shows `Windows NT 10.0`, hardware ANGLE D3D11, status bar `GFX HW`
- [ ] No regression to UAC (asInvoker), DPI, or window behavior