### PR TITLE
feat(build): release-time BeginWindowDrag-patch gate for Linux libcef.so

### DIFF
--- a/.changesets/1781494069-feat-build-add-release-time-beginwindowdrag-patch-gate-for-l-z63w.md
+++ b/.changesets/1781494069-feat-build-add-release-time-beginwindowdrag-patch-gate-for-l-z63w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(build): add release-time BeginWindowDrag-patch gate for Linux libcef.so (verify-cef-patch.sh) — advisory in bundle:linux, hard gate in build-appimage-linux.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -631,6 +631,10 @@ tasks:
                 # See docs/specs/patched-libcef-bundling-2026-05-08.md.
                 CEF_DIR="$(bash scripts/resolve-cef-runtime.sh)"
                 echo "Using CEF runtime from: $CEF_DIR"
+                # Advisory BeginWindowDrag-patch check — non-fatal here so `task dev`
+                # still works on the upstream cef-dll-sys fallback (no 3-hour CEF
+                # build required). The hard release gate is in build-appimage-linux.sh.
+                bash scripts/verify-cef-patch.sh "$CEF_DIR" || true
                 mkdir -p dist/cef/locales
                 cp -f "$CEF_DIR/libcef.so" dist/cef/
                 cp -f "$CEF_DIR/libEGL.so" dist/cef/ 2>/dev/null || true

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -174,6 +174,20 @@ out/Release_GN_x64/cefsimple --no-sandbox --url=https://example.com
 
 A window with example.com proves the libcef is functional. (The `BeginWindowDrag` patch isn't exercised by cefsimple — verification of THAT happens via `task package:linux` + the AgentMux app.)
 
+To check the patch is present without launching anything:
+
+```bash
+bash scripts/verify-cef-patch.sh ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64
+# exit 0 = patched · exit 1 = unpatched upstream · exit 2 = stripped (run on the unstripped build)
+```
+
+`task bundle:linux` runs this **advisorily** (a warning, so `task dev` still works on the
+upstream cef-dll-sys fallback); `scripts/build-appimage-linux.sh` runs it as a **hard
+release gate** that refuses to package an AppImage whose libcef.so lacks the patch.
+The symbol it keys on (`window_begin_window_drag_<apiver>`) lives in `.symtab` — present
+in the unstripped build, gone after `strip` — so the gate must (and does) run **before**
+the packaging strip. Override the gate with `AGENTMUX_SKIP_CEF_PATCH_CHECK=1` (emergency only).
+
 ---
 
 ## Using the built libcef in AgentMux

--- a/scripts/build-appimage-linux.sh
+++ b/scripts/build-appimage-linux.sh
@@ -74,6 +74,40 @@ require target/release/agentmux-mcp
 # the build output to keep packaging reproducible from a fresh checkout.
 require dist/frontend/index.html
 
+# --- Release gate: the bundled libcef.so MUST carry the BeginWindowDrag patch,
+#     or left-click window drag silently no-ops in the shipped AppImage (the
+#     runtime ABI guard only surfaces it after the user clicks). The symbol check
+#     needs an UNSTRIPPED .so: dist/cef/libcef.so is unstripped at this point in the
+#     canonical `task package:linux` flow (bundle:linux copies the build-tree output;
+#     the strip below runs on the AppDir copy). If dist/cef was pre-stripped
+#     out-of-band, fall back to verifying the resolved build-tree source. This is
+#     release-only — `task dev`/`task bundle` never run this script. Override with
+#     AGENTMUX_SKIP_CEF_PATCH_CHECK=1 (emergency only). ---
+if [ "${AGENTMUX_SKIP_CEF_PATCH_CHECK:-0}" != "1" ]; then
+    set +e
+    bash "$REPO_ROOT/scripts/verify-cef-patch.sh" dist/cef/libcef.so
+    patch_rc=$?
+    if [ "$patch_rc" = "2" ]; then
+        echo "→ dist/cef/libcef.so couldn't be verified (stripped?); checking the resolved source…" >&2
+        cef_src="$(bash "$REPO_ROOT/scripts/resolve-cef-runtime.sh" 2>/dev/null || true)"
+        if [ -n "$cef_src" ]; then
+            bash "$REPO_ROOT/scripts/verify-cef-patch.sh" "$cef_src"
+            patch_rc=$?
+        fi
+    fi
+    set -e
+    case "$patch_rc" in
+        0) echo "✓ libcef.so carries the BeginWindowDrag patch" ;;
+        1) echo "ERROR: bundled libcef.so lacks the BeginWindowDrag patch — refusing to" >&2
+           echo "       package a release with broken left-click window drag. Build the" >&2
+           echo "       patched libcef (docs/cef-build/build-patched-libcef.md) or set" >&2
+           echo "       AGENTMUX_SKIP_CEF_PATCH_CHECK=1 to override." >&2
+           exit 1 ;;
+        *) echo "WARNING: could not verify the BeginWindowDrag patch (stripped runtime and" >&2
+           echo "         no unstripped source to check). Proceeding — verify drag manually." >&2 ;;
+    esac
+fi
+
 echo "Building AgentMux v$VERSION AppImage → $OUTPUT"
 
 # --- 1. Wipe and recreate AppDir ---

