### PR TITLE
feat(registry): cross-channel agent definitions — write-mirror + read-first (P0.2b+c)

### DIFF
--- a/.changesets/1781348722-feat-registry-cross-channel-agent-definitions-write-mirror-r-0qld.md
+++ b/.changesets/1781348722-feat-registry-cross-channel-agent-definitions-write-mirror-r-0qld.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(registry): cross-channel agent definitions write-mirror + read-first (P0.2b+c)

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -806,7 +806,18 @@ impl Store {
             // Mirror the updated definition into the global store. (P0.2b.)
             self.registry_def_upsert(&agent.id);
         }
-        Ok(rows > 0)
+        // Cross-channel edit: an agent surfaced only via the global overlay has
+        // no local SQLite row, so the UPDATE affected 0 rows. Apply the edit to
+        // the global record directly (preserving its content/skills) so editing
+        // a cross-channel agent isn't silently dropped with a "not found" error
+        // — symmetric with the unconditional cross-channel delete. (reagent P1
+        // on #1385.)
+        let updated_global = if rows == 0 {
+            self.registry_def_update_definition_fields(agent)
+        } else {
+            false
+        };
+        Ok(rows > 0 || updated_global)
     }
 
     /// Delete a agent definition by id. Returns true if a row was deleted.

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -431,6 +431,20 @@ impl Store {
         Ok(count)
     }
 
+    /// Whether a definition with `id` exists in the LOCAL channel's SQLite
+    /// (`db_agents`). Gates the cross-channel content/skills fallback: a
+    /// locally-known agent with genuinely empty content/skills must NOT
+    /// resurrect them from the global record. (reagent P1 on #1385.)
+    pub(super) fn agent_def_exists_local(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM db_agents WHERE id = ?1)",
+            params![id],
+            |row| row.get(0),
+        )?;
+        Ok(exists)
+    }
+
     /// Delete all seeded agents (is_seeded=1). Used by reseed to clear built-in agents.
     pub fn agent_def_delete_seeded(&self) -> Result<usize, StoreError> {
         // Reagent P1 round 4 on #1013: capture the cascaded instance ids

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -683,6 +683,10 @@ impl Store {
         let mut snapshot = agent.clone();
         snapshot.updated_at = stamped_updated_at;
         self.agents_dual_write_definition_upsert(&snapshot)?;
+        // Mirror the freshly-defined agent into the global store (agent.define
+        // path). Without this a define-created agent stays channel-local until
+        // a later edit. (codex P2 on #1385.)
+        self.registry_def_upsert(&agent.id);
 
         Ok(None)
     }
@@ -847,11 +851,14 @@ impl Store {
             for instance_id in &cascaded_instance_ids {
                 self.agents_dual_write_instance_delete(instance_id)?;
             }
-            // Tombstone the global definition record so another channel's
-            // stale SQLite can't resurrect this deleted user agent. (P0.2b.)
-            self.registry_def_retire(id);
         }
-        Ok(rows > 0)
+        // Tombstone the global definition record so another channel's stale
+        // SQLite can't resurrect this deleted user agent — AND so an agent
+        // that exists in THIS channel only via the global overlay (no local
+        // SQLite row, rows == 0) is actually deletable instead of reappearing
+        // on the next agent_def_list. (P0.2b + codex P1 on #1385.)
+        let global_retired = self.registry_def_retire(id);
+        Ok(rows > 0 || global_retired)
     }
 
     // AgentContent / AgentSkill / AgentHistory CRUD moved to

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -362,23 +362,56 @@ impl Store {
     }
 
     pub fn agent_def_list(&self) -> Result<Vec<AgentDefinition>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT id, slug, name, icon, provider, description,
-                    working_directory, shell, provider_flags, auto_start,
-                    restart_on_crash, idle_timeout_minutes, created_at,
-                    agent_type, environment, agent_bus_id, is_seeded,
-                    accounts, parent_template_id, branch_label, updated_at,
-                    user_hidden, container_image, container_volumes, container_name
-             FROM db_agents
-             ORDER BY updated_at DESC, created_at ASC",
-        )?;
-        let rows = stmt.query_map([], map_agent_definition_row)?;
-        let mut agents = Vec::new();
-        for row in rows {
-            agents.push(row?);
+        // Local SQLite: this channel's templates (seeded) + its own user agents.
+        let local: Vec<AgentDefinition> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT id, slug, name, icon, provider, description,
+                        working_directory, shell, provider_flags, auto_start,
+                        restart_on_crash, idle_timeout_minutes, created_at,
+                        agent_type, environment, agent_bus_id, is_seeded,
+                        accounts, parent_template_id, branch_label, updated_at,
+                        user_hidden, container_image, container_volumes, container_name
+                 FROM db_agents
+                 ORDER BY updated_at DESC, created_at ASC",
+            )?;
+            let rows = stmt.query_map([], map_agent_definition_row)?;
+            let mut agents = Vec::new();
+            for row in rows {
+                agents.push(row?);
+            }
+            agents
+        };
+        // conn dropped. Overlay the GLOBAL cross-channel user-agent roster so
+        // an agent created in another channel appears here too. The global
+        // store wins for user rows (it's authoritative and holds cross-channel
+        // agents); templates (seeded — never in the global store) come from
+        // local SQLite. Falls back to SQLite-only when the global store is
+        // absent or unreadable. (P0.2c.)
+        let Some(reg) = self.shared_def_registry() else {
+            return Ok(local);
+        };
+        let global = match reg.list_active() {
+            Ok(recs) => recs,
+            Err(e) => {
+                tracing::warn!(error = %e, "def registry: global list failed, using SQLite only");
+                return Ok(local);
+            }
+        };
+        let mut by_id: std::collections::HashMap<String, AgentDefinition> =
+            local.into_iter().map(|d| (d.id.clone(), d)).collect();
+        for rec in &global {
+            let def = super::def_registry_mirror::record_to_agent_definition(rec);
+            by_id.insert(def.id.clone(), def);
         }
-        Ok(agents)
+        let mut result: Vec<AgentDefinition> = by_id.into_values().collect();
+        // Match the SQL ORDER BY: updated_at DESC, then created_at ASC.
+        result.sort_by(|a, b| {
+            b.updated_at
+                .cmp(&a.updated_at)
+                .then(a.created_at.cmp(&b.created_at))
+        });
+        Ok(result)
     }
 
     /// Count agent rows (used by seed engine to check if seeding is needed).
