### PR TITLE
fix(agent-pane): backfill registry session_id so cross-channel open resumes the original conversation

### DIFF
--- a/.changesets/1781600326-fix-agent-pane-backfill-registry-session-id-so-a-cross-chann-61b5.md
+++ b/.changesets/1781600326-fix-agent-pane-backfill-registry-session-id-so-a-cross-chann-61b5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): backfill registry session_id so a cross-channel open resumes the original conversation

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -25,6 +25,7 @@ pub mod rpc_types;
 pub mod schema;
 pub mod service;
 pub mod session_archive;
+pub mod session_backfill;
 pub mod shellexec;
 pub mod transcript_backfill;
 pub mod shellintegration;

--- a/agentmux-srv/src/backend/session_backfill.rs
+++ b/agentmux-srv/src/backend/session_backfill.rs
@@ -16,7 +16,7 @@
 //! idempotent startup pass keeps continuity solid without per-turn wiring.
 
 use crate::registry::Registry;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Encode an absolute workspace path to a Claude project-dir slug. Claude Code
 /// replaces each of `/ \ : .` with `-` (lossy — a literal `-` inside a segment is
@@ -28,12 +28,9 @@ pub fn encode_project_slug(path: &str) -> String {
         .collect()
 }
 
-/// The provider session id (jsonl stem) of the agent's **largest** session under
-/// `projects_dir/<slug>`. We pick the largest, not the newest, on purpose: an
-/// accidental fresh session (one started when a blank cross-channel open failed
-/// to resume) must never win over the real conversation. `None` when there are
-/// no session files (or the project dir doesn't exist).
-pub fn largest_session_id(projects_dir: &Path, slug: &str) -> Option<String> {
+/// The largest `(size, session-id)` directly under `projects_dir/<slug>`, or
+/// `None` if the dir doesn't exist / has no session files.
+fn largest_with_size(projects_dir: &Path, slug: &str) -> Option<(u64, String)> {
     let dir = projects_dir.join(slug);
     let mut best: Option<(u64, String)> = None;
     for entry in std::fs::read_dir(&dir).ok()?.flatten() {
@@ -47,6 +44,24 @@ pub fn largest_session_id(projects_dir: &Path, slug: &str) -> Option<String> {
             }
         }
     }
+    best
+}
+
+/// The provider session id (jsonl stem) of the agent's **largest** session across
+/// the candidate project roots (the account-wide default and, for identity-bound
+/// agents, the identity bundle). We pick the largest, not the newest, on purpose:
+/// an accidental fresh session (one started when a blank cross-channel open failed
+/// to resume) must never win over the real conversation. `None` when there are no
+/// session files under any root.
+pub fn largest_session_id(projects_dirs: &[PathBuf], slug: &str) -> Option<String> {
+    let mut best: Option<(u64, String)> = None;
+    for d in projects_dirs {
+        if let Some((sz, stem)) = largest_with_size(d, slug) {
+            if best.as_ref().map_or(true, |(b, _)| sz > *b) {
+                best = Some((sz, stem));
+            }
+        }
+    }
     best.map(|(_, stem)| stem)
 }
 
