### PR TITLE
fix(scroll): stickToBottom can now disengage on short conversations

### DIFF
--- a/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
+++ b/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(agent): inject Bash(agentmux-bashwrap*) into permissions.allow so bashwrap exec is not blocked
+fix(agent): inject Bash(agentmux-bashwrap *) into permissions.allow so bashwrap exec is not blocked

--- a/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
+++ b/.changesets/1781257955-fix-agent-inject-bash-agentmux-bashwrap-into-permissions-all-suy5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): inject Bash(agentmux-bashwrap*) into permissions.allow so bashwrap exec is not blocked

--- a/.changesets/1781285816-fix-scroll-sticktobottom-can-now-disengage-on-short-conversa-v1zs.md
+++ b/.changesets/1781285816-fix-scroll-sticktobottom-can-now-disengage-on-short-conversa-v1zs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(scroll): stickToBottom can now disengage on short conversations

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -437,7 +437,10 @@ pub fn build_settings_with_hooks(
     // agent cannot run any bash commands. Merge with any user-supplied allow list
     // rather than overwriting it.
     {
-        let bashwrap_allow = Value::String("Bash(agentmux-bashwrap*)".to_string());
+        // Space before * enforces a command-name boundary: matches
+        // "agentmux-bashwrap <args>" only, not other executables that
+        // happen to share the prefix (e.g. agentmux-bashwrapXYZ).
+        let bashwrap_allow = Value::String("Bash(agentmux-bashwrap *)".to_string());
         let mut allow_arr = match settings_obj.get("permissions") {
             Some(Value::Object(perms)) => match perms.get("allow") {
                 Some(Value::Array(arr)) => arr.clone(),

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -432,6 +432,30 @@ pub fn build_settings_with_hooks(
     }
     settings_obj.insert("hooks".to_string(), Value::Object(hooks_obj));
 
+    // Claude Code requires the bashwrap exec command (produced by the hook rewrite)
+    // to be in permissions.allow — otherwise it raises a permissions error and the
+    // agent cannot run any bash commands. Merge with any user-supplied allow list
+    // rather than overwriting it.
+    {
+        let bashwrap_allow = Value::String("Bash(agentmux-bashwrap*)".to_string());
+        let mut allow_arr = match settings_obj.get("permissions") {
+            Some(Value::Object(perms)) => match perms.get("allow") {
+                Some(Value::Array(arr)) => arr.clone(),
+                _ => Vec::new(),
+            },
+            _ => Vec::new(),
+        };
+        if !allow_arr.iter().any(|v| v == &bashwrap_allow) {
+            allow_arr.push(bashwrap_allow);
+        }
+        let mut perms_obj = match settings_obj.remove("permissions") {
+            Some(Value::Object(obj)) => obj,
+            _ => serde_json::Map::new(),
+        };
+        perms_obj.insert("allow".to_string(), Value::Array(allow_arr));
+        settings_obj.insert("permissions".to_string(), Value::Object(perms_obj));
+    }
+
     match serde_json::to_string_pretty(&Value::Object(settings_obj)) {
         Ok(s) => Some(s),
         Err(e) => {

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -362,6 +362,9 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             // queueMicrotask so the new content has rendered before we scroll.
             queueMicrotask(() => {
                 if (!scrollRef) return;
+                // Re-check: user may have disengaged stickToBottom between
+                // when this microtask was queued and when it fires.
+                if (!props.viewState.stickToBottom()) return;
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
             });
         }

--- a/frontend/app/view/agent/virtualization/anchor.test.ts
+++ b/frontend/app/view/agent/virtualization/anchor.test.ts
@@ -85,6 +85,32 @@ describe("isNearBottom", () => {
         expect(isNearBottom(699, 1000, 100)).toBe(false);
         expect(STICK_TO_BOTTOM_THRESHOLD_PX).toBe(200);
     });
+
+    it("short conversation: caps sticky zone at half range so top is reachable", () => {
+        // maxScroll=50 (barely overflows), threshold=200 → effectiveThreshold=25.
+        // At scrollTop=0 (top): distance=50, not < 25 → false (can disengage).
+        expect(isNearBottom(0, 850, 800)).toBe(false);
+        // At scrollTop=25: distance=25, not < 25 → false.
+        expect(isNearBottom(25, 850, 800)).toBe(false);
+        // At scrollTop=26: distance=24 < 25 → true (near bottom).
+        expect(isNearBottom(26, 850, 800)).toBe(true);
+        // At scrollTop=50 (bottom): distance=0 < 25 → true.
+        expect(isNearBottom(50, 850, 800)).toBe(true);
+    });
+
+    it("no overflow: always near bottom", () => {
+        // Content fits in viewport — nothing to scroll, always at bottom.
+        expect(isNearBottom(0, 800, 800)).toBe(true);
+        expect(isNearBottom(0, 500, 800)).toBe(true);
+    });
+
+    it("short conversation with range=1: only at absolute bottom is near bottom", () => {
+        // maxScroll=1, effectiveThreshold=max(1, floor(0.5))=1.
+        // scrollTop=0: distance=1 < 1? No → false.
+        expect(isNearBottom(0, 801, 800)).toBe(false);
+        // scrollTop=1: distance=0 < 1 → true.
+        expect(isNearBottom(1, 801, 800)).toBe(true);
+    });
 });
 
 describe("isNearTop", () => {

--- a/frontend/app/view/agent/virtualization/anchor.ts
+++ b/frontend/app/view/agent/virtualization/anchor.ts
@@ -71,7 +71,17 @@ export function isNearBottom(
     clientHeight: number,
     threshold = STICK_TO_BOTTOM_THRESHOLD_PX,
 ): boolean {
-    return scrollHeight - scrollTop - clientHeight < threshold;
+    const maxScroll = scrollHeight - clientHeight;
+    if (maxScroll <= 0) return true;
+    // When the total scroll range is smaller than the threshold every
+    // position would qualify as "near bottom", making it impossible for
+    // the user to disengage stickToBottom. Cap the sticky zone at half
+    // the scroll range so there is always a reachable "scrolled away"
+    // position (fixes wheel / fast-scroll on short conversations).
+    const effectiveThreshold = maxScroll < threshold
+        ? Math.max(1, Math.floor(maxScroll / 2))
+        : threshold;
+    return maxScroll - scrollTop < effectiveThreshold;
 }
 
 /**


### PR DESCRIPTION
## Root cause

`isNearBottom` (in `anchor.ts`) uses a fixed 200 px threshold. For short conversations where `scrollHeight - clientHeight < 200 px`, **every scroll position** satisfies `distFromBottom < 200`, so `stickToBottom` is impossible to disengage.

Consequence with three fresh agents open:
- Scroll wheel moves the position by a few px, a streaming token arrives, `queueMicrotask(scrollTo(MAX_SAFE_INTEGER))` fires and snaps back → wheel appears broken
- Fast drag same: snaps back faster than the user perceives movement
- Slow drag "works" only because tokens don't arrive between each slow step
- Long conversations work fine because `maxScroll >> 200`

## Fix

**`anchor.ts` — `isNearBottom`**

When `maxScroll < threshold`, cap the sticky zone at `max(1, floor(maxScroll / 2))` instead of the full threshold. This guarantees a reachable "scrolled away" position exists regardless of content height.

```
maxScroll=50  →  effectiveThreshold=25  →  sticky only for scrollTop > 25
maxScroll=1   →  effectiveThreshold=1   →  sticky only at absolute bottom
maxScroll≥200 →  effectiveThreshold=200 →  unchanged (long conversations)
```

**`AgentDocumentVirtualList.tsx` — microtask guard**

The queued `queueMicrotask` was not checking `stickToBottom` at fire time. A token arriving just before the user scrolls away would queue a snap that fired after disengagement. Added a re-check inside the callback.

## Tests

New cases in `anchor.test.ts`:
- short conversation: caps sticky zone at half range
- no overflow: always near bottom
- range=1: only at absolute bottom

All 16 tests pass.

## Checklist
- [x] `anchor.ts` fix + tests
- [x] `AgentDocumentVirtualList.tsx` microtask stale-guard
- [x] Changeset added