--- a/scripts/verify-cef-patch.sh
+++ b/scripts/verify-cef-patch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Verify a Linux libcef.so carries AgentMux's BeginWindowDrag patch.
+#
+# Why
+# ---
+# Left-click window drag on Linux calls CefWindow::BeginWindowDrag() via raw FFI
+# (agentmux-cef/src/ui_tasks.rs). That struct slot exists ONLY in a libcef.so built
+# from the a5af/cef fork (branch agentmux/7680-…). Bundle the upstream prebuilt CEF
+# instead and drag silently no-ops — the runtime ABI guard catches it, but only
+# after the user clicks the title bar and nothing happens. This is the build/
+# release-time guard that catches a regressed (unpatched) runtime before shipping.
+#
+# Detection
+# ---------
+# The patch compiles in the symbols `CefWindowImpl::BeginWindowDrag` and the CppToC
+# wrapper `window_begin_window_drag_<apiver>`. Their (mangled) names contain the
+# literal strings "BeginWindowDrag" / "begin_window_drag" and live in `.symtab` —
+# present in the UNSTRIPPED build output, GONE after `strip --strip-debug/-all`.
+# So this check is only meaningful on the unstripped runtime (the cef-build tree, or
+# dist/cef/libcef.so freshly copied by `task bundle:linux`), BEFORE packaging strips
+# it. A stripped .so has no symbol table and cannot be verified this way (exit 2).
+#
+# Usage:  verify-cef-patch.sh <runtime-dir | libcef.so path>
+# Exit:   0  patch present (symbol found)
+#         1  UNPATCHED — symbol table present but no BeginWindowDrag slot (the
+#            upstream prebuilt CEF; drag will silently no-op)
+#         2  cannot verify — stripped .so, missing file, or no nm/readelf available
+#
+# NOTE: no `set -o pipefail` — `grep -q` short-circuits on first match and SIGPIPEs
+# the symbol reader, which pipefail would surface as a spurious pipeline failure.
+set -eu
+
+arg="${1:-}"
+if [ -z "$arg" ]; then
+    echo "usage: verify-cef-patch.sh <runtime-dir | libcef.so>" >&2
+    exit 2
+fi
+if [ -d "$arg" ]; then SO="$arg/libcef.so"; else SO="$arg"; fi
+if [ ! -f "$SO" ]; then
+    echo "verify-cef-patch: libcef.so not found at $SO" >&2
+    exit 2
+fi
+
+PATTERN='BeginWindowDrag|begin_window_drag'
+
+# Pick a symbol reader: nm preferred, readelf -sW as fallback. Both emit the
+# (mangled) .symtab names that still contain the literal patch symbol.
+if command -v nm >/dev/null 2>&1; then
+    read_syms() { nm "$SO" 2>/dev/null; }
+elif command -v readelf >/dev/null 2>&1; then
+    read_syms() { readelf -sW "$SO" 2>/dev/null; }
+else
+    echo "verify-cef-patch: neither nm nor readelf available — cannot verify $SO" >&2
+    exit 2
+fi
+
+if read_syms | grep -qE "$PATTERN"; then
+    echo "verify-cef-patch: ✓ $SO carries the BeginWindowDrag patch" >&2
+    exit 0
+fi
+
+# No match. Distinguish "has symbols but unpatched" from "stripped (no symtab)".
+if read_syms | grep -q .; then
+    echo "verify-cef-patch: ✗ $SO has a symbol table but NO BeginWindowDrag slot." >&2
+    echo "                  This is the UNPATCHED upstream CEF — left-click window drag" >&2
+    echo "                  will silently no-op. Build the patched libcef" >&2
+    echo "                  (docs/cef-build/build-patched-libcef.md), or point" >&2
+    echo "                  AGENTMUX_CEF_RUNTIME_DIR at a patched Release_GN_x64." >&2
+    exit 1
+fi
+
+echo "verify-cef-patch: ? $SO is stripped (no symbol table) — cannot verify the" >&2
+echo "                  BeginWindowDrag patch by symbol. Run the check on the UNSTRIPPED" >&2
+echo "                  build output (the patch check must precede the packaging strip)." >&2
+exit 2


