### PR TITLE
chore(diag): log the agent's resolved bashwrap at spawn (stale-binary guardrail)

### DIFF
--- a/.changesets/1781355111-chore-diag-log-which-agentmux-bashwrap-an-agent-will-run-at--kw68.md
+++ b/.changesets/1781355111-chore-diag-log-which-agentmux-bashwrap-an-agent-will-run-at--kw68.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(diag): log which agentmux-bashwrap an agent will run at spawn — info when the bundled (version-locked) binary is used, WARN when it's missing and the agent will fall through to a possibly-stale system-PATH copy. Cross-check with agentmux-bashwrap --version (already supported). Cheap guardrail for the stale-binary trap (RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13)

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -561,7 +561,38 @@ impl Controller for ShellController {
                 // Bundled store — prepended (app-owned, version-locked).
                 if let Some(bundled_bin) = crate::backend::tool_store::bundled_tools_dir() {
                     if bundled_bin.exists() {
+                        // Guardrail: log which agentmux-bashwrap the agent will
+                        // actually run. A stale system-PATH copy silently
+                        // shadowing the bundled one is exactly the exit-130
+                        // trap (RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md); this
+                        // one line makes "which binary?" answerable at a glance
+                        // (cross-check the version with `agentmux-bashwrap
+                        // --version`).
+                        let bashwrap_exe = if cfg!(windows) {
+                            "agentmux-bashwrap.exe"
+                        } else {
+                            "agentmux-bashwrap"
+                        };
+                        let bw = bundled_bin.join(bashwrap_exe);
+                        if bw.exists() {
+                            tracing::info!(
+                                target: "agent-tools",
+                                path = %bw.display(),
+                                "agent bashwrap: bundled (version-locked, prepended to PATH)"
+                            );
+                        } else {
+                            tracing::warn!(
+                                target: "agent-tools",
+                                dir = %bundled_bin.display(),
+                                "agent bashwrap: bundled store present but agentmux-bashwrap MISSING — agent will resolve via system PATH (risk of a stale copy; see RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md)"
+                            );
+                        }
                         prepend.push(bundled_bin.to_string_lossy().into_owned());
+                    } else {
+                        tracing::warn!(
+                            target: "agent-tools",
+                            "agent bashwrap: no bundled tools dir — agent will resolve agentmux-bashwrap via system PATH (risk of a stale copy; see RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md)"
+                        );
                     }
                 }
 


### PR DESCRIPTION
Follow-up to the exit-130 / stale-bundle saga (#1368, #1382; `docs/retros/RETRO_BASHWRAP_STALE_BUNDLE_2026_06_13.md`).

The whole saga cost time because nothing told us *which* `agentmux-bashwrap` the agent actually ran. This adds that one line.

At agent spawn (`shell.rs`, where the agent PATH is wired) the sidecar now logs (`target = "agent-tools"`):
- **INFO** with the resolved path when the **bundled, version-locked** binary is used (prepended to PATH).
- **WARN** when the bundled store is missing or lacks the binary, so the agent will fall through to a **system-PATH copy** (the stale-binary trap) — pointing at the retro.

`agentmux-bashwrap --version` already works (clap derives it from the workspace version), so **path + version answers "which binary ran?" in seconds.**

### Follow-up 2 (PATH hygiene) — no action needed
Investigated: the stale Downloads-portable `tools/bin` is **not** in the persistent User or Machine PATH, nor in any shell profile — it's injected into the session at runtime (by the parent app/shell). There's nothing persistent to remove, and #1382's prepend already makes the bundled binary win over it regardless. So the hygiene item is effectively closed by #1382 + this guardrail.

`cargo check -p agentmux-srv` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)