### PR TITLE
feat(agent): answer AskUserQuestion via the Agent SDK control protocol

### DIFF
--- a/.changesets/1781563278-fix-agent-run-claude-on-persistent-controller-so-askuserques-cd4x.md
+++ b/.changesets/1781563278-fix-agent-run-claude-on-persistent-controller-so-askuserques-cd4x.md
@@ -1,5 +1,12 @@
 ---
-type: patch
+type: minor
 ---
 
-fix(agent): run Claude on persistent controller so AskUserQuestion works
+feat(agent): answer AskUserQuestion via the Agent SDK control protocol
+
+Claude now runs on the persistent controller with `--permission-prompt-tool stdio`
+and the sidecar answers the CLI's `can_use_tool` control_request with a
+control_response (`updatedInput.answers`). This is the only mechanism the CLI
+accepts for AskUserQuestion — delivering a tool_result on stdin does not work
+(the CLI auto-rejects it within the turn). Ordinary tools are auto-allowed to
+preserve current behavior. Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.

--- a/.changesets/1781563278-fix-agent-run-claude-on-persistent-controller-so-askuserques-cd4x.md
+++ b/.changesets/1781563278-fix-agent-run-claude-on-persistent-controller-so-askuserques-cd4x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): run Claude on persistent controller so AskUserQuestion works

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -63,6 +63,12 @@ struct PersistentInner {
     stdin_tx: Option<mpsc::Sender<String>>,
     /// Handle to kill the process.
     kill_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+    /// AskUserQuestion `can_use_tool` control_requests awaiting a user answer:
+    /// `tool_use_id -> (request_id, questions JSON)`. Filled by the stdout
+    /// reader when the CLI sends a `can_use_tool` control_request for
+    /// AskUserQuestion; consumed by `answer_question` to build the matching
+    /// `control_response`. Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    pending_questions: HashMap<String, (String, serde_json::Value)>,
 }
 
 /// PersistentSubprocessController keeps a long-running CLI process alive,
@@ -104,6 +110,7 @@ impl PersistentSubprocessController {
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
+                pending_questions: HashMap::new(),
             })),
             broker,
             event_bus,
@@ -167,28 +174,124 @@ impl PersistentSubprocessController {
             .map_err(|e| format!("stdin send failed: {e}"))
     }
 
-    /// Deliver an AskUserQuestion answer to the running CLI as a `tool_result`
-    /// on the live stdin, unblocking the agent's turn. Mirrors `send_message`
-    /// but emits a user turn whose content is a single `tool_result` block
-    /// keyed on the original `AskUserQuestion` tool_use id. The process must
-    /// already be running (the agent is mid-turn, blocked on this answer) — we
-    /// never spawn here. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
-    pub fn send_tool_result(&self, tool_use_id: String, content: String) -> Result<(), String> {
-        let json_msg = serde_json::json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [
-                    { "type": "tool_result", "tool_use_id": tool_use_id, "content": content }
-                ]
+    /// Answer a parked AskUserQuestion via the Agent SDK **control protocol**.
+    ///
+    /// The CLI asked us with a `can_use_tool` control_request (parked in
+    /// `pending_questions` by the stdout reader); we reply with a
+    /// `control_response` carrying `updatedInput.answers`. This is the ONLY
+    /// mechanism the CLI accepts — delivering a `tool_result` on stdin does NOT
+    /// work (the CLI auto-rejects AskUserQuestion within the turn). `answers` is
+    /// the JSON object mapping each question's text to the selected label(s) or
+    /// free-text. Process must already be running (agent is mid-turn, blocked on
+    /// this answer). Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md §2.3.
+    pub fn answer_question(&self, tool_use_id: String, answers: serde_json::Value) -> Result<(), String> {
+        let (request_id, questions, tx) = {
+            let mut inner = self.inner.lock().unwrap();
+            let (rid, qs) = inner
+                .pending_questions
+                .remove(&tool_use_id)
+                .ok_or_else(|| format!("no pending AskUserQuestion for tool_use_id {tool_use_id}"))?;
+            let tx = inner
+                .stdin_tx
+                .as_ref()
+                .ok_or("persistent process not running (cannot deliver answer)")?
+                .clone();
+            (rid, qs, tx)
+        };
+
+        let control_response = serde_json::json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": {
+                    "behavior": "allow",
+                    "updatedInput": { "questions": questions, "answers": answers },
+                    "toolUseID": tool_use_id,
+                }
             }
         });
+        tx.try_send(control_response.to_string())
+            .map_err(|e| format!("control_response send failed: {e}"))
+    }
 
