### PR TITLE
feat(agent): useForkSet reactive fork-set hook (forks Phase 2)

### DIFF
--- a/.changesets/1781600720-feat-agent-use-fork-set.md
+++ b/.changesets/1781600720-feat-agent-use-fork-set.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): useForkSet — reactive fork-set hook feeding the fork bar (forks Phase 2)

--- a/frontend/app/view/agent/fork/useForkSet.test.ts
+++ b/frontend/app/view/agent/fork/useForkSet.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, it } from "vitest";
+import { useForkSet } from "./useForkSet";
+import type { ForkDefinition } from "./fork-set";
+
+const def = (id: string, over: Partial<ForkDefinition> = {}): ForkDefinition => ({
+    id,
+    name: id,
+    created_at: 0,
+    ...over,
+});
+
+describe("useForkSet", () => {
+    it("derives the fork set from its reactive sources", () => {
+        createRoot((dispose) => {
+            const [defs] = createSignal<ForkDefinition[]>([
+                def("root"),
+                def("f1", { parent_id: "root", branch_label: "side" }),
+            ]);
+            const [open] = createSignal(new Map<string, string>());
+            const [active] = createSignal("root");
+            const forks = useForkSet({ definitions: defs, openBlockByDef: open, activeDefinitionId: active });
+            expect(forks().map((e) => e.definitionId)).toEqual(["root", "f1"]);
+            expect(forks().find((e) => e.isActive)?.definitionId).toBe("root");
+            dispose();
+        });
+    });
+
+    it("recomputes when the active definition changes", () => {
+        createRoot((dispose) => {
+            const [defs] = createSignal<ForkDefinition[]>([
+                def("root"),
+                def("f1", { parent_id: "root" }),
+            ]);
+            const [open] = createSignal(new Map<string, string>());
+            const [active, setActive] = createSignal("root");
+            const forks = useForkSet({ definitions: defs, openBlockByDef: open, activeDefinitionId: active });
+            expect(forks().find((e) => e.isActive)?.definitionId).toBe("root");
+            setActive("f1");
+            expect(forks().find((e) => e.isActive)?.definitionId).toBe("f1");
+            dispose();
+        });
+    });
+
+    it("recomputes when the open-block map changes", () => {
+        createRoot((dispose) => {
+            const [defs] = createSignal<ForkDefinition[]>([def("root"), def("f1", { parent_id: "root" })]);
+            const [open, setOpen] = createSignal<ReadonlyMap<string, string>>(new Map());
+            const [active] = createSignal("root");
+            const forks = useForkSet({ definitions: defs, openBlockByDef: open, activeDefinitionId: active });
+            expect(forks().find((e) => e.definitionId === "f1")?.blockId).toBeUndefined();
+            setOpen(new Map([["f1", "block-1"]]));
+            expect(forks().find((e) => e.definitionId === "f1")?.blockId).toBe("block-1");
+            dispose();
+        });
+    });
+
+    it("recomputes when a new fork is added to the definition list", () => {
+        createRoot((dispose) => {
+            const [defs, setDefs] = createSignal<ForkDefinition[]>([def("root")]);
+            const [open] = createSignal(new Map<string, string>());
+            const [active] = createSignal("root");
+            const forks = useForkSet({ definitions: defs, openBlockByDef: open, activeDefinitionId: active });
+            expect(forks()).toHaveLength(1);
+            setDefs([def("root"), def("f1", { parent_id: "root" })]);
+            expect(forks().map((e) => e.definitionId)).toEqual(["root", "f1"]);
+            dispose();
+        });
+    });
+});

--- a/frontend/app/view/agent/fork/useForkSet.ts
+++ b/frontend/app/view/agent/fork/useForkSet.ts
@@ -1,0 +1,36 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useForkSet — reactive composition of the fork set for an agent pane. Re-derives
+ * `computeForkSet(...)` whenever the definition list, the open-block map, or the
+ * pane's active definition changes, so the `<ForkBar>` stays in sync with no
+ * parallel state (the "derive from a source of truth" rule).
+ *
+ * The caller injects the three reactive sources — the agent-definition list
+ * (`useAgentDefinitions`), the open-definition→block map (`getOpenDefinitionMap`,
+ * refreshed on `agents:changed`), and the pane's active definition id (`agentId`
+ * meta) — keeping this hook pure and testable.
+ *
+ * Spec: docs/specs/SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md §6.
+ */
+
+import { createMemo, type Accessor } from "solid-js";
+import { computeForkSet, type ForkDefinition, type ForkSetEntry } from "./fork-set";
+
+export interface UseForkSetOpts {
+    /** All known agent definitions (lineage via `parent_id`). */
+    definitions: Accessor<ReadonlyArray<ForkDefinition>>;
+    /** definitionId → open blockId for currently-open panes. */
+    openBlockByDef: Accessor<ReadonlyMap<string, string>>;
+    /** The pane's active conversation's definition id. */
+    activeDefinitionId: Accessor<string>;
+}
+
+/** The fork set for this pane, recomputed reactively. Empty when the active
+ *  definition isn't in the list (e.g. not loaded yet). */
+export function useForkSet(opts: UseForkSetOpts): Accessor<ForkSetEntry[]> {
+    return createMemo(() =>
+        computeForkSet(opts.definitions(), opts.openBlockByDef(), opts.activeDefinitionId()),
+    );
+}


### PR DESCRIPTION
## What

`useForkSet` — the **reactive data layer** that feeds the `<ForkBar>`. Re-derives `computeForkSet(...)` whenever the agent-definition list, the open-definition→block map, or the pane's active definition changes, with no parallel state (the "derive from a source of truth" rule).

The three reactive sources are **injected by the caller** — `useAgentDefinitions`, `getOpenDefinitionMap` (refreshed on `agents:changed`), and the pane's active `agentId` — keeping the hook pure and unit-testable.

## Verification
- **vitest 4/4** — initial derive, recompute on active-definition change, on open-block-map change, and on a new fork appearing in the definition list.
- **tsc** clean.

## Where this sits (capstone status)

This completes the **data-wiring** half of the fork bar. The remaining half — *mounting* `<ForkBar>` into `agent-view.tsx` with functional in-pane switching — is gated on the **block-stack swap** (rendering a *different* fork's block inside the pane), which is a structural layout change that needs a running app to build/verify the render swap. Detailed in the PR discussion.

## Files
- `frontend/app/view/agent/fork/useForkSet.ts` (new)
- `frontend/app/view/agent/fork/useForkSet.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)