### PR TITLE
fix(scripts): make import-agents.sh resilient to bad source DBs

### DIFF
--- a/.changesets/1781338880-fix-scripts-import-agents-sh-skips-bad-old-source-dbs-instea-2hmt.md
+++ b/.changesets/1781338880-fix-scripts-import-agents-sh-skips-bad-old-source-dbs-instea-2hmt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(scripts): import-agents.sh skips bad/old source DBs instead of aborting; strip CRLF from slug

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -214,6 +214,24 @@ import_into() {
 
         local src_win; src_win=$(win_path "$src_db")
 
+        # Resilience: one unreadable / locked / corrupt / table-less source DB
+        # must never abort the whole import. Under `set -euo pipefail` the first
+        # sqlite error would propagate and silently drop every agent in DBs not
+        # yet scanned (observed: a stale `*.bak` channel mid-scan dropped a real
+        # agent whose data lived in a later-sorted DB). Probe the source first.
+        # Old pre-agent-schema versions (no db_agent_definitions table) are
+        # expected and numerous — skip those silently; WARN only on genuine
+        # problems (corruption, locks).
+        local _probe_err
+        if ! _probe_err=$(sqlite3 "$src_win" \
+            "SELECT 1 FROM db_agent_definitions LIMIT 1;" 2>&1 >/dev/null); then
+            case "$_probe_err" in
+                *"no such table"*) : ;;  # pre-agent-schema DB — nothing to import
+                *) echo "  WARN  skipping unreadable source DB (${_probe_err%%$'\n'*}): $src_db" >&2 ;;
+            esac
+            continue
+        fi
+
         # Detect which newer columns exist in the source schema so the SELECTs
         # below never reference a missing column. This MUST run BEFORE the agents
         # query: referencing an absent column (e.g. `slug` on a very old DB) makes
@@ -242,8 +260,12 @@ import_into() {
 
         # Use char(1) (ASCII unit-separator) instead of '|' so agent names that
         # contain a pipe character don't corrupt the field split.
+        # sqlite3.exe emits CRLF on Windows; the trailing CR contaminates the
+        # last char(1)-delimited field (the slug), which silently breaks the
+        # on-disk session lookup below. Strip CR so every field is clean.
         agents=$(db_query "$src_db" \
-            "SELECT id||char(1)||name||char(1)||COALESCE(${_col_slug},'') FROM db_agent_definitions WHERE $where;" 2>/dev/null)
+            "SELECT id||char(1)||name||char(1)||COALESCE(${_col_slug},'') FROM db_agent_definitions WHERE $where;" 2>/dev/null \
+            | tr -d '\r') || agents=""
         [ -z "$agents" ] && continue
 
         while IFS=$'\x01' read -r def_id agent_name agent_slug; do
