### PR TITLE
feat(trust-center): add OpenAI key-based account provider (Phase 3 — catalog)

### DIFF
--- a/.changesets/1781533200-feat-trust-center-openai-account.md
+++ b/.changesets/1781533200-feat-trust-center-openai-account.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): add OpenAI as a key-based account provider (validated against api.openai.com/v1/models), with icon and per-agent assignment support

--- a/frontend/app/view/agent/components/AgentIdentityPanel.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityPanel.tsx
@@ -28,7 +28,7 @@ import {
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 
-const ALL_PROVIDERS: AccountProvider[] = ["github", "aws", "anthropic", "custom"];
+const ALL_PROVIDERS: AccountProvider[] = ["github", "openai", "aws", "anthropic", "custom"];
 
 interface AgentIdentityPanelProps {
     agent: AgentDefinition;

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -15,7 +15,7 @@ import { Logger } from "@/util/logger";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type AccountProvider = "github" | "aws" | "anthropic" | "custom";
+export type AccountProvider = "github" | "openai" | "aws" | "anthropic" | "custom";
 export type AccountKind = "pat" | "role" | "api_key" | "env_ref";
 export type AccountStatus = "valid" | "expired" | "invalid" | "unknown" | "checking";
 export type IdentityTab = "accounts" | "assignments";
@@ -109,6 +109,7 @@ export function agentsAssignedToAccount(accountId: string, agents: AgentDefiniti
 
 export const PROVIDER_LABELS: Record<AccountProvider, string> = {
     github: "GitHub",
+    openai: "OpenAI",
     aws: "AWS",
     anthropic: "Anthropic",
     custom: "Custom",
@@ -116,6 +117,7 @@ export const PROVIDER_LABELS: Record<AccountProvider, string> = {
 
 export const PROVIDER_COLORS: Record<AccountProvider, string> = {
     github: "#e1effe",
+    openai: "#d1fae5",
     aws: "#fef3c7",
     anthropic: "#ede9fe",
     custom: "#f1f5f9",
@@ -359,7 +361,7 @@ export class IdentityViewModel implements ViewModel {
 
     accountsByProvider = (): Map<AccountProvider, Account[]> => {
         const map = new Map<AccountProvider, Account[]>();
-        const order: AccountProvider[] = ["github", "aws", "anthropic", "custom"];
+        const order: AccountProvider[] = ["github", "openai", "aws", "anthropic", "custom"];
         for (const p of order) {
             const group = this.accountsAtom().filter((a) => a.provider === p);
             if (group.length > 0) map.set(p, group);

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -23,6 +23,7 @@ import "./identity-view.scss";
 // See SPEC_TRUST_CENTER_2026_06_15.md §5.1/§6.
 const KEY_VALIDATION_ENDPOINT: Partial<Record<AccountProvider, string>> = {
     github: "api.github.com/user",
+    openai: "api.openai.com/v1/models",
     anthropic: "api.anthropic.com/v1/models",
 };
 
@@ -279,7 +280,7 @@ function DetailField({ label, value }: { label: string; value: string }): JSX.El
 
 function AssignmentsTab({ model }: { model: IdentityViewModel }): JSX.Element {
     const accounts = () => model.accountsAtom();
-    const providers = (): AccountProvider[] => ["github", "aws", "anthropic", "custom"];
+    const providers = (): AccountProvider[] => ["github", "openai", "aws", "anthropic", "custom"];
 
     // Collect all unique agent IDs across all accounts
     const agentIds = () => {
@@ -559,6 +560,7 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
                     <FormField label="Provider">
                         <select class="identity-select" value={provider()} onChange={(e) => setProvider(e.currentTarget.value as AccountProvider)}>
                             <option value="github">GitHub</option>
+                            <option value="openai">OpenAI</option>
                             <option value="aws">AWS</option>
                             <option value="anthropic">Anthropic</option>
                             <option value="custom">Custom</option>
@@ -574,6 +576,9 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
                             <Show when={provider() === "aws"}>
                                 <option value="role">IAM Role</option>
                                 <option value="env_ref">Env Reference</option>
+                            </Show>
+                            <Show when={provider() === "openai"}>
+                                <option value="api_key">API Key</option>
                             </Show>
                             <Show when={provider() === "anthropic"}>
                                 <option value="api_key">API Key</option>


### PR DESCRIPTION
## Summary

The key-based slice of Phase 3 (`specs/SPEC_TRUST_CENTER_2026_06_15.md`) — expand the Accounts catalog to **OpenAI**, which the Phase 2a key validator already probes (`GET api.openai.com/v1/models`). **No backend change** — the validator supports it; only the frontend catalog needed it.

- `AccountProvider += "openai"`; `PROVIDER_LABELS` / `PROVIDER_COLORS` entries.
- Account form: OpenAI option + API Key kind; `KEY_VALIDATION_ENDPOINT` entry so the §5.1 egress note names the exact endpoint.
- `accountsByProvider` order, `AssignmentsTab` providers, and the per-agent `AgentIdentityPanel` provider list all include OpenAI.
- `ProviderLogo` already ships an OpenAI icon.

Users can now add + validate an OpenAI key through the same secure keychain lifecycle shipped in 2a/2b (Validate → masked/non-recoverable → OS keychain).

## ⚠️ OAuth is NOT in this PR (blocked)

Full OAuth for Google / Microsoft / Slack (spec §4.2, §12.1) is **blocked on a product decision**: it needs registered OAuth-app **client IDs** (which don't exist yet) plus the **PKCE-vs-BYO-secret** choice (§11 Q2). Building the OAuth client now would be untestable scaffolding, so it's deferred until those are settled. Slack is also omitted from the key catalog for now — no bundled brand icon (the backend validator already supports it whenever an icon is added).

## Verification
- `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)