### PR TITLE
chore(ui): cursor design tokens + utilities + scrollbar lint guard (Phase 1+2)

### DIFF
--- a/.changesets/1781565397-chore-cursor-tokens-and-guard.md
+++ b/.changesets/1781565397-chore-cursor-tokens-and-guard.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(ui): add cursor design tokens + utilities and a stylelint guard against cursor on scrollbars

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,14 @@
                 "auto", "unset", "inherit", "initial"
             ]
         },
+        "rule-selector-property-disallowed-list": [
+            {
+                "/-webkit-scrollbar/": ["cursor"]
+            },
+            {
+                "message": "Scrollbars are scroll affordances, not links — never set `cursor` on a `::-webkit-scrollbar*` selector. Remove it so the thumb keeps the default arrow (it inherits it). See docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md."
+            }
+        ],
         "declaration-no-important": [true, {
             "message": "`!important` is forbidden — fix the underlying specificity or selector. If unavoidable, document the reason in a comment AND grandfather the file via `.stylelintignore`."
         }],

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -105,9 +105,23 @@ a.plain-link {
 .os-scrollbar-handle {
     // Arrow, not the link hand — the OverlayScrollbars drag handle is a scroll
     // affordance. (Agent panes scroll through OverlayScrollbars, so this is
-    // what made the conversation scrollbar show the hand.)
-    cursor: default;
+    // what made the conversation scrollbar show the hand.) Token-driven via the
+    // cursor design tokens; the `-webkit-scrollbar` guard in `.stylelintrc.json`
+    // can't cover this OS-library class, so it is set explicitly here.
+    cursor: var(--cursor-default);
 }
+
+// ─── Cursor utilities — interaction affordances ─────────────────────────────
+// Resolve to the `--cursor-*` design tokens (theme.scss). Use these on markup
+// that can't easily reach a component stylesheet; SCSS authors can also write
+// `cursor: var(--cursor-interactive)` directly. See
+// `docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md`.
+.u-cursor-interactive { cursor: var(--cursor-interactive); }
+.u-cursor-default     { cursor: var(--cursor-default); }
+.u-cursor-text        { cursor: var(--cursor-text); }
+.u-cursor-disabled    { cursor: var(--cursor-disabled); }
+.u-cursor-grab        { cursor: var(--cursor-grab); }
+.u-cursor-grabbing    { cursor: var(--cursor-grabbing); }
 
 .scrollbar-hide-until-hover {
     *::-webkit-scrollbar-thumb,

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -295,6 +295,22 @@
     --motion-slow:   280ms cubic-bezier(0.2, 1, 0.3, 1);
     --motion-spring: 400ms cubic-bezier(0.2, 0.9, 0.2, 1.2);
 
+    // Cursor — interaction affordances. Name the INTENT, not the raw keyword,
+    // so components read semantically and the mapping can move in one place.
+    // A scroll affordance (scrollbar thumb / handle) is NOT interactive in the
+    // click sense — it stays the arrow (`--cursor-default`), never the link
+    // hand. The `.u-cursor-*` utilities + the scrollbar guard in
+    // `.stylelintrc.json` keep this honest. See
+    // `docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md`.
+    --cursor-interactive: pointer;     // buttons, links, clickable rows
+    --cursor-default:     default;     // arrow — surfaces, scroll thumbs, chrome
+    --cursor-text:        text;        // editable text
+    --cursor-disabled:    not-allowed; // disabled controls
+    --cursor-grab:        grab;        // draggable, idle
+    --cursor-grabbing:    grabbing;    // draggable, active
+    --cursor-resize-x:    ew-resize;   // horizontal dividers
+    --cursor-resize-y:    ns-resize;   // vertical dividers
+
     // Z-index hierarchy (canonical source — SPEC_DESIGN_SYSTEM §5.3).
     // Naming is aspirational; existing `--zindex-*` tokens higher in
     // this file stay valid and will be re-pointed or retired in a


### PR DESCRIPTION
## What

Phase 1+2 of the cursor audit (`docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md`). Phase 0 (#1453) already fixed the scrollbar hand; this generalizes cursor styling and **prevents the bug class from recurring**.

Cursors were the one interaction primitive never tokenized — **229** raw `cursor:` declarations, no tokens/mixins/utilities — while spacing, type, radius, motion, and z-index all are. That asymmetry is exactly why a wrong global default (link-hand on scrollbars) could be set once and go unnoticed.

## Phase 1 — generalization

- **`theme.scss`**: semantic `--cursor-*` tokens (`interactive`, `default`, `text`, `disabled`, `grab`, `grabbing`, `resize-x/-y`). Name the intent, not the keyword.
- **`app.scss`**: `.u-cursor-*` utility classes resolving to the tokens (for markup that can't easily reach a component stylesheet; SCSS authors can also write `cursor: var(--cursor-interactive)`). `.os-scrollbar-handle` now reads `cursor: var(--cursor-default)`.

## Phase 2 — guardrail

- **`.stylelintrc.json`**: `rule-selector-property-disallowed-list` forbids the `cursor` property on any `::-webkit-scrollbar*` selector, with a message pointing at the analysis doc. This models the existing `z-index` allowed-list and `color-no-hex` design-system enforcement. After Phase 0 nothing sets cursor on those selectors, so it passes today and fails the moment someone re-adds the hand.

## Scope / not done

The 229-site migration to the utilities is **deliberately not** in this PR — it's opportunistic per-area hygiene (agent pane first), not a big-bang rewrite. Rationale in the analysis doc's phasing table.

## Verification

`node_modules` isn't present in this checkout, so I couldn't run `stylelint` locally — but the JSON validates, the rule name/shape match stylelint 17 core, and I scanned the tree to confirm no remaining `cursor` declaration sits inside a `::-webkit-scrollbar*` rule (the lone hit was the explanatory *comment* in the thumb rule, which stylelint doesn't evaluate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)