### PR TITLE
fix(build): agents run the app's own bashwrap, not a stale system-PATH copy

### DIFF
--- a/.changesets/1781339585-fix-build-agents-always-run-the-app-s-own-bashwrap-not-a-sta-nmpt.md
+++ b/.changesets/1781339585-fix-build-agents-always-run-the-app-s-own-bashwrap-not-a-sta-nmpt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): agents always run the app's own bashwrap, not a stale system-PATH copy — dev build now bundles agentmux-bashwrap into the runtime tools/bin, and the sidecar PREPENDS the bundled (version-locked) tools dir to the agent PATH instead of appending it (was the exit-130 root cause: a stale Downloads-portable bashwrap on the system PATH shadowed the fixed bundled one)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -463,11 +463,11 @@ tasks:
             # launcher now drives srv + host on macOS dev too, so build it
             # alongside the host. They co-locate in dist/cef-dev/ (flat
             # layout) — see dev:serve's Unix branch.
-            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef -p agentmux-launcher'
+            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef -p agentmux-launcher -p agentmux-bashwrap'
             - mkdir -p dist/cef
             - cp target/release/agentmux-cef dist/cef/agentmux-cef
             - cp target/release/agentmux-launcher dist/cef/agentmux-launcher
-            - echo "✓ Built host + launcher for macOS"
+            - echo "✓ Built host + launcher + bashwrap for macOS"
 
     build:host:linux:
         internal: true
@@ -488,11 +488,11 @@ tasks:
             # + host + srv co-located in dist/cef-dev/) has it — same as
             # build:host:darwin. Without this, dev:serve's launcher-not-found
             # guard hard-fails on Linux.
-            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef --features patched-libcef && PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-launcher'
+            - bash -c 'source "$HOME/.cargo/env" 2>/dev/null; PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-cef --features patched-libcef && PATH="$HOME/.cargo/bin:$PATH" cargo build --release -p agentmux-launcher -p agentmux-bashwrap'
             - mkdir -p dist/cef
             - cp target/release/agentmux-cef dist/cef/agentmux-cef
             - cp target/release/agentmux-launcher dist/cef/agentmux-launcher
-            - echo "✓ Built host + launcher for Linux"
+            - echo "✓ Built host + launcher + bashwrap for Linux"
 
     bundle:
         desc: Bundle runtime binaries alongside the host executable.
@@ -732,7 +732,9 @@ tasks:
                   # PATH (exit-130). See
                   # docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md.
                   mkdir -p "$DEV_DIR/tools/bin"
-                  cp target/release/agentmux-bashwrap "$DEV_DIR/tools/bin/" 2>/dev/null || true
+                  # Fail loud: build:host:{darwin,linux} build -p agentmux-bashwrap,
+                  # so a missing binary here is a real regression, not "optional".
+                  cp target/release/agentmux-bashwrap "$DEV_DIR/tools/bin/"
                   if [ ! -f "$DEV_DIR/agentmux-launcher" ]; then
                     echo "❌ $DEV_DIR/agentmux-launcher not found — build:host:{{OS}} should have staged it"
                     exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -693,7 +693,16 @@ tasks:
                   # runtime/agentmux-srv-{ver}-windows.x64.exe first
                   # (agentmux-launcher/src/srv_spawner.rs:295-307).
                   cp dist/bin/agentmux-srv-*-windows.x64.exe "$DEV_DIR/runtime/" 2>/dev/null || true
