### PR TITLE
fix(term): fix xterm paste truncation — chunked send, BPM on, larger buffer

### DIFF
--- a/.changesets/1781253563-fix-term-fix-xterm-paste-truncation-chunked-send-larger-inpu-u698.md
+++ b/.changesets/1781253563-fix-term-fix-xterm-paste-truncation-chunked-send-larger-inpu-u698.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(term): fix xterm paste truncation — chunked send, larger input buffer, BPM on by default

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -40,10 +40,17 @@ use crate::backend::storage::store::Store;
 use crate::backend::obj::{self, MetaMapType};
 use crate::backend::wps;
 
-/// Channel buffer size for shell input.
-/// 256 slots prevents burst-drop on large pastes arriving faster than the
-/// PTY write loop drains. Original Go value was 32 — too small for multi-chunk
-/// pastes.
+/// Cap on the out-of-order input reorder buffer (`input_seq_buf`).
+///
+/// The input channel itself is now **unbounded** (`unbounded_channel`): a
+/// bounded `try_send` silently dropped input on burst (large pastes arriving
+/// faster than the PTY write loop drains — the original truncation bug), and
+/// the proper backpressure remedy (`send().await`) can't be applied here
+/// because `send_input` is a synchronous trait method holding a `std::Mutex`.
+/// An unbounded channel guarantees no input is ever dropped; terminal input is
+/// human-paced (and the frontend now chunks large pastes at 4 KB / 5 ms), and
+/// the PTY drain loop keeps up, so the queue does not grow in practice. This
+/// constant only bounds the reorder buffer (pathological out-of-order seqs).
 const SHELL_INPUT_CH_SIZE: usize = 256;
 
 /// Detect the best available interactive shell on Windows.
