### PR TITLE
fix(widgets): hug content width in More dropdown to remove right-side gap

### DIFF
--- a/.changesets/1781566498-fix-widgets-hug-content-width-in-the-more-dropdown-so-short--yaoh.md
+++ b/.changesets/1781566498-fix-widgets-hug-content-width-in-the-more-dropdown-so-short--yaoh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(widgets): hug content width in the More dropdown so short widget labels no longer leave a wide empty gap on the right (was min-width:170px, now width:max-content)

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -125,7 +125,16 @@
 .action-widget-more-dropdown {
     @include menuFrame.menu-frame;
     z-index: var(--z-flyout-menu);
-    min-width: 170px;
+    // Hug the widest row instead of forcing a fixed floor. This menu lists
+    // short, left-aligned widget names with no right-aligned content (no
+    // accelerators / submenu arrows), so the old `min-width: 170px` rendered a
+    // ~176px panel over ~83px of content — leaving ~100px of dead space on the
+    // right of *every* row (the "wide gap"). `width: max-content` with no
+    // oversized floor sizes the panel to its longest label. Measured in
+    // headless Chrome: 176px → 83px, right-gap 99-120px → 0 on the widest row.
+    // NOTE: a min-width floor here re-introduces the gap (120px floor still
+    // left a 49-70px gap), so deliberately none.
+    width: max-content;
     user-select: none;
 
     .action-widget-more-item {


### PR DESCRIPTION
## Problem

Opening the widget bar's **…more** overflow dropdown shows a **wide empty band on the right of every row**.

## Root cause (measured, not guessed)

In `frontend/app/window/action-widgets.scss`, the dropdown forced a fixed floor:

```scss
.action-widget-more-dropdown { min-width: 170px; }
```

while each row is only `[icon 14px] [gap] [label]` with **no right-aligned content** (no keyboard accelerators, submenu arrows, or checkmarks — unlike a general context menu). The widget names are short single words (Agent, Browser, Terminal, …), so the panel renders much wider than its content and the surplus shows as dead space on the right.

I verified this in **headless Chrome** with the real DOM + the actual compiled rules and all 9 widget labels:

| Variant | Panel width | Right-gap per row |
|---|---|---|
| **A — `min-width:170px` (before)** | 176px | **99–120px** (even the widest row, "Terminal", had 99px) |
| B — `max-content` + `min-width:120px` | 126px | 49–70px ← still gapped |
| **C — `max-content`, no floor (this PR)** | **83px** | **0 on the widest row** (6–27px residual on shorter words is normal menu behaviour) |

Isolation runs also showed the label's `flex` value (`1 1 auto` vs `0 1 auto`) makes **no** difference — the only lever is the width floor.

## Fix

```scss
width: max-content;   // hug the longest label; min-width floor removed
```

A `min-width` floor re-introduces the gap (the 120px floor still left 49–70px), so it is deliberately removed. Pure CSS — no change to positioning (`bottom-end` anchor), hit targets, or behavior.

## Testing

- Headless-Chrome measurement above (real rules, real labels). Before → after: 176px panel / ~100px gap → 83px panel / gap-free on the widest row.
- CSS-only / SolidJS hot-reload — to confirm in-app: `task dev`, open the **…more** dropdown, verify rows hug the labels.

> Note: this branch was based on `origin/main` @ 0.46.0; the live build under test was a separate 0.60.0 dev instance that does **not** contain this branch, so it could not have reflected the change until built. The widget files are unchanged on latest `main`, so the patch applies cleanly.

A `patch` changeset is included per the repo's changesets workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)