### PR TITLE
feat(agent-pane): add `!cmd` shell execution prefix

### DIFF
--- a/.changesets/1781474064-feat-agent-pane-add-cmd-shell-execution-prefix-to-run-comman-3s7c.md
+++ b/.changesets/1781474064-feat-agent-pane-add-cmd-shell-execution-prefix-to-run-comman-3s7c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): add `!cmd` shell execution prefix to run commands in the agent working directory

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -161,6 +161,7 @@ pub const COMMAND_TOOL_DECISION: &str = "tooldecision";
 pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";
 pub const COMMAND_AGENT_STOP: &str = "agentstop";
+pub const COMMAND_SHELL_EXEC: &str = "shellexec";
 pub const COMMAND_WRITE_AGENT_CONFIG: &str = "writeagentconfig";
 pub const COMMAND_RESOLVE_CLI: &str = "resolvecli";
 pub const COMMAND_CHECK_CLI_AUTH: &str = "checkcliauth";
@@ -629,6 +630,23 @@ pub struct CommandAgentStopData {
     pub blockid: String,
     #[serde(default)]
     pub force: bool,
+}
+
+/// Data for ShellExecCommand — run a shell command in the agent's working directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandShellExecData {
+    pub blockid: String,
+    pub command: String,
+    #[serde(default)]
+    pub working_dir: String,
+}
+
+/// Result of ShellExecCommand.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellExecResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
 }
 
 /// A file to write as part of agent config.

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1167,6 +1167,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 };
                 proc.stdout(std::process::Stdio::piped());
                 proc.stderr(std::process::Stdio::piped());
+                // kill_on_drop: when the timeout fires the Child future is
+                // dropped; without this flag the OS process keeps running
+                // (e.g. `! sleep 1000` would linger indefinitely).
+                proc.kill_on_drop(true);
                 if let Some(ref dir) = cwd {
                     proc.current_dir(dir);
                 }
@@ -1204,14 +1208,16 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let status = child.wait().await
                     .map_err(|e| format!("shellexec: wait: {e}"))?;
 
