### PR TITLE
fix(container): pass global_output_zone through container-exec path (unbreak main)

### DIFF
--- a/.changesets/1781451735-fix-container-global-output-zone.md
+++ b/.changesets/1781451735-fix-container-global-output-zone.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(container): thread global_output_zone through the container-exec output path (publish_line) so main compiles — a semantic merge conflict between #1399 (added the 6th arg to handle_append_block_file) and #1357 (added the publish_line call site with the old signature).

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -1085,6 +1085,12 @@ impl SubprocessController {
             // this forces a non-zero exit even if inspect_exec can't be reached.
             let mut stream_errored = false;
 
+            // Resolve the agent's GLOBAL transcript zone once (see persistent.rs)
+            // so every container-exec `output` line is also mirrored to the
+            // cross-channel store. `None` for non-agent blocks.
+            let global_output_zone =
+                super::shell::resolve_global_output_zone(&wstore, &block_id);
+
             tracing::info!(block_id = %block_id, "container exec output reader started");
 
             let mut pinned = std::pin::pin!(output);
@@ -1113,7 +1119,7 @@ impl SubprocessController {
                             None => {
                                 // Stream ended — flush any remaining partial line.
                                 if !line_buf.trim().is_empty() {
-                                    Self::publish_line(&line_buf, &block_id, &session_id_field, &inner_arc, &wstore, &event_bus, &broker, &filestore, &health_monitor, &mut stats);
+                                    Self::publish_line(&line_buf, &block_id, &session_id_field, &inner_arc, &wstore, &event_bus, &broker, &filestore, &health_monitor, &mut stats, global_output_zone.as_deref());
                                 }
                                 tracing::info!(block_id = %block_id, "container exec output EOF");
                                 break;
@@ -1142,7 +1148,7 @@ impl SubprocessController {
                                 for ch in chunk.chars() {
                                     if ch == '\n' {
                                         if !line_buf.trim().is_empty() {
-                                            Self::publish_line(&line_buf, &block_id, &session_id_field, &inner_arc, &wstore, &event_bus, &broker, &filestore, &health_monitor, &mut stats);
+                                            Self::publish_line(&line_buf, &block_id, &session_id_field, &inner_arc, &wstore, &event_bus, &broker, &filestore, &health_monitor, &mut stats, global_output_zone.as_deref());
                                         }
                                         line_buf.clear();
                                     } else {
@@ -1255,6 +1261,7 @@ impl SubprocessController {
         filestore: &Option<Arc<crate::backend::storage::filestore::FileStore>>,
         health: &Arc<super::health::HealthMonitor>,
         stats: &mut super::session_stats::SessionStatsAccumulator,
+        global_output_zone: Option<&str>,
     ) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -1312,6 +1319,7 @@ impl SubprocessController {
                 SUBPROCESS_OUTPUT_SUBJECT,
                 line_with_newline.as_bytes(),
                 filestore.as_ref(),
+                global_output_zone,
             );
         }
     }


### PR DESCRIPTION
## Problem

`main` (`3e866dc0`) does not compile:

```
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
  --> agentmux-srv/src/backend/blockcontroller/subprocess.rs:1309:13
  argument #6 of type `Option<&str>` is missing
note: function defined here
  --> agentmux-srv/src/backend/blockcontroller/shell.rs:1220:8
```

## Root cause — semantic merge conflict (both PRs green individually)

- **#1399** (globalize agent transcript) added a 6th param `global_output_zone: Option<&str>` to `handle_append_block_file` and updated the **subprocess / persistent / acp** stdout readers to resolve the zone once and pass it.
- **#1357** (container Phase 2) merged in parallel and added a *new* call site — `SubprocessController::publish_line`, the container-exec output reader — built against the **old 5-arg** signature.

Neither PR's CI compiled the *merged* tree, so the break only surfaces on `main`.

## Fix

Resolve the agent's global transcript zone **once** before the container-exec reader loop (via the existing `resolve_global_output_zone`), thread it through `publish_line`, and pass it to `handle_append_block_file`. This is byte-for-byte the same pattern the other three controllers already use — in particular it does **not** add a per-line store lookup on the hot output path.

## Verification

- `task build:backend` → `Finished release profile [optimized] in 4m 06s` (only pre-existing warnings; the E0061 error is gone).

This is the same fix already carried on the `agenta/release-v0.45.0` branch; landing it standalone unblocks `main` for everyone independent of the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)