### PR TITLE
fix(build): slim the Linux release — AppImage strips + official-build libcef

### DIFF
--- a/.changesets/1781456067-fix-build-slim-the-linux-appimage-strip-frontend-source-maps-2mlx.md
+++ b/.changesets/1781456067-fix-build-slim-the-linux-appimage-strip-frontend-source-maps-2mlx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): slim the Linux AppImage — strip frontend source maps (~28MB) and use max-level zstd compression

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -91,6 +91,10 @@ If you see "class member cannot be redeclared" compile errors later, the patcher
 cd ~/cef-build/chromium_git/chromium/src
 gn gen out/Release_GN_x64 --args='
   is_debug=false
+  is_official_build=true
+  use_thin_lto=true
+  is_cfi=false
+  chrome_pgo_phase=0
   symbol_level=1
   is_component_build=false
   proprietary_codecs=true
@@ -100,6 +104,24 @@ gn gen out/Release_GN_x64 --args='
   cc_wrapper="ccache"
 '
 ```
+
+> **`is_official_build=true` is the size lever — do not omit it.** It enables
+> thin-LTO + identical-code-folding + full optimization. Without it (a plain
+> `is_debug=false` Release), `libcef.so` is **~2x** the official size:
+> ~414 MB stripped vs **~263 MB** with it — and the Linux AppImage ~190 vs
+> **~135 MB**. `is_cfi=false` and `chrome_pgo_phase=0` are disabled only to skip
+> their data/setup deps (they don't drive size). `symbol_level=1` keeps the
+> unstripped `.so` large (~1.5 GB of debug info) but `strip --strip-all` removes
+> all of it; ship the stripped binary. Verified 2026-06-14 on CEF 148.0.7778.180.
+>
+> Two gotchas after changing args on an existing tree:
+> 1. **Regenerate the gitignored wrappers first** or the build dies instantly on
+>    `cef/libcef_dll/ctocpp/views/window_ctocpp.cc` "missing and no known rule":
+>    `cd cef && python3 tools/translator.py --root-dir .` (the tree stays clean —
+>    identical API rewrite — so no `version_manager.py` needed).
+> 2. **Copy the new `snapshot_blob.bin` + `v8_context_snapshot.bin`** alongside
+>    `libcef.so` — `is_official_build` rebuilds V8, and stale snapshots crash the
+>    host on a checksum mismatch.
 
 ### 5. Build (use the OOM-resistant wrapper)
 

--- a/scripts/build-appimage-linux.sh
+++ b/scripts/build-appimage-linux.sh
@@ -138,6 +138,16 @@ fi
 #        agentmux-cef looks for next to its binary. ---
 cp -r dist/frontend "$APPDIR/usr/bin/frontend"
 
+# Strip frontend source maps from the release artifact (debug-only, ~28 MB).
+# Mirrors the STRIP_MAPS policy for release builds
+# (docs/specs/SPEC_PORTABLE_SOURCE_MAPS_2026_06_01.md): the app runs identically;
+# only prod-stack-trace symbolication is lost.
+_maps=$(find "$APPDIR/usr/bin/frontend" -name '*.map' | wc -l)
+if [ "$_maps" -gt 0 ]; then
+    find "$APPDIR/usr/bin/frontend" -name '*.map' -delete
+    echo "Stripped $_maps source-map file(s) from the AppImage frontend"
+fi
+
 # --- 6. Schema (optional — only present if `task copy:schema` ran) ---
 if [ -d dist/schema ]; then
     mkdir -p "$APPDIR/usr/share/agentmux"
@@ -186,9 +196,15 @@ for size in 16 32 48 64 128 256 512; do
 done
 
 # --- 11. Build the AppImage ---
+# appimagetool's bundled mksquashfs only ships the zstd compressor (no xz), so
+# crank zstd to its max level (22 vs the default 15). The bulk of the image is
+# libcef.so (~414 MB); the higher level trades build time for a smaller artifact.
+# Decompress cost is absorbed by AppRun's extract-once-cache on first launch.
 mkdir -p "$OUTDIR"
 rm -f "$OUTPUT"
-ARCH=x86_64 "$APPIMAGETOOL" --no-appstream "$APPDIR" "$OUTPUT"
+ARCH=x86_64 "$APPIMAGETOOL" --no-appstream \
+    --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+    "$APPDIR" "$OUTPUT"
 
 chmod +x "$OUTPUT"
 echo ""

--- a/specs/cef-size-reduction.md
+++ b/specs/cef-size-reduction.md
@@ -19,11 +19,20 @@
 
 The main library is ~70% of every distribution. File-level trimming is marginal.
 
-**IMPORTANT:** The official CEF builds (hosted on Spotify CDN, the official CEF build infra)
-already use `is_official_build=true` with full optimization (`/OPT:REF`, `/OPT:ICF`, LTO).
-PDB files are excluded from the minimal distribution. The 251 MB libcef.dll is **already
-stripped and optimized** — `symbol_level=0` would yield single-digit percent savings at best,
-not the ~50% initially estimated. The size is inherent to Chromium's codebase.
+**IMPORTANT:** The *official* CEF builds (hosted on Spotify CDN) use
+`is_official_build=true` with full optimization (`/OPT:REF`, `/OPT:ICF`, LTO), so for
+those, `symbol_level=0` yields single-digit-percent savings at best — the size is
+inherent to Chromium.
+
+> **CORRECTION (2026-06-14): this does NOT apply to our patched fork build.** This
+> spec assumed our `libcef` was already official. It wasn't — the local fork build
+> (`docs/cef-build/build-patched-libcef.md`) omitted `is_official_build`, so it was a
+> plain `is_debug=false` Release and ran **~2× bigger** than stock-official. Adding
+> `is_official_build=true` + `use_thin_lto=true` cut **`libcef.so` 414 → 263 MB
+> stripped** (below stock-official ~280 MB) and the **Linux AppImage 197 → 135 MB**
+> (now smaller than Windows/macOS). So for *our* build the official flags ARE the
+> ~50% lever — the build doc now sets them. See
+> [cef148-official-build-size in agent memory] / the updated build doc.
 
 ---
 
@@ -170,13 +179,13 @@ Effort: trivial. Marginal gain since the main library dominates.
 
 ### Scenario B: Custom Build — Feature Disable
 
-**NOTE:** The official CEF builds already use `is_official_build=true` with full
-optimization and ship without PDB files. `symbol_level=0` does NOT halve the DLL —
-the 251 MB is already optimized. The only meaningful savings from a custom build
-come from **disabling features**.
+**NOTE:** True for the *stock-official* CEF. **But our patched fork build did NOT
+set these** (see the correction above) — so for us they are the ~50% lever, not
+"already set". The build doc (`docs/cef-build/build-patched-libcef.md`) now sets
+them. The feature-disable flags below are a *further* ~20–40 MB on top.
 
 ```gn
