### PR TITLE
fix(term): make terminal scrollbar always visible and clickable

### DIFF
--- a/.changesets/1781253502-fix-term-make-scrollbar-thumb-always-visible-and-clickable-d0rc.md
+++ b/.changesets/1781253502-fix-term-make-scrollbar-thumb-always-visible-and-clickable-d0rc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): make scrollbar thumb always visible and clickable

--- a/.changesets/1781304156-fix-term-restore-url-hover-in-terminal-pane-4n5e.md
+++ b/.changesets/1781304156-fix-term-restore-url-hover-in-terminal-pane-4n5e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): restore URL hover in terminal pane

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -127,15 +127,6 @@
     }
 
     .terminal {
-        // .xterm-screen covers the full element area (including the scrollbar gutter) but
-        // only contains the canvas/rows for the text columns. pointer-events:none lets
-        // clicks in the scrollbar zone fall through to .xterm-viewport's native scrollbar,
-        // while children (canvas/rows) keep their default pointer-events:auto so text
-        // selection and input still work.
-        .xterm-screen {
-            pointer-events: none;
-        }
-
         // WebView2 renders the native textarea caret even at opacity:0
         // when the terminal background is transparent.
         .xterm-helper-textarea {

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -154,15 +154,19 @@
             overflow-y: auto;
 
             &::-webkit-scrollbar {
+                // Base width — customFit injects a per-terminal <style> rule that overrides
+                // this with 14px + sub-cell remainder so text columns tile flush to the
+                // scrollbar's left edge. cursor:pointer makes the whole track area show a
+                // hand cursor instead of the inherited text I-beam.
                 width: 14px;
                 height: 14px;
+                cursor: pointer;
             }
 
-            // Transparent track: the scrollbar lane (reserved only while the scrollbar is
-            // visible — see TermWrap.customFit) shows the terminal background instead of a
-            // contrasting strip. The thumb paints on top on hover.
+            // Transparent track so the scrollbar lane shows the terminal background.
             &::-webkit-scrollbar-track {
                 background-color: transparent;
+                cursor: pointer;
             }
 
             &::-webkit-scrollbar-thumb {

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -126,27 +126,16 @@
         }
     }
 
-    // The 18px width is the width of the scrollbar plus the margin
-    .term-scrollbar-show-observer {
-        z-index: calc(var(--zindex-xterm-viewport-overlay) - 1);
-        position: absolute;
-        top: 0;
-        right: 0;
-        height: 100%;
-        width: 18px;
-    }
-
-    .term-scrollbar-hide-observer {
-        z-index: calc(var(--zindex-xterm-viewport-overlay) + 1);
-        display: none;
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: calc(100% - 18px);
-    }
-
     .terminal {
+        // .xterm-screen covers the full element area (including the scrollbar gutter) but
+        // only contains the canvas/rows for the text columns. pointer-events:none lets
+        // clicks in the scrollbar zone fall through to .xterm-viewport's native scrollbar,
+        // while children (canvas/rows) keep their default pointer-events:auto so text
+        // selection and input still work.
+        .xterm-screen {
+            pointer-events: none;
+        }
+
         // WebView2 renders the native textarea caret even at opacity:0
         // when the terminal background is transparent.
         .xterm-helper-textarea {
@@ -178,7 +167,6 @@
 
             &::-webkit-scrollbar-thumb {
                 cursor: pointer;
-                display: none;
                 background-color: var(--scrollbar-thumb-color);
                 border-radius: 0;
                 margin: 0 1px 0 1px;
@@ -190,12 +178,6 @@
                 &:active {
                     background-color: var(--scrollbar-thumb-active-color);
                 }
-            }
-        }
-
-        &:hover {
-            .xterm-viewport::-webkit-scrollbar-thumb {
-                display: block;
             }
         }
     }

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -67,7 +67,6 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
     const { blockId, model } = props;
     let viewRef!: HTMLDivElement;
     let connectElemRef!: HTMLDivElement;
-    let scrollbarHideObserverRef!: HTMLDivElement;
 
     const [blockData] = WOS.useWaveObjectValue<Block>(WOS.makeORef("block", blockId));
     const termSettingsAtom = getSettingsPrefixAtom("term");
@@ -254,21 +253,6 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
         }
     });
 
