### PR TITLE
fix(release): use only the changeset title line in VERSION_HISTORY

### DIFF
--- a/.changesets/1781542833-fix-release-use-only-the-changeset-title-line-in-version-his-gfkm.md
+++ b/.changesets/1781542833-fix-release-use-only-the-changeset-title-line-in-version-his-gfkm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(release): use only the changeset title line in VERSION_HISTORY, not every body line

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,13 +57,13 @@ done
 
 echo "Release type: $RELEASE_TYPE" >&2
 
-# Capture descriptions (body after the second --- marker).
+# Capture one description per changeset: the first non-empty body line (the
+# changeset title). A changeset body may carry extra prose lines for reviewer
+# context; those must NOT each become their own changelog bullet (issue #1200).
 DESCRIPTIONS=()
 for f in "${CHANGESETS[@]}"; do
-    BODY="$(awk '/^---$/{n++;next} n==2 {print}' "$f" | sed '/^$/d')"
-    while IFS= read -r line; do
-        DESCRIPTIONS+=("$line")
-    done <<<"$BODY"
+    TITLE="$(awk '/^---$/{n++;next} n==2 && NF {print; exit}' "$f")"
+    [[ -n "$TITLE" ]] && DESCRIPTIONS+=("$TITLE")
 done
 
 if (( DRY_RUN )); then


### PR DESCRIPTION
## Problem (#1200)

`scripts/release.sh` split each consumed changeset's body into per-line bullets when assembling the `VERSION_HISTORY.md` entry. A changeset with a **multi-line body** polluted the changelog — every prose line became its own bullet. Observed in v0.40.1, where the `fix(linux): enable patched-libcef…` changeset produced ~26 junk bullets (caught by review, trimmed manually at the time).

## Fix

Capture only the **first non-empty body line** (the changeset title) per changeset:

```sh
TITLE="$(awk '/^---$/{n++;next} n==2 && NF {print; exit}' "$f")"
[[ -n "$TITLE" ]] && DESCRIPTIONS+=("$TITLE")
```

Extra body lines are reviewer context and no longer leak into the user-facing changelog.

## Verification

Tested the awk against a synthetic multi-line changeset:
- **Before:** title + 3 body lines → 4 bullets
- **After:** title only → 1 bullet

And against a real single-line changeset (unchanged behavior).

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)