### PR TITLE
fix(dev): reap a stale Vite squatting the dev port on relaunch

### DIFF
--- a/.changesets/1781602735-fix-dev-reap-a-stale-vite-squatting-the-dev-port-instead-of--9o62.md
+++ b/.changesets/1781602735-fix-dev-reap-a-stale-vite-squatting-the-dev-port-instead-of--9o62.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): reap a stale Vite squatting the dev port instead of erroring on relaunch

--- a/.changesets/1781622432-fix-dev-reap-guard-checks-cwd-so-another-clone-s-live-vite-i-7iw3.md
+++ b/.changesets/1781622432-fix-dev-reap-guard-checks-cwd-so-another-clone-s-live-vite-i-7iw3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): reap guard checks CWD so another clone's live Vite is never killed on port collision

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -830,8 +830,8 @@ tasks:
                         # port (hash collision); killing it would break that still-running
                         # session. Normalize both paths: lowercase, backslash→slash, strip
                         # leading drive letter so the comparison is drive-letter-agnostic.
-                        proc_wd="$(wmic process where "ProcessId=$pid" get WorkingDirectory /format:value 2>/dev/null | grep -i WorkingDirectory= | cut -d= -f2- | tr -d '\r\n' | tr '\\' '/' | tr '[:upper:]' '[:lower:]' | sed 's|^[a-z]/||' | sed 's|^[a-z]:/||')"
-                        our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||' | tr '\\' '/')"
+                        proc_wd="$(pwsh -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=$pid').WorkingDirectory" 2>/dev/null | tr -d '\r\n' | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
+                        our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
                         if [ -n "$proc_wd" ] && [ "$proc_wd" = "$our_root" ]; then
                           taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
                         else

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -823,12 +823,22 @@ tasks:
                   if [ "{{OS}}" = "windows" ]; then
                     pid="$(netstat -ano 2>/dev/null | grep -i LISTENING | grep ":$AGENTMUX_VITE_PORT " | awk '{print $NF}' | head -1)"
                     if [ -n "$pid" ]; then
-                      # Only reap node.exe — an orphaned Vite is always a node process.
-                      # A non-node holder (another app, a different clone's non-Vite server)
-                      # is treated as a foreign process and we fail fast rather than kill it.
                       proc="$(tasklist /FI "PID eq $pid" /FO CSV /NH 2>/dev/null | head -1 | cut -d',' -f1 | tr -d '"')"
                       if echo "$proc" | grep -qi "node"; then
-                        taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
+                        # Guard: only reap if the process's working directory is THIS clone's
+                        # root. A different clone's live Vite is also node.exe on the same
+                        # port (hash collision); killing it would break that still-running
+                        # session. Normalize both paths: lowercase, backslash→slash, strip
+                        # leading drive letter so the comparison is drive-letter-agnostic.
+                        proc_wd="$(wmic process where "ProcessId=$pid" get WorkingDirectory /format:value 2>/dev/null | grep -i WorkingDirectory= | cut -d= -f2- | tr -d '\r\n' | tr '\\' '/' | tr '[:upper:]' '[:lower:]' | sed 's|^[a-z]/||' | sed 's|^[a-z]:/||')"
+                        our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||' | tr '\\' '/')"
+                        if [ -n "$proc_wd" ] && [ "$proc_wd" = "$our_root" ]; then
+                          taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
+                        else
+                          echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose working dir ($proc_wd) does not match this clone ($our_root) — likely another dev instance."
+                          echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                          exit 1
+                        fi
                       else
                         echo "❌ Port $AGENTMUX_VITE_PORT is held by a non-node process ($proc, pid=$pid) — will not reap."
                         echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
@@ -840,7 +850,21 @@ tasks:
                     if [ -n "$pid" ]; then
                       proc="$(ps -p "$pid" -o comm= 2>/dev/null)"
                       if echo "$proc" | grep -qi "node"; then
