### PR TITLE
fix(tabs): more padding + live resize while renaming

### DIFF
--- a/.changesets/1781540118-fix-tab-padding-and-live-resize.md
+++ b/.changesets/1781540118-fix-tab-padding-and-live-resize.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): increase tab padding to match VS Code feel; resize live while typing during rename

--- a/frontend/app/tab/tab-measure.ts
+++ b/frontend/app/tab/tab-measure.ts
@@ -17,8 +17,9 @@ function getCtx(): CanvasRenderingContext2D | null {
 }
 
 // Non-text width budget:
-//   6px left-pad + 6px right-pad + 4px gap + 16px close-btn + 4px slack = 36px
-const TAB_PADDING_BUDGET = 36;
+//   10px left-pad + 10px right-pad + 4px gap + 16px close-btn + 12px slack = 52px
+// Matches .tab-inner { padding: 0 10px } in tab.scss.
+const TAB_PADDING_BUDGET = 52;
 export const TAB_MIN_WIDTH = 60;
 export const TAB_MAX_WIDTH = 260;
 

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -42,7 +42,7 @@
         display: flex;
         align-items: center;
         gap: var(--space-1);
-        padding: 0 var(--space-1-5);
+        padding: 0 10px;
         height: 100%;
         white-space: nowrap;
         border-radius: 0;

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -175,8 +175,15 @@ function Tab(props: TabProps): JSX.Element {
         newText = newText || originalName();
         editableRef.innerText = newText;
         setIsEditable(false);
+        props.onNaturalWidth?.(measureTabWidth(newText));
         fireAndForget(() => ObjectService.UpdateTabName(props.id, newText));
         setTimeout(() => refocusNode(null), 10);
+    };
+
+    const handleRenameInput = () => {
+        if (!editableRef || !props.onNaturalWidth) return;
+        const text = editableRef.innerText || originalName();
+        props.onNaturalWidth(measureTabWidth(text));
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -270,6 +277,7 @@ function Tab(props: TabProps): JSX.Element {
                         onDblClick={() => handleRenameTab()}
                         onBlur={handleBlur}
                         onKeyDown={handleKeyDown}
+                        onInput={handleRenameInput}
                     >
                         {tabData()?.name}
                     </div>


### PR DESCRIPTION
## Summary

- `.tab-inner` padding increased from `6px` → `10px` each side — matches VS Code's tab breathing room
- `TAB_PADDING_BUDGET` updated from `36` → `52px` so `measureTabWidth()` accounts for the real CSS padding
- Added `onInput` handler to the contentEditable rename field — tab width tracks keystrokes live as you type
- `handleBlur` now also calls `onNaturalWidth` with the committed name so the tab snaps to the correct size immediately on Enter/click-away/Escape

## Test plan

- [ ] Tabs look visually roomier (not clipped at text edges)
- [ ] Double-click rename → tab grows/shrinks in real time as you type
- [ ] Press Enter → tab locks to the new name width
- [ ] Press Escape → tab snaps back to the original name width
- [ ] Short label still produces a narrow tab (not over-widened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)