### PR TITLE
fix(markdown): make table-of-contents reactive to streaming text

### DIFF
--- a/.changesets/1781543103-fix-markdown-make-the-table-of-contents-reactive-to-streamin-xv89.md
+++ b/.changesets/1781543103-fix-markdown-make-the-table-of-contents-reactive-to-streamin-xv89.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(markdown): make the table-of-contents reactive to streaming text

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -373,7 +373,6 @@ const Markdown = (props: MarkdownProps) => {
         onClickExecute,
     } = props;
     const textAtomValue = useAtomValueSafe<string>(textAtom as any);
-    const tocItems: TocItem[] = [];
     const showToc = useAtomValueSafe(showTocAtom) ?? false;
     const [focusedHeading, setFocusedHeading] = createSignal<string | null>(null);
 
@@ -530,22 +529,29 @@ const Markdown = (props: MarkdownProps) => {
         try {
             const mdast = processor.parse(txt);
             const hast = processor.runSync(mdast);
-            // Update tocItems after processing
-            tocRefObj.current.forEach((item) => tocItems.push(item));
-            return toJsxRuntime(hast as any, {
+            const element = toJsxRuntime(hast as any, {
                 jsx: jsx as any,
                 jsxs: jsxs as any,
                 Fragment: Fragment as any,
                 passKeys: false,
                 components: markdownComponents as any,
             }) as JSX.Element;
+            // `tocRef` is local to this memo run, so the toc reflects only the
+            // current text — it no longer accumulates stale/duplicate headings
+            // across re-renders (issue #789).
+            return { element, toc: tocRefObj.current };
         } catch (e) {
             console.error("Markdown render error:", e);
-            return <pre>{txt}</pre>;
+            return { element: <pre>{txt}</pre>, toc: [] as TocItem[] };
         } finally {
             markEnd("markdown-render", `len=${txt.length}`);
         }
     });
+
+    // Reactive TOC, derived from the render memo. Re-derives whenever the text
+    // changes so streaming markdown keeps the TOC in sync, instead of the old
+    // non-reactive array that stayed stuck on the first heading set.
+    const tocItems = createMemo<TocItem[]>(() => renderedMarkdown().toc);
 
     onMount(() => {
         if (scrollable && contentsEl) {
@@ -571,19 +577,19 @@ const Markdown = (props: MarkdownProps) => {
                 when={scrollable}
                 fallback={
                     <div class={cn("content non-scrollable", contentClassName)}>
-                        {renderedMarkdown()}
+                        {renderedMarkdown().element}
                     </div>
                 }
             >
                 <div class={cn("content", contentClassName)} ref={contentsEl}>
-                    {renderedMarkdown()}
+                    {renderedMarkdown().element}
                 </div>
             </Show>
-            <Show when={showToc && tocItems.length > 0}>
+            <Show when={showToc && tocItems().length > 0}>
                 <div class="toc mt-1" ref={tocEl}>
                     <div class="toc-inner">
                         <h4 class="font-bold">Table of Contents</h4>
-                        {tocItems.map((item) => (
+                        {tocItems().map((item) => (
                             <a
                                 class="toc-item"
                                 style={{ "--indent-factor": item.depth } as any}
@@ -595,7 +601,7 @@ const Markdown = (props: MarkdownProps) => {
                     </div>
                 </div>
             </Show>
-            <Show when={showToc && tocItems.length === 0}>
+            <Show when={showToc && tocItems().length === 0}>
                 <div class="toc mt-1">
                     <div class="toc-inner">
                         <h4 class="font-bold">Table of Contents</h4>


### PR DESCRIPTION
## Problem (#789)

In `frontend/app/element/markdown.tsx`, `tocItems` was a plain mutable array that the `renderedMarkdown` memo **pushed** into on every render and **never cleared**. When `props.text` changes while `Markdown` stays mounted (settings/help panes with TOC enabled), two bugs followed:

1. The `<Show>`/`.map()` over the plain array wasn't reactive — the visible TOC stayed stuck on the initial heading set.
2. `tocItems.push(...)` accumulated headings across re-renders — producing stale/duplicated TOC items.

(Originally flagged by Codex as a P2 during the PR #786 virtualization review.)

## Fix

- `renderedMarkdown` now returns `{ element, toc }`. The toc is collected into the memo-local `tocRef` (fresh each run), so it reflects only the current text.
- A derived `const tocItems = createMemo(() => renderedMarkdown().toc)` drives the TOC reactively.
- JSX consumers updated: `renderedMarkdown().element` for content, `tocItems()` for the TOC list/empty-state.

Net effect: the TOC re-derives on each text change and no longer accumulates duplicates.

## Scope

Single file. Agent pane is unaffected (it never sets `showTocAtom`). No behavior change for non-TOC markdown — `renderedMarkdown().element` is the same JSX as before.

## Testing

`node_modules` isn't installed in this checkout, so `tsc` wasn't run; the refactor is type-safe by construction (memo return type changed to `{ element, toc }`, all consumers updated accordingly).

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)