### PR TITLE
feat(agent): fork-set derivation — data model for the fork bar (forks Phase 2)

### DIFF
--- a/.changesets/1781569700-feat-agent-fork-set.md
+++ b/.changesets/1781569700-feat-agent-fork-set.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): fork-set derivation — the data model for the fork bar (forks Phase 2)

--- a/frontend/app/view/agent/fork/fork-set.test.ts
+++ b/frontend/app/view/agent/fork/fork-set.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { computeForkSet, type ForkDefinition } from "./fork-set";
+
+const def = (id: string, over: Partial<ForkDefinition> = {}): ForkDefinition => ({
+    id,
+    name: id,
+    created_at: 0,
+    ...over,
+});
+
+describe("computeForkSet", () => {
+    it("returns [] when the active definition is unknown", () => {
+        expect(computeForkSet([def("a")], new Map(), "missing")).toEqual([]);
+    });
+
+    it("a lone root yields a single root entry", () => {
+        const r = computeForkSet([def("root")], new Map(), "root");
+        expect(r).toHaveLength(1);
+        expect(r[0]).toMatchObject({ definitionId: "root", isRoot: true, isActive: true, depth: 0 });
+    });
+
+    it("collects root + forks, root first, oldest sibling first", () => {
+        const defs = [
+            def("root", { created_at: 1 }),
+            def("f2", { parent_id: "root", created_at: 30, branch_label: "second" }),
+            def("f1", { parent_id: "root", created_at: 20, branch_label: "first" }),
+        ];
+        const r = computeForkSet(defs, new Map(), "f1");
+        expect(r.map((e) => e.definitionId)).toEqual(["root", "f1", "f2"]);
+        // Active is the one we asked about; root is flagged; titles use branch_label.
+        expect(r[0]).toMatchObject({ isRoot: true, isActive: false, title: "root" });
+        expect(r[1]).toMatchObject({ definitionId: "f1", isActive: true, title: "first", depth: 1 });
+        expect(r[2]).toMatchObject({ definitionId: "f2", isActive: false, title: "second", depth: 1 });
+    });
+
+    it("walks up from a deep fork to the lineage root", () => {
+        const defs = [
+            def("root"),
+            def("mid", { parent_id: "root" }),
+            def("leaf", { parent_id: "mid" }),
+        ];
+        const r = computeForkSet(defs, new Map(), "leaf");
+        expect(r.map((e) => e.definitionId)).toEqual(["root", "mid", "leaf"]);
+        expect(r.map((e) => e.depth)).toEqual([0, 1, 2]);
+        expect(r.find((e) => e.definitionId === "leaf")?.isActive).toBe(true);
+    });
+
+    it("treats a parent_id that isn't in the set as a root (orphaned fork)", () => {
+        // The parent definition was deleted; the fork becomes its own root.
+        const defs = [def("orphan", { parent_id: "gone" })];
+        const r = computeForkSet(defs, new Map(), "orphan");
+        expect(r).toHaveLength(1);
+        expect(r[0]).toMatchObject({ definitionId: "orphan", isRoot: true });
+    });
+
+    it("attaches the open blockId for currently-open forks only", () => {
+        const defs = [def("root"), def("f1", { parent_id: "root" })];
+        const open = new Map([["f1", "block-xyz"]]);
+        const r = computeForkSet(defs, open, "root");
+        expect(r.find((e) => e.definitionId === "root")?.blockId).toBeUndefined();
+        expect(r.find((e) => e.definitionId === "f1")?.blockId).toBe("block-xyz");
+    });
+
+    it("falls back to the definition name when branch_label is blank", () => {
+        const defs = [def("root", { name: "Claude Code", branch_label: "   " })];
+        expect(computeForkSet(defs, new Map(), "root")[0].title).toBe("Claude Code");
+    });
+
+    it("does not loop forever on a parent_id cycle", () => {
+        // a → b → a (corrupt data). Must terminate and include both once.
+        const defs = [
+            def("a", { parent_id: "b" }),
+            def("b", { parent_id: "a" }),
+        ];
+        const r = computeForkSet(defs, new Map(), "a");
+        const ids = r.map((e) => e.definitionId).sort();
+        expect(ids).toEqual(["a", "b"]);
+        // No duplicates from the cycle.
+        expect(new Set(ids).size).toBe(2);
+    });
+
+    it("the active fork is always present and flagged exactly once", () => {
+        const defs = [
+            def("root"),
+            def("f1", { parent_id: "root" }),
+            def("f2", { parent_id: "root" }),
+        ];
+        const r = computeForkSet(defs, new Map(), "f2");
+        expect(r.filter((e) => e.isActive)).toHaveLength(1);
+        expect(r.find((e) => e.isActive)?.definitionId).toBe("f2");
+    });
+});

