### PR TITLE
fix(host): eliminate ghost taskbar icon from pre-warmed pool window

### DIFF
--- a/.changesets/1781501000-fix-host-pool-window-ghost-taskbar-icon-hwnd-early-hide-k7m9.md
+++ b/.changesets/1781501000-fix-host-pool-window-ghost-taskbar-icon-hwnd-early-hide-k7m9.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+fix(host): eliminate ghost taskbar icon from pre-warmed pool window — apply WS_EX_TOOLWINDOW at on_window_created (reliable HWND) instead of on_after_created where BrowserHost::window_handle() can return null after page load

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -63,6 +63,24 @@ wrap_window_delegate! {
                 window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
             }
 
+            // Windows: hide pool windows from the taskbar at creation time.
+            // CefWindow::GetWindowHandle() is reliable here; BrowserHost::
+            // window_handle() (used in register_pool_window / on_after_created)
+            // can return null after the page loads — see window_pool.rs
+            // POOL_HWND_CACHE comment for the diagnosed CEF behaviour.
+            // This early call also pre-populates the HWND cache so
+            // promote_pool_window works even when on_after_created's
+            // BrowserHost lookup returns null.
+            #[cfg(target_os = "windows")]
+            if let Some((_, label)) = self.window_registration.as_ref() {
+                if label.starts_with("window-pool-") {
+                    let raw_hwnd = window.window_handle() as *mut std::ffi::c_void;
+                    if !raw_hwnd.is_null() {
+                        crate::commands::window_pool::init_pool_window_hwnd(label, raw_hwnd);
+                    }
+                }
+            }
+
             // Linux/macOS only — register this Window in state.windows
             // keyed by label, so the browser-pane Views path can attach
             // pane overlays to the right window. Popup delegates pass

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -256,6 +256,29 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
     // alive.
 }
 
+/// Called from `AgentMuxWindowDelegate::on_window_created` for pool windows
+/// (Windows only). Applies `WS_EX_TOOLWINDOW` and caches the HWND at the
+/// earliest reliable point — the CEF `CefWindow::GetWindowHandle()` is
+/// non-null here, whereas `BrowserHost::window_handle()` may return null
+/// by the time `on_after_created` fires (post-page-load CEF behaviour,
+/// diagnosed 2026-05-06; see `POOL_HWND_CACHE` doc above).
+///
+/// `register_pool_window` still runs later as belt-and-suspenders, but the
+/// taskbar hide and HWND cache are already correct by then.
+#[cfg(target_os = "windows")]
+pub fn init_pool_window_hwnd(label: &str, raw_hwnd: *mut std::ffi::c_void) {
+    pool_hwnd_cache()
+        .lock()
+        .unwrap()
+        .insert(label.to_string(), raw_hwnd as usize);
+    set_taskbar_hidden(raw_hwnd, true);
+    tracing::debug!(
+        target: "dnd:tearoff:pool",
+        label = %label,
+        "[pool] HWND cached + taskbar hidden at on_window_created (early path)"
+    );
+}
+
 /// Called from on_after_created when a pool window's browser is
 /// registered. Logs + applies WS_EX_TOOLWINDOW so the off-screen
 /// pool window doesn't show up in the taskbar / Alt+Tab. The


### PR DESCRIPTION
## Root Cause

With 2 instances open, 3 taskbar icons appeared. The third was a **pre-warmed pool window** (tear-off pool, `POOL_TARGET_SIZE=2`) positioned off-screen at `-32000,-32000` that never got `WS_EX_TOOLWINDOW` applied.

**Failure chain:**

1. `spawn_pool_window` creates a pool window via `post_create_window` → `window_create_top_level`
2. `on_after_created` fires → `register_pool_window` calls `BrowserHost::window_handle()` to get the HWND
3. `BrowserHost::window_handle()` returns **null** after the page loads — this is a documented CEF behaviour, diagnosed in the 2026-05-06 run and covered by the `POOL_HWND_CACHE` comment in `window_pool.rs`
4. `set_taskbar_hidden` is skipped (line 304-310) with the warning: `"HWND null at register time — taskbar hide skipped"`
5. Pool window has no `WS_EX_TOOLWINDOW` → Windows shows a taskbar button for the off-screen blank window

## Fix

Add `init_pool_window_hwnd()` to `window_pool.rs`, called from `AgentMuxWindowDelegate::on_window_created` in `app.rs`.

`CefWindow::GetWindowHandle()` (available in `on_window_created`) is reliably non-null — it's the same underlying Win32 HWND but accessed through the CEF Views Window object rather than `BrowserHost`. This fires **before** the page loads, so before the CEF bug that nullifies `BrowserHost::window_handle()`.

As a bonus, `init_pool_window_hwnd` also **pre-populates the HWND cache** — meaning `promote_pool_window` now has a guaranteed cache hit even on instances where `register_pool_window` encountered a null HWND.

`register_pool_window` (the `on_after_created` path) remains untouched and continues as belt-and-suspenders; its `set_taskbar_hidden` call is now a no-op because the style was already applied.

## Changes

- `agentmux-cef/src/commands/window_pool.rs` — new `pub fn init_pool_window_hwnd`  
- `agentmux-cef/src/app.rs` — call it in `on_window_created` for `window-pool-*` labels on Windows

## Test plan

- [ ] Open 2 instances — confirm exactly 2 taskbar icons, no ghost third icon
- [ ] Check `muxlog host '[pool]'` — should see `"HWND cached + taskbar hidden at on_window_created"` at startup, NOT the `"HWND null at register time"` warning
- [ ] Tear off a tab → confirm the promoted window appears in the taskbar normally (`set_taskbar_hidden(false)` still runs in `promote_pool_window`)
- [ ] Pool refills after promotion — confirm the refill pool window is also hidden from taskbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)