### PR TITLE
feat(agent): send-now queue — instant panel, boundary delivery, ArrowUp recall, no drop

### DIFF
--- a/.changesets/1781605307-feat-agent-send-now-queue-instant-panel-hold-until-next-tool-sdbj.md
+++ b/.changesets/1781605307-feat-agent-send-now-queue-instant-panel-hold-until-next-tool-sdbj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): send-now queue — instant panel, hold-until-next-tool-call delivery, ArrowUp recall, no 30s drop

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -736,7 +736,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         prevTool = tool;
         const turnIdle = phaseKind === "Idle" || phaseKind === "Done";
         if ((newToolCall || turnIdle) && commands.hasHeldMessages()) {
-            commands.flushHeldMessages();
+            void commands.flushHeldMessages();
         }
     });
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -672,7 +672,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // where the message flashed in the amber zone between Streaming
         // promotion and agent-message-accepted. See ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
         const wasAlreadyWorking = workingFromPhase(paneSnapshot(model.blockId)?.turnPhase ?? { kind: "Idle" });
-        dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
+        // Only start a NEW turn when the agent is idle. Dispatching TurnStart
+        // while a turn is already running regresses Streaming → Submitting, which
+        // hides the "Send now" affordance (isInterruptibleTurn is false during
+        // Submitting) until the next stream event — the "panel shows up a couple
+        // seconds late" bug. A queued-while-busy message rides the running turn;
+        // the queue-drain (agent-message-accepted) re-enters Submitting if needed.
+        if (!wasAlreadyWorking) {
+            dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
+        }
         return commands.sendMessage(message, wasAlreadyWorking);
     };
 
@@ -712,6 +720,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             log("auth", "Login Again — re-running the provider login flow");
             void status.startLaunchFlow();
         },
+    });
+
+    // Deliver queued-while-busy ("send now") messages at the next tool-call
+    // boundary — the agent finishes its current step and then picks them up
+    // (the CLI consumes a stdin message at its next inference, after the
+    // in-flight tool's result). Falls back to turn end (Idle/Done) so a
+    // tool-less turn still delivers. Holding until here is what lets ArrowUp
+    // recall an un-sent message first.
+    let prevTool: string | null = null;
+    createEffect(() => {
+        const tool = agentAtoms().currentToolAtom[0]();
+        const phaseKind = agentAtoms().turnPhaseAtom[0]().kind;
+        const newToolCall = tool !== null && tool !== prevTool;
+        prevTool = tool;
+        const turnIdle = phaseKind === "Idle" || phaseKind === "Done";
+        if ((newToolCall || turnIdle) && commands.hasHeldMessages()) {
+            commands.flushHeldMessages();
+        }
     });
 
     // AskUserQuestion answer handler. Defined after handleSendMessage because