--- a/frontend/app/view/agent/fork/fork-set.ts
+++ b/frontend/app/view/agent/fork/fork-set.ts
@@ -1,0 +1,131 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * fork-set — pure derivation of the **fork set** for an agent pane: the active
+ * conversation's lineage root plus every fork descended from it, in the order
+ * the fork bar renders them (root first, then by creation time).
+ *
+ * A fork is an `AgentDefinition` linked by `parent_id` to the one it branched
+ * from (created via `ForkAgentDefinitionCommand`). The fork set is therefore a
+ * pure function of the definition list + which definitions are currently open
+ * as panes — no parallel state, matching the "derive from a source of truth"
+ * rule (SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §5.3). The fork BAR (a
+ * later phase) renders these via <PaneRow>; the in-pane block-stack swap wires
+ * the `blockId` to the active view.
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §6.
+ */
+
+/** Minimal definition shape this module needs (subset of AgentDefinition). */
+export interface ForkDefinition {
+    id: string;
+    name: string;
+    /** Forked-from definition id; empty/undefined for a root. */
+    parent_id?: string;
+    /** Free-form branch label (e.g. "pr-422-review"); empty for a root. */
+    branch_label?: string;
+    /** Epoch ms — orders siblings oldest-first under the root. */
+    created_at: number;
+}
+
+/** One row in the fork bar. */
+export interface ForkSetEntry {
+    definitionId: string;
+    /** Display title: branch label when set, else the definition name. */
+    title: string;
+    /** True for the lineage root (rendered as the base entry). */
+    isRoot: boolean;
+    /** True for the pane's currently-active conversation. */
+    isActive: boolean;
+    /** The open block running this fork, if any (undefined = not open). */
+    blockId?: string;
+    /** Distance from the root (0 = root) — for optional indentation/ordering. */
+    depth: number;
+}
+
+/** Guard against a malformed `parent_id` cycle. Lineages are tiny in practice. */
+const MAX_LINEAGE_WALK = 1000;
+
+function titleOf(d: ForkDefinition): string {
+    const label = d.branch_label?.trim();
+    return label && label.length > 0 ? label : d.name;
+}
+
+/** Is `parentId` a usable link to a definition that exists in the set? */
+function hasParent(d: ForkDefinition, byId: Map<string, ForkDefinition>): boolean {
+    const p = d.parent_id;
+    return !!p && p.length > 0 && byId.has(p);
+}
+
+/**
+ * Compute the fork set for the pane whose active conversation is
+ * `activeDefinitionId`.
+ *
+ * - Walks `parent_id` up to the lineage **root** (a definition with no parent,
+ *   or whose parent isn't in `definitions`).
+ * - Collects the root + every descendant fork.
+ * - Orders root-first, then breadth-first by `created_at` (stable, oldest
+ *   sibling first) so the bar reads like a timeline of branches.
+ *
+ * Returns `[]` when `activeDefinitionId` isn't in `definitions` (e.g. the pane
+ * isn't an agent, or the list hasn't loaded yet) — callers render no bar.
+ *
+ * @param definitions   all known agent definitions (lineage via `parent_id`).
+ * @param openBlockByDef definitionId → open blockId for currently-open panes.
+ * @param activeDefinitionId the pane's active conversation's definition id.
+ */
+export function computeForkSet(
+    definitions: ReadonlyArray<ForkDefinition>,
+    openBlockByDef: ReadonlyMap<string, string>,
+    activeDefinitionId: string,
+): ForkSetEntry[] {
+    const byId = new Map<string, ForkDefinition>();
+    for (const d of definitions) byId.set(d.id, d);
+
+    const active = byId.get(activeDefinitionId);
+    if (!active) return [];
+
+    // 1) Walk to the lineage root.
+    let root = active;
+    for (let i = 0; i < MAX_LINEAGE_WALK && hasParent(root, byId); i++) {
+        root = byId.get(root.parent_id!)!;
+    }
+
+    // 2) Children index for a stable breadth-first descent from the root.
+    const childrenOf = new Map<string, ForkDefinition[]>();
+    for (const d of definitions) {
+        if (hasParent(d, byId)) {
+            const arr = childrenOf.get(d.parent_id!) ?? [];
+            arr.push(d);
+            childrenOf.set(d.parent_id!, arr);
+        }
+    }
+    for (const arr of childrenOf.values()) {
+        // Oldest sibling first; tie-break on id for determinism.
+        arr.sort((a, b) => a.created_at - b.created_at || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    }
+
+    // 3) BFS from the root, depth-tracked, cycle-guarded by a visited set.
+    const out: ForkSetEntry[] = [];
+    const visited = new Set<string>();
+    const queue: Array<{ def: ForkDefinition; depth: number }> = [{ def: root, depth: 0 }];
+    while (queue.length > 0 && out.length < MAX_LINEAGE_WALK) {
+        const { def, depth } = queue.shift()!;
+        if (visited.has(def.id)) continue;
+        visited.add(def.id);
+        out.push({
+            definitionId: def.id,
+            title: titleOf(def),
+            isRoot: def.id === root.id,
+            isActive: def.id === activeDefinitionId,
+            blockId: openBlockByDef.get(def.id),
+            depth,
+        });
+        for (const child of childrenOf.get(def.id) ?? []) {
+            if (!visited.has(child.id)) queue.push({ def: child, depth: depth + 1 });
+        }
+    }
+
+    return out;
+}


### PR DESCRIPTION
## What

The **pure data model** behind the bottom **fork bar** (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md` §6): `computeForkSet(definitions, openBlockByDef, activeDefinitionId)`.

Given the agent-definition list (lineage via `parent_id`) and which definitions are currently open as panes, it derives the active conversation's lineage **root** plus every **fork** descended from it, in the order the fork bar renders them (root first, then breadth-first, oldest-sibling-first — reads like a timeline of branches).

It's a **pure function of a source of truth** — no parallel state — per the spec's §5.3 "derive pins from a source of truth" rule. The fork bar (next phase) renders these via `<PaneRow>`; the in-pane block-stack swap wires each entry's `blockId` to the active view.

## Edge cases covered (and tested)

- Deep lineages → walks `parent_id` up to the true root.
- **Orphaned fork** (parent definition deleted) → becomes its own root.
- Blank/whitespace `branch_label` → falls back to the definition `name`.
- `openBlockByDef` attaches a `blockId` only to forks that are actually open.
- **Corrupt `parent_id` cycle** → terminates (visited-set + walk cap), no duplicates.
- Unknown active id → `[]` (caller renders no bar).
- Exactly one entry flagged `isActive`.

## Verification

- **vitest 9/9** (the cases above).
- **tsc** clean.

## Scope

Pure logic only — lands ahead of its consumer (the fork bar component) per the spec's phasing, so the UI builds on a tested data model. No production wiring yet (that needs the Phase-2 block-stack swap).

## Files

- `frontend/app/view/agent/fork/fork-set.ts` (new)
- `frontend/app/view/agent/fork/fork-set.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)