### PR TITLE
fix(term): file path links now open in Explorer/Finder on click

### DIFF
--- a/.changesets/1781305151-fix-term-file-path-links-now-open-in-explorer-finder-on-clic-sd4e.md
+++ b/.changesets/1781305151-fix-term-file-path-links-now-open-in-explorer-finder-on-clic-sd4e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): file path links now open in Explorer/Finder on click

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1053,8 +1053,13 @@ pub fn open_external(args: &serde_json::Value) -> Result<serde_json::Value, Stri
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing url".to_string())?;
 
-    // Only allow safe URL schemes
-    if !url.starts_with("http://") && !url.starts_with("https://") && !url.starts_with("devtools://") {
+    // Allow safe URL schemes. vscode:// is included so that file-path links
+    // with a :line suffix can open the file at the correct line in VS Code.
+    let allowed = url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("devtools://")
+        || url.starts_with("vscode://");
+    if !allowed {
         return Err(format!("Refusing to open URL with unsupported scheme: {}", url));
     }
 
@@ -1086,6 +1091,50 @@ pub fn open_external(args: &serde_json::Value) -> Result<serde_json::Value, Stri
             .arg(url)
             .spawn()
             .map_err(|e| format!("Failed to open URL: {}", e))?;
+    }
+
+    Ok(serde_json::Value::Null)
+}
+
+/// Open the system file manager with the given file selected.
+/// On Windows: `explorer /select,<path>`.
+/// On macOS:   `open -R <path>`.
+/// On Linux:   opens the parent directory via `xdg-open` (no cross-desktop
+///             "select file" standard exists).
+pub fn reveal_in_file_explorer(args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let file_path = args
+        .get("filePath")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing filePath".to_string())?;
+
+    #[cfg(target_os = "windows")]
+    {
+        // Convert forward slashes (from JS normalisation) back to backslashes.
+        let native = file_path.replace('/', "\\");
+        // /select,<path> must be a single argument — the comma is the delimiter
+        // between the switch and the path, not a shell separator.
+        let _ = std::process::Command::new("explorer.exe")
+            .arg(format!("/select,{}", native))
+            .spawn()
+            .map_err(|e| format!("Failed to reveal in Explorer: {}", e))?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open")
+            .args(["-R", file_path])
+            .spawn()
+            .map_err(|e| format!("Failed to reveal in Finder: {}", e))?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let parent = std::path::Path::new(file_path)
+            .parent()
+            .and_then(|p| p.to_str())
+            .unwrap_or(file_path);
+        let _ = std::process::Command::new("xdg-open")
+            .arg(parent)
+            .spawn()
+            .map_err(|e| format!("Failed to open parent directory: {}", e))?;
     }
 
     Ok(serde_json::Value::Null)

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -246,6 +246,7 @@ async fn route_command(
         "register_backend_window" => Ok(commands::window::register_backend_window(state, args)),
         "get_env" => Ok(commands::platform::get_env(args)),
         "open_external" => commands::platform::open_external(args),
+        "reveal_in_file_explorer" => commands::platform::reveal_in_file_explorer(args),
         "set_window_transparency" => commands::window::set_window_transparency(state, args),
         "set_window_opacity" => commands::window::set_window_opacity(state, args),
         "get_window_opacity" => commands::window::get_window_opacity(state, args),


### PR DESCRIPTION
## Summary

- Implements the missing `reveal_in_file_explorer` IPC backend handler — the frontend called `invokeCommand("reveal_in_file_explorer")` but `ipc.rs` had no matching arm, so every file-path link click silently dropped
- Adds `vscode://` to `open_external`'s scheme allowlist so that paths with a `:line` suffix (which use `vscode://file/<path>:<line>`) actually open in VS Code instead of being rejected

## Platform behaviour

| Platform | File path (no line) | Path with `:line` |
|----------|--------------------|--------------------|
| Windows  | `explorer /select,<path>` — opens Explorer with file selected | `vscode://file/<path>:<line>` via `open_external` |
| macOS    | `open -R <path>` — reveals in Finder with file selected | same |
| Linux    | `xdg-open <parent dir>` — opens parent folder | same |

## Test plan

- [ ] In a terminal, `echo /absolute/path/to/file.ts` — hover should underline, click should open Explorer/Finder with the file selected
- [ ] `echo src/components/App.tsx` from a directory with that file — relative path resolves and opens
- [ ] `echo /some/file.ts:42` — click should open VS Code at line 42 (requires VS Code installed)
- [ ] Invalid scheme (`ftp://...`) still rejected by `open_external`

🤖 Generated with [Claude Code](https://claude.com/claude-code)