### PR TITLE
feat(tabs): content-aware tab sizing (VS Code shrink model)

### DIFF
--- a/.changesets/1781493584-feat-tab-content-aware-sizing.md
+++ b/.changesets/1781493584-feat-tab-content-aware-sizing.md
@@ -1,0 +1,1 @@
+feat(tabs): content-aware tab sizing — measure label text, size each tab to fit (VS Code shrink model)

--- a/.changesets/1781493584-feat-tab-content-aware-sizing.md
+++ b/.changesets/1781493584-feat-tab-content-aware-sizing.md
@@ -1,1 +1,5 @@
+---
+type: minor
+---
+
 feat(tabs): content-aware tab sizing — measure label text, size each tab to fit (VS Code shrink model)

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -5,7 +5,7 @@ import { Logger } from "@/util/logger";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import { isWindows } from "@/util/platformutil";
-import { createMemo, onCleanup, onMount } from "solid-js";
+import { createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import clsx from "clsx";
 import { Tab } from "./tab";
@@ -21,7 +21,6 @@ import {
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { getApi } from "@/store/global";
-import { createSignal } from "solid-js";
 import { setTabGrabOffset } from "./tab-grab-offset";
 
 export interface DroppableTabProps {
@@ -41,6 +40,7 @@ export interface DroppableTabProps {
 export function DroppableTab(props: DroppableTabProps): JSX.Element {
     let tabWrapRef!: HTMLDivElement;
     const [isDragging, setIsDragging] = createSignal(false);
+    const [naturalWidth, setNaturalWidth] = createSignal<number | null>(null);
 
     // Gap before (left padding) — this tab is the afterTabId of the insertion point
     const gapBefore = createMemo(() => {
@@ -160,6 +160,9 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
             style={{
                 "padding-left": `${gapBefore()}px`,
                 "padding-right": `${gapAfter()}px`,
+                ...(naturalWidth() != null
+                    ? { "--tab-natural-width": `${naturalWidth()}px` }
+                    : {}),
             } as JSX.CSSProperties}
         >
             <Tab
@@ -174,6 +177,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 onClose={props.onClose}
                 onDragStart={() => {}}
                 onLoaded={() => {}}
+                onNaturalWidth={setNaturalWidth}
             />
         </div>
     );

--- a/frontend/app/tab/tab-measure.ts
+++ b/frontend/app/tab/tab-measure.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Singleton canvas for layout-free text measurement — synchronous,
+// no DOM reflow, safe to call on every label change.
+let _ctx: CanvasRenderingContext2D | null = null;
+
+function getCtx(): CanvasRenderingContext2D | null {
+    if (_ctx) return _ctx;
+    try {
+        const canvas = document.createElement("canvas");
+        _ctx = canvas.getContext("2d");
+    } catch {
+        _ctx = null;
+    }
+    return _ctx;
+}
+
+// Non-text width budget:
+//   6px left-pad + 6px right-pad + 4px gap + 16px close-btn + 4px slack = 36px
+const TAB_PADDING_BUDGET = 36;
+export const TAB_MIN_WIDTH = 60;
+export const TAB_MAX_WIDTH = 260;
+
+const DEFAULT_TAB_WIDTH = 160;
+
+/**
+ * Measures the natural pixel width for a workspace tab with the given label.
+ * Uses a hidden canvas (no DOM reflow). Returns a clamped value ready to set
+ * as `--tab-natural-width` on the `.tab-drop-wrapper` element.
+ */
+export function measureTabWidth(label: string): number {
+    const ctx = getCtx();
+    if (!ctx) return DEFAULT_TAB_WIDTH;
+
+    // Read the font from the document root so it stays in sync with theme changes.
+    const font = getComputedStyle(document.documentElement).font || "11px system-ui";
+    ctx.font = font;
+
+    const textWidth = ctx.measureText(label).width;
+    const natural = Math.ceil(textWidth) + TAB_PADDING_BUDGET;
+    return Math.min(Math.max(natural, TAB_MIN_WIDTH), TAB_MAX_WIDTH);
+}

--- a/frontend/app/tab/tab-measure.ts
+++ b/frontend/app/tab/tab-measure.ts
@@ -33,9 +33,11 @@ export function measureTabWidth(label: string): number {
     const ctx = getCtx();
     if (!ctx) return DEFAULT_TAB_WIDTH;
 
-    // Read the font from the document root so it stays in sync with theme changes.
-    const font = getComputedStyle(document.documentElement).font || "11px system-ui";
-    ctx.font = font;
+    // `.font` shorthand is not serialized by Chromium — always returns "".
+    // Read fontFamily explicitly and pair with the tab label's hardcoded
+    // font-size/weight (11px 400, from tab.scss .name).
+    const fontFamily = getComputedStyle(document.documentElement).fontFamily || "system-ui";
+    ctx.font = `400 11px ${fontFamily}`;
 
     const textWidth = ctx.measureText(label).width;
     const natural = Math.ceil(textWidth) + TAB_PADDING_BUDGET;

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -47,7 +47,7 @@
         white-space: nowrap;
         border-radius: 0;
         // Bound min-width so the flex-shrink contract on `.tab`
-        // (`flex: 0 1 var(--ws-tab-basis)`) actually propagates here.
+        // (`flex: 0 1 var(--tab-natural-width, 160px)`) actually propagates here.
         // Without this, `.tab-inner`'s default `min-width: auto`
         // pins it to its content's natural width, so a shrinking
         // `.tab` would clip the inner row from the right edge

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -16,7 +16,7 @@
     // tabbar.scss) no matter what.
     width: auto;
     min-width: 0;
-    max-width: var(--ws-tab-max, 200px);
+    max-width: var(--ws-tab-max, 260px);
     height: 100%;
     padding: 0 0 0 0;
     box-sizing: border-box;

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -12,6 +12,7 @@ import { Portal } from "solid-js/web";
 import type { JSX } from "solid-js";
 import { ObjectService } from "../store/services";
 import { makeORef, useWaveObjectValue } from "../store/wos";
+import { measureTabWidth } from "./tab-measure";
 import "./tab.scss";
 
 // 10 equally-spaced hues (0°, 36°, 72°, … 324°) — full spectrum, no near-duplicates
@@ -114,6 +115,7 @@ interface TabProps {
     onClose: (event: MouseEvent | null) => void;
     onDragStart: (event: DragEvent) => void;
     onLoaded: () => void;
+    onNaturalWidth?: (width: number) => void;
 }
 
 function Tab(props: TabProps): JSX.Element {
@@ -134,6 +136,13 @@ function Tab(props: TabProps): JSX.Element {
         const name = tabData()?.name;
         if (name) {
             setOriginalName(name);
+        }
+    });
+
+    createEffect(() => {
+        const name = tabData()?.name;
+        if (name && props.onNaturalWidth) {
+            props.onNaturalWidth(measureTabWidth(name));
         }
     });
 

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -4,25 +4,18 @@
 @use "../mixins.scss";
 
 .tab-bar {
-    // Workspace tabs adopt editor-tab-style sizing: each tab targets a
-    // preferred basis and shrinks with per-tab ellipsis when the row gets
-    // crowded, instead of staying at content-width and triggering horizontal
-    // scroll. Floor is `--ws-tab-min`; once every tab is at the floor and the
-    // row still overflows, `.tab-bar-scroll`'s `overflow-x: auto` re-engages
-    // as the safety net (no tabs are hidden — workspace tabs are
-    // unrecoverable from the bar today, unlike editor tabs which clip).
-    // Spec: specs/SPEC_WORKSPACE_TAB_SIZING_2026-05-27.md.
-    // Basis ~ VS Code "fit" mode default (~240px) — enough room for
-    // ~25 chars of file/title before ellipsis. Floor at 56px is the
-    // thin end a crowded tab shrinks to (a few chars + ellipsis) once
-    // widget labels have collapsed, before the scroll safety-net. Cap
-    // at 320px so a near-empty bar with one or two tabs still gives
-    // each tab a generous ~30-char window. Editor tabs run narrower
-    // (140 basis) because the editor pane itself is narrower than
-    // the workspace title bar.
-    --ws-tab-basis: 240px;
-    --ws-tab-min: 56px;
-    --ws-tab-max: 320px;
+    // Content-aware tab sizing (VS Code model): each tab's preferred width
+    // is measured from its label text via canvas.measureText() and injected
+    // as `--tab-natural-width` inline style on the wrapper by DroppableTab.
+    // This matches VS Code's "shrink" mode — short labels get narrow tabs,
+    // long labels get wide tabs, and all shrink proportionally under pressure.
+    // Spec: specs/SPEC_TAB_CONTENT_AWARE_SIZING_2026-06-14.md.
+    //
+    // `--tab-natural-width` fallback (160px) covers the initial paint before
+    // JS has run a measurement. Floor at 60px keeps the close button reachable.
+    // Cap at 260px prevents very long labels from dominating the bar.
+    --ws-tab-min: 60px;
+    --ws-tab-max: 260px;
 
     display: flex;
     flex-direction: row;
@@ -59,15 +52,16 @@
         }
 
         // Override tab.scss absolute positioning — render tabs in flex flow.
-        // grow=1 so tabs fill the bar's available width when there's
-        // room (matches VS Code "fit" mode with few tabs); shrink=1
-        // lets `.name`'s `text-overflow: ellipsis` trip once the bar
-        // gets crowded. Width is bounded by `--ws-tab-max` so a near-
-        // empty bar still doesn't blow tabs up absurdly wide.
+        // Each tab uses its measured natural width as flex-basis (set by
+        // DroppableTab as `--tab-natural-width`). grow=0 so tabs don't
+        // sprawl to fill slack — the `.tab-bar-fill` filler absorbs that.
+        // shrink=1 so all tabs compress proportionally under overflow;
+        // `.name`'s `text-overflow: ellipsis` trips once the tab narrows
+        // past its text. The 160px fallback covers initial paint before JS.
         .tab {
             position: relative;
             opacity: 1;
-            flex: 1 1 var(--ws-tab-basis);
+            flex: 0 1 var(--tab-natural-width, 160px);
             min-width: var(--ws-tab-min);
             max-width: var(--ws-tab-max);
             overflow: hidden;
@@ -118,11 +112,11 @@
     // once all tabs hit the floor and there's still overflow.
     .tab-drop-wrapper {
         position: relative;
-        // grow=1 so tabs fill the bar when there's room (matches VS
-        // Code's "fit" mode behavior with few tabs). Cap at
-        // `--ws-tab-max` so a near-empty bar still doesn't blow tabs
-        // up absurdly wide.
-        flex: 1 1 var(--ws-tab-basis);
+        // Wrapper mirrors the inner .tab sizing contract so both shrink
+        // in lockstep. `--tab-natural-width` is set as an inline style
+        // by DroppableTab once Tab fires onNaturalWidth; falls back to
+        // 160px until JS measures the label.
+        flex: 0 1 var(--tab-natural-width, 160px);
         min-width: var(--ws-tab-min);
         max-width: var(--ws-tab-max);
         display: flex;

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -290,7 +290,7 @@ const ActionWidgets = (): JSX.Element => {
     // Minimum tab strip reserved before widget labels are dropped (tier 1→2).
     const MIN_TAB_WIDTH = 120;
     // Per-tab comfortable width — labels collapse when each tab would fall
-    // below this. Deliberately above --ws-tab-min (56 px) so labels drop
+    // below this. Deliberately above --ws-tab-min (60 px) so labels drop
     // first, then tabs continue shrinking.
     const TAB_COLLAPSE_RESERVE_PX = 100;
     // Tighter reserves used for the tier 2→3 threshold (icon-only bar is

--- a/specs/SPEC_TAB_CONTENT_AWARE_SIZING_2026-06-14.md
+++ b/specs/SPEC_TAB_CONTENT_AWARE_SIZING_2026-06-14.md
@@ -1,0 +1,205 @@
+# Spec: Content-Aware Tab Sizing (VS Code Model)
+
+**Date:** 2026-06-14  
+**Status:** Draft  
+**Repo state:** `main` @ `4203a59e`  
+**Scope:** Workspace tab bar (`.tab-bar`) only. Editor tab strip is out of scope.
+
+---
+
+## 1. Problem
+
+The current model (`flex: 1 1 240px` on `.tab-drop-wrapper` and `.tab`) uses a **uniform fixed basis** for every tab regardless of label length. This produces two failure modes:
+
+- **Few tabs, short names** — tabs grow to fill the bar (`flex-grow: 1` active), stretching a 4-char label to 320 px. The empty space looks broken.
+- **Many tabs, mixed names** — all tabs shrink by the same factor. A 3-char label gets the same width as a 24-char label; the short one wastes space while the long one ellipsizes unnecessarily early.
+
+VS Code solves this by sizing each tab to **fit its own content**: measure the label text, add a fixed padding budget for icons and the close button, and set that as each tab's preferred width. Uniform shrink only kicks in when the bar overflows.
+
+---
+
+## 2. How VS Code Does It
+
+VS Code's tab sizing lives in `src/vs/workbench/browser/parts/editor/tabsTitleControl.ts`.
+
+### 2.1 Natural width per tab
+
+```
+naturalWidth = measureText(label) + ICON_WIDTH + CLOSE_WIDTH + H_PADDING
+```
+
+Where (from VS Code source, `editorLabel` metrics):
+
+| Component | Width | Notes |
+|---|---|---|
+| Label text | `canvas.measureText(label, font).width` | Measured at the tab's font (13 px `--vscode-font-family`) |
+| Icon | ~16 px | File-type icon; 0 if no icon |
+| Close button | 28 px | Hit area; hidden for inactive pinned tabs |
+| Horizontal padding | 18 px each side → **36 px total** | `padding: 0 9px` × 2 sides from `.tab` CSS |
+
+**Capped** at `[TAB_MIN_WIDTH, TAB_MAX_WIDTH]` after measurement.
+
+VS Code constants (from `tabsTitleControl.ts`):
+```ts
+const TAB_MIN_WIDTH = 50;   // px — just enough for icon + close
+const TAB_MAX_WIDTH = 160;  // px — "shrink" mode cap; "fit" mode has no max
+```
+
+### 2.2 When widths are (re)calculated
+
+VS Code recalculates on:
+- Editor opens or closes
+- Label changes (dirty marker `•`, rename)
+- Bar resizes (`ResizeObserver` on the tab strip container)
+- Zoom level change
+
+### 2.3 Overflow strategy
+
+Each tab gets its natural width as an explicit `width` style. When the total exceeds the strip:
+
+1. **Shrink mode (default in recent VS Code):** divide each tab's natural width by the overflow ratio — every tab shrinks proportionally. Short labels give up fewer pixels than long ones. Labels ellipsize inside the shrunk width.
+2. **Fixed mode:** all tabs are the same width, shrunk uniformly. Preferred for users who click the close button repeatedly at the same position.
+
+AgentMux already has a `SPEC_WORKSPACE_TAB_SIZING_2026-05-27.md` that picked a fixed basis (`160–240 px`). This spec supersedes it for the natural-width dimension: the basis is now **per-tab** (content-driven), not a global constant.
+
+---
+
+## 3. Proposed AgentMux Implementation
+
+### 3.1 Measurement
+
+Use a **hidden canvas** (singleton, mounted once) to measure label text width at the tab's actual rendered font. Canvas `measureText` is synchronous, layout-free, and cheap enough to call on every label change.
+
+```ts
+// frontend/app/tab/tab-measure.ts
+
+const _canvas = document.createElement('canvas');
+const _ctx = _canvas.getContext('2d')!;
+
+/** Returns the natural pixel width for a workspace tab with the given label. */
+export function measureTabWidth(label: string): number {
+  _ctx.font = getComputedStyle(document.documentElement)
+    .getPropertyValue('--tab-font') || '13px system-ui';
+  const textWidth = _ctx.measureText(label).width;
+  return clamp(
+    Math.ceil(textWidth) + TAB_PADDING_BUDGET,
+    TAB_MIN_WIDTH,
+    TAB_MAX_WIDTH,
+  );
+}
+
+const TAB_PADDING_BUDGET = 72; // 18px h-pad × 2 + 16px icon + 20px close
+const TAB_MIN_WIDTH      = 72; // icon + close + 3-char visible stub
+const TAB_MAX_WIDTH      = 260; // generous max; ~26 chars at 13px system-ui
+```
+
+### 3.2 CSS contract
+
+Replace the global `--ws-tab-basis: 240px` with a **per-tab inline style** carrying the measured width as `--tab-natural-width`:
+
+```tsx
+// droppable-tab.tsx (or tab.tsx) — add to inline style
+style={{ '--tab-natural-width': `${naturalWidth}px`, ...existingStyle }}
+```
+
+```scss
+// tabbar.scss
+
+.tab-drop-wrapper {
+  flex: 0 1 var(--tab-natural-width, 160px);  // natural width as basis; no grow
+  min-width: var(--ws-tab-min);               // 72px floor
+  max-width: var(--ws-tab-max);               // 260px ceiling (redundant safety)
+  // ... rest unchanged
+}
+
+.tab-bar-scroll .tab {
+  flex: 0 1 var(--tab-natural-width, 160px);
+  min-width: var(--ws-tab-min);
+  max-width: var(--ws-tab-max);
+  overflow: hidden;
+  // ... rest unchanged
+}
+```
+
+Keep `flex-grow: 0` — tabs **do not grow** into free space. The `.tab-bar-fill` filler (`flex: 1 1 auto`) absorbs slack to the right of the last tab, as today.
+
+### 3.3 Shrink strategy (bar overflow)
+
+CSS flex handles this without JS: when the sum of all `--tab-natural-width` bases exceeds the scroll container, each tab shrinks proportionally (`flex-shrink: 1`) toward `--ws-tab-min`. Labels ellipsize via the existing `.name { text-overflow: ellipsis }` rule.
+
+This is VS Code's **shrink mode** — the effective width of each tab under pressure is proportional to its natural width, so a short-name tab gives up fewer pixels than a long-name tab.
+
+Once every tab is at `--ws-tab-min` and the row still overflows, `.tab-bar-scroll { overflow-x: auto }` re-engages as the safety net. No tabs are hidden.
+
+### 3.4 Recalculation triggers
+
+| Event | Action |
+|---|---|
+| Tab label changes (rename, dirty mark) | Re-measure the affected tab only |
+| Tab added or removed | Re-measure the new tab; others unchanged |
+| Zoom level change (`--zoomfactor`) | Re-measure all tabs (font px changes) |
+| `ResizeObserver` on `.tab-bar-scroll` | No re-measure needed; CSS flex handles reflow |
+
+### 3.5 Fallback (no JS)
+
+The CSS fallback `var(--tab-natural-width, 160px)` means tabs render at 160 px until JS has run. This matches the prior fixed-basis behavior and avoids a layout jump on initial paint if measurement is deferred one frame.
+
+---
+
+## 4. Token Summary
+
+| Token | Value | Set by |
+|---|---|---|
+| `--tab-natural-width` | measured per tab | JS (inline style on `.tab-drop-wrapper`) |
+| `--ws-tab-min` | `72px` | `.tab-bar` CSS |
+| `--ws-tab-max` | `260px` | `.tab-bar` CSS |
+| `TAB_PADDING_BUDGET` | `72px` | `tab-measure.ts` constant |
+
+---
+
+## 5. Files Touched
+
+| File | Change |
+|---|---|
+| `frontend/app/tab/tab-measure.ts` | **New** — canvas measurement helper |
+| `frontend/app/tab/droppable-tab.tsx` | Pass `--tab-natural-width` as inline CSS var; call `measureTabWidth(label)` in an effect |
+| `frontend/app/tab/tabbar.scss` | Replace `--ws-tab-basis: 240px` global with per-tab var; update `--ws-tab-min/max` tokens |
+| `frontend/app/tab/tab.scss` | Update `max-width` fallback to match new max |
+
+No Rust changes. No RPC changes. No prop-shape changes (dead `tabWidth` prop stays untouched).
+
+---
+
+## 6. Before / After
+
+| Scenario | Before (fixed 240px basis) | After (content-aware) |
+|---|---|---|
+| 2 tabs, short names ("A", "B") | Each grows to ~320px — bar looks half-empty | Each sits at ~90px natural width |
+| 5 tabs, mixed lengths | All shrink uniformly regardless of length | Long-name tabs shrink more; short ones hold their width |
+| 12 tabs | All hit 56px floor immediately | Natural widths allow more tabs before hitting the floor |
+| Rename to longer name | All neighbours jump as bar reflows | Only the renamed tab's width changes |
+
+---
+
+## 7. Verification Checklist
+
+1. Single tab, 3-char name — tab width ≈ `measureText("abc") + 72px`, not 240px.
+2. Single tab, 24-char name — tab width ≈ natural; capped at 260px.
+3. Two tabs, different lengths — widths are visibly different.
+4. Open tabs until bar overflows — tabs shrink proportionally, not uniformly.
+5. Rename a tab — only that tab's width changes; neighbours don't jump.
+6. All tabs at min floor, still overflow — horizontal scroll re-engages.
+7. Zoom in (`--zoomfactor` = 1.25) — widths recalculate; no layout gap or overlap.
+8. Widget bar (`ActionWidgets`) visually unchanged.
+9. Drag-to-reorder still lands in the correct gap (DnD reads `getBoundingClientRect`, variable widths already work).
+10. Tear-off still triggers past the 5px threshold.
+
+---
+
+## 8. References
+
+- VS Code `tabsTitleControl.ts` — `computeTabLabels`, `redrawTab`, tab width calculation
+- `SPEC_WORKSPACE_TAB_SIZING_2026-05-27.md` — prior fixed-basis spec (superseded by §3 here)
+- `frontend/app/tab/tabbar.scss` — current flex contract
+- `docs/retros/RETRO_TAB_GAPS_ARCHITECTURE_ANALYSIS_2026_04_25.md` — why old JS-width approach failed (avoid repeating)
+- MDN `CanvasRenderingContext2D.measureText()` — layout-free text measurement


### PR DESCRIPTION
## Summary

- Replaces the uniform `240px` flex-basis with **per-tab natural widths** measured via `canvas.measureText(label)` in a new `tab-measure.ts` helper
- Each tab's preferred width = `ceil(textWidth) + 36px` (h-padding + gap + close button), clamped to `[60px, 260px]`
- `DroppableTab` receives the measured width via `onNaturalWidth` callback from `Tab` and injects it as `--tab-natural-width` inline CSS var on the wrapper
- `tabbar.scss` uses `flex: 0 1 var(--tab-natural-width, 160px)` on both `.tab-drop-wrapper` and `.tab` — tabs don't grow into slack, but shrink proportionally under overflow (VS Code "shrink" mode)
- Short labels get narrow tabs; long labels get wider tabs; all ellipsize from their natural width under crowding

## Before / After

| Scenario | Before | After |
|---|---|---|
| 2 tabs, short names | Each grows to ~320px — bar looks half-empty | Each sits at natural width (~90px for "A") |
| Mixed-length tabs | All shrink uniformly | Long names shrink more; short ones hold width |
| Rename a tab | All neighbours jump | Only renamed tab's width changes |

## Files

- `frontend/app/tab/tab-measure.ts` — new canvas measurement helper
- `frontend/app/tab/tab.tsx` — adds `onNaturalWidth` prop + measurement effect
- `frontend/app/tab/droppable-tab.tsx` — holds `naturalWidth` signal, injects CSS var
- `frontend/app/tab/tabbar.scss` — switches to `--tab-natural-width` flex-basis
- `frontend/app/tab/tab.scss` — updates `max-width` fallback to 260px
- `specs/SPEC_TAB_CONTENT_AWARE_SIZING_2026-06-14.md` — design spec

## Test plan

- [ ] Single tab, 3-char name → tab width ≈ natural (narrow, not 240px)
- [ ] Single tab, 24-char name → tab width ≈ natural, capped at 260px
- [ ] Two tabs with different label lengths → visibly different widths
- [ ] Open tabs until bar overflows → proportional shrink, labels ellipsize
- [ ] Rename a tab → only that tab's width changes
- [ ] All tabs at 60px floor, still overflow → horizontal scroll re-engages
- [ ] Zoom change → widths recalculate correctly
- [ ] Drag-to-reorder still works (DnD reads getBoundingClientRect, unaffected)
- [ ] Widget bar visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)