### PR TITLE
fix(build): commit canonical CEF GN args + de-noise libcef resolver

### DIFF
--- a/.changesets/1781474409-fix-build-commit-canonical-cef-gn-args-configure-script-so-l-i2tx.md
+++ b/.changesets/1781474409-fix-build-commit-canonical-cef-gn-args-configure-script-so-l-i2tx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): commit canonical CEF GN args + configure script so libcef rebuilds are slim by default; stop resolve-cef-runtime crying 'unpatched upstream' on the correct unstripped official build

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -87,22 +87,24 @@ If you see "class member cannot be redeclared" compile errors later, the patcher
 
 ### 4. Configure the build
 
+The canonical GN args are version-controlled at **`scripts/cef-build/args.gn`** in
+the agentmux repo — the exact configuration that built the shipped v0.45.0 libcef.
+Use the configure script: it regenerates the gitignored C-API wrappers (gotcha #1
+below), installs those args into the build tree, and runs `gn gen`:
+
+```bash
+# Run from your agentmux repo checkout. Defaults to ~/cef-build/chromium_git/chromium/src;
+# set AGENTMUX_CEF_SRC=/path/to/chromium/src if your tree is elsewhere.
+bash scripts/cef-build/configure-cef-build.sh
+```
+
+Equivalent manual steps, if you'd rather drive `gn` yourself:
+
 ```bash
 cd ~/cef-build/chromium_git/chromium/src
-gn gen out/Release_GN_x64 --args='
-  is_debug=false
-  is_official_build=true
-  use_thin_lto=true
-  is_cfi=false
-  chrome_pgo_phase=0
-  symbol_level=1
-  is_component_build=false
-  proprietary_codecs=true
-  ffmpeg_branding="Chrome"
-  use_sysroot=false
-  enable_nacl=false
-  cc_wrapper="ccache"
-'
+( cd cef && python3 tools/translator.py --root-dir . )           # regen wrappers FIRST
+cp /path/to/agentmux/scripts/cef-build/args.gn out/Release_GN_x64/args.gn
+./buildtools/linux64/gn gen out/Release_GN_x64
 ```
 
 > **`is_official_build=true` is the size lever — do not omit it.** It enables

--- a/scripts/cef-build/args.gn
+++ b/scripts/cef-build/args.gn
@@ -1,0 +1,42 @@
+# Canonical GN args for the AgentMux patched libcef.so (Linux x64).
+#
+# This is the EXACT configuration that produced the libcef.so shipped in the
+# v0.45.0 release (stripped 263 MB → 134 MB AppImage — the smallest of the three
+# platforms). Treat it as the source of truth; `docs/cef-build/build-patched-libcef.md`
+# defers to this file. `scripts/cef-build/configure-cef-build.sh` copies it into the
+# build tree's out/Release_GN_x64/args.gn and runs `gn gen`.
+#
+# The first block is CEF's standard GN_DEFINES set (what `cef_create_projects.sh`
+# emits for a non-component Release). The size-reduction block at the bottom is the
+# AgentMux addition — see the comment there.
+
+blink_heap_inside_shared_library=true
+clang_use_chrome_plugins=false
+enable_background_mode=false
+enable_downgrade_processing=false
+enable_linux_installer=false
+enable_resource_allowlist_generation=false
+enable_widevine=true
+forbid_non_component_debug_builds=false
+is_component_build=false
+is_debug=false
+optimize_webui=true
+target_cpu="x64"
+use_qt5=false
+use_qt6=false
+use_sysroot=false
+
+# --- size reduction (added 2026-06-14): official-build optimizations ---
+# is_official_build=true is THE size lever — it enables thin-LTO,
+# identical-code-folding, and full optimization, roughly halving libcef.so
+# (~414 MB → ~263 MB stripped; AppImage ~190 → ~135 MB). Do not omit it.
+# is_cfi / chrome_pgo_phase are disabled only to skip their profile/setup
+# dependencies — they do NOT drive size. Verified on CEF 148.0.7778.180.
+#
+# Gotcha: is_official_build rebuilds V8, so after building you MUST copy the
+# fresh snapshot_blob.bin + v8_context_snapshot.bin alongside libcef.so or the
+# host crashes on a checksum mismatch (the AppImage packager handles this).
+is_official_build=true
+use_thin_lto=true
+is_cfi=false
+chrome_pgo_phase=0

