### PR TITLE
feat(muxlog): cross-instance log discovery, NDJSON rendering, filters & recipes

### DIFF
--- a/.changesets/1781568947-feat-muxlog-cross-instance-log-discovery-ndjson-rendering-fi-ovsl.md
+++ b/.changesets/1781568947-feat-muxlog-cross-instance-log-discovery-ndjson-rendering-fi-ovsl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxlog): cross-instance log discovery, NDJSON rendering, filters and recipes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,18 +152,29 @@ These views exist in the codebase but are **not** widget-bar entries — do not 
 
 ## Log Access
 
-`$AGENTMUX_LOG_DIR` in AgentMux terminals is the shared `~/.agentmux/logs/` directory. The sidecar log lives there directly; the host log lives in the per-instance data dir and registers a pointer (`current-host-v<v>.path`) in the shared dir so `muxlog host` can resolve it.
+`muxlog` discovers and renders AgentMux logs across **every** running instance
+(shared dir, each `task dev` branch under `~/.agentmux/dev/<branch>/`, and per-build
+channels). It defaults to the **most-recently-active** instance — don't trust a
+single pointer; run `muxlog ls` first when several instances are up.
 
 | What | Command |
 |------|---------|
-| Tail host log | `muxlog host` |
+| List every instance's logs (newest first) | `muxlog ls` |
+| Tail host log (follow) | `muxlog host` |
 | Tail sidecar log | `muxlog srv` |
-| Frontend logs | `muxlog host '\[fe\]'` |
-| Memory heartbeat | `muxlog host mem_heartbeat` |
-| Full host log | `muxlog host cat` |
-| Launcher log | `cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"` |
+| Frontend `[fe]` lines | `muxlog fe` |
+| Search sidecar (agent transcript excluded) | `muxlog srv grep <regex>` |
+| Memory heartbeat | `muxlog host grep mem_heartbeat` |
+| Errors + warnings (host & sidecar) | `muxlog errors` |
+| Startup-handshake / reconnect-loop trace | `muxlog bridge` |
+| Target a specific instance | `muxlog host -i <branch\|version>` |
+| Launcher log | `muxlog launcher` |
+| Full usage | `muxlog help` |
 
