### PR TITLE
feat(windows): native-CEF Inno Setup installer

### DIFF
--- a/.changesets/1781476880-feat-windows-installer.md
+++ b/.changesets/1781476880-feat-windows-installer.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(windows): native-CEF Inno Setup .exe installer (`task package:installer`) — per-user install with the AgentMux icon, replacing the removed Tauri-era installer.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,6 +110,12 @@ tasks:
         cmds:
             - pwsh -File scripts/package-msix.ps1 {{.CLI_ARGS}}
 
+    package:installer:
+        desc: 'Build the Windows .exe installer (Inno Setup) from a portable build → ~/Desktop/AgentMux-<ver>-x64-setup.exe. Per-user install, native CEF (replaces the Tauri-era installer). Needs Inno Setup 6 (ISCC). `-- -PortableDir <dir>` to pick a specific portable. See packaging/windows/agentmux.iss.'
+        platforms: [windows]
+        cmds:
+            - pwsh -File scripts/package-installer.ps1 {{.CLI_ARGS}}
+
     package:macos:
         desc: >-
             Package the application as a signed macOS .app + .dmg (Developer ID,

--- a/packaging/windows/agentmux.iss
+++ b/packaging/windows/agentmux.iss
@@ -1,0 +1,74 @@
+; AgentMux Windows installer (Inno Setup 6) — native CEF.
+;
+; Built fresh after the Tauri removal (the old tauri-action NSIS/WiX path is gone).
+; Packages a `task package:release` portable into a per-user install that runs in
+; INSTALLED mode (per-user data dir), NOT portable mode — achieved by omitting the
+; `agentmux-portable.marker` (+ the seed `data\` and `README.txt`), exactly like
+; scripts/package-msix.ps1's staging. See agentmux-common::runtime_mode.
+;
+; Invoke via scripts/package-installer.ps1 (or `task package:installer`), which
+; passes these defines:
+;   /DAppVersion=<x.y.z>  /DSourceDir=<portable dir>  /DOutputDir=<output dir>
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0-dev"
+#endif
+#ifndef SourceDir
+  #error SourceDir is required (the unpacked portable folder)
+#endif
+#ifndef OutputDir
+  #define OutputDir "."
+#endif
+
+#define AppName "AgentMux"
+#define AppExe "agentmux.exe"
+#define AppPublisher "AgentMux"
+#define AppURL "https://github.com/agentmuxai/agentmux"
+; Repo-relative icon (this .iss lives in packaging/windows/).
+#define IconFile "..\..\agentmux-cef\resources\win\agentmux.ico"
+
+[Setup]
+; Stable AppId — keep constant across versions so upgrades replace in place.
+AppId={{7B4D9E2A-1C63-4F8B-9A57-AGENTMUXCEF01}}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}/issues
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+; Per-user install → no UAC elevation (the build is unsigned; keeps testing simple).
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputDir={#OutputDir}
+OutputBaseFilename=AgentMux-{#AppVersion}-x64-setup
+; The installer's own .exe icon + Add/Remove Programs icon.
+SetupIconFile={#IconFile}
+UninstallDisplayIcon={app}\{#AppExe}
+UninstallDisplayName={#AppName} {#AppVersion}
+WizardStyle=modern
+Compression=lzma2/max
+SolidCompression=yes
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+[Files]
+; agentmux.exe (root launcher) + the whole runtime\ tree. Deliberately NOT shipping
+; the portable marker / seed data\ / README.txt (→ installed-mode data dir).
+Source: "{#SourceDir}\agentmux.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\runtime\*"; DestDir: "{app}\runtime"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Ship the icon so shortcuts reference a stable file (independent of exe icon embedding).
+Source: "{#IconFile}"; DestDir: "{app}"; DestName: "agentmux.ico"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExe}"; IconFilename: "{app}\agentmux.ico"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; IconFilename: "{app}\agentmux.ico"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent

--- a/packaging/windows/agentmux.iss
+++ b/packaging/windows/agentmux.iss
@@ -29,7 +29,7 @@
 
 [Setup]
 ; Stable AppId — keep constant across versions so upgrades replace in place.
-AppId={{7B4D9E2A-1C63-4F8B-9A57-AGENTMUXCEF01}}
+AppId={{8654EA96-8EAA-4845-ADE9-352ADA712BC0}}
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppVerName={#AppName} {#AppVersion}

--- a/scripts/package-installer.ps1
+++ b/scripts/package-installer.ps1
@@ -1,0 +1,75 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Build the AgentMux Windows .exe installer (Inno Setup) from a portable build.
+
+.DESCRIPTION
+  Native-CEF Windows installer (the Tauri-era tauri-action installer is gone).
+  Wraps `packaging/windows/agentmux.iss`: resolves a portable build, reads the
+  version from package.json, and runs ISCC with the right defines. Output is a
+  per-user `AgentMux-<ver>-x64-setup.exe`.
+
+  Get a portable first with `task package:release` (or `task package`). By default
+  this picks the newest `agentmux-*-x64-portable` folder on the Desktop.
+
+.PARAMETER PortableDir  Portable folder to package. Default: newest on the Desktop.
+.PARAMETER OutputDir    Where to write the setup .exe. Default: the Desktop.
+
+.EXAMPLE  pwsh -File scripts/package-installer.ps1
+.EXAMPLE  pwsh -File scripts/package-installer.ps1 -PortableDir C:\path\to\portable
+#>
+param(
+  [string]$PortableDir = "",
+  [string]$OutputDir   = ""
+)
+$ErrorActionPreference = "Stop"
+$repo    = Split-Path -Parent $PSScriptRoot
+$desktop = [Environment]::GetFolderPath("Desktop")
+if (-not $OutputDir) { $OutputDir = $desktop }
+
+Write-Host "`n=== AgentMux Windows installer (Inno Setup) ===`n"
+
+# ── locate ISCC ──────────────────────────────────────────────────────────────
+$iscc = (Get-Command iscc -ErrorAction SilentlyContinue).Source
+if (-not $iscc) {
+  $iscc = Get-ChildItem @(
+    "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+    "${env:ProgramFiles}\Inno Setup 6\ISCC.exe",
+    "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe"
+  ) -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $iscc) {
+  throw "ISCC.exe (Inno Setup 6) not found. Install it from https://jrsoftware.org/isdl.php (or: winget install JRSoftware.InnoSetup)."
+}
+Write-Host "  iscc     : $iscc"
+
+# ── version (from package.json) ──────────────────────────────────────────────
+$version = (Get-Content -Raw (Join-Path $repo "package.json") | ConvertFrom-Json).version
+Write-Host "  version  : $version"
+
+# ── resolve portable dir ─────────────────────────────────────────────────────
+if (-not $PortableDir) {
+  $PortableDir = Get-ChildItem $desktop -Directory -Filter "agentmux-*-x64-portable" -ErrorAction SilentlyContinue |
+                 Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $PortableDir -or -not (Test-Path $PortableDir)) {
+  throw "No portable folder found. Run `task package:release` first (or pass -PortableDir)."
+}
+if (-not (Test-Path (Join-Path $PortableDir "agentmux.exe")))       { throw "portable missing agentmux.exe: $PortableDir" }
+if (-not (Test-Path (Join-Path $PortableDir "runtime\libcef.dll"))) { throw "portable missing runtime\libcef.dll: $PortableDir" }
+Write-Host "  portable : $PortableDir"
+Write-Host "  output   : $OutputDir`n"
+
+# ── build ────────────────────────────────────────────────────────────────────
+$iss = Join-Path $repo "packaging\windows\agentmux.iss"
+& $iscc /Qp `
+  "/DAppVersion=$version" `
+  "/DSourceDir=$PortableDir" `
+  "/DOutputDir=$OutputDir" `
+  $iss
+if ($LASTEXITCODE -ne 0) { throw "ISCC failed (exit $LASTEXITCODE)" }
+
+$setup = Join-Path $OutputDir "AgentMux-$version-x64-setup.exe"
+if (-not (Test-Path $setup)) { throw "expected installer not produced: $setup" }
+$mb = [math]::Round((Get-Item $setup).Length / 1MB, 1)
+Write-Host "`n[SUCCESS] $setup ($mb MB)"

--- a/scripts/package-installer.ps1
+++ b/scripts/package-installer.ps1
@@ -57,7 +57,21 @@ if (-not $PortableDir -or -not (Test-Path $PortableDir)) {
 }
 if (-not (Test-Path (Join-Path $PortableDir "agentmux.exe")))       { throw "portable missing agentmux.exe: $PortableDir" }
 if (-not (Test-Path (Join-Path $PortableDir "runtime\libcef.dll"))) { throw "portable missing runtime\libcef.dll: $PortableDir" }
-Write-Host "  portable : $PortableDir"
+
+# Guard: the bundled binary version MUST match package.json. The host exe is named
+# agentmux-<ver>.exe, so its filename is the binaries' version of record. The portable
+# is resolved by newest-mtime, so a lingering older build would otherwise silently yield
+# an AgentMux-<pkgver>-x64-setup.exe wrapping a different binary version. Mirrors
+# scripts/package-msix.ps1's skew guard.
+$hostExe = Get-ChildItem (Join-Path $PortableDir 'runtime') -Filter 'agentmux-*.exe' -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -match '^agentmux-(\d+\.\d+\.\d+)\.exe$' } | Select-Object -First 1
+if (-not $hostExe) { throw "No runtime\agentmux-<version>.exe in portable: $PortableDir — is this a CEF portable build?" }
+$portableVersion = [regex]::Match($hostExe.Name, '^agentmux-(\d+\.\d+\.\d+)\.exe$').Groups[1].Value
+if ($portableVersion -ne $version) {
+  throw "Version skew: package.json is $version but the portable bundles agentmux-$portableVersion.exe ($($hostExe.FullName)). Rebuild with 'task package:release' or pass an explicit -PortableDir."
+}
+
+Write-Host "  portable : $PortableDir (binver $portableVersion)"
 Write-Host "  output   : $OutputDir`n"
 
 # ── build ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a **fresh Windows `.exe` installer** for the native-CEF app. The Tauri-era `tauri-action` NSIS/WiX installer was removed with Tauri, so the only Windows artifact today is the portable ZIP — this restores a double-click installer.

## What's here
- **`packaging/windows/agentmux.iss`** — Inno Setup 6 script.
- **`scripts/package-installer.ps1`** — resolves the newest portable on the Desktop, reads the version from `package.json`, runs ISCC → `AgentMux-<ver>-x64-setup.exe`.
- **`task package:installer`** — wraps it (run after `task package:release`).

## Behavior
- Installs `agentmux.exe` + `runtime\` and **omits** the `agentmux-portable.marker` / seed `data\` / `README.txt`, so the app runs in **installed mode** (per-user data dir) — same staging contract as `scripts/package-msix.ps1`.
- **Proper icon:** `agentmux-cef/resources/win/agentmux.ico` is wired into the setup `.exe`, the Start-Menu + optional desktop shortcuts, and the uninstaller. Verified the built setup exe carries the AgentMux logo (not the default Inno icon).
- **Per-user install** (`PrivilegesRequired=lowest`) → no UAC.
- **Unsigned** — there's no Windows code-signing cert yet, so SmartScreen will warn ("More info → Run anyway"). Signing is a follow-up once a cert exists.

## Tested
Built locally → `~/Desktop/AgentMux-0.45.0-x64-setup.exe` (122 MB) from the v0.45.0 portable; icon confirmed.

Related cleanup (separate): the dead Tauri CI in `agentmux-builder` and the winget `.msi` reference are tracked for removal as we rebuild the release pipeline fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)