### PR TITLE
fix(agent-pane): schema v2 snapshot — lightweight overlay, no nodes[] serialization

### DIFF
--- a/.changesets/1781283396-fix-agent-write-state-schema-v2-replace-nodes-snapshot-with--tq14.md
+++ b/.changesets/1781283396-fix-agent-write-state-schema-v2-replace-nodes-snapshot-with--tq14.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): write-state schema v2 — replace nodes[] snapshot with lightweight overlay + NDJSON restore to eliminate renderer OOM

--- a/.changesets/1781283396-fix-agent-write-state-schema-v2-replace-nodes-snapshot-with--tq14.md
+++ b/.changesets/1781283396-fix-agent-write-state-schema-v2-replace-nodes-snapshot-with--tq14.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(agent): write-state schema v2 — replace nodes[] snapshot with lightweight overlay + NDJSON restore to eliminate renderer OOM
+fix(agent): write-state schema v2 — replace nodes[] snapshot with a lightweight overlay + NDJSON restore to eliminate the renderer OOM crash. v2 restore is scoped to same-block reopen (the OOM-critical path); cross-block "structural continuation" falls back to NDJSON replay until a unified per-agent log lands (follow-up).

--- a/docs/analysis/ANALYSIS_RENDERER_CRASH_WRITE_STATE_OOM_2026_06_12.md
+++ b/docs/analysis/ANALYSIS_RENDERER_CRASH_WRITE_STATE_OOM_2026_06_12.md
@@ -1,0 +1,135 @@
+# Renderer Crash — agent:session:write_state OOM / Long-Task
+
+**Date observed:** 2026-06-12  
+**Log evidence:** `~/.agentmux/logs/agentmux-host-v0.44.1.log.2026-06-12`  
+**Crash count:** 1 today (08:17:18 UTC); 4 yesterday (14:06–14:11 UTC, three of which say `detail:"Out of Memory"`)
+
+---
+
+## Observed Symptoms
+
+```
+08:17:16  [fe] ws message too large 7722686  (agent:session:write_state)
+08:17:16  [perf] long-task 126.0ms
+08:17:18  renderer process crashed  error_code=-36861  Crashpad_NotConnectedToHandler
+```
+
+Recovery dialog shown: "AgentMux hit a problem — renderer process crashed".
+
+Session data was safe on disk. User needed to click "Reload window."
+
+### Growth pattern today (293 oversized messages, 00:33–08:48 UTC)
+
+```
+~05:00 UTC  messages start at ~5.2 MB (just over the 5 MB MaxWebSocketSendSize limit)
+~07:00 UTC  messages reach ~7 MB
+~08:17 UTC  7.72 MB spike + 126 ms long-task → crash
+~08:30+     messages continue at 7.7–9.0 MB after recovery
+```
+
+The same two agent sessions (`definition_id` prefixes `38634ce` and `6dc8f91`) drive all of these; both have been running across the full session and accumulating conversation state.
+
+---
+
+## Root Cause Analysis
+
+### What write_state does
+
+`writeSnapshotNow` in `agent-view.tsx:325` runs every 30 s (dirty-flag gated) and on pane close. It:
+
+1. Captures `nodes = getDocument()` — the full in-memory SolidJS document array (every message, tool block, thinking block, diff, etc. across the entire conversation).
+2. Calls `JSON.stringify({ schemaVersion, savedAt, highWaterMark, historyOffset, nodes })`.
+3. Measures the resulting string with `new Blob([msg]).size` (`ws.ts:231`).
+4. **If ≤ 5 MB:** sends over WebSocket to the sidecar, which writes `output.state.json` to disk.
+5. **If > 5 MB:** logs "ws message too large" and drops the send. **The serialized string is already in memory at this point.**
+
+### Why it crashes
+
+The renderer crash is a **renderer-process OOM or hard-kill**, not a JavaScript exception. Three compounding factors:
+
+**1. Full-document serialization grows without bound.**  
+Every conversation turn appends nodes. A long session with many tool results, diffs, and large BashOutputViewer payloads can push `nodes` to several MB of raw JSON. There is no cap on what gets included in the snapshot.
+
+**2. JSON.stringify + Blob happen on the main render thread.**  
+Even when the message is too large and dropped, `JSON.stringify(snapshot)` already built a 7–10 MB string. `new Blob([msg])` built a 7–10 MB Blob. Both are allocated in the renderer's V8 heap. The 126 ms long-task is this serialization. Doing this every 30 s with an ever-growing document starves the render loop and spikes memory.
+
+**3. Memory never comes down.**  
+The `nodes` signal grows monotonically during a session. No trimming or offloading occurs. By the time the message reaches 7–8 MB, the renderer's resident set has been high for hours (peak_ws_mb 201.6 MB was recorded much earlier today). The spike from a large `JSON.stringify` call is enough to trigger the OOM path.
+
+**The 5 MB WebSocket cap is not the fix.** It prevents data loss on the wire but does nothing to reduce the serialization cost that causes the crash. The renderer creates the full string regardless.
+
+---
+
+## Code Locations
+
+| File | Line | Role |
+|------|------|------|
+| `frontend/app/view/agent/agent-view.tsx` | 325–380 | `writeSnapshotNow` + 30 s interval |
+| `frontend/app/view/agent/agent-view.tsx` | 340–357 | `JSON.stringify(snapshot)` + `write_state` call |
+| `frontend/app/store/ws.ts` | 12–13 | `WarnWebSocketSendSize = 1 MB`, `MaxWebSocketSendSize = 5 MB` |
+| `frontend/app/store/ws.ts` | 230–239 | `sendMessage` — serializes, measures, drops if > 5 MB |
+| `agentmux-srv/src/backend/rpc_types.rs` | 2033 | `CommandAgentSessionWriteStateData.content: String` |
+| `agentmux-srv/src/server/agent_handlers.rs` | 2027 | Backend handler — writes `output.state.json` |
+
+---
+
+## Fix Options
+
+### Option 1 — Cap nodes included in the snapshot (recommended, low risk)
+
+Include only the last N nodes (e.g. 200) in the `write_state` snapshot. Older nodes are already durably persisted in the `output` NDJSON log (written incrementally by `AgentSessionAppendOutputCommand`). On session restore, replay old nodes from NDJSON up to `highWaterMark`, then overlay the snapshot's recent nodes.
+
+**Pros:** Bounded snapshot size regardless of conversation length. Minimal behaviour change — restoration already uses `highWaterMark` to know where NDJSON replay ends. Safe to ship quickly.  
+**Cons:** Requires `historyRestore` to handle the case where the snapshot covers only the tail; test coverage needed.
+
+```typescript
+// agent-view.tsx — before JSON.stringify
+const MAX_SNAPSHOT_NODES = 200;
+const snapshotNodes = nodes.length > MAX_SNAPSHOT_NODES
+    ? nodes.slice(-MAX_SNAPSHOT_NODES)
+    : nodes;
+const snapshot = { schemaVersion, savedAt, highWaterMark, historyOffset, nodes: snapshotNodes };
+```
+
+### Option 2 — Measure size before serializing (quick defensive fix)
+
+Estimate document size before committing to full serialization. An approximation (e.g. sum of `node.content?.length` across nodes) can bail out early before the expensive `JSON.stringify`.
+
+**Pros:** Prevents the main-thread spike when the document is known to be large.  
+**Cons:** Heuristic — doesn't actually reduce the snapshot size on disk, just skips the save. A large document is never snapshotted, so crash recovery would fall back to NDJSON replay (which might be slower).
+
+### Option 3 — Offload serialization to a Web Worker
+
+Run `JSON.stringify(snapshot)` in a `Worker` so it doesn't block the render thread. The 30 s interval posts a structured-clone of `nodes` to the worker, which serializes and posts back the string.
+
+**Pros:** Eliminates the long-task / jank.  
+**Cons:** Structured-clone of large `nodes` is itself O(n). Does not reduce memory pressure in the render process. Higher implementation complexity.
+
+### Option 4 — Backend-reconstructed state (longer term)
+
+The sidecar already has the full conversation via the incrementally-appended `output` NDJSON log. Instead of the frontend sending the full document on every save, it could send only the lightweight `AgentPaneState` reducer state (turn phase, scroll position, filters, etc. — a few KB). On restore, the sidecar reconstructs `nodes` from the NDJSON log and the reducer state is applied on top.
+
+**Pros:** Eliminates the serialization problem at its root.  
+**Cons:** Requires backend changes to reconstruct `DocumentNode[]` from NDJSON, and careful matching with frontend reducer replay. Significant scope.
+
+---
+
+## Recommended Short-Term Fix
+
+**Ship Option 1** (node cap) as a quick patch. 200 nodes covers any realistic "recent context" need; older history is safely replayed from the NDJSON log. This immediately bounds the snapshot payload to roughly 1–2 MB and eliminates the OOM trigger.
+
+Pair it with a log warning when nodes are capped so the behaviour is observable:
+
+```typescript
+if (nodes.length > MAX_SNAPSHOT_NODES) {
+    log("history", `snapshot capped at ${MAX_SNAPSHOT_NODES}/${nodes.length} nodes (older nodes replay from NDJSON)`, "info");
+}
+```
+
+**Longer term** (Option 4) is the right architecture — the frontend shouldn't be the source of truth for the full conversation; the append-only NDJSON log already is.
+
+---
+
+## Recurrence Risk
+
+Without a fix, this crash will recur on any session that grows past ~5 MB of serialized `nodes`. A moderately-active day of agent usage (as observed today) is sufficient. Two sessions were already past this threshold at midnight and continued growing all day.