@@ -266,7 +288,12 @@ import_into() {
             # when importing across versions with different db_agent_definitions schemas.
             # Uses detected column names so source DBs lacking updated_at/user_hidden
             # fall back to created_at/0 rather than aborting the import.
-            sqlite3 "$src_win" \
+            # A schema mismatch in this single source DB (e.g. an old or `*.bak`
+            # DB missing a column named below) must skip THIS agent, not abort
+            # the whole import. Capture stderr and continue on failure rather
+            # than letting `set -e` propagate the error and drop later agents.
+            local _def_copy_err
+            if ! _def_copy_err=$(sqlite3 "$src_win" \
                 "ATTACH '$tgt_win' AS dst;
                  INSERT OR IGNORE INTO dst.db_agent_definitions
                    (id, slug, name, icon, provider, description,
@@ -279,7 +306,11 @@ import_into() {
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                     is_seeded, accounts, parent_id, branch_label,
                     ${_col_updated_at}, ${_col_user_hidden}
-                 FROM db_agent_definitions WHERE id='$def_id';"
+                 FROM db_agent_definitions WHERE id='$def_id';" 2>&1); then
+                echo "  WARN  $agent_name — definition copy failed; skipping (${_def_copy_err%%$'\n'*})" >&2
+                ((skipped++)) || true
+                continue
+            fi
 
             # Verify the definition was actually inserted.
             # db_agent_definitions has a UNIQUE index on slug — an INSERT OR IGNORE
@@ -350,7 +381,10 @@ import_into() {
                 lookup_slug=$(printf '%s' "$agent_name" | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9_-]/-/g')
             fi
             local resolved sess_id="" work_dir="" src_jsonl=""
-            resolved=$(best_session_for_slug "$lookup_slug")
+            # best_session_for_slug returns non-zero when the agent has no
+            # on-disk session (a normal case); `|| resolved=""` keeps that from
+            # aborting the whole import under `set -e`.
+            resolved=$(best_session_for_slug "$lookup_slug") || resolved=""
             if [ -n "$resolved" ]; then
                 # Tab-delimited fields; filesystem paths never contain a literal
                 # tab, so the split is unambiguous.
@@ -419,8 +453,11 @@ import_into() {
 
     echo ""
     echo "Imported: $imported  Skipped: $skipped"
-    [ "$imported" -gt 0 ] && \
+    # Use an `if` (not `&&`) so a zero-import run doesn't make this function —
+    # and the whole script under `set -e` — exit non-zero.
+    if [ "$imported" -gt 0 ]; then
         echo "Reopen the agent pane in the $target_version build to see the changes."
+    fi
 }
 
 # ── arg parsing ──────────────────────────────────────────────────────────────

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -308,20 +308,29 @@ import_into() {
                     ${_col_updated_at}, ${_col_user_hidden}
                  FROM db_agent_definitions WHERE id='$def_id';" 2>&1); then
                 case "$_def_copy_err" in
+                    *"dst."*)
+                        # Error names the attached TARGET schema (dst.*): the
+                        # target table is missing/corrupt or the target DB is not
+                        # an AgentMux DB. That's a target-side failure — abort,
+                        # don't mask it as a per-agent source skip (codex P2 on
+                        # #1380: "no such table: dst.db_agent_definitions").
+                        echo "ERROR: import aborted — target DB unusable for '$agent_name': ${_def_copy_err%%$'\n'*}" >&2
+                        exit 1
+                        ;;
                     *"no such column"*|*"no such table"*)
-                        # Source schema mismatch (an old / *.bak DB missing a
-                        # column the SELECT names) — skip THIS agent, continue.
+                        # SOURCE schema mismatch (an old / *.bak source missing a
+                        # column the SELECT names; the up-front probe already
+                        # proved the source TABLE exists) — skip THIS agent.
                         echo "  WARN  $agent_name — source schema mismatch; skipping (${_def_copy_err%%$'\n'*})" >&2
                         ((skipped++)) || true
                         continue
                         ;;
                     *)
-                        # The ATTACH/INSERT also writes the TARGET, so a non-schema
-                        # failure here is a target-side write problem (locked, read-only,
-                        # full disk, I/O). Abort loudly: silently skipping every agent
+                        # Any other failure (locked, read-only, full disk, I/O) is
+                        # target-side too — abort. Silently skipping every agent
                         # and exiting 0 would mask that the import never happened
                         # (codex P2 on #1380).
-                        echo "ERROR: import aborted — target write failed for '$agent_name': ${_def_copy_err%%$'\n'*}" >&2
+                        echo "ERROR: import aborted — write failed for '$agent_name': ${_def_copy_err%%$'\n'*}" >&2
                         exit 1
                         ;;
                 esac

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -194,7 +194,7 @@ import_into() {
 
     local tgt_win; tgt_win=$(win_path "$target_db")
     local ts; ts=$(now_ms)
-    local imported=0 skipped=0
+    local imported=0 skipped=0 copy_failures=0
 
     echo "Target: $target_db"
     echo ""
@@ -337,12 +337,18 @@ import_into() {
                         continue
                         ;;
                     *)
-                        # Any other failure (locked, read-only, full disk, I/O) is
-                        # target-side too — abort. Silently skipping every agent
-                        # and exiting 0 would mask that the import never happened
-                        # (codex P2 on #1380).
-                        echo "ERROR: import aborted — write failed for '$agent_name': ${_def_copy_err%%$'\n'*}" >&2
-                        exit 1
+                        # Ambiguous copy failure for THIS agent — e.g. a bare
+                        # `database is locked` / I/O error, which SQLite does not
+                        # attribute to source vs target (the source could lock
+                        # racing the up-front probe, or the target — the running
+                        # instance — could hold a transient write lock). Don't
+                        # abort the whole run: that would drop every later source
+                        # DB (codex P2 #345). WARN, record the failure, and skip
+                        # this agent. The end-of-run check exits non-zero so an
+                        # incomplete import is never reported as success.
+                        echo "  WARN  $agent_name — copy failed; skipping (${_def_copy_err%%$'\n'*})" >&2
+                        ((copy_failures++)) || true
+                        continue
                         ;;
                 esac
             fi
@@ -487,11 +493,19 @@ import_into() {
     done < <(all_dbs)
 
     echo ""
-    echo "Imported: $imported  Skipped: $skipped"
+    echo "Imported: $imported  Skipped: $skipped  Failed: $copy_failures"
     # Use an `if` (not `&&`) so a zero-import run doesn't make this function —
     # and the whole script under `set -e` — exit non-zero.
     if [ "$imported" -gt 0 ]; then
         echo "Reopen the agent pane in the $target_version build to see the changes."
+    fi
+    # Any per-agent copy failure (the ambiguous `*)` branch above) means the
+    # import is incomplete. Surface it as a non-zero exit so callers/CI never
+    # mistake a partial import for success — without having aborted the run and
+    # dropped the agents that DID copy.
+    if [ "$copy_failures" -gt 0 ]; then
+        echo "ERROR: $copy_failures agent(s) failed to copy (see WARN lines above); import incomplete." >&2
+        exit 1
     fi
 }
 

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -307,9 +307,24 @@ import_into() {
                     is_seeded, accounts, parent_id, branch_label,
                     ${_col_updated_at}, ${_col_user_hidden}
                  FROM db_agent_definitions WHERE id='$def_id';" 2>&1); then
-                echo "  WARN  $agent_name — definition copy failed; skipping (${_def_copy_err%%$'\n'*})" >&2
-                ((skipped++)) || true
-                continue
+                case "$_def_copy_err" in
+                    *"no such column"*|*"no such table"*)
+                        # Source schema mismatch (an old / *.bak DB missing a
+                        # column the SELECT names) — skip THIS agent, continue.
+                        echo "  WARN  $agent_name — source schema mismatch; skipping (${_def_copy_err%%$'\n'*})" >&2
+                        ((skipped++)) || true
+                        continue
+                        ;;
+                    *)
+                        # The ATTACH/INSERT also writes the TARGET, so a non-schema
+                        # failure here is a target-side write problem (locked, read-only,
+                        # full disk, I/O). Abort loudly: silently skipping every agent
+                        # and exiting 0 would mask that the import never happened
+                        # (codex P2 on #1380).
+                        echo "ERROR: import aborted — target write failed for '$agent_name': ${_def_copy_err%%$'\n'*}" >&2
+                        exit 1
+                        ;;
+                esac
             fi
 
             # Verify the definition was actually inserted.

--- a/scripts/import-agents.sh
+++ b/scripts/import-agents.sh
@@ -263,9 +263,20 @@ import_into() {
         # sqlite3.exe emits CRLF on Windows; the trailing CR contaminates the
         # last char(1)-delimited field (the slug), which silently breaks the
         # on-disk session lookup below. Strip CR so every field is clean.
-        agents=$(db_query "$src_db" \
-            "SELECT id||char(1)||name||char(1)||COALESCE(${_col_slug},'') FROM db_agent_definitions WHERE $where;" 2>/dev/null \
-            | tr -d '\r') || agents=""
+        # Distinguish a genuine query FAILURE (corruption hit mid-scan, or a
+        # column the WHERE/SELECT names — e.g. is_seeded — missing despite the
+        # table existing, which the up-front probe doesn't catch) from an empty
+        # result. A bare `|| agents=""` would mask the failure as "no agents"
+        # and skip the DB with no WARN (codex P2 on #1380). Capture stdout+stderr
+        # with the exit code; on failure WARN + skip this source DB.
+        local _agents_out
+        if _agents_out=$(sqlite3 "$src_win" \
+            "SELECT id||char(1)||name||char(1)||COALESCE(${_col_slug},'') FROM db_agent_definitions WHERE $where;" 2>&1); then
+            agents=$(printf '%s' "$_agents_out" | tr -d '\r')
+        else
+            echo "  WARN  skipping source DB (agent query failed: ${_agents_out%%$'\n'*}): $src_db" >&2
+            continue
+        fi
         [ -z "$agents" ] && continue
 
         while IFS=$'\x01' read -r def_id agent_name agent_slug; do


### PR DESCRIPTION
## Problem

`import-agents.sh` scans every `objects.db` under `~/.agentmux` and copies user agents into a target version. The per-source-DB loop runs under `set -euo pipefail` with several **unguarded** sqlite calls, so the **first error on any one source DB aborts the entire import** — silently dropping every agent in DBs not yet scanned, and exiting non-zero with no explanation.

**Observed live:** importing into a freshly-built 0.44.2 dropped a real agent (`Spixo`) whose data lived in a later-sorted DB. A stale `*.bak` channel (and old pre-agent-schema `versions/0.33.x` DBs) mid-scan tripped the abort. Running with `--name Spixo` "worked" only because the filter skipped the offending DBs before they could abort.

## Root causes fixed

| # | Abort point | Fix |
|---|---|---|
| 1 | `resolved=$(best_session_for_slug ...)` — the function returns non-zero when an agent has **no on-disk session** (a normal case), which `set -e` turned into a full abort | `\|\| resolved=""` at the call site |
| 2 | The definition-copy `INSERT` was unguarded; an old/`*.bak` source schema **missing a referenced column** errored → abort | capture stderr, `WARN` + skip that agent, `continue` |
| 3 | Unreadable / locked / **table-less** source DBs aborted the agents query | probe each DB first; pre-agent-schema DBs (no `db_agent_definitions`) skip **silently**, genuine corruption/locks `WARN` |
| 4 | `sqlite3.exe` emits **CRLF on Windows** → trailing `\r` on the last `char(1)` field (the slug) → silently broke on-disk session lookup | `tr -d '\r'` on the query result |
| 5 | `[ "$imported" -gt 0 ] && echo …` poisoned the function's exit code → a zero-import run exited 1 | converted to an `if` |

Net behavior: a single bad/old/locked source DB can no longer abort the import; problems are surfaced as `WARN` lines instead of a silent early exit.

## Testing

Re-ran the exact unscoped import that previously aborted:

- **Before:** aborted after the first 2 agents, exit 1, `Spixo` dropped, no summary.
- **After:** traverses all DBs (60+ ancient `0.33.x` DBs skipped silently), `exit 0`, prints `Imported: N  Skipped: M`, and `Maksi`/`Mopeo`/`Spixo` import correctly with their sessions wired.

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)