### PR TITLE
fix(agent): inject Bash(agentmux-bashwrap*) into permissions.allow

### DIFF
--- a/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
+++ b/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): inject Bash(agentmux-bashwrap*) into permissions.allow so bashwrap exec is not blocked

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -432,6 +432,30 @@ pub fn build_settings_with_hooks(
     }
     settings_obj.insert("hooks".to_string(), Value::Object(hooks_obj));
 
+    // Claude Code requires the bashwrap exec command (produced by the hook rewrite)
+    // to be in permissions.allow — otherwise it raises a permissions error and the
+    // agent cannot run any bash commands. Merge with any user-supplied allow list
+    // rather than overwriting it.
+    {
+        let bashwrap_allow = Value::String("Bash(agentmux-bashwrap*)".to_string());
+        let mut allow_arr = match settings_obj.get("permissions") {
+            Some(Value::Object(perms)) => match perms.get("allow") {
+                Some(Value::Array(arr)) => arr.clone(),
+                _ => Vec::new(),
+            },
+            _ => Vec::new(),
+        };
+        if !allow_arr.iter().any(|v| v == &bashwrap_allow) {
+            allow_arr.push(bashwrap_allow);
+        }
+        let mut perms_obj = match settings_obj.remove("permissions") {
+            Some(Value::Object(obj)) => obj,
+            _ => serde_json::Map::new(),
+        };
+        perms_obj.insert("allow".to_string(), Value::Array(allow_arr));
+        settings_obj.insert("permissions".to_string(), Value::Object(perms_obj));
+    }
+
     match serde_json::to_string_pretty(&Value::Object(settings_obj)) {
         Ok(s) => Some(s),
         Err(e) => {


### PR DESCRIPTION
## Summary

- The PreToolUse hook rewrites every Bash tool call to `agentmux-bashwrap exec --tool-id=... --b64-cmd=...`
- Claude Code treats that rewritten command as a new Bash invocation and checks it against `permissions.allow`
- Without a matching entry, Claude Code blocks it — agents see "bash-wrap unusable / permissions error"
- `build_settings_with_hooks` now appends `"Bash(agentmux-bashwrap*)"` to `permissions.allow`, merging with any user-supplied allow entries

## Test plan

- [ ] Start an agent pane
- [ ] Run a bash command from the agent (e.g. `ls`)
- [ ] Live streaming output appears — no permissions prompt or block
- [ ] Check `.claude/settings.json` in the agent workspace contains `"permissions": { "allow": ["Bash(agentmux-bashwrap*)"] }`
- [ ] User-supplied `permissions.allow` entries in agent settings are preserved alongside the injected entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)