--- a/docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md
+++ b/docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md
@@ -633,3 +633,30 @@ history may stop saving.
 "Archive this session" calls `agent:session:archive` for the current `definition_id`
 and closes the modal.  "Dismiss" closes without action; the modal re-appears after
 5 minutes if the condition persists.
+
+---
+
+## 15. Known limitation: cross-block continuation (follow-up)
+
+The durable NDJSON conversation log is stored **per-block** (`<blockId>/output`),
+while the v2 snapshot is **agent-anchored** (`agent:<defId>:current`, shared
+across every block of the agent). v1 papered over this by embedding the full
+composite `nodes[]` in the agent-anchored snapshot, so a brand-new pane for an
+existing agent ("structural continuation", Option E / PR #1007) could render the
+prior conversation. v2 removed `nodes[]` to fix the OOM, so a single
+`(sourceBlockId, highWaterMark)` cannot describe a conversation that is physically
+split across blocks.
+
+**Scope of this change:** v2 restore is taken only for a **same-block reopen**
+(`sourceBlockId === opts.blockId`) — the case the renderer OOM actually occurs in
+(a long-lived pane snapshotting every 30 s). On a cross-block open, restore falls
+back to NDJSON replay on the new block (no orphaning, no blank pane) and logs the
+reason. This means a fresh continuation pane does not inherit the prior block's
+rendered history under v2.
+
+**Follow-up:** restore full cross-block continuation by mirroring each agent
+output line into a single unified per-agent log (`agent:<defId>:current/output`
+via the existing `append_session_output`, which is currently never called by the
+live path) and having v2 count/read history by `definition_id`. That work must
+also handle the concurrency case of multiple live panes per agent definition
+appending to the same zone. Tracked as a follow-up to PR #1361.

--- a/docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md
+++ b/docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md
@@ -1,0 +1,635 @@
+# SPEC: write_state Option 4 — NDJSON-Reconstructed Snapshot (Schema v2)
+
+**Status:** Draft  
+**Date:** 2026-06-12  
+**Author:** AgentA  
+**Parent spec:** `SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md`  
+**Motivation:** `docs/analysis/ANALYSIS_RENDERER_CRASH_WRITE_STATE_OOM_2026_06_12.md`
+
+---
+
+## 1. Problem
+
+The schema-v1 snapshot (`output.state.json`) stores the entire `DocumentNode[]` array.
+For a long session this reaches 7–10 MB. `writeSnapshotNow` serialises it via
+`JSON.stringify` on the main render thread every 30 s, allocating a full-size string
+and a same-size `Blob` regardless of whether the WebSocket cap discards the write.
+This 126 ms+ long-task spikes memory and eventually triggers a renderer OOM crash (see
+analysis doc above).
+
+The underlying invariant is already correct: every event is already durably written
+to the NDJSON `output` blockfile by `AgentSessionAppendOutputCommand`. The frontend
+has everything it needs to reconstruct `DocumentNode[]` from that log; it does so
+today on the "slow path" (200-line ring-buffer replay). Option 4 exploits this: stop
+sending nodes in the snapshot; send only the UI-overlay state that cannot be
+reconstructed from NDJSON.
+
+---
+
+## 2. Design principle: unlimited history, disk is the only constraint
+
+A conversation session may grow to any size — 23 K lines today, 1 billion lines in
+the future.  AgentMux imposes **no artificial cap on session length**.  The only
+constraint is available disk space.  When disk space runs low, the app warns the
+user; it does not silently discard history or refuse to write.
+
+`RESTORE_WINDOW_LINES` (§6.3) is a **render viewport**, not a storage limit.  It
+controls how much history is loaded into the renderer on first open — analogous to
+a terminal emulator's scrollback buffer.  Everything outside the window is still on
+disk and reachable via load-older.  The user never loses history to this constant.
+
+## 3. Goals
+
+- **G1** Snapshot payload drops below ~5 KB for any session length. No more OOM.
+- **G2** Full conversation accessible regardless of length — via load-older if
+  outside the initial render viewport.
+- **G3** User-controlled UI state (collapsed nodes, pinned nodes, scroll position,
+  filter toggles) is preserved across close/reopen.
+- **G4** Backward-compatible: v1 snapshots continue to restore via the existing code
+  path until they age out.
+- **G5** No new sidecar parsing logic — reconstruction runs the existing
+  `parseHistoryLines` pipeline in the frontend.
+- **G6** Disk-space warning surfaced in the agent pane before the disk is full,
+  with a clear action (archive / free space). No silent data loss.
+
+### Non-goals
+
+- Making restoration faster than the v1 fast path. (NDJSON replay is inherently
+  slower than a pre-serialised `nodes[]` load. This is an acceptable trade.)
+- Persisting the agent CLI's own session memory.
+- Cross-instance sync.
+- Limiting how long a conversation can be.
+
+---
+
+## 3. State inventory: what lives where
+
+### 3.1 Fully reconstructable from NDJSON
+
+These fields are produced deterministically by replaying `output` lines through
+`parseHistoryLines(lines, outputFormat)`:
+
+| Field | How reconstructed |
+|---|---|
+| `DocumentNode[]` (all kinds) | Full `output` log, lines `[0, highWaterMark)` |
+| Node `id`, `type`, `status`, `result` | Carried in NDJSON events |
+| Tool params, markdown content, thinking | Carried in NDJSON events |
+| `SectionNode.isStartup` | Carried in NDJSON events |
+
+### 3.2 NOT reconstructable — must persist in snapshot overlay
+
+These are UI state produced by user interaction, absent from the event stream:
+
+| Field | Type | Default |
+|---|---|---|
+| `collapsedNodes` | `string[]` (serialised `Set<string>`) | `[]` |
+| `pinnedNodes` | `string[]` (serialised `Set<string>`) | `[]` |
+| `scrollPosition` | `number` (px from top) | `0` |
+| `filter.showThinking` | `boolean` | `false` |
+| `filter.showSuccessfulTools` | `boolean` | `true` |
+| `filter.showFailedTools` | `boolean` | `true` |
+| `filter.showIncoming` | `boolean` | `true` |
+| `filter.showOutgoing` | `boolean` | `true` |
+| `paneState.detailsOpen` | `boolean` | `false` |
+| `historyOffset` | `number` | `0` |
+
+`selectedNode` is transient cursor state and is deliberately NOT persisted.
+
+---
+
+## 4. Schema v2
+
+```typescript
+interface AgentPaneStateSnapshotV2 {
+  schemaVersion: 2;
+  savedAt: string;          // ISO 8601
+
+  /**
+   * NDJSON line count at save time.  On restore, fetch lines [0, highWaterMark)
+   * from the `output` blockfile and replay through parseHistoryLines.  After
+   * restore, the live-stream subscription resumes from this line index so
+   * background events written while the pane was closed are replayed exactly
+   * once.
+   */
+  highWaterMark: number;
+
+  /**
+   * NDJSON line index where the "load older" cursor should start.  Unchanged
+   * from v1.  On mount after restore, loadOlder() fetches
+   * [historyOffset - PAGE_SIZE, historyOffset) and prepends the parsed nodes.
+   */
+  historyOffset: number;
+
+  /** Serialised DocumentState overlay — applied on top of reconstructed nodes. */
+  documentState: {
+    collapsedNodeIds: string[];
+    pinnedNodeIds: string[];
+    scrollPosition: number;
+    filter: {
+      showThinking: boolean;
+      showSuccessfulTools: boolean;
+      showFailedTools: boolean;
+      showIncoming: boolean;
+      showOutgoing: boolean;
+    };
+  };
+
+  /** Serialised AgentPaneState overlay. */
+  paneState: {
+    detailsOpen: boolean;
+  };
+}
+```
+
+Persisted as `output.state.json` in the `agent:<definitionId>:current` zone — same
+file, same location, same sidecar RPC (`agent:session:write_state`) as v1.  Only
+the JSON content changes.
+
+---
+
+## 5. Write path changes (frontend)
+
+**File:** `frontend/app/view/agent/agent-view.tsx`
+
+### 5.1 Replace `writeSnapshotNow`
+
+```typescript
+const writeSnapshotNow = () => {
+    const nodes = getDocument();
+    if (!nodes) return;
+
+    // Capture UI overlay state before the async chain so we get the
+    // values at the moment of the save trigger, not after a potential
+    // 3 s RPC round-trip.
+    const [docState] = agentAtoms().documentStateAtom;
+    const [detailsOpen] = agentAtoms().detailsOpenAtom;
+    const capturedOffset = history.historyOffset();
+    const capturedDocState = docState();
+    const capturedDetailsOpen = detailsOpen();
+
+    inFlightSnapshot = inFlightSnapshot.then(async () => {
+        let highWaterMark = 0;
+        try {
+            const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                block_id: model.blockId,
+                filename: "output",
+            }, { timeout: 3000 });
+            highWaterMark = countResp?.count ?? 0;
+        } catch {
+            // Soft fail.
+        }
+
+        const snapshot: AgentPaneStateSnapshotV2 = {
+            schemaVersion: 2,
+            savedAt: new Date().toISOString(),
+            highWaterMark,
+            historyOffset: capturedOffset,
+            documentState: {
+                collapsedNodeIds: [...(capturedDocState?.collapsedNodes ?? [])],
+                pinnedNodeIds:    [...(capturedDocState?.pinnedNodes    ?? [])],
+                scrollPosition:   capturedDocState?.scrollPosition ?? 0,
+                filter:           capturedDocState?.filter ?? DEFAULT_FILTER_STATE,
+            },
+            paneState: {
+                detailsOpen: capturedDetailsOpen,
+            },
+        };
+
+        await RpcApi.AgentSessionWriteStateCommand(TabRpcClient, {
+            definition_id: agentId,
+            content: JSON.stringify(snapshot),
+        }, { timeout: 10000 });
+    }).catch((e) => {
+        log("history", `snapshot write failed: ${e?.message ?? e}`, "warn");
+    });
+};
+```
+
+`JSON.stringify` of this object is under 1 KB for any session. The OOM trigger is
+gone regardless of conversation length.
+
+### 5.2 Remove node-count log noise
+
+The v1 restore path logged `restored N nodes from snapshot`. Update the message to
+reflect that nodes come from NDJSON replay (see §6.3).
+
+---
+
+## 6. Read path changes (frontend)
+
+**File:** `frontend/app/view/agent/hooks/useHistoryPagination.ts`
+
+### 6.1 Schema version constant
+
+```typescript
+export const SNAPSHOT_SCHEMA_VERSION_V1 = 1;
+export const SNAPSHOT_SCHEMA_VERSION_V2 = 2;
+export const SNAPSHOT_SCHEMA_VERSION = SNAPSHOT_SCHEMA_VERSION_V2; // current write version
+```
+
+### 6.2 Restore dispatch
+
+Introduce a new reducer action to apply the overlay state after NDJSON nodes are set:
+
+```typescript
+// agent-document/reducer.ts
+| {
+    type: "HistoryRestored";
+    fromSnapshot: true;
+    nodes: DocumentNode[];
+    // v2 additions (optional — absent when restoring a v1 snapshot)
+    documentStateOverlay?: {
+        collapsedNodes: Set<string>;
+        pinnedNodes: Set<string>;
+        scrollPosition: number;
+        filter: FilterState;
+    };
+    paneStateOverlay?: {
+        detailsOpen: boolean;
+    };
+  }
+```
+
+The reducer applies `documentStateOverlay` to `state.documentState` and
+`paneStateOverlay` to the pane slice if present.  When absent (v1 restore), it
+behaves exactly as before.
+
+### 6.3 Fast path — v2 snapshot
+
+```typescript
+// Render viewport: how many NDJSON lines to load on first open.
+// This is NOT a storage cap — history grows without bound until disk
+// runs out (§2, §14).  Lines outside the window are on disk and
+// accessible via load-older.  5 000 lines ≈ the last few hundred
+// turns, which is the practical "recently visible" window.
+// See §13 for the memory/seek analysis behind this number.
+const RESTORE_WINDOW_LINES = 5_000;
+
+if (snapshot.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2) {
+    // Step 1: fetch at most RESTORE_WINDOW_LINES NDJSON lines ending at
+    // highWaterMark.  This bounds the response size regardless of how old
+    // the session is.
+    const hwm = snapshot.highWaterMark ?? 0;
+    const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
+    let nodes: DocumentNode[] = [];
+    if (hwm > 0) {
+        const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+            block_id: opts.blockId,
+            filename: "output",
+            offset: windowStart,
+            limit: hwm - windowStart,
+        }, { timeout: 30_000 });
+        if (!mounted) return;
+        nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+    }
+
+    // Step 2: reconstruct overlay state.
+    const ds = snapshot.documentState;
+    const documentStateOverlay = ds ? {
+        collapsedNodes: new Set<string>(ds.collapsedNodeIds ?? []),
+        pinnedNodes:    new Set<string>(ds.pinnedNodeIds    ?? []),
+        scrollPosition: ds.scrollPosition ?? 0,
+        filter:         ds.filter ?? DEFAULT_FILTER_STATE,
+    } : undefined;
+    const paneStateOverlay = snapshot.paneState ?? undefined;
+
+    // Step 3: dispatch.
+    batch(() => opts.model.dispatchDoc({
+        type: "HistoryRestored",
+        fromSnapshot: true,
+        nodes,
+        documentStateOverlay,
+        paneStateOverlay,
+    }));
+
+    // historyOffset is the load-older cursor — the start of the restore
+    // window, not the value stored in the snapshot (which was the cursor
+    // position at save time, potentially further back in a very long
+    // session).  Using windowStart ensures load-older pages correctly
+    // from just before the restore window.
+    setHistoryOffset(windowStart);
+    setHistoryTotal(hwm);
+    opts.onContinuationModts?.(stateResp.modts ?? 0);
+    opts.log(
+        "history",
+        `v2 restore: ${nodes.length} nodes from lines [${windowStart}, ${hwm})` +
+        (windowStart > 0 ? ` (${windowStart} older lines available via load-older)` : "") +
+        (ds?.collapsedNodeIds?.length ? `, ${ds.collapsedNodeIds.length} collapsed` : "") +
+        (ds?.pinnedNodeIds?.length    ? `, ${ds.pinnedNodeIds.length} pinned`       : ""),
+    );
+    opts.model.dispatchPane({ type: "InitReady", at: Date.now() });
+    opts.onHistoryReady?.();
+    return;
+}
+```
+
+### 6.4 Legacy v1 snapshot
+
+The existing `schemaVersion === 1 && Array.isArray(snapshot.nodes)` branch is
+unchanged.  v1 snapshots continue to restore nodes directly until they are
+overwritten by a v2 write or age out.
+
+### 6.5 Fallback chain (unchanged)
+
+```
+v2 snapshot → full NDJSON replay + overlay
+v1 snapshot → direct node restore (existing path)
+no snapshot → trailing-200-line NDJSON replay (existing path)
+```
+
+---
+
+## 7. Sidecar changes
+
+**None required for the core fix.** The sidecar writes whatever `content` string it
+receives from `agent:session:write_state` to `output.state.json`.  A v2 payload is
+smaller than a v1 payload; all existing validation (atomic write via temp+rename)
+continues to apply.
+
+### 7.1 `BlockfileReadRangeCommand` is unbounded — window matters
+
+`CommandBlockfileReadRangeData` has `offset: u64, limit: u64` with no server-side
+cap.  Passing `offset: 0, limit: 10_000_000` returns 10 M lines as a `Vec<String>`
+in one WebSocket message — potentially gigabytes.  The `RESTORE_WINDOW_LINES = 5000`
+bound in §6.3 is therefore essential; the sidecar will not protect against an
+oversized request.
+
+A 5 000-line response is ~600 KB–3 MB of NDJSON text — comfortably within one
+WebSocket message.  `parseHistoryLines` over 5 000 lines produces at most a few
+hundred `DocumentNode[]` items.
+
+---
+
+## 8. Migration
+
+| Snapshot found | schemaVersion | Has `nodes` | Action |
+|---|---|---|---|
+| None | — | — | Slow path (trailing 200-line replay) |
+| v1 | 1 | ✓ | v1 fast path (direct node restore, no change) |
+| v2 | 2 | ✗ | v2 fast path (NDJSON replay + overlay) |
+| Unknown version | other | any | Fall through to slow path (logged warn) |
+
+v1 snapshots expire naturally: the next 30 s dirty-flag tick after the first v2
+write overwrites `output.state.json` with a v2 payload.  No explicit migration step
+is needed.
+
+---
+
+## 9. DocumentState wiring
+
+`documentStateAtom` lives in `agentAtoms()` (created by `createAgentAtoms` in
+`state.ts:119`).  `agent-view.tsx` already holds a reference.  The capture in
+§5.1 reads it synchronously before the async RPC chain, so the snapshot reflects
+the UI state at trigger time.
+
+On restore (§6.3), the overlay is delivered to the reducer via `HistoryRestored`.
+The reducer applies it to `state.documentState`; the `AgentDocumentView` component
+re-reads from the atom on the next reactive tick.
+
+`collapsedNodes` and `pinnedNodes` are `Set<string>` keyed by node ID.  These IDs
+are stable: `parseHistoryLines` produces the same IDs for the same NDJSON input
+because IDs are embedded in the events (not derived from array index).  The overlay
+therefore correctly re-opens/closes the same nodes that were open/closed at save
+time.
+
+---
+
+## 10. Performance profile
+
+| Operation | v1 | v2 |
+|---|---|---|
+| Snapshot serialise | `JSON.stringify(N nodes)` — 10–126 ms, 7–10 MB alloc | `JSON.stringify(overlay)` — <1 ms, <1 KB |
+| Snapshot write | Same RPC, slower for large payloads | Same RPC, ~1 KB payload |
+| Restore — network | 0 extra RPCs (nodes embedded) | 1 `BlockfileReadRangeCommand` (≤ 5000 lines) |
+| Restore — parse | 0 (nodes pre-parsed) | `parseHistoryLines` over ≤ 5000 lines (~100–300 ms) |
+| Restore — wall clock | ~50–100 ms (WebSocket deserialise) | ~200–500 ms for a full 5000-line window |
+| Max response size | Grows unbounded (OOM) | Always ≤ ~3 MB regardless of session length |
+
+The restore latency increase is acceptable: the UI displays the `InitPending` loading
+state during this window.  The OOM elimination far outweighs the added restore time.
+
+Critically, **restore time is O(1) with respect to session length** because the
+window is fixed at `RESTORE_WINDOW_LINES`.  A 10 M-line session restores in the same
+time as a 5 000-line session.
+
+---
+
+## 11. Test plan
+
+### Unit
+
+- `writeSnapshotNow` sends a payload with `schemaVersion: 2` and no `nodes` key.
+- Serialised payload for a 10k-node document is < 5 KB.
+- `HistoryRestored` with `documentStateOverlay` applies `collapsedNodes` /
+  `pinnedNodes` / `filter` to reducer state.
+
+### Integration (in-app)
+
+1. Open a long session (> 500 NDJSON lines).
+2. Collapse two agent-message nodes; pin one tool node; scroll to mid-session.
+3. Close and reopen the pane.
+4. Verify: all conversation nodes present; collapsed nodes are collapsed; pinned node
+   is pinned; scroll position approximately restored.
+5. Verify no "ws message too large" log lines during the test.
+
+### Regression
+
+- Short sessions (< 50 nodes): restore still works; no extra RPC latency visible.
+- v1 snapshot on disk: falls through to v1 fast path; no regression.
+- No snapshot: falls through to slow path; no regression.
+
+---
+
+## 12. Open questions
+
+1. **`BlockfileReadRangeCommand` line cap.** Does the sidecar clamp `limit`?  If
+   yes, set the v2 restore loop's page size accordingly and document the cap.
+
+2. **Background-agent gap fill.** If the agent ran while the pane was closed, NDJSON
+   lines may exist in `[highWaterMark, currentTotal)`.  The live-stream subscription
+   will deliver these from subscribe-time forward.  A gap (events that landed after
+   save but before subscribe) is the same v1 limitation.  Phase 4 of the parent spec
+   addresses this; no change here.
+
+3. **`scrollPosition` restore accuracy.** The virtual list scroll model maps pixel
+   positions to node indices; a node that renders differently after NDJSON replay vs.
+   snapshot may shift the target.  A best-effort `scrollPosition` restore (snap to
+   nearest node boundary) is sufficient.  Exact pixel matching is not a goal.
+
+4. **`detailsOpen` wiring.** Confirm `detailsOpenAtom` is accessible from
+   `agent-view.tsx` (it is on `agentAtoms()`) and that `HistoryRestored` can set it.
+   If the pane state atom lives outside the reducer, apply it in the `batch()` call
+   via a separate `dispatchPane` action rather than embedding it in `HistoryRestored`.
+
+---
+
+## 13. Render viewport analysis (why 5 000 lines)
+
+### 13.1 Renderer memory limits that motivate the viewport size
+
+`BlockfileReadRangeCommand` has no server-side line cap (`rpc_types.rs:1020–1025`).
+For a session with N NDJSON lines:
+
+| N | Approx file size | `Vec<String>` response | `DocumentNode[]` after parse | V8 heap impact |
+|---|---|---|---|---|
+| 5 000 | ~600 KB | ~3 MB | ~200–800 nodes | < 50 MB |
+| 50 000 | ~6 MB | ~30 MB | ~2 000–8 000 nodes | ~200 MB |
+| 500 000 | ~60 MB | ~300 MB | ~20 000–80 000 nodes | ~2 GB — OOM |
+| 10 000 000 | ~1.2 GB | ~6 GB | out of memory | crash |
+
+The `RESTORE_WINDOW_LINES = 5_000` constant keeps all four columns in the first row
+regardless of actual session length.
+
+### 13.2 How long does it take to reach 10 M lines?
+
+Each agent turn (user message → assistant response with tools) produces roughly
+500–2 000 NDJSON lines (streaming deltas, tool events, results).  A heavy usage
+day like the crash day (2 long sessions, ~8 hours) produced an estimated 50 000–
+200 000 lines.  Reaching 10 M lines would require weeks to months of continuous
+heavy use.
+
+The more immediate concern is reaching the ~50 000 threshold (a few weeks for power
+users) where an unbounded restore would produce 2 GB+ of V8 allocations.  The
+bounded window addresses this.
+
+### 13.3 Disk growth is intentional — not bounded here
+
+The `output` blockfile grows without bound by design (§2).  At 10 M lines × 120
+bytes that is ~1.2 GB per agent session.  This is fine — disk is cheap and the data
+is valuable conversation history.  The only response to disk growth is the low-disk
+warning (§14), not a silent cap.
+
+The existing `agent:session:archive` RPC (`rpc_types.rs:2059–2072`) is a user-
+initiated action to snapshot-and-clear the current zone.  It is not called
+automatically; the user opts in.  A future "Start new session" or "Archive
+conversation" button in the pane UI would wire up this RPC.
+
+### 13.4 Seek cost — why the byte-offset index is required for large sessions
+
+**The invariant we want:** opening a pane backed by a 100 GB session history feels
+instant.  During live use this is already true — live events arrive over WebSocket
+and never touch the NDJSON file.  The risk is the **initial open**: the sidecar must
+seek to line `(totalLines - RESTORE_WINDOW_LINES)` to serve the restore request.
+
+With the current flat-file implementation in `readutil.rs`, that seek scans from
+byte 0 to find the target line's byte offset — O(file size).  Results:
+
+| File size | Seek time (approx) |
+|---|---|
+| 18 MB (today's Mopeo session) | < 10 ms ✓ |
+| 600 MB (~500 K lines) | ~300 ms — noticeable |
+| 6 GB (~5 M lines) | ~3 s — slow |
+| 100 GB (~80 M lines) | ~50 s — unusable |
+
+**The fix: a persistent byte-offset index (`output.idx`).**
+
+On every `append_output` call, the sidecar appends the current end-of-file byte
+offset as a little-endian u64 to a companion file `output.idx` in the same zone.
+After N appends, `output.idx` is exactly `N × 8` bytes.  To seek to line K:
+
+```
+byte_offset = read_u64(output.idx, offset = K × 8)   // one 8-byte read, O(1)
+seek(output, byte_offset)                              // OS seek, O(1)
+```
+
+With the index, **open time is O(1) regardless of session size**.  A 100 GB session
+opens in the same time as an 18 MB session.
+
+`readutil.rs::read_last_n_line_offsets` already builds a transient in-memory version
+of this index for tail reads.  Persisting it is a small additional write per
+`append_output` call.
+
+**This index is a prerequisite for the "unlimited history" design principle (§2).**
+Without it, sessions beyond ~50 MB exhibit a perceptible open delay, and sessions
+beyond ~1 GB are unusable.  It should be implemented in the same PR as the v2
+snapshot or shortly after, before users encounter large sessions in the wild.
+
+The index file itself scales as `N × 8` bytes.  At 1 billion lines it is 8 GB —
+large but seekable in O(1) (fixed-width records, no scan needed).  If the index
+itself becomes unwieldy, segment it alongside the data file.
+
+---
+
+## 14. Disk-space warning
+
+### 14.1 Principle
+
+The only reason to surface a warning about session size is **impending disk
+exhaustion**.  AgentMux must not cap history, compress it, or refuse writes.  It
+must warn the user in time for them to act (free space, archive a session, or buy
+more disk) before writes start failing silently.
+
+### 14.2 Warning levels
+
+| Level | Condition | UI surface |
+|---|---|---|
+| **Advisory** | Free disk < 1 GB | Subtle banner at top of agent pane: "Disk space is running low — X MB free" |
+| **Warning** | Free disk < 500 MB | Orange banner + badge on the pane tab |
+| **Critical** | Free disk < 200 MB | Modal dialog blocking new agent turns: "Almost out of disk space. AgentMux may stop saving conversation history. Free space to continue." |
+
+Thresholds are conservative intentionally: SQLite WAL files, CEF cache, and other
+AgentMux data also consume space.  The advisory fires early to leave headroom.
+
+### 14.3 How disk space is measured
+
+The sidecar has OS-level access to `statvfs` (Unix) / `GetDiskFreeSpaceEx`
+(Windows) against the data dir mount point (`~/.agentmux/`).  A new
+`system:disk_stats` RPC returns:
+
+```typescript
+interface DiskStats {
+  data_dir_bytes_used: number;   // total bytes in ~/.agentmux/ channel data dir
+  disk_free_bytes: number;       // free bytes on the containing volume
+  disk_total_bytes: number;      // total capacity of the volume
+}
+```
+
+The frontend polls this every 60 s (not on every turn — cheap enough).  The 60 s
+interval means the warning appears within a minute of crossing a threshold.
+
+### 14.4 Per-session size in the agent pane
+
+When `data_dir_bytes_used` / `session_bytes` is available, the agent pane settings
+panel (cog → Info tab) shows:
+
+```
+Conversation history: 18.2 MB (23 314 lines)
+Total AgentMux data:  46 MB
+Free disk:           234 GB
+```
+
+This is informational, not actionable — no "delete" button here.  The archive
+action ("Start new session") is a separate surface.
+
+### 14.5 Implementation sketch
+
+**Sidecar** (`agentmux-srv`):
+- Add `COMMAND_SYSTEM_DISK_STATS = "system:disk_stats"` RPC.
+- Handler calls `statvfs` / `GetDiskFreeSpaceEx` on the data dir path, returns
+  `DiskStats`.  No new dependencies; both syscalls are in `std`.
+
+**Frontend** (`agent-view.tsx` or a shared hook):
+- `useDiskStats()` hook: polls `system:disk_stats` every 60 s, returns the latest
+  `DiskStats` signal.
+- `DiskWarningBanner` component: reads `diskStats().disk_free_bytes`, renders the
+  appropriate level (§14.2) or nothing.
+- Inserted above the document list in `AgentDocumentView`, below the session digest
+  banner.
+
+### 14.6 What the critical modal says
+
+```
+Disk space critical
+Your disk has less than 200 MB free. AgentMux conversation
+history may stop saving.
+
+• Free up disk space, then dismiss this warning.
+• Or archive this session to release space used by its
+  history (the conversation is preserved in the archive).
+
+[Archive this session]  [Dismiss]
+```
+
+"Archive this session" calls `agent:session:archive` for the current `definition_id`
+and closes the modal.  "Dismiss" closes without action; the modal re-appears after
+5 minutes if the condition persists.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -346,7 +346,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         const [detailsOpen] = agentAtoms().detailsOpenAtom;
         const capturedDocState = docState();
         const capturedDetailsOpen = detailsOpen();
-        const capturedOffset = history.historyOffset();
 
         inFlightSnapshot = inFlightSnapshot.then(async () => {
             let highWaterMark = 0;
@@ -359,11 +358,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             } catch {
                 // Soft fail — snapshot still ships without the mark.
             }
+            // Note: no historyOffset field — v2 restore derives the render window
+            // from highWaterMark (windowStart = hwm - RESTORE_WINDOW_LINES), so a
+            // persisted offset would be dead/misleading.
             const snapshot = {
                 schemaVersion: SNAPSHOT_SCHEMA_VERSION,
                 savedAt: new Date().toISOString(),
                 highWaterMark,
-                historyOffset: capturedOffset,
                 documentState: {
                     collapsedNodeIds: capturedDocState ? [...capturedDocState.collapsedNodes] : [],
                     pinnedNodeIds: capturedDocState ? [...capturedDocState.pinnedNodes] : [],

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -39,6 +39,7 @@ import { useAgentStream } from "./useAgentStream";
 import { useActivityLog } from "./hooks/useActivityLog";
 import { useSessionDigest } from "./hooks/useSessionDigest";
 import { useHistoryPagination, SNAPSHOT_SCHEMA_VERSION } from "./hooks/useHistoryPagination";
+// SNAPSHOT_SCHEMA_VERSION re-exported from useHistoryPagination; imported here for the write path.
 import { useAgentControllerStatus } from "./hooks/useAgentControllerStatus";
 import { useInSessionSearch } from "./hooks/useInSessionSearch";
 import { useScrollToNode } from "./hooks/useScrollToNode";
@@ -298,6 +299,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // restore.
         onContinuationModts: (ms) => model.continuedFromMsAtom._set(ms),
         onHistoryReady: () => historyReadyFn?.(),
+        // Schema v2: apply DocumentState + pane overlay after NDJSON replay.
+        onSnapshotOverlay: ({ documentState, detailsOpen }) => {
+            const [, setDocState] = agentAtoms().documentStateAtom;
+            setDocState((prev) => ({ ...prev, ...documentState }));
+            if (typeof detailsOpen === "boolean") {
+                const [, setDetailsOpen] = agentAtoms().detailsOpenAtom;
+                setDetailsOpen(detailsOpen);
+            }
+        },
         log,
     });
 
@@ -325,9 +335,19 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // LAST and overwrite the close-time snapshot, losing recent nodes.
     let inFlightSnapshot: Promise<void> = Promise.resolve();
     const writeSnapshotNow = () => {
-        const nodes = getDocument();
-        if (!nodes) return;
+        // Schema v2: capture the lightweight overlay state (DocumentState +
+        // pane flags) synchronously before the async RPC chain so we snapshot
+        // the values at trigger time, not after a potential 3 s round-trip.
+        // nodes[] is NOT included — the NDJSON output log is the source of
+        // truth and is replayed on restore. This keeps the payload under 1 KB
+        // regardless of conversation length, eliminating the renderer OOM.
+        // See docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md.
+        const [docState] = agentAtoms().documentStateAtom;
+        const [detailsOpen] = agentAtoms().detailsOpenAtom;
+        const capturedDocState = docState();
+        const capturedDetailsOpen = detailsOpen();
         const capturedOffset = history.historyOffset();
+
         inFlightSnapshot = inFlightSnapshot.then(async () => {
             let highWaterMark = 0;
             try {
@@ -344,15 +364,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 savedAt: new Date().toISOString(),
                 highWaterMark,
                 historyOffset: capturedOffset,
-                nodes,
+                documentState: {
+                    collapsedNodeIds: capturedDocState ? [...capturedDocState.collapsedNodes] : [],
+                    pinnedNodeIds: capturedDocState ? [...capturedDocState.pinnedNodes] : [],
+                    scrollPosition: capturedDocState?.scrollPosition ?? 0,
+                    filter: capturedDocState?.filter ?? {
+                        showThinking: false,
+                        showSuccessfulTools: true,
+                        showFailedTools: true,
+                        showIncoming: true,
+                        showOutgoing: true,
+                    },
+                },
+                paneState: {
+                    detailsOpen: capturedDetailsOpen ?? false,
+                },
             };
-            // Option E (PR #1007 backend, this PR frontend): write
-            // the snapshot to the agent-anchored zone
-            // `agent:<defId>:current` so the next pane that opens for
-            // this AgentDefinition picks up where this one left off.
-            // `agentId` is the definition slug/UUID from block meta —
-            // non-empty here by the AgentViewWrapper `Show when=...`
-            // gate above.
             await RpcApi.AgentSessionWriteStateCommand(TabRpcClient, {
                 definition_id: agentId,
                 content: JSON.stringify(snapshot),

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -361,10 +361,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             // Note: no historyOffset field — v2 restore derives the render window
             // from highWaterMark (windowStart = hwm - RESTORE_WINDOW_LINES), so a
             // persisted offset would be dead/misleading.
+            //
+            // sourceBlockId records which block's per-block NDJSON `output` the
+            // highWaterMark counted. The snapshot itself is agent-anchored
+            // (definition_id zone) and survives across blocks, but the NDJSON it
+            // references is per-block — so restore must read history from this
+            // block, not from a fresh continuation pane's empty block.
             const snapshot = {
                 schemaVersion: SNAPSHOT_SCHEMA_VERSION,
                 savedAt: new Date().toISOString(),
                 highWaterMark,
+                sourceBlockId: model.blockId,
                 documentState: {
                     collapsedNodeIds: capturedDocState ? [...capturedDocState.collapsedNodes] : [],
                     pinnedNodeIds: capturedDocState ? [...capturedDocState.pinnedNodes] : [],

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -335,6 +335,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // LAST and overwrite the close-time snapshot, losing recent nodes.
     let inFlightSnapshot: Promise<void> = Promise.resolve();
     const writeSnapshotNow = () => {
+        // Don't let a cross-block continuation pane (one that mounted against a
+        // snapshot whose sourceBlockId names another block) overwrite the
+        // agent-anchored snapshot. It holds no durable history of its own, so a
+        // write would repoint the agent's snapshot at this near-empty block and
+        // make the original block's conversation unrestorable. See spec §15 / #1397.
+        if (history.snapshotIsForeignBlock()) {
+            return;
+        }
         // Schema v2: capture the lightweight overlay state (DocumentState +
         // pane flags) synchronously before the async RPC chain so we snapshot
         // the values at trigger time, not after a potential 3 s round-trip.

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -37,7 +37,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import type { AgentPaneModel } from "@/app/store/agent-pane-registration";
 import { parseHistoryLines } from "../parseHistoryLines";
 
-import type { LogFn } from "../types";
+import type { DocumentState, FilterState, LogFn } from "../types";
 export type { LogFn };
 
 export interface UseHistoryPaginationOptions {
@@ -80,6 +80,16 @@ export interface UseHistoryPaginationOptions {
      *  for an empty document). Used to gate the new-message enter animation
      *  so history rows don't animate on open/restore. See PR #1212. */
     onHistoryReady?: () => void;
+    /**
+     * Schema-v2 restore: called when a v2 snapshot is successfully read and
+     * its overlay state (DocumentState + pane flags) should be applied. The
+     * caller owns the atoms; the hook passes the deserialized overlay so the
+     * caller can apply it without coupling this hook to the atom types.
+     */
+    onSnapshotOverlay?: (overlay: {
+        documentState: Partial<DocumentState>;
+        detailsOpen?: boolean;
+    }) => void;
     log: LogFn;
 }
 
@@ -94,8 +104,22 @@ const PAGE_SIZE = 200;
 
 /** Sidecar filename for reducer-state snapshots, sibling to "output". */
 export const SNAPSHOT_FILENAME = "output.state.json";
-/** Current snapshot schema version. Bump on any breaking shape change. */
-export const SNAPSHOT_SCHEMA_VERSION = 1;
+/** Schema versions. v1 = nodes[] embedded; v2 = overlay only + NDJSON replay. */
+export const SNAPSHOT_SCHEMA_VERSION_V1 = 1;
+export const SNAPSHOT_SCHEMA_VERSION_V2 = 2;
+/** Version written by writeSnapshotNow. */
+export const SNAPSHOT_SCHEMA_VERSION = SNAPSHOT_SCHEMA_VERSION_V2;
+
+/** Render viewport: lines loaded on restore. Not a storage cap — see §2 of spec. */
+export const RESTORE_WINDOW_LINES = 5_000;
+
+const DEFAULT_FILTER_STATE: FilterState = {
+    showThinking: false,
+    showSuccessfulTools: true,
+    showFailedTools: true,
+    showIncoming: true,
+    showOutgoing: true,
+};
 
 export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHistoryPagination {
     const [historyOffset, setHistoryOffset] = createSignal(0);
@@ -198,33 +222,70 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 if (!mounted) return;
                 if (stateResp.content) {
                     const snapshot = JSON.parse(stateResp.content);
-                    if (snapshot && snapshot.schemaVersion === SNAPSHOT_SCHEMA_VERSION && Array.isArray(snapshot.nodes)) {
-                        batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes: snapshot.nodes }));
+                    const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
 
+                    // --- Schema v2: overlay only, reconstruct nodes from NDJSON ---
+                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2) {
+                        const hwm: number = typeof snapshot.highWaterMark === "number" ? snapshot.highWaterMark : 0;
+                        const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
+                        let nodes = [];
+                        if (hwm > 0) {
+                            const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                                block_id: opts.blockId,
+                                filename: "output",
+                                offset: windowStart,
+                                limit: hwm - windowStart,
+                            }, { timeout: 30_000 });
+                            if (!mounted) return;
+                            nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                        }
+                        batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes }));
+                        // Apply DocumentState + pane overlay via caller callback.
+                        const ds = snapshot.documentState;
+                        if (ds && opts.onSnapshotOverlay) {
+                            opts.onSnapshotOverlay({
+                                documentState: {
+                                    collapsedNodes: new Set<string>(ds.collapsedNodeIds ?? []),
+                                    pinnedNodes: new Set<string>(ds.pinnedNodeIds ?? []),
+                                    scrollPosition: typeof ds.scrollPosition === "number" ? ds.scrollPosition : 0,
+                                    filter: ds.filter ?? DEFAULT_FILTER_STATE,
+                                },
+                                detailsOpen: snapshot.paneState?.detailsOpen,
+                            });
+                        }
+                        setHistoryOffset(windowStart);
+                        setHistoryTotal(hwm);
+                        opts.onContinuationModts?.(modts);
+                        opts.log(
+                            "history",
+                            `v2 restore: ${nodes.length} nodes from lines [${windowStart}, ${hwm})` +
+                            (windowStart > 0 ? ` (${windowStart} older lines available via load-older)` : "") +
+                            (ds?.collapsedNodeIds?.length ? `, ${ds.collapsedNodeIds.length} collapsed` : ""),
+                        );
+                        opts.model.dispatchPane({ type: "InitReady", at: Date.now() });
+                        opts.onHistoryReady?.();
+                        return;
+                    }
+
+                    // --- Schema v1: nodes[] embedded (legacy fast path) ---
+                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V1 && Array.isArray(snapshot.nodes)) {
+                        batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes: snapshot.nodes }));
                         const offset = typeof snapshot.historyOffset === "number" && snapshot.historyOffset >= 0
                             ? snapshot.historyOffset
                             : 0;
                         setHistoryOffset(offset);
                         setHistoryTotal(typeof snapshot.highWaterMark === "number" ? snapshot.highWaterMark : snapshot.nodes.length);
-                        // Option E: surface the snapshot's modts so the
-                        // view model can render the "· continued from
-                        // Xm ago" chip in the title bar. The chip
-                        // suppresses itself when the gap is <30s (same
-                        // pane's own fresh write).
-                        const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
                         opts.onContinuationModts?.(modts);
                         opts.log(
                             "history",
-                            `restored ${snapshot.nodes.length} nodes from snapshot ` +
+                            `v1 restore: ${snapshot.nodes.length} nodes from snapshot ` +
                                 `(savedAt=${snapshot.savedAt ?? "unknown"}, loadOlder offset=${offset})`,
                         );
-                        opts.model.dispatchPane({
-                            type: "InitReady",
-                            at: Date.now(),
-                        });
+                        opts.model.dispatchPane({ type: "InitReady", at: Date.now() });
                         opts.onHistoryReady?.();
                         return;
                     }
+
                     opts.log(
                         "history",
                         `snapshot schema mismatch (got v${snapshot?.schemaVersion}); falling back to NDJSON replay`,

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -225,20 +225,25 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                     const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
 
                     // --- Schema v2: overlay only, reconstruct nodes from NDJSON ---
-                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2) {
-                        const hwm: number = typeof snapshot.highWaterMark === "number" ? snapshot.highWaterMark : 0;
+                    // Only taken when the snapshot carries a usable high-water mark.
+                    // `writeSnapshotNow` defaults hwm=0 when the line-count RPC fails
+                    // at write time; treating hwm=0 as "empty session" here would
+                    // render a blank pane and hide on-disk history. So when hwm<=0 we
+                    // deliberately fall through to the NDJSON ring-buffer replay below,
+                    // which derives the line count fresh from the backend.
+                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2
+                        && typeof snapshot.highWaterMark === "number"
+                        && snapshot.highWaterMark > 0) {
+                        const hwm: number = snapshot.highWaterMark;
                         const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
-                        let nodes = [];
-                        if (hwm > 0) {
-                            const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                                block_id: opts.blockId,
-                                filename: "output",
-                                offset: windowStart,
-                                limit: hwm - windowStart,
-                            }, { timeout: 30_000 });
-                            if (!mounted) return;
-                            nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
-                        }
+                        const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                            block_id: opts.blockId,
+                            filename: "output",
+                            offset: windowStart,
+                            limit: hwm - windowStart,
+                        }, { timeout: 30_000 });
+                        if (!mounted) return;
+                        const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                         batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes }));
                         // Apply DocumentState + pane overlay via caller callback.
                         const ds = snapshot.documentState;
