### PR TITLE
fix(term): make xterm-6 overlay scrollbar clickable (z-index above link-layer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.44.1"
+version = "0.44.2"
 
 [profile.release]
 strip = true

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -137,24 +137,21 @@
             caret-color: transparent !important; /* stylelint-disable-line declaration-no-important */
         }
 
+        // xterm 6 replaced the native-scrollbar viewport with a custom
+        // scrollable-element + overlay scrollbar DIVs (`.scrollbar.vertical`
+        // > `.slider`). `.xterm-viewport` is now an empty positioning anchor
+        // (scrollHeight === clientHeight always), so the `::-webkit-scrollbar`
+        // rules below are legacy no-ops kept only for the unlikely DOM-renderer
+        // fallback path; the real scrollbar is styled in the `.scrollbar` block.
         .xterm-viewport {
-            // xterm defaults this to `overflow-y: scroll`, which permanently reserves the
-            // 14px scrollbar gutter even with no scrollback — the dead lane to the right of
-            // the text. `auto` shows the scrollbar only when content overflows; TermWrap.
-            // customFit reserves a matching 14 px (≈1 column) of width only while it is shown.
             overflow-y: auto;
 
             &::-webkit-scrollbar {
-                // Base width — customFit injects a per-terminal <style> rule that overrides
-                // this with 14px + sub-cell remainder so text columns tile flush to the
-                // scrollbar's left edge. cursor:pointer makes the whole track area show a
-                // hand cursor instead of the inherited text I-beam.
                 width: 14px;
                 height: 14px;
                 cursor: pointer;
             }
 
-            // Transparent track so the scrollbar lane shows the terminal background.
             &::-webkit-scrollbar-track {
                 background-color: transparent;
                 cursor: pointer;
@@ -165,6 +162,37 @@
                 background-color: var(--scrollbar-thumb-color);
                 border-radius: 0;
                 margin: 0 1px 0 1px;
+
+                &:hover {
+                    background-color: var(--scrollbar-thumb-hover-color);
+                }
+
+                &:active {
+                    background-color: var(--scrollbar-thumb-active-color);
+                }
+            }
+        }
+
+        // xterm 6's overlay scrollbar (`.scrollbar.vertical` > `.slider`) is a
+        // later sibling of `.xterm-screen` inside `.xterm-scrollable-element`,
+        // so by DOM order it should paint above the text. But `.xterm-link-layer`
+        // (the canvas the WebLinks/FilePath providers hit-test) carries
+        // `z-index: 2`, and an explicit positive z-index beats the scrollbar's
+        // `z-index: auto` regardless of DOM order — so the link layer paints over
+        // the scrollbar and, now that `.xterm-screen` no longer has
+        // `pointer-events: none`, swallows every click in the scrollbar lane.
+        // Lift the scrollbar above the link layer (z:2) and helpers (z:5) so the
+        // thumb is clickable. Verified via elementFromPoint over the scrollbar
+        // lane: link-layer (blocked) → slider (clickable). The scrollbar only
+        // occupies the right 14px, so link hover over the text area is unaffected;
+        // when there is no overflow the scrollbar is `visibility:hidden` and not
+        // hit-tested, so the full width stays available for link hover.
+        .xterm-scrollable-element > .scrollbar {
+            z-index: 10;
+
+            .slider {
+                cursor: pointer;
+                background-color: var(--scrollbar-thumb-color);
 
                 &:hover {
                     background-color: var(--scrollbar-thumb-hover-color);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Symptom

Clicking the terminal scrollbar does nothing — the thumb won't drag, the track won't page-scroll.

## Root cause (xterm 5 → 6 migration debt)

xterm **6.0.0** replaced the native-scrollbar viewport with a custom **scrollable-element + overlay scrollbar DIVs**. The live DOM is now:

```
.xterm
├── .xterm-viewport            ← now EMPTY (scrollHeight === clientHeight always)
├── .xterm-scrollable-element
│   ├── .xterm-screen          ← text + canvases, incl. .xterm-link-layer (z-index: 2)
│   ├── .scrollbar.horizontal
│   └── .scrollbar.vertical > .slider   ← the REAL scrollbar (z-index: auto)
└── canvas
```

`.xterm-link-layer` (the canvas the WebLinks / FilePath link providers hit-test) carries **`z-index: 2`**. The overlay scrollbar is a *later sibling* of `.xterm-screen`, so by DOM order it should paint on top — but **an explicit positive z-index beats `z-index: auto` regardless of DOM order**, so the link layer painted over the scrollbar.

While `.xterm-screen` still had `pointer-events: none`, this was harmless — the link-layer *inherited* it and was click-through. Removing `pointer-events: none` to fix link hover (the earlier regression) let the `z:2` link-layer **swallow every click in the scrollbar lane**.

As a side effect of the xterm-6 rework, the `customFit` scrollbar-reservation logic and the `term.scss ::-webkit-scrollbar` rules (both written for xterm 5's native scrollbar) are now dead — `viewport.scrollHeight > clientHeight` is permanently false. They're left in place as no-ops/DOM-renderer-fallback and annotated; the real scrollbar is now styled in the new `.scrollbar` block.

## Fix

```scss
.xterm-scrollable-element > .scrollbar {
    z-index: 10;            // above .xterm-link-layer (z:2) and .xterm-helpers (z:5)
    .slider { cursor: pointer; background-color: var(--scrollbar-thumb-color); ... }
}
```

## Verification (live, via CDP `elementFromPoint` over the scrollbar lane)

| | hit-test result |
|---|---|
| before | `CANVAS.xterm-link-layer` — clicks blocked |
| after  | `DIV.slider` — clicks reach the scrollbar |

`elementFromPoint` resolves exactly what a real mouse click hits, so this is conclusive. The scrollbar occupies only the right 14px → link hover over the text area is unaffected; with no overflow the scrollbar is `visibility:hidden` and not hit-tested, leaving the full width available for hover.

## Note on terminal bug cluster

This is the same xterm 5→6 migration debt behind the recent run of terminal bugs (pointer-events/link hover, scrollbar). The custom terminal layer (`customFit`, `term.scss` scrollbar styling) was written against xterm 5's DOM and is subtly mismatched to xterm 6. Worth a follow-up pass to retire the dead `customFit` reservation path and `::-webkit-scrollbar` rules now that xterm 6 owns scrollbar layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)