### PR TITLE
feat(agent): per-provider model lists + provider-aware /model

### DIFF
--- a/.changesets/1781494433-feat-agent-per-provider-model-lists-provider-aware-model-cmd.md
+++ b/.changesets/1781494433-feat-agent-per-provider-model-lists-provider-aware-model-cmd.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): per-provider model lists + provider-aware `/model` — the `/model` picker now shows the active provider's models (Claude opus/sonnet/haiku, Codex gpt-5.5/gpt-5.4/gpt-5.1-codex-max/gpt-5.3-codex) and Codex honors the picked model; runtime `model` is now provider-scoped (P2 + model-side of P3 from SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION)

--- a/frontend/app/view/agent/buildRuntimeArgs.test.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.test.ts
@@ -30,7 +30,7 @@ describe("buildRuntimeArgs", () => {
             "--json",
             "--dangerously-bypass-approvals-and-sandbox",
             "--model",
-            "gpt-5.4",
+            "gpt-5.5",
             "-",
         ];
 
@@ -40,17 +40,24 @@ describe("buildRuntimeArgs", () => {
             // The exact things that killed the codex process before the fix:
             expect(out).not.toContain("--dangerously-skip-permissions");
             expect(out).not.toContain("sonnet");
-            // model is a ChatGPT-account-supported gpt-5.x, not the Claude ModelChoice
-            expect(out[out.indexOf("--model") + 1]).toBe("gpt-5.4");
+            // model is a ChatGPT-account-supported gpt-5.x default, not a Claude alias
+            expect(out[out.indexOf("--model") + 1]).toBe("gpt-5.5");
             // codex `exec` reads the prompt from the trailing positional `-`; the
             // model flag must sit before it, and nothing may follow it.
             expect(out[out.length - 1]).toBe("-");
         });
 
-        it("ignores the Claude-shaped runtime overrides (permission mode + ModelChoice)", () => {
+        it("falls back to the codex default when a carried-over Claude model is stored", () => {
+            // A pane created before per-provider models may have `model:"opus"`.
             const out = buildRuntimeArgs(CODEX_BASE, cfg({ permissionMode: "plan", model: "opus" }), "codex");
             expect(out).toEqual(CODEX_FIXED);
             expect(out).not.toContain("opus");
+        });
+
+        it("honors a user-picked codex model", () => {
+            const out = buildRuntimeArgs(CODEX_BASE, cfg({ model: "gpt-5.4" }), "codex");
+            expect(out[out.indexOf("--model") + 1]).toBe("gpt-5.4");
+            expect(out[out.length - 1]).toBe("-"); // still before the positional
         });
     });
 
@@ -66,6 +73,12 @@ describe("buildRuntimeArgs", () => {
             const out = buildRuntimeArgs(CLAUDE_BASE, cfg({ permissionMode: "plan" }), "claude");
             expect(out).not.toContain("--dangerously-skip-permissions");
             expect(out[out.indexOf("--permission-mode") + 1]).toBe("plan");
+        });
+
+        it("omits --effort on Haiku (effort 400s on Haiku 4.5) but keeps --model", () => {
+            const out = buildRuntimeArgs(CLAUDE_BASE, cfg({ model: "haiku" }), "claude");
+            expect(out[out.indexOf("--model") + 1]).toBe("haiku");
+            expect(out).not.toContain("--effort");
         });
     });
 

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -10,6 +10,7 @@
 
 import type { AgentRuntimeConfig, PermissionMode } from "./types";
 import { DEFAULT_RUNTIME_CONFIG } from "./types";
