### PR TITLE
feat(registry): global agent-definition store — cross-channel P0.2a

### DIFF
--- a/.changesets/1781346106-feat-registry-global-agent-definition-store-cross-channel-p0-3uyy.md
+++ b/.changesets/1781346106-feat-registry-global-agent-definition-store-cross-channel-p0-3uyy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(registry): global agent-definition store (cross-channel P0.2a)

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -34,9 +34,37 @@ pub struct DefinitionRecord {
     pub data: DefinitionRecordV1,
 }
 
+/// A content blob (system prompt / mcp / env / soul / startup) attached to
+/// a definition — mirrors a `db_agent_content` row. Carried in the global
+/// record so a cross-channel agent launches with its instructions even
+/// though `db_agent_content` is per-version. (codex P1 on #1384.)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DefContentBlob {
+    pub content_type: String,
+    pub content: String,
+}
+
+/// A skill attached to a definition — mirrors a `db_agent_skills` row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DefSkillBlob {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default)]
+    pub skill_type: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub content: String,
+}
+
 /// v1 definition payload — a faithful mirror of `AgentDefinition`'s
-/// columns. New fields go here under `#[serde(default)]` (so older files
-/// still deserialize) paired with a `DEF_MAX_SUPPORTED_SCHEMA` bump.
+/// columns, PLUS the per-definition content + skills blobs (which live in
+/// separate per-version tables and must travel with the definition for a
+/// cross-channel agent to launch with its instructions). New fields go
+/// here under `#[serde(default)]` (so older files still deserialize)
+/// paired with a `DEF_MAX_SUPPORTED_SCHEMA` bump.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DefinitionRecordV1 {
     pub id: String,
@@ -86,6 +114,13 @@ pub struct DefinitionRecordV1 {
     pub container_volumes: String,
     #[serde(default)]
     pub container_name: String,
+    /// System-prompt / mcp / env / soul / startup blobs (db_agent_content),
+    /// embedded so a cross-channel agent launches with its instructions.
+    #[serde(default)]
+    pub content: Vec<DefContentBlob>,
+    /// Skills (db_agent_skills) attached to this definition.
+    #[serde(default)]
+    pub skills: Vec<DefSkillBlob>,
 }
 
 #[derive(Debug, Error)]
