### PR TITLE
feat(agent): AskUserQuestion answers for one-shot/container agents (Phase 2)

### DIFF
--- a/.changesets/1781547328-feat-agent-askq-phase2-oneshot.md
+++ b/.changesets/1781547328-feat-agent-askq-phase2-oneshot.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): deliver AskUserQuestion answers for one-shot/container agents as a follow-up turn

--- a/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
@@ -1,7 +1,9 @@
 # SPEC: AskUserQuestion — interactive agent questions in the agent pane
 
 **Date:** 2026-06-15
-**Status:** Validated — implementing Phase 1 (smoke test passed 2026-06-15; see §10)
+**Status:** Phase 1 shipped (persistent agents, tool_result). Phase 2 shipped
+(one-shot/container agents — follow-up delivery; the resume+tool_result mechanism
+was empirically disproven, see §10.1).
 **Owner:** Agent pane (frontend stream/reducer/render) + sidecar (controller stdin delivery)
 **Related:** `SPEC_DECISION_PROMPT_2026_04_24.md` (sibling feature — tool *permission* gating, distinct from this), `ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.md` (agent→app callback precedent)
 
@@ -363,12 +365,24 @@ update in 7.2 (and/or a matching `tool_result` echo if the provider emits one). 
   `send_tool_result`. Single & multi-select & "Other". Local host agents only.
 - Gated on the §2 validation result.
 