-                        kill -9 "$pid" 2>/dev/null || true
+                        # Guard: only reap if it's OUR orphaned Vite (same CWD).
+                        # Another clone's live Vite on the same port (hash collision)
+                        # must not be killed.
+                        if command -v pwdx >/dev/null 2>&1; then
+                          proc_wd="$(pwdx "$pid" 2>/dev/null | cut -d: -f2- | tr -d ' \n')"
+                        else
+                          proc_wd="$(lsof -p "$pid" -a -d cwd -F n 2>/dev/null | grep '^n' | cut -c2-)"
+                        fi
+                        if [ -n "$proc_wd" ] && [ "$proc_wd" = "$CLONE_ROOT" ]; then
+                          kill -9 "$pid" 2>/dev/null || true
+                        else
+                          echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose working dir ($proc_wd) does not match this clone ($CLONE_ROOT) — likely another dev instance."
+                          echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                          exit 1
+                        fi
                       else
                         echo "❌ Port $AGENTMUX_VITE_PORT is held by a non-node process ($proc, pid=$pid) — will not reap."
                         echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -789,8 +789,8 @@ tasks:
                 # `cksum` is in POSIX coreutils and ships with git-bash on
                 # Windows + every Linux/macOS we target — no toolchain risk.
                 # Range is 5173-5372 (200 ports — far more than enough).
+                CLONE_ROOT="$(pwd)"
                 if [ -z "$AGENTMUX_VITE_PORT" ]; then
-                  CLONE_ROOT="$(pwd)"
                   PORT_OFFSET=$(( $(echo -n "$CLONE_ROOT" | cksum | cut -d' ' -f1) % 200 ))
                   AGENTMUX_VITE_PORT=$((5173 + PORT_OFFSET))
                   echo "Auto-selected Vite port $AGENTMUX_VITE_PORT for clone $CLONE_ROOT"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -811,10 +811,30 @@ tasks:
                 # as goroutine IDs ("g1"), not real OS PIDs — so $! is never
                 # a kill-able pid in this context.
                 if curl -s --max-time 1 "$VITE_URL" > /dev/null 2>&1; then
-                  echo "❌ Port $AGENTMUX_VITE_PORT is already in use by another process."
-                  echo "   The per-clone derivation collided (rare). Override with:"
-                  echo "   AGENTMUX_VITE_PORT=<free-port> task dev"
-                  exit 1
+                  # The per-clone port is held. The overwhelmingly common cause is
+                  # OUR OWN Vite, orphaned by a prior dev session: the host window
+                  # closed but the backgrounded Vite (unkillable here — $! is a
+                  # goroutine id under go-task's shell, see note above) kept squatting
+                  # the deterministic port, and --strictPort then strands every
+                  # relaunch. Reap it best-effort; if the port is STILL held we treat
+                  # it as a genuinely foreign process and fail as before. See
+                  # docs/retro/retro-dev-instance-vite-orphan-port-2026-06-16.md.
+                  echo "[dev] Port $AGENTMUX_VITE_PORT busy — reaping a stale Vite if present…"
+                  if [ "{{OS}}" = "windows" ]; then
+                    pid="$(netstat -ano 2>/dev/null | grep -i LISTENING | grep ":$AGENTMUX_VITE_PORT " | awk '{print $NF}' | head -1)"
+                    if [ -n "$pid" ]; then taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true; fi
+                  else
+                    pid="$(lsof -ti ":$AGENTMUX_VITE_PORT" 2>/dev/null | head -1)"
+                    if [ -n "$pid" ]; then kill -9 "$pid" 2>/dev/null || true; fi
+                  fi
+                  sleep 1
+                  if curl -s --max-time 1 "$VITE_URL" > /dev/null 2>&1; then
+                    echo "❌ Port $AGENTMUX_VITE_PORT is still in use after reaping (foreign process)."
+                    echo "   The per-clone derivation collided, or a non-dev process holds it. Override with:"
+                    echo "   AGENTMUX_VITE_PORT=<free-port> task dev"
+                    exit 1
+                  fi
+                  echo "[dev] Reaped stale Vite — port $AGENTMUX_VITE_PORT is free."
                 fi
 
                 # Don't `rm -rf $DEV_DIR` on exit — install-linux-desktop.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -822,10 +822,31 @@ tasks:
                   echo "[dev] Port $AGENTMUX_VITE_PORT busy — reaping a stale Vite if present…"
                   if [ "{{OS}}" = "windows" ]; then
                     pid="$(netstat -ano 2>/dev/null | grep -i LISTENING | grep ":$AGENTMUX_VITE_PORT " | awk '{print $NF}' | head -1)"
