### PR TITLE
fix(agent): answered AskUserQuestion no longer re-surfaces on reload (Phase 3)

### DIFF
--- a/.changesets/1781549878-fix-agent-askq-reload-dedup.md
+++ b/.changesets/1781549878-fix-agent-askq-reload-dedup.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): answered AskUserQuestion no longer re-surfaces its panel on history reload

--- a/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
@@ -385,10 +385,21 @@ update in 7.2 (and/or a matching `tool_result` echo if the provider emits one). 
   the true tool_result path (Phase 1).
 
 **Phase 3 — refinements.**
-- Structured (JSON) tool_result instead of the flat text block, if the model
-  benefits. Cross-provider parity (Gemini/Codex/Kimi translators emit the same
-  `tool_call` shape — most of Phase 1 is provider-agnostic once detection keys on
-  the tool name the provider uses). Persisted answer history in the transcript.
+- **Reload de-duplication — SHIPPED.** On history reload an *answered*
+  AskUserQuestion re-parsed as `awaiting_answer` and the panel re-surfaced for a
+  question already answered. Fixed in the agent-document orphan-scrub
+  (`scrubOrphanedInProgress`, runs on `SessionEnd` / `HistoryLoaded` /
+  `HistoryRestored`): an `awaiting_answer` tool node that has content *after* it
+  (the conversation continued → it was answered) is resolved to `success` with
+  `question` cleared, so the panel no longer re-opens. A **tail** awaiting_answer is
+  deliberately left untouched — a one-shot agent's turn ends (`SessionEnd`) with the
+  question as the tail and it is still answerable via a follow-up resume turn, so
+  scrubbing it would kill the panel before the user could answer.
+- **Deferred / not pursued:** structured (JSON) tool_result instead of flat text
+  (no evidence the model mis-parses the flat block — §10 validated it). Cross-provider
+  parity is moot: `AskUserQuestion` is Claude-specific; no other bundled provider
+  emits it (detection already keys on the tool name, so it's automatically a no-op
+  elsewhere).
 
 ---
 

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -816,6 +816,44 @@ describe("agent document reducer", () => {
             ]);
         });
 
