### PR TITLE
fix(agent): tool live-tail shows last stdout/stderr, not system chunks

### DIFF
--- a/.changesets/1781541229-fix-tool-live-tail-stdout-filter.md
+++ b/.changesets/1781541229-fix-tool-live-tail-stdout-filter.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): tool live-tail skips system chunks — shows last stdout/stderr or elapsed timer while waiting

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -38,6 +38,19 @@ import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { ToolBlockOverlay } from "./ToolBlockOverlay";
 
+// Ticks every second while a tool is running with no output yet.
+function ToolElapsedTicker(props: { startMs: number }): JSX.Element {
+    const [elapsed, setElapsed] = createSignal(
+        Math.floor((Date.now() - props.startMs) / 1000)
+    );
+    const interval = setInterval(
+        () => setElapsed(Math.floor((Date.now() - props.startMs) / 1000)),
+        1000
+    );
+    onCleanup(() => clearInterval(interval));
+    return <>{elapsed()}s…</>;
+}
+
 interface ToolBlockProps {
     node: ToolNode;
     /** User has clicked to pin this tool block open. */
@@ -230,24 +243,42 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                         {resultPill()?.label}
                     </span>
                 </Show>
-                {/* Live-tail: while the tool is streaming, show the most
-                    recent stdout/stderr line right in the collapsed row
-                    so the user can watch progress without expanding
-                    the overlay. With auto-expand-while-running, the
-                    panel below already shows the full stream — this
-                    tail still helps for the user-collapsed-mid-run
-                    case (and for tools the user manually pinned-closed
-                    while running). */}
-                <Show when={
-                    props.node.log?.open === true
-                    && (props.node.log?.chunks?.length ?? 0) > 0
-                }>
-                    <span
-                        class="agent-tool-live-tail"
-                        title={`latest stream output (${props.node.log?.chunks?.length ?? 0} chunks)`}
-                    >
-                        ↳ {props.node.log!.chunks[props.node.log!.chunks.length - 1].content}
-                    </span>
+                {/* Live-tail: while streaming, show the last stdout/stderr
+                    line so the user can watch real output without opening
+                    the overlay. Skips kind:"system" chunks — those are
+                    bashwrap internals ("[bashwrap] starting: N chars", PTY
+                    ready, etc.) and are not useful here. If no stdout/stderr
+                    has arrived yet (e.g. during a `sleep` prefix), show an
+                    elapsed timer instead so the user knows it's alive. */}
+                <Show when={props.node.log?.open === true}>
+                    {(() => {
+                        const chunks = props.node.log?.chunks ?? [];
+                        // Walk backwards — find the last real output chunk
+                        let lastOutput: { kind: string; content: string } | undefined;
+                        for (let i = chunks.length - 1; i >= 0; i--) {
+                            const c = chunks[i];
+                            if (c.kind === "stdout" || c.kind === "stderr") {
+                                lastOutput = c;
+                                break;
+                            }
+                        }
+                        if (lastOutput) {
+                            return (
+                                <span
+                                    class="agent-tool-live-tail"
+                                    title={`latest stream output (${chunks.length} chunks)`}
+                                >
+                                    ↳ {lastOutput.content}
+                                </span>
+                            );
+                        }
+                        // No stdout/stderr yet — show elapsed time
+                        return (
+                            <span class="agent-tool-live-tail agent-tool-live-tail--waiting">
+                                <ToolElapsedTicker startMs={props.node.timestamp ?? Date.now()} />
+                            </span>
+                        );
+                    })()}
                 </Show>
                 <Show when={props.node.tool === "Agent"}>
                     <button

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -311,6 +311,7 @@ export class ClaudeCodeStreamParser {
             status: "running",
             collapsed: false, // Show running tools
             summary,
+            timestamp: Date.now(),
         };
     }
 

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -229,6 +229,15 @@
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+
+                // Waiting state (no stdout yet — showing elapsed timer).
+                // Dimmer than real output so it reads as "pending" rather
+                // than actual tool content.
+                &--waiting {
+                    color: var(--secondary-text-color);
+                    background: transparent;
+                    font-family: inherit;
+                }
             }
 
         }


### PR DESCRIPTION
## Problem

For a Bash tool call like `sleep 10 && cat file.txt`, the collapsed ToolBlock row showed:

```
↳ [bashwrap] starting: 184 chars
```

…for the entire duration of the sleep. This is a `kind:"system"` internal bashwrap housekeeping chunk, not agent-visible output. The bug was `ToolBlock.tsx:249` blindly taking `chunks[chunks.length - 1]` regardless of chunk kind.

## Changes

- **`ToolBlock.tsx`** — walk chunks backwards to find the last `kind:"stdout"` or `kind:"stderr"` chunk; skip `kind:"system"` chunks in the live-tail
- **`ToolBlock.tsx`** — when no stdout/stderr has arrived yet (e.g. during `sleep`), show a `ToolElapsedTicker` component (`3s…`) so the user knows the tool is alive
- **`stream-parser.ts`** — stamp `timestamp: Date.now()` on tool_call creation so the elapsed ticker has a reliable start time
- **`_document-nodes.scss`** — add `.agent-tool-live-tail--waiting` modifier (dim, no background) so the timer reads as pending, not real output

## Before / After

| State | Before | After |
|---|---|---|
| `sleep 10 && cat file` during sleep | `↳ [bashwrap] starting: 184 chars` | `3s…` → `7s…` |
| First stdout arrives | `↳ [bashwrap] starting: 184 chars` | `↳ <first line of output>` |
| Multiple lines | May show a system chunk | Shows last stdout/stderr line |

## Test plan

- [ ] `sleep 5 && echo done` — row shows `0s…` → increments → `↳ done` when echo fires
- [ ] Fast command `echo hello` — no ticker flicker, shows `↳ hello` immediately
- [ ] Command with only stderr (`cat nonexistent`) — live-tail shows the stderr line
- [ ] Overlay panel still shows full chunk list including system chunks (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)