### PR TITLE
diag(browser-pane): instrument the redock create path (black-page triage)

### DIFF
--- a/.changesets/1781544000-diag-browser-pane-redock-create.md
+++ b/.changesets/1781544000-diag-browser-pane-redock-create.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(browser-pane): log the create register-result (Fresh/Closing/AlreadyLive), requested window, and rect on the redock path — surfaces the previously-silent AlreadyLive race so the black-page-on-redock cause is conclusive in a repro

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -239,6 +239,29 @@ impl BrowserPaneManager {
         match result {
             RegisterResult::AlreadyLive(label) => {
                 // Existing Live entry — re-navigate the existing browser.
+                //
+                // DIAGNOSTIC (redock black-page triage —
+                // ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15.md §2):
+                // if a redock's create lands here while the old pane is still
+                // Live (the close IPC hasn't flipped it to Closing yet), we
+                // only re-navigate the EXISTING browser — which is still
+                // parented to the *old* (floater) window — and never create a
+                // pane in the requested `window_label`. The target window then
+                // shows black until the old pane closes. Logging requested
+                // window + rect makes this race visible in a repro; if a redock
+                // hits this arm, it is the smoking gun.
+                tracing::info!(
+                    block_id,
+                    label = %label,
+                    requested_window = %window_label,
+                    rect = ?(rect.x, rect.y, rect.width, rect.height),
+                    "browser pane create hit AlreadyLive — re-navigating existing browser (NOT creating in requested window)"
+                );
+                crate::browser_pane::trace::pane_trace(
+                    block_id,
+                    "create-already-live",
+                    &format!("label={label} requested_win={window_label} url={url}"),
+                );
                 if let Some(browser) = state.get_browser(&label) {
                     if let Some(frame) = browser.main_frame() {
                         frame.load_url(Some(&CefString::from(url)));
@@ -261,6 +284,8 @@ impl BrowserPaneManager {
                 // docs/analysis/ANALYSIS_BROWSER_PANE_REDOCK_LOAD_RACE_2026_05_29.md.
                 tracing::info!(
                     block_id,
+                    requested_window = %window_label,
+                    rect = ?(rect.x, rect.y, rect.width, rect.height),
                     "browser pane create deferred — block_id still Closing; reducer will replay on close-completion"
                 );
                 crate::browser_pane::trace::pane_trace(
@@ -274,7 +299,10 @@ impl BrowserPaneManager {
                 crate::browser_pane::trace::pane_trace(
                     block_id,
                     "create-request",
-                    &format!("url={url} label={label} win={window_label}"),
+                    &format!(
+                        "url={url} label={label} win={window_label} rect=({},{},{},{})",
+                        rect.x, rect.y, rect.width, rect.height
+                    ),
                 );
                 let mut task = CreateBrowserPaneTask::new(
                     state.clone(),


### PR DESCRIPTION
## Summary

Diagnostics-only instrumentation to pin down the **black-page-on-redock** symptom (Defect B in `docs/analysis/ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15.md`). The exact cause can't be reproduced headless, so this makes the next live repro conclusive instead of guessing — and it surfaces a previously-invisible race.

- **`AlreadyLive` arm was completely silent.** It's the prime suspect: if a redock's `browser_pane_create` races *ahead* of the `browser_pane_close` (old pane still `Live`), the host only re-navigates the existing browser — which is still parented to the dying floater window — and **never creates a pane in the requested window**, so the target shows black. Now logs `label` + `requested_window` + `rect` (both `tracing` and `pane_trace`).
- **`Closing` + `Fresh` arms** now also log `requested_window` + `rect`, so a zero/garbage-bounds pane (the other black-page suspect — an invisible HWND) is visible too.

No behavior change.

## How to use
Reproduce the redock → black pane, then check the host log for the `block_id`:
- A `create-already-live` / "hit AlreadyLive" line on redock → **confirmed cause** (create raced the close); fix = recreate-in-target on window-label mismatch.
- A zero/garbage `rect=(…)` → invisible-bounds cause.
- Only `create-deferred-closing` then a successful replay → load race already handled; black is elsewhere (stale GPU surface).

## Verification
- `cargo check -p agentmux-cef` — clean.

Refs #768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)