### PR TITLE
fix(agent-pane): cross-channel restore uses stale highWaterMark — re-derive from global zone

### DIFF
--- a/.changesets/1781618951-fix-agent-pane-cross-channel-restore-uses-stale-highwatermar-b4fp.md
+++ b/.changesets/1781618951-fix-agent-pane-cross-channel-restore-uses-stale-highwatermar-b4fp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): cross-channel restore uses stale highWaterMark — re-derive from global zone

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -257,7 +257,32 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             || snapshot.sourceBlockId === ""
                             || snapshot.sourceBlockId === opts.blockId);
                     if (v2SameBlock) {
-                        const hwm: number = snapshot.highWaterMark;
+                        // When the snapshot is agent-anchored (sourceBlockId=""), the stored
+                        // highWaterMark was written by a *prior* block's local line count and
+                        // can be far smaller than the global zone (e.g. hwm=15 from a short
+                        // accidental session while the real conversation has 5000+ lines). Re-
+                        // derive the live count via line_count, which transparently returns the
+                        // global-zone total for a fresh empty block. Only take the larger value
+                        // so a genuinely new/short agent (hwm=5, live=5) isn't widened.
+                        let hwm: number = snapshot.highWaterMark;
+                        const isAgentAnchored = typeof snapshot.sourceBlockId !== "string"
+                            || snapshot.sourceBlockId === "";
+                        if (isAgentAnchored && snapshot.sourceBlockId !== opts.blockId) {
+                            try {
+                                const liveCount = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                                    block_id: opts.blockId,
+                                    filename: "output",
+                                }, { timeout: 5000 });
+                                if (!mounted) return;
+                                const liveHwm = liveCount?.count ?? 0;
+                                if (liveHwm > hwm) {
+                                    opts.log("history", `v2 cross-channel: hwm ${hwm} → ${liveHwm} (global zone)`);
+                                    hwm = liveHwm;
+                                }
+                            } catch {
+                                // soft fail — proceed with stored hwm
+                            }
+                        }
                         const windowStart = Math.max(0, hwm - RESTORE_WINDOW_LINES);
                         const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
                             block_id: opts.blockId,


### PR DESCRIPTION
## Root cause

When an agent opens in a fresh channel (new build, new portable), the v2 snapshot has `sourceBlockId=""` (agent-anchored, set by #1472) but its `highWaterMark` was written by the **prior block's local line count** — which can be very small.

Example: the accidental `e96ed91b` session in this incident had `hwm=15` (15 NDJSON events). The real conversation has ~5008 lines in the global zone.

In `useHistoryPagination`, `v2SameBlock` passes (hwm>0, sourceBlockId="" ✓), so the fast path fires with `read_range(offset=0, limit=15)`. The backend's `global_output_source` correctly redirects to the global zone, but only 15 lines are fetched. `historyOffset` is set to 0 → `loadOlder` is a no-op. The user sees the **first 15 lines of a 5000-node conversation** — indistinguishable from empty.

## Fix

When the snapshot is agent-anchored (`sourceBlockId=""` or absent) AND this is a cross-channel open (block is not the one that wrote the snapshot), call `BlockfileLineCountCommand` first. For a fresh empty block the backend transparently returns the global-zone total via `global_output_source`. Only take the larger value so a genuinely short/new agent is unaffected.

## Relationship

This is the **third mechanism** of the cross-channel history regression:
- **#1472** — snapshot normalize (sourceBlockId poisoning → fallback skipped)  
- **#1479** — session_id backfill (provider --resume targets original session)
- **This PR** — stale hwm caps the read window to the prior short session's length

All three must be in place for a cross-channel open to show the full conversation.

## Test plan

- [ ] Open any agent in a fresh build channel — full conversation renders (last 5000 lines, load-older available for the rest)
- [ ] Open an agent that has never run — fresh/empty pane (hwm=0 falls through to NDJSON replay, unaffected)
- [ ] Open an agent in the SAME channel where it last ran — stored hwm matches live count, no extra RPC fired (isAgentAnchored false when sourceBlockId=opts.blockId)
- [ ] `npm test` passes (useHistoryPagination tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)