### PR TITLE
fix(term): terminal scrollbar flush to the pane's right edge

### DIFF
--- a/.changesets/1781334657-fix-term-terminal-scrollbar-sits-flush-against-the-pane-s-ri-gvrl.md
+++ b/.changesets/1781334657-fix-term-terminal-scrollbar-sits-flush-against-the-pane-s-ri-gvrl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): terminal scrollbar sits flush against the pane's right edge — grow .xterm to fill the flex connect width so the overlay scrollbar (anchored right:0) no longer floats a zoom-varying sub-cell remainder away from the edge

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -129,6 +129,20 @@
     }
 
     .terminal {
+        // `.term-connectelem` is a flex row and `.xterm` is a flex item that
+        // otherwise sizes to its content width (cols × cellWidth). That left a
+        // variable strip of free flex space — `connectWidth − cols·cellWidth`,
+        // 0..<1 cell — to the RIGHT of the overlay scrollbar (which is anchored
+        // `right: 0` inside `.xterm-scrollable-element`). The strip's width
+        // changed with zoom (cellWidth changes → remainder changes), so the
+        // scrollbar visibly floated a few px off the pane's right edge. Grow
+        // `.xterm` to fill the connect width so the scrollable-element — and
+        // thus the `right: 0` scrollbar — sit flush against the pane edge. The
+        // text grid (`.xterm-screen`, still cols·cellWidth) stays left-aligned;
+        // the now-interior remainder is terminal background, and the fading
+        // overlay scrollbar covers the rightmost sliver.
+        flex-grow: 1;
+
         // WebView2 renders the native textarea caret even at opacity:0
         // when the terminal background is transparent.
         .xterm-helper-textarea {

--- a/scripts/cdp-sbflush-probe.js
+++ b/scripts/cdp-sbflush-probe.js
@@ -1,0 +1,32 @@
+(() => {
+  const term = document.querySelector('.xterm');
+  if (!term) return JSON.stringify({ error: 'no terminal' });
+  const connect = term.closest('.term-connectelem') || document.querySelector('.term-connectelem');
+  const m = (el, label) => {
+    if (!el) return { label, missing: true };
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return {
+      label,
+      right: +r.right.toFixed(1), w: +r.width.toFixed(1),
+      cssWidth: cs.width, display: cs.display, position: cs.position,
+    };
+  };
+  const connectR = connect?.getBoundingClientRect();
+  const vbar = term.querySelector('.scrollbar.vertical');
+  const vbarR = vbar?.getBoundingClientRect();
+  return JSON.stringify({
+    connectRight: connectR ? +connectR.right.toFixed(1) : null,
+    connectW: connectR ? +connectR.width.toFixed(1) : null,
+    layers: [
+      m(connect, 'connect'),
+      m(term, 'xterm'),
+      m(term.querySelector('.xterm-viewport'), 'viewport'),
+      m(term.querySelector('.xterm-scrollable-element'), 'scrollable'),
+      m(term.querySelector('.xterm-screen'), 'screen'),
+      m(vbar, 'scrollbar-vertical'),
+    ],
+    // gap from scrollbar right edge to the connect (pane) right edge:
+    scrollbar_to_paneRight: (vbarR && connectR) ? +(connectR.right - vbarR.right).toFixed(1) : null,
+  }, null, 2);
+})()


### PR DESCRIPTION
## Symptom

A gap to the **right of the terminal scrollbar** — annoying, and its width **changed with zoom level**.

## Root cause

`.term-connectelem` is a `display: flex` row, and `.xterm` is a flex item that sizes to its **content** width (`cols × cellWidth`), not the full pane width. That left a strip of free flex space — `connectWidth − cols·cellWidth` (0 to <1 cell) — on the right. The xterm-6 overlay scrollbar is anchored `right: 0` inside `.xterm-scrollable-element` (which inherits `.xterm`'s narrow width), so the scrollbar floated that strip-width away from the pane edge. Because the remainder is `width mod cellWidth`, it changed every time the cell size changed → **zoom-dependent gap**.

## Fix

```scss
.terminal { flex-grow: 1; }   /* .xterm fills the connect width */
```

`.xterm` now fills the connect width, so `.xterm-scrollable-element` and its `right: 0` scrollbar sit **flush** against the pane's right edge — at every zoom, since this no longer depends on the grid remainder. The text grid (`.xterm-screen`, still `cols·cellWidth`) stays left-aligned; the now-interior remainder is terminal background, and the fading overlay scrollbar covers the rightmost sliver.

## Verified (CDP)

`scrollbar-right-edge → pane-right-edge` gap: **7px → 0**. `.xterm` width 1064 → 1071 (= connect width). A flush-edge screenshot confirms the terminal background runs to the pane border with no strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)