### PR TITLE
feat(editor): scratch buffer, file-tree context menu, widget defaults

### DIFF
--- a/.changesets/1781479844-feat-editor-scratch-buffers-file-tree-context-menu-widget-de-g4xt.md
+++ b/.changesets/1781479844-feat-editor-scratch-buffers-file-tree-context-menu-widget-de-g4xt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): scratch buffers, file-tree context menu, widget default UX

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -52,7 +52,8 @@
         "blockdef": {
             "meta": {
                 "view": "editor",
-                "file": ""
+                "editor:tree_expanded": false,
+                "editor:scratch": true
             }
         }
     },

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1521,7 +1521,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 if !canonical.starts_with(&canonical_home) {
                     return Err("deleteeditorfile: path outside home directory".to_string());
                 }
-                if canonical.is_dir() {
+                // Use symlink_metadata (not metadata) to detect symlinks without following them.
+                // Deleting via `canonical` would delete the symlink TARGET; we always remove the
+                // entry at the original path so the symlink itself is unlinked.
+                let meta = std::fs::symlink_metadata(path)
+                    .map_err(|e| format!("deleteeditorfile: {e}"))?;
+                if meta.file_type().is_symlink() {
+                    std::fs::remove_file(path).map_err(|e| format!("deleteeditorfile: {e}"))?;
+                } else if canonical.is_dir() {
                     if cmd.recursive {
                         std::fs::remove_dir_all(&canonical).map_err(|e| format!("deleteeditorfile: {e}"))?;
                     } else {
@@ -1603,27 +1610,39 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // Validate + resolve destination.
                 let expanded_dest = expand_home_dir_safe(&cmd.destination_path);
                 let dest_path = expanded_dest.as_path();
+
+                // Coarse home-boundary check before any filesystem mutation.
+                // We use the unexpanded path here because the dest may not exist yet
+                // (canonicalize fails on non-existent paths).
+                if !dest_path.starts_with(&home) {
+                    return Err("movescratchfile: destination outside home directory".to_string());
+                }
+                // Reject existing destination to avoid silent data loss.
+                if dest_path.exists() {
+                    return Err("movescratchfile: destination already exists".to_string());
+                }
+                // Create parent directories if needed.
+                if let Some(parent) = dest_path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| format!("movescratchfile: create dirs: {e}"))?;
+                }
+                // Canonicalize parent (now guaranteed to exist) + append filename.
                 let canonical_dest = dest_path.parent()
                     .and_then(|p| p.canonicalize().ok())
                     .map(|p| p.join(dest_path.file_name().unwrap_or_default()))
                     .ok_or_else(|| "movescratchfile: invalid destination path".to_string())?;
+                // Fine-grained home-boundary check with canonical paths.
                 if !canonical_dest.starts_with(&canonical_home) {
                     return Err("movescratchfile: destination outside home directory".to_string());
                 }
-                if let Some(parent) = canonical_dest.parent() {
-                    std::fs::create_dir_all(parent)
-                        .map_err(|e| format!("movescratchfile: create dirs: {e}"))?;
-                }
+                // Copy then remove scratch source (cross-device-safe move).
                 std::fs::copy(&scratch_path, &canonical_dest)
-                    .map_err(|e| format!("movescratchfile: {e}"))?;
-                // Mark sidecar as saved.
+                    .map_err(|e| format!("movescratchfile: copy: {e}"))?;
+                std::fs::remove_file(&scratch_path)
+                    .map_err(|e| format!("movescratchfile: remove scratch: {e}"))?;
+                // Clean up the .meta sidecar.
                 let meta_path = scratch_dir.join(format!("{}.md.meta", cmd.scratch_id));
-                if let Ok(bytes) = std::fs::read_to_string(&meta_path) {
-                    if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&bytes) {
-                        json["saved_to"] = serde_json::json!(canonical_dest.to_string_lossy());
-                        let _ = std::fs::write(&meta_path, json.to_string());
-                    }
-                }
+                let _ = std::fs::remove_file(&meta_path);
                 Ok(Some(serde_json::json!({ "file_path": canonical_dest.to_string_lossy() })))
             })
         }),

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1461,7 +1461,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 if !canonical_parent.starts_with(&canonical_home) {
                     return Err("createeditorfile: path outside home directory".to_string());
                 }
-                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.is_empty() {
+                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.contains('\0') || cmd.name == "." || cmd.name == ".." || cmd.name.is_empty() {
                     return Err("createeditorfile: name must be a plain filename".to_string());
                 }
                 let file_path = canonical_parent.join(&cmd.name);
@@ -1491,7 +1491,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 if !canonical_parent.starts_with(&canonical_home) {
                     return Err("createeditordir: path outside home directory".to_string());
                 }
-                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.is_empty() {
+                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.contains('\0') || cmd.name == "." || cmd.name == ".." || cmd.name.is_empty() {
                     return Err("createeditordir: name must be a plain name".to_string());
                 }
                 let dir_path = canonical_parent.join(&cmd.name);

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1372,6 +1372,263 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         }),
     );
 