--- a/scripts/cef-build/configure-cef-build.sh
+++ b/scripts/cef-build/configure-cef-build.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Configure the patched-CEF build tree with AgentMux's canonical GN args so a
+# from-scratch rebuild produces the slim, official-build libcef.so by default.
+#
+# Without this, the size-reduction flags (is_official_build=true, ...) lived only
+# in an untracked out/Release_GN_x64/args.gn on one machine — wipe ~/cef-build and
+# a rebuild silently regresses to the ~2x-larger non-official binary. This script
+# makes scripts/cef-build/args.gn (version-controlled) the source of truth.
+#
+# Usage:
+#   bash scripts/cef-build/configure-cef-build.sh
+#   AGENTMUX_CEF_SRC=/path/to/chromium/src bash scripts/cef-build/configure-cef-build.sh
+#
+# Prereqs: the chromium+cef tree must already be synced and patched (see
+# docs/cef-build/build-patched-libcef.md steps 1-3). This script only does the
+# `gn gen` configure step (step 4) — it does NOT sync, patch, or build.
+#
+# What it does (idempotent):
+#   1. Regenerate the gitignored CEF C-API wrappers via translator.py — these get
+#      cleaned and the build otherwise dies instantly on
+#      `cef/libcef_dll/ctocpp/views/window_ctocpp.cc` "missing and no known rule"
+#      (it's translator-generated for the patched CefWindow::begin_window_drag API).
+#   2. Copy the canonical args.gn into out/Release_GN_x64/ (backing up any existing).
+#   3. Run `gn gen out/Release_GN_x64`.
+#
+# After it succeeds, build with the OOM-resistant ninja wrapper (step 5 of the doc).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CANONICAL_ARGS="$SCRIPT_DIR/args.gn"
+CEF_SRC="${AGENTMUX_CEF_SRC:-$HOME/cef-build/chromium_git/chromium/src}"
+OUT_DIR="out/Release_GN_x64"
+
+if [ ! -f "$CANONICAL_ARGS" ]; then
+    echo "ERROR: canonical args not found at $CANONICAL_ARGS" >&2
+    exit 1
+fi
+if [ ! -d "$CEF_SRC" ]; then
+    echo "ERROR: chromium/src tree not found at $CEF_SRC" >&2
+    echo "       Sync + patch it first (docs/cef-build/build-patched-libcef.md steps 1-3)," >&2
+    echo "       or set AGENTMUX_CEF_SRC to your chromium/src path." >&2
+    exit 1
+fi
+if [ ! -f "$CEF_SRC/cef/tools/translator.py" ]; then
+    echo "ERROR: $CEF_SRC/cef/tools/translator.py missing — is the cef checkout in place?" >&2
+    exit 1
+fi
+
+cd "$CEF_SRC"
+
+# 1. Regenerate the translator-produced C-API wrappers (gitignored; cleaned by
+#    `git clean` / fresh checkouts). NO `--quiet` — it's an invalid option.
+echo "==> Regenerating CEF C-API wrappers (translator.py)…"
+( cd cef && python3 tools/translator.py --root-dir . )
+
+# 2. Install the canonical args.gn (back up any existing one).
+mkdir -p "$OUT_DIR"
+if [ -f "$OUT_DIR/args.gn" ] && ! cmp -s "$CANONICAL_ARGS" "$OUT_DIR/args.gn"; then
+    backup="$OUT_DIR/args.gn.bak-$(node -p 'Date.now()' 2>/dev/null || echo prev)"
+    cp "$OUT_DIR/args.gn" "$backup"
+    echo "==> Backed up existing args.gn → $backup"
+fi
+cp "$CANONICAL_ARGS" "$OUT_DIR/args.gn"
+echo "==> Installed canonical args.gn → $CEF_SRC/$OUT_DIR/args.gn"
+
+# 3. gn gen — prefer the in-tree gn (no PATH dependency), fall back to PATH.
+if [ -x "buildtools/linux64/gn" ]; then
+    GN="./buildtools/linux64/gn"
+elif command -v gn >/dev/null 2>&1; then
+    GN="gn"
+else
+    echo "ERROR: no gn binary — expected buildtools/linux64/gn or gn on PATH" >&2
+    echo "       (add depot_tools to PATH, or run \`gclient sync\` to populate buildtools)." >&2
+    exit 1
+fi
+echo "==> Running $GN gen $OUT_DIR …"
+"$GN" gen "$OUT_DIR"
+
+echo ""
+echo "✓ Configured $CEF_SRC/$OUT_DIR with the canonical official-build args."
+echo "  Next: build with the OOM-resistant wrapper (doc step 5):"
+echo "    systemd-run --user --scope --collect --unit=cef-build.scope ~/cef-build/ninja-with-retry.sh"

