### PR TITLE
feat(agent): PaneRegions declarative region container (forks Phase 1)

### DIFF
--- a/.changesets/1781572475-feat-agent-pane-regions.md
+++ b/.changesets/1781572475-feat-agent-pane-regions.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): PaneRegions declarative region container (forks Phase 1, aux-pins)

--- a/frontend/app/view/agent/components/PaneRegions.scss
+++ b/frontend/app/view/agent/components/PaneRegions.scss
@@ -1,0 +1,43 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PaneRegions — per-region layout contracts. The agent pane is a flex column;
+// `stream` is the only flex-grow region (the scrolling conversation), every
+// other region is fixed-height / shrink-to-content, and `overlay` is z-stacked
+// over the column. Token-driven; no raw values beyond structural zeros.
+// Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §5.1.
+
+.pane-region {
+    // Default: a fixed band in the column that shrinks to its content and never
+    // gets crushed by the flex-grow `stream` region.
+    flex: 0 0 auto;
+    flex-shrink: 0;
+    min-width: 0;
+}
+
+// The conversation — the single region that absorbs remaining height and scrolls.
+.pane-region--stream {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+// Tall-but-bounded bands scroll internally rather than pushing the column.
+.pane-region--dock { max-height: 45%; overflow-y: auto; }
+.pane-region--queue { max-height: 30vh; overflow-y: auto; }
+
+// The pane's *real* layers: z-stacked over the column, not in flex flow. The
+// wrapper is a positioning context only — it doesn't capture pointer events
+// (each surface re-enables them on its own painted area + clips via usePaneOverlay).
+.pane-region--overlay {
+    position: absolute;
+    inset: 0;
+    z-index: var(--z-pane-overlay, 4);
+    pointer-events: none;
+
+    > * {
+        pointer-events: auto;
+    }
+}

--- a/frontend/app/view/agent/components/PaneRegions.test.tsx
+++ b/frontend/app/view/agent/components/PaneRegions.test.tsx
@@ -1,0 +1,87 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for PaneRegions — the declarative agent-pane region container.
+ * Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §5.1.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { createSignal, type JSX } from "solid-js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PaneRegions, PANE_REGION_ORDER, type PaneRegionName } from "./PaneRegions";
+
+afterEach(() => cleanup());
+
+describe("PaneRegions", () => {
+    it("wraps each provided region with its modifier class + data-region", () => {
+        const { container } = render(() => (
+            <PaneRegions regions={{ "top-fixed": <span>banner</span>, stream: <span>convo</span> }} />
+        ));
+        const top = container.querySelector('[data-region="top-fixed"]');
+        const stream = container.querySelector('[data-region="stream"]');
+        expect(top).toHaveClass("pane-region", "pane-region--top-fixed");
+        expect(stream).toHaveClass("pane-region", "pane-region--stream");
+        expect(top).toHaveTextContent("banner");
+        expect(stream).toHaveTextContent("convo");
+    });
+
+    it("renders regions in the canonical top→bottom order", () => {
+        const { container } = render(() => (
+            <PaneRegions
+                regions={{
+                    // Provide them out of order; the component must reorder.
+                    forks: <span>forks</span>,
+                    "top-fixed": <span>top</span>,
+                    input: <span>input</span>,
+                    stream: <span>stream</span>,
+                }}
+            />
+        ));
+        const order = [...container.querySelectorAll("[data-region]")].map(
+            (el) => el.getAttribute("data-region"),
+        );
+        expect(order).toEqual(["top-fixed", "stream", "input", "forks"]);
+        // And they follow the canonical sequence.
+        const canonicalIdx = (r: string) => PANE_REGION_ORDER.indexOf(r as PaneRegionName);
+        expect(order.map(canonicalIdx)).toEqual([...order.map(canonicalIdx)].sort((a, b) => a - b));
+    });
+
+    it("renders no wrapper for an absent region", () => {
+        const { container } = render(() => (
+            <PaneRegions regions={{ stream: <span>only</span> }} />
+        ));
+        expect(container.querySelector('[data-region="dock"]')).toBeNull();
+        expect(container.querySelectorAll("[data-region]")).toHaveLength(1);
+    });
+
+    it("treats an empty array (and all-nullish content) as no content", () => {
+        const { container } = render(() => (
+            <PaneRegions regions={{ dock: [] as JSX.Element[], alert: [null, false] as unknown as JSX.Element[], stream: <span>x</span> }} />
+        ));
+        expect(container.querySelector('[data-region="dock"]')).toBeNull();
+        expect(container.querySelector('[data-region="alert"]')).toBeNull();
+        expect(container.querySelector('[data-region="stream"]')).not.toBeNull();
+    });
+
+    it("renders an array of nodes within one region", () => {
+        render(() => (
+            <PaneRegions regions={{ forks: [<span>a</span>, <span>b</span>] }} />
+        ));
+        expect(screen.getByText("a")).toBeInTheDocument();
+        expect(screen.getByText("b")).toBeInTheDocument();
+    });
+
+    it("reactively shows/hides a region as its content toggles", () => {
+        const [show, setShow] = createSignal(false);
+        const { container } = render(() => (
+            <PaneRegions regions={{ stream: <span>s</span>, forks: show() ? <span>bar</span> : undefined }} />
+        ));
+        expect(container.querySelector('[data-region="forks"]')).toBeNull();
+        setShow(true);
+        expect(container.querySelector('[data-region="forks"]')).not.toBeNull();
+        setShow(false);
+        expect(container.querySelector('[data-region="forks"]')).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/PaneRegions.tsx
+++ b/frontend/app/view/agent/components/PaneRegions.tsx
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PaneRegions — the declarative region container for the agent pane.
+ *
+ * Replaces the hand-ordered ~16-surface JSX stack in `agent-view.tsx` with a
+ * `region → content` map: surfaces *register into a named region* instead of
+ * being positioned by JSX accident. Each region owns its layout contract
+ * (flex / z-order / max-height) in `PaneRegions.scss`; surfaces just declare
+ * which region they belong to.
+ *
+ * This is the §5.1 region model of
+ * `docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md`, and the shared
+ * dependency the session-digest accessory and the forthcoming fork bar both
+ * register into. Presentational only — it owns no state.
+ */
+
+import { For, Show, type JSX } from "solid-js";
+import "./PaneRegions.scss";
+
+/** Named regions, top → bottom. `overlay` is z-stacked over the column (the
+ *  pane's *real* layers — focused panel, pane-scoped modals); everything else
+ *  is in the flex column. `stream` is the single flex-grow region. */
+export type PaneRegionName =
+    | "top-fixed" // transient banners (progress, search, digest)
+    | "dock" // pinned long-running processes (ActivityDock)
+    | "stream" // the conversation (flex: 1, scrolls)
+    | "alert" // working-row · decision · question · disconnected
+    | "queue" // pending messages
+    | "status" // composer strip
+    | "input" // details · slash · footer textarea
+    | "forks" // the fork bar (conversations in this pane)
+    | "overlay"; // focused panel · pane-scoped modals (z-stacked, clipped)
+
+/** Canonical render order. The flex column flows top→bottom; `overlay` renders
+ *  last so it stacks above the column. */
+export const PANE_REGION_ORDER: readonly PaneRegionName[] = [
+    "top-fixed",
+    "dock",
+    "stream",
+    "alert",
+    "queue",
+    "status",
+    "input",
+    "forks",
+    "overlay",
+] as const;
+
+export interface PaneRegionsProps {
+    /** Content per region. A region absent from the map (or with empty content)
+     *  renders no wrapper — zero layout cost for the common case. */
+    regions: Partial<Record<PaneRegionName, JSX.Element | JSX.Element[]>>;
+}
+
+/** True when a region has anything renderable (a non-empty array / a node). */
+function hasContent(c: JSX.Element | JSX.Element[] | undefined): boolean {
+    if (c == null || c === false) return false;
+    if (Array.isArray(c)) return c.some((x) => x != null && x !== false);
+    return true;
+}
+
+export const PaneRegions = (props: PaneRegionsProps): JSX.Element => {
+    return (
+        <For each={PANE_REGION_ORDER}>
+            {(name) => {
+                const content = (): JSX.Element | JSX.Element[] | undefined => props.regions[name];
+                return (
+                    <Show when={hasContent(content())}>
+                        <div class={`pane-region pane-region--${name}`} data-region={name}>
+                            {content()}
+                        </div>
+                    </Show>
+                );
+            }}
+        </For>
+    );
+};
+
+PaneRegions.displayName = "PaneRegions";


### PR DESCRIPTION
## What

The **§5.1 region model** of `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md`: `<PaneRegions>`, a declarative `region → content` map that replaces the hand-ordered ~16-surface JSX stack in `agent-view.tsx`.

Surfaces **register into a named region** — `top-fixed / dock / stream / alert / queue / status / input / forks / overlay` — instead of being positioned by JSX accident. Each region owns its layout contract in `PaneRegions.scss`: `stream` is the lone flex-grow band (the scrolling conversation), `overlay` is z-stacked over the column (the pane's *real* layers — focused panel, pane-scoped modals), and the rest are shrink-to-content. An absent or empty region renders **no wrapper** (zero layout cost).

Presentational only — it owns no state, matching the "derive from a source of truth" discipline.

## Why now (it's unblocking another agent)

This is the shared dependency the **session-digest accessory** is explicitly blocked on — `SPEC_SESSION_DIGEST_AS_PANE_ACCESSORY_2026_06_15.md` states "Building `<PaneRow>` / `<PaneRegions>` — owned by the forks/aux-pins spec Phase 1," and its Phase B registers the digest into the `top-fixed` region map. The fork bar will register into the `forks` region the same way.

## Scope

Lands the **container + region model + tests**. The pixel-sensitive migration of `agent-view.tsx`'s render tree onto it gets its **own** follow-up PR, so the whole render tree isn't refactored in one blind shot.

## Verification

- **vitest 6/6** — region modifier classes + `data-region`, canonical top→bottom ordering (provided out of order → reordered), absent-region skip, empty-array/all-nullish treated as no content, array-of-nodes in one region, reactive show/hide.
- **stylelint** clean; **tsc** clean.

## Files

- `frontend/app/view/agent/components/PaneRegions.tsx` (new)
- `frontend/app/view/agent/components/PaneRegions.scss` (new)
- `frontend/app/view/agent/components/PaneRegions.test.tsx` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)