### PR TITLE
feat(trust-center): Phase 1 — rename hub + Accounts tab

### DIFF
--- a/.changesets/1781526400-feat-trust-center-accounts-tab.md
+++ b/.changesets/1781526400-feat-trust-center-accounts-tab.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): rename the app-wide "Identity & Memory" hub to "Trust Center" and add an Accounts tab for managing service credentials alongside Identity and Memory bundles

--- a/frontend/app/modals/bundle-manager-modal.tsx
+++ b/frontend/app/modals/bundle-manager-modal.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/app/store/singleton-modal";
 import { IdentityManager } from "@/app/view/identity/identity-manager";
 import { MemoryManager } from "@/app/view/memory/memory-manager";
+import { AccountsManager } from "@/app/view/accounts/accounts-manager";
 import "./bundle-manager-modal.scss";
 
 /**
@@ -57,7 +58,7 @@ import "./bundle-manager-modal.scss";
 export const SINGLETON_KIND_BUNDLE_MANAGER: SingletonKind = "bundle-manager";
 
 /** Which section the left rail currently shows. */
-type BundleSection = "identities" | "memories";
+type BundleSection = "accounts" | "identities" | "memories";
 
 /**
  * Resolve a window *label* to its human display name ("Window N", the
@@ -80,7 +81,7 @@ function windowNameForLabel(label: string): string {
  * windows can take it.
  */
 export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
-    const [section, setSection] = createSignal<BundleSection>("identities");
+    const [section, setSection] = createSignal<BundleSection>("accounts");
 
     // Release the singleton on unmount — guaranteed regardless of HOW the
     // modal closes. The Close button and ESC route through `onClose`, but
@@ -93,6 +94,7 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
     const handleClose = () => props.close();
 
     const rail: { id: BundleSection; label: string; icon: string }[] = [
+        { id: "accounts", label: "Accounts", icon: "key" },
         { id: "identities", label: "Identities", icon: "id-card" },
         { id: "memories", label: "Memories", icon: "brain" },
     ];
@@ -100,7 +102,7 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
     return (
         <Modal open={true} onClose={handleClose} scope="window" size="xl">
             <div class="modal-panel-header">
-                <div class="modal-panel-title">Identity &amp; Memory</div>
+                <div class="modal-panel-title">Trust Center</div>
             </div>
             <div class="modal-panel-body bundle-manager-body">
                 <nav class="bundle-manager-rail" aria-label="Bundle section">
@@ -131,6 +133,12 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
                      * choice; both stay consistent via the `*:changed`
                      * WPS events regardless.
                      */}
+                    <div
+                        class="bundle-manager-pane"
+                        classList={{ "is-hidden": section() !== "accounts" }}
+                    >
+                        <AccountsManager />
+                    </div>
                     <div
                         class="bundle-manager-pane"
                         classList={{ "is-hidden": section() !== "identities" }}