-    const onScrollbarShowObserver = () => {
-        // xterm v6 reworked the viewport/scrollbar — try both old and new class names
-        const termViewport = (viewRef.getElementsByClassName("xterm-viewport")[0] ??
-            viewRef.getElementsByClassName("xterm-scroll-area")[0]) as HTMLDivElement;
-        if (termViewport) termViewport.style.zIndex = "var(--zindex-xterm-viewport-overlay)";
-        if (scrollbarHideObserverRef) scrollbarHideObserverRef.style.display = "block";
-    };
-
-    const onScrollbarHideObserver = () => {
-        const termViewport = (viewRef.getElementsByClassName("xterm-viewport")[0] ??
-            viewRef.getElementsByClassName("xterm-scroll-area")[0]) as HTMLDivElement;
-        if (termViewport) termViewport.style.zIndex = "auto";
-        if (scrollbarHideObserverRef) scrollbarHideObserverRef.style.display = "none";
-    };
-
     const stickerConfig = createMemo(() => ({
         charWidth: 8,
         charHeight: 16,
@@ -419,14 +403,7 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                     {model.agentRuntimeLabel()}
                 </div>
             </Show>
-            <div class="term-connectelem" ref={connectElemRef!}>
-                <div class="term-scrollbar-show-observer" onPointerOver={onScrollbarShowObserver} />
-                <div
-                    ref={scrollbarHideObserverRef!}
-                    class="term-scrollbar-hide-observer"
-                    onPointerOver={onScrollbarHideObserver}
-                />
-            </div>
+            <div class="term-connectelem" ref={connectElemRef!} />
             <Search {...searchProps} />
         </div>
     );

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -424,6 +424,10 @@ export class TermWrap {
         if (this.mainFileSubject) {
             this.mainFileSubject.release();
         }
+        if (this.scrollbarStyleEl) {
+            this.scrollbarStyleEl.remove();
+            this.scrollbarStyleEl = null;
+        }
         try {
             this.terminal.dispose();
         } catch (e) {
@@ -604,6 +608,10 @@ export class TermWrap {
     // ResizeObserver on the viewport (setupScrollbarRefit) uses this to re-fit only when
     // the scrollbar toggles, not on every size tick.
     private lastScrollbarVisible: boolean = false;
+    // Per-terminal <style> element injected into <head> to override the scrollbar width
+    // with a concrete pixel value. CSS var() is unreliable in ::-webkit-scrollbar
+    // pseudo-elements — style injection avoids that limitation.
+    private scrollbarStyleEl: HTMLStyleElement | null = null;
 
     private customFit() {
         const dims = this.fitAddon.proposeDimensions();
@@ -636,6 +644,26 @@ export class TermWrap {
             const reservation = scrollbarVisible ? TermWrap.SCROLLBAR_WIDTH : 0;
             const availPx = this.connectElem.clientWidth - padX - reservation; // perf:allow-layout-read — resize/fit path, not per-keystroke
             dims.cols = Math.max(2, Math.floor(availPx / cellWidth));
+            // Widen the scrollbar by the sub-cell remainder so text columns tile flush to
+            // its left edge with no visible gap: (cols * cellWidth) + (14 + remainder) = connW.
+            // Inject a concrete <style> rule per terminal — CSS var() in ::-webkit-scrollbar
+            // pseudo-elements is not reliably inherited in Chromium, so we bypass it entirely.
+            if (viewport && scrollbarVisible) {
+                const remainder = Math.max(0, availPx - dims.cols * cellWidth);
+                if (remainder > 0) {
+                    const sbWidth = TermWrap.SCROLLBAR_WIDTH + remainder;
+                    if (!this.scrollbarStyleEl) {
+                        this.scrollbarStyleEl = document.createElement("style");
+                        document.head.appendChild(this.scrollbarStyleEl);
+                        viewport.setAttribute("data-term-block", this.blockId);
+                    }
+                    this.scrollbarStyleEl.textContent = `[data-term-block="${this.blockId}"]::-webkit-scrollbar { width: ${sbWidth}px !important; }`;
+                } else if (this.scrollbarStyleEl) {
+                    this.scrollbarStyleEl.textContent = "";
+                }
+            } else if (this.scrollbarStyleEl) {
+                this.scrollbarStyleEl.textContent = "";
+            }
         }
         if (this.terminal.rows !== dims.rows || this.terminal.cols !== dims.cols) {
             core?._renderService?.clear?.();


### PR DESCRIPTION
## Summary

- Removes the show/hide observer div mechanism — the observer divs in the scrollbar zone were intercepting the clicks they were meant to let through
- Makes the scrollbar thumb permanently visible (removes the `.terminal:hover` gate that hid the thumb when the cursor moved from the text area onto the scrollbar track, mid-reach)
- Sub-cell gap fix: `customFit` injects a per-terminal `<style>` that widens the scrollbar to `14px + remainder` so text columns tile flush to the scrollbar left edge with no zoom-dependent gap
- **Fixes URL hover regression** (reagent P1 on first two commits): the initial fix incorrectly added `.xterm-screen { pointer-events: none }`. Since `pointer-events` is inherited, that made all canvas/row children inherit `none` too, removing the entire screen subtree from hit-testing — events fell through to `.xterm-viewport`, bypassing xterm's Linkifier2 (bound to `.xterm-screen`), so `WebLinksAddon` and `FilePathLinkProvider` lost hover-underline and click-activation. The third commit removes the rule. The scrollbar remains clickable: `customFit` sizes `.xterm-screen` to exactly `cols × cellWidth`, so it ends flush with the scrollbar left edge and never overlaps it.

## Test plan

- [ ] Open a terminal pane, run a command with lots of output to generate scrollback
- [ ] Hover over the scrollbar — thumb stays visible (no disappearing on approach)
- [ ] Click the scrollbar thumb — scrolls correctly
- [ ] Click-drag the scrollbar thumb — drag works
- [ ] Click in the scrollbar track (above/below thumb) — jumps scroll position
- [ ] Hover over a URL/file path in the terminal — cursor changes to pointer, link underlines
- [ ] Click the URL — opens link
- [ ] Text selection by click-drag in the terminal still works
- [ ] Keyboard input still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)