@@ -520,6 +553,11 @@ impl Store {
         // Phase 3a dual-write (Phase 3b: errors propagate): mirror to
         // db_agents so readers see the new row immediately.
         self.agents_dual_write_definition_upsert(&snapshot)?;
+        // Mirror into the global cross-channel definition store. Content +
+        // skills are inserted after the definition (separate calls), so this
+        // initial record is content-less; agent_content_set / agent_skill_*
+        // re-mirror with the full payload. (P0.2b.)
+        self.registry_def_upsert(&agent.id);
         // Reagent P1 on #1013 round 2: do NOT mutate the caller's
         // `&mut AgentDefinition` here. The PR is supposed to be
         // zero-behaviour-change; the previous version reflected
@@ -670,7 +708,8 @@ impl Store {
         }
         // The hide flag is per-row; the write must still hit the legacy
         // table (cascade source) — dual-write mirrors into `db_agents`
-        // for the next read.
+        // for the next read. (Templates are seeded; they do NOT go to the
+        // global cross-channel def store, so no mirror here.)
         let rows = conn.execute(
             "UPDATE db_agent_definitions SET user_hidden = ?1 WHERE id = ?2",
             params![if hidden { 1_i64 } else { 0_i64 }, id],
@@ -746,6 +785,8 @@ impl Store {
         // db_agents so the next read sees the new name/payload.
         if rows > 0 {
             self.agents_dual_write_definition_upsert(agent)?;
+            // Mirror the updated definition into the global store. (P0.2b.)
+            self.registry_def_upsert(&agent.id);
         }
         Ok(rows > 0)
     }
@@ -792,6 +833,9 @@ impl Store {
             for instance_id in &cascaded_instance_ids {
                 self.agents_dual_write_instance_delete(instance_id)?;
             }
+            // Tombstone the global definition record so another channel's
+            // stale SQLite can't resurrect this deleted user agent. (P0.2b.)
+            self.registry_def_retire(id);
         }
         Ok(rows > 0)
     }

--- a/agentmux-srv/src/backend/storage/content.rs
+++ b/agentmux-srv/src/backend/storage/content.rs
@@ -54,18 +54,24 @@ impl Store {
 
     /// Upsert a content blob for an agent.
     pub fn agent_content_set(&self, content: &AgentContent) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO db_agent_content (agent_id, content_type, content, updated_at)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(agent_id, content_type) DO UPDATE SET content=?3, updated_at=?4",
-            params![
-                content.agent_id,
-                content.content_type,
-                content.content,
-                content.updated_at,
-            ],
-        )?;
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_agent_content (agent_id, content_type, content, updated_at)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(agent_id, content_type) DO UPDATE SET content=?3, updated_at=?4",
+                params![
+                    content.agent_id,
+                    content.content_type,
+                    content.content,
+                    content.updated_at,
+                ],
+            )?;
+        }
+        // conn dropped — re-mirror the definition so the global cross-channel
+        // record carries the updated content (no-op for seeded templates).
+        // (P0.2b.)
+        self.registry_def_upsert(&content.agent_id);
         Ok(())
     }
 
@@ -74,22 +80,47 @@ impl Store {
         &self,
         agent_id: &str,
     ) -> Result<Vec<AgentContent>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT agent_id, content_type, content, updated_at
-             FROM db_agent_content WHERE agent_id=?1 ORDER BY content_type ASC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(AgentContent {
-                agent_id: row.get(0)?,
-                content_type: row.get(1)?,
-                content: row.get(2)?,
-                updated_at: row.get(3)?,
-            })
-        })?;
-        let mut contents = Vec::new();
-        for row in rows {
-            contents.push(row?);
+        let contents: Vec<AgentContent> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT agent_id, content_type, content, updated_at
+                 FROM db_agent_content WHERE agent_id=?1 ORDER BY content_type ASC",
+            )?;
+            let rows = stmt.query_map(params![agent_id], |row| {
+                Ok(AgentContent {
+                    agent_id: row.get(0)?,
+                    content_type: row.get(1)?,
+                    content: row.get(2)?,
+                    updated_at: row.get(3)?,
+                })
+            })?;
+            let mut contents = Vec::new();
+            for row in rows {
+                contents.push(row?);
+            }
+            contents
+        };
+        if !contents.is_empty() {
+            return Ok(contents);
+        }
+        // Cross-channel fallback: a user agent created in another channel has
+        // its content on the global definition record, not in this channel's
+        // SQLite. Surface it so the agent launches with its instructions.
+        // (P0.2c — closes the content/skills cross-channel gap.)
+        if let Some(reg) = self.shared_def_registry() {
+            if let Ok(Some(rec)) = reg.get(agent_id) {
+                return Ok(rec
+                    .data
+                    .content
+                    .iter()
+                    .map(|c| AgentContent {
+                        agent_id: agent_id.to_string(),
+                        content_type: c.content_type.clone(),
+                        content: c.content.clone(),
+                        updated_at: rec.data.updated_at,
+                    })
+                    .collect());
+            }
         }
         Ok(contents)
     }

--- a/agentmux-srv/src/backend/storage/content.rs
+++ b/agentmux-srv/src/backend/storage/content.rs
@@ -37,19 +37,51 @@ impl Store {
             "SELECT agent_id, content_type, content, updated_at
              FROM db_agent_content WHERE agent_id=?1 AND content_type=?2",
         )?;