@@ -253,18 +258,34 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                                 detailsOpen: snapshot.paneState?.detailsOpen,
                             });
                         }
-                        setHistoryOffset(windowStart);
-                        setHistoryTotal(hwm);
+                        // Trust the backend's reported total over the snapshot's hwm:
+                        // `rangeResp.total` is the line count the backend can actually
+                        // serve (clamped to its ring-buffer window), so load-older never
+                        // asks for offsets below the floor. See the invariant at the
+                        // NDJSON replay path below.
+                        const available = typeof rangeResp.total === "number" ? rangeResp.total : hwm;
+                        const clampedStart = Math.min(windowStart, available);
+                        setHistoryOffset(clampedStart);
+                        setHistoryTotal(available);
                         opts.onContinuationModts?.(modts);
                         opts.log(
                             "history",
-                            `v2 restore: ${nodes.length} nodes from lines [${windowStart}, ${hwm})` +
-                            (windowStart > 0 ? ` (${windowStart} older lines available via load-older)` : "") +
+                            `v2 restore: ${nodes.length} nodes from lines [${clampedStart}, ${available})` +
+                            (clampedStart > 0 ? ` (${clampedStart} older lines available via load-older)` : "") +
                             (ds?.collapsedNodeIds?.length ? `, ${ds.collapsedNodeIds.length} collapsed` : ""),
                         );
                         opts.model.dispatchPane({ type: "InitReady", at: Date.now() });
                         opts.onHistoryReady?.();
                         return;
