### PR TITLE
fix(security): strip ipc_token from renderer URL; denylist secret keys in get_env

### DIFF
--- a/.changesets/1781334291-fix-security-strip-ipc-token-from-renderer-url-and-denylist--c4vo.md
+++ b/.changesets/1781334291-fix-security-strip-ipc-token-from-renderer-url-and-denylist--c4vo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(security): strip ipc_token from renderer URL and denylist secret keys in get_env

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -125,15 +125,40 @@ pub fn ensure_auth_dir(
 }
 
 /// Get an environment variable value.
+///
+/// Security: refuses keys whose name suggests a secret (cloud keys, API
+/// tokens, passwords, the AgentMux auth key, etc.). `get_env` is reachable by
+/// any IPC caller holding the bearer token — including agent processes and
+/// browser-pane code — so an unrestricted reader is a direct
+/// credential-exfiltration path. The legitimate frontend never depends on this
+/// command in the CEF host (the `getEnv` shim returns "" and resolves real
+/// values from window globals), so the denylist is transparent to the app.
+/// See reports security sweep 2026-06-12 (get-env-unrestricted).
 pub fn get_env(args: &serde_json::Value) -> serde_json::Value {
     let key = args
         .get("key")
         .and_then(|v| v.as_str())
         .unwrap_or_default();
+    if is_sensitive_env_key(key) {
+        tracing::warn!(key = %key, "get_env: refused to expose a secret-looking env var");
+        return serde_json::Value::Null;
+    }
     match std::env::var(key) {
         Ok(val) => serde_json::json!(val),
         Err(_) => serde_json::Value::Null,
     }
+}
+
+/// True if an env-var name looks like it holds a secret and must not be
+/// exposed over the IPC `get_env` command. Substring match on the
+/// upper-cased key so prefixed/suffixed variants (AWS_SECRET_ACCESS_KEY,
+/// GITHUB_TOKEN, AGENTMUX_AUTH_KEY, …) are all caught.
+fn is_sensitive_env_key(key: &str) -> bool {
+    const NEEDLES: [&str; 7] = [
+        "KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "CREDENTIAL", "AUTH",
+    ];
+    let upper = key.to_ascii_uppercase();
+    NEEDLES.iter().any(|needle| upper.contains(needle))
 }
 
 /// The ephemeral build label of a local portable, read from the

--- a/frontend/cef-init.ts
+++ b/frontend/cef-init.ts
@@ -32,6 +32,19 @@ export async function setupCefApi(): Promise<void> {
         window.__AGENTMUX_IPC_TOKEN__ = token;
     }
 
+    // Security: strip the IPC port/token from the visible URL immediately after
+    // capturing them into window globals. Leaving them in window.location.href
+    // exposes the bearer token for the whole page lifetime (referrer leakage to
+    // remote browser-pane origins, devtools, crash dumps). Subsequent reads use
+    // the window globals above, not the URL. Other params (e.g. windowLabel) are
+    // preserved. See reports security sweep 2026-06-12 (ipc-token-in-url).
+    if (port || token) {
+        const url = new URL(window.location.href);
+        url.searchParams.delete("ipc_token");
+        url.searchParams.delete("ipc_port");
+        window.history.replaceState(window.history.state, "", url.toString());
+    }
+
     // Pre-fetch all cached values from Rust host via IPC
     await initCefApi();
 


### PR DESCRIPTION
Two effort-S security hardening fixes from the 2026-06-12 repo sweep (`reports/sweep-2026-06-12/35-security.md`) that shrink the `ipc_token` blast radius — the dominant theme of the sweep. Both verified by build.

## 1. Strip `ipc_token`/`ipc_port` from the renderer URL  (`ipc-token-in-url`, P2)
`frontend/cef-init.ts` captured the IPC port + bearer token from the URL query into `window` globals but **never removed them from the URL**, so the token sat in `window.location.href` for the whole page lifetime — a referrer-leakage vector to remote browser-pane origins, plus exposure via devtools and crash dumps. Found independently by 3 sweep cells.

**Fix:** after capturing into the globals, strip both params via `history.replaceState`. Other params (e.g. `windowLabel`) are preserved; all later reads use the window globals, not the URL.

## 2. Denylist secret keys in the `get_env` IPC command  (`get-env-unrestricted`, P2)
`agentmux-cef/src/commands/platform.rs::get_env` read **any** env var with no filter. Reachable by any IPC caller holding the bearer token (agent processes, browser-pane code), it was a direct credential-exfiltration path — `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `AGENTMUX_AUTH_KEY`, etc.

**Fix:** refuse keys whose upper-cased name contains `KEY/SECRET/TOKEN/PASSWORD/PASSWD/CREDENTIAL/AUTH` (logs a warning, returns null). **Transparent to the app:** the frontend's CEF `getEnv` shim returns `""` and resolves real values (HOME, endpoints) from window globals — it never depends on this command. Verified by reading the resolution path (`getenv.ts` → window globals first; `cef-api.ts:273` shim returns `""`).

## Verification
- `tsc --noEmit`: no errors referencing `cef-init.ts` (pre-existing errors elsewhere are unrelated).
- `cargo check -p agentmux-cef`: `Finished` clean; only pre-existing unrelated warnings.

## Explicitly deferred (not safe as static-review quick wins)
- **Remote debug port (9222)** — *not* gated off, because it's **load-bearing for browser-pane CDP** (`browser_api/resolver.rs:72-73`, `routes.rs` connect CDP over it; bails if port==0). Disabling it in prod would break browser panes. Filed as a separate issue — the real fix (randomize/auth the CDP port) is non-trivial.
- **CSP + mermaid SVG sanitize** — need live-renderer testing (a too-strict CSP breaks the renderer and wouldn't be caught by static review).
- **Renderer sandbox `no_sandbox=1` (P1)** — effort-L; filed as a tracking issue.

Part of a sweep follow-up series (PR 1 of 4). See `reports/sweep-2026-06-12/50-top10.md` items #1, #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
