### PR TITLE
feat(trust-center): secure API-key storage + validation backend (Phase 2a)

### DIFF
--- a/.changesets/1781527600-feat-trust-center-key-validation-keychain.md
+++ b/.changesets/1781527600-feat-trust-center-key-validation-keychain.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): secure API-key storage backend — validate keys against the live service, store them in the OS keychain (never plaintext in the DB), and expose them via the new account.key.verify RPC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "agentmux-bashwrap"
 version = "0.45.0"
 dependencies = [
@@ -120,6 +131,7 @@ dependencies = [
  "futures-util",
  "hex",
  "json_comments",
+ "keyring",
  "libc",
  "mdns-sd",
  "minidumper",
@@ -148,6 +160,7 @@ dependencies = [
  "whoami",
  "windows-sys 0.59.0",
  "winres",
+ "zeroize",
  "zip",
 ]
 
@@ -256,6 +269,158 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.4.1",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.28",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling 3.11.0",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,8 +439,14 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -285,7 +456,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -456,6 +627,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +886,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -746,6 +958,16 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -847,6 +1069,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,7 +1087,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -865,6 +1098,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -896,7 +1130,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -952,6 +1186,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1238,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "failspot"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1292,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fastrand"
@@ -1125,6 +1427,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand 2.4.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,7 +1462,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1271,6 +1601,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -1280,6 +1616,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1631,12 +1985,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1674,6 +2049,20 @@ name = "json_comments"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+
+[[package]]
+name = "keyring"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "kqueue"
@@ -1763,6 +2152,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +2248,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36e83ad165be7e0ad2e3ae3be9afffdda0c2c9a7e70c628e5541f11443e3041"
 dependencies = [
- "fastrand",
+ "fastrand 2.4.1",
  "flume",
  "if-addrs",
  "log",
@@ -1864,6 +2269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1923,7 +2337,7 @@ dependencies = [
  "log",
  "mach2",
  "memmap2",
- "memoffset",
+ "memoffset 0.9.1",
  "minidump-common",
  "nix 0.29.0",
  "procfs-core",
@@ -1972,6 +2386,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -2045,6 +2471,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,7 +2517,38 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2113,6 +2603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2652,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.4.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2209,7 +2726,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2273,7 +2790,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2529,7 +3056,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2634,6 +3161,20 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rustix"
@@ -2777,7 +3318,49 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "secret-service"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2817,7 +3400,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2852,7 +3435,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2992,7 +3575,17 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3042,6 +3635,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3657,17 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3087,7 +3697,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3120,7 +3730,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.4.1",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
@@ -3153,7 +3763,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3164,7 +3774,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3257,7 +3867,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3302,6 +3912,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3392,7 +4019,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3484,6 +4111,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3636,6 +4274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,7 +4370,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3911,7 +4555,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3922,7 +4566,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3933,7 +4577,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3944,7 +4588,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4212,6 +4856,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4271,7 +4924,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4287,7 +4940,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4346,6 +4999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4364,8 +5027,74 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.26.4",
+ "once_cell",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -4385,7 +5114,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4405,7 +5134,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4414,6 +5143,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4445,7 +5188,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4481,4 +5224,42 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -36,6 +36,12 @@ sysinfo = "0.34"
 parking_lot = "0.12"
 notify = "7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+# OS-native secret storage (macOS Keychain / Windows Credential Manager /
+# Linux Secret Service) for Trust Center API keys. See
+# specs/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
+keyring = "2"
+# Zero plaintext secret buffers on drop.
+zeroize = { version = "1", features = ["zeroize_derive"] }
 mdns-sd = "0.12"
 which = "7"
 flate2 = "1"

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -300,6 +300,12 @@ pub const COMMAND_LIST_IDENTITY_ACCOUNTS: &str = "listidentityaccounts";
 pub const COMMAND_GET_IDENTITY_ACCOUNT: &str = "getidentityaccount";
 pub const COMMAND_UPSERT_IDENTITY_ACCOUNT: &str = "upsertidentityaccount";
 pub const COMMAND_DELETE_IDENTITY_ACCOUNT: &str = "deleteidentityaccount";
+/// Trust Center: validate (optional, user-initiated) + securely store an API
+/// key. The plaintext goes to the OS keychain; the DB keeps only a
+/// `SecretRef::Keychain` pointer + masked tail + metadata. Used for both new
+/// accounts and replacing a key on an existing one (via `accountId`).
+/// See specs/SPEC_TRUST_CENTER_2026_06_15.md §5/§6.
+pub const COMMAND_ACCOUNT_KEY_VERIFY: &str = "account.key.verify";
 
 // Agent ↔ Identity junction
 pub const COMMAND_LINK_AGENT_IDENTITY: &str = "linkagentidentity";

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -63,6 +63,19 @@ pub enum SecretRef {
         /// (PR E).
         dir: String,
     },
+    /// **API key / token stored in the OS-native secret store** (macOS
+    /// Keychain / Windows Credential Manager / Linux Secret Service),
+    /// addressed by `(service, account)`. The plaintext is NEVER held in
+    /// the DB — only this pointer. Written by the Trust Center key flow
+    /// after a successful live validation; resolved to the real value at
+    /// agent spawn time via `crate::identity::secret_store`. See
+    /// specs/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
+    Keychain {
+        /// Keychain service string — always `"agentmux"`.
+        service: String,
+        /// Keychain account string — `"acct:<account_id>"`.
+        account: String,
+    },
 }
 
 /// An identity account (reusable credential, linked to agents via the

--- a/agentmux-srv/src/identity/key_validator.rs
+++ b/agentmux-srv/src/identity/key_validator.rs
@@ -1,0 +1,208 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Live API-key validation for the Trust Center.
+//!
+//! Each supported service has a probe that makes a single minimal
+//! authenticated request and maps the response to non-secret metadata
+//! (account name, scopes, etc.). This is the only outbound call the key
+//! flow makes, and it fires only on the user's explicit Validate click
+//! (see specs/SPEC_TRUST_CENTER_2026_06_15.md §5.1, §6).
+//!
+//! The plaintext key is passed in by value, used to build one request, and
+//! never logged. Callers must keep it out of logs/transcripts.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde_json::json;
+
+/// Outcome of a validation probe. `metadata` is non-secret JSON safe to
+/// persist on the account row + show in the UI; `masked_tail` is the
+/// last few chars for the locked display.
+#[derive(Debug, Clone)]
+pub struct ValidationOutcome {
+    pub valid: bool,
+    pub metadata: serde_json::Value,
+    pub masked_tail: String,
+    pub error: Option<String>,
+}
+
+impl ValidationOutcome {
+    fn invalid(masked_tail: String, error: impl Into<String>) -> Self {
+        Self {
+            valid: false,
+            metadata: json!({}),
+            masked_tail,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Masked hint for the locked display: bullet run + last 4 chars. Stored
+/// alongside the account so the panel can render `••••••••3f9a` without the
+/// secret. Keys shorter than 4 chars are fully masked (no tail leak).
+pub fn masked_tail(secret: &str) -> String {
+    let n = secret.chars().count();
+    if n <= 4 {
+        return "•".repeat(n.max(4));
+    }
+    let tail: String = secret.chars().skip(n - 4).collect();
+    format!("••••••••{tail}")
+}
+
+fn client() -> &'static reqwest::Client {
+    static C: OnceLock<reqwest::Client> = OnceLock::new();
+    C.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .user_agent("AgentMux")
+            .build()
+            .expect("reqwest client build failed")
+    })
+}
+
+/// Validate `key` for `provider`. Makes one outbound HTTPS request. Returns
+/// a non-`valid` outcome (never errors the RPC) so the caller can surface a
+/// structured message and stay in the entry state.
+pub async fn validate(provider: &str, key: &str) -> ValidationOutcome {
+    let tail = masked_tail(key);
+    match provider {
+        "github" => github(key, tail).await,
+        "openai" => openai(key, tail).await,
+        "anthropic" => anthropic(key, tail).await,
+        "slack" => slack(key, tail).await,
+        other => ValidationOutcome::invalid(
+            tail,
+            format!("no validator for provider '{other}' — save without validating"),
+        ),
+    }
+}
+
+async fn github(key: &str, tail: String) -> ValidationOutcome {
+    let resp = match client()
+        .get("https://api.github.com/user")
+        .header("Authorization", format!("Bearer {key}"))
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ValidationOutcome::invalid(tail, format!("network error: {e}")),
+    };
+    if !resp.status().is_success() {
+        return ValidationOutcome::invalid(tail, format!("GitHub rejected the token ({})", resp.status()));
+    }
+    // Scopes come back in a response header, not the body.
+    let scopes = resp
+        .headers()
+        .get("x-oauth-scopes")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| {
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let body: serde_json::Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    let login = body.get("login").and_then(|v| v.as_str()).unwrap_or("");
+    ValidationOutcome {
+        valid: true,
+        metadata: json!({ "github_username": login, "github_scopes": scopes }),
+        masked_tail: tail,
+        error: None,
+    }
+}
+
+async fn openai(key: &str, tail: String) -> ValidationOutcome {
+    let resp = match client()
+        .get("https://api.openai.com/v1/models")
+        .header("Authorization", format!("Bearer {key}"))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ValidationOutcome::invalid(tail, format!("network error: {e}")),
+    };
+    if !resp.status().is_success() {
+        return ValidationOutcome::invalid(tail, format!("OpenAI rejected the key ({})", resp.status()));
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    let model_count = body.get("data").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0);
+    ValidationOutcome {
+        valid: true,
+        metadata: json!({ "openai_model_count": model_count }),
+        masked_tail: tail,
+        error: None,
+    }
+}
+
+async fn anthropic(key: &str, tail: String) -> ValidationOutcome {
+    let resp = match client()
+        .get("https://api.anthropic.com/v1/models")
+        .header("x-api-key", key)
+        .header("anthropic-version", "2023-06-01")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ValidationOutcome::invalid(tail, format!("network error: {e}")),
+    };
+    if !resp.status().is_success() {
+        return ValidationOutcome::invalid(tail, format!("Anthropic rejected the key ({})", resp.status()));
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    let model_count = body.get("data").and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0);
+    ValidationOutcome {
+        valid: true,
+        metadata: json!({ "anthropic_model_count": model_count }),
+        masked_tail: tail,
+        error: None,
+    }
+}
+
+async fn slack(key: &str, tail: String) -> ValidationOutcome {
+    let resp = match client()
+        .post("https://slack.com/api/auth.test")
+        .header("Authorization", format!("Bearer {key}"))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ValidationOutcome::invalid(tail, format!("network error: {e}")),
+    };
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => return ValidationOutcome::invalid(tail, format!("bad response: {e}")),
+    };
+    // Slack returns 200 with { ok: false, error } for bad tokens.
+    if !body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+        let err = body.get("error").and_then(|v| v.as_str()).unwrap_or("invalid token");
+        return ValidationOutcome::invalid(tail, format!("Slack rejected the token: {err}"));
+    }
+    let team = body.get("team").and_then(|v| v.as_str()).unwrap_or("");
+    let user = body.get("user").and_then(|v| v.as_str()).unwrap_or("");
+    ValidationOutcome {
+        valid: true,
+        metadata: json!({ "slack_team": team, "slack_user": user }),
+        masked_tail: tail,
+        error: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masks_all_but_last_four() {
+        assert_eq!(masked_tail("ghp_abcdef123456"), "••••••••3456");
+    }
+
+    #[test]
+    fn short_keys_fully_masked_no_tail_leak() {
+        assert_eq!(masked_tail("ab"), "••••");
+        assert_eq!(masked_tail("abcd"), "••••");
+    }
+}

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -30,8 +30,10 @@
 
 pub mod auth_patterns;
 pub mod auth_session;
