### PR TITLE
fix(ui): widen More dropdown a touch + rename hamburger Toolchain → Toolchain Manager

### DIFF
--- a/.changesets/1781572370-fix-widgets-give-the-more-dropdown-a-small-min-width-floor-1-ss6f.md
+++ b/.changesets/1781572370-fix-widgets-give-the-more-dropdown-a-small-min-width-floor-1-ss6f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(widgets): give the More dropdown a small min-width floor (120px) so it isn't razor-tight while still hugging content

--- a/.changesets/1781572378-feat-menu-rename-the-hamburger-toolchain-entry-to-toolchain--j4g8.md
+++ b/.changesets/1781572378-feat-menu-rename-the-hamburger-toolchain-entry-to-toolchain--j4g8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(menu): rename the hamburger 'Toolchain' entry to 'Toolchain Manager'

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -125,16 +125,14 @@
 .action-widget-more-dropdown {
     @include menuFrame.menu-frame;
     z-index: var(--z-flyout-menu);
-    // Hug the widest row instead of forcing a fixed floor. This menu lists
-    // short, left-aligned widget names with no right-aligned content (no
-    // accelerators / submenu arrows), so the old `min-width: 170px` rendered a
-    // ~176px panel over ~83px of content — leaving ~100px of dead space on the
-    // right of *every* row (the "wide gap"). `width: max-content` with no
-    // oversized floor sizes the panel to its longest label. Measured in
-    // headless Chrome: 176px → 83px, right-gap 99-120px → 0 on the widest row.
-    // NOTE: a min-width floor here re-introduces the gap (120px floor still
-    // left a 49-70px gap), so deliberately none.
+    // Hug the widest row rather than forcing the old fixed `min-width: 170px`
+    // (which rendered a ~176px panel over ~83px of short, left-aligned widget
+    // names — ~100px of dead space on the right of every row). `width:
+    // max-content` sizes the panel to its longest label; a small `min-width`
+    // floor adds a little breathing room so the menu isn't razor-tight, without
+    // returning to the lopsided 170px gap.
     width: max-content;
+    min-width: 120px;
     user-select: none;
 
     .action-widget-more-item {

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -136,7 +136,7 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
                 // Toolchain — visibility + control over the dev tools AgentMux
                 // runs CLIs in (node/npm/git/docker + provider CLIs), incl. the
                 // effective PATH. See SPEC_TOOLCHAIN_MANAGER_2026-06-15.
-                label: "Toolchain",
+                label: "Toolchain Manager",
                 icon: "wrench",
                 onClick: () => openToolchainModal(),
             },


### PR DESCRIPTION
Two small UI tweaks (follow-ups to #1459), both on the title-bar/hamburger surfaces.

### 1. Widget **More** dropdown — a bit wider
#1459 sized the dropdown with `width: max-content`, which hugs the longest widget label very tightly (~83px). This adds a modest `min-width: 120px` floor so the menu has a little breathing room and isn't razor-tight — while staying well clear of the old lopsided `min-width: 170px` gap (~100px of dead space) that #1459 removed.

`frontend/app/window/action-widgets.scss`:
```scss
width: max-content;
min-width: 120px;   /* small comfort floor */
```

### 2. Hamburger **"Toolchain" → "Toolchain Manager"**
Renames the hamburger menu entry (added in #1457) for clarity. Label-only; the click handler (`openToolchainModal`) is unchanged.

`frontend/app/window/hamburger-menu.tsx`:
```
label: "Toolchain"  →  "Toolchain Manager"
```

### Notes
- Two atomic commits, one changeset each.
- CSS/label only — no behavior or positioning change; hot-reloads in `task dev`.
- The Toolchain **modal title** itself still reads "Toolchain"; say the word if you want that renamed to match too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)