### PR TITLE
feat(toolchain): Toolchain manager modal (hamburger ▸ Toolchain) — P1

### DIFF
--- a/.changesets/1781565739-feat-toolchain-manager-modal.md
+++ b/.changesets/1781565739-feat-toolchain-manager-modal.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(toolchain): Toolchain manager in the hamburger menu — a new "Toolchain" item opens a modal showing the effective PATH (and how it was derived), OS/arch, and the detected version + path + status of node, npm, git, docker and every provider CLI, with install links for anything missing. P1 of SPEC_TOOLCHAIN_MANAGER (read-only; install-in-place is P2).

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -228,6 +228,8 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     .envs(paths.to_env_vars())
     .env("AGENTMUX_APP_PATH", &app_path_str)
     .env("PATH", &enriched.path)
+    // Record how PATH was derived so the Toolchain modal can show it.
+    .env("AGENTMUX_PATH_SOURCE", enriched.source.as_str())
     .stdin(std::process::Stdio::piped())
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped());

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -270,6 +270,9 @@ async fn main() {
     // See SPEC_TOOLCHAIN_MANAGER_2026-06-15 §3.1.
     let path_source = agentmux_common::enrich_current_process_path();
     if path_source != agentmux_common::PathSource::Inherited {
+        // Record the source for the Toolchain modal (the host sets this when it
+        // spawns the srv; on a direct launch we set it here after enriching).
+        std::env::set_var("AGENTMUX_PATH_SOURCE", path_source.as_str());
         tracing::info!(
             source = path_source.as_str(),
             "Enriched srv PATH on direct launch (stripped PATH detected)"

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -470,6 +470,27 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    // toolchain.env — report the environment the srv resolves tools in: the
+    // effective PATH, how it was derived (set by the host/srv PATH enricher,
+    // see SPEC_TOOLCHAIN_MANAGER §3), and OS/arch. Powers the Toolchain
+    // modal's Environment section so PATH problems are diagnosable.
+    engine.register_handler(
+        "toolchain.env",
+        Box::new(|_data, _ctx| {
+            Box::pin(async move {
+                let path = std::env::var("PATH").unwrap_or_default();
+                let path_source =
+                    std::env::var("AGENTMUX_PATH_SOURCE").unwrap_or_else(|_| "inherited".to_string());
+                Ok(Some(serde_json::json!({
+                    "path": path,
+                    "pathSource": path_source,
+                    "os": std::env::consts::OS,
+                    "arch": std::env::consts::ARCH,
+                })))
+            })
+        }),
+    );
 }
 
 /// Re-export from shared crate for internal use.

--- a/docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md
+++ b/docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md
@@ -154,8 +154,8 @@ Introduce a small **core-tools catalog** (node, npm, git, docker; each with id, 
 
 ## 6. Rollout
 
-- **P0 (ship first, standalone):** §3 PATH enrichment in `agentmux-common` + host sidecar spawn. Independently valuable; unblocks installs immediately. Its own AgentO PR + reagent + changeset (`fix`).
-- **P1:** `toolchain.status` RPC + core-tools catalog + read-only Toolchain modal (Environment + Core + Agent CLI sections, versions/paths/PATH-source, links only).
+- **P0 (shipped, #1454):** §3 PATH enrichment in `agentmux-common` + host sidecar spawn. Independently valuable; unblocks installs immediately.
+- **P1 (shipped):** core-tools catalog + read-only Toolchain modal (Environment + Core + Agent CLI sections, versions/paths/PATH-source, links only). **Decomposition note:** rather than one batch `toolchain.status` RPC, P1 reuses the existing `resolvecli` RPC per row (it already does versioned-dir→PATH→`--version` for any tool, incl. non-npm like docker) and adds only a tiny **`toolchain.env`** RPC for the Environment block (`{ path, pathSource, os, arch }`, sourced from the host-set `AGENTMUX_PATH_SOURCE`). Lower-risk, less new backend. The batch `toolchain.status` remains a possible later optimization if per-row latency matters.
 - **P2:** Install/Repair in place for npm providers (wire `install.start` into rows).
 - **P3:** One-click `brew install` for core tools where `brew` is detected; fold in kimi Python prereq + Node min-version flagging.
 

--- a/frontend/app/modals/toolchain-modal.scss
+++ b/frontend/app/modals/toolchain-modal.scss
@@ -1,0 +1,202 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.toolchain-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3, 12px);
+
+    .modal-panel-title {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2, 8px);
+    }
+}
+
+.toolchain-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4, 16px);
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.toolchain-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1, 6px);
+}
+
+.toolchain-section-title {
+    margin: 0 0 var(--space-1, 6px);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.6;
+}
+
+// ── Environment ───────────────────────────────────────────────────────
+.toolchain-env-line {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
+    font-size: 0.85rem;
+    padding: 2px 0;
+}
+
+.toolchain-env-key {
+    min-width: 92px;
+    opacity: 0.6;
+}
+
+.toolchain-path-toggle {
+    align-self: flex-start;
+    margin-top: 2px;
+}
+
+.toolchain-path-dump {
+    margin: var(--space-1, 6px) 0 0;
+    padding: var(--space-2, 8px);
+    border-radius: var(--radius-md, 6px);
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.1));
+    font-size: 0.75rem;
+    line-height: 1.45;
+    max-height: 180px;
+    overflow-y: auto;
+    white-space: pre;
+}
+
+// ── Tool rows ─────────────────────────────────────────────────────────
+.toolchain-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3, 12px);
+    padding: var(--space-2, 8px) var(--space-2, 8px);
+    border-radius: var(--radius-md, 6px);
+
+    &:hover {
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.07));
+    }
+}
+
+.toolchain-row--missing .toolchain-row-name {
+    opacity: 0.85;
+}
+
+.toolchain-row-icon {
+    width: 20px;
+    text-align: center;
+    margin-top: 3px;
+    opacity: 0.8;
+}
+
+.toolchain-row-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.toolchain-row-title {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2, 8px);
+}
+
+.toolchain-row-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.toolchain-row-path {
+    font-size: 0.74rem;
+    opacity: 0.55;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.toolchain-row-cmd {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
+
+    code {
+        font-size: 0.74rem;
+        padding: 1px 6px;
+        border-radius: 4px;
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.12));
+    }
+}
+
+.toolchain-row-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1, 6px);
+    margin-top: 2px;
+}
+
+// ── Pills ─────────────────────────────────────────────────────────────
+.toolchain-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.15));
+
+    &--ok {
+        background: rgba(46, 160, 67, 0.18);
+        color: var(--success-color, #2ea043);
+    }
+    &--warn {
+        background: rgba(219, 154, 4, 0.18);
+        color: var(--warning-color, #d29922);
+    }
+    &--muted {
+        opacity: 0.7;
+    }
+}
+
+// ── Buttons ───────────────────────────────────────────────────────────
+.toolchain-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    padding: 4px 10px;
+    border-radius: var(--radius-md, 6px);
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    background: var(--button-bg, transparent);
+    cursor: pointer;
+
+    &:hover {
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.12));
+    }
+    &--ghost {
+        border-color: transparent;
+    }
+}
+
+.toolchain-link-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    padding: 4px 6px;
+    border: none;
+    background: transparent;
+    color: var(--link-color, #58a6ff);
+    cursor: pointer;
+    border-radius: 4px;
+
+    &:hover {
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.12));
+    }
+}

