### PR TITLE
feat(agent-pane): surface classified failure cause on non-zero agent exit

### DIFF
--- a/.changesets/1781569327-feat-agent-pane-failure-wiring.md
+++ b/.changesets/1781569327-feat-agent-pane-failure-wiring.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): surface the classified failure cause when an agent exits non-zero (SPEC_AGENT_FAILURE_DIAGNOSTICS Phase 2 — pane path). The `SubprocessController` now captures a stderr tail, runs it through `failure::classify`, and emits an `agentfailure` event; the pane shows the real reason (auth, rate-limit, OOM, context, …) + stderr tail instead of a bare "exited with code N".

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -552,6 +552,12 @@ impl SubprocessController {
         // Resolve the agent's GLOBAL transcript zone once (see persistent.rs).
         let global_output_zone =
             super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
+        // Retain the terminal `result` frame so a failure reported on STDOUT
+        // (auth / rate-limit / usage — the common case; claude may even exit 0)
+        // can be classified, not just stderr-reported ones. Shared with the
+        // process_waiter below.
+        let last_result_frame: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let last_result_frame_read = Arc::clone(&last_result_frame);
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -580,12 +586,16 @@ impl SubprocessController {
                         // so token_estimate stays consistent across controller types.
                         stats.record_line(line.len(), &wstore_read);
 
-                        // Classify output for health monitoring
+                        // Classify output for health monitoring + retain the
+                        // terminal `result` frame for failure classification.
                         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
                             let (meaningful, error) = classify_output_line(&parsed);
                             health_read.record_output(meaningful);
                             if let Some((class, msg)) = error {
                                 health_read.record_error(class, msg);
+                            }
+                            if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
+                                *last_result_frame_read.lock().unwrap() = Some(parsed);
                             }
                         }
 
