### PR TITLE
feat(agent-pane): render session digest as a PaneRow accessory (Phase A)

### DIFF
--- a/.changesets/1781548000-feat-digest-panerow.md
+++ b/.changesets/1781548000-feat-digest-panerow.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): render the session digest as a PaneRow accessory — single status-accented row (fresh/stale/generating/failed) with age + "+N new" stale hint, replacing the bespoke banner

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -919,15 +919,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 matchCount={search.matchCount}
             />
 
-            <Show when={!digest.dismissed()}>
-                <SessionDigestBanner
-                    summary={digest.summary}
-                    generatedAt={digest.generatedAt}
-                    loading={digest.loading}
-                    onDismiss={digest.dismiss}
-                    onRegenerate={() => digest.fetch(true)}
-                />
-            </Show>
+            <SessionDigestBanner
+                accessory={digest.accessory}
+                onDismiss={digest.dismiss}
+                onRegenerate={() => digest.fetch(true)}
+            />
 
             {/* Title-bar action overlay: ⚙ Agent / 👤 Identity.
                 Gated only on the tab being open — NOT on currentAgent()

--- a/frontend/app/view/agent/components/SessionDigestBanner.tsx
+++ b/frontend/app/view/agent/components/SessionDigestBanner.tsx
@@ -2,21 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * SessionDigestBanner — collapsible AI-generated summary of recent session activity.
+ * SessionDigestBanner — the AI-generated session summary rendered as a Pane
+ * Accessory row (`<PaneRow>`), in the `top-fixed` region.
  *
- * Shown when the user returns to an agent pane that was idle for >1 hour and has
- * accumulated >20 lines of new activity since the last visit.
+ * The digest is derived from a single source of truth in `useSessionDigest`
+ * (block meta + transient signals → `computeDigestAccessory`); this component
+ * is presentational only — it maps the resolved `DigestAccessory` onto the
+ * shared row chrome. A ≤10-word summary is the row title (no markdown body);
+ * the status accent surfaces fresh / stale / generating / failed, so a drifted
+ * summary visibly invites a refresh (↻).
+ *
+ * Spec: docs/specs/SPEC_SESSION_DIGEST_AS_PANE_ACCESSORY_2026_06_15.md.
  */
 
-import { createSignal, Show, type Accessor, type JSX } from "solid-js";
-import { Markdown } from "@/app/element/markdown";
+import { Show, type Accessor, type JSX } from "solid-js";
+import { PaneRow, type PaneRowAccent } from "./PaneRow";
+import type { DigestAccessory, DigestStatus } from "../digest/digest-accessory";
 
 interface SessionDigestBannerProps {
-    summary: Accessor<string | null>;
-    generatedAt: Accessor<number | null>;
-    loading: Accessor<boolean>;
+    accessory: Accessor<DigestAccessory | null>;
     onDismiss: () => void;
     onRegenerate: () => void;
+}
+
+/** Map digest lifecycle → the shared PaneRow status accent. */
+function accentFor(status: DigestStatus): PaneRowAccent {
+    switch (status) {
+        case "generating": return "running";
+        case "stale": return "idle"; // amber — drifted from the conversation
+        case "failed": return "error";
+        case "fresh": return "neutral";
+    }
 }
 
 function formatAge(ms: number): string {
@@ -27,62 +43,31 @@ function formatAge(ms: number): string {
     return `${Math.floor(hours / 24)}d ago`;
 }
 
-export const SessionDigestBanner = (props: SessionDigestBannerProps): JSX.Element => {
-    const [expanded, setExpanded] = createSignal(true);
+/** Right-of-title meta: age, plus a "+N new" hint when the digest is stale. */
+function metaFor(row: DigestAccessory): string | undefined {
+    const parts: string[] = [];
+    if (row.generatedAt) parts.push(formatAge(row.generatedAt));
+    if (row.stale && row.linesSinceDigest > 0) parts.push(`+${row.linesSinceDigest} new`);
+    return parts.length ? parts.join(" · ") : undefined;
+}
 
+export const SessionDigestBanner = (props: SessionDigestBannerProps): JSX.Element => {
     return (
-        <Show when={props.summary() != null || props.loading()}>
-            <div class="agent-session-digest">
-                <div class="agent-session-digest-header">
-                    <button
-                        class="agent-session-digest-toggle"
-                        onClick={() => setExpanded((v) => !v)}
-                        title={expanded() ? "Collapse" : "Expand"}
-                    >
-                        {expanded() ? "\u25BC" : "\u25B6"}
-                    </button>
-                    <span class="agent-session-digest-title">
-                        Session digest
-                        <Show when={props.generatedAt()}>
-                            {(ts) => (
-                                <span class="agent-session-digest-age">
-                                    {" \u00B7 "}{formatAge(ts())}
-                                </span>
-                            )}
-                        </Show>
-                    </span>
-                    <button
-                        class="agent-session-digest-action"
-                        onClick={props.onRegenerate}
-                        title="Regenerate digest"
-                        disabled={props.loading()}
-                    >
-                        {"\u21BB"}
-                    </button>
-                    <button
-                        class="agent-session-digest-action agent-session-digest-dismiss"
-                        onClick={props.onDismiss}
-                        title="Dismiss"
-                    >
-                        {"\u00D7"}
-                    </button>
+        <Show when={props.accessory()}>
+            {(row) => (
+                <div class="agent-session-digest">
+                    <PaneRow
+                        sigil={row().status === "generating" ? "↻" : "✦"}
+                        title={row().title}
+                        meta={metaFor(row())}
+                        accent={accentFor(row().status)}
+                        actions={[
+                            { glyph: "↻", title: "Regenerate digest", onClick: () => props.onRegenerate() },
+                            { glyph: "×", title: "Dismiss", onClick: () => props.onDismiss() },
+                        ]}
+                    />
                 </div>
-                <Show when={expanded() && props.loading()}>
-                    <div class="agent-session-digest-loading">Generating digest\u2026</div>
-                </Show>
-                <Show when={expanded() && !props.loading()}>
-                    <div class="agent-session-digest-body">
-                        <Show
-                            when={props.summary()}
-                            fallback={<span class="agent-session-digest-empty">No summary available.</span>}
-                        >
-                            {/* scrollable={false}: avoid OverlayScrollbars on reactive
-                                agent markdown (replaceChild crash, #1326). */}
-                            {(s) => <Markdown text={s()} scrollable={false} />}
-                        </Show>
-                    </div>
-                </Show>
-            </div>
+            )}
         </Show>
     );
 };

--- a/frontend/app/view/agent/hooks/useSessionDigest.ts
+++ b/frontend/app/view/agent/hooks/useSessionDigest.ts
@@ -23,9 +23,10 @@
  *   - dismiss()     — hide the banner for this session
  */
 
-import { createSignal, onMount, type Accessor } from "solid-js";
+import { createMemo, createSignal, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { computeDigestAccessory, type DigestAccessory } from "../digest/digest-accessory";
 
 import type { LogFn } from "../types";
 export type { LogFn };
@@ -44,6 +45,14 @@ export interface UseSessionDigest {
     generatedAt: Accessor<number | null>;
     loading: Accessor<boolean>;
     dismissed: Accessor<boolean>;
+    /**
+     * The digest projected into the Pane Accessories row model, or null when
+     * no row should render (dismissed, or empty + not generating). Reactively
+     * derived from block meta + the transient signals — the single source of
+     * truth for the digest surface. See
+     * docs/specs/SPEC_SESSION_DIGEST_AS_PANE_ACCESSORY_2026_06_15.md §3.
+     */
+    accessory: Accessor<DigestAccessory | null>;
     fetch: (force?: boolean) => Promise<void>;
     dismiss: () => void;
 }
@@ -53,10 +62,12 @@ export function useSessionDigest(opts: UseSessionDigestOptions): UseSessionDiges
     const [generatedAt, setGeneratedAt] = createSignal<number | null>(null);
     const [loading, setLoading] = createSignal(false);
     const [dismissed, setDismissed] = createSignal(false);
+    const [failed, setFailed] = createSignal(false);
 
     const fetch = async (force = false): Promise<void> => {
         if (loading()) return;
         setLoading(true);
+        setFailed(false);
         try {
             const result = await RpcApi.SessionDigestCommand(TabRpcClient, {
                 block_id: opts.blockId,
@@ -71,13 +82,40 @@ export function useSessionDigest(opts: UseSessionDigestOptions): UseSessionDiges
             }
         } catch (err: any) {
             opts.log("digest", `failed to generate session digest: ${err?.message ?? String(err)}`, "warn");
-            setSummary(null);
+            setFailed(true);
         } finally {
             setLoading(false);
         }
     };
 
     const dismiss = () => setDismissed(true);
+
+    // Reactive projection into the Pane Accessories row model. Reads block meta
+    // (line counts, cached digest) + the transient signals; the accessory
+    // module decides row vs. null and the status (generating/fresh/stale/failed).
+    const accessory = createMemo<DigestAccessory | null>(() => {
+        const meta = opts.block()?.meta ?? {};
+        const num = (k: string): number | undefined =>
+            typeof meta[k] === "number" ? (meta[k] as number) : undefined;
+        const str = (k: string): string | undefined =>
+            typeof meta[k] === "string" ? (meta[k] as string) : undefined;
+        return computeDigestAccessory(
+            opts.blockId,
+            {
+                summary: str("session:digest_summary"),
+                generatedAt: num("session:digest_generated_at"),
+                digestLastLineCount: num("session:digest_last_line_count"),
+                lineCount: num("session:line_count"),
+            },
+            {
+                loading: loading(),
+                dismissed: dismissed(),
+                failed: failed(),
+                summary: summary(),
+                generatedAt: generatedAt(),
+            },
+        );
+    });
 
     onMount(() => {
         const meta = opts.block()?.meta ?? {};
@@ -112,5 +150,5 @@ export function useSessionDigest(opts: UseSessionDigestOptions): UseSessionDiges
         }
     });
 
-    return { summary, generatedAt, loading, dismissed, fetch, dismiss };
+    return { summary, generatedAt, loading, dismissed, accessory, fetch, dismiss };
 }


### PR DESCRIPTION
## What

With the shared **`<PaneRow>`** primitive (#1462) and the **digest accessory data model** (#1467) merged, this wires them together — the session digest stops being a bespoke collapsible banner and becomes one more **Pane Accessory** row. (`SPEC_SESSION_DIGEST_AS_PANE_ACCESSORY_2026_06_15.md` §3 / Phase A.)

- **`useSessionDigest`** — exposes a reactive **`accessory`** projection (`computeDigestAccessory` over block meta + the transient signals): the single source of truth for the surface. Adds a `failed` signal so a failed refresh **keeps the prior summary** with an error accent (the old code blanked it).
- **`SessionDigestBanner`** — presentational reskin onto `<PaneRow>`: the ≤10-word summary is the row title, sigil ✦ (↻ while generating), status accent (`generating→running`, `fresh→neutral`, `stale→idle/amber`, `failed→error`), meta = age + **"+N new"** when stale, actions ↻ regenerate / × dismiss.
- **`agent-view`** — passes `accessory`; the null-when-dismissed/empty contract lives in the accessory, so the outer `<Show>` guard is gone.

## UX gain
A **stale** summary (≥20 lines added since it was generated — the staleness the backend already computes) is now visually flagged with an amber accent + "+N new" and invites a one-click refresh — something the old banner couldn't show.

## Verification
- `npm run build` — clean.
- `vitest run digest-accessory.test.ts` — 11 passed (model unchanged).

Builds on #1462 (PaneRow) and #1467 (digest accessory model). Part of the Pane Accessories convergence with smike's forks work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)