### PR TITLE
feat(agent): default Claude to Opus + xhigh effort; add xhigh effort level

### DIFF
--- a/.changesets/1781474770-feat-agent-default-claude-to-opus-xhigh-add-xhigh-effort.md
+++ b/.changesets/1781474770-feat-agent-default-claude-to-opus-xhigh-add-xhigh-effort.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): default Claude runtime to Opus + xhigh effort, add xhigh effort level — `xhigh` (between high and max) is the coding/agentic sweet spot and Claude Code's own default; the default model now resolves to the current Opus (4.8)

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -105,6 +105,7 @@ function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
         make("low", "Low", "Minimal reasoning effort", "low"),
         make("medium", "Medium", "Balanced reasoning effort", "medium", ["med"]),
         make("high", "High", "High reasoning effort", "high"),
+        make("xhigh", "X-High", "Best for coding/agentic (Claude Code default)", "xhigh", ["extra-high"]),
         make("max", "Max", "Maximum reasoning effort", "max"),
     ];
 }

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -51,6 +51,7 @@ const EFFORT_LABELS: Record<string, string> = {
     low: "Low",
     medium: "Medium",
     high: "High",
+    xhigh: "X-High",
     max: "Max",
 };
 

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -303,6 +303,7 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                             <option value="low">Low</option>
                             <option value="medium">Medium</option>
                             <option value="high">High</option>
+                            <option value="xhigh">X-High (coding/agentic)</option>
                             <option value="max">Max (Opus only)</option>
                         </select>
                     </div>

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -523,7 +523,7 @@ export type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn
  */
 export type PermissionMode = "bypass" | "auto" | "acceptEdits" | "plan" | "default";
 export type ModelChoice = "opus" | "sonnet" | "haiku";
-export type EffortLevel = "low" | "medium" | "high" | "max";
+export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface AgentRuntimeConfig {
     permissionMode: PermissionMode;
@@ -533,8 +533,11 @@ export interface AgentRuntimeConfig {
 
 export const DEFAULT_RUNTIME_CONFIG: AgentRuntimeConfig = {
     permissionMode: "bypass",
-    model: "sonnet",
-    effort: "medium",
+    // Default to Opus (the `claude` CLI resolves `--model opus` to the current
+    // Opus, i.e. Opus 4.8) at xhigh effort — the coding/agentic sweet spot and
+    // Claude Code's own default. effort is Claude-only and works on Opus/Sonnet.
+    model: "opus",
+    effort: "xhigh",
 };
 
 /**


### PR DESCRIPTION
## What

Defaults the Claude runtime to **Opus + `xhigh`** effort, and adds the **`xhigh`** effort level (it was missing).

- **`EffortLevel`** gains `xhigh` (between `high` and `max`), surfaced in the `/effort` slash command and the agent control-bar dropdown. Passes through as `--effort xhigh` to the `claude` CLI (effort is Claude-only; no whitelist to update).
- **`DEFAULT_RUNTIME_CONFIG`**: model `sonnet` → `opus` (the CLI resolves `--model opus` to the current Opus, **4.8**) and effort `medium` → `xhigh`.

## Why

`xhigh` is the best setting for most coding/agentic work and **Claude Code’s own default**; `high` is Anthropic’s API default. Per the latest Anthropic model reference, `xhigh` (Opus 4.7+) sits between `high` and `max`.

## Notes

- effort works on Opus/Sonnet; it **errors on Haiku 4.5** — gating `--effort` by model is a tracked follow-up (pre-existing for `max` too).
- Frontend-only change; type-clean (`tsc`). A `minor` changeset is included.
- Backed by a provider models/effort/settings reference doc (kept local for now under `docs/providers/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)