### PR TITLE
fix(startup): self-heal + recovery UI for host-bridge init failure

### DIFF
--- a/.changesets/1781522760-fix-startup-self-heal-recovery-ui-for-host-bridge-init-failu-lrmz.md
+++ b/.changesets/1781522760-fix-startup-self-heal-recovery-ui-for-host-bridge-init-failu-lrmz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(startup): self-heal + recovery UI for host-bridge init failure (auto-reload guard, Reload button, Ctrl+R/F5 keybinding)

--- a/docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
+++ b/docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
@@ -1,0 +1,226 @@
+# SPEC: Host-Bridge Init Failure — Self-Heal + Recovery UI
+
+**Date:** 2026-06-15
+**Status:** Draft
+**Scope:** `frontend/app/init/error-display.ts` + `frontend/app-init.ts` startup-error path
+
+---
+
+## 1. Problem
+
+When the frontend can't establish `window.api` (the CEF host bridge), the app
+dies on a bare, dead error screen:
+
+```
+AgentMux failed to start
+Error: [initApp] window.api still undefined after 5s — host API bridge failed to initialize
+Press F12 for console details. Try closing and reopening the app.
+```
+
+There is **no recovery action** (no reload button, no auto-retry) — the only
+way out is F12 + manual `location.reload()` or killing the window.
+
+### Observed incident (2026-06-15)
+
+A running **dev** instance logged this error **385 times in a storm** at 03:35,
+~31 min after a clean startup where the bridge installed fine (`window.api
+available: true`, backend on `127.0.0.1:51078`).
+
+**Root cause:** `git checkout` / `git pull` / `git rebase` were run in the same
+clone the dev instance's **Vite** was watching. A branch switch rewrites
+hundreds of source files at once; Vite reacts with **full-page reloads**, and
+*mid-checkout* the module tree is briefly inconsistent (imports unresolvable),
+so `bootstrap()`'s async bridge handshake can't finish before `initApp`'s 5s
+guard throws. Each reload fails the same way → the 385× storm. **The backend
+was alive the whole time** — a reload once the tree settled would have
+recovered instantly.
+
+### Why this matters beyond dev
+
+The same dead-end appears for any transient bridge hiccup: a stale **pooled
+window** whose host IPC port went away, a renderer reload racing host
+readiness, or a slow backend spawn (>5s). In every case the backend is usually
+reachable seconds later, so the app should **self-heal**, not wedge.
+
+---
+
+## 2. Goals
+
+1. **Self-heal transient failures** — retry the bridge handshake, then do a
+   *bounded* full reload, before ever showing a hard error.
+2. **No reload storms** — a loop guard so a persistent failure can never repeat
+   the 385× behaviour.
+3. **Recovery UI** — when auto-heal gives up, show a branded screen with a
+   one-click **Reload** (and **Reopen window**) action, a plain-language cause,
+   and collapsible technical details — not just "press F12."
+4. **Honest status** — during auto-retry, show "Reconnecting… (attempt N/M)" so
+   the user isn't staring at a frozen screen.
+
+## 3. Non-Goals
+
+- Fixing Vite's full-reload behaviour itself (it's correct to reload on a mass
+  change). The operational lesson — *don't run git branch ops in a clone a dev
+  instance is serving* — is documented, not enforced in code.
+- Changing the host IPC / pooled-window lifecycle (separate track).
+
+---
+
+## 3.5 Existing precedent — mirror, don't invent
+
+The codebase already solves this exact shape for two adjacent failures; the fix
+should reuse their patterns:
+
+- **WebGL context loss** (`frontend/bootstrap.ts:59-73`): a `webglcontextlost`
+  listener that reads a **`sessionStorage` reload counter**, auto-reloads after
+  1s if under `CONTEXT_LOSS_MAX_RELOADS`, **suppresses** past the cap (logs
+  "possible driver issue"), and **resets the counter after 60s** of stability.
+  → The bridge-init recovery should be a near-copy of this loop guard.
+
+- **Renderer crash** (`agentmux-cef/src/client/mod.rs:1457`): the host already
+  renders "a recovery HTML page that offers Reload / Quit buttons." Two gaps:
+  (1) it only triggers on a renderer *crash*, not a frontend JS bridge-init
+  failure (which keeps the renderer alive but wedged), and (2) per
+  `client/mod.rs:1435`, that page is a `data:` URI where `location.reload()`
+  reloads the *wrong* page. The bridge-failure case is different — the document
+  is a real `http://localhost:5270/?…` URL, so `location.reload()` **does**
+  work and preserves the `__AGENTMUX_IPC_PORT__`/token query params.
+
+**Why `Ctrl+R` did nothing (observed 2026-06-15):** AgentMux's main window is a
+CEF host, not a browser — there is **no `Ctrl+R` → reload keybinding** wired
+(the host's only reload path is `POST /agentmux/browser/reload` → CDP
+`Page.reload`, used for *browser panes*, not the app window). And the WebGL
+auto-reload above doesn't fire for a bridge-init failure. So the user's only
+recovery was close+reopen — which is the whole motivation for this spec.
+
+## 4. Design
+
+### 4.1 Retry the handshake before failing (`app-init.ts`)
+
+The 5s `window.api` poll currently rejects outright. Replace with a bounded
+**retry of the bridge handshake**:
+
+- Poll `window.api` for up to ~8s (cover slow backend spawn — `initCefApi`
+  itself waits up to 30s for `backend-ready`, so align the guard or let it run).
+- If still unset, treat as a transient and escalate to the reload path (4.2)
+  rather than throwing to a dead screen.
+
+### 4.2 Bounded auto-reload with a loop guard
+
+A persistent failure must not reload forever (that *is* the 385× bug). Use a
+**time-windowed counter in `sessionStorage`**:
+
+```
+key: "amux:bridge-reload-attempts"  →  { count, firstAt }
+```
+
+On bridge-init failure:
+1. Read the counter. If `count < MAX_RELOADS` (e.g. 3) within a window
+   (e.g. 30s), increment, show the "Reconnecting…" overlay (4.3), and
+   `location.reload()` after a short backoff (e.g. 800ms × count).
+2. If `count >= MAX_RELOADS`, **stop** — clear the counter and render the
+   recovery UI (4.4) with reason "auto-recovery gave up after N attempts."
+3. On a **successful** bridge init, clear the counter (so a later unrelated
+   failure starts fresh).
+
+This bounds the worst case to MAX_RELOADS reloads, never a storm.
+
+### 4.3 "Reconnecting" overlay (transient state)
+
+While auto-reloading, show a minimal centered card over the splash:
+
+```
+⟳  Reconnecting to AgentMux…
+   attempt 2 of 3
+```
+
+so the user sees progress, not a frozen grey screen.
+
+### 4.4 Recovery UI (terminal state) — replaces `showStartupError`
+
+A branded card (reuses app theme tokens), replacing the bare `<div>`:
+
+```
+┌────────────────────────────────────────────┐
+│  ⚠  AgentMux couldn't connect to its host   │
+│                                              │
+│  The UI loaded but lost its link to the      │
+│  AgentMux host process. This is usually       │
+│  temporary — reloading fixes it.              │
+│                                              │
+│   [ ⟳ Reload ]   [ ⧉ Reopen window ]          │
+│                                              │
+│   ▸ Technical details                         │
+│     [initApp] window.api still undefined…     │
+│     Press F12 for the full console.           │
+└────────────────────────────────────────────┘
+```
+
+- **Reload** → `location.reload()` (primary; clears the loop counter first so
+  the manual reload gets a fresh budget).
+- **Reopen window** → best-effort: if `window.api` later exists use the host
+  "new window" path; otherwise `location.assign(location.pathname +
+  location.search)` to re-navigate with the original query params (preserving
+  `__AGENTMUX_IPC_PORT__`/token).
+- **Technical details** → `<details>` collapsible holding the raw message +
+  the F12 hint (today's content), so the surface is friendly by default but the
+  detail is one click away.
+- Dev-mode line (when `import.meta.env.DEV`): "If you just switched git
+  branches in this clone, Vite reloaded mid-change — Reload should recover."
+
+### 4.6 Keyboard reload (complementary)
+
+Because users *expect* `Ctrl+R`/`F5` to reload (and tried it), wire a global
+reload keybinding on the **app window** (not just browser panes), so the
+keyboard works even when the UI is wedged:
+
+- Frontend: a capture-phase `keydown` listener registered in `bootstrap.ts`
+  *before* the bridge handshake (so it survives a wedged init) → `Ctrl+R` /
+  `F5` → `location.reload()`.
+- This is independent of `window.api`, so it works in exactly the broken state
+  where the user needs it most. Loop guard from 4.2 still applies.
+
+### 4.5 API shape
+
+```ts
+// error-display.ts
+export function showStartupError(message: string, opts?: {
+    recoverable?: boolean;     // default true → show Reload/Reopen
+    reason?: "bridge" | "window" | "unknown";
+}): void;
+
+export function showReconnecting(attempt: number, max: number): void;
+
+// returns true if it scheduled a reload (caller should stop), false if the
+// budget is exhausted and the recovery UI was shown instead.
+export function tryAutoReload(reason: string): boolean;
+```
+
+---
+
+## 5. Files
+
+| File | Change |
+|------|--------|
+| `frontend/app/init/error-display.ts` | Recovery card + `showReconnecting` + `tryAutoReload` (loop-guarded) |
+| `frontend/app-init.ts` | On bridge-init timeout: `tryAutoReload()` instead of bare `showStartupError`; clear counter on success |
+| `frontend/app/init/error-display.scss` *(new, optional)* | Card + button styles (or inline, matching current approach) |
+
+## 6. Test / Verify
+
+- Unit: loop guard — N failures → exactly MAX_RELOADS reloads then terminal UI;
+  success resets the counter.
+- Manual (dev): with a dev instance running, `git checkout` another branch in
+  the served clone → confirm the window shows "Reconnecting…", auto-reloads ≤3×,
+  and recovers once the tree settles (instead of the 385× dead-screen storm).
+- Manual: kill the host IPC (simulate dead bridge) → after the budget, the
+  recovery card shows with a working **Reload** button.
+
+## 7. Changeset
+
+`patch` — UX/resilience fix, no schema or API change.
+
+## 8. Operational note (not code)
+
+Don't run `git checkout` / `rebase` / `pull` in a clone a dev instance is
+actively serving — use a separate worktree (`git worktree add`) or stop
+`task dev` first. This spec makes that mistake *recoverable*, not impossible.

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -2,40 +2,201 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Show a startup error message in the DOM so the user never sees
- * an infinite grey/blank screen.
+ * Startup-failure UI + self-heal recovery.
+ *
+ * When the frontend can't establish `window.api` (the host bridge) the app
+ * must not wedge on a dead screen with no way out. The failure is almost
+ * always transient: a Vite full-reload mid-change in dev (e.g. a git branch
+ * switch in the served clone), a slow backend spawn, or a stale pooled window
+ * whose host IPC went away. The backend is usually reachable a moment later,
+ * so we self-heal.
+ *
+ * Mirrors the WebGL-context-loss recovery in `bootstrap.ts`: a bounded,
+ * `sessionStorage`-guarded auto-reload (so a persistent failure can't storm —
+ * the 2026-06-15 incident reloaded 385×), then a recovery card with a
+ * one-click Reload. `location.reload()` works here because this is a real
+ * `http://localhost` document (not the host's `data:` crash page), and it
+ * preserves the `__AGENTMUX_IPC_PORT__`/token query params.
+ *
+ * Spec: docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
  */
-export function showStartupError(message: string): void {
+
+const RELOAD_KEY = "amux-startup-recover-reloads";
+const MAX_RELOADS = 3;
+
+function getReloadCount(): number {
+    try {
+        return parseInt(sessionStorage.getItem(RELOAD_KEY) ?? "0", 10) || 0;
+    } catch {
+        return 0;
+    }
+}
+
+function setReloadCount(n: number): void {
+    try {
+        sessionStorage.setItem(RELOAD_KEY, String(n));
+    } catch {
+        // sessionStorage unavailable — degrades to no auto-reload (manual card).
+    }
+}
+
+/**
+ * Clear the auto-reload budget. Call after a successful startup so a later,
+ * unrelated failure begins with a fresh budget (and call before a *manual*
+ * reload so the user's click always gets a full set of retries).
+ */
+export function clearStartupReloadCount(): void {
+    setReloadCount(0);
+}
+
+/**
+ * Attempt to self-heal a startup failure.
+ *
+ * If the bounded reload budget isn't exhausted, show a "Reconnecting…" overlay
+ * and reload after a short backoff — returns `true`, meaning the caller should
+ * stop (the page is about to reload). Otherwise reset the budget, render the
+ * recovery card, and return `false`.
+ */
+export function tryAutoRecover(message: string): boolean {
+    const attempt = getReloadCount() + 1;
+    if (attempt <= MAX_RELOADS) {
+        setReloadCount(attempt);
+        showReconnecting(attempt, MAX_RELOADS);
+        // Backoff grows per attempt so a still-churning dev tree gets a moment
+        // to settle between reloads.
+        setTimeout(() => location.reload(), 700 * attempt);
+        return true;
+    }
+    // Budget exhausted — STOP auto-reloading (this is the 385×-storm guard) and
+    // reset so the user's manual Reload gets a fresh budget.
+    setReloadCount(0);
+    showStartupError(message);
+    return false;
+}
+
+function mountRoot(): HTMLElement {
     document.body.style.visibility = "visible";
     document.body.style.opacity = "1";
     document.body.classList.remove("is-transparent");
-
-    // Remove the "Starting AgentMux..." loader
     const loader = document.getElementById("startup-loading");
     if (loader) loader.remove();
+    const main = document.getElementById("main") ?? document.body;
+    main.innerHTML = "";
+    return main;
+}
 
-    // Show error in the main div
-    const main = document.getElementById("main");
-    if (main) {
-        main.innerHTML = "";
-        const errorDiv = document.createElement("div");
-        errorDiv.style.cssText = "padding: 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #f7f7f7;";
+const FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
 
-        const title = document.createElement("h2");
-        title.textContent = "AgentMux failed to start";
-        title.style.cssText = "color: #ff6b6b; margin-bottom: 16px;";
-        errorDiv.appendChild(title);
+/** Transient state shown while an auto-reload is pending. */
+export function showReconnecting(attempt: number, max: number): void {
+    const main = mountRoot();
+    const wrap = document.createElement("div");
+    wrap.style.cssText =
+        "display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;gap:12px;" +
+        `font-family:${FONT};color:#e8e8e8;background:#101012;`;
 
-        const msg = document.createElement("pre");
-        msg.textContent = message;
-        msg.style.cssText = "background: #1a1a1a; padding: 16px; border-radius: 8px; overflow-x: auto; white-space: pre-wrap; font-size: 13px;";
-        errorDiv.appendChild(msg);
+    const spinner = document.createElement("div");
+    spinner.textContent = "⟳";
+    spinner.style.cssText = "font-size:34px;animation:amux-spin 1s linear infinite;";
 
-        const hint = document.createElement("p");
-        hint.textContent = "Press F12 for console details. Try closing and reopening the app.";
-        hint.style.cssText = "margin-top: 16px; color: rgba(255,255,255,0.5); font-size: 13px;";
-        errorDiv.appendChild(hint);
+    const label = document.createElement("div");
+    label.textContent = "Reconnecting to AgentMux…";
+    label.style.cssText = "font-size:15px;";
 
-        main.appendChild(errorDiv);
+    const sub = document.createElement("div");
+    sub.textContent = `attempt ${attempt} of ${max}`;
+    sub.style.cssText = "font-size:12px;color:rgba(255,255,255,0.5);";
+
+    const style = document.createElement("style");
+    style.textContent = "@keyframes amux-spin{to{transform:rotate(360deg)}}";
+
+    wrap.append(spinner, label, sub, style);
+    main.appendChild(wrap);
+}
+
+/**
+ * Terminal recovery card. Friendly by default with a one-click Reload; the raw
+ * error + F12 hint live behind a collapsible <details>.
+ */
+export function showStartupError(message: string): void {
+    const main = mountRoot();
+
+    const card = document.createElement("div");
+    card.style.cssText =
+        "max-width:560px;margin:14vh auto 0;padding:28px 32px;border-radius:12px;background:#17181b;" +
+        "border:1px solid rgba(255,255,255,0.08);box-shadow:0 8px 40px rgba(0,0,0,0.5);" +
+        `font-family:${FONT};color:#e8e8e8;`;
+
+    const title = document.createElement("h2");
+    title.textContent = "AgentMux lost its connection to the host";
+    title.style.cssText = "margin:0 0 10px;font-size:18px;color:#ffd479;";
+    card.appendChild(title);
+
+    const body = document.createElement("p");
+    body.textContent =
+        "The interface loaded but couldn't reach the AgentMux host process. " +
+        "This is almost always temporary — reloading reconnects it.";
+    body.style.cssText = "margin:0 0 18px;font-size:14px;line-height:1.5;color:rgba(255,255,255,0.8);";
+    card.appendChild(body);
+
+    try {
+        if (import.meta.env?.DEV) {
+            const dev = document.createElement("p");
+            dev.textContent =
+                "Dev: if you just switched git branches in this clone, Vite reloaded mid-change — Reload should recover.";
+            dev.style.cssText = "margin:0 0 18px;font-size:12px;color:rgba(255,255,255,0.45);";
+            card.appendChild(dev);
+        }
+    } catch {
+        // import.meta.env unavailable — skip the dev hint.
     }
+
+    const row = document.createElement("div");
+    row.style.cssText = "display:flex;gap:10px;margin-bottom:18px;";
+
+    const reload = document.createElement("button");
+    reload.textContent = "⟳ Reload";
+    reload.style.cssText =
+        "padding:9px 18px;border-radius:7px;border:none;cursor:pointer;font-size:13px;font-weight:600;" +
+        "background:#4c8dff;color:#fff;";
+    reload.onclick = () => {
+        clearStartupReloadCount(); // a manual reload gets a fresh budget
+        location.reload();
+    };
+
+    const reopen = document.createElement("button");
+    reopen.textContent = "Reopen window";
+    reopen.style.cssText =
+        "padding:9px 18px;border-radius:7px;border:1px solid rgba(255,255,255,0.18);cursor:pointer;" +
+        "font-size:13px;background:transparent;color:#e8e8e8;";
+    reopen.onclick = () => {
+        clearStartupReloadCount();
+        // Re-navigate to the same URL — preserves the IPC port/token query
+        // params, a fuller reset than reload().
+        location.assign(location.pathname + location.search);
+    };
+
+    row.append(reload, reopen);
+    card.appendChild(row);
+
+    const details = document.createElement("details");
+    const summary = document.createElement("summary");
+    summary.textContent = "Technical details";
+    summary.style.cssText = "cursor:pointer;font-size:12px;color:rgba(255,255,255,0.55);";
+    details.appendChild(summary);
+
+    const pre = document.createElement("pre");
+    pre.textContent = message;
+    pre.style.cssText =
+        "margin:10px 0 0;background:#0d0e10;padding:12px;border-radius:7px;overflow-x:auto;" +
+        "white-space:pre-wrap;font-size:12px;color:rgba(255,255,255,0.7);";
+    details.appendChild(pre);
+
+    const hint = document.createElement("p");
+    hint.textContent = "Press F12 for the full console.";
+    hint.style.cssText = "margin:8px 0 0;font-size:11px;color:rgba(255,255,255,0.4);";
+    details.appendChild(hint);
+
+    card.appendChild(details);
+    main.appendChild(card);
 }

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -9,6 +9,7 @@ import { initLogPipe } from "./log/log-pipe";
 import { initErrorForwarder } from "./log/error-forwarder";
 import { setupCefApi } from "./cef-init";
 import { initApp } from "./app-init";
+import { tryAutoRecover, clearStartupReloadCount } from "./app/init/error-display";
 import { benchMark } from "@/util/startup-bench";
 import { initPerf } from "@/perf";
 
@@ -72,6 +73,24 @@ document.addEventListener("webglcontextlost", (event) => {
     setTimeout(() => window.location.reload(), 1000);
 }, true);
 
+// ── Keyboard reload (host-window recovery) ───────────────────────────────────
+// AgentMux's app window is CEF, not a browser, so Ctrl+R / F5 aren't wired to a
+// page reload (the host's only reload path is for browser *panes*). Register a
+// capture-phase handler BEFORE the bridge handshake so it works even when the
+// UI is wedged on a startup failure — the exact state where users reach for it.
+window.addEventListener(
+    "keydown",
+    (e) => {
+        const isReload =
+            e.key === "F5" || ((e.ctrlKey || e.metaKey) && (e.key === "r" || e.key === "R"));
+        if (isReload) {
+            e.preventDefault();
+            window.location.reload();
+        }
+    },
+    true,
+);
+
 // ── Static CSS imports ──────────────────────────────────────────────────────
 import "overlayscrollbars/overlayscrollbars.css";
 import "./app/app.scss";
@@ -130,6 +149,9 @@ async function bootstrap() {
         try {
             await initApp();
             log("INFO", "✅ Main application loaded successfully");
+            // Successful startup — reset the auto-reload budget so a later,
+            // unrelated failure begins with a full set of retries.
+            clearStartupReloadCount();
         } catch (initError) {
             log("ERROR", "Failed in initApp:", initError);
             log("ERROR", "Init error name:", (initError as Error)?.name);
@@ -142,28 +164,19 @@ async function bootstrap() {
         log("ERROR", "❌ Bootstrap failed:", error);
         log("ERROR", "Stack:", (error as Error).stack);
 
-        document.body.innerHTML = "";
-        const errorDiv = document.createElement("div");
-        errorDiv.style.cssText = "padding: 20px; font-family: monospace; color: red;";
-
-        const title = document.createElement("h1");
-        title.textContent = "AgentMux Failed to Start";
-        errorDiv.appendChild(title);
-
-        const errorPre = document.createElement("pre");
-        errorPre.textContent = String(error);
-        errorDiv.appendChild(errorPre);
-
-        const stackPre = document.createElement("pre");
-        stackPre.textContent = (error as Error).stack || "";
-        errorDiv.appendChild(stackPre);
-
-        const helpText = document.createElement("p");
-        helpText.textContent = "Check the browser console (F12) for more details.";
-        errorDiv.appendChild(helpText);
-
-        document.body.appendChild(errorDiv);
-        throw error;
+        // Self-heal: a bridge-init failure is almost always transient (a Vite
+        // full-reload mid-change in dev, a slow backend spawn, or a stale
+        // pooled window). tryAutoRecover does a bounded auto-reload; only when
+        // the budget is exhausted does it render the recovery card (with a
+        // manual Reload). Either way the user never gets the old dead screen.
+        const detail = `${String(error)}\n\n${(error as Error)?.stack ?? ""}`.trim();
+        const reloading = tryAutoRecover(detail);
+        if (!reloading) {
+            // Recovery card is shown; re-throw so the structured error
+            // forwarder still ships the failure to the host log.
+            throw error;
+        }
+        // Page is about to reload — swallow so no UI flashes before navigation.
     }
 }
 

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -78,18 +78,21 @@ document.addEventListener("webglcontextlost", (event) => {
 // page reload (the host's only reload path is for browser *panes*). Register a
 // capture-phase handler BEFORE the bridge handshake so it works even when the
 // UI is wedged on a startup failure — the exact state where users reach for it.
-window.addEventListener(
-    "keydown",
-    (e) => {
-        const isReload =
-            e.key === "F5" || ((e.ctrlKey || e.metaKey) && (e.key === "r" || e.key === "R"));
-        if (isReload) {
-            e.preventDefault();
-            window.location.reload();
-        }
-    },
-    true,
-);
+//
+// SCOPED TO STARTUP ONLY: this handler is removed the moment the app finishes
+// loading (see the success path in bootstrap()). Leaving it active for the
+// whole session would hijack pane-level Ctrl+R — terminal reverse-i-search
+// (bash/zsh/readline), editor shortcuts — and reload the whole app instead.
+// [reagent #1424 P1]
+const startupReloadKeyHandler = (e: KeyboardEvent) => {
+    const isReload =
+        e.key === "F5" || ((e.ctrlKey || e.metaKey) && (e.key === "r" || e.key === "R"));
+    if (isReload) {
+        e.preventDefault();
+        window.location.reload();
+    }
+};
+window.addEventListener("keydown", startupReloadKeyHandler, true);
 
 // ── Static CSS imports ──────────────────────────────────────────────────────
 import "overlayscrollbars/overlayscrollbars.css";
@@ -150,8 +153,11 @@ async function bootstrap() {
             await initApp();
             log("INFO", "✅ Main application loaded successfully");
             // Successful startup — reset the auto-reload budget so a later,
-            // unrelated failure begins with a full set of retries.
+            // unrelated failure begins with a full set of retries, and drop the
+            // startup reload keybinding so pane-level Ctrl+R (terminal
+            // reverse-i-search, editor) works normally. [reagent #1424 P1]
             clearStartupReloadCount();
+            window.removeEventListener("keydown", startupReloadKeyHandler, true);
         } catch (initError) {
             log("ERROR", "Failed in initApp:", initError);
             log("ERROR", "Init error name:", (initError as Error)?.name);


### PR DESCRIPTION
## Problem

When the frontend can't establish `window.api` (the CEF host bridge), the app died on a bare dead screen — *"AgentMux Failed to Start … Check the browser console (F12)"* (rendered by `bootstrap.ts`'s catch) — with **no recovery action**.

The failure is almost always **transient**: a Vite full-reload mid-change in dev (e.g. a `git checkout` in the served clone), a slow backend spawn, or a stale pooled window whose host IPC went away. The backend is usually reachable a moment later.

### Observed incident (2026-06-15)
A dev instance logged `window.api still undefined after 5s` **385 times** — a reload-and-fail *storm* ~31 min after a clean startup. Root cause: `git checkout`/`rebase` in the clone Vite was serving → mass file churn → Vite full reloads over a momentarily-inconsistent module tree → `bootstrap()` couldn't finish the bridge handshake before `initApp`'s 5s guard. And `Ctrl+R` did nothing because the **CEF app window has no reload keybinding** — so close+reopen was the only way out.

## Fix (mirrors the existing WebGL-context-loss recovery in `bootstrap.ts`)

- **`error-display.ts`**: bounded, `sessionStorage`-guarded **auto-reload** (max 3, backoff, reset on success) — a persistent failure can **never** storm (the 385× guard). On exhaustion, a friendly **recovery card** with a one-click **Reload** + **Reopen** and collapsible technical details replaces the dead div. Adds `showReconnecting` overlay + `tryAutoRecover`. `location.reload()` works here (real `localhost` URL, not the host's `data:` crash page) and preserves the IPC port/token query params.
- **`bootstrap.ts`**: catch → `tryAutoRecover` instead of the bare div; clears the reload budget on successful startup; and wires **`Ctrl+R` / `F5` → reload** (registered capture-phase *before* the handshake, so it works even when the UI is wedged — the exact thing the user reached for).

## Test
- `task build:frontend:dev` → clean.
- Manual (per spec §6): with a dev instance running, `git checkout` another branch in the served clone → expect "Reconnecting… (n/3)" → auto-recovers once the tree settles, instead of the 385× dead-screen storm. Killing the host IPC → recovery card with a working Reload.

## Operational note
Don't run git branch ops in a clone a dev instance is actively serving — use `git worktree` or stop `task dev`. This PR makes that mistake **recoverable**, not impossible.

Spec: `docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md`.