### PR TITLE
feat(agent): interactive AskUserQuestion panel + answer delivery

### DIFF
--- a/.changesets/1781543065-feat-agent-ask-user-question.md
+++ b/.changesets/1781543065-feat-agent-ask-user-question.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): render AskUserQuestion as an interactive panel and deliver the answer to the agent

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -167,6 +167,30 @@ impl PersistentSubprocessController {
             .map_err(|e| format!("stdin send failed: {e}"))
     }
 
+    /// Deliver an AskUserQuestion answer to the running CLI as a `tool_result`
+    /// on the live stdin, unblocking the agent's turn. Mirrors `send_message`
+    /// but emits a user turn whose content is a single `tool_result` block
+    /// keyed on the original `AskUserQuestion` tool_use id. The process must
+    /// already be running (the agent is mid-turn, blocked on this answer) — we
+    /// never spawn here. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    pub fn send_tool_result(&self, tool_use_id: String, content: String) -> Result<(), String> {
+        let json_msg = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    { "type": "tool_result", "tool_use_id": tool_use_id, "content": content }
+                ]
+            }
+        });
+
+        let inner = self.inner.lock().unwrap();
+        let tx = inner.stdin_tx.as_ref()
+            .ok_or("persistent process not running (cannot deliver answer)")?;
+        tx.try_send(json_msg.to_string())
+            .map_err(|e| format!("stdin send failed: {e}"))
+    }
+
     /// Spawn the persistent CLI process.
     fn spawn_process(&self, config: PersistentSpawnConfig) -> Result<(), String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -161,8 +161,10 @@ pub const COMMAND_TOOL_DECISION: &str = "tooldecision";
 pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";
 /// Deliver an AskUserQuestion answer to the running agent CLI as a tool_result.
+/// Lowercase, no separators — matches the sibling command-name convention
+/// (`agentinput`, `agentstop`, `tooldecision`).
 /// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
-pub const COMMAND_AGENT_ANSWER: &str = "agent.answer";
+pub const COMMAND_AGENT_ANSWER: &str = "agentanswer";
 pub const COMMAND_AGENT_STOP: &str = "agentstop";
 pub const COMMAND_SHELL_EXEC: &str = "shellexec";
 /// Stop a running persistent shell node (Phase 3) — UI stop button.

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -160,6 +160,9 @@ pub const COMMAND_TOOL_DECISION: &str = "tooldecision";
 // Subprocess agent commands
 pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";
+/// Deliver an AskUserQuestion answer to the running agent CLI as a tool_result.
+/// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+pub const COMMAND_AGENT_ANSWER: &str = "agent.answer";
 pub const COMMAND_AGENT_STOP: &str = "agentstop";
 pub const COMMAND_SHELL_EXEC: &str = "shellexec";
 /// Stop a running persistent shell node (Phase 3) — UI stop button.
@@ -591,6 +594,19 @@ pub struct CommandToolDecisionData {
     /// this verbatim into the agent's next prompt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feedback: Option<String>,
+}
+
+/// Data for AgentAnswerCommand — an AskUserQuestion answer delivered back to
+/// the running agent CLI as a `tool_result` over the persistent controller's
+/// live stdin. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandAgentAnswerData {
+    pub blockid: String,
+    /// The `AskUserQuestion` tool_use id the answer responds to.
+    pub tool_use_id: String,
+    /// Canonical flat-text rendering of the user's selections; becomes the
+    /// tool_result content the model consumes.
+    pub answer_text: String,
 }
 
 // ---- Subprocess agent command data types ----

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -27,8 +27,10 @@ use crate::backend::rpc_types::{
     COMMAND_GET_AI_RATE_LIMIT, COMMAND_ROUTE_ANNOUNCE, COMMAND_ROUTE_UNANNOUNCE,
     COMMAND_SET_META, COMMAND_SET_CONFIG, COMMAND_APP_INFO,
     COMMAND_SUBPROCESS_SPAWN, COMMAND_AGENT_INPUT, COMMAND_AGENT_STOP, COMMAND_TOOL_DECISION,
+    COMMAND_AGENT_ANSWER,
     COMMAND_WRITE_AGENT_CONFIG, COMMAND_SHELL_EXEC, COMMAND_SHELL_STOP,
     CommandSubprocessSpawnData, CommandAgentInputData, CommandAgentStopData, CommandWriteAgentConfigData,
+    CommandAgentAnswerData,
     CommandShellExecData, ShellExecResult, CommandShellStopData,
 };
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
@@ -769,6 +771,44 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     "[tooldecision] received (delivery mechanism deferred to PR-3b/PR-4)"
                 );
                 Ok(None)
+            })
+        }),
+    );
+
+    // agent.answer → deliver an AskUserQuestion answer to the running agent
+    // CLI as a `tool_result` over the persistent controller's live stdin,
+    // unblocking the agent's turn. Unlike tooldecision (no-op delivery), this
+    // path is real: the persistent controller (host agents, --input-format
+    // stream-json) keeps stdin open for the session. Container / one-shot
+    // subprocess agents have no live stdin — they return UNSUPPORTED_CONTROLLER
+    // (Phase 2). Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    engine.register_handler(
+        COMMAND_AGENT_ANSWER,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandAgentAnswerData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.answer: {e}"))?;
+                if cmd.tool_use_id.is_empty() {
+                    return Err("agent.answer: MISSING_ARG: tool_use_id".to_string());
+                }
+                let ctrl = blockcontroller::get_controller(&cmd.blockid)
+                    .ok_or_else(|| format!("agent.answer: no controller for block {}", cmd.blockid))?;
+                if let Some(persistent_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
+                {
+                    persistent_ctrl.send_tool_result(cmd.tool_use_id.clone(), cmd.answer_text)?;
+                    tracing::info!(
+                        block_id = %cmd.blockid,
+                        tool_use_id = %cmd.tool_use_id,
+                        "[agent.answer] tool_result delivered to persistent stdin"
+                    );
+                    Ok(None)
+                } else {
+                    Err("agent.answer: UNSUPPORTED_CONTROLLER: answering AskUserQuestion \
+                         requires a persistent (host) agent; container/one-shot agents are \
+                         not yet supported (Phase 2)".to_string())
+                }
             })
         }),
     );