+        // AskUserQuestion answered before reload (conversation continued past
+        // the question) — must resolve to `success` and clear `question` so the
+        // question panel does NOT re-surface. SPEC_ASK_USER_QUESTION §13/Phase 3.
+        it("resolves an answered AskUserQuestion (content after) to success", () => {
+            const q = tool("q1", {
+                status: "awaiting_answer",
+                question: { type: "ask_user_question", tool_use_id: "q1", questions: [] },
+                summary: "❓ Waiting for your answer",
+            });
+            const after = md("m1", "the agent continued after the answer");
+            const r = update(seed([q, after]), { type: "ScrubOrphanedInProgress", at: 1000 });
+            const scrubbed = r.state.nodes[0] as ToolNode;
+            expect(scrubbed.status).toBe("success");
+            expect(scrubbed.question).toBeUndefined();
+            expect(scrubbed.summary).toBe("❓ Question answered");
+            expect(r.events).toEqual([
+                { type: "orphans-scrubbed", markdownCanceled: 0, toolsCanceled: 1 },
+            ]);
+        });
+
+        // A TAIL AskUserQuestion is left alone — a one-shot agent's turn ends
+        // (SessionEnd) with the question as the tail, and it's still
+        // answerable via a follow-up resume turn. Scrubbing it would kill the
+        // panel before the user could answer.
+        it("leaves a tail-pending AskUserQuestion untouched", () => {
+            const q = tool("q1", {
+                status: "awaiting_answer",
+                question: { type: "ask_user_question", tool_use_id: "q1", questions: [] },
+                summary: "❓ Waiting for your answer",
+            });
+            const s0 = seed([md("m1"), q]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 1000 });
+            // No allocation, no events — nothing to scrub.
+            expect(r.state).toBe(s0);
+            expect((r.state.nodes[1] as ToolNode).status).toBe("awaiting_answer");
+            expect(r.events).toEqual([]);
+        });
+
         // Codex + reagent P2 on #1104: scrubbing must also close
         // the streaming log. Otherwise ToolBlock's live-tail branch
         // (gated on log.open) keeps rendering a canceled tool as

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -35,6 +35,14 @@ import {
  *     `thinking` off and set `canceled: true` (+ `canceledAt`).
  *   - Tool nodes with `status === "running"` → set
  *     `status: "canceled"`.
+ *   - Tool nodes with `status === "awaiting_answer"` (AskUserQuestion)
+ *     that have content AFTER them → the conversation continued past the
+ *     question, so it was answered → set `status: "success"` and clear
+ *     `question`, so the question panel does NOT re-surface on reload (the
+ *     bug this fixes — SPEC_ASK_USER_QUESTION_2026_06_15 §13/Phase 3). A
+ *     TAIL awaiting_answer is left alone (same last-node heuristic as
+ *     thinking): a one-shot agent that just asked has the question as the
+ *     tail when SessionEnd fires, and it's still answerable.
  *
  * `pending_approval` tools are left alone: they represent a user
  * decision still in flight, not an interrupted stream. The user
@@ -106,6 +114,24 @@ function scrubOrphanedInProgress(
             // spinner" goal. Codex + reagent P2 on PR #1104.
             const closedLog = n.log != null ? { ...n.log, open: false } : n.log;
             next[i] = { ...n, status: "canceled", log: closedLog };
+            toolsCanceled++;
+            continue;
+        }
+        // AskUserQuestion that has content AFTER it was answered (the
+        // conversation continued past the question) → resolve to success and
+        // clear `question` so the panel doesn't re-surface on reload. A TAIL
+        // awaiting_answer (i === lastIdx) is deliberately left alone: it may
+        // still be answerable — a one-shot agent that just asked (SessionEnd
+        // fires while the question is the tail) or a resumable reopened
+        // session. Using the same last-node heuristic as the thinking scrub.
+        if (n.type === "tool" && n.status === "awaiting_answer" && i !== lastIdx) {
+            if (!next) next = nodes.slice();
+            next[i] = {
+                ...n,
+                status: "success",
+                question: undefined,
+                summary: "❓ Question answered",
+            };
             toolsCanceled++;
             continue;
         }


### PR DESCRIPTION
## What

Phase 3 of AskUserQuestion: fix a real reload bug. On history reload, an **answered** `AskUserQuestion` re-parsed as `awaiting_answer` and the question panel **re-opened** for a question that was already answered (the stream transcript has the tool_use but no following tool_result, since the answer was delivered out-of-band via stdin or a follow-up turn).

## Fix

Extend the agent-document orphan-scrub (`scrubOrphanedInProgress`, which already runs on `SessionEnd` / `HistoryLoaded` / `HistoryRestored`):

- An `awaiting_answer` tool node **with content after it** → the conversation continued past the question, so it was answered → resolve to `success` and clear `question`. The panel no longer re-surfaces.
- A **tail** `awaiting_answer` is **left untouched** — deliberately. A one-shot agent's turn ends (`SessionEnd` fires) with the question as the tail node, and it's still answerable via a follow-up resume turn (Phase 2). Scrubbing it would kill the panel before the user could answer. This reuses the exact last-node heuristic the existing thinking-node scrub uses.

## Why this matters / the subtle part

The naive version (resolve all `awaiting_answer` on scrub) would have broken Phase 2: a one-shot agent legitimately has the question as the tail when `SessionEnd` fires, so it must survive the scrub. Only questions with *content after them* are provably answered.

## Tests

Two new reducer tests: answered (content after) → `success` + `question` cleared; tail-pending → untouched (no allocation, no events). `node_modules` isn't present in this checkout so I couldn't run vitest locally — the logic mirrors the adjacent running-tool / thinking-node scrub tests.

Spec §9 Phase 3 updated (also records why structured-JSON and cross-provider parity are not pursued — flat text is validated and `AskUserQuestion` is Claude-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)