-                  echo "Built $DEV_DIR with launcher layout (launcher at root, host + DLLs + srv in runtime/)"
+                  # Streaming bash wrapper — agents resolve `agentmux-bashwrap`
+                  # via the bundled tools/bin (agentmux-srv prepends it to the
+                  # agent PATH). Without this, dev agents fall through to a
+                  # STALE agentmux-bashwrap elsewhere on the system PATH and
+                  # silently run a pre-fix binary (exit-130). Mirrors
+                  # scripts/package-portable.sh:121. See
+                  # docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md.
+                  mkdir -p "$DEV_DIR/runtime/tools/bin"
+                  cp target/release/agentmux-bashwrap.exe "$DEV_DIR/runtime/tools/bin/"
+                  echo "Built $DEV_DIR with launcher layout (launcher at root, host + DLLs + srv in runtime/, bashwrap in runtime/tools/bin/)"
                 else
                   # Unix flat layout (Phase 1,
                   # SPEC_LAUNCHER_MACOS_DEV_INTEGRATION_2026_05_30): launcher
@@ -717,6 +726,13 @@ tasks:
                     SRV_SRC="dist/bin/agentmux-srv-{{.VERSION}}-linux.x64"
                   fi
                   cp "$SRV_SRC" "$DEV_DIR/agentmux-srv" 2>/dev/null || true