-                // Truncate raw bytes before from_utf8_lossy so we never slice
-                // at a mid-codepoint offset (which would panic on a &str index).
-                let truncate_output = |bytes: Vec<u8>| -> String {
-                    let total = bytes.len();
-                    let capped = if total > MAX_OUTPUT as usize { &bytes[..MAX_OUTPUT as usize] } else { &bytes[..] };
-                    let s = String::from_utf8_lossy(capped);
-                    if total > MAX_OUTPUT as usize {
-                        format!("{s}…[truncated, {total} bytes total]")
+                // `take(MAX_OUTPUT)` already caps each buffer at MAX_OUTPUT bytes,
+                // so `bytes.len()` is at most MAX_OUTPUT — checking `> MAX_OUTPUT`
+                // would always be false (dead code). Instead, check for equality:
+                // if we read exactly MAX_OUTPUT bytes the take adapter hit its limit
+                // and there may be more data the user didn't see.
+                let format_output = |bytes: Vec<u8>| -> String {
+                    let len = bytes.len();
+                    let s = String::from_utf8_lossy(&bytes);
+                    if len == MAX_OUTPUT as usize {
+                        format!("{s}…[output capped at {MAX_OUTPUT} bytes]")
                     } else {
                         s.into_owned()
                     }
@@ -1219,8 +1225,8 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
                 let result = ShellExecResult {
                     exit_code: status.code().unwrap_or(1),
-                    stdout: truncate_output(stdout_buf),
-                    stderr: truncate_output(stderr_buf),
+                    stdout: format_output(stdout_buf),
+                    stderr: format_output(stderr_buf),
                 };
                 Ok(Some(serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?))
             })

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1185,50 +1185,48 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let mut stderr_buf: Vec<u8> = Vec::new();
 
                 use tokio::io::AsyncReadExt as _;
-                // Read one extra sentinel byte per stream. If we receive
-                // MAX_OUTPUT+1 bytes the output was genuinely truncated (we can
-                // tell definitively). If we receive ≤MAX_OUTPUT bytes the read
-                // completed without hitting the cap.
+                // Each stream's capped-read and drain run in the SAME concurrent
+                // branch.  A two-phase approach (cap-read all, then drain all)
+                // deadlocks: when stdout exceeds the cap, its read_to_end returns
+                // but the process is now blocked on write() to a full pipe, so it
+                // never writes to stderr, so stderr's read_to_end never gets EOF.
+                // Both reads block, the drain phase is never reached, and the whole
+                // handler hangs for the full 300 s timeout.
                 //
-                // Use `(&mut pipe).take(n)` rather than `pipe.take(n)` so the
-                // Take adapter borrows the pipe instead of consuming it — the
-                // original handles stay available for the drain phase below.
+                // Solution: read MAX_OUTPUT+1 sentinel bytes per stream (≤ MAX_OUTPUT
+                // → complete; MAX_OUTPUT+1 → truncated), then immediately drain the
+                // remainder.  stdout and stderr pipelines run concurrently with each
+                // other, and with child.wait().
                 let status = tokio::time::timeout(
                     std::time::Duration::from_secs(TIMEOUT_SECS),
                     async {
-                        // Named bindings required: join! futures borrow the
-                        // Take adapters and Sink values across poll points, so
-                        // temporaries created inside join! arms are freed too
-                        // early (E0716). Bind every short-lived value here first.
-                        let mut sout_take = (&mut stdout_pipe).take(MAX_OUTPUT + 1);
-                        let mut serr_take = (&mut stderr_pipe).take(MAX_OUTPUT + 1);
-                        let (sout, serr) = tokio::join!(
-                            sout_take.read_to_end(&mut stdout_buf),
-                            serr_take.read_to_end(&mut stderr_buf),
-                        );
-                        sout.map_err(|e| format!("shellexec: stdout read: {e}"))?;
-                        serr.map_err(|e| format!("shellexec: stderr read: {e}"))?;
-                        // sout_take / serr_take drop here, releasing their borrows
-                        // on stdout_pipe / stderr_pipe so we can use them below.
-                        drop(sout_take);
-                        drop(serr_take);
-
-                        // Drain any remaining output concurrently with child.wait().
-                        // Without draining, a command that emits more than MAX_OUTPUT
-                        // bytes blocks on its write() syscall (the pipe buffer is full
-                        // and nobody is reading) until the RPC timeout fires.  On Unix
-                        // this often manifests as SIGPIPE flipping an otherwise-zero
-                        // exit code.  Draining lets the process flush and exit cleanly
-                        // so the reported exit code is the real one.
-                        let mut sink_out = tokio::io::sink();
-                        let mut sink_err = tokio::io::sink();
-                        let (drain_sout, drain_serr, wait) = tokio::join!(
-                            tokio::io::copy(&mut stdout_pipe, &mut sink_out),
-                            tokio::io::copy(&mut stderr_pipe, &mut sink_err),
+                        let (sout, serr, wait) = tokio::join!(
+                            // stdout branch: cap-read then drain
+                            async {
+                                let mut take = (&mut stdout_pipe).take(MAX_OUTPUT + 1);
+                                take.read_to_end(&mut stdout_buf).await
+                                    .map_err(|e| format!("shellexec: stdout read: {e}"))?;
+                                drop(take); // release &mut borrow so stdout_pipe is usable
+                                let mut sink = tokio::io::sink();
+                                tokio::io::copy(&mut stdout_pipe, &mut sink).await
+                                    .map_err(|e| format!("shellexec: drain stdout: {e}"))?;
+                                Ok::<(), String>(())
+                            },
+                            // stderr branch: cap-read then drain
+                            async {
+                                let mut take = (&mut stderr_pipe).take(MAX_OUTPUT + 1);
+                                take.read_to_end(&mut stderr_buf).await
+                                    .map_err(|e| format!("shellexec: stderr read: {e}"))?;
+                                drop(take);
+                                let mut sink = tokio::io::sink();
+                                tokio::io::copy(&mut stderr_pipe, &mut sink).await
+                                    .map_err(|e| format!("shellexec: drain stderr: {e}"))?;
+                                Ok::<(), String>(())
+                            },
                             child.wait(),
                         );
-                        drain_sout.map_err(|e| format!("shellexec: drain stdout: {e}"))?;
-                        drain_serr.map_err(|e| format!("shellexec: drain stderr: {e}"))?;
+                        sout?;
+                        serr?;
                         wait.map_err(|e| format!("shellexec: wait: {e}"))
                     }
                 )

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1133,14 +1133,28 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                             expanded.display()
                         ));
                     }
-                    if !expanded.exists() {
-                        return Err(format!(
-                            "shellexec: working directory does not exist: {}",
+                    // Canonicalize to resolve all symlinks before handing the
+                    // path to the shell. Without this a symlinked working_dir
+                    // would silently run the shell in the symlink target
+                    // (potentially outside the agent workspace), matching the
+                    // symlink-escape protection in writeagentconfig.
+                    let canonical = expanded.canonicalize()
+                        .map_err(|e| format!(
+                            "shellexec: cannot resolve working directory '{}': {e}",
                             expanded.display()
-                        ));
-                    }
-                    Some(expanded)
+                        ))?;
+                    Some(canonical)
                 };
