### PR TITLE
feat(agent): OpenEditor MCP tool — agents can open editor panes

### DIFF
--- a/.changesets/1781535001-feat-agent-open-editor-mcp-tool.md
+++ b/.changesets/1781535001-feat-agent-open-editor-mcp-tool.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): OpenEditor MCP tool + /api/v1/pane/open route so agents can open editor panes

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -55,6 +55,20 @@ const SHELL_STOP_TOOL: &str = r#"{
   }
 }"#;
 
+const OPEN_EDITOR_TOOL: &str = r#"{
+  "name": "OpenEditor",
+  "description": "Open a file in an AgentMux editor pane next to this conversation. Use when you want the user to see a file you're discussing or editing. Pass an absolute host path. Fire-and-forget: returns once the pane is opened.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "file":  { "type": "string", "description": "Absolute path to the file to open" },
+      "title": { "type": "string", "description": "Optional tab/pane title (defaults to the file name)" },
+      "split": { "type": "string", "enum": ["right", "left", "down", "up"], "description": "Where to place the new pane relative to this agent pane (default: right)" }
+    },
+    "required": ["file"]
+  }
+}"#;
+
 #[tokio::main]
 async fn main() {
     let local_url = std::env::var("AGENTMUX_LOCAL_URL").unwrap_or_default();
@@ -127,10 +141,11 @@ async fn main() {
             "tools/list" => {
                 let shell: Value = serde_json::from_str(SHELL_TOOL).expect("static json");
                 let shell_stop: Value = serde_json::from_str(SHELL_STOP_TOOL).expect("static json");
+                let open_editor: Value = serde_json::from_str(OPEN_EDITOR_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop] }
+                    "result": { "tools": [shell, shell_stop, open_editor] }
                 })
             }
             "tools/call" => {
@@ -284,6 +299,68 @@ async fn call_tool(
             } else {
                 format!("shell {shell_id} was not running (unknown or already exited)")
             })