--- a/scripts/resolve-cef-runtime.sh
+++ b/scripts/resolve-cef-runtime.sh
@@ -46,21 +46,37 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # `validate_dir <dir>` — print to stdout and exit 0 if `<dir>` has libcef.so +
 # icudtl.dat. Returns 1 (no output) if either file is missing.
-# When the directory does provide both files, also do a size sanity warning.
+# When the directory provides both files, emit a diagnostic keyed on <kind>:
+#   cargo-cache → the cef-dll-sys prebuilt download. It NEVER carries AgentMux's
+#                 BeginWindowDrag patch (regardless of size), so resolving here
+#                 means left-click window drag silently no-ops — the real alarm,
+#                 and it's about provenance, not file size.
+#   override | cef-build → an operator/dev-built tree. A >1 GB libcef.so here is
+#                 just an unstripped build (the dev tree keeps symbols); the
+#                 AppImage packager strips it to ~260 MB at bundle time. That is
+#                 NORMAL — emit at most a soft INFO, never the upstream alarm.
+#                 (Pre-fix this size check false-alarmed "likely unpatched upstream"
+#                 on the correct official build — see the v0.45.0 slim-libcef work.)
 validate_dir() {
-    local dir="$1"
+    local dir="$1" kind="${2:-cef-build}"
     if [ ! -f "$dir/libcef.so" ] || [ ! -f "$dir/icudtl.dat" ]; then
         return 1
     fi
-    local size_bytes
-    size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
-    local size_mb=$((size_bytes / 1024 / 1024))
-    if [ "$size_bytes" -gt 1073741824 ]; then
-        echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — likely unpatched upstream debug build." >&2
-        echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
-        echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then either" >&2
-        echo "         (a) move the result to ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64, or" >&2
+    if [ "$kind" = "cargo-cache" ]; then
+        echo "WARNING: resolved libcef.so to the cef-dll-sys cargo cache at $dir." >&2
+        echo "         This is the upstream prebuilt CEF — it lacks AgentMux's BeginWindowDrag" >&2
+        echo "         patch, so left-click window drag will silently no-op. Build the patched" >&2
+        echo "         libcef (docs/cef-build/build-patched-libcef.md), then either" >&2
+        echo "         (a) place it at ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64, or" >&2
         echo "         (b) export AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64." >&2
+    else
+        local size_bytes
+        size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
+        if [ "$size_bytes" -gt 1073741824 ]; then
+            local size_mb=$((size_bytes / 1024 / 1024))
+            echo "INFO: libcef.so at $dir is ${size_mb} MB — an unstripped build; the AppImage" >&2
+            echo "      packager strips it to ~260 MB at bundle time (expected, not a problem)." >&2
+        fi
     fi
     echo "$dir"
     return 0
@@ -73,7 +89,7 @@ validate_dir() {
 #    be used. Falling through would yield a successful but drag-broken bundle.
 #    (Codex P2 on PR #743.)
 if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
-    if validate_dir "$AGENTMUX_CEF_RUNTIME_DIR"; then
+    if validate_dir "$AGENTMUX_CEF_RUNTIME_DIR" override; then
         exit 0
     fi
     echo "ERROR: AGENTMUX_CEF_RUNTIME_DIR=$AGENTMUX_CEF_RUNTIME_DIR" >&2
@@ -85,21 +101,27 @@ if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
     exit 1
 fi
 
-# 2. Standard cef-build layout under $HOME.
-candidates=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
+# 2. Standard cef-build layout under $HOME (your patched, dev-built tree).
+CEF_BUILD_DIR="$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64"
+if validate_dir "$CEF_BUILD_DIR" cef-build; then
+    exit 0
+fi
 
-# 3. Cargo cef-dll-sys cache. Find first match in either debug or release.
+# 3. Cargo cef-dll-sys cache — the upstream prebuilt fallback (no BeginWindowDrag).
+#    Find first match in either debug or release.
+cargo_candidates=()
 while IFS= read -r d; do
-    candidates+=("$d")
+    cargo_candidates+=("$d")
 done < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
 
-for dir in "${candidates[@]}"; do
-    if validate_dir "$dir"; then
+for dir in "${cargo_candidates[@]}"; do
+    if validate_dir "$dir" cargo-cache; then
         exit 0
     fi
 done
 
 echo "ERROR: could not find libcef.so + icudtl.dat in any of these locations:" >&2
-for c in "${candidates[@]}"; do echo "  - $c" >&2; done
+echo "  - $CEF_BUILD_DIR" >&2
+for c in "${cargo_candidates[@]}"; do echo "  - $c" >&2; done
 echo "Build the patched libcef (see docs/cef-build/build-patched-libcef.md) or run \`cargo build -p agentmux-cef\` to populate the cef-dll-sys fallback cache." >&2
 exit 1

--- a/scripts/resolve-cef-runtime.sh
+++ b/scripts/resolve-cef-runtime.sh
@@ -23,13 +23,18 @@
 # Each candidate is validated by checking for libcef.so + icudtl.dat (necessary
 # minimum for a usable CEF runtime).
 #
-# Sanity check (warning, not failure)
-# -----------------------------------
-# If the chosen libcef.so is suspiciously large (>1 GB), it is almost certainly the
-# unstripped upstream debug build from cef-dll-sys, which means it lacks our
-# BeginWindowDrag patch. The runtime ABI guard in agentmux-cef will catch this and
-# log a warning at runtime, but we surface the issue at build time too so it's
-# obvious before the user clicks the binary and finds drag silently broken.
+# Diagnostics (warning vs. info, never failure)
+# ---------------------------------------------
+# The real risk is resolving to the cef-dll-sys cargo cache: that's the upstream
+# prebuilt CEF, which lacks our BeginWindowDrag patch regardless of file size, so
+# left-click window drag silently no-ops. We emit a WARNING whenever we fall through
+# to that candidate. The runtime ABI guard in agentmux-cef also catches it at
+# runtime, but surfacing it at build time makes it obvious before the user clicks.
+#
+# Size is NOT a reliable patched/unpatched signal: the patched dev build is ~1.5 GB
+# UNSTRIPPED (the AppImage packager strips it to ~260 MB at bundle time), so on the
+# cef-build/override trees a >1 GB libcef.so is expected — we emit a soft INFO there,
+# not the unpatched-provenance alarm.
 #
 # Output
 # ------


### PR DESCRIPTION
## Why

Follow-up to #1406 (the slim-libcef release work). I'd flagged "wire the slim libcef into CI" as the open item — but **there is no CI release path**; releases are built locally via `task package:linux`. `resolve-cef-runtime.sh` already auto-resolves to the official-rebuilt `~/cef-build/.../Release_GN_x64` tree and the packager strips it (1.5 GB → 263 MB → 134 MB AppImage), so the next local release is *already* slim. This PR hardens that real path instead of building CI nobody uses.

## What

- **`scripts/cef-build/args.gn`** — version-control the exact GN config that built the shipped v0.45.0 libcef (`is_official_build=true` + thin-LTO — the ~2x size lever). Previously these flags lived only in an untracked `out/Release_GN_x64/args.gn` on one machine; wipe `~/cef-build` and a rebuild silently regresses to the non-official ~414 MB binary.
- **`scripts/cef-build/configure-cef-build.sh`** — one-command configure step: regenerate the gitignored translator C-API wrappers (the `window_ctocpp.cc` "missing and no known rule" gotcha), install `args.gn`, run `gn gen`. Idempotent; honors `AGENTMUX_CEF_SRC`.
- **`scripts/resolve-cef-runtime.sh`** — the `>1 GB` size check used to print `WARNING: ... likely unpatched upstream debug build` on the **correct** unstripped official build (false alarm that would send a future maintainer chasing a ghost). The warning is now scoped to the cef-dll-sys **cargo-cache** candidate — the only one that's genuinely unpatched regardless of size. The dev/override tree gets a soft `INFO` ("unstripped, packager strips at bundle time") instead.
- **docs** — step 4 of `build-patched-libcef.md` now points at the committed args + configure script.

## Verification

- Both scripts pass `bash -n`.
- `resolve-cef-runtime.sh` on the live 1.5 GB official tree now emits the soft INFO and still prints the correct path on stdout.
- Override path still hard-fails on a bad `AGENTMUX_CEF_RUNTIME_DIR` (no silent fallthrough — preserves the #743 invariant).
- No `dist/` / binary artifacts staged; 5 files, all source/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)