+
+                // 300s process timeout matches the frontend's RPC timeout so
+                // the client sees a clean error rather than a silent EC-TIME.
+                const TIMEOUT_SECS: u64 = 300;
+                // 1 MB cap per stream — bounded during read via take() so a
+                // runaway command (`! yes`, `! dd if=/dev/zero`) cannot exhaust
+                // RAM before the timeout fires. The pipes are read concurrently
+                // to prevent deadlock when one buffer fills while the process is
+                // blocked writing to the other.
+                const MAX_OUTPUT: u64 = 1_000_000;
 
                 let mut proc = if cfg!(windows) {
                     let mut c = tokio::process::Command::new("cmd");
@@ -1151,41 +1165,62 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     c.args(["-c", &cmd.command]);
                     c
                 };
+                proc.stdout(std::process::Stdio::piped());
+                proc.stderr(std::process::Stdio::piped());
                 if let Some(ref dir) = cwd {
                     proc.current_dir(dir);
                 }
 
-                // 300s process timeout matches the frontend's RPC timeout so
-                // the client sees a clean error rather than a silent EC-TIME.
-                const TIMEOUT_SECS: u64 = 300;
-                let output = tokio::time::timeout(
+                let mut child = proc.spawn()
+                    .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+
+                let mut stdout_pipe = child.stdout.take().expect("stdout piped");
+                let mut stderr_pipe = child.stderr.take().expect("stderr piped");
+
+                let mut stdout_buf: Vec<u8> = Vec::new();
+                let mut stderr_buf: Vec<u8> = Vec::new();
+
+                use tokio::io::AsyncReadExt as _;
+                tokio::time::timeout(
                     std::time::Duration::from_secs(TIMEOUT_SECS),
-                    proc.output(),
+                    async {
+                        // Bind Take adapters to named vars — the read_to_end
+                        // futures borrow them, and temporaries in join! arms
+                        // would be dropped before the futures complete (E0716).
+                        let mut sout_take = stdout_pipe.take(MAX_OUTPUT);
+                        let mut serr_take = stderr_pipe.take(MAX_OUTPUT);
+                        let (sout, serr) = tokio::join!(
+                            sout_take.read_to_end(&mut stdout_buf),
+                            serr_take.read_to_end(&mut stderr_buf),
+                        );
+                        sout.map_err(|e| format!("shellexec: stdout read: {e}"))?;
+                        serr.map_err(|e| format!("shellexec: stderr read: {e}"))?;
+                        Ok::<_, String>(())
+                    }
                 )
                 .await
-                .map_err(|_| format!("shellexec: command timed out after {TIMEOUT_SECS}s"))?
-                .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+                .map_err(|_| format!("shellexec: timed out after {TIMEOUT_SECS}s"))??;
+                // Pipes are consumed/dropped by the join! — child can now exit.
+                let status = child.wait().await
+                    .map_err(|e| format!("shellexec: wait: {e}"))?;
 
-                // Cap each stream at 1 MB to prevent OOM when the user runs
-                // something like `! cat /var/log/large.log`.
-                const MAX_OUTPUT: usize = 1_000_000;
-                let stdout_raw = String::from_utf8_lossy(&output.stdout);
-                let stdout = if stdout_raw.len() > MAX_OUTPUT {
-                    format!("{}…[truncated, {} bytes total]", &stdout_raw[..MAX_OUTPUT], stdout_raw.len())
-                } else {
-                    stdout_raw.into_owned()
-                };
-                let stderr_raw = String::from_utf8_lossy(&output.stderr);
-                let stderr = if stderr_raw.len() > MAX_OUTPUT {
-                    format!("{}…[truncated, {} bytes total]", &stderr_raw[..MAX_OUTPUT], stderr_raw.len())
-                } else {
-                    stderr_raw.into_owned()
+                // Truncate raw bytes before from_utf8_lossy so we never slice
+                // at a mid-codepoint offset (which would panic on a &str index).
+                let truncate_output = |bytes: Vec<u8>| -> String {
+                    let total = bytes.len();
+                    let capped = if total > MAX_OUTPUT as usize { &bytes[..MAX_OUTPUT as usize] } else { &bytes[..] };
+                    let s = String::from_utf8_lossy(capped);
+                    if total > MAX_OUTPUT as usize {
+                        format!("{s}…[truncated, {total} bytes total]")
+                    } else {
+                        s.into_owned()
+                    }
                 };
 
                 let result = ShellExecResult {
-                    exit_code: output.status.code().unwrap_or(1),
-                    stdout,
-                    stderr,
+                    exit_code: status.code().unwrap_or(1),
+                    stdout: truncate_output(stdout_buf),
+                    stderr: truncate_output(stderr_buf),
                 };
                 Ok(Some(serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?))
             })

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1185,41 +1185,66 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let mut stderr_buf: Vec<u8> = Vec::new();
 
                 use tokio::io::AsyncReadExt as _;
