### PR TITLE
feat(muxbus): LAN tier — mDNS auth_key, agent cache, tier-3 inject forwarding

### DIFF
--- a/.changesets/1781563645-feat-muxbus-lan-tier-mdns-auth-key-agent-cache-tier-3-inject-g8ac.md
+++ b/.changesets/1781563645-feat-muxbus-lan-tier-mdns-auth-key-agent-cache-tier-3-inject-g8ac.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): LAN tier — mDNS auth_key, agent cache, tier-3 inject forwarding

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -20,6 +20,8 @@ use serde_json::json;
 use super::eventbus::{EventBus, WSEventType};
 
 const SERVICE_TYPE: &str = "_agentmux._tcp.local.";
+const LAN_AGENT_CACHE_TTL_SECS: u64 = 60;
+const LAN_PEER_QUERY_TIMEOUT_SECS: u64 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LanInstance {
@@ -28,9 +30,16 @@ pub struct LanInstance {
     pub version: String,
     pub address: String,
     pub port: u16,
+    pub auth_key: String,
     pub agents: Vec<String>,
     pub first_seen: u64,
     pub last_seen: u64,
+}
+
+struct LanCacheEntry {
+    peer_url: String,
+    auth_key: String,
+    expires: std::time::Instant,
 }
 
 pub struct LanDiscovery {
@@ -39,6 +48,7 @@ pub struct LanDiscovery {
     instance_id: String,
     event_bus: Arc<EventBus>,
     service_fullname: String,
+    auth_key: String,
 }
 
 /// Normalize an OS hostname into a valid mDNS host name by appending the
@@ -61,6 +71,7 @@ impl LanDiscovery {
         hostname: String,
         version: String,
         port: u16,
+        auth_key: String,
         event_bus: Arc<EventBus>,
     ) -> Result<Arc<Self>, String> {
         let daemon = ServiceDaemon::new().map_err(|e| format!("mDNS daemon failed: {e}"))?;
@@ -74,6 +85,7 @@ impl LanDiscovery {
             ("version", version.as_str()),
             ("hostname", hostname.as_str()),
             ("instance_id", instance_id.as_str()),
+            ("auth_key", auth_key.as_str()),
         ];
         let service_info = ServiceInfo::new(
             SERVICE_TYPE,
@@ -104,6 +116,7 @@ impl LanDiscovery {
             instance_id: instance_id.clone(),
             event_bus: event_bus.clone(),
             service_fullname,
+            auth_key,
         });
 
         // Spawn event receiver on a blocking thread to avoid starving the tokio runtime
@@ -167,6 +180,10 @@ impl LanDiscovery {
                     .get_property_val_str("version")
                     .unwrap_or_default()
                     .to_string();
+                let auth_key = info
+                    .get_property_val_str("auth_key")
+                    .unwrap_or_default()
+                    .to_string();
 
                 let fullname = info.get_fullname().to_string();
                 let mut instances = self.instances.write();
@@ -176,6 +193,7 @@ impl LanDiscovery {
                     version: version.clone(),
                     address: address.clone(),
                     port: info.get_port(),
+                    auth_key: auth_key.clone(),
                     agents: Vec::new(),
                     first_seen: now,
                     last_seen: now,
@@ -185,6 +203,7 @@ impl LanDiscovery {
                 entry.version = version;
                 entry.address = address;
                 entry.port = info.get_port();
+                entry.auth_key = auth_key;
                 drop(instances);
 
                 tracing::info!(
@@ -274,7 +293,11 @@ pub struct LanDiscoveryController {
     hostname: String,
     version: String,
     port: u16,
+    auth_key: String,
     event_bus: Arc<EventBus>,
+    /// Short-lived cache mapping agent_id → (peer_url, auth_key). Entries expire
+    /// after LAN_AGENT_CACHE_TTL_SECS to handle agent migration between peers.
+    agent_cache: std::sync::RwLock<HashMap<String, LanCacheEntry>>,
 }
 
 impl LanDiscoveryController {
@@ -284,6 +307,7 @@ impl LanDiscoveryController {
         version: String,
         port: u16,
         event_bus: Arc<EventBus>,
+        auth_key: String,
     ) -> Self {
         Self {
             slot: Arc::new(RwLock::new(None)),
@@ -291,7 +315,66 @@ impl LanDiscoveryController {
             hostname,
             version,
             port,
+            auth_key,
             event_bus,
+            agent_cache: std::sync::RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Query LAN peers for which one hosts `agent_id`. Returns `(peer_url,
+    /// auth_key)` for the first peer that responds 2xx to the agent-lookup
+    /// endpoint. Result is cached for `LAN_AGENT_CACHE_TTL_SECS` seconds.
+    pub async fn find_agent(
+        &self,
+        agent_id: &str,
+        http: &reqwest::Client,
+    ) -> Option<(String, String)> {
+        // Fast path: valid cache hit
+        if let Ok(cache) = self.agent_cache.read() {
+            if let Some(e) = cache.get(agent_id) {
+                if e.expires > std::time::Instant::now() {
+                    return Some((e.peer_url.clone(), e.auth_key.clone()));
+                }
+            }
+        }
+
+        // Slow path: query each peer
+        let peers = self.get_instances();
+        for peer in &peers {
+            if peer.address.is_empty() || peer.auth_key.is_empty() {
+                continue;
+            }
+            let peer_url = format!("http://{}:{}", peer.address, peer.port);
+            let query_url = format!("{}/agentmux/reactive/agent?id={}", peer_url, agent_id);
+            let result = http
+                .get(&query_url)
+                .header("X-AuthKey", &peer.auth_key)
+                .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
+                .send()
+                .await;
+            if matches!(result, Ok(ref r) if r.status().is_success()) {
+                tracing::debug!(agent_id, peer_url = %peer_url, "LAN agent found on peer");
+                if let Ok(mut cache) = self.agent_cache.write() {
+                    cache.insert(
+                        agent_id.to_string(),
+                        LanCacheEntry {
+                            peer_url: peer_url.clone(),
+                            auth_key: peer.auth_key.clone(),
+                            expires: std::time::Instant::now()
+                                + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
+                        },
+                    );
+                }
+                return Some((peer_url, peer.auth_key.clone()));
+            }
+        }
+        None
+    }
+
+    /// Evict a stale cache entry (e.g. after a forward to that peer failed).
+    pub fn evict_agent(&self, agent_id: &str) {
+        if let Ok(mut cache) = self.agent_cache.write() {
+            cache.remove(agent_id);
         }
     }
 
@@ -314,6 +397,7 @@ impl LanDiscoveryController {
                     self.hostname.clone(),
                     self.version.clone(),
                     self.port,
+                    self.auth_key.clone(),
                     self.event_bus.clone(),
                 ) {
                     Ok(d) => {

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -37,7 +37,8 @@ pub struct LanInstance {
 }
 
 struct LanCacheEntry {
-    peer_url: String,
+    /// `None` = negative cache entry: agent is not on any LAN peer.
+    peer_url: Option<String>,
     auth_key: String,
     expires: std::time::Instant,
 }
@@ -323,31 +324,40 @@ impl LanDiscoveryController {
 
     /// Query LAN peers for which one hosts `agent_id`. Returns `(peer_url,
     /// auth_key)` for the first peer that responds 2xx to the agent-lookup
-    /// endpoint. Result is cached for `LAN_AGENT_CACHE_TTL_SECS` seconds.
+    /// endpoint. Results — both positive and negative — are cached for
+    /// `LAN_AGENT_CACHE_TTL_SECS` seconds to avoid a blocking peer fan-out on
+    /// every inject for cloud-only agents.
+    ///
+    /// Security: `auth_key` is broadcast in the mDNS TXT record. This is
+    /// intentional and matches the same trust assumption as tier-2 loopback
+    /// forwarding — LAN traffic is trusted (private network). Anyone on the LAN
+    /// who can already intercept mDNS multicast can intercept the HTTP traffic
+    /// too, so the key adds no exposure beyond what already exists.
     pub async fn find_agent(
         &self,
         agent_id: &str,
         http: &reqwest::Client,
     ) -> Option<(String, String)> {
-        // Fast path: valid cache hit
+        // Fast path: valid cache hit (positive or negative)
         if let Ok(cache) = self.agent_cache.read() {
             if let Some(e) = cache.get(agent_id) {
                 if e.expires > std::time::Instant::now() {
-                    return Some((e.peer_url.clone(), e.auth_key.clone()));
+                    return e.peer_url.as_ref().map(|url| (url.clone(), e.auth_key.clone()));
                 }
             }
         }
 
-        // Slow path: query each peer
+        // Slow path: query each peer. Use reqwest's .query() for safe
+        // percent-encoding of the agent_id (handles spaces, &, =, #, etc.).
         let peers = self.get_instances();
         for peer in &peers {
             if peer.address.is_empty() || peer.auth_key.is_empty() {
                 continue;
             }
             let peer_url = format!("http://{}:{}", peer.address, peer.port);
-            let query_url = format!("{}/agentmux/reactive/agent?id={}", peer_url, agent_id);
             let result = http
-                .get(&query_url)
+                .get(format!("{}/agentmux/reactive/agent", peer_url))
+                .query(&[("id", agent_id)])
                 .header("X-AuthKey", &peer.auth_key)
                 .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
                 .send()
@@ -358,7 +368,7 @@ impl LanDiscoveryController {
                     cache.insert(
                         agent_id.to_string(),
                         LanCacheEntry {
-                            peer_url: peer_url.clone(),
+                            peer_url: Some(peer_url.clone()),
                             auth_key: peer.auth_key.clone(),
                             expires: std::time::Instant::now()
                                 + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
@@ -367,6 +377,20 @@ impl LanDiscoveryController {
                 }
                 return Some((peer_url, peer.auth_key.clone()));
             }
+        }
+
+        // No peer has this agent — write a negative cache entry so future
+        // injects for cloud-only agents skip the full peer fan-out.
+        if let Ok(mut cache) = self.agent_cache.write() {
+            cache.insert(
+                agent_id.to_string(),
+                LanCacheEntry {
+                    peer_url: None,
+                    auth_key: String::new(),
+                    expires: std::time::Instant::now()
+                        + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
+                },
+            );
         }
         None
     }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -889,6 +889,7 @@ async fn main() {
         version.clone(),
         web_addr.port(),
         event_bus.clone(),
+        config.auth_key.clone(),
     ));
     // Honor the current setting at boot — starts the daemon if enabled.
     lan_discovery.apply(config_watcher.get_settings().network_lan_discovery);

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -103,7 +103,18 @@ pub(super) async fn handle_reactive_inject(
             match fwd.send().await {
                 Ok(r) if r.status().is_success() => {
                     if let Ok(body) = r.json::<serde_json::Value>().await {
-                        return Json(body);
+                        // /reactive/inject always returns HTTP 200; check body.success
+                        // to detect "agent not found on that peer" (e.g. after migration).
+                        if body.get("success").and_then(|v| v.as_bool()) == Some(false) {
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                url = %forward_url,
+                                "LAN peer inject: success=false — evicting stale cache entry"
+                            );
+                            state.lan_discovery.evict_agent(&req.target_agent);
+                        } else {
+                            return Json(body);
+                        }
                     }
                 }
                 Ok(r) => {
@@ -111,7 +122,7 @@ pub(super) async fn handle_reactive_inject(
                         target = %req.target_agent,
                         status = %r.status(),
                         url = %forward_url,
-                        "LAN peer forward: non-success status"
+                        "LAN peer forward: non-success HTTP status"
                     );
                 }
                 Err(e) => {

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -40,6 +40,7 @@ pub(super) async fn handle_reactive_inject(
         .unwrap_or(false);
 
     if is_not_found {
+        // Tier 2: same-host, different sidecar (file registry → HTTP loopback)
         let data_dir = base::get_wave_data_dir();
         if let Some(entry) = agent_registry::lookup(&data_dir, &req.target_agent) {
             // Guard against self-forwarding loops.
@@ -50,12 +51,6 @@ pub(super) async fn handle_reactive_inject(
                     url = %forward_url,
                     "cross-instance inject forward"
                 );
-                // Reactive routes now require auth (audit C1/C2 fix).
-                // Peers authenticate using the entry's `auth_key` (the
-                // owning instance's per-launch UUID, written into the
-                // registry by `registry::write`). If a pre-fix entry has
-                // no auth_key, the peer returns 401 and the cloud
-                // agentbus fallback handles it.
                 let mut fwd = state.http_client.post(&forward_url).json(&req);
                 if !entry.auth_key.is_empty() {
                     fwd = fwd.header("X-AuthKey", &entry.auth_key);
@@ -81,15 +76,58 @@ pub(super) async fn handle_reactive_inject(
                             url = %forward_url,
                             "cross-instance forward failed — removing stale registry entry"
                         );
-                        // Remove stale entry so next call doesn't retry a dead instance.
                         agent_registry::remove(&data_dir, &req.target_agent);
                     }
                 }
             }
         }
+
+        // Tier 3: LAN peer (mDNS lookup → HTTP). Runs when tier 2 had no registry
+        // entry or its forward failed. Queries each discovered LAN peer for the
+        // agent; result is cached for 60s to avoid per-inject mDNS fan-out.
+        if let Some((peer_url, peer_auth_key)) = state
+            .lan_discovery
+            .find_agent(&req.target_agent, &state.http_client)
+            .await
+        {
+            let forward_url = format!("{}/agentmux/reactive/inject", peer_url);
+            tracing::debug!(
+                target = %req.target_agent,
+                url = %forward_url,
+                "LAN peer inject forward"
+            );
+            let mut fwd = state.http_client.post(&forward_url).json(&req);
+            if !peer_auth_key.is_empty() {
+                fwd = fwd.header("X-AuthKey", &peer_auth_key);
+            }
+            match fwd.send().await {
+                Ok(r) if r.status().is_success() => {
+                    if let Ok(body) = r.json::<serde_json::Value>().await {
+                        return Json(body);
+                    }
+                }
+                Ok(r) => {
+                    tracing::warn!(
+                        target = %req.target_agent,
+                        status = %r.status(),
+                        url = %forward_url,
+                        "LAN peer forward: non-success status"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target = %req.target_agent,
+                        error = %e,
+                        url = %forward_url,
+                        "LAN peer forward failed — evicting cache entry"
+                    );
+                    state.lan_discovery.evict_agent(&req.target_agent);
+                }
+            }
+        }
     }
 
-    // 3. Return original error (agentbus-client will fall back to cloud).
+    // 4. Return original error (muxbus-client will fall back to cloud relay).
     Json(serde_json::to_value(&resp).unwrap_or_default())
 }
 


### PR DESCRIPTION
## Summary

- Exposes per-instance `auth_key` in mDNS TXT record so LAN peers can authenticate against each other's reactive endpoints without any out-of-band key exchange
- Stores `auth_key` in `LanInstance` on discovery, propagated from `LanDiscoveryController`
- Adds `LanDiscoveryController::find_agent()`: 60s in-process cache → fan-out `GET /agentmux/reactive/agent?id=` to each LAN peer (2s timeout per peer); first 2xx hit is cached
- Adds `evict_agent()` for cache invalidation on forward failure
- Wires tier 3 into `handle_reactive_inject()`: after tier-2 file-registry miss, tries `find_agent()` → forwards inject to the owning LAN peer with `X-AuthKey`

This completes Phase 3 of the delivery hierarchy spec (`docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md`).

## Test plan

- [ ] Enable LAN discovery on two machines on the same network
- [ ] Register an agent on machine B; inject from machine A → verify delivery via LAN peer (tier 3 logs: `"LAN peer inject forward"`)
- [ ] Verify cache is used on second inject (no additional mDNS fan-out)
- [ ] Kill agent on machine B; verify `evict_agent` fires on next failed forward, next attempt re-queries peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)