@@ -163,6 +198,8 @@ mod tests {
                 container_image: String::new(),
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
+                content: Vec::new(),
+                skills: Vec::new(),
             },
         }
     }

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -1,0 +1,230 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Global **agent-definition** registry file format + per-row validation.
+//!
+//! Sibling of `schema.rs` (which describes the named *instance* record).
+//! This record carries a full agent **definition** so the roster can be
+//! reconstructed from any channel/version without joining the local
+//! channel's SQLite — the foundation of cross-channel agent persistence
+//! (`docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`, P0.2).
+//!
+//! Layering: the `registry` module must NOT depend on `backend::storage`
+//! (which already depends on `registry` — that would cycle). So the fields
+//! of `AgentDefinition` are mirrored here as a self-contained struct; the
+//! `AgentDefinition <-> DefinitionRecordV1` conversion lives in
+//! `backend::storage` (the dependent side). Bumping
+//! `DEF_MAX_SUPPORTED_SCHEMA` is the additive-evolution path, exactly like
+//! the instance record.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Lowest envelope schema this binary will load.
+pub const DEF_MIN_SUPPORTED_SCHEMA: u32 = 1;
+/// Highest envelope schema this binary will write or read. Bumped per
+/// release that adds fields to the definition payload.
+pub const DEF_MAX_SUPPORTED_SCHEMA: u32 = 1;
+
+/// On-disk envelope for a global agent-definition record. Stored at
+/// `<shared>/agents/definitions/<id>.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DefinitionRecord {
+    pub schema_version: u32,
+    pub data: DefinitionRecordV1,
+}
+
+/// v1 definition payload — a faithful mirror of `AgentDefinition`'s
+/// columns. New fields go here under `#[serde(default)]` (so older files
+/// still deserialize) paired with a `DEF_MAX_SUPPORTED_SCHEMA` bump.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DefinitionRecordV1 {
+    pub id: String,
+    #[serde(default)]
+    pub slug: String,
+    pub name: String,
+    #[serde(default)]
+    pub icon: String,
+    pub provider: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub working_directory: String,
+    #[serde(default)]
+    pub shell: String,
+    #[serde(default)]
+    pub provider_flags: String,
+    #[serde(default)]
+    pub auto_start: i64,
+    #[serde(default)]
+    pub restart_on_crash: i64,
+    #[serde(default)]
+    pub idle_timeout_minutes: i64,
+    #[serde(default)]
+    pub created_at: i64,
+    #[serde(default)]
+    pub agent_type: String,
+    #[serde(default)]
+    pub environment: String,
+    #[serde(default)]
+    pub agent_bus_id: String,
+    #[serde(default)]
+    pub is_seeded: i64,
+    #[serde(default)]
+    pub accounts: String,
+    #[serde(default)]
+    pub parent_id: String,
+    #[serde(default)]
+    pub branch_label: String,
+    #[serde(default)]
+    pub updated_at: i64,
+    #[serde(default)]
+    pub user_hidden: i64,
+    #[serde(default)]
+    pub container_image: String,
+    #[serde(default)]
+    pub container_volumes: String,
+    #[serde(default)]
+    pub container_name: String,
+}
+
+#[derive(Debug, Error)]
+pub enum DefValidationError {
+    #[error("schema_version {version} outside supported [{min}, {max}]")]
+    UnsupportedSchema { version: u32, min: u32, max: u32 },
+    #[error("filename {filename:?} does not match data.id {id:?}")]
+    IdMismatch { filename: String, id: String },
+    #[error("required field missing: {0}")]
+    MissingField(&'static str),
+}
+
+/// Per-row validation. Mirrors `schema::validate`: reject anything that
+/// would surface a malformed definition to the roster. Failures are
+/// skipped (not auto-fixed), logged, and the file stays on disk for ops
+/// triage.
+pub fn validate(filename_stem: &str, rec: &DefinitionRecord) -> Result<(), DefValidationError> {
+    if rec.schema_version < DEF_MIN_SUPPORTED_SCHEMA || rec.schema_version > DEF_MAX_SUPPORTED_SCHEMA
+    {
+        return Err(DefValidationError::UnsupportedSchema {
+            version: rec.schema_version,
+            min: DEF_MIN_SUPPORTED_SCHEMA,
+            max: DEF_MAX_SUPPORTED_SCHEMA,
+        });
+    }
+    let d = &rec.data;
+    if d.id.is_empty() {
+        return Err(DefValidationError::MissingField("id"));
+    }
+    if d.id != filename_stem {
+        return Err(DefValidationError::IdMismatch {
+            filename: filename_stem.to_string(),
+            id: d.id.clone(),
+        });
+    }
+    if d.name.is_empty() {
+        return Err(DefValidationError::MissingField("name"));
+    }
+    if d.provider.is_empty() {
+        return Err(DefValidationError::MissingField("provider"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str) -> DefinitionRecord {
+        DefinitionRecord {
+            schema_version: 1,
+            data: DefinitionRecordV1 {
+                id: id.to_string(),
+                slug: id.to_string(),
+                name: "Demo".to_string(),
+                icon: "✦".to_string(),
+                provider: "claude".to_string(),
+                description: String::new(),
+                working_directory: String::new(),
+                shell: String::new(),
+                provider_flags: String::new(),
+                auto_start: 0,
+                restart_on_crash: 0,
+                idle_timeout_minutes: 0,
+                created_at: 1,
+                agent_type: "host".to_string(),
+                environment: String::new(),
+                agent_bus_id: String::new(),
+                is_seeded: 0,
+                accounts: String::new(),
+                parent_id: String::new(),
+                branch_label: String::new(),
+                updated_at: 1,
+                user_hidden: 0,
+                container_image: String::new(),
+                container_volumes: "[]".to_string(),
+                container_name: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn happy_path() {
+        validate("abc", &rec("abc")).unwrap();
+    }
+
+    #[test]
+    fn unsupported_schema_is_rejected() {
+        let mut r = rec("abc");
+        r.schema_version = 999;
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            DefValidationError::UnsupportedSchema { .. }
+        ));
+    }
+
+    #[test]
+    fn filename_mismatch_is_rejected() {
+        assert!(matches!(
+            validate("xyz", &rec("abc")).unwrap_err(),
+            DefValidationError::IdMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_name_is_rejected() {
+        let mut r = rec("abc");
+        r.data.name = String::new();
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            DefValidationError::MissingField("name")
+        ));
+    }
+
+    #[test]
+    fn missing_provider_is_rejected() {
+        let mut r = rec("abc");
+        r.data.provider = String::new();
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            DefValidationError::MissingField("provider")
+        ));
+    }
+
+    #[test]
+    fn unknown_fields_survive_round_trip() {
+        // A future field this binary doesn't know must deserialize cleanly
+        // (serde ignores unknown keys) so a newer writer's record still loads.
+        let raw = serde_json::json!({
+            "schema_version": 1,
+            "data": {
+                "id": "abc", "name": "Demo", "provider": "claude",
+                "future_field": "ignored"
+            }
+        });
+        let parsed: DefinitionRecord = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.data.id, "abc");
+        assert_eq!(parsed.data.provider, "claude");
+        // Defaulted field absent from JSON.
+        assert_eq!(parsed.data.container_volumes, "");
+    }
+}

--- a/agentmux-srv/src/registry/def_store.rs
+++ b/agentmux-srv/src/registry/def_store.rs
@@ -1,0 +1,362 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `DefinitionStore` — file-per-definition CRUD on `<root>/<id>.json`
+//! with a sibling `retired/<id>.json` tombstone tree.
+//!
+//! Sibling of `store.rs` (the named-*instance* `Registry`). Same on-disk
+//! discipline: atomic rename for cross-process safety, a forward-compat
+//! merge that preserves unknown fields, refuses schema downgrades, and
+//! never clobbers an unparseable file. Holds the GLOBAL agent-definition
+//! roster so any channel/version sees the same agents (P0.2 of
+//! `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`).
+//!
+//! The forward-compat merge helpers below intentionally parallel the
+//! private ones in `store.rs`. They are kept separate (not shared) so
+//! this addition is fully isolated from the in-production instance
+//! registry; a later cleanup can extract a generic file-store both use.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde_json::Value;
+use thiserror::Error;
+
+use super::atomic::{rename_atomic, write_atomic};
+use super::def_schema::{validate, DefValidationError, DefinitionRecord, DEF_MAX_SUPPORTED_SCHEMA};
+
+#[derive(Debug, Error)]
+pub enum DefStoreError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("validation: {0}")]
+    Validation(#[from] DefValidationError),
+}
+
+pub struct DefinitionStore {
+    root: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl DefinitionStore {
+    /// Open or create the store rooted at `root`. Ensures the active dir
+    /// and `retired/` subdir both exist.
+    pub fn open(root: PathBuf) -> Result<Self, DefStoreError> {
+        std::fs::create_dir_all(&root)?;
+        std::fs::create_dir_all(root.join("retired"))?;
+        Ok(Self {
+            root,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn active_path(&self, id: &str) -> PathBuf {
+        self.root.join(format!("{id}.json"))
+    }
+
+    fn retired_path(&self, id: &str) -> PathBuf {
+        self.root.join("retired").join(format!("{id}.json"))
+    }
+
+    /// Insert or update a definition. Preserves unknown top-level + `data`
+    /// fields on an existing file (forward-compat); refuses to overwrite a
+    /// corrupt or higher-schema file.
+    pub fn upsert(&self, rec: &DefinitionRecord) -> Result<(), DefStoreError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let path = self.active_path(&rec.data.id);
+        let bytes = match std::fs::read(&path) {
+            Ok(existing) => match merge_for_write(&existing, rec)? {
+                Some(b) => b,
+                None => return Ok(()),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => to_pretty(rec)?,
+            Err(e) => return Err(e.into()),
+        };
+        write_atomic(&path, &bytes)?;
+        Ok(())
+    }
+
+    /// Soft-delete → move into `retired/` (tombstone). Idempotent. The
+    /// tombstone prevents another channel's migration from resurrecting an
+    /// agent the user deliberately deleted.
+    pub fn retire(&self, id: &str) -> Result<(), DefStoreError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let from = self.active_path(id);
+        if !from.exists() {
+            return Ok(());
+        }
+        rename_atomic(&from, &self.retired_path(id))?;
+        Ok(())
+    }
+
+    /// Move a record back from `retired/` to active. Idempotent.
+    pub fn unretire(&self, id: &str) -> Result<(), DefStoreError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let from = self.retired_path(id);
+        if !from.exists() {
+            return Ok(());
+        }
+        rename_atomic(&from, &self.active_path(id))?;
+        Ok(())
+    }
+
+    /// Hard-delete (drops both active and retired files). Mirrors SQLite
+    /// `agent_def_delete`. Use [`Self::retire`] when a resurrection-proof
+    /// tombstone is wanted instead.
+    pub fn hard_delete(&self, id: &str) -> Result<(), DefStoreError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        for p in [self.active_path(id), self.retired_path(id)] {
+            match std::fs::remove_file(&p) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    pub fn exists(&self, id: &str) -> bool {
+        self.active_path(id).exists()
+    }
+
+    pub fn exists_anywhere(&self, id: &str) -> bool {
+        self.active_path(id).exists() || self.retired_path(id).exists()
+    }
+
+    /// Read every valid active definition. Invalid files are skipped +
+    /// logged (left on disk for ops triage).
+    pub fn list_active(&self) -> Result<Vec<DefinitionRecord>, DefStoreError> {
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            match read_and_validate(&path, stem) {
+                Ok(rec) => out.push(rec),
+                Err(e) => {
+                    tracing::warn!(
+                        file = %path.display(),
+                        error = %e,
+                        "def registry: skipping invalid record"
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn read_and_validate(path: &Path, stem: &str) -> Result<DefinitionRecord, DefStoreError> {
+    let bytes = std::fs::read(path)?;
+    let rec: DefinitionRecord = serde_json::from_slice(&bytes)?;
+    validate(stem, &rec)?;
+    Ok(rec)
+}
+
+fn to_pretty(rec: &DefinitionRecord) -> Result<Vec<u8>, serde_json::Error> {
+    let mut bytes = serde_json::to_vec_pretty(rec)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Merge an in-memory record into an on-disk file's raw JSON, preserving
+/// fields beyond this binary's struct shape. Returns `Ok(None)` (skip,
+/// leave file intact) on corrupt JSON, missing `schema_version`, or
+/// `schema_version` above `DEF_MAX_SUPPORTED_SCHEMA`. Parallels
+/// `store.rs::merge_for_write` (see module docs).
+fn merge_for_write(
+    existing: &[u8],
+    rec: &DefinitionRecord,
+) -> Result<Option<Vec<u8>>, DefStoreError> {
+    let on_disk: Value = match serde_json::from_slice(existing) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "def registry: existing file is unparseable JSON — refusing to overwrite"
+            );
+            return Ok(None);
+        }
+    };
+    // `try_from` so a number above u32::MAX is treated as unparseable
+    // rather than wrapping past the forward-compat guard.
+    let on_disk_version = on_disk
+        .get("schema_version")
+        .and_then(|v| v.as_u64())
+        .and_then(|v| u32::try_from(v).ok());
+    match on_disk_version {
+        Some(v) if v > DEF_MAX_SUPPORTED_SCHEMA => {
+            tracing::warn!(
+                on_disk = v,
+                writer_max = DEF_MAX_SUPPORTED_SCHEMA,
+                "def registry: on-disk schema_version > writer max — refusing downgrade"
+            );
+            return Ok(None);
+        }
+        Some(_) => {}
+        None => {
+            tracing::warn!("def registry: existing file lacks schema_version — refusing to overwrite");
+            return Ok(None);
+        }
+    }
+    let mut merged = on_disk;
+    let updates = serde_json::to_value(rec)?;
+    merge_known(&mut merged, &updates);
+    let mut bytes = serde_json::to_vec_pretty(&merged)?;
+    bytes.push(b'\n');
+    Ok(Some(bytes))
+}
+
+/// Overwrite `target`'s top-level keys with `updates`' keys, preserving
+/// keys absent from `updates`; recurses into `data`.
+fn merge_known(target: &mut Value, updates: &Value) {
+    let (Some(t), Some(u)) = (target.as_object_mut(), updates.as_object()) else {
+        *target = updates.clone();
+        return;
+    };
+    for (k, v) in u {
+        if k == "data" {
+            if let Some(t_data) = t.get_mut("data") {
+                merge_known(t_data, v);
+                continue;
+            }
+        }
+        t.insert(k.clone(), v.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::DefinitionRecordV1;
+
+    fn store() -> (tempfile::TempDir, DefinitionStore) {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = DefinitionStore::open(tmp.path().join("definitions")).unwrap();
+        (tmp, s)
+    }
+
+    fn rec(id: &str, name: &str) -> DefinitionRecord {
+        DefinitionRecord {
+            schema_version: 1,
+            data: DefinitionRecordV1 {
+                id: id.to_string(),
+                slug: id.to_string(),
+                name: name.to_string(),
+                icon: "✦".to_string(),
+                provider: "claude".to_string(),
+                description: String::new(),
+                working_directory: String::new(),
+                shell: String::new(),
+                provider_flags: String::new(),
+                auto_start: 0,
+                restart_on_crash: 0,
+                idle_timeout_minutes: 0,
+                created_at: 1,
+                agent_type: "host".to_string(),
+                environment: String::new(),
+                agent_bus_id: String::new(),
+                is_seeded: 0,
+                accounts: String::new(),
+                parent_id: String::new(),
+                branch_label: String::new(),
+                updated_at: 1,
+                user_hidden: 0,
+                container_image: String::new(),
+                container_volumes: "[]".to_string(),
+                container_name: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn upsert_then_list() {
+        let (_t, s) = store();
+        s.upsert(&rec("aaa", "Demo")).unwrap();
+        let listed = s.list_active().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].data.name, "Demo");
+    }
+
+    #[test]
+    fn upsert_update_replaces_known_fields() {
+        let (_t, s) = store();
+        s.upsert(&rec("aaa", "Demo")).unwrap();
+        s.upsert(&rec("aaa", "Renamed")).unwrap();
+        let listed = s.list_active().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].data.name, "Renamed");
+    }
+
+    #[test]
+    fn retire_then_unretire_round_trips() {
+        let (_t, s) = store();
+        s.upsert(&rec("aaa", "Demo")).unwrap();
+        s.retire("aaa").unwrap();
+        assert!(s.list_active().unwrap().is_empty());
+        assert!(s.exists_anywhere("aaa"));
+        s.unretire("aaa").unwrap();
+        assert_eq!(s.list_active().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn hard_delete_removes_both_paths() {
+        let (_t, s) = store();
+        s.upsert(&rec("aaa", "Demo")).unwrap();
+        s.retire("aaa").unwrap();
+        s.upsert(&rec("bbb", "Demo2")).unwrap();
+        s.hard_delete("aaa").unwrap();
+        s.hard_delete("bbb").unwrap();
+        assert!(!s.exists_anywhere("aaa"));
+        assert!(!s.exists_anywhere("bbb"));
+    }
+
+    #[test]
+    fn unknown_field_survives_older_writer_update() {
+        let (_t, s) = store();
+        // Write a record carrying a future field directly to disk.
+        let path = s.root().join("aaa.json");
+        let raw = serde_json::json!({
+            "schema_version": 1,
+            "data": {
+                "id": "aaa", "name": "Demo", "provider": "claude",
+                "tags": ["keep-me"]
+            }
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+        // An older binary updates a known field.
+        s.upsert(&rec("aaa", "Renamed")).unwrap();
+        let on_disk: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(on_disk.pointer("/data/tags"), Some(&serde_json::json!(["keep-me"])));
+        assert_eq!(on_disk.pointer("/data/name"), Some(&serde_json::json!("Renamed")));
+    }
+
+    #[test]
+    fn refuses_to_downgrade_higher_schema_on_disk() {
+        let (_t, s) = store();
+        let path = s.root().join("aaa.json");
+        let v999 = serde_json::json!({
+            "schema_version": 999,
+            "data": { "id": "aaa", "future_only": "field" }
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&v999).unwrap()).unwrap();
+        s.upsert(&rec("aaa", "Renamed")).unwrap();
+        let after: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(after.pointer("/schema_version"), Some(&serde_json::json!(999)));
+        assert_eq!(after.pointer("/data/future_only"), Some(&serde_json::json!("field")));
+    }
+}

--- a/agentmux-srv/src/registry/def_store.rs
+++ b/agentmux-srv/src/registry/def_store.rs
@@ -75,7 +75,18 @@ impl DefinitionStore {
                 Some(b) => b,
                 None => return Ok(()),
             },
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => to_pretty(rec)?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Don't resurrect a tombstoned definition: a missing active
+                // file plus an existing `retired/<id>.json` means the agent
+                // was deliberately deleted (possibly in another channel). A
+                // stale cross-channel mirror calling `upsert` must NOT recreate
+                // it; the caller must `unretire` first to bring it back.
+                // (codex P1 on #1384.)
+                if self.retired_path(&rec.data.id).exists() {
+                    return Ok(());
+                }
+                to_pretty(rec)?
+            }
             Err(e) => return Err(e.into()),
         };
         write_atomic(&path, &bytes)?;
@@ -279,6 +290,8 @@ mod tests {
                 container_image: String::new(),
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
+                content: Vec::new(),
+                skills: Vec::new(),
             },
         }
     }
@@ -358,5 +371,23 @@ mod tests {
         let after: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(after.pointer("/schema_version"), Some(&serde_json::json!(999)));
         assert_eq!(after.pointer("/data/future_only"), Some(&serde_json::json!("field")));
+    }
+
+    #[test]
+    fn upsert_does_not_resurrect_a_tombstoned_definition() {
+        let (_t, s) = store();
+        s.upsert(&rec("aaa", "Demo")).unwrap();
+        s.retire("aaa").unwrap();
+        // A stale cross-channel mirror upserts the same id.
+        s.upsert(&rec("aaa", "Resurrected")).unwrap();
+        // Tombstone respected: still not active, not resurrected.
+        assert!(
+            s.list_active().unwrap().is_empty(),
+            "tombstoned definition must not be resurrected by upsert"
+        );
+        assert!(s.exists_anywhere("aaa"), "tombstone file still present");
+        // An explicit unretire is required to bring it back.
+        s.unretire("aaa").unwrap();
+        assert_eq!(s.list_active().unwrap().len(), 1);
     }
 }

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -31,8 +31,8 @@ mod tests;
 pub use migrate::{migrate_from_sqlite_once, MigrateStats};
 pub use paths::resolve_shared_registry_dir;
 pub use def_schema::{
-    DefValidationError, DefinitionRecord, DefinitionRecordV1, DEF_MAX_SUPPORTED_SCHEMA,
-    DEF_MIN_SUPPORTED_SCHEMA,
+    DefContentBlob, DefSkillBlob, DefValidationError, DefinitionRecord, DefinitionRecordV1,
+    DEF_MAX_SUPPORTED_SCHEMA, DEF_MIN_SUPPORTED_SCHEMA,
 };
 pub use def_store::{DefStoreError, DefinitionStore};
 pub use schema::{

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -18,6 +18,8 @@
 #![allow(dead_code, unused_imports)]
 
 mod atomic;
+mod def_schema;
+mod def_store;
 mod migrate;
 mod paths;
 mod schema;
@@ -28,6 +30,11 @@ mod tests;
 
 pub use migrate::{migrate_from_sqlite_once, MigrateStats};
 pub use paths::resolve_shared_registry_dir;
+pub use def_schema::{
+    DefValidationError, DefinitionRecord, DefinitionRecordV1, DEF_MAX_SUPPORTED_SCHEMA,
+    DEF_MIN_SUPPORTED_SCHEMA,
+};
+pub use def_store::{DefStoreError, DefinitionStore};
 pub use schema::{
     NamedAgentRecord, NamedAgentRecordV1, ValidationError, MAX_SUPPORTED_SCHEMA,
     MIN_SUPPORTED_SCHEMA,


### PR DESCRIPTION
**P0.2 step 1** of cross-channel agent persistence — `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (§11.4).

## Why
The instance registry references definitions by FK and joins their names/providers from the **current channel's** SQLite — which won't exist for an agent from another channel. So definitions need a **global** home of their own. This PR adds that store (the foundation); later steps mirror writes to it and read from it.

## What
- **`def_schema.rs`** — `DefinitionRecord` carrying all 25 `AgentDefinition` fields. The `registry` module can't depend on `backend::storage` (that would cycle — `backend::storage` already depends on `registry`), so the fields are mirrored here and the `AgentDefinition ↔ record` conversion lives on the dependent side. Includes a forward-compat (unknown-field) round-trip test.
- **`def_store.rs`** — `DefinitionStore`: file-per-definition CRUD at `~/.agentmux/shared/agents/definitions/<id>.json` with a `retired/` tombstone tree. `upsert` preserves unknown fields, refuses schema downgrades, never clobbers a corrupt/newer file; `retire`/`unretire` give resurrection-proof deletes; `hard_delete`, `list_active`.

## Scope / risk
**Store-only and unwired** (behind the module's existing `#![allow(dead_code)]`) — mirrors exactly how the instance registry's "PR A" staged its store before wiring. No behavior change. `cargo test`: **12 new tests pass**; no change to the in-production instance `Registry`.

The forward-compat merge helpers intentionally parallel `store.rs` to keep this isolated from the live instance registry; a follow-up can extract a shared generic file-store (noted in the module docs).

## Series
P0.1 (merged, #1383) → **P0.2a (this)** → P0.2b write-path mirror → P0.2c read-first + startup wiring + global migration → P0.3 re-root instances registry → P0.4 → P1 → P2 → P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)