+pub mod key_validator;
 pub mod migration;
 pub mod resolver;
+pub mod secret_store;
 
 // Legacy convenience re-export — newer call sites use
 // `resolver::inject_identity_env_with_broker` directly so the OAuth

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -382,6 +382,36 @@ pub fn inject_identity_env(
 /// (`app_api.rs` AgentSendCommand + `websocket.rs` AgentInputCommand)
 /// pass `Some(broker.clone())` so the IdentityManager's bindings table
 /// flips its status badge without a reload. Per spec §4.4.
+/// Async wrapper around [`inject_identity_env_with_broker`] for use from
+/// async spawn handlers. The underlying path does blocking I/O — synchronous
+/// SQLite reads and, for `SecretRef::Keychain` accounts, a blocking
+/// `keyring` (D-Bus Secret Service on Linux) read — so it runs on a blocking
+/// thread via `spawn_blocking` rather than stalling an async runtime worker.
+/// Takes ownership of `env_vars` and returns it with identity vars merged in.
+/// On the rare task-join failure the original map is returned unchanged so
+/// the static `cmd:env` vars are never lost. See spec §12.2.
+pub async fn inject_identity_env_async(
+    wstore: Arc<Store>,
+    broker: Option<Arc<Broker>>,
+    block_id: String,
+    env_vars: HashMap<String, String>,
+) -> HashMap<String, String> {
+    let fallback = env_vars.clone();
+    match tokio::task::spawn_blocking(move || {
+        let mut env = env_vars;
+        inject_identity_env_with_broker(wstore, broker, &block_id, &mut env);
+        env
+    })
+    .await
+    {
+        Ok(merged) => merged,
+        Err(e) => {
+            tracing::warn!(target: "identity", "identity injection task join failed: {e}");
+            fallback
+        }
+    }
+}
+
 pub fn inject_identity_env_with_broker(
     wstore: Arc<Store>,
     broker: Option<Arc<Broker>>,

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -207,6 +207,12 @@ pub enum ResolverError {
     #[error("OAuthConfigDir is a config-dir pointer, not a resolvable secret — routed via the oauth-class injection path, not resolve_secret")]
     OAuthConfigDirNotASecret,
 
+    /// The OS keychain read failed (no entry, locked store, or no Secret
+    /// Service agent). Trust Center API keys (`SecretRef::Keychain`) live
+    /// in the OS keychain; this surfaces a resolution failure at spawn.
+    #[error("keychain error: {0}")]
+    KeychainError(String),
+
     #[error("storage error: {0}")]
     Storage(#[from] StoreError),
 }
@@ -322,6 +328,16 @@ pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolverError> {
             // `resolve_secret` entirely.
             let _ = dir;
             Err(ResolverError::OAuthConfigDirNotASecret)
+        }
+        SecretRef::Keychain { account, .. } => {
+            // Trust Center API keys: pull the plaintext from the OS
+            // keychain at spawn time. The account string is
+            // `acct:<account_id>`; secret_store reconstructs the key
+            // from the id, so strip the namespace prefix here.
+            let account_id = account.strip_prefix("acct:").unwrap_or(account);
+            crate::identity::secret_store::get(account_id)
+                .map(|z| z.to_string())
+                .map_err(ResolverError::KeychainError)
         }
     }
 }

--- a/agentmux-srv/src/identity/secret_store.rs
+++ b/agentmux-srv/src/identity/secret_store.rs
@@ -1,0 +1,69 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OS-native secret storage for Trust Center API keys.
+//!
+//! Backs `SecretRef::Keychain { service, account }`. The plaintext key
+//! lives only in the OS keychain (macOS Keychain / Windows Credential
+//! Manager / Linux Secret Service via the `keyring` crate); the DB holds
+//! just the pointer plus non-secret metadata + a masked tail. Reads return
+//! a `Zeroizing<String>` so the plaintext is wiped from memory on drop.
+//!
+//! See specs/SPEC_TRUST_CENTER_2026_06_15.md §7 (best practices) and §12.2.
+//!
+//! NOTE: an encrypted-file fallback for headless Linux without a Secret
+//! Service agent is a documented follow-up (spec §12.2); the desktop app
+//! ships with a keychain on all three platforms, so keyring is the path
+//! here. Failures surface as a typed error rather than a silent downgrade.
+
+use keyring::Entry;
+use zeroize::Zeroizing;
+
+/// Keychain service string — constant across all AgentMux secrets.
+pub const SERVICE: &str = "agentmux";
+
+/// Build the keychain account string for an identity-account id.
+pub fn account_key(account_id: &str) -> String {
+    format!("acct:{account_id}")
+}
+
+fn entry(account_id: &str) -> Result<Entry, String> {
+    Entry::new(SERVICE, &account_key(account_id))
+        .map_err(|e| format!("keychain entry init failed: {e}"))
+}
+
+/// Store (or overwrite) the secret for `account_id` in the OS keychain.
+pub fn put(account_id: &str, secret: &str) -> Result<(), String> {
+    entry(account_id)?
+        .set_password(secret)
+        .map_err(|e| format!("keychain write failed: {e}"))
+}
+
+/// Read the secret for `account_id`. Returned wrapped in `Zeroizing` so it
+/// is wiped on drop. Resolved at agent spawn time when injecting env vars.
+pub fn get(account_id: &str) -> Result<Zeroizing<String>, String> {
+    let pw = entry(account_id)?
+        .get_password()
+        .map_err(|e| format!("keychain read failed: {e}"))?;
+    Ok(Zeroizing::new(pw))
+}
+
+/// Delete the secret for `account_id`. A missing entry is treated as
+/// success (idempotent delete).
+pub fn delete(account_id: &str) -> Result<(), String> {
+    match entry(account_id)?.delete_password() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(format!("keychain delete failed: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_key_is_namespaced() {
+        assert_eq!(account_key("abc123"), "acct:abc123");
+    }
+}

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -37,6 +37,7 @@ use crate::backend::rpc_types::{
     // v6 identity / instance / fork
     COMMAND_LIST_IDENTITY_ACCOUNTS, COMMAND_GET_IDENTITY_ACCOUNT,
     COMMAND_UPSERT_IDENTITY_ACCOUNT, COMMAND_DELETE_IDENTITY_ACCOUNT,
+    COMMAND_ACCOUNT_KEY_VERIFY,
     COMMAND_LINK_AGENT_IDENTITY, COMMAND_UNLINK_AGENT_IDENTITY,
     COMMAND_LIST_AGENT_IDENTITIES,
     COMMAND_LIST_AGENT_INSTANCES, COMMAND_GET_AGENT_INSTANCE,
@@ -81,10 +82,37 @@ use crate::backend::rpc_types::{
 };
 use crate::backend::storage::{AgentDefinition, AgentContent, AgentSkill};
 use crate::backend::storage::store::{
-    AgentInstance, Identity, IdentityAccount, InstanceStatus, Memory,
+    AgentInstance, Identity, IdentityAccount, InstanceStatus, Memory, SecretRef,
 };
 
 use super::AppState;
+
+/// Request for `account.key.verify` (Trust Center key flow). The `api_key`
+/// field is a secret — never log this struct.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VerifyKeyReq {
+    /// Service id: "github" | "openai" | "anthropic" | "slack" | … .
+    provider: String,
+    /// Account display name (user-chosen label).
+    name: String,
+    #[serde(default)]
+    display_name: String,
+    /// Account kind; defaults to "api_key" when empty.
+    #[serde(default)]
+    kind: String,
+    /// The pasted secret. Used once to (optionally) validate + store in the
+    /// OS keychain, then dropped. Never persisted in the DB, never logged.
+    api_key: String,
+    /// When true, run a live validation probe before storing (user clicked
+    /// "Validate"). When false, store with status "unknown" (the "Save
+    /// without validating" air-gapped path).
+    #[serde(default)]
+    validate: bool,
+    /// Set to replace the key on an existing account; empty mints a new one.
+    #[serde(default)]
+    account_id: String,
+}
 
 pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // listagents → return all agent definitions, optionally filtered by
@@ -1191,6 +1219,109 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
+    // Trust Center: validate (optional) + securely store an API key.
+    // The plaintext goes to the OS keychain; the DB row keeps only the
+    // SecretRef::Keychain pointer + masked tail + non-secret metadata.
+    // See specs/SPEC_TRUST_CENTER_2026_06_15.md §5/§6.
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_ACCOUNT_KEY_VERIFY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                // NB: `req.api_key` is a secret — never log `req`.
+                let req: VerifyKeyReq = serde_json::from_value(data)
+                    .map_err(|e| format!("account.key.verify: {e}"))?;
+
+                let account_id = if req.account_id.is_empty() {
+                    uuid::Uuid::new_v4().to_string()
+                } else {
+                    req.account_id.clone()
+                };
+
+                // Optional live validation — the single outbound probe, fired
+                // only when the user clicked "Validate" (validate=true).
+                let (status, metadata, masked_tail, valid) = if req.validate {
+                    let outcome =
+                        crate::identity::key_validator::validate(&req.provider, &req.api_key).await;
+                    if !outcome.valid {
+                        // Nothing stored — surface a structured error so the UI
+                        // stays in the entry state.
+                        return Ok(Some(serde_json::json!({
+                            "valid": false,
+                            "error": outcome.error.unwrap_or_else(|| "validation failed".to_string()),
+                        })));
+                    }
+                    ("valid".to_string(), outcome.metadata, outcome.masked_tail, true)
+                } else {
+                    (
+                        "unknown".to_string(),
+                        serde_json::json!({}),
+                        crate::identity::key_validator::masked_tail(&req.api_key),
+                        false,
+                    )
+                };
+
+                // Store the plaintext in the OS keychain; the DB never sees it.
+                crate::identity::secret_store::put(&account_id, &req.api_key)
+                    .map_err(|e| format!("account.key.verify: {e}"))?;
+
+                // Non-secret context for display: metadata + masked tail.
+                let mut context = metadata;
+                if let serde_json::Value::Object(ref mut m) = context {
+                    m.insert("masked_tail".to_string(), serde_json::json!(masked_tail));
+                }
+
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let created_at = wstore
+                    .identity_get(&account_id)
+                    .ok()
+                    .flatten()
+                    .map(|a| a.created_at)
+                    .filter(|&c| c != 0)
+                    .unwrap_or(now);
+
+                let account = IdentityAccount {
+                    id: account_id.clone(),
+                    name: req.name.clone(),
+                    provider: req.provider.clone(),
+                    kind: if req.kind.is_empty() { "api_key".to_string() } else { req.kind.clone() },
+                    display_name: req.display_name.clone(),
+                    secret_ref: SecretRef::Keychain {
+                        service: crate::identity::secret_store::SERVICE.to_string(),
+                        account: crate::identity::secret_store::account_key(&account_id),
+                    },
+                    context,
+                    status,
+                    created_at,
+                    updated_at: now,
+                };
+                wstore
+                    .identity_upsert(&account)
+                    .map_err(|e| format!("account.key.verify: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "identityaccounts:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::json!({
+                    "valid": valid,
+                    "accountId": account_id,
+                    "maskedTail": account.context.get("masked_tail").cloned().unwrap_or_default(),
+                    "status": account.status,
+                    "metadata": account.context,
+                })))
+            })
+        }),
+    );
+
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
     engine.register_handler(
@@ -1201,6 +1332,15 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandDeleteIdentityAccountData = serde_json::from_value(data)
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;
+                // If this account stored its secret in the OS keychain, drop
+                // it too so no orphaned credential survives the DB row.
+                if let Ok(Some(acct)) = wstore.identity_get(&cmd.id) {
+                    if matches!(acct.secret_ref, SecretRef::Keychain { .. }) {
+                        if let Err(e) = crate::identity::secret_store::delete(&cmd.id) {
+                            tracing::warn!(target: "identity", "keychain delete for {} failed: {e}", cmd.id);
+                        }
+                    }
+                }
                 let deleted = wstore
                     .identity_delete(&cmd.id)
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1235,7 +1235,10 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let req: VerifyKeyReq = serde_json::from_value(data)
                     .map_err(|e| format!("account.key.verify: {e}"))?;
 
-                let account_id = if req.account_id.is_empty() {
+                // New account (mint id) vs. key replacement on an existing
+                // account. Rollback semantics differ: see the upsert below.
+                let is_new = req.account_id.is_empty();
+                let account_id = if is_new {
                     uuid::Uuid::new_v4().to_string()
                 } else {
                     req.account_id.clone()
@@ -1265,8 +1268,18 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 };
 
                 // Store the plaintext in the OS keychain; the DB never sees it.
-                crate::identity::secret_store::put(&account_id, &req.api_key)
+                // `keyring` is blocking (sync D-Bus on Linux), so run it off the
+                // async runtime worker via spawn_blocking.
+                {
+                    let aid = account_id.clone();
+                    let key = req.api_key.clone();
+                    tokio::task::spawn_blocking(move || {
+                        crate::identity::secret_store::put(&aid, &key)
+                    })
+                    .await
+                    .map_err(|e| format!("account.key.verify: keychain task: {e}"))?
                     .map_err(|e| format!("account.key.verify: {e}"))?;
+                }
 
                 // Non-secret context for display: metadata + masked tail.
                 let mut context = metadata;
@@ -1302,16 +1315,29 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     updated_at: now,
                 };
                 if let Err(e) = wstore.identity_upsert(&account) {
-                    // DB write failed after the keychain write — roll the
-                    // secret back so we don't leave an orphaned credential
-                    // with no DB row to reclaim it later. Best-effort; a
-                    // failed rollback is logged but the original error wins.
-                    if let Err(de) = crate::identity::secret_store::delete(&account_id) {
-                        tracing::warn!(
-                            target: "identity",
-                            "rollback of orphaned keychain secret for {} failed: {de}",
-                            account_id,
-                        );
+                    // DB write failed after the keychain write.
+                    //  - New account: nothing references the secret yet, so
+                    //    roll it back to avoid an orphan with no DB row.
+                    //  - Replacement: the existing DB row still points at this
+                    //    keychain entry. Deleting it would destroy the
+                    //    previously-working credential; leave the (now
+                    //    overwritten) secret in place — resolution still works
+                    //    with the new key, and the user can retry to fix
+                    //    metadata. So only roll back for new accounts.
+                    if is_new {
+                        let aid = account_id.clone();
+                        if let Err(de) = tokio::task::spawn_blocking(move || {
+                            crate::identity::secret_store::delete(&aid)
+                        })
+                        .await
+                        .unwrap_or_else(|je| Err(format!("join: {je}")))
+                        {
+                            tracing::warn!(
+                                target: "identity",
+                                "rollback of orphaned keychain secret for {} failed: {de}",
+                                account_id,
+                            );
+                        }
                     }
                     return Err(format!("account.key.verify: {e}"));
                 }
@@ -1345,9 +1371,16 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;
                 // If this account stored its secret in the OS keychain, drop
                 // it too so no orphaned credential survives the DB row.
+                // `keyring` is blocking, so run it via spawn_blocking.
                 if let Ok(Some(acct)) = wstore.identity_get(&cmd.id) {
                     if matches!(acct.secret_ref, SecretRef::Keychain { .. }) {
-                        if let Err(e) = crate::identity::secret_store::delete(&cmd.id) {
+                        let aid = cmd.id.clone();
+                        let res = tokio::task::spawn_blocking(move || {
+                            crate::identity::secret_store::delete(&aid)
+                        })
+                        .await
+                        .unwrap_or_else(|je| Err(format!("join: {je}")));
+                        if let Err(e) = res {
                             tracing::warn!(target: "identity", "keychain delete for {} failed: {e}", cmd.id);
                         }
                     }

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -1301,9 +1301,20 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                wstore
-                    .identity_upsert(&account)
-                    .map_err(|e| format!("account.key.verify: {e}"))?;
+                if let Err(e) = wstore.identity_upsert(&account) {
+                    // DB write failed after the keychain write — roll the
+                    // secret back so we don't leave an orphaned credential
+                    // with no DB row to reclaim it later. Best-effort; a
+                    // failed rollback is logged but the original error wins.
+                    if let Err(de) = crate::identity::secret_store::delete(&account_id) {
+                        tracing::warn!(
+                            target: "identity",
+                            "rollback of orphaned keychain secret for {} failed: {de}",
+                            account_id,
+                        );
+                    }
+                    return Err(format!("account.key.verify: {e}"));
+                }
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "identityaccounts:changed".to_string(),
                     scopes: vec![],

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -515,12 +515,13 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // `identitybundlebindings:changed:<bundle_id>` event
                 // when the expiry probe updates an account's status
                 // (PR D — spec §4.4).
-                crate::identity::resolver::inject_identity_env_with_broker(
+                env_vars = crate::identity::resolver::inject_identity_env_async(
                     wstore.clone(),
                     Some(broker.clone()),
-                    &cmd.block_id,
-                    &mut env_vars,
-                );
+                    cmd.block_id.clone(),
+                    env_vars,
+                )
+                .await;
                 let session_id_field = obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -910,12 +910,13 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                 // hand-in lets the OAuth expiry probe (PR D, spec §4.4)
                 // publish `identitybundlebindings:changed:<bundle_id>`
                 // when it flips a token's status valid→expired etc.
-                crate::identity::resolver::inject_identity_env_with_broker(
+                env_vars = crate::identity::resolver::inject_identity_env_async(
                     wstore.clone(),
                     Some(broker.clone()),
-                    &cmd.blockid,
-                    &mut env_vars,
-                );
+                    cmd.blockid.clone(),
+                    env_vars,
+                )
+                .await;
                 // MuxBus cloud token — injects MUXBUS_TOKEN + MUXBUS_COGNITO_DOMAIN
                 // if the user has authenticated via muxbus.login. No-op if no
                 // credentials are stored. Auto-refreshes if token is nearly expired.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -686,6 +686,34 @@ class RpcApiType {
         return client.rpcCall("deleteidentityaccount", data, opts);
     }
 
+    // command "account.key.verify" [call]
+    // Trust Center: optionally validate (validate=true → single user-initiated
+    // outbound probe) then store an API key in the OS keychain. The plaintext
+    // is never returned; on success the response carries only the masked tail +
+    // non-secret metadata. See SPEC_TRUST_CENTER_2026_06_15.md §5/§6.
+    AccountKeyVerifyCommand(
+        client: RpcClient,
+        data: {
+            provider: string;
+            name: string;
+            displayName?: string;
+            kind?: string;
+            apiKey: string;
+            validate: boolean;
+            accountId?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<{
+        valid: boolean;
+        error?: string;
+        accountId?: string;
+        maskedTail?: string;
+        status?: string;
+        metadata?: Record<string, unknown>;
+    }> {
+        return client.rpcCall("account.key.verify", data, opts);
+    }
+
     // command "linkagentidentity" [call]
     LinkAgentIdentityCommand(
         client: RpcClient,

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -21,11 +21,16 @@ export type AccountStatus = "valid" | "expired" | "invalid" | "unknown" | "check
 export type IdentityTab = "accounts" | "assignments";
 
 export interface SecretRef {
-    backend: "env" | "secrets_manager" | "plaintext_dev";
+    backend: "env" | "secrets_manager" | "plaintext_dev" | "keychain";
     env_var?: string;
     sm_path?: string;
     sm_json_path?: string;
     value?: string; // plaintext_dev only
+    // keychain only — pointer into the OS secret store. The plaintext is
+    // never carried here; resolved backend-side at spawn. See
+    // specs/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
+    service?: string;
+    account?: string;
 }
 
 export interface AccountContext {
@@ -37,6 +42,13 @@ export interface AccountContext {
     anthropic_model?: string;
     endpoint?: string;
     description?: string;
+    // Trust Center key flow — non-secret display hint (e.g. "••••••••3f9a")
+    // and per-service validation metadata. Populated by account.key.verify.
+    masked_tail?: string;
+    openai_model_count?: number;
+    anthropic_model_count?: number;
+    slack_team?: string;
+    slack_user?: string;
 }
 
 export interface Account {
@@ -182,6 +194,8 @@ function secretRefFromBackend(s: IdentityAccount["secret_ref"]): SecretRef {
             };
         case "plaintext_dev":
             return { backend: "plaintext_dev", value: s.plaintext_dev };
+        case "keychain":
+            return { backend: "keychain", service: s.service, account: s.account };
     }
 }
 
@@ -201,6 +215,8 @@ function secretRefToBackend(s: SecretRef): IdentityAccount["secret_ref"] {
             };
         case "plaintext_dev":
             return { backend: "plaintext_dev", plaintext_dev: s.value ?? "" };
+        case "keychain":
+            return { backend: "keychain", service: s.service ?? "", account: s.account ?? "" };
     }
 }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -273,7 +273,10 @@ declare global {
     type SecretRef =
         | { backend: "env"; env_var: string }
         | { backend: "secrets_manager"; sm_path: string; sm_json_path?: string }
-        | { backend: "plaintext_dev"; plaintext_dev: string };
+        | { backend: "plaintext_dev"; plaintext_dev: string }
+        // Trust Center API keys: pointer into the OS keychain. Plaintext is
+        // never carried here. See SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
+        | { backend: "keychain"; service: string; account: string };
 
     type IdentityAccount = {
         id: string;


### PR DESCRIPTION
## Summary

Phase 2a of `specs/SPEC_TRUST_CENTER_2026_06_15.md` — the **backend** for the secure key lifecycle (§5–§7). The frontend Entry→Validate→Locked panel is Phase 2b; this PR is the storage + validation engine + RPC, with unit tests.

- **`SecretRef::Keychain { service, account }`** — a pointer into the OS-native secret store. The plaintext key is **never** stored in the DB.
- **`secret_store.rs`** — `keyring`-backed `put`/`get`/`delete` (macOS Keychain / Windows Credential Manager / Linux Secret Service). Reads return a `Zeroizing<String>` so plaintext is wiped on drop.
- **`key_validator.rs`** — per-service live probes (GitHub `/user`, OpenAI `/v1/models`, Anthropic `/v1/models`, Slack `auth.test`) returning non-secret metadata + a masked tail. Unknown providers fall through to "save without validating". `masked_tail()` never leaks a tail for keys ≤4 chars.
- **`account.key.verify` RPC** — optional **user-initiated** validation (`validate` flag), then stores the secret in the keychain and upserts an `IdentityAccount` carrying only the pointer + masked tail + metadata. Returns metadata + `maskedTail` only — **never the key**. Handles new accounts and key replacement (`accountId`).
- **Resolver** — `SecretRef::Keychain` resolves via the keychain at agent spawn; deleting an account now also drops its keychain secret (no orphans).
- **Frontend types** — `keychain` `SecretRef` variant (gotypes + `identity-model` converters), `AccountContext` masked-tail/metadata fields, `AccountKeyVerifyCommand` binding.

Adds `keyring` + `zeroize`. Security posture per §7: no plaintext at rest, no key returned to the UI, keychain-backed, zeroized buffers, one-way masked display.

## Verification
- `cargo check -p agentmux-srv` — clean.
- `cargo test` — `key_validator` (masking) + `secret_store` tests pass.
- `npm run build` — clean.

## Deferred to Phase 2b
- The Accounts-tab key UI: Entry → Validate (with the §5.1 egress help) → Locked masked display + metadata, "Save without validating", Replace.
- AWS key validation (needs SigV4) and the broader OAuth catalog (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)