### PR TITLE
fix(agent): codex default -> gpt-5.5; do not send --effort to Claude Haiku (provider P1)

### DIFF
--- a/.changesets/1781492815-fix-agent-provider-p1-codex-gpt55-default-gate-effort-haiku.md
+++ b/.changesets/1781492815-fix-agent-provider-p1-codex-gpt55-default-gate-effort-haiku.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): bump codex default model to gpt-5.5 and stop sending `--effort` to Claude Haiku (it 400s on Haiku 4.5) — first slice of the per-provider models/effort generalization (SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION)

--- a/docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md
+++ b/docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md
@@ -1,0 +1,235 @@
+<!--
+Copyright 2026, AgentMux Corp.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Provider Models, Effort & Settings — Reference (2026-06-14)
+
+Reference for updating AgentMux's provider docs/config. Covers the latest models,
+reasoning/effort levels, and key settings for **every provider AgentMux ships**
+(`claude`, `codex`, `muxcode`, `gemini`, `qwen`, `kimi`, `openclaw`, `pi`, `copilot`).
+
+- **Claude/Anthropic data is authoritative** (pulled from the bundled `claude-api`
+  reference, cache 2026-06-04). **All other providers** are from web sources dated
+  2026 — cited at the bottom; **verify before pinning**, model lines move fast.
+- AgentMux's current values are quoted from
+  `agentmux-srv/src/backend/providers.rs`, `frontend/app/view/agent/providers/index.ts`,
+  `frontend/app/view/agent/types.ts`, and `buildRuntimeArgs.ts`.
+
+---
+
+## 0. TL;DR — what's stale in AgentMux today
+
+| Gap | Current AgentMux | Should be | Where |
+|---|---|---|---|
+| **Effort missing `xhigh`** | `EffortLevel = "low"\|"medium"\|"high"\|"max"` | add **`xhigh`** (between `high` and `max`) | `frontend/app/view/agent/types.ts:209` |
+| **Effort is "Claude-only"** | effort flag only built for `claude` | effort/reasoning is now **common** — Codex (`-c model_reasoning_effort`), Gemini (`thinking_level`) all have it | `buildRuntimeArgs.ts`, providers |
+| **Codex default model stale** | `gpt-5.4` | `gpt-5.5` (current frontier; `gpt-5.1-codex-max`/`gpt-5.3-codex` for Codex-tuned) | `buildRuntimeArgs.ts:38` |
+| **Claude effort default** | `"medium"` | Anthropic default is **`high`**; **`xhigh`** is the Claude-Code coding/agentic default | `types.ts:236` |
+| **Effort errors on Haiku** | effort flag sent regardless of model | effort **400s on Haiku 4.5** — gate it off when model=`haiku` | provider arg build |
+| **Per-provider model lists** | model picker is Claude-only (`opus/sonnet/haiku`) | each provider now has a distinct, fast-moving model line (below) | provider defs |
+
+**The unifying insight** (the "slightly different but common" framing): every modern
+coding agent now exposes the same three knobs — **(1) a model tier, (2) a
+reasoning/effort level, (3) a permission/auto-approve mode.** Only the *names* and
+*allowed values* differ. AgentMux's `AgentRuntimeConfig {permissionMode, model, effort}`
+already models this; it just needs the value sets widened per provider (see §11).
+
+---
+
+## 1. Claude / Anthropic (`claude`) — AUTHORITATIVE
+
+CLI: `claude` (`@anthropic-ai/claude-code`). AgentMux aliases `opus/sonnet/haiku`.
+
+### Models (current)
+
+| Tier | Model ID | Context | In/Out $ per 1M | Notes |
+|---|---|---|---|---|
+| Most capable | `claude-fable-5` | 1M | $10 / $50 | Most capable widely-released model; thinking always on; new tokenizer (~30% more tokens); not under ZDR |
+| **Default (Opus)** | `claude-opus-4-8` | 1M | $5 / $25 | Anthropic's default — "use unless user names another"; state-of-the-art agentic |
+| Opus prev | `claude-opus-4-7` | 1M | $5 / $25 | |
+| Opus older | `claude-opus-4-6` | 1M | $5 / $25 | |
+| Balanced (Sonnet) | `claude-sonnet-4-6` | 1M | $3 / $15 | Best speed/intelligence balance |
+| Fast (Haiku) | `claude-haiku-4-5` | 200K | $1 / $5 | Fastest/cheapest; **effort param errors here** |
+
+> AgentMux's `opus/sonnet/haiku` aliases resolve via the `claude` CLI. Map them to
+> the IDs above in docs. Consider adding a **"fable"/"most-capable"** tier. Note
+> AgentMux defaults to `sonnet` (cost) while Anthropic's API default is `opus-4-8`.
+
+### Effort (reasoning depth)
+
+`output_config: {effort: ...}` — **`low | medium | high | xhigh | max`**
+
+- **Default `high`** (equivalent to omitting). `medium` is a balanced point; `low` for subagents/simple tasks.
+- **`xhigh`** (added Opus 4.7; between `high` and `max`) — **best for most coding/agentic work; the Claude Code default.** Use ≥`high` for intelligence-sensitive work.
+- **`max`** — Fable 5, Opus 4.6+, Sonnet 4.6 only (not Haiku/older Sonnets). Use when correctness > cost.
+- Effort **works on** Fable 5, Opus 4.5/4.6/4.7/4.8, Sonnet 4.6. **Errors on Sonnet 4.5 / Haiku 4.5.**
+
+### Thinking
+
+- **Adaptive thinking** is the mode: `thinking: {type: "adaptive"}` (Claude decides depth; auto-interleaves between tool calls).
+- **`budget_tokens` is gone** on Fable 5 / Opus 4.7 / 4.8 (400 error); deprecated on Opus 4.6 / Sonnet 4.6. Control depth with `effort` instead.
+- Thinking **display defaults to `"omitted"`** on Fable 5 / Opus 4.7 / 4.8 (set `display: "summarized"` to surface reasoning).
+- Fable 5: thinking always on — omit the `thinking` param (an explicit `{type:"disabled"}` 400s).
+
+### Key settings / breaking changes (Opus 4.7 / 4.8 / Fable 5)
+
+- **`temperature`, `top_p`, `top_k` are removed** — sending any → 400. Steer via prompting.
+- **No last-assistant-turn prefill** → 400 (use structured outputs / system prompt).
+- Stream when `max_tokens` > ~16K. Output ceilings: 128K (Fable/Opus), 64K (Sonnet), 64K (Haiku).
+- Fable 5 only: requires 30-day data retention; safety classifiers can return `stop_reason:"refusal"` (HTTP 200).
+
+---
+
+## 2. OpenAI Codex (`codex`)
+
+CLI: `codex` (`@openai/codex`, AgentMux pin `0.116.0`). AgentMux launch: `exec --json --dangerously-bypass-approvals-and-sandbox -`. Default model `gpt-5.4` (**stale**). Context 200K.
+
+### Models (current, 2026)
+
+| Model | Role |
+|---|---|
+| **`gpt-5.5`** | Newest frontier — more intelligent *and* more token-efficient than 5.4 |
+| `gpt-5.4` | Prior frontier (AgentMux's current default) |
+| `gpt-5.1-codex-max` | Codex-tuned, long-horizon agentic |
+| `gpt-5.3-codex` | Codex-tuned |
+
+### Reasoning effort
+
+GPT-5.5 supports **`none | low | medium | high | xhigh`** (default **`medium`**).
+- `low` efficient; `medium` balanced; `high` for complex agentic where latency matters less; **`xhigh`** for the hardest async agentic tasks/evals.
+- Codex CLI passes effort as `-c model_reasoning_effort="..."` (or via TUI). **Note the shared `xhigh` value with Claude.**
+
+### Settings
+- Permission/sandbox baked into AgentMux base args (`--dangerously-bypass-approvals-and-sandbox`); no `--permission-mode`. Positional `-` must stay last.
+- Session field: `thread_id`. Output: `codex-json`. `CODEX_HOME` must pre-exist.
+
+---
+
+## 3. Google Gemini (`gemini`)
+
+CLI: `gemini` (`@google/gemini-cli`, AgentMux pin `0.32.1`). AgentMux launch: `--output-format stream-json --yolo -p`. Context **1M**.
+
+### Models (current, 2026)
+
+| Model | Released | Role |
+|---|---|---|
+| `gemini-3.1-pro` | 2026-02-19 | Latest Pro (preview in Gemini CLI) |
+| `gemini-3.5-flash` | 2026-05-19 | Latest Flash |
+| `gemini-3-flash` | — | Fast tier (in Gemini CLI) |
+| `gemini-3-deep-think` | 2026-02-12 | Deep reasoning |
+
+### Reasoning ("thinking_level")
+
+`thinking_level: **minimal | low | medium | high**` (3.1 Pro added `MEDIUM`). Balances quality/latency/cost — the Gemini analog of Claude/Codex effort.
+
+### Settings
+- Permission: `--yolo` (bypass) vs none (default); no `--permission-mode`.
+- `GEMINI_FORCE_FILE_STORAGE=true` set by AgentMux (skip macOS Keychain). Output: `gemini-json`. Resume `-r`.
+
+---
+
+## 4. Qwen Code (`qwen`) — Alibaba, OpenRouter-backed
+
+CLI: `qwen` (`@qwen-code/qwen-code`, fork of Gemini CLI). AgentMux drives it OpenAI-compatible via `OPENAI_BASE_URL=https://openrouter.ai/api/v1` + `OPENAI_API_KEY` (+ optional `OPENAI_MODEL`). Same `--yolo`, `gemini-json` surface.
+
+### Models (current, 2026)
+- **`qwen3.6-max-preview`** (2026-04-20) — tops several coding benchmarks (SWE-bench Pro, Terminal-Bench 2.0).
+- **`qwen3.6-plus`** (2026-03-30).
+- `qwen3-coder` line — long-horizon autonomous coding.
+
+Reasoning is model/endpoint-dependent (OpenAI-compatible `reasoning_effort` where the OpenRouter route supports it). Qwen OAuth free tier retired 2026-04-15 → API-key only.
+
+---
+
+## 5. Kimi Code (`kimi`) — Moonshot AI
+
+CLI: `kimi` (**Python**, `pip install kimi-cli`). AgentMux launch: `--print --output-format stream-json --yolo -p`. Context 128K. Output `kimi-stream-json`.
+
+### Models (current, 2026)
+- **`kimi-k2.6`** (2026-04-20) — 1T params (32B active MoE), self-hostable (Modified MIT). Built for plan→write→test→debug loops lasting days; **agent-swarm**: native 300 parallel sub-agents / 4,000 coordinated steps.
+- `kimi-k2.5` — prior.
+
+Permission: `--yolo` only. Auth: API-key (`["info"]` / `["login"]`).
+
+---
+
+## 6. GitHub Copilot CLI (`copilot`) — Microsoft
+
+CLI: `copilot` (`@github/copilot`). AgentMux runs **ACP** (`--acp`) — `-p`/stdin mode not yet supported. Context 128K. Output `acp`. Model selection is via Copilot's own config (backed by GPT-5.x / Claude / Gemini depending on the user's Copilot plan). No AgentMux-side model/effort flags.
+
+---
+
+## 7. OpenClaw (`openclaw`) — model-agnostic
+
+CLI: `openclaw acp` (ACP bridge → local OpenClaw Gateway over WebSocket; **gateway daemon must be running**). Backing LLM chosen in OpenClaw config (defaults to Pi; can wire Claude/Codex/Gemini/local). No AgentMux-side model/effort.
+
+---
+
+## 8. Pi (`pi`) — Plandex / standalone
+
+CLI: `pi --json` (ACP). Lightweight coding agent that also powers OpenClaw; read/write/bash/edit tools. Model chosen in Pi config (`["config","get","provider"]`). No AgentMux-side model/effort.
+
+---
+
+## 9. Mux Code (`muxcode`) — AgentMux first-party
+
+CLI: `muxcode run -p` (`@a5af/muxcode`). Flexible backend: local GGUF, Anthropic, OpenAI, or any OpenAI-compatible endpoint (selected by `OPENAI_BASE_URL`/`OPENAI_API_KEY` etc.). Claude-compatible NDJSON (`claude-stream-json`), context 200K. Models/effort follow whichever backend is wired.
+
+---
+
+## 10. Cross-provider comparison — the "common but different" knobs
+
+| Provider | Reasoning/effort knob | Values | Default | Permission/auto |
+|---|---|---|---|---|
+| **Claude** | `effort` | low, medium, high, **xhigh**, max | high | 5 modes (`--permission-mode`, `--dangerously-skip-permissions`) |
+| **Codex** | `model_reasoning_effort` | none, low, medium, high, **xhigh** | medium | baked bypass (no mode flag) |
+| **Gemini** | `thinking_level` | minimal, low, medium, high | (model) | `--yolo` / none |
+| **Qwen** | `reasoning_effort` (OpenAI-compat) | route-dependent | — | `--yolo` / none |
+| **Kimi** | (none surfaced via CLI) | — | — | `--yolo` |
+| **Copilot / OpenClaw / Pi / Mux** | provider-internal | — | — | ACP / config |
+
+**Observation:** Claude, Codex, and Gemini have converged on a 4–5 step reasoning
+scale; **`xhigh` is now shared by Claude (Opus 4.7/4.8) and OpenAI (GPT-5.5)** as the
+"hardest agentic" tier. AgentMux's effort enum should add `xhigh` and the docs should
+present effort as a cross-provider concept (mapped per provider), not a Claude-only one.
+
+---
+
+## 11. Concrete AgentMux changes implied (for the doc/config update)
+
+1. **`frontend/app/view/agent/types.ts:209`** — `EffortLevel`: add `"xhigh"` →
+   `"low" | "medium" | "high" | "xhigh" | "max"`. Update the `/effort` slash-command
+   choices and `buildRuntimeArgs.ts` accordingly.
+2. **Claude effort default** — docs should state Anthropic's default is `high` and the
+   coding sweet spot is `xhigh`; decide whether AgentMux's `"medium"` default
+   (`types.ts:236`) should move to `high`.
+3. **Gate effort by model** — don't emit `--effort` for `haiku` (errors on Haiku 4.5).
+4. **`buildRuntimeArgs.ts:38`** — bump Codex default `gpt-5.4` → `gpt-5.5`; surface
+   Codex `model_reasoning_effort` (it shares the `low/medium/high/xhigh` scale).
+5. **Generalize effort beyond Claude** — wire Codex (`-c model_reasoning_effort`) and
+   Gemini (`thinking_level`) through the same `AgentRuntimeConfig.effort` with a
+   per-provider value map.
+6. **New canonical doc** — there is no central provider/model reference today
+   (info is scattered in `providers.rs`, `index.ts`, `provider-auth-isolation.md`).
+   This file is the seed; promote a maintained `docs/providers/` set.
+7. **Model lists** — capture each provider's current line (above) so the picker can
+   show real model choices, not Claude-only.
+
+---
+
+## Sources
+
+Claude/Anthropic: bundled `claude-api` skill reference (cache 2026-06-04) — authoritative.
+
+Non-Claude (web, 2026 — verify before pinning):
+- [Introducing GPT-5.5 | OpenAI](https://openai.com/index/introducing-gpt-5-5/)
+- [Using GPT-5.5 | OpenAI API](https://developers.openai.com/api/docs/guides/latest-model)
+- [Building more with GPT-5.1-Codex-Max | OpenAI](https://openai.com/index/gpt-5-1-codex-max/)
+- [Codex Changelog | OpenAI Developers](https://developers.openai.com/codex/changelog)
+- [Gemini 3.1 Pro | Google blog](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/)
+- [Gemini 3 Flash | Google blog](https://blog.google/products/gemini/gemini-3-flash/)
+- [Gemini 3 Flash | Google Cloud docs (thinking_level)](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-flash)
+- [Moonshot AI releases Kimi K2.6 | MarkTechPost](https://www.marktechpost.com/2026/04/20/moonshot-ai-releases-kimi-k2-6-with-long-horizon-coding-agent-swarm-scaling-to-300-sub-agents-and-4000-coordinated-steps/)
+- [Kimi K2.6 vs Qwen3.6 Max vs DeepSeek V4 | DeepLearning.AI The Batch](https://www.deeplearning.ai/the-batch/kimi-k2-6-matches-open-qwen3-6-max-anddeepseek-v4-falls-just-behind-top-closed-models)
+- [Qwen3.6-Max-Preview vs Plus vs Kimi K2.6 | Lushbinary](https://lushbinary.com/blog/qwen-3-6-max-preview-vs-plus-vs-kimi-k2-6-comparison/)

--- a/docs/specs/SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md
+++ b/docs/specs/SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md
@@ -1,0 +1,209 @@
+<!--
+Copyright 2026, AgentMux Corp.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# SPEC: Per-Provider Models + Generalized Reasoning/Effort
+
+- **Date:** 2026-06-14
+- **Status:** Draft / proposed
+- **Area:** `frontend/app/view/agent` (runtime config, `buildRuntimeArgs`, control bar, `/model` + `/effort` slash commands, provider defs), `agentmux-srv/src/backend/providers.rs`
+- **Source:** `docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md` (provider report)
+- **Related:** PR #1411 (landed the `xhigh` effort level + Claude default → Opus/xhigh), provider report §0/§11
+
+---
+
+## 0. One-line
+
+The agent runtime config models a single Claude-only `(model, effort)`, but **every
+provider AgentMux ships now has its own model line and its own reasoning/effort
+knob**. Generalize `model` and `effort` to be **per-provider** — provider-supplied
+choice lists + a per-provider mapping to CLI flags — and refresh the stale values
+(Codex `gpt-5.4` → `gpt-5.5`, gate Claude `--effort` off for Haiku).
+
+### Already landed (PR #1411) — do not redo
+
+- `EffortLevel` gained **`xhigh`** (between `high` and `max`); surfaced in `/effort`, the control-bar dropdown, and `EFFORT_LABELS`.
+- `DEFAULT_RUNTIME_CONFIG`: Claude default → `model: "opus"` (resolves to Opus 4.8 via the CLI), `effort: "xhigh"`.
+
+This spec covers the **remaining** gaps from the report (§11 items 1, 3, 5, 7).
+
+---
+
+## 1. Background — current behavior (code-grounded)
+
+- `AgentRuntimeConfig` (`frontend/app/view/agent/types.ts:528`) is global:
+  `{ permissionMode: PermissionMode, model: ModelChoice, effort: EffortLevel }`.
+- `ModelChoice = "opus" | "sonnet" | "haiku"` (`types.ts:525`) — **Claude names only**.
+- `EffortLevel = "low" | "medium" | "high" | "xhigh" | "max"` (`types.ts:526`).
+- `buildRuntimeArgs.ts` emits flags **Claude-only**:
+  - `--model {model}` only when `!providerId || providerId === "claude"` (`buildRuntimeArgs.ts:100-103`).
+  - `--effort {effort}` only when `!providerId || providerId === "claude"` (`:104-106`).
+  - Codex hardcodes `--model CODEX_DEFAULT_MODEL` = `"gpt-5.4"` (`:38`, `:110-114`), placed before the trailing `-` prompt positional. **No Codex reasoning flag.**
+  - Gemini/Qwen/Kimi: no `--model`, no reasoning flag.
+- The control-bar **model dropdown** (`AgentControlBar.tsx:~290`) and `/model` choices
+  (`commands/global/runtime.ts`) are **hardcoded to opus/sonnet/haiku** regardless of
+  the pane's provider — so for a Codex/Gemini pane the dropdown shows Claude models
+  that are ignored.
+
+### Problems
+
+1. **Model picker is wrong for non-Claude panes** — shows Claude models; the selection is dropped (Codex falls back to a hardcoded default; Gemini/Kimi/Qwen use their CLI default).
+2. **Reasoning is Claude-only** — but Codex (`model_reasoning_effort`) and Gemini (`thinking_level`) have the same kind of knob (report §10). Users can't tune them.
+3. **Stale values** — Codex default `gpt-5.4` (current is `gpt-5.5`); each provider's model line has moved (report §1–§9).
+4. **Effort errors on Haiku** — Claude `--effort` 400s on Haiku 4.5; we emit it unconditionally.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+1. `model` and `effort` become **per-provider**: each provider supplies a model choice list and a reasoning-knob descriptor; the picker + arg builder read from the active provider.
+2. Refresh model lists + defaults to current values (report §1–§9); bump Codex default to `gpt-5.5`.
+3. Emit each provider's reasoning flag correctly (Claude `--effort`, Codex `-c model_reasoning_effort=…`, Gemini `thinking_level`), with the canonical effort scale mapped per provider.
+4. Gate effort by model (skip Claude `--effort` on `haiku`).
+5. Keep the abstraction in `ProviderDefinition`/`ProviderConfig` so adding a provider = adding data, not branches.
+
+**Non-goals**
+- Per-model pricing/context UI (the report is the reference; not surfaced in-app here).
+- OpenClaw / Pi / Copilot / Mux model selection (model is chosen in their own config / ACP; AgentMux passes nothing — leave as today).
+- Migrating stored `agent:runtime` blobs beyond a forward-compatible default (see §3.5).
+
+---
+
+## 3. Design
+
+### 3.1 Per-provider model lists
+
+Add to `ProviderDefinition` (TS, `providers/index.ts:35`) and `ProviderConfig`
+(Rust, `providers.rs:34`):
+
+```ts
+interface ProviderModel { value: string; label: string; default?: boolean }
+// new field on ProviderDefinition:
+models?: ProviderModel[];          // omitted/empty ⇒ provider has no AgentMux-side model picker
+modelFlag?: string | null;         // e.g. "--model"; null ⇒ don't emit (model chosen in provider config)
+```
+
+- `AgentRuntimeConfig.model` becomes a **free `string`** (provider-scoped value), not the
+  Claude `ModelChoice` enum. Keep `ModelChoice` as a Claude-local alias type for clarity,
+  but `runtime.model` is just `string`.
+- The control-bar dropdown and `/model` choices render `provider.models` for the active
+  provider; if `models` is empty, hide the model control.
+- `buildRuntimeArgs`: emit `provider.modelFlag` + `runtime.model` when both are present
+  (replaces the `claude`-only branch and the Codex special-case). The **Codex positional
+  `-` rule still applies** — append model flag before the trailing `-`.
+
+### 3.2 Generalized reasoning / effort
+
+Add a reasoning descriptor to each provider:
+
+```ts
+interface ReasoningSpec {
+  // canonical AgentMux effort values this provider accepts, in display order
+  levels: EffortLevel[];                 // e.g. claude: [low,medium,high,xhigh,max]
+  // how to emit: a flag template; {value} substituted with the mapped provider value
+  emit: { kind: "flag"; flag: string }   // claude: "--effort {value}"
+       | { kind: "config"; key: string } // codex: -c model_reasoning_effort="{value}"
+       | { kind: "flag-eq"; flag: string }; // gemini: "--thinking-level={value}" (verify)
+  // map canonical EffortLevel → provider's wire value (identity unless noted)
+  map?: Partial<Record<EffortLevel, string>>;
+  default?: EffortLevel;
+}
+reasoning?: ReasoningSpec;               // omitted ⇒ no reasoning control for this provider
+```
+
+- The `/effort` command + control-bar effort dropdown render `provider.reasoning.levels`.
+- `buildRuntimeArgs` emits the reasoning arg via `reasoning.emit` with the mapped value;
+  for `config` kind, emit `-c <key>="<value>"` **before** Codex's trailing `-`.
+- Canonical scale stays `low | medium | high | xhigh | max`. Providers that lack a level
+  map it (Gemini has no `xhigh`/`max` → map both to `high`; Gemini has `minimal` → expose
+  as an extra level only on Gemini, or map our `low` → `minimal`/`low` per §6 decision).
+
+### 3.3 Model-gated effort
+
+`reasoning` emission is also gated by model: a provider may declare models for which
+effort must not be sent.
+
+```ts
+// on ProviderModel: noReasoning?: true
+```
+
+Claude `haiku` → `noReasoning: true` (effort 400s on Haiku 4.5). `buildRuntimeArgs` skips
+the reasoning arg when the active model has `noReasoning`. (Also covers `max` being
+invalid on non-Opus — optionally clamp `max`→`xhigh` for `sonnet`; see §8.)
+
+### 3.4 Refreshed values (report §1–§9)
+
+Encode current model lines as `provider.models` (verify each against the CLI before
+pinning — model strings move):
+
+- **claude**: `opus` (default), `sonnet`, `haiku` (+ optional `fable`/most-capable). Aliases → current IDs (Opus 4.8 / Sonnet 4.6 / Haiku 4.5).
+- **codex**: `gpt-5.5` (default), `gpt-5.4`, `gpt-5.1-codex-max`, `gpt-5.3-codex`. **Bump `CODEX_DEFAULT_MODEL` → `gpt-5.5`** (`buildRuntimeArgs.ts:38`) until the picker lands; then drive from `models`.
+- **gemini**: `gemini-3.1-pro`, `gemini-3.5-flash`, `gemini-3-flash`, `gemini-3-deep-think`.
+- **qwen**: `qwen3.6-max-preview`, `qwen3.6-plus`, `qwen3-coder` (OpenRouter ids via `OPENAI_MODEL`).
+- **kimi**: `kimi-k2.6`, `kimi-k2.5`.
+- **muxcode / openclaw / pi / copilot**: no AgentMux-side model list (`models` omitted).
+
+### 3.5 Migration / back-compat
+
+- `getRuntimeConfig` (`buildRuntimeArgs.ts:122`) already falls back to `DEFAULT_RUNTIME_CONFIG`.
+- Stored `agent:runtime.model` values (`"opus"|"sonnet"|"haiku"`) remain valid for Claude.
+- When the active provider's `models` doesn't contain the stored `model`, fall back to that
+  provider's default model (don't pass a foreign model string to a CLI). Same for `effort`
+  not in `reasoning.levels`.
+
+---
+
+## 4. Per-provider matrix (target)
+
+| Provider | Model list (default ⋆) | Reasoning knob | Emit | Notes |
+|---|---|---|---|---|
+| claude | opus⋆, sonnet, haiku | low,medium,high,xhigh,max | `--effort {v}` | gate off on haiku; `max` Opus-only |
+| codex | **gpt-5.5⋆**, gpt-5.4, gpt-5.1-codex-max, gpt-5.3-codex | none,low,medium,high,xhigh | `-c model_reasoning_effort="{v}"` | before trailing `-` |
+| gemini | gemini-3.1-pro, gemini-3.5-flash, gemini-3-flash, gemini-3-deep-think | minimal,low,medium,high | `--thinking-level={v}` *(verify)* | map xhigh/max→high |
+| qwen | qwen3.6-max-preview, qwen3.6-plus, qwen3-coder | (route-dependent) | OpenAI `reasoning_effort` via env/`-c` | OpenRouter-backed |
+| kimi | kimi-k2.6, kimi-k2.5 | — | — | no CLI reasoning flag surfaced |
+| muxcode/openclaw/pi/copilot | — (provider config) | — | — | model chosen in their config / ACP |
+
+> Exact CLI flags (`-c model_reasoning_effort`, gemini `--thinking-level`) must be
+> **verified against each CLI's `--help`** during implementation — flags move between
+> CLI versions. The pinned CLI versions are in the provider defs (`codex 0.116.0`,
+> `gemini-cli 0.32.1`).
+
+---
+
+## 5. Touch points
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/types.ts:525-526` | `model: string` on `AgentRuntimeConfig`; keep `EffortLevel` as the canonical scale |
+| `frontend/app/view/agent/providers/index.ts:35-88` | add `models`, `modelFlag`, `reasoning` to `ProviderDefinition`; populate per provider (§4) |
+| `agentmux-srv/src/backend/providers.rs:34-83` | mirror the new fields on `ProviderConfig` (kept in parity with TS) |
+| `frontend/app/view/agent/buildRuntimeArgs.ts:96-114` | replace Claude-only `--model`/`--effort` + Codex special-case with provider-driven `modelFlag`/`reasoning.emit`; honor `noReasoning`; bump `CODEX_DEFAULT_MODEL`→`gpt-5.5` (interim) |
+| `frontend/app/view/agent/commands/global/runtime.ts` | `/model` + `/effort` choices read the active provider's `models` / `reasoning.levels` |
+| `frontend/app/view/agent/components/AgentControlBar.tsx` | model + effort dropdowns render the active provider's lists; hide when empty |
+
+---
+
+## 6. Phasing
+
+- **P1 — interim refresh (small, low-risk):** bump `CODEX_DEFAULT_MODEL` → `gpt-5.5`; gate Claude `--effort` off for `haiku`. No schema change. (Could ship immediately, like #1411.)
+- **P2 — data model:** add `models`/`modelFlag`/`reasoning` to `ProviderDefinition` + `ProviderConfig`; populate Claude + Codex + Gemini. `model` → `string`.
+- **P3 — wire UI + args:** picker reads provider lists; `buildRuntimeArgs` emits per-provider model + reasoning; back-compat fallback (§3.5).
+- **P4 — remaining providers:** qwen reasoning via OpenRouter; verify/confirm flags; Gemini `minimal` handling.
+
+---
+
+## 7. Testing
+
+- Unit (`buildRuntimeArgs`): for each provider, assert the emitted argv — Claude `--effort xhigh` (and **absent** for `haiku`); Codex `-c model_reasoning_effort="high"` placed **before** the trailing `-`; Gemini thinking-level flag; non-Claude panes get their own model, never a Claude alias.
+- Back-compat: a stored `{model:"opus", effort:"xhigh"}` on a Codex pane falls back to Codex defaults, not `--model opus`.
+- Manual (`task dev`): switch a pane's provider → model/effort dropdowns repopulate; pick a model/effort → correct flag reaches the CLI (check `muxlog srv`); a real turn runs on each of claude/codex/gemini.
+
+## 8. Open questions
+
+1. **Gemini effort granularity** — expose `minimal` as a Gemini-only level, or map our `low`→`minimal`? (Keeps the canonical scale 5-wide vs. per-provider extra.)
+2. **`max` on non-Opus Claude** — clamp `max`→`xhigh` for `sonnet` (effort `max` is Opus-tier only), or just document it?
+3. **Codex reasoning surface** — confirm `-c model_reasoning_effort="…"` is the stable CLI path vs. a dedicated flag in `codex 0.116.0`.
+4. **Qwen** — does the OpenRouter route honor `reasoning_effort`, and is it set via env (`OPENAI_*`) or `-c`?

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -32,10 +32,12 @@ const PERMISSION_STRIP = new Set([
 
 // Default codex model. The Claude-named `ModelChoice` (opus/sonnet/haiku) does
 // not apply to codex, and codex 0.116.0's baked default (gpt-5.3-codex) is
-// rejected for ChatGPT-account auth. gpt-5.4 is a current ChatGPT-supported
-// codex model. Per-provider model selection is a follow-up — see
-// docs/analysis/CODEX_AGENT_LAUNCH_DOA_2026_06_02.md.
-const CODEX_DEFAULT_MODEL = "gpt-5.4";
+// rejected for ChatGPT-account auth. gpt-5.5 is the current ChatGPT-supported
+// codex frontier (more intelligent + more token-efficient than gpt-5.4).
+// Per-provider model selection is a follow-up — see
+// docs/specs/SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md
+// (re-verify ChatGPT-account availability when bumping the codex CLI pin).
+const CODEX_DEFAULT_MODEL = "gpt-5.5";
 
 /**
  * Build final CLI args from base provider args and runtime config.
@@ -101,7 +103,10 @@ export function buildRuntimeArgs(
     if (supportsModel) {
         args.push("--model", config.model);
     }
-    if (!providerId || providerId === "claude") {
+    // --effort: claude only, and NOT on Haiku — `--effort` 400s on Haiku 4.5
+    // (effort is supported on Opus/Sonnet only). Skip it so a `haiku` pane
+    // doesn't error out on every turn.
+    if ((!providerId || providerId === "claude") && config.model !== "haiku") {
         args.push("--effort", config.effort);
     }
 


### PR DESCRIPTION
## What

**P1** of the provider models/effort generalization — a small, no-schema slice from `docs/specs/SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md` (ships immediately, like #1411):

- **`buildRuntimeArgs`**: `CODEX_DEFAULT_MODEL` `gpt-5.4` -> **`gpt-5.5`** (current ChatGPT-supported Codex frontier).
- **`buildRuntimeArgs`**: **gate Claude `--effort` off when model is `haiku`** — effort is Opus/Sonnet-only and **400s on Haiku 4.5**, so a `haiku` pane errored on every turn.

Also lands the **design spec** and the **provider reference report** it draws from (`docs/specs/` + `docs/providers/`).

## Why

From the provider report (latest model/effort survey): Codex `gpt-5.4` is stale, and Anthropic effort levels error on Haiku.

## Notes

- Frontend-only, type-clean (`tsc`). `patch` changeset included.
- The Codex bump assumes `gpt-5.5` is ChatGPT-account-available in `codex 0.116.0` (the current frontier in Codex); comment flags re-verification on CLI pin bumps. Easy revert if an account tier lacks it.
- Remaining phases (per-provider model lists, generalized reasoning for Codex `model_reasoning_effort` + Gemini `thinking_level`) are in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)