### PR TITLE
feat(agent-pane): persistent shell node Phase 3 — stop / tree-kill

### DIFF
--- a/.changesets/1781494592-feat-agent-pane-persistent-shell-node-phase-3-shellstop-tool-mjk0.md
+++ b/.changesets/1781494592-feat-agent-pane-persistent-shell-node-phase-3-shellstop-tool-mjk0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): persistent shell node Phase 3 — ShellStop tool + UI stop button (tree-kill, no more taskkill roulette)

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 const SHELL_TOOL: &str = r#"{
   "name": "Shell",
-  "description": "Start a long-running shell process. Returns immediately with a shell_id. Output streams live in the conversation document. Use for build systems, watchers, dev servers — anything that should run in the background without blocking the conversation.",
+  "description": "Start a long-running shell process. Returns immediately with a shell_id. Output streams live in the conversation document. Use for build systems, watchers, dev servers — anything that should run in the background without blocking the conversation. Stop it later with ShellStop(shell_id) — never use kill/taskkill on a shell you started.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -40,6 +40,18 @@ const SHELL_TOOL: &str = r#"{
       "env":   { "type": "object",  "description": "Extra environment variables", "additionalProperties": { "type": "string" } }
     },
     "required": ["cmd"]
+  }
+}"#;
+
+const SHELL_STOP_TOOL: &str = r#"{
+  "name": "ShellStop",
+  "description": "Stop a running shell started by Shell(). Pass the shell_id returned by Shell. Tree-kills the whole process group (e.g. `task dev` and its child task.exe/node processes), so prefer this over kill/taskkill — those can hit other agents' or the host's processes by name.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior Shell() call" }
+    },
+    "required": ["shell_id"]
   }
 }"#;
 