-        let inner = self.inner.lock().unwrap();
-        let tx = inner.stdin_tx.as_ref()
-            .ok_or("persistent process not running (cannot deliver answer)")?;
-        tx.try_send(json_msg.to_string())
-            .map_err(|e| format!("stdin send failed: {e}"))
+    /// Push a raw NDJSON line to the live stdin (used to emit control_responses
+    /// from the stdout-reader task, which only holds an `Arc<Mutex<Inner>>`).
+    fn push_stdin(inner: &Arc<Mutex<PersistentInner>>, line: String) {
+        let guard = inner.lock().unwrap();
+        if let Some(tx) = guard.stdin_tx.as_ref() {
+            let _ = tx.try_send(line);
+        }
+    }
+
+    /// Handle a control-protocol frame from the CLI's stdout. `control_request`
+    /// of subtype `can_use_tool`: AskUserQuestion is **parked** (the frontend
+    /// panel — rendered from the assistant stream — answers it via
+    /// `answer_question`); every other tool is **auto-allowed** to preserve the
+    /// current bypass/yolo UX (Phase 1; Phase 2 routes these to the decision
+    /// prompt, #551). `control_response` frames (replies to requests we initiate,
+    /// none today) are logged and dropped. These frames are NOT conversation
+    /// output and never reach the blockfile.
+    /// Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md §4.2.
+    fn handle_control_frame(
+        kind: &str,
+        parsed: &serde_json::Value,
+        block_id: &str,
+        inner: &Arc<Mutex<PersistentInner>>,
+    ) {
+        if kind == "control_response" {
+            return;
+        }
+        // control_request
+        let req = match parsed.get("request") {
+            Some(r) => r,
+            None => return,
+        };
+        let subtype = req.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+        let request_id = parsed
+            .get("request_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if subtype != "can_use_tool" {
+            tracing::info!(block_id = %block_id, subtype = %subtype, "persistent control_request: unhandled subtype, ignoring");
+            return;
+        }
+
+        let tool_name = req.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+        let tool_use_id = req
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let input = req.get("input").cloned().unwrap_or_else(|| serde_json::json!({}));
+
+        if tool_name == "AskUserQuestion" {
+            // Park; the frontend question panel will answer via answer_question().
+            let questions = input
+                .get("questions")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!([]));
+            {
+                let mut guard = inner.lock().unwrap();
+                guard
+                    .pending_questions
+                    .insert(tool_use_id.clone(), (request_id, questions));
+            }
+            tracing::info!(block_id = %block_id, tool_use_id = %tool_use_id, "AskUserQuestion parked; awaiting user answer");
+        } else {
+            // Auto-allow every other tool (preserve today's bypass UX).
+            let resp = serde_json::json!({
+                "type": "control_response",
+                "response": {
+                    "subtype": "success",
+                    "request_id": request_id,
+                    "response": { "behavior": "allow", "updatedInput": input }
+                }
+            });
+            Self::push_stdin(inner, resp.to_string());
+        }
     }
 
     /// Spawn the persistent CLI process.
@@ -388,6 +491,16 @@ impl PersistentSubprocessController {
 
                 // Parse JSON for health monitoring and session ID capture
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&line) {
+                    // Control-protocol frames (can_use_tool / AskUserQuestion) are
+                    // NOT conversation output — handle them and skip the blockfile
+                    // so the frontend stream never sees them.
+                    // Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+                    if let Some(kind) = parsed.get("type").and_then(|v| v.as_str()) {
+                        if kind == "control_request" || kind == "control_response" {
+                            Self::handle_control_frame(kind, &parsed, &block_id_read, &inner_read);
+                            continue;
+                        }
+                    }
                     let (meaningful, _error) = classify_output_line(&parsed);
                     health_read.record_output(meaningful);
                     if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -99,17 +99,19 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     id: "claude",
     display_name: "Claude Code",
     cli_command: "claude",
-    // Persistent (bidirectional stream-json) so the agent's turn can BLOCK on a
-    // tool_use and consume a tool_result over live stdin — required for the
-    // AskUserQuestion flow (SPEC_ASK_USER_QUESTION_2026_06_15.md). In `-p`
-    // subprocess mode the CLI auto-rejects AskUserQuestion with
-    // `Error: Answer questions?` ~7ms after emitting it (no interactive stdin to
-    // answer on), so the question panel never renders.
+    // Persistent (bidirectional stream-json) + the Agent SDK CONTROL PROTOCOL is
+    // the only way AskUserQuestion (and interactive tool-permission) works headless.
+    // The CLI auto-rejects AskUserQuestion with `Error: Answer questions?` in any
+    // mode UNLESS the driver speaks the control protocol: launch with
+    // `--permission-prompt-tool stdio` (+ a non-bypass `--permission-mode`), then
+    // answer the CLI's `can_use_tool` control_request with a control_response
+    // carrying `updatedInput.answers`. See SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md
+    // (§2 captured the exact wire bytes against bundled CLI v2.1.178).
     //
