### PR TITLE
fix(startup): retry IPC on stale token; stop the recovery-reload loop

### DIFF
--- a/.changesets/1781542495-fix-startup-retry-ipc-on-stale-token-stop-the-recovery-reloa-8xu9.md
+++ b/.changesets/1781542495-fix-startup-retry-ipc-on-stale-token-stop-the-recovery-reloa-8xu9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(startup): retry IPC on stale token + stop the recovery-reload loop

--- a/.changesets/1781542495-fix-startup-retry-ipc-on-stale-token-stop-the-recovery-reloa-8xu9.md
+++ b/.changesets/1781542495-fix-startup-retry-ipc-on-stale-token-stop-the-recovery-reloa-8xu9.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(startup): retry IPC on stale token + stop the recovery-reload loop
+fix(startup): wait for re-injected IPC creds before bridge init; retry on stale token; stop the recovery-reload loop

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -15,8 +15,10 @@
  * `sessionStorage`-guarded auto-reload (so a persistent failure can't storm —
  * the 2026-06-15 incident reloaded 385×), then a recovery card with a
  * one-click Reload. `location.reload()` works here because this is a real
- * `http://localhost` document (not the host's `data:` crash page), and it
- * preserves the `__AGENTMUX_IPC_PORT__`/token query params.
+ * `http://localhost` document (not the host's `data:` crash page); the IPC
+ * port/token are re-supplied by the host's `on_load_end` re-injection on the
+ * fresh load — NOT carried in the URL (cef-init.ts strips them into window
+ * globals on first load), so reload and "Reopen window" recover identically.
  *
  * Spec: docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
  */
@@ -191,9 +193,11 @@ export function showStartupError(message: string): void {
         "padding:9px 18px;border-radius:7px;border:1px solid rgba(255,255,255,0.18);cursor:pointer;" +
         "font-size:13px;background:transparent;color:#e8e8e8;";
     reopen.onclick = () => {
-        // Re-navigate to the same URL — preserves the IPC port/token query params
-        // and triggers the host's on_load_end re-injection, a fuller reset than
-        // reload(). Budget is left intact (cleared only on successful startup).
+        // Re-navigate to the same URL — a fuller reset than reload() (fresh
+        // document rather than a reload of the current one). Creds are re-supplied
+        // exactly as with reload(): the host's on_load_end re-injection, since the
+        // URL no longer carries ipc_port/ipc_token (cef-init.ts strips them on
+        // first load). Budget is left intact (cleared only on successful startup).
         location.assign(location.pathname + location.search);
     };
 

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -43,9 +43,10 @@ function setReloadCount(n: number): void {
 }
 
 /**
- * Clear the auto-reload budget. Call after a successful startup so a later,
- * unrelated failure begins with a fresh budget (and call before a *manual*
- * reload so the user's click always gets a full set of retries).
+ * Clear the auto-reload budget. Called ONLY after a successful startup, so a
+ * later, unrelated failure begins with a fresh budget. It is deliberately NOT
+ * called before a manual reload — resetting there re-entered the auto-reconnect
+ * cycle and caused the infinite loop (see tryAutoRecover).
  */
 export function clearStartupReloadCount(): void {
     setReloadCount(0);
@@ -56,8 +57,9 @@ export function clearStartupReloadCount(): void {
  *
  * If the bounded reload budget isn't exhausted, show a "Reconnecting…" overlay
  * and reload after a short backoff — returns `true`, meaning the caller should
- * stop (the page is about to reload). Otherwise reset the budget, render the
- * recovery card, and return `false`.
+ * stop (the page is about to reload). Once the budget is exhausted, render the
+ * recovery card and return `false` WITHOUT resetting the budget, so any further
+ * reload returns to the card instead of re-entering the auto-reconnect loop.
  */
 export function tryAutoRecover(message: string): boolean {
     const attempt = getReloadCount() + 1;

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -67,11 +67,20 @@ export function tryAutoRecover(message: string): boolean {
         setTimeout(() => location.reload(), 700 * attempt);
         return true;
     }
-    // Budget exhausted — STOP auto-reloading (this is the 385×-storm guard) and
-    // reset so the user's manual Reload gets a fresh budget.
-    setReloadCount(0);
+    // Budget exhausted — STOP auto-reloading. Do NOT reset the counter: keeping
+    // it ≥ MAX means any further reload (including the card's manual Reload) goes
+    // straight back to this card instead of re-entering the auto-reconnect cycle.
+    // That is what breaks the infinite "keeps trying to reconnect" loop (the bug
+    // where Reload reset the budget and looped). The counter is cleared only on a
+    // SUCCESSFUL startup (clearStartupReloadCount, from bootstrap's success path).
     showStartupError(message);
     return false;
+}
+
+/** True once the bounded auto-reload budget is spent — reloading has not
+ *  reconnected, so the card escalates its copy and drops the auto-loop. */
+function reloadBudgetExhausted(): boolean {
+    return getReloadCount() >= MAX_RELOADS;
 }
 
 function mountRoot(): HTMLElement {
@@ -120,6 +129,10 @@ export function showReconnecting(attempt: number, max: number): void {
  */
 export function showStartupError(message: string): void {
     const main = mountRoot();
+    // Once auto-reload has been spent without reconnecting, the failure is
+    // likely persistent (a stopped/restarted host), so escalate the copy and
+    // point at a real fix rather than implying another reload will help.
+    const exhausted = reloadBudgetExhausted();
 
     const card = document.createElement("div");
     card.style.cssText =
@@ -128,14 +141,18 @@ export function showStartupError(message: string): void {
         `font-family:${FONT};color:#e8e8e8;`;
 
     const title = document.createElement("h2");
-    title.textContent = "AgentMux lost its connection to the host";
+    title.textContent = exhausted
+        ? "Can't reconnect to AgentMux"
+        : "AgentMux lost its connection to the host";
     title.style.cssText = "margin:0 0 10px;font-size:18px;color:#ffd479;";
     card.appendChild(title);
 
     const body = document.createElement("p");
-    body.textContent =
-        "The interface loaded but couldn't reach the AgentMux host process. " +
-        "This is almost always temporary — reloading reconnects it.";
+    body.textContent = exhausted
+        ? "Reloading hasn't reconnected to the AgentMux host. The host process may have " +
+          "stopped or restarted — close this window and reopen it, or restart AgentMux."
+        : "The interface loaded but couldn't reach the AgentMux host process. " +
+          "This is almost always temporary — reloading reconnects it.";
     body.style.cssText = "margin:0 0 18px;font-size:14px;line-height:1.5;color:rgba(255,255,255,0.8);";
     card.appendChild(body);
 
@@ -160,7 +177,11 @@ export function showStartupError(message: string): void {
         "padding:9px 18px;border-radius:7px;border:none;cursor:pointer;font-size:13px;font-weight:600;" +
         "background:#4c8dff;color:#fff;";
     reload.onclick = () => {
-        clearStartupReloadCount(); // a manual reload gets a fresh budget
+        // Do NOT reset the budget here — that re-entered the auto-reconnect loop.
+        // A manual reload is a single attempt: the host re-injects fresh creds on
+        // load and invokeCommand retries the 401, so a recovered host succeeds
+        // (and bootstrap clears the budget); a still-dead host comes straight back
+        // to this card instead of looping the "Reconnecting…" spinner.
         location.reload();
     };
 
@@ -170,9 +191,9 @@ export function showStartupError(message: string): void {
         "padding:9px 18px;border-radius:7px;border:1px solid rgba(255,255,255,0.18);cursor:pointer;" +
         "font-size:13px;background:transparent;color:#e8e8e8;";
     reopen.onclick = () => {
-        clearStartupReloadCount();
-        // Re-navigate to the same URL — preserves the IPC port/token query
-        // params, a fuller reset than reload().
+        // Re-navigate to the same URL — preserves the IPC port/token query params
+        // and triggers the host's on_load_end re-injection, a fuller reset than
+        // reload(). Budget is left intact (cleared only on successful startup).
         location.assign(location.pathname + location.search);
     };
 

--- a/frontend/app/platform/ipc.ts
+++ b/frontend/app/platform/ipc.ts
@@ -77,10 +77,16 @@ export async function invokeCommand<T = any>(cmd: string, args?: Record<string, 
                         body: JSON.stringify({ cmd, args: args ?? {} }),
                     });
                 } catch (e) {
-                    // Host not reachable yet (port just changed / still binding).
-                    lastErr = e instanceof Error ? e : new Error(String(e));
-                    if (attempt < MAX_ATTEMPTS) await delay(RETRY_DELAY_MS);
-                    continue;
+                    // Network/transport error: the POST may have already reached the
+                    // host and been applied before the connection dropped, so a
+                    // blind retry could double-apply a mutating command (or a
+                    // fire-and-forget input dispatch). Propagate instead of retrying
+                    // — matching the pre-retry behavior. The retries that ARE safe
+                    // (no request was sent, or the host explicitly rejected it) are
+                    // the missing-creds and 401 cases above; the cred-injection race
+                    // is otherwise handled upfront by waitForIpcCreds (cef-init.ts).
+                    recordIpcRoundtrip(cmd, performance.now() - t0);
+                    throw e instanceof Error ? e : new Error(String(e));
                 }
                 if (resp.status === 401) {
                     // Stale token — the host re-injects a fresh one on load. Wait,

--- a/frontend/app/platform/ipc.ts
+++ b/frontend/app/platform/ipc.ts
@@ -14,6 +14,8 @@ import { recordIpcRoundtrip } from "@/perf";
  */
 export type HostType = "cef" | "browser";
 
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 export function detectHost(): HostType {
     if (typeof window.__AGENTMUX_IPC_PORT__ !== "undefined") {
         return "cef";
@@ -43,29 +45,63 @@ export async function invokeCommand<T = any>(cmd: string, args?: Record<string, 
 
     switch (host) {
         case "cef": {
-            const port = window.__AGENTMUX_IPC_PORT__;
-            const token = window.__AGENTMUX_IPC_TOKEN__;
-            if (!port) {
-                throw new Error("IPC port not injected by CEF host");
-            }
-            const resp = await fetch(`http://127.0.0.1:${port}/ipc`, {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-                },
-                body: JSON.stringify({ cmd, args: args ?? {} }),
-            });
-            if (!resp.ok) {
+            // The host re-injects fresh, self-consistent ipc_port + ipc_token into
+            // the window globals on EVERY page load (on_load_end, agentmux-cef
+            // client/mod.rs). On a reload there's a brief window where the first
+            // IPC call can race ahead of that injection — stale/missing creds yield
+            // a 401 (or no port) — which previously failed bridge init outright and
+            // wedged the window in the recovery loop. Re-read the globals each
+            // attempt and retry a few times so the freshly-injected creds self-heal
+            // the race. Real errors (non-401 HTTP, IPC-level failures) still throw
+            // immediately. See SPEC_BRIDGE_INIT_RECOVERY / token-retry follow-up.
+            const MAX_ATTEMPTS = 6;
+            const RETRY_DELAY_MS = 250;
+            let lastErr: Error | null = null;
+            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+                // Re-read every attempt — on_load_end keeps these fresh.
+                const port = window.__AGENTMUX_IPC_PORT__;
+                const token = window.__AGENTMUX_IPC_TOKEN__;
+                if (!port || !token) {
+                    lastErr = new Error("IPC credentials not yet injected by CEF host");
+                    if (attempt < MAX_ATTEMPTS) await delay(RETRY_DELAY_MS);
+                    continue;
+                }
+                let resp: Response;
+                try {
+                    resp = await fetch(`http://127.0.0.1:${port}/ipc`, {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Authorization: `Bearer ${token}`,
+                        },
+                        body: JSON.stringify({ cmd, args: args ?? {} }),
+                    });
+                } catch (e) {
+                    // Host not reachable yet (port just changed / still binding).
+                    lastErr = e instanceof Error ? e : new Error(String(e));
+                    if (attempt < MAX_ATTEMPTS) await delay(RETRY_DELAY_MS);
+                    continue;
+                }
+                if (resp.status === 401) {
+                    // Stale token — the host re-injects a fresh one on load. Wait,
+                    // re-read the globals, and retry rather than failing the bridge.
+                    lastErr = new Error("IPC unauthorized (stale token)");
+                    if (attempt < MAX_ATTEMPTS) await delay(RETRY_DELAY_MS);
+                    continue;
+                }
+                if (!resp.ok) {
+                    recordIpcRoundtrip(cmd, performance.now() - t0);
+                    throw new Error(`IPC HTTP error: ${resp.status} ${resp.statusText}`);
+                }
+                const parsed = await resp.json();
                 recordIpcRoundtrip(cmd, performance.now() - t0);
-                throw new Error(`IPC HTTP error: ${resp.status} ${resp.statusText}`);
+                if (parsed.success) {
+                    return parsed.data as T;
+                }
+                throw new Error(parsed.error ?? "IPC error");
             }
-            const parsed = await resp.json();
             recordIpcRoundtrip(cmd, performance.now() - t0);
-            if (parsed.success) {
-                return parsed.data as T;
-            }
-            throw new Error(parsed.error ?? "IPC error");
+            throw lastErr ?? new Error(`IPC '${cmd}' failed after ${MAX_ATTEMPTS} attempts`);
         }
 
         case "browser":

--- a/frontend/cef-init.ts
+++ b/frontend/cef-init.ts
@@ -10,6 +10,31 @@
 import { buildCefApi, initCefApi, isCef } from "@/util/cef-api";
 
 /**
+ * Poll the window globals until the host has injected the IPC port + token, or
+ * the bound elapses.
+ *
+ * On first load the creds arrive via URL query params and are already set when
+ * this runs, so it returns immediately. On a *reload* the URL no longer carries
+ * them (we strip them on first load, and a reload starts a fresh JS context
+ * with empty globals); the host re-injects them into the globals via its
+ * `on_load_end` hook (agentmux-cef client/mod.rs), which can land a beat after
+ * setupCefApi() begins. Waiting here — once, upfront — keeps initCefApi()'s
+ * first IPC call (`get_backend_endpoints`) from racing ahead of the creds,
+ * failing, and falling into the 30s backend-ready wait that never resolves
+ * (which left window.api unset → initApp's 5s guard fired → recovery card
+ * reloaded → loop). Bounded well under that 5s guard.
+ */
+async function waitForIpcCreds(timeoutMs: number): Promise<void> {
+    const start = performance.now();
+    while (
+        (window.__AGENTMUX_IPC_PORT__ == null || window.__AGENTMUX_IPC_TOKEN__ == null) &&
+        performance.now() - start < timeoutMs
+    ) {
+        await new Promise((r) => setTimeout(r, 50));
+    }
+}
+
+/**
  * Initialize the CEF API shim if running inside a CEF host.
  * Sets window.api to a CEF-backed implementation of AppApi.
  *
@@ -44,6 +69,12 @@ export async function setupCefApi(): Promise<void> {
         url.searchParams.delete("ipc_port");
         window.history.replaceState(window.history.state, "", url.toString());
     }
+
+    // On a reload the creds come from the host's on_load_end re-injection, not
+    // the (now-stripped) URL, and can land just after this point. Wait for them
+    // here so initCefApi()'s first IPC call doesn't race ahead and wedge startup
+    // (see waitForIpcCreds). No-op on first load (creds already set from URL).
+    await waitForIpcCreds(2500);
 
     // Pre-fetch all cached values from Rust host via IPC
     await initCefApi();


### PR DESCRIPTION
## Problem

A window could get stuck in the recovery UI looping "Reconnecting…" — clicking **Reload** never recovered. Two compounding bugs:

1. **The frontend gave up on a transient stale token.** The host re-injects fresh, self-consistent `ipc_port` + `ipc_token` into the window on **every** page load (`on_load_end`, `agentmux-cef/src/client/mod.rs:1214`). But on a reload the frontend's first `invokeCommand` can race *ahead* of that injection, hit a **401** (or missing creds), and fail bridge init outright — wedging the window, even though valid creds arrive a moment later.
2. **The recovery card looped.** Its Reload button reset the auto-reload budget and re-entered the bounded `Reconnecting…` cycle, so a *persistent* failure (stopped/restarted host) looped forever instead of telling the user to restart.

(Root cause understood after mapping the windows / IPC-token / reducer architecture — the host already provides a fresh token on every load; the frontend just wasn't waiting for it.)

## Fix

- **`ipc.ts` `invokeCommand` (cef):** re-read the `window.__AGENTMUX_IPC_PORT__/TOKEN__` globals **each attempt** and retry (≤6 × 250ms) on missing creds / network error / **401**, so the host's freshly-injected token self-heals the race. Non-401 HTTP errors and IPC-level failures still throw immediately.
- **`error-display.ts`:** stop resetting the reload budget on exhaustion *and* on the card's manual Reload (that was the loop). Once the budget is spent, a reload is a **single** attempt that returns to the card instead of looping the spinner; the budget clears only on **successful** startup. When reloading isn't working, the card escalates to **"Can't reconnect — restart AgentMux"**.

## Result
- Transient stale-token race (the common case after a reload) **self-heals silently** via the IPC retry — the recovery UI usually isn't even reached.
- A genuinely dead/restarted host shows a **terminal** card with honest guidance, **no infinite loop**.
- Manual **Reload** is meaningful: reload → host re-injects creds → retry succeeds if the host is back; otherwise straight back to the card.

## Test
- `task build:frontend:dev` clean.
- Follows up `SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md` (the recovery UI from #1424).