@@ -1218,6 +1244,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onSendMessage={handleSendMessage}
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}
+                    onRecallLatestQueued={commands.recallLatestHeld}
                     getCompletions={commands.completions}
                     viewModel={model}
                 />

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -392,6 +392,13 @@ interface AgentFooterProps {
      */
     onStopAgent?: () => void;
     /**
+     * Recall the most-recently queued ("send now") message — invoked on
+     * ArrowUp when the composer is empty (Claude-Code-CLI un-queue gesture).
+     * Returns the recalled message text (and removes it from the queue), or
+     * null when nothing is queued. The composer restores the text for editing.
+     */
+    onRecallLatestQueued?: () => { text: string } | null;
+    /**
      * Slash command completions. When the textarea value matches
      * `^/\w*$` (no space), AgentFooter calls this with the prefix
      * (no leading slash) and renders the SlashAutocomplete dropdown.
@@ -627,6 +634,23 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             if (e.key === "Escape") {
                 e.preventDefault();
                 setAutocompletePrefix(null);
+                return;
+            }
+        }
+        // ArrowUp on an EMPTY composer recalls the most-recently queued
+        // ("send now") message back into the textarea — the Claude-Code-CLI
+        // un-queue gesture. The message was held (not yet sent), so this is a
+        // true un-send. Only when empty so we don't fight cursor movement or
+        // clobber in-progress text. No-op (default behavior) if nothing queued.
+        if (e.key === "ArrowUp" && textareaRef && textareaRef.value.length === 0) {
+            const recalled = props.onRecallLatestQueued?.();
+            if (recalled) {
+                e.preventDefault();
+                textareaRef.value = recalled.text;
+                textareaRef.setSelectionRange(recalled.text.length, recalled.text.length);
+                // Recompute autocomplete + auto-grow + scroll for the restored text.
+                updateAutocomplete();
+                props.onTyping?.();
                 return;
             }
         }

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -48,7 +48,7 @@ export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Elem
                 <div class="agent-pending-header">
                     <span class="agent-spinner-dot" />
                     <span class="agent-pending-header-text">
-                        Queued — will send when the agent is idle (
+                        Queued — sends at the agent's next step; ↑ to edit (
                         {queuedMessages().length}
                         {queuedMessages().length === 1 ? " message" : " messages"})
                     </span>

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -98,7 +98,7 @@ export interface UseAgentCommands {
      * turn end) so a queued message lands just before the agent's next tool
      * call — it finishes its current train of thought, then picks it up.
      */
-    flushHeldMessages: () => void;
+    flushHeldMessages: () => Promise<void>;
     /**
      * Pop the most-recently queued (held, not-yet-delivered) message off the
      * "send now" queue and return its text so the composer can restore it —
@@ -389,14 +389,17 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             }
         }
 
-        // Kick off the send AND (for idle sends) start the expiry clock together,
-        // so the 30s timer measures backend acceptance time only — not the
-        // pre-send cmd:args metadata round-trip. Codex P2 on PR #752.
-        RpcApi.AgentInputCommand(TabRpcClient, {
-            blockid: opts.blockId,
-            message,
-            message_id: messageId,
-        }).catch((err) => {
+        // Await the send so callers can sequence multiple deliveries (the flush
+        // loop relies on this to preserve submission order — ReAgent P2 on
+        // PR #1484). The cmd:args round-trip above already completed, so the 30s
+        // expiry below still measures backend acceptance time. Codex P2 on PR #752.
+        try {
+            await RpcApi.AgentInputCommand(TabRpcClient, {
+                blockid: opts.blockId,
+                message,
+                message_id: messageId,
+            });
+        } catch (err: any) {
             opts.log("error", err?.message ?? String(err), "error");
             // RPC outright failed — remove the pending entry so the user
             // doesn't see a ghost row for a message the backend never received.
@@ -404,7 +407,8 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 type: "PendingMessageRejected",
                 id: messageId,
             });
-        });
+            return;
+        }
 
         if (!armExpiry) return;
         // Pending acceptance timeout (issue #728 gap 2) — only for idle sends,
@@ -427,11 +431,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
      * and a failed RPC removes the pending entry via the catch in
      * `deliverToBackend`.
      */
-    const flushHeldMessages = (): void => {
+    const flushHeldMessages = async (): Promise<void> => {
         if (heldQueue.length === 0) return;
         const items = heldQueue.splice(0, heldQueue.length);
+        // Deliver sequentially (await each) so messages reach the CLI's stdin in
+        // submission order — concurrent delivery let the per-item cmd:args
+        // round-trips race and reorder the sends. ReAgent P2 on PR #1484.
         for (const item of items) {
-            void deliverToBackend(item.text, item.id, /* armExpiry */ false);
+            await deliverToBackend(item.text, item.id, /* armExpiry */ false);
         }
     };
 

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -92,6 +92,22 @@ export interface UseAgentCommands {
      *  `wasAlreadyWorking` should be true when a turn was in-flight before
      *  the caller dispatched TurnStart — drives PendingMessage.enqueuedWhileBusy. */
     sendMessage: (message: string, wasAlreadyWorking?: boolean) => Promise<void>;
+    /**
+     * Deliver any messages held while the agent was busy (the "send now"
+     * queue). Called by the agent view at the next tool-call boundary (or
+     * turn end) so a queued message lands just before the agent's next tool
+     * call — it finishes its current train of thought, then picks it up.
+     */
+    flushHeldMessages: () => void;
+    /**
+     * Pop the most-recently queued (held, not-yet-delivered) message off the
+     * "send now" queue and return its text so the composer can restore it —
+     * the Claude-Code-CLI ArrowUp "un-queue" gesture. Returns null if the
+     * queue is empty. The message was never sent, so this is a true un-send.
+     */
+    recallLatestHeld: () => { text: string } | null;
+    /** True when there are queued-while-busy messages awaiting delivery. */
+    hasHeldMessages: () => boolean;
     /** Return to the agent picker by clearing the agent-identity meta keys. */
     back: () => Promise<void>;
     /**
@@ -157,6 +173,16 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     onCleanup(() => {
         for (const id of pendingExpiryTimers) clearTimeout(id);
         pendingExpiryTimers.clear();
+    });
+
+    // Messages typed while the agent was busy are HELD here (not sent yet),
+    // shown in the "send now" panel. They are delivered by `flushHeldMessages`
+    // at the next tool-call boundary, or recalled un-sent via `recallLatestHeld`
+    // (ArrowUp). Holding — rather than sending immediately — is what makes the
+    // recall a true un-send and lets the message land at a clean boundary.
+    const heldQueue: Array<{ id: string; text: string }> = [];
+    onCleanup(() => {
+        heldQueue.length = 0;
     });
 
     // ── Inline picker state ───────────────────────────────────────────
@@ -318,6 +344,33 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             requestAnimationFrame(() => opts.onSent?.());
         }
 
+        if (wasAlreadyWorking) {
+            // Agent is busy: HOLD the message in the "send now" queue instead of
+            // sending it now. `flushHeldMessages` delivers it at the next
+            // tool-call boundary (so the agent finishes its current step first),
+            // and ArrowUp can recall it un-sent before then. No expiry timer —
+            // the message must persist until it is actually delivered, not drop
+            // off after 30s (the bug this fixes).
+            heldQueue.push({ id: messageId, text: message });
+            return;
+        }
+
+        // Idle send: deliver immediately and arm the lost-delivery safety timer.
+        await deliverToBackend(message, messageId, /* armExpiry */ true);
+    };
+
+    /**
+     * Deliver a single message to the backend: apply runtime args (permission
+     * mode / model / effort) for this turn, fire `AgentInputCommand`, and —
+     * for immediate (idle) sends — arm the lost-delivery expiry. The backend
+     * echoes `agent-message-accepted` (keyed on `messageId`), which promotes
+     * the pending entry into the conversation.
+     */
+    const deliverToBackend = async (
+        message: string,
+        messageId: string,
+        armExpiry: boolean,
+    ): Promise<void> => {
         // Apply runtime args (permission mode, model, effort) before this turn.
         const prov = opts.provider();
         if (prov) {
@@ -336,13 +389,9 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             }
         }
 
-        // Kick off the send AND start the expiry clock together, so the
-        // 30s timer measures backend acceptance time only — not the
-        // pre-send cmd:args metadata round-trip. Codex P2 on PR #752
-        // caught the prior order: a slow runtime-args update could
-        // burn most of the 30s before AgentInputCommand even fired,
-        // so the expiry would remove the pending entry minutes before
-        // the agent had a chance to accept it.
+        // Kick off the send AND (for idle sends) start the expiry clock together,
+        // so the 30s timer measures backend acceptance time only — not the
+        // pre-send cmd:args metadata round-trip. Codex P2 on PR #752.
         RpcApi.AgentInputCommand(TabRpcClient, {
             blockid: opts.blockId,
             message,
@@ -350,20 +399,18 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }).catch((err) => {
             opts.log("error", err?.message ?? String(err), "error");
             // RPC outright failed — remove the pending entry so the user
-            // doesn't see a ghost row for a message the backend never
-            // received. Log already surfaces the error elsewhere.
+            // doesn't see a ghost row for a message the backend never received.
             opts.model.dispatchPane({
                 type: "PendingMessageRejected",
                 id: messageId,
             });
         });
 
-        // Pending acceptance timeout (issue #728 gap 2). The reducer
-        // removes the ghost entry if the backend doesn't echo
-        // `agent-message-accepted` within PENDING_TIMEOUT_MS of the
-        // send. Idempotent when the message lands first.
-        // Tracked + cleared on pane unmount to avoid dispatching against
-        // an unregistered slot (which throws).
+        if (!armExpiry) return;
+        // Pending acceptance timeout (issue #728 gap 2) — only for idle sends,
+        // where a missing `agent-message-accepted` within PENDING_TIMEOUT_MS
+        // means the delivery was lost. Held (queued-while-busy) messages get NO
+        // expiry; they wait until flushed. Cleared on pane unmount.
         const expiryId = setTimeout(() => {
             pendingExpiryTimers.delete(expiryId);
             opts.model.dispatchPane({
@@ -373,6 +420,34 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }, PENDING_TIMEOUT_MS);
         pendingExpiryTimers.add(expiryId);
     };
+
+    /**
+     * Deliver every held ("send now") message, oldest first. Called at the next
+     * tool-call boundary / turn end. No expiry — these are being delivered now,
+     * and a failed RPC removes the pending entry via the catch in
+     * `deliverToBackend`.
+     */
+    const flushHeldMessages = (): void => {
+        if (heldQueue.length === 0) return;
+        const items = heldQueue.splice(0, heldQueue.length);
+        for (const item of items) {
+            void deliverToBackend(item.text, item.id, /* armExpiry */ false);
+        }
+    };
+
+    /**
+     * Pop the most-recently held message off the queue, remove its pending
+     * entry, and return its text so the composer can restore it (ArrowUp
+     * un-queue). Null if nothing is held. The message was never sent.
+     */
+    const recallLatestHeld = (): { text: string } | null => {
+        const item = heldQueue.pop();
+        if (!item) return null;
+        opts.model.dispatchPane({ type: "PendingMessageRejected", id: item.id });
+        return { text: item.text };
+    };
+
+    const hasHeldMessages = (): boolean => heldQueue.length > 0;
 
     // Delegate to the model so the pane-frame header button and any other
     // call sites go through a single implementation.
@@ -405,6 +480,9 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
 
     return {
         sendMessage,
+        flushHeldMessages,
+        recallLatestHeld,
+        hasHeldMessages,
         back,
         stopAgent,
         pickerSpec,

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -181,8 +181,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     // (ArrowUp). Holding — rather than sending immediately — is what makes the
     // recall a true un-send and lets the message land at a clean boundary.
     const heldQueue: Array<{ id: string; text: string }> = [];
+    // Re-entrancy guard: only ONE flush drains the queue at a time. The flush
+    // effect fires fire-and-forget on every tool/phase change, so without this
+    // a second boundary could start a concurrent flush whose AgentInputCommand
+    // interleaves with the first's — reordering sends. ReAgent P2 on PR #1484.
+    let flushing = false;
     onCleanup(() => {
         heldQueue.length = 0;
+        flushing = false;
     });
 
     // ── Inline picker state ───────────────────────────────────────────
@@ -432,13 +438,22 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
      * `deliverToBackend`.
      */
     const flushHeldMessages = async (): Promise<void> => {
-        if (heldQueue.length === 0) return;
-        const items = heldQueue.splice(0, heldQueue.length);
-        // Deliver sequentially (await each) so messages reach the CLI's stdin in
-        // submission order — concurrent delivery let the per-item cmd:args
-        // round-trips race and reorder the sends. ReAgent P2 on PR #1484.
-        for (const item of items) {
-            await deliverToBackend(item.text, item.id, /* armExpiry */ false);
+        // Single-flight: if a flush is already draining, let it finish — its
+        // loop re-checks the queue each iteration, so any message queued while
+        // it runs is picked up in order. A concurrent flush would let two
+        // AgentInputCommand chains interleave and reorder sends. P2 on PR #1484.
+        if (flushing) return;
+        flushing = true;
+        try {
+            // Drain one at a time, awaiting each delivery (incl. its cmd:args
+            // round-trip) so messages reach the CLI's stdin in submission order.
+            // shift() (not a snapshot) so items queued mid-flush are included.
+            while (heldQueue.length > 0) {
+                const item = heldQueue.shift()!;
+                await deliverToBackend(item.text, item.id, /* armExpiry */ false);
+            }
+        } finally {
+            flushing = false;
         }
     };
 


### PR DESCRIPTION
Reworks the **"send now" panel** for messages typed while an agent is busy, per the three reported issues.

## Fixes

**1. Panel appears instantly.** `handleSendMessage` dispatched `TurnStart` unconditionally; doing so while a turn is already running regresses the phase `Streaming → Submitting`, and the "Send now" button is gated on `isInterruptibleTurn` (false during `Submitting`) — so it only reappeared on the next stream event ("a couple seconds late"). Now `TurnStart` fires only when the agent is idle.

**2. Queued messages no longer drop.** Root cause: the pending→conversation promotion is driven entirely by the backend `agent-message-accepted` event, which **only the subprocess controller emitted**. Claude now uses the **persistent** controller (#1451), which never emitted it — and the persistent CLI does **not** echo the user prompt in its stream (verified). So a queued message had *no* render path; the only thing that ever removed it was the 30s `PENDING_TIMEOUT_MS`, which silently dropped it. 

Now:
- The persistent controller emits `agent-message-accepted` on receive (threaded `message_id` from the `agentinput` RPC), so sent messages render and clear from the queue — fixes idle-send rendering too.
- A queued-while-busy message is **held in the frontend** (no RPC, no expiry) until delivered — it cannot drop while waiting.

**3. Delivered at the next tool-call boundary + ArrowUp recall.** The held message is flushed at the next tool-call boundary (`currentTool` change) or turn end, so it lands just before the agent's next tool call — the agent finishes its current train of thought, then picks it up (the CLI consumes a stdin message at its next inference). Because the message is *held* (never sent until then), **ArrowUp on an empty composer** pulls it back into the composer and removes it from the queue — a true un-send, matching the Claude Code CLI gesture.

## Changes
- `persistent.rs`: `send_message(message, message_id, config)` + `publish_message_accepted` (mirrors subprocess); threaded in `websocket.rs`; `app_api.rs` programmatic send passes `None`.
- `useAgentCommands.ts`: held queue + `flushHeldMessages` / `recallLatestHeld` / `hasHeldMessages`; idle sends keep immediate delivery + lost-delivery expiry.
- `agent-view.tsx`: skip `TurnStart` when working; tool-boundary/turn-end effect drives the flush; wire ArrowUp recall.
- `AgentFooter.tsx`: ArrowUp recall handler + prop. `PendingMessagesPanel.tsx`: updated copy.

## Testing
- `cargo check -p agentmux-srv` — clean.
- `tsc --noEmit` — clean for all touched files (unrelated pre-existing errors only surface under a wrong local node; node 24 required).
- No existing tests broken (reducer/state unchanged; no Footer/Panel/commands test files; panel copy not asserted).
- **Not run locally:** frontend vitest (needs node ≥24, not installed here) and the full app. Recommend a real-app pass: send to a busy Claude pane → panel shows instantly → ArrowUp recalls → otherwise it lands at the next tool call → it never drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