--- a/frontend/app/modals/toolchain-modal.tsx
+++ b/frontend/app/modals/toolchain-modal.tsx
@@ -278,7 +278,11 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
                                     {showPath() ? "Hide" : "Show"} effective PATH
                                 </button>
                                 <Show when={showPath()}>
-                                    <pre class="toolchain-path-dump">{e().path.split(":").join("\n")}</pre>
+                                    <pre class="toolchain-path-dump">
+                                        {e()
+                                            .path.split(e().os === "windows" ? ";" : ":")
+                                            .join("\n")}
+                                    </pre>
                                 </Show>
                             </>
                         )}

--- a/frontend/app/modals/toolchain-modal.tsx
+++ b/frontend/app/modals/toolchain-modal.tsx
@@ -120,24 +120,19 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
             setRows(idx, { loading: false, found: false });
             return;
         }
-        const data =
-            row.kind === "core"
-                ? {
-                      provider_id: row.id,
-                      cli_command: (def as any).cliCommand,
-                      npm_package: "",
-                      pinned_version: "",
-                      windows_install_command: "",
-                      unix_install_command: "",
-                  }
-                : {
-                      provider_id: (def as any).id,
-                      cli_command: (def as any).cliCommand,
-                      npm_package: (def as any).npmPackage,
-                      pinned_version: (def as any).pinnedVersion,
-                      windows_install_command: (def as any).windowsInstallCommand ?? "",
-                      unix_install_command: (def as any).unixInstallCommand ?? "",
-                  };
+        // Detection MUST be pure — `resolvecli` is resolve-OR-install: with a
+        // non-empty `npm_package` it `npm install`s any provider not found in
+        // the versioned dir. We pass an EMPTY npm_package so it only probes the
+        // versioned install dir then the system PATH (never installs). Install
+        // is an explicit, user-initiated action (P2). See SPEC_TOOLCHAIN_MANAGER.
+        const data = {
+            provider_id: row.id,
+            cli_command: (def as any).cliCommand,
+            npm_package: "",
+            pinned_version: "",
+            windows_install_command: "",
+            unix_install_command: "",
+        };
         try {
             const r = await RpcApi.ResolveCliCommand(TabRpcClient, data, { timeout: 12000 });
             setRows(idx, {

--- a/frontend/app/modals/toolchain-modal.tsx
+++ b/frontend/app/modals/toolchain-modal.tsx
@@ -1,0 +1,312 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ToolchainModal — the hamburger ▸ "Toolchain" surface.
+ *
+ * Gives users visibility + control over the toolchain AgentMux runs CLIs in:
+ *  - **Environment** — the effective PATH the srv resolves tools in, how it was
+ *    derived (login-shell / fallback-dirs / inherited), and OS/arch. Makes the
+ *    GUI-launch PATH problem (the "NPM failed" bug) diagnosable rather than
+ *    mysterious.
+ *  - **Core tools** — Node.js, npm, Git, Docker (versions + paths + status).
+ *  - **Agent CLIs** — every provider, detected version + source.
+ *
+ * P1 (this file) is read-only: detection + install *links*. Install/repair in
+ * place (reusing `install.start`) is P2. See
+ * docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md.
+ */
+
+import { createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { createStore } from "solid-js/store";
+
+import { Modal } from "@/element/modal";
+import { openModal, type ModalCloseProps } from "@/app/store/modalmodel";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { getApi } from "@/store/global";
+import { getPlatform } from "@/util/platformutil";
+import { CORE_TOOLS, type Platform } from "@/app/view/agent/providers/toolchain-catalog";
+import { getProviderList } from "@/app/view/agent/providers";
+import "./toolchain-modal.scss";
+
+interface ToolRow {
+    id: string;
+    label: string;
+    icon: string;
+    kind: "core" | "provider";
+    loading: boolean;
+    found: boolean;
+    version?: string;
+    path?: string;
+    /** "local_install" | "system_path" — where resolvecli found it. */
+    source?: string;
+    optional?: boolean;
+    minVersion?: string;
+    docsUrl?: string;
+    installUrl?: string;
+    installCommand?: string;
+}
+
+interface ToolEnv {
+    path: string;
+    pathSource: string;
+    os: string;
+    arch: string;
+}
+
+function platformKey(): Platform {
+    switch (getPlatform()) {
+        case "win32":
+            return "windows";
+        case "darwin":
+            return "macos";
+        default:
+            return "linux";
+    }
+}
+
+/** Human label for the PATH-source badge. */
+function pathSourceLabel(src: string): string {
+    switch (src) {
+        case "login-shell":
+            return "from your login shell";
+        case "fallback-dirs":
+            return "from well-known dirs (login shell unavailable)";
+        default:
+            return "inherited from the launching process";
+    }
+}
+
+export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
+    const plat = platformKey();
+    const [env, setEnv] = createSignal<ToolEnv | null>(null);
+    const [showPath, setShowPath] = createSignal(false);
+
+    // Build the initial (loading) row list: core tools, then provider CLIs.
+    const coreRows: ToolRow[] = CORE_TOOLS.map((t) => ({
+        id: t.id,
+        label: t.label,
+        icon: t.icon,
+        kind: "core",
+        loading: true,
+        found: false,
+        optional: t.optional,
+        minVersion: t.minVersion,
+        docsUrl: t.docsUrl,
+        installUrl: t.installUrls[plat],
+        installCommand: t.installCommand?.[plat],
+    }));
+    const providerRows: ToolRow[] = getProviderList().map((p) => ({
+        id: p.id,
+        label: p.displayName,
+        icon: p.icon,
+        kind: "provider",
+        loading: true,
+        found: false,
+        docsUrl: p.docsUrl,
+        installUrl: p.docsUrl,
+    }));
+
+    const [rows, setRows] = createStore<ToolRow[]>([...coreRows, ...providerRows]);
+
+    const probe = async (idx: number) => {
+        const row = rows[idx];
+        const def =
+            row.kind === "core"
+                ? CORE_TOOLS.find((t) => t.id === row.id)
+                : getProviderList().find((p) => p.id === row.id);
+        if (!def) {
+            setRows(idx, { loading: false, found: false });
+            return;
+        }
+        const data =
+            row.kind === "core"
+                ? {
+                      provider_id: row.id,
+                      cli_command: (def as any).cliCommand,
+                      npm_package: "",
+                      pinned_version: "",
+                      windows_install_command: "",
+                      unix_install_command: "",
+                  }
+                : {
+                      provider_id: (def as any).id,
+                      cli_command: (def as any).cliCommand,
+                      npm_package: (def as any).npmPackage,
+                      pinned_version: (def as any).pinnedVersion,
+                      windows_install_command: (def as any).windowsInstallCommand ?? "",
+                      unix_install_command: (def as any).unixInstallCommand ?? "",
+                  };
+        try {
+            const r = await RpcApi.ResolveCliCommand(TabRpcClient, data, { timeout: 12000 });
+            setRows(idx, {
+                loading: false,
+                found: true,
+                version: r.version && r.version !== "unknown" ? r.version : undefined,
+                path: r.cli_path,
+                source: r.source,
+            });
+        } catch {
+            // resolvecli throws when the tool is found nowhere.
+            setRows(idx, { loading: false, found: false });
+        }
+    };
+
+    onMount(() => {
+        RpcApi.ToolchainEnvCommand(TabRpcClient, { timeout: 8000 })
+            .then(setEnv)
+            .catch(() => setEnv(null));
+        // Probe every row in parallel — each updates its own store entry.
+        rows.forEach((_, i) => void probe(i));
+    });
+
+    const refresh = () => {
+        rows.forEach((_, i) => setRows(i, { loading: true, found: false, version: undefined }));
+        rows.forEach((_, i) => void probe(i));
+    };
+
+    const open = (url?: string) => {
+        if (url) getApi().openExternal(url);
+    };
+    const copy = (cmd?: string) => {
+        if (cmd) void navigator.clipboard?.writeText(cmd);
+    };
+
+    const renderRow = (row: ToolRow): JSX.Element => (
+        <div class="toolchain-row" classList={{ "toolchain-row--missing": !row.loading && !row.found }}>
+            <i class={`toolchain-row-icon fa-solid fa-${row.icon}`} aria-hidden="true" />
+            <div class="toolchain-row-main">
+                <div class="toolchain-row-title">
+                    <span class="toolchain-row-name">{row.label}</span>
+                    <Show when={row.loading}>
+                        <span class="toolchain-pill toolchain-pill--muted">Checking…</span>
+                    </Show>
+                    <Show when={!row.loading && row.found}>
+                        <span class="toolchain-pill toolchain-pill--ok">
+                            <i class="fa-solid fa-check" /> {row.version ?? "installed"}
+                        </span>
+                        <Show when={row.source === "local_install"}>
+                            <span class="toolchain-pill toolchain-pill--muted">managed</span>
+                        </Show>
+                    </Show>
+                    <Show when={!row.loading && !row.found}>
+                        <span
+                            class="toolchain-pill"
+                            classList={{
+                                "toolchain-pill--warn": !row.optional,
+                                "toolchain-pill--muted": row.optional,
+                            }}
+                        >
+                            {row.optional ? "Not installed (optional)" : "Not found"}
+                        </span>
+                    </Show>
+                </div>
+                <Show when={row.found && row.path}>
+                    <div class="toolchain-row-path" title={row.path}>
+                        {row.path}
+                    </div>
+                </Show>
+                <Show when={!row.loading && !row.found && row.installCommand}>
+                    <div class="toolchain-row-cmd">
+                        <code>{row.installCommand}</code>
+                        <button class="toolchain-link-btn" onClick={() => copy(row.installCommand)} title="Copy">
+                            <i class="fa-solid fa-copy" />
+                        </button>
+                    </div>
+                </Show>
+            </div>
+            <div class="toolchain-row-actions">
+                <Show when={!row.loading && !row.found && row.installUrl}>
+                    <button class="toolchain-btn" onClick={() => open(row.installUrl)}>
+                        Install <i class="fa-solid fa-arrow-up-right-from-square" />
+                    </button>
+                </Show>
+                <Show when={row.docsUrl}>
+                    <button class="toolchain-link-btn" onClick={() => open(row.docsUrl)} title="Docs">
+                        <i class="fa-solid fa-book" />
+                    </button>
+                </Show>
+            </div>
+        </div>
+    );
+
+    return (
+        <Modal open={true} onClose={props.close} scope="window" size="lg">
+            <div class="modal-panel-header toolchain-header">
+                <div class="modal-panel-title">
+                    <i class="fa-solid fa-wrench" /> Toolchain
+                </div>
+                <button class="toolchain-btn toolchain-btn--ghost" onClick={refresh}>
+                    <i class="fa-solid fa-rotate" /> Refresh
+                </button>
+            </div>
+            <div class="modal-panel-body toolchain-body">
+                {/* Environment */}
+                <section class="toolchain-section">
+                    <h3 class="toolchain-section-title">Environment</h3>
+                    <Show when={env()} fallback={<div class="toolchain-env-line">Loading…</div>}>
+                        {(e) => (
+                            <>
+                                <div class="toolchain-env-line">
+                                    <span class="toolchain-env-key">Platform</span>
+                                    <span>
+                                        {e().os} · {e().arch}
+                                    </span>
+                                </div>
+                                <div class="toolchain-env-line">
+                                    <span class="toolchain-env-key">PATH source</span>
+                                    <span
+                                        class="toolchain-pill"
+                                        classList={{
+                                            "toolchain-pill--ok": e().pathSource === "login-shell",
+                                            "toolchain-pill--warn":
+                                                e().pathSource === "inherited" &&
+                                                plat !== "windows",
+                                            "toolchain-pill--muted":
+                                                e().pathSource === "fallback-dirs" ||
+                                                plat === "windows",
+                                        }}
+                                    >
+                                        {pathSourceLabel(e().pathSource)}
+                                    </span>
+                                </div>
+                                <button
+                                    class="toolchain-link-btn toolchain-path-toggle"
+                                    onClick={() => setShowPath((v) => !v)}
+                                >
+                                    {showPath() ? "Hide" : "Show"} effective PATH
+                                </button>
+                                <Show when={showPath()}>
+                                    <pre class="toolchain-path-dump">{e().path.split(":").join("\n")}</pre>
+                                </Show>
+                            </>
+                        )}
+                    </Show>
+                </section>
+
+                {/* Core tools */}
+                <section class="toolchain-section">
+                    <h3 class="toolchain-section-title">Core tools</h3>
+                    <For each={rows.filter((r) => r.kind === "core")}>{renderRow}</For>
+                </section>
+
+                {/* Agent CLIs */}
+                <section class="toolchain-section">
+                    <h3 class="toolchain-section-title">Agent CLIs</h3>
+                    <For each={rows.filter((r) => r.kind === "provider")}>{renderRow}</For>
+                </section>
+            </div>
+            <div class="modal-panel-footer">
+                <button class="modal-btn modal-btn--confirm" data-modal-dismiss onClick={() => props.close()}>
+                    Close
+                </button>
+            </div>
+        </Modal>
+    );
+};
+
+/** Hamburger entry point. */
+export function openToolchainModal(): void {
+    openModal(ToolchainModal);
+}

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1386,6 +1386,16 @@ class RpcApiType {
         return client.rpcCall("resolvecli", data, opts);
     }
 
+    // command "toolchain.env" [call] — report the effective PATH the srv
+    // resolves tools in, how it was derived, and OS/arch. Powers the
+    // Toolchain modal's Environment section. See SPEC_TOOLCHAIN_MANAGER.
+    ToolchainEnvCommand(
+        client: RpcClient,
+        opts?: RpcOpts,
+    ): Promise<{ path: string; pathSource: string; os: string; arch: string }> {
+        return client.rpcCall("toolchain.env", {}, opts);
+    }
+
     // command "checkcliauth" [call]
     CheckCliAuthCommand(client: RpcClient, data: CommandCheckCliAuthData, opts?: RpcOpts): Promise<CheckCliAuthResult> {
         return client.rpcCall("checkcliauth", data, opts);

--- a/frontend/app/view/agent/providers/toolchain-catalog.ts
+++ b/frontend/app/view/agent/providers/toolchain-catalog.ts
@@ -1,0 +1,96 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Core toolchain catalog — the system tools AgentMux relies on beyond the
+ * provider CLIs: Node.js, npm, Git, and Docker. The Toolchain modal renders
+ * one row per entry (detected version + path + status) alongside the provider
+ * CLIs from `PROVIDERS`. This is the one place to add "anything we need" later
+ * (ripgrep, uv/python for kimi, …).
+ *
+ * Detection reuses the existing `resolvecli` RPC (versioned-install-dir →
+ * system PATH → `--version`), so a core tool with an empty `npmPackage` simply
+ * resolves on PATH. See docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md §5.
+ */
+
+export type Platform = "windows" | "macos" | "linux";
+
+export interface CoreTool {
+    /** Stable id + the binary name probed on PATH. */
+    id: string;
+    cliCommand: string;
+    label: string;
+    /** Font Awesome (solid) icon name, rendered as `fa-solid fa-<icon>`. */
+    icon: string;
+    /** Recommended minimum version (warn-only — never blocks). */
+    minVersion?: string;
+    /** Optional — a missing optional tool shows an info pill, not a warning. */
+    optional?: boolean;
+    description?: string;
+    docsUrl?: string;
+    /** Official install landing page per platform. */
+    installUrls: Record<Platform, string>;
+    /** Copyable one-liner per platform (shown next to the install link). */
+    installCommand?: Partial<Record<Platform, string>>;
+    /** Homebrew formula — enables the P3 one-click install when brew exists. */
+    brewFormula?: string;
+}
+
+const NODE_DOWNLOAD = "https://nodejs.org/en/download";
+
+export const CORE_TOOLS: CoreTool[] = [
+    {
+        id: "node",
+        cliCommand: "node",
+        label: "Node.js",
+        icon: "cube",
+        minVersion: "18",
+        description: "JavaScript runtime — required to install & run the npm-based agent CLIs.",
+        docsUrl: "https://nodejs.org/",
+        installUrls: { windows: NODE_DOWNLOAD, macos: NODE_DOWNLOAD, linux: NODE_DOWNLOAD },
+        installCommand: { macos: "brew install node", linux: "sudo apt install -y nodejs npm" },
+        brewFormula: "node",
+    },
+    {
+        id: "npm",
+        cliCommand: "npm",
+        label: "npm",
+        icon: "box",
+        description: "Node package manager — ships with Node.js; installs the agent CLIs.",
+        docsUrl: "https://docs.npmjs.com/",
+        installUrls: { windows: NODE_DOWNLOAD, macos: NODE_DOWNLOAD, linux: NODE_DOWNLOAD },
+        installCommand: { macos: "brew install node", linux: "sudo apt install -y nodejs npm" },
+        brewFormula: "node",
+    },
+    {
+        id: "git",
+        cliCommand: "git",
+        label: "Git",
+        icon: "code-branch",
+        minVersion: "2.23",
+        description: "Version control — used by Claude/OpenClaw for project context.",
+        docsUrl: "https://git-scm.com/",
+        installUrls: {
+            windows: "https://git-scm.com/download/win",
+            macos: "https://git-scm.com/download/mac",
+            linux: "https://git-scm.com/download/linux",
+        },
+        installCommand: { macos: "brew install git", linux: "sudo apt install -y git" },
+        brewFormula: "git",
+    },
+    {
+        id: "docker",
+        cliCommand: "docker",
+        label: "Docker",
+        icon: "box-open",
+        optional: true,
+        description: "Container runtime — only needed for container-mode agents.",
+        docsUrl: "https://docs.docker.com/get-docker/",
+        installUrls: {
+            windows: "https://docs.docker.com/desktop/install/windows-install/",
+            macos: "https://docs.docker.com/desktop/install/mac-install/",
+            linux: "https://docs.docker.com/engine/install/",
+        },
+        brewFormula: "docker",
+    },
+];

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -22,6 +22,7 @@ import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
 import { openBundleManager } from "@/app/modals/bundle-manager-modal";
+import { openToolchainModal } from "@/app/modals/toolchain-modal";
 import { isMacOS } from "@/util/platformutil";
 import { createMemo, type JSX } from "solid-js";
 import "./hamburger-menu.scss";
@@ -130,6 +131,14 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
                 label: "Trust Center",
                 icon: "shield-halved",
                 onClick: () => openBundleManager(),
+            },
+            {
+                // Toolchain — visibility + control over the dev tools AgentMux
+                // runs CLIs in (node/npm/git/docker + provider CLIs), incl. the
+                // effective PATH. See SPEC_TOOLCHAIN_MANAGER_2026-06-15.
+                label: "Toolchain",
+                icon: "wrench",
+                onClick: () => openToolchainModal(),
             },
             {
                 label: "DevTools",


### PR DESCRIPTION
## What

A first-class **Toolchain** surface (hamburger ▸ Toolchain) so users can see — and diagnose — the dev toolchain AgentMux runs CLIs in. Builds on the P0 PATH fix (#1454); this is **P1** of `SPEC_TOOLCHAIN_MANAGER_2026-06-15` (read-only).

A window-scoped modal with three sections:
- **Environment** — the *effective PATH* the srv resolves tools in + a **source badge** (`login-shell` / `fallback-dirs` / `inherited`), OS/arch, and a Show-PATH toggle. This makes the GUI-launch PATH problem (the "NPM failed" class) visible instead of mysterious.
- **Core tools** — node / npm / git / docker: detected version + resolved path + status pill.
- **Agent CLIs** — every provider: version + source (`local_install` vs `system_path`).

Missing tools get an **Install** link (+ copyable command). Docker is marked optional, so its absence reads as info, not a warning.

## Design / decomposition

- **Reuses `resolvecli`** per row (it already does versioned-dir → PATH → `--version` for any tool, incl. non-npm like docker) — no new batch resolver, lower risk.
- Adds only a tiny **`toolchain.env`** RPC → `{ path, pathSource, os, arch }`. `pathSource` comes from `AGENTMUX_PATH_SOURCE`, set by the host (P0) when it enriches the srv PATH (srv also sets it on the direct-launch fallback).
- New `toolchain-catalog.ts` is the single place to add more tools later (ripgrep, uv/python for kimi…).

## Cross-platform

Probes use `which`/`where`; the modal is platform-agnostic; the PATH-source badge reflects P0's per-OS enrichment (no-op on Windows, where the badge reads "inherited" as muted, not a warning).

## Scope

Read-only by design. **Install/repair in place** (reuse `install.start`) is **P2**; **one-click `brew`** is **P3** — both tracked in the spec.

## Verification

- `cargo check` clean on `agentmux-srv` + `agentmux-cef`; `cargo test -p agentmux-common` (P0) green.
- `tsc --noEmit`: zero new errors from the added files (toolchain-modal, toolchain-catalog, rpc-api, hamburger-menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)