-        let result = stmt.query_row(params![agent_id, content_type], |row| {
-            Ok(AgentContent {
-                agent_id: row.get(0)?,
-                content_type: row.get(1)?,
-                content: row.get(2)?,
-                updated_at: row.get(3)?,
-            })
-        });
-        match result {
-            Ok(content) => Ok(Some(content)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(StoreError::Sqlite(e)),
+        let local = {
+            let result = stmt.query_row(params![agent_id, content_type], |row| {
+                Ok(AgentContent {
+                    agent_id: row.get(0)?,
+                    content_type: row.get(1)?,
+                    content: row.get(2)?,
+                    updated_at: row.get(3)?,
+                })
+            });
+            match result {
+                Ok(content) => Some(content),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(StoreError::Sqlite(e)),
+            }
+        };
+        drop(stmt);
+        drop(conn);
+        if local.is_some() {
+            return Ok(local);
         }
+        // Cross-channel fallback (same gate as agent_content_get_all): only for
+        // an agent absent from local SQLite. Launch reads `env` via this single
+        // path, so without it a cross-channel agent would launch missing its
+        // env vars. (codex P2 on #1385.)
+        if self.agent_def_exists_local(agent_id)? {
+            return Ok(local);
+        }
+        if let Some(reg) = self.shared_def_registry() {
+            if let Ok(Some(rec)) = reg.get(agent_id) {
+                if let Some(c) = rec
+                    .data
+                    .content
+                    .iter()
+                    .find(|c| c.content_type == content_type)
+                {
+                    return Ok(Some(AgentContent {
+                        agent_id: agent_id.to_string(),
+                        content_type: c.content_type.clone(),
+                        content: c.content.clone(),
+                        updated_at: rec.data.updated_at,
+                    }));
+                }
+            }
+        }
+        Ok(local)
     }
 
     /// Upsert a content blob for an agent.

--- a/agentmux-srv/src/backend/storage/content.rs
+++ b/agentmux-srv/src/backend/storage/content.rs
@@ -76,37 +76,49 @@ impl Store {
     }
 
     /// Get all content blobs for an agent.
+    /// LOCAL channel's content blobs only — NO cross-channel fallback. Used
+    /// by the def-registry mirror (which always operates on a local agent, so
+    /// must never read the global record) and by `agent_content_get_all`.
+    pub(super) fn agent_content_get_all_local(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<AgentContent>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT agent_id, content_type, content, updated_at
+             FROM db_agent_content WHERE agent_id=?1 ORDER BY content_type ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(AgentContent {
+                agent_id: row.get(0)?,
+                content_type: row.get(1)?,
+                content: row.get(2)?,
+                updated_at: row.get(3)?,
+            })
+        })?;
+        let mut contents = Vec::new();
+        for row in rows {
+            contents.push(row?);
+        }
+        Ok(contents)
+    }
+
     pub fn agent_content_get_all(
         &self,
         agent_id: &str,
     ) -> Result<Vec<AgentContent>, StoreError> {
-        let contents: Vec<AgentContent> = {
-            let conn = self.conn.lock().unwrap();
-            let mut stmt = conn.prepare(
-                "SELECT agent_id, content_type, content, updated_at
-                 FROM db_agent_content WHERE agent_id=?1 ORDER BY content_type ASC",
-            )?;
-            let rows = stmt.query_map(params![agent_id], |row| {
-                Ok(AgentContent {
-                    agent_id: row.get(0)?,
-                    content_type: row.get(1)?,
-                    content: row.get(2)?,
-                    updated_at: row.get(3)?,
-                })
-            })?;
-            let mut contents = Vec::new();
-            for row in rows {
-                contents.push(row?);
-            }
-            contents
-        };
-        if !contents.is_empty() {
-            return Ok(contents);
+        let local = self.agent_content_get_all_local(agent_id)?;
+        if !local.is_empty() {
+            return Ok(local);
         }
-        // Cross-channel fallback: a user agent created in another channel has
-        // its content on the global definition record, not in this channel's
-        // SQLite. Surface it so the agent launches with its instructions.
-        // (P0.2c — closes the content/skills cross-channel gap.)
+        // Local is empty. Fall back to the global record ONLY for a
+        // cross-channel agent (one absent from local SQLite). A locally-known
+        // agent with genuinely empty content must return empty — otherwise
+        // deleting its content would resurrect it from the global record.
+        // (reagent P1 on #1385.)
+        if self.agent_def_exists_local(agent_id)? {
+            return Ok(local);
+        }
         if let Some(reg) = self.shared_def_registry() {
             if let Ok(Some(rec)) = reg.get(agent_id) {
                 return Ok(rec
@@ -122,7 +134,7 @@ impl Store {
                     .collect());
             }
         }
-        Ok(contents)
+        Ok(local)
     }
 
     /// Delete a specific content blob. Returns true if a row was deleted.

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -158,13 +158,19 @@ impl Store {
     /// Mirror a user-agent deletion as a global tombstone (`retired/`) so
     /// another channel's stale SQLite can't resurrect it via `upsert`.
     /// Best-effort.
-    pub(super) fn registry_def_retire(&self, def_id: &str) {
+    pub(super) fn registry_def_retire(&self, def_id: &str) -> bool {
         let Some(reg) = self.shared_def_registry() else {
-            return;
+            return false;
         };
+        // Whether an ACTIVE global record existed — lets the delete path
+        // report success for a cross-channel agent that has no local SQLite
+        // row. (codex P1 on #1385.)
+        let existed = reg.exists(def_id);
         if let Err(e) = reg.retire(def_id) {
             tracing::warn!(def_id, error = %e, "def registry: mirror retire failed");
+            return false;
         }
+        existed
     }
 }
 
@@ -303,6 +309,30 @@ mod tests {
         assert!(
             def_store.get("local-1").unwrap().unwrap().data.skills.is_empty(),
             "deletion must propagate cross-channel"
+        );
+    }
+
+    #[test]
+    fn delete_tombstones_a_cross_channel_only_agent() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        // A user agent that exists ONLY in the global store (no local SQLite row).
+        def_store
+            .upsert(&global_user_agent("remote-1", "Remote"))
+            .unwrap();
+        store.set_def_registry(def_store.clone());
+        // It appears in the roster via the global overlay.
+        assert!(store.agent_def_list().unwrap().iter().any(|d| d.id == "remote-1"));
+
+        // Deleting it (rows == 0 locally) must tombstone the global record and
+        // report success — not silently leave it to reappear. (codex P1.)
+        let deleted = store.agent_def_delete("remote-1").unwrap();
+        assert!(deleted, "cross-channel delete must report success");
+        assert!(!def_store.exists("remote-1"), "global record tombstoned");
+        assert!(
+            !store.agent_def_list().unwrap().iter().any(|d| d.id == "remote-1"),
+            "deleted cross-channel agent must not reappear in the roster"
         );
     }
 }

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -1,0 +1,226 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Global agent-definition registry mirror.
+//!
+//! Mirrors `db_agent_definitions` mutations (with the agent's content +
+//! skills) into the GLOBAL definition store at
+//! `~/.agentmux/shared/agents/definitions/` so an agent created in one
+//! channel is visible in every channel. SQLite remains authoritative for
+//! the local channel; the global store is the cross-channel view.
+//! Best-effort: every failure is logged, never propagated. Sibling of
+//! `registry_mirror.rs` (the named-instance mirror).
+//!
+//! Cross-channel agent persistence, P0.2b
+//! (`docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`).
+
+use crate::registry::{
+    DefContentBlob, DefSkillBlob, DefinitionRecord, DefinitionRecordV1, DEF_MAX_SUPPORTED_SCHEMA,
+};
+
+use super::agents::AgentDefinition;
+use super::content::AgentContent;
+use super::skills::AgentSkill;
+use super::store::Store;
+
+/// Build a global definition record from a definition row + its content and
+/// skills (which live in separate tables and must travel with the
+/// definition for a cross-channel agent to launch with its instructions).
+pub(super) fn agent_definition_to_record(
+    def: &AgentDefinition,
+    content: &[AgentContent],
+    skills: &[AgentSkill],
+) -> DefinitionRecord {
+    let data = DefinitionRecordV1 {
+        id: def.id.clone(),
+        slug: def.slug.clone(),
+        name: def.name.clone(),
+        icon: def.icon.clone(),
+        provider: def.provider.clone(),
+        description: def.description.clone(),
+        working_directory: def.working_directory.clone(),
+        shell: def.shell.clone(),
+        provider_flags: def.provider_flags.clone(),
+        auto_start: def.auto_start,
+        restart_on_crash: def.restart_on_crash,
+        idle_timeout_minutes: def.idle_timeout_minutes,
+        created_at: def.created_at,
+        agent_type: def.agent_type.clone(),
+        environment: def.environment.clone(),
+        agent_bus_id: def.agent_bus_id.clone(),
+        is_seeded: def.is_seeded,
+        accounts: def.accounts.clone(),
+        parent_id: def.parent_id.clone(),
+        branch_label: def.branch_label.clone(),
+        updated_at: def.updated_at,
+        user_hidden: def.user_hidden,
+        container_image: def.container_image.clone(),
+        container_volumes: def.container_volumes.clone(),
+        container_name: def.container_name.clone(),
+        content: content
+            .iter()
+            .map(|c| DefContentBlob {
+                content_type: c.content_type.clone(),
+                content: c.content.clone(),
+            })
+            .collect(),
+        skills: skills
+            .iter()
+            .map(|s| DefSkillBlob {
+                id: s.id.clone(),
+                name: s.name.clone(),
+                trigger: s.trigger.clone(),
+                skill_type: s.skill_type.clone(),
+                description: s.description.clone(),
+                content: s.content.clone(),
+            })
+            .collect(),
+    };
+    DefinitionRecord {
+        schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+        data,
+    }
+}
+
+/// Reconstruct an `AgentDefinition` from a global record (inverse of
+/// [`agent_definition_to_record`]) — the read path for a cross-channel
+/// agent whose definition isn't in the local channel's SQLite. Content +
+/// skills are carried separately on the record and surfaced via the
+/// content/skills read fallbacks.
+pub(super) fn record_to_agent_definition(rec: &DefinitionRecord) -> AgentDefinition {
+    let d = &rec.data;
+    AgentDefinition {
+        id: d.id.clone(),
+        slug: d.slug.clone(),
+        name: d.name.clone(),
+        icon: d.icon.clone(),
+        provider: d.provider.clone(),
+        description: d.description.clone(),
+        working_directory: d.working_directory.clone(),
+        shell: d.shell.clone(),
+        provider_flags: d.provider_flags.clone(),
+        auto_start: d.auto_start,
+        restart_on_crash: d.restart_on_crash,
+        idle_timeout_minutes: d.idle_timeout_minutes,
+        created_at: d.created_at,
+        agent_type: d.agent_type.clone(),
+        environment: d.environment.clone(),
+        agent_bus_id: d.agent_bus_id.clone(),
+        is_seeded: d.is_seeded,
+        accounts: d.accounts.clone(),
+        parent_id: d.parent_id.clone(),
+        branch_label: d.branch_label.clone(),
+        updated_at: d.updated_at,
+        user_hidden: d.user_hidden,
+        container_image: d.container_image.clone(),
+        container_volumes: d.container_volumes.clone(),
+        container_name: d.container_name.clone(),
+    }
+}
+
+impl Store {
+    /// Mirror a definition (by id) into the global store, reading its full
+    /// row + content + skills from SQLite. Best-effort: a missing global
+    /// store or any failure is logged, never propagated (SQLite stays
+    /// authoritative). No-op when the definition no longer exists.
+    ///
+    /// `upsert` itself refuses to resurrect a tombstoned id, so a stale
+    /// mirror call for a deleted agent won't un-delete it.
+    pub(super) fn registry_def_upsert(&self, def_id: &str) {
+        let Some(reg) = self.shared_def_registry() else {
+            return;
+        };
+        let def = match self.agent_def_get(def_id) {
+            Ok(Some(d)) => d,
+            Ok(None) => return,
+            Err(e) => {
+                tracing::warn!(def_id, error = %e, "def registry: read definition failed, skipping mirror");
+                return;
+            }
+        };
+        // Only USER agents go to the global cross-channel store. Seeded
+        // templates are manifest-managed and re-seeded per channel (and
+        // their hide flag is per-channel UI state), so they stay local.
+        if def.is_seeded != 0 {
+            return;
+        }
+        let content = self.agent_content_get_all(def_id).unwrap_or_default();
+        let skills = self.agent_skill_list(def_id).unwrap_or_default();
+        let rec = agent_definition_to_record(&def, &content, &skills);
+        if let Err(e) = reg.upsert(&rec) {
+            tracing::warn!(def_id, error = %e, "def registry: mirror upsert failed");
+        }
+    }
+
+    /// Mirror a user-agent deletion as a global tombstone (`retired/`) so
+    /// another channel's stale SQLite can't resurrect it via `upsert`.
+    /// Best-effort.
+    pub(super) fn registry_def_retire(&self, def_id: &str) {
+        let Some(reg) = self.shared_def_registry() else {
+            return;
+        };
+        if let Err(e) = reg.retire(def_id) {
+            tracing::warn!(def_id, error = %e, "def registry: mirror retire failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{
+        DefContentBlob, DefSkillBlob, DefinitionRecord, DefinitionRecordV1, DefinitionStore,
+        DEF_MAX_SUPPORTED_SCHEMA,
+    };
+    use std::sync::Arc;
+
+    fn global_user_agent(id: &str, name: &str) -> DefinitionRecord {
+        DefinitionRecord {
+            schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+            data: DefinitionRecordV1 {
+                id: id.to_string(),
+                name: name.to_string(),
+                provider: "claude".to_string(),
+                is_seeded: 0,
+                content: vec![DefContentBlob {
+                    content_type: "agentmd".to_string(),
+                    content: "be helpful".to_string(),
+                }],
+                skills: vec![DefSkillBlob {
+                    id: "sk1".to_string(),
+                    name: "greet".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn read_first_surfaces_cross_channel_agent_with_content_and_skills() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        // A user agent that exists only in the global store (another channel).
+        def_store
+            .upsert(&global_user_agent("remote-1", "Remote"))
+            .unwrap();
+        store.set_def_registry(def_store);
+
+        // Roster includes the cross-channel agent (it's not in local SQLite).
+        let list = store.agent_def_list().unwrap();
+        assert!(
+            list.iter().any(|d| d.id == "remote-1" && d.name == "Remote"),
+            "agent_def_list must include the global-only user agent"
+        );
+
+        // Content + skills fall back to the global record (local SQLite empty),
+        // so the cross-channel agent launches with its instructions.
+        let content = store.agent_content_get_all("remote-1").unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0].content, "be helpful");
+        let skills = store.agent_skill_list("remote-1").unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "greet");
+    }
+}

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -144,8 +144,11 @@ impl Store {
         if def.is_seeded != 0 {
             return;
         }
-        let content = self.agent_content_get_all(def_id).unwrap_or_default();
-        let skills = self.agent_skill_list(def_id).unwrap_or_default();
+        // LOCAL-only reads: the mirror operates on a local agent, so it must
+        // never read the global record (that would re-mirror just-deleted
+        // content/skills back, defeating the deletion). (reagent P1 on #1385.)
+        let content = self.agent_content_get_all_local(def_id).unwrap_or_default();
+        let skills = self.agent_skill_list_local(def_id).unwrap_or_default();
         let rec = agent_definition_to_record(&def, &content, &skills);
         if let Err(e) = reg.upsert(&rec) {
             tracing::warn!(def_id, error = %e, "def registry: mirror upsert failed");
@@ -222,5 +225,84 @@ mod tests {
         let skills = store.agent_skill_list("remote-1").unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "greet");
+    }
+
+    fn local_def(id: &str, name: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: name.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+        }
+    }
+
+    fn skill(id: &str, agent_id: &str, name: &str) -> AgentSkill {
+        AgentSkill {
+            id: id.to_string(),
+            agent_id: agent_id.to_string(),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: "prompt".to_string(),
+            description: String::new(),
+            content: String::new(),
+            created_at: 1,
+        }
+    }
+
+    #[test]
+    fn local_skill_delete_does_not_resurrect_from_global() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        store.set_def_registry(def_store.clone());
+
+        // Create a LOCAL user agent with one skill (mirrored to global).
+        let mut def = local_def("local-1", "Local");
+        store.agent_def_insert(&mut def).unwrap();
+        store
+            .agent_skill_insert(&skill("sk-1", "local-1", "greet"))
+            .unwrap();
+        assert_eq!(
+            def_store.get("local-1").unwrap().unwrap().data.skills.len(),
+            1,
+            "skill mirrored to global"
+        );
+
+        // Delete the skill in this (local) channel.
+        store.agent_skill_delete("sk-1").unwrap();
+
+        // Local read must NOT resurrect the deleted skill from the global
+        // record (the agent is local, just skill-less now). (reagent P1.)
+        assert!(
+            store.agent_skill_list("local-1").unwrap().is_empty(),
+            "deleted local skill must not reappear from the global record"
+        );
+        // And the deletion propagated to the global record (the mirror used a
+        // local-only read, so it didn't re-write the stale skill).
+        assert!(
+            def_store.get("local-1").unwrap().unwrap().data.skills.is_empty(),
+            "deletion must propagate cross-channel"
+        );
     }
 }

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -172,6 +172,32 @@ impl Store {
         }
         existed
     }
+
+    /// Apply a definition edit directly to the global record's definition
+    /// fields, PRESERVING its existing content + skills. Used when editing a
+    /// cross-channel agent that has no local SQLite row to update. Returns
+    /// whether a global record was found + updated. Best-effort. Tombstoned
+    /// (retired) agents are not resurrected — `get` reads only the active tree.
+    pub(super) fn registry_def_update_definition_fields(&self, agent: &AgentDefinition) -> bool {
+        let Some(reg) = self.shared_def_registry() else {
+            return false;
+        };
+        let mut rec = match reg.get(&agent.id) {
+            Ok(Some(r)) => r,
+            _ => return false,
+        };
+        // Keep the record's content + skills; replace the definition fields.
+        let kept_content = std::mem::take(&mut rec.data.content);
+        let kept_skills = std::mem::take(&mut rec.data.skills);
+        let mut new_rec = agent_definition_to_record(agent, &[], &[]);
+        new_rec.data.content = kept_content;
+        new_rec.data.skills = kept_skills;
+        if let Err(e) = reg.upsert(&new_rec) {
+            tracing::warn!(def_id = %agent.id, error = %e, "def registry: cross-channel update failed");
+            return false;
+        }
+        true
+    }
 }
 
 #[cfg(test)]