### PR DESCRIPTION
## Why

Closes the last open item from the slim-libcef work (#1406, #1408): nothing forced a check that the shipped `libcef.so` still carries AgentMux's **BeginWindowDrag** patch. Bundle the upstream prebuilt CEF (the cef-dll-sys cargo-cache fallback) and left-click window drag silently no-ops — the runtime ABI guard only surfaces it *after* the user clicks the title bar and nothing happens.

## How

`scripts/verify-cef-patch.sh <runtime-dir | libcef.so>` greps `.symtab` for the patch symbol (`window_begin_window_drag_<apiver>` / `CefWindowImpl::BeginWindowDrag`):

| Exit | Meaning |
|---|---|
| `0` | patched (symbol found) |
| `1` | **unpatched upstream** — symbol table present, no slot (the regression) |
| `2` | stripped / can't verify (run on the unstripped build) |

**Key constraint:** the symbol survives only in the **unstripped** `.so` — `strip` removes `.symtab` entirely, so the shipped 263 MB binary has zero trace. The check therefore runs on the unstripped runtime, *before* packaging strips it. (Empirically confirmed: `strings`/`nm` find the symbol in the 1.5 GB build output, nothing in the stripped copy.)

## Wiring

- **`bundle:linux`** — advisory (`|| true`): prints a warning but proceeds, so `task dev` still works on the upstream cef-dll-sys fallback (no 3-hour CEF build needed).
- **`build-appimage-linux.sh`** — **hard gate** (release-only script; never run by `task dev`): refuses to package an AppImage whose `libcef.so` lacks the patch. If `dist/cef` was pre-stripped out-of-band, it falls back to verifying the resolved unstripped source. `AGENTMUX_SKIP_CEF_PATCH_CHECK=1` overrides (emergency only).

Mirrors the existing `verify-cef-version.sh` gate on the Windows bundle.

## Verification

All three exit codes tested against real binaries on this machine:
- patched build tree (1.5 GB unstripped) → **exit 0** (~5s nm scan)
- upstream cargo-cache `.so` (1.3 GB unstripped) → **exit 1** ✅ catches the regression
- stripped `dist/cef/libcef.so` (263 MB) → **exit 2** → gate falls back to resolved source → **pass**

`task --list` + PyYAML confirm the Taskfile edit is valid; both scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)