### PR TITLE
feat(editor): context menu polish — confirm dialog, Collapse Folder, F2 rename

### DIFF
--- a/.changesets/1781474695-feat-editor-context-menu-polish-confirm-dialog-collapse-fold-7498.md
+++ b/.changesets/1781474695-feat-editor-context-menu-polish-confirm-dialog-collapse-fold-7498.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): context menu polish — confirm dialog, Collapse Folder, F2 rename shortcut

--- a/frontend/app/components/confirm-dialog.scss
+++ b/frontend/app/components/confirm-dialog.scss
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ConfirmDialog — modal overlay used by the file-tree delete flow.
+
+.confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+.confirm-dialog {
+    background: var(--modal-bg-color, #1e1e2e);
+    border: 1px solid var(--border-color, #45475a);
+    border-radius: 6px;
+    padding: 20px 24px;
+    min-width: 300px;
+    max-width: 460px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+    color: var(--main-text-color);
+}
+
+.confirm-dialog-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.confirm-dialog-message {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    line-height: 1.5;
+    margin-bottom: 20px;
+}
+
+.confirm-dialog-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.confirm-btn {
+    padding: 5px 14px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 80ms ease, opacity 80ms ease;
+
+    &--cancel {
+        background: transparent;
+        border: 1px solid var(--border-color, #45475a);
+        color: var(--main-text-color);
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.05);
+        }
+    }
+
+    &--danger {
+        background: var(--error-color, #f38ba8);
+        border: 1px solid transparent;
+        color: #1e1e2e;
+        font-weight: 500;
+
+        &:hover {
+            opacity: 0.88;
+        }
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--accent-color, #89b4fa);
+        outline-offset: 2px;
+    }
+}

--- a/frontend/app/components/confirm-dialog.tsx
+++ b/frontend/app/components/confirm-dialog.tsx
@@ -1,0 +1,68 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ConfirmDialog — modal replacement for window.confirm() with dark-theme styling.
+// Used by the file-tree delete flow.
+
+import { onCleanup, onMount, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import "./confirm-dialog.scss";
+
+interface Props {
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export function ConfirmDialog(props: Props): JSX.Element {
+    let cancelBtnRef: HTMLButtonElement | undefined;
+
+    onMount(() => cancelBtnRef?.focus());
+
+    const onOverlayKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") { e.preventDefault(); props.onCancel(); }
+    };
+
+    const onOverlayPointerDown = (e: PointerEvent) => {
+        // Click on the overlay backdrop (not the dialog itself) → cancel.
+        if ((e.target as HTMLElement).classList.contains("confirm-overlay")) {
+            props.onCancel();
+        }
+    };
+
+    onCleanup(() => {
+        // Nothing to clean up, but having this here makes linters happy.
+    });
+
+    return (
+        <Portal>
+            <div
+                class="confirm-overlay"
+                onKeyDown={onOverlayKeyDown}
+                onPointerDown={onOverlayPointerDown}
+            >
+                <div class="confirm-dialog" role="dialog" aria-modal="true">
+                    <div class="confirm-dialog-title">{props.title}</div>
+                    <div class="confirm-dialog-message">{props.message}</div>
+                    <div class="confirm-dialog-actions">
+                        <button
+                            ref={cancelBtnRef}
+                            class="confirm-btn confirm-btn--cancel"
+                            onClick={props.onCancel}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            class="confirm-btn confirm-btn--danger"
+                            onClick={props.onConfirm}
+                        >
+                            {props.confirmLabel ?? "Delete"}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Portal>
+    );
+}

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -641,27 +641,43 @@ export class EditorViewModel implements ViewModel {
         }
     }
 
-    /** Delete a file or folder, closing any open tabs that were pointing to it. */
-    async deleteFile(path: string, recursive: boolean): Promise<void> {
+    /** Delete a file or folder, closing any open tabs that were pointing to it.
+     *
+     *  When `confirmNeeded` is provided, the caller is responsible for showing
+     *  a confirmation UI. It receives a `proceed` callback — call it to execute
+     *  the delete; not calling it aborts. When omitted, falls back to
+     *  `window.confirm` (for programmatic or non-UI callers). */
+    async deleteFile(
+        path: string,
+        recursive: boolean,
+        confirmNeeded?: (proceed: () => void) => void,
+    ): Promise<void> {
         const label = recursive ? "folder and all its contents" : "file";
         const name = path.split(/[/\\]/).pop() ?? path;
-        if (!window.confirm(`Delete ${name} (${label})? This cannot be undone.`)) return;
-        try {
-            await RpcApi.DeleteEditorFileCommand(TabRpcClient, { path, recursive });
-            // Force-close tabs that pointed at the deleted path or any child.
-            const canon = canonicalizePath(path);
-            for (const tab of snapshot(this.blockId)?.tabs ?? []) {
-                const tabCanon = canonicalizePath(tab.filePath);
-                if (tabCanon === canon || tabCanon.startsWith(canon + "/") || tabCanon.startsWith(canon + "\\")) {
-                    dispatch(this.blockId, { type: "CloseTab", tabId: tab.id, force: true, source: "system" });
+
+        const doDelete = async () => {
+            try {
+                await RpcApi.DeleteEditorFileCommand(TabRpcClient, { path, recursive });
+                const canon = canonicalizePath(path);
+                for (const tab of snapshot(this.blockId)?.tabs ?? []) {
+                    const tabCanon = canonicalizePath(tab.filePath);
+                    if (tabCanon === canon || tabCanon.startsWith(canon + "/") || tabCanon.startsWith(canon + "\\")) {
+                        dispatch(this.blockId, { type: "CloseTab", tabId: tab.id, force: true, source: "system" });
+                    }
                 }
+                const parentPath = path.replace(/[/\\][^/\\]*$/, "") || path;
+                const entryName = path.split(/[/\\]/).pop() ?? "";
+                this.treeModel.removeEntryOptimistic(parentPath, entryName);
+            } catch (e: unknown) {
+                console.error(`[editor] delete failed: ${e instanceof Error ? e.message : String(e)}`);
             }
-            // Remove optimistically from tree + refresh parent.
-            const parentPath = path.replace(/[/\\][^/\\]*$/, "") || path;
-            const entryName = path.split(/[/\\]/).pop() ?? "";
-            this.treeModel.removeEntryOptimistic(parentPath, entryName);
-        } catch (e: unknown) {
-            console.error(`[editor] delete failed: ${e instanceof Error ? e.message : String(e)}`);
+        };
+
+        if (confirmNeeded) {
+            confirmNeeded(() => void doDelete());
+        } else {
+            if (!window.confirm(`Delete ${name} (${label})? This cannot be undone.`)) return;
+            await doDelete();
         }
     }
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -440,9 +440,9 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 { type: "action", label: "Open in Terminal", onSelect: () => void model.openInTerminal(path) },
                 { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
                 { type: "action", label: "Collapse Folder", onSelect: () => model.treeModel.collapseFolder(path) },
-                { type: "separator" },
             ];
             if (!isRoot) {
+                items.push({ type: "separator" });
                 items.push({ type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) });
                 items.push({
                     type: "action",

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -441,9 +441,9 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
                 { type: "action", label: "Collapse Folder", onSelect: () => model.treeModel.collapseFolder(path) },
                 { type: "separator" },
-                { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
             ];
             if (!isRoot) {
+                items.push({ type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) });
                 items.push({
                     type: "action",
                     label: "Delete",

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -7,6 +7,7 @@
 
 import { createEffect, createSignal, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
 import { ContextMenu, type ContextMenuItem } from "@/app/components/context-menu";
+import { ConfirmDialog } from "@/app/components/confirm-dialog";
 import { EditorView, basicSetup } from "codemirror";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
@@ -407,6 +408,11 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     const [ctxMenu, setCtxMenu] = createSignal<{ items: ContextMenuItem[]; x: number; y: number } | null>(null);
     const [renamingPath, setRenamingPath] = createSignal<string | null>(null);
     const [newEntry, setNewEntry] = createSignal<{ parentPath: string; kind: "file" | "dir" } | null>(null);
+    const [deleteConfirm, setDeleteConfirm] = createSignal<{
+        title: string;
+        message: string;
+        onConfirm: () => void;
+    } | null>(null);
 
     const buildContextMenuItems = (path: string | null, isDir: boolean): ContextMenuItem[] => {
         if (!path) {
@@ -424,6 +430,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 { type: "action", label: "Refresh", onSelect: () => void model.treeModel.refresh() },
             ];
         }
+        const name = path.split(/[/\\]/).pop() ?? path;
         if (isDir) {
             return [
                 { type: "action", label: "New File…", onSelect: () => { void model.treeModel.expandFolder(path); setNewEntry({ parentPath: path, kind: "file" }); } },
@@ -431,9 +438,21 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 { type: "separator" },
                 { type: "action", label: "Open in Terminal", onSelect: () => void model.openInTerminal(path) },
                 { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
+                { type: "action", label: "Collapse Folder", onSelect: () => model.treeModel.collapseFolder(path) },
                 { type: "separator" },
                 { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
-                { type: "action", label: "Delete", danger: true, onSelect: () => void model.deleteFile(path, true) },
+                {
+                    type: "action",
+                    label: "Delete",
+                    danger: true,
+                    onSelect: () => void model.deleteFile(path, true, (proceed) => {
+                        setDeleteConfirm({
+                            title: `Delete folder "${name}"?`,
+                            message: `This will permanently delete "${name}" and all its contents. This cannot be undone.`,
+                            onConfirm: proceed,
+                        });
+                    }),
+                },
             ];
         }
         return [
@@ -449,7 +468,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             { type: "action", label: "Reveal in Explorer", onSelect: () => void model.revealInExplorer(path) },
             { type: "separator" },
             { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
-            { type: "action", label: "Delete", danger: true, onSelect: () => void model.deleteFile(path, false) },
+            {
+                type: "action",
+                label: "Delete",
+                danger: true,
+                onSelect: () => void model.deleteFile(path, false, (proceed) => {
+                    setDeleteConfirm({
+                        title: `Delete "${name}"?`,
+                        message: `This will permanently delete "${name}". This cannot be undone.`,
+                        onConfirm: proceed,
+                    });
+                }),
+            },
         ];
     };
 
@@ -547,6 +577,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         newEntry={newEntry()}
                         onNewEntryConfirm={(parent, name, kind) => void handleNewEntryConfirm(parent, name, kind)}
                         onNewEntryCancel={() => setNewEntry(null)}
+                        onStartRename={(path) => setRenamingPath(path)}
                     />
                     <Show when={!model.filePathAtom()}>
                         <div class="editor-tree-path-input">
@@ -718,6 +749,19 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         x={menu().x}
                         y={menu().y}
                         onClose={() => setCtxMenu(null)}
+                    />
+                )}
+            </Show>
+
+            {/* Delete confirmation modal — replaces window.confirm() */}
+            <Show when={deleteConfirm()}>
+                {(dc) => (
+                    <ConfirmDialog
+                        title={dc().title}
+                        message={dc().message}
+                        confirmLabel="Delete"
+                        onConfirm={() => { dc().onConfirm(); setDeleteConfirm(null); }}
+                        onCancel={() => setDeleteConfirm(null)}
                     />
                 )}
             </Show>

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -432,7 +432,8 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         }
         const name = path.split(/[/\\]/).pop() ?? path;
         if (isDir) {
-            return [
+            const isRoot = model.treeModel.rootsAtom().some((r) => r.path === path);
+            const items: ContextMenuItem[] = [
                 { type: "action", label: "New File…", onSelect: () => { void model.treeModel.expandFolder(path); setNewEntry({ parentPath: path, kind: "file" }); } },
                 { type: "action", label: "New Folder…", onSelect: () => { void model.treeModel.expandFolder(path); setNewEntry({ parentPath: path, kind: "dir" }); } },
                 { type: "separator" },
@@ -441,7 +442,9 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 { type: "action", label: "Collapse Folder", onSelect: () => model.treeModel.collapseFolder(path) },
                 { type: "separator" },
                 { type: "action", label: "Rename…", shortcut: "F2", onSelect: () => setRenamingPath(path) },
-                {
+            ];
+            if (!isRoot) {
+                items.push({
                     type: "action",
                     label: "Delete",
                     danger: true,
@@ -452,8 +455,9 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                             onConfirm: proceed,
                         });
                     }),
-                },
-            ];
+                });
+            }
+            return items;
         }
         return [
             { type: "action", label: "Open", onSelect: () => void model.openFile(path) },

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -34,6 +34,8 @@ interface FileTreeProps {
     newEntry?: { parentPath: string; kind: "file" | "dir" } | null;
     onNewEntryConfirm?: (parentPath: string, name: string, kind: "file" | "dir") => void;
     onNewEntryCancel?: () => void;
+    /** Called when F2 is pressed in the tree — trigger rename for the given path. */
+    onStartRename?: (path: string) => void;
 }
 
 export function FileTree(props: FileTreeProps): JSX.Element {
@@ -45,8 +47,15 @@ export function FileTree(props: FileTreeProps): JSX.Element {
         }
     };
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "F2" && props.onStartRename && props.activeFilePath) {
+            e.preventDefault();
+            props.onStartRename(props.activeFilePath);
+        }
+    };
+
     return (
-        <div class="file-tree">
+        <div class="file-tree" tabIndex={0} onKeyDown={handleKeyDown}>
             <FileTreeToolbar
                 model={props.model}
                 showHidden={props.showHidden}


### PR DESCRIPTION
## Summary

- **Replace `window.confirm()` with a proper modal** — new `ConfirmDialog` component (`frontend/app/components/confirm-dialog.tsx`) with dark-theme styling, backdrop click to cancel, Escape key, and focus-managed Cancel button as default. The delete flow now shows a descriptive message with the item name.
- **"Collapse Folder" in the dir context menu** — calls `model.treeModel.collapseFolder(path)` (already implemented in `FileTreeModel`), collapses the right-clicked folder without changing focus.
- **F2 keyboard shortcut** — pressing F2 while the file tree is focused triggers rename on the currently active file (`activeFilePath`). The tree root `<div>` now has `tabIndex={0}` so it can receive keyboard events.

## Files changed

| File | Change |
|---|---|
| `frontend/app/components/confirm-dialog.tsx` | New modal component |
| `frontend/app/components/confirm-dialog.scss` | Dark-theme modal styles |
| `frontend/app/view/editor/editor-model.ts` | `deleteFile()` accepts optional `confirmNeeded` callback |
| `frontend/app/view/editor/editor-view.tsx` | Wires confirm dialog, adds Collapse Folder to dir menu, passes `onStartRename` |
| `frontend/app/view/editor/file-tree.tsx` | Adds `onStartRename` prop, F2 key handler on root div |

## Test plan

- [ ] Right-click a file → Delete → confirm dialog appears with file name in message
- [ ] Click Cancel in dialog → file is NOT deleted, tree unchanged
- [ ] Click Delete in dialog → file deleted, tabs closed, tree updated
- [ ] Press Escape while dialog open → dialog closes, file not deleted
- [ ] Click backdrop (outside dialog box) → dialog closes, file not deleted
- [ ] Right-click a folder → "Collapse Folder" item is present → clicking it collapses the folder in the tree
- [ ] Open a file, click the file tree to give it focus, press F2 → inline rename input appears for the active file
- [ ] Right-click a folder → Delete → confirm dialog shows folder name + contents warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)