@@ -334,5 +360,35 @@ mod tests {
             !store.agent_def_list().unwrap().iter().any(|d| d.id == "remote-1"),
             "deleted cross-channel agent must not reappear in the roster"
         );
+    }
+
+    #[test]
+    fn update_edits_a_cross_channel_only_agent_preserving_content_skills() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        // Global-only agent WITH content + skills.
+        def_store
+            .upsert(&global_user_agent("remote-1", "Remote"))
+            .unwrap();
+        store.set_def_registry(def_store.clone());
+
+        // Edit it (no local SQLite row → UPDATE affects 0 rows).
+        let mut edited = record_to_agent_definition(&global_user_agent("remote-1", "Remote"));
+        edited.name = "Renamed".to_string();
+        let ok = store.agent_def_update(&mut edited).unwrap();
+        assert!(ok, "cross-channel update must report success, not 'not found'");
+
+        // Global record reflects the edit; content + skills are preserved.
+        let rec = def_store.get("remote-1").unwrap().unwrap();
+        assert_eq!(rec.data.name, "Renamed");
+        assert_eq!(rec.data.content.len(), 1, "content preserved");
+        assert_eq!(rec.data.skills.len(), 1, "skills preserved");
+        // The roster shows the new name.
+        assert!(store
+            .agent_def_list()
+            .unwrap()
+            .iter()
+            .any(|d| d.id == "remote-1" && d.name == "Renamed"));
     }
 }

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -7,6 +7,7 @@
 pub mod agents;
 pub mod agents_consolidate;
 pub mod content;