-    // #406 originally switched this to Subprocess to dodge a Windows
-    // anonymous-pipe "no response" hang in the then-Node.js CLI. The CLI is now a
-    // native binary (v2.1.x), so that root cause is gone; the spec's §10 smoke
-    // test confirmed persistent streams correctly against the native CLI.
+    // CRITICAL: `--dangerously-skip-permissions` DISABLES that routing (it bypasses
+    // canUseTool), so it must NOT be in persistent_launch_args. The persistent
+    // controller's ControlChannel auto-allows ordinary tools to preserve today's
+    // yolo UX; only AskUserQuestion is surfaced to the user.
     controller_type: ControllerType::Persistent,
     launch_args: &[
         "-p",
@@ -126,7 +128,12 @@ static CLAUDE: ProviderConfig = ProviderConfig {
         "stream-json",
         "--verbose",
         "--include-partial-messages",
-        "--dangerously-skip-permissions",
+        // Enable the control protocol so the sidecar can answer can_use_tool /
+        // AskUserQuestion. Replaces --dangerously-skip-permissions (which bypasses it).
+        "--permission-prompt-tool",
+        "stdio",
+        "--permission-mode",
+        "default",
     ]),
     resume_flag: Some("--resume"),
     session_id_field: "session_id",

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -99,7 +99,18 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     id: "claude",
     display_name: "Claude Code",
     cli_command: "claude",
-    controller_type: ControllerType::Subprocess,
+    // Persistent (bidirectional stream-json) so the agent's turn can BLOCK on a
+    // tool_use and consume a tool_result over live stdin — required for the
+    // AskUserQuestion flow (SPEC_ASK_USER_QUESTION_2026_06_15.md). In `-p`
+    // subprocess mode the CLI auto-rejects AskUserQuestion with
+    // `Error: Answer questions?` ~7ms after emitting it (no interactive stdin to
+    // answer on), so the question panel never renders.
+    //
+    // #406 originally switched this to Subprocess to dodge a Windows
+    // anonymous-pipe "no response" hang in the then-Node.js CLI. The CLI is now a
+    // native binary (v2.1.x), so that root cause is gone; the spec's §10 smoke
+    // test confirmed persistent streams correctly against the native CLI.
+    controller_type: ControllerType::Persistent,
     launch_args: &[
         "-p",
         "--output-format",
@@ -477,10 +488,14 @@ mod tests {
     }
 
     #[test]
-    fn claude_subprocess_with_persistent_args_present() {
+    fn claude_persistent_with_persistent_args_present() {
         let p = get_provider("claude").unwrap();
+        // Claude runs on the persistent controller so AskUserQuestion can block
+        // on a tool_use and consume a tool_result over live stdin (see the
+        // controller_type comment on `static CLAUDE`).
         assert!(p.persistent_launch_args.is_some());
-        assert_eq!(p.controller_type, ControllerType::Subprocess);
+        assert_eq!(p.controller_type, ControllerType::Persistent);
+        assert_eq!(p.controller_type_str(), "persistent");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -610,16 +610,20 @@ pub struct CommandToolDecisionData {
 }
 
 /// Data for AgentAnswerCommand — an AskUserQuestion answer delivered back to
-/// the running agent CLI as a `tool_result` over the persistent controller's
-/// live stdin. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+/// the running agent CLI via the Agent SDK control protocol (a `control_response`
+/// carrying `updatedInput.answers`). Spec:
+/// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommandAgentAnswerData {
     pub blockid: String,
-    /// The `AskUserQuestion` tool_use id the answer responds to.
+    /// The `AskUserQuestion` tool_use id the answer responds to (correlates with
+    /// the parked `can_use_tool` control_request).
     pub tool_use_id: String,
-    /// Canonical flat-text rendering of the user's selections; becomes the
-    /// tool_result content the model consumes.
-    pub answer_text: String,
+    /// The user's selections as a JSON object mapping each question's text to the
+    /// chosen option label (a `[labels]` array for multiSelect, or free-text for
+    /// "Other"). Becomes `updatedInput.answers` in the control_response.
+    #[serde(default)]
+    pub answers: serde_json::Value,
 }
 
 // ---- Subprocess agent command data types ----

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -775,13 +775,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
         }),
     );
 
