### PR TITLE
feat(agent-pane): context window usage bar in composer strip

### DIFF
--- a/.changesets/1781226140-feat-agent-pane-context-window-fill-bar-in-composer-strip-ep1c.md
+++ b/.changesets/1781226140-feat-agent-pane-context-window-fill-bar-in-composer-strip-ep1c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): context window fill bar in composer strip

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -70,7 +70,8 @@ export interface AgentPaneProjections {
      * Current input-token count as of the last message_start — equals the
      * total context fill (all conversation history) sent to the model.
      * Driven by the same TokensIn command as turnTokens.input; fires once
-     * per turn at message_start. null until the first turn completes.
+     * per turn at message_start. Resets to null on TurnEnd, so it is live
+     * only while a turn is in flight.
      */
     contextTokens?: (next: number | null) => void;
 }

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -70,8 +70,8 @@ export interface AgentPaneProjections {
      * Current input-token count as of the last message_start — equals the
      * total context fill (all conversation history) sent to the model.
      * Driven by the same TokensIn command as turnTokens.input; fires once
-     * per turn at message_start. Resets to null on TurnEnd, so it is live
-     * only while a turn is in flight.
+     * per turn at message_start. Persists through TurnEnd so the bar stays
+     * visible between turns. Clears only on TurnReset (session wipe).
      */
     contextTokens?: (next: number | null) => void;
 }
