### PR TITLE
fix(term): terminal fills block body edge-to-edge (remove pane gaps)

### DIFF
--- a/.changesets/1781316529-fix-term-remove-the-5px-term-connectelem-margin-that-framed--gfl7.md
+++ b/.changesets/1781316529-fix-term-remove-the-5px-term-connectelem-margin-that-framed--gfl7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): remove the 5px term-connectelem margin that framed every terminal pane with block-background gaps on all four sides — the terminal now fills the block body edge-to-edge

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -59,8 +59,10 @@
         min-height: 0;
         overflow: hidden;
         line-height: 1;
-        margin: 5px;
-        margin-left: var(--space-1);
+        // No inset — the terminal fills the block body edge-to-edge. The old
+        // `margin: 5px` (4px left) painted a frame of the block background
+        // around the terminal on all four sides; we want zero gaps.
+        margin: 0;
     }
 
     .term-htmlelem {

--- a/scripts/cdp-gap-probe.js
+++ b/scripts/cdp-gap-probe.js
@@ -1,0 +1,73 @@
+(() => {
+  const term = document.querySelector('.xterm');
+  if (!term) return JSON.stringify({ error: 'no terminal' });
+  const connect = term.closest('.term-connectelem') || document.querySelector('.term-connectelem');
+  const screen = term.querySelector('.xterm-screen');
+  const scrollable = term.querySelector('.xterm-scrollable-element');
+  // Walk up to the block content frame that paints the background behind the gap.
+  const blockInner = term.closest('.block-frame-default-inner') || term.closest('[class*="block-content"]') || connect?.parentElement;
+
+  const box = (el, label) => {
+    if (!el) return { label, missing: true };
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return {
+      label,
+      cls: el.className?.toString?.().slice(0, 40),
+      x: +r.x.toFixed(1), y: +r.y.toFixed(1), w: +r.width.toFixed(1), h: +r.height.toFixed(1),
+      right: +r.right.toFixed(1), bottom: +r.bottom.toFixed(1),
+      margin: cs.margin, padding: cs.padding,
+      bg: cs.backgroundColor,
+    };
+  };
+
+  // cell size from xterm core
+  const core = term.__core || null;
+  let cell = null, cols = null, rows = null;
+  try {
+    // reach via a known global if present, else skip
+    const anyTerm = window.__lastTerm;
+    if (anyTerm?._core) {
+      const d = anyTerm._core._renderService.dimensions;
+      cell = { w: +d.css.cell.width.toFixed(2), h: +d.css.cell.height.toFixed(2) };
+      cols = anyTerm.cols; rows = anyTerm.rows;
+    }
+  } catch (e) {}
+
+  const connectR = connect?.getBoundingClientRect();
+  const screenR = screen?.getBoundingClientRect();
+  const blockR = blockInner?.getBoundingClientRect();
+
+  // Gaps between the text (screen) and the connect element edges, and between
+  // connect element and the block frame (margins).
+  const gaps = {};
+  if (connectR && screenR) {
+    gaps.screen_to_connect = {
+      left: +(screenR.left - connectR.left).toFixed(1),
+      right: +(connectR.right - screenR.right).toFixed(1),
+      top: +(screenR.top - connectR.top).toFixed(1),
+      bottom: +(connectR.bottom - screenR.bottom).toFixed(1),
+    };
+  }
+  if (blockR && connectR) {
+    gaps.connect_to_block = {
+      left: +(connectR.left - blockR.left).toFixed(1),
+      right: +(blockR.right - connectR.right).toFixed(1),
+      top: +(connectR.top - blockR.top).toFixed(1),
+      bottom: +(blockR.bottom - connectR.bottom).toFixed(1),
+    };
+  }
+
+  return JSON.stringify({
+    dpr: window.devicePixelRatio,
+    cell, cols, rows,
+    layers: [
+      box(blockInner, 'block-inner'),
+      box(connect, 'term-connectelem'),
+      box(term, 'xterm'),
+      box(scrollable, 'scrollable-element'),
+      box(screen, 'xterm-screen'),
+    ],
+    gaps,
+  }, null, 2);
+})()


### PR DESCRIPTION
## Symptom

Terminal panes had a visible gap/frame on the right, bottom, and left — same width on the right as height on the bottom.

## Root cause

`.term-connectelem` (the terminal body element) had:
```scss
margin: 5px;
margin-left: var(--space-1);  /* 4px */
```
So every terminal pane was inset by 5px top/right/bottom and 4px left, and that inset exposed the `.block-frame-default-inner` background (`rgba(13,14,15,0.5)`) as a frame around the terminal — exactly the "right == bottom, also left" gaps reported.

## Fix

`margin: 0` — the terminal fills the block body edge-to-edge.

## Verified (CDP layout measurement, `scripts/cdp-gap-probe.js`)

| gap (connect → block frame) | before | after |
|---|---|---|
| left | 4px | **0** |
| right | 5px | **0** |
| top | 5px | **0** (33px = the term header, not a gap) |
| bottom | 5px | **0** |

The only residue is the inherent sub-cell grid remainder (text grid can't fill a fractional last cell: ~5px right / ~2px bottom). A zoomed corner screenshot confirms it blends into the near-black terminal background — no visible seam. If you still want that absolute-zeroed, the follow-up is to paint the terminal container background to match the theme bg; flagging rather than doing it blind since it can interact with transparent terminal themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)