--- a/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
@@ -1,0 +1,482 @@
+# SPEC: AskUserQuestion — interactive agent questions in the agent pane
+
+**Date:** 2026-06-15
+**Status:** Validated — implementing Phase 1 (smoke test passed 2026-06-15; see §10)
+**Owner:** Agent pane (frontend stream/reducer/render) + sidecar (controller stdin delivery)
+**Related:** `SPEC_DECISION_PROMPT_2026_04_24.md` (sibling feature — tool *permission* gating, distinct from this), `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md` (agent→app callback precedent)
+
+---
+
+## 1. Summary
+
+When an agent (Claude Code, and any provider that supports it) calls the
+**`AskUserQuestion`** tool, it is asking the human a structured multiple-choice
+question and **blocking its turn** until it receives a `tool_result`. Today
+AgentMux does not recognise this tool: the call flows through the translator as a
+generic `tool_call`, renders as an ordinary "running" tool node, and **never
+completes** — because nothing in AgentMux ever sends the answer back. The agent
+hangs until the turn times out or the user kills it. (This is the exact failure
+the user observed: an `AskUserQuestion` call inside an AgentMux agent pane errored
+out with no way to answer.)
+
+This spec defines:
+1. **Detection** — recognise the `AskUserQuestion` tool_use in the stream and
+   model it as a first-class "awaiting answer" state on the tool node.
+2. **Rendering** — an interactive question panel (N questions, single- or
+   multi-select options, a free-text "Other") in the agent pane.
+3. **Delivery** — route the user's answer back into the running agent CLI as a
+   `tool_result` content block over the **persistent controller's live stdin**,
+   unblocking the agent's turn.
+
+This is **not** the same feature as `SPEC_DECISION_PROMPT` (Allow/Deny gating of a
+tool the agent wants to run). AskUserQuestion is a tool the agent *deliberately
+invokes* to consult the human; the answer is data the model consumes, not a
+permission verdict. The two share UI patterns but are distinct flows.
+
+---
+
+## 2. The load-bearing finding: the delivery channel already exists
+
+The decision-prompt spec (§9.1) flagged answer-delivery as the unsolved blocker —
+because it analysed the **one-shot subprocess** controller, which runs the CLI in
+`-p` / `--print` mode with no live stdin. That blocker **does not apply to host
+agents**, which use the **persistent** controller:
+
+- `frontend/app/view/agent/providers/index.ts:161` — the Claude provider's
+  `persistentLaunchArgs` are
+  `["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"]`.
+  This is a **bidirectional** NDJSON session: the CLI reads user messages from
+  stdin for the life of the process.
+- `agentmux-srv/src/backend/blockcontroller/persistent.rs:4-11` — "A single CLI
+  process is spawned on first message and kept alive for the entire session. User
+  messages are written as NDJSON lines to stdin **without closing it**. This
+  enables mid-turn input."
+- `persistent.rs:146-168` — `send_message()` already writes
+  `{"type":"user","message":{"role":"user","content":<string>}}` to the live
+  stdin. An AskUserQuestion answer is the same channel with a different content
+  shape: a `tool_result` block instead of a text turn.
+
+So for **host (persistent) agents the delivery path is feasible today**. The
+one-shot subprocess path (container agents, providers launched per-turn with `-p`)
+is Phase 2 — see §9.
+
+> **Validation gate (must verify before building):** does
+> `claude --input-format stream-json --output-format stream-json --dangerously-skip-permissions`
+> actually *emit* an `AskUserQuestion` `tool_use` and then *consume* a matching
+> `tool_result` to continue, or does Claude Code suppress the tool in
+> headless/stream-json mode? The entire Phase-1 design hinges on this being
+> "emits + consumes". §10 specifies the smoke test. If Claude suppresses it,
+> Phase 1 still applies to any provider that does emit it, and the Claude path
+> becomes a CLI-flag/upstream question.
+
+---
+
+## 3. Current state (evidence)
+
+| Concern | State | Reference |
+|---|---|---|
+| `AskUserQuestion` recognised anywhere | ❌ literal string absent in repo | grep `docs/ specs/ frontend/ agentmux-srv/` → none |
+| Tool_use → StreamEvent | ✅ generic | `claude-translator.ts:174-196`, `:301-322`, `:363-389` emit `{type:"tool_call", tool, id, params}` |
+| StreamEvent → DocumentNode (ToolNode) | ✅ generic | `stream-parser.ts` `eventToNode()` switch; unknown tools → `tool: "Other"` |
+| ToolNode model + status enum | ✅ | `frontend/app/view/agent/types.ts:207-243` — `status: "running" \| "pending_approval" \| "success" \| "failed" \| "denied" \| "canceled"`, plus `pendingPermission?` |
+| Interactive panel pattern | ✅ (for permissions) | `components/AgentDecisionPanel.tsx`; collected via `pendingDecisions()` in `agent-view.tsx:432-489`, submitted via `RpcApi.ToolDecisionCommand` |
+| Decision RPC backend | ⚠️ audit-log only | `websocket.rs:717-774` — validates + logs; delivery deferred |
+| **Live stdin to running agent** | ✅ **persistent only** | `persistent.rs:146-168` `send_message()` |
+| Document reducer | ✅ | `agent-document-store.ts:84-158` dispatch; state `nodes/sessionPhase/nodeIdSet` in `agent-document/types.ts:17-37`; commands in `:53-131` (`StreamFlush`, `ToolChunkAppend`, …) |
+| Pane-state reducer (turn phase) | ✅ | `agent-pane-state/reducer.ts:65-200`; `TurnPhase` union in `types.ts:118-152` |
+
+**Net:** an `AskUserQuestion` call today becomes a `ToolNode{ tool:"Other",
+status:"running" }` that never resolves. Everything needed to fix it — translator,
+reducer, node model, panel pattern, live stdin — exists; it must be connected and
+given a question-specific shape.
+
+---
+
+## 4. The `AskUserQuestion` tool contract
+
+The tool input (Anthropic/Claude Code schema) is an object with a `questions`
+array (1–4 questions). Each question:
+
+```jsonc
+{
+  "questions": [
+    {
+      "question": "Which auth method should we use?",
+      "header": "Auth method",          // short chip label (≤12 chars)
+      "multiSelect": false,              // true → checkbox semantics
+      "options": [
+        { "label": "OAuth (Recommended)", "description": "Browser-based device flow" },
+        { "label": "API key",             "description": "Static key in settings" }
+      ]
+    }
+    // … up to 4 questions
+  ]
+}
+```
+
+Semantics AgentMux must honour:
+- **1–4 questions**, rendered together in one panel; all must be answered before
+  submit (unless the panel allows partial → see §8 open questions).
+- **`multiSelect`** — single-select (radio) vs multi-select (checkbox) per question.
+- **Free-text "Other"** — the harness always allows the user to supply custom text
+  instead of a listed option. The panel MUST offer an "Other" free-text entry per
+  question.
+- The agent expects a **`tool_result`** keyed on the tool_use `id`, whose content
+  conveys the user's selection(s) per question.
+
+---
+
+## 5. Architecture overview
+
+```
+ Claude CLI (persistent, stream-json)
+        │  tool_use: AskUserQuestion {questions:[…]}   (stdout NDJSON)
+        ▼
+ useAgentStream → ClaudeTranslator.translate()           [unchanged: emits tool_call]
+        ▼
+ ClaudeCodeStreamParser.eventToNode()                    [NEW: special-case AskUserQuestion]
+        │  → ToolNode{ tool:"AskUserQuestion", status:"awaiting_answer", question:{…} }
+        ▼
+ dispatchDoc(StreamFlush)  → agent-document reducer       [node carries `question`]
+        ▼
+ AgentDocumentVirtualList renders the node
+        │
+ agent-view.tsx pendingQuestions()  ─────────────────────[NEW: mirror of pendingDecisions()]
+        ▼
+ <AgentQuestionPanel question=… onAnswer=…>               [NEW component]
+        │  user picks options / types "Other" / submits
+        ▼
+ RpcApi.AgentAnswerCommand({ blockid, tool_use_id, answers })   [NEW RPC]
+        ▼
+ websocket.rs COMMAND_AGENT_ANSWER handler                [NEW handler]
+        ▼
+ PersistentSubprocessController.send_tool_result(id, content)   [NEW method]
+        │  writes {"type":"user","message":{"role":"user",
+        │           "content":[{"type":"tool_result","tool_use_id":id,"content":…}]}}
+        ▼
+ Claude CLI consumes tool_result → turn continues → emits next assistant message
+        ▼
+ ToolNode transitions running→success (answer echoed as its result)
+```
+
+---
+
+## 6. Data model changes
+
+### 6.1 `frontend/app/view/agent/types.ts`
+
+Add the request shape (parsed from the tool input) and an answer shape:
+
+```typescript
+export interface AskUserQuestionOption {
+    label: string;
+    description?: string;
+}
+
+export interface AskUserQuestionItem {
+    question: string;
+    header: string;
+    multiSelect: boolean;
+    options: AskUserQuestionOption[];
+}
+
+export interface AskUserQuestionRequest {
+    type: "ask_user_question";
+    tool_use_id: string;            // the AskUserQuestion tool_use id; echoed in the tool_result
+    questions: AskUserQuestionItem[];
+}
+
+/** One question's answer. `selected` are chosen option labels; `other`
+ *  is free-text the user typed instead of (or in addition to) options. */
+export interface AskUserQuestionAnswer {
+    header: string;
+    selected: string[];             // chosen option labels (length 1 for single-select)
+    other?: string;                 // free-text "Other"
+}
+```
+
+Extend `ToolNode` (mirrors the existing `pendingPermission` pattern):
+- add `"awaiting_answer"` to the `status` union,
+- add `question?: AskUserQuestionRequest`.
+
+> **Modeling choice:** AskUserQuestion is carried on `ToolNode`, not a new node
+> type, because it *is* a tool_use with a tool lifecycle: `awaiting_answer` →
+> (answer delivered as tool_result) → `success` with the answer as `result`. This
+> reuses the tool node's rendering, dedup index, and the `pendingPermission`
+> collection analogue with the least new plumbing.
+
+### 6.2 Backend wire types — `agentmux-srv/src/backend/rpc_types.rs`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandAgentAnswerData {
+    pub blockid: String,
+    pub tool_use_id: String,
+    /// Canonical, human-readable rendering of the user's selections, ready to
+    /// hand to the model as the tool_result content (see §7.3 for the format).
+    pub answer_text: String,
+}
+```
+
+Add `COMMAND_AGENT_ANSWER: &str = "agent.answer"` alongside the existing command
+constants.
+
+---
+
+## 7. Pipeline changes (implementation-ready)
+
+### 7.1 Detection — `frontend/app/view/agent/stream-parser.ts`
+
+In `eventToNode()` (the `tool_call` case that today builds a `ToolNode`), branch on
+`event.tool === "AskUserQuestion"`:
+- when the params are fully parsed (the translator emits a final `tool_call` with
+  populated `params` from `content_block_stop` / the top-level `assistant`
+  message — `claude-translator.ts:363-389`, `:174-196`),
+- build the node with `status: "awaiting_answer"` and
+  `question: { type:"ask_user_question", tool_use_id: event.id, questions: params.questions }`.
+
+Guard: if `params.questions` is missing/empty (e.g. only the streaming
+`content_block_start` placeholder arrived), keep `status:"running"` and let the
+later fully-parsed `tool_call` upgrade it — the node-id dedup in `useAgentStream`
+already updates an existing tool node in place.
+
+No translator change is required — `AskUserQuestion` already arrives as a
+`tool_call`. Detection lives entirely in the parser/reducer layer.
+
+### 7.2 Rendering — new `components/AgentQuestionPanel.tsx` + `agent-view.tsx`
+
+- **Collection:** add `pendingQuestions()` next to `pendingDecisions()`
+  (`agent-view.tsx:432-489`): scan document nodes for
+  `node.type === "tool" && node.status === "awaiting_answer" && node.question`,
+  oldest-first. Render the panel for the head of the queue (same single-active
+  pattern the decision panel uses).
+- **Panel** (`AgentQuestionPanel.tsx`, mirroring `AgentDecisionPanel.tsx`):
+  - one section per question: header chip + prompt + options as radios
+    (`multiSelect:false`) or checkboxes (`multiSelect:true`), plus an **"Other"**
+    free-text input,
+  - keyboard-driven (number keys to toggle options, Enter to submit, Esc to
+    minimise/defer), matching the decision panel's interaction language,
+  - submit is disabled until every question has at least one selection or an
+    "Other" value,
+  - on submit, encode answers (§7.3) and call
+    `props.onAnswer({ tool_use_id, answers })`.
+- **Submit handler** in `agent-view.tsx` (`handleAnswer`, mirror of `handleDecide`)
+  builds `answer_text` and dispatches `RpcApi.AgentAnswerCommand(TabRpcClient,
+  { blockid, tool_use_id, answer_text })`. Optimistically flip the node to a
+  pending/answered state so the panel dismisses immediately; the real `success`
+  transition lands when the tool_result is echoed back in the stream.
+
+### 7.3 Answer encoding (the `tool_result` content)
+
+The model needs a clear, unambiguous rendering. Canonical format (one block of
+text), per question:
+
+```
+<header>: <comma-joined selected labels>[, Other: <free text>]
+```
+
+Example for a two-question answer:
+
+```
+Auth method: OAuth (Recommended)
+Library: date-fns, Other: luxon
+```
+
+This string is `CommandAgentAnswerData.answer_text` and becomes the `tool_result`
+content. (Rationale: a flat labelled block is robust for the model to parse and
+mirrors how the question was posed. A structured JSON tool_result is a possible
+future refinement — see §8.)
+
+### 7.4 Delivery — `agentmux-srv`
+
+**RPC handler** (`websocket.rs`, register `COMMAND_AGENT_ANSWER` near
+`COMMAND_AGENT_INPUT` at `:844`): parse `CommandAgentAnswerData`, look up the
+controller via `blockcontroller::get_controller(&cmd.blockid)`, downcast to
+`PersistentSubprocessController`, and call the new `send_tool_result`. If the
+controller is not persistent (container/one-shot), return a typed error
+(`UNSUPPORTED_CONTROLLER`) so the frontend can show "answering isn't supported for
+this agent yet" — Phase 2 (§9).
+
+**Controller method** (`persistent.rs`, beside `send_message` at `:146`):
+
+```rust
+/// Deliver an AskUserQuestion answer as a tool_result on the live stdin,
+/// unblocking the agent's turn. Mirrors send_message but emits a user turn
+/// whose content is a single tool_result block keyed on the tool_use id.
+pub fn send_tool_result(&self, tool_use_id: String, content: String) -> Result<(), String> {
+    let json_msg = serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                { "type": "tool_result", "tool_use_id": tool_use_id, "content": content }
+            ]
+        }
+    });
+    let inner = self.inner.lock().unwrap();
+    let tx = inner.stdin_tx.as_ref()
+        .ok_or("persistent process not running")?;
+    tx.try_send(json_msg.to_string())
+        .map_err(|e| format!("stdin send failed: {e}"))
+}
+```
+
+No new env/identity injection is needed (the process is already running; we are
+only writing to its stdin). The existing stdin-writer task (`persistent.rs:317-335`)
+appends the newline and flushes.
+
+### 7.5 Completion
+
+When the CLI consumes the `tool_result`, it continues the turn and the existing
+stream path renders the next assistant content. The AskUserQuestion ToolNode
+should transition `awaiting_answer → success`; drive this from the optimistic
+update in 7.2 (and/or a matching `tool_result` echo if the provider emits one). The
+`result` carries `answer_text` for display.
+
+---
+
+## 8. UX details
+
+- **One panel at a time** — queue multiple pending questions oldest-first (reuse
+  the decision-panel single-active discipline).
+- **Per-question validation** — submit disabled until each question is answered
+  (selection or "Other").
+- **"Other" is always present** — required by the tool contract; never hide it.
+- **Multi-select** renders checkboxes; **single-select** renders radios. "Other"
+  coexists with selections for multi-select; for single-select, choosing "Other"
+  clears any radio selection.
+- **Defer/minimise** (Esc) — collapses the panel but keeps the node in
+  `awaiting_answer`; a banner/affordance lets the user reopen it. The agent stays
+  blocked (it asked a question), so the panel must remain reachable.
+- **Dismiss safety** — there is no "ignore" that silently drops the question: the
+  agent is blocked on a tool_result. If the user truly wants to abandon, offer an
+  explicit "Skip / answer later" that either (a) keeps it pending, or (b) sends a
+  tool_result of "(user declined to answer)" so the agent can proceed. Default:
+  keep pending; never auto-send without user action.
+
+---
+
+## 9. Phasing
+
+**Phase 1 — host (persistent) agents, Claude.**
+- Detection + node model + `AgentQuestionPanel` + `agent.answer` RPC +
+  `send_tool_result`. Single & multi-select & "Other". Local host agents only.
+- Gated on the §2 validation result.
+
+**Phase 2 — one-shot / container agents.**
+- The subprocess controller has no live stdin. Options: resume the session via the
+  provider's `--resume <session_id>` with the tool_result as the new input
+  (a fresh subprocess per answer), or buffer the answer for the next turn. Decide
+  per-provider. Until then, those agents surface "answering not supported on this
+  connection" (the `UNSUPPORTED_CONTROLLER` path from 7.4).
+
+**Phase 3 — refinements.**
+- Structured (JSON) tool_result instead of the flat text block, if the model
+  benefits. Cross-provider parity (Gemini/Codex/Kimi translators emit the same
+  `tool_call` shape — most of Phase 1 is provider-agnostic once detection keys on
+  the tool name the provider uses). Persisted answer history in the transcript.
+
+---
+
+## 10. Validation / smoke test — ✅ PASSED 2026-06-15
+
+Run against the user's `claude` (`C:\Users\asafe\.local\bin\claude`) with the
+**exact** persistent args from §2 (`--input-format stream-json --output-format
+stream-json --verbose --include-partial-messages --dangerously-skip-permissions`,
+plus `--model sonnet`). Two-phase Python harness (real OS pipes; an MSYS FIFO won't
+reach the native Windows binary). Result:
+
+```
+emits_AskUserQuestion = True      # tool_use emitted, turn blocked (no 'result' first)
+consumes_tool_result  = True      # after the tool_result, the turn produced a 'result'
+```
+
+Confirmed exact wire shape of the tool_use (matches §4/§6 schema):
+
+```jsonc
+{ "type":"tool_use", "id":"toolu_…", "name":"AskUserQuestion",
+  "input": { "questions": [
+    { "question":"Pick a color", "header":"Color", "multiSelect":false,
+      "options":[ {"label":"Red","description":"Red"}, {"label":"Blue","description":"Blue"} ] }
+  ] },
+  "caller": { "type":"direct" } }
+```
+
+And the answer that unblocked it:
+`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_…","content":"Color: Blue"}]}}`
+
+**Conclusions:** (a) `--dangerously-skip-permissions` does **not** suppress the
+tool; (b) `input.questions[]` is the exact schema; (c) a **flat labelled-text**
+tool_result content is consumed correctly — so §7.3's encoding is validated. Phase 1
+is unblocked. Original procedure retained below for re-validation on CLI upgrades.
+
+---
+
+### Original procedure (for re-validation)
+
+Before writing UI, confirm the contract empirically against the bundled Claude CLI:
+
+1. Spawn `claude` with the persistent args (§2) in a scratch dir.
+2. Send a user turn that reliably elicits an `AskUserQuestion` (e.g. "Ask me a
+   multiple-choice question about X using the AskUserQuestion tool").
+3. Capture stdout NDJSON. Confirm a `tool_use` with `name:"AskUserQuestion"` and a
+   `questions` array appears, and that the turn **blocks** (no `result` event).
+4. Write to stdin:
+   `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"<id>","content":"Auth method: OAuth"}]}}`
+5. Confirm the agent **continues** the turn (emits further assistant content /
+   `result`) — i.e. it consumed the tool_result.
+
+If (3) shows the tool is suppressed in this mode, escalate to a CLI-flag/upstream
+question and scope Phase 1 to whichever provider does emit it. If (5) fails, the
+content shape is wrong — adjust the `tool_result` block accordingly.
+
+---
+
+## 11. Files to touch (summary)
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/types.ts` | `AskUserQuestion{Option,Item,Request,Answer}` types; `ToolNode.status += "awaiting_answer"`; `ToolNode.question?` |
+| `frontend/app/view/agent/stream-parser.ts` | special-case `tool === "AskUserQuestion"` in `eventToNode()` |
+| `frontend/app/view/agent/components/AgentQuestionPanel.tsx` | **new** — interactive question panel (mirror of `AgentDecisionPanel`) |
+| `frontend/app/view/agent/agent-view.tsx` | `pendingQuestions()`, `handleAnswer()`, render the panel |
+| `frontend/app/store/rpc-api.ts` | `AgentAnswerCommand` binding |
+| `agentmux-srv/src/backend/rpc_types.rs` | `CommandAgentAnswerData`, `COMMAND_AGENT_ANSWER` |
+| `agentmux-srv/src/server/websocket.rs` | register `COMMAND_AGENT_ANSWER` handler |
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | `send_tool_result()` |
+
+---
+
+## 12. Non-goals
+
+- Permission/Allow-Deny gating — that's `SPEC_DECISION_PROMPT_2026_04_24.md`.
+- One-shot/container answer delivery (Phase 2).
+- Persisting/replaying answered questions across session reloads beyond what the
+  normal transcript already captures (Phase 3).
+- A generic "agent asks app for arbitrary input" framework — this spec is scoped to
+  the concrete `AskUserQuestion` tool contract. Generalisation can follow once the
+  one verb is solid (same philosophy as the `pane.open`/`amux` analysis).
+
+---
+
+## 13. Open questions — RESOLVED (2026-06-15)
+
+- **Validation gate (§2/§10):** ✅ **RESOLVED** — Claude Code *both* emits the
+  `AskUserQuestion` tool_use *and* consumes a `tool_result` to continue, under the
+  exact persistent args. Smoke test passed (§10).
+- **`--dangerously-skip-permissions` interaction:** ✅ **RESOLVED** — does not
+  suppress the tool; it still fires (confirmed in §10).
+- **Answer format:** ✅ **RESOLVED — flat labelled text** (§7.3). The smoke test fed
+  `"Color: Blue"` and the model consumed it cleanly. Structured JSON deferred to
+  Phase 3 only if a real mis-parse surfaces.
+- **Optimistic vs echo-driven completion:** ✅ **RESOLVED — optimistic on submit,
+  reconciled by the stream.** Flip the node out of `awaiting_answer` immediately so
+  the panel dismisses; the subsequent assistant content / `result` (which the smoke
+  test confirmed arrives) drives the final `success`. No artificial timeout needed
+  in the happy path; keep a long fallback only to clear a stuck panel if the process
+  died.
+- **Defer semantics:** ✅ **RESOLVED — keep-pending.** Esc minimises; the node stays
+  `awaiting_answer` and reachable. Never auto-decline or auto-send. An explicit
+  "answer later" affordance keeps it pending; no silent drop.
+
+No blocking unknowns remain for Phase 1.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -93,6 +93,13 @@ class RpcApiType {
         return client.rpcCall("tooldecision", data, opts);
     }
 
+    // command "agent.answer" [call]
+    // Deliver an AskUserQuestion answer to the running agent CLI as a
+    // tool_result. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    AgentAnswerCommand(client: RpcClient, data: CommandAgentAnswerData, opts?: RpcOpts): Promise<void> {
+        return client.rpcCall("agent.answer", data, opts);
+    }
+
     // command "controllerresync" [call]
     ControllerResyncCommand(client: RpcClient, data: CommandControllerResyncData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("controllerresync", data, opts);

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -93,11 +93,11 @@ class RpcApiType {
         return client.rpcCall("tooldecision", data, opts);
     }
 
-    // command "agent.answer" [call]
+    // command "agentanswer" [call]
     // Deliver an AskUserQuestion answer to the running agent CLI as a
     // tool_result. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
     AgentAnswerCommand(client: RpcClient, data: CommandAgentAnswerData, opts?: RpcOpts): Promise<void> {
-        return client.rpcCall("agent.answer", data, opts);
+        return client.rpcCall("agentanswer", data, opts);
     }
 
     // command "controllerresync" [call]

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -507,11 +507,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // panel dismisses immediately. The agent's continuation (the next
         // assistant content / result the smoke test confirmed arrives) drives
         // the rest of the conversation; the node carries the answer as its
-        // summary for the record.
+        // summary for the record. We snapshot the original node(s) so a failed
+        // delivery can roll the transition back (see the catch below).
+        const originals: import("./types").ToolNode[] = [];
         const updated: import("./types").ToolNode[] = [];
         for (const n of getDocument()) {
             if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
             if (n.question?.tool_use_id !== outcome.tool_use_id) continue;
+            originals.push(n);
             updated.push({
                 ...n,
                 status: "success",
@@ -533,7 +536,19 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             tool_use_id: outcome.tool_use_id,
             answer_text: outcome.answer_text,
         }).catch((err: unknown) => {
+            // Delivery failed — most commonly UNSUPPORTED_CONTROLLER on a
+            // container / one-shot agent (no live stdin; Phase 2). Roll the
+            // node back to awaiting_answer so the panel re-surfaces and the
+            // user isn't falsely told the question was answered while the
+            // agent is still blocked.
             log("error", `agent.answer failed: ${String(err)}`);
+            if (originals.length > 0) {
+                dispatchDoc(
+                    model.blockId,
+                    { type: "StreamFlush", newNodes: [], updatedNodes: originals },
+                    "user",
+                );
+            }
         });
     };
     const status = useAgentControllerStatus({

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -54,6 +54,7 @@ import { DragOverlay } from "@/app/element/dragoverlay";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { ActivityLogPanel } from "./components/ActivityLogPanel";
 import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
+import { AgentQuestionPanel, type AnswerOutcome } from "./components/AgentQuestionPanel";
 import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter, AgentWorkingRow, AgentAuxInfoBar } from "./components/AgentFooter";
@@ -485,6 +486,54 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             feedback: decision.feedback,
         }).catch((err: unknown) => {
             log("error", `tool:decision failed: ${String(err)}`);
+        });
+    };
+
+    // Pending AskUserQuestion queue — every ToolNode in `awaiting_answer`,
+    // oldest first. The question panel renders the head; Submit transitions
+    // the node and delivers the answer to the agent CLI as a tool_result.
+    // Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    const pendingQuestions = (): import("./types").ToolNode[] => {
+        const docs = getDocument();
+        const out: import("./types").ToolNode[] = [];
+        for (const n of docs) {
+            if (n.type === "tool" && n.status === "awaiting_answer" && n.question) out.push(n);
+        }
+        return out;
+    };
+
+    const handleAnswer = (outcome: AnswerOutcome) => {
+        // Optimistic transition: flip the node out of awaiting_answer so the
+        // panel dismisses immediately. The agent's continuation (the next
+        // assistant content / result the smoke test confirmed arrives) drives
+        // the rest of the conversation; the node carries the answer as its
+        // summary for the record.
+        const updated: import("./types").ToolNode[] = [];
+        for (const n of getDocument()) {
+            if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
+            if (n.question?.tool_use_id !== outcome.tool_use_id) continue;
+            updated.push({
+                ...n,
+                status: "success",
+                question: undefined,
+                summary: `❓ Answered — ${outcome.answer_text.replace(/\n/g, "; ")}`,
+            });
+        }
+        if (updated.length > 0) {
+            dispatchDoc(
+                model.blockId,
+                { type: "StreamFlush", newNodes: [], updatedNodes: updated },
+                "user",
+            );
+        }
+        // Deliver the answer to the running agent CLI as a tool_result over the
+        // persistent controller's live stdin.
+        void RpcApi.AgentAnswerCommand(TabRpcClient, {
+            blockid: model.blockId,
+            tool_use_id: outcome.tool_use_id,
+            answer_text: outcome.answer_text,
+        }).catch((err: unknown) => {
+            log("error", `agent.answer failed: ${String(err)}`);
         });
     };
     const status = useAgentControllerStatus({
@@ -937,6 +986,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     // prompt remains reachable.
                     log("agent", "Decision minimized");
                 }}
+            />
+
+            {/* AskUserQuestion panel — surfaced when a tool call is in
+                `awaiting_answer` (the agent asked the user a structured
+                question and is blocked on the answer). Submitting delivers a
+                tool_result over the persistent controller's stdin.
+                Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md. */}
+            <AgentQuestionPanel
+                pending={pendingQuestions}
+                onAnswer={handleAnswer}
+                onDefer={() => log("agent", "Question minimized")}
             />
 
             {/* Queue sits directly below the feed so the user's newly-

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -1,0 +1,203 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AgentQuestionPanel — interactive AskUserQuestion prompt floated over the
+// agent conversation. Colors bind to the global theme tokens.
+// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+
+.agent-question-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    margin: var(--space-2) 0;
+    padding: var(--space-3);
+    background: var(--modal-bg-color, #232323);
+    border: 1px solid var(--accent-color);
+    border-radius: var(--radius-md, 0);
+    box-shadow: var(--shadow-lg, 0 12px 24px rgba(0, 0, 0, 0.35));
+    color: var(--main-text-color);
+    outline: none;
+}
+
+.agent-question-panel-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.agent-question-panel-icon {
+    font-size: 14px;
+}
+
+.agent-question-panel-title {
+    font-weight: var(--font-weight-medium, 500);
+    font-size: var(--text-base, 13px);
+}
+
+.agent-question-panel-queue {
+    margin-left: auto;
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+}
+
+.agent-question-panel-q {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    border: none;
+}
+
+.agent-question-panel-q-prompt {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    padding: 0;
+    font-size: var(--text-base, 13px);
+    color: var(--main-text-color);
+}
+
+.agent-question-panel-q-chip {
+    flex: 0 0 auto;
+    padding: 1px var(--space-1-5);
+    background: rgba(var(--accent-color-rgb, 65, 159, 224), 0.18);
+    color: var(--accent-color);
+    border-radius: var(--radius-sm, 0);
+    font-size: var(--text-xs, 11px);
+    font-weight: var(--font-weight-medium, 500);
+    white-space: nowrap;
+}
+
+.agent-question-panel-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.agent-question-panel-option {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-1-5) var(--space-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm, 0);
+    cursor: pointer;
+    transition: background 80ms ease, border-color 80ms ease;
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+
+    input {
+        margin-top: 2px;
+        accent-color: var(--accent-color);
+        flex: 0 0 auto;
+    }
+
+    &--checked {
+        border-color: var(--accent-color);
+        background: rgba(var(--accent-color-rgb, 65, 159, 224), 0.1);
+    }
+}
+
+.agent-question-panel-option-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+}
+
+.agent-question-panel-option-label {
+    font-size: var(--text-sm, 12px);
+}
+
+.agent-question-panel-option-desc {
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+}
+
+.agent-question-panel-other {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+}
+
+.agent-question-panel-other-label {
+    flex: 0 0 auto;
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+}
+
+.agent-question-panel-other-input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-1) var(--space-1-5);
+    background: var(--form-element-bg-color, var(--main-bg-color));
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm, 0);
+    color: var(--main-text-color);
+    font-size: var(--text-sm, 12px);
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+    }
+}
+
+.agent-question-panel-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+}
+
+.agent-question-panel-btn {
+    padding: var(--space-1-5) var(--space-3);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm, 0);
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: pointer;
+    font-size: var(--text-sm, 12px);
+    transition: background 80ms ease, opacity 80ms ease;
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+
+    &--submit {
+        background: var(--accent-color);
+        border-color: var(--accent-color);
+        color: var(--button-text-color, #000);
+
+        &:hover {
+            opacity: 0.9;
+            background: var(--accent-color);
+        }
+
+        &:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+    }
+}
+
+.agent-question-panel-minimized {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin: var(--space-2) 0;
+    padding: var(--space-1-5) var(--space-3);
+    background: var(--modal-bg-color, #232323);
+    border: 1px solid var(--accent-color);
+    border-radius: var(--radius-md, 0);
+    color: var(--main-text-color);
+    cursor: pointer;
+    font-size: var(--text-sm, 12px);
+}
+
+.agent-question-panel-minimized-cta {
+    color: var(--secondary-text-color);
+    font-size: var(--text-xs, 11px);
+}

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -1,0 +1,253 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentQuestionPanel — surfaced when a `ToolNode` in the pane has
+ * `status === "awaiting_answer"` (the agent called the `AskUserQuestion`
+ * tool and is blocked on the user's answer). Renders the question(s) with
+ * single- or multi-select options plus a free-text "Other", and submits the
+ * answer so the caller can deliver it back to the agent as a tool_result.
+ *
+ * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+ */
+
+import { createEffect, createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import type { AskUserQuestionAnswer, AskUserQuestionRequest, ToolNode } from "../types";
+import "./AgentQuestionPanel.scss";
+
+export interface AnswerOutcome {
+    tool_use_id: string;
+    answers: AskUserQuestionAnswer[];
+    /** Canonical flat-text rendering handed to the agent as the tool_result
+     *  content. Format (per question): "<header>: <labels>[, Other: <text>]". */
+    answer_text: string;
+}
+
+interface AgentQuestionPanelProps {
+    /** Pending questions, oldest first. The panel shows the head. */
+    pending: Accessor<ToolNode[]>;
+    /** User answer. Caller advances the queue by transitioning the node. */
+    onAnswer: (outcome: AnswerOutcome) => void | Promise<void>;
+    /** Defer — leave the node in awaiting_answer; minimise without answering. */
+    onDefer?: () => void;
+}
+
+/** Per-question working state. */
+interface QState {
+    selected: string[];
+    other: string;
+}
+
+// Mirrors AgentDecisionPanel's clip: register the pane overlay against the
+// live panel root so it floats above the conversation. Mounted only while the
+// panel is visible so usePaneOverlay sees an attached element.
+const QuestionPanelClip = (p: { getEl: Accessor<HTMLElement | null | undefined> }): JSX.Element => {
+    usePaneOverlay(p.getEl);
+    return null;
+};
+
+export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element => {
+    let rootRef: HTMLElement | undefined;
+
+    const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
+    const queueDepth = () => props.pending().length;
+    const request = (): AskUserQuestionRequest | null => head()?.question ?? null;
+
+    const [minimized, setMinimized] = createSignal(false);
+    const [state, setState] = createSignal<QState[]>([]);
+
+    // Reset working state whenever the head question changes (new tool_use_id,
+    // queue advance). Keyed on tool_use_id so we never inherit a prior
+    // question's selections.
+    createEffect(() => {
+        const r = request();
+        void r?.tool_use_id; // touch so the effect re-runs on change
+        setMinimized(false);
+        setState((r?.questions ?? []).map(() => ({ selected: [], other: "" })));
+    });
+
+    const setQ = (i: number, next: Partial<QState>) => {
+        setState((prev) => prev.map((q, idx) => (idx === i ? { ...q, ...next } : q)));
+    };
+
+    const toggleOption = (qi: number, label: string, multi: boolean) => {
+        const cur = state()[qi];
+        if (!cur) return;
+        if (multi) {
+            const has = cur.selected.includes(label);
+            setQ(qi, { selected: has ? cur.selected.filter((l) => l !== label) : [...cur.selected, label] });
+        } else {
+            // Single-select: choosing an option clears any "Other" text.
+            setQ(qi, { selected: [label], other: "" });
+        }
+    };
+
+    const setOther = (qi: number, text: string, multi: boolean) => {
+        // For single-select, typing "Other" supersedes the radio choice.
+        if (!multi && text.length > 0) {
+            setQ(qi, { other: text, selected: [] });
+        } else {
+            setQ(qi, { other: text });
+        }
+    };
+
+    const questionAnswered = (qi: number): boolean => {
+        const s = state()[qi];
+        return !!s && (s.selected.length > 0 || s.other.trim().length > 0);
+    };
+
+    const allAnswered = createMemo<boolean>(() => {
+        const r = request();
+        if (!r) return false;
+        return r.questions.every((_, i) => questionAnswered(i));
+    });
+
+    const buildOutcome = (): AnswerOutcome | null => {
+        const r = request();
+        if (!r) return null;
+        const answers: AskUserQuestionAnswer[] = r.questions.map((q, i) => {
+            const s = state()[i] ?? { selected: [], other: "" };
+            const other = s.other.trim();
+            return { header: q.header, selected: s.selected, ...(other ? { other } : {}) };
+        });
+        const answer_text = answers
+            .map((a) => {
+                const parts = [...a.selected];
+                if (a.other) parts.push(`Other: ${a.other}`);
+                return `${a.header}: ${parts.join(", ")}`;
+            })
+            .join("\n");
+        return { tool_use_id: r.tool_use_id, answers, answer_text };
+    };
+
+    const submit = () => {
+        if (!allAnswered()) return;
+        const outcome = buildOutcome();
+        if (outcome) void props.onAnswer(outcome);
+    };
+
+    const defer = () => {
+        setMinimized(true);
+        props.onDefer?.();
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            // Don't hijack Enter while typing in an "Other" field.
+            const tag = (e.target as HTMLElement | null)?.tagName;
+            if (tag === "INPUT" || tag === "TEXTAREA") return;
+            e.preventDefault();
+            submit();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            defer();
+        }
+    };
+
+    return (
+        <Show when={request()} keyed>
+            {(r) => (
+                <Show
+                    when={!minimized()}
+                    fallback={
+                        <button
+                            type="button"
+                            class="agent-question-panel-minimized"
+                            onClick={() => setMinimized(false)}
+                        >
+                            <span class="agent-question-panel-icon" aria-hidden="true">❓</span>
+                            <span>Question waiting</span>
+                            <span class="agent-question-panel-minimized-cta">click to answer</span>
+                        </button>
+                    }
+                >
+                    <QuestionPanelClip getEl={() => rootRef} />
+                    {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+                    <div
+                        ref={(el) => (rootRef = el)}
+                        class="agent-question-panel"
+                        role="group"
+                        aria-label="Agent question"
+                        tabindex={-1}
+                        onKeyDown={onKeyDown}
+                    >
+                        <div class="agent-question-panel-header">
+                            <span class="agent-question-panel-icon" aria-hidden="true">❓</span>
+                            <span class="agent-question-panel-title">The agent is asking</span>
+                            <Show when={queueDepth() > 1}>
+                                <span class="agent-question-panel-queue">+{queueDepth() - 1} more</span>
+                            </Show>
+                        </div>
+
+                        <For each={r.questions}>
+                            {(q, qi) => (
+                                <fieldset class="agent-question-panel-q">
+                                    <legend class="agent-question-panel-q-prompt">
+                                        <span class="agent-question-panel-q-chip">{q.header}</span>
+                                        {q.question}
+                                    </legend>
+                                    <div class="agent-question-panel-options">
+                                        <For each={q.options}>
+                                            {(opt) => {
+                                                const checked = () =>
+                                                    state()[qi()]?.selected.includes(opt.label) ?? false;
+                                                return (
+                                                    <label
+                                                        class="agent-question-panel-option"
+                                                        classList={{ "agent-question-panel-option--checked": checked() }}
+                                                    >
+                                                        <input
+                                                            type={q.multiSelect ? "checkbox" : "radio"}
+                                                            name={`amux-q-${r.tool_use_id}-${qi()}`}
+                                                            checked={checked()}
+                                                            onChange={() => toggleOption(qi(), opt.label, q.multiSelect)}
+                                                        />
+                                                        <span class="agent-question-panel-option-body">
+                                                            <span class="agent-question-panel-option-label">{opt.label}</span>
+                                                            <Show when={opt.description}>
+                                                                <span class="agent-question-panel-option-desc">{opt.description}</span>
+                                                            </Show>
+                                                        </span>
+                                                    </label>
+                                                );
+                                            }}
+                                        </For>
+                                        <label class="agent-question-panel-other">
+                                            <span class="agent-question-panel-other-label">Other</span>
+                                            <input
+                                                type="text"
+                                                class="agent-question-panel-other-input"
+                                                placeholder="Type a custom answer…"
+                                                value={state()[qi()]?.other ?? ""}
+                                                onInput={(e) => setOther(qi(), e.currentTarget.value, q.multiSelect)}
+                                            />
+                                        </label>
+                                    </div>
+                                </fieldset>
+                            )}
+                        </For>
+
+                        <div class="agent-question-panel-actions">
+                            <button
+                                type="button"
+                                class="agent-question-panel-btn agent-question-panel-btn--cancel"
+                                onClick={defer}
+                            >
+                                Answer later
+                            </button>
+                            <button
+                                type="button"
+                                class="agent-question-panel-btn agent-question-panel-btn--submit"
+                                disabled={!allAnswered()}
+                                onClick={submit}
+                            >
+                                Submit answer
+                            </button>
+                        </div>
+                    </div>
+                </Show>
+            )}
+        </Show>
+    );
+};

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -214,6 +214,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 failed: props.node.status === "failed",
                 canceled: props.node.status === "canceled",
                 pending_approval: props.node.status === "pending_approval",
+                awaiting_answer: props.node.status === "awaiting_answer",
                 denied: props.node.status === "denied",
             })}
             data-tool={props.node.tool.toLowerCase()}

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -51,6 +51,7 @@ interface ToolBlockProps {
 const STATUS_ICON: Record<ToolNode["status"], string> = {
     running: "⏳",
     pending_approval: "⚠",
+    awaiting_answer: "❓",
     success: "✓",
     failed: "✗",
     denied: "⊘",

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -38,6 +38,7 @@ export interface ToolBlockOverlayProps {
 const STATUS_LABEL: Record<ToolNode["status"], string> = {
     running: "running",
     pending_approval: "awaiting approval",
+    awaiting_answer: "awaiting answer",
     success: "ok",
     failed: "failed",
     denied: "denied",

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -301,6 +301,33 @@ export class ClaudeCodeStreamParser {
         // Store pending tool call for when result arrives
         this.pendingToolCalls.set(event.id, event);
 
+        // AskUserQuestion is a tool the agent calls to consult the human; it
+        // blocks the turn on a tool_result. When the params are fully parsed
+        // (input.questions[]), surface it as `awaiting_answer` so the question
+        // panel renders. Until the questions array lands (the streaming
+        // placeholder tool_call has empty params), keep it `running` — a later
+        // fully-parsed tool_call with the same id upgrades it in place.
+        // Spec: SPEC_ASK_USER_QUESTION_2026_06_15.md.
+        if (event.tool === "AskUserQuestion") {
+            const questions = (event.params as { questions?: unknown })?.questions;
+            if (Array.isArray(questions) && questions.length > 0) {
+                return {
+                    type: "tool",
+                    id: event.id,
+                    tool: this.normalizeToolName(event.tool),
+                    params: event.params,
+                    status: "awaiting_answer",
+                    collapsed: false,
+                    summary: "❓ Waiting for your answer",
+                    question: {
+                        type: "ask_user_question",
+                        tool_use_id: event.id,
+                        questions: questions as import("./types").AskUserQuestionItem[],
+                    },
+                };
+            }
+        }
+
         const summary = this.generateToolSummary(event.tool, event.params, "running");
 
         return {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -224,9 +224,13 @@ export interface ToolNode {
      *                          collapsed with the ⏹ icon, never with a
      *                          spinner. Spec:
      *                          SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
+     *  - `awaiting_answer`   — the agent called `AskUserQuestion` and is
+     *                          blocked on the user's answer (delivered as a
+     *                          tool_result). Carries `question`. Spec:
+     *                          SPEC_ASK_USER_QUESTION_2026_06_15.md.
      *  Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.2.
      */
-    status: "running" | "pending_approval" | "success" | "failed" | "denied" | "canceled";
+    status: "running" | "pending_approval" | "awaiting_answer" | "success" | "failed" | "denied" | "canceled";
     duration?: number; // Seconds
     result?: ToolResult;
     /** Live streaming buffer. Populated when the provider emits
@@ -240,6 +244,9 @@ export interface ToolNode {
     /** Set when status === "pending_approval". Carried into the
      *  decision panel + echoed back through `tool:decision` IPC. */
     pendingPermission?: PermissionRequestEvent;
+    /** Set when status === "awaiting_answer" (the tool is AskUserQuestion).
+     *  Drives the question panel; the answer goes back as a tool_result. */
+    question?: AskUserQuestionRequest;
 }
 
 /**
@@ -449,6 +456,44 @@ export type PermissionPreview =
     | { kind: "bash"; command: string }
     | { kind: "text"; content: string }
     | { kind: "none" };
+
+/**
+ * AskUserQuestion — the agent called the `AskUserQuestion` tool to ask the
+ * human a structured multiple-choice question and is BLOCKING its turn on a
+ * `tool_result`. Parsed from the tool_use `input` (validated wire shape:
+ * `input.questions[]`). The answer is delivered back over the persistent
+ * controller's live stdin as a tool_result.
+ *
+ * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+ */
+export interface AskUserQuestionOption {
+    label: string;
+    description?: string;
+}
+
+export interface AskUserQuestionItem {
+    question: string;
+    /** Short chip label (≤12 chars), e.g. "Auth method". */
+    header: string;
+    /** true → checkbox semantics (pick many); false → radio (pick one). */
+    multiSelect: boolean;
+    options: AskUserQuestionOption[];
+}
+
+export interface AskUserQuestionRequest {
+    type: "ask_user_question";
+    /** The AskUserQuestion tool_use id; echoed in the tool_result reply. */
+    tool_use_id: string;
+    questions: AskUserQuestionItem[];
+}
+
+/** One question's answer. `selected` are chosen option labels (length 1 for
+ *  single-select); `other` is free-text the user typed instead of / alongside. */
+export interface AskUserQuestionAnswer {
+    header: string;
+    selected: string[];
+    other?: string;
+}
 
 export interface AgentMessageEvent {
     type: "agent_message";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -164,6 +164,15 @@ declare global {
         feedback?: string;
     };
 
+    // CommandAgentAnswerData — AskUserQuestion answer, delivered back to the
+    // running agent CLI as a tool_result over the persistent controller's
+    // stdin. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    type CommandAgentAnswerData = {
+        blockid: string;
+        tool_use_id: string;
+        answer_text: string;
+    };
+
     // wshrpc.CommandBlockSetViewData
     type CommandBlockSetViewData = {
         blockid: string;


### PR DESCRIPTION
## What

Makes the **`AskUserQuestion`** tool work inside AgentMux. When an agent calls it, AgentMux now renders an interactive question panel and routes the user's answer back to the agent — previously the call rendered as a generic "running" tool that **never resolved** (the agent hung; this is the failure that surfaced when an `AskUserQuestion` call errored out in an agent pane).

## Validated first (SPEC §10)

Before building, I ran a two-phase smoke test against the bundled `claude` CLI with the exact persistent stream-json args. Result: **`emits_AskUserQuestion = True`** and **`consumes_tool_result = True`** — claude emits the tool_use, blocks the turn, and continues once fed a flat-text `tool_result`. Confirmed the exact wire schema (`input.questions[]`). This de-risked the one load-bearing unknown; all spec open questions are resolved.

## How

- **Detect** (`stream-parser.ts`): `AskUserQuestion` already arrives as a `tool_call`; special-case it → `ToolNode{ status: "awaiting_answer", question }`.
- **Render** (`AgentQuestionPanel.tsx/.scss`): N questions, single/multi-select, required free-text **Other**, submit / answer-later, theme-bound styling. Collected via `pendingQuestions()` (mirror of `pendingDecisions()`).
- **Deliver**: `handleAnswer()` → `RpcApi.AgentAnswerCommand` → `agent.answer` handler → `PersistentSubprocessController.send_tool_result()`, which writes a `{type:"user", content:[{type:"tool_result", tool_use_id, content}]}` block to the **live stdin** of the host agent process. Optimistic `awaiting_answer → success` transition dismisses the panel; the agent's continuation drives the rest.

## Scope (Phase 1)

- **Host (persistent) agents** — they keep stdin open (`--input-format stream-json`). Container/one-shot agents return `UNSUPPORTED_CONTROLLER` (Phase 2, per the analysis).
- Flat labelled-text answer encoding (validated). Idempotency/structured JSON deferred.

## Verification

`cargo check -p agentmux-srv` passes (only pre-existing warnings). Frontend couldn't be `tsc`'d in this checkout (`node_modules` absent); changes mirror the existing `AgentDecisionPanel`/`pendingDecisions`/`ToolDecisionCommand` patterns.

Spec: `docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md` (includes the §10 validation results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)