@@ -187,8 +187,8 @@ export function dispatch(
     proj("currentTool", prev.currentTool, slot.state.currentTool, slot.proj.currentTool);
     proj("turnTokens", prev.turnTokens, slot.state.turnTokens, slot.proj.turnTokens);
     proj("contextTokens",
-        prev.turnTokens?.input ?? null,
-        slot.state.turnTokens?.input ?? null,
+        prev.lastContextTokens ?? null,
+        slot.state.lastContextTokens ?? null,
         slot.proj.contextTokens);
     proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
     proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -66,6 +66,13 @@ export interface AgentPaneProjections {
      * Reducer-owned (PR #1068). Drives the chevron's unread badge.
      */
     composerUnreadCount?: (next: number) => void;
+    /**
+     * Current input-token count as of the last message_start — equals the
+     * total context fill (all conversation history) sent to the model.
+     * Driven by the same TokensIn command as turnTokens.input; fires once
+     * per turn at message_start. null until the first turn completes.
+     */
+    contextTokens?: (next: number | null) => void;
 }
 
 interface Slot {
@@ -178,6 +185,10 @@ export function dispatch(
     proj("sessionStats", prev.sessionStats, slot.state.sessionStats, slot.proj.sessionStats);
     proj("currentTool", prev.currentTool, slot.state.currentTool, slot.proj.currentTool);
     proj("turnTokens", prev.turnTokens, slot.state.turnTokens, slot.proj.turnTokens);
+    proj("contextTokens",
+        prev.turnTokens?.input ?? null,
+        slot.state.turnTokens?.input ?? null,
+        slot.proj.contextTokens);
     proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
     proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);
     proj("turnPhase", prev.turnPhase, slot.state.turnPhase, slot.proj.turnPhase);

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -483,7 +483,7 @@ export function update(
                 output: state.turnTokens?.output ?? 0,
             };
             const nextState = bumpEvent(
-                { ...state, turnTokens: next },
+                { ...state, turnTokens: next, lastContextTokens: command.input },
                 nowMs,
                 0,
             );

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -440,7 +440,7 @@ export function update(
                     sessionStats: null,
                     currentTool: null,
                     turnTokens: null,
-                    lastContextTokens: null,
+                    lastContextTokens: 0,
                     // TurnReset is a wholesale clear → Idle. The
                     // working/stopping cascade lives entirely on
                     // turnPhase since PR G.

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -440,6 +440,7 @@ export function update(
                     sessionStats: null,
                     currentTool: null,
                     turnTokens: null,
+                    lastContextTokens: null,
                     // TurnReset is a wholesale clear → Idle. The
                     // working/stopping cascade lives entirely on
                     // turnPhase since PR G.

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -230,6 +230,16 @@ export interface AgentPaneState {
      * SPEC_AGENT_COMPOSER_SLIM_STATUS_2026_05_26.md §5.4.
      */
     composerUnreadCount: number;
+
+    /**
+     * Input-token count from the most recent message_start — the full
+     * context fill sent to the model on that turn. Unlike `turnTokens`,
+     * this field is NOT cleared at TurnEnd so the context-window bar
+     * stays visible between turns showing the last known fill level.
+     * Cleared only when the pane is created (initialState) or on an
+     * explicit TurnReset (session wipe).
+     */
+    lastContextTokens: number | null;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -237,6 +247,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     sessionStats: null,
     currentTool: null,
     turnTokens: null,
+    lastContextTokens: null,
     pending: [],
     initPhase: { kind: "InitPending" },
     lastEventMs: null,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -182,6 +182,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 sessionStats: a.sessionStatsAtom[1],
                 currentTool: a.currentToolAtom[1],
                 turnTokens: a.turnTokensAtom[1],
+                contextTokens: a.contextTokensAtom[1],
                 pending: a.pendingMessagesAtom[1],
                 initPhase: a.initPhaseAtom[1],
                 turnPhase: a.turnPhaseAtom[1],
@@ -944,6 +945,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onToggleExpanded={() =>
                     dispatchPane(model.blockId, { type: "DetailsToggle" }, "user")
                 }
+                contextTokens={agentAtoms().contextTokensAtom[0]()}
+                contextWindow={provider()?.contextWindow}
             />
 
             <div class="agent-composer-region">

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -30,6 +30,7 @@
 import { Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 
 import type { PermissionMode, SessionStats, TurnTokens } from "../types";
+import { ContextWindowBar } from "./ContextWindowBar";
 
 const PERMISSION_LABELS: Record<PermissionMode, string> = {
     bypass: "Bypass",
@@ -106,6 +107,10 @@ interface AgentComposerStripProps {
     unreadCount: number;
     /** Dispatches `DetailsToggle` to the pane reducer. */
     onToggleExpanded: () => void;
+    /** Current context fill in tokens (from message_start). null = no turn yet. */
+    contextTokens?: number | null;
+    /** Provider's max context window size. undefined = unknown provider. */
+    contextWindow?: number;
 }
 
 export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element => {
@@ -257,6 +262,7 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         {PERMISSION_LABELS[props.permissionMode!]}
                     </span>
                 </Show>
+                <ContextWindowBar tokens={props.contextTokens} contextWindow={props.contextWindow} />
                 <button
                     type="button"
                     class="agent-composer-strip-chevron"

--- a/frontend/app/view/agent/components/ContextWindowBar.tsx
+++ b/frontend/app/view/agent/components/ContextWindowBar.tsx
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Show, type JSX } from "solid-js";
+
+interface ContextWindowBarProps {
+    /** Current input-token count (context fill). null = no turn yet. */
+    tokens: number | null | undefined;
+    /** Model max context window. undefined = provider unknown. */
+    contextWindow: number | undefined;
+}
+
+function fmtK(n: number): string {
+    return `${Math.round(n / 100) / 10}k`;
+}
+
+type Band = "low" | "mid" | "high" | "critical";
+
+function band(fraction: number): Band {
+    if (fraction >= 0.9) return "critical";
+    if (fraction >= 0.75) return "high";
+    if (fraction >= 0.5) return "mid";
+    return "low";
+}
+
+export function ContextWindowBar(props: ContextWindowBarProps): JSX.Element {
+    return (
+        <Show when={props.tokens != null && props.tokens! > 0}>
+            <div
+                class="ctx-window-bar"
+                title={contextTitle(props.tokens!, props.contextWindow)}
+                aria-label={contextTitle(props.tokens!, props.contextWindow)}
+            >
+                <Show
+                    when={props.contextWindow != null}
+                    fallback={
+                        <span class="ctx-window-raw">
+                            {fmtK(props.tokens!)} ctx
+                        </span>
+                    }
+                >
+                    {(() => {
+                        const fraction = props.tokens! / props.contextWindow!;
+                        const b = band(fraction);
+                        const pct = Math.min(100, Math.round(fraction * 100));
+                        return (
+                            <div class={`ctx-window-track ctx-window-track--${b}`}>
+                                <div
+                                    class="ctx-window-fill"
+                                    style={{ width: `${pct}%` }}
+                                />
+                                <span class="ctx-window-label">
+                                    {fmtK(props.tokens!)} / {fmtK(props.contextWindow!)}
+                                </span>
+                            </div>
+                        );
+                    })()}
+                </Show>
+            </div>
+        </Show>
+    );
+}
+
+function contextTitle(tokens: number, contextWindow: number | undefined): string {
+    if (contextWindow == null) {
+        return `Context: ${tokens.toLocaleString()} tokens`;
+    }
+    const pct = ((tokens / contextWindow) * 100).toFixed(1);
+    return `Context window: ${tokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens (${pct}%)\nThis is the total conversation history sent to the model on each turn.`;
+}
+
+ContextWindowBar.displayName = "ContextWindowBar";

--- a/frontend/app/view/agent/components/ContextWindowBar.tsx
+++ b/frontend/app/view/agent/components/ContextWindowBar.tsx
@@ -24,6 +24,16 @@ function band(fraction: number): Band {
 }
 
 export function ContextWindowBar(props: ContextWindowBarProps): JSX.Element {
+    // Reactive accessors so updates to props.tokens mid-turn (successive
+    // message_start events) re-render the bar. An IIFE inside <Show> only
+    // runs once when `when` first becomes truthy and freezes thereafter.
+    const fraction = () =>
+        props.tokens != null && props.contextWindow != null
+            ? props.tokens / props.contextWindow
+            : null;
+    const b = () => { const f = fraction(); return f != null ? band(f) : "low"; };
+    const pct = () => { const f = fraction(); return f != null ? Math.min(100, Math.round(f * 100)) : 0; };
+
     return (
         <Show when={props.tokens != null && props.tokens! > 0}>
             <div
@@ -39,22 +49,15 @@ export function ContextWindowBar(props: ContextWindowBarProps): JSX.Element {
                         </span>
                     }
                 >
-                    {(() => {
-                        const fraction = props.tokens! / props.contextWindow!;
-                        const b = band(fraction);
-                        const pct = Math.min(100, Math.round(fraction * 100));
-                        return (
-                            <div class={`ctx-window-track ctx-window-track--${b}`}>
-                                <div
-                                    class="ctx-window-fill"
-                                    style={{ width: `${pct}%` }}
-                                />
-                                <span class="ctx-window-label">
-                                    {fmtK(props.tokens!)} / {fmtK(props.contextWindow!)}
-                                </span>
-                            </div>
-                        );
-                    })()}
+                    <div class={`ctx-window-track ctx-window-track--${b()}`}>
+                        <div
+                            class="ctx-window-fill"
+                            style={{ width: `${pct()}%` }}
+                        />
+                        <span class="ctx-window-label">
+                            {fmtK(props.tokens!)} / {fmtK(props.contextWindow!)}
+                        </span>
+                    </div>
                 </Show>
             </div>
         </Show>

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -79,6 +79,12 @@ export interface ProviderDefinition {
      *  the user launches the agent so we can show install links
      *  instead of letting the CLI fail with cryptic stderr. */
     systemPrereqs?: SystemPrereq[];
+    /**
+     * The model's maximum input token capacity (context window size).
+     * Used by the composer strip to render a context-fill progress bar.
+     * Omit for providers whose context window is unknown or variable.
+     */
+    contextWindow?: number;
 }
 
 /** Shared git prereq — claude-code calls `git` from session-start
@@ -139,6 +145,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // anthropics/claude-code#29898). Without git the CLI fails
         // with `Error: Git is required but was not found.`.
         systemPrereqs: [GIT_PREREQ],
+        contextWindow: 200_000,
     },
     codex: {
         id: "codex",
@@ -166,6 +173,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         resumeFlag: null,
         sessionIdField: "thread_id",
         controllerType: "subprocess",
+        contextWindow: 200_000,
     },
     // muxcode — AgentMux's first-party agentic coding CLI.
     // Supports local GGUF inference via llama-server, Anthropic, OpenAI, and
@@ -199,6 +207,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         resumeFlag: "--resume",
         sessionIdField: "session_id",
         controllerType: "subprocess",
+        contextWindow: 200_000,
     },
     gemini: {
         id: "gemini",
@@ -226,6 +235,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         resumeFlag: "-r",
         sessionIdField: "session_id",
         controllerType: "subprocess",
+        contextWindow: 1_000_000,
     },
     // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
     // Same stream-json headless surface → reuses the gemini translator
@@ -320,6 +330,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // Same git dependency as Claude Code — OpenClaw uses git for
         // project-context features when invoking the Codex harness.
         systemPrereqs: [GIT_PREREQ],
+        contextWindow: 200_000,
     },
     // Kimi Code CLI — Moonshot AI's coding agent.
     // Python-based CLI (not npm). Supports stream-json output and OpenAI-style tool calls.
@@ -347,6 +358,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         resumeFlag: null,
         sessionIdField: "session_id",
         controllerType: "subprocess",
+        contextWindow: 128_000,
     },
     // GitHub Copilot CLI — Microsoft's coding agent.
     // Runs in ACP mode (`--acp` flag) so the existing ACP controller
@@ -379,6 +391,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         resumeFlag: null,
         sessionIdField: "sessionId",
         controllerType: "acp",
+        contextWindow: 128_000,
     },
     // Pi — the lightweight coding agent that powers OpenClaw.
     // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -56,6 +56,12 @@ export interface AgentAtoms {
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
     /**
+     * Total input-token count from the last message_start event — equals
+     * the full context fill (all conversation history) sent to the model
+     * on that turn. null until the first turn completes.
+     */
+    contextTokensAtom: SignalPair<number | null>;
+    /**
      * Messages sent by the user that the backend hasn't picked up yet.
      * Rendered in a pending zone between the conversation and the composer.
      * When the backend emits `agent-message-accepted` for a given id, the
@@ -148,6 +154,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         sessionStatsAtom: createSignal<SessionStats | null>(null),
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
+        contextTokensAtom: createSignal<number | null>(null),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
         // gap1 (#993) reshaped InitPhase from string union to discriminated
         // union; turnPhase from PR B is now the sole working-state encoding

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -58,7 +58,7 @@ export interface AgentAtoms {
     /**
      * Total input-token count from the last message_start event — equals
      * the full context fill (all conversation history) sent to the model
-     * on that turn. Resets to null on TurnEnd — live only during a turn.
+     * on that turn. Persists through TurnEnd; clears on TurnReset (session wipe).
      */
     contextTokensAtom: SignalPair<number | null>;
     /**

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -58,7 +58,7 @@ export interface AgentAtoms {
     /**
      * Total input-token count from the last message_start event — equals
      * the full context fill (all conversation history) sent to the model
-     * on that turn. null until the first turn completes.
+     * on that turn. Resets to null on TurnEnd — live only during a turn.
      */
     contextTokensAtom: SignalPair<number | null>;
     /**

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -263,8 +263,10 @@
 
 @include mixins.respect-reduced-motion {
     // Critical context fill: keep the pulse but slow it down.
-    // Freezing it entirely would hide the "danger" signal under reduced motion.
-    .ctx-window-fill {
+    // Must match specificity of .ctx-window-track--critical .ctx-window-fill
+    // (0,2,0) — a bare .ctx-window-fill (0,1,0) is outranked by the animation
+    // shorthand and the duration override silently loses.
+    .ctx-window-track--critical .ctx-window-fill {
         animation-duration: 2.4s;
     }
 }

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -195,3 +195,76 @@
         display: none;
     }
 }
+
+// ── Context Window Fill Bar ────────────────────────────────────────────
+// Rendered inside AgentComposerStrip's right segment by ContextWindowBar.
+
+.ctx-window-bar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    opacity: 0.75;
+    cursor: default;
+
+    &:hover { opacity: 1; }
+}
+
+.ctx-window-raw {
+    color: var(--color-text-secondary, #888);
+}
+
+.ctx-window-track {
+    position: relative;
+    height: 6px;
+    width: 72px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.1);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+}
+
+.ctx-window-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.3s ease;
+
+    .ctx-window-track--low &     { background: #4caf50; }
+    .ctx-window-track--mid &     { background: #ffc107; }
+    .ctx-window-track--high &    { background: #ff9800; }
+    .ctx-window-track--critical & {
+        background: #f44336;
+        animation: ctx-pulse 1.2s ease-in-out infinite;
+    }
+}
+
+.ctx-window-label {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    text-align: center;
+    font-size: 9px;
+    line-height: 1;
+    color: rgba(255, 255, 255, 0.9);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 2px;
+}
+
+@keyframes ctx-pulse {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.6; }
+}
+
+@include mixins.respect-reduced-motion {
+    // Critical context fill: keep the pulse but slow it down.
+    // Freezing it entirely would hide the "danger" signal under reduced motion.
+    .ctx-window-fill {
+        animation-duration: 2.4s;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `contextWindow?: number` field to `ProviderDefinition` with values for all known providers (claude 200k, codex 200k, gemini 1M, muxcode 200k, openclaw 200k, kimi 128k, copilot 128k; qwen and pi intentionally unset).
- Adds `contextTokensAtom` (driven by `turnTokens.input` from `message_start`) to `AgentAtoms` and wires it through the pane-state store's projection layer.
- New `ContextWindowBar` component: when tokens > 0 renders either a progress bar (if `contextWindow` is known) or a plain "Xk ctx" count. Color bands: green < 50%, yellow 50–75%, orange 75–90%, pulsing red ≥ 90%.
- `AgentComposerStrip` gains `contextTokens` / `contextWindow` props and renders `<ContextWindowBar>` between the permission pill and chevron.
- `agent-view.tsx` passes `contextTokens={agentAtoms().contextTokensAtom[0]()}` and `contextWindow={provider()?.contextWindow}`.
- SCSS appended to `_composer-strip.scss`: `.ctx-window-bar`, `.ctx-window-track`, `.ctx-window-fill`, `.ctx-window-label`, `ctx-pulse` keyframe, reduced-motion rule.

## Test plan

- [ ] Start an agent turn; after `message_start` arrives the bar should appear in the strip with the correct fill percentage.
- [ ] Test with `claude` (200k window): context bar shows e.g. "45k / 200k".
- [ ] Test with `gemini` (1M window): bar shows proportionally tiny fill at typical usage.
- [ ] If you can simulate a near-full context (≥90%), confirm the bar turns red and pulses.
- [ ] Test with a provider that has no `contextWindow` (e.g. `qwen`): strip shows plain "Xk ctx" text, no progress bar.
- [ ] Before any turn completes, the bar should not render at all (tokens null / 0).
- [ ] Verify narrow-pane (<240px) doesn't break — `_composer-strip.scss` already drops stats at that width; the context bar sits in the same right segment.
- [ ] Enable reduced-motion in OS settings: pulse animation should slow rather than stop entirely.

Follow-up to the context window spec at `docs/specs/SPEC_CONTEXT_WINDOW_INDICATOR_2026_06_11.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)