+pub mod def_registry_mirror;
 pub mod dual_write;
 pub mod error;
 pub mod filestore;

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -32,37 +32,48 @@ pub struct AgentSkill {
 
 impl Store {
     /// List all skills for an agent, ordered by created_at ascending.
-    pub fn agent_skill_list(&self, agent_id: &str) -> Result<Vec<AgentSkill>, StoreError> {
-        let skills: Vec<AgentSkill> = {
-            let conn = self.conn.lock().unwrap();
-            let mut stmt = conn.prepare(
-                "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
-                 FROM db_agent_skills WHERE agent_id=?1 ORDER BY created_at ASC",
-            )?;
-            let rows = stmt.query_map(params![agent_id], |row| {
-                Ok(AgentSkill {
-                    id: row.get(0)?,
-                    agent_id: row.get(1)?,
-                    name: row.get(2)?,
-                    trigger: row.get(3)?,
-                    skill_type: row.get(4)?,
-                    description: row.get(5)?,
-                    content: row.get(6)?,
-                    created_at: row.get(7)?,
-                })
-            })?;
-            let mut skills = Vec::new();
-            for row in rows {
-                skills.push(row?);
-            }
-            skills
-        };
-        if !skills.is_empty() {
-            return Ok(skills);
+    /// LOCAL channel's skills only — NO cross-channel fallback. Used by the
+    /// def-registry mirror (which always operates on a local agent) and by
+    /// `agent_skill_list`.
+    pub(super) fn agent_skill_list_local(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<AgentSkill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
+             FROM db_agent_skills WHERE agent_id=?1 ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(AgentSkill {
+                id: row.get(0)?,
+                agent_id: row.get(1)?,
+                name: row.get(2)?,
+                trigger: row.get(3)?,
+                skill_type: row.get(4)?,
+                description: row.get(5)?,
+                content: row.get(6)?,
+                created_at: row.get(7)?,
+            })
+        })?;
+        let mut skills = Vec::new();
+        for row in rows {
+            skills.push(row?);
         }
-        // Cross-channel fallback: a user agent from another channel has its
-        // skills on the global definition record, not in this channel's
-        // SQLite. (P0.2c.)
+        Ok(skills)
+    }
+
+    pub fn agent_skill_list(&self, agent_id: &str) -> Result<Vec<AgentSkill>, StoreError> {
+        let local = self.agent_skill_list_local(agent_id)?;
+        if !local.is_empty() {
+            return Ok(local);
+        }
+        // Fall back to the global record ONLY for a cross-channel agent
+        // (absent from local SQLite); a locally-known agent with genuinely no
+        // skills must return empty, not resurrect them. (reagent P1 on #1385.)
+        if self.agent_def_exists_local(agent_id)? {
+            return Ok(local);
+        }
         if let Some(reg) = self.shared_def_registry() {
             if let Ok(Some(rec)) = reg.get(agent_id) {
                 return Ok(rec
@@ -82,7 +93,7 @@ impl Store {
                     .collect());
             }
         }
-        Ok(skills)
+        Ok(local)
     }
 
     /// Get a single skill by id.

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -33,26 +33,54 @@ pub struct AgentSkill {
 impl Store {
     /// List all skills for an agent, ordered by created_at ascending.
     pub fn agent_skill_list(&self, agent_id: &str) -> Result<Vec<AgentSkill>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
-             FROM db_agent_skills WHERE agent_id=?1 ORDER BY created_at ASC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(AgentSkill {
-                id: row.get(0)?,
-                agent_id: row.get(1)?,
-                name: row.get(2)?,
-                trigger: row.get(3)?,
-                skill_type: row.get(4)?,
-                description: row.get(5)?,
-                content: row.get(6)?,
-                created_at: row.get(7)?,
-            })
-        })?;
-        let mut skills = Vec::new();
-        for row in rows {
-            skills.push(row?);
+        let skills: Vec<AgentSkill> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
+                 FROM db_agent_skills WHERE agent_id=?1 ORDER BY created_at ASC",
+            )?;
+            let rows = stmt.query_map(params![agent_id], |row| {
+                Ok(AgentSkill {
+                    id: row.get(0)?,
+                    agent_id: row.get(1)?,
+                    name: row.get(2)?,
+                    trigger: row.get(3)?,
+                    skill_type: row.get(4)?,
+                    description: row.get(5)?,
+                    content: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            })?;
+            let mut skills = Vec::new();
+            for row in rows {
+                skills.push(row?);
+            }
+            skills
+        };
+        if !skills.is_empty() {
+            return Ok(skills);
+        }
+        // Cross-channel fallback: a user agent from another channel has its
+        // skills on the global definition record, not in this channel's
+        // SQLite. (P0.2c.)
+        if let Some(reg) = self.shared_def_registry() {
+            if let Ok(Some(rec)) = reg.get(agent_id) {
+                return Ok(rec
+                    .data
+                    .skills
+                    .iter()
+                    .map(|s| AgentSkill {
+                        id: s.id.clone(),
+                        agent_id: agent_id.to_string(),
+                        name: s.name.clone(),
+                        trigger: s.trigger.clone(),
+                        skill_type: s.skill_type.clone(),
+                        description: s.description.clone(),
+                        content: s.content.clone(),
+                        created_at: rec.data.created_at,
+                    })
+                    .collect());
+            }
         }
         Ok(skills)
     }
@@ -85,49 +113,77 @@ impl Store {
 
     /// Insert a new skill.
     pub fn agent_skill_insert(&self, skill: &AgentSkill) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO db_agent_skills (id, agent_id, name, trigger, skill_type, description, content, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                skill.id,
-                skill.agent_id,
-                skill.name,
-                skill.trigger,
-                skill.skill_type,
-                skill.description,
-                skill.content,
-                skill.created_at
-            ],
-        )?;
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_agent_skills (id, agent_id, name, trigger, skill_type, description, content, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    skill.id,
+                    skill.agent_id,
+                    skill.name,
+                    skill.trigger,
+                    skill.skill_type,
+                    skill.description,
+                    skill.content,
+                    skill.created_at
+                ],
+            )?;
+        }
+        // Re-mirror the owning definition (no-op for seeded templates). (P0.2b.)
+        self.registry_def_upsert(&skill.agent_id);
         Ok(())
     }
 
     /// Update an existing skill (all fields except id, agent_id, created_at).
     pub fn agent_skill_update(&self, skill: &AgentSkill) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "UPDATE db_agent_skills SET name=?1, trigger=?2, skill_type=?3, description=?4, content=?5
