### PR TITLE
fix(widgets): repair phantom drop indicator after right-click unpin

### DIFF
--- a/.changesets/1781500000-fix-widget-pinbar-phantom-drop-indicator-after-rightclick-unpin-x3k2.md
+++ b/.changesets/1781500000-fix-widget-pinbar-phantom-drop-indicator-after-rightclick-unpin-x3k2.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+fix(widgets): repair phantom drop indicator after right-click unpin — replaces brittle ref/signal dual-state with a single DragState machine, adds primary-button guard and global OS-interrupt cleanup (closes #1432)

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -322,13 +322,37 @@ const ActionWidgets = (): JSX.Element => {
     });
 
     // ── Drag-to-reorder (pinned only, saves to widget:pinned) ─────────────────
+    //
+    // State machine: idle → pending (left-button down) → dragging (threshold exceeded)
+    // A single DragState signal replaces the previous ref/signal duplication.
 
-    const [draggingKey, setDraggingKey] = createSignal<string | null>(null);
-    const [dropIndex, setDropIndex] = createSignal<number | null>(null);
+    type DragState =
+        | { phase: "idle" }
+        | { phase: "pending"; key: string; startX: number; startY: number; pointerId: number }
+        | { phase: "dragging"; key: string; dropIndex: number };
+
+    const DRAG_IDLE: DragState = { phase: "idle" };
+    const [dragState, setDragState] = createSignal<DragState>(DRAG_IDLE);
+
+    const draggingKey = () => { const s = dragState(); return s.phase === "dragging" ? s.key      : null; };
+    const dropIndex   = () => { const s = dragState(); return s.phase === "dragging" ? s.dropIndex : null; };
+
     let containerRef!: HTMLDivElement;