@@ -103,11 +110,12 @@ struct ShellControllerInner {
     status_version: i32,
     /// Connection name for the shell process.
     conn_name: String,
-    /// Input channel sender (sends to the PTY input loop).
-    input_tx: Option<mpsc::Sender<BlockInputUnion>>,
+    /// Input channel sender (sends to the PTY input loop). Unbounded so input
+    /// is never dropped on burst — see `SHELL_INPUT_CH_SIZE` doc.
+    input_tx: Option<mpsc::UnboundedSender<BlockInputUnion>>,
     /// Input channel receiver (consumed by the PTY input loop).
     #[allow(dead_code)]
-    input_rx: Option<mpsc::Receiver<BlockInputUnion>>,
+    input_rx: Option<mpsc::UnboundedReceiver<BlockInputUnion>>,
     /// OS PID of the running child process, kept for signal delivery in stop().
     child_pid: Option<u32>,
     /// Unix timestamp (ms) when the process was spawned; None until first spawn.
@@ -348,8 +356,9 @@ impl Controller for ShellController {
         }
         self.publish_status();
 
-        // Create input channel
-        let (input_tx, input_rx) = mpsc::channel(SHELL_INPUT_CH_SIZE);
+        // Create input channel. Unbounded: input must never be silently
+        // dropped on burst (the paste-truncation bug). See SHELL_INPUT_CH_SIZE.
+        let (input_tx, input_rx) = mpsc::unbounded_channel();
         {
             let mut inner = self.inner.lock().unwrap();
             inner.input_tx = Some(input_tx);
@@ -1040,7 +1049,7 @@ impl Controller for ShellController {
             None => return Err("controller is not running".to_string()),
         };
         match seq {
-            None => tx.try_send(input).map_err(|e| format!("send_input: {e}")),
+            None => tx.send(input).map_err(|e| format!("send_input: {e}")),
             Some(s) => {
                 // Detect session reset: seq==0 means the TermViewModel
                 // restarted and its per-block counter is back at zero.
@@ -1060,14 +1069,16 @@ impl Controller for ShellController {
 
                 let next = inner.input_seq_next;
                 if s == next {
-                    // Advance before sending — a try_send failure must not leave the
+                    // Advance before sending — a send failure must not leave the
                     // backend stuck waiting for a seq the frontend will never resend.
                     inner.input_seq_next += 1;
-                    if let Err(e) = tx.try_send(input) {
+                    if let Err(e) = tx.send(input) {
+                        // Unbounded send only fails if the receiver is gone
+                        // (controller stopped) — nothing to do but drop quietly.
                         tracing::warn!(
                             block_id = %self.block_id,
                             seq = s,
-                            "send_input: channel full, dropping in-order packet: {e}"
+                            "send_input: input channel closed, discarding packet: {e}"
                         );
                         return Ok(());
                     }
@@ -1077,11 +1088,11 @@ impl Controller for ShellController {
                         match inner.input_seq_buf.remove(&expected) {
                             Some(buffered) => {
                                 inner.input_seq_next += 1;
-                                if let Err(e) = tx.try_send(buffered) {
+                                if let Err(e) = tx.send(buffered) {
                                     tracing::warn!(
                                         block_id = %self.block_id,
                                         seq = expected,
-                                        "send_input drain: channel full, dropping buffered packet: {e}"
+                                        "send_input drain: input channel closed, discarding buffered packet: {e}"
                                     );
                                 }
                             }

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -40,8 +40,11 @@ use crate::backend::storage::store::Store;
 use crate::backend::obj::{self, MetaMapType};
 use crate::backend::wps;
 
-/// Channel buffer size for shell input (matches Go's 32).
-const SHELL_INPUT_CH_SIZE: usize = 32;
+/// Channel buffer size for shell input.
+/// 256 slots prevents burst-drop on large pastes arriving faster than the
+/// PTY write loop drains. Original Go value was 32 — too small for multi-chunk
+/// pastes.
+const SHELL_INPUT_CH_SIZE: usize = 256;
 
 /// Detect the best available interactive shell on Windows.
 ///

--- a/docs/specs/SPEC_XTERM_PASTE_TRUNCATION_2026_06_12.md
+++ b/docs/specs/SPEC_XTERM_PASTE_TRUNCATION_2026_06_12.md
@@ -1,0 +1,251 @@
+# SPEC: xterm Terminal Paste Truncation Fix
+
+**Date:** 2026-06-12  
+**Status:** Proposed  
+**Area:** Terminal (xterm pane)  
+**Severity:** P1 — data loss, silent
+
+---
+
+## Problem
+
+Pasting a large block of text into an AgentMux xterm terminal pane silently truncates the
+content. The user sees only the first fraction of what they pasted with no error or warning.
+No user-visible feedback is given; the truncation is only visible as a warning in backend
+logs (`"input reorder buffer full, dropping"`).
+
+---
+
+## Root Cause
+
+The truncation happens at the backend input channel. The full pipeline is:
+
+```
+Clipboard (navigator.clipboard.readText)
+  → terminal.paste(text)           [xterm.js paste()]
+  → onData event(s)                [xterm may emit multiple chunks]
+  → sendDataHandler(data)          [termwrap.ts:450]
+  → base64-encode + sendWSCommand  [termViewModel.ts:343-351]
+  → WebSocket "blockinput" frame   [one frame per onData chunk]
+  → shell.rs send_input()          [websocket.rs:428-445]
+  → mpsc::Sender<BlockInputUnion>  [shell.rs:565-589]
+  → PTY write loop write_all()     [shell.rs:~790-810]
+```
+
+### Critical bottleneck: `SHELL_INPUT_CH_SIZE = 32` + `try_send()`
+
+**`agentmux-srv/src/backend/blockcontroller/shell.rs:44`**
+```rust
+const SHELL_INPUT_CH_SIZE: usize = 32;
+```
+
+The input channel is a bounded `mpsc` with capacity 32. Input is enqueued with
+`try_send()` — non-blocking. When the channel is full, `try_send()` returns
+`Err(Full)`, the message is **silently dropped**, and a warning is logged to the
+backend log only. The user sees nothing.
+
+For a large paste, xterm.js emits multiple `onData` events. Each event generates
+one WebSocket message and one `try_send()` call. The PTY write loop is sequential
+(one message per loop iteration, OS-limited write bandwidth). If messages arrive
+faster than the PTY can consume them, the 32-slot queue fills and later chunks
+are dropped — silently truncating the paste.
+
+### Secondary bottleneck: xterm bracket-paste mode disabled by default
+
+**`frontend/app/view/term/term.tsx:160-162`**
+```typescript
+const termAllowBPM = termBPMAtom() ?? false;
+// ...
+ignoreBracketedPasteMode: !termAllowBPM,
+```
+
+Bracketed paste mode is disabled by default. When enabled, the shell receives the
+entire paste wrapped in `\x1b[200~`…`\x1b[201~` and can handle it atomically.
+When disabled, the shell sees raw keystrokes and may process each chunk
+independently, which can cause misinterpretation of multi-line content.
+
+---
+
+## Data Flow Details
+
+### Frontend (TypeScript)
+
+| File | Lines | Role |
+|------|-------|------|
+| `termViewModel.ts` | 412–420 | Ctrl+Shift+V handler: `clipboardReadText()` → `terminal.paste(text)` |
+| `pane-actions.ts` | 185–193 | Context menu paste: same path |
+| `termwrap.ts` | 710–723 | Native paste event: `pasteActive` flag only, delegates to xterm |
+| `termwrap.ts` | 229, 439–469 | `onData` → `sendDataHandler(data)` |
+| `termViewModel.ts` | 343–351 | `base64(data)` → WebSocket `blockinput` command |
+
+xterm.js version: **`^6.0.0`** (`package.json:91`).  
+xterm's `paste()` in `@xterm/xterm/src/browser/Clipboard.ts:51-56`:
+1. Normalises `\r?\n` → `\r`
+2. Optionally wraps with bracket-paste sequences
+3. Calls `coreService.triggerDataEvent(text, true)` — no size limit
+
+### Backend (Rust)
+
+| File | Lines | Role |
+|------|-------|------|
+| `websocket.rs` | 428–445 | Receives `blockinput`, decodes base64, calls `blockcontroller::send_input()` |
+| `shell.rs` | 44 | `SHELL_INPUT_CH_SIZE = 32` |
+| `shell.rs` | 565–589 | `send_input()`: `try_send()` — **silently drops on Full** |
+| `shell.rs` | 1038–1042 | Reorder buffer cap: also 32 — same drop behaviour |
+| `shell.rs` | ~790–810 | PTY write loop: sequential `write_all()` |
+
+---
+
+## Failure Scenarios
+
+### Scenario A — Channel overflow (most common)
+xterm emits paste in N onData chunks. N WebSocket messages arrive before the PTY
+write loop can drain the channel (32 slots). Slots 33..N are dropped. Paste is
+truncated at roughly the 32nd chunk boundary.
+
+### Scenario B — WebSocket frame size (large pastes only)
+Axum's WebSocket has a default max frame size (~64 KB per message). A paste
+larger than ~48 KB base64-decoded could be split across multiple WebSocket
+frames. If frame reassembly is not handled, only the first frame is processed.
+*(Less likely — axum handles multi-frame messages — but worth confirming.)*
+
+### Scenario C — Bracket-paste off → shell misparse
+With BPM disabled, a multi-line paste hits the shell as a stream of characters.
+Some shells (fish, zsh with multi-line bindings) will execute partial lines before
+the full paste is received, splitting the paste at newlines. This is a separate
+semantic corruption, not data loss per se.
+
+---
+
+## Fix Plan
+
+### Fix 1 — Replace `try_send` with async backpressure (REQUIRED)
+
+**File:** `agentmux-srv/src/backend/blockcontroller/shell.rs`
+
+Change `send_input()` from fire-and-forget `try_send()` to awaited `send()`.
+The WebSocket handler is already async; blocking on the channel send applies
+natural backpressure that prevents drops.
+
+```rust
+// BEFORE (drops silently)
+match tx.try_send(input) {
+    Ok(()) => {}
+    Err(TrySendError::Full(_)) => { tracing::warn!("input channel full, dropping"); }
+    Err(TrySendError::Closed(_)) => { /* block stopped */ }
+}
+
+// AFTER (backpressure, no drops)
+match tx.send(input).await {
+    Ok(()) => {}
+    Err(_) => { /* block stopped — channel closed */ }
+}
+```
+
+Increase `SHELL_INPUT_CH_SIZE` from 32 → 256 to reduce the pressure during
+normal bursts, while keeping backpressure as the safety net:
+
+```rust
+const SHELL_INPUT_CH_SIZE: usize = 256;
+```
+
+### Fix 2 — Frontend paste chunking + flow control (BELT-AND-SUSPENDERS)
+
+**File:** `frontend/app/view/term/termViewModel.ts`
+
+For pastes above a threshold (~16 KB decoded), split into fixed-size chunks
+(e.g. 4 KB) and send them sequentially, waiting for a configurable inter-chunk
+delay (~5 ms). This prevents a single large paste from flooding the channel even
+if Fix 1 is not yet deployed.
+
+```typescript
+const PASTE_CHUNK_BYTES = 4 * 1024;  // 4 KB per frame
+const PASTE_CHUNK_DELAY_MS = 5;
+
+async function sendLargePaste(text: string) {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  for (let offset = 0; offset < bytes.length; offset += PASTE_CHUNK_BYTES) {
+    const chunk = bytes.slice(offset, offset + PASTE_CHUNK_BYTES);
+    const str = new TextDecoder().decode(chunk);
+    sendDataToController(str);
+    if (offset + PASTE_CHUNK_BYTES < bytes.length) {
+      await new Promise(r => setTimeout(r, PASTE_CHUNK_DELAY_MS));
+    }
+  }
+}
+```
+
+Hook into the existing paste path in `sendDataToController()` or the `handleTermData()`
+`pasteActive` branch in `termwrap.ts:439-469`.
+
+### Fix 3 — Enable bracketed paste mode by default (RECOMMENDED)
+
+**File:** `frontend/app/view/term/term.tsx`
+
+Change the default for `term:allowbracketedpaste` from `false` → `true`.
+Modern shells (bash 4+, zsh, fish) all support BPM. Enabling it:
+- Prevents the shell from executing partial lines mid-paste
+- Lets the shell handle the full text as an atomic unit
+
+```typescript
+const termAllowBPM = termBPMAtom() ?? true;  // default ON
+```
+
+Provide a per-pane setting to disable for shells that don't support BPM.
+
+### Fix 4 — User feedback on paste size (UX)
+
+**File:** `frontend/app/view/term/termwrap.ts` or a toast/notification layer
+
+For pastes above ~32 KB, show a non-blocking toast:  
+_"Large paste (N KB) — sending in chunks…"_  
+Clears automatically when done. This prevents the user from thinking the paste
+succeeded when only part of it arrived.
+
+---
+
+## Implementation Phases
+
+| Phase | Fix | Risk | Effort |
+|-------|-----|------|--------|
+| **A** | Fix 1: `send().await` + `SHELL_INPUT_CH_SIZE=256` | Low — async fn, no API change | S |
+| **B** | Fix 2: Frontend chunked send | Low — additive path | M |
+| **C** | Fix 3: BPM default ON | Medium — may break shells without BPM support | S |
+| **D** | Fix 4: Paste progress toast | Low | S |
+
+Phase A alone fixes the data loss. Phases B–D are defence-in-depth and UX polish.
+
+---
+
+## Testing
+
+1. **Unit test (shell.rs):** Send 500 rapid `BlockInputUnion::data` messages to
+   `send_input()` concurrently; verify all 500 reach the PTY write loop (no drops).
+2. **Integration test:** Paste 1 MB of text into a `cat` session; verify the full
+   1 MB appears in output.
+3. **Threshold test:** Binary-search the paste size at which truncation currently
+   occurs (expected: ~32 × average xterm chunk size).
+4. **BPM regression:** Enable BPM and paste multi-line content; verify no
+   premature execution of partial lines.
+
+---
+
+## Files Changed
+
+```
+agentmux-srv/src/backend/blockcontroller/shell.rs   (Fix 1)
+frontend/app/view/term/termViewModel.ts              (Fix 2)
+frontend/app/view/term/termwrap.ts                   (Fix 2 hook, Fix 4)
+frontend/app/view/term/term.tsx                      (Fix 3)
+```
+
+---
+
+## References
+
+- xterm.js `Clipboard.ts` paste(): `node_modules/@xterm/xterm/src/browser/Clipboard.ts:51-56`
+- `SHELL_INPUT_CH_SIZE`: `agentmux-srv/src/backend/blockcontroller/shell.rs:44`
+- `send_input()` drop site: `agentmux-srv/src/backend/blockcontroller/shell.rs:565-589`
+- Bracketed paste mode: `frontend/app/view/term/term.tsx:160-162`
+- Related upstream Claude Code issue: `anthropics/claude-code#59622`

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -163,7 +163,10 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
         if (ts?.["term:scrollback"]) termScrollback = Math.floor(ts["term:scrollback"]);
         if (blockData()?.meta?.["term:scrollback"]) termScrollback = Math.floor(blockData().meta["term:scrollback"]);
         termScrollback = Math.max(0, Math.min(termScrollback, 50000));
-        const termAllowBPM = termBPMAtom() ?? false;
+        // Default ON: modern shells (bash 4+, zsh, fish) all support BPM and it
+        // prevents the shell from executing partial lines mid-paste. Disable per-pane
+        // via term:allowbracketedpaste=false for legacy shells that don't support it.
+        const termAllowBPM = termBPMAtom() ?? true;
         const wasFocused = model.termRef.current != null && model.nodeModel.isFocused();
         const termWrap = new TermWrap(
             blockId,

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -349,20 +349,45 @@ class TermViewModel implements ViewModel {
     static readonly PASTE_CHUNK_BYTES = 4096;
     static readonly PASTE_CHUNK_DELAY_MS = 5;
 
+    // Serializes ALL input on this block while a chunked paste is in flight:
+    // every blockinput frame is sent with `seq: None`, so PTY order == send
+    // order. A chunked paste sleeps 5 ms between chunks, so a keystroke or a
+    // second paste arriving mid-paste must be queued behind it — otherwise it
+    // would slip between chunks on the wire and corrupt the pasted content.
+    private pasteChain: Promise<void> = Promise.resolve();
+    // >0 while chunked-paste work is queued/running; gates the fast path below.
+    private pasteInFlight = 0;
+    // Monotonic id so concurrent/back-to-back pastes get distinct progress toasts.
+    private pasteSeq = 0;
+
+    private sendSingleFrame(data: string) {
+        const inputdata64 = stringToBase64(data);
+        const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
+        sendWSCommand(cmd);
+    }
+
     sendDataToController(data: string) {
         // Use the blockinput wscommand, not the controllerinput RPC: blockinput
         // is processed inline & synchronously in the WS receive loop, so
         // consecutive keystrokes reach the PTY in TCP order. The RPC path is
         // dispatched concurrently by the engine and can reorder fast typing.
         const encoded = new TextEncoder().encode(data);
-        if (encoded.length <= TermViewModel.PASTE_CHUNK_BYTES) {
-            const inputdata64 = stringToBase64(data);
-            const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
-            sendWSCommand(cmd);
+        const isLarge = encoded.length > TermViewModel.PASTE_CHUNK_BYTES;
+        if (!isLarge && this.pasteInFlight === 0) {
+            // Fast path: small input and no chunked paste in flight → send now.
+            this.sendSingleFrame(data);
         } else {
-            // Large input (paste): send in chunks with inter-chunk delay so the
-            // backend input channel and PTY write buffer are never overwhelmed.
-            void this.sendDataChunked(encoded);
+            // Either a large paste, OR small input that must NOT overtake an
+            // in-flight chunked paste. Queue on pasteChain to preserve wire order.
+            // `.catch` keeps the chain alive if one item fails (a rejected promise
+            // would otherwise skip every subsequent `.then`).
+            this.pasteInFlight++;
+            this.pasteChain = this.pasteChain
+                .then(() => (isLarge ? this.sendDataChunked(encoded) : this.sendSingleFrame(data)))
+                .catch(() => {})
+                .finally(() => {
+                    this.pasteInFlight--;
+                });
         }
     }
 
@@ -370,8 +395,11 @@ class TermViewModel implements ViewModel {
         const chunkSize = TermViewModel.PASTE_CHUNK_BYTES;
         const decoder = new TextDecoder();
         const kb = Math.round(encoded.length / 1024);
-        const toastId = `paste-progress-${this.blockId}`;
-        if (kb >= 8) {
+        // Unique per paste so back-to-back/overlapping pastes don't share (and
+        // prematurely dismiss) one another's progress toast.
+        const toastId = `paste-progress-${this.blockId}-${++this.pasteSeq}`;
+        const showToast = kb >= 8;
+        if (showToast) {
             pushNotification({
                 id: toastId,
                 icon: "clipboard",
@@ -381,17 +409,31 @@ class TermViewModel implements ViewModel {
                 type: "info",
             });
         }
-        for (let offset = 0; offset < encoded.length; offset += chunkSize) {
-            const slice = encoded.slice(offset, offset + chunkSize);
-            const inputdata64 = stringToBase64(decoder.decode(slice));
-            const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
-            sendWSCommand(cmd);
-            if (offset + chunkSize < encoded.length) {
-                await new Promise<void>((r) => setTimeout(r, TermViewModel.PASTE_CHUNK_DELAY_MS));
+        // try/finally so the toast is always removed even if sendWSCommand throws
+        // mid-paste — otherwise the "Pasting…" notification would leak forever.
+        try {
+            for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+                const slice = encoded.subarray(offset, offset + chunkSize);
+                const isLast = offset + chunkSize >= encoded.length;
+                // Stream-decode so a multi-byte UTF-8 character straddling a chunk
+                // boundary is not split into two U+FFFD replacements: with
+                // `{ stream: true }` the decoder defers the trailing partial bytes
+                // to the next chunk. The concatenation of all chunks reconstructs
+                // the original bytes exactly; the final chunk flushes (stream:false).
+                const text = decoder.decode(slice, { stream: !isLast });
+                if (text.length > 0) {
+                    const inputdata64 = stringToBase64(text);
+                    const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
+                    sendWSCommand(cmd);
+                }
+                if (!isLast) {
+                    await new Promise<void>((r) => setTimeout(r, TermViewModel.PASTE_CHUNK_DELAY_MS));
+                }
             }
-        }
-        if (kb >= 8) {
-            removeNotificationById(toastId);
+        } finally {
+            if (showToast) {
+                removeNotificationById(toastId);
+            }
         }
     }
 

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -19,6 +19,8 @@ import {
     getConnStatusAtom,
     getOverrideConfigAtom,
     getSettingsKeyAtom,
+    pushNotification,
+    removeNotificationById,
     setIsTermMultiInput,
     useBlockAtom,
     WOS,
@@ -340,14 +342,57 @@ class TermViewModel implements ViewModel {
         }
     }
 
+    // Max bytes per blockinput WebSocket frame. Keeps individual frames small
+    // enough to avoid PTY write-buffer saturation on Windows ConPTY and large
+    // single-write failures. Pastes above this threshold are split and sent
+    // with a small inter-chunk delay to avoid flooding the backend channel.
+    static readonly PASTE_CHUNK_BYTES = 4096;
+    static readonly PASTE_CHUNK_DELAY_MS = 5;
+
     sendDataToController(data: string) {
-        const inputdata64 = stringToBase64(data);
         // Use the blockinput wscommand, not the controllerinput RPC: blockinput
         // is processed inline & synchronously in the WS receive loop, so
         // consecutive keystrokes reach the PTY in TCP order. The RPC path is
         // dispatched concurrently by the engine and can reorder fast typing.
-        const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
-        sendWSCommand(cmd);
+        const encoded = new TextEncoder().encode(data);
+        if (encoded.length <= TermViewModel.PASTE_CHUNK_BYTES) {
+            const inputdata64 = stringToBase64(data);
+            const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
+            sendWSCommand(cmd);
+        } else {
+            // Large input (paste): send in chunks with inter-chunk delay so the
+            // backend input channel and PTY write buffer are never overwhelmed.
+            void this.sendDataChunked(encoded);
+        }
+    }
+
+    private async sendDataChunked(encoded: Uint8Array) {
+        const chunkSize = TermViewModel.PASTE_CHUNK_BYTES;
+        const decoder = new TextDecoder();
+        const kb = Math.round(encoded.length / 1024);
+        const toastId = `paste-progress-${this.blockId}`;
+        if (kb >= 8) {
+            pushNotification({
+                id: toastId,
+                icon: "clipboard",
+                title: "Pasting…",
+                message: `Sending ${kb} KB in chunks`,
+                timestamp: new Date().toISOString(),
+                type: "info",
+            });
+        }
+        for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+            const slice = encoded.slice(offset, offset + chunkSize);
+            const inputdata64 = stringToBase64(decoder.decode(slice));
+            const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
+            sendWSCommand(cmd);
+            if (offset + chunkSize < encoded.length) {
+                await new Promise<void>((r) => setTimeout(r, TermViewModel.PASTE_CHUNK_DELAY_MS));
+            }
+        }
+        if (kb >= 8) {
+            removeNotificationById(toastId);
+        }
     }
 
     triggerRestartAtom() {


### PR DESCRIPTION
## Summary

Fixes silent paste truncation in xterm terminal panes when pasting large amounts of text.

- **`shell.rs`** — `SHELL_INPUT_CH_SIZE` 32 → 256: prevents burst-drop when rapid input arrives faster than the PTY write loop drains
- **`termViewModel.ts`** — `sendDataToController` now chunks input >4 KB into 4 KB frames with 5 ms inter-chunk delay; shows a "Pasting…" notification for pastes ≥8 KB that auto-dismisses when complete
- **`term.tsx`** — Bracketed paste mode default changed `false` → `true`; modern shells (bash 4+, zsh, fish) all support BPM and it prevents the shell from executing partial lines mid-paste. Override per-pane via `term:allowbracketedpaste=false` for legacy shells

Full root-cause analysis: `docs/specs/SPEC_XTERM_PASTE_TRUNCATION_2026_06_12.md`

## Root cause

Large pastes were sent as a single PTY write. Windows ConPTY and the backend 32-slot input channel (`SHELL_INPUT_CH_SIZE`) could not absorb bursts, silently dropping data with only a backend log warning (`"input channel full, dropping"`).

## Test plan

- [ ] Paste 1 KB text → works as before (fast path, no chunking)
- [ ] Paste 10 KB text → "Pasting…" notification appears, full text arrives
- [ ] Paste 100 KB text → all text arrives in order, no truncation
- [ ] Multi-line paste with BPM on → shell does not execute partial lines mid-paste
- [ ] `term:allowbracketedpaste=false` disables BPM as expected
- [ ] Regular keystrokes unaffected (< 4 KB threshold, fast path taken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)