### PR TITLE
feat(agent): ForkBar fork switcher (forks Phase 2)

### DIFF
--- a/.changesets/1781573038-feat-agent-fork-bar.md
+++ b/.changesets/1781573038-feat-agent-fork-bar.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): ForkBar UI — the bottom-of-pane fork switcher (forks Phase 2)

--- a/frontend/app/view/agent/fork/ForkBar.scss
+++ b/frontend/app/view/agent/fork/ForkBar.scss
@@ -1,0 +1,33 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ForkBar — bottom-of-pane fork switcher. A vertical stack of <PaneRow>s (one
+// per fork) plus the "+ fork" affordance. Row chrome comes from PaneRow.scss;
+// this only owns the container band + the add button. Token-driven.
+// Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §7.
+
+.fork-bar {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--border-color);
+    background: var(--tab-strip-bg, rgba(255, 255, 255, 0.03));
+}
+
+.fork-bar-add {
+    align-self: flex-start;
+    margin: var(--space-0-5) var(--space-1);
+    padding: 2px var(--space-2);
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm, 0);
+    color: var(--secondary-text-color);
+    cursor: var(--cursor-interactive);
+    font-size: var(--text-xs);
+    transition: color 80ms ease, border-color 80ms ease, background 80ms ease;
+
+    &:hover {
+        color: var(--main-text-color);
+        border-color: var(--accent-color);
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+}