@@ -113,11 +125,12 @@ async fn main() {
                 })
             }
             "tools/list" => {
-                let tool: Value = serde_json::from_str(SHELL_TOOL).expect("static json");
+                let shell: Value = serde_json::from_str(SHELL_TOOL).expect("static json");
+                let shell_stop: Value = serde_json::from_str(SHELL_STOP_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [tool] }
+                    "result": { "tools": [shell, shell_stop] }
                 })
             }
             "tools/call" => {
@@ -232,6 +245,45 @@ async fn call_tool(
                 .unwrap_or("unknown");
 
             Ok(shell_id.to_string())
+        }
+        "ShellStop" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/shell/stop", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&json!({ "shell_id": shell_id }))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("shell/stop failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            let stopped = result.get("stopped").and_then(|v| v.as_bool()).unwrap_or(false);
+            Ok(if stopped {
+                format!("stopped shell {shell_id}")
+            } else {
+                format!("shell {shell_id} was not running (unknown or already exited)")
+            })
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -162,6 +162,8 @@ pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";
 pub const COMMAND_AGENT_STOP: &str = "agentstop";
 pub const COMMAND_SHELL_EXEC: &str = "shellexec";
+/// Stop a running persistent shell node (Phase 3) — UI stop button.
+pub const COMMAND_SHELL_STOP: &str = "shellstop";
 pub const COMMAND_WRITE_AGENT_CONFIG: &str = "writeagentconfig";
 pub const COMMAND_RESOLVE_CLI: &str = "resolvecli";
 pub const COMMAND_CHECK_CLI_AUTH: &str = "checkcliauth";
@@ -647,6 +649,12 @@ pub struct ShellExecResult {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
+}
+
+/// Data for ShellStopCommand — stop a running persistent shell node by id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandShellStopData {
+    pub shell_id: String,
 }
 
 /// A file to write as part of agent config.

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -66,11 +66,15 @@ impl ShellSessionRegistry {
 
     /// Stop every running shell. For srv-shutdown cleanup so long-running
     /// children (`task dev` → `task.exe`/`node`) don't orphan and hold ports.
-    pub fn stop_all(&self) {
+    /// Returns the number of shells signalled (so the caller can skip the
+    /// grace-period sleep when there was nothing to stop).
+    pub fn stop_all(&self) -> usize {
         let drained: Vec<_> = self.shells.lock().drain().map(|(_, tx)| tx).collect();
+        let n = drained.len();
         for tx in drained {
             let _ = tx.send(());
         }
+        n
     }
 }
 

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -15,8 +15,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use parking_lot::Mutex;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::backend::wps::{Broker, WaveEvent, EVENT_SHELL_CHUNK};
 
@@ -27,6 +28,78 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Per-shell stop handles. `ShellStop` (MCP tool / UI button) looks up a
+/// `shell_id` and fires the oneshot, which makes the owning `ShellNodeRunner`
+/// tree-kill its child. Mirrors `InstallSessionRegistry`; lives in
+/// `AppState.shell_sessions`. Phase 3 of SPEC_PERSISTENT_SHELL_NODE.
+#[derive(Default)]
+pub struct ShellSessionRegistry {
+    shells: Mutex<HashMap<String, oneshot::Sender<()>>>,
+}
+
+impl ShellSessionRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn insert(&self, shell_id: String, tx: oneshot::Sender<()>) {
+        self.shells.lock().insert(shell_id, tx);
+    }
+
+    /// Request stop of a running shell. Returns false if the id is unknown
+    /// (never started, or already exited). Removing here also closes the
+    /// window for the runner's own natural-exit `remove`.
+    pub fn stop(&self, shell_id: &str) -> bool {
+        if let Some(tx) = self.shells.lock().remove(shell_id) {
+            let _ = tx.send(());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Drop a shell's handle without signalling — called by the runner on
+    /// natural exit so its `kill_task` resolves `Err` (= not stopped).
+    fn remove(&self, shell_id: &str) {
+        self.shells.lock().remove(shell_id);
+    }
+
+    /// Stop every running shell. For srv-shutdown cleanup so long-running
+    /// children (`task dev` → `task.exe`/`node`) don't orphan and hold ports.
+    pub fn stop_all(&self) {
+        let drained: Vec<_> = self.shells.lock().drain().map(|(_, tx)| tx).collect();
+        for tx in drained {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Kill the entire process tree rooted at `pid`. `Child::kill` / `kill_on_drop`
+/// only reap the wrapper shell (`cmd /C` / `sh -c`); a `task dev` spawns
+/// `task.exe` → `cargo`/`node` grandchildren that survive otherwise.
+///
+/// Scoped strictly to OUR `pid` — never by image name. Killing `task.exe`
+/// by name is the cross-instance hazard that let agent "Mazs" nuke peer
+/// dev servers (see SPEC_PERSISTENT_SHELL_PHASE3_STOP §1).
+fn kill_tree(pid: u32) {
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+    #[cfg(unix)]
+    {
+        // Negative pid targets the process group created via process_group(0).
+        let pgid = pid as i32;
+        unsafe { libc::kill(-pgid, libc::SIGTERM) };
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        unsafe { libc::kill(-pgid, libc::SIGKILL) };
+    }
+}
+
 pub struct ShellNodeRunner {
     pub shell_id: String,
     pub block_id: String,
@@ -34,6 +107,9 @@ pub struct ShellNodeRunner {
     pub cwd: Option<String>,
     pub extra_env: HashMap<String, String>,
     pub broker: Arc<Broker>,
+    /// Stop registry — the runner registers its `shell_id` here so
+    /// `ShellStop` can tree-kill it, and removes itself on natural exit.
+    pub registry: Arc<ShellSessionRegistry>,
 }
 
 impl ShellNodeRunner {
@@ -78,15 +154,42 @@ impl ShellNodeRunner {
 
         child_cmd.stdout(std::process::Stdio::piped());
         child_cmd.stderr(std::process::Stdio::piped());
+        // Backstop: reap the wrapper shell if this runner task is ever dropped.
+        child_cmd.kill_on_drop(true);
+        // Unix: own process group so kill_tree can signal the whole group
+        // (-pgid). Windows uses taskkill /T on the pid instead.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+            child_cmd.process_group(0);
+        }
 
         let mut child = match child_cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
                 publish_chunk(&broker, &block_id, &shell_id, "system", &format!("[spawn error: {e}]"), now_ms());
-                publish_exit(&broker, &block_id, &shell_id, 1, now_ms());
+                publish_exit(&broker, &block_id, &shell_id, 1, false, now_ms());
                 return;
             }
         };
+
+        // Register a stop handle. `ShellStop` fires `cancel_rx`, and `kill_task`
+        // tree-kills this child. On natural exit we drop the sender (via
+        // registry.remove) so `kill_task` resolves Err → "not stopped".
+        let pid = child.id();
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        self.registry.insert(shell_id.clone(), cancel_tx);
+        let kill_task = tokio::spawn(async move {
+            match cancel_rx.await {
+                Ok(()) => {
+                    if let Some(pid) = pid {
+                        let _ = tokio::task::spawn_blocking(move || kill_tree(pid)).await;
+                    }
+                    true // stopped by request
+                }
+                Err(_) => false, // sender dropped → natural exit
+            }
+        });
 
         let stdout = child.stdout.take().expect("stdout piped");
         let stderr = child.stderr.take().expect("stderr piped");
@@ -124,12 +227,17 @@ impl ShellNodeRunner {
 
         let _ = tokio::join!(t_stdout, t_stderr);
 
+        // Drop our stop handle (no-op if ShellStop already removed it) so the
+        // natural-exit path lets `kill_task` resolve.
+        self.registry.remove(&shell_id);
+
         let exit_code = match child.wait().await {
             Ok(status) => status.code().unwrap_or(-1),
             Err(_) => -1,
         };
 
-        publish_exit(&broker, &block_id, &shell_id, exit_code, now_ms());
+        let was_stopped = kill_task.await.unwrap_or(false);
+        publish_exit(&broker, &block_id, &shell_id, exit_code, was_stopped, now_ms());
     }
 }
 
@@ -177,7 +285,44 @@ fn publish_chunk(broker: &Broker, _block_id: &str, shell_id: &str, kind: &str, c
     });
 }
 
-fn publish_exit(broker: &Broker, _block_id: &str, shell_id: &str, exit_code: i32, ts: u64) {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stop_signals_then_is_idempotent() {
+        let reg = ShellSessionRegistry::new();
+        let (tx, rx) = oneshot::channel::<()>();
+        reg.insert("s1".to_string(), tx);
+        assert!(reg.stop("s1")); // fires the channel
+        assert!(rx.await.is_ok());
+        assert!(!reg.stop("s1")); // second stop: unknown id
+    }
+
+    #[tokio::test]
+    async fn remove_drops_sender_without_signalling() {
+        let reg = ShellSessionRegistry::new();
+        let (tx, rx) = oneshot::channel::<()>();
+        reg.insert("s2".to_string(), tx);
+        reg.remove("s2"); // natural-exit path
+        assert!(rx.await.is_err()); // sender dropped → Err, not Ok
+        assert!(!reg.stop("s2"));
+    }
+
+    #[tokio::test]
+    async fn stop_all_fires_every_handle() {
+        let reg = ShellSessionRegistry::new();
+        let (tx1, rx1) = oneshot::channel::<()>();
+        let (tx2, rx2) = oneshot::channel::<()>();
+        reg.insert("a".to_string(), tx1);
+        reg.insert("b".to_string(), tx2);
+        reg.stop_all();
+        assert!(rx1.await.is_ok());
+        assert!(rx2.await.is_ok());
+    }
+}
+
+fn publish_exit(broker: &Broker, _block_id: &str, shell_id: &str, exit_code: i32, stopped: bool, ts: u64) {
     broker.publish(WaveEvent {
         event: EVENT_SHELL_CHUNK.to_string(),
         scopes: shell_scopes(shell_id),
@@ -187,6 +332,9 @@ fn publish_exit(broker: &Broker, _block_id: &str, shell_id: &str, exit_code: i32
             "shell_id": shell_id,
             "op": "exit",
             "exit_code": exit_code,
+            // True when the exit was caused by ShellStop (tree-killed), so the
+            // frontend renders the grey "stopped" status instead of exited-err.
+            "stopped": stopped,
             "timestamp": ts,
         })),
     });

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1032,6 +1032,7 @@ async fn main() {
                 }
             }
         },