@@ -203,7 +211,7 @@ const BundleManagerElsewhereBannerInner = (props: {
                 onClick={focusHolder}
                 title="Bring the holding window to the front"
             >
-                Identity &amp; Memory is open in {holderName()} — click to focus
+                Trust Center is open in {holderName()} — click to focus
             </button>
         </Show>
     );

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AccountsManager — the context-free Accounts management UI, rendered as the
+// **Accounts** tab of the Trust Center (bundle-manager-modal). Phase 1 of
+// SPEC_TRUST_CENTER_2026_06_15.md: surface the existing IdentityAccount model
+// app-wide with no backend changes.
+//
+// It owns a block-free `IdentityViewModel` instance (the existing accounts
+// view-model — account CRUD goes through the module-level RPC + cache, so the
+// blockId/nodeModel it carries for the ViewModel interface are inert here) and
+// composes the already-built `AccountsTab` + `AccountForm` so styling and the
+// add/edit/delete lifecycle come for free. Identity-bundle and Memory
+// management remain in their own Trust Center tabs.
+
+import { onCleanup, Show, type JSX } from "solid-js";
+import type { BlockNodeModel } from "@/app/block/blocktypes";
+import { IdentityViewModel } from "@/app/view/identity/identity-model";
+import { AccountsTab, AccountForm } from "@/app/view/identity/identity-view";
+import "@/app/view/identity/identity-view.scss";
+
+export function AccountsManager(): JSX.Element {
+    // Block-free instance. `IdentityViewModel` only uses blockId/nodeModel to
+    // satisfy the ViewModel interface; all account CRUD flows through the
+    // module-level cache + `*IdentityAccountCommand` RPCs, so a synthetic id
+    // and a stub nodeModel are safe. Created once per mount (SolidJS component
+    // bodies run a single time).
+    const model = new IdentityViewModel("trust-center:accounts", {} as BlockNodeModel);
+    onCleanup(() => model.dispose());
+
+    return (
+        <div class="identity-view">
+            <div class="identity-header">
+                <span class="identity-header-title">Accounts</span>
+                <button
+                    class="identity-add-btn"
+                    onClick={() => model.openAddForm()}
+                    title="Add account"
+                >
+                    + Add
+                </button>
+            </div>
+
+            <div class="identity-body">
+                <AccountsTab model={model} />
+            </div>
+
+            <Show when={model.formOpenAtom()}>
+                <AccountForm model={model} />
+            </Show>
+        </div>
+    );
+}
+
+AccountsManager.displayName = "AccountsManager";

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -311,14 +311,21 @@ export class IdentityViewModel implements ViewModel {
     formErrorAtom: Accessor<string | null> = this._formError[0];
     private setFormError: Setter<string | null> = this._formError[1];
 
+    /** Unsubscribe from the account cache; assigned in the constructor,
+     *  invoked in dispose() so direct callers don't leak a listener. */
+    private _unsubAccounts: (() => void) | null = null;
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
         // Initial paint from cache (may be empty on first launch).
         this.setAccounts(loadAccounts());
         // Stay in sync with module-level cache updates from any source
-        // (other panes, RPC events, etc.).
-        const unsub = subscribeAccountChanges((accounts) => {
+        // (other panes, RPC events, etc.). The unsubscribe is stashed and
+        // invoked in dispose() so callers that mount this model directly
+        // (e.g. the Trust Center Accounts tab) don't leak a listener per
+        // open/close.
+        this._unsubAccounts = subscribeAccountChanges((accounts) => {
             this.setAccounts(accounts);
             // Keep the selected account fresh if it was edited externally.
             const sel = this.selectedAccountAtom();
@@ -330,11 +337,6 @@ export class IdentityViewModel implements ViewModel {
         });
         // Force a refresh in case the cache hasn't been primed yet.
         void refreshAccountCache();
-        // No explicit dispose — subscription leaks per ViewModel are
-        // bounded by the number of identity panes ever opened in a
-        // session (small). If this becomes a memory concern, wire
-        // `unsub` to ViewModel teardown (no such hook exists today).
-        void unsub;
     }
 
     // ── Derived helpers ──────────────────────────────────────────────────────
@@ -441,6 +443,9 @@ export class IdentityViewModel implements ViewModel {
     }
 
     dispose(): void {
-        // nothing to clean up — no backend subscriptions
+        // Drop the account-cache subscription so direct callers (Trust
+        // Center Accounts tab) don't leak a listener per open/close.
+        this._unsubAccounts?.();
+        this._unsubAccounts = null;
     }
 }

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -80,7 +80,7 @@ export function IdentityPanel(props: { model: IdentityViewModel }): JSX.Element 
 
 // ── Accounts tab ─────────────────────────────────────────────────────────────
 
-function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Element {
+export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Element {
     const groups = () => model.accountsByProvider();
 
     return (

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -121,14 +121,14 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
                 onClick: () => openModal(CommandPaletteModal),
             },
             {
-                // Bundle-management PR 4 (Feature 2) — the app-wide
-                // Identity & Memory bundle manager. Opens the manager
-                // modal here when the app-wide singleton is free; when it
-                // is held in another window, focuses that window instead
-                // (the persistent "open elsewhere" banner stays the
-                // durable affordance). See SPEC_BUNDLE_MANAGEMENT §3.
-                label: "Identity & Memory",
-                icon: "id-card",
+                // Trust Center — the app-wide hub for Accounts, Identity,
+                // and Memory. Opens the manager modal here when the app-wide
+                // singleton is free; when it is held in another window,
+                // focuses that window instead (the persistent "open
+                // elsewhere" banner stays the durable affordance).
+                // See SPEC_BUNDLE_MANAGEMENT §3, SPEC_TRUST_CENTER_2026_06_15.
+                label: "Trust Center",
+                icon: "shield-halved",
                 onClick: () => openBundleManager(),
             },
             {


### PR DESCRIPTION
## Summary

Phase 1 of `specs/SPEC_TRUST_CENTER_2026_06_15.md` — surface the existing `IdentityAccount` model app-wide as the new **Trust Center** hub. **No backend changes.**

- **Rename** the hamburger "Identity & Memory" entry → **"Trust Center"** (`shield-halved` icon). Modal title and the "open elsewhere" banner follow suit.
- **Add an Accounts tab** (first in the left rail) to the existing `bundle-manager-modal` singleton. The Identity + Memory tabs are untouched; all cross-window singleton coordination is inherited unchanged.
- **New `AccountsManager`** (`frontend/app/view/accounts/accounts-manager.tsx`) — context-free, composes the already-built `AccountsTab` + `AccountForm` against a block-free `IdentityViewModel`. Account CRUD flows through the module-level cache + `*IdentityAccountCommand` RPCs, so the ViewModel's `blockId`/`nodeModel` are inert here. Reuses existing `identity-view` styles — no new SCSS, no duplicated UI.
- Export `AccountsTab` from `identity-view.tsx` for reuse.

This makes account management — previously buried in the per-agent settings overlay — reachable app-wide alongside Identity and Memory, matching the unified hub in the spec.

## What's deferred (later phases)
- Phase 2: secure key lifecycle (Validate → live probe → masked/non-recoverable → keychain).
- Phase 3: broad service catalog + OAuth.
- Phase 4: account↔identity quick-bind, status surfacing.

## Test plan
- [ ] `npm run build` passes (verified locally).
- [ ] Hamburger → "Trust Center" opens the modal; left rail shows Accounts / Identities / Memory.
- [ ] Accounts tab lists existing accounts grouped by provider; Add/Edit/Delete works via existing RPCs.
- [ ] Identity + Memory tabs behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)