-                    if [ -n "$pid" ]; then taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true; fi
+                    if [ -n "$pid" ]; then
+                      # Only reap node.exe — an orphaned Vite is always a node process.
+                      # A non-node holder (another app, a different clone's non-Vite server)
+                      # is treated as a foreign process and we fail fast rather than kill it.
+                      proc="$(tasklist /FI "PID eq $pid" /FO CSV /NH 2>/dev/null | head -1 | cut -d',' -f1 | tr -d '"')"
+                      if echo "$proc" | grep -qi "node"; then
+                        taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
+                      else
+                        echo "❌ Port $AGENTMUX_VITE_PORT is held by a non-node process ($proc, pid=$pid) — will not reap."
+                        echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                        exit 1
+                      fi
+                    fi
                   else
                     pid="$(lsof -ti ":$AGENTMUX_VITE_PORT" 2>/dev/null | head -1)"
-                    if [ -n "$pid" ]; then kill -9 "$pid" 2>/dev/null || true; fi
+                    if [ -n "$pid" ]; then
+                      proc="$(ps -p "$pid" -o comm= 2>/dev/null)"
+                      if echo "$proc" | grep -qi "node"; then
+                        kill -9 "$pid" 2>/dev/null || true
+                      else
+                        echo "❌ Port $AGENTMUX_VITE_PORT is held by a non-node process ($proc, pid=$pid) — will not reap."
+                        echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                        exit 1
+                      fi
+                    fi
                   fi
                   sleep 1
                   if curl -s --max-time 1 "$VITE_URL" > /dev/null 2>&1; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -825,20 +825,22 @@ tasks:
                     if [ -n "$pid" ]; then
                       proc="$(tasklist /FI "PID eq $pid" /FO CSV /NH 2>/dev/null | head -1 | cut -d',' -f1 | tr -d '"')"
                       if echo "$proc" | grep -qi "node"; then
-                        # Guard: only reap if the process's working directory is THIS clone's
+                        # Guard: only reap if the process's CommandLine references THIS clone's
                         # root. A different clone's live Vite is also node.exe on the same
                         # port (hash collision); killing it would break that still-running
-                        # session. Normalize both paths: lowercase, backslash→slash, strip
-                        # leading drive letter so the comparison is drive-letter-agnostic.
-                        proc_wd="$(pwsh -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=$pid').WorkingDirectory" 2>/dev/null | tr -d '\r\n' | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
-                        our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
-                        if [ -n "$proc_wd" ] && [ "$proc_wd" = "$our_root" ]; then
-                          taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
-                        else
-                          echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose working dir ($proc_wd) does not match this clone ($our_root) — likely another dev instance."
-                          echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
-                          exit 1
+                        # session. CommandLine is a real Win32_Process property (WorkingDirectory
+                        # is not). Falls back to kill-without-check when no PowerShell available.
+                        _ps="$(command -v pwsh 2>/dev/null)"; [ -z "$_ps" ] && _ps="$(command -v powershell.exe 2>/dev/null)"
+                        if [ -n "$_ps" ]; then
+                          proc_cmd="$("$_ps" -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=$pid').CommandLine" 2>/dev/null | tr -d '\r\n' | tr '[:upper:]' '[:lower:]' | tr '\\' '/')"
+                          our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
+                          if [ -n "$proc_cmd" ] && ! echo "$proc_cmd" | grep -qF "$our_root"; then
+                            echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose command line does not reference this clone ($our_root) — likely another dev instance."
+                            echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                            exit 1
+                          fi
                         fi
+                        taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
                       else
                         echo "❌ Port $AGENTMUX_VITE_PORT is held by a non-node process ($proc, pid=$pid) — will not reap."
                         echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
@@ -854,7 +856,7 @@ tasks:
                         # Another clone's live Vite on the same port (hash collision)
                         # must not be killed.
                         if command -v pwdx >/dev/null 2>&1; then
-                          proc_wd="$(pwdx "$pid" 2>/dev/null | cut -d: -f2- | tr -d ' \n')"
+                          proc_wd="$(pwdx "$pid" 2>/dev/null | cut -d: -f2- | sed 's/^[[:space:]]*//' | tr -d '\n')"
                         else
                           proc_wd="$(lsof -p "$pid" -a -d cwd -F n 2>/dev/null | grep '^n' | cut -c2-)"
                         fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -789,7 +789,7 @@ tasks:
                 # `cksum` is in POSIX coreutils and ships with git-bash on
                 # Windows + every Linux/macOS we target — no toolchain risk.
                 # Range is 5173-5372 (200 ports — far more than enough).