-Works identically across `task dev`, portable, and install builds. Logs auto-rotate daily and are retained for 7 days.
+Renders NDJSON as `time level target message`; `--raw` for original JSON. Works
+identically across `task dev`, portable, and install builds. Not loaded in a
+tool-spawned subshell? Call the core directly: `node ~/.agentmux/shell/muxlog.mjs ls`.
+Full reference: `docs/MUXLOG.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,16 +100,22 @@ task package:linux      # Linux AppImage (writes to ~/Desktop)
 
 ### Logs
 
-Inside AgentMux terminals, `$AGENTMUX_LOG_DIR` is set to the shared `~/.agentmux/logs/` directory. That directory holds the sidecar log directly, plus pointer files (`current-host-v<v>.path`, `current-srv-v<v>.path`) for both processes — the host log itself lives in the per-instance data dir, but its pointer here lets `muxlog host` find it from any context. The shipped `muxlog` shell helper handles the indirection:
+The `muxlog` helper (shipped in every AgentMux terminal) **discovers and renders logs across every running instance** — the shared dir, each `task dev` instance (`~/.agentmux/dev/<branch>/`), and per-build channels — so you never hunt for a file or guess a version. It defaults to the **most-recently-active** instance and renders the NDJSON logs as compact `time  level  target  message`.
 
 | What | Command |
 |------|---------|
-| Tail host log | `muxlog host` |
-| Tail sidecar log | `muxlog srv` |
-| Frontend lines only | `muxlog host '\[fe\]'` |
-| Full host log | `muxlog host cat` |
+| List every instance's logs (newest first) | `muxlog ls` |
+| Tail the active host log (follow) | `muxlog host` |
+| Tail the active sidecar log | `muxlog srv` |
+| Frontend `[fe]` lines only | `muxlog fe` |
+| Launcher log | `muxlog launcher` |
+| Search the sidecar (agent transcript excluded) | `muxlog srv grep <regex>` |
+| Errors + warnings across host & sidecar | `muxlog errors` |
+| Startup-handshake trace (debug reconnect loops) | `muxlog bridge` |
+| Target a specific instance | `muxlog host -i <branch\|version>` |
+| Full usage | `muxlog help` |
 
-Works identically across `task dev`, portable, and installed builds. Logs auto-rotate daily and are retained for 7 days. Full per-process layout and pointer-file mechanics: [docs.agentmux.ai/internals/data-layout](https://docs.agentmux.ai/internals/data-layout/) and [/internals/debugging](https://docs.agentmux.ai/internals/debugging/).
+Works identically across `task dev`, portable, and installed builds. Full reference (targets, filters, recipes, how discovery works): **[docs/MUXLOG.md](docs/MUXLOG.md)**. Per-process log layout and the underlying data dirs: [docs.agentmux.ai/internals/data-layout](https://docs.agentmux.ai/internals/data-layout/) and [/internals/debugging](https://docs.agentmux.ai/internals/debugging/).
 
 ## Widgets
 

--- a/agentmux-srv/src/backend/shellintegration.rs
+++ b/agentmux-srv/src/backend/shellintegration.rs
@@ -17,6 +17,10 @@ const BASH_SCRIPT: &str = include_str!("shellintegration/bash.sh");
 const ZSH_SCRIPT: &str = include_str!("shellintegration/zsh.sh");
 const PWSH_SCRIPT: &str = include_str!("shellintegration/pwsh.ps1");
 const FISH_SCRIPT: &str = include_str!("shellintegration/fish.fish");
+/// Shared muxlog core (Node). Deployed once at `<shell>/muxlog.mjs`; every
+/// shell's `muxlog` function delegates to it. One tested implementation does log
+/// discovery + NDJSON rendering + filtering for all shells.
+const MUXLOG_JS: &str = include_str!("shellintegration/muxlog.mjs");
 const VERSION_MARKER: &str = env!("CARGO_PKG_VERSION");
 
 // ─── Shell type ──────────────────────────────────────────────────────────────
@@ -85,6 +89,14 @@ pub fn deploy_scripts(wave_data_dir: &Path) {
             tracing::warn!("shell integration: failed to write {}: {}", path.display(), e);
             all_ok = false;
         }
+    }
+
+    // Deploy the shared muxlog core next to the per-shell dirs. Each rcfile
+    // resolves it relative to its own location and delegates to `node muxlog.mjs`.
+    let muxlog_path = shell_base.join("muxlog.mjs");
+    if let Err(e) = std::fs::write(&muxlog_path, MUXLOG_JS) {
+        tracing::warn!("shell integration: failed to write {}: {}", muxlog_path.display(), e);
+        all_ok = false;
     }
 
     // Write version marker only if all scripts deployed successfully

--- a/agentmux-srv/src/backend/shellintegration/bash.sh
+++ b/agentmux-srv/src/backend/shellintegration/bash.sh
@@ -84,37 +84,30 @@ _agentmux_si_prompt_command() {
     _agentmux_si_agent_env
 }
 
-# ─── muxlog helper ────────────────────────────────────────────────────────────
-# Usage: muxlog [host|srv] [tail|cat|<pattern>]
+# ─── muxlog ───────────────────────────────────────────────────────────────────
+# Discover, render & follow AgentMux logs across every running instance.
+# Delegates to the shared Node core (muxlog.mjs, deployed next to this rcfile).
+#   muxlog                 tail the most-recently-active host log (follow)
+#   muxlog ls              list every instance's logs (newest first)
+#   muxlog srv grep <re>   search the active sidecar log (transcript excluded)
+#   muxlog bridge          startup-handshake trace (debug reconnect loops)
+#   muxlog help            full usage
+# Resolve muxlog.mjs once, at source time (BASH_SOURCE = this rcfile).
+_AGENTMUX_MUXLOG_JS="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)/muxlog.mjs"
 muxlog() {
-    local target="${1:-host}"
-    local action="${2:-tail}"
-    if [ -z "$AGENTMUX_LOG_DIR" ]; then
-        echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2
-        return 1
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXLOG_JS" ]; then
+        node "$_AGENTMUX_MUXLOG_JS" "$@"
+        return
     fi
+    # Fallback (no node / core missing): legacy pointer-based tail, so logs are
+    # never wholly inaccessible.
+    local target="${1:-host}" action="${2:-tail}"
+    [ -z "$AGENTMUX_LOG_DIR" ] && { echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2; return 1; }
     local ptr="$AGENTMUX_LOG_DIR/current-${target}-v${AGENTMUX_VERSION}.path"
-    if [ ! -f "$ptr" ]; then
-        echo "Unknown log target '$target'. Available:" >&2
-        ls "$AGENTMUX_LOG_DIR"/current-*.path 2>/dev/null \
-            | sed 's|.*/current-||;s|\.path||' >&2
-        return 1
-    fi
-    local ptr_content="$(cat "$ptr")"
-    # Pointer content may be a basename (legacy: resolve under
-    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix:
-    # the global pointer at <root>/logs/ writes the absolute path so
-    # discovery works from outside the instance dir).
-    local logfile
-    case "$ptr_content" in
-        /* | ?:[/\\]*) logfile="$ptr_content" ;;
-        *)            logfile="$AGENTMUX_LOG_DIR/$ptr_content" ;;
-    esac
-    case "$action" in
-        tail) tail -f "$logfile" ;;
-        cat)  cat "$logfile" ;;
-        *)    grep "$action" "$logfile" ;;
-    esac
+    [ -f "$ptr" ] || { echo "muxlog: Node core unavailable and no pointer for '$target'" >&2; return 1; }
+    local pc logfile; pc="$(cat "$ptr")"
+    case "$pc" in /* | ?:[/\\]*) logfile="$pc" ;; *) logfile="$AGENTMUX_LOG_DIR/$pc" ;; esac
+    case "$action" in tail) tail -f "$logfile" ;; cat) cat "$logfile" ;; *) grep "$action" "$logfile" ;; esac
 }
 
 # Append to PROMPT_COMMAND (array-safe)

--- a/agentmux-srv/src/backend/shellintegration/fish.fish
+++ b/agentmux-srv/src/backend/shellintegration/fish.fish
@@ -50,8 +50,17 @@ function _agentmux_si_agent_env
     end
 end
 
-# ─── muxlog helper ────────────────────────────────────────────────────────────
+# ─── muxlog ───────────────────────────────────────────────────────────────────
+# Discover, render & follow AgentMux logs across every running instance.
+# Delegates to the shared Node core (muxlog.mjs). `muxlog help` for usage,
+# `muxlog ls` to list every instance's logs.
+set -g _agentmux_muxlog_js (dirname (status -f))/../muxlog.mjs
 function muxlog
+    if command -q node; and test -f "$_agentmux_muxlog_js"
+        node "$_agentmux_muxlog_js" $argv
+        return
+    end
+    # Fallback (no node / core missing): legacy pointer-based tail.
     set -l target (test (count $argv) -ge 1; and echo $argv[1]; or echo "host")
     set -l action (test (count $argv) -ge 2; and echo $argv[2]; or echo "tail")
     if not set -q AGENTMUX_LOG_DIR
@@ -60,14 +69,10 @@ function muxlog
     end
     set -l ptr "$AGENTMUX_LOG_DIR/current-$target-v$AGENTMUX_VERSION.path"
     if not test -f "$ptr"
-        echo "Unknown log target '$target'. Check $AGENTMUX_LOG_DIR for current-*.path files." >&2
+        echo "muxlog: Node core unavailable and no pointer for '$target'" >&2
         return 1
     end
     set -l ptr_content (cat "$ptr")
-    # Pointer content may be a basename (legacy: resolve under
-    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix:
-    # global pointer writes the absolute path so discovery works
-    # from outside the instance dir).
     set -l logfile
     if string match -q '/*' "$ptr_content"; or string match -q '?:[/\\]*' "$ptr_content"
         set logfile "$ptr_content"

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// muxlog — discover, render, and follow AgentMux logs across every instance.
+//
+// Deployed by agentmux-srv next to the shell rcfiles (~/.agentmux/shell/muxlog.mjs);
+// the bash/zsh/pwsh/fish `muxlog` functions delegate here. Run standalone with
+// `node muxlog.mjs ...` (works from any subshell, unlike the shell function).
+//
+// Why a Node core instead of per-shell functions: log lines are structured NDJSON,
+// they live in three different root trees (shared, dev/<branch>, channels/local-*),
+// and the old version-pinned pointer routinely resolved a STALE instance's log.
+// One tested implementation does discovery + JSON rendering + filtering uniformly.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = os.homedir();
+const AGENTMUX = path.join(HOME, ".agentmux");
+
+// ─── Log discovery ────────────────────────────────────────────────────────────
+// Logs can live in any of these roots (the shared dir alone is NOT enough — dev
+// builds and per-build channels keep their host log in their own data dir):
+//   ~/.agentmux/logs/                                  (shared: srv, launcher, some host)
+//   ~/.agentmux/dev/<branch>/<hash>/logs/              (task dev, keyed on branch)
+//   ~/.agentmux/channels/local-*/versions/<v>/.../logs/(portable/per-build)
+function* logRoots() {
+    yield { dir: path.join(AGENTMUX, "logs"), source: "shared" };
+    for (const p of glob(path.join(AGENTMUX, "dev", "*", "*", "logs")))
+        yield { dir: p, source: "dev:" + p.split(path.sep).at(-3) };
+    for (const p of glob(path.join(AGENTMUX, "channels", "*", "versions", "*", "*", "logs")))
+        yield { dir: p, source: "channel:" + p.split(path.sep).at(-5) };
+}
+
+// Tiny one-level-per-`*` glob (no deps). Only handles `*` path segments.
+function glob(pattern) {
+    const parts = pattern.split(path.sep);
+    let bases = [parts[0] === "" ? path.sep : parts[0]];
+    for (let i = 1; i < parts.length; i++) {
+        const seg = parts[i];
+        const next = [];
+        for (const base of bases) {
+            if (seg.includes("*")) {
+                const re = new RegExp("^" + seg.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$");
+                let entries = [];
+                try { entries = fs.readdirSync(base, { withFileTypes: true }); } catch { /* skip */ }
+                for (const e of entries) if (re.test(e.name)) next.push(path.join(base, e.name));
+            } else {
+                next.push(path.join(base, seg));
+            }
+        }
+        bases = next;
+    }
+    return bases.filter((p) => { try { return fs.existsSync(p); } catch { return false; } });
+}
+
+const TARGET_GLOB = {
+    host: /^agentmux-host-v.*\.log(\..*)?$/,
+    srv: /^agentmuxsrv-v.*\.log(\..*)?$/,
+    launcher: /^agentmux-launcher\.log$/,
+};
+
+// Returns [{target, file, mtime, size, version, source}] across all roots, newest first.
+function discover(target) {
+    const out = [];
+    const want = target === "fe" || target === "all" ? null : target;
+    for (const { dir, source } of logRoots()) {
+        let entries = [];
+        try { entries = fs.readdirSync(dir); } catch { continue; }
+        for (const name of entries) {
+            for (const [t, re] of Object.entries(TARGET_GLOB)) {
+                if (want && t !== want) continue;
+                if (!re.test(name)) continue;
+                const full = path.join(dir, name);
+                let st; try { st = fs.statSync(full); } catch { continue; }
+                const ver = (name.match(/v(\d+\.\d+\.\d+)/) || [])[1] || "?";
+                out.push({ target: t, file: full, mtime: st.mtimeMs, size: st.size, version: ver, source });
+            }
+        }
+    }
+    return out.sort((a, b) => b.mtime - a.mtime);
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+const LVL_COLOR = { ERROR: "\x1b[31m", WARN: "\x1b[33m", INFO: "\x1b[2m", DEBUG: "\x1b[2m" };
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m";
+
+// An NDJSON log line → one compact human line (or null if filtered out).
+function renderLine(raw, opt) {
+    const t = raw.trim();
+    if (!t) return null;
+    let j;
+    try { j = JSON.parse(t); } catch { return opt.raw ? t : t; } // non-JSON: pass through
+    const fields = j.fields || {};
+    const msg = fields.message ?? j.message ?? "";
+    const target = j.target || "";
+    const level = (j.level || "INFO").toUpperCase();
+
+    // Default: drop agent-conversation transcript noise (the srv log is mostly this).
+    if (!opt.all && /blockcontroller::subprocess|subprocess stdout → blockfile/.test(target + " " + msg)) return null;
+    if (opt.level && !opt.level.includes(level.toLowerCase())) return null;
+    if (opt.target && !target.includes(opt.target)) return null;
+    if (opt.excludeTarget && target.includes(opt.excludeTarget)) return null;
+    if (opt.grep && !opt.grep.test(String(msg))) return null;
+    if (opt.since && j.timestamp && j.timestamp < opt.since) return null;
+
+    if (opt.raw) return t;
+    const ts = (j.timestamp || "").replace(/^.*T/, "").replace(/\..*$/, "") || "--:--:--";
+    const c = LVL_COLOR[level] ?? "";
+    let line = `${DIM}${ts}${RESET} ${c}${level.padEnd(5)}${RESET} ${DIM}${shortTarget(target)}${RESET}  ${msg}`;
+    if (opt.verbose) {
+        const extra = { ...fields }; delete extra.message;
+        const keys = Object.keys(extra);
+        if (keys.length) line += `  ${DIM}${JSON.stringify(extra)}${RESET}`;
+    }
+    return line;
+}
+
+function shortTarget(t) {
+    // agentmux_cef::commands::backend → cef:backend ; agentmux_srv::server → srv:server
+    return t.replace(/^agentmux_/, "").replace(/::/g, ":").replace(/:[^:]+:/g, ":");
+}
+
+// ─── Follow (tail -f over NDJSON) ─────────────────────────────────────────────
+// Read for display. For a plain tail of a huge file we only need the end, so
+// read the last 8 MB (the launcher log can reach hundreds of MB). When we have
+// to scan/filter the whole history (grep, recipes, explicit filters) pass
+// whole=true so matches aren't missed.
+function readForDisplay(file, whole) {
+    let size = 0; try { size = fs.statSync(file).size; } catch { return ""; }
+    const WINDOW = 8 * 1024 * 1024;
+    if (whole || size <= WINDOW) { try { return fs.readFileSync(file, "utf8"); } catch { return ""; } }
+    const fd = fs.openSync(file, "r");
+    const buf = Buffer.alloc(WINDOW);
+    fs.readSync(fd, buf, 0, WINDOW, size - WINDOW);
+    fs.closeSync(fd);
+    const s = buf.toString("utf8");
+    return s.slice(s.indexOf("\n") + 1); // drop the partial first line
+}
+
+// Filter FIRST, then keep the last n survivors — so `muxlog bridge`/`grep`
+// returns the last n *matching* lines, not "the last n lines, if any match".
+function printLastLines(file, n, opt, whole = false) {
+    const rendered = [];
+    for (const l of readForDisplay(file, whole).split("\n")) {
+        const r = renderLine(l, opt); if (r != null) rendered.push(r);
+    }
+    const out = n > 0 ? rendered.slice(-n) : rendered;
+    for (const r of out) process.stdout.write(r + "\n");
+}
+
+function follow(file, opt) {
+    let size; try { size = fs.statSync(file).size; } catch { size = 0; }
+    setInterval(() => {
+        let st; try { st = fs.statSync(file); } catch { return; }
+        if (st.size < size) size = 0;            // truncated/rotated
+        if (st.size === size) return;
+        const fd = fs.openSync(file, "r");
+        const buf = Buffer.alloc(st.size - size);
+        fs.readSync(fd, buf, 0, buf.length, size);
+        fs.closeSync(fd);
+        size = st.size;
+        for (const l of buf.toString("utf8").split("\n")) {
+            const r = renderLine(l, opt); if (r != null) process.stdout.write(r + "\n");
+        }
+    }, 400);
+}
+
+// ─── ls ───────────────────────────────────────────────────────────────────────
+function listInstances() {
+    const all = discover("all").concat(discover("host"), discover("srv"), discover("launcher"));
+    const seen = new Set();
+    const rows = [];
+    for (const e of discover("host").concat(discover("srv"), discover("launcher"))) {
+        if (seen.has(e.file)) continue; seen.add(e.file);
+        rows.push(e);
+    }
+    rows.sort((a, b) => b.mtime - a.mtime);
+    if (!rows.length) { console.log("No AgentMux logs found under ~/.agentmux."); return; }
+    console.log(`${"TARGET".padEnd(9)}${"VERSION".padEnd(9)}${"SOURCE".padEnd(22)}${"AGE".padEnd(8)}${"SIZE".padEnd(8)}PATH`);
+    for (const e of rows) {
+        console.log(
+            e.target.padEnd(9) + e.version.padEnd(9) + e.source.slice(0, 21).padEnd(22) +
+            age(e.mtime).padEnd(8) + human(e.size).padEnd(8) + e.file,
+        );
+    }
+}
+function age(ms) {
+    const s = Math.floor((Date.now() - ms) / 1000);
+    if (s < 90) return s + "s";
+    if (s < 5400) return Math.floor(s / 60) + "m";
+    if (s < 129600) return Math.floor(s / 3600) + "h";
+    return Math.floor(s / 86400) + "d";
+}
+function human(b) { return b < 1024 ? b + "B" : b < 1048576 ? (b / 1024).toFixed(0) + "K" : (b / 1048576).toFixed(1) + "M"; }
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+function parse(argv) {
+    const opt = { n: 200, all: false, raw: false, verbose: false };
+    const pos = [];
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "-a" || a === "--all") opt.all = true;
+        else if (a === "--raw") opt.raw = true;
+        else if (a === "-v" || a === "--verbose") opt.verbose = true;
+        else if (a === "-n") opt.n = parseInt(argv[++i], 10) || 200;
+        else if (a === "-i" || a === "--instance") opt.instance = argv[++i];
+        else if (a === "--level") opt.level = argv[++i].toLowerCase().split(",");
+        else if (a === "--target") opt.target = argv[++i];
+        else if (a === "--exclude-target") opt.excludeTarget = argv[++i];
+        else if (a === "--since") opt.since = argv[++i];
+        else if (a === "--grep") opt.grep = new RegExp(argv[++i], "i");
+        else pos.push(a);
+    }
+    return { opt, pos };
+}
+
+function resolveFile(target, opt) {
+    let cands = discover(target);
+    if (opt.instance) cands = cands.filter((e) => e.file.toLowerCase().includes(opt.instance.toLowerCase()) || e.source.includes(opt.instance) || e.version.includes(opt.instance));
+    if (!cands.length) {
+        console.error(`muxlog: no ${target} log found${opt.instance ? ` matching '${opt.instance}'` : ""}. Try \`muxlog ls\`.`);
+        process.exit(1);
+    }
+    return cands[0].file; // most recently active
+}
+
+const HELP = `muxlog — AgentMux log viewer
+
+  muxlog [host|srv|launcher|fe|all] [tail|cat|grep <re>]   default: host tail (follow)
+  muxlog ls                          list every instance's logs (newest first)
+  muxlog errors                      ERROR/WARN across host+srv (active instance)
+  muxlog bridge                      startup-handshake trace (debug reconnect loops)
+
+Options (any position):
+  -i <substr>   pick the instance whose log path/branch/version matches <substr>
+  -n <N>        history lines before following (default 200)
+  -a            include agent-transcript noise (excluded by default)
+  --grep <re>   filter on the message field only (not the whole JSON line)
+  --level a,b   only these levels (error,warn,info,debug)
+  --target <s>  only log lines whose target contains <s>
+  --since <ts>  only lines at/after ISO <ts> (e.g. 2026-06-15T23:30)
+  --raw         emit the original NDJSON   --verbose  include structured fields`;
+
+function main() {
+    const { opt, pos } = parse(process.argv.slice(2));
+    const cmd = pos[0] || "host";
+
+    if (cmd === "help" || cmd === "-h" || cmd === "--help") { console.log(HELP); return; }
+    if (cmd === "ls") { listInstances(); return; }
+
+    if (cmd === "errors") {
+        opt.level = ["error", "warn"];
+        for (const tgt of ["host", "srv"]) {
+            const f = discover(tgt).filter((e) => !opt.instance || e.file.includes(opt.instance))[0];
+            if (f) { console.log(`\n=== ${tgt}: ${f.file} ===`); printLastLines(f.file, opt.n, opt, true); }
+        }
+        return;
+    }
+    if (cmd === "bridge") {
+        // The startup handshake — correlate cred injection with bridge-init outcome.
+        opt.grep = /Loading URL|Injected IPC|backend.?ready|window\.api|Bootstrap|setupCefApi|reconnect|on_load_end/i;
+        opt.all = true;
+        const f = resolveFile("host", opt);
+        console.log(`=== bridge trace: ${f} ===`);
+        printLastLines(f, opt.n, opt, true);
+        return;
+    }
+
+    const targets = ["host", "srv", "launcher", "fe", "all"];
+    const target = targets.includes(cmd) ? cmd : "host";
+    const action = (targets.includes(cmd) ? pos[1] : pos[0]) || "tail";
+    if (action === "grep") { const re = pos[pos.indexOf("grep") + 1]; if (re) opt.grep = new RegExp(re, "i"); }
+    if (target === "fe") opt.grep = opt.grep || /\[fe\]/;
+
+    const file = resolveFile(target === "fe" ? "host" : target === "all" ? "host" : target, opt);
+
+    if (action === "cat" || action === "grep") { printLastLines(file, 0, opt, true); return; }
+    // default: tail -f (print last -n lines, then follow)
+    printLastLines(file, opt.n, opt);
+    follow(file, opt);
+}
+
+main();

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -93,7 +93,16 @@ function renderLine(raw, opt) {
     const t = raw.trim();
     if (!t) return null;
     let j;
-    try { j = JSON.parse(t); } catch { return opt.raw ? t : t; } // non-JSON: pass through
+    try {
+        j = JSON.parse(t);
+    } catch {
+        // Non-JSON line (a panic backtrace, a raw println). It has no structured
+        // fields, so any structured filter excludes it; a --grep must still match
+        // its text. Otherwise pass it through verbatim so nothing is lost.
+        if (opt.level || opt.target || opt.excludeTarget || opt.since) return null;
+        if (opt.grep && !opt.grep.test(t)) return null;
+        return t;
+    }
     const fields = j.fields || {};
     const msg = fields.message ?? j.message ?? "";
     const target = j.target || "";
@@ -171,7 +180,6 @@ function follow(file, opt) {
 
 // ─── ls ───────────────────────────────────────────────────────────────────────
 function listInstances() {
-    const all = discover("all").concat(discover("host"), discover("srv"), discover("launcher"));
     const seen = new Set();
     const rows = [];
     for (const e of discover("host").concat(discover("srv"), discover("launcher"))) {
@@ -208,7 +216,7 @@ function parse(argv) {
         else if (a === "-v" || a === "--verbose") opt.verbose = true;
         else if (a === "-n") opt.n = parseInt(argv[++i], 10) || 200;
         else if (a === "-i" || a === "--instance") opt.instance = argv[++i];
-        else if (a === "--level") opt.level = argv[++i].toLowerCase().split(",");
+        else if (a === "--level") { const v = argv[++i]; if (v) opt.level = v.toLowerCase().split(","); }
         else if (a === "--target") opt.target = argv[++i];
         else if (a === "--exclude-target") opt.excludeTarget = argv[++i];
         else if (a === "--since") opt.since = argv[++i];
@@ -255,7 +263,7 @@ function main() {
     if (cmd === "errors") {
         opt.level = ["error", "warn"];
         for (const tgt of ["host", "srv"]) {
-            const f = discover(tgt).filter((e) => !opt.instance || e.file.includes(opt.instance))[0];
+            const f = discover(tgt).filter((e) => !opt.instance || e.file.toLowerCase().includes(opt.instance.toLowerCase()))[0];
             if (f) { console.log(`\n=== ${tgt}: ${f.file} ===`); printLastLines(f.file, opt.n, opt, true); }
         }
         return;

--- a/agentmux-srv/src/backend/shellintegration/pwsh.ps1
+++ b/agentmux-srv/src/backend/shellintegration/pwsh.ps1
@@ -59,19 +59,24 @@ function Global:_agentmux_si_prompt {
     _agentmux_si_agent_env
 }
 
-# ─── muxlog helper ────────────────────────────────────────────────────────────
+# ─── muxlog ───────────────────────────────────────────────────────────────────
+# Discover, render & follow AgentMux logs across every running instance.
+# Delegates to the shared Node core (muxlog.mjs). `muxlog help` for usage,
+# `muxlog ls` to list every instance's logs.
+$global:AgentmuxMuxlogJs = Join-Path $PSScriptRoot "..\muxlog.mjs"
 function Global:muxlog {
-    param([string]$Target = "host", [string]$Action = "tail")
-    if (-not $env:AGENTMUX_LOG_DIR) {
-        Write-Error "AGENTMUX_LOG_DIR not set - run inside an AgentMux terminal"
+    if ((Get-Command node -ErrorAction SilentlyContinue) -and (Test-Path $global:AgentmuxMuxlogJs)) {
+        node $global:AgentmuxMuxlogJs @args
         return
     }
+    # Fallback (no node / core missing): legacy pointer-based tail.
+    $Target = if ($args.Count -ge 1) { $args[0] } else { "host" }
+    $Action = if ($args.Count -ge 2) { $args[1] } else { "tail" }
+    if (-not $env:AGENTMUX_LOG_DIR) { Write-Error "AGENTMUX_LOG_DIR not set - run inside an AgentMux terminal"; return }
     $ptr = Join-Path $env:AGENTMUX_LOG_DIR "current-$Target-v$($env:AGENTMUX_VERSION).path"
-    if (-not (Test-Path $ptr)) {
-        Write-Error "Unknown log target '$Target'. Check $env:AGENTMUX_LOG_DIR for current-*.path files."
-        return
-    }
-    $logfile = Join-Path $env:AGENTMUX_LOG_DIR (Get-Content $ptr)
+    if (-not (Test-Path $ptr)) { Write-Error "muxlog: Node core unavailable and no pointer for '$Target'"; return }
+    $pc = Get-Content $ptr
+    $logfile = if ($pc -match '^([A-Za-z]:[\\/]|[\\/])') { $pc } else { Join-Path $env:AGENTMUX_LOG_DIR $pc }
     switch ($Action) {
         "tail" { Get-Content $logfile -Wait -Tail 50 }
         "cat"  { Get-Content $logfile }

--- a/agentmux-srv/src/backend/shellintegration/zsh.sh
+++ b/agentmux-srv/src/backend/shellintegration/zsh.sh
@@ -85,34 +85,24 @@ _agentmux_si_precmd() {
     _agentmux_si_agent_env
 }
 
-# ─── muxlog helper ────────────────────────────────────────────────────────────
+# ─── muxlog ───────────────────────────────────────────────────────────────────
+# Discover, render & follow AgentMux logs across every running instance.
+# Delegates to the shared Node core (muxlog.mjs). `muxlog help` for full usage,
+# `muxlog ls` to list every instance's logs.
+_AGENTMUX_MUXLOG_JS="${${(%):-%x}:A:h}/../muxlog.mjs"
 muxlog() {
-    local target="${1:-host}"
-    local action="${2:-tail}"
-    if [ -z "$AGENTMUX_LOG_DIR" ]; then
-        echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2
-        return 1
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXLOG_JS" ]; then
+        node "$_AGENTMUX_MUXLOG_JS" "$@"
+        return
     fi
+    # Fallback (no node / core missing): legacy pointer-based tail.
+    local target="${1:-host}" action="${2:-tail}"
+    [ -z "$AGENTMUX_LOG_DIR" ] && { echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2; return 1; }
     local ptr="$AGENTMUX_LOG_DIR/current-${target}-v${AGENTMUX_VERSION}.path"
-    if [ ! -f "$ptr" ]; then
-        echo "Unknown log target '$target'. Available:" >&2
-        ls "$AGENTMUX_LOG_DIR"/current-*.path 2>/dev/null \
-            | sed 's|.*/current-||;s|\.path||' >&2
-        return 1
-    fi
-    local ptr_content="$(cat "$ptr")"
-    # Pointer content may be a basename (legacy: resolve under
-    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix).
-    local logfile
-    case "$ptr_content" in
-        /* | ?:[/\\]*) logfile="$ptr_content" ;;
-        *)            logfile="$AGENTMUX_LOG_DIR/$ptr_content" ;;
-    esac
-    case "$action" in
-        tail) tail -f "$logfile" ;;
-        cat)  cat "$logfile" ;;
-        *)    grep "$action" "$logfile" ;;
-    esac
+    [ -f "$ptr" ] || { echo "muxlog: Node core unavailable and no pointer for '$target'" >&2; return 1; }
+    local pc logfile; pc="$(cat "$ptr")"
+    case "$pc" in /* | ?:[/\\]*) logfile="$pc" ;; *) logfile="$AGENTMUX_LOG_DIR/$pc" ;; esac
+    case "$action" in tail) tail -f "$logfile" ;; cat) cat "$logfile" ;; *) grep "$action" "$logfile" ;; esac
 }
 
 autoload -U add-zsh-hook

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -1,0 +1,116 @@
+# `muxlog` — the AgentMux log viewer
+
+`muxlog` is shipped in every AgentMux terminal (bash / zsh / pwsh / fish). It
+**discovers, renders, and follows** the AgentMux logs for you — across every
+running instance — so debugging never starts with a file hunt.
+
+> One implementation: the shells delegate to a small Node core
+> (`muxlog.mjs`, deployed next to the shell rcfiles). Run it directly from any
+> subshell or script with `node ~/.agentmux/shell/muxlog.mjs …` if the `muxlog`
+> function isn't loaded (e.g. inside a tool-spawned `bash -c`).
+
+---
+
+## Quick start
+
+```bash
+muxlog ls           # what logs exist, newest first, with version + age
+muxlog              # follow the most-recently-active host log
+muxlog srv          # follow the active sidecar log
+muxlog bridge       # startup-handshake trace — debug "Can't reconnect" loops
+muxlog errors       # just the ERROR/WARN lines across host + sidecar
+muxlog help         # full usage
+```
+
+`muxlog` always defaults to the **most-recently-active** instance. With several
+instances running (dev + portables + different versions), that's almost always
+the one you mean — and `muxlog ls` shows the rest.
+
+---
+
+## Targets
+
+| Target | Log |
+|--------|-----|
+| `host` (default) | CEF host — windows, IPC bridge, `[fe]` frontend lines, heartbeat |
+| `srv` | sidecar — RPC, blocks, shells, config |
+| `launcher` | launcher — process/DLL/startup diagnostics (portable & installed only) |
+| `fe` | the host log, pre-filtered to frontend `[fe]` lines |
+| `all` | host (alias for the active host log; combined view is a roadmap item) |
+
+## Actions
+
+| Action | Meaning |
+|--------|---------|
+| `tail` (default) | print the last `-n` lines, then **follow** (like `tail -f`) |
+| `cat` | the whole log, rendered |
+| `grep <regex>` | lines whose **message** matches `<regex>` (not the whole JSON) |
+
+```bash
+muxlog host                 # follow host
+muxlog srv cat              # dump the sidecar log
+muxlog host grep "window\.api"
+```
+
+## Options (any position)
+
+| Option | Effect |
+|--------|--------|
+| `-i <substr>` | pick the instance whose log path / branch / version contains `<substr>` |
+| `-n <N>` | history lines before following (default 200) |
+| `-a` | include agent-transcript noise (the sidecar's `…→ blockfile` lines), excluded by default |
+| `--grep <re>` | filter on the message field only |
+| `--level a,b` | only these levels (`error,warn,info,debug`) |
+| `--target <s>` | only lines whose tracing target contains `<s>` |
+| `--since <ts>` | only lines at/after ISO `<ts>` (e.g. `2026-06-15T23:30`) |
+| `--raw` | emit the original NDJSON (don't render) |
+| `--verbose` | append the structured fields after the message |
+
+```bash
+muxlog srv -i fix-shell grep "shell\.spawn"   # a specific dev branch's sidecar
+muxlog host --level error,warn                 # only problems, then follow
+muxlog srv --since 2026-06-15T23:30 cat        # a time window
+```
+
+## Recipes
+
+| Recipe | What it shows |
+|--------|---------------|
+| `muxlog ls` | every instance's logs: target, version, source (`shared` / `dev:<branch>` / `channel:…`), age, size, path |
+| `muxlog errors` | ERROR + WARN across the active host and sidecar |
+| `muxlog bridge` | the startup handshake — `Loading URL`, `Injected IPC …`, `backend-ready`, `window.api`, `Bootstrap failed` — correlated in time, so a reconnect loop is obvious at a glance |
+
+---
+
+## How discovery works (and why it's better)
+
+AgentMux logs live in **three** root trees, not one:
+
+```
+~/.agentmux/logs/                                   shared: sidecar, launcher, some host
+~/.agentmux/dev/<branch>/<hash>/logs/               task dev — keyed on the git branch
+~/.agentmux/channels/local-*/versions/<v>/.../logs/ portable / per-build instances
+```
+
+The old `muxlog` followed a single version-pinned pointer
+(`current-host-v<version>.path`) in the shared dir only. With many instances that
+pointer routinely resolved a **stale** instance — and it was blind to the
+`dev/<branch>` logs entirely. `muxlog ls` / the most-recently-active default fix
+both: every root is scanned, results are ranked by modification time, and you can
+always pin a specific one with `-i`.
+
+## Notes
+
+- **Rendering** turns each NDJSON line into `HH:MM:SS  LEVEL  target  message`.
+  Tracing targets are shortened (`agentmux_cef::commands::backend` → `cef:backend`).
+  Use `--raw` for the original JSON, `--verbose` to see the structured fields.
+- **Transcript noise is excluded by default.** The sidecar log is mostly agent
+  conversation (`subprocess stdout → blockfile`); `muxlog` drops it so searches
+  hit real events. Pass `-a` to include it.
+- **Follow is efficient** on huge logs — a plain `tail` reads only the end of the
+  file; a `grep`/recipe/filter scans the whole history so no match is missed.
+- **Fallback:** if `node` isn't on `PATH`, `muxlog` degrades to the legacy
+  pointer-based `tail`/`cat`/`grep` so logs are never wholly inaccessible.
+
+Implementation: `agentmux-srv/src/backend/shellintegration/muxlog.mjs` (core) and
+the per-shell `muxlog` delegators in the same directory.


### PR DESCRIPTION
## Why

`muxlog` was a version-pinned pointer tail — host/srv only, raw NDJSON, single instance. In a real debugging session (a startup reconnect loop) it actively got in the way: it resolved a **6-day-stale** instance's log, was blind to the `~/.agentmux/dev/<branch>/` and `channels/local-*` log trees, and grepping the sidecar hit agent-transcript noise. Every hunt began with a manual `find` + giant-JSON `grep`.

## What

A shared **Node core** (`muxlog.mjs`, deployed next to the shell rcfiles) that the bash/zsh/pwsh/fish `muxlog` functions delegate to — one tested implementation instead of four divergent shell ports.

- **Discovery across all three log roots** (shared · `dev/<branch>` · `channels/local-*`), ranked by mtime → defaults to the **most-recently-active** instance.
- **`muxlog ls`** — every instance's logs with version, source (`shared`/`dev:<branch>`/`channel:…`), age, size, path.
- **NDJSON rendering** — `time  level  target  message` (shortened tracing targets); `--raw` / `--verbose`.
- **Targets** host·srv·launcher·fe; **filters** `-i` (instance), `--grep` (message field only), `--level`, `--since`, `--target`; **agent-transcript noise excluded by default** (`-a` to include).
- **Recipes** — `muxlog errors` (host+srv WARN/ERROR), `muxlog bridge` (startup-handshake correlation, purpose-built for the reconnect-loop class of bug).
- **Fallback** — if `node` isn't on PATH, degrades to the legacy pointer tail so logs are never inaccessible.

## Docs (emphasis of this PR)

- README **Logs** section rewritten with the new command set.
- New **`docs/MUXLOG.md`** — full reference (targets, actions, options, recipes, how discovery works).
- `CLAUDE.md` Log Access table updated (what agents read).

## Test

`node --check` clean; smoke-tested against live logs on Windows — `ls` (discovers shared+dev+channel logs newest-first), `bridge` (renders the exact handshake trace), `grep`/`cat`/filters/rendering all verified. Default `tail` follows like `tail -f`.

> Follow-ups (not in this PR): a combined time-interleaved `all` view; deploy redeploys only on version bump (`VERSION_MARKER` = cargo version) — a content-hash marker would redeploy on script edits too; and the docs-site (`docs.agentmux.ai`) page to mirror `docs/MUXLOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)