### PR TITLE
fix(bashwrap): keep CONIN writer alive until after child.wait()

### DIFF
--- a/.changesets/1781302822-fix-bashwrap-keep-conin-writer-alive-until-after-child-wait--dg0t.md
+++ b/.changesets/1781302822-fix-bashwrap-keep-conin-writer-alive-until-after-child-wait--dg0t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(bashwrap): keep CONIN writer alive until after child.wait() — prevents CTRL_C_EVENT exit 130 on Windows

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -11,7 +11,9 @@
 //!   if PTY allocation fails. The PTY path keeps glibc's stdout
 //!   line-buffered so partial chunks reach the overlay in real time;
 //!   bash's startup DSR (`\x1b[6n`) is satisfied by pre-loading the
-//!   master writer with `\x1b[1;1R` and dropping it immediately, and
+//!   master writer with `\x1b[1;1R`; the writer is held alive until
+//!   after child.wait() (dropping it earlier sends CTRL_C_EVENT on
+//!   Windows — ConPTY CONIN lifetime invariant, same as pair.master); and
 //!   the user's command is prefixed `exec </dev/null;` so stdin-
 //!   reading children see EOF rather than blocking on the PTY's
 //!   stdin (ConPTY doesn't EOF on master-writer drop). The pipe
@@ -530,16 +532,21 @@ async fn run_via_pty(
 
     let reader = pair.master.try_clone_reader().context("PTY try_clone_reader")?;
 
-    // Pre-load bash's stdin with a DSR response and drop the writer.
-    // Bash's readline blocks on `\x1b[6n` until it reads a matching
-    // CSI report; queuing the response upfront unblocks that read
-    // without keeping the master writer open across the child.
-    {
+    // Write the DSR response into the master writer, then hold the
+    // writer alive until after child.wait(). On Windows, closing the
+    // CONIN pipe write-end while the pseudoconsole is still attached
+    // sends CTRL_C_EVENT to the child (exit 130 / SIGINT). This is
+    // the same ConPTY-lifetime invariant as pair.master itself — both
+    // must outlive child.wait(). The `exec </dev/null;` prefix in the
+    // command redirects bash's stdin after startup, so no future writes
+    // to the writer are needed; we just keep the handle open.
+    let writer = {
         use std::io::Write as _;
-        let mut writer = pair.master.take_writer().context("PTY take_writer")?;
-        let _ = writer.write_all(b"\x1b[1;1R");
-        let _ = writer.flush();
-    }
+        let mut w = pair.master.take_writer().context("PTY take_writer")?;
+        let _ = w.write_all(b"\x1b[1;1R");
+        let _ = w.flush();
+        w
+    };
 
     let (tx, rx) = mpsc::channel::<LineEvent>(1024);
     let tx_reader = tx.clone();
@@ -550,12 +557,13 @@ async fn run_via_pty(
 
     let publisher_handle = spawn_publisher_loop(args, wps.cloned(), buffered.clone(), rx);
 
-    // Move the whole pair (master + dropped-slave-handle slot) into
-    // the wait task so its destructor runs after child reaps.
+    // Move pair AND writer into the wait task — both must outlive
+    // child.wait() to satisfy the ConPTY lifetime contract on Windows.
     let exit_code = tokio::task::spawn_blocking(move || -> Result<i32> {
         let mut child = child;
         let status = child.wait().context("PTY child wait")?;
-        // pair drops here, after wait returns — triggers reader EOF.
+        // pair and writer both drop here, after child has exited.
+        drop(writer);
         drop(pair);
         Ok(status.exit_code() as i32)
     })


### PR DESCRIPTION
## Problem

`run_via_pty` called `pair.master.take_writer()`, wrote the DSR response (`\x1b[1;1R`), then immediately dropped the writer in a scoped block. On Windows, closing the ConPTY CONIN pipe's write-end while a process is attached sends `CTRL_C_EVENT` to the child. Result: every bash command exited 130 in ~30 ms with no output.

The module comment already documented the ConPTY lifetime invariant for `pair.master` — the writer requires the same treatment.

## Fix

Return the writer out of the DSR block and move it into the `spawn_blocking` wait closure alongside `pair`, so both drop only after `child.wait()` returns:

```rust
// before: writer dropped here ← sends CTRL_C_EVENT
{
    let mut writer = pair.master.take_writer()?;
    writer.write_all(b"\x1b[1;1R")?;
}

// after: writer held until child exits
let writer = {
    let mut w = pair.master.take_writer()?;
    w.write_all(b"\x1b[1;1R")?;
    w
};
// ... later in spawn_blocking:
drop(writer);  // safe — child already exited
drop(pair);
```

The `exec </dev/null;` command prefix still redirects bash's stdin to `/dev/null` after startup, so no future writes to the writer are needed — the handle just needs to stay open.

## Test

Build passes (`cargo build -p agentmux-bashwrap`). Live test: bash commands that previously exited 130 immediately now run to completion.