+                    }
+                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2) {
+                        // v2 snapshot with hwm<=0 (write-time count failure). Don't
+                        // render empty — fall through to NDJSON replay.
+                        opts.log(
+                            "history",
+                            "v2 snapshot has no usable highWaterMark; falling back to NDJSON replay",
+                            "warn",
+                        );
                     }
 
                     // --- Schema v1: nodes[] embedded (legacy fast path) ---

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -126,15 +126,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
 
-    // Block whose per-block NDJSON `output` holds this pane's durable history.
-    // Defaults to this pane's own block, but a schema-v2 snapshot read from the
-    // agent-anchored zone (`agent:<defId>:current`) carries the `sourceBlockId`
-    // it was written from. On cross-block "structural continuation" (Option E) a
-    // fresh pane gets a new blockId whose per-block output is empty, so history
-    // (initial window AND load-older) must be read from the snapshot's source
-    // block instead. Live new output still streams into this pane's own block.
-    const [historyBlockId, setHistoryBlockId] = createSignal(opts.blockId);
-
     /**
      * Load the previous page of history and prepend to the document.
      * Called by AgentDocumentView when the user scrolls near the top.
@@ -152,7 +143,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
             const loadLimit = currentOffset - newOffset;
 
             const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                block_id: historyBlockId(),
+                block_id: opts.blockId,
                 filename: "output",
                 offset: newOffset,
                 limit: loadLimit,
@@ -234,27 +225,31 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                     const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
 
                     // --- Schema v2: overlay only, reconstruct nodes from NDJSON ---
-                    // Only taken when the snapshot carries a usable high-water mark.
-                    // `writeSnapshotNow` defaults hwm=0 when the line-count RPC fails
-                    // at write time; treating hwm=0 as "empty session" here would
-                    // render a blank pane and hide on-disk history. So when hwm<=0 we
-                    // deliberately fall through to the NDJSON ring-buffer replay below,
-                    // which derives the line count fresh from the backend.
-                    if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2
+                    // Taken only for a SAME-BLOCK reopen with a usable high-water mark:
+                    //
+                    //  - hwm>0: `writeSnapshotNow` defaults hwm=0 when the line-count RPC
+                    //    fails at write time; treating hwm=0 as "empty session" would
+                    //    render a blank pane and hide on-disk history, so hwm<=0 falls
+                    //    through to the NDJSON replay (which re-derives the count).
+                    //  - sourceBlockId === opts.blockId: the durable NDJSON history is
+                    //    per-block, but the snapshot is agent-anchored (shared across all
+                    //    of an agent's blocks). When a *new* block opens for the same
+                    //    agent (cross-block "structural continuation"), this block's own
+                    //    output is empty, so we must NOT read it as if it were the source.
+                    //    Cross-block continuation needs a unified per-agent log; until
+                    //    that lands (follow-up to PR #1361) we fall through to NDJSON
+                    //    replay on this block rather than restore a fragmented/blank view.
+                    const v2SameBlock = snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2
                         && typeof snapshot.highWaterMark === "number"
-                        && snapshot.highWaterMark > 0) {
+                        && snapshot.highWaterMark > 0
+                        && (typeof snapshot.sourceBlockId !== "string"
+                            || snapshot.sourceBlockId === ""
+                            || snapshot.sourceBlockId === opts.blockId);
+                    if (v2SameBlock) {
                         const hwm: number = snapshot.highWaterMark;
                         const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
-                        // History lives in the block the snapshot was written from.
-                        // For same-pane reopen this equals opts.blockId; for cross-block
-                        // continuation it points at the original block whose output holds
-                        // the conversation. Route load-older to the same block.
-                        const srcBlockId = typeof snapshot.sourceBlockId === "string" && snapshot.sourceBlockId
-                            ? snapshot.sourceBlockId
-                            : opts.blockId;
-                        setHistoryBlockId(srcBlockId);
                         const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                            block_id: srcBlockId,
+                            block_id: opts.blockId,
                             filename: "output",
                             offset: windowStart,
                             limit: hwm - windowStart,
@@ -296,11 +291,18 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         return;
                     }
                     if (snapshot?.schemaVersion === SNAPSHOT_SCHEMA_VERSION_V2) {
-                        // v2 snapshot with hwm<=0 (write-time count failure). Don't
-                        // render empty — fall through to NDJSON replay.
+                        // v2 snapshot we deliberately didn't fast-path: either hwm<=0
+                        // (write-time count failure) or a cross-block continuation
+                        // (sourceBlockId !== this block). Don't render empty — fall
+                        // through to NDJSON replay on this block.
+                        const crossBlock = typeof snapshot.sourceBlockId === "string"
+                            && snapshot.sourceBlockId !== ""
+                            && snapshot.sourceBlockId !== opts.blockId;
                         opts.log(
                             "history",
-                            "v2 snapshot has no usable highWaterMark; falling back to NDJSON replay",
+                            crossBlock
+                                ? "v2 snapshot is from another block (cross-block continuation not yet supported); falling back to NDJSON replay"
+                                : "v2 snapshot has no usable highWaterMark; falling back to NDJSON replay",
                             "warn",
                         );
                     }

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -126,6 +126,15 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
 
+    // Block whose per-block NDJSON `output` holds this pane's durable history.
+    // Defaults to this pane's own block, but a schema-v2 snapshot read from the
+    // agent-anchored zone (`agent:<defId>:current`) carries the `sourceBlockId`
+    // it was written from. On cross-block "structural continuation" (Option E) a
+    // fresh pane gets a new blockId whose per-block output is empty, so history
+    // (initial window AND load-older) must be read from the snapshot's source
+    // block instead. Live new output still streams into this pane's own block.
+    const [historyBlockId, setHistoryBlockId] = createSignal(opts.blockId);
+
     /**
      * Load the previous page of history and prepend to the document.
      * Called by AgentDocumentView when the user scrolls near the top.
@@ -143,7 +152,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
             const loadLimit = currentOffset - newOffset;
 
             const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                block_id: opts.blockId,
+                block_id: historyBlockId(),
                 filename: "output",
                 offset: newOffset,
                 limit: loadLimit,
@@ -236,8 +245,16 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         && snapshot.highWaterMark > 0) {
                         const hwm: number = snapshot.highWaterMark;
                         const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
+                        // History lives in the block the snapshot was written from.
+                        // For same-pane reopen this equals opts.blockId; for cross-block
+                        // continuation it points at the original block whose output holds
+                        // the conversation. Route load-older to the same block.
+                        const srcBlockId = typeof snapshot.sourceBlockId === "string" && snapshot.sourceBlockId
+                            ? snapshot.sourceBlockId
+                            : opts.blockId;
+                        setHistoryBlockId(srcBlockId);
                         const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                            block_id: opts.blockId,
+                            block_id: srcBlockId,
                             filename: "output",
                             offset: windowStart,
                             limit: hwm - windowStart,

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -98,6 +98,16 @@ export interface UseHistoryPagination {
     historyTotal: Accessor<number>;
     loadingOlder: Accessor<boolean>;
     loadOlder: () => Promise<void>;
+    /**
+     * True when this pane mounted against a v2 snapshot whose `sourceBlockId`
+     * names a DIFFERENT block (cross-block "structural continuation" — a second
+     * pane for an agent already shown elsewhere). Such a pane is a transient
+     * viewer: it must NOT overwrite the agent-anchored snapshot, or it would
+     * repoint it at its own (near-empty) block and make the original block's
+     * conversation unrestorable. The caller gates `writeSnapshotNow` on this.
+     * Cross-block continuation restore itself is deferred (see spec §15, #1397).
+     */
+    snapshotIsForeignBlock: Accessor<boolean>;
 }
 
 const PAGE_SIZE = 200;