@@ -54,11 +69,15 @@ pub fn largest_session_id(projects_dir: &Path, slug: &str) -> Option<String> {
 /// largest provider session. Idempotent (skips records that already carry a
 /// non-empty id). Returns the number populated. Best-effort per record — a
 /// record with no `source_agents_base` or no transcript is skipped, never fatal.
-pub fn backfill_session_ids(reg: &Registry, projects_dir: &Path) -> usize {
+pub fn backfill_session_ids(reg: &Registry, shared_dir: &Path) -> usize {
     let records = match reg.list_active() {
         Ok(r) => r,
         Err(_) => return 0,
     };
+    let default_projects = shared_dir
+        .join("providers")
+        .join("claude")
+        .join("projects");
     let mut count = 0;
     for mut rec in records {
         if rec.data.session_id.as_deref().map_or(false, |s| !s.is_empty()) {
@@ -70,7 +89,23 @@ pub fn backfill_session_ids(reg: &Registry, projects_dir: &Path) -> usize {
         let base = base.trim_end_matches(['/', '\\']);
         let workspace = format!("{base}/{}", rec.data.working_dir);
         let slug = encode_project_slug(&workspace);
-        let Some(sid) = largest_session_id(projects_dir, &slug) else {
+        // Candidate project roots: the account-wide default, plus the agent's
+        // identity bundle when bound to a non-default identity — identity-bound
+        // agents write sessions under `identities/<id>/claude/projects` (per
+        // `history::claude_adapter` discovery). [reagent #1479 P2]
+        let mut dirs = vec![default_projects.clone()];
+        if let Some(id) = rec.data.identity_id.as_deref() {
+            if !id.is_empty() && id != "default" {
+                dirs.push(
+                    shared_dir
+                        .join("identities")
+                        .join(id)
+                        .join("claude")
+                        .join("projects"),
+                );
+            }
+        }
+        let Some(sid) = largest_session_id(&dirs, &slug) else {
             continue;
         };
         rec.data.session_id = Some(sid.clone());
@@ -109,7 +144,7 @@ mod tests {
     #[test]
     fn largest_session_beats_a_fresh_short_one() {
         let tmp = tempfile::tempdir().unwrap();
-        let projects = tmp.path();
+        let projects = tmp.path().to_path_buf();
         let slug = "C--Users-x--agentmux-agents-naki";
         let dir = projects.join(slug);
         fs::create_dir_all(&dir).unwrap();
@@ -119,11 +154,11 @@ mod tests {
         fs::write(dir.join("e96ed91b-short.jsonl"), vec![b'x'; 15_000]).unwrap();
         // The recovery guarantee: pick the LARGE original, never the tiny recent.
         assert_eq!(
-            largest_session_id(projects, slug).as_deref(),
+            largest_session_id(&[projects.clone()], slug).as_deref(),
             Some("91f26930-long")
         );
         // Missing project dir is graceful.
-        assert_eq!(largest_session_id(projects, "nope"), None);
+        assert_eq!(largest_session_id(&[projects], "nope"), None);
     }
 
     fn rec(id: &str, base: Option<&str>, wd: &str, sid: Option<&str>) -> NamedAgentRecord {
@@ -149,7 +184,8 @@ mod tests {
     #[test]
     fn backfill_fills_empties_picks_largest_and_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        let projects = tmp.path().join("projects");
+        let shared = tmp.path();
+        let projects = shared.join("providers").join("claude").join("projects");
         let base = r"C:\agents";
         // Provider sessions for agent "naki" (working_dir naki-0612a).
         let slug = encode_project_slug(&format!("{base}/naki-0612a"));
@@ -158,14 +194,14 @@ mod tests {
         fs::write(dir.join("LONG.jsonl"), vec![b'x'; 1_000_000]).unwrap();
         fs::write(dir.join("short.jsonl"), vec![b'x'; 1_000]).unwrap();
 
-        let reg = Registry::open(tmp.path().join("registry")).unwrap();
+        let reg = Registry::open(shared.join("registry")).unwrap();
         reg.upsert(&rec("naki", Some(base), "naki-0612a", None)).unwrap();
         // Already-wired record must be left untouched.
         reg.upsert(&rec("keep", Some(base), "keep-x", Some("EXISTING"))).unwrap();
         // No transcript on disk → skipped, not an error.
         reg.upsert(&rec("notx", Some(base), "ghost-x", None)).unwrap();
 
-        let n = backfill_session_ids(&reg, &projects);
+        let n = backfill_session_ids(&reg, shared);
         assert_eq!(n, 1, "only the one empty record with a transcript is filled");
 
         let by = |id: &str| {
@@ -180,6 +216,42 @@ mod tests {
         assert_eq!(by("notx").data.session_id, None, "no transcript → left null");
 
         // Idempotent: a second pass fills nothing.
-        assert_eq!(backfill_session_ids(&reg, &projects), 0);
+        assert_eq!(backfill_session_ids(&reg, shared), 0);
+    }
+
+    #[test]
+    fn backfill_resolves_identity_bundle_sessions() {
+        // An identity-bound agent writes sessions under
+        // identities/<id>/claude/projects, NOT the default root. [reagent #1479 P2]
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = tmp.path();
+        let base = r"C:\agents";
+        let slug = encode_project_slug(&format!("{base}/bound-0612a"));
+        let idir = shared
+            .join("identities")
+            .join("bundle1")
+            .join("claude")
+            .join("projects")
+            .join(&slug);
+        fs::create_dir_all(&idir).unwrap();
+        fs::write(idir.join("BOUND.jsonl"), vec![b'x'; 500_000]).unwrap();
+
+        let reg = Registry::open(shared.join("registry")).unwrap();
+        let mut r = rec("bound", Some(base), "bound-0612a", None);
+        r.data.identity_id = Some("bundle1".to_string());
+        reg.upsert(&r).unwrap();
+
+        assert_eq!(backfill_session_ids(&reg, shared), 1);
+        let got = reg
+            .list_active()
+            .unwrap()
+            .into_iter()
+            .find(|x| x.data.instance_id == "bound")
+            .unwrap();
+        assert_eq!(
+            got.data.session_id.as_deref(),
+            Some("BOUND"),
+            "identity-bound session resolved from the bundle dir"
+        );
     }
 }

--- a/agentmux-srv/src/backend/session_backfill.rs
+++ b/agentmux-srv/src/backend/session_backfill.rs
@@ -1,0 +1,185 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backfill the registry record `session_id` from each agent's provider
+//! transcript, so a cross-channel open `--resume`s the original conversation
+//! instead of starting a fresh session.
+//!
+//! Background: the registry `session_id` is **read** on launch (surfaced to the
+//! picker, which passes it as `--resume <sid>` on the first turn of a reattached
+//! block — `agent_handlers.rs`) but was **never written** by production code, so
+//! it was always `null`. A fresh-build / cross-channel open therefore had no sid
+//! to resume and spawned a brand-new session, which then shadowed the original.
+//! See docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md.
+//!
+//! Once populated, `--resume` keeps the same session id across turns, so a single
+//! idempotent startup pass keeps continuity solid without per-turn wiring.
+
+use crate::registry::Registry;
+use std::path::Path;
+
+/// Encode an absolute workspace path to a Claude project-dir slug. Claude Code
+/// replaces each of `/ \ : .` with `-` (lossy — a literal `-` inside a segment is
+/// indistinguishable from a separator; this matches the CLI's own scheme and the
+/// `decode_project_path` direction in `history::claude_adapter`).
+pub fn encode_project_slug(path: &str) -> String {
+    path.chars()
+        .map(|c| if matches!(c, '/' | '\\' | ':' | '.') { '-' } else { c })
+        .collect()
+}
+
+/// The provider session id (jsonl stem) of the agent's **largest** session under
+/// `projects_dir/<slug>`. We pick the largest, not the newest, on purpose: an
+/// accidental fresh session (one started when a blank cross-channel open failed
+/// to resume) must never win over the real conversation. `None` when there are
+/// no session files (or the project dir doesn't exist).
+pub fn largest_session_id(projects_dir: &Path, slug: &str) -> Option<String> {
+    let dir = projects_dir.join(slug);
+    let mut best: Option<(u64, String)> = None;
+    for entry in std::fs::read_dir(&dir).ok()?.flatten() {
+        let p = entry.path();
+        if p.extension().map_or(false, |e| e == "jsonl") {
+            if let (Ok(meta), Some(stem)) = (entry.metadata(), p.file_stem()) {
+                let stem = stem.to_string_lossy().to_string();
+                if best.as_ref().map_or(true, |(sz, _)| meta.len() > *sz) {
+                    best = Some((meta.len(), stem));
+                }
+            }
+        }
+    }
+    best.map(|(_, stem)| stem)
+}
+
+/// Populate `session_id` for registry records that lack one, from the agent's
+/// largest provider session. Idempotent (skips records that already carry a
+/// non-empty id). Returns the number populated. Best-effort per record — a
+/// record with no `source_agents_base` or no transcript is skipped, never fatal.
+pub fn backfill_session_ids(reg: &Registry, projects_dir: &Path) -> usize {
+    let records = match reg.list_active() {
+        Ok(r) => r,
+        Err(_) => return 0,
+    };
+    let mut count = 0;
+    for mut rec in records {
+        if rec.data.session_id.as_deref().map_or(false, |s| !s.is_empty()) {
+            continue; // already wired
+        }
+        let Some(base) = rec.data.source_agents_base.as_deref() else {
+            continue;
+        };
+        let base = base.trim_end_matches(['/', '\\']);
+        let workspace = format!("{base}/{}", rec.data.working_dir);
+        let slug = encode_project_slug(&workspace);
+        let Some(sid) = largest_session_id(projects_dir, &slug) else {
+            continue;
+        };
+        rec.data.session_id = Some(sid.clone());
+        if reg.upsert(&rec).is_ok() {
+            count += 1;
+            tracing::info!(
+                instance = %rec.data.instance_name,
+                session_id = %sid,
+                "registry: backfilled session_id for cross-channel resume"
+            );
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{NamedAgentRecord, NamedAgentRecordV1};
+    use std::fs;
+
+    #[test]
+    fn encode_slug_matches_claude_convention() {
+        // Verified against a real on-disk slug (Naki).
+        assert_eq!(
+            encode_project_slug(r"C:\Users\asafe\.agentmux\agents\naki-0612a"),
+            "C--Users-asafe--agentmux-agents-naki-0612a"
+        );
+        // POSIX path; a literal '-' inside a segment is preserved.
+        assert_eq!(
+            encode_project_slug("/home/u/.agentmux/agents/foo-bar"),
+            "-home-u--agentmux-agents-foo-bar"
+        );
+    }
+
+    #[test]
+    fn largest_session_beats_a_fresh_short_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path();
+        let slug = "C--Users-x--agentmux-agents-naki";
+        let dir = projects.join(slug);
+        fs::create_dir_all(&dir).unwrap();
+        // The original long conversation...
+        fs::write(dir.join("91f26930-long.jsonl"), vec![b'x'; 6_000_000]).unwrap();
+        // ...and the accidental fresh short one started after the bug.
+        fs::write(dir.join("e96ed91b-short.jsonl"), vec![b'x'; 15_000]).unwrap();
+        // The recovery guarantee: pick the LARGE original, never the tiny recent.
+        assert_eq!(
+            largest_session_id(projects, slug).as_deref(),
+            Some("91f26930-long")
+        );
+        // Missing project dir is graceful.
+        assert_eq!(largest_session_id(projects, "nope"), None);
+    }
+
+    fn rec(id: &str, base: Option<&str>, wd: &str, sid: Option<&str>) -> NamedAgentRecord {
+        NamedAgentRecord {
+            schema_version: 3,
+            data: NamedAgentRecordV1 {
+                instance_id: id.to_string(),
+                instance_name: id.to_string(),
+                definition_id: "claude-code".to_string(),
+                identity_id: Some("default".to_string()),
+                memory_id: None,
+                session_id: sid.map(String::from),
+                working_dir: wd.to_string(),
+                source_agents_base: base.map(String::from),
+                created_at_ms: 1,
+                last_launched_at_ms: 1,
+                created_by_version: "(legacy)".to_string(),
+                last_launched_by_version: "(legacy)".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn backfill_fills_empties_picks_largest_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let base = r"C:\agents";
+        // Provider sessions for agent "naki" (working_dir naki-0612a).
+        let slug = encode_project_slug(&format!("{base}/naki-0612a"));
+        let dir = projects.join(&slug);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("LONG.jsonl"), vec![b'x'; 1_000_000]).unwrap();
+        fs::write(dir.join("short.jsonl"), vec![b'x'; 1_000]).unwrap();
+
+        let reg = Registry::open(tmp.path().join("registry")).unwrap();
+        reg.upsert(&rec("naki", Some(base), "naki-0612a", None)).unwrap();
+        // Already-wired record must be left untouched.
+        reg.upsert(&rec("keep", Some(base), "keep-x", Some("EXISTING"))).unwrap();
+        // No transcript on disk → skipped, not an error.
+        reg.upsert(&rec("notx", Some(base), "ghost-x", None)).unwrap();
+
+        let n = backfill_session_ids(&reg, &projects);
+        assert_eq!(n, 1, "only the one empty record with a transcript is filled");
+
+        let by = |id: &str| {
+            reg.list_active()
+                .unwrap()
+                .into_iter()
+                .find(|r| r.data.instance_id == id)
+                .unwrap()
+        };
+        assert_eq!(by("naki").data.session_id.as_deref(), Some("LONG"), "largest session");
+        assert_eq!(by("keep").data.session_id.as_deref(), Some("EXISTING"), "untouched");
+        assert_eq!(by("notx").data.session_id, None, "no transcript → left null");
+
+        // Idempotent: a second pass fills nothing.
+        assert_eq!(backfill_session_ids(&reg, &projects), 0);
+    }
+}

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -637,14 +637,11 @@ async fn main() {
         registry::resolve_shared_registry_dir(),
         registry::resolve_shared_transcripts_dir(),
     ) {
-        if let Some(projects) = tdir
-            .ancestors()
-            .nth(2)
-            .map(|shared| shared.join("providers").join("claude").join("projects"))
-            .filter(|p| p.is_dir())
-        {
+        if let Some(shared) = tdir.ancestors().nth(2) {
             if let Ok(reg) = registry::Registry::open(reg_root) {
-                let n = backend::session_backfill::backfill_session_ids(&reg, &projects);
+                // Pass the shared dir; the backfill resolves both the default
+                // `providers/claude/projects` and per-identity bundle roots.
+                let n = backend::session_backfill::backfill_session_ids(&reg, shared);
                 if n > 0 {
                     tracing::info!(
                         backfilled = n,

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -626,6 +626,35 @@ async fn main() {
             tracing::info!(healed, "global transcripts: healed poisoned snapshot sourceBlockIds");
         }
     }
+
+    // Backfill the registry `session_id` from each agent's largest provider
+    // session, so a cross-channel / fresh-build open `--resume`s the ORIGINAL
+    // conversation instead of starting a new session that shadows it. The id is
+    // read on launch (picker → `--resume <sid>`) but was never written, so it was
+    // always null. Idempotent; once set, `--resume` keeps it stable across turns.
+    // See docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md.
+    if let (Some(reg_root), Some(tdir)) = (
+        registry::resolve_shared_registry_dir(),
+        registry::resolve_shared_transcripts_dir(),
+    ) {
+        if let Some(projects) = tdir
+            .ancestors()
+            .nth(2)
+            .map(|shared| shared.join("providers").join("claude").join("projects"))
+            .filter(|p| p.is_dir())
+        {
+            if let Ok(reg) = registry::Registry::open(reg_root) {
+                let n = backend::session_backfill::backfill_session_ids(&reg, &projects);
+                if n > 0 {
+                    tracing::info!(
+                        backfilled = n,
+                        "registry: session_id backfill for cross-channel resume"
+                    );
+                }
+            }
+        }
+    }
+
     // Saga durability — see SPEC_SAGA_DURABILITY_2026-05-01.md.
     // Backed by its own SQLite file (`sagas.db`) so saga writes
     // commit independently of the wstore connection. Failure here


### PR DESCRIPTION
Second half of the continuity regression (#1475 retro). Companion to the display fix #1472.

## Root cause

The registry record `session_id` is **read** on launch (surfaced to the picker, which passes `--resume <sid>` on the first turn of a reattached block) but is **never written by production code** — every `.session_id = Some(..)` in the tree is in tests. So a cross-channel / fresh-build open has no session to resume → the CLI starts a **new** provider session, which after one turn latches in and **shadows the original conversation**.

## Fix

An idempotent startup backfill (`backend::session_backfill`) that populates `session_id` from each agent's **largest** provider session — *largest, not newest*, so an accidental fresh session (started when a blank cross-channel open failed to resume) can never win over the real conversation. Once set, `--resume` keeps the same id across turns, so a single startup pass keeps continuity solid without per-turn wiring. This **also recovers** already-affected agents (e.g. Naki → its original 6 MB session).

## Tests (high-value)

- `encode_slug_matches_claude_convention` — workspace→project-slug encoding (verified against a real on-disk slug).
- `largest_session_beats_a_fresh_short_one` — the recovery guarantee: pick the 6 MB original over a 15 KB fresh one.
- `backfill_fills_empties_picks_largest_and_is_idempotent` — only fills empties, picks largest, skips records with no transcript, idempotent on re-run.

`cargo test -p agentmux-srv session_backfill` → **3 passed**. Backend builds clean.

> Pairs with #1472 (display) — both are needed for a fully-recovered cross-channel open: #1472 heals the snapshot anchor, this resumes the original session. Follow-up (retro): a run-live-in-A → open-in-fresh-B e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)