### PR TITLE
fix(agent-pane): scope subagent ⚡ panels to the owning pane

### DIFF
--- a/.changesets/1781523209-fix-agent-pane-scope-subagent-panels-to-the-owning-pane-so-t-llx1.md
+++ b/.changesets/1781523209-fix-agent-pane-scope-subagent-panels-to-the-owning-pane-so-t-llx1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): scope subagent ⚡ panels to the owning pane so terminal-spawned subagents stop leaking into unrelated agent panes

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -109,7 +109,18 @@ impl SubagentWatcher {
 
     /// Start watching a Claude Code agent's session directory for subagent files.
     /// Spawns a background tokio task for debounced file event processing.
-    pub fn watch_agent(self: &Arc<Self>, agent_id: &str, config_dir: PathBuf) {
+    ///
+    /// `parent_block_id` is the pane/block that owns this Claude instance (from
+    /// the reactive register request). It is stamped onto every emitted subagent
+    /// event so the frontend can route the ⚡ panel to the originating pane only,
+    /// instead of every agent pane rendering every subagent globally.
+    ///
+    /// Note: the watcher dedupes by `agent_id`, so if the same agent_id is
+    /// registered from two blocks, events carry the first registrant's block id.
+    /// That edge case (same instance name in two panes) is rare; the common
+    /// leak — a terminal Claude's subagents showing up in unrelated agent panes —
+    /// is fully fixed because the terminal block id never matches an agent pane.
+    pub fn watch_agent(self: &Arc<Self>, agent_id: &str, parent_block_id: &str, config_dir: PathBuf) {
         // Derive the projects directory where Claude stores session data
         let projects_dir = config_dir.join("projects");
         if !projects_dir.exists() {
@@ -200,11 +211,12 @@ impl SubagentWatcher {
         }
 
         // Scan for any existing subagent files
-        self.scan_existing_subagents(agent_id, &projects_dir);
+        self.scan_existing_subagents(agent_id, parent_block_id, &projects_dir);
 
         // Spawn async task to process file change notifications
         let self_clone = Arc::clone(self);
         let parent_agent = agent_id.to_string();
+        let parent_block_id = parent_block_id.to_string();
         tokio::spawn(async move {
             loop {
                 let path = match rx.recv().await {
@@ -228,7 +240,7 @@ impl SubagentWatcher {
                 }
 
                 for changed_path in paths {
-                    self_clone.process_jsonl_change(&parent_agent, &changed_path);
+                    self_clone.process_jsonl_change(&parent_agent, &parent_block_id, &changed_path);
                 }
             }
         });
@@ -281,7 +293,7 @@ impl SubagentWatcher {
     // ── Internal methods ──────────────────────────────────────────────────
 
     /// Scan for existing subagent JSONL files in a projects directory.
-    fn scan_existing_subagents(&self, parent_agent: &str, projects_dir: &Path) {
+    fn scan_existing_subagents(&self, parent_agent: &str, parent_block_id: &str, projects_dir: &Path) {
         if !projects_dir.exists() {
             return;
         }
@@ -299,7 +311,7 @@ impl SubagentWatcher {
                         let path = file.path();
                         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                             if name.starts_with("agent-") && name.ends_with(".jsonl") {
-                                self.process_jsonl_change(parent_agent, &path);
+                                self.process_jsonl_change(parent_agent, parent_block_id, &path);
                             }
                         }
                     }
@@ -310,7 +322,7 @@ impl SubagentWatcher {
 
     /// Process a changed/new JSONL subagent file. Reads new lines, updates state,
     /// and broadcasts events via EventBus.
-    fn process_jsonl_change(&self, parent_agent: &str, jsonl_path: &Path) {
+    fn process_jsonl_change(&self, parent_agent: &str, parent_block_id: &str, jsonl_path: &Path) {
         // Extract agent ID from filename: agent-<id>.jsonl
         let agent_id = match jsonl_path
             .file_stem()
@@ -430,6 +442,7 @@ impl SubagentWatcher {
                             "agentId": info_snapshot.agent_id,
                             "slug": info_snapshot.slug,
                             "parentAgent": parent_agent,
+                            "parentBlockId": parent_block_id,
                             "sessionId": session_id,
                             "model": info_snapshot.model,
                         }
@@ -456,6 +469,7 @@ impl SubagentWatcher {
                         "data": {
                             "agentId": agent_id,
                             "parentAgent": parent_agent,
+                            "parentBlockId": parent_block_id,
                             "newEvents": new_events.len(),
                             "totalEvents": info_snapshot.event_count,
                             "events": new_events,
@@ -477,6 +491,7 @@ impl SubagentWatcher {
                         "data": {
                             "agentId": agent_id,
                             "parentAgent": parent_agent,
+                            "parentBlockId": parent_block_id,
                             "totalEvents": info_snapshot.event_count,
                         }
                     }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -173,8 +173,10 @@ pub(super) async fn handle_reactive_register(
             agent_registry::write(&data_dir, &req.agent_id, &state.local_web_url, &req.block_id);
 
             // Auto-watch this agent's Claude Code config dir for subagent JSONL files.
+            // Pass block_id so subagent events are stamped with the owning pane,
+            // letting the frontend route ⚡ panels to that pane only.
             if let Some(config_dir) = subagent_watcher::derive_claude_config_dir(&req.agent_id) {
-                state.subagent_watcher.watch_agent(&req.agent_id, config_dir);
+                state.subagent_watcher.watch_agent(&req.agent_id, &req.block_id, config_dir);
             }
 
             Json(json!({"success": true})).into_response()

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2290,7 +2290,14 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            state.subagent_watcher.watch_agent(&agent_id, std::path::PathBuf::from(config_dir));
+            // Optional block_id (arg 2) — stamps emitted subagent events with the
+            // owning pane so the frontend can filter. Defaults to "" for callers
+            // that don't supply it (events then match no pane, which is correct
+            // for this manual/legacy entry point).
+            let block_id: String = service::get_optional_arg(args, 2)
+                .unwrap_or(None)
+                .unwrap_or_default();
+            state.subagent_watcher.watch_agent(&agent_id, &block_id, std::path::PathBuf::from(config_dir));
             WebReturnType::success_empty()
         }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -521,6 +521,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Subagent event subscriptions. See hooks/useSubagentEvents.ts.
     useSubagentEvents({
+        blockId: model.blockId,
         documentAtom: agentAtoms().documentAtom,
         log,
     });

--- a/frontend/app/view/agent/hooks/useSubagentEvents.ts
+++ b/frontend/app/view/agent/hooks/useSubagentEvents.ts
@@ -22,6 +22,14 @@ import type { DocumentNode, SubagentLinkNode } from "../types";
 import type { LogFn } from "./useAgentControllerStatus";
 
 export interface UseSubagentEventsOptions {
+    /**
+     * The block id of THIS agent pane. subagent:* events are a global
+     * broadcast stamped with `parentBlockId` (the pane that owns the parent
+     * Claude). We only render subagents whose parentBlockId matches, so a
+     * subagent spawned by an unrelated pane — or by a Claude running in a
+     * terminal pane — does not leak a ⚡ panel into this pane.
+     */
+    blockId: string;
     documentAtom: SignalPair<DocumentNode[]>;
     log: LogFn;
 }
@@ -35,6 +43,10 @@ export function useSubagentEvents(opts: UseSubagentEventsOptions): void {
             handler: (event: WaveEvent) => {
                 const data = event?.data as any;
                 if (!data?.agentId) return;
+                // Drop subagents owned by a different pane (or no pane). This is
+                // the fix for ⚡ panels leaking into unrelated agent panes — the
+                // event is broadcast to every client, so each pane must filter.
+                if (data.parentBlockId !== opts.blockId) return;
                 const linkNode: SubagentLinkNode = {
                     type: "subagent_link",
                     id: `subagent_${data.agentId}`,
@@ -56,6 +68,7 @@ export function useSubagentEvents(opts: UseSubagentEventsOptions): void {
             handler: (event: WaveEvent) => {
                 const data = event?.data as any;
                 if (!data?.agentId) return;
+                if (data.parentBlockId !== opts.blockId) return;
                 const nodeId = `subagent_${data.agentId}`;
                 setDoc((prev) =>
                     prev.map((n) =>


### PR DESCRIPTION
## Problem

Agent panes accumulate panels with a thunder symbol (⚡) and a short hash code. These are **subagent link badges** (`SubagentLinkBlock`) representing Claude Task-tool subagents. They were appearing in agent panes **unrelated** to where the subagent was spawned — most visibly for subagents spawned by Claude instances running in **terminal** panes, which should never surface in an agent pane at all. Clicking one opens the subagent's raw session JSONL, which renders unformatted.

## Root cause

A missing parent-pane filter on **both** ends:

- **Backend** (`subagent_watcher.rs`): `subagent:spawned` / `:activity` / `:completed` are broadcast **globally** to every websocket client, and the payload carried only the parent Claude `agentId` — no identifier for the owning pane/block.
- **Frontend** (`useSubagentEvents.ts`): the hook is mounted in **every** agent pane and appended a `subagent_link` node for **any** event with an `agentId` — zero filtering. So every pane rendered every subagent spawned anywhere.

## Fix

Thread the registering **block id** through the watcher and stamp it on every emitted event as `parentBlockId`. The block id is already available at the `reactive/register` call (`reactive.rs`). The frontend hook now receives the pane's own `blockId` and renders a subagent only when `parentBlockId` matches — so terminal-spawned (and other panes') subagents are dropped.

### Changes
- `agentmux-srv/src/backend/subagent_watcher.rs` — `watch_agent` takes `parent_block_id`, threaded through `scan_existing_subagents` / `process_jsonl_change`; added `parentBlockId` to all three event payloads.
- `agentmux-srv/src/server/reactive.rs` — pass `req.block_id` into `watch_agent`.
- `agentmux-srv/src/server/service.rs` — `subagent.WatchAgent` RPC accepts an optional block_id arg (defaults to `""`).
- `frontend/app/view/agent/hooks/useSubagentEvents.ts` — new required `blockId` option; filter `parentBlockId === blockId` on spawned + completed.
- `frontend/app/view/agent/agent-view.tsx` — pass `model.blockId`.

## Scope / notes

- Subagent watching is triggered **only** by the `reactive/register` HTTP path, which fires only for **terminal** blocks (via the `AGENTMUX_AGENT_ID` OSC). Agent panes don't register their own Claude for watching today, so this filter cleanly eliminates the cross-pane leak with no loss of legitimate behavior.
- **Follow-ups (out of scope):** (1) wiring agent panes to surface their *own* subagents, and (2) the poorly-formatted raw-JSONL rendering shown when a subagent panel is expanded.

## Testing
- `cargo check -p agentmux-srv` passes.
- Frontend `node_modules` not installed in this checkout; changes are a single new required string option + a string equality guard (no new types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)