+    // ── Editor file-tree mutations ─────────────────────────────────────
+    // Spec: specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md
+    // All handlers validate the target path is under the user's home directory
+    // before performing any mutation — same policy as writeeditorfile.
+
+    // openinshell → reveal a path in the OS file manager
+    engine.register_handler(
+        "openinshell",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { path: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("openinshell: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.path);
+                let path = expanded.as_path();
+                let home = dirs::home_dir()
+                    .ok_or("openinshell: cannot determine home directory")?;
+                let canonical_home = home.canonicalize()
+                    .map_err(|e| format!("openinshell: home: {e}"))?;
+                let canonical = path.canonicalize()
+                    .map_err(|e| format!("openinshell: {e}"))?;
+                if !canonical.starts_with(&canonical_home) {
+                    return Err(format!("openinshell: path outside home directory"));
+                }
+                #[cfg(target_os = "windows")]
+                { let _ = std::process::Command::new("explorer.exe").arg(format!("/select,{}", canonical.display())).spawn(); }
+                #[cfg(target_os = "macos")]
+                { let _ = std::process::Command::new("open").arg("-R").arg(&canonical).spawn(); }
+                #[cfg(target_os = "linux")]
+                {
+                    let target = if canonical.is_dir() { canonical.clone() } else { canonical.parent().unwrap_or(&canonical).to_path_buf() };
+                    let _ = std::process::Command::new("xdg-open").arg(&target).spawn();
+                }
+                Ok(None)
+            })
+        }),
+    );
+
+    // renameeditorfile → rename a file or folder (name only, same parent directory)
+    engine.register_handler(
+        "renameeditorfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { old_path: String, new_name: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("renameeditorfile: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.old_path);
+                let old_path = expanded.as_path();
+                let home = dirs::home_dir().ok_or("renameeditorfile: cannot determine home")?;
+                let canonical_home = home.canonicalize().map_err(|e| format!("renameeditorfile: home: {e}"))?;
+                let canonical_old = old_path.canonicalize().map_err(|e| format!("renameeditorfile: {e}"))?;
+                if !canonical_old.starts_with(&canonical_home) {
+                    return Err("renameeditorfile: path outside home directory".to_string());
+                }
+                if cmd.new_name.contains('/') || cmd.new_name.contains('\\') || cmd.new_name == ".." || cmd.new_name.is_empty() {
+                    return Err("renameeditorfile: new_name must be a plain filename".to_string());
+                }
+                let new_path = canonical_old.parent()
+                    .ok_or("renameeditorfile: no parent directory")?
+                    .join(&cmd.new_name);
+                if new_path.exists() {
+                    return Err(format!("renameeditorfile: destination already exists"));
+                }
+                std::fs::rename(&canonical_old, &new_path)
+                    .map_err(|e| format!("renameeditorfile: {e}"))?;
+                Ok(Some(serde_json::json!({ "new_path": new_path.to_string_lossy() })))
+            })
+        }),
+    );
+
+    // createeditorfile → create an empty file inside an existing directory
+    engine.register_handler(
+        "createeditorfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { parent_path: String, name: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("createeditorfile: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.parent_path);
+                let parent = expanded.as_path();
+                let home = dirs::home_dir().ok_or("createeditorfile: cannot determine home")?;
+                let canonical_home = home.canonicalize().map_err(|e| format!("createeditorfile: home: {e}"))?;
+                let canonical_parent = parent.canonicalize().map_err(|e| format!("createeditorfile: {e}"))?;
+                if !canonical_parent.starts_with(&canonical_home) {
+                    return Err("createeditorfile: path outside home directory".to_string());
+                }
+                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.is_empty() {
+                    return Err("createeditorfile: name must be a plain filename".to_string());
+                }
+                let file_path = canonical_parent.join(&cmd.name);
+                if file_path.exists() {
+                    return Err("createeditorfile: file already exists".to_string());
+                }
+                std::fs::write(&file_path, "").map_err(|e| format!("createeditorfile: {e}"))?;
+                Ok(Some(serde_json::json!({ "file_path": file_path.to_string_lossy() })))
+            })
+        }),
+    );
+
+    // createeditordir → create a directory inside an existing directory
+    engine.register_handler(
+        "createeditordir",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { parent_path: String, name: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("createeditordir: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.parent_path);
+                let parent = expanded.as_path();
+                let home = dirs::home_dir().ok_or("createeditordir: cannot determine home")?;
+                let canonical_home = home.canonicalize().map_err(|e| format!("createeditordir: home: {e}"))?;
+                let canonical_parent = parent.canonicalize().map_err(|e| format!("createeditordir: {e}"))?;
+                if !canonical_parent.starts_with(&canonical_home) {
+                    return Err("createeditordir: path outside home directory".to_string());
+                }
+                if cmd.name.contains('/') || cmd.name.contains('\\') || cmd.name.is_empty() {
+                    return Err("createeditordir: name must be a plain name".to_string());
+                }
+                let dir_path = canonical_parent.join(&cmd.name);
+                if dir_path.exists() {
+                    return Err("createeditordir: already exists".to_string());
+                }
+                std::fs::create_dir(&dir_path).map_err(|e| format!("createeditordir: {e}"))?;
+                Ok(Some(serde_json::json!({ "dir_path": dir_path.to_string_lossy() })))
+            })
+        }),
+    );
+
+    // deleteeditorfile → delete a file or directory
+    engine.register_handler(
+        "deleteeditorfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { path: String, recursive: bool }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("deleteeditorfile: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.path);
+                let path = expanded.as_path();
+                let home = dirs::home_dir().ok_or("deleteeditorfile: cannot determine home")?;
+                let canonical_home = home.canonicalize().map_err(|e| format!("deleteeditorfile: home: {e}"))?;
+                let canonical = path.canonicalize().map_err(|e| format!("deleteeditorfile: {e}"))?;
+                if !canonical.starts_with(&canonical_home) {
+                    return Err("deleteeditorfile: path outside home directory".to_string());
+                }
+                if canonical.is_dir() {
+                    if cmd.recursive {
+                        std::fs::remove_dir_all(&canonical).map_err(|e| format!("deleteeditorfile: {e}"))?;
+                    } else {
+                        std::fs::remove_dir(&canonical).map_err(|e| format!("deleteeditorfile: directory not empty: {e}"))?;
+                    }
+                } else {
+                    std::fs::remove_file(&canonical).map_err(|e| format!("deleteeditorfile: {e}"))?;
+                }
+                Ok(None)
+            })
+        }),
+    );
+
+    // ── Scratch file service ────────────────────────────────────────────
+    // Spec: specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
+
+    // createscratchfile → create a scratch buffer file in ~/.agentmux/cache/scratch/
+    engine.register_handler(
+        "createscratchfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { display_name: Option<String> }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("createscratchfile: {e}"))?;
+                let home = dirs::home_dir()
+                    .ok_or("createscratchfile: cannot determine home directory")?;
+                let scratch_dir = home.join(".agentmux").join("cache").join("scratch");
+                std::fs::create_dir_all(&scratch_dir)
+                    .map_err(|e| format!("createscratchfile: create dir: {e}"))?;
+                let scratch_id = uuid::Uuid::new_v4().to_string();
+                let display_name = cmd.display_name.unwrap_or_else(|| "Untitled".to_string());
+                let file_path = scratch_dir.join(format!("{}.md", scratch_id));
+                std::fs::write(&file_path, "")
+                    .map_err(|e| format!("createscratchfile: {e}"))?;
+                let created_at = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let meta = serde_json::json!({
+                    "display_name": display_name,
+                    "scratch_id": scratch_id,
+                    "created_at": created_at,
+                });
+                let meta_path = scratch_dir.join(format!("{}.md.meta", scratch_id));
+                std::fs::write(&meta_path, meta.to_string())
+                    .map_err(|e| format!("createscratchfile: meta: {e}"))?;
+                Ok(Some(serde_json::json!({
+                    "scratch_id": scratch_id,
+                    "file_path": file_path.to_string_lossy(),
+                    "display_name": display_name,
+                })))
+            })
+        }),
+    );
+
+    // movescratchfile → promote a scratch buffer to a real user-chosen path (Save As)
+    engine.register_handler(
+        "movescratchfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { scratch_id: String, destination_path: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("movescratchfile: {e}"))?;
+                let home = dirs::home_dir()
+                    .ok_or("movescratchfile: cannot determine home")?;
+                let canonical_home = home.canonicalize()
+                    .map_err(|e| format!("movescratchfile: home: {e}"))?;
+                // Validate scratch_id has no path components.
+                if cmd.scratch_id.contains('/') || cmd.scratch_id.contains('\\') || cmd.scratch_id.contains("..") {
+                    return Err("movescratchfile: invalid scratch_id".to_string());
+                }
+                let scratch_dir = home.join(".agentmux").join("cache").join("scratch");
+                let scratch_path = scratch_dir.join(format!("{}.md", cmd.scratch_id));
+                if !scratch_path.exists() {
+                    return Err(format!("movescratchfile: scratch file not found"));
+                }
+                // Validate + resolve destination.
+                let expanded_dest = expand_home_dir_safe(&cmd.destination_path);
+                let dest_path = expanded_dest.as_path();
+                let canonical_dest = dest_path.parent()
+                    .and_then(|p| p.canonicalize().ok())
+                    .map(|p| p.join(dest_path.file_name().unwrap_or_default()))
+                    .ok_or_else(|| "movescratchfile: invalid destination path".to_string())?;
+                if !canonical_dest.starts_with(&canonical_home) {
+                    return Err("movescratchfile: destination outside home directory".to_string());
+                }
+                if let Some(parent) = canonical_dest.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| format!("movescratchfile: create dirs: {e}"))?;
+                }
+                std::fs::copy(&scratch_path, &canonical_dest)
+                    .map_err(|e| format!("movescratchfile: {e}"))?;
+                // Mark sidecar as saved.
+                let meta_path = scratch_dir.join(format!("{}.md.meta", cmd.scratch_id));
+                if let Ok(bytes) = std::fs::read_to_string(&meta_path) {
+                    if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&bytes) {
+                        json["saved_to"] = serde_json::json!(canonical_dest.to_string_lossy());
+                        let _ = std::fs::write(&meta_path, json.to_string());
+                    }
+                }
+                Ok(Some(serde_json::json!({ "file_path": canonical_dest.to_string_lossy() })))
+            })
+        }),
+    );
+
     // ── LSP RPCs ───────────────────────────────────────────────────
     // Three handlers backing the editor pane's LSP integration:
     //   * lspstart — spawn (or attach to) the server for a file

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1527,6 +1527,15 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let meta = std::fs::symlink_metadata(path)
                     .map_err(|e| format!("deleteeditorfile: {e}"))?;
                 if meta.file_type().is_symlink() {
+                    // On Windows, directory junctions/symlinks must use remove_dir;
+                    // remove_file fails for directory symlinks on that platform.
+                    #[cfg(windows)]
+                    if path.is_dir() {
+                        std::fs::remove_dir(path).map_err(|e| format!("deleteeditorfile: {e}"))?;
+                    } else {
+                        std::fs::remove_file(path).map_err(|e| format!("deleteeditorfile: {e}"))?;
+                    }
+                    #[cfg(not(windows))]
                     std::fs::remove_file(path).map_err(|e| format!("deleteeditorfile: {e}"))?;
                 } else if canonical.is_dir() {
                     if cmd.recursive {
@@ -1559,19 +1568,77 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let scratch_dir = home.join(".agentmux").join("cache").join("scratch");
                 std::fs::create_dir_all(&scratch_dir)
                     .map_err(|e| format!("createscratchfile: create dir: {e}"))?;
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+
+                // Scan existing .md.meta files: prune expired ones, reuse the most
+                // recent active one (no saved_to, created within 30 days).
+                let mut best: Option<(u64, String, String)> = None; // (created_at, scratch_id, display_name)
+                if let Ok(entries) = std::fs::read_dir(&scratch_dir) {
+                    for entry in entries.flatten() {
+                        let meta_path = entry.path();
+                        let fname = meta_path
+                            .file_name()
+                            .and_then(|f| f.to_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !fname.ends_with(".md.meta") {
+                            continue;
+                        }
+                        let Ok(content) = std::fs::read_to_string(&meta_path) else { continue };
+                        let Ok(meta_json) = serde_json::from_str::<serde_json::Value>(&content) else { continue };
+                        // Skip already-promoted scratch files (saved_to present + non-null).
+                        if meta_json.get("saved_to").map_or(false, |v| !v.is_null()) {
+                            continue;
+                        }
+                        let created_at = meta_json.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
+                        let sid = meta_json.get("scratch_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                        if created_at == 0 || sid.is_empty() {
+                            continue;
+                        }
+                        if now_ms.saturating_sub(created_at) > THIRTY_DAYS_MS {
+                            // Prune expired pair.
+                            let _ = std::fs::remove_file(scratch_dir.join(format!("{}.md", sid)));
+                            let _ = std::fs::remove_file(&meta_path);
+                            continue;
+                        }
+                        // Track most recent active scratch.
+                        if best.as_ref().map_or(true, |(best_ts, _, _)| created_at > *best_ts) {
+                            let dname = meta_json
+                                .get("display_name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("Untitled")
+                                .to_string();
+                            best = Some((created_at, sid, dname));
+                        }
+                    }
+                }
+
+                // Reuse most recent active scratch if the backing file still exists.
+                if let Some((_, ref scratch_id, ref display_name)) = best {
+                    let file_path = scratch_dir.join(format!("{}.md", scratch_id));
+                    if file_path.exists() {
+                        return Ok(Some(serde_json::json!({
+                            "scratch_id": scratch_id,
+                            "file_path": file_path.to_string_lossy(),
+                            "display_name": display_name,
+                        })));
+                    }
+                }
+
+                // No reusable active scratch found — mint a fresh UUID pair.
                 let scratch_id = uuid::Uuid::new_v4().to_string();
                 let display_name = cmd.display_name.unwrap_or_else(|| "Untitled".to_string());
                 let file_path = scratch_dir.join(format!("{}.md", scratch_id));
                 std::fs::write(&file_path, "")
                     .map_err(|e| format!("createscratchfile: {e}"))?;
-                let created_at = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64;
                 let meta = serde_json::json!({
                     "display_name": display_name,
                     "scratch_id": scratch_id,
-                    "created_at": created_at,
+                    "created_at": now_ms,
                 });
                 let meta_path = scratch_dir.join(format!("{}.md.meta", scratch_id));
                 std::fs::write(&meta_path, meta.to_string())

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1434,8 +1434,8 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let home = dirs::home_dir().ok_or("renameeditorfile: cannot determine home")?;
                 let canonical_home = home.canonicalize().map_err(|e| format!("renameeditorfile: home: {e}"))?;
                 let canonical_old = old_path.canonicalize().map_err(|e| format!("renameeditorfile: {e}"))?;
-                if !canonical_old.starts_with(&canonical_home) {
-                    return Err("renameeditorfile: path outside home directory".to_string());
+                if !canonical_old.starts_with(&canonical_home) || canonical_old == canonical_home {
+                    return Err("renameeditorfile: path outside or is the home directory".to_string());
                 }
                 if cmd.new_name.contains('/') || cmd.new_name.contains('\\') || cmd.new_name.contains('\0') || cmd.new_name == ".." || cmd.new_name == "." || cmd.new_name.is_empty() {
                     return Err("renameeditorfile: new_name must be a plain filename".to_string());

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -35,6 +35,15 @@ use super::service::update_object_meta;
 
 use super::AppState;
 
+// Per-process token written into scratch claim files. Stale claim files from a
+// previous process run have a different token and are ignored during reuse scans,
+// allowing crash-recovery (the scratch becomes reclaimable on restart).
+static SCRATCH_SESSION_TOKEN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+fn scratch_session_token() -> &'static str {
+    SCRATCH_SESSION_TOKEN.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
 /// Enumerate drives/mounts accessible from the current OS user.
 /// Used by the `geteditorroots` RPC so the editor file-tree exposes
 /// every reachable filesystem root, not just $HOME.
@@ -1573,10 +1582,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     .unwrap_or_default()
                     .as_millis() as u64;
                 const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+                let session_token = scratch_session_token();
 
-                // Scan existing .md.meta files: prune expired ones, reuse the most
-                // recent active one (no saved_to, created within 30 days).
-                let mut best: Option<(u64, String, String)> = None; // (created_at, scratch_id, display_name)
+                // Phase 1: scan .md.meta files, collect candidates and prune expired pairs.
+                // A candidate is: not saved, not expired, not in exclude_scratch_ids.
+                let mut candidates: Vec<(u64, String, String)> = Vec::new(); // (created_at, sid, display_name)
                 if let Ok(entries) = std::fs::read_dir(&scratch_dir) {
                     for entry in entries.flatten() {
                         let meta_path = entry.path();
@@ -1590,7 +1600,6 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         }
                         let Ok(content) = std::fs::read_to_string(&meta_path) else { continue };
                         let Ok(meta_json) = serde_json::from_str::<serde_json::Value>(&content) else { continue };
-                        // Skip already-promoted scratch files (saved_to present + non-null).
                         if meta_json.get("saved_to").map_or(false, |v| !v.is_null()) {
                             continue;
                         }
@@ -1599,41 +1608,76 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         if created_at == 0 || sid.is_empty() {
                             continue;
                         }
-                        // Skip scratch files already open in another pane.
                         if cmd.exclude_scratch_ids.as_deref().map_or(false, |ex| ex.iter().any(|e| e == &sid)) {
                             continue;
                         }
                         if now_ms.saturating_sub(created_at) > THIRTY_DAYS_MS {
-                            // Prune expired pair.
+                            // Prune expired pair (all three files: .md, .md.meta, .md.claim).
                             let _ = std::fs::remove_file(scratch_dir.join(format!("{}.md", sid)));
                             let _ = std::fs::remove_file(&meta_path);
+                            let _ = std::fs::remove_file(scratch_dir.join(format!("{}.md.claim", sid)));
                             continue;
                         }
-                        // Track most recent active scratch.
-                        if best.as_ref().map_or(true, |(best_ts, _, _)| created_at > *best_ts) {
-                            let dname = meta_json
-                                .get("display_name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("Untitled")
-                                .to_string();
-                            best = Some((created_at, sid, dname));
+                        let dname = meta_json
+                            .get("display_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Untitled")
+                            .to_string();
+                        candidates.push((created_at, sid, dname));
+                    }
+                }
+
+                // Phase 2: try to atomically claim the most-recent candidate.
+                // Claim files prevent two concurrent createscratchfile calls from
+                // returning the same backing file to different panes. Each claim file
+                // stores the per-process session token; a claim from a previous process
+                // (crash/restart) has a different token and is cleared so recovery works.
+                candidates.sort_by(|a, b| b.0.cmp(&a.0)); // most recent first
+                let mut chosen: Option<(String, String)> = None;
+                for (_, sid, dname) in &candidates {
+                    let claim_path = scratch_dir.join(format!("{}.md.claim", sid));
+                    // Evict stale claims from a previous process session.
+                    if claim_path.exists() {
+                        if let Ok(tok) = std::fs::read_to_string(&claim_path) {
+                            if tok.trim() == session_token {
+                                // Valid live claim — another concurrent call already owns this.
+                                continue;
+                            }
                         }
+                        // Stale claim (different session) — remove so we can reclaim.
+                        let _ = std::fs::remove_file(&claim_path);
+                    }
+                    // Try to exclusively create the claim file. If another concurrent
+                    // call wins the race, it will have already created it → we skip.
+                    match std::fs::OpenOptions::new().write(true).create_new(true).open(&claim_path) {
+                        Ok(mut f) => {
+                            use std::io::Write as _;
+                            let _ = f.write_all(session_token.as_bytes());
+                            let file_path = scratch_dir.join(format!("{}.md", sid));
+                            if file_path.exists() {
+                                chosen = Some((sid.clone(), dname.clone()));
+                            } else {
+                                // Backing file gone (deleted externally) — release claim.
+                                let _ = std::fs::remove_file(&claim_path);
+                            }
+                        }
+                        Err(_) => continue, // Concurrent call claimed this one first.
+                    }
+                    if chosen.is_some() {
+                        break;
                     }
                 }
 
-                // Reuse most recent active scratch if the backing file still exists.
-                if let Some((_, ref scratch_id, ref display_name)) = best {
+                if let Some((scratch_id, display_name)) = chosen {
                     let file_path = scratch_dir.join(format!("{}.md", scratch_id));
-                    if file_path.exists() {
-                        return Ok(Some(serde_json::json!({
-                            "scratch_id": scratch_id,
-                            "file_path": file_path.to_string_lossy(),
-                            "display_name": display_name,
-                        })));
-                    }
+                    return Ok(Some(serde_json::json!({
+                        "scratch_id": scratch_id,
+                        "file_path": file_path.to_string_lossy(),
+                        "display_name": display_name,
+                    })));
                 }
 
-                // No reusable active scratch found — mint a fresh UUID pair.
+                // No reusable candidate — mint a fresh UUID pair.
                 let scratch_id = uuid::Uuid::new_v4().to_string();
                 let display_name = cmd.display_name.unwrap_or_else(|| "Untitled".to_string());
                 let file_path = scratch_dir.join(format!("{}.md", scratch_id));
@@ -1647,6 +1691,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let meta_path = scratch_dir.join(format!("{}.md.meta", scratch_id));
                 std::fs::write(&meta_path, meta.to_string())
                     .map_err(|e| format!("createscratchfile: meta: {e}"))?;
+                // Claim the fresh scratch so subsequent calls don't immediately reuse it.
+                let claim_path = scratch_dir.join(format!("{}.md.claim", scratch_id));
+                let _ = std::fs::write(&claim_path, session_token);
                 Ok(Some(serde_json::json!({
                     "scratch_id": scratch_id,
                     "file_path": file_path.to_string_lossy(),
@@ -1718,9 +1765,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     .map_err(|e| format!("movescratchfile: copy: {e}"))?;
                 std::fs::remove_file(&scratch_path)
                     .map_err(|e| format!("movescratchfile: remove scratch: {e}"))?;
-                // Clean up the .meta sidecar.
+                // Clean up the .meta sidecar and the claim file.
                 let meta_path = scratch_dir.join(format!("{}.md.meta", cmd.scratch_id));
                 let _ = std::fs::remove_file(&meta_path);
+                let claim_path = scratch_dir.join(format!("{}.md.claim", cmd.scratch_id));
+                let _ = std::fs::remove_file(&claim_path);
                 Ok(Some(serde_json::json!({ "file_path": canonical_dest.to_string_lossy() })))
             })
         }),

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1428,7 +1428,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 if !canonical_old.starts_with(&canonical_home) {
                     return Err("renameeditorfile: path outside home directory".to_string());
                 }
-                if cmd.new_name.contains('/') || cmd.new_name.contains('\\') || cmd.new_name == ".." || cmd.new_name.is_empty() {
+                if cmd.new_name.contains('/') || cmd.new_name.contains('\\') || cmd.new_name.contains('\0') || cmd.new_name == ".." || cmd.new_name == "." || cmd.new_name.is_empty() {
                     return Err("renameeditorfile: new_name must be a plain filename".to_string());
                 }
                 let new_path = canonical_old.parent()
@@ -1518,8 +1518,8 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let home = dirs::home_dir().ok_or("deleteeditorfile: cannot determine home")?;
                 let canonical_home = home.canonicalize().map_err(|e| format!("deleteeditorfile: home: {e}"))?;
                 let canonical = path.canonicalize().map_err(|e| format!("deleteeditorfile: {e}"))?;
-                if !canonical.starts_with(&canonical_home) {
-                    return Err("deleteeditorfile: path outside home directory".to_string());
+                if !canonical.starts_with(&canonical_home) || canonical == canonical_home {
+                    return Err("deleteeditorfile: path outside or is the home directory".to_string());
                 }
                 // Use symlink_metadata (not metadata) to detect symlinks without following them.
                 // Deleting via `canonical` would delete the symlink TARGET; we always remove the

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1617,6 +1617,13 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 if !dest_path.starts_with(&home) {
                     return Err("movescratchfile: destination outside home directory".to_string());
                 }
+                // Reject ".." components before create_dir_all — the coarse starts_with
+                // check is purely lexical and passes paths like ~/foo/../../../tmp/evil
+                // because the prefix matches, but create_dir_all would then materialize
+                // directories outside the home boundary before the canonical check fires.
+                if dest_path.components().any(|c| c == std::path::Component::ParentDir) {
+                    return Err("movescratchfile: destination path must not contain '..' components".to_string());
+                }
                 // Reject existing destination to avoid silent data loss.
                 if dest_path.exists() {
                     return Err("movescratchfile: destination already exists".to_string());

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1560,7 +1560,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         Box::new(|data, _ctx| {
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
-                struct Cmd { display_name: Option<String> }
+                struct Cmd { display_name: Option<String>, exclude_scratch_ids: Option<Vec<String>> }
                 let cmd: Cmd = serde_json::from_value(data)
                     .map_err(|e| format!("createscratchfile: {e}"))?;
                 let home = dirs::home_dir()
@@ -1597,6 +1597,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         let created_at = meta_json.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
                         let sid = meta_json.get("scratch_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
                         if created_at == 0 || sid.is_empty() {
+                            continue;
+                        }
+                        // Skip scratch files already open in another pane.
+                        if cmd.exclude_scratch_ids.as_deref().map_or(false, |ex| ex.iter().any(|e| e == &sid)) {
                             continue;
                         }
                         if now_ms.saturating_sub(created_at) > THIRTY_DAYS_MS {

--- a/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
+++ b/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
@@ -60,7 +60,7 @@ Two specific gaps:
       "meta": {
         "view": "editor",
         "editor:scratch": true,
-        "editor:filetree-visible": false
+        "editor:tree_expanded": false
       }
     }
   }
@@ -69,7 +69,7 @@ Two specific gaps:
 
 - `editor:scratch: true` — signals the editor view to create/reopen a scratch buffer
   instead of showing an empty state.
-- `editor:filetree-visible: false` — tree starts collapsed. User can expand via the
+- `editor:tree_expanded: false` — tree starts collapsed. User can expand via the
   tree-toggle button (already exists in the toolbar). The expanded/collapsed state
   is then persisted per-pane in block meta.
 
@@ -169,11 +169,11 @@ overwrite prompt on frontend).
 
 ### 8. File tree collapsed state
 
-`editor:filetree-visible` is a block meta key (persisted in sidecar per pane):
+`editor:tree_expanded` is a block meta key (persisted in sidecar per pane):
 
 - Default from widget blockdef: `false` (collapsed).
 - Toggling the tree-toggle button in the editor toolbar sets
-  `editor:filetree-visible: true/false` in the pane's block meta.
+  `editor:tree_expanded: true/false` in the pane's block meta.
 - Survives tab close/reopen and pane resize.
 
 No new infrastructure needed — block meta persistence already exists.
@@ -184,7 +184,7 @@ No new infrastructure needed — block meta persistence already exists.
 
 | Component | Change | New? |
 |-----------|--------|------|
-| `widgets.json` | Add `editor:scratch: true`, `editor:filetree-visible: false` | No (edit) |
+| `widgets.json` | Add `editor:scratch: true`, `editor:tree_expanded: false` | No (edit) |
 | `EditorTab` interface | `filePath: string \| null`, add `scratchId`, `displayName`, `isScratch` | No (edit) |
 | `editor-pane-state-store.ts` | Handle `filePath: null` in all read/write paths | No (edit) |
 | `agentmux-srv/src/editor/scratch.rs` | `ScratchFileService` — create, recover, clean up | **Yes (new)** |

--- a/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
+++ b/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
@@ -1,0 +1,239 @@
+# SPEC: Editor Widget Default UX — Scratch File + Collapsed Tree
+
+Status: Draft
+Date: 2026-06-14
+Depends on: `SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md`, `app-api-pane-open.md`
+Related: `SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md`
+
+---
+
+## Problem
+
+Clicking the **Editor** widget in the dock today calls `createBlock` with
+`blockdef.meta = { view: "editor", file: "" }`. The result is an editor pane with
+no file open and an expanded (but empty) file tree — a blank-stare UX. Users have
+to manually navigate the tree, find a file, and click it before they can do anything.
+
+Two specific gaps:
+
+1. **No scratch/untitled buffer.** There is no way to open the editor and start
+   typing without first picking a file. `EditorTab` requires a `filePath`; the model
+   has no concept of an in-memory or deferred-path buffer.
+
+2. **File tree is open by default.** For users who just want to take a quick note or
+   paste something, the tree is noise. It should start collapsed and expand on demand.
+
+---
+
+## Goals
+
+1. Clicking the Editor widget opens the pane with the file tree **collapsed**.
+2. A new **scratch buffer** (Untitled-1, Untitled-2, …) is automatically open and
+   focused — the user can start typing immediately.
+3. The scratch file is backed by a cache file on disk so content survives crashes
+   and app restarts.
+4. Saving promotes the scratch file to a real path (Save As flow).
+5. Multiple scratch buffers are supported (one per click, or via New File action).
+6. Old unsaved scratch files are auto-recovered on next open; old *saved or
+   discarded* scratch files are cleaned up.
+
+---
+
+## Non-Goals
+
+- A full "workspace" model (no multi-root, no `.agentmux-workspace` file).
+- System file-picker dialog (we use an inline rename-style path entry instead).
+- Scratch files shared between panes or across windows.
+
+---
+
+## Design
+
+### 1. Widget default behavior change
+
+`agentmux-srv/src/config/widgets.json` — update the editor widget blockdef:
+
+```json
+{
+  "defwidget@editor": {
+    "blockdef": {
+      "meta": {
+        "view": "editor",
+        "editor:scratch": true,
+        "editor:filetree-visible": false
+      }
+    }
+  }
+}
+```
+
+- `editor:scratch: true` — signals the editor view to create/reopen a scratch buffer
+  instead of showing an empty state.
+- `editor:filetree-visible: false` — tree starts collapsed. User can expand via the
+  tree-toggle button (already exists in the toolbar). The expanded/collapsed state
+  is then persisted per-pane in block meta.
+
+### 2. Scratch file infrastructure (`ScratchFileService`)
+
+New backend service in `agentmux-srv/src/editor/scratch.rs`:
+
+```
+~/.agentmux/cache/scratch/
+    <uuid>.md          ← active scratch file, auto-created
+    <uuid>.md.meta     ← JSON sidecar: { displayName, createdAt, lastModifiedAt, savedTo }
+```
+
+**Directory:** `{data_dir}/cache/scratch/` — inside the per-instance data dir so
+multiple AgentMux instances each have isolated scratch files. On first write, the dir
+is created if absent.
+
+**Lifecycle:**
+
+| Event | Action |
+|-------|--------|
+| User opens editor widget (`editor:scratch: true`) | Service checks for an existing active scratch file (no `savedTo`, modified < 30 days). Reuses the most recent one, or creates a new UUID file. |
+| User types | `writeeditorfile` saves to the scratch path on every Ctrl+S (same as regular files). Auto-save every 30 s of idle if dirty (Phase 2). |
+| User hits Ctrl+Shift+S / "Save As" | Inline path-entry field appears in the tab header. User types a destination path. Backend copies scratch → destination, sets `savedTo` in the `.meta` sidecar, reopens the tab with the real path. Scratch file is then eligible for cleanup. |
+| Pane closed (buffer still unsaved) | File stays in `cache/scratch/`. On next open, it is recovered (shown with ↻ recovery indicator in the tab name). |
+| App restarted, scratch file exists | Editor widget auto-reopens the unsaved scratch file (recovery). |
+| Scratch file is older than 30 days and has never been saved | Cleanup pass on startup deletes it. |
+
+### 3. `EditorTab` model changes
+
+`frontend/app/store/editor-pane-state-store.ts` — extend `EditorTab`:
+
+```typescript
+interface EditorTab {
+  // ... existing fields ...
+  filePath: string | null;  // null = scratch/untitled (was always string)
+  scratchId?: string;       // UUID of the backing scratch file; set when filePath is null
+  displayName: string;      // "Untitled-1", "report.md", etc. — used in tab label
+  isScratch: boolean;       // true when backed by a scratch cache file
+}
+```
+
+**Key invariant:** `filePath === null` iff `isScratch === true && scratchId !== null`.
+All read/write RPCs route to the scratch path when `filePath` is null.
+
+### 4. New RPC: `createscratchfile`
+
+`agentmux-srv/src/server/websocket.rs` — new command:
+
+```
+Request:  { cmd: "createscratchfile", data: { display_name?: string } }
+Response: { scratch_id: string, file_path: string, display_name: string }
+```
+
+The frontend calls this once when `editor:scratch: true` is set and no active
+scratch tab exists yet. The response path is used as the backing `filePath` internally
+(not shown in the tab label — `displayName` is shown instead).
+
+### 5. `pane.open` with `is_new: true`
+
+Per the updated `app-api-pane-open.md`, agents can also trigger scratch buffer creation:
+
+```json
+{ "view": "editor", "is_new": true, "language": "markdown" }
+```
+
+The handler calls `createscratchfile` internally, then opens the tab pointing to
+the returned scratch path with `isScratch: true`.
+
+### 6. Save As flow (inline path entry)
+
+When the user saves an untitled/scratch tab (Ctrl+S first time, or Ctrl+Shift+S any time):
+
+1. The tab header's filename area switches to an editable `<input>` field,
+   pre-filled with the suggested path (e.g. `~/notes/untitled.md`).
+2. User edits the path and presses Enter (or Esc to cancel).
+3. On Enter: backend runs `movescratchfile { scratch_id, destination_path }`.
+   - Validates destination path is within allowed roots.
+   - Creates parent dirs if needed.
+   - Moves (not copies) the scratch file to the destination.
+   - Updates `.meta` sidecar with `savedTo`.
+4. Tab `filePath` is updated to the real path, `isScratch` → false, `scratchId` cleared.
+5. Tab `dirty` is cleared.
+
+No system file-picker dialog is used — the inline approach is consistent with the
+tab-rename interaction already used for tab titles.
+
+### 7. New RPC: `movescratchfile`
+
+```
+Request:  { cmd: "movescratchfile", data: { scratch_id: string, destination_path: string } }
+Response: { file_path: string } | { error: string }
+```
+
+Errors: `PATH_DENIED`, `PARENT_DIR_CREATE_FAILED`, `DESTINATION_EXISTS` (offer
+overwrite prompt on frontend).
+
+### 8. File tree collapsed state
+
+`editor:filetree-visible` is a block meta key (persisted in sidecar per pane):
+
+- Default from widget blockdef: `false` (collapsed).
+- Toggling the tree-toggle button in the editor toolbar sets
+  `editor:filetree-visible: true/false` in the pane's block meta.
+- Survives tab close/reopen and pane resize.
+
+No new infrastructure needed — block meta persistence already exists.
+
+---
+
+## Infrastructure Summary
+
+| Component | Change | New? |
+|-----------|--------|------|
+| `widgets.json` | Add `editor:scratch: true`, `editor:filetree-visible: false` | No (edit) |
+| `EditorTab` interface | `filePath: string \| null`, add `scratchId`, `displayName`, `isScratch` | No (edit) |
+| `editor-pane-state-store.ts` | Handle `filePath: null` in all read/write paths | No (edit) |
+| `agentmux-srv/src/editor/scratch.rs` | `ScratchFileService` — create, recover, clean up | **Yes (new)** |
+| `websocket.rs` | `createscratchfile` command | **Yes (new)** |
+| `websocket.rs` | `movescratchfile` command | **Yes (new)** |
+| `rpc_types.rs` | `CommandCreateScratchFile`, `CommandMoveScratchFile` structs | **Yes (new)** |
+| `frontend/app/view/editor/editor-tab-header.tsx` | Save As inline input field | No (edit) |
+| `frontend/app/view/editor/editor-view.tsx` | Handle `editor:scratch` meta on mount | No (edit) |
+| `app-api-pane-open.md` | `is_new: true` variant | Updated |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Scratch buffer (3–4 days)
+
+- `ScratchFileService` with create + recover + cleanup
+- `createscratchfile` RPC
+- `EditorTab.filePath: string | null` + `isScratch` flag
+- Widget blockdef: `editor:scratch: true`
+- Tab label shows "Untitled-1" (no Save As yet — Ctrl+S saves to scratch path, title
+  stays "Untitled-1 ●")
+
+### Phase 2 — Save As flow (1–2 days)
+
+- `movescratchfile` RPC
+- Inline path-entry field in tab header on Ctrl+Shift+S
+- Ctrl+S on a scratch file triggers Save As the first time
+
+### Phase 3 — Auto-save + recovery UI (1 day)
+
+- 30-second idle auto-save to scratch path
+- Recovery indicator (↻) in tab name when reopening an unsaved crash survivor
+- Startup recovery scan and popup: "Restore 2 unsaved files?"
+
+### Phase 4 — `pane.open is_new` + agent access (1 day)
+
+- Wire `is_new: true` in `app-api-pane-open.md` handler to `ScratchFileService`
+- Update agent system prompt docs
+
+---
+
+## Open Questions
+
+- **Multiple untitled buffers:** Should a second click on the editor widget create a
+  second scratch file (Untitled-2), or focus the existing untitled pane?
+  Recommendation: create a new one; the user clicked the widget intentionally.
+- **Scratch file directory location:** `{data_dir}/cache/scratch/` vs a fixed
+  `~/.agentmux/cache/scratch/` shared across instances?
+  Recommendation: per-instance data dir to match the isolation invariants (I6).
+- **Auto-save default on/off:** Recommendation: off in Phase 1 (explicit Ctrl+S only),
+  on in Phase 3 after recovery UI exists so users can verify it's working.

--- a/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
+++ b/docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
@@ -83,9 +83,11 @@ New backend service in `agentmux-srv/src/editor/scratch.rs`:
     <uuid>.md.meta     ← JSON sidecar: { displayName, createdAt, lastModifiedAt, savedTo }
 ```
 
-**Directory:** `{data_dir}/cache/scratch/` — inside the per-instance data dir so
-multiple AgentMux instances each have isolated scratch files. On first write, the dir
-is created if absent.
+**Directory:** `~/.agentmux/cache/scratch/` — in the shared global data root, NOT
+per-instance. This is intentional: scratch content is user data (unsaved work) and
+must be recoverable across channels and build versions, the same way agents and auth
+are global (I6 applies to app state, not user content). On first write, the dir is
+created if absent. A 30-day cleanup pass on startup prunes orphaned files.
 
 **Lifecycle:**
 

--- a/docs/specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md
+++ b/docs/specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md
@@ -1,0 +1,309 @@
+# SPEC: File Tree Right-Click Context Menu
+
+Status: Draft
+Date: 2026-06-14
+Depends on: `SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md`
+Related: `SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md`
+
+---
+
+## Problem
+
+The editor pane's file tree (`frontend/app/view/editor/file-tree.tsx`) supports
+single-click (preview open) and double-click (pin tab) — nothing else. Users have
+no way to create, rename, delete, or copy file paths from inside the tree. Every
+such action requires switching to a terminal. This is a significant friction point
+that makes the editor pane feel incomplete as a file-management surface.
+
+---
+
+## Goals
+
+1. Right-click on a **file** → context menu with file-level actions.
+2. Right-click on a **folder** → context menu with folder-level actions.
+3. Right-click on **empty space** in the tree → context menu for tree-level actions.
+4. All destructive actions require confirmation.
+5. All file-mutation actions go through backend RPCs (no shell commands from frontend).
+6. Backend validates all paths against allowed roots (same policy as `readeditorfile` /
+   `writeeditorfile`).
+
+---
+
+## Non-Goals
+
+- Drag-and-drop move/copy (separate feature).
+- Clipboard integration for cut/copy/paste of files (separate feature).
+- Multi-select context menus (separate feature; single-node only for now).
+- Symlink creation or management.
+
+---
+
+## Menu Definitions
+
+### File node context menu
+
+| Action | Shortcut | Notes |
+|--------|----------|-------|
+| **Open** | — | Pinned tab (same as double-click) |
+| **Open to the Side** | — | Split-right of current pane |
+| **Open in New Tab** | — | New app tab |
+| *(separator)* | | |
+| **Copy Path** | — | Absolute path to clipboard |
+| **Copy Relative Path** | — | Relative to workspace root |
+| *(separator)* | | |
+| **Rename…** | F2 | Inline rename (see §Rename flow) |
+| **Delete** | Del | Confirm dialog before RPC |
+| *(separator)* | | |
+| **Reveal in Explorer** | — | `open_in_shell` RPC (platform-aware) |
+
+### Folder node context menu
+
+| Action | Shortcut | Notes |
+|--------|----------|-------|
+| **New File…** | — | Inline name entry in tree (see §New File flow) |
+| **New Folder…** | — | Inline name entry in tree |
+| *(separator)* | | |
+| **Rename…** | F2 | Inline rename |
+| **Delete** | Del | Recursive confirm dialog |
+| *(separator)* | | |
+| **Open in Terminal** | — | `agent.open` or `term` pane with `cwd` set to this folder |
+| **Reveal in Explorer** | — | Platform shell open |
+| *(separator)* | | |
+| **Collapse Folder** | — | Collapses this node and all descendants |
+
+### Empty-space context menu
+
+| Action | Notes |
+|--------|-------|
+| **New File…** | Creates in workspace root |
+| **New Folder…** | Creates in workspace root |
+| *(separator)* | |
+| **Refresh** | Re-runs `listeditordir` from root |
+| **Change Workspace Root…** | Inline path-entry in tree toolbar (already exists as a gap — covered here) |
+
+---
+
+## Flows
+
+### Rename flow
+
+1. User picks "Rename…" or presses F2 on a selected tree node.
+2. The node label is replaced with an `<input>` pre-filled with the current name
+   (not the full path — name only).
+3. Enter confirms; Esc cancels.
+4. On confirm: `renameeditorfile { old_path, new_name }` RPC.
+   Backend constructs `new_path = parent(old_path) / new_name`, validates, renames.
+5. If the renamed file was open in a tab: tab's `filePath` and `displayName` are
+   updated via a new `FileRenamed` tab command in the editor-pane-state-store.
+6. Tree node updates in place (no full re-scan needed — update node label locally,
+   re-sort siblings if needed).
+
+### New File / New Folder flow
+
+1. User picks "New File…" from folder or empty-space menu.
+2. A placeholder node appears inline in the tree (inside the target folder,
+   or at root level) with an `<input>` for the filename, auto-focused.
+3. Enter confirms; Esc cancels and removes the placeholder.
+4. On confirm:
+   - **New File:** `createeditorfile { parent_path, name }` RPC. Backend writes an
+     empty file. Frontend opens it in a preview tab.
+   - **New Folder:** `createeditordir { parent_path, name }` RPC. Backend creates the
+     directory. Tree node is added collapsed.
+5. Collision: if a file/folder with that name already exists, the input border turns
+   red with an inline error label; the placeholder stays focused for re-entry.
+
+### Delete flow
+
+1. User picks "Delete" or presses Del.
+2. A confirmation dialog appears:
+   - File: "Delete `filename`? This cannot be undone."
+   - Folder: "Delete `foldername` and all its contents? This cannot be undone."
+3. Confirm: `deleteeditorfile { path, recursive: boolean }` RPC.
+4. If the deleted file/folder had open tabs: those tabs are closed with a
+   `dirty: false` override (we don't prompt to save a file that no longer exists).
+5. Tree node is removed immediately on RPC success.
+
+### Open in Terminal flow
+
+1. Backend: `pane.open { view: "term", cwd: folder_path }` via the existing App API.
+2. The terminal opens in a split-right position by default.
+
+---
+
+## New RPC Commands
+
+All go in `agentmux-srv/src/server/websocket.rs` with types in `rpc_types.rs`.
+
+### `renameeditorfile`
+
+```
+Request:  { cmd: "renameeditorfile", data: { old_path: string, new_name: string } }
+Response: { new_path: string }
+Errors:   PATH_DENIED, DESTINATION_EXISTS, IO_ERROR
+```
+
+### `createeditorfile`
+
+```
+Request:  { cmd: "createeditorfile", data: { parent_path: string, name: string } }
+Response: { file_path: string }
+Errors:   PATH_DENIED, DESTINATION_EXISTS, IO_ERROR
+```
+
+### `createeditordir`
+
+```
+Request:  { cmd: "createeditordir", data: { parent_path: string, name: string } }
+Response: { dir_path: string }
+Errors:   PATH_DENIED, DESTINATION_EXISTS, IO_ERROR
+```
+
+### `deleteeditorfile`
+
+```
+Request:  { cmd: "deleteeditorfile", data: { path: string, recursive: boolean } }
+Response: {}
+Errors:   PATH_DENIED, IO_ERROR
+```
+
+`recursive: true` is required for non-empty directories; the backend enforces this
+(a non-empty dir with `recursive: false` returns `IO_ERROR: "directory not empty"`).
+
+### `openinshell` (reveal in Explorer/Finder)
+
+```
+Request:  { cmd: "openinshell", data: { path: string } }
+Response: {}
+```
+
+Platform behavior:
+- **Windows:** `explorer.exe /select,<path>` (selects the file in Explorer)
+- **macOS:** `open -R <path>` (reveals in Finder)
+- **Linux:** `xdg-open <parent_dir>` (opens parent directory)
+
+This RPC should be path-validated (allowed roots) to prevent exposing arbitrary
+filesystem paths, even though it's read-only.
+
+---
+
+## Frontend: `<ContextMenu>` Component
+
+No SolidJS context menu primitive exists in the codebase today. A minimal one is
+needed.
+
+**Component signature:**
+
+```typescript
+// frontend/app/components/context-menu.tsx
+interface ContextMenuItem {
+  type: "action" | "separator";
+  label?: string;
+  shortcut?: string;
+  disabled?: boolean;
+  danger?: boolean;  // red label for destructive actions
+  onSelect?: () => void;
+}
+
+function ContextMenu(props: {
+  items: ContextMenuItem[];
+  x: number;
+  y: number;
+  onClose: () => void;
+}): JSX.Element
+```
+
+**Behavior:**
+- Renders as a `position: fixed` overlay at `(x, y)`, clamped to viewport bounds.
+- Click outside or Esc → `onClose()`.
+- Keyboard: Arrow Up/Down to navigate, Enter to select, Esc to close.
+- Single-level only (no submenus for Phase 1).
+- Styled consistent with the existing tab context menu (`tab-context-menu-cleanup.md`).
+
+**Integration point in `file-tree.tsx`:**
+
+```typescript
+// Add onContextMenu handler to each TreeNode and the tree root:
+const [ctxMenu, setCtxMenu] = createSignal<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
+
+// On right-click:
+function handleContextMenu(e: MouseEvent, node: NodeData | null) {
+  e.preventDefault();
+  setCtxMenu({ x: e.clientX, y: e.clientY, items: buildMenuItems(node) });
+}
+```
+
+---
+
+## Path Safety
+
+All new backend RPCs follow the same validation as the existing `readeditorfile` and
+`writeeditorfile` handlers:
+
+1. Resolve the path to absolute.
+2. Check it is under `home_dir()` (current rule). Phase 2: check against user-configured
+   allowed roots once that system exists.
+3. Reject any path containing `..` components that escape the allowed root.
+4. Return `PATH_DENIED` on violation — never a partial success.
+
+---
+
+## Tab Synchronization
+
+When file-system mutations happen, open editor tabs must stay consistent:
+
+| RPC | Tab effect |
+|-----|-----------|
+| `renameeditorfile` | Tabs with matching `filePath` get `FileRenamed { new_path }` command |
+| `deleteeditorfile` | Tabs with matching `filePath` or a matching path prefix (folder delete) get `TabForceClose` |
+| `createeditorfile` | No effect on existing tabs; new file opens in a new preview tab |
+| `createeditordir` | No effect on existing tabs |
+
+The `FileRenamed` and `TabForceClose` commands need to be added to
+`EditorPaneCommand` in `editor-pane-state-store.ts`.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Read-only actions (1–2 days)
+
+- `<ContextMenu>` component
+- Right-click on file: Open, Open to the Side, Copy Path, Copy Relative Path, Reveal in Explorer
+- Right-click on folder: Reveal in Explorer, Collapse Folder
+- Right-click on empty space: Refresh
+- `openinshell` RPC
+
+No mutations, no new backend file-ops. Unlocks the most common user actions immediately.
+
+### Phase 2 — Rename + New File/Folder (2–3 days)
+
+- `renameeditorfile`, `createeditorfile`, `createeditordir` RPCs
+- Inline rename flow (F2 / "Rename…")
+- Inline new-file/folder placeholder in tree
+- `FileRenamed` tab command + synchronization
+
+### Phase 3 — Delete + Open in Terminal (1–2 days)
+
+- `deleteeditorfile` RPC
+- Delete confirmation dialog component (reusable)
+- `TabForceClose` tab command + synchronization
+- "Open in Terminal" action (via `pane.open term`)
+
+### Phase 4 — Keyboard shortcuts + multi-select (future)
+
+- F2 for rename, Del for delete, without context menu
+- Multi-file select + batch operations
+
+---
+
+## Open Questions
+
+- **Undo for delete?** Recommendation: no undo in Phase 3 (confirmation dialog is
+  the safety net). Trash/recycle-bin integration is a separate, platform-specific
+  feature.
+- **Rename collision behavior:** Should renaming to an existing name offer to
+  overwrite or always reject? Recommendation: always reject with an inline error;
+  overwrite is an explicit copy+delete, not a rename.
+- **"Open in Terminal" split position:** Right of current pane (default) or user-
+  configurable? Recommendation: right of current pane for Phase 3; make configurable
+  later via settings.

--- a/docs/specs/app-api-pane-open.md
+++ b/docs/specs/app-api-pane-open.md
@@ -1,8 +1,24 @@
 # App API — `pane.open` Spec
 
-Status: Proposed
+Status: Partially Implemented (MVP shipped; idempotency, `is_new`, and `mode` pending)
 Date: 2026-04-20
+Updated: 2026-06-14
 Depends on: `app-api-extension.md`, `app-api-status.md`
+
+## Implementation Status (as of 2026-06-14)
+
+| Feature | Status |
+|---------|--------|
+| Basic `pane.open` handler in `app_api.rs` | ✅ Shipped (skeleton) |
+| `view`, `file`, `url`, `cwd`, `title`, `tab_id`, `split_direction`, `split_reference_block_id`, `focus` | ✅ Shipped in `CommandPaneOpenData` |
+| Idempotency (focus existing pane on same file) | ❌ Not implemented |
+| Path sandboxing / allowed-roots validation | ❌ Not implemented |
+| `is_new` (scratch/untitled file creation) | ❌ Not implemented — see `SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md` |
+| `mode: "preview" \| "pinned"` | ❌ Not implemented |
+| `language` hint | ❌ Not implemented |
+| `amux open <path>` CLI bridge | ❌ Not implemented — see `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md` |
+
+> **Note:** The view name in the live RPC is `"editor"` (not `"codeeditor"` as written below in the original design). All future code should use `"editor"`. The spec body below is being kept historically accurate and updated with corrections inline.
 
 ## Motivation
 
@@ -55,22 +71,26 @@ log while I work" flows become one-shot.
 ```typescript
 {
   // What to show
-  view: "preview" | "codeeditor" | "term" | "web" | "sysinfo" | "help";
+  // NOTE: live RPC uses "editor" not "codeeditor" — codeeditor is deprecated
+  view: "preview" | "editor" | "term" | "web" | "sysinfo" | "help";
 
   // View-specific arguments (mutually exclusive by view)
-  file?: string;      // absolute or workspace-relative path; required for preview/codeeditor
+  file?: string;      // absolute or workspace-relative path; required for editor/preview unless is_new=true
+  is_new?: boolean;   // PENDING: if true, open a scratch/untitled buffer (no file path required)
+  language?: string;  // PENDING: hint for syntax highlighting ("markdown", "typescript", etc.)
   url?: string;       // required for web
   cwd?: string;       // optional for term (defaults to current pane's cwd)
 
   // Placement
   placement?: {
-    tab?: "current" | "new" | string;   // default "current"; string = tab name
-    split?: "right" | "below" | "tab";  // default "right" when tab=current
-    focus?: boolean;                    // default true
+    tab?: "current" | "new" | string;                       // default "current"; string = tab name
+    split?: "right" | "below" | "left" | "above" | "tab";  // default "right" when tab=current
+    focus?: boolean;                                         // default true
   };
 
   // Behavior
-  idempotent?: boolean;  // default true for file/url views, false for term
+  idempotent?: boolean;  // PENDING: default true for file/url views, false for term
+  mode?: "preview" | "pinned";  // PENDING: default "pinned"; "preview" = single-click VS Code style tab
   title?: string;        // optional explicit pane title
 }
 ```
@@ -148,18 +168,21 @@ Update the agent startup/system prompt generation to mention
 `pane.open` alongside `agent.send` / `agent.open`, with a one-line
 example. Without discoverability, no agent will know to call it.
 
-## Open questions
+## Open questions (resolved 2026-06-14)
 
-- Should we ship a thin shell wrapper (`agentmux pane open <file>`)
-  so shell-based agents can call this without writing a WebSocket
-  client? Aligns with the "CLI tool" gap noted in `app-api-status.md`.
-- Placement grammar: do we need `split: "left" | "above"` for
-  completeness, or is "right / below / new tab" sufficient for agent
-  use cases?
-- Should `pane.open` accept multiple files and open them as a group
-  (common when writing a spec + opening the affected source files)?
-- Permission model: do we want a per-agent capability check before
-  honoring `pane.open`, or is the existing App API authkey sufficient?
+- **Shell wrapper:** Yes — `amux open <file>` is Phase 1 of the agent CLI bridge.
+  Design finalized in `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md`.
+  Pending spec approval before implementation.
+- **Placement grammar:** Extended to include `"left"` and `"above"` (added above).
+  Full four-direction split is necessary for agent-driven layouts.
+- **Multiple files:** Yes — a future `files: string[]` variant should open them as
+  a tab group. Not in scope for Phase 1 (single-file only).
+- **Permission model:** Existing App API authkey is sufficient for Phase 1. Per-agent
+  capability flags are a Phase 3+ concern alongside the MCP façade.
+- **`is_new` flow:** Scratch file semantics are specified in
+  `SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md`. The `pane.open` protocol simply
+  accepts `is_new: true` (no `file` field) and delegates scratch file creation to
+  the `ScratchFileService`.
 
 ## Affected files
 

--- a/frontend/app/components/context-menu.scss
+++ b/frontend/app/components/context-menu.scss
@@ -28,7 +28,8 @@
     cursor: default;
     gap: 16px;
 
-    &:hover:not(.ctx-menu-item--disabled) {
+    &:hover:not(.ctx-menu-item--disabled),
+    &.ctx-menu-item--focused:not(.ctx-menu-item--disabled) {
         background: #313244;
     }
 
@@ -40,7 +41,8 @@
     &.ctx-menu-item--danger {
         color: #f38ba8;
 
-        &:hover:not(.ctx-menu-item--disabled) {
+        &:hover:not(.ctx-menu-item--disabled),
+        &.ctx-menu-item--focused:not(.ctx-menu-item--disabled) {
             background: rgba(243, 139, 168, 0.15);
         }
     }

--- a/frontend/app/components/context-menu.scss
+++ b/frontend/app/components/context-menu.scss
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.ctx-menu {
+    background: #1e1e2e;
+    border: 1px solid #313244;
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+    min-width: 180px;
+    max-width: 260px;
+    padding: 4px 0;
+    user-select: none;
+    font-size: 13px;
+    color: #cdd6f4;
+}
+
+.ctx-menu-sep {
+    height: 1px;
+    background: #313244;
+    margin: 4px 0;
+}
+
+.ctx-menu-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 5px 12px;
+    cursor: default;
+    gap: 16px;
+
+    &:hover:not(.ctx-menu-item--disabled) {
+        background: #313244;
+    }
+
+    &.ctx-menu-item--disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    &.ctx-menu-item--danger {
+        color: #f38ba8;
+
+        &:hover:not(.ctx-menu-item--disabled) {
+            background: rgba(243, 139, 168, 0.15);
+        }
+    }
+}
+
+.ctx-menu-label {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ctx-menu-shortcut {
+    font-size: 11px;
+    color: #6c7086;
+    flex-shrink: 0;
+}

--- a/frontend/app/components/context-menu.tsx
+++ b/frontend/app/components/context-menu.tsx
@@ -5,7 +5,7 @@
 // all pane content. Items are plain data; callers build the list and attach
 // onSelect handlers. Single-level only — no submenus.
 
-import { createEffect, onCleanup, type JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import "./context-menu.scss";
 
@@ -27,8 +27,19 @@ interface Props {
 
 export function ContextMenu(props: Props): JSX.Element {
     let menuRef: HTMLDivElement | undefined;
+    const [focusedIdx, setFocusedIdx] = createSignal(-1);
+
+    // Indices of selectable (non-separator, non-disabled) items.
+    const selectableIndices = (): number[] =>
+        props.items.reduce<number[]>((acc, item, i) => {
+            if (item.type === "action" && !item.disabled) acc.push(i);
+            return acc;
+        }, []);
 
     createEffect(() => {
+        // Focus the menu div so arrow keys work immediately.
+        menuRef?.focus();
+
         const handlePointerDown = (e: PointerEvent) => {
             if (!menuRef?.contains(e.target as Node)) props.onClose();
         };
@@ -36,6 +47,29 @@ export function ContextMenu(props: Props): JSX.Element {
             if (e.key === "Escape") {
                 e.stopPropagation();
                 props.onClose();
+            } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                e.preventDefault();
+                e.stopPropagation();
+                const sel = selectableIndices();
+                if (!sel.length) return;
+                const cur = focusedIdx();
+                const pos = sel.indexOf(cur);
+                if (e.key === "ArrowDown") {
+                    setFocusedIdx(sel[(pos + 1) % sel.length]);
+                } else {
+                    setFocusedIdx(sel[(pos - 1 + sel.length) % sel.length]);
+                }
+            } else if (e.key === "Enter") {
+                e.preventDefault();
+                e.stopPropagation();
+                const idx = focusedIdx();
+                if (idx >= 0) {
+                    const item = props.items[idx];
+                    if (item?.type === "action" && !item.disabled) {
+                        item.onSelect?.();
+                        props.onClose();
+                    }
+                }
             }
         };
         // Capture phase so we intercept before pane handlers.
@@ -49,15 +83,15 @@ export function ContextMenu(props: Props): JSX.Element {
 
     // Clamp to viewport so the menu never clips off-screen.
     const style = (): JSX.CSSProperties => {
-        const x = Math.min(props.x, window.innerWidth - 220);
+        const x = Math.min(props.x, window.innerWidth - 260);
         const y = Math.min(props.y, window.innerHeight - 400);
         return { position: "fixed", left: `${x}px`, top: `${y}px`, "z-index": "9999" };
     };
 
     return (
         <Portal>
-            <div ref={(el) => { menuRef = el; }} class="ctx-menu" style={style()}>
-                {props.items.map((item) =>
+            <div ref={(el) => { menuRef = el; }} class="ctx-menu" style={style()} tabIndex={-1}>
+                {props.items.map((item, i) =>
                     item.type === "separator" ? (
                         <div class="ctx-menu-sep" />
                     ) : (
@@ -66,6 +100,7 @@ export function ContextMenu(props: Props): JSX.Element {
                             classList={{
                                 "ctx-menu-item--disabled": !!item.disabled,
                                 "ctx-menu-item--danger": !!item.danger,
+                                "ctx-menu-item--focused": focusedIdx() === i,
                             }}
                             onPointerDown={(e) => {
                                 e.stopPropagation();
@@ -74,6 +109,7 @@ export function ContextMenu(props: Props): JSX.Element {
                                     props.onClose();
                                 }
                             }}
+                            onPointerEnter={() => { if (!item.disabled) setFocusedIdx(i); }}
                         >
                             <span class="ctx-menu-label">{item.label}</span>
                             {item.shortcut && (

--- a/frontend/app/components/context-menu.tsx
+++ b/frontend/app/components/context-menu.tsx
@@ -1,0 +1,88 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal context menu component. Renders into a Portal so it floats above
+// all pane content. Items are plain data; callers build the list and attach
+// onSelect handlers. Single-level only — no submenus.
+
+import { createEffect, onCleanup, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import "./context-menu.scss";
+
+export interface ContextMenuItem {
+    type: "action" | "separator";
+    label?: string;
+    shortcut?: string;
+    disabled?: boolean;
+    danger?: boolean;
+    onSelect?: () => void;
+}
+
+interface Props {
+    items: ContextMenuItem[];
+    x: number;
+    y: number;
+    onClose: () => void;
+}
+
+export function ContextMenu(props: Props): JSX.Element {
+    let menuRef: HTMLDivElement | undefined;
+
+    createEffect(() => {
+        const handlePointerDown = (e: PointerEvent) => {
+            if (!menuRef?.contains(e.target as Node)) props.onClose();
+        };
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.stopPropagation();
+                props.onClose();
+            }
+        };
+        // Capture phase so we intercept before pane handlers.
+        document.addEventListener("pointerdown", handlePointerDown, true);
+        document.addEventListener("keydown", handleKeyDown, true);
+        onCleanup(() => {
+            document.removeEventListener("pointerdown", handlePointerDown, true);
+            document.removeEventListener("keydown", handleKeyDown, true);
+        });
+    });
+
+    // Clamp to viewport so the menu never clips off-screen.
+    const style = (): JSX.CSSProperties => {
+        const x = Math.min(props.x, window.innerWidth - 220);
+        const y = Math.min(props.y, window.innerHeight - 400);
+        return { position: "fixed", left: `${x}px`, top: `${y}px`, "z-index": "9999" };
+    };
+
+    return (
+        <Portal>
+            <div ref={(el) => { menuRef = el; }} class="ctx-menu" style={style()}>
+                {props.items.map((item) =>
+                    item.type === "separator" ? (
+                        <div class="ctx-menu-sep" />
+                    ) : (
+                        <div
+                            class="ctx-menu-item"
+                            classList={{
+                                "ctx-menu-item--disabled": !!item.disabled,
+                                "ctx-menu-item--danger": !!item.danger,
+                            }}
+                            onPointerDown={(e) => {
+                                e.stopPropagation();
+                                if (!item.disabled) {
+                                    item.onSelect?.();
+                                    props.onClose();
+                                }
+                            }}
+                        >
+                            <span class="ctx-menu-label">{item.label}</span>
+                            {item.shortcut && (
+                                <span class="ctx-menu-shortcut">{item.shortcut}</span>
+                            )}
+                        </div>
+                    )
+                )}
+            </div>
+        </Portal>
+    );
+}

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -54,6 +54,15 @@ export interface EditorTab {
      *  Double-click opens as pinned. Editing or explicit pin promotes a
      *  preview to pinned. Matches VS Code semantics. */
     isPreview: boolean;
+    /** Scratch/untitled buffer — backed by a cache file in
+     *  ~/.agentmux/cache/scratch/. True while the file hasn't been
+     *  promoted to a real user-chosen path via Save As. */
+    isScratch?: boolean;
+    /** UUID of the backing scratch cache file. Set iff isScratch is true. */
+    scratchId?: string;
+    /** Label to show in the tab instead of the bare filename. Used for
+     *  scratch buffers ("Untitled-1") and may be set by pane.open callers. */
+    displayName?: string;
 }
 
 export interface ClosedTab {
@@ -111,6 +120,23 @@ export type EditorPaneCommand =
            *  appends a non-preview tab. Activating an already-open tab
            *  is unchanged regardless of mode. */
           mode?: "preview" | "pinned";
+          source?: EditorCommandSource;
+      }
+    | {
+          type: "OpenScratch";
+          /** Real path of the backing cache file (in ~/.agentmux/cache/scratch/). */
+          filePath: string;
+          scratchId: string;
+          displayName: string;
+          language?: string;
+          source?: EditorCommandSource;
+      }
+    | {
+          type: "PromoteScratch";
+          /** Scratch tab to promote. */
+          tabId: string;
+          /** The user-chosen real path the scratch was moved to. */
+          newPath: string;
           source?: EditorCommandSource;
       }
     | { type: "CloseTab"; tabId: string; force?: boolean; source?: EditorCommandSource }
@@ -676,6 +702,58 @@ export function update(
                     },
                 ],
             };
+        }
+
+        case "OpenScratch": {
+            const canon = canonicalizePath(command.filePath);
+            // If a scratch tab already points to this file, just activate it.
+            const existing = state.tabs.find((t) => t.filePath === canon && t.isScratch);
+            if (existing) {
+                return {
+                    state: { ...state, activeTabId: existing.id },
+                    events: [{ type: "TabActivated", tabId: existing.id, filePath: existing.filePath }],
+                };
+            }
+            const tab: EditorTab = {
+                id: newTabId(),
+                filePath: canon,
+                language: command.language ?? "markdown",
+                readOnly: false,
+                dirty: false,
+                contentHash: "",
+                loadError: null,
+                contentLoaded: false,
+                isPreview: false,
+                isScratch: true,
+                scratchId: command.scratchId,
+                displayName: command.displayName,
+            };
+            const nextTabs = [...state.tabs, tab];
+            return {
+                state: { ...state, tabs: nextTabs, activeTabId: tab.id },
+                events: [{ type: "TabOpened", tabId: tab.id, filePath: tab.filePath, atIndex: nextTabs.length - 1 }],
+            };
+        }
+
+        case "PromoteScratch": {
+            const idx = findTabIndex(state, command.tabId);
+            if (idx < 0) return { state, events: [] };
+            const tab = state.tabs[idx];
+            const nextTab: EditorTab = {
+                ...tab,
+                filePath: canonicalizePath(command.newPath),
+                language: deriveLanguage(command.newPath),
+                isScratch: false,
+                scratchId: undefined,
+                displayName: undefined,
+                dirty: false,
+            };
+            const nextTabs = [
+                ...state.tabs.slice(0, idx),
+                nextTab,
+                ...state.tabs.slice(idx + 1),
+            ];
+            return { state: { ...state, tabs: nextTabs }, events: [{ type: "TabSaved", tabId: tab.id }] };
         }
 
         case "RenameFile": {

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -883,6 +883,17 @@ export function snapshot(blockId: string): EditorPaneState | null {
     return slots.get(blockId)?.state ?? null;
 }
 
+/** Return the scratchId of every scratch tab currently open across ALL editor panes. */
+export function getAllActiveScratchIds(): string[] {
+    const ids: string[] = [];
+    for (const slot of slots.values()) {
+        for (const tab of slot.state.tabs) {
+            if (tab.isScratch && tab.scratchId) ids.push(tab.scratchId);
+        }
+    }
+    return ids;
+}
+
 /** Test/dev helper — clears every slot AND resets the event sink. */
 export function resetAllSlots(): void {
     slots.clear();

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1223,6 +1223,72 @@ class RpcApiType {
         return client.rpcCall("geteditorroots", data, opts);
     }
 
+    // command "openinshell" [call] — reveal a path in the OS file manager.
+    // Spec: specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md
+    OpenInShellCommand(
+        client: RpcClient,
+        data: { path: string },
+        opts?: RpcOpts,
+    ): Promise<void> {
+        return client.rpcCall("openinshell", data, opts);
+    }
+
+    // command "renameeditorfile" [call] — rename a file or folder in the editor tree.
+    RenameEditorFileCommand(
+        client: RpcClient,
+        data: { old_path: string; new_name: string },
+        opts?: RpcOpts,
+    ): Promise<{ new_path: string }> {
+        return client.rpcCall("renameeditorfile", data, opts);
+    }
+
+    // command "createeditorfile" [call] — create an empty file in the editor tree.
+    CreateEditorFileCommand(
+        client: RpcClient,
+        data: { parent_path: string; name: string },
+        opts?: RpcOpts,
+    ): Promise<{ file_path: string }> {
+        return client.rpcCall("createeditorfile", data, opts);
+    }
+
+    // command "createeditordir" [call] — create a directory in the editor tree.
+    CreateEditorDirCommand(
+        client: RpcClient,
+        data: { parent_path: string; name: string },
+        opts?: RpcOpts,
+    ): Promise<{ dir_path: string }> {
+        return client.rpcCall("createeditordir", data, opts);
+    }
+
+    // command "deleteeditorfile" [call] — delete a file or directory.
+    DeleteEditorFileCommand(
+        client: RpcClient,
+        data: { path: string; recursive: boolean },
+        opts?: RpcOpts,
+    ): Promise<void> {
+        return client.rpcCall("deleteeditorfile", data, opts);
+    }
+
+    // command "createscratchfile" [call] — create a scratch buffer file in
+    // ~/.agentmux/cache/scratch/. Returns the backing path + scratch_id.
+    // Spec: specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
+    CreateScratchFileCommand(
+        client: RpcClient,
+        data: { display_name?: string } = {},
+        opts?: RpcOpts,
+    ): Promise<{ scratch_id: string; file_path: string; display_name: string }> {
+        return client.rpcCall("createscratchfile", data, opts);
+    }
+
+    // command "movescratchfile" [call] — promote a scratch buffer to a real path (Save As).
+    MoveScratchFileCommand(
+        client: RpcClient,
+        data: { scratch_id: string; destination_path: string },
+        opts?: RpcOpts,
+    ): Promise<{ file_path: string }> {
+        return client.rpcCall("movescratchfile", data, opts);
+    }
+
     // ── LSP — Phase 1 of SPEC_EDITOR_LSP_AND_THEMES_2026-05-26.md ──────
     // Backend is a dumb proxy: lspstart spawns (or attaches to) the
     // server for (workspace, language); lspsend forwards an arbitrary

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1274,7 +1274,7 @@ class RpcApiType {
     // Spec: specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md
     CreateScratchFileCommand(
         client: RpcClient,
-        data: { display_name?: string } = {},
+        data: { display_name?: string; exclude_scratch_ids?: string[] } = {},
         opts?: RpcOpts,
     ): Promise<{ scratch_id: string; file_path: string; display_name: string }> {
         return client.rpcCall("createscratchfile", data, opts);

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -555,6 +555,16 @@ export class EditorViewModel implements ViewModel {
         const tab = this.activeTabAtom();
         if (!tab?.isScratch || !tab.scratchId) return;
         try {
+            // Flush the live in-memory buffer to the scratch file on disk first.
+            // MoveScratchFileCommand copies from disk, so without this step any
+            // edits since the last auto-save would be silently discarded.
+            const liveContent = this._contentByTab.get(tab.id);
+            if (liveContent !== undefined) {
+                await RpcApi.WriteEditorFileCommand(TabRpcClient, {
+                    path: tab.filePath,
+                    content: liveContent,
+                });
+            }
             const result = await RpcApi.MoveScratchFileCommand(TabRpcClient, {
                 scratch_id: tab.scratchId,
                 destination_path: destPath,
@@ -565,7 +575,10 @@ export class EditorViewModel implements ViewModel {
                 newPath: result.file_path,
                 source: "user",
             });
-            // Re-load content from the new path to sync the hash.
+            // Clear cached buffer so openFile reloads from disk and syncs the
+            // contentHash. Without this the early-return guard at openFile:372
+            // (contentLoaded && _contentByTab.has) skips the hash update.
+            this._contentByTab.delete(tab.id);
             await this.openFile(result.file_path);
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -28,6 +28,7 @@ import {
     setEventSink,
     snapshot,
     unregisterEditorPane,
+    getAllActiveScratchIds,
 } from "@/app/store/editor-pane-state-store";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -523,7 +524,12 @@ export class EditorViewModel implements ViewModel {
             return;
         }
         try {
-            const result = await RpcApi.CreateScratchFileCommand(TabRpcClient, {});
+            // Exclude scratch files already open in any editor pane so that
+            // two panes never share the same backing scratch file.
+            const excludeIds = getAllActiveScratchIds();
+            const result = await RpcApi.CreateScratchFileCommand(TabRpcClient, {
+                exclude_scratch_ids: excludeIds.length > 0 ? excludeIds : undefined,
+            });
             const events = dispatch(this.blockId, {
                 type: "OpenScratch",
                 filePath: result.file_path,
@@ -535,12 +541,18 @@ export class EditorViewModel implements ViewModel {
             const opened = events.find((e) => e.type === "TabOpened" || e.type === "TabActivated");
             if (!opened || (opened.type !== "TabOpened" && opened.type !== "TabActivated")) return;
             const tabId = opened.tabId;
-            this._contentByTab.set(tabId, "");
+            // Read the actual on-disk content — the backend may have returned a
+            // reused scratch file that already has content from a prior session.
+            // Seeding "" here would clobber that content on the next Ctrl+S.
+            const fileResult = await RpcApi.ReadEditorFileCommand(TabRpcClient, { path: result.file_path });
+            const content = fileResult?.content ?? "";
+            this._contentByTab.set(tabId, content);
             this._contentVersion[1]((v) => v + 1);
+            const hash = content === "" ? "" : await sha256Hex(content);
             dispatch(this.blockId, {
                 type: "TabContentLoaded",
                 tabId,
-                contentHash: "",
+                contentHash: hash,
                 readOnly: false,
                 source: "system",
             });

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -39,6 +39,7 @@ const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
 const META_LEGACY_FILE = "file";
+const META_SCRATCH = "editor:scratch";
 const TREE_WIDTH_DEFAULT = 240;
 const TREE_WIDTH_MIN = 150;
 const TREE_WIDTH_MAX = 600;
@@ -280,6 +281,9 @@ export class EditorViewModel implements ViewModel {
         const legacyFile = meta?.[META_LEGACY_FILE];
         if (typeof legacyFile === "string" && legacyFile) {
             void this.openFile(legacyFile);
+        } else if (meta?.[META_SCRATCH] === true && snapshot(blockId)?.tabs.length === 0) {
+            // Widget default: open a scratch buffer when no file was persisted.
+            void this.openScratch();
         }
     }
 
@@ -504,6 +508,170 @@ export class EditorViewModel implements ViewModel {
                 error: `Save failed: ${message}`,
                 source: "system",
             });
+        }
+    }
+
+    // ── Scratch buffer ──────────────────────────────────────────────────
+
+    /** Open (or focus) a scratch buffer. Called from the constructor when
+     *  editor:scratch is true and no other file is open. */
+    async openScratch(): Promise<void> {
+        // Reuse an existing scratch tab if one is already open in this pane.
+        const existing = snapshot(this.blockId)?.tabs.find((t) => t.isScratch);
+        if (existing) {
+            dispatch(this.blockId, { type: "SwitchTab", tabId: existing.id, source: "system" });
+            return;
+        }
+        try {
+            const result = await RpcApi.CreateScratchFileCommand(TabRpcClient, {});
+            const events = dispatch(this.blockId, {
+                type: "OpenScratch",
+                filePath: result.file_path,
+                scratchId: result.scratch_id,
+                displayName: result.display_name,
+                language: "markdown",
+                source: "system",
+            });
+            const opened = events.find((e) => e.type === "TabOpened" || e.type === "TabActivated");
+            if (!opened || (opened.type !== "TabOpened" && opened.type !== "TabActivated")) return;
+            const tabId = opened.tabId;
+            this._contentByTab.set(tabId, "");
+            this._contentVersion[1]((v) => v + 1);
+            dispatch(this.blockId, {
+                type: "TabContentLoaded",
+                tabId,
+                contentHash: "",
+                readOnly: false,
+                source: "system",
+            });
+        } catch {
+            // Scratch creation failed — editor opens in empty state, user can
+            // open a file manually.
+        }
+    }
+
+    /** Promote the active scratch tab to a real path (Save As). */
+    async saveFileAs(destPath: string): Promise<void> {
+        const tab = this.activeTabAtom();
+        if (!tab?.isScratch || !tab.scratchId) return;
+        try {
+            const result = await RpcApi.MoveScratchFileCommand(TabRpcClient, {
+                scratch_id: tab.scratchId,
+                destination_path: destPath,
+            });
+            dispatch(this.blockId, {
+                type: "PromoteScratch",
+                tabId: tab.id,
+                newPath: result.file_path,
+                source: "user",
+            });
+            // Re-load content from the new path to sync the hash.
+            await this.openFile(result.file_path);
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            dispatch(this.blockId, {
+                type: "TabContentLoadFailed",
+                tabId: tab.id,
+                error: `Save As failed: ${message}`,
+                source: "system",
+            });
+        }
+    }
+
+    // ── File tree mutations ─────────────────────────────────────────────
+
+    /** Rename a file/folder. Updates open tabs and refreshes the tree. */
+    async renameFile(path: string, newName: string): Promise<void> {
+        try {
+            const result = await RpcApi.RenameEditorFileCommand(TabRpcClient, {
+                old_path: path,
+                new_name: newName,
+            });
+            dispatch(this.blockId, {
+                type: "RenameFile",
+                oldPath: path,
+                newPath: result.new_path,
+                source: "system",
+            });
+            // Refresh the parent directory.
+            const parentPath = path.replace(/[/\\][^/\\]*$/, "") || path;
+            void this.treeModel.refreshPath(parentPath);
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            // Surface the error via the active tab's loadError if there is one,
+            // otherwise just log — rename failures are rare and recoverable.
+            console.error(`[editor] rename failed: ${msg}`);
+        }
+    }
+
+    /** Delete a file or folder, closing any open tabs that were pointing to it. */
+    async deleteFile(path: string, recursive: boolean): Promise<void> {
+        const label = recursive ? "folder and all its contents" : "file";
+        const name = path.split(/[/\\]/).pop() ?? path;
+        if (!window.confirm(`Delete ${name} (${label})? This cannot be undone.`)) return;
+        try {
+            await RpcApi.DeleteEditorFileCommand(TabRpcClient, { path, recursive });
+            // Force-close tabs that pointed at the deleted path or any child.
+            const canon = canonicalizePath(path);
+            for (const tab of snapshot(this.blockId)?.tabs ?? []) {
+                const tabCanon = canonicalizePath(tab.filePath);
+                if (tabCanon === canon || tabCanon.startsWith(canon + "/") || tabCanon.startsWith(canon + "\\")) {
+                    dispatch(this.blockId, { type: "CloseTab", tabId: tab.id, force: true, source: "system" });
+                }
+            }
+            // Remove optimistically from tree + refresh parent.
+            const parentPath = path.replace(/[/\\][^/\\]*$/, "") || path;
+            const entryName = path.split(/[/\\]/).pop() ?? "";
+            this.treeModel.removeEntryOptimistic(parentPath, entryName);
+        } catch (e: unknown) {
+            console.error(`[editor] delete failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
+    /** Create an empty file in the tree. Opens it as a preview tab on success. */
+    async createFile(parentPath: string, name: string): Promise<void> {
+        try {
+            const result = await RpcApi.CreateEditorFileCommand(TabRpcClient, { parent_path: parentPath, name });
+            this.treeModel.addEntryOptimistic(parentPath, { name, is_dir: false, is_symlink: false });
+            await this.openFilePreview(result.file_path);
+        } catch (e: unknown) {
+            console.error(`[editor] create file failed: ${e instanceof Error ? e.message : String(e)}`);
+            throw e;
+        }
+    }
+
+    /** Create a directory in the tree. Ensures it's visible. */
+    async createDir(parentPath: string, name: string): Promise<void> {
+        try {
+            await RpcApi.CreateEditorDirCommand(TabRpcClient, { parent_path: parentPath, name });
+            this.treeModel.addEntryOptimistic(parentPath, { name, is_dir: true, is_symlink: false });
+        } catch (e: unknown) {
+            console.error(`[editor] create dir failed: ${e instanceof Error ? e.message : String(e)}`);
+            throw e;
+        }
+    }
+
+    /** Reveal a path in the OS file manager. */
+    async revealInExplorer(path: string): Promise<void> {
+        try {
+            await RpcApi.OpenInShellCommand(TabRpcClient, { path });
+        } catch {
+            // Non-fatal — some platforms may not support this.
+        }
+    }
+
+    /** Open the folder in a terminal pane (split right of the current pane). */
+    async openInTerminal(folderPath: string): Promise<void> {
+        try {
+            // pane.open with view=term and cwd=folderPath (App API Tier 1).
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (RpcApi as any).OpenPaneCommand?.(TabRpcClient, {
+                view: "term",
+                cwd: folderPath,
+                split_direction: "right",
+            });
+        } catch {
+            // pane.open might not be registered yet — fail silently.
         }
     }
 

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -680,6 +680,7 @@ export class EditorViewModel implements ViewModel {
                 view: "term",
                 cwd: folderPath,
                 split_direction: "right",
+                split_reference_block_id: this.blockId,
             });
         } catch {
             // pane.open might not be registered yet — fail silently.

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -580,27 +580,39 @@ export class EditorViewModel implements ViewModel {
 
     // ── File tree mutations ─────────────────────────────────────────────
 
-    /** Rename a file/folder. Updates open tabs and refreshes the tree. */
+    /** Rename a file/folder. Updates open tabs (including children for dirs) and refreshes the tree. */
     async renameFile(path: string, newName: string): Promise<void> {
         try {
             const result = await RpcApi.RenameEditorFileCommand(TabRpcClient, {
                 old_path: path,
                 new_name: newName,
             });
+            // Update the exact tab for this path.
             dispatch(this.blockId, {
                 type: "RenameFile",
                 oldPath: path,
                 newPath: result.new_path,
                 source: "system",
             });
+            // Also update any tabs that are children of a renamed directory.
+            // Canonicalize both paths with a trailing sep so we don't match
+            // "~/proj2" when renaming "~/proj".
+            const oldCanon = canonicalizePath(path);
+            const newCanon = canonicalizePath(result.new_path);
+            const oldPrefix = oldCanon + "/";
+            const newPrefix = newCanon + "/";
+            for (const tab of snapshot(this.blockId)?.tabs ?? []) {
+                const tabCanon = canonicalizePath(tab.filePath);
+                if (tabCanon.startsWith(oldPrefix)) {
+                    const newTabPath = newPrefix + tabCanon.slice(oldPrefix.length);
+                    dispatch(this.blockId, { type: "RenameFile", oldPath: tab.filePath, newPath: newTabPath, source: "system" });
+                }
+            }
             // Refresh the parent directory.
             const parentPath = path.replace(/[/\\][^/\\]*$/, "") || path;
             void this.treeModel.refreshPath(parentPath);
         } catch (e: unknown) {
-            const msg = e instanceof Error ? e.message : String(e);
-            // Surface the error via the active tab's loadError if there is one,
-            // otherwise just log — rename failures are rare and recoverable.
-            console.error(`[editor] rename failed: ${msg}`);
+            console.error(`[editor] rename failed: ${e instanceof Error ? e.message : String(e)}`);
         }
     }
 
@@ -663,9 +675,8 @@ export class EditorViewModel implements ViewModel {
     /** Open the folder in a terminal pane (split right of the current pane). */
     async openInTerminal(folderPath: string): Promise<void> {
         try {
-            // pane.open with view=term and cwd=folderPath (App API Tier 1).
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            await (RpcApi as any).OpenPaneCommand?.(TabRpcClient, {
+            // pane.open is a raw RPC — no typed wrapper exists yet in RpcApi.
+            await TabRpcClient.rpcCall("pane.open", {
                 view: "term",
                 cwd: folderPath,
                 split_direction: "right",

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -34,6 +34,7 @@ export function EditorTabStrip(props: Props): JSX.Element {
 
 function Tab(props: { tab: EditorTab; active: boolean; model: EditorViewModel }): JSX.Element {
     const basename = () => {
+        if (props.tab.displayName) return props.tab.displayName;
         const fp = props.tab.filePath;
         const i = Math.max(fp.lastIndexOf("/"), fp.lastIndexOf("\\"));
         return i >= 0 ? fp.slice(i + 1) : fp;

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -230,6 +230,34 @@
     font-size: 11px;
 }
 
+.file-tree-row--renaming {
+    // Don't show hover highlight while the inline input is active.
+    background: transparent !important;
+}
+
+.file-tree-row--new-entry {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+// Inline rename / new-entry input — matches the row height, no border-radius.
+.file-tree-inline-input {
+    flex: 1;
+    min-width: 0;
+    background: var(--input-bg-color, #1e1e2e);
+    border: 1px solid var(--accent-color, #89b4fa);
+    border-radius: 2px;
+    color: var(--text-color);
+    font-size: inherit;
+    font-family: inherit;
+    padding: 0 4px;
+    height: 18px;
+    outline: none;
+
+    &:focus {
+        box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.25);
+    }
+}
+
 // ── Main column (CodeMirror or empty-state) ─────────────────────────────────
 
 .editor-main-column {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -441,7 +441,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             { type: "separator" },
             { type: "action", label: "Copy Path", onSelect: () => void copyToClipboard(path) },
             { type: "action", label: "Copy Relative Path", onSelect: () => {
-                const root = model.treeModel.rootsAtom().find((r) => path.startsWith(r.path));
+                const root = model.treeModel.rootsAtom().find((r) => path === r.path || path.startsWith(r.path + "/") || path.startsWith(r.path + "\\"));
                 const rel = root ? path.slice(root.path.length).replace(/^[/\\]/, "") : path;
                 void copyToClipboard(rel);
             }},

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -421,8 +421,8 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         }
         if (isDir) {
             return [
-                { type: "action", label: "New File…", onSelect: () => setNewEntry({ parentPath: path, kind: "file" }) },
-                { type: "action", label: "New Folder…", onSelect: () => setNewEntry({ parentPath: path, kind: "dir" }) },
+                { type: "action", label: "New File…", onSelect: () => { void model.treeModel.expandFolder(path); setNewEntry({ parentPath: path, kind: "file" }); } },
+                { type: "action", label: "New Folder…", onSelect: () => { void model.treeModel.expandFolder(path); setNewEntry({ parentPath: path, kind: "dir" }); } },
                 { type: "separator" },
                 { type: "action", label: "Open in Terminal", onSelect: () => void model.openInTerminal(path) },
                 { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -6,6 +6,7 @@
 // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
 
 import { createEffect, createSignal, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
+import { ContextMenu, type ContextMenuItem } from "@/app/components/context-menu";
 import { EditorView, basicSetup } from "codemirror";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
@@ -402,6 +403,70 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         }
     };
 
+    // ── File-tree context menu ────────────────────────────────────────
+    const [ctxMenu, setCtxMenu] = createSignal<{ items: ContextMenuItem[]; x: number; y: number } | null>(null);
+    const [renamingPath, setRenamingPath] = createSignal<string | null>(null);
+    const [newEntry, setNewEntry] = createSignal<{ parentPath: string; kind: "file" | "dir" } | null>(null);
+
+    const buildContextMenuItems = (path: string | null, isDir: boolean): ContextMenuItem[] => {
+        if (!path) {
+            // Background right-click → tree-level actions.
+            const homeRoot = model.treeModel.rootsAtom().find((r) => r.isHome)?.path ?? "";
+            return [
+                { type: "action", label: "New File…", onSelect: () => setNewEntry({ parentPath: homeRoot, kind: "file" }) },
+                { type: "action", label: "New Folder…", onSelect: () => setNewEntry({ parentPath: homeRoot, kind: "dir" }) },
+                { type: "separator" },
+                { type: "action", label: "Refresh", onSelect: () => void model.treeModel.refresh() },
+            ];
+        }
+        if (isDir) {
+            return [
+                { type: "action", label: "New File…", onSelect: () => setNewEntry({ parentPath: path, kind: "file" }) },
+                { type: "action", label: "New Folder…", onSelect: () => setNewEntry({ parentPath: path, kind: "dir" }) },
+                { type: "separator" },
+                { type: "action", label: "Open in Terminal", onSelect: () => void model.openInTerminal(path) },
+                { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
+                { type: "separator" },
+                { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
+                { type: "action", label: "Delete", danger: true, onSelect: () => void model.deleteFile(path, true) },
+            ];
+        }
+        return [
+            { type: "action", label: "Open", onSelect: () => void model.openFile(path) },
+            { type: "separator" },
+            { type: "action", label: "Copy Path", onSelect: () => void copyToClipboard(path) },
+            { type: "action", label: "Copy Relative Path", onSelect: () => {
+                const root = model.treeModel.rootsAtom().find((r) => path.startsWith(r.path));
+                const rel = root ? path.slice(root.path.length).replace(/^[/\\]/, "") : path;
+                void copyToClipboard(rel);
+            }},
+            { type: "separator" },
+            { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
+            { type: "separator" },
+            { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
+            { type: "action", label: "Delete", danger: true, onSelect: () => void model.deleteFile(path, false) },
+        ];
+    };
+
+    const handleTreeContextMenu = (path: string | null, isDir: boolean, e: MouseEvent) => {
+        setCtxMenu({ items: buildContextMenuItems(path, isDir), x: e.clientX, y: e.clientY });
+    };
+
+    const handleRenameConfirm = async (path: string, newName: string) => {
+        setRenamingPath(null);
+        await model.renameFile(path, newName);
+    };
+
+    const handleNewEntryConfirm = async (parentPath: string, name: string, kind: "file" | "dir") => {
+        setNewEntry(null);
+        try {
+            if (kind === "file") await model.createFile(parentPath, name);
+            else await model.createDir(parentPath, name);
+        } catch {
+            // Error already logged in model; tree will re-sync on next refresh.
+        }
+    };
+
     // ── LSP install banner state ──────────────────────────────────────
     // Dismissed-for-session list keyed by language. Allows the operator
     // to silence the banner per session; it returns on next launch if the
@@ -470,6 +535,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         onFileClick={(path) => void model.openFilePreview(path)}
                         onFileDblClick={(path) => void model.openFile(path)}
                         onToggleHidden={() => void model.toggleShowHidden()}
+                        onContextMenu={handleTreeContextMenu}
+                        renamingPath={renamingPath()}
+                        onRenameConfirm={(path, name) => void handleRenameConfirm(path, name)}
+                        onRenameCancel={() => setRenamingPath(null)}
+                        newEntry={newEntry()}
+                        onNewEntryConfirm={(parent, name, kind) => void handleNewEntryConfirm(parent, name, kind)}
+                        onNewEntryCancel={() => setNewEntry(null)}
                     />
                     <Show when={!model.filePathAtom()}>
                         <div class="editor-tree-path-input">
@@ -632,6 +704,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                     </div>
                 </Show>
             </div>
+
+            {/* File-tree context menu — rendered via Portal above everything */}
+            <Show when={ctxMenu()}>
+                {(menu) => (
+                    <ContextMenu
+                        items={menu().items}
+                        x={menu().x}
+                        y={menu().y}
+                        onClose={() => setCtxMenu(null)}
+                    />
+                )}
+            </Show>
         </div>
     );
 }

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -411,10 +411,15 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     const buildContextMenuItems = (path: string | null, isDir: boolean): ContextMenuItem[] => {
         if (!path) {
             // Background right-click → tree-level actions.
-            const homeRoot = model.treeModel.rootsAtom().find((r) => r.isHome)?.path ?? "";
+            const homeRoot = model.treeModel.rootsAtom().find((r) => r.isHome)?.path;
+            if (!homeRoot) {
+                return [
+                    { type: "action", label: "Refresh", onSelect: () => void model.treeModel.refresh() },
+                ];
+            }
             return [
-                { type: "action", label: "New File…", onSelect: () => setNewEntry({ parentPath: homeRoot, kind: "file" }) },
-                { type: "action", label: "New Folder…", onSelect: () => setNewEntry({ parentPath: homeRoot, kind: "dir" }) },
+                { type: "action", label: "New File…", onSelect: () => { void model.treeModel.expandFolder(homeRoot); setNewEntry({ parentPath: homeRoot, kind: "file" }); } },
+                { type: "action", label: "New Folder…", onSelect: () => { void model.treeModel.expandFolder(homeRoot); setNewEntry({ parentPath: homeRoot, kind: "dir" }); } },
                 { type: "separator" },
                 { type: "action", label: "Refresh", onSelect: () => void model.treeModel.refresh() },
             ];

--- a/frontend/app/view/editor/file-tree-model.ts
+++ b/frontend/app/view/editor/file-tree-model.ts
@@ -134,6 +134,58 @@ export class FileTreeModel {
         this._expanded[1](new Set<string>());
     }
 
+    /** Collapse a single folder without affecting siblings. */
+    collapseFolder(path: string): void {
+        const next = new Set(this._expanded[0]());
+        next.delete(path);
+        this._expanded[1](next);
+    }
+
+    /** Re-fetch a single path (e.g. after a file-system mutation in that dir). */
+    async refreshPath(path: string): Promise<void> {
+        await this.load(path);
+    }
+
+    /** Optimistically remove an entry from a loaded parent. Used after delete
+     *  so the tree updates immediately without a full re-fetch. */
+    removeEntryOptimistic(parentPath: string, name: string): void {
+        const setData = (updater: (map: Map<string, NodeData>) => void) => {
+            const next = new Map(this._data[0]());
+            updater(next);
+            this._data[1](next);
+        };
+        setData((map) => {
+            const existing = map.get(parentPath);
+            if (existing?.entries) {
+                map.set(parentPath, {
+                    ...existing,
+                    entries: existing.entries.filter((e) => e.name !== name),
+                });
+            }
+        });
+    }
+
+    /** Optimistically add an entry to a loaded parent. Used after create. */
+    addEntryOptimistic(parentPath: string, entry: DirEntry): void {
+        const setData = (updater: (map: Map<string, NodeData>) => void) => {
+            const next = new Map(this._data[0]());
+            updater(next);
+            this._data[1](next);
+        };
+        setData((map) => {
+            const existing = map.get(parentPath);
+            if (existing?.entries) {
+                const entries = [...existing.entries, entry];
+                // Re-sort: dirs first, then alpha.
+                entries.sort((a, b) => {
+                    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+                    return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+                });
+                map.set(parentPath, { ...existing, entries });
+            }
+        });
+    }
+
     private async load(path: string): Promise<void> {
         const setData = (updater: (map: Map<string, NodeData>) => void) => {
             const next = new Map(this._data[0]());

--- a/frontend/app/view/editor/file-tree-model.ts
+++ b/frontend/app/view/editor/file-tree-model.ts
@@ -141,6 +141,17 @@ export class FileTreeModel {
         this._expanded[1](next);
     }
 
+    /** Expand a folder and lazy-load its children if not yet fetched. */
+    async expandFolder(path: string): Promise<void> {
+        if (this.isExpanded(path)) return;
+        const next = new Set(this._expanded[0]());
+        next.add(path);
+        this._expanded[1](next);
+        if (!this._data[0]().has(path)) {
+            await this.load(path);
+        }
+    }
+
     /** Re-fetch a single path (e.g. after a file-system mutation in that dir). */
     async refreshPath(path: string): Promise<void> {
         await this.load(path);

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -307,10 +307,19 @@ function InlineInput(props: InlineInputProps): JSX.Element {
         }
     });
 
+    // Guard against Escape → onCancel unmounts the input → blur fires confirm.
+    let committed = false;
     const confirm = () => {
+        if (committed) return;
+        committed = true;
         const v = value().trim();
         if (v) props.onConfirm(v);
         else props.onCancel();
+    };
+    const cancel = () => {
+        if (committed) return;
+        committed = true;
+        props.onCancel();
     };
 
     return (
@@ -324,7 +333,7 @@ function InlineInput(props: InlineInputProps): JSX.Element {
             onKeyDown={(e) => {
                 e.stopPropagation();
                 if (e.key === "Enter") confirm();
-                if (e.key === "Escape") props.onCancel();
+                if (e.key === "Escape") cancel();
             }}
             onBlur={confirm}
             onClick={(e) => e.stopPropagation()}

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -9,24 +9,42 @@
 // to the file-tree-toolbar so they don't leak to the rest of the editor.
 //
 // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
+// Context menu: specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md
 
-import { createMemo, For, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { FileTreeModel, isHiddenName, joinPath, type Root } from "./file-tree-model";
 
 interface FileTreeProps {
     model: FileTreeModel;
     activeFilePath: string;
     showHidden: boolean;
-    /** Called on file row single-click — VS Code-style "preview" open
-     *  (replaces the current preview tab if any). */
+    /** Called on file row single-click — VS Code-style "preview" open. */
     onFileClick: (path: string) => void;
-    /** Called on file row double-click — pins the tab so subsequent
-     *  preview-opens don't replace it. */
+    /** Called on file row double-click — pins the tab. */
     onFileDblClick?: (path: string) => void;
     onToggleHidden: () => void;
+    /** Right-click on a node or empty tree background.
+     *  path=null means the background was right-clicked. */
+    onContextMenu?: (path: string | null, isDir: boolean, e: MouseEvent) => void;
+    /** When non-null, the node at this path renders an inline rename input. */
+    renamingPath?: string | null;
+    onRenameConfirm?: (path: string, newName: string) => void;
+    onRenameCancel?: () => void;
+    /** When set, renders an inline new-entry input inside the specified parent. */
+    newEntry?: { parentPath: string; kind: "file" | "dir" } | null;
+    onNewEntryConfirm?: (parentPath: string, name: string, kind: "file" | "dir") => void;
+    onNewEntryCancel?: () => void;
 }
 
 export function FileTree(props: FileTreeProps): JSX.Element {
+    const handleBackgroundContextMenu = (e: MouseEvent) => {
+        if (props.onContextMenu) {
+            e.preventDefault();
+            e.stopPropagation();
+            props.onContextMenu(null, false, e);
+        }
+    };
+
     return (
         <div class="file-tree">
             <FileTreeToolbar
@@ -34,7 +52,10 @@ export function FileTree(props: FileTreeProps): JSX.Element {
                 showHidden={props.showHidden}
                 onToggleHidden={props.onToggleHidden}
             />
-            <div class="file-tree-body">
+            <div
+                class="file-tree-body"
+                onContextMenu={handleBackgroundContextMenu}
+            >
                 <For each={props.model.rootsAtom()}>
                     {(root: Root) => (
                         <TreeNode
@@ -48,6 +69,13 @@ export function FileTree(props: FileTreeProps): JSX.Element {
                             showHidden={props.showHidden}
                             onFileClick={props.onFileClick}
                             onFileDblClick={props.onFileDblClick}
+                            onContextMenu={props.onContextMenu}
+                            renamingPath={props.renamingPath}
+                            onRenameConfirm={props.onRenameConfirm}
+                            onRenameCancel={props.onRenameCancel}
+                            newEntry={props.newEntry}
+                            onNewEntryConfirm={props.onNewEntryConfirm}
+                            onNewEntryCancel={props.onNewEntryCancel}
                         />
                     )}
                 </For>
@@ -108,12 +136,20 @@ interface TreeNodeProps {
     showHidden: boolean;
     onFileClick: (path: string) => void;
     onFileDblClick?: (path: string) => void;
+    onContextMenu?: (path: string | null, isDir: boolean, e: MouseEvent) => void;
+    renamingPath?: string | null;
+    onRenameConfirm?: (path: string, newName: string) => void;
+    onRenameCancel?: () => void;
+    newEntry?: { parentPath: string; kind: "file" | "dir" } | null;
+    onNewEntryConfirm?: (parentPath: string, name: string, kind: "file" | "dir") => void;
+    onNewEntryCancel?: () => void;
 }
 
 function TreeNode(props: TreeNodeProps): JSX.Element {
     const expanded = createMemo(() => props.model.isExpanded(props.path));
     const nodeData = createMemo(() => props.model.getNodeData(props.path));
     const isActive = createMemo(() => props.path === props.activeFilePath);
+    const isRenaming = createMemo(() => props.renamingPath === props.path);
 
     const filteredEntries = createMemo(() => {
         const data = nodeData();
@@ -127,11 +163,6 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
         if (props.isDir) {
             void props.model.toggleExpand(props.path);
         } else {
-            // Single-click → preview-open (VS Code-style). The browser will
-            // also fire `dblclick` separately when it's a double-click —
-            // that path handles pinning. We don't try to suppress this
-            // first click: if it preview-opens then dblclick pins the same
-            // tab, the user sees the file load once and the tab persist.
             props.onFileClick(props.path);
         }
     };
@@ -144,6 +175,14 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
         }
     };
 
+    const handleContextMenu = (e: MouseEvent) => {
+        if (props.onContextMenu) {
+            e.preventDefault();
+            e.stopPropagation();
+            props.onContextMenu(props.path, props.isDir, e);
+        }
+    };
+
     return (
         <div>
             <div
@@ -151,11 +190,13 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                 classList={{
                     "file-tree-row--active": isActive(),
                     "file-tree-row--dir": props.isDir,
+                    "file-tree-row--renaming": isRenaming(),
                 }}
                 style={{ "padding-left": `${4 + props.depth * 16}px` }}
-                onClick={handleClick}
+                onClick={isRenaming() ? undefined : handleClick}
                 onDblClick={handleDblClick}
-                title={props.path}
+                onContextMenu={handleContextMenu}
+                title={isRenaming() ? undefined : props.path}
             >
                 <Show
                     when={props.isDir}
@@ -165,10 +206,21 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                         class={`fa fa-chevron-${expanded() ? "down" : "right"} file-tree-chevron`}
                     />
                 </Show>
-                <i class={`fa fa-${iconForEntry(props.name, props.isDir, isActive())} file-tree-icon`} />
-                <span class="file-tree-label">{props.name}</span>
-                <Show when={props.isSymlink}>
-                    <span class="file-tree-symlink" aria-label="symlink">↗</span>
+                <Show
+                    when={!isRenaming()}
+                    fallback={
+                        <InlineInput
+                            initialValue={props.name}
+                            onConfirm={(v) => props.onRenameConfirm?.(props.path, v)}
+                            onCancel={() => props.onRenameCancel?.()}
+                        />
+                    }
+                >
+                    <i class={`fa fa-${iconForEntry(props.name, props.isDir, isActive())} file-tree-icon`} />
+                    <span class="file-tree-label">{props.name}</span>
+                    <Show when={props.isSymlink}>
+                        <span class="file-tree-symlink" aria-label="symlink">↗</span>
+                    </Show>
                 </Show>
             </div>
             <Show when={props.isDir && expanded()}>
@@ -188,6 +240,26 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                         ⚠ {nodeData()?.error}
                     </div>
                 </Show>
+                {/* New-entry placeholder — rendered inside this dir when active */}
+                <Show when={props.newEntry?.parentPath === props.path}>
+                    <div
+                        class="file-tree-row file-tree-row--new-entry"
+                        style={{ "padding-left": `${4 + (props.depth + 1) * 16}px` }}
+                    >
+                        <span class="file-tree-chevron-spacer" />
+                        <i class={`fa fa-${props.newEntry?.kind === "dir" ? "folder" : "file"} file-tree-icon`} />
+                        <InlineInput
+                            initialValue=""
+                            placeholder={props.newEntry?.kind === "dir" ? "folder name" : "file name"}
+                            onConfirm={(v) => {
+                                if (props.newEntry) {
+                                    props.onNewEntryConfirm?.(props.newEntry.parentPath, v, props.newEntry.kind);
+                                }
+                            }}
+                            onCancel={() => props.onNewEntryCancel?.()}
+                        />
+                    </div>
+                </Show>
                 <For each={filteredEntries()}>
                     {(entry) => (
                         <TreeNode
@@ -201,6 +273,13 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                             showHidden={props.showHidden}
                             onFileClick={props.onFileClick}
                             onFileDblClick={props.onFileDblClick}
+                            onContextMenu={props.onContextMenu}
+                            renamingPath={props.renamingPath}
+                            onRenameConfirm={props.onRenameConfirm}
+                            onRenameCancel={props.onRenameCancel}
+                            newEntry={props.newEntry}
+                            onNewEntryConfirm={props.onNewEntryConfirm}
+                            onNewEntryCancel={props.onNewEntryCancel}
                         />
                     )}
                 </For>
@@ -209,9 +288,52 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
     );
 }
 
+interface InlineInputProps {
+    initialValue: string;
+    placeholder?: string;
+    onConfirm: (value: string) => void;
+    onCancel: () => void;
+}
+
+function InlineInput(props: InlineInputProps): JSX.Element {
+    const [value, setValue] = createSignal(props.initialValue);
+    let inputRef: HTMLInputElement | undefined;
+
+    createEffect(() => {
+        // Auto-focus and select-all on mount.
+        if (inputRef) {
+            inputRef.focus();
+            inputRef.select();
+        }
+    });
+
+    const confirm = () => {
+        const v = value().trim();
+        if (v) props.onConfirm(v);
+        else props.onCancel();
+    };
+
+    return (
+        <input
+            ref={(el) => { inputRef = el; }}
+            class="file-tree-inline-input"
+            type="text"
+            value={value()}
+            placeholder={props.placeholder}
+            onInput={(e) => setValue(e.currentTarget.value)}
+            onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === "Enter") confirm();
+                if (e.key === "Escape") props.onCancel();
+            }}
+            onBlur={confirm}
+            onClick={(e) => e.stopPropagation()}
+        />
+    );
+}
+
 function iconForEntry(name: string, isDir: boolean, isActive: boolean): string {
     if (isDir) return "folder";
-    // Active file gets a filled-dot indicator (`circle-dot`) per spec.
     if (isActive) return "circle-dot";
     const lower = name.toLowerCase();
     if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(lower)) return "file-code";


### PR DESCRIPTION
## Summary

- **Editor widget default UX** — clicking the Editor widget now opens with the file tree collapsed and an `Untitled` scratch buffer already open and focused. Users can start typing immediately without touching the file tree.
- **Scratch file infrastructure** — new `createscratchfile` / `movescratchfile` RPCs back scratch buffers with real files in `~/.agentmux/cache/scratch/<uuid>.md`. Content survives crashes; Save As promotes to a user-chosen path.
- **File tree right-click context menu** — right-clicking a file, folder, or empty tree background opens a context menu with: Open, Copy Path, Copy Relative Path, Rename (inline), Delete (with confirm), New File (inline placeholder), New Folder (inline placeholder), Open in Terminal, Reveal in Explorer.
- **Reusable `<ContextMenu>` component** — Portal-based, keyboard-navigable (Esc), closes on outside click, viewport-clamped.
- **7 new backend handlers** — `openinshell` (platform-aware reveal in Explorer/Finder/Files), `renameeditorfile`, `createeditorfile`, `createeditordir`, `deleteeditorfile`, `createscratchfile`, `movescratchfile`. All path-validated against home dir.
- **Optimistic tree updates** — add/remove entries immediately after mutations without waiting for a full re-fetch.
- **Specs** — two new specs (`SPEC_EDITOR_WIDGET_DEFAULT_UX`, `SPEC_FILE_TREE_CONTEXT_MENU`) + freshened `app-api-pane-open.md`.

## Files changed

| Area | Files |
|------|-------|
| Widget config | `agentmux-srv/src/config/widgets.json` |
| Backend handlers | `agentmux-srv/src/server/websocket.rs` |
| ContextMenu component | `frontend/app/components/context-menu.{tsx,scss}` |
| State store | `frontend/app/store/editor-pane-state-store.ts` |
| RPC API | `frontend/app/store/rpc-api.ts` |
| Editor model | `frontend/app/view/editor/editor-model.ts` |
| Tab strip | `frontend/app/view/editor/editor-tab-strip.tsx` |
| Editor view | `frontend/app/view/editor/editor-view.{tsx,scss}` |
| File tree | `frontend/app/view/editor/file-tree.{tsx,model.ts}` |
| Specs | `docs/specs/SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md`, `docs/specs/SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md`, `docs/specs/app-api-pane-open.md` |

## Test plan

- [ ] Click Editor widget → pane opens with tree collapsed, "Untitled" tab active, CodeMirror focused
- [ ] Type in scratch buffer → dirty indicator (`*`) appears in tab
- [ ] Ctrl+S → saves to scratch path (no Save As yet — Phase 2)
- [ ] Close and reopen editor widget → new Untitled (recovery Phase 3)
- [ ] Right-click a file in tree → menu shows Open, Copy Path, Rename, Delete, Reveal
- [ ] Rename a file → inline input, Enter to confirm, node label updates
- [ ] New File in a folder → placeholder appears, type name, Enter → file created, opens in preview tab
- [ ] Delete a file → `window.confirm` → file removed, tab force-closed
- [ ] Reveal in Explorer → OS file manager opens at that path (Windows/macOS/Linux)
- [ ] Right-click empty tree area → New File / New Folder / Refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)