--- a/frontend/app/view/agent/fork/ForkBar.test.tsx
+++ b/frontend/app/view/agent/fork/ForkBar.test.tsx
@@ -1,0 +1,112 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for ForkBar — the bottom-of-pane fork switcher.
+ * Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §7.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ForkBar } from "./ForkBar";
+import type { ForkSetEntry } from "./fork-set";
+
+const entry = (over: Partial<ForkSetEntry> & { definitionId: string }): ForkSetEntry => ({
+    title: over.definitionId,
+    isRoot: false,
+    isActive: false,
+    depth: 0,
+    ...over,
+});
+
+afterEach(() => cleanup());
+
+describe("ForkBar", () => {
+    it("renders nothing for a single-conversation pane (root only)", () => {
+        const { container } = render(() => (
+            <ForkBar forks={[entry({ definitionId: "root", isRoot: true, isActive: true })]} onSwitch={() => {}} />
+        ));
+        expect(container.querySelector(".fork-bar")).toBeNull();
+    });
+
+    it("renders one row per fork once a second fork exists", () => {
+        render(() => (
+            <ForkBar
+                forks={[
+                    entry({ definitionId: "root", title: "main", isRoot: true, isActive: true }),
+                    entry({ definitionId: "f1", title: "side-thread", depth: 1 }),
+                ]}
+                onSwitch={() => {}}
+            />
+        ));
+        expect(screen.getByText("main")).toBeInTheDocument();
+        expect(screen.getByText("side-thread")).toBeInTheDocument();
+    });
+
+    it("marks the active fork's row aria-selected", () => {
+        const { container } = render(() => (
+            <ForkBar
+                forks={[
+                    entry({ definitionId: "root", isRoot: true }),
+                    entry({ definitionId: "f1", title: "active-one", isActive: true, depth: 1 }),
+                ]}
+                onSwitch={() => {}}
+            />
+        ));
+        const tabs = [...container.querySelectorAll('[role="tab"]')];
+        const active = tabs.find((t) => t.getAttribute("aria-selected") === "true");
+        expect(active).toHaveTextContent("active-one");
+    });
+
+    it("fires onSwitch with the fork's definitionId when a row is clicked", async () => {
+        const onSwitch = vi.fn();
+        render(() => (
+            <ForkBar
+                forks={[
+                    entry({ definitionId: "root", title: "main", isRoot: true, isActive: true }),
+                    entry({ definitionId: "f1", title: "side", depth: 1 }),
+                ]}
+                onSwitch={onSwitch}
+            />
+        ));
+        await userEvent.setup().click(screen.getByText("side"));
+        expect(onSwitch).toHaveBeenCalledWith("f1");
+    });
+
+    it("offers a close action on non-root forks only", async () => {
+        const onClose = vi.fn();
+        render(() => (
+            <ForkBar
+                forks={[
+                    entry({ definitionId: "root", title: "main", isRoot: true, isActive: true }),
+                    entry({ definitionId: "f1", title: "side", depth: 1 }),
+                ]}
+                onSwitch={() => {}}
+                onClose={onClose}
+            />
+        ));
+        // Only one close button — for the non-root fork.
+        const closeBtns = screen.getAllByRole("button", { name: /^Close / });
+        expect(closeBtns).toHaveLength(1);
+        await userEvent.setup().click(closeBtns[0]);
+        expect(onClose).toHaveBeenCalledWith("f1");
+    });
+
+    it("fires onFork when the + affordance is clicked", async () => {
+        const onFork = vi.fn();
+        render(() => (
+            <ForkBar
+                forks={[
+                    entry({ definitionId: "root", isRoot: true, isActive: true }),
+                    entry({ definitionId: "f1", depth: 1 }),
+                ]}
+                onSwitch={() => {}}
+                onFork={onFork}
+            />
+        ));
+        await userEvent.setup().click(screen.getByRole("button", { name: "Fork this conversation" }));
+        expect(onFork).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/view/agent/fork/ForkBar.tsx
+++ b/frontend/app/view/agent/fork/ForkBar.tsx
@@ -1,0 +1,83 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ForkBar — the bottom-of-pane "fork bar": one row per conversation fork in
+ * this pane, the active one promoted. Click (or ↓/↑ — wired later) loads a
+ * fork; `+` forks the current conversation; `⌫` closes a fork.
+ *
+ * Presentational: it renders a fork set (from `computeForkSet`) via the shared
+ * `<PaneRow>` chrome and reports user intent through callbacks. It owns no data
+ * and performs no switching — the caller wires `onSwitch` to the block-stack
+ * swap and `onFork` to the `/btw` flow. Registers into the `forks` region of
+ * `<PaneRegions>`. Spec: SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §7.
+ */
+
+import { For, Show, type JSX } from "solid-js";
+import { PaneRow, type PaneRowAccent } from "../components/PaneRow";
+import type { ForkSetEntry } from "./fork-set";
+import "./ForkBar.scss";
+
+export interface ForkBarProps {
+    /** The fork set for this pane (from `computeForkSet`), root first. */
+    forks: ForkSetEntry[];
+    /** Load a fork — switch the pane to that conversation. */
+    onSwitch: (definitionId: string) => void;
+    /** Fork the active conversation into a new sibling (the `+` affordance). */
+    onFork?: () => void;
+    /** Close a fork (never offered for the root — that's closing the pane). */
+    onClose?: (definitionId: string) => void;
+}
+
+/** Status accent for a fork row: active is promoted; an open-but-inactive fork
+ *  reads `running` (live in the background); a not-open fork reads `idle`. */
+function accentFor(f: ForkSetEntry): PaneRowAccent {
+    if (f.isActive) return "active";
+    return f.blockId ? "running" : "idle";
+}
+
+export const ForkBar = (props: ForkBarProps): JSX.Element => {
+    // A single-conversation pane (root only) shows no bar — zero cost for the
+    // common case; the bar appears once a second fork exists.
+    return (
+        <Show when={props.forks.length > 1}>
+            <div class="fork-bar" role="tablist" aria-label="Conversation forks">
+                <For each={props.forks}>
+                    {(f) => (
+                        <div role="tab" aria-selected={f.isActive}>
+                            <PaneRow
+                                sigil={f.isActive ? "▣" : "⑂"}
+                                title={f.title}
+                                accent={accentFor(f)}
+                                onActivate={() => props.onSwitch(f.definitionId)}
+                                actions={
+                                    !f.isRoot && props.onClose
+                                        ? [{
+                                            glyph: "⌫",
+                                            title: `Close ${f.title}`,
+                                            danger: true,
+                                            onClick: () => props.onClose!(f.definitionId),
+                                        }]
+                                        : []
+                                }
+                            />
+                        </div>
+                    )}
+                </For>
+                <Show when={props.onFork}>
+                    <button
+                        type="button"
+                        class="fork-bar-add"
+                        title="Fork this conversation"
+                        aria-label="Fork this conversation"
+                        onClick={() => props.onFork!()}
+                    >
+                        + fork
+                    </button>
+                </Show>
+            </div>
+        </Show>
+    );
+};
+
+ForkBar.displayName = "ForkBar";


### PR DESCRIPTION
## What

The bottom-of-pane **fork bar** (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md` §7): one `<PaneRow>` per conversation **fork** in the pane (from `computeForkSet`), the active one promoted.

- **Click** a row → load that fork (`onSwitch`).
- **`+ fork`** → fork the current conversation (`onFork` — the `/btw` flow).
- **`⌫` close** → on **non-root** forks only (closing the root is closing the pane).
- A single-conversation pane (root only) renders **no bar** — zero cost for the common case.

Composes the two already-shipped primitives — the `<PaneRow>` chrome and the `computeForkSet` derivation — and registers into the `forks` region of `<PaneRegions>`.

## Scope

Presentational only: owns no data, performs no switching. The caller wires `onSwitch` to the **block-stack swap** and `onFork` to the **`/btw`** flow (both later phases). Lands the tested UI ahead of the data wiring (`useForkSet`) so those build on a verified component.

## Verification

- **vitest 6/6** — root-only → no bar, one row per fork, active row `aria-selected`, `onSwitch` fires the fork's `definitionId`, close action on non-root only (fires `onClose`), `+` fires `onFork`.
- **stylelint** clean; **tsc** clean.

## Files

- `frontend/app/view/agent/fork/ForkBar.tsx` (new)
- `frontend/app/view/agent/fork/ForkBar.scss` (new)
- `frontend/app/view/agent/fork/ForkBar.test.tsx` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)