+        shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
     };
 
     // Saga durability PR 2 — resume-on-startup. Walk any sagas the

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1123,6 +1123,9 @@ async fn main() {
     );
 
     // 7. Build router and serve on both listeners
+    // Keep a handle to the shell registry for shutdown cleanup — `state` is
+    // moved into the router below. [reagent #1422 P2]
+    let shell_sessions_shutdown = state.shell_sessions.clone();
     let router = build_router(state);
 
     let web_server = axum::serve(web_listener, router.clone());
@@ -1192,6 +1195,18 @@ async fn main() {
         _ = stdin_token.cancelled() => {
             tracing::info!("shutdown signal received, exiting");
         }
+    }
+
+    // Shutdown cleanup — tree-kill any persistent shells so long-running
+    // children (`task dev` → task.exe/node) don't orphan on srv exit. stop_all()
+    // fires each shell's cancel handle; the kill_tasks run taskkill/killpg
+    // asynchronously, so give them a brief grace to complete before we exit.
+    // (`kill_on_drop` only reaps the wrapper shell and doesn't fire on a clean
+    // process exit, so this is the real orphan guard.) [reagent #1422 P2]
+    let live = shell_sessions_shutdown.stop_all();
+    if live > 0 {
+        tracing::info!(count = live, "shutdown: stopping persistent shells");
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
     }
 }
 

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -2938,6 +2938,7 @@ mod recent_sessions_tests {
             auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
             container_manager: None,
+            shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
         };
 
         // Seed: 1 SEEDED definition (template), 1 identity bundle, 1