@@ -739,9 +749,10 @@ impl SubprocessController {
         let health_wait = Arc::clone(&self.health_monitor);
         let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         let stderr_tail_wait = Arc::clone(&stderr_tail);
+        let last_result_frame_wait = Arc::clone(&last_result_frame);
         tokio::spawn(async move {
-            // Classified failure cause for a genuine non-zero exit (None on clean
-            // exit or user-initiated stop). Surfaced to the pane after the loop.
+            // Classified failure cause for a genuine non-zero exit / stdout error
+            // frame (None on clean exit or user-initiated stop). Surfaced after the loop.
             let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
             // Wait for either process exit or kill signal
             tokio::select! {
@@ -780,17 +791,24 @@ impl SubprocessController {
                         inner.kill_tx = None;
                     }
 
-                    // Classify a genuine non-zero exit into a real cause so the
-                    // pane can show the reason instead of a bare "exit N". A
-                    // user-initiated stop goes through the kill arm and is not a
-                    // failure, so it is intentionally left unclassified.
-                    if exit_code != 0 {
+                    // Classify a genuine non-zero exit OR a failure reported on
+                    // stdout as an error `result` frame (auth / rate-limit / usage —
+                    // claude may even exit 0) into a real cause, so the pane shows
+                    // the reason instead of a bare "exit N". A user-initiated stop
+                    // goes through the kill arm and is left unclassified.
+                    let result_frame = last_result_frame_wait.lock().unwrap().clone();
+                    let frame_is_error = result_frame
+                        .as_ref()
+                        .and_then(|f| f.get("is_error"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if exit_code != 0 || frame_is_error {
                         let tail = stderr_tail_wait.lock().unwrap().join("\n");
                         run_failure = Some(crate::agents::failure::classify(
                             Some(exit_code),
                             exit_signal,
                             &tail,
-                            None,
+                            result_frame.as_ref(),
                         ));
                     }
                 }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -681,7 +681,12 @@ impl SubprocessController {
             tracing::info!(block_id = %block_id_read, "stdout_reader exiting");
         });
 
-        // Spawn stderr reader (log warnings, don't publish)
+        // Capture a bounded tail of stderr so a non-zero exit can be classified
+        // into a real cause (SPEC_AGENT_FAILURE_DIAGNOSTICS Phase 2) instead of a
+        // bare "exit N". Shared with the process_waiter below.
+        let stderr_tail: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let stderr_tail_reader = Arc::clone(&stderr_tail);
+        // Spawn stderr reader (logs warnings + retains a tail for classification)
         let block_id_err = self.block_id.clone();
         tokio::spawn(async move {
             let reader = BufReader::new(stderr);
@@ -700,6 +705,13 @@ impl SubprocessController {
                                 stderr = %line,
                                 "subprocess stderr"
                             );
+                            // Retain the last ~40 non-empty lines for classification.
+                            let mut buf = stderr_tail_reader.lock().unwrap();
+                            buf.push(line);
+                            let overflow = buf.len().saturating_sub(40);
+                            if overflow > 0 {
+                                buf.drain(0..overflow);
+                            }
                         }
                     }
                 }
@@ -726,19 +738,30 @@ impl SubprocessController {
         let run_lock = Arc::clone(&self.run_lock);
         let health_wait = Arc::clone(&self.health_monitor);
         let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
+        let stderr_tail_wait = Arc::clone(&stderr_tail);
         tokio::spawn(async move {
+            // Classified failure cause for a genuine non-zero exit (None on clean
+            // exit or user-initiated stop). Surfaced to the pane after the loop.
+            let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
             // Wait for either process exit or kill signal
             tokio::select! {
                 exit_result = child.wait() => {
-                    let exit_code = match exit_result {
-                        Ok(status) => status.code().unwrap_or(-1),
+                    let (exit_code, exit_signal) = match exit_result {
+                        Ok(status) => {
+                            let code = status.code().unwrap_or(-1);
+                            #[cfg(unix)]
+                            let sig = std::os::unix::process::ExitStatusExt::signal(&status);
+                            #[cfg(not(unix))]
+                            let sig: Option<i32> = None;
+                            (code, sig)
+                        }
                         Err(e) => {
                             tracing::warn!(
                                 block_id = %block_id_wait,
                                 error = %e,
                                 "subprocess wait error"
                             );
-                            -1
+                            (-1, None)
                         }
                     };
 
@@ -755,6 +778,20 @@ impl SubprocessController {
                         SubprocessController::set_status(&mut inner, STATUS_DONE);
                         inner.current_pid = None;
                         inner.kill_tx = None;
+                    }
+
+                    // Classify a genuine non-zero exit into a real cause so the
+                    // pane can show the reason instead of a bare "exit N". A
+                    // user-initiated stop goes through the kill arm and is not a
+                    // failure, so it is intentionally left unclassified.
+                    if exit_code != 0 {
+                        let tail = stderr_tail_wait.lock().unwrap().join("\n");
+                        run_failure = Some(crate::agents::failure::classify(
+                            Some(exit_code),
+                            exit_signal,
+                            &tail,
+                            None,
+                        ));
                     }
                 }
                 force = kill_rx => {
@@ -819,6 +856,20 @@ impl SubprocessController {
                     }
                 };
                 super::publish_controller_status(broker, &status);
+            }
+
+            // Surface the classified failure cause to the pane (Phase 2 of
+            // SPEC_AGENT_FAILURE_DIAGNOSTICS). A dedicated `agentfailure` event so
+            // the pane shows the real reason — auth, rate-limit, OOM, etc. — and
+            // the stderr tail, instead of just an opaque exit code.
+            if let (Some(failure), Some(broker)) = (run_failure.as_ref(), broker_wait.as_ref()) {
+                broker.publish(wps::WaveEvent {
+                    event: "agentfailure".to_string(),
+                    scopes: vec![format!("block:{}", block_id_wait)],
+                    sender: String::new(),
+                    persist: 0,
+                    data: serde_json::to_value(failure).ok(),
+                });
             }
 
             // Release run lock

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -558,7 +558,7 @@ impl SubprocessController {
         // process_waiter below.
         let last_result_frame: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
         let last_result_frame_read = Arc::clone(&last_result_frame);
-        tokio::spawn(async move {
+        let stdout_reader_handle = tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             let mut stats = super::session_stats::SessionStatsAccumulator::new(block_id_read.clone());
@@ -698,7 +698,7 @@ impl SubprocessController {
         let stderr_tail_reader = Arc::clone(&stderr_tail);
         // Spawn stderr reader (logs warnings + retains a tail for classification)
         let block_id_err = self.block_id.clone();
-        tokio::spawn(async move {
+        let stderr_reader_handle = tokio::spawn(async move {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             loop {
@@ -751,9 +751,12 @@ impl SubprocessController {
         let stderr_tail_wait = Arc::clone(&stderr_tail);
         let last_result_frame_wait = Arc::clone(&last_result_frame);
         tokio::spawn(async move {
-            // Classified failure cause for a genuine non-zero exit / stdout error
-            // frame (None on clean exit or user-initiated stop). Surfaced after the loop.
+            // Classified failure cause, surfaced to the pane after the readers drain.
             let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
+            // Set on a clean (non-killed) exit so classification runs AFTER the
+            // stdout/stderr readers are joined — otherwise the final error line can
+            // race the buffer read and be lost (reagent P1).
+            let mut clean_exit: Option<(i32, Option<i32>)> = None;
             // Wait for either process exit or kill signal
             tokio::select! {
                 exit_result = child.wait() => {
@@ -791,26 +794,9 @@ impl SubprocessController {
                         inner.kill_tx = None;
                     }
 
-                    // Classify a genuine non-zero exit OR a failure reported on
-                    // stdout as an error `result` frame (auth / rate-limit / usage —
-                    // claude may even exit 0) into a real cause, so the pane shows
-                    // the reason instead of a bare "exit N". A user-initiated stop
-                    // goes through the kill arm and is left unclassified.
-                    let result_frame = last_result_frame_wait.lock().unwrap().clone();
-                    let frame_is_error = result_frame
-                        .as_ref()
-                        .and_then(|f| f.get("is_error"))
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    if exit_code != 0 || frame_is_error {
-                        let tail = stderr_tail_wait.lock().unwrap().join("\n");
-                        run_failure = Some(crate::agents::failure::classify(
-                            Some(exit_code),
-                            exit_signal,
-                            &tail,
-                            result_frame.as_ref(),
-                        ));
-                    }
+                    // Defer classification until after the readers are joined
+                    // (below); a user-initiated stop (kill arm) stays unclassified.
+                    clean_exit = Some((exit_code, exit_signal));
                 }
                 force = kill_rx => {
                     let force = force.unwrap_or(false);
@@ -853,6 +839,32 @@ impl SubprocessController {
                 }
             }
 
+            // Classify a genuine non-zero exit OR a failure reported on stdout as
+            // an error `result` frame (auth / rate-limit / usage — claude may even
+            // exit 0). Join the stdout + stderr readers first (bounded) so their
+            // final lines — the ones carrying the error text — are in the buffers
+            // before we read them (reagent P1).
+            if let Some((exit_code, exit_signal)) = clean_exit {
+                let drain = std::time::Duration::from_secs(2);
+                let _ = tokio::time::timeout(drain, stdout_reader_handle).await;
+                let _ = tokio::time::timeout(drain, stderr_reader_handle).await;
+                let result_frame = last_result_frame_wait.lock().unwrap().clone();
+                let frame_is_error = result_frame
+                    .as_ref()
+                    .and_then(|f| f.get("is_error"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if exit_code != 0 || frame_is_error {
+                    let tail = stderr_tail_wait.lock().unwrap().join("\n");
+                    run_failure = Some(crate::agents::failure::classify(
+                        Some(exit_code),
+                        exit_signal,
+                        &tail,
+                        result_frame.as_ref(),
+                    ));
+                }
+            }
+
             // Update health monitor with exit status
             {
                 let inner = inner_wait.lock().unwrap();
@@ -882,7 +894,7 @@ impl SubprocessController {
             // the stderr tail, instead of just an opaque exit code.
             if let (Some(failure), Some(broker)) = (run_failure.as_ref(), broker_wait.as_ref()) {
                 broker.publish(wps::WaveEvent {
-                    event: "agentfailure".to_string(),
+                    event: wps::EVENT_AGENT_FAILURE.to_string(),
                     scopes: vec![format!("block:{}", block_id_wait)],
                     sender: String::new(),
                     persist: 0,

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -40,6 +40,10 @@ pub const EVENT_AGENT_MESSAGE_ACCEPTED: &str = "agent-message-accepted";
 pub const EVENT_ROUTE_GONE: &str = "route:gone";
 pub const EVENT_BLOCK_STATS: &str = "blockstats";
 pub const EVENT_AGENT_HEALTH: &str = "agenthealth";
+/// Fired when an agent subprocess exits non-zero (or reports an error on its
+/// terminal `result` frame). Carries the classified `AgentFailure` so the pane
+/// shows the real cause instead of a bare exit code.
+pub const EVENT_AGENT_FAILURE: &str = "agentfailure";
 /// Fired by `handle_shell_create` when a persistent shell is launched.
 /// Frontend creates the ShellNode row on receipt.
 /// Payload: `{ shell_id, cmd, cwd?, title, timestamp }`.

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -51,8 +51,10 @@ export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions
                 if (!f) return;
                 let msg = f.title || "Agent run failed";
                 if (f.detail) msg += ` — ${f.detail}`;
-                if (f.exitCode != null) msg += ` [exit ${f.exitCode}]`;
-                else if (f.signal != null) msg += ` [signal ${f.signal}]`;
+                // Prefer signal when present (matches AgentFailure::explain(); a
+                // signal kill stores exitCode as -1, so "[exit -1]" would mislead).
+                if (f.signal != null) msg += ` [signal ${f.signal}]`;
+                else if (f.exitCode != null) msg += ` [exit ${f.exitCode}]`;
                 if (f.retryable) msg += " (retryable)";
                 opts.log("subprocess", msg, "error");
                 if (f.stderrTail) {

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -21,7 +21,7 @@ export interface UseControllerStatusEventsOptions {
 
 export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions): void {
     onMount(() => {
-        const unsub = waveEventSubscribe({
+        const unsubStatus = waveEventSubscribe({
             eventType: "controllerstatus",
             scope: WOS.makeORef("block", opts.blockId),
             handler: (event) => {
@@ -38,6 +38,32 @@ export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions
                 }
             },
         });
-        onCleanup(() => unsub());
+
+        // Rich failure cause emitted alongside a non-zero exit
+        // (SPEC_AGENT_FAILURE_DIAGNOSTICS Phase 2): surfaces the real reason —
+        // auth, rate-limit, OOM, context, etc. — plus the stderr tail, instead of
+        // just "exited with code N".
+        const unsubFailure = waveEventSubscribe({
+            eventType: "agentfailure",
+            scope: WOS.makeORef("block", opts.blockId),
+            handler: (event) => {
+                const f = (event as any)?.data as AgentFailure | undefined;
+                if (!f) return;
+                let msg = f.title || "Agent run failed";
+                if (f.detail) msg += ` — ${f.detail}`;
+                if (f.exitCode != null) msg += ` [exit ${f.exitCode}]`;
+                else if (f.signal != null) msg += ` [signal ${f.signal}]`;
+                if (f.retryable) msg += " (retryable)";
+                opts.log("subprocess", msg, "error");
+                if (f.stderrTail) {
+                    opts.log("subprocess", `claude stderr (tail):\n${f.stderrTail}`, "error");
+                }
+            },
+        });
+
+        onCleanup(() => {
+            unsubStatus();
+            unsubFailure();
+        });
     });
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -75,6 +75,29 @@ declare global {
         is_agent_pane?: boolean;
     };
 
+    // agents.failure.AgentFailure — payload of the `agentfailure` wave event
+    // (classified cause of a non-zero agent exit). snake_case `code`, camelCase rest.
+    type AgentFailure = {
+        code:
+            | "rate_limited"
+            | "overloaded"
+            | "usage_limit"
+            | "auth"
+            | "context_exceeded"
+            | "max_turns"
+            | "network"
+            | "killed"
+            | "no_output"
+            | "spawn_failure"
+            | "unknown_non_zero";
+        title: string;
+        detail: string;
+        exitCode?: number;
+        signal?: number;
+        stderrTail?: string;
+        retryable: boolean;
+    };
+
     // waveobj.BlockDef
     type BlockDef = {
         files?: {[key: string]: FileDef};


### PR DESCRIPTION
Completes the half of [`SPEC_AGENT_FAILURE_DIAGNOSTICS`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md) that #1353 left undone: surfacing the **real cause** of a failed agent run **in the pane**.

## Problem
#1353 shipped the pure `failure::classify()` taxonomy but only wired it into the **headless** runner (`agents/runner.rs`). The interactive **pane** path (`blockcontroller/subprocess.rs` — what an agent like *Spixo* runs in) never classified anything: its stderr reader explicitly *"log warnings, don't publish"*, and it surfaced only the raw exit code → the pane shows an opaque **"exited with code 1."** (Spec §line 45, G2.)

## Change
**Backend (`subprocess.rs`):**
- The stderr reader now retains a bounded tail (last ~40 lines) in a shared buffer.
- On a **genuine non-zero exit** (the clean-exit arm; a user-initiated stop via the kill arm is intentionally *not* a failure), it runs `(exit_code, signal, stderr_tail)` through `agents::failure::classify` and publishes a dedicated **`agentfailure`** wave event scoped to the block.
- A dedicated event (rather than a field on `BlockControllerRuntimeStatus`) avoids touching ~20 status constructors and models a failure as an event, not recurring status.

**Frontend (`useControllerStatusEvents.ts` + `gotypes.d.ts`):**
- Subscribes to `agentfailure` and renders the real reason — `title — detail [exit N] (retryable)` + the stderr tail — as error log lines, instead of just the exit code.
- Adds the `AgentFailure` wire type.

## Scope
Covers the **main subprocess agent path** (Spixo's). The container-exec path and the `persistent`/`acp` controllers, plus a structured pane *banner* (spec P3) and the exit-0-error-frame case (G3), remain follow-ups.

## Verification
`task build:backend` ✓ (release, warnings only) · `task build:frontend` ✓. So an agent that dies on e.g. an auth/rate-limit error will now show *that*, not "exit 1" — which is also the fastest way to see why Spixo is dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)