### PR TITLE
feat(registry): re-root instance registry to global shared dir + scan all channels (cross-channel P0.3b)

### DIFF
--- a/.changesets/1781355693-feat-registry-re-root-instance-registry-to-global-shared-dir-66ja.md
+++ b/.changesets/1781355693-feat-registry-re-root-instance-registry-to-global-shared-dir-66ja.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(registry): re-root instance registry to global shared dir + scan all channels (cross-channel P0.3b)

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -51,16 +51,17 @@ pub struct Store {
     /// stops coinciding with the channel agents dir, and using it to strip /
     /// re-join `working_directory` would drop every live instance.
     ///
-    /// `None` for in-memory test stores and — for now — production too: the
-    /// accessor falls back to the registry's parent, which equals the channel
-    /// agents dir in the pre-re-root layout for installed/portable builds, so
-    /// behavior is unchanged. It is wired from `AGENTMUX_AGENTS_DIR` in P0.3b,
-    /// atomically with the re-root to the global shared registry (setting it
-    /// before the re-root would diverge in dev mode, where
-    /// `AGENTMUX_AGENTS_DIR` ≠ the channel-local registry parent). When set,
-    /// it must be passed in explicitly — never read from ambient env inside
-    /// the Store — so tests running inside an AgentMux pane don't pick up the
-    /// host's `AGENTMUX_AGENTS_DIR`. See
+    /// In production it is wired from `AGENTMUX_AGENTS_DIR` in `main.rs`
+    /// (P0.3b), atomically with the re-root to the global shared registry —
+    /// which is why the wiring waited for the re-root: setting it earlier would
+    /// diverge in dev mode, where `AGENTMUX_AGENTS_DIR` ≠ the (then
+    /// channel-local) registry parent. `None` only for in-memory test stores
+    /// and odd envs where the var is unset; the accessor then falls back to the
+    /// registry's parent (which equals the channel agents dir in the pre-re-root
+    /// layout), so existing mirror tests are unchanged. When set, it is passed
+    /// in explicitly — never read from ambient env inside the Store — so tests
+    /// running inside an AgentMux pane don't pick up the host's
+    /// `AGENTMUX_AGENTS_DIR`. See
     /// `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (P0.3).
     registry_agents_base: Mutex<Option<PathBuf>>,
 }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -383,23 +383,33 @@ async fn main() {
                 let migration_ok = match home_dir {
                     Some(home) => match registry::migrate_from_sqlite_once(&home, &reg) {
                         Ok(stats) => {
-                            if stats.dbs_scanned > 0 || stats.records_written > 0 {
+                            if stats.dbs_scanned > 0
+                                || stats.records_written > 0
+                                || stats.dbs_skipped > 0
+                            {
                                 tracing::info!(
                                     dbs_scanned = stats.dbs_scanned,
+                                    dbs_skipped = stats.dbs_skipped,
                                     rows_seen = stats.rows_seen,
                                     records_written = stats.records_written,
                                     records_skipped_existing = stats.records_skipped_existing,
                                     records_skipped_unmappable = stats.records_skipped_unmappable,
                                     complete = stats.complete,
-                                    "registry: one-shot SQLite migration finished"
+                                    "registry: cross-channel SQLite migration finished"
                                 );
                             }
-                            // Gate attach on `complete` — partial
-                            // migration leaves the registry detached
-                            // so the read path serves SQLite (full,
-                            // current-version-only view) rather than
-                            // a half-populated registry.
-                            stats.complete
+                            // Attach the registry whenever the migration ran —
+                            // do NOT gate on `complete`. The scan now spans every
+                            // channel + dev tree, so a single corrupt/locked
+                            // objects.db in an unrelated channel must not disable
+                            // cross-channel My Agents for everyone (codex P1 on
+                            // #1389). The records that DID read are served now,
+                            // and the live mirror backfills the current channel's
+                            // named agents regardless of migration. On any skipped
+                            // DB the migration leaves the marker deferred, so a
+                            // future launch retries that source (idempotent via
+                            // exists_anywhere).
+                            true
                         }
                         Err(e) => {
                             tracing::warn!(

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -457,11 +457,11 @@ async fn main() {
     } else {
         tracing::warn!("registry: could not resolve shared registry dir — mirror disabled");
     }
-    // Attach the GLOBAL (cross-channel) agent-definition store. Unlike the
-    // instance registry above (channel-scoped), this lives under
-    // ~/.agentmux/shared/ so user agents created in one channel are visible
-    // in every channel. Best-effort: disabled when the shared dir can't be
-    // resolved. See SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md (P0.2).
+    // Attach the GLOBAL (cross-channel) agent-definition store. Sibling of the
+    // instance registry above — since P0.3b both live under ~/.agentmux/shared/
+    // (definitions/ and registry/), so user agents created in one channel are
+    // visible in every channel. Best-effort: disabled when the shared dir can't
+    // be resolved. See SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md (P0.2/P0.3).
     if let Some(def_dir) = registry::resolve_shared_definitions_dir() {
         match registry::DefinitionStore::open(def_dir.clone()) {
             Ok(def_store) => {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -366,16 +366,17 @@ async fn main() {
     if let Some(root) = registry::resolve_shared_registry_dir() {
         match registry::Registry::open(root.clone()) {
             Ok(reg) => {
-                // PR B — one-shot backfill from every per-version
-                // objects.db into the registry. Idempotent via marker
-                // file in the registry root. Read-only on SQLite.
+                // One-shot backfill from every channel/version + dev objects.db
+                // into the registry. Idempotent via the marker file in the
+                // registry root. Read-only on SQLite.
                 //
-                // Gating: the registry is only attached to wstore if
-                // migration completes (Ok) — that way the read path
-                // never serves a partial view. On Err, mirror writes
-                // are also disabled (registry stays detached); SQLite
-                // remains authoritative and the next launch retries
-                // the migration via the same marker logic.
+                // Attach policy: the registry is attached whenever the migration
+                // RUNS (returns Ok), and intentionally serves the partial set of
+                // readable records — a corrupt/locked DB in an unrelated channel
+                // must not disable cross-channel My Agents (see the Ok arm below,
+                // codex P1 on #1389). On Err (e.g. the registry itself failed) or
+                // when the home can't be resolved, the registry stays detached and
+                // SQLite remains authoritative; the next launch retries.
                 // The generalized migration scans EVERY channel +dev tree under
                 // the true home, so derive ~/.agentmux from the now-global
                 // registry root: registry → agents → shared → <home>.

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -376,16 +376,16 @@ async fn main() {
                 // are also disabled (registry stays detached); SQLite
                 // remains authoritative and the next launch retries
                 // the migration via the same marker logic.
-                let shared_home = root
-                    .parent()
-                    .and_then(|p| p.parent())
-                    .map(|p| p.to_path_buf());
-                let migration_ok = match shared_home {
+                // The generalized migration scans EVERY channel +dev tree under
+                // the true home, so derive ~/.agentmux from the now-global
+                // registry root: registry → agents → shared → <home>.
+                let home_dir = root.ancestors().nth(3).map(|p| p.to_path_buf());
+                let migration_ok = match home_dir {
                     Some(home) => match registry::migrate_from_sqlite_once(&home, &reg) {
                         Ok(stats) => {
-                            if stats.versions_scanned > 0 || stats.records_written > 0 {
+                            if stats.dbs_scanned > 0 || stats.records_written > 0 {
                                 tracing::info!(
-                                    versions_scanned = stats.versions_scanned,
+                                    dbs_scanned = stats.dbs_scanned,
                                     rows_seen = stats.rows_seen,
                                     records_written = stats.records_written,
                                     records_skipped_existing = stats.records_skipped_existing,
@@ -412,7 +412,7 @@ async fn main() {
                     None => {
                         tracing::warn!(
                             root = %root.display(),
-                            "registry: cannot resolve shared home (root has fewer than 2 ancestors) — leaving registry detached"
+                            "registry: cannot resolve home (root has fewer than 3 ancestors) — leaving registry detached"
                         );
                         false
                     }
@@ -420,17 +420,21 @@ async fn main() {
                 if migration_ok {
                     tracing::info!(root = %root.display(), "registry: shared agent registry attached");
                     wstore_raw.set_registry(Arc::new(reg));
-                    // NB: the channel agents base (AGENTMUX_AGENTS_DIR) is NOT
-                    // wired here yet — it is set in P0.3b, atomically with the
-                    // re-root to the global ~/.agentmux/shared/agents/registry/.
-                    // Setting it before the re-root would change DEV behavior:
-                    // there AGENTMUX_AGENTS_DIR (~/.agentmux/dev/<branch>/agents)
-                    // differs from the channel-local reg.agents_root()
-                    // (~/.agentmux/agents), so the mirror would start writing
-                    // branch-local rows into the shared dev registry and leak
-                    // workspaces across branches (codex P2 on #1387). Until
-                    // then `registry_agents_base()` falls back to the registry
-                    // parent — exactly today's behavior in every mode.
+                    // Now that the registry is GLOBAL for every mode, anchor the
+                    // mirror/read working_directory base on the CURRENT channel's
+                    // agents dir (AGENTMUX_AGENTS_DIR) — NOT the registry's parent
+                    // (shared/agents), which no longer contains any instance. In
+                    // dev this is ~/.agentmux/dev/<branch>/agents, in installed/
+                    // portable it is channels/<ch>/agents; either way it is the
+                    // correct per-channel anchor. (Cross-channel rows surfaced
+                    // from OTHER channels still re-join under this channel's dir
+                    // until P0.4 encodes the source base per record.)
+                    if let Some(base) = std::env::var_os("AGENTMUX_AGENTS_DIR") {
+                        if !base.is_empty() {
+                            wstore_raw
+                                .set_registry_agents_base(std::path::PathBuf::from(base));
+                        }
+                    }
                 }
             }
             Err(e) => tracing::warn!(

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -89,14 +89,14 @@ pub fn migrate_from_sqlite_once(
     }
 
     let mut stats = MigrateStats::default();
-    let sources = enumerate_sources(home);
+    let (sources, enum_incomplete) = enumerate_sources(home);
 
     let mut latest_by_id: HashMap<String, RowSnapshot> = HashMap::new();
-    // True iff any DB threw a non-transient-looking error. We use this to skip
-    // writing the marker so the next launch retries — otherwise a brief
-    // filesystem hiccup permanently omits those rows from the registry-backed
-    // dropdown.
-    let mut any_db_failed = false;
+    // True iff any DB threw a non-transient-looking error OR a directory that
+    // should have been enumerable was unreadable. We use this to skip writing
+    // the marker so the next launch retries — otherwise a brief filesystem
+    // hiccup permanently omits those rows from the registry-backed dropdown.
+    let mut any_db_failed = enum_incomplete;
 
     for src in sources {
         stats.dbs_scanned += 1;
@@ -192,19 +192,28 @@ pub fn migrate_from_sqlite_once(
 
 /// Enumerate every per-(channel,version) and per-dev-branch `objects.db` under
 /// `home`, pairing each with the agents dir its rows are anchored on.
-fn enumerate_sources(home: &Path) -> Vec<SqliteSource> {
+///
+/// Returns `(sources, incomplete)`. `incomplete` is true if any directory that
+/// *should* be enumerable failed to read for a reason other than "doesn't
+/// exist" (permissions, a transient FS/network-home hiccup, a non-dir in the
+/// way). The caller treats that like an unreadable DB and DEFERS the one-shot
+/// marker so a future launch retries — otherwise a transiently-unreadable
+/// `versions/` (or `dev/`) would silently finalize the migration and omit that
+/// tree's named agents forever (codex P2 on #1389).
+fn enumerate_sources(home: &Path) -> (Vec<SqliteSource>, bool) {
     let mut out = Vec::new();
+    let mut incomplete = false;
 
     // Installed/portable: home/channels/<ch>/versions/<v>/data/db/objects.db,
     // anchored on home/channels/<ch>/agents.
-    if let Ok(rd) = std::fs::read_dir(home.join("channels")) {
+    if let Some(rd) = read_dir_tracking(&home.join("channels"), &mut incomplete) {
         for ch in rd.flatten() {
             let ch_dir = ch.path();
             if !ch_dir.is_dir() {
                 continue;
             }
             let agents_root = ch_dir.join("agents");
-            if let Ok(vrd) = std::fs::read_dir(ch_dir.join("versions")) {
+            if let Some(vrd) = read_dir_tracking(&ch_dir.join("versions"), &mut incomplete) {
                 for v in vrd.flatten() {
                     let db = v.path().join("data").join("db").join("objects.db");
                     if db.is_file() {
@@ -219,54 +228,73 @@ fn enumerate_sources(home: &Path) -> Vec<SqliteSource> {
     }
 
     // Dev: home/dev/<branch>[/<sub>]/data/db/objects.db, anchored on
-    // <instance_dir>/agents (instance_dir = the dir that holds `data`). The
-    // depth under dev/ varies (branch, sometimes branch/sub-hash), so search
-    // a bounded number of levels for a `data/db/objects.db`.
-    collect_dev_sources(&home.join("dev"), &mut out, 0);
+    // <instance_dir>/agents (instance_dir = the dir that holds `data`).
+    collect_dev_sources(&home.join("dev"), &mut out, &mut incomplete);
 
-    out
+    (out, incomplete)
 }
 
-/// Instance-internal subdirectories (`DataPaths::ensure_dirs`) — never branch
-/// or sub-hash containers. The dev walk must NOT descend into these: an agent
-/// workspace under `<instance>/agents/<slug>/` can itself contain a nested
-/// AgentMux `data/db/objects.db` (e.g. an agent that ran its own instance),
-/// which must not be mistaken for a migration source (reagent P2 on #1389).
-const DEV_INTERNAL_DIRS: &[&str] =
-    &["data", "agents", "logs", "cef-cache", "runtime", "config"];
-
-/// Recursively locate dev instance dirs (those with `data/db/objects.db`) and
-/// anchor each on its sibling `agents/` dir. An instance dir is a leaf (we stop
-/// descending once a DB is found), and descent skips instance-internal dirs so
-/// the walk only traverses branch / sub-hash containers. Bounded depth is a
-/// backstop against pathological/looping trees.
-fn collect_dev_sources(dir: &Path, out: &mut Vec<SqliteSource>, depth: usize) {
-    if depth > 4 {
-        return;
+/// `read_dir` that distinguishes "absent" (fine — nothing to scan) from
+/// "present but unreadable" (sets `incomplete` so the marker defers). Returns
+/// `None` in both error cases; the iterator otherwise.
+fn read_dir_tracking(path: &Path, incomplete: &mut bool) -> Option<std::fs::ReadDir> {
+    match std::fs::read_dir(path) {
+        Ok(rd) => Some(rd),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(_) => {
+            *incomplete = true;
+            None
+        }
     }
+}
+
+/// Locate dev instance dirs (those with `data/db/objects.db`) and anchor each
+/// on its sibling `agents/` dir. The dev layout is at most two levels under
+/// `dev/`: `dev/<branch>/data/...` (older single-level layout) or
+/// `dev/<branch>/<sub-hash>/data/...`. We check exactly those depths and never
+/// descend into an instance's own subdirs — so an agent workspace
+/// (`<instance>/agents/<slug>/`) that holds a nested AgentMux `objects.db` is
+/// never mistaken for a source (reagent P2), and a dev branch whose slug
+/// happens to equal an internal dir name like `data`/`agents` is still scanned
+/// (no name-based skip-list — codex P2).
+fn collect_dev_sources(dev_root: &Path, out: &mut Vec<SqliteSource>, incomplete: &mut bool) {
+    let Some(branches) = read_dir_tracking(dev_root, incomplete) else {
+        return;
+    };
+    for branch in branches.flatten() {
+        let bdir = branch.path();
+        if !bdir.is_dir() {
+            continue;
+        }
+        // Depth 1: the branch dir is itself the instance dir (older layout).
+        // If so it is a leaf — do NOT descend into its agents/ etc.
+        if push_if_instance(&bdir, out) {
+            continue;
+        }
+        // Depth 2: each child (the sub-hash dir) may be the instance dir.
+        if let Some(subs) = read_dir_tracking(&bdir, incomplete) {
+            for sub in subs.flatten() {
+                let sdir = sub.path();
+                if sdir.is_dir() {
+                    push_if_instance(&sdir, out);
+                }
+            }
+        }
+    }
+}
+
+/// Push `dir` as a source iff it holds `data/db/objects.db`. Returns whether it
+/// did (so the caller can treat an instance dir as a leaf).
+fn push_if_instance(dir: &Path, out: &mut Vec<SqliteSource>) -> bool {
     let db = dir.join("data").join("db").join("objects.db");
     if db.is_file() {
         out.push(SqliteSource {
             db_path: db,
             agents_root: dir.join("agents"),
         });
-        return;
-    }
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for e in rd.flatten() {
-            if !e.path().is_dir() {
-                continue;
-            }
-            // Skip instance internals (esp. `agents/`) so we never walk into an
-            // agent's workspace and pick up a nested objects.db as a source.
-            if e.file_name()
-                .to_str()
-                .is_some_and(|n| DEV_INTERNAL_DIRS.contains(&n))
-            {
-                continue;
-            }
-            collect_dev_sources(&e.path(), out, depth + 1);
-        }
+        true
+    } else {
+        false
     }
 }
 
@@ -693,6 +721,47 @@ mod tests {
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].data.instance_id, "inst-real");
         assert_eq!(recs[0].data.working_dir, "realagent");
+    }
+
+    #[test]
+    fn migrate_dev_branch_named_like_internal_dir_is_scanned() {
+        // A git branch can legitimately be named "data"/"agents"/etc. The dev
+        // scan must NOT skip it (no name-based filter at the branch level —
+        // codex P2 on #1389).
+        let (home, reg) = fresh_home();
+        let inst_dir = home.path().join("dev").join("data").join("sub");
+        let wd = inst_dir.join("agents").join("a1");
+        std::fs::create_dir_all(&wd).unwrap();
+        make_db_at(
+            &inst_dir,
+            &[("inst-d", "D", 100, &wd.to_string_lossy(), false)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.dbs_scanned, 1, "branch named 'data' must still be scanned");
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn migrate_defers_marker_when_versions_dir_is_unreadable() {
+        // A channel's versions/ that is present but unreadable (here: a FILE in
+        // its place, which makes read_dir fail with a non-NotFound error) must
+        // defer the marker so the channel is retried — not be silently treated
+        // as empty (codex P2 on #1389).
+        let (home, reg) = fresh_home();
+        let ch = home.path().join("channels").join("stable");
+        std::fs::create_dir_all(&ch).unwrap();
+        std::fs::write(ch.join("versions"), b"not a directory").unwrap();
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert!(
+            !stats.complete,
+            "an unreadable versions/ must defer the marker"
+        );
+        assert!(
+            !reg.root().join(MARKER).exists(),
+            "marker deferred so the channel is retried next launch"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -37,14 +37,21 @@ pub struct MigrateStats {
     /// Number of per-(channel,version) / per-dev-branch `objects.db` files
     /// scanned (was "versions" when the scan was single-channel).
     pub dbs_scanned: usize,
+    /// DBs that existed but couldn't be read (corrupt / locked). Counted and
+    /// skipped — they must NOT disable the whole cross-channel registry now
+    /// that the scan spans every channel (codex P1 on #1389).
+    pub dbs_skipped: usize,
     pub rows_seen: usize,
     pub records_written: usize,
     pub records_skipped_existing: usize,
     pub records_skipped_unmappable: usize,
-    /// True iff every DB read cleanly. Callers gate registry attachment on
-    /// this — partial migrations leave the registry detached so reads keep
-    /// falling back to SQLite, and the next launch retries (no marker written
-    /// when `false`).
+    /// True iff every DB read cleanly. Controls only whether the one-shot
+    /// **marker** is written: on any skipped DB the marker is deferred so a
+    /// future launch retries that (possibly transiently-unreadable) DB. It
+    /// does NOT gate registry attachment — `main.rs` attaches whenever the
+    /// migration runs, so one bad DB in an unrelated channel can't disable
+    /// cross-channel My Agents (the readable records are served now; the live
+    /// mirror backfills the current channel regardless).
     pub complete: bool,
 }
 
@@ -122,8 +129,9 @@ pub fn migrate_from_sqlite_once(
                 tracing::warn!(
                     db = %src.db_path.display(),
                     error = %e,
-                    "registry-migrate: DB unreadable — will retry on next launch"
+                    "registry-migrate: DB unreadable — skipping this source; registry still attaches, marker deferred to retry"
                 );
+                stats.dbs_skipped += 1;
                 any_db_failed = true;
             }
         }
@@ -249,11 +257,13 @@ fn write_marker(path: &Path, stats: &MigrateStats) -> std::io::Result<()> {
     let body = format!(
         "migrated_at: {now}\n\
          dbs_scanned: {}\n\
+         dbs_skipped: {}\n\
          rows_seen: {}\n\
          records_written: {}\n\
          records_skipped_existing: {}\n\
          records_skipped_unmappable: {}\n",
         stats.dbs_scanned,
+        stats.dbs_skipped,
         stats.rows_seen,
         stats.records_written,
         stats.records_skipped_existing,
@@ -816,10 +826,14 @@ mod tests {
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.records_written, 1, "good DB still migrated");
+        assert_eq!(stats.dbs_skipped, 1, "bad DB counted, not fatal");
         assert!(
             !reg.root().join(MARKER).exists(),
-            "marker MUST NOT be written when any DB was unreadable"
+            "marker deferred (retry) when a DB was unreadable — but the registry still attaches (see main.rs); good records are already written"
         );
+        // The good record is present regardless of the deferred marker — a bad
+        // unrelated DB must not hide cross-channel agents (codex P1 on #1389).
+        assert_eq!(reg.list_active().unwrap().len(), 1);
 
         // Next launch retries; the good row is idempotency-skipped, and the
         // bad DB now reads (replaced with a valid file under the same wd).
@@ -884,8 +898,9 @@ mod tests {
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         // Only one had a *file*, and it failed to read — no panic, no rows.
-        // Marker deferred so the next launch retries.
+        // Marker deferred so the next launch retries; the bad DB is counted.
         assert_eq!(stats.dbs_scanned, 1);
+        assert_eq!(stats.dbs_skipped, 1);
         assert_eq!(stats.records_written, 0);
         assert!(
             !reg.root().join(MARKER).exists(),

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -174,10 +174,11 @@ pub fn migrate_from_sqlite_once(
         stats.records_written += 1;
     }
 
-    // Only finalize the migration when every DB we encountered was readable.
-    // On any per-DB error, defer the marker so a future launch retries AND
-    // signal `complete = false` so main.rs leaves the registry detached for
-    // this session (reads fall back to SQLite — preferred over a partial view).
+    // `complete` is true only when every DB we encountered was readable. It
+    // gates ONLY the one-shot marker: on any skipped DB the marker is deferred
+    // so a future launch retries that source. It does NOT detach the registry —
+    // main.rs attaches whenever the migration returns Ok and serves the records
+    // that did read (codex P1 on #1389); see the field doc above.
     stats.complete = !any_db_failed;
     if stats.complete {
         write_marker(&marker_path, &stats)?;
@@ -226,10 +227,19 @@ fn enumerate_sources(home: &Path) -> Vec<SqliteSource> {
     out
 }
 
+/// Instance-internal subdirectories (`DataPaths::ensure_dirs`) — never branch
+/// or sub-hash containers. The dev walk must NOT descend into these: an agent
+/// workspace under `<instance>/agents/<slug>/` can itself contain a nested
+/// AgentMux `data/db/objects.db` (e.g. an agent that ran its own instance),
+/// which must not be mistaken for a migration source (reagent P2 on #1389).
+const DEV_INTERNAL_DIRS: &[&str] =
+    &["data", "agents", "logs", "cef-cache", "runtime", "config"];
+
 /// Recursively locate dev instance dirs (those with `data/db/objects.db`) and
-/// anchor each on its sibling `agents/` dir. Bounded depth guards against
-/// pathological trees; an instance dir is a leaf (we stop descending once a
-/// DB is found).
+/// anchor each on its sibling `agents/` dir. An instance dir is a leaf (we stop
+/// descending once a DB is found), and descent skips instance-internal dirs so
+/// the walk only traverses branch / sub-hash containers. Bounded depth is a
+/// backstop against pathological/looping trees.
 fn collect_dev_sources(dir: &Path, out: &mut Vec<SqliteSource>, depth: usize) {
     if depth > 4 {
         return;
@@ -244,10 +254,18 @@ fn collect_dev_sources(dir: &Path, out: &mut Vec<SqliteSource>, depth: usize) {
     }
     if let Ok(rd) = std::fs::read_dir(dir) {
         for e in rd.flatten() {
-            let p = e.path();
-            if p.is_dir() {
-                collect_dev_sources(&p, out, depth + 1);
+            if !e.path().is_dir() {
+                continue;
             }
+            // Skip instance internals (esp. `agents/`) so we never walk into an
+            // agent's workspace and pick up a nested objects.db as a source.
+            if e.file_name()
+                .to_str()
+                .is_some_and(|n| DEV_INTERNAL_DIRS.contains(&n))
+            {
+                continue;
+            }
+            collect_dev_sources(&e.path(), out, depth + 1);
         }
     }
 }
@@ -621,6 +639,60 @@ mod tests {
         let recs = reg.list_active().unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].data.working_dir, "devagent");
+    }
+
+    #[test]
+    fn migrate_dev_ignores_nested_agent_workspace_db() {
+        // An agent running inside a dev instance can create its OWN nested
+        // AgentMux data dir under <instance>/agents/<slug>/. The dev walk must
+        // NOT descend into agents/ and pick that nested objects.db up as a
+        // migration source (reagent P2 on #1389).
+        let (home, reg) = fresh_home();
+        let inst_dir = home.path().join("dev").join("mybranch").join("sub");
+        // NO instance-level DB — only a nested one inside an agent workspace.
+        let nested_inst = inst_dir.join("agents").join("nestedmux");
+        let nested_wd = nested_inst.join("agents").join("inner");
+        std::fs::create_dir_all(&nested_wd).unwrap();
+        make_db_at(
+            &nested_inst,
+            &[("inst-nested", "Nested", 100, &nested_wd.to_string_lossy(), false)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(
+            stats.dbs_scanned, 0,
+            "must not descend into agent workspaces under dev/"
+        );
+        assert!(reg.list_active().unwrap().is_empty());
+    }
+
+    #[test]
+    fn migrate_dev_picks_instance_db_and_ignores_nested() {
+        // With an instance-level DB present, the walk stops at the instance dir
+        // (leaf) and never descends into its agents/ — so a nested workspace DB
+        // is ignored even when the real instance DB exists.
+        let (home, reg) = fresh_home();
+        let inst_dir = home.path().join("dev").join("mybranch").join("sub");
+        let wd = inst_dir.join("agents").join("realagent");
+        std::fs::create_dir_all(&wd).unwrap();
+        make_db_at(
+            &inst_dir,
+            &[("inst-real", "Real", 100, &wd.to_string_lossy(), false)],
+        );
+        let nested_inst = inst_dir.join("agents").join("nestedmux");
+        let nested_wd = nested_inst.join("agents").join("inner");
+        std::fs::create_dir_all(&nested_wd).unwrap();
+        make_db_at(
+            &nested_inst,
+            &[("inst-nested", "Nested", 200, &nested_wd.to_string_lossy(), false)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.dbs_scanned, 1, "only the instance-level dev DB is a source");
+        let recs = reg.list_active().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].data.instance_id, "inst-real");
+        assert_eq!(recs[0].data.working_dir, "realagent");
     }
 
     #[test]

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -1,12 +1,30 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! One-shot SQLite → file-registry migration. Runs at most once per
-//! `<root>/.migrated_from_sqlite` marker; idempotent and read-only on
-//! every SQLite it touches. See SPEC §8.
+//! One-shot SQLite → file-registry migration for named **instances**.
+//!
+//! Runs at most once per `<registry_root>/.migrated_from_sqlite` marker;
+//! idempotent and read-only on every SQLite it touches.
+//!
+//! P0.3 re-roots the registry to the GLOBAL `~/.agentmux/shared/agents/
+//! registry/`, so this scan is generalized from "the current channel's
+//! per-version DBs" to **every channel and every dev branch on the machine**:
+//!
+//! ```text
+//!   <home>/channels/<ch>/versions/<v>/data/db/objects.db   (installed/portable)
+//!   <home>/dev/<branch>[/<sub>]/data/db/objects.db         (dev)
+//! ```
+//!
+//! **Landmine #1 — per-source anchoring.** A row's `working_directory` is
+//! absolute under *its own* channel's agents dir (`channels/<ch>/agents`, or
+//! `<instance_dir>/agents` for dev). Stripping every row against a single
+//! global agents root would mark rows from other channels "unmappable", so
+//! each source DB carries the agents dir its rows are anchored on, and
+//! [`row_to_record`] strips against that. See
+//! `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` §11.5.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags};
 
@@ -16,39 +34,47 @@ use super::store::{Registry, RegistryError};
 /// Outcome stats — surfaced in the marker file + the srv log.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MigrateStats {
-    pub versions_scanned: usize,
+    /// Number of per-(channel,version) / per-dev-branch `objects.db` files
+    /// scanned (was "versions" when the scan was single-channel).
+    pub dbs_scanned: usize,
     pub rows_seen: usize,
     pub records_written: usize,
     pub records_skipped_existing: usize,
     pub records_skipped_unmappable: usize,
-    /// True iff every per-version DB read cleanly. Callers gate
-    /// registry attachment on this — partial migrations leave the
-    /// registry detached so reads keep falling back to SQLite, and
-    /// the next launch retries (no marker written when `false`).
+    /// True iff every DB read cleanly. Callers gate registry attachment on
+    /// this — partial migrations leave the registry detached so reads keep
+    /// falling back to SQLite, and the next launch retries (no marker written
+    /// when `false`).
     pub complete: bool,
 }
 
-/// Marker filename. Lives in the registry root so the registry's
-/// existence implies the migration question has been asked at least
-/// once.
+/// Marker filename. Lives in the registry root so the registry's existence
+/// implies the migration question has been asked at least once.
 const MARKER: &str = ".migrated_from_sqlite";
 
-/// Scan every per-version `data/db/objects.db` and populate the
-/// shared registry. Skipped if the marker file exists. Never
-/// overwrites an existing registry record (idempotency + respect
-/// for newer-written data). The SQLite files are opened **read-only**
-/// — never modified.
+/// A per-(channel,version) / per-dev-branch SQLite source, paired with the
+/// agents dir whose subtree its `working_directory` values are absolute under.
+struct SqliteSource {
+    db_path: PathBuf,
+    agents_root: PathBuf,
+}
+
+/// Scan every channel + dev `objects.db` under `home` and populate the shared
+/// registry. Skipped if the marker file exists. Never overwrites an existing
+/// registry record (idempotency + respect for newer-written data). The SQLite
+/// files are opened **read-only** — never modified.
 ///
-/// On dedup conflicts (same `instance_id` in multiple versions), the
-/// row with the latest `started_at` wins.
+/// On dedup conflicts (same `instance_id` in multiple versions/channels), the
+/// row with the latest `started_at` wins; any version expressing "forget"
+/// intent (`display_hidden`) is preserved as a tombstone.
 pub fn migrate_from_sqlite_once(
-    shared_home: &Path,
+    home: &Path,
     registry: &Registry,
 ) -> Result<MigrateStats, RegistryError> {
     let marker_path = registry.root().join(MARKER);
     if marker_path.exists() {
-        // Marker present ⇒ a prior run completed; treat as complete
-        // so callers attach the registry.
+        // Marker present ⇒ a prior run completed; treat as complete so
+        // callers attach the registry.
         return Ok(MigrateStats {
             complete: true,
             ..MigrateStats::default()
@@ -56,48 +82,27 @@ pub fn migrate_from_sqlite_once(
     }
 
     let mut stats = MigrateStats::default();
-    let agents_root = registry.agents_root().ok_or_else(|| {
-        RegistryError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "registry root has no parent",
-        ))
-    })?;
-
-    let versions_root = shared_home.join("versions");
-    if !versions_root.is_dir() {
-        stats.complete = true;
-        write_marker(&marker_path, &stats)?;
-        return Ok(stats);
-    }
+    let sources = enumerate_sources(home);
 
     let mut latest_by_id: HashMap<String, RowSnapshot> = HashMap::new();
-    // True iff any per-version DB threw a non-transient-looking error.
-    // We use this to skip writing the marker so the next launch
-    // retries — otherwise a brief filesystem hiccup permanently
-    // omits those rows from the registry-backed dropdown.
+    // True iff any DB threw a non-transient-looking error. We use this to skip
+    // writing the marker so the next launch retries — otherwise a brief
+    // filesystem hiccup permanently omits those rows from the registry-backed
+    // dropdown.
     let mut any_db_failed = false;
 
-    for entry in std::fs::read_dir(&versions_root)? {
-        let v_dir = entry?.path();
-        if !v_dir.is_dir() {
-            continue;
-        }
-        let db_path = v_dir.join("data").join("db").join("objects.db");
-        if !db_path.is_file() {
-            continue;
-        }
-        stats.versions_scanned += 1;
-
-        match read_named_rows(&db_path) {
+    for src in sources {
+        stats.dbs_scanned += 1;
+        match read_named_rows(&src.db_path, &src.agents_root) {
             Ok(rows) => {
                 for row in rows {
                     stats.rows_seen += 1;
                     let key = row.id.clone();
                     match latest_by_id.get_mut(&key) {
                         Some(existing) if existing.started_at >= row.started_at => {
-                            // Existing snapshot wins on started_at, but
-                            // OR the hidden flag — any version expressing
-                            // "forget" intent is preserved as a tombstone.
+                            // Existing snapshot wins on started_at, but OR the
+                            // hidden flag — any version expressing "forget"
+                            // intent is preserved as a tombstone.
                             existing.display_hidden =
                                 existing.display_hidden || row.display_hidden;
                         }
@@ -115,9 +120,9 @@ pub fn migrate_from_sqlite_once(
             }
             Err(e) => {
                 tracing::warn!(
-                    db = %db_path.display(),
+                    db = %src.db_path.display(),
                     error = %e,
-                    "registry-migrate: per-version DB unreadable — will retry on next launch"
+                    "registry-migrate: DB unreadable — will retry on next launch"
                 );
                 any_db_failed = true;
             }
@@ -125,16 +130,15 @@ pub fn migrate_from_sqlite_once(
     }
 
     for (id, row) in latest_by_id {
-        // Check active AND retired — a record retired by a newer
-        // version's "Forget agent" must NOT be resurrected just
-        // because an older version's SQLite still lists it as
-        // visible.
+        // Check active AND retired — a record retired by a newer version's
+        // "Forget agent" must NOT be resurrected just because an older
+        // version's SQLite still lists it as visible.
         if registry.exists_anywhere(&id) {
             stats.records_skipped_existing += 1;
             continue;
         }
         let display_hidden = row.display_hidden;
-        let Some(rec) = row_to_record(&row, agents_root) else {
+        let Some(rec) = row_to_record(&row) else {
             stats.records_skipped_unmappable += 1;
             continue;
         };
@@ -147,10 +151,9 @@ pub fn migrate_from_sqlite_once(
             stats.records_skipped_unmappable += 1;
             continue;
         }
-        // Preserve pre-registry "forget" intent: if any version's
-        // SQLite had this row hidden, move the freshly-written
-        // registry file to retired/ so the dropdown stays consistent
-        // with the user's prior soft-delete.
+        // Preserve pre-registry "forget" intent: if any version's SQLite had
+        // this row hidden, move the freshly-written registry file to retired/
+        // so the dropdown stays consistent with the user's prior soft-delete.
         if display_hidden {
             if let Err(e) = registry.retire(&id) {
                 tracing::warn!(
@@ -163,32 +166,94 @@ pub fn migrate_from_sqlite_once(
         stats.records_written += 1;
     }
 
-    // Only finalize the migration when every DB we encountered was
-    // readable. On any per-DB error, defer the marker so a future
-    // launch retries the migration AND signal `complete = false` so
-    // main.rs leaves the registry detached for this session (reads
-    // fall back to SQLite — preferred over serving a partial view).
+    // Only finalize the migration when every DB we encountered was readable.
+    // On any per-DB error, defer the marker so a future launch retries AND
+    // signal `complete = false` so main.rs leaves the registry detached for
+    // this session (reads fall back to SQLite — preferred over a partial view).
     stats.complete = !any_db_failed;
     if stats.complete {
         write_marker(&marker_path, &stats)?;
     } else {
         tracing::info!(
-            "registry-migrate: deferring marker write; one or more per-version DBs were unreadable and will be retried next launch"
+            "registry-migrate: deferring marker write; one or more DBs were unreadable and will be retried next launch"
         );
     }
     Ok(stats)
+}
+
+/// Enumerate every per-(channel,version) and per-dev-branch `objects.db` under
+/// `home`, pairing each with the agents dir its rows are anchored on.
+fn enumerate_sources(home: &Path) -> Vec<SqliteSource> {
+    let mut out = Vec::new();
+
+    // Installed/portable: home/channels/<ch>/versions/<v>/data/db/objects.db,
+    // anchored on home/channels/<ch>/agents.
+    if let Ok(rd) = std::fs::read_dir(home.join("channels")) {
+        for ch in rd.flatten() {
+            let ch_dir = ch.path();
+            if !ch_dir.is_dir() {
+                continue;
+            }
+            let agents_root = ch_dir.join("agents");
+            if let Ok(vrd) = std::fs::read_dir(ch_dir.join("versions")) {
+                for v in vrd.flatten() {
+                    let db = v.path().join("data").join("db").join("objects.db");
+                    if db.is_file() {
+                        out.push(SqliteSource {
+                            db_path: db,
+                            agents_root: agents_root.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Dev: home/dev/<branch>[/<sub>]/data/db/objects.db, anchored on
+    // <instance_dir>/agents (instance_dir = the dir that holds `data`). The
+    // depth under dev/ varies (branch, sometimes branch/sub-hash), so search
+    // a bounded number of levels for a `data/db/objects.db`.
+    collect_dev_sources(&home.join("dev"), &mut out, 0);
+
+    out
+}
+
+/// Recursively locate dev instance dirs (those with `data/db/objects.db`) and
+/// anchor each on its sibling `agents/` dir. Bounded depth guards against
+/// pathological trees; an instance dir is a leaf (we stop descending once a
+/// DB is found).
+fn collect_dev_sources(dir: &Path, out: &mut Vec<SqliteSource>, depth: usize) {
+    if depth > 4 {
+        return;
+    }
+    let db = dir.join("data").join("db").join("objects.db");
+    if db.is_file() {
+        out.push(SqliteSource {
+            db_path: db,
+            agents_root: dir.join("agents"),
+        });
+        return;
+    }
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                collect_dev_sources(&p, out, depth + 1);
+            }
+        }
+    }
 }
 
 fn write_marker(path: &Path, stats: &MigrateStats) -> std::io::Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     let body = format!(
         "migrated_at: {now}\n\
-         versions_scanned: {}\n\
+         dbs_scanned: {}\n\
          rows_seen: {}\n\
          records_written: {}\n\
          records_skipped_existing: {}\n\
          records_skipped_unmappable: {}\n",
-        stats.versions_scanned,
+        stats.dbs_scanned,
         stats.rows_seen,
         stats.records_written,
         stats.records_skipped_existing,
@@ -204,22 +269,25 @@ struct RowSnapshot {
     identity_id: String,
     memory_id: String,
     working_directory: String,
+    /// The agents dir this row's `working_directory` is absolute under — the
+    /// source channel's `agents/` (landmine #1). Travels with the row through
+    /// dedup so the winner is stripped against its own channel.
+    agents_root: PathBuf,
     started_at: i64,
     created_at: i64,
     display_hidden: bool,
 }
 
-/// True iff the error is SQLite reporting "this column/table doesn't
-/// exist in this DB's schema." Distinguishes a pre-v8 DB (skip
-/// silently — those agents weren't named, so wouldn't appear in the
-/// dropdown anyway) from corruption (caller logs + continues +
-/// defers the marker).
+/// True iff the error is SQLite reporting "this column/table doesn't exist in
+/// this DB's schema." Distinguishes a pre-v8 DB (skip silently — those agents
+/// weren't named, so wouldn't appear in the dropdown anyway) from corruption
+/// (caller logs + continues + defers the marker).
 ///
 /// rusqlite reports prepare-time schema mismatches as
 /// `Error::SqlInputError { msg, sql, offset }` and runtime errors as
-/// `Error::SqliteFailure(_, Some(msg))`. Both shapes carry the
-/// canonical SQLite phrases, but only message inspection
-/// distinguishes them from other failures with the same error code.
+/// `Error::SqliteFailure(_, Some(msg))`. Both shapes carry the canonical
+/// SQLite phrases, but only message inspection distinguishes them from other
+/// failures with the same error code.
 fn is_missing_column_or_table(e: &rusqlite::Error) -> bool {
     let msg = match e {
         rusqlite::Error::SqliteFailure(_, Some(msg)) => msg.as_str(),
@@ -229,18 +297,21 @@ fn is_missing_column_or_table(e: &rusqlite::Error) -> bool {
     msg.starts_with("no such column") || msg.starts_with("no such table")
 }
 
-fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> {
+fn read_named_rows(
+    db_path: &Path,
+    agents_root: &Path,
+) -> Result<Vec<RowSnapshot>, rusqlite::Error> {
     let conn = Connection::open_with_flags(
         db_path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
     // Older schemas (pre-v8) lack `instance_name` / `working_directory`
-    // columns. Suppress ONLY the specific "no such column/table"
-    // errors — broader SqliteFailures (corruption, locked, etc.) must
-    // surface so the caller can log + continue with the next DB.
-    // Include hidden rows — the caller turns them into retired/
-    // tombstones so a pre-registry "Forget agent" intent survives
-    // migration even if another version still has the row visible.
+    // columns. Suppress ONLY the specific "no such column/table" errors —
+    // broader SqliteFailures (corruption, locked, etc.) must surface so the
+    // caller can log + continue with the next DB. Include hidden rows — the
+    // caller turns them into retired/ tombstones so a pre-registry "Forget
+    // agent" intent survives migration even if another version still has the
+    // row visible.
     let mut stmt = match conn.prepare(
         "SELECT id, instance_name, definition_id, identity_id, memory_id,
                 working_directory, started_at, created_at, display_hidden
@@ -260,6 +331,7 @@ fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> 
             identity_id: row.get(3)?,
             memory_id: row.get(4)?,
             working_directory: row.get(5)?,
+            agents_root: agents_root.to_path_buf(),
             started_at: row.get(6)?,
             created_at: row.get(7)?,
             display_hidden: row.get::<_, i64>(8)? != 0,
@@ -268,9 +340,11 @@ fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> 
     iter.collect()
 }
 
-fn row_to_record(row: &RowSnapshot, agents_root: &Path) -> Option<NamedAgentRecord> {
+fn row_to_record(row: &RowSnapshot) -> Option<NamedAgentRecord> {
     let abs = std::path::Path::new(&row.working_directory);
-    let rel = abs.strip_prefix(agents_root).ok()?;
+    // Strip against THIS row's own source-channel agents dir (landmine #1),
+    // not a single global root — else rows from other channels look unmappable.
+    let rel = abs.strip_prefix(&row.agents_root).ok()?;
     let rel_str = rel.to_string_lossy().to_string();
     if rel_str.is_empty() || rel_str == "." {
         return None;
@@ -281,16 +355,17 @@ fn row_to_record(row: &RowSnapshot, agents_root: &Path) -> Option<NamedAgentReco
         definition_id: row.definition_id.clone(),
         identity_id: empty_to_none(&row.identity_id),
         memory_id: empty_to_none(&row.memory_id),
-        // This per-channel SQLite consolidation does not carry session_id
-        // yet; the global migration (P0.3) reads it from db_agent_instances.
-        // Until then these stay session-less (v1) and v1-binary-readable.
+        // The legacy per-channel rows don't carry session_id through this
+        // consolidation path; live mirroring (registry_mirror.rs) populates it
+        // on the next launch/update. Until then these stay session-less (v1)
+        // and v1-binary-readable.
         session_id: None,
         working_dir: rel_str,
         created_at_ms: row.created_at,
         last_launched_at_ms: row.started_at,
-        // We don't know what version originally inserted these rows.
-        // Tag them so post-migration audits can tell. PR C will
-        // never overwrite a record so these stay forever.
+        // We don't know what version originally inserted these rows. Tag them
+        // so post-migration audits can tell. The migration never overwrites a
+        // record (exists_anywhere skip) so these stay.
         created_by_version: "(legacy)".to_string(),
         last_launched_by_version: "(legacy)".to_string(),
     };
@@ -313,23 +388,12 @@ mod tests {
     use super::*;
     use rusqlite::params;
 
-    /// Build a per-version SQLite at `<version_dir>/data/db/objects.db`
-    /// with a minimal `db_agent_instances` schema and the given rows.
-    fn make_version_db(version_dir: &Path, rows: &[(&str, &str, i64, &str)]) {
-        let rows: Vec<_> = rows.iter().map(|(a, b, c, d)| (*a, *b, *c, *d, false)).collect();
-        make_version_db_with_hidden(version_dir, &rows);
-    }
-
-    /// Variant that lets each row carry an explicit `display_hidden`
-    /// flag. Used by tests that exercise tombstone propagation.
-    fn make_version_db_with_hidden(
-        version_dir: &Path,
-        rows: &[(&str, &str, i64, &str, bool)],
-    ) {
-        let db_path = version_dir.join("data").join("db");
-        std::fs::create_dir_all(&db_path).unwrap();
-        let db_path = db_path.join("objects.db");
-        let conn = Connection::open(&db_path).unwrap();
+    /// Build a per-version SQLite at `<version_dir>/data/db/objects.db` with a
+    /// minimal `db_agent_instances` schema and the given rows.
+    fn make_db_at(version_dir: &Path, rows: &[(&str, &str, i64, &str, bool)]) {
+        let db_dir = version_dir.join("data").join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let conn = Connection::open(db_dir.join("objects.db")).unwrap();
         conn.execute_batch(
             "CREATE TABLE db_agent_instances (
                 id TEXT PRIMARY KEY,
@@ -361,17 +425,59 @@ mod tests {
         }
     }
 
+    /// The agents dir for a channel under `home`.
+    fn channel_agents(home: &Path, channel: &str) -> PathBuf {
+        home.join("channels").join(channel).join("agents")
+    }
+
+    /// Build a channel/version DB with the given (id, name, started_at, wd) rows.
+    fn make_channel_db(
+        home: &Path,
+        channel: &str,
+        version: &str,
+        rows: &[(&str, &str, i64, &str)],
+    ) {
+        let rows: Vec<_> = rows.iter().map(|(a, b, c, d)| (*a, *b, *c, *d, false)).collect();
+        let v_dir = home
+            .join("channels")
+            .join(channel)
+            .join("versions")
+            .join(version);
+        make_db_at(&v_dir, &rows);
+    }
+
+    fn make_channel_db_with_hidden(
+        home: &Path,
+        channel: &str,
+        version: &str,
+        rows: &[(&str, &str, i64, &str, bool)],
+    ) {
+        let v_dir = home
+            .join("channels")
+            .join(channel)
+            .join("versions")
+            .join(version);
+        make_db_at(&v_dir, rows);
+    }
+
     fn fresh_home() -> (tempfile::TempDir, Registry) {
         let home = tempfile::tempdir().unwrap();
-        let reg = Registry::open(home.path().join("agents").join("registry")).unwrap();
+        // Registry rooted at the GLOBAL shared location, mirroring production.
+        let reg = Registry::open(
+            home.path()
+                .join("shared")
+                .join("agents")
+                .join("registry"),
+        )
+        .unwrap();
         (home, reg)
     }
 
     #[test]
-    fn migrate_with_no_versions_dir_writes_marker_and_no_rows() {
+    fn migrate_with_no_channels_writes_marker_and_no_rows() {
         let (home, reg) = fresh_home();
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
-        assert_eq!(stats.versions_scanned, 0);
+        assert_eq!(stats.dbs_scanned, 0);
         assert_eq!(stats.records_written, 0);
         assert!(reg.root().join(MARKER).exists());
     }
@@ -381,13 +487,13 @@ mod tests {
         let (home, reg) = fresh_home();
         // Empty home — marker gets written on first call.
         migrate_from_sqlite_once(home.path(), &reg).unwrap();
-        // Add a version DB AFTER the marker — second run must NOT pick it up.
-        let agents_root = home.path().join("agents");
-        let v_dir = home.path().join("versions").join("0.33.821");
-        let wd = agents_root.join("demo-1");
+        // Add a channel DB AFTER the marker — second run must NOT pick it up.
+        let wd = channel_agents(home.path(), "stable").join("demo-1");
         std::fs::create_dir_all(&wd).unwrap();
-        make_version_db(
-            &v_dir,
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
             &[("inst-1", "demo", 100, &wd.to_string_lossy())],
         );
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
@@ -401,15 +507,15 @@ mod tests {
     #[test]
     fn migrate_writes_one_record_per_unique_id() {
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd_a = agents_root.join("demo-a");
-        let wd_b = agents_root.join("demo-b");
+        let agents = channel_agents(home.path(), "stable");
+        let wd_a = agents.join("demo-a");
+        let wd_b = agents.join("demo-b");
         std::fs::create_dir_all(&wd_a).unwrap();
         std::fs::create_dir_all(&wd_b).unwrap();
-        let v_dir = home.path().join("versions").join("0.33.821");
-        make_version_db(
-            &v_dir,
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
             &[
                 ("inst-a", "demoA", 100, &wd_a.to_string_lossy()),
                 ("inst-b", "demoB", 200, &wd_b.to_string_lossy()),
@@ -423,17 +529,59 @@ mod tests {
     }
 
     #[test]
+    fn migrate_anchors_each_row_on_its_own_channel() {
+        // Landmine #1: two agents in two DIFFERENT channels, each
+        // working_directory absolute under its OWN channel's agents dir. Both
+        // must migrate with the correct relative slug — neither is dropped as
+        // "unmappable" just because the other channel's agents root differs.
+        let (home, reg) = fresh_home();
+        let wd_a = channel_agents(home.path(), "stable").join("alpha");
+        let wd_b = channel_agents(home.path(), "local-main-b28b7a").join("beta");
+        std::fs::create_dir_all(&wd_a).unwrap();
+        std::fs::create_dir_all(&wd_b).unwrap();
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.44.2",
+            &[("inst-a", "Alpha", 100, &wd_a.to_string_lossy())],
+        );
+        make_channel_db(
+            home.path(),
+            "local-main-b28b7a",
+            "0.44.2",
+            &[("inst-b", "Beta", 200, &wd_b.to_string_lossy())],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.dbs_scanned, 2);
+        assert_eq!(stats.rows_seen, 2);
+        assert_eq!(stats.records_skipped_unmappable, 0, "per-channel anchoring");
+        assert_eq!(stats.records_written, 2);
+        let mut recs = reg.list_active().unwrap();
+        recs.sort_by(|a, b| a.data.instance_id.cmp(&b.data.instance_id));
+        assert_eq!(recs[0].data.working_dir, "alpha");
+        assert_eq!(recs[1].data.working_dir, "beta");
+    }
+
+    #[test]
     fn migrate_picks_latest_started_at_on_dedup() {
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("demo");
+        let wd = channel_agents(home.path(), "stable").join("demo");
         std::fs::create_dir_all(&wd).unwrap();
-        // Same instance_id in two versions, different started_at.
-        let v1 = home.path().join("versions").join("0.33.800");
-        let v2 = home.path().join("versions").join("0.33.821");
-        make_version_db(&v1, &[("inst-1", "demo", 100, &wd.to_string_lossy())]);
-        make_version_db(&v2, &[("inst-1", "demo", 200, &wd.to_string_lossy())]);
+        // Same instance_id in two versions of the same channel, different
+        // started_at.
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.800",
+            &[("inst-1", "demo", 100, &wd.to_string_lossy())],
+        );
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
+            &[("inst-1", "demo", 200, &wd.to_string_lossy())],
+        );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.rows_seen, 2);
@@ -444,13 +592,33 @@ mod tests {
     }
 
     #[test]
+    fn migrate_handles_dev_layout() {
+        // Dev instance lives at home/dev/<branch>/<sub>/data/db/objects.db,
+        // anchored on home/dev/<branch>/<sub>/agents. The recursive dev walk
+        // must find it and strip against the sibling agents dir.
+        let (home, reg) = fresh_home();
+        let inst_dir = home.path().join("dev").join("mybranch").join("69d7a34a");
+        let wd = inst_dir.join("agents").join("devagent");
+        std::fs::create_dir_all(&wd).unwrap();
+        make_db_at(
+            &inst_dir,
+            &[("inst-dev", "DevAgent", 100, &wd.to_string_lossy(), false)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.dbs_scanned, 1);
+        assert_eq!(stats.records_written, 1);
+        let recs = reg.list_active().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].data.working_dir, "devagent");
+    }
+
+    #[test]
     fn migrate_skips_when_registry_already_has_record() {
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("demo");
+        let wd = channel_agents(home.path(), "stable").join("demo");
         std::fs::create_dir_all(&wd).unwrap();
-        // Pre-existing registry record (e.g. PR A already wrote it).
+        // Pre-existing registry record (e.g. the live mirror already wrote it).
         reg.upsert(&NamedAgentRecord {
             schema_version: MAX_SUPPORTED_SCHEMA,
             data: NamedAgentRecordV1 {
@@ -469,8 +637,12 @@ mod tests {
         })
         .unwrap();
         // Legacy SQLite row with the SAME instance_id but older data.
-        let v_dir = home.path().join("versions").join("0.33.821");
-        make_version_db(&v_dir, &[("inst-1", "legacyname", 100, &wd.to_string_lossy())]);
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
+            &[("inst-1", "legacyname", 100, &wd.to_string_lossy())],
+        );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.records_skipped_existing, 1);
@@ -483,16 +655,13 @@ mod tests {
 
     #[test]
     fn migrate_skips_when_record_is_retired() {
-        // A user "Forgot" an agent (its registry file is in retired/).
-        // Another version's SQLite still has display_hidden=0 for that
-        // id. Migration must NOT resurrect the row into active/.
+        // A user "Forgot" an agent (its registry file is in retired/). Another
+        // version's SQLite still has display_hidden=0 for that id. Migration
+        // must NOT resurrect the row into active/.
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("demo");
+        let wd = channel_agents(home.path(), "stable").join("demo");
         std::fs::create_dir_all(&wd).unwrap();
 
-        // Pre-tombstone a retired record.
         let retired_record = NamedAgentRecord {
             schema_version: MAX_SUPPORTED_SCHEMA,
             data: NamedAgentRecordV1 {
@@ -514,34 +683,38 @@ mod tests {
         assert!(reg.list_active().unwrap().is_empty());
         assert!(reg.exists_anywhere("inst-1"));
 
-        // Legacy SQLite still has display_hidden=0 for the same id.
-        let v_dir = home.path().join("versions").join("0.33.821");
-        make_version_db(&v_dir, &[("inst-1", "demo", 100, &wd.to_string_lossy())]);
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
+            &[("inst-1", "demo", 100, &wd.to_string_lossy())],
+        );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.rows_seen, 1);
         assert_eq!(stats.records_skipped_existing, 1);
         assert_eq!(stats.records_written, 0);
-        // Tombstone must remain in retired/, NOT moved to active.
         assert!(reg.list_active().unwrap().is_empty());
         assert!(reg.root().join("retired").join("inst-1.json").exists());
     }
 
     #[test]
     fn migrate_silently_skips_pre_v8_schema() {
-        // Real production case: an older SQLite (pre-v8) lacks the
-        // `instance_name` column. rusqlite reports this as
-        // `Error::SqlInputError` during prepare. The migrator must
-        // treat it as "nothing to migrate from this version" — NOT
-        // as a real DB failure that defers the marker.
+        // An older SQLite (pre-v8) lacks the `instance_name` column. rusqlite
+        // reports this as `Error::SqlInputError` during prepare. The migrator
+        // must treat it as "nothing to migrate from this version" — NOT a real
+        // DB failure that defers the marker.
         let (home, reg) = fresh_home();
-        // Build a per-version DB with the OLD schema (no
-        // instance_name / working_directory / display_hidden cols).
-        let v_dir = home.path().join("versions").join("0.33.643");
-        let db_dir = v_dir.join("data").join("db");
+        let db_dir = home
+            .path()
+            .join("channels")
+            .join("stable")
+            .join("versions")
+            .join("0.33.643")
+            .join("data")
+            .join("db");
         std::fs::create_dir_all(&db_dir).unwrap();
-        let db_path = db_dir.join("objects.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = Connection::open(db_dir.join("objects.db")).unwrap();
         conn.execute_batch(
             "CREATE TABLE db_agent_instances (
                 id TEXT PRIMARY KEY,
@@ -555,7 +728,7 @@ mod tests {
         drop(conn);
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
-        assert_eq!(stats.versions_scanned, 1);
+        assert_eq!(stats.dbs_scanned, 1);
         assert_eq!(stats.rows_seen, 0);
         assert!(stats.complete, "pre-v8 schema must not block the marker");
         assert!(reg.root().join(MARKER).exists());
@@ -563,73 +736,81 @@ mod tests {
 
     #[test]
     fn migrate_writes_legacy_hidden_row_as_tombstone() {
-        // Pre-registry "Forget agent" intent must survive migration:
-        // a single-version row with display_hidden=1 should land in
-        // retired/, not active/.
+        // Pre-registry "Forget agent" intent must survive migration: a
+        // single-version row with display_hidden=1 should land in retired/.
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("forgotten");
+        let wd = channel_agents(home.path(), "stable").join("forgotten");
         std::fs::create_dir_all(&wd).unwrap();
-        let v_dir = home.path().join("versions").join("0.33.821");
-        make_version_db_with_hidden(
-            &v_dir,
+        make_channel_db_with_hidden(
+            home.path(),
+            "stable",
+            "0.33.821",
             &[("inst-1", "forgotten", 100, &wd.to_string_lossy(), true)],
         );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.records_written, 1);
-        assert!(reg.list_active().unwrap().is_empty(),
-            "hidden legacy row must NOT appear active");
-        assert!(reg.root().join("retired").join("inst-1.json").exists(),
-            "hidden legacy row must be migrated as retired tombstone");
+        assert!(
+            reg.list_active().unwrap().is_empty(),
+            "hidden legacy row must NOT appear active"
+        );
+        assert!(
+            reg.root().join("retired").join("inst-1.json").exists(),
+            "hidden legacy row must be migrated as retired tombstone"
+        );
     }
 
     #[test]
     fn migrate_preserves_forget_intent_across_versions() {
-        // Same id in two versions: one hides it (Forget), the other
-        // still has it visible. The "forget" must win — registry
-        // tombstone, not active record.
+        // Same id in two versions: one hides it (Forget), the other still has
+        // it visible. The "forget" must win — registry tombstone, not active.
         let (home, reg) = fresh_home();
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("toggled");
+        let wd = channel_agents(home.path(), "stable").join("toggled");
         std::fs::create_dir_all(&wd).unwrap();
-        let v1 = home.path().join("versions").join("0.33.800");
-        let v2 = home.path().join("versions").join("0.33.821");
-        // v1 has it visible; v2 has it hidden (user later Forgot it).
-        make_version_db_with_hidden(
-            &v1,
+        make_channel_db_with_hidden(
+            home.path(),
+            "stable",
+            "0.33.800",
             &[("inst-1", "toggled", 100, &wd.to_string_lossy(), false)],
         );
-        make_version_db_with_hidden(
-            &v2,
+        make_channel_db_with_hidden(
+            home.path(),
+            "stable",
+            "0.33.821",
             &[("inst-1", "toggled", 200, &wd.to_string_lossy(), true)],
         );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.records_written, 1);
-        assert!(reg.list_active().unwrap().is_empty(),
-            "hidden intent in any version must propagate to registry tombstone");
+        assert!(
+            reg.list_active().unwrap().is_empty(),
+            "hidden intent in any version must propagate to registry tombstone"
+        );
         assert!(reg.root().join("retired").join("inst-1.json").exists());
     }
 
     #[test]
     fn migrate_defers_marker_on_unreadable_db() {
-        // A briefly-unreadable per-version DB during startup must NOT
-        // bake "permanently skip" into the marker. Marker is only
-        // written when every DB read succeeded.
+        // A briefly-unreadable DB during startup must NOT bake "permanently
+        // skip" into the marker. Marker is only written when every DB read.
         let (home, reg) = fresh_home();
-        // Good DB.
-        let agents_root = home.path().join("agents");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        let wd = agents_root.join("demo");
+        let wd = channel_agents(home.path(), "stable").join("demo");
         std::fs::create_dir_all(&wd).unwrap();
-        let good_v = home.path().join("versions").join("0.33.821");
-        make_version_db(&good_v, &[("inst-good", "demo", 100, &wd.to_string_lossy())]);
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
+            &[("inst-good", "demo", 100, &wd.to_string_lossy())],
+        );
         // Bad DB — looks like a SQLite file but is corrupt.
-        let bad_v = home.path().join("versions").join("0.33.800");
-        let bad_db_dir = bad_v.join("data").join("db");
+        let bad_db_dir = home
+            .path()
+            .join("channels")
+            .join("stable")
+            .join("versions")
+            .join("0.33.800")
+            .join("data")
+            .join("db");
         std::fs::create_dir_all(&bad_db_dir).unwrap();
         std::fs::write(bad_db_dir.join("objects.db"), b"not actually sqlite").unwrap();
 
@@ -640,20 +821,21 @@ mod tests {
             "marker MUST NOT be written when any DB was unreadable"
         );
 
-        // Next launch retries the migration; the good rows are
-        // idempotency-skipped (exists_anywhere), and the bad DB now
-        // works (simulate by replacing with a valid file pointing at
-        // the same `wd` so we don't need a second working-dir
-        // fixture).
+        // Next launch retries; the good row is idempotency-skipped, and the
+        // bad DB now reads (replaced with a valid file under the same wd).
         std::fs::remove_file(bad_db_dir.join("objects.db")).unwrap();
-        make_version_db(&bad_v, &[("inst-other", "demo", 50, &wd.to_string_lossy())]);
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.800",
+            &[("inst-other", "demo", 50, &wd.to_string_lossy())],
+        );
         let stats2 = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert!(stats2.complete, "complete flag set on clean retry");
         assert!(
             reg.root().join(MARKER).exists(),
             "marker written on the retry once all DBs read successfully"
         );
-        // Retry: 2 rows seen, 1 new written (inst-other), 1 skipped existing (inst-good).
         assert_eq!(stats2.records_skipped_existing, 1);
         assert_eq!(stats2.records_written, 1);
     }
@@ -661,10 +843,14 @@ mod tests {
     #[test]
     fn migrate_skips_unmappable_working_dirs() {
         let (home, reg) = fresh_home();
-        // Working dir is OUTSIDE the agents root — unmappable.
-        let v_dir = home.path().join("versions").join("0.33.821");
+        // Working dir is OUTSIDE any channel agents root — unmappable.
         let outside = home.path().join("not_under_agents").join("foo");
-        make_version_db(&v_dir, &[("inst-x", "demo", 100, &outside.to_string_lossy())]);
+        make_channel_db(
+            home.path(),
+            "stable",
+            "0.33.821",
+            &[("inst-x", "demo", 100, &outside.to_string_lossy())],
+        );
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         assert_eq!(stats.rows_seen, 1);
@@ -675,20 +861,31 @@ mod tests {
     #[test]
     fn migrate_tolerates_missing_or_corrupt_dbs() {
         let (home, reg) = fresh_home();
-        // Version dir with no DB file.
-        std::fs::create_dir_all(home.path().join("versions").join("0.33.700")).unwrap();
-        // Version dir with corrupt DB.
-        let bad_v = home.path().join("versions").join("0.33.701");
-        let db_dir = bad_v.join("data").join("db");
+        // Channel/version dir with no DB file.
+        std::fs::create_dir_all(
+            home.path()
+                .join("channels")
+                .join("stable")
+                .join("versions")
+                .join("0.33.700"),
+        )
+        .unwrap();
+        // Channel/version dir with corrupt DB.
+        let db_dir = home
+            .path()
+            .join("channels")
+            .join("stable")
+            .join("versions")
+            .join("0.33.701")
+            .join("data")
+            .join("db");
         std::fs::create_dir_all(&db_dir).unwrap();
         std::fs::write(db_dir.join("objects.db"), b"not a sqlite file").unwrap();
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
-        // Both version dirs scanned; only one had a *file*, and it
-        // failed to read — no panic, no rows migrated. Marker is
-        // deferred so the next launch retries; see the dedicated
-        // `migrate_defers_marker_on_unreadable_db` test.
-        assert_eq!(stats.versions_scanned, 1);
+        // Only one had a *file*, and it failed to read — no panic, no rows.
+        // Marker deferred so the next launch retries.
+        assert_eq!(stats.dbs_scanned, 1);
         assert_eq!(stats.records_written, 0);
         assert!(
             !reg.root().join(MARKER).exists(),

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -28,13 +28,12 @@ pub fn resolve_shared_registry_dir() -> Option<PathBuf> {
 
 /// Resolve the GLOBAL `<home>/shared/agents/definitions/` directory.
 ///
-/// Unlike [`resolve_shared_registry_dir`] (channel-scoped — its
-/// `AGENTMUX_DATA_DIR` walk-up lands on `channels/<ch>`), the definition
-/// store is **channel-independent**: it lives under the global
-/// `~/.agentmux/shared/` so an agent created in one channel is visible in
-/// every channel (cross-channel agent persistence, P0.2). Resolves via the
-/// launcher-exported `AGENTMUX_SHARED_DIR`, with a test override and a
-/// `~/.agentmux/shared` fallback.
+/// Sibling of [`resolve_shared_registry_dir`]: since P0.3 both the definition
+/// store and the instance registry are **channel-independent**, resolved via
+/// the same [`resolve_global_shared_root`] so an agent created/named in one
+/// channel is visible in every channel (cross-channel agent persistence,
+/// P0.2/P0.3). Resolves via the launcher-exported `AGENTMUX_SHARED_DIR`, with
+/// a test override and a `~/.agentmux/shared` fallback.
 pub fn resolve_shared_definitions_dir() -> Option<PathBuf> {
     resolve_global_shared_root().map(|h| h.join("agents").join("definitions"))
 }

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -5,24 +5,25 @@
 
 use std::path::PathBuf;
 
-/// Resolve `<shared_home>/agents/registry/`.
+/// Resolve the GLOBAL `<home>/shared/agents/registry/` directory.
 ///
-/// The registry is shared across every portable/installed version on
-/// the same machine — it must NOT use the per-version data dir.
+/// P0.3 re-roots the named-**instance** registry from the old
+/// channel-scoped `channels/<ch>/agents/registry/` (which walked
+/// `AGENTMUX_DATA_DIR` up three levels and so landed inside the current
+/// channel) to the channel-independent `~/.agentmux/shared/`. An agent
+/// named in one channel is then visible in every channel, exactly like the
+/// definition store ([`resolve_shared_definitions_dir`]) — the two are now
+/// siblings under `shared/agents/`.
 ///
-/// Resolution order:
-/// 1. `AGENTMUX_HOME_OVERRIDE` — test-only escape hatch, matching
-///    `agentmux-common::data_paths` convention.
-/// 2. Walk up from `AGENTMUX_DATA_DIR` (per-version data dir set by
-///    the launcher) by three levels: `data → versions/<v> → versions
-///    → <shared_home>`. Robust against the launcher running without
-///    a real home dir (CI).
-/// 3. Fall back to `~/.agentmux/`.
+/// The base directory that instance `working_directory` values are stored
+/// *relative to* is tracked separately (the Store's `registry_agents_base`,
+/// fed from `AGENTMUX_AGENTS_DIR`) — it must stay the current channel's
+/// agents dir even though the registry files are now global.
 ///
-/// Returns `None` only if every source fails — caller treats this as
-/// "registry disabled," no write attempts.
+/// Returns `None` only if the global shared root can't be resolved — caller
+/// treats this as "registry disabled," no write attempts.
 pub fn resolve_shared_registry_dir() -> Option<PathBuf> {
-    resolve_shared_home().map(|h| h.join("agents").join("registry"))
+    resolve_global_shared_root().map(|h| h.join("agents").join("registry"))
 }
 
 /// Resolve the GLOBAL `<home>/shared/agents/definitions/` directory.
@@ -56,26 +57,6 @@ fn resolve_global_shared_root() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".agentmux").join("shared"))
 }
 
-fn resolve_shared_home() -> Option<PathBuf> {
-    if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
-        if !s.is_empty() {
-            return Some(PathBuf::from(s));
-        }
-    }
-    if let Ok(s) = std::env::var("AGENTMUX_DATA_DIR") {
-        if !s.is_empty() {
-            let p = PathBuf::from(s);
-            // .../versions/<v>/data → ancestors()[3] = .../
-            if let Some(root) = p.ancestors().nth(3) {
-                if !root.as_os_str().is_empty() {
-                    return Some(root.to_path_buf());
-                }
-            }
-        }
-    }
-    dirs::home_dir().map(|h| h.join(".agentmux"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,22 +75,38 @@ mod tests {
     fn override_wins() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear();
+        // The override is the ~/.agentmux root; the global registry lives at
+        // root/shared/agents/registry (P0.3 re-root).
         std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
         let r = resolve_shared_registry_dir().unwrap();
-        assert_eq!(r, PathBuf::from("/tmp/test-home/agents/registry"));
+        assert_eq!(
+            r,
+            PathBuf::from("/tmp/test-home/shared/agents/registry")
+        );
         clear();
     }
 
     #[test]
-    fn walks_up_from_data_dir() {
+    fn registry_uses_shared_dir_and_ignores_data_dir() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear();
+        // The instance registry is GLOBAL now: it resolves from the shared
+        // root, NOT by walking up the per-version AGENTMUX_DATA_DIR (which
+        // would land in the current channel). Set both and confirm the
+        // channel-scoped data dir is ignored.
+        std::env::set_var("AGENTMUX_SHARED_DIR", "/home/user/.agentmux/shared");
         std::env::set_var(
             "AGENTMUX_DATA_DIR",
-            "/home/user/.agentmux/versions/0.33.822/data",
+            "/home/user/.agentmux/channels/stable/versions/0.44.2/data",
         );
         let r = resolve_shared_registry_dir().unwrap();
-        assert_eq!(r, PathBuf::from("/home/user/.agentmux/agents/registry"));
+        assert_eq!(
+            r,
+            PathBuf::from("/home/user/.agentmux/shared/agents/registry")
+        );
+        // Sibling of the definition store — both under shared/agents/.
+        let d = resolve_shared_definitions_dir().unwrap();
+        assert_eq!(r.parent(), d.parent());
         clear();
     }
 
@@ -117,7 +114,7 @@ mod tests {
     fn falls_back_to_home() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear();
-        // No env set — uses dirs::home_dir(). Just assert non-None.
+        // No env set — uses dirs::home_dir()/.agentmux/shared. Non-None.
         assert!(resolve_shared_registry_dir().is_some());
     }
 


### PR DESCRIPTION
## What

Completes **P0.3**: the named-**instance** registry moves from the channel-scoped `channels/<ch>/agents/registry/` to the global `~/.agentmux/shared/agents/registry/` — sibling of the P0.2 definition store. An agent named in one channel is now **visible in every channel**. The startup migration is generalized to scan **every channel + dev tree** on the machine, anchoring each row on its own source channel's agents dir.

Builds directly on **#1387** (P0.3a), which pre-decoupled the working-dir relative base into `Store::registry_agents_base`.

## How

### `paths.rs` — re-root
- `resolve_shared_registry_dir()` now resolves via `resolve_global_shared_root()` (the channel-independent root, same as the definition store) instead of walking `AGENTMUX_DATA_DIR` up three levels. Removed the now-dead `resolve_shared_home()`.
- Tests: override → `root/shared/agents/registry`; new test asserts the registry resolves from the shared root and **ignores** a channel-scoped `AGENTMUX_DATA_DIR`; registry + definitions are siblings under `shared/agents/`.

### `main.rs` — home derivation + base wiring
- `home = registry-root.ancestors().nth(3)` (registry → agents → shared → `~/.agentmux`), fed to the generalized migration.
- Wire the working-dir base from `AGENTMUX_AGENTS_DIR` right after `set_registry` — now safe in **all** modes (the registry is global, so `AGENTMUX_AGENTS_DIR` is the correct per-channel/per-dev anchor). This is the wiring P0.3a deferred to dodge the dev-leak (codex P2 on #1387).

### `migrate.rs` — generalized scan, per-source anchoring (**landmine #1**)
- `enumerate_sources()` walks `channels/<ch>/versions/<v>/data/db/objects.db` (anchored on `channels/<ch>/agents`) **plus** the dev tree `dev/<branch>[/<sub>]/data/db/objects.db` (anchored on `<instance_dir>/agents`, located via a bounded recursive search since dev depth varies).
- Each `RowSnapshot` carries its **own** source `agents_root`; `row_to_record` strips `working_directory` against **that** — so rows from other channels aren't dropped as "unmappable".
- Stat renamed `versions_scanned` → `dbs_scanned`. Dedup / forget-intent / pre-v8-skip / marker-defer logic unchanged.

## Landmines (§11.5)
- **#1 per-source anchoring** — handled (each row carries its source agents root). New test `migrate_anchors_each_row_on_its_own_channel`.
- **#2 concurrent multi-process writes** — every running channel's srv now writes the same global registry. Safety rests on the existing atomic-rename upsert + `retired/` tombstone tree; concurrent startup migrations converge (`exists_anywhere` skips written ids; same-id writes are content-identical, last atomic rename wins).
- **#3 marker relocation** — the `.migrated_from_sqlite` marker moves with the registry root, so the migration re-runs once into the global location, idempotent via `exists_anywhere`. Expected/acceptable.

## Tests
- **14 migrate** (incl. `migrate_anchors_each_row_on_its_own_channel`, `migrate_handles_dev_layout`), **5 paths**, **54 instance_** — all pass.

Per `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` §11.4/§11.5.

**Follow-up P0.4**: encode the source base per record so cross-channel rows reconstruct their absolute `working_directory` instead of re-joining under the current channel's agents dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)