### PR TITLE
fix(linux): capability-probed ANGLE backend precedence (HW Vulkan → HW GL → SwiftShader)

### DIFF
--- a/.changesets/1781400497-fix-linux-accelerate-gpu-enable-webgl-on-vmware-guests-angle-3blm.md
+++ b/.changesets/1781400497-fix-linux-accelerate-gpu-enable-webgl-on-vmware-guests-angle-3blm.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(linux): accelerate GPU + enable WebGL on VMware guests (ANGLE-gl + ignore-gpu-blocklist, VM-gated)
+fix(linux): capability-probed ANGLE backend precedence (hardware Vulkan → hardware GL → SwiftShader) — fixes burst-paint terminals and enables hardware WebGL on VMware/SVGA3D (and any no-Vulkan-but-has-GL) guests, with no vendor gate

--- a/.changesets/1781400497-fix-linux-accelerate-gpu-enable-webgl-on-vmware-guests-angle-3blm.md
+++ b/.changesets/1781400497-fix-linux-accelerate-gpu-enable-webgl-on-vmware-guests-angle-3blm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux): accelerate GPU + enable WebGL on VMware guests (ANGLE-gl + ignore-gpu-blocklist, VM-gated)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "agentmux-cef"
 version = "0.44.1"
 dependencies = [
  "agentmux-common",
+ "ash",
  "axum 0.8.9",
  "cef",
  "chrono",
@@ -230,6 +231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -512,7 +522,7 @@ dependencies = [
  "cargo_metadata",
  "cef-dll-sys",
  "clap",
- "libloading",
+ "libloading 0.9.0",
  "objc2",
  "plist",
  "semver",
@@ -1586,6 +1596,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libloading"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -97,6 +97,13 @@ winres = "0.1"
 # `spawn_blocking` task that doesn't unwind on outer-task abort).
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Vulkan device enumeration for the startup GPU-tier probe (hardware Vulkan →
+# hardware GL → software precedence). Used only to read physical-device types;
+# the host already bundles libvulkan.so.1. See app.rs `has_hardware_vulkan` and
+# docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md.
+ash = "0.38"
+
 [dev-dependencies]
 # Property tests for the shadow projection (master spec §8.14
 # subscriber idempotency contract). Mirrors agentmux-launcher's

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -241,25 +241,108 @@ extern "C" fn write_linux_window_properties(
     1
 }
 
-/// Best-effort detection of a VMware guest. On VMware, CEF's default
-/// ANGLE-on-Vulkan lands on software SwiftShader (no hardware Vulkan ICD) and
-/// Chromium's GPU blocklist disables accelerated WebGL/compositing for the
-/// virtual GPU. We use this to auto-route ANGLE onto the hardware SVGA3D GL
-/// path and override the blocklist (see `on_before_command_line_processing`).
-/// Cached — the DMI files don't change during a run.
+/// GPU capability tier, measured once at startup to drive ANGLE backend
+/// selection. Precedence: hardware Vulkan → hardware GL → software (SwiftShader).
+/// ANGLE is only retargeted, never bypassed. See the GPU block in
+/// `on_before_command_line_processing` and
+/// docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md.
 #[cfg(target_os = "linux")]
-fn is_vmware_guest() -> bool {
-    use std::sync::OnceLock;
-    static VMWARE: OnceLock<bool> = OnceLock::new();
-    *VMWARE.get_or_init(|| {
-        ["/sys/class/dmi/id/sys_vendor", "/sys/class/dmi/id/product_name"]
-            .iter()
-            .any(|p| {
-                std::fs::read_to_string(p)
-                    .map(|s| s.to_ascii_lowercase().contains("vmware"))
-                    .unwrap_or(false)
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GpuTier {
+    /// A hardware Vulkan device is present — leave Chromium's default (Vulkan).
+    HwVulkan,
+    /// No hardware Vulkan but a DRM render node exists — route ANGLE to GL and
+    /// override the GPU blocklist (the VMware/SVGA3D case).
+    HwGl,
+    /// Neither — leave Chromium's default (software SwiftShader).
+    Software,
+}
+
+#[cfg(target_os = "linux")]
+impl GpuTier {
+    fn as_str(self) -> &'static str {
+        match self {
+            GpuTier::HwVulkan => "hw-vulkan",
+            GpuTier::HwGl => "hw-gl",
+            GpuTier::Software => "software",
+        }
+    }
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "hw-vulkan" => Some(GpuTier::HwVulkan),
+            "hw-gl" => Some(GpuTier::HwGl),
+            "software" => Some(GpuTier::Software),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve the GPU tier once. `on_before_command_line_processing` runs per
+/// process; the browser process (which starts first, before any child is
+/// spawned) finds `AGENTMUX_GPU_TIER` unset, probes the hardware, and publishes
+/// the result. Child processes (gpu/renderer/utility) inherit that env var and
+/// read it back — so the `VkInstance` probe runs exactly once, in the browser.
+#[cfg(target_os = "linux")]
+fn detect_gpu_tier() -> GpuTier {
+    if let Ok(v) = std::env::var("AGENTMUX_GPU_TIER") {
+        if let Some(t) = GpuTier::from_str(&v) {
+            return t;
+        }
+    }
+    let tier = if has_hardware_vulkan() {
+        GpuTier::HwVulkan
+    } else if has_drm_render_node() {
+        GpuTier::HwGl
+    } else {
+        GpuTier::Software
+    };
+    // Publish for child processes (inherited through the environment on spawn).
+    std::env::set_var("AGENTMUX_GPU_TIER", tier.as_str());
+    tracing::info!(tier = tier.as_str(), "resolved GPU tier for ANGLE selection");
+    tier
+}
+
+/// True if a *hardware* Vulkan device is present. Enumerates Vulkan physical
+/// devices and accepts any whose `device_type` is not `CPU` — llvmpipe/lavapipe/
+/// SwiftShader all report `CPU`. Fully defensive: any load/create/enumerate
+/// failure ⇒ false (we then fall through to the GL check).
+#[cfg(target_os = "linux")]
+fn has_hardware_vulkan() -> bool {
+    use ash::vk;
+    let entry = match unsafe { ash::Entry::load() } {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    let app_info = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_0);
+    let create_info = vk::InstanceCreateInfo::default().application_info(&app_info);
+    let instance = match unsafe { entry.create_instance(&create_info, None) } {
+        Ok(i) => i,
+        Err(_) => return false,
+    };
+    let has_hw = unsafe { instance.enumerate_physical_devices() }
+        .map(|devices| {
+            devices.iter().any(|&d| {
+                unsafe { instance.get_physical_device_properties(d) }.device_type
+                    != vk::PhysicalDeviceType::CPU
             })
-    })
+        })
+        .unwrap_or(false);
+    unsafe { instance.destroy_instance(None) };
+    has_hw
+}
+
+/// True if a DRM render node (`/dev/dri/renderD*`) exists — a kernel GPU with a
+/// render node, i.e. a real hardware GL path (vmwgfx on VMware, i915/amdgpu/
+/// nvidia on bare metal). Heuristic; the spec's §7 upgrade path tightens this to
+/// a `GL_RENDERER` software-marker check.
+#[cfg(target_os = "linux")]
+fn has_drm_render_node() -> bool {
+    std::fs::read_dir("/dev/dri")
+        .map(|rd| {
+            rd.flatten()
+                .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
+        })
+        .unwrap_or(false)
 }
 
 /// Compute a centered 70% rect for the monitor the window is currently on.
@@ -513,40 +596,46 @@ wrap_app! {
                     cmd.append_switch_with_value(Some(&oz_key), Some(&oz_val));
                 }
 
-                // ── GPU backend on virtual guests (ANGLE + blocklist) ────────
-                // CEF 148 defaults ANGLE to Vulkan. VMware guests expose no
-                // hardware Vulkan ICD (only software llvmpipe/SwiftShader), so
-                // ANGLE falls to software SwiftShader — its present path stalls
-                // requestAnimationFrame and the xterm terminal paints in bursts
-                // ("type 10 chars, pause, dump"). VMware DOES expose hardware
-                // OpenGL (SVGA3D via Mesa svga), so route ANGLE onto GL. And
-                // once on hardware GL, Chromium's GPU blocklist flags the
-                // virtual GPU as unreliable and disables accelerated WebGL +
-                // gpu_compositing; `--ignore-gpu-blocklist` overrides that
-                // (verified: WebGL2 renders on SVGA3D, GPU process stable, and
-                // xterm auto-upgrades to its WebGL renderer). Both are gated on
-                // VMware detection so real-hardware Linux keeps Chromium's
-                // defaults.
+                // ── ANGLE backend precedence (capability-probed) ─────────────
+                // Precedence: hardware Vulkan → hardware GL → software
+                // (SwiftShader). CEF 148 defaults ANGLE to Vulkan and accepts a
+                // *software* Vulkan ICD over a perfectly good hardware-GL path —
+                // exactly the VMware case (no HW Vulkan, but HW SVGA3D GL), where
+                // the result is SwiftShader: burst-paint terminals + no WebGL. We
+                // measure the GPU tier and retarget ANGLE accordingly; ANGLE is
+                // never bypassed, only pointed at the best real backend. On the
+                // HW-GL rung we also --ignore-gpu-blocklist (Chromium blocklists
+                // the virtual GPU it just lost Vulkan on). No vendor gate: VMware
+                // simply lands in the HW-GL rung by measurement, real GPUs stay
+                // on Vulkan, headless stays software. Win/macOS report hardware
+                // and land in the top rung untouched.
+                // Spec: docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md
                 //
-                // Override: AGENTMUX_ANGLE={gl,vulkan,swiftshader,default} sets
-                // the ANGLE backend explicitly (wins over the VM default);
-                // AGENTMUX_CEF_EXTRA_FLAGS appends arbitrary switches (below).
-                #[cfg(target_os = "linux")]
-                let vm_gpu = is_vmware_guest();
-                #[cfg(not(target_os = "linux"))]
-                let vm_gpu = false;
-
-                let angle = std::env::var("AGENTMUX_ANGLE")
+                // Authority: explicit AGENTMUX_ANGLE env > measured precedence >
+                // Chromium default. AGENTMUX_CEF_EXTRA_FLAGS appends switches.
+                let angle_override = std::env::var("AGENTMUX_ANGLE")
                     .ok()
-                    .filter(|s| !s.is_empty())
-                    .or_else(|| vm_gpu.then(|| "gl".to_string()));
+                    .filter(|s| !s.is_empty());
+
+                #[cfg(target_os = "linux")]
+                let (angle, ignore_blocklist): (Option<String>, bool) = match angle_override {
+                    Some(a) => (Some(a), false),
+                    None => match detect_gpu_tier() {
+                        GpuTier::HwVulkan => (None, false),
+                        GpuTier::HwGl => (Some("gl".to_string()), true),
+                        GpuTier::Software => (None, false),
+                    },
+                };
+                #[cfg(not(target_os = "linux"))]
+                let (angle, ignore_blocklist): (Option<String>, bool) = (angle_override, false);
+
                 if let Some(angle) = angle {
                     cmd.append_switch_with_value(
                         Some(&CefString::from("use-angle")),
                         Some(&CefString::from(angle.as_str())),
                     );
                 }
-                if vm_gpu {
+                if ignore_blocklist {
                     cmd.append_switch(Some(&CefString::from("ignore-gpu-blocklist")));
                 }
 

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -241,6 +241,27 @@ extern "C" fn write_linux_window_properties(
     1
 }
 
+/// Best-effort detection of a VMware guest. On VMware, CEF's default
+/// ANGLE-on-Vulkan lands on software SwiftShader (no hardware Vulkan ICD) and
+/// Chromium's GPU blocklist disables accelerated WebGL/compositing for the
+/// virtual GPU. We use this to auto-route ANGLE onto the hardware SVGA3D GL
+/// path and override the blocklist (see `on_before_command_line_processing`).
+/// Cached — the DMI files don't change during a run.
+#[cfg(target_os = "linux")]
+fn is_vmware_guest() -> bool {
+    use std::sync::OnceLock;
+    static VMWARE: OnceLock<bool> = OnceLock::new();
+    *VMWARE.get_or_init(|| {
+        ["/sys/class/dmi/id/sys_vendor", "/sys/class/dmi/id/product_name"]
+            .iter()
+            .any(|p| {
+                std::fs::read_to_string(p)
+                    .map(|s| s.to_ascii_lowercase().contains("vmware"))
+                    .unwrap_or(false)
+            })
+    })
+}
+
 /// Compute a centered 70% rect for the monitor the window is currently on.
 /// Returns (x, y, width, height) or None if the monitor can't be determined.
 fn get_monitor_centered_70pct(window: &Window) -> Option<(i32, i32, i32, i32)> {
@@ -490,6 +511,65 @@ wrap_app! {
                     let oz_key = CefString::from("ozone-platform");
                     let oz_val = CefString::from(ozone_choice.as_str());
                     cmd.append_switch_with_value(Some(&oz_key), Some(&oz_val));
+                }
+
+                // ── GPU backend on virtual guests (ANGLE + blocklist) ────────
+                // CEF 148 defaults ANGLE to Vulkan. VMware guests expose no
+                // hardware Vulkan ICD (only software llvmpipe/SwiftShader), so
+                // ANGLE falls to software SwiftShader — its present path stalls
+                // requestAnimationFrame and the xterm terminal paints in bursts
+                // ("type 10 chars, pause, dump"). VMware DOES expose hardware
+                // OpenGL (SVGA3D via Mesa svga), so route ANGLE onto GL. And
+                // once on hardware GL, Chromium's GPU blocklist flags the
+                // virtual GPU as unreliable and disables accelerated WebGL +
+                // gpu_compositing; `--ignore-gpu-blocklist` overrides that
+                // (verified: WebGL2 renders on SVGA3D, GPU process stable, and
+                // xterm auto-upgrades to its WebGL renderer). Both are gated on
+                // VMware detection so real-hardware Linux keeps Chromium's
+                // defaults.
+                //
+                // Override: AGENTMUX_ANGLE={gl,vulkan,swiftshader,default} sets
+                // the ANGLE backend explicitly (wins over the VM default);
+                // AGENTMUX_CEF_EXTRA_FLAGS appends arbitrary switches (below).
+                #[cfg(target_os = "linux")]
+                let vm_gpu = is_vmware_guest();
+                #[cfg(not(target_os = "linux"))]
+                let vm_gpu = false;
+
+                let angle = std::env::var("AGENTMUX_ANGLE")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| vm_gpu.then(|| "gl".to_string()));
+                if let Some(angle) = angle {
+                    cmd.append_switch_with_value(
+                        Some(&CefString::from("use-angle")),
+                        Some(&CefString::from(angle.as_str())),
+                    );
+                }
+                if vm_gpu {
+                    cmd.append_switch(Some(&CefString::from("ignore-gpu-blocklist")));
+                }
+
+                // ── Arbitrary extra Chromium switches (dev/diagnostics) ───────
+                // AGENTMUX_CEF_EXTRA_FLAGS lets us A/B GPU/compositor flags
+                // without a recompile: space-separated tokens, each either
+                // `--switch`, `--switch=value`, or `switch=value`. Used to hunt
+                // the WebGL / gpu-compositing gate on VM guests. Empty/unset → no-op.
+                if let Ok(extra) = std::env::var("AGENTMUX_CEF_EXTRA_FLAGS") {
+                    for tok in extra.split_whitespace() {
+                        let tok = tok.trim_start_matches("--");
+                        if tok.is_empty() {
+                            continue;
+                        }
+                        if let Some((k, v)) = tok.split_once('=') {
+                            cmd.append_switch_with_value(
+                                Some(&CefString::from(k)),
+                                Some(&CefString::from(v)),
+                            );
+                        } else {
+                            cmd.append_switch(Some(&CefString::from(tok)));
+                        }
+                    }
                 }
 
                 // ── GPU channel + frame-production tuning ─────────────────────

--- a/docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md
+++ b/docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md
@@ -1,0 +1,156 @@
+# SPEC: Linux GPU Backend Precedence (capability-probed ANGLE selection)
+
+**Date:** 2026-06-13
+**Status:** Implemented in PR #1394 — replaces the initial VMware DMI gate
+**Author:** AgentU
+**Related:** `agentmux-cef/src/app.rs` (`on_before_command_line_processing`, `is_vmware_guest`), `agentmux-cef/Cargo.toml`, `frontend/app/view/term/termwrap.ts`, `frontend/util/gpuutil.ts`, `frontend/app/statusbar/GpuStatus.tsx`
+
+---
+
+## 1. Problem
+
+On Linux, CEF 148 defaults ANGLE to **Vulkan**. Chromium accepts the first Vulkan
+ICD it finds and never reconsiders — even when that ICD is **software**
+(llvmpipe/lavapipe, or the bundled SwiftShader) and a perfectly good **hardware
+OpenGL** path exists alongside it.
+
+That is exactly the situation in a VMware guest:
+
+- **No hardware Vulkan** — the only Vulkan ICDs are software (llvmpipe/lavapipe +
+  bundled SwiftShader). `hardwareSupportsVulkan: false`.
+- **Hardware OpenGL is present** — VMware SVGA3D via Mesa `svga` exposes GL 4.3 /
+  GLES 3.1 with direct rendering.
+
+So Chromium lands on **software SwiftShader**, whose present path stalls
+`requestAnimationFrame`; the xterm terminal paints in bursts ("type 10 chars,
+pause, dump"), and accelerated WebGL is unavailable (the terminal is stuck on
+xterm's slow DOM renderer).
+
+PR #1394 fixed this by **gating on a VMware DMI string match**
+(`is_vmware_guest()` reading `/sys/class/dmi/id/*`). That works but is a hack: it
+hardcodes a vendor, doesn't generalize to other no-Vulkan-but-has-GL configs, and
+describes the *environment* instead of measuring *capability*.
+
+## 2. Goal
+
+Pick the ANGLE backend by a **measured capability precedence**, identical on every
+platform, with **no vendor gate**. The precedence we want:
+
+> **hardware Vulkan → hardware GL → software (SwiftShader)**
+
+VMware should then "just work" by falling into the correct rung on its own, while
+real GPUs keep Chromium's preferred Vulkan path and headless boxes stay software.
+
+Non-goals: changing Windows/macOS behavior (their defaults are already hardware —
+D3D11 / Metal); implementing per-feature blocklist overrides; touching the GPU
+process's own init.
+
+## 3. Key insight — ANGLE is never bypassed, only retargeted
+
+Chromium always renders through ANGLE on Linux. This design never disables ANGLE;
+it only chooses **which backend ANGLE targets**. Whenever a hardware backend ANGLE
+can use is available, that hardware backend runs. The override fires **only** to
+correct the one wrong default — accepting *software Vulkan over hardware GL*.
+
+## 4. Design — startup capability probe
+
+Measure two facts once, in the browser process, before CEF GPU init:
+
+| signal | how | meaning |
+|---|---|---|
+| `has_hw_vulkan` | enumerate Vulkan physical devices (`ash`); true if **any** `device_type != CPU` | DISCRETE/INTEGRATED/VIRTUAL = hardware; llvmpipe/lavapipe/SwiftShader = `CPU` = software |
+| `has_hw_gl` | a DRM **render node** exists (`/dev/dri/renderD*`) | a kernel GPU with a render node ⇒ a real GL path (vmwgfx on VMware, i915/amdgpu/nvidia on bare metal) |
+
+### 4.1 Decision table (no platform gate)
+
+| tier | condition | `--use-angle` | `--ignore-gpu-blocklist` | who lands here |
+|---|---|---|---|---|
+| **HW Vulkan** | `has_hw_vulkan` | *(none — Chromium default)* | no | real GPU (Linux/Win/mac) |
+| **HW GL** | `!has_hw_vulkan && has_hw_gl` | `gl` | **yes** | **VMware/SVGA3D**, GL-only GPUs |
+| **Software** | neither | *(none — default)* | no | headless / no GPU |
+
+VMware lands in **HW GL** because it *measurably* has no hardware Vulkan but does
+have a render node — not because of a vendor string.
+
+### 4.2 Why `--ignore-gpu-blocklist` couples to the HW-GL rung
+
+The blocklist override is a separate concern from backend choice, but it couples
+naturally: the HW-GL rung means *"this GPU does hardware GL but Chromium's
+preferred path (Vulkan) isn't available here"* — precisely the virtual/unusual-GPU
+profile Chromium blocklists WebGL + gpu_compositing for. Having *chosen* HW GL as
+the best real path, we tell Chromium to trust it. It is applied **only** on the
+HW-GL rung; HW-Vulkan and Software boxes never get it.
+
+Residual risk: a real GPU with HW GL, no Vulkan, and a *legitimate* blocklist
+reason (rare). Mitigation/upgrade path in §7.
+
+### 4.3 Authority order
+
+1. **Explicit env** — `AGENTMUX_ANGLE={gl,vulkan,swiftshader,default}` forces the
+   backend and short-circuits the probe (sets `--use-angle` only; does not auto-add
+   the blocklist override — pair with `AGENTMUX_CEF_EXTRA_FLAGS=--ignore-gpu-blocklist`
+   if wanted).
+2. **Measured precedence** — the table above.
+3. **Chromium default** — when the probe says HW Vulkan or Software.
+
+`AGENTMUX_CEF_EXTRA_FLAGS` (space-separated switches) is always appended last.
+
+### 4.4 Where it runs (process model)
+
+`on_before_command_line_processing` fires per process. We probe **once**, in the
+browser process (empty `process_type`), and publish the resolved tier via an
+inherited env var (`AGENTMUX_GPU_TIER`) so child processes (gpu/renderer/utility)
+apply the same flags **without re-creating a `VkInstance`**. The Vulkan probe is
+fully defensive: any load/enumerate failure ⇒ treated as "no HW Vulkan" and we
+fall through to the GL check.
+
+### 4.5 Cross-platform
+
+The probe is effectively Linux-only in practice: Windows (D3D11) and macOS (Metal)
+report hardware and land in the HW-Vulkan-equivalent top rung untouched. No
+`#[cfg]` branching in the decision — the measurement simply returns "hardware
+present" where it should.
+
+## 5. Downstream effects (no extra code)
+
+With the HW-GL rung active, `--ignore-gpu-blocklist` un-gates WebGL, and the
+existing frontend paths react on their own:
+
+- `termwrap.ts` `detectWebGLSupport()` now succeeds ⇒ xterm auto-selects its
+  **WebGL renderer** (`loaded webgl renderer!`) instead of the DOM renderer.
+- `gpuutil.ts` / `GpuStatus.tsx` GFX badge probes WebGL ⇒ reads **HW**.
+
+## 6. Implementation plan
+
+1. `agentmux-cef/Cargo.toml`: add `ash` (Vulkan enumeration; the host already
+   bundles `libvulkan.so.1`). Linux-only dependency.
+2. `agentmux-cef/src/app.rs`:
+   - Replace `is_vmware_guest()` with `detect_gpu_tier() -> GpuTier`
+     (`HwVulkan | HwGl | Software`), cached + published via env for subprocesses.
+   - `has_hardware_vulkan()` (ash) and `has_drm_render_node()` helpers.
+   - Rewrite the GPU block in `on_before_command_line_processing` to apply the
+     §4.1 table with the §4.3 authority order.
+3. Keep `AGENTMUX_ANGLE` and `AGENTMUX_CEF_EXTRA_FLAGS` overrides.
+
+## 7. Verification & upgrade path
+
+**Already verified** (PR #1394, VMware guest): `--use-angle=gl` +
+`--ignore-gpu-blocklist` ⇒ `glRenderer = ANGLE(... SVGA3D ... GL 4.3)`,
+`skiaBackendType GaneshGL`, `featureStatus.webgl=enabled`, live `getContext('webgl2')`
+renders `[0,255,0,255]`, `processCrashCount 0`, terminal on WebGL renderer. This
+spec must reproduce **identical** behavior on the same box via the general path
+(probe ⇒ HW-GL rung), plus: HW-Vulkan box ⇒ no flags (stays Vulkan); headless ⇒ no
+flags (stays software).
+
+**Upgrade path** (future): replace the `has_hw_gl` render-node heuristic with a
+real `GL_RENDERER` check (throwaway EGL context, reject software-marker strings —
+the `SOFTWARE_MARKERS` list already exists in `gpuutil.ts`) to tighten the
+blocklist-override decision on exotic GL-only GPUs.
+
+## 8. Risks
+
+- `--ignore-gpu-blocklist` force-enables features Chromium flagged risky; scoped to
+  the HW-GL rung (not global), but a render-node heuristic can over-trust an
+  exotic GL stack — §7 upgrade addresses this.
+- Adds a `VkInstance` create+enumerate at startup (~tens of ms, once, browser
+  process only); fully guarded so any failure degrades to "no HW Vulkan".


### PR DESCRIPTION
## Problem
On Linux, CEF 148 defaults ANGLE to **Vulkan** and accepts the first Vulkan ICD it finds — even a **software** one — never reconsidering a perfectly good hardware GL path. On a VMware guest there's no hardware Vulkan (only llvmpipe/lavapipe/SwiftShader) but there *is* hardware OpenGL (SVGA3D via Mesa svga), so Chromium lands on **software SwiftShader**: the xterm terminal paints in bursts ("type 10 chars, pause, dump") and accelerated WebGL is unavailable (terminal stuck on the DOM renderer).

## Fix — a measured precedence, no vendor gate
Pick the ANGLE backend by **capability**, identical on every platform:

> **hardware Vulkan → hardware GL → software (SwiftShader)**

At startup the browser process probes once and publishes the tier (`AGENTMUX_GPU_TIER`) for child processes to inherit:
- `has_hardware_vulkan()` — enumerate Vulkan physical devices (`ash`); any non-`CPU` `device_type` ⇒ hardware Vulkan.
- `has_drm_render_node()` — `/dev/dri/renderD*` exists ⇒ a real hardware GL path.

| tier | condition | `--use-angle` | `--ignore-gpu-blocklist` |
|---|---|---|---|
| HW Vulkan | has HW Vulkan | — (default) | no |
| **HW GL** | no HW Vulkan, render node | `gl` | **yes** |
| Software | neither | — (default) | no |

ANGLE is only **retargeted**, never bypassed — wherever a hardware backend exists, it's used. VMware lands in the HW-GL rung *by measurement* (no vendor string); real GPUs stay on Vulkan; headless stays software; Windows (D3D11) / macOS (Metal) report hardware and are untouched. `--ignore-gpu-blocklist` couples to the HW-GL rung only.

## Verified on a VMware guest — via the general path, no env vars
- probe resolves `tier="hw-gl"`; `--use-angle=gl` + `--ignore-gpu-blocklist` auto-applied
- `featureStatus.webgl=enabled`, `gpu_compositing=enabled`, `skiaBackendType=GaneshGL`
- live `getContext('webgl2')` → `ANGLE (VMware Inc., SVGA3D … OpenGL 4.3)`; earlier `clear`+`readPixels` round-trips, `processCrashCount 0`
- xterm auto-upgrades DOM → WebGL renderer; burst-paint gone (confirmed by hand)

## Overrides
- `AGENTMUX_ANGLE={gl,vulkan,swiftshader,default}` — force the backend (wins over the probe).
- `AGENTMUX_CEF_EXTRA_FLAGS` — append arbitrary Chromium switches (dev/diag).

## Notes
- Design doc: `docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md`.
- `has_hw_gl` is a render-node heuristic; documented upgrade path is a real `GL_RENDERER` software-marker check (spec §7).
- Separate from the Linux taskbar-icon regression (CEF 146→148 struct change broke the #669 app_id workaround) — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