+                  # Streaming bash wrapper — flat layout means the sidecar's
+                  # bundled_tools_dir is "$DEV_DIR/tools/bin". Without this,
+                  # agents resolve a stale agentmux-bashwrap off the system
+                  # PATH (exit-130). See
+                  # docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md.
+                  mkdir -p "$DEV_DIR/tools/bin"
+                  cp target/release/agentmux-bashwrap "$DEV_DIR/tools/bin/" 2>/dev/null || true
                   if [ ! -f "$DEV_DIR/agentmux-launcher" ]; then
                     echo "❌ $DEV_DIR/agentmux-launcher not found — build:host:{{OS}} should have staged it"
                     exit 1

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -534,30 +534,51 @@ impl Controller for ShellController {
             // See specs/SPEC_RETIRE_WSH_2026_04_12.md.
             c.env("AGENTMUX", "1");
 
-            // Append AgentMux-managed tool dirs to PATH so agents can use
-            // jq, rg, etc. without the host having them installed system-wide.
-            // Appended (not prepended) so system PATH always wins.
+            // Wire AgentMux-managed tool dirs into the agent's PATH.
+            //
+            // Two stores, two precedence rules:
+            //
+            //   • Bundled store (`<exe_dir>/tools/bin`) ships the app's OWN
+            //     version-locked binaries — notably `agentmux-bashwrap`, the
+            //     streaming hook that MUST match the running build. It is
+            //     PREPENDED so it wins over any stale copy elsewhere on the
+            //     system PATH. A stale system-PATH `agentmux-bashwrap` (from a
+            //     leftover portable) silently shadowed the fixed one and
+            //     reintroduced the exit-130 bug — see
+            //     docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md. The
+            //     bundled jq/rg winning too is intended: agents get the app's
+            //     curated, deterministic tool versions regardless of host.
+            //
+            //   • User-managed store (`~/.agentmux/tools/bin`) holds tools the
+            //     user installed via /tools. APPENDED so the user's own system
+            //     PATH still wins for those.
             {
                 let sep = if cfg!(windows) { ";" } else { ":" };
                 let current_path = std::env::var("PATH").unwrap_or_default();
-                let mut extra: Vec<String> = Vec::new();
+                let mut prepend: Vec<String> = Vec::new();
+                let mut append: Vec<String> = Vec::new();
 
-                // User-managed store (~/.agentmux/tools/bin/)
-                if let Some(user_bin) = crate::backend::tool_store::user_tools_dir() {
-                    if user_bin.exists() {
-                        extra.push(user_bin.to_string_lossy().into_owned());
-                    }
-                }
-
-                // Bundled store (ships with the app, e.g. runtime/tools/bin/)
+                // Bundled store — prepended (app-owned, version-locked).
                 if let Some(bundled_bin) = crate::backend::tool_store::bundled_tools_dir() {
                     if bundled_bin.exists() {
-                        extra.push(bundled_bin.to_string_lossy().into_owned());
+                        prepend.push(bundled_bin.to_string_lossy().into_owned());
                     }
                 }
 
-                if !extra.is_empty() {
-                    c.env("PATH", format!("{current_path}{sep}{}", extra.join(sep)));
+                // User-managed store — appended (system PATH still wins).
+                if let Some(user_bin) = crate::backend::tool_store::user_tools_dir() {
+                    if user_bin.exists() {
+                        append.push(user_bin.to_string_lossy().into_owned());
+                    }
+                }
+
+                if !prepend.is_empty() || !append.is_empty() {
+                    let mut parts = prepend;
+                    if !current_path.is_empty() {
+                        parts.push(current_path);
+                    }
+                    parts.extend(append);
+                    c.env("PATH", parts.join(sep));
                 }
             }
 

--- a/docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md
+++ b/docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md
@@ -1,0 +1,106 @@
+# Retro: the exit-130 fix was correct for weeks — the agent never ran it
+
+**Date:** 2026-06-13
+**Severity:** High (masked a real fix; caused repeated "still broken" cycles)
+**Status:** Root-caused. Immediate stopgap applied. Deterministic fix proposed (not yet shipped).
+
+---
+
+## TL;DR
+
+The bashwrap **exit-130 fix (#1368) was correct and merged to `main`**, yet agents (e.g. Qooma) in a fresh `task dev` build kept hitting exit 130. Cause is **not** the code — it's the **build/bundle/resolution path**:
+
+The agent's `agentmux-bashwrap` hook is a **bare PATH lookup**, the dev build **doesn't populate its own `tools/bin`**, the sidecar **appends** tool dirs ("system PATH wins"), and a **stale Downloads portable** (`agentmux-0.44.1+g6fc6d864.dirty.…-portable\runtime\tools\bin`, built *before* the fix) was sitting on the **system PATH**. So every agent resolved that stale binary instead of the build it was part of.
+
+**The "fix didn't work" reports throughout the saga were a bundling artifact, not a code regression.** Manual tests passed because they ran `./target/release/agentmux-bashwrap.exe` directly; the *agent* ran a different, stale binary off the system PATH.
+
+---
+
+## How it actually resolves (the 3-layer trap)
+
+1. **The hook is a bare command.** `agentmux-srv/src/backend/agent_config.rs:331` injects the Claude Code hook as `"command": "agentmux-bashwrap hook"` — resolved via the **agent process's PATH**, not an absolute path.
+
+2. **Tool dirs are appended, gated on existence.** `agentmux-srv/src/backend/blockcontroller/shell.rs:~540`:
+   ```rust
+   // "Appended (not prepended) so system PATH always wins."
+   // user store (~/.agentmux/tools/bin) — only if .exists()
+   // bundled store (<exe_dir>/tools/bin) — only if .exists()
+   c.env("PATH", format!("{current_path}{sep}{}", extra.join(sep)));
+   ```
+   - In a dev build the sidecar runs from `dist/cef-dev/runtime/`, so `bundled_tools_dir()` = `dist/cef-dev/runtime/tools/bin` — **which `task dev` never creates** → not added.
+   - `~/.agentmux/tools/bin` — **doesn't exist** → not added.
+   - Net: **no tool dir on the agent PATH**, and even if one existed it's appended → a system-PATH copy still wins.
+
+3. **A stale portable was on the system PATH.**
+   ```
+   PATH ⊃ C:\Users\asafe\Downloads\agentmux-0.44.1+g6fc6d864.dirty.20260612T092359…-portable\runtime\tools\bin
+   ```
+   `g6fc6d864` predates #1368. `Get-Command agentmux-bashwrap` → that path. The agent ran it → exit 130.
+
+### Evidence
+`~/.agentmux/logs/bashwrap-debug.log`, current build, 08:12:38:
+```
+exec start tool_id=toolu_01Gq38… command_len=57
+spawning bash -c via PTY …
+PATH fix-up …
+publisher done … chunks_published=0 chunks_failed=0     ← exit-130 signature
+```
+No `PTY child exited exit_code=` line — but that diagnostic line **is part of #1368**. Its absence proves the running binary predates the fix. (An earlier 01:57 entry that *did* run a fixed binary shows `PTY child exited exit_code=0`.)
+
+`bundled_tools_dir()` also deliberately returns `None` under `target/debug|release` (so a bare `cargo run` host has no bundled store) — fine in principle, but it means dev correctness depends entirely on the assembled `dist/cef-dev/runtime/tools/bin`, which isn't assembled.
+
+---
+
+## Why the package path worked but dev didn't
+
+Packaging copies the freshly-built tool into the portable: `cp target/release/agentmux-bashwrap.exe $PORTABLE/runtime/tools/bin/`. So **packaged** builds bundle the current binary. The **dev** path (`task dev` → `dev:serve` → `build:host` → `bundle`) assembles the CEF runtime but **never populates `runtime/tools/bin`**. Dev silently inherits whatever `agentmux-bashwrap` is first on the system PATH.
+
+---
+
+## Immediate stopgap (applied 2026-06-13)
+
+Overwrote the PATH-winning stale binary with a fresh build:
+```
+cp -f target/release/agentmux-bashwrap.exe \
+  "C:\Users\asafe\Downloads\agentmux-…g6fc6d864…-portable\runtime\tools\bin\agentmux-bashwrap.exe"
+```
+Verified the fresh binary: `echo …; cat; echo EOF_OK` → `<exited 0>` (no 130; the brace-group `{…} </dev/null` gives stdin-readers EOF without hanging). Qooma's next bash call uses it. **This is a hack — it patches a random Downloads build that happens to be on PATH. The build must stop depending on that.**
+
+---
+
+## Deterministic fix (proposed)
+
+Two changes, both needed; **B is the real determinism fix**:
+
+### A — Dev build bundles its own tools (`Taskfile.yml`)
+Have the dev assembly (`dev:serve` / `build:host`) copy the freshly-built tool binaries into `dist/cef-dev/runtime/tools/bin/`, mirroring the package path. Then the bundled store exists for dev and contains the *current* binary. (Necessary but not sufficient — see B.)
+
+### B — Resolve `agentmux-bashwrap` by absolute path, not bare PATH (the real fix)
+`agentmux-bashwrap` is **the app's own version-locked streaming hook**, not a generic user tool like `jq`/`rg`. It must never be resolved by a bare PATH lookup that a stale system copy can win.
+- Change the hook injection (`agent_config.rs`) to use the **absolute path to the bundled binary** (`<exe_dir>/tools/bin/agentmux-bashwrap[.exe]`, with the `target/release` dev fallback), e.g. `"command": "<abs>/agentmux-bashwrap hook"`.
+- Equivalently, **prepend** AgentMux-owned tool dirs for app-owned binaries (keep append-semantics only for generic third-party tools). The current blanket "append so system PATH wins" is correct for `jq` but wrong for our own hook.
+- This makes the binary version-locked to the running build and immune to any stale copy anywhere on PATH.
+
+### C — Don't let stale portables poison the PATH (hygiene + guardrail)
+- The stale `…Downloads\…portable\runtime\tools\bin` on the system PATH is the proximate trigger. Recommend removing portable `tools/bin` dirs from the persistent system/user PATH.
+- Guardrail: at sidecar startup, **log the resolved `agentmux-bashwrap` path + its version** (add `--version` to bashwrap) and warn if it isn't the bundled one. A one-line "agent will use bashwrap at X (vY)" would have caught this in seconds.
+
+### Verification plan for the fix
+After A+B, on a fresh `task dev`: run an agent bash command and confirm `bashwrap-debug.log` shows the `PTY child exited exit_code=0` line (proves the #1368 binary) and that the resolved path is `dist/cef-dev/runtime/tools/bin/…`, regardless of what's on the system PATH.
+
+---
+
+## Lessons
+
+1. **"Merged" ≠ "shipped to the runtime that runs it."** A fix landing on `main` and even in `target/release` doesn't mean the *agent* executes it. Always verify *which binary actually ran* (path + version), not just the source.
+2. **Version-locked, app-owned binaries must be resolved by absolute path** — never a bare PATH lookup with app dirs appended behind the system PATH.
+3. **Dev and package build paths must bundle identically.** Dev skipping `tools/bin` created a class of "works in package, broken in dev (or vice-versa)" bugs that are maddening to chase.
+4. **Cheap observability would have saved the whole saga**: log the resolved hook binary path + version at agent spawn. Add `agentmux-bashwrap --version`.
+5. The repeated "still broken" cycles cost real time precisely because we trusted the source/the merge instead of inspecting the live binary the agent invoked.
+
+---
+
+## Related
+- #1368 (the exit-130 code fix — correct), D#1205 (floating-pane/tear-off thread), `docs/retros/RETRO_BASHWRAP_EXIT130_2026_06_12.md` (the original code-level retro — this one is the *delivery* retro).
+
+*Written 2026-06-13 by AgentX.*


### PR DESCRIPTION
## Root cause

The exit-130 fix (#1368) has been on `main` for a while, yet agents in a fresh `task dev` build kept hitting exit 130. **The code was right; the build never shipped it to the agent.** Full write-up: `docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md`.

The agent's `agentmux-bashwrap` hook is a **bare PATH lookup**. It resolved on the system PATH to a **stale leftover portable**:
```
C:\Users\asafe\Downloads\agentmux-…g6fc6d864…-portable\runtime\tools\bin\agentmux-bashwrap.exe   (pre-fix)
```
…because:
- **`task dev` never populated its own `runtime/tools/bin`** → the bundled store was empty in dev.
- **The sidecar *appended* tool dirs** ("system PATH wins", `shell.rs`) → even a present bundled binary couldn't win.

So every agent ran whatever `agentmux-bashwrap` happened to be first on the system PATH.

## Fix

**A — `Taskfile.yml` `dev:serve`** copies the freshly-built `agentmux-bashwrap` into the dev runtime's `tools/bin` (Windows: `$DEV_DIR/runtime/tools/bin`; Unix flat: `$DEV_DIR/tools/bin`), mirroring `scripts/package-portable.sh:121`. The bundled store now exists in dev with the **current** binary.

**B — `shell.rs`** now **prepends** the bundled (app-owned, version-locked) tools dir to the agent PATH and **appends** only the user store. `agentmux-bashwrap` is the app's own streaming hook and must match the running build — it now wins over any stale copy anywhere on PATH. (Bundled `jq`/`rg` winning too is intended: agents get deterministic tool versions. User-managed `~/.agentmux/tools/bin` stays appended so the user's system PATH still wins for those.)

## Why this is the real fix vs. the stopgap

The immediate unblock (overwriting the PATH-winning stale binary) patched a random Downloads build — non-deterministic. This makes the dev build **bundle and prefer its own** version-locked binary, so it can't happen again regardless of what's on the host PATH.

## Verification

- `cargo check -p agentmux-srv` clean.
- After this, a fresh `task dev` produces `dist/cef-dev/runtime/tools/bin/agentmux-bashwrap.exe` (current build), and the sidecar prepends it → the agent's `agentmux-bashwrap` resolves to it. Confirm via `bashwrap-debug.log`: the `PTY child exited exit_code=N` line (present only in the fixed binary) + `chunks_published > 0`.

## Follow-ups (in the retro, not this PR)
- `agentmux-bashwrap --version` + log the resolved hook path/version at agent spawn (cheap guardrail that would've caught this instantly).
- Get stale portable `tools/bin` dirs off the persistent system PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)