### PR TITLE
fix(cef): unbreak Windows build — HWND needs .0 before *mut c_void cast

### DIFF
--- a/.changesets/1781566603-fix-cef-hwnd-cast.md
+++ b/.changesets/1781566603-fix-cef-hwnd-cast.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): add `.0` before the `HWND -> *mut c_void` cast in app.rs (unbreak the Windows build; windows 0.57 `HWND` is a non-primitive struct).

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -74,7 +74,7 @@ wrap_window_delegate! {
             #[cfg(target_os = "windows")]
             if let Some((_, label)) = self.window_registration.as_ref() {
                 if label.starts_with("window-pool-") {
-                    let raw_hwnd = window.window_handle() as *mut std::ffi::c_void;
+                    let raw_hwnd = window.window_handle().0 as *mut std::ffi::c_void;
                     if !raw_hwnd.is_null() {
                         crate::commands::window_pool::init_pool_window_hwnd(label, raw_hwnd);
                     }


### PR DESCRIPTION
## Problem
`main` does not compile on Windows:
```
error[E0605]: non-primitive cast: `HWND` as `*mut c_void`
  --> agentmux-cef/src/app.rs:77:36
```

## Cause
`app.rs:77` (the Windows pool-window HWND pre-cache path) casts
`window.window_handle() as *mut std::ffi::c_void`, but the `windows` 0.57 `HWND`
is a non-primitive struct `HWND(pub isize)` — you can't `as`-cast it. The sibling
macOS path (`app.rs:132`) returns a raw `NSView*`, so it compiles — which is why
the **v0.46.0 macOS/Linux artifacts built fine while the Windows build was broken**.

## Fix
Add `.0` before the cast — `window.window_handle().0 as *mut std::ffi::c_void` —
matching the established convention (`client/mod.rs:498`, `callbacks.rs:41`, `drag.rs:180`).

## Verification
`task build:host` → `Finished release profile [optimized] in 1m 54s` (warnings only; E0605 gone). A full `task package` Windows portable is building on this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)