### PR TITLE
fix(agents): surface cross-channel agents in "My Agents"

### DIFF
--- a/.changesets/1781405424-my-agents-global-registry.md
+++ b/.changesets/1781405424-my-agents-global-registry.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agents): surface cross-channel agents in "My Agents". Fix the live registry mirror to anchor on the GLOBAL workspace root (the live-write twin of #1393 — newly-created agents were silently dropped as "not representable"), and source the My-Agents list from the global registry (deduped by definition+name, enriched with local running state, local-only agents appended) so agents created in any build/channel/version appear.

--- a/agentmux-srv/src/backend/storage/registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/registry_mirror.rs
@@ -28,16 +28,33 @@ use super::store::{AgentInstance, Store};
 /// cross-version dropdown.
 fn agent_instance_to_record(
     inst: &AgentInstance,
-    agents_root: &Path,
+    global_agents_root: Option<&Path>,
+    channel_agents_base: &Path,
 ) -> Result<crate::registry::NamedAgentRecord, String> {
     use crate::registry::{NamedAgentRecord, NamedAgentRecordV1};
-    let rel = relative_workdir(&inst.working_directory, agents_root).ok_or_else(|| {
-        format!(
-            "working_directory {:?} is not under {:?}",
-            inst.working_directory,
-            agents_root.display()
-        )
-    })?;
+    // Agent workspaces are GLOBAL (`<home>/agents/<name>`), so anchor on that
+    // global root FIRST, falling back to this channel's agents dir only for a
+    // legacy in-channel workspace. This MUST match `registry/migrate.rs`'s
+    // `row_to_record` — the one-shot migration and this live mirror have to stamp
+    // the same `source_agents_base` for a given agent or a reader sees two
+    // different bases. Without the global branch, every real (global) workspace
+    // failed strip_prefix and the agent was dropped from the registry ("not
+    // representable") — the live-write twin of the bug #1393 fixed in the
+    // migration.
+    let (rel, base): (String, &Path) = global_agents_root
+        .and_then(|g| relative_workdir(&inst.working_directory, g).map(|r| (r, g)))
+        .or_else(|| {
+            relative_workdir(&inst.working_directory, channel_agents_base)
+                .map(|r| (r, channel_agents_base))
+        })
+        .ok_or_else(|| {
+            format!(
+                "working_directory {:?} is under neither the global agents root {:?} nor the channel base {:?}",
+                inst.working_directory,
+                global_agents_root.map(|p| p.display().to_string()),
+                channel_agents_base.display()
+            )
+        })?;
     let version = env!("CARGO_PKG_VERSION").to_string();
     let data = NamedAgentRecordV1 {
         instance_id: inst.id.clone(),
@@ -49,11 +66,11 @@ fn agent_instance_to_record(
         // record can `--resume` without joining the current channel's SQLite.
         session_id: empty_to_none(&inst.session_id),
         working_dir: rel,
-        // v3: the agents dir `working_dir` is relative to — this row lives in
-        // the CURRENT channel, so its source base is the channel agents dir we
-        // just stripped against. Lets a different channel reconstruct the
-        // absolute path instead of re-joining under its own agents dir (P0.4).
-        source_agents_base: Some(agents_root.to_string_lossy().to_string()),
+        // v3: the agents dir `working_dir` is relative to — the GLOBAL workspace
+        // root for a normal agent, or this channel's agents dir for a legacy
+        // in-channel workspace. Stored absolute so any channel reconstructs the
+        // path via `source_agents_base.join(working_dir)` (P0.4).
+        source_agents_base: Some(base.to_string_lossy().to_string()),
         created_at_ms: inst.created_at,
         last_launched_at_ms: inst.started_at,
         created_by_version: version.clone(),
@@ -148,7 +165,14 @@ impl Store {
             tracing::warn!("registry: no agents base — skipping mirror");
             return;
         };
-        let rec = match agent_instance_to_record(inst, &agents_root) {
+        // Agent workspaces are GLOBAL (`<home>/agents/<name>`). Derive `<home>`
+        // from the registry root exactly as main.rs does for the one-shot
+        // migration (registry = `<home>/shared/agents/registry` → `nth(3)` strips
+        // registry→agents→shared = `<home>`), so the live mirror and the migration
+        // anchor identically. `None` in shallow test/pre-re-root layouts → the
+        // mirror falls back to the per-channel base.
+        let global_agents_root = reg.root().ancestors().nth(3).map(|h| h.join("agents"));
+        let rec = match agent_instance_to_record(inst, global_agents_root.as_deref(), &agents_root) {
             Ok(rec) => rec,
             Err(e) => {
                 tracing::warn!(

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -1632,6 +1632,77 @@ mod tests {
         assert_eq!(records[0].data.working_dir, "demo-fixture");
     }
 
+    /// Production-shaped store: registry at `<tmp>/shared/agents/registry` (so the
+    /// mirror derives the GLOBAL workspace root `<tmp>/agents` via the registry
+    /// root's 3rd ancestor), with the per-channel base set to
+    /// `<tmp>/channels/<ch>/agents` (= AGENTMUX_AGENTS_DIR).
+    fn store_with_global_registry() -> (tempfile::TempDir, Store, Arc<crate::registry::Registry>) {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("agents")).unwrap();
+        let reg_root = tmp.path().join("shared").join("agents").join("registry");
+        let reg = Arc::new(crate::registry::Registry::open(reg_root).unwrap());
+        let store = Store::open_in_memory().unwrap();
+        store.set_registry(reg.clone());
+        let channel_agents = tmp.path().join("channels").join("local-x").join("agents");
+        std::fs::create_dir_all(&channel_agents).unwrap();
+        store.set_registry_agents_base(channel_agents);
+        let mut agent = sample_agent("def-mirror", "mirror");
+        store.agent_def_insert(&mut agent).unwrap();
+        (tmp, store, reg)
+    }
+
+    #[test]
+    fn mirror_anchors_global_workspace() {
+        // The bug this fixes: agent workspaces are GLOBAL (`<home>/agents/<name>`),
+        // NOT under the per-channel agents dir. The live mirror must anchor on the
+        // global root (derived from the registry root) and mirror the agent — not
+        // drop it as "not representable" (the live-write twin of #1393).
+        let (tmp, store, reg) = store_with_global_registry();
+        let global_agents = tmp.path().join("agents"); // <home>/agents
+        let inst = make_named_inst("inst-g", "qooma", &global_agents);
+        store.instance_create(&inst).unwrap();
+        let records = reg.list_active().unwrap();
+        assert_eq!(records.len(), 1, "global workspace must mirror, not be dropped");
+        assert_eq!(records[0].data.working_dir, "qooma-fixture");
+        assert_eq!(
+            records[0].data.source_agents_base.as_deref(),
+            Some(global_agents.to_string_lossy().as_ref()),
+            "anchored on the GLOBAL workspace root, not the channel base"
+        );
+    }
+
+    #[test]
+    fn mirror_per_channel_legacy_workspace_still_works() {
+        // A legacy in-channel workspace (under channels/<ch>/agents, not the global
+        // root) still mirrors via the per-channel fallback.
+        let (tmp, store, reg) = store_with_global_registry();
+        let channel_agents = tmp.path().join("channels").join("local-x").join("agents");
+        let inst = make_named_inst("inst-c", "legacy", &channel_agents);
+        store.instance_create(&inst).unwrap();
+        let records = reg.list_active().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].data.working_dir, "legacy-fixture");
+        assert_eq!(
+            records[0].data.source_agents_base.as_deref(),
+            Some(channel_agents.to_string_lossy().as_ref()),
+            "fell back to the per-channel base"
+        );
+    }
+
+    #[test]
+    fn mirror_skips_workspace_under_neither_root() {
+        // A workspace under neither the global nor the channel root (a user cwd) is
+        // skipped — parity with the migration's skip-unmappable behavior.
+        let (tmp, store, reg) = store_with_global_registry();
+        let outside = tmp.path().join("projects").join("foo");
+        let inst = make_named_inst("inst-o", "stray", &outside);
+        store.instance_create(&inst).unwrap();
+        assert!(
+            reg.list_active().unwrap().is_empty(),
+            "non-agent workspace must not be mirrored"
+        );
+    }
+
     #[test]
     fn instance_create_unnamed_does_not_mirror() {
         let (tmp, store, reg) = store_with_registry();

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1803,18 +1803,108 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty());
 
-                let instances = wstore
-                    // Picker "My Agents": include continuations.
-                    // Under Option E a continuation row is the most-
-                    // recent named instance of an agent the user
-                    // actively used — exactly what we want surfaced.
-                    .instance_list_named(
-                        raw_limit,
-                        None,
-                        identity_filter,
-                        /* include_continuations */ true,
-                    )
-                    .map_err(|e| format!("listrecentsessions: {e}"))?;
+                // "My Agents" sources from the cross-version REGISTRY when it's
+                // available, so agents created in ANY build / channel / version
+                // appear here — not just this instance's local SQLite sessions
+                // (the live mirror, registry_mirror.rs, keeps the registry current
+                // for global workspaces). Falls back to local SQLite when the
+                // registry couldn't be resolved (CI / odd envs). Cross-channel rows
+                // arrive as synthetic instances (no live block); the per-instance
+                // snapshot enrichment below lights up the ones that ALSO ran here.
+                let instances: Vec<AgentInstance> = match wstore.shared_agent_registry() {
+                    Some(reg) => {
+                        let agents_root = wstore.registry_agents_base();
+                        let mut records = reg
+                            .list_active()
+                            .map_err(|e| format!("listrecentsessions: registry: {e}"))?;
+                        if let Some(idf) = identity_filter {
+                            records.retain(|r| r.data.identity_id.as_deref() == Some(idf));
+                        }
+                        // Dedup by (definition_id, instance_name) keeping the newest
+                        // launch — the registry read path lacks SQLite's chain-root
+                        // collapse, so two fresh heads of one logical agent would
+                        // otherwise double up. Sort newest-first within each group,
+                        // collapse, then re-sort by recency.
+                        records.sort_by(|a, b| {
+                            a.data
+                                .definition_id
+                                .cmp(&b.data.definition_id)
+                                .then_with(|| a.data.instance_name.cmp(&b.data.instance_name))
+                                .then_with(|| {
+                                    b.data.last_launched_at_ms.cmp(&a.data.last_launched_at_ms)
+                                })
+                        });
+                        records.dedup_by(|a, b| {
+                            a.data.definition_id == b.data.definition_id
+                                && a.data.instance_name == b.data.instance_name
+                        });
+                        records.sort_by(|a, b| {
+                            b.data.last_launched_at_ms.cmp(&a.data.last_launched_at_ms)
+                        });
+                        records.truncate(raw_limit);
+                        // Local chain-heads: (a) OVERLAY the live block_id/session
+                        // onto agents that also ran in this channel, (b) APPEND
+                        // purely-local agents not (yet) mirrored, so nothing the
+                        // user has here disappears.
+                        let local_heads = wstore
+                            .instance_list_named(raw_limit, None, identity_filter, false)
+                            .unwrap_or_default();
+                        let local_by_id: std::collections::HashMap<&str, &AgentInstance> =
+                            local_heads.iter().map(|i| (i.id.as_str(), i)).collect();
+                        let mut out: Vec<AgentInstance> = records
+                            .into_iter()
+                            .map(|rec| {
+                                let d = rec.data;
+                                if let Some(li) = local_by_id.get(d.instance_id.as_str()) {
+                                    return (*li).clone();
+                                }
+                                // Reconstruct the absolute workdir from the record's
+                                // source base (v3) or the current channel (legacy).
+                                let working_directory = match d.source_agents_base.as_deref() {
+                                    Some(src) => std::path::Path::new(src)
+                                        .join(&d.working_dir)
+                                        .to_string_lossy()
+                                        .to_string(),
+                                    None => match agents_root.as_ref() {
+                                        Some(root) => root
+                                            .join(&d.working_dir)
+                                            .to_string_lossy()
+                                            .to_string(),
+                                        None => d.working_dir.clone(),
+                                    },
+                                };
+                                AgentInstance {
+                                    id: d.instance_id,
+                                    definition_id: d.definition_id,
+                                    parent_instance_id: String::new(),
+                                    block_id: String::new(),
+                                    session_id: d.session_id.unwrap_or_default(),
+                                    status: "available".to_string(),
+                                    github_context: String::new(),
+                                    started_at: d.last_launched_at_ms,
+                                    ended_at: 0,
+                                    created_at: d.created_at_ms,
+                                    identity_id: d.identity_id.unwrap_or_default(),
+                                    memory_id: d.memory_id.unwrap_or_default(),
+                                    instance_name: d.instance_name,
+                                    working_directory,
+                                    display_hidden: false,
+                                }
+                            })
+                            .collect();
+                        let have: std::collections::HashSet<String> =
+                            out.iter().map(|i| i.id.clone()).collect();
+                        for li in local_heads {
+                            if !have.contains(&li.id) {
+                                out.push(li);
+                            }
+                        }
+                        out
+                    }
+                    None => wstore
+                        .instance_list_named(raw_limit, None, identity_filter, true)
+                        .map_err(|e| format!("listrecentsessions: {e}"))?,
+                };
 
                 let defs = wstore
                     .agent_def_list()

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1842,21 +1842,36 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             b.data.last_launched_at_ms.cmp(&a.data.last_launched_at_ms)
                         });
                         records.truncate(raw_limit);
-                        // Local chain-heads: (a) OVERLAY the live block_id/session
-                        // onto agents that also ran in this channel, (b) APPEND
-                        // purely-local agents not (yet) mirrored, so nothing the
-                        // user has here disappears.
-                        let local_heads = wstore
-                            .instance_list_named(raw_limit, None, identity_filter, false)
+                        // Local agents in PICKER mode (include_continuations=true):
+                        // collapses each chain to one row AND surfaces orphan
+                        // continuations (head hard-deleted) as their own root, so
+                        // they don't vanish from "My Agents" (reagent P2). Indexed by
+                        // (definition_id, instance_name) — the SAME key the registry
+                        // dedup uses — keeping the newest, so overlay AND the
+                        // local-only append agree on identity (reagent P1).
+                        let local = wstore
+                            .instance_list_named(raw_limit, None, identity_filter, true)
                             .unwrap_or_default();
-                        let local_by_id: std::collections::HashMap<&str, &AgentInstance> =
-                            local_heads.iter().map(|i| (i.id.as_str(), i)).collect();
+                        let mut local_by_key: std::collections::HashMap<
+                            (String, String),
+                            AgentInstance,
+                        > = std::collections::HashMap::new();
+                        for li in local {
+                            let key = (li.definition_id.clone(), li.instance_name.clone());
+                            match local_by_key.get(&key) {
+                                Some(e) if e.started_at >= li.started_at => {}
+                                _ => {
+                                    local_by_key.insert(key, li);
+                                }
+                            }
+                        }
                         let mut out: Vec<AgentInstance> = records
                             .into_iter()
                             .map(|rec| {
                                 let d = rec.data;
-                                if let Some(li) = local_by_id.get(d.instance_id.as_str()) {
-                                    return (*li).clone();
+                                let key = (d.definition_id.clone(), d.instance_name.clone());
+                                if let Some(li) = local_by_key.get(&key) {
+                                    return li.clone();
                                 }
                                 // Reconstruct the absolute workdir from the record's
                                 // source base (v3) or the current channel (legacy).
@@ -1892,10 +1907,17 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 }
                             })
                             .collect();
-                        let have: std::collections::HashSet<String> =
-                            out.iter().map(|i| i.id.clone()).collect();
-                        for li in local_heads {
-                            if !have.contains(&li.id) {
+                        // APPEND local-only agents — those whose (definition_id,
+                        // instance_name) no registry record represents (created
+                        // before the live mirror could register them, or orphan
+                        // continuations). Keyed identically to the dedup, so a deduped
+                        // agent's local head never re-appears as a duplicate row.
+                        let have_keys: std::collections::HashSet<(String, String)> = out
+                            .iter()
+                            .map(|i| (i.definition_id.clone(), i.instance_name.clone()))
+                            .collect();
+                        for (key, li) in local_by_key {
+                            if !have_keys.contains(&key) {
                                 out.push(li);
                             }
                         }


### PR DESCRIPTION
## Problem
"My Agents" showed only the current instance's local sessions, never your agents from other builds/channels — even though the cross-channel registry exists. Two root causes:

1. **The live mirror was dropping every new agent.** `registry_mirror.rs` anchored `working_directory` on the per-channel `AGENTMUX_AGENTS_DIR`, but workspaces are **global** (`~/.agentmux/agents/<name>`), so `strip_prefix` failed and each new agent was skipped (`instance not representable as record`). This is the **live-write twin of the bug #1393 fixed in the one-shot migration** — so the registry only ever got agents from that one migration, and nothing new (e.g. a just-created "Mzap") propagated.
2. **"My Agents" never read the registry.** The grid's `listrecentsessions` handler read only local SQLite.

## Fix
1. **`registry_mirror.rs`** — anchor **global-first** (per-channel fallback), deriving `<home>/agents` from the registry root exactly as `migrate.rs`/`main.rs` do. New agents now register.
2. **`listrecentsessions` ("My Agents")** — source from the global registry when available: `list_active` → dedup by `(definition_id, instance_name)` keeping newest → reconstruct workdir → **overlay** live local rows (running `block_id`/`session_id`) and **append** local-only agents. Cross-channel rows become synthetic instances; the existing snapshot/preview loop + `RecentSessionRow` shape are untouched, so **zero frontend change**. SQLite path kept as the no-registry fallback.

## Why this is safe / how surfaces interact
- Agent definitions + auth are global (#1387–#1393), so cross-channel rows resolve their definition + stay logged in; reattach uses the reconstructed `working_directory` + `continueOfInstanceId` (existing flow).
- Dedup by `(definition_id, instance_name)` closes the gap `registry_mirror.rs:133` called out (the registry read path lacks SQLite's chain-root collapse).

## Tests
`mirror_anchors_global_workspace`, `mirror_per_channel_legacy_workspace_still_works`, `mirror_skips_workspace_under_neither_root` (store.rs). 91 store + 24 migrate tests pass; full srv suite green.

Completes the cross-channel chain: #1391 (definitions migration) → #1393 (instances migration) → this (live mirror + My-Agents read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)