### PR TITLE
fix(toolchain): enrich GUI-launch PATH so node/npm/git resolve (P0)

### DIFF
--- a/.changesets/1781565161-fix-gui-launch-path-enrichment.md
+++ b/.changesets/1781565161-fix-gui-launch-path-enrichment.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(toolchain): GUI-launched AgentMux can find nvm/Homebrew node, npm & git — enrich the srv's PATH from the user's login shell (+ well-known toolchain dirs) so `npm install`/agent CLIs resolve when launched from Finder/Dock/DMG (was failing with "npm: command not found"). Additive, login-shell-sourced, no-op on Windows. P0 of SPEC_TOOLCHAIN_MANAGER.

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -201,6 +201,18 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
         &auth_key[..8.min(auth_key.len())]
     );
 
+    // GUI launches (Finder / Dock / mounted DMG) inherit launchd's stripped
+    // PATH, so the srv can't find nvm/Homebrew node/npm/git — `npm install`
+    // dies with "command not found" and agent CLIs can't resolve their
+    // interpreter. Reconstruct a usable PATH from the user's login shell +
+    // well-known toolchain dirs (additive; never drops a system dir; no-op on
+    // Windows). See SPEC_TOOLCHAIN_MANAGER_2026-06-15 §3.
+    let enriched = agentmux_common::resolve_login_path();
+    tracing::info!(
+        source = enriched.source.as_str(),
+        "Resolved srv PATH for toolchain spawning"
+    );
+
     let mut cmd = std::process::Command::new(&backend_path);
     cmd.args([
         "--wavedata",
@@ -215,6 +227,7 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     // chain (launcher → host, host → srv).
     .envs(paths.to_env_vars())
     .env("AGENTMUX_APP_PATH", &app_path_str)
+    .env("PATH", &enriched.path)
     .stdin(std::process::Stdio::piped())
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped());

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -9,12 +9,17 @@ pub mod errors;
 pub mod ipc;
 pub mod layout_types;
 pub mod runtime_mode;
+pub mod toolchain_path;
 
 pub use cli::make_cli_cmd;
 pub use data_paths::DataPaths;
 pub use errors::{AgentMuxError, AmxCode};
 pub use layout_types::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
 pub use runtime_mode::{is_dev_build_exe, is_dev_self, RuntimeMode};
+pub use toolchain_path::{
+    enrich_current_process_path, looks_like_launchd_default, resolve_login_path, EnrichedPath,
+    PathSource,
+};
 
 /// Crate-wide test-only lock for env-var-touching tests. Both
 /// `runtime_mode::tests` and `data_paths::tests` mutate process-global

--- a/agentmux-common/src/toolchain_path.rs
+++ b/agentmux-common/src/toolchain_path.rs
@@ -1,0 +1,413 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GUI-launch PATH enrichment.
+//!
+//! When AgentMux launches from Finder / Dock / a mounted DMG as a `.app`,
+//! it inherits launchd's stripped PATH (`/usr/bin:/bin:/usr/sbin:/sbin`).
+//! nvm- and Homebrew-installed `node` / `npm` / `git` live in the user's
+//! *login-shell* PATH, which a GUI launch never sees — so the CLI installer
+//! (`Command::new("npm")`) dies with `npm: command not found`, and spawned
+//! agent CLIs can't find their interpreter either.
+//!
+//! [`resolve_login_path`] reconstructs a usable PATH from the user's login
+//! shell (`$SHELL -lic 'printf … "$PATH"'`, with a hard timeout) unioned with
+//! well-known toolchain directories. It is **purely additive** — inherited
+//! system directories are never dropped — and a no-op on Windows (whose GUI
+//! apps inherit a usable PATH).
+//!
+//! See `docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` §3.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// How the effective PATH was produced — surfaced in logs and (later) the
+/// Toolchain modal so PATH problems are diagnosable rather than mysterious.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSource {
+    /// The inherited PATH was already sufficient (or we're on Windows); unchanged.
+    Inherited,
+    /// Augmented from the user's login shell (`$SHELL -lic`).
+    LoginShell,
+    /// Login-shell capture failed; augmented from well-known dirs only.
+    FallbackDirs,
+}
+
+impl PathSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PathSource::Inherited => "inherited",
+            PathSource::LoginShell => "login-shell",
+            PathSource::FallbackDirs => "fallback-dirs",
+        }
+    }
+}
+
+/// The enriched PATH plus a record of how it was derived.
+#[derive(Debug, Clone)]
+pub struct EnrichedPath {
+    pub path: String,
+    pub source: PathSource,
+}
+
+/// The launchd-default PATH a Finder/Dock-launched macOS `.app` inherits.
+const LAUNCHD_DEFAULT_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+/// Build a usable PATH for spawning the toolchain (`node`/`npm`/`git`/`docker`
+/// and the provider CLIs). Additive over the inherited PATH; never removes an
+/// inherited entry. On Windows this returns the inherited PATH unchanged.
+pub fn resolve_login_path() -> EnrichedPath {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+
+    #[cfg(not(unix))]
+    {
+        return EnrichedPath {
+            path: inherited,
+            source: PathSource::Inherited,
+        };
+    }
+
+    #[cfg(unix)]
+    {
+        let login_shell = capture_login_shell_path(&resolve_user_shell());
+        build_enriched(&inherited, login_shell.as_deref(), &wellknown_dirs())
+    }
+}
+
+/// True when the current PATH is the stripped launchd default (every entry is
+/// one of `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`) — i.e. a GUI launch that
+/// never saw the user's shell. Used by the srv to decide whether the cheap
+/// guard should pay for a login-shell spawn on a *direct* launch.
+pub fn looks_like_launchd_default(path: &str) -> bool {
+    let defaults: HashSet<&str> = LAUNCHD_DEFAULT_DIRS.iter().copied().collect();
+    let entries: Vec<&str> = path.split(':').filter(|e| !e.is_empty()).collect();
+    !entries.is_empty() && entries.iter().all(|e| defaults.contains(e))
+}
+
+/// Enrich the *current process'* PATH in place, but only when it looks like the
+/// stripped launchd default. Idempotent and cheap when the PATH is already
+/// healthy (no shell spawn). Returns the source used. Intended for the srv's
+/// direct-launch fallback; the host enriches the srv's PATH unconditionally
+/// when it spawns it (it knows it is the GUI entry point).
+pub fn enrich_current_process_path() -> PathSource {
+    let current = std::env::var("PATH").unwrap_or_default();
+    if !looks_like_launchd_default(&current) {
+        return PathSource::Inherited;
+    }
+    let enriched = resolve_login_path();
+    if enriched.source != PathSource::Inherited {
+        std::env::set_var("PATH", &enriched.path);
+    }
+    enriched.source
+}
+
+/// The user's login shell, falling back to a per-OS default.
+#[cfg(unix)]
+fn resolve_user_shell() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".to_string()
+            } else {
+                "/bin/bash".to_string()
+            }
+        })
+}
+
+/// Run `<shell> -lic 'printf …"$PATH"'` and return the captured PATH, or `None`
+/// on timeout / failure / empty. A sentinel wraps the value so noise printed by
+/// the user's rc files to stdout can't corrupt the parse. Bounded by a 2s hard
+/// timeout so a slow/hung rc file can never block startup.
+#[cfg(unix)]
+fn capture_login_shell_path(shell: &str) -> Option<String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    // `printf` without a trailing newline; markers isolate our value from any
+    // banner the rc files emit to stdout.
+    let script = r#"printf '__AMUX_PATH__%s__AMUX_END__' "$PATH""#;
+
+    let mut child = Command::new(shell)
+        .args(["-lic", script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let mut stdout = child.stdout.take()?;
+    // Read on a worker thread so a hung child can't block us past the timeout.
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let buf = match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(b) => {
+            let _ = child.wait();
+            b
+        }
+        Err(_) => {
+            // Timed out — kill the child; the reader thread unblocks when the
+            // pipe closes and exits on its own (its send is discarded).
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+    };
+
+    parse_sentinel(&buf)
+}
+
+/// Extract the PATH wrapped between the sentinels, ignoring surrounding noise.
+fn parse_sentinel(buf: &str) -> Option<String> {
+    const START: &str = "__AMUX_PATH__";
+    const END: &str = "__AMUX_END__";
+    let s = buf.find(START)? + START.len();
+    let e = buf[s..].find(END)? + s;
+    let path = &buf[s..e];
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+/// Well-known toolchain directories, existence-checked and de-duplicated. An
+/// absent directory costs nothing (filtered out), so the list can be generous.
+#[cfg(unix)]
+fn wellknown_dirs() -> Vec<String> {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let mut candidates: Vec<String> = Vec::new();
+
+    if !home.is_empty() {
+        if let Some(bin) = nvm_current_bin(&home) {
+            candidates.push(bin);
+        }
+    }
+    candidates.push("/opt/homebrew/bin".to_string());
+    candidates.push("/opt/homebrew/sbin".to_string());
+    candidates.push("/usr/local/bin".to_string());
+    if !home.is_empty() {
+        candidates.push(format!("{home}/.local/bin"));
+        candidates.push(format!("{home}/.cargo/bin"));
+    }
+    candidates.push("/opt/local/bin".to_string());
+
+    #[cfg(target_os = "linux")]
+    {
+        candidates.push("/snap/bin".to_string());
+        candidates.push("/var/lib/flatpak/exports/bin".to_string());
+        if !home.is_empty() {
+            candidates.push(format!("{home}/.local/share/flatpak/exports/bin"));
+        }
+    }
+
+    candidates
+        .into_iter()
+        .filter(|d| Path::new(d).is_dir())
+        .collect()
+}
+
+/// Resolve the `bin` dir of the nvm "current/default" Node, if nvm is present.
+/// Prefers the `default` alias; falls back to the highest installed version.
+#[cfg(unix)]
+fn nvm_current_bin(home: &str) -> Option<String> {
+    let versions_dir = format!("{home}/.nvm/versions/node");
+    if !Path::new(&versions_dir).is_dir() {
+        return None;
+    }
+
+    // Prefer the `default` alias (e.g. "v20.18.0", "20", "lts/*", "node").
+    if let Ok(alias) = std::fs::read_to_string(format!("{home}/.nvm/alias/default")) {
+        let a = alias.trim();
+        if !a.is_empty() {
+            let v = if a.starts_with('v') {
+                a.to_string()
+            } else {
+                format!("v{a}")
+            };
+            let bin = format!("{versions_dir}/{v}/bin");
+            if Path::new(&bin).is_dir() {
+                return Some(bin);
+            }
+        }
+    }
+
+    // Fall back to the highest installed version (numeric, not lexical, so
+    // v10 > v9).
+    let mut versions: Vec<(u64, u64, u64, String)> = std::fs::read_dir(&versions_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with('v'))
+        .map(|n| {
+            let (a, b, c) = parse_semverish(&n);
+            (a, b, c, n)
+        })
+        .collect();
+    versions.sort();
+    versions
+        .last()
+        .map(|(_, _, _, n)| format!("{versions_dir}/{n}/bin"))
+}
+
+/// Parse a leading "vMAJOR.MINOR.PATCH" into a comparable tuple. Missing or
+/// non-numeric parts sort as 0.
+fn parse_semverish(v: &str) -> (u64, u64, u64) {
+    let core = v.strip_prefix('v').unwrap_or(v);
+    let mut it = core.split('.');
+    let p = |o: Option<&str>| o.and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+    (p(it.next()), p(it.next()), p(it.next()))
+}
+
+/// Pure merge: priority order is login-shell entries, then well-known dirs,
+/// then the inherited PATH — de-duplicated, first occurrence wins. Inherited
+/// entries are always preserved (appended), so the result is a superset.
+fn build_enriched(inherited: &str, login_shell: Option<&str>, wellknown: &[String]) -> EnrichedPath {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut out: Vec<&str> = Vec::new();
+    let used_login = login_shell.is_some();
+
+    if let Some(ls) = login_shell {
+        for e in ls.split(':') {
+            if !e.is_empty() && seen.insert(e) {
+                out.push(e);
+            }
+        }
+    }
+
+    let before = out.len();
+    for d in wellknown {
+        if !d.is_empty() && seen.insert(d.as_str()) {
+            out.push(d.as_str());
+        }
+    }
+    let wellknown_added = out.len() > before;
+
+    for e in inherited.split(':') {
+        if !e.is_empty() && seen.insert(e) {
+            out.push(e);
+        }
+    }
+
+    let path = out.join(":");
+    // Did we actually change anything vs. just the inherited set?
+    let changed = path != normalize(inherited);
+    let source = if !changed {
+        PathSource::Inherited
+    } else if used_login {
+        PathSource::LoginShell
+    } else if wellknown_added {
+        PathSource::FallbackDirs
+    } else {
+        PathSource::Inherited
+    };
+
+    EnrichedPath { path, source }
+}
+
+/// De-dup + drop empties, preserving order — for comparing "did we change it".
+fn normalize(path: &str) -> String {
+    let mut seen = HashSet::new();
+    path.split(':')
+        .filter(|e| !e.is_empty() && seen.insert(*e))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sentinel_ignores_rc_noise() {
+        let buf = "welcome to my shell!\nsome banner\n__AMUX_PATH__/opt/homebrew/bin:/usr/bin__AMUX_END__";
+        assert_eq!(
+            parse_sentinel(buf).as_deref(),
+            Some("/opt/homebrew/bin:/usr/bin")
+        );
+    }
+
+    #[test]
+    fn parse_sentinel_none_when_missing_or_empty() {
+        assert_eq!(parse_sentinel("no markers here"), None);
+        assert_eq!(parse_sentinel("__AMUX_PATH____AMUX_END__"), None);
+    }
+
+    #[test]
+    fn launchd_default_detection() {
+        assert!(looks_like_launchd_default("/usr/bin:/bin:/usr/sbin:/sbin"));
+        assert!(looks_like_launchd_default("/bin:/usr/bin"));
+        assert!(!looks_like_launchd_default(
+            "/opt/homebrew/bin:/usr/bin:/bin"
+        ));
+        assert!(!looks_like_launchd_default(""));
+    }
+
+    #[test]
+    fn semverish_sorts_numerically() {
+        assert!(parse_semverish("v10.0.0") > parse_semverish("v9.99.99"));
+        assert_eq!(parse_semverish("v20.18.1"), (20, 18, 1));
+        assert_eq!(parse_semverish("vbogus"), (0, 0, 0));
+    }
+
+    #[test]
+    fn build_prepends_login_shell_and_preserves_inherited() {
+        let e = build_enriched(
+            "/usr/bin:/bin",
+            Some("/opt/homebrew/bin:/usr/bin:/bin"),
+            &[],
+        );
+        // login-shell entry comes first; inherited /bin still present once.
+        assert_eq!(e.path, "/opt/homebrew/bin:/usr/bin:/bin");
+        assert_eq!(e.source, PathSource::LoginShell);
+    }
+
+    #[test]
+    fn build_falls_back_to_wellknown_when_no_login_shell() {
+        let e = build_enriched(
+            "/usr/bin:/bin",
+            None,
+            &["/opt/homebrew/bin".to_string()],
+        );
+        assert_eq!(e.path, "/opt/homebrew/bin:/usr/bin:/bin");
+        assert_eq!(e.source, PathSource::FallbackDirs);
+    }
+
+    #[test]
+    fn build_reports_inherited_when_nothing_added() {
+        // login shell returns exactly the inherited set (e.g. launched from a
+        // terminal that already had the system PATH and nothing else).
+        let e = build_enriched("/usr/bin:/bin", Some("/usr/bin:/bin"), &[]);
+        assert_eq!(e.path, "/usr/bin:/bin");
+        assert_eq!(e.source, PathSource::Inherited);
+    }
+
+    #[test]
+    fn build_dedups_across_all_sources() {
+        let e = build_enriched(
+            "/usr/bin:/bin:/usr/bin",
+            Some("/opt/homebrew/bin:/usr/bin"),
+            &["/opt/homebrew/bin".to_string(), "/usr/local/bin".to_string()],
+        );
+        assert_eq!(e.path, "/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_via_real_sh_roundtrips_path() {
+        // /bin/sh honors -c; -lic is accepted (login+interactive flags are
+        // tolerated). The script echoes $PATH between the sentinels.
+        let got = capture_login_shell_path("/bin/sh");
+        // On any unix dev/CI box /bin/sh exists and $PATH is non-empty.
+        assert!(got.is_some(), "expected a captured PATH from /bin/sh");
+        assert!(!got.unwrap().is_empty());
+    }
+}

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -263,6 +263,19 @@ async fn main() {
     // 1. Init tracing (stderr + rolling file)
     let _log_guard = init_logging();
 
+    // 1b. Direct-launch PATH fallback. The host enriches the srv's PATH when it
+    // spawns it (sidecar.rs), so in normal operation this is a cheap no-op.
+    // It only does work when the srv is launched directly with a stripped
+    // launchd PATH (some dev paths), so installs/CLIs still resolve node/npm.
+    // See SPEC_TOOLCHAIN_MANAGER_2026-06-15 §3.1.
+    let path_source = agentmux_common::enrich_current_process_path();
+    if path_source != agentmux_common::PathSource::Inherited {
+        tracing::info!(
+            source = path_source.as_str(),
+            "Enriched srv PATH on direct launch (stripped PATH detected)"
+        );
+    }
+
     // 2. Parse CLI args and build config
     let args = CliArgs::parse();
     let config = config::Config::from_env_and_args(&args).unwrap_or_else(|e| {

--- a/docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md
+++ b/docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md
@@ -1,0 +1,196 @@
+# SPEC: Toolchain Manager + GUI-launch PATH enrichment
+
+- **Date:** 2026-06-15
+- **Status:** Draft
+- **Author:** AgentO
+- **Related:** `SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md` (system-prereq probe + modal), `SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md`
+
+---
+
+## 0. TL;DR
+
+Two coupled deliverables:
+
+1. **P0 — Fix "NPM failed" at the root.** When AgentMux is launched from Finder/Dock/DMG as a `.app`, `agentmux-srv` inherits launchd's stripped PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). nvm/Homebrew-installed `node`/`npm` are **not** on it, so `install.start`'s `Command::new("npm")` fails with `npm: command not found`. Enrich the process PATH from the user's **login shell** (+ well-known toolchain dirs) so GUI launches can find the toolchain. This fixes both CLI **install** and CLI **execution**.
+
+2. **Toolchain Manager modal** — a new hamburger (≡) menu item → a window-scoped modal that gives users **visibility and control** over the toolchain AgentMux uses: detected versions + paths for `node`, `npm`, `git`, `docker`, and every provider CLI, with **install / repair in place** and the **resolved PATH** AgentMux is actually using (so PATH problems are diagnosable, not mysterious).
+
+The PATH fix removes the failure; the Toolchain modal makes the toolchain *legible and fixable* by the user instead of a black box.
+
+---
+
+## 1. Problem
+
+### 1.1 The acute bug (reproduced)
+- The running 0.44.1 GUI app's srv has `PATH=/usr/bin:/bin:/usr/sbin:/sbin` (read live off the process).
+- The user's `npm` is nvm/Homebrew-managed (`/opt/homebrew/opt/node@20/bin/npm`, `~/.nvm/...`), none on that PATH.
+- Repro: `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin npm install … → sh: npm: command not found`.
+- `install_handlers.rs` spawns `Command::new("npm")` relying on PATH (`agentmux-srv/src/server/install_handlers.rs:446`). No PATH enrichment exists anywhere in the repo (grep for login-shell capture returns nothing).
+- **Blast radius:** the majority of devs install Node via nvm/Homebrew → most macOS (and many Linux) alpha users hit "NPM failed" the moment they run the packaged app normally. This is the central "do users have the right prereqs" risk for the 0.45.0 alpha.
+
+### 1.2 The deeper gap
+There is **no surface** where a user can see what AgentMux detects, what PATH it's using, what versions are installed, or fix a missing/broken tool. Prereq feedback today is reactive (a pre-launch `AgentPrereqModal`, a Node banner) and per-provider. Users have **no power** to inspect or manage the toolchain centrally.
+
+### 1.3 Secondary oddity — RESOLVED (not a bug)
+v0.44.1's `@anthropic-ai/claude-code@2.1.173` maps `bin.claude → bin/claude.exe`. Investigated: `bin/claude.exe` is a **Mach-O 64-bit arm64** executable (not a Windows PE), runs correctly (`claude.exe --version → 2.1.173 (Claude Code)`), and the package ships per-platform `optionalDependencies` (`@anthropic-ai/claude-code-darwin-arm64` is installed as a sibling; the `install.cjs` postinstall copies the platform-correct binary to the fixed name `bin/claude.exe`). The `.exe` suffix is a cosmetic fixed filename, **not** corruption or a cross-platform mistake. **The install is healthy** — "NPM failed" was purely the PATH issue (§1.1). Consequence for the modal: "Repair" does **not** need to special-case this; a normal reinstall is fine.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+- GUI-launched AgentMux resolves the same toolchain the user's terminal does (P0).
+- A single Toolchain modal: detect + show versions/paths for node, npm, git, docker, and all provider CLIs.
+- Install/repair provider CLIs **in place** from the modal (reuse `install.start`).
+- Surface the **effective PATH** AgentMux is using + its source (login-shell / enriched / fallback) for self-diagnosis.
+- Guided install for non-npm system tools (node/git/docker) — links + copyable commands, and one-click where a trusted package manager is detected (e.g. `brew`).
+
+**Non-goals (this iteration)**
+- Auto-installing Docker or Node silently (we link/guide; we do not background-install heavyweight runtimes without consent).
+- Managing multiple Node versions / acting as a version manager.
+- Windows-specific deep PATH heuristics beyond the existing `where`-based probes (Windows GUI apps inherit a usable PATH; the launchd-stripping problem is macOS/Linux-shaped).
+
+---
+
+## 3. P0 — GUI-launch PATH enrichment
+
+### 3.1 Where
+Enrich **once, in the host before it spawns the srv**, so the srv and every CLI it spawns inherit the corrected PATH. Anchor: `agentmux-cef/src/sidecar.rs:197-226` (the `Command::new(&backend_path)…envs(...)` site). A fallback enrichment in `agentmux-srv/src/main.rs` (~`fn main` line 229) guards the case where srv is launched directly (`task dev` on macOS/Linux invokes the host which spawns srv; standalone srv launches are dev-only).
+
+Decision: implement the resolver in `agentmux-common` (shared) as `resolve_login_path()` and call it from the host's sidecar spawn. Single source of truth, testable.
+
+### 3.2 How — `resolve_login_path()`
+1. **Detect a stripped PATH.** If the current PATH ⊆ the known launchd-default set (`/usr/bin:/bin:/usr/sbin:/sbin`) OR is missing a node/npm/git, attempt enrichment. (Always attempt on macOS GUI; cheap.)
+2. **Capture the login-shell PATH.** Run `$SHELL -lic 'printf "%s" "$PATH"'` (fallback `/bin/zsh` on macOS, `/bin/bash` on Linux) with:
+   - a hard **timeout** (≤2s) — never block startup on a slow rc file;
+   - `stdin` null, output captured;
+   - failure → skip to step 3 only.
+   Verified working: `$SHELL -lic 'echo $PATH'` returns the full nvm/Homebrew PATH on this machine.
+3. **Union with well-known toolchain dirs** (existence-checked, de-duplicated, login-shell entries first):
+   - **All Unix:** `~/.nvm/versions/node/<current|default>/bin`, `/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`, `~/.local/bin`, `~/.cargo/bin`, `/opt/local/bin`. `<current>` for nvm resolved via `~/.nvm/alias/default` then highest `vNN`.
+   - **Linux also:** `/snap/bin`, `/var/lib/flatpak/exports/bin`, `~/.local/share/flatpak/exports/bin` (resolves Q4 — Snap/Flatpak-packaged git/node/docker). All existence-checked, so absent dirs cost nothing.
+4. **Merge** the result over the inherited PATH (enriched entries take precedence; never *drop* inherited entries).
+5. **Record** the final PATH + its source (`login-shell` | `fallback-dirs` | `inherited`) so the Toolchain modal and logs can show it.
+
+### 3.3 Security / correctness
+- Running `$SHELL -lic` sources the user's own rc files — same trust boundary as their terminal; no privilege escalation. Document the timeout + that we only read `$PATH` (no other env exfil).
+- Pure-additive to PATH: we never remove the system dirs, so we can't break system tool resolution.
+- Windows: no-op (return inherited PATH). Gate the shell invocation behind `#[cfg(unix)]`.
+- Idempotent: safe to call once at host startup; result cached.
+
+### 3.4 Tests
+- `resolve_login_path()` unit tests with a fake `$SHELL` script emitting a known PATH (timeout path, non-zero-exit path, empty-output path → fallback).
+- Existence-filtering + de-dup + precedence ordering.
+- Windows cfg returns inherited unchanged.
+
+---
+
+## 4. Toolchain Manager — UX
+
+### 4.1 Entry point
+Add to `frontend/app/window/hamburger-menu.tsx` `menuItems()` (~line 107, before the Settings group):
+```ts
+{ label: "Toolchain", icon: "wrench", onClick: () => openModal(ToolchainModal) },
+```
+`openModal` already imported from `@/app/store/modalmodel`. `ToolchainModal` receives the auto-injected `{ close }` prop, wrapped in `<Modal scope="window">` (`frontend/app/element/modal.tsx`).
+
+### 4.2 Layout
+A window-scoped modal, three sections:
+
+1. **Environment** (top, collapsible)
+   - Effective PATH AgentMux is using + **source badge** (`login shell` / `fallback dirs` / `inherited`).
+   - OS + arch, AgentMux version + channel, instances dir.
+   - "Copy diagnostics" button (PATH + all detected versions) for bug reports.
+
+2. **Core tools** — fixed rows: `node`, `npm`, `git`, `docker`.
+   - Each row: icon, name, **detected version** (or "Not found"), resolved path, status pill (✓ found / ⚠ missing / ⚠ outdated-vs-min).
+   - Action: **external tools** (node/git/docker) → "Install ↗" (platform install URL) + a copyable command, **always available** (v1 baseline). One-click "Install with Homebrew" is a **P3 add-on** (resolves Q3): shown only when `brew` is detected, requires an **explicit confirm**, runs `brew install <formula>` through the existing streamed-install channel with live output, and is **never** auto-run. Link+command remain the always-present fallback so the modal is useful even without brew.
+   - `node` row shows the Node **minimum** (18+) and flags outdated **warn-only** — a ⚠ pill + "Node 18+ recommended", never a launch block (resolves Q2). Rationale: exact-path version detection is fuzzy, claude's native binary needs no Node, and blocking is hostile; the existing Node banner stays warn-only too.
+
+3. **Agent CLIs** — iterate `Object.values(PROVIDERS)` from `frontend/app/view/agent/providers/index.ts`.
+   - Each row: provider icon + displayName, detected version + source (`local_install` versioned dir / `system_path`), status pill.
+   - Action: **managed (npm) providers** → **Install / Repair** button in place (reuses the `install.start` streamed flow, same as `AgentInstallModal`); **non-npm** (kimi/pip, claude/native) → guided install (docs link + command).
+   - Show declared `systemPrereqs` per provider (e.g. claude→git) with their own found/missing state, so "claude needs git and git is missing" is visible here.
+
+### 4.3 Install / repair in place
+- Reuse `RpcApi.InstallStartCommand({ providerId, cliCommand, npmPackage, pinnedVersion })` → `{ sessionId }`, subscribe to `install_chunk` WPS events scoped `install:<sessionId>` (exact pattern in `AgentInstallModal.tsx:121-158`). Render live output inline in the row (expandable) or a sub-panel.
+- "Repair" = re-run `install.start` with the pinned version (idempotent reinstall into the versioned dir).
+- After completion, re-probe that row.
+
+---
+
+## 5. Detection — RPC surface
+
+### 5.1 Reuse
+- Provider CLI version/path: `RpcApi.ResolveCliCommand` (`cli_handlers.rs:14`) already returns `{ cli_path, version, source }` and is the exact call `launch-flow.ts:75` uses for docker. Use it for each provider **and** for `docker` (`provider_id:"docker", cli_command:"docker", npm_package:""`).
+- PATH presence/path for arbitrary tools: `RpcApi.ResolvePrereqsCommand({ tools })` → `{ tool, found, path }[]` (`install_handlers.rs:101`).
+- Node/npm: host API `getApi().checkNodejsAvailable()` → `{ available, version, npm_available, npm_version, path }` (`cef-api.ts:595`).
+
+### 5.2 New — `toolchain.status` (batch)
+Add one srv RPC that returns the whole picture in a single round-trip (avoids N sequential probes + gives the enriched PATH the srv is using):
+```ts
+ToolchainStatusCommand(client): Promise<{
+  path: string;                 // effective PATH the srv is using
+  pathSource: "login-shell" | "fallback-dirs" | "inherited";
+  os: string; arch: string;
+  tools: Array<{
+    id: string;                 // "node" | "npm" | "git" | "docker" | provider id
+    kind: "core" | "provider";
+    found: boolean;
+    version: string | null;     // via get_cli_version (cli_handlers.rs:514) — runs `<tool> --version`, 5s timeout
+    path: string | null;        // which/where, or versioned install dir
+    source: "system_path" | "local_install" | null;
+    managed: boolean;           // true → installable via install.start (npm providers)
+    minVersion?: string;        // e.g. node "18"
+  }>;
+}>
+```
+Backend: assemble from `resolve_tool_path` + `get_cli_version` (both already in `cli_handlers.rs`/`install_handlers.rs`) + the enriched-PATH record from §3.5. `git`/`docker`/`node`/`npm` probed by name; providers probed via the versioned-dir-then-PATH logic already in `resolve.cli`. Reuse `is_safe_cli_command` validation.
+
+### 5.3 Toolchain catalog
+Introduce a small **core-tools catalog** (node, npm, git, docker; each with id, label, icon, minVersion?, install URLs per platform, optional `brewFormula`) alongside the existing provider list. Put it next to `providers/index.ts` (e.g. `toolchain-catalog.ts`) so the modal has one place to add "anything we need" later (ripgrep, uv/python for kimi, etc.). This also lets us fold in the deferred kimi-Python prereq from the prereq audit.
+
+---
+
+## 6. Rollout
+
+- **P0 (ship first, standalone):** §3 PATH enrichment in `agentmux-common` + host sidecar spawn. Independently valuable; unblocks installs immediately. Its own AgentO PR + reagent + changeset (`fix`).
+- **P1:** `toolchain.status` RPC + core-tools catalog + read-only Toolchain modal (Environment + Core + Agent CLI sections, versions/paths/PATH-source, links only).
+- **P2:** Install/Repair in place for npm providers (wire `install.start` into rows).
+- **P3:** One-click `brew install` for core tools where `brew` is detected; fold in kimi Python prereq + Node min-version flagging.
+
+Each phase is a separate PR through the AgentO → reagent → squash flow.
+
+---
+
+## 7. Touch points (files)
+
+- `agentmux-common/src/` — new `resolve_login_path()` (+ tests).
+- `agentmux-cef/src/sidecar.rs:197` — call enricher before spawning srv; record PATH source.
+- `agentmux-srv/src/main.rs:229` — fallback enrichment for direct-launch.
+- `agentmux-srv/src/server/install_handlers.rs` / `cli_handlers.rs` — `toolchain.status` handler (reuse `resolve_tool_path`, `get_cli_version`, `is_safe_cli_command`).
+- `frontend/app/store/rpc-api.ts` — `ToolchainStatusCommand`.
+- `frontend/app/window/hamburger-menu.tsx:107` — menu item.
+- `frontend/app/view/.../ToolchainModal.tsx` — new modal (reuse `Modal`, `install_chunk` pattern from `AgentInstallModal.tsx`).
+- `frontend/app/view/agent/providers/toolchain-catalog.ts` — new core-tools catalog.
+
+---
+
+## 8. Tests
+
+- `resolve_login_path()` unit tests (§3.4).
+- `toolchain.status` handler: tool found/missing, version parse, provider local-install vs system-path, PATH-source field, `is_safe_cli_command` rejection.
+- Frontend: modal renders rows from a mocked `toolchain.status`; Install button calls `install.start` and re-probes on `done`.
+
+---
+
+## 9. Resolved decisions
+
+All four open questions are now resolved (decisions baked into §1.3, §3.2, §4.2 above):
+
+1. **claude.exe on macOS — RESOLVED, not a bug.** `bin/claude.exe` is a Mach-O arm64 binary that runs correctly (`2.1.173`); the package uses per-platform `optionalDependencies` and `install.cjs` writes the platform binary to a fixed `.exe` filename. The v0.44.1 install is healthy. **"Repair" needs no special-casing** — a normal reinstall suffices (see §1.3). The only failure was the PATH issue.
+2. **Node min-version — RESOLVED: warn-only.** Show a ⚠ "Node 18+ recommended" pill in the modal + keep the existing banner warn-only. Never block launch (§4.2). Fuzzy version detection + claude's no-Node native binary make blocking inappropriate.
+3. **One-click brew — RESOLVED: P3 add-on, link+command is v1 baseline.** Always show install URL + copyable command. Add one-click `brew install` only in P3, only when `brew` is detected, behind explicit confirm, via the streamed-install channel, never auto-run (§4.2).
+4. **Linux PATH — RESOLVED: include Snap + Flatpak.** Add `/snap/bin`, `/var/lib/flatpak/exports/bin`, `~/.local/share/flatpak/exports/bin` to the existence-checked dir union (§3.2 step 3).
+
+No remaining blockers — the spec is ready to implement starting at P0.


### PR DESCRIPTION
## What

Root-cause fix for the **"NPM failed"** install error. When AgentMux launches from Finder / Dock / a mounted DMG as a `.app`, it inherits launchd's stripped PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). nvm/Homebrew `node`/`npm`/`git` live in the user's **login-shell** PATH, which a GUI launch never sees — so `install.start`'s `Command::new("npm")` died with `npm: command not found`, and spawned agent CLIs couldn't resolve their interpreter. This hits the majority of macOS users (nvm/Homebrew Node) — the central "do users have the right prereqs" risk for the alpha.

**P0** of `docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` (the Toolchain Manager modal — P1–P3 — builds on this).

## How

- **`agentmux-common::toolchain_path`** — `resolve_login_path()` reconstructs a usable PATH from `$SHELL -lic 'printf … "$PATH"'` (2s hard timeout; sentinel-isolated parse so rc-file stdout banners can't corrupt it) unioned with existence-checked well-known dirs (nvm current/default, Homebrew, `/usr/local/bin`, `~/.local/bin`, `~/.cargo/bin`; +Snap/Flatpak on Linux). **Purely additive** — never drops an inherited system dir. **No-op on Windows** (`#[cfg(not(unix))]` early return — Windows GUI apps already inherit a usable PATH). Returns a `PathSource` (`login-shell` / `fallback-dirs` / `inherited`) for diagnostics + the future modal.
- **host `sidecar.rs`** — sets the enriched PATH on the srv it spawns (logs the source).
- **srv `main.rs`** — cheap direct-launch fallback: enriches only when the current PATH looks like the stripped launchd default (won't pay for a shell spawn when already healthy).

## Cross-platform

| OS | Behavior |
|----|----------|
| macOS | Enriches from login shell + Homebrew/nvm dirs |
| Linux | Same + Snap/Flatpak export dirs |
| Windows | No-op (GUI inherits usable PATH) |

## Tests

9 unit tests in `toolchain_path`: sentinel parsing (incl. rc-noise), launchd-default detection, semver-ish nvm version sort, additive/dedup merge + `PathSource` reporting, and a real-`/bin/sh` round-trip. `cargo test -p agentmux-common` green; `agentmux-srv` + `agentmux-cef` compile clean.

## Spec open questions — all resolved

- `claude.exe` on macOS is a healthy Mach-O arm64 binary (per-platform `optionalDependencies`), **not** corruption → "Repair" needs no special-casing.
- Node min-version: **warn-only**.
- One-click `brew`: **P3**, link+command is the v1 baseline.
- Linux PATH: include Snap + Flatpak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)