-# Already set by official builds (included for completeness)
+# THE size lever for our fork build (it omitted these — now set in the build doc)
 is_official_build=true
 use_thin_lto=true
 exclude_unwind_tables=true


### PR DESCRIPTION
Two-part Linux release size reduction.

## 1. AppImage packaging (`scripts/build-appimage-linux.sh`)
- **Strip frontend source maps** (~28 MB) — debug-only, matches the Windows/macOS `STRIP_MAPS` policy.
- **Max-level zstd** (`-Xcompression-level 22`). (xz+BCJ would be smaller, but the AppImage type2-runtime's squashfuse only supports zlib/zstd — an xz image won't mount.)

## 2. The real lever: libcef was a non-official build (`docs/cef-build/`, `specs/`)
The patched fork `libcef.so` was built **without `is_official_build`** — a plain `is_debug=false` Release — so it ran **~2× stock-official**. Corrects the build doc's gn args to set `is_official_build=true` + `use_thin_lto=true` (CFI/PGO off to skip their deps), and fixes `specs/cef-size-reduction.md`, whose "libcef is already official" premise was wrong for our build.

## Verified (CEF 148.0.7778.180)
- `libcef.so` **414 → 263 MB** stripped (below stock-official ~280 MB); `dist/cef` 709 → 313 MB.
- **AppImage 197.7 → 134.6 MB** — now smaller than Windows (168) and macOS (139).
- Launches clean (no V8 snapshot mismatch), hardware WebGL via the cap-probe (GaneshGL), terminal on the WebGL renderer.

## Notes / gotchas documented
- Regenerate the gitignored `ctocpp` wrappers (`translator.py`) before building, or it dies on a missing `window_ctocpp.cc`.
- Copy the new V8 snapshots alongside the rebuilt libcef (stale ones crash on checksum mismatch).
- **Distribution follow-up (separate):** the slim `libcef.so` is local; CI/release must fetch the official-built runtime for releases to ship the 135 MB AppImage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