+        }
+        "OpenEditor" => {
+            let file = arguments
+                .get("file")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: file"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let split = arguments
+                .get("split")
+                .and_then(|v| v.as_str())
+                .filter(|s| matches!(*s, "right" | "left" | "down" | "up"))
+                .unwrap_or("right");
+
+            let url = format!("{}/api/v1/pane/open", local_url.trim_end_matches('/'));
+            let mut body = json!({
+                "view": "editor",
+                "file": file,
+                "focus": true,
+            });
+            // Place the editor relative to the calling agent pane when we know
+            // its block id (AGENTMUX_BLOCKID); otherwise the sidecar inserts it
+            // at the tab root.
+            if !block_id.is_empty() {
+                body["split_direction"] = json!(split);
+                body["split_reference_block_id"] = json!(block_id);
+            }
+            if let Some(title) = arguments.get("title").and_then(|v| v.as_str()) {
+                body["title"] = json!(title);
+            }
+
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("pane.open failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            let block = result
+                .get("block_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+
+            Ok(format!("Opened {file} in editor pane (block {block})"))
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -859,116 +859,125 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn register_pane_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
-    let event_bus = state.event_bus.clone();
-
+    let state = state.clone();
     engine.register_handler(
         COMMAND_PANE_OPEN,
         Box::new(move |data, _ctx| {
-            let wstore = wstore.clone();
-            let event_bus = event_bus.clone();
+            let state = state.clone();
             Box::pin(async move {
                 let cmd: CommandPaneOpenData = serde_json::from_value(data)
                     .map_err(|e| format!("pane.open: {e}"))?;
-
-                tracing::info!(view = %cmd.view, "pane.open");
-
-                // Build meta for the requested view, validating required args
-                let meta = build_pane_meta(&cmd)?;
-
-                // Resolve tab
-                let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
-
-                // Create block
-                let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
-                    .map_err(|e| format!("pane.open: create_block: {e}"))?;
-                let block_id = block.oid.clone();
-
-                // Enqueue layout action — split if requested, else append
-                let (actiontype, targetblockid, position) = resolve_placement(
-                    cmd.split_direction.as_deref(),
-                    cmd.split_reference_block_id.as_deref(),
-                );
-                let focused = cmd.focus.unwrap_or(true);
-
-                {
-                    let tab: Tab = wstore.must_get(&tab_id)
-                        .map_err(|e| format!("pane.open: reload tab: {e}"))?;
-                    if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
-                        let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
-                        actions.push(obj::LayoutActionData {
-                            actiontype,
-                            actionid: uuid::Uuid::new_v4().to_string(),
-                            blockid: block_id.clone(),
-                            nodesize: None,
-                            indexarr: None,
-                            focused,
-                            magnified: false,
-                            ephemeral: false,
-                            targetblockid,
-                            position,
-                        });
-                        layout.pendingbackendactions = Some(actions);
-                        let _ = wstore.update(&mut layout);
-                    }
-                }
-
-                tracing::info!(
-                    block_id = %block_id,
-                    view = %cmd.view,
-                    "pane.open: block created + layout updated"
-                );
-
-                // Broadcast block + tab + layout updates
-                {
-                    let mut updates = Vec::new();
-                    if let Ok(updated_block) = wstore.must_get::<Block>(&block_id) {
-                        updates.push(obj::WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: "block".into(),
-                            oid: block_id.clone(),
-                            obj: Some(obj::wave_obj_to_value(&updated_block)),
-                        });
-                    }
-                    if let Ok(updated_tab) = wstore.must_get::<Tab>(&tab_id) {
-                        updates.push(obj::WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: "tab".into(),
-                            oid: tab_id.clone(),
-                            obj: Some(obj::wave_obj_to_value(&updated_tab)),
-                        });
-                        if let Ok(updated_layout) = wstore.must_get::<obj::LayoutState>(&updated_tab.layoutstate) {
-                            updates.push(obj::WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: "layout".into(),
-                                oid: updated_tab.layoutstate.clone(),
-                                obj: Some(obj::wave_obj_to_value(&updated_layout)),
-                            });
-                        }
-                    }
-                    for update in &updates {
-                        let oref = format!("{}:{}", update.otype, update.oid);
-                        if let Ok(data) = serde_json::to_value(update) {
-                            event_bus.broadcast_event(
-                                &crate::backend::eventbus::WSEventType {
-                                    eventtype: "waveobj:update".to_string(),
-                                    oref,
-                                    data: Some(data),
-                                },
-                            );
-                        }
-                    }
-                }
-
-                Ok(Some(serde_json::to_value(&PaneOpenResult {
-                    block_id,
-                    tab_id,
-                    view: cmd.view,
-                    created: true,
-                }).unwrap()))
+                let result = open_pane(&state, cmd).await?;
+                Ok(Some(serde_json::to_value(&result).unwrap()))
             })
         }),
     );