-                tokio::time::timeout(
+                // Read one extra sentinel byte per stream. If we receive
+                // MAX_OUTPUT+1 bytes the output was genuinely truncated (we can
+                // tell definitively). If we receive ≤MAX_OUTPUT bytes the read
+                // completed without hitting the cap.
+                //
+                // Use `(&mut pipe).take(n)` rather than `pipe.take(n)` so the
+                // Take adapter borrows the pipe instead of consuming it — the
+                // original handles stay available for the drain phase below.
+                let status = tokio::time::timeout(
                     std::time::Duration::from_secs(TIMEOUT_SECS),
                     async {
-                        // Bind Take adapters to named vars — the read_to_end
-                        // futures borrow them, and temporaries in join! arms
-                        // would be dropped before the futures complete (E0716).
-                        let mut sout_take = stdout_pipe.take(MAX_OUTPUT);
-                        let mut serr_take = stderr_pipe.take(MAX_OUTPUT);
+                        // Named bindings required: join! futures borrow the
+                        // Take adapters and Sink values across poll points, so
+                        // temporaries created inside join! arms are freed too
+                        // early (E0716). Bind every short-lived value here first.
+                        let mut sout_take = (&mut stdout_pipe).take(MAX_OUTPUT + 1);
+                        let mut serr_take = (&mut stderr_pipe).take(MAX_OUTPUT + 1);
                         let (sout, serr) = tokio::join!(
                             sout_take.read_to_end(&mut stdout_buf),
                             serr_take.read_to_end(&mut stderr_buf),
                         );
                         sout.map_err(|e| format!("shellexec: stdout read: {e}"))?;
                         serr.map_err(|e| format!("shellexec: stderr read: {e}"))?;
-                        Ok::<_, String>(())
+                        // sout_take / serr_take drop here, releasing their borrows
+                        // on stdout_pipe / stderr_pipe so we can use them below.
+                        drop(sout_take);
+                        drop(serr_take);
+
+                        // Drain any remaining output concurrently with child.wait().
+                        // Without draining, a command that emits more than MAX_OUTPUT
+                        // bytes blocks on its write() syscall (the pipe buffer is full
+                        // and nobody is reading) until the RPC timeout fires.  On Unix
+                        // this often manifests as SIGPIPE flipping an otherwise-zero
+                        // exit code.  Draining lets the process flush and exit cleanly
+                        // so the reported exit code is the real one.
+                        let mut sink_out = tokio::io::sink();
+                        let mut sink_err = tokio::io::sink();
+                        let (drain_sout, drain_serr, wait) = tokio::join!(
+                            tokio::io::copy(&mut stdout_pipe, &mut sink_out),
+                            tokio::io::copy(&mut stderr_pipe, &mut sink_err),
+                            child.wait(),
+                        );
+                        drain_sout.map_err(|e| format!("shellexec: drain stdout: {e}"))?;
+                        drain_serr.map_err(|e| format!("shellexec: drain stderr: {e}"))?;
+                        wait.map_err(|e| format!("shellexec: wait: {e}"))
                     }
                 )
                 .await
                 .map_err(|_| format!("shellexec: timed out after {TIMEOUT_SECS}s"))??;
-                // Pipes are consumed/dropped by the join! — child can now exit.
-                let status = child.wait().await
-                    .map_err(|e| format!("shellexec: wait: {e}"))?;
 
-                // `take(MAX_OUTPUT)` already caps each buffer at MAX_OUTPUT bytes,
-                // so `bytes.len()` is at most MAX_OUTPUT — checking `> MAX_OUTPUT`
-                // would always be false (dead code). Instead, check for equality:
-                // if we read exactly MAX_OUTPUT bytes the take adapter hit its limit
-                // and there may be more data the user didn't see.
                 let format_output = |bytes: Vec<u8>| -> String {
-                    let len = bytes.len();
-                    let s = String::from_utf8_lossy(&bytes);
-                    if len == MAX_OUTPUT as usize {
+                    // bytes.len() > MAX_OUTPUT means we read the MAX_OUTPUT+1
+                    // sentinel — the stream was truncated.  Checking for equality
+                    // with MAX_OUTPUT (without +1) would be a false positive for
+                    // commands that emit exactly MAX_OUTPUT bytes.
+                    if bytes.len() > MAX_OUTPUT as usize {
+                        let s = String::from_utf8_lossy(&bytes[..MAX_OUTPUT as usize]);
                         format!("{s}…[output capped at {MAX_OUTPUT} bytes]")
                     } else {
-                        s.into_owned()
+                        String::from_utf8_lossy(&bytes).into_owned()
                     }
                 };
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -27,8 +27,9 @@ use crate::backend::rpc_types::{
     COMMAND_GET_AI_RATE_LIMIT, COMMAND_ROUTE_ANNOUNCE, COMMAND_ROUTE_UNANNOUNCE,
     COMMAND_SET_META, COMMAND_SET_CONFIG, COMMAND_APP_INFO,
     COMMAND_SUBPROCESS_SPAWN, COMMAND_AGENT_INPUT, COMMAND_AGENT_STOP, COMMAND_TOOL_DECISION,
-    COMMAND_WRITE_AGENT_CONFIG,
+    COMMAND_WRITE_AGENT_CONFIG, COMMAND_SHELL_EXEC,
     CommandSubprocessSpawnData, CommandAgentInputData, CommandAgentStopData, CommandWriteAgentConfigData,
+    CommandShellExecData, ShellExecResult,
 };
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
 use super::service::update_object_meta;
@@ -1100,6 +1101,56 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     }
                     None => Ok(None),
                 }