-                CLONE_ROOT="$(pwd)"
+                CLONE_ROOT="$(pwd -P 2>/dev/null || pwd)"
                 if [ -z "$AGENTMUX_VITE_PORT" ]; then
                   PORT_OFFSET=$(( $(echo -n "$CLONE_ROOT" | cksum | cut -d' ' -f1) % 200 ))
                   AGENTMUX_VITE_PORT=$((5173 + PORT_OFFSET))
@@ -829,16 +829,20 @@ tasks:
                         # root. A different clone's live Vite is also node.exe on the same
                         # port (hash collision); killing it would break that still-running
                         # session. CommandLine is a real Win32_Process property (WorkingDirectory
-                        # is not). Falls back to kill-without-check when no PowerShell available.
+                        # is not). Uses trailing-slash anchor to prevent superstring matches
+                        # (repo vs repo-v2). Fails safe: if ownership can't be verified, errors.
                         _ps="$(command -v pwsh 2>/dev/null)"; [ -z "$_ps" ] && _ps="$(command -v powershell.exe 2>/dev/null)"
-                        if [ -n "$_ps" ]; then
-                          proc_cmd="$("$_ps" -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=$pid').CommandLine" 2>/dev/null | tr -d '\r\n' | tr '[:upper:]' '[:lower:]' | tr '\\' '/')"
-                          our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
-                          if [ -n "$proc_cmd" ] && ! echo "$proc_cmd" | grep -qF "$our_root"; then
-                            echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose command line does not reference this clone ($our_root) — likely another dev instance."
-                            echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
-                            exit 1
-                          fi
+                        if [ -z "$_ps" ]; then
+                          echo "❌ Cannot verify Vite ownership (no pwsh/powershell.exe found) — will not reap."
+                          echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                          exit 1
+                        fi
+                        proc_cmd="$("$_ps" -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=$pid').CommandLine" 2>/dev/null | tr -d '\r\n' | tr '[:upper:]' '[:lower:]' | tr '\\' '/')"
+                        our_root="$(echo "$CLONE_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|^/[a-z]/||' | sed 's|^[a-z]:/||')"
+                        if [ -z "$proc_cmd" ] || ! echo "$proc_cmd" | grep -qF "${our_root}/"; then
+                          echo "❌ Port $AGENTMUX_VITE_PORT is held by a node process whose command line does not reference this clone (${our_root}) — likely another dev instance."
+                          echo "   Override with: AGENTMUX_VITE_PORT=<free-port> task dev"
+                          exit 1
                         fi
                         taskkill /PID "$pid" /T /F > /dev/null 2>&1 || true
                       else


### PR DESCRIPTION
## Problem

`task dev` appeared to 'keep crashing on launch.' Root cause (retro: `docs/retro/retro-dev-instance-vite-orphan-port-2026-06-16.md`): when the host window closes, the backgrounded **Vite orphans** and squats the **deterministic per-clone port**; the next `task dev` then dies immediately on the `--strictPort` pre-check (`❌ Port … already in use` → `dev:serve exit status 1`). Confirmed live: a `node` Vite holding the port with **0** host processes alive.

A shell `trap`/`$!` cleanup is **impossible** here — `dev:serve` runs in go-task's embedded shell (mvdan/sh) where `$!` is a goroutine id, not a killable OS PID (the code even notes this).

## Fix

Make the busy-port pre-check **self-heal** instead of erroring: reap the process holding the port (`taskkill /PID /T /F` on Windows, `kill -9` on Unix via `lsof -ti`), re-check, and only fail if something **foreign** still holds it. Additive + best-effort: if the reap can't run, it falls through to the same error as before — **no regression**. Keeps `--strictPort` (loud failure beats silent rebind).

## Test

`task --list` parses. The reap path degrades safely to the prior behavior; full exercise needs a live `task dev` (the foreground host-loop can't run in CI). Follow-up noted in the retro: a `dev:doctor` reaper + applying the same to `dev:standalone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)