@@ -125,6 +135,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     const [historyOffset, setHistoryOffset] = createSignal(0);
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
+    const [snapshotIsForeignBlock, setSnapshotIsForeignBlock] = createSignal(false);
 
     /**
      * Load the previous page of history and prepend to the document.
@@ -298,6 +309,13 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         const crossBlock = typeof snapshot.sourceBlockId === "string"
                             && snapshot.sourceBlockId !== ""
                             && snapshot.sourceBlockId !== opts.blockId;
+                        if (crossBlock) {
+                            // Mark this pane as a transient cross-block viewer so the
+                            // caller suppresses snapshot writes — otherwise it would
+                            // clobber the agent-anchored snapshot that still references
+                            // the block holding the real conversation.
+                            setSnapshotIsForeignBlock(true);
+                        }
                         opts.log(
                             "history",
                             crossBlock
@@ -417,5 +435,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
         historyTotal,
         loadingOlder,
         loadOlder,
+        snapshotIsForeignBlock,
     };
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `writeSnapshotNow` was serializing full `DocumentNode[]` (7–10 MB for long sessions) into a JSON blob every 30s on the main render thread, causing 126ms long-tasks and renderer OOM crashes (`error_code=-36861`)
- **Schema v2**: The snapshot payload is now always < 1 KB — `highWaterMark` + `documentState` (collapsedNodeIds, pinnedNodeIds, scrollPosition, filter) + `paneState.detailsOpen`; `nodes[]` is removed entirely
- **v2 restore path**: On open, fetches the trailing `RESTORE_WINDOW_LINES = 5_000` lines from `blockfile output` via `BlockfileReadRangeCommand` and replays through `parseHistoryLines`; older history remains on disk and is accessible via load-older
- **Legacy support**: v1 snapshots (with `nodes[]`) continue to restore via the existing path; schema version mismatch falls back to NDJSON ring-buffer replay

## Details

The session history is now unlimited (disk is the only constraint). The `RESTORE_WINDOW_LINES` constant is a render viewport, not a storage cap — it controls how many lines are loaded on pane open for a fast initial render. All prior history remains readable via the existing load-older pagination.

Closes the renderer crash reported in `docs/analysis/ANALYSIS_RENDERER_CRASH_WRITE_STATE_OOM_2026_06_12.md`.

Spec: `docs/specs/SPEC_WRITE_STATE_NDJSON_RESTORE_2026_06_12.md`

## Test plan

- [ ] Open an existing agent pane with a long session (>200 lines) — verify history restores and scroll position is preserved
- [ ] Let `writeSnapshotNow` fire (30s idle) — verify no memory spike in DevTools Memory tab
- [ ] Close and reopen pane — verify v2 restore path (check console for `v2 restore: N nodes from lines [X, Y)`)
- [ ] Open a pane with an old v1 snapshot — verify legacy path still works (console: `v1 restore: N nodes from snapshot`)
- [ ] Scroll to top, trigger load-older — verify pages load correctly past the initial 5000-line window

🤖 Generated with [Claude Code](https://claude.com/claude-code)