-             WHERE id=?6",
-            params![
-                skill.name,
-                skill.trigger,
-                skill.skill_type,
-                skill.description,
-                skill.content,
-                skill.id
-            ],
-        )?;
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE db_agent_skills SET name=?1, trigger=?2, skill_type=?3, description=?4, content=?5
+                 WHERE id=?6",
+                params![
+                    skill.name,
+                    skill.trigger,
+                    skill.skill_type,
+                    skill.description,
+                    skill.content,
+                    skill.id
+                ],
+            )?
+        };
+        // conn dropped — re-mirror the definition (no-op for seeded). (P0.2b.)
+        if rows > 0 {
+            self.registry_def_upsert(&skill.agent_id);
+        }
         Ok(rows > 0)
     }
 
     /// Delete a skill by id. Returns true if a row was deleted.
     pub fn agent_skill_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_agent_skills WHERE id=?1",
-            params![id],
-        )?;
+        let (rows, agent_id) = {
+            let conn = self.conn.lock().unwrap();
+            // Capture the owning agent_id before the delete so we can
+            // re-mirror its definition afterwards.
+            let agent_id: Option<String> = match conn.query_row(
+                "SELECT agent_id FROM db_agent_skills WHERE id=?1",
+                params![id],
+                |row| row.get(0),
+            ) {
+                Ok(v) => Some(v),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(StoreError::Sqlite(e)),
+            };
+            let rows = conn.execute("DELETE FROM db_agent_skills WHERE id=?1", params![id])?;
+            (rows, agent_id)
+        };
+        // conn dropped — re-mirror the definition so the global record drops
+        // the removed skill (no-op for seeded templates). (P0.2b.)
+        if rows > 0 {
+            if let Some(aid) = agent_id {
+                self.registry_def_upsert(&aid);
+            }
+        }
         Ok(rows > 0)
     }
 }

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -15,7 +15,7 @@ use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::obj::{wave_obj_from_json, wave_obj_to_json, StoreObj};
-use crate::registry::Registry;
+use crate::registry::{DefinitionStore, Registry};
 
 use super::error::StoreError;
 use super::migrations::{check_schema_compat, run_object_schema, stamp_version, OBJECT_SCHEMA_VERSION};