+            })
+        }),
+    );
+
+    // shellexec → run a shell command in the agent's working directory and return output.
+    // Invoked by the `!cmd` prefix in the agent pane composer.
+    engine.register_handler(
+        COMMAND_SHELL_EXEC,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandShellExecData = serde_json::from_value(data)
+                    .map_err(|e| format!("shellexec: {e}"))?;
+                tracing::info!(block_id = %cmd.blockid, command = %cmd.command, "ShellExec");
+
+                let cwd: Option<std::path::PathBuf> = if cmd.working_dir.is_empty() {
+                    None
+                } else {
+                    let expanded = expand_home_dir_safe(&cmd.working_dir);
+                    if expanded.exists() {
+                        Some(expanded)
+                    } else {
+                        return Err(format!(
+                            "shellexec: working directory does not exist: {}",
+                            expanded.display()
+                        ));
+                    }
+                };
+
+                let mut proc = if cfg!(windows) {
+                    let mut c = tokio::process::Command::new("cmd");
+                    c.args(["/C", &cmd.command]);
+                    c
+                } else {
+                    let mut c = tokio::process::Command::new("sh");
+                    c.args(["-c", &cmd.command]);
+                    c
+                };
+                if let Some(ref dir) = cwd {
+                    proc.current_dir(dir);
+                }
+
+                let output = proc.output().await
+                    .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+
+                let result = ShellExecResult {
+                    exit_code: output.status.code().unwrap_or(1),
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                };
+                Ok(Some(serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?))
             })
         }),
     );

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1107,9 +1107,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
     // shellexec → run a shell command in the agent's working directory and return output.
     // Invoked by the `!cmd` prefix in the agent pane composer.