@@ -3224,6 +3225,7 @@ mod recent_sessions_tests {
             auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
             container_manager: None,
+            shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
         };
 
         // One seeded template + one already-user-owned definition.

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -130,6 +130,10 @@ pub struct AppState {
     /// `None` when Docker is not available on this host — container agents
     /// will refuse to start rather than crashing the server.
     pub container_manager: Option<std::sync::Arc<crate::backend::container::ContainerManager>>,
+    /// Phase 3 — per-shell stop handles so `ShellStop` (MCP tool) and the UI
+    /// stop button can tree-kill a running persistent shell node. See
+    /// `docs/specs/SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md`.
+    pub shell_sessions: std::sync::Arc<crate::backend::shell_node::ShellSessionRegistry>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.
@@ -233,6 +237,9 @@ pub fn build_router(state: AppState) -> Router {
         // Shell tool POSTs here; we publish shell_node_create + spawn a
         // ShellNodeRunner that streams shell_chunk events to the frontend.
         .route("/api/v1/shell/create", post(handle_shell_create))
+        // Stop a persistent shell (Phase 3). agentmux-mcp's `ShellStop` tool
+        // POSTs here; tree-kills the shell's process group.
+        .route("/api/v1/shell/stop", post(handle_shell_stop))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -503,10 +510,33 @@ async fn handle_shell_create(
         cwd: effective_cwd,
         extra_env: effective_env,
         broker: Arc::clone(&state.broker),
+        registry: Arc::clone(&state.shell_sessions),
     };
     tokio::spawn(runner.run());
 
     (StatusCode::OK, Json(ShellCreateResponse { shell_id }))
+}
+
+// ---- Shell stop ----
+
+#[derive(serde::Deserialize)]
+struct ShellStopRequest {
+    shell_id: String,
+}
+
+/// `POST /api/v1/shell/stop` — stop a running persistent shell.
+///
+/// Called by `agentmux-mcp`'s `ShellStop` tool. Tree-kills the shell's
+/// process group (so `task dev` → `task.exe`/`node` grandchildren die too),
+/// which makes the runner publish a `stopped` exit event. Returns `{ stopped }`
+/// — false if the id is unknown (never started or already exited).
+async fn handle_shell_stop(
+    State(state): State<AppState>,
+    Json(req): Json<ShellStopRequest>,
+) -> impl IntoResponse {
+    let stopped = state.shell_sessions.stop(&req.shell_id);
+    tracing::info!(shell_id = %req.shell_id, stopped, "shell.stop");
+    (StatusCode::OK, Json(json!({ "stopped": stopped })))
 }
 
 // ---- Auth Middleware ----

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -71,6 +71,7 @@ pub(crate) fn test_state() -> AppState {
         auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
         install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
         container_manager: None,
+        shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
     }
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -27,9 +27,9 @@ use crate::backend::rpc_types::{
     COMMAND_GET_AI_RATE_LIMIT, COMMAND_ROUTE_ANNOUNCE, COMMAND_ROUTE_UNANNOUNCE,
     COMMAND_SET_META, COMMAND_SET_CONFIG, COMMAND_APP_INFO,
     COMMAND_SUBPROCESS_SPAWN, COMMAND_AGENT_INPUT, COMMAND_AGENT_STOP, COMMAND_TOOL_DECISION,
-    COMMAND_WRITE_AGENT_CONFIG, COMMAND_SHELL_EXEC,
+    COMMAND_WRITE_AGENT_CONFIG, COMMAND_SHELL_EXEC, COMMAND_SHELL_STOP,
     CommandSubprocessSpawnData, CommandAgentInputData, CommandAgentStopData, CommandWriteAgentConfigData,
-    CommandShellExecData, ShellExecResult,
+    CommandShellExecData, ShellExecResult, CommandShellStopData,
 };
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
 use super::service::update_object_meta;
@@ -1101,6 +1101,24 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     }
                     None => Ok(None),
                 }
