### PR TITLE
feat(muxbus): delivery hierarchy P1+P2 — agent ID injection, URL fix, cloud push subscriber

### DIFF
--- a/.changesets/1781541131-feat-muxbus-delivery-hierarchy-p1-p2-agent-id-injection-url--zlkj.md
+++ b/.changesets/1781541131-feat-muxbus-delivery-hierarchy-p1-p2-agent-id-injection-url--zlkj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): delivery hierarchy P1+P2 — agent ID injection, URL fix, cloud push subscriber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1390,7 +1391,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2598,7 +2599,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3278,8 +3279,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3466,6 +3471,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -3546,7 +3553,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3791,6 +3798,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -46,6 +46,7 @@ tar = "0.4"
 tempfile = "3"
 bollard = { version = "0.18", features = ["chrono"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 
 [target.'cfg(windows)'.dependencies]
 # Out-of-process crash dump capture via VEH + named-pipe IPC.

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -815,6 +815,11 @@ async fn main() {
         reactive_handler,
     ));
 
+    // Cloud push subscriber — single WS connection per sidecar that the cloud
+    // uses to push reactive injections instead of polling.
+    // No-op until the user connects via muxbus.login.
+    crate::muxbus::cloud_subscriber::CloudSubscriber::init_global(wstore.clone());
+
     // Set up docsite directory
     if let Some(app_path) = base::get_wave_app_path() {
         let docsite_dir = app_path.join("docsite");

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -142,10 +142,12 @@ async fn run_loop(
         //   b) Credentials exist but refresh failed transiently → back off and retry
         let has_stored_creds = wstore.muxbus_load().ok().flatten().is_some();
         let token = match load_valid_token(&wstore, &http).await {
-            Some(t) => {
-                delay_secs = RECONNECT_DELAY_SECS; // token loaded; reset back-off
-                t
-            }
+            // Do NOT reset back-off here: a valid token loads on every iteration,
+            // so resetting on load would pin the delay at the base value and
+            // defeat exponential back-off for the common "valid token, WS endpoint
+            // unreachable" failure. Back-off is reset only after a *healthy*
+            // connection — see the clean-disconnect and >30s-session branches below.
+            Some(t) => t,
             None if !has_stored_creds => {
                 // No credentials at all — wait for muxbus.login to signal us
                 while let Some(msg) = ctrl_rx.recv().await {

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -30,6 +30,13 @@ use crate::backend::storage::store::Store;
 const MUXBUS_WS_URL: &str = "wss://muxbus.agentmux.ai/ws";
 const RECONNECT_DELAY_SECS: u64 = 5;
 const MAX_RECONNECT_DELAY_SECS: u64 = 60;
+// Application-level keepalive. Without it, a silently half-open WS (NAT/firewall
+// idle drop, server stall with no FIN/RST) leaves read.next() blocked forever:
+// the subscriber looks connected but receives no pushes and never reconnects.
+// We send a WS Ping every PING_INTERVAL and force a reconnect if no frame of any
+// kind (data, ping, or pong) arrives within IDLE_TIMEOUT.
+const PING_INTERVAL_SECS: u64 = 30;
+const IDLE_TIMEOUT_SECS: u64 = 90;
 
 // ── Wire protocol ─────────────────────────────────────────────────────────────
 
@@ -224,10 +231,17 @@ async fn connect_and_run(
         .await
         .map_err(|e| format!("send subscribe: {e}"))?;
 
+    let mut keepalive = tokio::time::interval(Duration::from_secs(PING_INTERVAL_SECS));
+    // The first tick fires immediately; skip it so we don't ping before any idle.
+    keepalive.tick().await;
+    let mut last_activity = std::time::Instant::now();
+
     loop {
         tokio::select! {
             // Incoming WebSocket message from cloud
             msg = read.next() => {
+                // Any frame — data, ping, or pong — proves the link is alive.
+                last_activity = std::time::Instant::now();
                 match msg {
                     None => return Ok(()), // server closed
                     Some(Err(e)) => return Err(format!("ws recv: {e}")),
@@ -242,7 +256,19 @@ async fn connect_and_run(
                         let _ = write.send(Message::Pong(data)).await;
                     }
                     Some(Ok(Message::Close(_))) => return Ok(()),
-                    Some(Ok(_)) => {} // binary frames etc — ignore
+                    Some(Ok(_)) => {} // pong / binary frames etc — ignore (already counted as activity)
+                }
+            }
+
+            // Keepalive tick: detect a half-open connection and ping to keep NAT open.
+            _ = keepalive.tick() => {
+                if last_activity.elapsed() >= Duration::from_secs(IDLE_TIMEOUT_SECS) {
+                    return Err(format!(
+                        "keepalive timeout: no frames for {}s", IDLE_TIMEOUT_SECS
+                    ));
+                }
+                if let Err(e) = write.send(Message::Ping(Vec::<u8>::new().into())).await {
+                    return Err(format!("keepalive ping failed: {e}"));
                 }
             }
 
@@ -317,11 +343,15 @@ async fn load_valid_token(wstore: &Store, http: &reqwest::Client) -> Option<Stri
         Ok(Some(c)) if !c.access_token.is_empty() => c,
         _ => return None,
     };
-    if creds.is_valid() {
+    // Gate on nearly_expired (300s buffer), not is_valid (exact expiry): a token
+    // with only seconds of life would otherwise open a long-lived WS that the
+    // cloud drops right after the handshake, causing reconnect churn. Refresh
+    // proactively while there's still a comfortable margin.
+    if !creds.nearly_expired() {
         return Some(creds.access_token);
     }
-    // Token expired (or nearly so) — try refresh
-    tracing::info!("cloud_subscriber: access token expired, attempting refresh");
+    // Token expired or within the refresh buffer — try refresh
+    tracing::info!("cloud_subscriber: access token expired or near expiry, attempting refresh");
     match crate::muxbus::pkce::refresh_token(&creds, http).await {
         Ok(refreshed) => {
             if let Err(e) = wstore.muxbus_save(&refreshed) {

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -1,0 +1,310 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cloud push subscription — replaces per-agent polling with a single
+//! sidecar-level WebSocket to muxbus.agentmux.ai.
+//!
+//! When MUXBUS_TOKEN is present, the subscriber:
+//!   1. Opens wss://muxbus.agentmux.ai/ws with the bearer token.
+//!   2. Sends { type: "subscribe", agents: [...all known agents...] }.
+//!   3. Listens for { type: "inject", ... } pushes and delivers via ReactiveHandler.
+//!   4. Sends { type: "ack", id } after delivery.
+//!   5. Reconnects with exponential back-off on any disconnect.
+//!
+//! Agents register/unregister via add_agent()/remove_agent().
+//! No MUXBUS_TOKEN → subscriber stays idle.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async_tls_with_config, tungstenite::Message};
+
+use crate::backend::reactive::handler::get_global_handler;
+use crate::backend::reactive::types::InjectionRequest;
+use crate::backend::storage::store::Store;
+
+const MUXBUS_WS_URL: &str = "wss://muxbus.agentmux.ai/ws";
+const RECONNECT_DELAY_SECS: u64 = 5;
+const MAX_RECONNECT_DELAY_SECS: u64 = 60;
+
+// ── Wire protocol ─────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMsg {
+    Subscribe { agents: Vec<String> },
+    #[serde(rename = "subscribe:add")]
+    SubscribeAdd { agents: Vec<String> },
+    #[serde(rename = "subscribe:remove")]
+    SubscribeRemove { agents: Vec<String> },
+    Ack { id: String },
+    Ping,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ServerMsg {
+    Inject {
+        id: String,
+        target_agent: String,
+        message: String,
+        source_agent: Option<String>,
+        priority: Option<String>,
+    },
+    Subscribed {
+        #[allow(dead_code)]
+        agents: Vec<String>,
+    },
+    Pong,
+    Error {
+        message: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+// ── Control channel ───────────────────────────────────────────────────────────
+
+enum CtrlMsg {
+    AddAgent(String),
+    RemoveAgent(String),
+    ReloadToken,
+}
+
+// ── Public struct ─────────────────────────────────────────────────────────────
+
+pub struct CloudSubscriber {
+    ctrl_tx: mpsc::UnboundedSender<CtrlMsg>,
+    /// In-memory copy of subscribed agents, kept in sync with the WS loop
+    /// so add_agent/remove_agent can be called before the WS connects.
+    agents: Arc<Mutex<HashSet<String>>>,
+}
+
+static GLOBAL_SUBSCRIBER: OnceLock<CloudSubscriber> = OnceLock::new();
+
+pub fn get_global_subscriber() -> Option<&'static CloudSubscriber> {
+    GLOBAL_SUBSCRIBER.get()
+}
+
+impl CloudSubscriber {
+    /// Initialize the global subscriber and start the background WS loop.
+    /// Should be called once at startup. No-op if already initialized.
+    pub fn init_global(wstore: Arc<Store>) {
+        let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel::<CtrlMsg>();
+        let agents = Arc::new(Mutex::new(HashSet::<String>::new()));
+        let subscriber = CloudSubscriber {
+            ctrl_tx,
+            agents: agents.clone(),
+        };
+        if GLOBAL_SUBSCRIBER.set(subscriber).is_err() {
+            return; // already initialized
+        }
+        tokio::spawn(run_loop(wstore, agents, ctrl_rx));
+    }
+
+    /// Notify the WS loop that a new agent is registered locally.
+    pub fn add_agent(&self, agent_id: &str) {
+        self.agents.lock().unwrap().insert(agent_id.to_string());
+        let _ = self.ctrl_tx.send(CtrlMsg::AddAgent(agent_id.to_string()));
+    }
+
+    /// Notify the WS loop that an agent has been unregistered.
+    pub fn remove_agent(&self, agent_id: &str) {
+        self.agents.lock().unwrap().remove(agent_id);
+        let _ = self.ctrl_tx.send(CtrlMsg::RemoveAgent(agent_id.to_string()));
+    }
+
+    /// Called after muxbus.login completes — trigger a fresh WS connection
+    /// with the newly stored token.
+    pub fn reload_token(&self) {
+        let _ = self.ctrl_tx.send(CtrlMsg::ReloadToken);
+    }
+}
+
+// ── Background loop ───────────────────────────────────────────────────────────
+
+async fn run_loop(
+    wstore: Arc<Store>,
+    agents: Arc<Mutex<HashSet<String>>>,
+    mut ctrl_rx: mpsc::UnboundedReceiver<CtrlMsg>,
+) {
+    let mut delay_secs = RECONNECT_DELAY_SECS;
+
+    loop {
+        // Load token — if none, wait for a ReloadToken ctrl signal
+        let token = match load_valid_token(&wstore) {
+            Some(t) => t,
+            None => {
+                // No token; drain ctrl messages until we get ReloadToken
+                while let Some(msg) = ctrl_rx.recv().await {
+                    if matches!(msg, CtrlMsg::ReloadToken) {
+                        break;
+                    }
+                    // AddAgent / RemoveAgent already updated `agents` mutex — nothing else to do
+                }
+                continue;
+            }
+        };
+
+        tracing::info!("cloud_subscriber: connecting to {}", MUXBUS_WS_URL);
+
+        match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &wstore).await {
+            Ok(()) => {
+                tracing::info!("cloud_subscriber: disconnected cleanly, reconnecting in {}s", delay_secs);
+                delay_secs = RECONNECT_DELAY_SECS; // reset on clean disconnect
+            }
+            Err(e) => {
+                tracing::warn!("cloud_subscriber: error: {e}, reconnecting in {}s", delay_secs);
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
+    }
+}
+
+async fn connect_and_run(
+    token: &str,
+    agents: Arc<Mutex<HashSet<String>>>,
+    ctrl_rx: &mut mpsc::UnboundedReceiver<CtrlMsg>,
+    wstore: &Arc<Store>,
+) -> Result<(), String> {
+    use tokio_tungstenite::tungstenite::http::Request;
+
+    let request = Request::builder()
+        .uri(MUXBUS_WS_URL)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Host", "muxbus.agentmux.ai")
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", generate_ws_key())
+        .body(())
+        .map_err(|e| format!("build request: {e}"))?;
+
+    let (ws_stream, _) = connect_async_tls_with_config(request, None, false, None)
+        .await
+        .map_err(|e| format!("connect: {e}"))?;
+
+    tracing::info!("cloud_subscriber: WebSocket connected");
+    let (mut write, mut read) = ws_stream.split();
+
+    // Initial subscription for all currently-registered agents
+    let initial_agents: Vec<String> = agents.lock().unwrap().iter().cloned().collect();
+    let sub_msg = serde_json::to_string(&ClientMsg::Subscribe { agents: initial_agents })
+        .map_err(|e| format!("serialize subscribe: {e}"))?;
+    write.send(Message::Text(sub_msg.into()))
+        .await
+        .map_err(|e| format!("send subscribe: {e}"))?;
+
+    loop {
+        tokio::select! {
+            // Incoming WebSocket message from cloud
+            msg = read.next() => {
+                match msg {
+                    None => return Ok(()), // server closed
+                    Some(Err(e)) => return Err(format!("ws recv: {e}")),
+                    Some(Ok(Message::Text(text))) => {
+                        if let Ok(server_msg) = serde_json::from_str::<ServerMsg>(&text) {
+                            if let Err(e) = handle_server_msg(server_msg, &mut write, wstore).await {
+                                tracing::warn!("cloud_subscriber: handle msg error: {e}");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = write.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) => return Ok(()),
+                    Some(Ok(_)) => {} // binary frames etc — ignore
+                }
+            }
+
+            // Control messages from register/unregister calls
+            ctrl = ctrl_rx.recv() => {
+                match ctrl {
+                    None => return Ok(()), // channel closed
+                    Some(CtrlMsg::AddAgent(id)) => {
+                        let msg = serde_json::to_string(&ClientMsg::SubscribeAdd { agents: vec![id] })
+                            .unwrap_or_default();
+                        let _ = write.send(Message::Text(msg.into())).await;
+                    }
+                    Some(CtrlMsg::RemoveAgent(id)) => {
+                        let msg = serde_json::to_string(&ClientMsg::SubscribeRemove { agents: vec![id] })
+                            .unwrap_or_default();
+                        let _ = write.send(Message::Text(msg.into())).await;
+                    }
+                    Some(CtrlMsg::ReloadToken) => {
+                        // Close and let the outer loop reconnect with the new token
+                        let _ = write.send(Message::Close(None)).await;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_server_msg(
+    msg: ServerMsg,
+    write: &mut (impl SinkExt<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin),
+    _wstore: &Arc<Store>,
+) -> Result<(), String> {
+    match msg {
+        ServerMsg::Inject { id, target_agent, message, source_agent, priority } => {
+            let req = InjectionRequest {
+                target_agent: target_agent.clone(),
+                message,
+                source_agent,
+                request_id: Some(id.clone()),
+                priority,
+                wait_for_idle: false,
+            };
+            let resp = get_global_handler().inject_message(req);
+            tracing::debug!(
+                injection_id = %id,
+                target_agent = %target_agent,
+                success = resp.success,
+                "cloud_subscriber: delivered injection"
+            );
+            // Always ACK — if delivery failed (agent not local), the cloud
+            // should not retry since the sidecar confirmed it received the message.
+            let ack = serde_json::to_string(&ClientMsg::Ack { id })
+                .map_err(|e| format!("serialize ack: {e}"))?;
+            write.send(Message::Text(ack.into()))
+                .await
+                .map_err(|e| format!("send ack: {e}"))?;
+        }
+        ServerMsg::Error { message } => {
+            tracing::warn!("cloud_subscriber: server error: {message}");
+        }
+        ServerMsg::Pong | ServerMsg::Subscribed { .. } | ServerMsg::Unknown => {}
+    }
+    Ok(())
+}
+
+fn load_valid_token(wstore: &Store) -> Option<String> {
+    match wstore.muxbus_load() {
+        Ok(Some(creds)) if !creds.access_token.is_empty() => Some(creds.access_token),
+        _ => None,
+    }
+}
+
+fn generate_ws_key() -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    let bytes: [u8; 16] = std::array::from_fn(|_| rand_byte());
+    STANDARD.encode(bytes)
+}
+
+fn rand_byte() -> u8 {
+    // Simple non-crypto random — used only for WS handshake key
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    (t & 0xFF) as u8
+}

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -49,7 +49,6 @@ enum ClientMsg {
     #[serde(rename = "subscribe:remove")]
     SubscribeRemove { agents: Vec<String> },
     Ack { id: String },
-    Ping,
 }
 
 #[derive(Deserialize)]
@@ -134,6 +133,26 @@ impl CloudSubscriber {
 
 // ── Background loop ───────────────────────────────────────────────────────────
 
+/// Sleep for `secs`, waking early if a `CtrlMsg::ReloadToken` arrives (e.g. after
+/// a fresh muxbus.login). AddAgent/RemoveAgent messages are drained without ending
+/// the sleep — they already updated the shared `agents` set. Returns true if the
+/// wait was cut short by a ReloadToken (caller should reconnect immediately), or
+/// false if the full duration elapsed (or the control channel closed).
+async fn backoff_sleep(secs: u64, ctrl_rx: &mut mpsc::UnboundedReceiver<CtrlMsg>) -> bool {
+    let deadline = tokio::time::sleep(Duration::from_secs(secs));
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            _ = &mut deadline => return false,
+            msg = ctrl_rx.recv() => match msg {
+                Some(CtrlMsg::ReloadToken) => return true,
+                Some(_) => {} // AddAgent / RemoveAgent already applied to `agents`
+                None => return false, // channel closed — outer loop will exit/park
+            },
+        }
+    }
+}
+
 async fn run_loop(
     wstore: Arc<Store>,
     agents: Arc<Mutex<HashSet<String>>>,
@@ -147,7 +166,16 @@ async fn run_loop(
         // Two distinct None cases:
         //   a) No credentials in DB at all → wait for muxbus.login ReloadToken signal
         //   b) Credentials exist but refresh failed transiently → back off and retry
-        let has_stored_creds = wstore.muxbus_load().ok().flatten().is_some();
+        // "Has usable creds" must match load_valid_token's own gate (non-empty
+        // access_token), otherwise a row with an empty token would make this true
+        // while load_valid_token returns None — sending the loop into a perpetual
+        // ~60s no-op back-off instead of parking for a ReloadToken.
+        let has_stored_creds = wstore
+            .muxbus_load()
+            .ok()
+            .flatten()
+            .map(|c| !c.access_token.is_empty())
+            .unwrap_or(false);
         let token = match load_valid_token(&wstore, &http).await {
             // Do NOT reset back-off here: a valid token loads on every iteration,
             // so resetting on load would pin the delay at the base value and
@@ -164,12 +192,16 @@ async fn run_loop(
                 continue;
             }
             None => {
-                // Credentials present but refresh failed transiently — back off and retry
+                // Credentials present but refresh failed transiently — back off and
+                // retry. The sleep is interruptible so a fresh muxbus.login wakes it.
                 tracing::warn!(
                     "cloud_subscriber: token refresh failed, retrying in {}s",
                     delay_secs
                 );
-                tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+                if backoff_sleep(delay_secs, &mut ctrl_rx).await {
+                    delay_secs = RECONNECT_DELAY_SECS; // ReloadToken — retry now
+                    continue;
+                }
                 delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
                 continue;
             }
@@ -194,7 +226,12 @@ async fn run_loop(
             }
         }
 
-        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        // Interruptible back-off: a muxbus.login → reload_token() during the wait
+        // wakes us immediately instead of stalling reconnect for up to 60s.
+        if backoff_sleep(delay_secs, &mut ctrl_rx).await {
+            delay_secs = RECONNECT_DELAY_SECS;
+            continue;
+        }
         delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
     }
 }

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -132,14 +132,15 @@ async fn run_loop(
     agents: Arc<Mutex<HashSet<String>>>,
     mut ctrl_rx: mpsc::UnboundedReceiver<CtrlMsg>,
 ) {
+    let http = reqwest::Client::new();
     let mut delay_secs = RECONNECT_DELAY_SECS;
 
     loop {
-        // Load token — if none, wait for a ReloadToken ctrl signal
-        let token = match load_valid_token(&wstore) {
+        // Load token — refresh if expired, wait for ReloadToken if none stored
+        let token = match load_valid_token(&wstore, &http).await {
             Some(t) => t,
             None => {
-                // No token; drain ctrl messages until we get ReloadToken
+                // No usable credentials; drain ctrl messages until we get ReloadToken
                 while let Some(msg) = ctrl_rx.recv().await {
                     if matches!(msg, CtrlMsg::ReloadToken) {
                         break;
@@ -152,7 +153,7 @@ async fn run_loop(
 
         tracing::info!("cloud_subscriber: connecting to {}", MUXBUS_WS_URL);
 
-        match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &wstore).await {
+        match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &wstore, &http).await {
             Ok(()) => {
                 tracing::info!("cloud_subscriber: disconnected cleanly, reconnecting in {}s", delay_secs);
                 delay_secs = RECONNECT_DELAY_SECS; // reset on clean disconnect
@@ -172,17 +173,15 @@ async fn connect_and_run(
     agents: Arc<Mutex<HashSet<String>>>,
     ctrl_rx: &mut mpsc::UnboundedReceiver<CtrlMsg>,
     wstore: &Arc<Store>,
+    _http: &reqwest::Client,
 ) -> Result<(), String> {
     use tokio_tungstenite::tungstenite::http::Request;
 
+    // Only set Authorization — tungstenite adds Connection/Upgrade/Sec-WebSocket-*
+    // automatically. Setting them manually causes duplicate headers in the handshake.
     let request = Request::builder()
         .uri(MUXBUS_WS_URL)
         .header("Authorization", format!("Bearer {}", token))
-        .header("Host", "muxbus.agentmux.ai")
-        .header("Connection", "Upgrade")
-        .header("Upgrade", "websocket")
-        .header("Sec-WebSocket-Version", "13")
-        .header("Sec-WebSocket-Key", generate_ws_key())
         .body(())
         .map_err(|e| format!("build request: {e}"))?;
 
@@ -286,25 +285,30 @@ async fn handle_server_msg(
     Ok(())
 }
 
-fn load_valid_token(wstore: &Store) -> Option<String> {
-    match wstore.muxbus_load() {
-        Ok(Some(creds)) if !creds.access_token.is_empty() => Some(creds.access_token),
-        _ => None,
+/// Load a valid (non-expired) access token, refreshing via refresh_token if needed.
+/// Saves refreshed credentials back to the store. Returns None if no credentials
+/// are stored, the token is expired and refresh fails, or the refresh_token is absent.
+async fn load_valid_token(wstore: &Store, http: &reqwest::Client) -> Option<String> {
+    let creds = match wstore.muxbus_load() {
+        Ok(Some(c)) if !c.access_token.is_empty() => c,
+        _ => return None,
+    };
+    if creds.is_valid() {
+        return Some(creds.access_token);
+    }
+    // Token expired (or nearly so) — try refresh
+    tracing::info!("cloud_subscriber: access token expired, attempting refresh");
+    match crate::muxbus::pkce::refresh_token(&creds, http).await {
+        Ok(refreshed) => {
+            if let Err(e) = wstore.muxbus_save(&refreshed) {
+                tracing::warn!(error = %e, "cloud_subscriber: failed to save refreshed credentials");
+            }
+            Some(refreshed.access_token)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "cloud_subscriber: token refresh failed; user must re-login via muxbus.login");
+            None
+        }
     }
 }
 
-fn generate_ws_key() -> String {
-    use base64::{engine::general_purpose::STANDARD, Engine};
-    let bytes: [u8; 16] = std::array::from_fn(|_| rand_byte());
-    STANDARD.encode(bytes)
-}
-
-fn rand_byte() -> u8 {
-    // Simple non-crypto random — used only for WS handshake key
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let t = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
-    (t & 0xFF) as u8
-}

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -136,29 +136,51 @@ async fn run_loop(
     let mut delay_secs = RECONNECT_DELAY_SECS;
 
     loop {
-        // Load token — refresh if expired, wait for ReloadToken if none stored
+        // Load token — refresh if expired.
+        // Two distinct None cases:
+        //   a) No credentials in DB at all → wait for muxbus.login ReloadToken signal
+        //   b) Credentials exist but refresh failed transiently → back off and retry
+        let has_stored_creds = wstore.muxbus_load().ok().flatten().is_some();
         let token = match load_valid_token(&wstore, &http).await {
-            Some(t) => t,
-            None => {
-                // No usable credentials; drain ctrl messages until we get ReloadToken
+            Some(t) => {
+                delay_secs = RECONNECT_DELAY_SECS; // token loaded; reset back-off
+                t
+            }
+            None if !has_stored_creds => {
+                // No credentials at all — wait for muxbus.login to signal us
                 while let Some(msg) = ctrl_rx.recv().await {
-                    if matches!(msg, CtrlMsg::ReloadToken) {
-                        break;
-                    }
-                    // AddAgent / RemoveAgent already updated `agents` mutex — nothing else to do
+                    if matches!(msg, CtrlMsg::ReloadToken) { break; }
+                    // AddAgent / RemoveAgent already updated `agents` mutex
                 }
+                continue;
+            }
+            None => {
+                // Credentials present but refresh failed transiently — back off and retry
+                tracing::warn!(
+                    "cloud_subscriber: token refresh failed, retrying in {}s",
+                    delay_secs
+                );
+                tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+                delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
                 continue;
             }
         };
 
         tracing::info!("cloud_subscriber: connecting to {}", MUXBUS_WS_URL);
+        let session_start = std::time::Instant::now();
 
         match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &wstore, &http).await {
             Ok(()) => {
-                tracing::info!("cloud_subscriber: disconnected cleanly, reconnecting in {}s", delay_secs);
-                delay_secs = RECONNECT_DELAY_SECS; // reset on clean disconnect
+                // Clean disconnect — reset back-off
+                delay_secs = RECONNECT_DELAY_SECS;
+                tracing::info!("cloud_subscriber: disconnected cleanly");
             }
             Err(e) => {
+                // If the session was healthy for >30s before the error, treat it as
+                // network instability rather than a persistent failure and reset back-off.
+                if session_start.elapsed().as_secs() > 30 {
+                    delay_secs = RECONNECT_DELAY_SECS;
+                }
                 tracing::warn!("cloud_subscriber: error: {e}, reconnecting in {}s", delay_secs);
             }
         }

--- a/agentmux-srv/src/muxbus/mod.rs
+++ b/agentmux-srv/src/muxbus/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod cloud_subscriber;
 pub mod pkce;

--- a/agentmux-srv/src/server/muxbus_handlers.rs
+++ b/agentmux-srv/src/server/muxbus_handlers.rs
@@ -70,6 +70,10 @@ pub fn register_muxbus_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         if let Err(e) = wstore.muxbus_save(&result.credentials) {
                             tracing::warn!(error = %e, "muxbus.login: failed to save credentials");
                         }
+                        // Kick the cloud subscriber to open a WS with the new token
+                        if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
+                            sub.reload_token();
+                        }
                         let resp = MuxBusLoginResp {
                             success: true,
                             email: result.credentials.user_email,

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -177,6 +177,11 @@ pub(super) async fn handle_reactive_register(
                 state.subagent_watcher.watch_agent(&req.agent_id, config_dir);
             }
 
+            // Notify cloud subscriber so it can subscribe for cloud-push delivery
+            if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
+                sub.add_agent(&req.agent_id);
+            }
+
             Json(json!({"success": true})).into_response()
         }
         Err(e) => (
@@ -203,6 +208,10 @@ pub(super) async fn handle_reactive_unregister(
     // Drop the subagent filesystem watcher (handle + channel + task) — the
     // symmetric teardown for the watch_agent() call in the register handler.
     state.subagent_watcher.unwatch_agent(&req.agent_id);
+    // Notify cloud subscriber so it stops subscribing for this agent
+    if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
+        sub.remove_agent(&req.agent_id);
+    }
     Json(json!({"success": true}))
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -924,6 +924,15 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // a scope and the frontend's per-block subscription
                 // doesn't receive them.
                 env_vars.insert("AGENTMUX_BLOCKID".to_string(), cmd.blockid.clone());
+                // Agent display name for MuxBus self-identification.
+                // muxbus-client reads AGENTMUX_AGENT_ID (preferred) or AGENT_NAME
+                // to know who it is when sending/receiving messages.
+                let agent_display_name = crate::backend::obj::meta_get_string(
+                    &block.meta, "agentName", "",
+                );
+                if !agent_display_name.is_empty() {
+                    env_vars.insert("AGENTMUX_AGENT_ID".to_string(), agent_display_name);
+                }
                 // PATH includes BOTH bundled tools dir (portable
                 // builds, runtime/tools/bin/) AND user tools dir
                 // (~/.agentmux/tools/bin/). bundled is None in dev

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -925,13 +925,15 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // doesn't receive them.
                 env_vars.insert("AGENTMUX_BLOCKID".to_string(), cmd.blockid.clone());
                 // Agent display name for MuxBus self-identification.
-                // muxbus-client reads AGENTMUX_AGENT_ID (preferred) or AGENT_NAME
-                // to know who it is when sending/receiving messages.
-                let agent_display_name = crate::backend::obj::meta_get_string(
-                    &block.meta, "agentName", "",
-                );
-                if !agent_display_name.is_empty() {
-                    env_vars.insert("AGENTMUX_AGENT_ID".to_string(), agent_display_name);
+                // muxbus-client reads AGENTMUX_AGENT_ID (preferred) or AGENT_NAME.
+                // Only set if not already present in cmd:env — user-provided values take precedence.
+                if !env_vars.contains_key("AGENTMUX_AGENT_ID") {
+                    let agent_display_name = crate::backend::obj::meta_get_string(
+                        &block.meta, "agentName", "",
+                    );
+                    if !agent_display_name.is_empty() {
+                        env_vars.insert("AGENTMUX_AGENT_ID".to_string(), agent_display_name);
+                    }
                 }
                 // PATH includes BOTH bundled tools dir (portable
                 // builds, runtime/tools/bin/) AND user tools dir

--- a/docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md
+++ b/docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md
@@ -1,0 +1,356 @@
+# MuxBus Delivery Hierarchy
+
+**Date:** 2026-06-15  
+**Status:** Draft  
+**Authors:** naki
+
+---
+
+## 1. Problem Statement
+
+AgentMux agents need to send messages to each other across three scopes:
+
+1. **Same host** — agent in pane A → agent in pane B, same machine
+2. **Same LAN** — agent on laptop → agent on desktop, same network
+3. **WAN** — agent on one machine → agent on another over the internet
+
+These three scopes have radically different latency, cost, and trust profiles. Additionally:
+
+- **Cloud → local delivery**: reagent notifications from the cloud (e.g., a PR review event) must be able to push a message _down_ into a locally running agent pane — the agent doesn't poll, the sidecar delivers it.
+- **Promote on context**: when the intended recipient isn't reachable at a lower tier, the message should automatically escalate — not fail.
+
+The current system has all the mechanical pieces but they are not unified into a single delivery stack.
+
+---
+
+## 2. Existing Infrastructure Inventory
+
+### Tier 1 — Same sidecar instance (already working)
+
+- `ReactiveHandler` (`backend/reactive/handler.rs`) holds `agent_id → block_id` mappings in memory.
+- Injection: write `\r message\r` + 3 delayed `\r` directly to the PTY block.
+- Rate limit: 10 req/sec per target, token bucket.
+- Latency: <1ms.
+
+### Tier 2 — Same host, different sidecar instances (already working)
+
+- `AgentEntry` registry: `{data_dir}/agents/{agent_id}.json` — written on register, cleaned up on unregister.
+- Each entry contains: `local_url` (http://127.0.0.1:PORT), `auth_key` (per-launch UUID), `block_id`, `pid`.
+- Cross-instance forward: HTTP POST to peer's `/agentmux/reactive/inject` with `X-AuthKey`.
+- Stale entries (>4h) cleaned at startup.
+- Latency: 1–5ms loopback.
+
+### Tier 3 — LAN peers (spec exists, not built)
+
+- `specs/lan-awareness-and-embedded-jekt-api.md` proposes mDNS (`_agentmux._tcp.local`).
+- `backend/lan_discovery/` exists for host presence (peer list for UI), but doesn't carry agent registry.
+- **Gap**: no way to find which LAN host has agent B running.
+
+### Tier 4 — Cloud / WAN (partially working)
+
+- `muxbus.agentmux.ai` — Fastify on Lambda, DynamoDB.
+- REST API: `POST /reactive/inject` stores injection, `GET /reactive/pending/{id}` polls for delivery.
+- **Current model is pull-only**: agent must poll to find pending injections — no push path to locally running panes.
+- Auth: Cognito PKCE (MUXBUS_TOKEN) for desktop users; `client_credentials` for M2M agents.
+- Latency: 50–300ms.
+
+### Client (muxbus-client npm package)
+
+Already implements **local-first** in `injectTerminal()`:
+1. Try `AGENTMUX_LOCAL_URL/wave/reactive/inject` (5s timeout).
+2. If unavailable or "not found" → fall through to cloud REST.
+3. Cloud: stores injection, polls `/reactive/status/{id}` every 1s for up to 15s.
+
+**Core gap**: polling (step 3) means cloud→local delivery has 0–5s latency and requires the agent to be running the muxbus client with a polling loop.
+
+---
+
+## 3. Model: NATS Leaf Node (adapted)
+
+The right mental model is [NATS Leaf Nodes](https://docs.nats.io/running-a-nats-service/configuration/leafnodes):
+
+- Each **AgentMux sidecar** is a **leaf node** — it knows about the agents running on its host.
+- **MuxBus cloud** is the **core cluster** — it routes messages between leaf nodes it can't deliver locally.
+- **Subscriptions propagate upward**: when a sidecar starts, it tells the cloud "I have agents X, Y, Z — push anything addressed to them here".
+- **Messages flow downward**: cloud holds a message for agent X, pushes it to the leaf node (sidecar) that registered X, sidecar delivers locally.
+
+This eliminates polling for cloud→local delivery and makes cloud purely a relay-of-last-resort for WAN.
+
+---
+
+## 4. Delivery Tiers (Unified Model)
+
+```
+Sender (agent A)
+  │
+  ▼
+[muxbus-client / MuxBus SDK]
+  │
+  ├── Tier 1: Same-sidecar in-memory (ReactiveHandler)
+  │     Condition: recipient registered in local handler
+  │     Transport: direct PTY write
+  │     Latency: <1ms
+  │     Auth: none (in-process)
+  │
+  ├── Tier 2: Same-host, peer sidecar (file registry lookup → HTTP)
+  │     Condition: {data_dir}/agents/{agent_id}.json exists, local_url ≠ sender
+  │     Transport: HTTP POST to peer's /agentmux/reactive/inject
+  │     Latency: 1–5ms (loopback)
+  │     Auth: entry.auth_key in X-AuthKey header
+  │
+  ├── Tier 3: LAN peer (mDNS discovery → HTTP) [TO BUILD]
+  │     Condition: tier 1+2 failed, mDNS lookup finds host with agent B
+  │     Transport: HTTP POST to peer's /agentmux/reactive/inject on LAN IP
+  │     Latency: 5–30ms
+  │     Auth: auth_key embedded in mDNS TXT record (or negotiated)
+  │
+  └── Tier 4: Cloud relay (WebSocket subscription) [NEEDS UPGRADE]
+        Condition: all local/LAN tiers failed (or recipient is WAN-only)
+        Transport: WebSocket to muxbus.agentmux.ai; cloud pushes to recipient's leaf node
+        Latency: 50–300ms
+        Auth: MUXBUS_TOKEN (Cognito JWT)
+```
+
+### Tier Promotion Logic
+
+```
+for tier in [1, 2, 3, 4]:
+    result = try_deliver(tier, message)
+    if result.success:
+        return result
+    if result.error == "not_found":
+        continue           # recipient not at this tier, try next
+    if result.error == "timeout":
+        mark_tier_unhealthy(tier, 30s)
+        continue           # tier temporarily down, skip
+    if result.error == "auth_failed":
+        break              # don't promote auth failures to cloud
+return delivery_failed
+```
+
+**No parallel fan-out**: waterfall in order, not scatter-gather. Reasons:
+- Same-host delivery is the common case and is <5ms — no benefit to concurrent cloud attempt.
+- Parallel would risk double-delivery to agents running locally AND through cloud.
+- Cloud tier has auth cost (JWT fetch); waste if agent is local.
+
+**Exception**: cloud-push path (incoming cloud → local) is always delivered at Tier 1 or 2 — the sidecar never re-promotes a cloud message.
+
+---
+
+## 5. Cloud Push Subscription (Replace Polling)
+
+### Current (polling-based — bad)
+
+```
+Agent running in pane:
+  every 5s → GET /reactive/pending/{agent_id}
+           → if any: deliver locally via AGENTMUX_LOCAL_URL
+           → POST /reactive/ack
+
+Problem: 0–5s latency for cloud→local; requires agent to run polling loop;
+         N agents × 1 poll/5s = N×12 req/min against cloud.
+```
+
+### Target (WebSocket subscription — good)
+
+```
+Sidecar startup:
+  → Open WebSocket to wss://muxbus.agentmux.ai/ws (with MUXBUS_TOKEN)
+  → Send: { type: "subscribe", agents: ["agent-a", "agent-b", ...] }
+
+Agent registers in sidecar:
+  → Sidecar sends: { type: "subscribe:add", agents: ["new-agent"] }
+
+Cloud receives message for "new-agent":
+  → Finds sidecar WebSocket subscribed for "new-agent"
+  → Pushes: { type: "inject", target: "new-agent", message: "...", id: "uuid" }
+  → Sidecar delivers via Tier 1 (ReactiveHandler)
+  → Sidecar sends: { type: "ack", id: "uuid" }
+
+Benefits:
+  - Zero polling — cloud push latency is network RTT only (<100ms)
+  - One persistent WS per sidecar instance (not per agent)
+  - Cloud maintains per-sidecar subscription map (DynamoDB or in-memory)
+  - Sidecar automatically subscribes new agents as they register
+```
+
+### Sidecar WebSocket Manager (new component)
+
+Lives in `agentmux-srv/src/muxbus/cloud_subscriber.rs`:
+
+```rust
+pub struct CloudSubscriber {
+    token: Arc<Mutex<Option<String>>>,     // refreshed from DB
+    ws: Arc<Mutex<Option<WebSocket>>>,
+    subscribed_agents: Arc<Mutex<HashSet<String>>>,
+    reactive_handler: &'static ReactiveHandler,
+    wstore: Arc<Store>,
+}
+
+impl CloudSubscriber {
+    pub async fn run(&self) {
+        loop {
+            match self.connect_and_subscribe().await {
+                Ok(()) => {}   // clean disconnect
+                Err(e) => {
+                    tracing::warn!("cloud_subscriber: {e}, reconnecting in 5s");
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+            }
+        }
+    }
+
+    async fn connect_and_subscribe(&self) -> Result<(), Error> {
+        let token = self.load_token().await?;
+        let ws = connect_wss("wss://muxbus.agentmux.ai/ws", &token).await?;
+        // send subscribe for all known agents
+        // then loop on incoming messages, deliver via ReactiveHandler
+    }
+
+    pub fn add_agent(&self, agent_id: &str) {
+        // called by reactive/register handler
+        // sends { type: "subscribe:add", agents: [agent_id] } if WS is open
+    }
+
+    pub fn remove_agent(&self, agent_id: &str) {
+        // called by reactive/unregister handler
+        // sends { type: "subscribe:remove", agents: [agent_id] } if WS is open
+    }
+}
+```
+
+**No MUXBUS_TOKEN = no cloud subscription**: if the user hasn't connected via `muxbus.login`, the sidecar doesn't open a cloud WS. Cloud→local delivery degrades gracefully to "unavailable" — local/LAN delivery is unaffected.
+
+---
+
+## 6. LAN Tier (Phase 3 build plan)
+
+### Discovery: mDNS TXT records
+
+Each sidecar advertises:
+```
+Service:  _agentmux._tcp.local
+Host:     {hostname}.local
+Port:     {web_port}
+TXT:
+  auth_key={auth_key}          # for forwarding requests
+  instance={instance_id}       # dedup across channels
+  version={version}
+```
+
+On startup: `lan_discovery` already binds mDNS. Extend it to include `auth_key` in TXT.
+
+### Agent discovery across LAN
+
+When tier 2 fails (no local file registry entry), before trying cloud:
+1. Broadcast a DNS-SD query for `_agentmux._tcp.local`.
+2. For each discovered peer, try `GET {peer_url}/agentmux/reactive/agent?id={agent_id}`.
+3. First 200 response: forward inject to that peer.
+4. Cache the peer URL in a short-lived in-memory map (`agent_id → peer_url`, TTL 60s).
+
+This avoids broadcasting a full inject to all LAN peers. The agent lookup is a cheap idempotent GET.
+
+### Auth
+
+Peer's `auth_key` is in the mDNS TXT record. Use it as `X-AuthKey` when forwarding. This is safe since LAN traffic is not internet-exposed; same trust model as the existing tier 2 loopback forwarding.
+
+---
+
+## 7. Addressing
+
+All tiers use the same logical address: `agent_id` (string, case-insensitive).
+
+`agent_id` is:
+- The agent's `name` field from `db_agent_definitions` (user-visible name like "claude", "codex")
+- Or a fallback to `AGENT_NAME` env var (set by the launcher)
+- Case-normalized to lowercase at delivery time
+
+**No host:port in addresses** — location is resolved at delivery time, not embedded in the address. This allows agents to move between hosts without re-wiring senders.
+
+---
+
+## 8. Deduplication
+
+Each message carries a `message_id: UUID`. Sidecars keep a **ring buffer of 200 recently-seen IDs** (per scope: local + cloud). On receive:
+- If `message_id` in ring buffer: drop silently, ACK to sender.
+- If not: deliver, add to ring buffer.
+
+This handles:
+- Cloud retrying after ACK timeout.
+- Concurrent delivery attempts via tier 3 and tier 4 racing.
+
+TTL on seen IDs: 5 minutes. Ring buffer evicts by age, not count.
+
+---
+
+## 9. Build Sequence
+
+### Phase 1 — Unify existing tiers (low effort, high value)
+
+Already works mechanically. Just needs wiring:
+
+1. **Inject `AGENT_NAME` into every spawn env** — muxbus-client reads this to know its own identity. Currently not injected. Add to `websocket.rs` spawn path (next to `AGENTMUX_AUTH_KEY`).
+2. **Bundle muxbus-client** with agentmux-mcp package — currently agents must separately install it. Include in the tools bundle so every agent pane gets it.
+3. **Fix muxbus-client local URL path** — client hits `/wave/reactive/inject` but sidecar exposes `/agentmux/reactive/inject`. Align these.
+
+### Phase 2 — Cloud push subscription (replace polling)
+
+Medium effort. Highest impact for reagent notifications:
+
+1. Add `cloud_subscriber.rs` to `agentmux-srv/src/muxbus/`.
+2. Wire into `ReactiveHandler::register_agent()` / `unregister_agent()` — subscriber tracks active agents.
+3. Add WebSocket endpoint to MuxBus cloud server (`wss://muxbus.agentmux.ai/ws`).
+4. Cloud server maintains `agent_id → [sidecar_ws]` map (DynamoDB TTL per subscription, heartbeat refresh).
+5. On `POST /reactive/inject`: check subscription map first; if sidecar WS open, push and wait for ACK; only fall back to DynamoDB queue if no subscriber.
+6. CloudSubscriber only runs when `MUXBUS_TOKEN` is present (user connected via `muxbus.login`).
+
+### Phase 3 — LAN tier (mDNS agent lookup)
+
+Low/medium effort:
+
+1. Add `auth_key` to existing `lan_discovery` mDNS TXT record.
+2. Add `GET /agentmux/reactive/agent?id=` endpoint (already exists via `/agentmux/reactive/agent`).
+3. In `handle_reactive_inject()` — after tier 2 file registry miss, before tier 4 cloud: query mDNS for peers, try agent lookup, forward if found.
+4. Add in-memory LAN peer cache (`HashMap<agent_id, (url, timestamp)>`, TTL 60s).
+
+### Phase 4 — WAN promote via cloud relay
+
+Already works at the API level. Needs:
+1. muxbus-client to set message_id and pass it through all tiers.
+2. Deduplication ring buffer on receive.
+3. Cloud server WebSocket push (from Phase 2) handles the actual delivery.
+
+---
+
+## 10. What NOT to Build
+
+- **Persistent message store on sidecar** — in-memory is fine. Lost on restart; users accept this. DynamoDB in cloud is the durable layer for WAN messages.
+- **Message ordering guarantees** — best-effort FIFO. Cross-tier causal ordering is a CRDT/vector-clock problem; not worth it for CLI agent message passing.
+- **Per-agent auth keys** — the per-sidecar auth_key is sufficient. Per-agent would require key distribution infra.
+- **Direct WebSocket between sidecars on LAN** — HTTP forwarding (Tier 2/3) is simpler and the latency difference (5ms vs 2ms) doesn't matter for agent messaging.
+
+---
+
+## 11. Environment Variables (Unified Reference)
+
+| Variable | Set By | Used By | Tier |
+|----------|--------|---------|------|
+| `AGENTMUX_LOCAL_URL` | sidecar (main.rs) | muxbus-client, bashwrap, mcp | Tier 1/2 |
+| `AGENTMUX_AUTH_KEY` | sidecar (websocket.rs spawn) | muxbus-client, bashwrap | Tier 2 (forwarding) |
+| `AGENT_NAME` | sidecar (websocket.rs spawn) **[TO ADD]** | muxbus-client (self-identification) | all |
+| `MUXBUS_TOKEN` | sidecar (websocket.rs spawn, from db_muxbus_credentials) | muxbus-client (cloud auth), CloudSubscriber | Tier 4 |
+| `MUXBUS_COGNITO_DOMAIN` | sidecar (websocket.rs spawn) | muxbus-client (token refresh) | Tier 4 |
+| `MUXBUS_URL` | agent config / default | muxbus-client | Tier 4 |
+| `MUXBUS_AGENT_ID` | agent config / AGENT_NAME fallback | muxbus-client | all |
+
+---
+
+## 12. Open Questions
+
+1. **mDNS on Windows**: Windows Firewall prompts on mDNS bind. The existing `lan_discovery` already handles the opt-in toggle for this. Tier 3 should respect the same `network_lan_discovery` setting.
+
+2. **Cloud WS reconnect during token expiry**: CloudSubscriber holds a token reference and refreshes from `db_muxbus_credentials`. If token expires mid-connection, the WS must close and re-open with a fresh token. Need backoff to avoid rapid reconnect loop.
+
+3. **Multiple sidecar instances on same host (multi-channel)**: Tier 2 file registry handles this correctly today. Tier 3 (LAN) must de-dup — mDNS may return multiple instances of the same host, each at different ports. Agent lookup (`GET /reactive/agent`) is idempotent so querying both is safe.
+
+4. **Container/SSH/WSL panes**: `AGENTMUX_LOCAL_URL` points to `127.0.0.1` which is unreachable from inside a container. For container panes, the sidecar should inject the Docker bridge IP or host-gateway instead. Out of scope for this spec.

--- a/docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md
+++ b/docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md
@@ -289,7 +289,7 @@ TTL on seen IDs: 5 minutes. Ring buffer evicts by age, not count.
 
 Already works mechanically. Just needs wiring:
 
-1. **Inject `AGENT_NAME` into every spawn env** — muxbus-client reads this to know its own identity. Currently not injected. Add to `websocket.rs` spawn path (next to `AGENTMUX_AUTH_KEY`).
+1. **Inject `AGENTMUX_AGENT_ID` into every spawn env** — muxbus-client reads this (preferred over the `AGENT_NAME` fallback) to know its own identity. Injected by the `websocket.rs` spawn path (next to `AGENTMUX_AUTH_KEY`), sourced from the block's `agentName` meta.
 2. **Bundle muxbus-client** with agentmux-mcp package — currently agents must separately install it. Include in the tools bundle so every agent pane gets it.
 3. **Fix muxbus-client local URL path** — client hits `/wave/reactive/inject` but sidecar exposes `/agentmux/reactive/inject`. Align these.
 
@@ -337,7 +337,7 @@ Already works at the API level. Needs:
 |----------|--------|---------|------|
 | `AGENTMUX_LOCAL_URL` | sidecar (main.rs) | muxbus-client, bashwrap, mcp | Tier 1/2 |
 | `AGENTMUX_AUTH_KEY` | sidecar (websocket.rs spawn) | muxbus-client, bashwrap | Tier 2 (forwarding) |
-| `AGENT_NAME` | sidecar (websocket.rs spawn) **[TO ADD]** | muxbus-client (self-identification) | all |
+| `AGENTMUX_AGENT_ID` | sidecar (websocket.rs spawn, from `agentName` meta) | muxbus-client (self-identification; falls back to `AGENT_NAME`) | all |
 | `MUXBUS_TOKEN` | sidecar (websocket.rs spawn, from db_muxbus_credentials) | muxbus-client (cloud auth), CloudSubscriber | Tier 4 |
 | `MUXBUS_COGNITO_DOMAIN` | sidecar (websocket.rs spawn) | muxbus-client (token refresh) | Tier 4 |
 | `MUXBUS_URL` | agent config / default | muxbus-client | Tier 4 |


### PR DESCRIPTION
## Summary

- **Phase 1 — unify existing tiers**: inject `AGENTMUX_AGENT_ID` (agent display name from block meta) into every agent spawn env so `muxbus-client` can self-identify without guessing; fix `muxbus-client` local URL (`/wave/reactive/inject` → `/agentmux/reactive/inject`)
- **Phase 2 — replace cloud polling with WebSocket push**: new `CloudSubscriber` in `muxbus/cloud_subscriber.rs` opens one persistent WS per sidecar to `wss://muxbus.agentmux.ai/ws`, subscribes for all locally-registered agents, delivers cloud pushes via `ReactiveHandler`, reconnects with exponential back-off
- Wires `add_agent`/`remove_agent` into reactive register/unregister handlers; calls `reload_token()` after `muxbus.login` so WS opens immediately

## Test plan

- [ ] Launch an agent pane — confirm `AGENTMUX_AGENT_ID` is set in the agent's env (`echo $AGENTMUX_AGENT_ID`)
- [ ] muxbus-client `injectTerminal` to a same-host agent — confirm it hits `/agentmux/reactive/inject` (not `/wave/...`)
- [ ] Connect via `muxbus.login` — confirm cloud subscriber opens WS connection (check sidecar logs for "cloud_subscriber: WebSocket connected")
- [ ] Send a reactive inject from cloud — confirm it arrives in <1s without polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)