+    let wstore_se = state.wstore.clone();
     engine.register_handler(
         COMMAND_SHELL_EXEC,
-        Box::new(|data, _ctx| {
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_se.clone();
             Box::pin(async move {
                 let cmd: CommandShellExecData = serde_json::from_value(data)
                     .map_err(|e| format!("shellexec: {e}"))?;
@@ -1118,6 +1120,24 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // ~/.agentmux/logs/ in plaintext.
                 tracing::info!(block_id = %cmd.blockid, "ShellExec");
                 tracing::debug!(command = %cmd.command, "ShellExec command");
+
+                // Reject container agents: their filesystem lives inside the
+                // Docker container, so running sh on the host gives misleading
+                // results or mutates the wrong environment.  Routing through
+                // `docker exec` is tracked as a follow-up feature.
+                let block: crate::backend::obj::Block = wstore
+                    .get(&cmd.blockid)
+                    .map_err(|e| format!("shellexec: load block: {e}"))?
+                    .ok_or_else(|| format!("shellexec: block {} not found", cmd.blockid))?;
+                let agent_mode = crate::backend::obj::meta_get_string(
+                    &block.meta, "agentMode", "host",
+                );
+                if agent_mode == "container" {
+                    return Err(
+                        "shellexec: container agents are not supported; \
+                         run the command from within the agent session instead".to_string()
+                    );
+                }
 
                 let cwd: Option<std::path::PathBuf> = if cmd.working_dir.is_empty() {
                     None
@@ -1171,12 +1191,27 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // dropped; without this flag the OS process keeps running
                 // (e.g. `! sleep 1000` would linger indefinitely).
                 proc.kill_on_drop(true);
+                // Unix: put the shell in its own process group so that compound
+                // commands (`! a | b`, `! foo &`) are in the same group and can
+                // all be killed at once on timeout.  kill_on_drop only kills the
+                // direct sh child; without process_group(0), grandchildren
+                // get reparented to init and outlive the timeout.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::CommandExt as _;
+                    proc.process_group(0);
+                }
                 if let Some(ref dir) = cwd {
                     proc.current_dir(dir);
                 }
 
                 let mut child = proc.spawn()
                     .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+
+                // Capture the PID before taking stdout/stderr (id() requires
+                // the Child to still have its stdio handles on some platforms).
+                #[cfg(unix)]
+                let child_pgid = child.id().map(|id| id as libc::pid_t);
 
                 let mut stdout_pipe = child.stdout.take().expect("stdout piped");
                 let mut stderr_pipe = child.stderr.take().expect("stderr piped");
@@ -1197,7 +1232,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // → complete; MAX_OUTPUT+1 → truncated), then immediately drain the
                 // remainder.  stdout and stderr pipelines run concurrently with each
                 // other, and with child.wait().
-                let status = tokio::time::timeout(
+                let timeout_result = tokio::time::timeout(
                     std::time::Duration::from_secs(TIMEOUT_SECS),
                     async {
                         let (sout, serr, wait) = tokio::join!(
@@ -1230,8 +1265,24 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         wait.map_err(|e| format!("shellexec: wait: {e}"))
                     }
                 )
-                .await
-                .map_err(|_| format!("shellexec: timed out after {TIMEOUT_SECS}s"))??;
+                .await;
+
+                // On timeout: kill_on_drop kills the direct sh/cmd child, but
+                // compound commands (`! a | b`, `! foo &`) fork grandchildren
+                // in the same process group.  Kill the whole group so they don't
+                // linger.  (Unix only; on Windows the job-object approach is a
+                // separate follow-up since tokio doesn't expose it yet.)
+                #[cfg(unix)]
+                if timeout_result.is_err() {
+                    if let Some(pgid) = child_pgid {
+                        // SAFETY: kill() is async-signal-safe; negative pid
+                        // addresses the process group with id=pgid.
+                        unsafe { libc::kill(-pgid, libc::SIGKILL); }
+                    }
+                }
+
+                let status = timeout_result
+                    .map_err(|_| format!("shellexec: timed out after {TIMEOUT_SECS}s"))??;
 
                 let format_output = |bytes: Vec<u8>| -> String {
                     // bytes.len() > MAX_OUTPUT means we read the MAX_OUTPUT+1

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1113,20 +1113,33 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
             Box::pin(async move {
                 let cmd: CommandShellExecData = serde_json::from_value(data)
                     .map_err(|e| format!("shellexec: {e}"))?;
-                tracing::info!(block_id = %cmd.blockid, command = %cmd.command, "ShellExec");
+                // Log block_id at info; keep the command at debug so secrets
+                // passed as CLI args (API tokens, passwords) don't land in
+                // ~/.agentmux/logs/ in plaintext.
+                tracing::info!(block_id = %cmd.blockid, "ShellExec");
+                tracing::debug!(command = %cmd.command, "ShellExec command");
 
                 let cwd: Option<std::path::PathBuf> = if cmd.working_dir.is_empty() {
                     None
                 } else {
                     let expanded = expand_home_dir_safe(&cmd.working_dir);
-                    if expanded.exists() {
-                        Some(expanded)
-                    } else {
+                    // Reject non-absolute paths to prevent relative traversal
+                    // (e.g. "../etc") from resolving against the sidecar's cwd.
+                    // expand_home_dir_safe turns "~" into an absolute home path;
+                    // anything still relative after expansion is suspicious.
+                    if !expanded.is_absolute() {
+                        return Err(format!(
+                            "shellexec: working_dir must be absolute, got: {}",
+                            expanded.display()
+                        ));
+                    }
+                    if !expanded.exists() {
                         return Err(format!(
                             "shellexec: working directory does not exist: {}",
                             expanded.display()
                         ));
                     }
+                    Some(expanded)
                 };
 
                 let mut proc = if cfg!(windows) {
@@ -1142,13 +1155,37 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     proc.current_dir(dir);
                 }
 
-                let output = proc.output().await
-                    .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+                // 300s process timeout matches the frontend's RPC timeout so
+                // the client sees a clean error rather than a silent EC-TIME.
+                const TIMEOUT_SECS: u64 = 300;
+                let output = tokio::time::timeout(
+                    std::time::Duration::from_secs(TIMEOUT_SECS),
+                    proc.output(),
+                )
+                .await
+                .map_err(|_| format!("shellexec: command timed out after {TIMEOUT_SECS}s"))?
+                .map_err(|e| format!("shellexec: spawn failed: {e}"))?;
+
+                // Cap each stream at 1 MB to prevent OOM when the user runs
+                // something like `! cat /var/log/large.log`.
+                const MAX_OUTPUT: usize = 1_000_000;
+                let stdout_raw = String::from_utf8_lossy(&output.stdout);
+                let stdout = if stdout_raw.len() > MAX_OUTPUT {
+                    format!("{}…[truncated, {} bytes total]", &stdout_raw[..MAX_OUTPUT], stdout_raw.len())
+                } else {
+                    stdout_raw.into_owned()
+                };
+                let stderr_raw = String::from_utf8_lossy(&output.stderr);
+                let stderr = if stderr_raw.len() > MAX_OUTPUT {
+                    format!("{}…[truncated, {} bytes total]", &stderr_raw[..MAX_OUTPUT], stderr_raw.len())
+                } else {
+                    stderr_raw.into_owned()
+                };
 
                 let result = ShellExecResult {
                     exit_code: output.status.code().unwrap_or(1),
-                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    stdout,
+                    stderr,
                 };
                 Ok(Some(serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?))
             })

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1119,6 +1119,17 @@ class RpcApiType {
         return client.rpcCall("agentinput", data, opts);
     }
 
+    // command "shellexec" [call]
+    // Run a shell command in the agent's working directory. Invoked by the
+    // `!cmd` composer prefix. Returns buffered stdout/stderr after completion.
+    ShellExecCommand(
+        client: RpcClient,
+        data: { blockid: string; command: string; working_dir: string },
+        opts?: RpcOpts,
+    ): Promise<{ exit_code: number; stdout: string; stderr: string }> {
+        return client.rpcCall("shellexec", data, opts);
+    }
+
     // command "agentstop" [call]
     AgentStopCommand(client: RpcClient, data: CommandAgentStopData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("agentstop", data, opts);

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -253,9 +253,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 await dispatchBangCommand(trimmed.slice(1).trim(), opts.blockId, buildCommandContext());
             } finally {
                 // TurnStart was dispatched by handleSendMessage before sendMessage
-                // was called. Always reset it — even if dispatchBangCommand throws —
-                // so the pane returns to Idle instead of waiting for the 30s watchdog.
-                opts.model.dispatchPane({ type: "TurnReset" }, "system");
+                // was called. Reset it so the pane returns to Idle instead of waiting
+                // for the 30s watchdog — but only if the pane was idle when !cmd was
+                // submitted. If wasAlreadyWorking is true, a real agent turn was
+                // already streaming; resetting to Idle here would clobber its UI state
+                // until the next backend event arrives.
+                if (!wasAlreadyWorking) {
+                    opts.model.dispatchPane({ type: "TurnReset" }, "system");
+                }
             }
             return;
         }

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -249,8 +249,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // not stay in Submitting state for the full 30s watchdog window — no
         // agent turn was initiated, only a sidecar shell exec.
         if (trimmed.startsWith("!")) {
-            await dispatchBangCommand(trimmed.slice(1).trim(), opts.blockId, buildCommandContext());
-            opts.model.dispatchPane({ type: "TurnReset" }, "system");
+            try {
+                await dispatchBangCommand(trimmed.slice(1).trim(), opts.blockId, buildCommandContext());
+            } finally {
+                // TurnStart was dispatched by handleSendMessage before sendMessage
+                // was called. Always reset it — even if dispatchBangCommand throws —
+                // so the pane returns to Idle instead of waiting for the 30s watchdog.
+                opts.model.dispatchPane({ type: "TurnReset" }, "system");
+            }
             return;
         }
 

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -244,8 +244,13 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // Bang commands: `!cmd` runs a shell command in the agent's working
         // directory and surfaces output in the launch log. Never falls through
         // to the backend agent queue.
+        // TurnStart was already dispatched by handleSendMessage (agent-view.tsx)
+        // before this function was called. Reset it immediately so the pane does
+        // not stay in Submitting state for the full 30s watchdog window — no
+        // agent turn was initiated, only a sidecar shell exec.
         if (trimmed.startsWith("!")) {
             await dispatchBangCommand(trimmed.slice(1).trim(), opts.blockId, buildCommandContext());
+            opts.model.dispatchPane({ type: "TurnReset" }, "system");
             return;
         }
 
@@ -421,11 +426,13 @@ async function dispatchBangCommand(
     const workingDir = (ctx.block()?.meta?.["cmd:cwd"] as string | undefined) ?? "";
     ctx.log("system", `$ ${command}`);
     try {
-        const result = await RpcApi.ShellExecCommand(TabRpcClient, {
-            blockid: blockId,
-            command,
-            working_dir: workingDir,
-        });
+        const result = await RpcApi.ShellExecCommand(
+            TabRpcClient,
+            { blockid: blockId, command, working_dir: workingDir },
+            // Long timeout: shell commands like `npm test` or `cargo build` can
+            // take minutes. Default 5s RPC timeout would return EC-TIME immediately.
+            { timeout: 300_000 },
+        );
         if (result.stdout) ctx.log("system", result.stdout.trimEnd());
         if (result.stderr) ctx.log("system", result.stderr.trimEnd(), "warn");
         if (result.exit_code !== 0) {

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -240,6 +240,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // handled client-side and must not touch the backend queue at
         // all. Unknown `/foo` falls through to a real turn.
         const trimmed = message.trim();
+
+        // Bang commands: `!cmd` runs a shell command in the agent's working
+        // directory and surfaces output in the launch log. Never falls through
+        // to the backend agent queue.
+        if (trimmed.startsWith("!")) {
+            await dispatchBangCommand(trimmed.slice(1).trim(), opts.blockId, buildCommandContext());
+            return;
+        }
+
         if (trimmed.startsWith("/")) {
             const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
             if (outcome.kind === "handled") return;
@@ -390,4 +399,39 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         closeHelp,
         availableCommands,
     };
+}
+
+/**
+ * Run a shell command in the agent's working directory via the `shellexec`
+ * RPC and surface stdout/stderr in the launch log.
+ *
+ * Called when the user prefixes a composer message with `!`. The blockId is
+ * passed explicitly (rather than via ctx) because ctx.blockId is a string and
+ * we need it for the RPC payload; ctx provides only the log sink here.
+ */
+async function dispatchBangCommand(
+    command: string,
+    blockId: string,
+    ctx: SlashCommandContext,
+): Promise<void> {
+    if (!command) {
+        ctx.log("system", "!: command required", "warn");
+        return;
+    }
+    const workingDir = (ctx.block()?.meta?.["cmd:cwd"] as string | undefined) ?? "";
+    ctx.log("system", `$ ${command}`);
+    try {
+        const result = await RpcApi.ShellExecCommand(TabRpcClient, {
+            blockid: blockId,
+            command,
+            working_dir: workingDir,
+        });
+        if (result.stdout) ctx.log("system", result.stdout.trimEnd());
+        if (result.stderr) ctx.log("system", result.stderr.trimEnd(), "warn");
+        if (result.exit_code !== 0) {
+            ctx.log("system", `exit ${result.exit_code}`, "warn");
+        }
+    } catch (e) {
+        ctx.log("system", `!: ${(e as Error).message ?? String(e)}`, "warn");
+    }
 }


### PR DESCRIPTION
## Summary

- Typing `!ls -la` in the agent pane composer runs the command in the agent's working directory (`cmd:cwd`) and surfaces stdout/stderr in the launch log — without touching the agent's conversation queue
- Platform-aware: uses `cmd /C` on Windows, `sh -c` on Unix
- Working directory is validated (must exist) and `~` is expanded before spawning

## Changes

| File | What |
|------|------|
| `agentmux-srv/src/backend/rpc_types.rs` | `COMMAND_SHELL_EXEC` constant + `CommandShellExecData` / `ShellExecResult` structs |
| `agentmux-srv/src/server/websocket.rs` | `shellexec` RPC handler — spawns shell, captures output, returns buffered result |
| `frontend/app/store/rpc-api.ts` | `ShellExecCommand` RPC client method |
| `frontend/app/view/agent/hooks/useAgentCommands.ts` | `!` intercept in `sendMessage` + `dispatchBangCommand` module-level function |

## How it works

```
User types: ! ls -la
  → sendMessage() sees trimmed.startsWith("!")
  → dispatchBangCommand("ls -la", blockId, ctx)
      → logs "$ ls -la" to launch log
      → RpcApi.ShellExecCommand({ blockid, command, working_dir: cmd:cwd })
      → backend: sh -c "ls -la" in agent's cwd
      → stdout/stderr logged; non-zero exit code shown as "exit N"
```

## Out of scope / future

- Streaming output (currently buffered — returns after command completes)
- PTY / interactive commands (vim, ssh)
- Autocomplete for `!` in the composer
- Using the block's `cmd:shell` metadata as the interpreter

## Test plan

- [ ] `! ls` in agent pane → directory listing appears in launch log
- [ ] `! pwd` → shows agent's working directory
- [ ] `! false` → "exit 1" warning appears
- [ ] `! nonexistent_cmd` → stderr appears as warning
- [ ] Regular `/clear` and plain messages still work after the intercept
- [ ] Rust: `cargo check -p agentmux-srv` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)