### PR TITLE
feat(editor): theme-bound colors + tight line-number gutter

### DIFF
--- a/.changesets/1781524995-feat-editor-theme-bound-colors-tight-gutter.md
+++ b/.changesets/1781524995-feat-editor-theme-bound-colors-tight-gutter.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): bind CodeMirror colors to the global theme and tighten the line-number gutter

--- a/frontend/app/view/editor/editor-theme.ts
+++ b/frontend/app/view/editor/editor-theme.ts
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// CodeMirror chrome theme bound to the app's global theme tokens
+// (frontend/app/theme.scss + frontend/app/themes/*.scss). The editor follows
+// whatever theme the user has active instead of a fixed dark palette.
+//
+// Syntax-token colors come from oneDark's highlight style: the app theme
+// system has no per-token color tokens, and oneDark's palette reads well on
+// every (dark) app theme. Only the chrome — background, text, gutters,
+// cursor, selection — is rebound to CSS variables here.
+
+import { EditorView } from "@codemirror/view";
+import { syntaxHighlighting } from "@codemirror/language";
+import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
+import type { Extension } from "@codemirror/state";
+
+const editorChromeTheme = EditorView.theme(
+    {
+        "&": {
+            color: "var(--main-text-color)",
+            // Transparent so the pane's themed background (and window
+            // translucency) shows through the editor body.
+            backgroundColor: "transparent",
+        },
+        ".cm-content": {
+            caretColor: "var(--accent-color)",
+        },
+        ".cm-cursor, .cm-dropCursor": {
+            borderLeftColor: "var(--accent-color)",
+        },
+        "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+            {
+                backgroundColor: "var(--highlight-bg-color)",
+            },
+        ".cm-activeLine": {
+            backgroundColor: "rgba(255, 255, 255, 0.035)",
+        },
+        ".cm-gutters": {
+            backgroundColor: "transparent",
+            color: "var(--secondary-text-color)",
+            border: "none",
+        },
+        ".cm-activeLineGutter": {
+            backgroundColor: "rgba(255, 255, 255, 0.035)",
+            color: "var(--main-text-color)",
+        },
+        ".cm-foldPlaceholder": {
+            backgroundColor: "transparent",
+            border: "none",
+            color: "var(--secondary-text-color)",
+        },
+        ".cm-panels": {
+            backgroundColor: "var(--block-bg-solid-color)",
+            color: "var(--main-text-color)",
+        },
+        ".cm-searchMatch": {
+            backgroundColor: "rgba(var(--accent-color-rgb, 65, 159, 224), 0.25)",
+            outline: "1px solid var(--border-color)",
+        },
+        ".cm-searchMatch.cm-searchMatch-selected": {
+            backgroundColor: "rgba(var(--accent-color-rgb, 65, 159, 224), 0.45)",
+        },
+        ".cm-tooltip": {
+            backgroundColor: "var(--modal-bg-color)",
+            border: "1px solid var(--border-color)",
+            color: "var(--main-text-color)",
+        },
+    },
+    { dark: true },
+);
+
+export const editorTheme: Extension = [editorChromeTheme, syntaxHighlighting(oneDarkHighlightStyle)];

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -541,6 +541,21 @@
         // resize together.
         font-size: calc(13px * var(--editor-zoom, 1));
     }
+
+    // Tight gutter — no debugger/breakpoint margin to reserve, so the line
+    // numbers sit flush against the code with just 1px of breathing room.
+    // The fold gutter (unused; no folding UI) and the lint gutter column are
+    // hidden. lintGutter() stays in the extension set because it backs the
+    // inline diagnostic underlines — only its empty marker column is removed
+    // here — so the only visible gutter is the line numbers.
+    .cm-foldGutter,
+    .cm-gutter-lint {
+        display: none;
+    }
+
+    .cm-lineNumbers .cm-gutterElement {
+        padding: 0 1px 0 6px;
+    }
 }
 
 // ── LSP install banner (Phase 1 of SPEC_EDITOR_LSP_AND_THEMES) ────────

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -11,9 +11,9 @@ import { ConfirmDialog } from "@/app/components/confirm-dialog";
 import { EditorView, basicSetup } from "codemirror";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
-import { oneDark } from "@codemirror/theme-one-dark";
 import { search } from "@codemirror/search";
 import { lintGutter } from "@codemirror/lint";
+import { editorTheme } from "./editor-theme";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { settingsAtom } from "@/store/global";
@@ -255,8 +255,12 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
         const extensions: Extension[] = [
             basicSetup,
-            oneDark,
+            editorTheme,
             search(),
+            // lintGutter installs the lint state field that backs the inline
+            // diagnostic underlines (LSP pushes via setDiagnostics). We keep
+            // it for that field but hide its gutter column in CSS — there's
+            // no debugger/breakpoint margin, so the numbers sit tight to code.
             lintGutter(),
             lintCompartment.of([]),
             EditorView.lineWrapping,


### PR DESCRIPTION
## What

Two editor polish changes requested:

1. **Colors bound to the global theme.** The editor previously used a hardcoded `oneDark` CodeMirror theme. Now the chrome — background, text, gutters, cursor, selection, search matches, tooltips — is bound to the app's theme tokens (`--block-bg-color`, `--main-text-color`, `--accent-color`, `--secondary-text-color`, `--highlight-bg-color`, `--border-color`, …), so the editor follows whatever theme the user has active (tokyo-night, nord, monokai, dracula, gruvbox, high-contrast, …). Syntax-token colors still come from oneDark's highlight style — the theme system has no per-token color tokens, and that palette reads well on every dark theme.

2. **Tight line-number gutter.** Removed the large gap between the line numbers and the code. There's no debugger/breakpoint margin to reserve, so:
   - the unused **fold-gutter** column is hidden,
   - the **lint-gutter** marker column is hidden (collapsed to 0 width),
   - line-number right padding is collapsed to **1px**.

   `lintGutter()` stays in the extension set because it installs the lint state field that backs the **inline diagnostic underlines** (LSP pushes via `setDiagnostics`). Only its empty marker column is hidden in CSS, so diagnostics still render — just without the reserved gap.

## Files

- `frontend/app/view/editor/editor-theme.ts` (new) — `editorTheme` extension: CSS-var-bound chrome + `syntaxHighlighting(oneDarkHighlightStyle)`.
- `frontend/app/view/editor/editor-view.tsx` — swap `oneDark` → `editorTheme`; keep `lintGutter()` with an explanatory comment.
- `frontend/app/view/editor/editor-view.scss` — hide `.cm-foldGutter` / `.cm-gutter-lint`, tighten `.cm-lineNumbers` padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)