### PR TITLE
fix(agent-pane): normalize MSYS /c/ cwd for persistent Shell node

### DIFF
--- a/.changesets/1781478316-fix-agent-pane-normalize-msys-c-cwd-for-persistent-shell-so--3vz8.md
+++ b/.changesets/1781478316-fix-agent-pane-normalize-msys-c-cwd-for-persistent-shell-so--3vz8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): normalize MSYS /c/ cwd for persistent Shell so task dev / vite servers spawn on Windows (os error 267)

--- a/agentmux-srv/src/backend/base.rs
+++ b/agentmux-srv/src/backend/base.rs
@@ -268,6 +268,55 @@ pub fn expand_home_dir_safe(path: &str) -> PathBuf {
     expand_home_dir(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// Convert an MSYS / Git-Bash POSIX drive path to a native Windows path.
+///
+/// Agents on Windows typically run inside a bash shell (MSYS2 / Git Bash),
+/// so they naturally emit paths like `/c/Users/asafe/project` or the WSL
+/// form `/mnt/c/Users/asafe/project`. Passing one of those straight to
+/// `std::process::Command::current_dir` makes `CreateProcess` fail with
+/// `os error 267` (ERROR_DIRECTORY, "The directory name is invalid").
+///
+/// Recognised forms (case-insensitive drive letter):
+/// - `/c`            → `C:\`
+/// - `/c/Users/x`    → `C:\Users\x`
+/// - `/mnt/c/Users/x`→ `C:\Users\x`
+///
+/// Anything that isn't a POSIX drive path is returned unchanged. This is a
+/// no-op on non-Windows targets (the input is already a valid POSIX path).
+pub fn msys_to_windows_path(path: &str) -> String {
+    #[cfg(windows)]
+    {
+        // Strip an optional WSL `/mnt` prefix so both `/c/...` and
+        // `/mnt/c/...` reduce to the same `/<drive>/<rest>` shape.
+        let stripped = path.strip_prefix("/mnt").unwrap_or(path);
+        let bytes = stripped.as_bytes();
+        let is_drive_path = bytes.len() >= 2
+            && bytes[0] == b'/'
+            && (bytes[1] as char).is_ascii_alphabetic()
+            && (bytes.len() == 2 || bytes[2] == b'/');
+        if is_drive_path {
+            let drive = (bytes[1] as char).to_ascii_uppercase();
+            let rest = stripped[2..].replace('/', "\\"); // "" or "\Users\x"
+            return format!("{drive}:{}", if rest.is_empty() { "\\" } else { &rest });
+        }
+    }
+    let _ = path; // silence unused on non-windows
+    path.to_string()
+}
+
+/// Normalize a user/agent-supplied working directory for use with
+/// `Command::current_dir`: first convert MSYS/Git-Bash POSIX drive paths to
+/// native Windows form (see [`msys_to_windows_path`]), then expand a leading
+/// `~`. Returns `None` for an empty/whitespace input.
+pub fn normalize_working_dir(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let win = msys_to_windows_path(raw);
+    Some(expand_home_dir_safe(&win).to_string_lossy().into_owned())
+}
+
 /// After a lexical join, verify that no symlinked ancestor of the
 /// candidate path escapes `base_canonical`. The lexical helper alone
 /// can't catch this: if `<base>/.claude` is a symlink to `/tmp/outside`
@@ -666,6 +715,27 @@ mod tests {
         // non-ASCII letters do NOT match (they wouldn't be valid drive
         // letters on Windows anyway).
         assert!(!has_drive_letter_prefix("Ω:foo"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_msys_to_windows_path() {
+        assert_eq!(msys_to_windows_path("/c/Users/asafe/p"), "C:\\Users\\asafe\\p");
+        assert_eq!(msys_to_windows_path("/mnt/c/Users/asafe/p"), "C:\\Users\\asafe\\p");
+        assert_eq!(msys_to_windows_path("/d/work"), "D:\\work");
+        assert_eq!(msys_to_windows_path("/c"), "C:\\");
+        // Already-native paths pass through untouched.
+        assert_eq!(msys_to_windows_path("C:\\Users\\asafe"), "C:\\Users\\asafe");
+        // Not a drive path: leading `/usr` is not `/<letter>/`.
+        assert_eq!(msys_to_windows_path("/usr/bin"), "/usr/bin");
+        // `/ab/...` — second segment is multi-char, not a drive.
+        assert_eq!(msys_to_windows_path("/ab/c"), "/ab/c");
+    }
+
+    #[test]
+    fn test_normalize_working_dir_empty() {
+        assert_eq!(normalize_working_dir(""), None);
+        assert_eq!(normalize_working_dir("   "), None);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -52,8 +52,25 @@ impl ShellNodeRunner {
             c
         };
 
+        // Only set the working directory if it actually exists. The cwd is
+        // normalized upstream (handle_shell_create → base::normalize_working_dir),
+        // but a stale or mistyped path would otherwise make the spawn fail hard
+        // with os error 267 (ERROR_DIRECTORY) on Windows. Mirror the agent-CLI
+        // spawn's graceful fallback (subprocess.rs): warn via a system chunk and
+        // run in the server's cwd rather than killing the shell before it starts.
         if let Some(ref cwd) = self.cwd {
-            child_cmd.current_dir(cwd);
+            if std::path::Path::new(cwd).is_dir() {
+                child_cmd.current_dir(cwd);
+            } else {
+                publish_chunk(
+                    &broker,
+                    &block_id,
+                    &shell_id,
+                    "system",
+                    &format!("[cwd not found: {cwd} — running in the server's working directory]"),
+                    now_ms(),
+                );
+            }
         }
         for (k, v) in &self.extra_env {
             child_cmd.env(k, v);

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -430,6 +430,13 @@ async fn handle_shell_create(
         })
     });
 
+    // Normalize the cwd before it reaches the spawner. Agents on Windows run
+    // inside a bash shell and emit MSYS paths like `/c/Users/asafe/project`;
+    // passing those straight to `Command::current_dir` fails with os error 267
+    // (ERROR_DIRECTORY). This converts them to native form and expands `~`.
+    let effective_cwd =
+        effective_cwd.and_then(|c| crate::backend::base::normalize_working_dir(&c));
+
     // Env parity with the agent CLI: start from the agent block's stored
     // cmd:env (the per-agent env the agent process is launched with — same
     // shape app_api.rs / websocket.rs read), then let the caller-supplied


### PR DESCRIPTION
## Problem

Long-running processes launched via the agent **Shell** tool (persistent shell node) fail instantly on Windows. Observed live in the running 0.45.0 instance (agent "Mazs"): every `npm run dev` for the landing-page dev server renders a red exited-err block:

```
✗ agentmux-landing dev server [0:00]
npm run dev → exit 1
[spawn error: The directory name is invalid. (os error 267)]
```

## Root cause

Agents on Windows run inside a bash shell (MSYS2 / Git Bash), so they pass MSYS-style working directories to `Shell(cmd, cwd)` — e.g. `/c/Users/asafe/.agentmux/agents/mazs-0527n/agentmux-landing`. `ShellNodeRunner` forwarded that string straight to `Command::current_dir`, and `CreateProcess` rejects `/c/...` with **os error 267 (ERROR_DIRECTORY)**.

The agent-CLI spawn path (`subprocess.rs`) never hit this because it guards with `if dir_path.exists()` and silently falls back. `shell_node.rs` had no `~` expansion, no MSYS conversion, and no existence guard.

(The target dir `C:\Users\asafe\...\agentmux-landing` exists and has a `package.json` — path style was the *only* problem.)

## Fix

- **`base.rs`**: add `msys_to_windows_path` (`/c/..` and `/mnt/c/..` → `C:\..`) and `normalize_working_dir` (MSYS convert + `~` expansion). Unit tested (Windows-gated).
- **`mod.rs` `handle_shell_create`**: normalize `effective_cwd` before spawn + logging, so both the agent-supplied `cwd` and the `cmd:cwd` fallback are handled.
- **`shell_node.rs`**: guard `current_dir` on directory existence; on a missing dir emit a `system` chunk and fall back to the server cwd instead of a fatal spawn error — mirroring the agent-CLI graceful path.

## Test

- `cargo test --bin agentmux-srv -- msys_to_windows normalize_working_dir` → 2 passed.
- `task build:backend` (release) → clean.

## Follow-ups (not in this PR)

Phase 3 of `SPEC_PERSISTENT_SHELL_NODE` is still unimplemented and matters for dev servers: no **stop** capability (no `ShellStop` tool / UI stop button / process registry) and no cleanup-on-close, so a `task dev` can't be killed and orphans its port. Tracked separately.