-    let draggingKeyRef: string | null = null;
-    let dropIndexRef: number | null = null;
-    let dragStartRef: { x: number; y: number; key: string } | null = null;
+
+    // Cancel drag if the OS interrupts the gesture or the window loses visibility
+    // (e.g. Alt+Tab with a button held). pointerup during a normal drop is handled
+    // by the element's handlePointerUp — no global pointerup listener needed because
+    // setPointerCapture redirects it to the element once dragging begins.
+    createEffect(() => {
+        if (dragState().phase === "idle") return;
+        const cancel = () => setDragState(DRAG_IDLE);
+        window.addEventListener("pointercancel",    cancel, { capture: true });
+        window.addEventListener("visibilitychange", cancel);
+        onCleanup(() => {
+            window.removeEventListener("pointercancel",    cancel, { capture: true });
+            window.removeEventListener("visibilitychange", cancel);
+        });
+    });
 
     onMount(() => {
         const header = containerRef?.closest(".window-header") as HTMLElement | null;
@@ -386,18 +410,18 @@ const ActionWidgets = (): JSX.Element => {
     });
 
     const handlePointerDown = (key: string, e: PointerEvent) => {
-        dragStartRef = { x: e.clientX, y: e.clientY, key };
+        if (e.button !== 0) return;
+        setDragState({ phase: "pending", key, startX: e.clientX, startY: e.clientY, pointerId: e.pointerId });
     };
 
     const handlePointerMove = (e: PointerEvent) => {
-        if (!dragStartRef) return;
-        if (!draggingKeyRef) {
-            const dx = e.clientX - dragStartRef.x;
-            const dy = e.clientY - dragStartRef.y;
+        const state = dragState();
+        if (state.phase === "idle") return;
+        if (state.phase === "pending") {
+            const dx = e.clientX - state.startX;
+            const dy = e.clientY - state.startY;
             if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
-            (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-            draggingKeyRef = dragStartRef.key;
-            setDraggingKey(dragStartRef.key);
+            (e.currentTarget as HTMLElement).setPointerCapture(state.pointerId);
         }
         e.preventDefault();
         if (!containerRef) return;
@@ -410,30 +434,25 @@ const ActionWidgets = (): JSX.Element => {
                 break;
             }
         }
-        if (newIndex !== dropIndexRef) {
-            dropIndexRef = newIndex;
-            setDropIndex(newIndex);
+        if (state.phase === "pending") {
+            setDragState({ phase: "dragging", key: state.key, dropIndex: newIndex });
+        } else if (state.dropIndex !== newIndex) {
+            setDragState({ ...state, dropIndex: newIndex });
         }
     };
 
     const handlePointerUp = (_e: PointerEvent) => {
-        const wasActuallyDragging = draggingKeyRef != null;
-        const dk = draggingKeyRef;
-        const di = dropIndexRef;
-        dragStartRef = null;
-        draggingKeyRef = null;
-        dropIndexRef = null;
-        setDraggingKey(null);
-        setDropIndex(null);
-        if (!wasActuallyDragging || dk == null || di == null) return;
+        const state = dragState();
+        setDragState(DRAG_IDLE);
+        if (state.phase !== "dragging") return;
         const current = pinnedWidgets();
         const shortNames = current.map(({ key }) => key.replace("defwidget@", ""));
-        const dragShort = dk.replace("defwidget@", "");
+        const dragShort = state.key.replace("defwidget@", "");
         const fromIdx = shortNames.indexOf(dragShort);
         if (fromIdx === -1) return;
         const next = [...shortNames];
         next.splice(fromIdx, 1);
-        const adjustedDrop = fromIdx < di ? di - 1 : di;
+        const adjustedDrop = fromIdx < state.dropIndex ? state.dropIndex - 1 : state.dropIndex;
         next.splice(adjustedDrop, 0, dragShort);
         if (next.join(",") !== shortNames.join(",")) {
             fireAndForget(async () => {
@@ -442,13 +461,7 @@ const ActionWidgets = (): JSX.Element => {
         }
     };
 
-    const handlePointerCancel = () => {
-        dragStartRef = null;
-        draggingKeyRef = null;
-        dropIndexRef = null;
-        setDraggingKey(null);
-        setDropIndex(null);
-    };
+    const handlePointerCancel = () => setDragState(DRAG_IDLE);
 
     // ── Context menu active state (keeps hover highlight while menu is open) ──
     const [contextMenuActiveKey, setContextMenuActiveKey] = createSignal<string | null>(null);
@@ -495,6 +508,7 @@ const ActionWidgets = (): JSX.Element => {
     const handlePinnedContextMenu = (e: MouseEvent, key: string) => {
         e.preventDefault();
         e.stopPropagation();
+        setDragState(DRAG_IDLE);
         armContextMenuDismiss(key);
         const shortName = key.replace("defwidget@", "");
         ContextMenuModel.showContextMenu(

--- a/specs/SPEC_WIDGET_PINBAR_DND_STATE_2026_06_15.md
+++ b/specs/SPEC_WIDGET_PINBAR_DND_STATE_2026_06_15.md
@@ -1,0 +1,252 @@
+# Spec: Widget Pin-Bar DnD State Machine — Robustness Rethink
+
+**Date:** 2026-06-15  
+**Status:** Proposed  
+**Affected file:** `frontend/app/window/action-widgets.tsx`
+
+---
+
+## 1. Bug Description
+
+**Symptom:** After unpinning a widget via right-click → context menu, hovering over the
+remaining widgets causes the accent-colored drop indicator to appear. The indicator
+disappears only when the user clicks a widget. The indicator should appear exclusively
+during an active left-button drag.
+
+**Steps to reproduce:**
+1. Right-click any pinned widget → "Unpin from bar"
+2. Move the mouse > 5 px from the click origin over any remaining widget slot
+3. Observe: drop indicator appears as if dragging
+4. Click any widget → indicator disappears
+
+---
+
+## 2. Root-Cause Analysis
+
+### 2a. Primary bug — no button guard
+
+`handlePointerDown` sets `dragStartRef` unconditionally for **all** pointer buttons:
+
+```ts
+const handlePointerDown = (key: string, e: PointerEvent) => {
+    dragStartRef = { x: e.clientX, y: e.clientY, key };  // fires for button 0, 1, 2
+};
+```
+
+A right-click (button 2) sets `dragStartRef`. The right-button `pointerup` fires on
+the context-menu overlay (which appears synchronously and captures pointer focus), not
+on the widget slot. `dragStartRef` is never cleared.
+
+### 2b. Orphaned drag state after context-menu escape
+
+Any interaction that transfers pointer focus away from the widget bar can orphan drag
+state without triggering the cleanup path:
+
+| Escape scenario | `pointerup` received by widget slot? |
+|---|---|
+| Right-click → custom context menu appears | No — overlay captures it |
+| Window loses focus (Alt+Tab) | No — browser swallows it |
+| OS-level interruption (notification) | No |
+| Left-drag → release outside browser window | No |
+
+`handlePointerCancel` handles one OS-level cancel but is not wired to any of the above.
+
+### 2c. Ref/signal duplication — two sources of truth
+
+The drag state is stored in **both** mutable module-level refs *and* reactive signals:
+
+```ts
+// Refs (synchronous, for event-handler reads)
+let draggingKeyRef: string | null = null;
+let dropIndexRef: number | null = null;
+let dragStartRef: { x: number; y: number; key: string } | null = null;
+
+// Signals (reactive, for render)
+const [draggingKey, setDraggingKey] = createSignal<string | null>(null);
+const [dropIndex, setDropIndex] = createSignal<number | null>(null);
+```
+
+Any code path that updates refs without updating signals (or vice versa) leaves the
+render out of sync with the event system. The current cancel path (`handlePointerCancel`)
+correctly resets both; the right-click escape path resets neither.
+
+### 2d. No explicit state machine
+
+The drag lifecycle is encoded as ad-hoc if/else checks inside event handlers rather
+than a typed state machine. Valid states are not enumerated, so it is unclear which
+transitions are legal, and guards against illegal transitions are missing.
+
+---
+
+## 3. Proposed Redesign
+
+### 3a. Single typed state signal
+
+Replace the three refs + two signals with one `createSignal<DragState>`:
+
+```ts
+type DragState =
+    | { phase: "idle" }
+    | { phase: "pending";  key: string; startX: number; startY: number; pointerId: number }
+    | { phase: "dragging"; key: string; dropIndex: number };
+
+const [dragState, setDragState] = createSignal<DragState>({ phase: "idle" });
+```
+
+Derived accessors for the render:
+```ts
+const draggingKey  = () => dragState().phase === "dragging" ? dragState().key      : null;
+const dropIndex    = () => dragState().phase === "dragging" ? dragState().dropIndex : null;
+```
+
+Benefits:
+- Single source of truth — no ref/signal divergence possible
+- Solid signals are synchronously readable in event handlers; refs are unnecessary
+- Impossible states (e.g. `dropIndex` set while `draggingKey` null) cannot occur
+
+### 3b. Primary-button guard
+
+```ts
+const handlePointerDown = (key: string, e: PointerEvent) => {
+    if (e.button !== 0) return;  // ignore right-click, middle-click, etc.
+    setDragState({ phase: "pending", key, startX: e.clientX, startY: e.clientY, pointerId: e.pointerId });
+};
+```
+
+Right-clicks never enter `pending` and therefore can never orphan drag state.
+
+### 3c. Global fallback cleanup
+
+While in `pending` or `dragging`, register a **global** `pointerup` listener as a
+fallback cleanup. Unregister it when returning to `idle`.
+
+```ts
+createEffect(() => {
+    const state = dragState();
+    if (state.phase === "idle") return;
+
+    const cancel = () => setDragState({ phase: "idle" });
+    window.addEventListener("pointerup",     cancel, { capture: true });
+    window.addEventListener("pointercancel", cancel, { capture: true });
+    window.addEventListener("visibilitychange", cancel);
+
+    onCleanup(() => {
+        window.removeEventListener("pointerup",     cancel, { capture: true });
+        window.removeEventListener("pointercancel", cancel, { capture: true });
+        window.removeEventListener("visibilitychange", cancel);
+    });
+});
+```
+
+This catches:
+- Right-click pointerup that fires on an overlay
+- Window focus loss (Alt+Tab, OS interruption)
+- Release outside the browser window
+
+The capture-phase `pointerup` listener fires before the overlay's bubble-phase listener,
+so it reliably catches every pointer release regardless of which element receives it.
+
+### 3d. Clear drag state explicitly on context-menu open
+
+As a belt-and-suspenders measure, `handlePinnedContextMenu` and `handleBarContextMenu`
+should reset drag state before opening any menu:
+
+```ts
+const handlePinnedContextMenu = (e: MouseEvent, key: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragState({ phase: "idle" });  // always reset — menu supersedes any pending drag
+    armContextMenuDismiss(key);
+    // ... rest unchanged
+};
+```
+
+### 3e. State machine transition table
+
+| From \ Event        | `pointerdown (btn=0)` | `pointermove (>5px)` | `pointerup`   | `pointercancel` / `visibilitychange` |
+|---|---|---|---|---|
+| `idle`              | → `pending`           | (no-op)              | (no-op)       | (no-op)                              |
+| `pending`           | → `pending` (reset)   | → `dragging`         | → `idle`      | → `idle`                             |
+| `dragging`          | (blocked by capture)  | update `dropIndex`   | → `idle` + commit reorder | → `idle` (cancel)         |
+
+No transition not listed in this table should occur.
+
+---
+
+## 4. Render Changes
+
+The render `<Show>` conditions need only check the reactive accessors — no logic change:
+
+```tsx
+// Before each slot:
+<Show when={draggingKey() != null && dropIndex() === idx() && draggingKey() !== key}>
+    <div class="action-widget-drop-indicator" />
+</Show>
+
+// After last slot:
+<Show when={draggingKey() != null && dropIndex() === visiblePinnedWidgets().length}>
+    <div class="action-widget-drop-indicator" />
+</Show>
+```
+
+The slot class is unchanged:
+```tsx
+class={clsx("action-widget-slot", {
+    dragging:       draggingKey() === key,
+    "context-active": contextMenuActiveKey() === key,
+})}
+```
+
+---
+
+## 5. What Is NOT Changing
+
+- The drop indicator's visual design (2px accent line)
+- The DRAG_THRESHOLD (5 px)
+- The reorder commit logic (splice + `SetConfigCommand`)
+- The `contextMenuActiveKey` signal and `armContextMenuDismiss`
+- The More dropdown, pin/unpin RPCs, tier collapse logic
+
+---
+
+## 6. Implementation Checklist
+
+- [ ] Replace `dragStartRef` / `draggingKeyRef` / `dropIndexRef` / `draggingKey` signal / `dropIndex` signal with single `DragState` signal
+- [ ] Add `e.button !== 0` guard in `handlePointerDown`
+- [ ] Add global `pointerup`/`pointercancel`/`visibilitychange` cleanup effect
+- [ ] Call `setDragState({ phase: "idle" })` at top of `handlePinnedContextMenu` and `handleBarContextMenu`
+- [ ] Update `handlePointerMove` to use `dragState()` reads instead of refs
+- [ ] Update `handlePointerUp` to use `dragState()` reads instead of refs
+- [ ] Remove now-unnecessary `draggingKeyRef`, `dropIndexRef`, `dragStartRef` let declarations
+- [ ] Add changeset: `patch "fix(widgets): repair phantom drop-indicator after right-click unpin"`
+- [ ] Verify: right-click unpin → hover → no indicator
+- [ ] Verify: left-drag reorder still works end-to-end
+- [ ] Verify: drag → Alt+Tab → return → no stale indicator
+
+---
+
+## 7. Minimal Patch (If Full Redesign Is Deferred)
+
+If the full state-machine redesign is deferred, apply this three-line patch as a
+stopgap. It fixes the root cause (right-click sets dragStartRef) without touching
+the broader architecture:
+
+```diff
+ const handlePointerDown = (key: string, e: PointerEvent) => {
++    if (e.button !== 0) return;
+     dragStartRef = { x: e.clientX, y: e.clientY, key };
+ };
+```
+
+And add a reset in `handlePinnedContextMenu`:
+```diff
+ const handlePinnedContextMenu = (e: MouseEvent, key: string) => {
+     e.preventDefault();
+     e.stopPropagation();
++    dragStartRef = null; draggingKeyRef = null; dropIndexRef = null;
++    setDraggingKey(null); setDropIndex(null);
+     armContextMenuDismiss(key);
+```
+
+The stopgap does not address Alt+Tab escape, window-blur escape, or the
+ref/signal duplication, but eliminates the reported symptom.


### PR DESCRIPTION
## Summary

- **Bug**: After unpinning a widget via right-click → context menu, hovering over the remaining widget bar showed the accent-colored drop indicator. Clicking any widget made it disappear. The indicator should only appear during an active left-button drag.
- **Root cause**: `onPointerDown` fired for all mouse buttons including right-click (button 2). The right-button `pointerup` was swallowed by the context-menu overlay (which receives focus before the button releases), leaving `dragStartRef` set. Subsequent mouse movement > 5px over any slot activated drag mode.
- **Structural issue**: Drag state was split across 3 mutable refs + 2 reactive signals — two sources of truth that could diverge on any escape path.

## Changes

**`frontend/app/window/action-widgets.tsx`**
- Replaced `dragStartRef` / `draggingKeyRef` / `dropIndexRef` / `draggingKey` signal / `dropIndex` signal with a single `DragState` discriminated union signal (`idle | pending | dragging`)
- Added `e.button !== 0` guard in `handlePointerDown` — right/middle clicks never enter `pending` state
- Added `createEffect` that registers global `pointercancel` + `visibilitychange` cleanup while not idle — handles Alt+Tab, OS interrupts, and other escape scenarios
- `handlePinnedContextMenu` resets drag state as belt-and-suspenders before opening menu
- `handlePointerMove` now computes `dropIndex` before updating state — single `setDragState` per frame instead of two

**`specs/SPEC_WIDGET_PINBAR_DND_STATE_2026_06_15.md`** — full analysis and design spec

## Test plan

- [ ] Right-click a pinned widget → "Unpin from bar" → hover over remaining widgets → **no drop indicator appears**
- [ ] Left-drag a pinned widget to reorder → drop indicator appears during drag, clears on release — reorder commits correctly
- [ ] Left-drag → release outside the window → no stale indicator on return
- [ ] Alt+Tab while left-dragging → return → indicator is cleared
- [ ] Right-click opens context menu normally, closes normally — no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)