+import { getProvider } from "./providers";
 
 /**
  * Permission mode → CLI flags mapping.
@@ -110,11 +111,17 @@ export function buildRuntimeArgs(
         args.push("--effort", config.effort);
     }
 
-    // Codex uses a gpt-5.x model (not ModelChoice), and the flag must precede its
-    // trailing `-` prompt positional.
+    // Codex uses a gpt-5.x model, and the flag must precede its trailing `-`
+    // prompt positional. Use the user-picked model when it's a valid codex
+    // model; otherwise the provider default. (A pane carried over from before
+    // per-provider models may still have a Claude model like "opus" stored —
+    // never pass that to codex.)
     if (providerId === "codex") {
+        const codexModels = getProvider("codex")?.models ?? [];
+        const picked = codexModels.find((m) => m.value === config.model)?.value;
+        const fallback = codexModels.find((m) => m.default)?.value ?? CODEX_DEFAULT_MODEL;
         const promptPositional = args[args.length - 1] === "-" ? args.pop()! : null;
-        args.push("--model", CODEX_DEFAULT_MODEL);
+        args.push("--model", picked ?? fallback);
         if (promptPositional !== null) args.push(promptPositional);
     }
 

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -20,7 +20,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
 import { getRuntimeConfig } from "../../buildRuntimeArgs";
-import type { AgentRuntimeConfig, EffortLevel, ModelChoice, PermissionMode } from "../../types";
+import type { AgentRuntimeConfig, EffortLevel, PermissionMode } from "../../types";
 import type { SlashChoice, SlashCommand, SlashCommandContext, SlashResult } from "../types";
 
 type RuntimeUpdateResult =
@@ -58,17 +58,18 @@ function runtimeError(error: string): SlashResult {
 
 function modelChoices(ctx: SlashCommandContext): SlashChoice[] {
     const current = getRuntimeConfig(ctx.block()?.meta).model;
-    const make = (value: string, label: string, description: string, model: ModelChoice): SlashChoice => ({
-        value,
-        label,
-        description,
-        current: current === model,
-    });
-    return [
-        { ...make("opus", "Opus", "Claude Opus — highest quality", "opus"), aliases: ["claude-opus"] },
-        { ...make("sonnet", "Sonnet", "Claude Sonnet — balanced", "sonnet"), aliases: ["claude-sonnet"] },
-        { ...make("haiku", "Haiku", "Claude Haiku — fastest", "haiku"), aliases: ["claude-haiku"] },
-    ];
+    // Per-provider model list — Claude shows opus/sonnet/haiku, codex shows the
+    // gpt-5.x line, etc. Providers without a `models` list (kimi/openclaw/pi/
+    // copilot/gemini/qwen/muxcode pick their model in their own config) show no
+    // choices here.
+    const models = ctx.provider()?.models ?? [];
+    return models.map((m) => ({
+        value: m.value,
+        label: m.label,
+        description: m.description ?? m.value,
+        current: current === m.value,
+        aliases: m.aliases,
+    }));
 }
 
 export const modelCommand: SlashCommand = {
@@ -78,7 +79,7 @@ export const modelCommand: SlashCommand = {
     arg: { kind: "enum", required: true, choices: modelChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const result = await updateRuntime(ctx, { model: arg as ModelChoice });
+        const result = await updateRuntime(ctx, { model: arg });
         if (result.ok === false) return runtimeError(result.error);
         return { kind: "ok", message: `model set to ${result.updated.model} (applies to next turn)` };
     },

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -32,6 +32,15 @@ export interface SystemPrereq {
     };
 }
 
+/** One selectable model for a provider's `--model` flag. */
+export interface ProviderModel {
+    value: string;          // the model string passed to the CLI (e.g. "opus", "gpt-5.5")
+    label: string;          // UI label
+    default?: boolean;      // the default model for this provider
+    description?: string;   // optional one-liner shown in the /model picker
+    aliases?: string[];     // optional /model aliases (e.g. "claude-opus")
+}
+
 export interface ProviderDefinition {
     id: string;
     displayName: string;
@@ -85,6 +94,15 @@ export interface ProviderDefinition {
      * Omit for providers whose context window is unknown or variable.
      */
     contextWindow?: number;
+    /**
+     * AgentMux-side model choices for this provider's `--model` flag. Drives the
+     * `/model` slash command (and, for Claude, the control-bar dropdown). Mark one
+     * `default`. Omit for providers whose model is chosen in their own config
+     * (muxcode/openclaw/pi/copilot) — those show no AgentMux model picker.
+     * NOTE: model strings move with the upstream provider — keep current; see
+     * docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md.
+     */
+    models?: ProviderModel[];
 }
 
 /** Shared git prereq — claude-code calls `git` from session-start
@@ -146,6 +164,12 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // with `Error: Git is required but was not found.`.
         systemPrereqs: [GIT_PREREQ],
         contextWindow: 200_000,
+        // Aliases resolve to the current model (e.g. opus → Opus 4.8) via the CLI.
+        models: [
+            { value: "opus", label: "Opus", default: true, description: "Claude Opus — highest quality", aliases: ["claude-opus"] },
+            { value: "sonnet", label: "Sonnet", description: "Claude Sonnet — balanced", aliases: ["claude-sonnet"] },
+            { value: "haiku", label: "Haiku", description: "Claude Haiku — fastest", aliases: ["claude-haiku"] },
+        ],
     },
     codex: {
         id: "codex",
@@ -174,6 +198,13 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "thread_id",
         controllerType: "subprocess",
         contextWindow: 200_000,
+        // Verify ChatGPT-account availability when bumping the codex CLI pin.
+        models: [
+            { value: "gpt-5.5", label: "GPT-5.5", default: true, description: "Current codex frontier" },
+            { value: "gpt-5.4", label: "GPT-5.4", description: "Prior frontier" },
+            { value: "gpt-5.1-codex-max", label: "GPT-5.1-Codex-Max", description: "Codex-tuned, long-horizon" },
+            { value: "gpt-5.3-codex", label: "GPT-5.3-Codex", description: "Codex-tuned" },
+        ],
     },
     // muxcode — AgentMux's first-party agentic coding CLI.
     // Supports local GGUF inference via llama-server, Anthropic, OpenAI, and

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -527,7 +527,9 @@ export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface AgentRuntimeConfig {
     permissionMode: PermissionMode;
-    model: ModelChoice;
+    // Provider-scoped model string (a value from the active provider's
+    // `models` list). `ModelChoice` stays as the Claude-local alias type.
+    model: string;
     effort: EffortLevel;
 }
 


### PR DESCRIPTION
## What

Implements the **model side** of `SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14` (P2 + part of P3). Frontend-only — no Rust / no provider-config parity changes.

- `ProviderDefinition` gains `models: ProviderModel[]` (`value`/`label`/`default`/`description`/`aliases`). Populated for:
  - **Claude** — opus (default) / sonnet / haiku
  - **Codex** — gpt-5.5 (default) / gpt-5.4 / gpt-5.1-codex-max / gpt-5.3-codex
  - Providers that pick their model in their own config (muxcode/openclaw/pi/copilot — and, for now, gemini/qwen/kimi) omit `models` → no AgentMux model picker shown.
- **`/model` is now provider-aware** — reads the *active* provider's `models` via `ctx.provider()`. A Codex pane finally shows Codex models instead of Claude's (and the pick reaches the CLI).
- `AgentRuntimeConfig.model` is now a provider-scoped `string` (the Claude-local `ModelChoice` alias type stays for the control-bar dropdown).
- `buildRuntimeArgs`: Codex emits the user-picked model when valid, else the provider default. A pane carried over with a Claude model (`opus`) falls back to `gpt-5.5` rather than passing a Claude name to codex.

## Drive-by fix

Corrects the codex test default `gpt-5.4` → `gpt-5.5` (the #1411-era bump left the test stale; the repo doesn't gate PRs on vitest so it went unnoticed). Adds cases for picked-model, carried-over fallback, and the Haiku no-effort gate.

## Deferred (tracked in the spec)

- Control-bar model/effort dropdown is still hard-gated to Claude (`AgentControlBar.tsx` returns null for other providers) — opening it needs UX + cross-provider auth verification.
- Reasoning generalization (Codex `model_reasoning_effort`, Gemini `thinking_level`) — needs live per-provider CLI verification.

## Tests

`buildRuntimeArgs.test.ts` — 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)