+            })
+        }),
+    );
+
+    // shellstop → tree-kill a running persistent shell node (Phase 3). Invoked
+    // by the UI stop button on a running PersistentShellBlock. The runner then
+    // publishes a `stopped` exit event.
+    let shell_sessions_stop = state.shell_sessions.clone();
+    engine.register_handler(
+        COMMAND_SHELL_STOP,
+        Box::new(move |data, _ctx| {
+            let registry = shell_sessions_stop.clone();
+            Box::pin(async move {
+                let req: CommandShellStopData = serde_json::from_value(data)
+                    .map_err(|e| format!("shellstop: {e}"))?;
+                let stopped = registry.stop(&req.shell_id);
+                tracing::info!(shell_id = %req.shell_id, stopped, "shellstop");
+                Ok(Some(serde_json::json!({ "stopped": stopped })))
             })
         }),
     );

--- a/docs/specs/SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md
+++ b/docs/specs/SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md
@@ -1,0 +1,122 @@
+# SPEC: Persistent Shell Node — Phase 3 (Stop / Lifecycle)
+
+**Date:** 2026-06-14
+**Status:** Draft → implementing
+**Builds on:** `SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md` (Phases 1–2 merged: #1338, #1356) and the MSYS cwd fix (#1415).
+
+---
+
+## 1. Problem
+
+Phases 1–2 let an agent launch a long-running process (`task dev`, vite, watchers) via the `Shell` MCP tool; it streams into a colored `PersistentShellBlock` row. But **there is no way to stop it**:
+
+- No `ShellStop` tool, no stop endpoint, no process registry.
+- `PersistentShellBlock` has no stop button (the Phase-1 spec promised `■`).
+- `ShellNodeRunner` is fire-and-forget; nothing holds a kill handle.
+- The `"stopped"` status exists in the type but is never produced.
+
+Consequences observed in the field (2026-06-14, agent "Mazs"): an agent with no clean way to stop its own launch resorted to **`taskkill task.exe`**, which — because `task.exe` is shared across instances/peers — killed *other* instances' dev servers and itself. A self-stop handle removes the entire reason to reach for `taskkill`.
+
+Additionally, `tokio::process::Child::kill` / `kill_on_drop` only kill the **direct child** (`cmd /C` / `sh -c`), not the process *tree* (`task dev` → `task.exe` → `cargo`/`node`…). A real stop must kill the tree.
+
+---
+
+## 2. Goals
+
+- Agent can stop a shell it started: `ShellStop(shell_id)`.
+- User can stop a running shell from the UI: a `■` button on the running `PersistentShellBlock`.
+- Stop kills the **whole process tree** (not just the wrapper shell), so `task dev`/vite actually terminate.
+- The row transitions to **`stopped`** status (grey) — distinct from `exited-err`.
+- Baseline orphan protection: `kill_on_drop` + registry so shells don't leak on srv shutdown.
+
+## 3. Non-Goals (follow-ups)
+
+- `ShellInput(shell_id, text)` (stdin) — Phase 3b.
+- `ShellStatus(shell_id)` query tool — Phase 3b.
+- Pane-close cleanup integration with `process_tracker` kill-tree — Phase 3c (registry is in place; wiring the host-exit/pane-close hook is separate).
+- PTY / live-output fidelity for `\r` progress bars — separate track.
+
+---
+
+## 4. Design
+
+### 4.1 Backend — `ShellSessionRegistry`
+
+New registry in `AppState` (mirrors `InstallSessionRegistry`), mapping `shell_id → oneshot::Sender<()>`:
+
+```rust
+#[derive(Default)]
+pub struct ShellSessionRegistry {
+    shells: Mutex<HashMap<String, oneshot::Sender<()>>>,
+}
+impl ShellSessionRegistry {
+    fn insert(&self, shell_id, tx);
+    pub fn stop(&self, shell_id) -> bool;   // remove + send(()) → triggers tree-kill
+    fn remove(&self, shell_id);             // idempotent (natural exit)
+    pub fn stop_all(&self);                 // shutdown cleanup
+}
+```
+
+### 4.2 `ShellNodeRunner` changes (`backend/shell_node.rs`)
+
+- Spawn with a process group on Unix (`#[cfg(unix)] cmd.process_group(0)`) and `kill_on_drop(true)`.
+- Register a `cancel_tx` keyed by `shell_id`; capture `child.id()` (pid).
+- A small `kill_task` awaits `cancel_rx`:
+  - `Ok(())` → **stop requested** → `kill_tree(pid)` → `was_stopped = true`.
+  - `Err(_)` (sender dropped on natural exit) → `was_stopped = false`.
+- Main read loop is unchanged; when the child dies (naturally or killed) its pipes close, the loop ends, then `child.wait()`.
+- On loop end, `registry.remove(shell_id)` (drops the sender so `kill_task` resolves on natural exit), `await kill_task` for `was_stopped`.
+- `publish_exit` gains a `stopped: bool` field.
+
+`kill_tree(pid)`:
+- **Windows:** `taskkill /PID <pid> /T /F` (kills the tree — the same mechanism, used correctly and scoped to *our* pid, not by image name).
+- **Unix:** `kill(-pgid, SIGTERM)` then `SIGKILL` after a short grace.
+
+### 4.3 Endpoints
+
+- **HTTP** `POST /api/v1/shell/stop` `{ shell_id }` → `state.shell_sessions.stop(shell_id)` (for the MCP `ShellStop` tool). Auth-gated like `/shell/create`.
+- **WS RPC** `shellstop` `{ shell_id }` → same registry call (for the UI stop button).
+
+Both are thin wrappers over `ShellSessionRegistry::stop`.
+
+### 4.4 MCP — `agentmux-mcp`
+
+Add `ShellStop` tool:
+```json
+{ "name": "ShellStop",
+  "description": "Stop a running shell started by Shell(). Kills the whole process tree.",
+  "inputSchema": { "type": "object", "properties": { "shell_id": {"type":"string"} }, "required": ["shell_id"] } }
+```
+Handler POSTs `{ shell_id }` to `/api/v1/shell/stop`.
+
+### 4.5 Frontend
+
+- `RpcApi.ShellStopCommand({ shell_id })` → WS `shellstop`.
+- `PersistentShellBlock`: render a `■` stop button when `status === "running"`; `onClick` → `ShellStopCommand`, `stopPropagation` (don't toggle expand). Optimistic: leave status to the `exit` event.
+- `useAgentStream` shell `exit` handler: when `stopped === true`, dispatch `ShellStatusUpdate` with status `"stopped"` instead of `exited-ok/err`. (Reducer already supports `"stopped"`.)
+
+---
+
+## 5. Files
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/server/shell_handlers.rs` *(new)* or `server/mod.rs` | `ShellSessionRegistry` + `/api/v1/shell/stop` handler |
+| `agentmux-srv/src/server/mod.rs` | add `shell_sessions` to `AppState`; pass to runner; register route |
+| `agentmux-srv/src/main.rs` | construct `shell_sessions` |
+| `agentmux-srv/src/backend/shell_node.rs` | registry hook, `kill_tree`, process group, `stopped` in exit |
+| `agentmux-srv/src/server/websocket.rs` | `shellstop` WS RPC handler |
+| `agentmux-mcp/src/main.rs` | `ShellStop` tool + handler |
+| `frontend/app/store/rpc-api.ts` | `ShellStopCommand` |
+| `frontend/app/view/agent/components/PersistentShellBlock.tsx` | `■` stop button |
+| `frontend/app/view/agent/useAgentStream.ts` | `stopped` → status `"stopped"` |
+
+## 6. Test / Verify
+
+- Unit: `ShellSessionRegistry` stop/remove idempotency.
+- Live (dev build): `Shell("task dev")` → row green/running → click `■` → tree dies (no orphan `task.exe`/node), row turns grey `stopped`. Agent `ShellStop(shell_id)` does the same.
+- Confirm no leftover `node`/`task.exe` after stop (the orphan check that bit us earlier).
+
+## 7. Changeset
+
+`patch` — additive feature, no schema break.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1130,6 +1130,18 @@ class RpcApiType {
         return client.rpcCall("shellexec", data, opts);
     }
 
+    // command "shellstop" [call]
+    // Stop a running persistent shell node (Phase 3). Invoked by the UI stop
+    // button on a running PersistentShellBlock; tree-kills the process group.
+    // Returns { stopped: false } if the id is unknown / already exited.
+    ShellStopCommand(
+        client: RpcClient,
+        data: { shell_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ stopped: boolean }> {
+        return client.rpcCall("shellstop", data, opts);
+    }
+
     // command "agentstop" [call]
     AgentStopCommand(client: RpcClient, data: CommandAgentStopData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("agentstop", data, opts);

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -15,6 +15,8 @@ import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import type { ShellNode, ToolLogChunk } from "../types";
 
 interface PersistentShellBlockProps {
@@ -77,6 +79,22 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
 
     const expanded = () => props.pinned;
 
+    // Stop button (Phase 3): tree-kills the running process. Status updates
+    // arrive via the `stopped` exit event, so we don't optimistically mutate.
+    const [stopping, setStopping] = createSignal(false);
+    const handleStop = async (e: MouseEvent) => {
+        e.stopPropagation(); // don't toggle the expand panel
+        if (stopping()) return;
+        setStopping(true);
+        try {
+            await RpcApi.ShellStopCommand(TabRpcClient, { shell_id: props.node.id });
+        } catch {
+            // Best-effort — the exit event reconciles the final status.
+        } finally {
+            setStopping(false);
+        }
+    };
+
     // createChunkCapper tracks total lines incrementally and returns hiddenLines.
     // Using capChunksByLines directly only returns keptLines (no hidden count).
     const chunkCap = createChunkCapper(MAX_TOOL_OUTPUT_LINES);
@@ -103,6 +121,16 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
                 <span class="agent-shell-elapsed">[{elapsed()}]</span>
                 <Show when={lastLine()}>
                     <span class="agent-shell-live-tail">↳ {lastLine()}</span>
+                </Show>
+                <Show when={props.node.status === "running"}>
+                    <button
+                        class="agent-shell-stop"
+                        title="Stop process"
+                        disabled={stopping()}
+                        onClick={handleStop}
+                    >
+                        ■
+                    </button>
                 </Show>
             </div>
             <div

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -89,6 +89,40 @@
     white-space: nowrap;
 }
 
+// Stop button (Phase 3) — tree-kills the running process. Pinned to the
+// right edge; `margin-left: auto` covers the case where the live-tail (which
+// otherwise grows to fill) is hidden.
+.agent-shell-stop {
+    flex: 0 0 auto;
+    margin-left: auto;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 11px;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 3px;
+    cursor: pointer;
+    opacity: 0.55;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+    &:hover {
+        opacity: 1;
+        color: var(--error-color, #ff6b6b);
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+
+    &:disabled {
+        opacity: 0.3;
+        cursor: default;
+    }
+}
+
+.agent-shell-summary:hover .agent-shell-stop {
+    opacity: 0.85;
+}
+
 // Pulsing cursor shown while the shell is still streaming
 .agent-shell-streaming-indicator {
     display: inline-block;

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -200,7 +200,12 @@ export function useAgentStream({
         if (!shellId) return;
         if (d.op === "exit") {
             const exitCode = typeof d.exit_code === "number" ? d.exit_code : -1;
-            const status: ShellNode["status"] = exitCode === 0 ? "exited-ok" : "exited-err";
+            // `stopped` = the exit was caused by ShellStop (tree-killed), so show
+            // the grey "stopped" status rather than a red exited-err for the
+            // non-zero code the kill produces.
+            const status: ShellNode["status"] = d.stopped === true
+                ? "stopped"
+                : exitCode === 0 ? "exited-ok" : "exited-err";
             pendingShellExits.push({ shellId, status, exitCode, exitedAt: d.timestamp ?? Date.now() });
             scheduleFlush();
             return;


### PR DESCRIPTION
## What

Phase 3 of the persistent shell node (`SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md`). Phases 1–2 (#1338, #1356) + the MSYS cwd fix (#1415) let agents launch long-running processes (`task dev`, vite) as streaming `PersistentShellBlock` rows — but there was **no way to stop them**.

## Why this matters (real incident)

With no clean self-stop, an agent ("Mazs") resorted to **`taskkill task.exe`** to clean up a launch. Because `task.exe` is shared across instances/peers, that killed *other* instances' dev servers — and itself, mid-turn, creating a self-destruct loop. A scoped, tree-killing **ShellStop** removes the entire reason to reach for `taskkill`.

It also fixes the orphan problem: `Child::kill`/`kill_on_drop` only reap the wrapper shell (`cmd /C`); `task dev` → `task.exe`/`node` grandchildren survived. Stop now kills the whole tree.

## Changes

**Backend**
- `ShellSessionRegistry` (`shell_id` → oneshot cancel handle) in `AppState`, mirroring `InstallSessionRegistry`. Unit-tested (3 tests).
- `ShellNodeRunner`: registers on spawn, removes on natural exit, watches a cancel signal; on stop **tree-kills its OWN pid** — `taskkill /PID <pid> /T /F` (Windows) / `killpg` (Unix). Never by image name. `kill_on_drop` + Unix `process_group(0)` as backstops. Exit event gains a `stopped` flag.
- `POST /api/v1/shell/stop` (for MCP) and WS `shellstop` RPC (for UI) — both thin wrappers over `registry.stop()`.

**MCP (`agentmux-mcp`)**
- `ShellStop(shell_id)` tool. Both tool descriptions explicitly steer agents away from `kill`/`taskkill`.

**Frontend**
- `RpcApi.ShellStopCommand`; `useAgentStream` maps `stopped` → grey `"stopped"` status.
- `PersistentShellBlock`: hover-revealed `■` stop button on running rows.

## Test

- `cargo test --bin agentmux-srv -- shell_node::tests` → 3 passed (stop/remove/stop_all semantics).
- `cargo check` (srv + mcp) clean; `task build:frontend:dev` clean.
- Live verify (after merge/build): `Shell("task dev")` → green row → click `■` → tree dies (no orphan `task.exe`/`node`), row turns grey `stopped`. `ShellStop(shell_id)` does the same from the agent.

## Follow-ups (not in this PR)

`ShellInput`/`ShellStatus` tools (Phase 3b); pane-close/host-exit cleanup via the existing `process_tracker` kill-tree (Phase 3c); PTY for `\r` progress fidelity.