### PR TITLE
feat(trust-center): brand-tile Accounts gallery with connected counts + OAuth/Key chooser

### DIFF
--- a/.changesets/1781601051-feat-trust-center-brand-tile-accounts-gallery-with-connected-p6uw.md
+++ b/.changesets/1781601051-feat-trust-center-brand-tile-accounts-gallery-with-connected-p6uw.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): brand-tile Accounts gallery with connected counts and OAuth/Key chooser

--- a/frontend/app/view/accounts/AccountsGallery.tsx
+++ b/frontend/app/view/accounts/AccountsGallery.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AccountsGallery — the brand-tile landing for the Trust Center Accounts tab.
+ * Renders a grid of service logos, each with a badge showing how many accounts
+ * are connected for that brand. Clicking a tile opens a small chooser of the
+ * brand's auth modes (OAuth / Key); picking one opens the Add-account form
+ * preset to that provider + kind. SPEC_TRUST_CENTER_2026_06_15.md §3.
+ */
+
+import { createSignal, For, Show, type JSX } from "solid-js";
+import { ProviderLogo } from "@/element/ProviderLogo";
+import type { AccountKind, AccountProvider, IdentityViewModel } from "@/app/view/identity/identity-model";
+import { SERVICE_CATALOG, modeLabel, type AuthMode, type ServiceTile } from "./accounts-catalog";
+import "./accounts-gallery.scss";
+
+export function AccountsGallery({ model }: { model: IdentityViewModel }): JSX.Element {
+    const [chooser, setChooser] = createSignal<ServiceTile | null>(null);
+
+    const countFor = (id: AccountProvider): number => model.accountsByProvider().get(id)?.length ?? 0;
+
+    const pick = (tile: ServiceTile, mode: AuthMode) => {
+        const kind: AccountKind = mode === "oauth" ? "oauth" : tile.keyKind;
+        setChooser(null);
+        model.openAddFormFor(tile.id, kind);
+    };
+
+    return (
+        <div class="accounts-gallery">
+            <div class="accounts-gallery-grid">
+                <For each={SERVICE_CATALOG}>
+                    {(tile) => {
+                        const n = () => countFor(tile.id);
+                        return (
+                            <button
+                                type="button"
+                                class="account-tile"
+                                classList={{ "account-tile--connected": n() > 0 }}
+                                onClick={() => setChooser(tile)}
+                                aria-label={`${tile.displayName} — ${n()} connected, add account`}
+                            >
+                                <Show when={n() > 0}>
+                                    <span class="account-tile-count" title={`${n()} connected`}>{n()}</span>
+                                </Show>
+                                <span class="account-tile-logo">
+                                    <ProviderLogo provider={tile.id} size={32} />
+                                </span>
+                                <span class="account-tile-name">{tile.displayName}</span>
+                                <span class="account-tile-status">
+                                    {n() > 0 ? `${n()} connected` : (tile.blurb ?? "Connect")}
+                                </span>
+                            </button>
+                        );
+                    }}
+                </For>
+            </div>
+
+            {/* Tile-click chooser: OAuth and/or Key, per the brand's authModes. */}
+            <Show when={chooser()}>
+                {(tile) => (
+                    <div
+                        class="accounts-chooser-overlay"
+                        onClick={(e) => e.target === e.currentTarget && setChooser(null)}
+                    >
+                        <div class="accounts-chooser" role="dialog" aria-label={`Connect ${tile().displayName}`}>
+                            <div class="accounts-chooser-header">
+                                <span class="account-tile-logo">
+                                    <ProviderLogo provider={tile().id} size={20} />
+                                </span>
+                                <span class="accounts-chooser-title">Connect {tile().displayName}</span>
+                                <button
+                                    type="button"
+                                    class="accounts-chooser-close"
+                                    onClick={() => setChooser(null)}
+                                    aria-label="Close"
+                                >
+                                    ✕
+                                </button>
+                            </div>
+                            <div class="accounts-chooser-modes">
+                                <For each={tile().authModes}>
+                                    {(mode) => {
+                                        const m = modeLabel(mode);
+                                        return (
+                                            <button
+                                                type="button"
+                                                class="accounts-chooser-mode"
+                                                onClick={() => pick(tile(), mode)}
+                                            >
+                                                <span class="accounts-chooser-mode-title">{m.title}</span>
+                                                <span class="accounts-chooser-mode-sub">{m.sub}</span>
+                                            </button>
+                                        );
+                                    }}
+                                </For>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </Show>
+        </div>
+    );
+}
+
+AccountsGallery.displayName = "AccountsGallery";

--- a/frontend/app/view/accounts/accounts-catalog.ts
+++ b/frontend/app/view/accounts/accounts-catalog.ts
@@ -1,0 +1,44 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Account service catalog — the brands shown as tiles in the Trust Center
+ * Accounts gallery, and which auth paths each offers. Clicking a tile opens a
+ * chooser of the brand's `authModes`; picking one opens the Add-account form
+ * preset to that provider + the matching account kind.
+ *
+ * `keyKind` is the account kind to preset for the "key" path (the form's
+ * Kind dropdown still lets the user refine it). The "oauth" path always presets
+ * kind = "oauth". See SPEC_TRUST_CENTER_2026_06_15.md §3/§4/§12.3.
+ */
+
+import type { AccountKind, AccountProvider } from "@/app/view/identity/identity-model";
+
+export type AuthMode = "oauth" | "key";
+
+export interface ServiceTile {
+    id: AccountProvider;
+    displayName: string;
+    /** Auth paths offered, in chooser display order. */
+    authModes: AuthMode[];
+    /** Account kind to preset when the user picks the "key" path. */
+    keyKind: AccountKind;
+    /** One-line descriptor under the tile name. */
+    blurb?: string;
+}
+
+export const SERVICE_CATALOG: ServiceTile[] = [
+    { id: "github", displayName: "GitHub", authModes: ["oauth", "key"], keyKind: "pat", blurb: "Repos, Actions, PRs" },
+    { id: "google", displayName: "Google", authModes: ["oauth"], keyKind: "api_key", blurb: "Workspace, Cloud" },
+    { id: "aws", displayName: "AWS", authModes: ["oauth", "key"], keyKind: "role", blurb: "IAM, deploy" },
+    { id: "openai", displayName: "OpenAI", authModes: ["key"], keyKind: "api_key", blurb: "API key" },
+    { id: "anthropic", displayName: "Anthropic", authModes: ["key"], keyKind: "api_key", blurb: "API key" },
+    { id: "slack", displayName: "Slack", authModes: ["oauth"], keyKind: "api_key", blurb: "Messaging" },
+    { id: "custom", displayName: "Custom", authModes: ["key"], keyKind: "api_key", blurb: "Any bearer token" },
+];
+
+export function modeLabel(mode: AuthMode): { title: string; sub: string } {
+    return mode === "oauth"
+        ? { title: "Connect with OAuth", sub: "Browser login — no key to manage" }
+        : { title: "Add API key / token", sub: "Validated & stored in your OS keychain" };
+}

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -1,0 +1,182 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Trust Center Accounts gallery — brand tiles + per-tile connected count +
+// the OAuth/Key chooser. SPEC_TRUST_CENTER_2026_06_15.md §3.
+
+.accounts-gallery {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3, 12px);
+
+    .accounts-gallery-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+        gap: var(--space-2, 8px);
+    }
+
+    .account-tile {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 6px;
+        padding: var(--space-3, 12px) var(--space-2, 8px);
+        background: var(--button-secondary-bg-color, rgba(127, 127, 127, 0.08));
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        color: inherit;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 90ms ease, border-color 90ms ease, transform 90ms ease;
+
+        &:hover {
+            background: var(--hover-bg-color);
+            border-color: var(--accent-color);
+            transform: translateY(-1px);
+        }
+
+        &:focus-visible {
+            outline: 1px solid var(--accent-color);
+            outline-offset: 1px;
+        }
+
+        &--connected {
+            border-color: color-mix(in srgb, var(--accent-color) 45%, var(--border-color));
+        }
+    }
+
+    .account-tile-count {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        border-radius: 8px;
+        background: var(--accent-color);
+        color: var(--button-text-color, #fff);
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 16px;
+        text-align: center;
+    }
+
+    .account-tile-logo {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 38px;
+        height: 38px;
+    }
+
+    .account-tile-name {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--main-text-color);
+    }
+
+    .account-tile-status {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        text-align: center;
+        line-height: 1.3;
+    }
+}
+
+.accounts-connected-heading {
+    margin-top: var(--space-4, 16px);
+    margin-bottom: var(--space-2, 8px);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--secondary-text-color);
+}
+
+// ── Tile-click chooser (OAuth / Key) ──────────────────────────────────────────
+.accounts-chooser-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: var(--zindex-modal-wrapper);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.accounts-chooser {
+    width: 320px;
+    max-width: calc(100vw - 32px);
+    background: var(--modal-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    overflow: hidden;
+
+    .accounts-chooser-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2, 8px);
+        padding: var(--space-3, 12px);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .accounts-chooser-title {
+        flex: 1;
+        font-weight: 600;
+        font-size: 13px;
+    }
+
+    .accounts-chooser-close {
+        background: transparent;
+        border: none;
+        color: var(--secondary-text-color);
+        cursor: pointer;
+        font-size: 13px;
+        padding: 2px 4px;
+
+        &:hover {
+            color: var(--main-text-color);
+        }
+    }
+
+    .accounts-chooser-modes {
+        display: flex;
+        flex-direction: column;
+        padding: var(--space-2, 8px);
+        gap: var(--space-2, 8px);
+    }
+
+    .accounts-chooser-mode {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        padding: var(--space-2, 8px) var(--space-3, 12px);
+        background: var(--button-secondary-bg-color, rgba(127, 127, 127, 0.08));
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        color: inherit;
+        font-family: inherit;
+        text-align: left;
+        cursor: pointer;
+        transition: background 90ms ease, border-color 90ms ease;
+
+        &:hover {
+            background: var(--hover-bg-color);
+            border-color: var(--accent-color);
+        }
+    }
+
+    .accounts-chooser-mode-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--main-text-color);
+    }
+
+    .accounts-chooser-mode-sub {
+        font-size: 11px;
+        color: var(--secondary-text-color);
+    }
+}

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -17,6 +17,7 @@ import { onCleanup, Show, type JSX } from "solid-js";
 import type { BlockNodeModel } from "@/app/block/blocktypes";
 import { IdentityViewModel } from "@/app/view/identity/identity-model";
 import { AccountsTab, AccountForm } from "@/app/view/identity/identity-view";