@@ -33,6 +33,12 @@ pub struct Store {
     /// `db_agent_instances` parallel-write to this registry when set.
     /// See `docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md`.
     registry: Mutex<Option<Arc<Registry>>>,
+    /// GLOBAL (cross-channel) agent-definition store. `None` for in-memory
+    /// test stores and when the shared dir can't be resolved; `Some` for
+    /// production srv. Definition mutations mirror to it so an agent created
+    /// in one channel is visible in every channel (cross-channel agent
+    /// persistence, `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`).
+    def_registry: Mutex<Option<Arc<DefinitionStore>>>,
 }
 
 impl Store {
@@ -106,6 +112,7 @@ impl Store {
         Ok(Self {
             conn: Mutex::new(conn),
             registry: Mutex::new(None),
+            def_registry: Mutex::new(None),
         })
     }
 
@@ -131,6 +138,23 @@ impl Store {
     /// case by falling back to SQLite.
     pub fn shared_agent_registry(&self) -> Option<Arc<Registry>> {
         self.registry()
+    }
+
+    /// Attach the GLOBAL (cross-channel) agent-definition store. Called
+    /// once on srv startup after `Store::open`, before the store is
+    /// wrapped in `Arc`. Definition mutations then mirror to it.
+    pub fn set_def_registry(&self, def_registry: Arc<DefinitionStore>) {
+        *self.def_registry.lock().unwrap_or_else(|e| e.into_inner()) = Some(def_registry);
+    }
+
+    /// Public accessor for the global agent-definition store. `None` when
+    /// it couldn't be resolved at startup (CI / unusual envs / in-memory
+    /// tests); callers fall back to SQLite.
+    pub fn shared_def_registry(&self) -> Option<Arc<DefinitionStore>> {
+        self.def_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     /// Table name for a StoreObj type: `db_<otype>`.

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -431,6 +431,26 @@ async fn main() {
     } else {
         tracing::warn!("registry: could not resolve shared registry dir — mirror disabled");
     }
+    // Attach the GLOBAL (cross-channel) agent-definition store. Unlike the
+    // instance registry above (channel-scoped), this lives under
+    // ~/.agentmux/shared/ so user agents created in one channel are visible
+    // in every channel. Best-effort: disabled when the shared dir can't be
+    // resolved. See SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md (P0.2).
+    if let Some(def_dir) = registry::resolve_shared_definitions_dir() {
+        match registry::DefinitionStore::open(def_dir.clone()) {
+            Ok(def_store) => {
+                wstore_raw.set_def_registry(Arc::new(def_store));
+                tracing::info!(dir = %def_dir.display(), "def registry: global definition store attached");
+            }
+            Err(e) => tracing::warn!(
+                dir = %def_dir.display(),
+                error = %e,
+                "def registry: failed to open global definition store — definitions stay channel-local"
+            ),
+        }
+    } else {
+        tracing::warn!("def registry: could not resolve shared definitions dir — global definitions disabled");
+    }
     let wstore = Arc::new(wstore_raw);
     let filestore = Arc::new(FileStore::open(&db_dir.join("filestore.db")).unwrap_or_else(|e| {
         tracing::error!("Failed to open file store: {}", e);

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -65,7 +65,7 @@ pub struct DefSkillBlob {
 /// cross-channel agent to launch with its instructions). New fields go
 /// here under `#[serde(default)]` (so older files still deserialize)
 /// paired with a `DEF_MAX_SUPPORTED_SCHEMA` bump.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct DefinitionRecordV1 {
     pub id: String,
     #[serde(default)]

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -26,6 +26,13 @@ pub const DEF_MIN_SUPPORTED_SCHEMA: u32 = 1;
 /// release that adds fields to the definition payload.
 pub const DEF_MAX_SUPPORTED_SCHEMA: u32 = 1;
 
+/// Serde default for `container_volumes` — preserves the db invariant that
+/// an omitted value is the empty JSON array `"[]"`, not `""` (which would
+/// surface via the read-path overlay). (reagent P2 on #1385.)
+fn default_container_volumes() -> String {
+    "[]".to_string()
+}
+
 /// On-disk envelope for a global agent-definition record. Stored at
 /// `<shared>/agents/definitions/<id>.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -110,7 +117,7 @@ pub struct DefinitionRecordV1 {
     pub user_hidden: i64,
     #[serde(default)]
     pub container_image: String,
-    #[serde(default)]
+    #[serde(default = "default_container_volumes")]
     pub container_volumes: String,
     #[serde(default)]
     pub container_name: String,
@@ -261,7 +268,7 @@ mod tests {
         let parsed: DefinitionRecord = serde_json::from_value(raw).unwrap();
         assert_eq!(parsed.data.id, "abc");
         assert_eq!(parsed.data.provider, "claude");
-        // Defaulted field absent from JSON.
-        assert_eq!(parsed.data.container_volumes, "");
+        // Defaulted field absent from JSON now uses the "[]" db invariant.
+        assert_eq!(parsed.data.container_volumes, "[]");
     }
 }

--- a/agentmux-srv/src/registry/def_store.rs
+++ b/agentmux-srv/src/registry/def_store.rs
@@ -140,6 +140,20 @@ impl DefinitionStore {
         self.active_path(id).exists() || self.retired_path(id).exists()
     }
 
+    /// Read a single active definition record by id. `None` if absent;
+    /// invalid/corrupt files surface as an error (caller logs + falls back).
+    pub fn get(&self, id: &str) -> Result<Option<DefinitionRecord>, DefStoreError> {
+        match std::fs::read(self.active_path(id)) {
+            Ok(bytes) => {
+                let rec: DefinitionRecord = serde_json::from_slice(&bytes)?;
+                validate(id, &rec)?;
+                Ok(Some(rec))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Read every valid active definition. Invalid files are skipped +
     /// logged (left on disk for ops triage).
     pub fn list_active(&self) -> Result<Vec<DefinitionRecord>, DefStoreError> {

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -29,7 +29,7 @@ mod store;
 mod tests;
 
 pub use migrate::{migrate_from_sqlite_once, MigrateStats};
-pub use paths::resolve_shared_registry_dir;
+pub use paths::{resolve_shared_definitions_dir, resolve_shared_registry_dir};
 pub use def_schema::{
     DefContentBlob, DefSkillBlob, DefValidationError, DefinitionRecord, DefinitionRecordV1,
     DEF_MAX_SUPPORTED_SCHEMA, DEF_MIN_SUPPORTED_SCHEMA,

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -42,8 +42,10 @@ pub fn resolve_shared_definitions_dir() -> Option<PathBuf> {
 fn resolve_global_shared_root() -> Option<PathBuf> {
     if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
         if !s.is_empty() {
-            // Test escape hatch: the override IS the shared root.
-            return Some(PathBuf::from(s));
+            // Consistent with data_paths everywhere else: the override is the
+            // ~/.agentmux root, with the shared dir at root/shared. (reagent
+            // P2 on #1385.)
+            return Some(PathBuf::from(s).join("shared"));
         }
     }
     if let Ok(s) = std::env::var("AGENTMUX_SHARED_DIR") {
@@ -138,7 +140,11 @@ mod tests {
         clear();
         std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
         let r = resolve_shared_definitions_dir().unwrap();
-        assert_eq!(r, PathBuf::from("/tmp/test-home/agents/definitions"));
+        // Override is the ~/.agentmux root; shared lives at root/shared.
+        assert_eq!(
+            r,
+            PathBuf::from("/tmp/test-home/shared/agents/definitions")
+        );
         clear();
     }
 }

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -25,6 +25,35 @@ pub fn resolve_shared_registry_dir() -> Option<PathBuf> {
     resolve_shared_home().map(|h| h.join("agents").join("registry"))
 }
 
+/// Resolve the GLOBAL `<home>/shared/agents/definitions/` directory.
+///
+/// Unlike [`resolve_shared_registry_dir`] (channel-scoped — its
+/// `AGENTMUX_DATA_DIR` walk-up lands on `channels/<ch>`), the definition
+/// store is **channel-independent**: it lives under the global
+/// `~/.agentmux/shared/` so an agent created in one channel is visible in
+/// every channel (cross-channel agent persistence, P0.2). Resolves via the
+/// launcher-exported `AGENTMUX_SHARED_DIR`, with a test override and a
+/// `~/.agentmux/shared` fallback.
+pub fn resolve_shared_definitions_dir() -> Option<PathBuf> {
+    resolve_global_shared_root().map(|h| h.join("agents").join("definitions"))
+}
+
+/// The global, channel-independent `<home>/shared` root.
+fn resolve_global_shared_root() -> Option<PathBuf> {
+    if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
+        if !s.is_empty() {
+            // Test escape hatch: the override IS the shared root.
+            return Some(PathBuf::from(s));
+        }
+    }
+    if let Ok(s) = std::env::var("AGENTMUX_SHARED_DIR") {
+        if !s.is_empty() {
+            return Some(PathBuf::from(s));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".agentmux").join("shared"))
+}
+
 fn resolve_shared_home() -> Option<PathBuf> {
     if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
         if !s.is_empty() {
@@ -56,6 +85,7 @@ mod tests {
     fn clear() {
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
         std::env::remove_var("AGENTMUX_DATA_DIR");
+        std::env::remove_var("AGENTMUX_SHARED_DIR");
     }
 
     #[test]
@@ -87,5 +117,28 @@ mod tests {
         clear();
         // No env set — uses dirs::home_dir(). Just assert non-None.
         assert!(resolve_shared_registry_dir().is_some());
+    }
+
+    #[test]
+    fn definitions_dir_uses_shared_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_SHARED_DIR", "/home/user/.agentmux/shared");
+        let r = resolve_shared_definitions_dir().unwrap();
+        assert_eq!(
+            r,
+            PathBuf::from("/home/user/.agentmux/shared/agents/definitions")
+        );
+        clear();
+    }
+
+    #[test]
+    fn definitions_dir_override_wins() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        let r = resolve_shared_definitions_dir().unwrap();
+        assert_eq!(r, PathBuf::from("/tmp/test-home/agents/definitions"));
+        clear();
     }
 }


### PR DESCRIPTION
**P0.2b+c** of cross-channel agent persistence — `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (§11.4). Builds on the global DefinitionStore from #1384 (P0.2a).

## What this makes work
A **user agent created in one channel now appears — and launches with its instructions/skills — in every channel.**

## Write mirror (best-effort; SQLite stays authoritative)
- `agent_def_insert`/`update` → `registry_def_upsert`; `agent_def_delete` → `registry_def_retire` (resurrection-proof tombstone).
- `agent_content_set` + `agent_skill_insert`/`update`/`delete` → re-mirror, so the global record carries **current content + skills**.
- **Skips seeded templates** — they're manifest-managed/re-seeded per channel and their hide flag is per-channel UI state; only `is_seeded=0` user agents go global.
- All mirror calls are **conn-drop-safe** (the mirror re-acquires the SQLite lock, so the writers were restructured to drop `conn` first).

## Read-first (global wins for user agents; SQLite fallback)
- `agent_def_list` merges the global user-agent roster over local templates (sorted `updated_at DESC, created_at ASC`).
- `agent_content_get_all` + `agent_skill_list` **fall back to the global record** when local SQLite is empty → a cross-channel agent launches with its configured instructions/skills. **This closes the content/skills P1 codex raised on #1384.**

## Wiring
Channel-independent `resolve_shared_definitions_dir` (via `AGENTMUX_SHARED_DIR`, *not* the channel-scoped `AGENTMUX_DATA_DIR` walk-up) · `Store.def_registry` + `set_def_registry`/`shared_def_registry` · main.rs startup construction · `DefinitionStore::get` · `record_to_agent_definition`.

## Scope / risk
Mirror is best-effort (failures logged, never propagated; SQLite remains the source of truth for the local channel). When the global store can't be resolved, everything falls back to today's SQLite-only behavior. **26 def tests pass**, including a read-first integration test (`Store` + global store → roster + content/skills fallback).

## Deliberately NOT here → immediate follow-up **P0.2d**
The **one-time global migration** backfilling *existing* agents from every channel's per-version `objects.db`. Until that lands, an existing agent goes global on its **next edit**; newly-created agents go global immediately.

## Series
P0.1 (#1383) → P0.2a (#1384) → **P0.2b+c (this)** → P0.2d migration → P0.3 re-root instances registry → P0.4 → P1 → P2 → P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)