+}
+
+/// Core `pane.open` logic, shared by the WebSocket RPC handler
+/// (`register_pane_open`) and the HTTP route `POST /api/v1/pane/open`
+/// (`agentmux-mcp`'s `OpenEditor` tool). Creates a block for the requested
+/// view, enqueues a layout action (split or insert), and broadcasts the
+/// block/tab/layout updates so the frontend renders the new pane.
+pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<PaneOpenResult, String> {
+    let wstore = state.wstore.clone();
+    let event_bus = state.event_bus.clone();
+
+    tracing::info!(view = %cmd.view, "pane.open");
+
+    // Build meta for the requested view, validating required args
+    let meta = build_pane_meta(&cmd)?;
+
+    // Resolve tab
+    let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
+
+    // Create block
+    let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
+        .map_err(|e| format!("pane.open: create_block: {e}"))?;
+    let block_id = block.oid.clone();
+
+    // Enqueue layout action — split if requested, else append
+    let (actiontype, targetblockid, position) = resolve_placement(
+        cmd.split_direction.as_deref(),
+        cmd.split_reference_block_id.as_deref(),
+    );
+    let focused = cmd.focus.unwrap_or(true);
+
+    {
+        let tab: Tab = wstore.must_get(&tab_id)
+            .map_err(|e| format!("pane.open: reload tab: {e}"))?;
+        if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
+            let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
+            actions.push(obj::LayoutActionData {
+                actiontype,
+                actionid: uuid::Uuid::new_v4().to_string(),
+                blockid: block_id.clone(),
+                nodesize: None,
+                indexarr: None,
+                focused,
+                magnified: false,
+                ephemeral: false,
+                targetblockid,
+                position,
+            });
+            layout.pendingbackendactions = Some(actions);
+            let _ = wstore.update(&mut layout);
+        }
+    }
+
+    tracing::info!(
+        block_id = %block_id,
+        view = %cmd.view,
+        "pane.open: block created + layout updated"
+    );
+
+    // Broadcast block + tab + layout updates
+    {
+        let mut updates = Vec::new();
+        if let Ok(updated_block) = wstore.must_get::<Block>(&block_id) {
+            updates.push(obj::WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "block".into(),
+                oid: block_id.clone(),
+                obj: Some(obj::wave_obj_to_value(&updated_block)),
+            });
+        }
+        if let Ok(updated_tab) = wstore.must_get::<Tab>(&tab_id) {
+            updates.push(obj::WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "tab".into(),
+                oid: tab_id.clone(),
+                obj: Some(obj::wave_obj_to_value(&updated_tab)),
+            });
+            if let Ok(updated_layout) = wstore.must_get::<obj::LayoutState>(&updated_tab.layoutstate) {
+                updates.push(obj::WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: "layout".into(),
+                    oid: updated_tab.layoutstate.clone(),
+                    obj: Some(obj::wave_obj_to_value(&updated_layout)),
+                });
+            }
+        }
+        for update in &updates {
+            let oref = format!("{}:{}", update.otype, update.oid);
+            if let Ok(data) = serde_json::to_value(update) {
+                event_bus.broadcast_event(
+                    &crate::backend::eventbus::WSEventType {
+                        eventtype: "waveobj:update".to_string(),
+                        oref,
+                        data: Some(data),
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(PaneOpenResult {
+        block_id,
+        tab_id,
+        view: cmd.view,
+        created: true,
+    })
 }
 
 /// Build the metadata map for a pane.open request, validating required args.

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -241,6 +241,11 @@ pub fn build_router(state: AppState) -> Router {
         // Stop a persistent shell (Phase 3). agentmux-mcp's `ShellStop` tool
         // POSTs here; tree-kills the shell's process group.
         .route("/api/v1/shell/stop", post(handle_shell_stop))
+        // Open a pane (editor/term/browser/…) from an agent tool call.
+        // agentmux-mcp's OpenEditor tool POSTs `{view:"editor", file, …}` here;
+        // shares the exact pane.open logic with the WebSocket RPC handler
+        // (app_api::open_pane). See ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.
+        .route("/api/v1/pane/open", post(handle_pane_open))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -538,6 +543,31 @@ async fn handle_shell_stop(
     let stopped = state.shell_sessions.stop(&req.shell_id);
     tracing::info!(shell_id = %req.shell_id, stopped, "shell.stop");
     (StatusCode::OK, Json(json!({ "stopped": stopped })))
+}
+
+/// `POST /api/v1/pane/open` — open a pane (editor/term/browser/…).
+///
+/// Called by `agentmux-mcp`'s `OpenEditor` tool. Thin HTTP wrapper over
+/// `app_api::open_pane` (the same logic the WebSocket `pane.open` RPC uses):
+/// creates the block, enqueues the layout action, and broadcasts the updates
+/// so the frontend renders the pane. Body is `CommandPaneOpenData`.
+async fn handle_pane_open(
+    State(state): State<AppState>,
+    Json(req): Json<crate::backend::rpc_types::CommandPaneOpenData>,
+) -> impl IntoResponse {
+    match app_api::open_pane(&state, req).await {
+        Ok(result) => (StatusCode::OK, Json(json!(result))).into_response(),
+        Err(e) => {
+            // Argument/validation errors from build_pane_meta are the caller's
+            // fault (400); everything else is a server-side failure (500).
+            let status = if e.starts_with("MISSING_ARG") || e.starts_with("INVALID_VIEW") {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(json!({ "error": e }))).into_response()
+        }
+    }
 }
 
 // ---- Auth Middleware ----

--- a/docs/specs/app-api-pane-open.md
+++ b/docs/specs/app-api-pane-open.md
@@ -2,21 +2,34 @@
 
 Status: Partially Implemented (MVP shipped; idempotency, `is_new`, and `mode` pending)
 Date: 2026-04-20
-Updated: 2026-06-14
+Updated: 2026-06-15
 Depends on: `app-api-extension.md`, `app-api-status.md`
 
-## Implementation Status (as of 2026-06-14)
+## Implementation Status (as of 2026-06-15)
 
 | Feature | Status |
 |---------|--------|
 | Basic `pane.open` handler in `app_api.rs` | ✅ Shipped (skeleton) |
 | `view`, `file`, `url`, `cwd`, `title`, `tab_id`, `split_direction`, `split_reference_block_id`, `focus` | ✅ Shipped in `CommandPaneOpenData` |
+| Shared `open_pane()` core + `POST /api/v1/pane/open` HTTP route | ✅ Shipped — auth-gated like `/api/v1/shell/create` |
+| `OpenEditor` MCP tool (agent-accessible, auto-discovered by Claude Code) | ✅ Shipped in `agentmux-mcp` — Phase 1, local connections, file only |
 | Idempotency (focus existing pane on same file) | ❌ Not implemented |
 | Path sandboxing / allowed-roots validation | ❌ Not implemented |
+| Path translation (container/SSH/WSL agents) | ❌ Not implemented — Phase 2, see analysis §5 |
 | `is_new` (scratch/untitled file creation) | ❌ Not implemented — see `SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md` |
 | `mode: "preview" \| "pinned"` | ❌ Not implemented |
 | `language` hint | ❌ Not implemented |
 | `amux open <path>` CLI bridge | ❌ Not implemented — see `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md` |
+
+> **Agent transport (2026-06-15):** an agent inside an AgentMux pane can now open
+> an editor pane by calling the `OpenEditor` MCP tool (exposed by `agentmux-mcp`,
+> the same server that exposes `Shell`). The tool POSTs `{view:"editor", file, …}`
+> to the auth-gated `POST /api/v1/pane/open` route, which calls the shared
+> `app_api::open_pane()` — the identical logic the WebSocket `pane.open` RPC uses.
+> The editor opens split beside the calling agent pane (overridable via the `split`
+> arg). Phase 1 is **local connections, single file, new pane each call**
+> (no idempotency/reuse yet). The `amux` CLI in the analysis remains a separate,
+> additive surface for non-MCP/shell agents.
 
 > **Note:** The view name in the live RPC is `"editor"` (not `"codeeditor"` as written below in the original design). All future code should use `"editor"`. The spec body below is being kept historically accurate and updated with corrections inline.
 


### PR DESCRIPTION
## What

Phase 1 of `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md` — give agents running inside AgentMux a way to **open editor panes**.

The `pane.open` RPC already opened an editor on a file, but there was no agent-accessible transport (the analysis flagged this as the bottleneck). This wires the existing capability to the MCP server that agents already speak.

## How

1. **Shared core** — extracted the `pane.open` handler body into `app_api::open_pane(state, cmd) -> Result<PaneOpenResult, String>`. The WebSocket `pane.open` RPC handler now calls it; behavior is unchanged.
2. **HTTP route** — new auth-gated `POST /api/v1/pane/open`, mirroring `/api/v1/shell/create`. Thin wrapper over `open_pane`; returns 400 on `MISSING_ARG`/`INVALID_VIEW`, 500 otherwise.
3. **MCP tool** — added `OpenEditor` to `agentmux-mcp` (the same server that exposes `Shell`, auto-discovered by Claude Code). It POSTs `{view:"editor", file, …}` with `X-AuthKey` and opens the editor **split beside the calling agent pane** (`AGENTMUX_BLOCKID`), overridable via the `split` arg.

## Scope (Phase 1)

- ✅ Local connections, single file, new pane per call.
- ❌ Idempotency/reuse, path translation (container/SSH/WSL), `is_new` scratch buffers — all called out as follow-ups in the analysis and the updated spec status table.
- The `amux` CLI (for non-MCP/shell agents) remains a separate additive surface; not in this PR.

## Files

- `agentmux-srv/src/server/app_api.rs` — extract `open_pane`; RPC handler delegates to it.
- `agentmux-srv/src/server/mod.rs` — `POST /api/v1/pane/open` route + `handle_pane_open`.
- `agentmux-mcp/src/main.rs` — `OpenEditor` tool (schema + `tools/list` + `call_tool`).
- `docs/specs/app-api-pane-open.md` — implementation-status update.

## Verification

`cargo check -p agentmux-srv` and `cargo check -p agentmux-mcp` both pass (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)