+import { AccountsGallery } from "./AccountsGallery";
 import "@/app/view/identity/identity-view.scss";
 
 export function AccountsManager(): JSX.Element {
@@ -42,7 +43,13 @@ export function AccountsManager(): JSX.Element {
             </div>
 
             <div class="identity-body">
-                <AccountsTab model={model} />
+                {/* Brand-tile landing: pick a service → OAuth / Key. */}
+                <AccountsGallery model={model} />
+                {/* Connected accounts (manage existing); shows its own empty state. */}
+                <Show when={model.accountsAtom().length > 0}>
+                    <div class="accounts-connected-heading">Connected accounts</div>
+                    <AccountsTab model={model} />
+                </Show>
             </div>
 
             <Show when={model.formOpenAtom()}>

--- a/frontend/app/view/accounts/oauth-catalog.ts
+++ b/frontend/app/view/accounts/oauth-catalog.ts
@@ -46,6 +46,26 @@ export const OAUTH_SERVICES: Partial<Record<AccountProvider, OAuthServiceInfo>> 
             "Create a GitHub OAuth App (Settings → Developer settings → OAuth Apps), " +
             "enable “Device Flow”, and paste its Client ID below. No client secret is needed.",
     },
+    google: {
+        provider: "google",
+        flow: "pkce",
+        builtIn: false,
+        requiresSecret: false, // PKCE loopback — no confidential secret
+        consoleUrl: "https://console.cloud.google.com/apis/credentials",
+        byoHint:
+            "Create an OAuth client of type “Desktop app” in Google Cloud Console " +
+            "and paste its Client ID below.",
+    },
+    slack: {
+        provider: "slack",
+        flow: "pkce",
+        builtIn: false,
+        requiresSecret: true, // Slack mandates a confidential client secret
+        consoleUrl: "https://api.slack.com/apps",
+        byoHint:
+            "Create a Slack app, then paste its Client ID and Client Secret below " +
+            "(Slack requires a client secret).",
+    },
 };
 
 export function oauthInfo(provider: AccountProvider): OAuthServiceInfo | undefined {

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -15,7 +15,7 @@ import { Logger } from "@/util/logger";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type AccountProvider = "github" | "openai" | "aws" | "anthropic" | "custom";
+export type AccountProvider = "github" | "openai" | "aws" | "anthropic" | "google" | "slack" | "custom";
 export type AccountKind = "pat" | "role" | "api_key" | "env_ref" | "oauth";
 export type AccountStatus = "valid" | "expired" | "invalid" | "unknown" | "checking";
 export type IdentityTab = "accounts" | "assignments";
@@ -112,6 +112,8 @@ export const PROVIDER_LABELS: Record<AccountProvider, string> = {
     openai: "OpenAI",
     aws: "AWS",
     anthropic: "Anthropic",
+    google: "Google",
+    slack: "Slack",
     custom: "Custom",
 };
 
@@ -120,6 +122,8 @@ export const PROVIDER_COLORS: Record<AccountProvider, string> = {
     openai: "#d1fae5",
     aws: "#fef3c7",
     anthropic: "#ede9fe",
+    google: "#e8f0fe",
+    slack: "#f3e8fd",
     custom: "#f1f5f9",
 };
 
@@ -326,6 +330,13 @@ export class IdentityViewModel implements ViewModel {
     editingAccountAtom: Accessor<Account | null> = this._editingAccount[0];
     private setEditingAccount: Setter<Account | null> = this._editingAccount[1];
 
+    // Preset provider/kind for a fresh Add form, set when the user clicks a
+    // brand tile in the Accounts gallery (→ openAddFormFor). The AccountForm
+    // reads this for its initial Provider/Kind when not editing.
+    private _addPreset = createSignal<{ provider: AccountProvider; kind: AccountKind } | null>(null);
+    addPresetAtom: Accessor<{ provider: AccountProvider; kind: AccountKind } | null> = this._addPreset[0];
+    private setAddPreset: Setter<{ provider: AccountProvider; kind: AccountKind } | null> = this._addPreset[1];
+
     private _formError = createSignal<string | null>(null);
     formErrorAtom: Accessor<string | null> = this._formError[0];
     private setFormError: Setter<string | null> = this._formError[1];
@@ -362,7 +373,7 @@ export class IdentityViewModel implements ViewModel {
 
     accountsByProvider = (): Map<AccountProvider, Account[]> => {
         const map = new Map<AccountProvider, Account[]>();
-        const order: AccountProvider[] = ["github", "openai", "aws", "anthropic", "custom"];
+        const order: AccountProvider[] = ["github", "google", "aws", "openai", "anthropic", "slack", "custom"];
         for (const p of order) {
             const group = this.accountsAtom().filter((a) => a.provider === p);
             if (group.length > 0) map.set(p, group);
@@ -439,18 +450,29 @@ export class IdentityViewModel implements ViewModel {
 
     openAddForm = (): void => {
         this.setEditingAccount(null);
+        this.setAddPreset(null);
+        this.setFormError(null);
+        this.setFormOpen(true);
+    };
+
+    /** Open a fresh Add form pre-set to a provider + auth kind (brand tile). */
+    openAddFormFor = (provider: AccountProvider, kind: AccountKind): void => {
+        this.setEditingAccount(null);
+        this.setAddPreset({ provider, kind });
         this.setFormError(null);
         this.setFormOpen(true);
     };
 
     openEditForm = (account: Account): void => {
         this.setEditingAccount(account);
+        this.setAddPreset(null);
         this.setFormError(null);
         this.setFormOpen(true);
     };
 
     cancelForm = (): void => {
         this.setEditingAccount(null);
+        this.setAddPreset(null);
         this.setFormError(null);
         this.setFormOpen(false);
     };

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -364,14 +364,29 @@ function AssignmentsTab({ model }: { model: IdentityViewModel }): JSX.Element {
 
 // ── Add/Edit form ─────────────────────────────────────────────────────────────
 
+// Default account kind for a provider — used to reset the Kind select on a
+// provider switch so it never holds a value invalid for the new provider.
+// Google/Slack are OAuth-only; GitHub/AWS default to their primary key kind.
+function defaultKindFor(provider: AccountProvider): AccountKind {
+    if (provider === "google" || provider === "slack") return "oauth";
+    if (provider === "github") return "pat";
+    if (provider === "aws") return "role";
+    return "api_key"; // openai, anthropic, custom
+}
+
 export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Element {
     const editing = () => model.editingAccountAtom();
     const isEdit = () => editing() !== null;
 
+    // Preset from a brand tile (Accounts gallery → openAddFormFor). Only used
+    // for a fresh Add (editing wins). Read once at setup; the form remounts on
+    // each open so this is always current.
+    const preset = model.addPresetAtom();
+
     // Form field signals
     const [name, setName] = createSignal(editing()?.name ?? "");
-    const [provider, setProvider] = createSignal<AccountProvider>(editing()?.provider ?? "github");
-    const [kind, setKind] = createSignal<AccountKind>(editing()?.kind ?? "pat");
+    const [provider, setProvider] = createSignal<AccountProvider>(editing()?.provider ?? preset?.provider ?? "github");
+    const [kind, setKind] = createSignal<AccountKind>(editing()?.kind ?? preset?.kind ?? "pat");
     const [displayName, setDisplayName] = createSignal(editing()?.display_name ?? "");
     const [secretBackend, setSecretBackend] = createSignal<SecretRef["backend"]>(editing()?.secret_ref.backend ?? "keychain");
     const [secretEnvVar, setSecretEnvVar] = createSignal(editing()?.secret_ref.env_var ?? "");
@@ -567,15 +582,18 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
                             onChange={(e) => {
                                 const p = e.currentTarget.value as AccountProvider;
                                 setProvider(p);
-                                // Don't leave "oauth" selected for a provider that
-                                // doesn't support it after a switch.
-                                if (kind() === "oauth" && !supportsOAuth(p)) setKind("api_key");
+                                // Kinds are provider-specific; reset to a valid
+                                // default for the new provider so the Kind select
+                                // never shows a stale/invalid value.
+                                setKind(defaultKindFor(p));
                             }}
                         >
                             <option value="github">GitHub</option>
-                            <option value="openai">OpenAI</option>
+                            <option value="google">Google</option>
                             <option value="aws">AWS</option>
+                            <option value="openai">OpenAI</option>
                             <option value="anthropic">Anthropic</option>
+                            <option value="slack">Slack</option>
                             <option value="custom">Custom</option>
                         </select>
                     </FormField>


### PR DESCRIPTION
> Stacked on #1478 (service-OAuth connect flow). Base = `feat/trust-center-oauth-frontend`; review/merge #1478 first.

## What

The Trust Center **Accounts** tab now lands on a **grid of brand tiles** instead of a bare list:

- one tile per service (GitHub, Google, AWS, OpenAI, Anthropic, Slack, Custom), each with its **logo** and a **badge showing how many accounts are connected** for that brand;
- clicking a tile opens a small **chooser of the brand's auth modes** — **Connect with OAuth** and/or **Add API key** — and picking one opens the Add-account form **preset** to that provider + kind.

The existing connected-accounts list now renders **below** the gallery (once you have accounts) for managing them.

## Files
- **`accounts-catalog.ts`** (new) — `SERVICE_CATALOG`: the brands shown as tiles + their auth modes + the key kind to preset.
- **`AccountsGallery.tsx`** (new) — the tile grid, connected-count badges (from the existing `accountsByProvider()` cache), and the OAuth/Key chooser.
- **`accounts-gallery.scss`** (new) — tile + chooser styling.
- **`accounts-manager.tsx`** — render the gallery as the landing; list below when accounts exist.
- **`identity-model.ts`** — `AccountProvider += "google" | "slack"` (backend stores `provider` as a free **String**, so no backend change); `PROVIDER_LABELS`/`PROVIDER_COLORS` + grouping-order entries; `openAddFormFor(provider, kind)` + a preset signal the form reads.
- **`identity-view.tsx`** `AccountForm` — read the tile preset for initial Provider/Kind; add Google/Slack to the Provider select; `defaultKindFor` resets Kind to a valid default on a provider switch so OAuth-only brands land on the OAuth path.
- **`oauth-catalog.ts`** — add Google (PKCE) and Slack (PKCE + BYO secret) so their tiles offer OAuth (BYO until built-in client ids are provisioned).

## Notes
- `ProviderLogo` already has brand SVGs for GitHub/Google/AWS/OpenAI/Anthropic and a first-letter fallback for Slack/Custom, so tiles render today.
- Provider remains a free string backend-side, so adding Google/Slack needed no backend/migration work.
- Google/Slack in the agent-identity **assignment matrix** is a small follow-up (those provider arrays are intentionally left at the original 5).

## Testing
`node_modules` isn't installed here, so `tsc` wasn't run locally; the change is self-contained (new catalog + gallery component + model preset). Manual check: Trust Center → Accounts → tile grid with badges → click GitHub → chooser (OAuth / Key) → form opens preset.

Spec: `specs/SPEC_TRUST_CENTER_2026_06_15.md` §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)