-**Phase 2 — one-shot / container agents.**
-- The subprocess controller has no live stdin. Options: resume the session via the
-  provider's `--resume <session_id>` with the tool_result as the new input
-  (a fresh subprocess per answer), or buffer the answer for the next turn. Decide
-  per-provider. Until then, those agents surface "answering not supported on this
-  connection" (the `UNSUPPORTED_CONTROLLER` path from 7.4).
+**Phase 2 — one-shot / container agents — SHIPPED (follow-up delivery).**
+- The subprocess / container controllers are strictly one-shot (stdin closes after
+  each turn). The originally-planned mechanism — resume with `--resume <session_id>`
+  and feed the `tool_result` — was **empirically disproven** (§10.1): when a one-shot
+  turn ends, the CLI *abandons* the pending `AskUserQuestion` tool_use, so a later
+  `tool_result` referencing it is dropped (the model reports "the user sent an empty
+  message"). There is no dangling tool_use to complete.
+- **Therefore Phase 2 delivers the answer as a normal follow-up turn**, not a
+  tool_result. The agent resumes the session (the existing `agentinput`/`--resume`
+  path) and receives the answer text as a regular user message; with the question
+  fresh in context, it continues correctly. This is a frontend fallback: the panel
+  first tries `agent.answer` (Phase 1 tool_result path); on `UNSUPPORTED_CONTROLLER`
+  it routes `answer_text` through the standard `handleSendMessage` path. The
+  optimistic success is kept; the panel never dead-ends on a one-shot agent.
+- Semantic caveat: for one-shot/container agents the answer is a *message*, not a
+  protocol tool_result — so the `AskUserQuestion` tool_use stays unanswered in the
+  transcript (harmless; the turn already ended cleanly). Persistent agents remain on
+  the true tool_result path (Phase 1).
 
 **Phase 3 — refinements.**
 - Structured (JSON) tool_result instead of the flat text block, if the model
@@ -429,6 +443,31 @@ Before writing UI, confirm the contract empirically against the bundled Claude C
 If (3) shows the tool is suppressed in this mode, escalate to a CLI-flag/upstream
 question and scope Phase 1 to whichever provider does emit it. If (5) fails, the
 content shape is wrong — adjust the `tool_result` block accordingly.
+
+### 10.1 One-shot / resume smoke test — Phase 2 finding (2026-06-15)
+
+To decide the Phase 2 mechanism, the same harness was run in **one-shot** mode
+(`claude -p --output-format stream-json …`, no `--input-format`) followed by a
+**resume** turn:
+
+```
+one_shot_emits_askq   = True     # one-shot -p DOES emit the AskUserQuestion tool_use
+one_shot_turn_ends    = True     # the turn then ends with a `result` (process exits)
+resume_accepts_result = "no-op"  # --resume + a tool_result for that id did NOT answer it
+resume_error          = False    # no hard error — but the model logged
+                                 #   "the user sent an empty message" and just greeted
+```
+
+**Conclusion:** when a one-shot turn ends, the CLI **abandons** the pending
+`AskUserQuestion` tool_use. On resume there is no open tool_use to complete, so a
+`tool_result` referencing it is silently dropped. The "resume + tool_result"
+mechanism is therefore **not viable** for one-shot/container agents.
+
+The viable path — and what Phase 2 ships — is to deliver the answer as a **normal
+follow-up user turn** over the existing `--resume` `agentinput` path. The agent
+continues the session with the answer as context. (A plain follow-up message is the
+ordinary, working resume path; only the *tool_result block* is what the abandoned
+tool_use can't consume.)
 
 ---
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -502,55 +502,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         return out;
     };
 
-    const handleAnswer = (outcome: AnswerOutcome) => {
-        // Optimistic transition: flip the node out of awaiting_answer so the
-        // panel dismisses immediately. The agent's continuation (the next
-        // assistant content / result the smoke test confirmed arrives) drives
-        // the rest of the conversation; the node carries the answer as its
-        // summary for the record. We snapshot the original node(s) so a failed
-        // delivery can roll the transition back (see the catch below).
-        const originals: import("./types").ToolNode[] = [];
-        const updated: import("./types").ToolNode[] = [];
-        for (const n of getDocument()) {
-            if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
-            if (n.question?.tool_use_id !== outcome.tool_use_id) continue;
-            originals.push(n);
-            updated.push({
-                ...n,
-                status: "success",
-                question: undefined,
-                summary: `❓ Answered — ${outcome.answer_text.replace(/\n/g, "; ")}`,
-            });
-        }
-        if (updated.length > 0) {
-            dispatchDoc(
-                model.blockId,
-                { type: "StreamFlush", newNodes: [], updatedNodes: updated },
-                "user",
-            );
-        }
-        // Deliver the answer to the running agent CLI as a tool_result over the
-        // persistent controller's live stdin.
-        void RpcApi.AgentAnswerCommand(TabRpcClient, {
-            blockid: model.blockId,
-            tool_use_id: outcome.tool_use_id,
-            answer_text: outcome.answer_text,
-        }).catch((err: unknown) => {
-            // Delivery failed — most commonly UNSUPPORTED_CONTROLLER on a
-            // container / one-shot agent (no live stdin; Phase 2). Roll the
-            // node back to awaiting_answer so the panel re-surfaces and the
-            // user isn't falsely told the question was answered while the
-            // agent is still blocked.
-            log("error", `agent.answer failed: ${String(err)}`);
-            if (originals.length > 0) {
-                dispatchDoc(
-                    model.blockId,
-                    { type: "StreamFlush", newNodes: [], updatedNodes: originals },
-                    "user",
-                );
-            }
-        });
-    };
     const status = useAgentControllerStatus({
         blockId: model.blockId,
         provider,
@@ -719,6 +670,61 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         const wasAlreadyWorking = workingFromPhase(paneSnapshot(model.blockId)?.turnPhase ?? { kind: "Idle" });
         dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
         return commands.sendMessage(message, wasAlreadyWorking);
+    };
+
+    // AskUserQuestion answer handler. Defined after handleSendMessage because
+    // the non-persistent fallback below delegates to it.
+    const handleAnswer = (outcome: AnswerOutcome) => {
+        // Optimistic transition: flip the node out of awaiting_answer so the
+        // panel dismisses immediately. We snapshot the original node(s) so a
+        // failed delivery can roll the transition back.
+        const originals: import("./types").ToolNode[] = [];
+        const updated: import("./types").ToolNode[] = [];
+        for (const n of getDocument()) {
+            if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
+            if (n.question?.tool_use_id !== outcome.tool_use_id) continue;
+            originals.push(n);
+            updated.push({
+                ...n,
+                status: "success",
+                question: undefined,
+                summary: `❓ Answered — ${outcome.answer_text.replace(/\n/g, "; ")}`,
+            });
+        }
+        const applyDoc = (nodes: import("./types").ToolNode[]) => {
+            if (nodes.length > 0) {
+                dispatchDoc(model.blockId, { type: "StreamFlush", newNodes: [], updatedNodes: nodes }, "user");
+            }
+        };
+        applyDoc(updated);
+
+        // Phase 1 path: persistent (host) agents have a live stdin, so the
+        // answer is delivered as a tool_result that resumes the blocked turn.
+        void RpcApi.AgentAnswerCommand(TabRpcClient, {
+            blockid: model.blockId,
+            tool_use_id: outcome.tool_use_id,
+            answer_text: outcome.answer_text,
+        }).catch((err: unknown) => {
+            const msg = String(err);
+            // Phase 2 path: one-shot / container agents have no live stdin, and
+            // the CLI abandons the AskUserQuestion tool_use when the turn ends —
+            // a tool_result can no longer reach it (validated empirically:
+            // SPEC §10.1). Deliver the answer as a normal follow-up turn
+            // instead; the agent resumes the session and continues from the
+            // question with the answer as context. Keep the optimistic success.
+            if (msg.includes("UNSUPPORTED_CONTROLLER")) {
+                log("agent", "Delivering AskUserQuestion answer as a follow-up message (non-persistent agent)");
+                void handleSendMessage(outcome.answer_text).catch((e: unknown) => {
+                    log("error", `answer follow-up failed: ${String(e)}`);
+                    applyDoc(originals);
+                });
+                return;
+            }
+            // Any other failure: roll the node back so the panel re-surfaces
+            // rather than falsely showing "answered" while the agent is blocked.
+            log("error", `agent.answer failed: ${msg}`);
+            applyDoc(originals);
+        });
     };
 
     // ── Startup sequence ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Phase 2 of AskUserQuestion (`SPEC_ASK_USER_QUESTION_2026_06_15.md`): make the question panel functional for **one-shot / container** agents, not just persistent host agents.

## The finding that reshaped the approach

I empirically tested the originally-planned mechanism (resume the session with `--resume <sid>` and feed back a `tool_result`). It **does not work**:

```
one_shot_emits_askq   = True     # claude -p DOES emit the AskUserQuestion tool_use
one_shot_turn_ends    = True     # the turn then ends with a `result`
resume + tool_result  = no-op    # the model logs "the user sent an empty message" and just greets
```

When a one-shot turn ends, the CLI **abandons** the pending `AskUserQuestion` tool_use, so a later `tool_result` for it is dropped. There's no dangling tool_use to complete. (Recorded in SPEC §10.1.)

## What ships instead

Deliver the answer as a **normal follow-up user turn** over the existing `--resume` `agentinput` path. The agent resumes the session and continues from the question with the answer as context — the ordinary, working resume path; only the *tool_result block* is what the abandoned tool_use can't consume.

**Frontend-only** change: the panel first tries `agent.answer` (Phase 1 tool_result path, for persistent agents); on `UNSUPPORTED_CONTROLLER` it routes `answer_text` through the standard `handleSendMessage`. Optimistic success is kept; the panel no longer dead-ends on one-shot/container agents. Other failures still roll the node back.

## Notes

- Backend unchanged — the Phase 1 `UNSUPPORTED_CONTROLLER` response is the trigger.
- `handleAnswer` moved below `handleSendMessage` to avoid use-before-define.
- Semantic caveat (documented): for one-shot/container the answer is a *message*, not a protocol tool_result, so the tool_use stays unanswered in the transcript (harmless — the turn already ended). Persistent agents remain on the true tool_result path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)