### PR TITLE
feat(agent-pane): pinned activity dock (Phase 1 — shell adapter)

### DIFF
--- a/.changesets/1781525238-feat-agent-pane-pinned-activity-dock-phase-1-long-running-sh-e62n.md
+++ b/.changesets/1781525238-feat-agent-pane-pinned-activity-dock-phase-1-long-running-sh-e62n.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): pinned activity dock (Phase 1) — long-running shells pinned atop the pane, click to expand live log

--- a/docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md
+++ b/docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md
@@ -1,0 +1,273 @@
+# SPEC: Pinned Activity Dock — Unified Long-Running Activities
+
+**(shell · cron · subagent · …)**
+
+**Date:** 2026-06-15
+**Status:** Draft
+**Builds on:** `SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md` (Phases 1–2),
+`SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md` (stop / tree-kill, PR #1422),
+MSYS cwd fix (#1415), and the existing subagent stack
+(`subagent_watcher.rs`, `useSubagentEvents.ts`, swarm pane).
+
+> Supersedes the shell-only framing of this file's first draft. The dock is
+> **not** shell-specific — a shell, a cron, and a subagent are all *kinds* of the
+> same thing: a long-running activity that should stay glanceable and
+> expandable.
+
+---
+
+## 1. Problem
+
+Long-running things an agent starts are **scattered and scroll away**:
+
+- A **shell** (`task dev`, vite) is a row buried deep in the conversation.
+- A **subagent** (Task tool) lives in the *Swarm* pane — a different surface
+  entirely; you context-switch to check on it.
+- A **cron / recurring** check has no first-class home at all.
+
+There is no single, glanceable place that answers *"what's running for me right
+now, and how is it doing?"* Each kind also re-implements its own status chrome.
+
+---
+
+## 2. Core idea
+
+**One abstraction, one dock.** Introduce a **`PinnedActivity`** — anything
+long-running the agent spawns — and render every instance as a uniform colored
+row in a **dock pinned to the top of the agent pane**. Click a row → its
+**live view expands**; click again → collapses. Kinds are pluggable:
+
+| Kind | Today's surface | Live view (expand) | Stop action |
+|------|-----------------|--------------------|-------------|
+| `shell` | inline `PersistentShellBlock` | streaming log (`ToolOverlayLog`) | `ShellStop` (tree-kill) |
+| `cron` | — (new) | iteration timeline | `ShellStop` (kill loop) |
+| `subagent` | Swarm pane card | live transcript / current tool | cancel subagent (`agentstop`) |
+| *(future)* `download`, `build`, `deploy`… | — | kind-specific | kind-specific |
+
+The dock is the **live control surface**; each kind keeps its existing detailed
+surface (inline block, swarm pane, subagent view) as the deep/permanent view.
+
+```
+┌─ AgentControlBar ───────────────────────────────────────────┐
+├─ Activity dock (pinned, sticky) ────────────────────────────┤
+│ ⟩ task dev          [run 4:12] ↳ vite ready in 312ms      ■ │  ← shell
+│ ⟳ check disk q60s   [run 2:00] ↳ 41% used                 ■ │  ← cron
+│ ◆ refactor auth     [run 1:08] ↳ editing auth/login.ts    ■ │  ← subagent
+├─ Conversation document (scrolls under the dock) ────────────┤
+```
+
+---
+
+## 3. The `PinnedActivity` abstraction
+
+A presentational + behavioral contract every kind implements (frontend):
+
+```ts
+type ActivityKind = "shell" | "cron" | "subagent";
+type ActivityStatus = "running" | "done" | "error" | "stopped";
+
+interface PinnedActivity {
+    id: string;
+    kind: ActivityKind;
+    title: string;            // command, cron label, or subagent task
+    status: ActivityStatus;
+    startedAt: number;        // Unix ms
+    endedAt?: number;
+    sigil: string;            // ⟩ / ⟳ / ◆  (per kind, colored by status)
+    tailLine?: () => string;  // latest line / current step — the collapsed tail
+    canStop: boolean;
+    stop: () => void;         // ShellStop / kill loop / cancel subagent
+    Expanded: Component;      // the kind-specific live view rendered on expand
+}
+```
+
+**Adapters** map each existing source onto it — no new persistence, all derived:
+
+- **Shell adapter** — `ShellNode`s from the agent-document store
+  (`status === "running" || recentlyExited`). `stop` → `ShellStopCommand`.
+  `Expanded` → the existing shell `ToolOverlayLog`.
+- **Subagent adapter** — `SubagentInfo` from `useSubagentEvents` /
+  `swarm-model.ts`. `SubagentStatus::Active → running`, `Completed → done`.
+  `stop` → cancel (`AgentStopCommand` on the subagent block). `tailLine` →
+  current tool / last message. `Expanded` → condensed `subagent-view`.
+- **Cron adapter** — `CronActivity` (a `shell` running an interval loop, §6).
+  `Expanded` → iteration timeline.
+
+Status colors/sigils unify in `_shell-node.scss` → renamed/extended to
+`_activity-dock.scss`; every kind reuses the same row chrome.
+
+---
+
+## 4. The dock (UI)
+
+- **Sticky strip** between `AgentControlBar` and the conversation document in
+  `agent-view.tsx`. The conversation scrolls *under* it.
+- **One row per running activity.** Collapsed row = sigil + title + elapsed +
+  tail + stop. **Click → `Expanded` view inline; click again → collapse.**
+  Expand state stored in the existing **`pinnedNodes`** set keyed by activity
+  `id`, so dock and the kind's own surface (inline block, swarm) stay in sync.
+- **Ordering:** running-first, focus-first, interleaved across kinds — see **D3**.
+- **Stack + summary:** ≤ 3 rows inline; overflow collapses to a truthful
+  "▸ N more" chip with a scrollable full list — see **D6**.
+- **Exit handling:** linger time depends on terminal status (done/stopped fade,
+  error persists until acknowledged) — see **D4**. The detailed surface (inline
+  block / Swarm card) always remains as the record.
+- **Responsive:** reuse the container-query tiers from
+  `SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09` (hide tail <400px, elapsed
+  ≥600px, stop-without-hover ≥900px).
+
+### Components / files
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/components/ActivityDock.tsx` *(new)* | merges adapters → sorted activity list → rows |
+| `frontend/app/view/agent/components/ActivityRow.tsx` *(new)* | uniform collapsed row + inline `Expanded` slot |
+| `frontend/app/view/agent/activity/adapters.ts` *(new)* | shell / subagent / cron → `PinnedActivity` |
+| `frontend/app/view/agent/agent-view.tsx` | mount `<ActivityDock>` |
+| `frontend/app/view/agent/styles/_shell-node.scss` → `_activity-dock.scss` | shared row/sigil/status styles |
+| `PersistentShellBlock.tsx`, `SubagentLinkBlock.tsx` | "pinned above" compact mode while running |
+
+---
+
+## 5. Part B — Auto-detect long-running shells
+
+So the agent never has to *predict* duration (only relevant to the `shell`
+kind; subagents/crons are explicit by construction):
+
+- **Launch heuristic** — known shapes (`task dev`, `vite`, `*serve*`,
+  `*--watch`, `nodemon`, `next dev`, `cargo watch`, `tail -f`, `ping -t`, …)
+  route a `Bash` call to a ShellNode → dock, returning the `shell_id`.
+- **Overrun promotion** (the catch-all; original spec §7 / Phase 4):
+  `agentmux-bashwrap` already wraps every `Bash` call — if one is still running
+  after a threshold (~30s, `agent:bashwrap_promote_secs`), **promote** it to a
+  ShellNode, publish `shell_node_create` retroactively (→ dock), and return:
+  *"Still running after 30s — promoted to background shell `<id>`; watch it in
+  the dock, stop with `ShellStop(<id>)`."* → **no command can hang the agent.**
+
+---
+
+## 6. Part C — Cron / "stays active"
+
+A recurring check is a `shell` whose work is periodic — pinned and observable
+like any activity:
+
+- Sugar tool `ShellEvery(cmd, interval_secs, title?)` → a ShellNode running the
+  cross-platform equivalent of `while true; do <cmd>; sleep <n>; done`, each
+  iteration delimited by a `system` chunk (`── 11:32:00 ──`) so the live view
+  reads as a timeline. Stop = `ShellStop` (tree-kills the loop).
+
+**Explicit non-goal — scheduling the *agent*.** "Every minute the *agent*
+re-evaluates and acts" needs a scheduler that triggers **agent turns**
+(`CronCreate` / `ScheduleWakeup` in the agent runtime) — a separate spec. This
+dock makes the *process/subagent* side first-class and observable; the two
+compose (a scheduled agent could keep a `ShellEvery` monitor pinned).
+
+---
+
+## 7. Architecture
+
+```
+            ┌─────────────── ActivityDock (derived signal) ───────────────┐
+            │  merge + sort(running first, by startedAt)                   │
+            └───▲────────────────────▲───────────────────────▲────────────┘
+                │                     │                       │
+        shell adapter          subagent adapter          cron adapter
+                │                     │                       │
+        agent-document          useSubagentEvents        ShellEvery /
+        store (ShellNode)        / swarm-model            interval ShellNode
+                │                     │                       │
+        ShellStopCommand        AgentStopCommand          ShellStopCommand
+        (tree-kill, #1422)      (cancel subagent)         (kill loop)
+```
+
+- **No new backend state for the dock** — it's a pure frontend merge of streams
+  that already exist. Subagents already publish status (`subagent_watcher.rs`);
+  shells already stream (`shell_chunk`); cron is a shell.
+- **Extensibility:** a new kind = one adapter implementing `PinnedActivity` +
+  an `Expanded` component. The dock, row chrome, stack/summary, and responsive
+  behaviour are kind-agnostic.
+
+---
+
+## 8. Resolved design decisions
+
+### D1 — Dock vs. Swarm: complementary, not duplicate
+- **Dock = active + glanceable, scoped to *this* agent pane.** It shows only
+  activities spawned by this pane's agent (block-scoped — see D5), in their
+  running + briefly-terminal state. It is a "now active" mini-bar.
+- **Swarm = full roster + management + history** across the whole swarm
+  (all subagents incl. completed, detail, spawn). It is the "library."
+- A running subagent appears in **both, intentionally** — like a now-playing bar
+  vs. the full library. They are different scopes, not a render conflict.
+- **Stop is shared + idempotent.** Dock-stop and Swarm-stop call the *same* RPC
+  (`ShellStopCommand` for shells, `AgentStopCommand` on the subagent block for
+  subagents). The Phase-3 shell registry is already idempotent (`stop()` on an
+  unknown id is a no-op), and `AgentStopCommand` is too — so a double-stop from
+  the two surfaces can never misbehave.
+
+### D2 — Durability: session-scoped, replay-backed (no new persistence)
+- The dock is a **live** surface. On a pane reload, a *running* activity
+  reappears because **its source already replays**: shells via the
+  `shell_chunk` persist:1024 ring on resubscribe (Phases 1–2), subagents via
+  their own store (`subagent_watcher.rs`), cron because it *is* a shell.
+- The dock therefore wires **no new FileStore persistence**. Terminal
+  activities are not in the dock (they live in the conversation / Swarm).
+- **Across a full app restart**, ShellNodes/cron do **not** survive (consistent
+  with the original spec §10 Q1 — ShellNode is session-scoped). App-restart
+  durability for cron is an explicit **future enhancement**, not v1.
+
+### D3 — Ordering: running-first, focus-first, interleaved
+- Sort key: **running before terminal**; within running, the **expanded**
+  activity floats to the top (you're focused on it), then by `startedAt`
+  **descending** (newest spawn on top).
+- Terminal rows sink below running and auto-dismiss per D4.
+- **Interleaved across kinds** — one unified "what's active" list; the per-kind
+  sigil (`⟩` shell / `⟳` cron / `◆` subagent) distinguishes them. Grouping by
+  kind appears **only** inside the overflow summary (D6).
+
+### D4 — Exit retention: by terminal status
+- `done` (clean exit / completed subagent) → linger ~8 s, then fade out.
+- `stopped` (user-initiated) → linger ~3 s, then dismiss (you did it).
+- `error` (non-zero exit / failed subagent) → **persist until acknowledged**
+  (`×` dismiss) — failures never silently vanish.
+- In every case the **permanent record** (inline block / Swarm card) remains;
+  the dock only sheds the *live* row.
+
+### D5 — Tear-off / moves: travels with the pane (confirmed)
+The dock is **block-scoped** — `agent-view.tsx` renders per `model.blockId`
+(`registerAgentPane(model.blockId)`), and the activity list is derived from that
+block's shells/subagents. So it **travels with the agent pane** through tear-off,
+floating-pane, and layout moves automatically — no window-scoped state. It also
+renders in the chromeless floating-pane layout (it's core agent state, not tab
+chrome).
+
+### D6 — Cap & overflow: 3 inline, truthful summary, scroll (no silent drop)
+- Show up to **3** rows inline (ordered per D3). A 4th+ collapses the overflow
+  into a **"▸ N more (2 shells · 1 subagent)"** chip whose count is **always the
+  true total** — click expands a **scrollable** list of *all* activities.
+- The expanded activity (if any) always stays visible; only un-expanded rows
+  past the cap move into the summary.
+- **No silent truncation:** nothing is ever hidden without the count reflecting
+  it; the full set is always one click + scroll away.
+
+---
+
+## 9. Relation to existing work
+
+- **Phases 1–3** (ShellNode, streaming, stop/tree-kill) — the `shell` adapter's
+  substrate.
+- **Subagent stack** (`subagent_watcher.rs`, `useSubagentEvents.ts`,
+  `SubagentLinkBlock`, swarm pane, `subagent-view`) — the `subagent` adapter's
+  substrate; the dock is a new *live* view of it, not a replacement.
+- **`SPEC_AGENT_PANE_RESPONSIVE_AUX_INFO_2026_06_09`** — the dock *is* aux info;
+  reuse its tiers.
+- **Original persistent-shell spec §7 + Phase 4** — concrete design for bashwrap
+  auto-promotion, now with the UI to surface it.
+
+## 10. Suggested phasing
+
+1. **Dock + shell adapter** — highest value, reuses Phases 1–3; establishes the
+   `PinnedActivity` contract and row chrome.
+2. **Subagent adapter** — proves the generalization (a non-shell kind in the
+   same dock); biggest "wow" since subagents currently live elsewhere.
+3. **Overrun promotion** (§5) — kills the "agent picked Bash and it hung" class.
+4. **Launch heuristic** (§5) + **cron sugar** (§6).

--- a/frontend/app/view/agent/activity/shell-adapter.ts
+++ b/frontend/app/view/agent/activity/shell-adapter.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shell adapter — maps `ShellNode`s (agent-document store) onto `PinnedActivity`
+ * for the dock. The dock is a pure derived view; no new state.
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§3, D2)
+ */
+
+import type { DocumentNode, ShellNode } from "../types";
+import type { PinnedActivity, ActivityStatus } from "./types";
+
+function shellStatusToActivity(s: ShellNode["status"]): ActivityStatus {
+    switch (s) {
+        case "running": return "running";
+        case "stopped": return "stopped";
+        case "exited-err": return "error";
+        case "exited-ok": return "done";
+    }
+}
+
+export function shellToActivity(n: ShellNode): PinnedActivity {
+    return {
+        id: n.id,
+        kind: "shell",
+        title: n.title,
+        status: shellStatusToActivity(n.status),
+        startedAt: n.spawnedAt,
+        endedAt: n.exitedAt,
+        canStop: n.status === "running",
+        shell: n,
+    };
+}
+
+/** Pull every shell node out of the document and map to activities. */
+export function shellActivities(nodes: ReadonlyArray<DocumentNode>): PinnedActivity[] {
+    const out: PinnedActivity[] = [];
+    for (const n of nodes) {
+        if (n.type === "shell") out.push(shellToActivity(n as ShellNode));
+    }
+    return out;
+}

--- a/frontend/app/view/agent/activity/types.ts
+++ b/frontend/app/view/agent/activity/types.ts
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PinnedActivity — the unified abstraction behind the pinned activity dock.
+ *
+ * Anything long-running an agent spawns (a shell, a cron, a subagent) maps onto
+ * this contract and renders as a uniform row in the dock at the top of the
+ * agent pane. Phase 1 implements only the `shell` kind; `cron` and `subagent`
+ * adapters slot in later without touching the dock/row chrome.
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md
+ */
+
+import type { ShellNode } from "../types";
+
+export type ActivityKind = "shell" | "cron" | "subagent";
+
+/** Normalized lifecycle across every kind (D3/D4 ordering + retention). */
+export type ActivityStatus = "running" | "done" | "error" | "stopped";
+
+export interface PinnedActivity {
+    id: string;
+    kind: ActivityKind;
+    title: string;
+    status: ActivityStatus;
+    /** Unix ms — drives the elapsed timer and the D3 newest-first ordering. */
+    startedAt: number;
+    /** Unix ms when it reached a terminal status (drives D4 retention). */
+    endedAt?: number;
+    /** True while the activity can be stopped (running). */
+    canStop: boolean;
+
+    // ── Kind-specific source, read by the row's tail + Expanded view ──
+    /** Present when `kind === "shell"` (also "cron", which is a shell). */
+    shell?: ShellNode;
+}
+
+/** Per-kind sigil; colored by status in CSS. */
+export const KIND_SIGIL: Record<ActivityKind, string> = {
+    shell: "⟩",
+    cron: "⟳",
+    subagent: "◆",
+};
+
+/** Milliseconds a terminal row lingers in the dock before auto-dismiss (D4).
+ *  `error` is Infinity — it persists until the user acknowledges it. */
+export const RETENTION_MS: Record<ActivityStatus, number> = {
+    running: Infinity,
+    done: 8_000,
+    stopped: 3_000,
+    error: Infinity,
+};

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -52,6 +52,7 @@ import { useAgentCommands } from "./hooks/useAgentCommands";
 import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
 import { DragOverlay } from "@/app/element/dragoverlay";
 import { AgentControlBar } from "./components/AgentControlBar";
+import { ActivityDock } from "./components/ActivityDock";
 import { ActivityLogPanel } from "./components/ActivityLogPanel";
 import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
 import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
@@ -877,6 +878,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onTabChange={(tab) => { model._lastOverlayTab = tab; }}
                 />
             </Show>
+
+            {/* Pinned activity dock — long-running shells (and later crons /
+                subagents) stay glanceable at the top while the conversation
+                scrolls under it. SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15. */}
+            <ActivityDock
+                documentAtom={agentAtoms().documentAtom}
+                documentStateAtom={agentAtoms().documentStateAtom}
+            />
 
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -1,0 +1,171 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ActivityDock — a strip pinned to the top of the agent pane listing every
+ * long-running activity (Phase 1: shells) as a uniform row. Click a row → its
+ * live view expands; click again → collapses. The conversation scrolls under it.
+ *
+ * Pure derived view of the agent-document store — no new state. Expand state is
+ * the shared `documentState.pinnedNodes`, so the dock and the inline
+ * PersistentShellBlock stay in sync.
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md
+ *   (D1 dock vs swarm · D3 ordering · D4 retention · D6 cap/overflow)
+ */
+
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { ActivityRow } from "./ActivityRow";
+import { shellActivities } from "../activity/shell-adapter";
+import { RETENTION_MS, type ActivityKind, type ActivityStatus, type PinnedActivity } from "../activity/types";
+import type { SignalPair } from "../state";
+import type { DocumentNode, DocumentState } from "../types";
+
+const MAX_INLINE = 3;
+
+// D3 — running first, then error, stopped, done.
+const STATUS_RANK: Record<ActivityStatus, number> = { running: 0, error: 1, stopped: 2, done: 3 };
+
+const KIND_PLURAL: Record<ActivityKind, string> = { shell: "shell", cron: "cron", subagent: "subagent" };
+
+function overflowSummary(items: PinnedActivity[]): string {
+    const counts = new Map<ActivityKind, number>();
+    for (const a of items) counts.set(a.kind, (counts.get(a.kind) ?? 0) + 1);
+    return [...counts.entries()]
+        .map(([k, n]) => `${n} ${KIND_PLURAL[k]}${n === 1 ? "" : "s"}`)
+        .join(" · ");
+}
+
+interface ActivityDockProps {
+    documentAtom: SignalPair<DocumentNode[]>;
+    documentStateAtom: SignalPair<DocumentState>;
+}
+
+export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
+    const [nodes] = props.documentAtom;
+    const [docState, setDocState] = props.documentStateAtom;
+    const [now, setNow] = createSignal(Date.now());
+    const [dismissed, setDismissed] = createSignal<Set<string>>(new Set());
+    const [overflowOpen, setOverflowOpen] = createSignal(false);
+
+    const allActivities = createMemo(() => shellActivities(nodes()));
+
+    const activityById = createMemo(() => {
+        const m = new Map<string, PinnedActivity>();
+        for (const a of allActivities()) m.set(a.id, a);
+        return m;
+    });
+
+    // Tick once a second only while a terminal row is lingering toward expiry.
+    const hasExpiring = createMemo(() =>
+        allActivities().some(
+            (a) => a.status !== "running" && RETENTION_MS[a.status] !== Infinity && a.endedAt != null,
+        ),
+    );
+    createEffect(() => {
+        if (!hasExpiring()) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    // D4 — running always; terminal within its retention window; never dismissed.
+    const visible = createMemo(() => {
+        const dm = dismissed();
+        const t = now();
+        return allActivities().filter((a) => {
+            if (dm.has(a.id)) return false;
+            if (a.status === "running") return true;
+            const ret = RETENTION_MS[a.status];
+            if (ret === Infinity) return true; // error → until acknowledged
+            return a.endedAt != null && t - a.endedAt < ret;
+        });
+    });
+
+    // D3 — running-first, expanded-first, newest-first.
+    const ordered = createMemo(() => {
+        const pinned = docState().pinnedNodes;
+        return [...visible()].sort((x, y) => {
+            const rank = STATUS_RANK[x.status] - STATUS_RANK[y.status];
+            if (rank !== 0) return rank;
+            const exp = (pinned.has(x.id) ? 0 : 1) - (pinned.has(y.id) ? 0 : 1);
+            if (exp !== 0) return exp;
+            return y.startedAt - x.startedAt;
+        });
+    });
+
+    // D6 — up to MAX_INLINE inline; expanded rows past the cap stay visible.
+    const inline = createMemo(() => {
+        const all = ordered();
+        const pinned = docState().pinnedNodes;
+        const head = all.slice(0, MAX_INLINE);
+        const keptTail = all.slice(MAX_INLINE).filter((a) => pinned.has(a.id));
+        return [...head, ...keptTail];
+    });
+    const overflow = createMemo(() => {
+        const shown = new Set(inline().map((a) => a.id));
+        return ordered().filter((a) => !shown.has(a.id));
+    });
+
+    // Rows currently rendered (inline + expanded overflow). Keyed by id string so
+    // rows persist across chunk updates (the For sees equal strings).
+    const renderedIds = createMemo(() => {
+        const list = overflowOpen() ? [...inline(), ...overflow()] : inline();
+        return list.map((a) => a.id);
+    });
+
+    const togglePin = (id: string): void =>
+        setDocState((prev) => {
+            const pinned = new Set(prev.pinnedNodes);
+            if (pinned.has(id)) pinned.delete(id);
+            else pinned.add(id);
+            return { ...prev, pinnedNodes: pinned };
+        });
+
+    const stop = (id: string): void => {
+        const a = activityById().get(id);
+        if (a?.kind === "shell" || a?.kind === "cron") {
+            RpcApi.ShellStopCommand(TabRpcClient, { shell_id: id }).catch(() => {
+                // best-effort; the exit event reconciles status
+            });
+        }
+    };
+
+    const dismiss = (id: string): void =>
+        setDismissed((prev) => {
+            const next = new Set(prev);
+            next.add(id);
+            return next;
+        });
+
+    return (
+        <Show when={ordered().length > 0}>
+            <div class="agent-activity-dock">
+                <For each={renderedIds()}>
+                    {(id) => (
+                        <ActivityRow
+                            activity={() => activityById().get(id)}
+                            expanded={() => docState().pinnedNodes.has(id)}
+                            onToggle={() => togglePin(id)}
+                            onStop={() => stop(id)}
+                            onDismiss={() => dismiss(id)}
+                        />
+                    )}
+                </For>
+                <Show when={overflow().length > 0}>
+                    <button
+                        class="agent-activity-overflow"
+                        onClick={() => setOverflowOpen((v) => !v)}
+                    >
+                        {overflowOpen()
+                            ? "▾ fewer"
+                            : `▸ ${overflow().length} more (${overflowSummary(overflow())})`}
+                    </button>
+                </Show>
+            </div>
+        </Show>
+    );
+};
+
+ActivityDock.displayName = "ActivityDock";

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -58,12 +58,23 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
         return m;
     });
 
-    // Tick once a second only while a terminal row is lingering toward expiry.
-    const hasExpiring = createMemo(() =>
-        allActivities().some(
-            (a) => a.status !== "running" && RETENTION_MS[a.status] !== Infinity && a.endedAt != null,
-        ),
-    );
+    // Tick once a second only while a terminal row is STILL within its retention
+    // window. The `now() - endedAt < retention` check is what lets this go false:
+    // ShellNodes linger in the document forever, so without it the guard stayed
+    // true permanently and the 1Hz setInterval never cleared — a perpetual
+    // re-render loop per pane after the first shell exited (reagent #1428 P2).
+    // Depending on now() means each tick re-evaluates; once every lingering row
+    // has aged past its retention the effect re-runs and clears the interval.
+    const hasExpiring = createMemo(() => {
+        const t = now();
+        return allActivities().some(
+            (a) =>
+                a.status !== "running" &&
+                RETENTION_MS[a.status] !== Infinity &&
+                a.endedAt != null &&
+                t - a.endedAt < RETENTION_MS[a.status],
+        );
+    });
     createEffect(() => {
         if (!hasExpiring()) return;
         const id = setInterval(() => setNow(Date.now()), 1000);

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -1,0 +1,153 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ActivityRow — one uniform row in the pinned activity dock. Kind-agnostic
+ * chrome (sigil + title + elapsed + tail + stop); the expanded view dispatches
+ * by kind (Phase 1: shell → streaming log).
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§4)
+ */
+
+import clsx from "clsx";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
+import type { ToolLogChunk } from "../types";
+
+const KIND_CLASS: Record<string, string> = {
+    stdout: "agent-tool-log-line--stdout",
+    stderr: "agent-tool-log-line--stderr",
+    system: "agent-tool-log-line--system",
+};
+
+function formatElapsed(ms: number): string {
+    const totalSec = Math.max(0, Math.floor(ms / 1000));
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+interface ActivityRowProps {
+    /** Reactive accessor — returns undefined if the activity just left. */
+    activity: () => PinnedActivity | undefined;
+    expanded: () => boolean;
+    onToggle: () => void;
+    onStop: () => void;
+    onDismiss: () => void;
+}
+
+export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
+    const [now, setNow] = createSignal(Date.now());
+
+    const isRunning = createMemo(() => props.activity()?.status === "running");
+    createEffect(() => {
+        if (!isRunning()) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    const elapsed = createMemo(() => {
+        const a = props.activity();
+        if (!a) return "";
+        const end = a.endedAt ?? now();
+        return formatElapsed(end - a.startedAt);
+    });
+
+    // Terminal statuses override the kind sigil with a result glyph.
+    const sigil = createMemo(() => {
+        const a = props.activity();
+        if (!a) return "";
+        switch (a.status) {
+            case "running": return KIND_SIGIL[a.kind];
+            case "done": return "✓";
+            case "error": return "✗";
+            case "stopped": return "■";
+        }
+    });
+
+    const tail = createMemo((): string | undefined => {
+        const sh = props.activity()?.shell;
+        if (!sh) return undefined;
+        const chunks = sh.log.chunks;
+        for (let i = chunks.length - 1; i >= 0; i--) {
+            const c = chunks[i];
+            if ((c.kind === "stdout" || c.kind === "stderr") && c.content.trim()) {
+                return c.content.trim();
+            }
+        }
+        return undefined;
+    });
+
+    // Expanded shell log — same cap + renderer as PersistentShellBlock.
+    const chunkCap = createChunkCapper(MAX_TOOL_OUTPUT_LINES);
+    const capped = createMemo(() => {
+        const sh = props.activity()?.shell;
+        return sh
+            ? chunkCap(sh.log.chunks as ToolLogChunk[])
+            : { chunks: [] as ToolLogChunk[], hiddenLines: 0 };
+    });
+
+    return (
+        <Show when={props.activity()}>
+            {(a) => (
+                <div
+                    class={clsx("agent-activity-row", a().kind, a().status, {
+                        expanded: props.expanded(),
+                    })}
+                >
+                    <div class="agent-activity-summary" onClick={props.onToggle}>
+                        <span class="agent-activity-sigil">{sigil()}</span>
+                        <span class="agent-activity-title">{a().title}</span>
+                        <span class="agent-activity-elapsed">[{elapsed()}]</span>
+                        <Show when={tail()}>
+                            <span class="agent-activity-tail">↳ {tail()}</span>
+                        </Show>
+                        <Show when={a().canStop}>
+                            <button
+                                class="agent-activity-stop"
+                                title="Stop"
+                                onClick={(e) => { e.stopPropagation(); props.onStop(); }}
+                            >
+                                ■
+                            </button>
+                        </Show>
+                        <Show when={!a().canStop && a().status === "error"}>
+                            <button
+                                class="agent-activity-dismiss"
+                                title="Dismiss"
+                                onClick={(e) => { e.stopPropagation(); props.onDismiss(); }}
+                            >
+                                ×
+                            </button>
+                        </Show>
+                    </div>
+
+                    <Show when={props.expanded() && a().shell}>
+                        <div
+                            class="agent-activity-log agent-tool-overlay-log"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <Show when={capped().hiddenLines > 0}>
+                                <OutputHiddenMarker hidden={capped().hiddenLines} noun="line" from="tail" />
+                            </Show>
+                            <For each={capped().chunks}>
+                                {(chunk) => (
+                                    <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
+                                        {capChars(chunk.content)}
+                                    </pre>
+                                )}
+                            </For>
+                            <Show when={a().shell!.log.open}>
+                                <div class="agent-shell-streaming-indicator" />
+                            </Show>
+                        </div>
+                    </Show>
+                </div>
+            )}
+        </Show>
+    );
+};
+
+ActivityRow.displayName = "ActivityRow";

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -145,3 +145,134 @@
         display: none;
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pinned activity dock — long-running activities (shell/cron/subagent) pinned
+// to the top of the agent pane. SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.
+// ─────────────────────────────────────────────────────────────────────────────
+
+.agent-activity-dock {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--main-bg-color, #161616);
+    max-height: 45%;            // never let the dock eat the whole pane
+    overflow-y: auto;
+    z-index: 2;
+}
+
+.agent-activity-row {
+    border-left: 3px solid var(--border-color);
+    transition: border-left-color 0.2s ease;
+
+    &.running  { border-left-color: var(--term-bright-green); }
+    &.done     { border-left-color: var(--accent-color); opacity: 0.75; }
+    &.error    { border-left-color: var(--error-color, #ff6b6b); }
+    &.stopped  { border-left-color: var(--secondary-text-color); opacity: 0.6; }
+
+    & + & { border-top: 1px solid var(--border-color); }
+}
+
+.agent-activity-summary {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    cursor: pointer;
+    user-select: none;
+    min-height: 24px;
+
+    &:hover { background: var(--hover-bg-color, rgba(255, 255, 255, 0.04)); }
+}
+
+.agent-activity-sigil {
+    flex: 0 0 auto;
+    font-size: 12px;
+    width: 14px;
+    text-align: center;
+
+    .running &  { color: var(--term-bright-green); }
+    .done &     { color: var(--accent-color); }
+    .error &    { color: var(--error-color, #ff6b6b); }
+    .stopped &  { color: var(--secondary-text-color); }
+}
+
+.agent-activity-title {
+    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 40%;
+}
+
+.agent-activity-elapsed {
+    flex: 0 0 auto;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+}
+
+.agent-activity-tail {
+    flex: 1 1 0;
+    min-width: 0;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0.75;
+}
+
+.agent-activity-stop,
+.agent-activity-dismiss {
+    flex: 0 0 auto;
+    margin-left: auto;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 11px;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 3px;
+    cursor: pointer;
+    opacity: 0.55;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+    &:hover {
+        opacity: 1;
+        color: var(--error-color, #ff6b6b);
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+}
+
+.agent-activity-summary:hover .agent-activity-stop,
+.agent-activity-summary:hover .agent-activity-dismiss { opacity: 0.85; }
+
+// Expanded live log — reuses the tool-overlay log line styles.
+.agent-activity-log {
+    padding: var(--space-1) var(--space-2) var(--space-2);
+    max-height: 320px;
+    overflow-y: auto;
+    background: var(--block-bg-color, rgba(0, 0, 0, 0.18));
+}
+
+.agent-activity-overflow {
+    appearance: none;
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    padding: var(--space-1) var(--space-2);
+    font-size: 11px;
+    color: var(--secondary-text-color);
+
+    &:hover { background: var(--hover-bg-color, rgba(255, 255, 255, 0.04)); color: var(--main-text-color); }
+}
+
+@container agent-pane (max-width: 399px) {
+    .agent-activity-tail { display: none; }
+}


### PR DESCRIPTION
## What

A strip **pinned to the top of the agent pane** lists long-running shells as uniform colored rows. **Click a row → its live log expands; click again → collapses.** The conversation scrolls *under* it, so a `task dev` / vite never scrolls away.

> ⚠️ **Stacked on #1422** (Phase 3 stop) — the dock's stop button uses `ShellStopCommand`. The diff here shows the Phase 3 commit too until #1422 merges; rebase onto main after that and only the dock commit remains.

## Design

- **Pure derived view** of the agent-document store — no new state. Expand uses the shared `documentState.pinnedNodes`, so the dock and the inline `PersistentShellBlock` stay in sync.
- **Generalized `PinnedActivity` contract** (`kind: shell | cron | subagent`) so the cron + subagent adapters slot in later **without touching the dock/row chrome** — Phase 1 ships only the `shell` adapter.
- Implements the resolved spec decisions: **D3** ordering (running → expanded → newest-first), **D4** retention (done 8s / stopped 3s / error-until-ack), **D6** cap (3 inline + truthful `▸ N more (…)` overflow), **D5** travels with the pane (block-scoped via `agent-view.tsx`).
- Stop button reuses **Phase 3 `ShellStop`** (tree-kill).

## Files
New: `activity/types.ts`, `activity/shell-adapter.ts`, `components/ActivityDock.tsx`, `components/ActivityRow.tsx`. Modified: `agent-view.tsx` (mount above the conversation), `styles/_shell-node.scss` (dock chrome).

## Verified live (dev build)
- Dock renders a running shell at the top: `⟩ ping test [0:13] ↳ Reply from 127.0.0.1… ■`.
- Click row → live log expands (50 streamed lines).
- Click ■ → row → `stopped`, and `PING.EXE` count → **0** (tree-killed, no orphan).
- `task build:frontend:dev` clean.

## Next (per spec)
Phase 2 — **subagent adapter** (proves the generalization with a non-shell kind); then overrun promotion + launch heuristic + cron sugar.

Spec: `docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md`.