-    // agent.answer → deliver an AskUserQuestion answer to the running agent
-    // CLI as a `tool_result` over the persistent controller's live stdin,
-    // unblocking the agent's turn. Unlike tooldecision (no-op delivery), this
-    // path is real: the persistent controller (host agents, --input-format
-    // stream-json) keeps stdin open for the session. Container / one-shot
-    // subprocess agents have no live stdin — they return UNSUPPORTED_CONTROLLER
-    // (Phase 2). Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    // agent.answer → deliver an AskUserQuestion answer to the running agent CLI
+    // via the Agent SDK **control protocol**: the persistent controller replies
+    // to the CLI's parked `can_use_tool` control_request with a control_response
+    // carrying `updatedInput.answers`. (Delivering a `tool_result` on stdin does
+    // NOT work — the CLI auto-rejects AskUserQuestion within the turn; see spec
+    // §2/§3.) Only the persistent controller speaks the control protocol;
+    // container/one-shot subprocess agents return UNSUPPORTED_CONTROLLER (Phase 2).
+    // Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
     engine.register_handler(
         COMMAND_AGENT_ANSWER,
         Box::new(|data, _ctx| {
@@ -797,11 +798,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     .as_any()
                     .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
                 {
-                    persistent_ctrl.send_tool_result(cmd.tool_use_id.clone(), cmd.answer_text)?;
+                    persistent_ctrl.answer_question(cmd.tool_use_id.clone(), cmd.answers)?;
                     tracing::info!(
                         block_id = %cmd.blockid,
                         tool_use_id = %cmd.tool_use_id,
-                        "[agent.answer] tool_result delivered to persistent stdin"
+                        "[agent.answer] control_response delivered to persistent stdin"
                     );
                     Ok(None)
                 } else {

--- a/docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md
+++ b/docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md
@@ -1,0 +1,162 @@
+# SPEC: Agent Control Protocol — fix AskUserQuestion (+ unblock tool-permission UI) and align muxbus delivery
+
+**Date:** 2026-06-15
+**Status:** Draft — evidence captured, ready to implement
+**Owner:** agent pane / sidecar (persistent controller)
+**Supersedes the delivery design in:** `SPEC_ASK_USER_QUESTION_2026_06_15.md` (its §2/§7 premise — "deliver a `tool_result` on stdin to answer AskUserQuestion" — is empirically **disproven**; see §2 below).
+**Related/unblocked:** `SPEC_DECISION_PROMPT_2026_04_24.md` (#551 tool-permission UI), `SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md` (Tier-1 injection coupling, §6).
+
+---
+
+## 1. Summary
+
+The built-in **`AskUserQuestion`** tool never works in an AgentMux Claude pane: the CLI emits the tool_use and then **auto-rejects it with `Error: Answer questions?`** ~3–7 ms later, regardless of controller (subprocess `-p` *or* persistent `--input-format stream-json`) and regardless of model. No question panel ever renders.
+
+**Root cause (proven, §2):** in any headless/stream-json mode the CLI has no interactive surface for AskUserQuestion. The *only* supported way to answer it is the **Claude Agent SDK control protocol**: the driver launches the CLI with `--permission-prompt-tool stdio`, and answers a `can_use_tool` **`control_request`** with a `control_response` carrying `updatedInput.answers`. AgentMux never speaks this protocol — it pipes user messages and reads assistant messages, nothing more. Worse, it launches Claude with **`--dangerously-skip-permissions`, which disables the very routing AskUserQuestion needs.**
+
+This spec replaces the (wrong) tool_result-on-stdin delivery with a real **control-protocol client** in the persistent controller. The same channel also carries **tool-permission** `can_use_tool` requests — so implementing it once unblocks both AskUserQuestion **and** the per-tool decision prompt (#551). Finally, persistent stream-json Claude has **no PTY**, so muxbus Tier-1 injection (currently raw PTY writes) must become controller-aware (§6).
+
+---
+
+## 2. Evidence (captured 2026-06-15, bundled CLI v2.1.178)
+
+All four findings below are from direct measurement, not docs.
+
+### 2.1 The bug reproduces in BOTH controllers, BOTH models
+
+- Real subprocess agent (block `27b6f287`, opus): tool_use `22:17:52.361` → `tool_result {"content":"Answer questions?","is_error":true}` `22:17:52.368` (**+7 ms**), turn continued.
+- Real persistent agent "Makp" (block `55a0265a`, opus, launched with `--input-format stream-json`): tool_use `22:57:59.764` → auto-error `22:57:59.767` (**+3 ms**). Persistent made **no** difference.
+- Clean standalone harness (no AgentMux), bundled CLI, persistent args, **sonnet AND opus**: `emitted=True, auto_error=True, turn_ended=True` both times.
+
+→ The controller flip (PR #1451) is necessary-but-insufficient; the spec's §10 "validation passed" does **not** reproduce.
+
+### 2.2 The control protocol DOES make it work
+
+Driving the **bundled** CLI v2.1.178 through the official `@anthropic-ai/claude-agent-sdk` with a `canUseTool` callback (executable pointed at the bundled binary via a tee-proxy):
+
+```
+ANSWERED_VIA_canUseTool = true | AUTO_ERROR_SEEN = false
+RESULT: "You picked Red! 🔴"
+```
+
+The model consumed the answer we returned. No "Answer questions?".
+
+### 2.3 Exact wire protocol (captured bytes, request_ids preserved)
+
+1. **Driver → CLI — initialize** (first stdin control message):
+   ```json
+   {"type":"control_request","request_id":"n5eu8utar8","request":{"subtype":"initialize","systemPrompt":[""]}}
+   ```
+2. **CLI → driver — initialize response** (echoes `request_id`, returns slash-commands etc.):
+   ```json
+   {"type":"control_response","response":{"subtype":"success","request_id":"n5eu8utar8","response":{"commands":[…]}}}
+   ```
+3. **CLI → driver — can_use_tool** (when AskUserQuestion fires):
+   ```json
+   {"type":"control_request","request_id":"04d963d9-…","request":{
+     "subtype":"can_use_tool","tool_name":"AskUserQuestion","display_name":"AskUserQuestion",
+     "input":{"questions":[{"question":"…","header":"…","options":[…],"multiSelect":false}]},
+     "tool_use_id":"toolu_01Lx…"}}
+   ```
+4. **Driver → CLI — control_response with the answer** (echoes `request_id`):
+   ```json
+   {"type":"control_response","response":{"subtype":"success","request_id":"04d963d9-…","response":{
+     "behavior":"allow",
+     "updatedInput":{"questions":[…original…],"answers":{"<question text>":"<label|[labels]|freetext>"}},
+     "toolUseID":"toolu_01Lx…"}}}
+   ```
+
+Correlation key is `request_id` (CLI→driver requests use a UUID; driver→CLI requests use a short token). For permission gating of an ordinary tool, the same `can_use_tool` request arrives with that tool's name; the response is `{"behavior":"allow","updatedInput":…}` or `{"behavior":"deny","message":…}`.
+
+### 2.4 The launch-flag diff (the load-bearing change)
+
+| Purpose | SDK (works) | AgentMux persistent today (broken) |
+|---|---|---|
+| streaming I/O | `--input-format stream-json --output-format stream-json --verbose` | same ✓ |
+| **enable control protocol** | **`--permission-prompt-tool stdio`** | **absent** ✗ |
+| **permission mode** | **`--permission-mode default`** | **`--dangerously-skip-permissions`** (bypasses the routing) ✗ |
+| partial streaming | (absent) | `--include-partial-messages` (orthogonal, keep) |
+
+**`--dangerously-skip-permissions` must be removed for Claude** and replaced with `--permission-prompt-tool stdio --permission-mode <mode>`. Consequence: AgentMux now **owns every permission decision** over the control channel — it must answer `can_use_tool` for *all* non-auto-allowed tools, not just AskUserQuestion (see §4.3, §5 Phase 1 "auto-allow" handler to preserve today's yolo UX).
+
+---
+
+## 3. Why the previous design can't work
+
+`SPEC_ASK_USER_QUESTION` assumed: emit tool_use → turn **blocks** → driver sends a `tool_result` on stdin → turn resumes. But the CLI **resolves the tool_use itself** (auto-error) within the same turn — it never blocks on a tool_result. The answer is delivered as a **`control_response` to a `can_use_tool` control_request**, carrying `updatedInput.answers` — a *different channel and shape*. So the `agent.answer` → `send_tool_result` backend (#1441) targets a channel the CLI is not listening on. **Reusable** from #1441: the frontend `AgentQuestionPanel`, the queue/`pendingQuestions()` UI. **Must replace:** the detection source (control_request, not a stream tool_call) and the delivery (control_response, not tool_result), and the answer encoding (`answers` map, not `"Header: label"` text).
+
+---
+
+## 4. Architecture
+
+### 4.1 Control-channel demultiplexer (persistent controller)
+
+The persistent CLI's stdout NDJSON now carries two interleaved classes:
+- **conversation** — `system|stream_event|assistant|user|result` (today's path → blockfile/frontend, unchanged),
+- **control** — `control_request` (CLI asks us) and `control_response` (CLI answers our `initialize`).
+
+Add a demux in the stdout reader (`persistent.rs`): lines with `type ∈ {control_request, control_response}` are routed to a new `ControlChannel`; everything else flows as today.
+
+### 4.2 ControlChannel responsibilities
+
+1. On spawn, **send `initialize`** (generate a short `request_id`, keep a pending map) and await its `control_response`.
+2. For each inbound `control_request`:
+   - `subtype == "can_use_tool"`, `tool_name == "AskUserQuestion"` → surface to the frontend (questions), **await the user's answer**, reply `control_response{behavior:"allow", updatedInput:{questions, answers}, toolUseID}`.
+   - `subtype == "can_use_tool"`, any other tool → **auto-allow** (`behavior:"allow", updatedInput:input`) in Phase 1 to preserve today's bypass UX; in Phase 2 route to the decision prompt (#551).
+   - other subtypes (`set_permission_mode`, hook callbacks, `control_cancel_request`) → Phase 1: log + safe default (allow / ack); Phase 2: handle.
+3. Correlate by `request_id`; tolerate out-of-order; never block the conversation reader (answers arrive asynchronously from the UI).
+
+### 4.3 Answer delivery (replaces `send_tool_result`)
+
+New controller method `respond_control(request_id, response_json)` writes a `control_response` line to the live stdin (same writer task as `send_message`). The frontend `agent.answer` RPC now lands here instead of `send_tool_result`. Encode the answer as `updatedInput.answers` (question text → label / `[labels]` for multiSelect / free-text for "Other"); pass through the original `questions`; include `toolUseID`.
+
+### 4.4 Frontend
+
+- Detection moves from `stream-parser.ts` (a stream tool_call) to a **control event** the sidecar forwards (e.g. a new `agent:question` blockfile/event carrying `{tool_use_id, request_id, questions}`). The `AgentQuestionPanel` + `pendingQuestions()` queue are reused.
+- `handleAnswer` builds the `answers` map and calls the (rewired) `agent.answer` RPC with `{blockid, request_id, tool_use_id, answers}`.
+- The optimistic dismiss stays; final state lands when the turn resumes.
+
+---
+
+## 5. Phased implementation
+
+### Phase 1 — AskUserQuestion via control protocol (Claude persistent) ← THIS CHANGE
+1. `providers.rs` (+ frontend `providers/index.ts`): Claude `persistent_launch_args` → replace `--dangerously-skip-permissions` with `--permission-prompt-tool stdio --permission-mode default`. Keep `--include-partial-messages`. (Controller already `Persistent` from #1451.)
+2. `persistent.rs`: control demux in the stdout reader; `ControlChannel` (initialize handshake, pending-request map); `respond_control()` on the stdin writer.
+3. `persistent.rs` control handler: auto-allow non-AskUserQuestion `can_use_tool`; for AskUserQuestion emit an `agent:question` event + await answer.
+4. `websocket.rs`: rewire `COMMAND_AGENT_ANSWER` → `respond_control()` (control_response), drop the `send_tool_result` path. `rpc_types.rs`: answer payload becomes `{blockid, request_id, tool_use_id, answers}`.
+5. Frontend: consume the `agent:question` event; reuse `AgentQuestionPanel`; build `answers`; call rewired `agent.answer`.
+6. Remove/▢ the now-dead `send_tool_result` + stream-parser AskUserQuestion special-case (or keep parser detection only as a fallback "blocked" indicator).
+
+**Phase 1 exit criteria (must verify in a real pane):** create a Claude agent, trigger AskUserQuestion, panel renders, answer it, the model continues with the chosen answer; ordinary tools (Bash/Edit) still run without per-call prompts (auto-allow).
+
+### Phase 2 — tool-permission decision prompt (#551) [follow-up]
+Route non-auto-allowed `can_use_tool` to `AgentDecisionPanel` instead of auto-allow; persist allow-rules; honor `--permission-mode` from settings. The control channel built in Phase 1 is the missing transport `SPEC_DECISION_PROMPT §1` flagged.
+
+### Phase 3 — muxbus Tier-1 controller-aware injection (§6) [follow-up]
+Make `ReactiveHandler` delivery controller-aware so messages reach persistent stream-json agents.
+
+### One-shot/container agents
+No live control channel → AskUserQuestion stays unanswerable there; use the SDK's **`defer`** semantics (process exits, resumes from persisted session) or fall back to "ask as a normal follow-up message." Out of scope for Phase 1 (persistent/host agents only).
+
+---
+
+## 6. muxbus coupling (why this spec touches delivery)
+
+muxbus Tier-1 (`ReactiveHandler::inject_message`) delivers by **PTY keystrokes** (`message\r` + 3 delayed `\r`) and is explicitly "terminal" injection; it does **not** branch on controller type. A persistent stream-json Claude has **no PTY** — its inbox is `persistent.rs::send_message` (a `{type:"user",…}` NDJSON line). So once Claude is persistent (Phase 1), **PTY injection silently fails to reach it.** Fix: a controller-aware "deliver to running agent" primitive — `send_message` (stream-json) for persistent agents, PTY write for shell/term agents — that muxbus Tier-1 calls. This is the *only* genuine overlap with the Agent SDK: the SDK is the local-injection arm for stream-json agents, **not** a replacement for muxbus's routing/addressing/relay (which the SDK has no concept of). Tracked as Phase 3.
+
+---
+
+## 7. Risks / open questions
+
+- **Permission chatter:** `--permission-mode default` may route many tools through `can_use_tool`. Mitigation: auto-allow in the handler (Phase 1); consider `--permission-mode acceptEdits` or allow-rules to cut volume. **Verify** which mode still routes AskUserQuestion through the control channel (bypass/skip modes do **not** — that's the current bug).
+- **initialize necessity:** the load-bearing flag is `--permission-prompt-tool stdio`; `initialize` may be optional for `can_use_tool`. Send it to match the SDK; confirm during impl whether it's required.
+- **`--include-partial-messages` interaction** with the control protocol (SDK omits it) — keep but verify no interference.
+- **Hooks/`set_permission_mode`/`control_cancel_request`** subtypes — Phase 1 logs + safe-defaults; enumerate fully in Phase 2.
+- **Frontend reload/dedup** of an answered question (the `scrubOrphanedInProgress` logic from #1445) must move to the control-event model.
+
+---
+
+## 8. Validation assets
+
+Reproduction harness lives at `/tmp/askq-evidence/` (this machine): `driver.mjs` (SDK + canUseTool), `claude-proxy.js` (tee-proxy), captured `wire-in.ndjson` / `wire-out.ndjson` / `argv.log`. Re-run to re-confirm the wire shapes on CLI upgrades.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -699,12 +699,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         };
         applyDoc(updated);
 
-        // Phase 1 path: persistent (host) agents have a live stdin, so the
-        // answer is delivered as a tool_result that resumes the blocked turn.
+        // Phase 1 path: persistent (host) agents speak the control protocol, so
+        // the answer is delivered as a control_response (updatedInput.answers)
+        // that resumes the turn the CLI parked on the can_use_tool request.
         void RpcApi.AgentAnswerCommand(TabRpcClient, {
             blockid: model.blockId,
             tool_use_id: outcome.tool_use_id,
-            answer_text: outcome.answer_text,
+            answers: outcome.answers_map,
         }).catch((err: unknown) => {
             const msg = String(err);
             // Phase 2 path: one-shot / container agents have no live stdin, and

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -19,8 +19,13 @@ import "./AgentQuestionPanel.scss";
 export interface AnswerOutcome {
     tool_use_id: string;
     answers: AskUserQuestionAnswer[];
-    /** Canonical flat-text rendering handed to the agent as the tool_result
-     *  content. Format (per question): "<header>: <labels>[, Other: <text>]". */
+    /** Control-protocol `updatedInput.answers`: each question's TEXT → the
+     *  chosen label (string), a label array (multiSelect), or free-text ("Other").
+     *  This is what the agent CLI consumes via the control_response. Spec:
+     *  SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md §2.3. */
+    answers_map: Record<string, string | string[]>;
+    /** Flat-text rendering kept for the optimistic node summary + the one-shot/
+     *  container follow-up fallback (which has no control channel). */
     answer_text: string;
 }
 
@@ -118,7 +123,17 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                 return `${a.header}: ${parts.join(", ")}`;
             })
             .join("\n");
-        return { tool_use_id: r.tool_use_id, answers, answer_text };
+        // Control-protocol answers map, keyed by each question's TEXT (not header).
+        // Free-text "Other" wins; multiSelect → label array; else single label.
+        const answers_map: Record<string, string | string[]> = {};
+        r.questions.forEach((q, i) => {
+            const s = state()[i] ?? { selected: [], other: "" };
+            const other = s.other.trim();
+            if (other) answers_map[q.question] = other;
+            else if (q.multiSelect) answers_map[q.question] = s.selected;
+            else answers_map[q.question] = s.selected[0] ?? "";
+        });
+        return { tool_use_id: r.tool_use_id, answers, answers_map, answer_text };
     };
 
     const submit = () => {

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -157,7 +157,17 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         launchArgs: ["-p", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",
-        controllerType: "subprocess",
+        // Persistent (bidirectional stream-json) so a turn can BLOCK on a
+        // tool_use and consume a tool_result over live stdin — required for
+        // AskUserQuestion (SPEC_ASK_USER_QUESTION_2026_06_15.md). In `-p`
+        // subprocess mode the CLI auto-rejects AskUserQuestion with
+        // `Error: Answer questions?`, so the question panel never renders.
+        // (#406's Subprocess switch dodged a Windows pipe hang in the old
+        // Node.js CLI; the CLI is native now, so that root cause is gone.)
+        // Keep this in sync with `static CLAUDE` in agentmux-srv providers.rs.
+        // controllerType selects persistentLaunchArgs over launchArgs in
+        // useAgentCommands.ts.
+        controllerType: "persistent",
         persistentLaunchArgs: ["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         // Claude Code calls `git` at session-start (issue
         // anthropics/claude-code#29898). Without git the CLI fails

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -157,18 +157,18 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         launchArgs: ["-p", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",
-        // Persistent (bidirectional stream-json) so a turn can BLOCK on a
-        // tool_use and consume a tool_result over live stdin — required for
-        // AskUserQuestion (SPEC_ASK_USER_QUESTION_2026_06_15.md). In `-p`
-        // subprocess mode the CLI auto-rejects AskUserQuestion with
-        // `Error: Answer questions?`, so the question panel never renders.
-        // (#406's Subprocess switch dodged a Windows pipe hang in the old
-        // Node.js CLI; the CLI is native now, so that root cause is gone.)
-        // Keep this in sync with `static CLAUDE` in agentmux-srv providers.rs.
-        // controllerType selects persistentLaunchArgs over launchArgs in
-        // useAgentCommands.ts.
+        // Persistent (bidirectional stream-json) + the Agent SDK CONTROL PROTOCOL
+        // is the only way AskUserQuestion works headless: the CLI auto-rejects it
+        // ("Error: Answer questions?") unless launched with `--permission-prompt-tool
+        // stdio` and answered via a control_response. `--dangerously-skip-permissions`
+        // DISABLES that routing, so it must NOT be here. The persistent controller's
+        // ControlChannel auto-allows ordinary tools to preserve today's yolo UX and
+        // surfaces only AskUserQuestion to the user. Keep in sync with `static CLAUDE`
+        // in agentmux-srv/providers.rs. controllerType selects persistentLaunchArgs
+        // over launchArgs in useAgentCommands.ts.
+        // Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
         controllerType: "persistent",
-        persistentLaunchArgs: ["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
+        persistentLaunchArgs: ["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--permission-prompt-tool", "stdio", "--permission-mode", "default"],
         // Claude Code calls `git` at session-start (issue
         // anthropics/claude-code#29898). Without git the CLI fails
         // with `Error: Git is required but was not found.`.

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -164,13 +164,14 @@ declare global {
         feedback?: string;
     };
 
-    // CommandAgentAnswerData — AskUserQuestion answer, delivered back to the
-    // running agent CLI as a tool_result over the persistent controller's
-    // stdin. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+    // CommandAgentAnswerData — AskUserQuestion answer, delivered to the running
+    // agent CLI via the Agent SDK control protocol (a control_response carrying
+    // updatedInput.answers). Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
     type CommandAgentAnswerData = {
         blockid: string;
         tool_use_id: string;
-        answer_text: string;
+        // question text → chosen label | label[] (multiSelect) | free-text ("Other")
+        answers: {[key: string]: string | string[]};
     };
 
     // wshrpc.CommandBlockSetViewData


### PR DESCRIPTION
## Problem

Calling **AskUserQuestion** from a Claude agent pane renders no question panel — the agent instantly gets `Error: Answer questions?` back and continues.

**Root cause (confirmed in a live v0.46.0 srv log, block `27b6f287`, model `claude-opus-4-8`):** the Claude provider defaults to the **subprocess (`-p`) controller**. In `-p`/print mode the Claude CLI has no interactive stdin, so it **auto-rejects its own AskUserQuestion tool_use** ~7ms after emitting it:

```
22:17:52.361  assistant tool_use  name=AskUserQuestion  input={questions:[…]}   ✅ valid
22:17:52.368  user tool_result    content="Answer questions?"  is_error=true     ❌ +7ms, from the CLI itself
```

The frontend node flips `awaiting_answer → failed` before first paint, so `pendingQuestions()` never catches it → no panel.

AskUserQuestion (`SPEC_ASK_USER_QUESTION_2026_06_15.md`, #1441/#1444/#1445) was designed + validated **only for the persistent controller** (`--input-format stream-json`, bidirectional), where the turn genuinely **blocks** on the tool_use and consumes a `tool_result` over live stdin. Phase 2's subprocess fallback can't engage either, because the CLI's auto-error resolves the tool mid-turn.

## Fix

Flip Claude to `ControllerType::Persistent` in **both** provider configs:
- `agentmux-srv/src/backend/providers.rs` (`static CLAUDE`)
- `frontend/app/view/agent/providers/index.ts` (seeds the block's `controller` meta at agent creation)

`persistent_launch_args` were already defined in both; `controllerType` selects them automatically.

## Why this is safe now

#406 originally switched Claude `Persistent → Subprocess` to dodge a **Windows anonymous-pipe "no response" hang in the then-Node.js CLI**. The Claude CLI is now a **native binary (v2.1.x)** — both the user's standalone install and the npm-bundled `@anthropic-ai/claude-code` (which now just pulls `claude-code-linux-x64`). That Node-process root cause is gone, and the spec's §10 smoke test already confirmed persistent mode streams correctly against the native CLI on Windows.

## Tests

- `agentmux-srv` provider tests: **11/11** pass (incl. updated `claude_persistent_with_persistent_args_present`)
- frontend provider tests: **25/25** pass

## Caveats for reviewers

- Persistent hasn't been Claude's default since #406 — runtime behavior (multi-turn, resume, stop) should get a manual smoke test, not just unit tests.
- **Existing** Claude agents keep `controller: subprocess` in their persisted block meta; only **newly created** Claude agents get persistent. A meta migration for existing agents is out of scope here.
- Re-validating persistent on Windows against the *npm-bundled* native binary (vs the standalone the spec tested) is recommended before relying on it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)