### PR TITLE
fix(term): terminal I/O has priority over perf telemetry on WS egress

### DIFF
--- a/.changesets/1781625002-fix-term-give-terminal-i-o-priority-over-perf-telemetry-on-t-cqk0.md
+++ b/.changesets/1781625002-fix-term-give-terminal-i-o-priority-over-perf-telemetry-on-t-cqk0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): give terminal I/O priority over perf telemetry on the WebSocket egress

--- a/agentmux-srv/src/backend/eventbus.rs
+++ b/agentmux-srv/src/backend/eventbus.rs
@@ -10,11 +10,32 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
-use super::wps::{WaveEvent, WpsClient};
+use super::wps::{WaveEvent, WpsClient, EVENT_SYS_INFO, EVENT_BLOCK_STATS, EVENT_BLOCK_FILE};
 
 // ---- Event type constants ----
 
 pub const WS_EVENT_RPC: &str = "rpc";
+
+/// Egress priority lane for a server→client event.
+///
+/// `Background` is reserved for droppable perf telemetry (sysinfo + per-block
+/// stats) that must never delay interactive terminal I/O; everything else is
+/// `Priority`. The WebSocket egress loop drains the priority lane before the
+/// background lane (see `server/websocket.rs` and
+/// `docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Lane {
+    Priority,
+    Background,
+}
+
+/// The pair of receivers handed to a WebSocket connection on registration.
+/// Terminal echo + interactive events arrive on `priority`; perf telemetry on
+/// `background`.
+pub struct WsReceivers {
+    pub priority: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+    pub background: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+}
 
 // ---- Types ----
 
@@ -28,9 +49,21 @@ pub struct WSEventType {
 }
 
 struct WindowWatchData {
-    sender: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
+    /// Interactive lane: terminal echo, RPC-routed wave events, obj updates.
+    priority: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
+    /// Background lane: droppable perf telemetry (sysinfo, blockstats).
+    background: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
     #[allow(dead_code)]
     tab_id: String,
+}
+
+impl WindowWatchData {
+    fn sender(&self, lane: Lane) -> &tokio::sync::mpsc::UnboundedSender<serde_json::Value> {
+        match lane {
+            Lane::Priority => &self.priority,
+            Lane::Background => &self.background,
+        }
+    }
 }
 
 /// Global event bus for dispatching WebSocket events to connected clients.
@@ -46,22 +79,23 @@ impl EventBus {
     }
 
     /// Register a WebSocket connection for receiving events.
-    /// Returns a receiver channel for the connection.
-    pub fn register_ws(
-        &self,
-        conn_id: &str,
-        tab_id: &str,
-    ) -> tokio::sync::mpsc::UnboundedReceiver<serde_json::Value> {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    /// Returns the priority + background receiver pair for the connection.
+    pub fn register_ws(&self, conn_id: &str, tab_id: &str) -> WsReceivers {
+        let (priority_tx, priority_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (background_tx, background_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut watches = self.watches.lock().unwrap();
         watches.insert(
             conn_id.to_string(),
             WindowWatchData {
-                sender: tx,
+                priority: priority_tx,
+                background: background_tx,
                 tab_id: tab_id.to_string(),
             },
         );
-        rx
+        WsReceivers {
+            priority: priority_rx,
+            background: background_rx,
+        }
     }
 
     /// Unregister a WebSocket connection.
@@ -96,8 +130,15 @@ impl EventBus {
         }
     }
 
-    /// Send an event to a single connection by conn_id. No-op if not found.
+    /// Send an event to a single connection by conn_id, on the priority lane.
+    /// No-op if not found.
     pub fn send_to_conn(&self, conn_id: &str, event: &WSEventType) {
+        self.send_to_conn_lane(conn_id, event, Lane::Priority);
+    }
+
+    /// Send an event to a single connection by conn_id on a specific lane.
+    /// No-op if not found.
+    pub fn send_to_conn_lane(&self, conn_id: &str, event: &WSEventType, lane: Lane) {
         let data = match serde_json::to_value(event) {
             Ok(v) => v,
             Err(e) => {
@@ -107,14 +148,19 @@ impl EventBus {
         };
         let watches = self.watches.lock().unwrap();
         if let Some(watch) = watches.get(conn_id) {
-            if watch.sender.send(data).is_err() {
+            if watch.sender(lane).send(data).is_err() {
                 tracing::warn!("failed to send event to conn {}", conn_id);
             }
         }
     }
 
-    /// Send an event to all connected WebSocket clients.
+    /// Broadcast an event to all connected WebSocket clients, on the priority lane.
     pub fn broadcast_event(&self, event: &WSEventType) {
+        self.broadcast_event_lane(event, Lane::Priority);
+    }
+
+    /// Broadcast an event to all connected WebSocket clients on a specific lane.
+    pub fn broadcast_event_lane(&self, event: &WSEventType, lane: Lane) {
         let data = match serde_json::to_value(event) {
             Ok(v) => v,
             Err(e) => {
@@ -124,7 +170,7 @@ impl EventBus {
         };
         let watches = self.watches.lock().unwrap();
         for (conn_id, watch) in watches.iter() {
-            if watch.sender.send(data.clone()).is_err() {
+            if watch.sender(lane).send(data.clone()).is_err() {
                 tracing::warn!("failed to send event to conn {}", conn_id);
             }
         }
@@ -143,7 +189,7 @@ impl EventBus {
         let watches = self.watches.lock().unwrap();
         for watch in watches.values() {
             if watch.tab_id == tab_id {
-                let _ = watch.sender.send(data.clone());
+                let _ = watch.sender(Lane::Priority).send(data.clone());
             }
         }
     }
@@ -174,6 +220,15 @@ impl EventBusBridge {
 
 impl WpsClient for EventBusBridge {
     fn send_event(&self, route_id: &str, event: WaveEvent) {
+        // Perf telemetry is droppable and must never delay interactive terminal
+        // I/O, so route sysinfo + per-block stats to the background lane and
+        // everything else to the priority lane. This is the only place the raw
+        // WaveEvent type is visible before it's wrapped as an opaque RPC
+        // envelope. See SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.
+        let lane = match event.event.as_str() {
+            EVENT_SYS_INFO | EVENT_BLOCK_STATS => Lane::Background,
+            _ => Lane::Priority,
+        };
         // Wrap as RPC eventrecv message (format expected by frontend)
         let ws_event = WSEventType {
             eventtype: WS_EVENT_RPC.to_string(),
@@ -187,9 +242,9 @@ impl WpsClient for EventBusBridge {
         // only for legacy callers that pass "ws-main" (none remain after the
         // per-conn-id fix), so this always takes the targeted path in practice.
         if route_id == "ws-main" {
-            self.event_bus.broadcast_event(&ws_event);
+            self.event_bus.broadcast_event_lane(&ws_event, lane);
         } else {
-            self.event_bus.send_to_conn(route_id, &ws_event);
+            self.event_bus.send_to_conn_lane(route_id, &ws_event, lane);
         }
     }
 }
@@ -228,8 +283,10 @@ mod tests {
         };
         bus.broadcast_event(&event);
 
-        assert!(rx1.try_recv().is_ok());
-        assert!(rx2.try_recv().is_ok());
+        // Default broadcast lands on the priority lane.
+        assert!(rx1.priority.try_recv().is_ok());
+        assert!(rx2.priority.try_recv().is_ok());
+        assert!(rx1.background.try_recv().is_err());
     }
 
     #[test]
@@ -245,8 +302,58 @@ mod tests {
         };
         bus.send_to_tab("tab-1", &event);
 
-        assert!(rx1.try_recv().is_ok());
-        assert!(rx2.try_recv().is_err()); // tab-2 should not receive
+        assert!(rx1.priority.try_recv().is_ok());
+        assert!(rx2.priority.try_recv().is_err()); // tab-2 should not receive
+    }
+
+    #[test]
+    fn test_lane_separation() {
+        // A background-lane send must not land on the priority lane, and vice
+        // versa — this is the core of "terminal typing has complete priority
+        // over perf monitoring".
+        let bus = EventBus::new();
+        let mut rx = bus.register_ws("conn-1", "tab-1");
+
+        let event = WSEventType {
+            eventtype: WS_EVENT_RPC.to_string(),
+            oref: String::new(),
+            data: None,
+        };
+        bus.send_to_conn_lane("conn-1", &event, Lane::Background);
+        assert!(rx.priority.try_recv().is_err()); // nothing on priority
+        assert!(rx.background.try_recv().is_ok()); // telemetry on background
+
+        bus.send_to_conn_lane("conn-1", &event, Lane::Priority);
+        assert!(rx.background.try_recv().is_err()); // nothing on background
+        assert!(rx.priority.try_recv().is_ok()); // interactive on priority
+    }
+
+    #[test]
+    fn test_bridge_routes_telemetry_to_background() {
+        // EventBusBridge must demote sysinfo + blockstats to the background lane
+        // and keep everything else (e.g. terminal blockfile output) on priority.
+        let bus = Arc::new(EventBus::new());
+        let mut rx = bus.register_ws("conn-1", "tab-1");
+        let bridge = EventBusBridge::new(bus.clone());
+
+        let telemetry = |event: &str| WaveEvent {
+            event: event.to_string(),
+            scopes: vec![],
+            sender: String::new(),
+            persist: 0,
+            data: None,
+        };
+
+        bridge.send_event("conn-1", telemetry(EVENT_SYS_INFO));
+        bridge.send_event("conn-1", telemetry(EVENT_BLOCK_STATS));
+        assert!(rx.priority.try_recv().is_err()); // no telemetry on priority
+        assert!(rx.background.try_recv().is_ok()); // sysinfo
+        assert!(rx.background.try_recv().is_ok()); // blockstats
+
+        // Terminal output (blockfile) stays on the interactive priority lane.
+        bridge.send_event("conn-1", telemetry(EVENT_BLOCK_FILE));
+        assert!(rx.priority.try_recv().is_ok());
+        assert!(rx.background.try_recv().is_err());
     }
 
     #[test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -254,6 +254,19 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
             // Background event lane → WebSocket. Droppable perf telemetry
             // (sysinfo/blockstats) only; serviced when the priority lanes above
             // are momentarily idle, so it can never delay a keystroke echo.
+            //
+            // Tradeoff of `biased;`: a SUSTAINED priority-lane flood (e.g.
+            // `! yes` pumping terminal output continuously) keeps the priority
+            // branches ready, so this lane is starved and its unbounded receiver
+            // accumulates sysinfo/blockstats until the flood pauses, then
+            // flushes as a stale burst. Acceptable for now because telemetry
+            // ingress is low-rate (sysinfo ~1/s) and a flood also saturates the
+            // socket writes — during which the priority lanes do drain, so this
+            // lane gets serviced — making true never-empty starvation the rare
+            // worst case. Phase 2 bounds it properly by coalescing this lane to
+            // the latest reading per (event, scope), so it cannot grow and the
+            // post-flood flush is one current frame, not a backlog. See
+            // SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md §4.2.
             Some(event) = background_rx.recv() => {
                 if forward_event(&mut socket, event).await {
                     break;

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -124,7 +124,15 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
 
     tracing::info!(conn_id = %conn_id, "WebSocket client connected");
 
-    let mut event_rx = state.event_bus.register_ws(&conn_id, &tab_id);
+    // Two egress lanes per connection: interactive (terminal echo, RPC-routed
+    // wave events, obj updates) and background (droppable perf telemetry —
+    // sysinfo/blockstats). The select! below drains priority before background
+    // so typing never waits behind a perf tick. See
+    // docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md.
+    let crate::backend::eventbus::WsReceivers {
+        priority: mut priority_rx,
+        background: mut background_rx,
+    } = state.event_bus.register_ws(&conn_id, &tab_id);
     tracing::info!("[ws-perf] register_ws: {:.2}ms", ws_start.elapsed().as_secs_f64() * 1000.0);
 
     // Optional messagebus receiver — activated when pane sends bus:register
@@ -170,37 +178,35 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
 
     loop {
         tokio::select! {
-            // Forward event bus events → WebSocket.
-            // Two sources feed the event bus:
-            //   1. WPS Broker (via EventBusBridge) — already wrapped as
-            //      { eventtype: "rpc", data: { command: "eventrecv", data: WaveEvent } }
-            //   2. Direct broadcasts (e.g., SetMeta's obj:update) — raw
-            //      { eventtype: "waveobj:update", oref: "block:xxx", data: ... }
-            // Type 1: forward as-is (already RPC-wrapped).
-            // Type 2: wrap as RPC "eventrecv" so the frontend WshRouter routes
-            //         it to handleWaveEvent → updateWaveObject → Jotai re-render.
-            Some(event) = event_rx.recv() => {
-                let msg = if event["eventtype"] == "rpc" {
-                    // Already an RPC message (from WPS broker via EventBusBridge)
-                    serde_json::to_string(&event).unwrap_or_default()
-                } else {
-                    // Raw event bus event — wrap as RPC eventrecv
-                    let wave_event = json!({
-                        "event": event["eventtype"],
-                        "scopes": [event["oref"]],
-                        "data": event["data"],
-                    });
-                    let wrapped = json!({
-                        "eventtype": "rpc",
-                        "data": {
-                            "command": "eventrecv",
-                            "data": wave_event,
-                        },
-                    });
-                    serde_json::to_string(&wrapped).unwrap_or_default()
-                };
-                if socket.send(Message::Text(msg.into())).await.is_err() {
-                    break;
+            // Biased: poll branches top-to-bottom so interactive terminal I/O
+            // always wins over droppable perf telemetry. Order = incoming
+            // keystrokes → RPC replies → agent bus → priority events (terminal
+            // echo) → background events (sysinfo/blockstats) → keepalive ping.
+            // See docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md.
+            biased;
+
+            // Incoming WebSocket messages → parse & dispatch (keystrokes first)
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = socket.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        match handle_incoming_text(&text, &engine, &state, &mut socket).await {
+                            Err(true) => break,
+                            Ok(Some((new_rx, agent_id))) => {
+                                // bus:register returned a new receiver
+                                bus_rx = Some(new_rx);
+                                bus_agent_id = Some(agent_id);
+                            }
+                            _ => {}
+                        }
+                    }
+                    Some(Ok(_)) => {
+                        // Binary or other message types — ignore
+                    }
+                    Some(Err(_)) => break,
                 }
             }
 
@@ -233,28 +239,24 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
                 }
             }
 
-            // Incoming WebSocket messages → parse & dispatch
-            msg = socket.recv() => {
-                match msg {
-                    Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data))) => {
-                        let _ = socket.send(Message::Pong(data)).await;
-                    }
-                    Some(Ok(Message::Text(text))) => {
-                        match handle_incoming_text(&text, &engine, &state, &mut socket).await {
-                            Err(true) => break,
-                            Ok(Some((new_rx, agent_id))) => {
-                                // bus:register returned a new receiver
-                                bus_rx = Some(new_rx);
-                                bus_agent_id = Some(agent_id);
-                            }
-                            _ => {}
-                        }
-                    }
-                    Some(Ok(_)) => {
-                        // Binary or other message types — ignore
-                    }
-                    Some(Err(_)) => break,
+            // Priority event lane → WebSocket. Two sources feed it:
+            //   1. WPS Broker (via EventBusBridge) — already wrapped as
+            //      { eventtype: "rpc", data: { command: "eventrecv", data: WaveEvent } }
+            //   2. Direct broadcasts (e.g., SetMeta's obj:update) — raw
+            //      { eventtype: "waveobj:update", oref: "block:xxx", data: ... }
+            // This carries terminal echo output and all interactive events.
+            Some(event) = priority_rx.recv() => {
+                if forward_event(&mut socket, event).await {
+                    break;
+                }
+            }
+
+            // Background event lane → WebSocket. Droppable perf telemetry
+            // (sysinfo/blockstats) only; serviced when the priority lanes above
+            // are momentarily idle, so it can never delay a keystroke echo.
+            Some(event) = background_rx.recv() => {
+                if forward_event(&mut socket, event).await {
+                    break;
                 }
             }
 
@@ -281,6 +283,37 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
     if let Some(ref agent_id) = bus_agent_id {
         state.messagebus.unregister(agent_id);
     }
+}
+
+/// Forward a queued event-bus value to the WebSocket. Returns `true` if the
+/// send failed (the caller should break the loop).
+///
+/// Two shapes arrive: already-RPC-wrapped values (from the WPS broker via
+/// EventBusBridge) are forwarded as-is; raw event-bus values (e.g. SetMeta's
+/// `waveobj:update`) are wrapped as an RPC `eventrecv` so the frontend
+/// WshRouter routes them to handleWaveEvent → updateWaveObject. Shared by both
+/// the priority and background egress lanes.
+async fn forward_event(socket: &mut WebSocket, event: serde_json::Value) -> bool {
+    let msg = if event["eventtype"] == "rpc" {
+        // Already an RPC message (from WPS broker via EventBusBridge)
+        serde_json::to_string(&event).unwrap_or_default()
+    } else {
+        // Raw event bus event — wrap as RPC eventrecv
+        let wave_event = json!({
+            "event": event["eventtype"],
+            "scopes": [event["oref"]],
+            "data": event["data"],
+        });
+        let wrapped = json!({
+            "eventtype": "rpc",
+            "data": {
+                "command": "eventrecv",
+                "data": wave_event,
+            },
+        });
+        serde_json::to_string(&wrapped).unwrap_or_default()
+    };
+    socket.send(Message::Text(msg.into())).await.is_err()
 }
 
 /// Handle an incoming text message.

--- a/docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md
+++ b/docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md
@@ -1,0 +1,305 @@
+# SPEC: Terminal I/O Has Complete Priority Over Perf Monitoring
+
+**Date:** 2026-06-16
+**Status:** Phase 1 implemented (priority/background egress lanes + biased select); Phases 2–4 proposed
+**Author:** smike (agent)
+**Area:** `agentmux-srv` WebSocket egress · sysinfo collector · terminal echo path
+**Related history:** PR #926 (`fix(term): remove writeInFlight guard from echo fast path`), `SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md`, `docs/terminal-input-latency-report.md`, `SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31.md`
+
+---
+
+## 1. The symptom
+
+After a terminal pane has been open and busy for a long session, typed keystrokes
+echo back with a small, periodic stutter — the echo is **"delayed by a tick,"** and
+the tick **lines up with the CPU/perf readout refreshing** (the sysinfo widget /
+per-core popover updating once a second). On a fresh session it's imperceptible; it
+grows with use. This is *not* a regression of the previously-fixed typing-latency
+bugs (those were frontend frame-pacing and a write-in-flight guard — see §7). It is a
+new, distinct quirk in the **backend egress scheduling**.
+
+**Design intent (non-negotiable):** typing inside the terminal must have **complete
+priority over perf monitoring.** Perf telemetry is a best-effort, droppable, 1 Hz
+cosmetic readout; a keystroke echo is an interactive, latency-critical signal. When
+the two contend, the keystroke wins every time — never the reverse.
+
+---
+
+## 2. Root cause — confirmed in code
+
+### 2.1 Terminal echo and sysinfo share **one** FIFO channel
+
+Every WebSocket connection registers exactly **one** unbounded receiver for *all*
+server→client wave events:
+
+`agentmux-srv/src/backend/eventbus.rs:50-65`
+```rust
+pub fn register_ws(&self, conn_id: &str, tab_id: &str)
+    -> tokio::sync::mpsc::UnboundedReceiver<serde_json::Value> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();   // ONE channel for everything
+    ...
+    rx
+}
+```
+
+Both of these ride that same channel, FIFO:
+
+- **Terminal echo output** — the PTY read loop appends to the block file and publishes
+  a `blockfile` append event (`shell.rs` → `handle_append_block_file` → `broker.publish`).
+- **Perf telemetry** — the sysinfo loop publishes a `sysinfo` event (scope `local`)
+  **plus one `block:<id>` `blockstats` event per tracked block** every tick
+  (`sysinfo.rs:188` and `sysinfo.rs:275`).
+
+All of them funnel through `broker.publish` → `EventBusBridge::send_event` →
+`event_bus.send_to_conn` → the connection's single `event_rx`
+(`eventbus.rs:100-114`). **There is no separation between interactive terminal data
+and droppable telemetry.**
+
+### 2.2 The egress `select!` is **unbiased** — telemetry can win the race
+
+`agentmux-srv/src/server/websocket.rs:171-273`
+```rust
+loop {
+    tokio::select! {
+        // (no `biased;` — branches are polled in RANDOM order)
+        Some(event) = event_rx.recv() => {          // ← terminal echo AND sysinfo, same branch
+            let msg = ...serde_json::to_string(&event)...;
+            if socket.send(Message::Text(msg.into())).await.is_err() { break; }
+        }
+        Some(rpc_msg) = rpc_output_rx.recv() => { ... }   // RPC replies
+        msg = socket.recv() => { ... }                    // incoming keystrokes
+        _ = ping_interval.tick() => { ... }
+    }
+}
+```
+
+Two compounding problems:
+
+1. **Same branch.** Terminal echo and sysinfo are *indistinguishable* here — both are
+   just "an item on `event_rx`." Because the channel is FIFO, if a sysinfo burst was
+   enqueued microseconds before the echo, the echo waits behind the entire burst.
+2. **Unbiased select.** Even across branches, `tokio::select!` without `biased;`
+   polls in a **random** order, so an incoming keystroke (`socket.recv`) and a ready
+   telemetry frame (`event_rx`) have equal odds — the runtime may service the
+   telemetry write first and make the keystroke wait for a `socket.send().await` to
+   complete. (`biased;` is already an accepted pattern in this codebase —
+   `subprocess.rs:1185` uses it.)
+
+Each `socket.send(...).await` is a real suspension point. When the loop chooses to
+flush a sysinfo/blockstats frame, the next keystroke echo cannot be written until that
+send completes — **one frame of head-of-line blocking, paced at exactly the sysinfo
+tick.** That is the "delayed by a tick that lines up with the perf info."
+
+### 2.3 Why it **grows with use** ("after long use")
+
+The sysinfo tick's cost and burst size both scale with how much you've done this
+session:
+
+- **Per-tick burst grows with open blocks.** The collector emits one `blockstats`
+  event *per tracked block* every tick (`sysinfo.rs:236-276`, `broker.publish` inside
+  the per-block loop). Open more panes/agents/terminals over a long session → more
+  `blockstats` events enqueued ahead of / interleaved with your echo on the shared
+  FIFO, every single tick.
+- **Collection cost grows with total process count.** Pass 1 refreshes **all**
+  processes on the machine to populate the PID→parent links
+  (`sysinfo.rs:197-201`, `ProcessesToUpdate::All`). The more processes running after a
+  long session (spawned agents, shells, build tools), the longer the tick holds and
+  the larger the downstream payload — widening the window in which an echo can land
+  behind it.
+
+So the stutter is invisible early (1 sysinfo event, ~no blocks, few processes) and
+becomes a perceptible periodic tick late (sysinfo + N blockstats, many processes),
+exactly matching the report.
+
+### 2.4 Secondary (frontend) contributor
+
+When the **per-core CPU popover is open**, each sysinfo event reconciles an
+`<Index>` over every core on the browser main thread
+(`CpuCoresPopover.tsx:80-98, 229-286`) — on a high-core machine that competes with
+xterm's render on the same thread. This is real but secondary: it only bites with the
+popover open and on many-core machines. `SystemStats.tsx` itself is cheap (8 scalar
+values). The dominant, always-present cause is the backend shared-channel HOL blocking
+in §2.1–§2.3. Frontend mitigation is **Phase 3** (optional).
+
+---
+
+## 3. Design principle
+
+> **Interactive terminal I/O is a priority lane. Perf telemetry is a background lane.
+> The background lane may never delay the priority lane — not by a frame, not by a
+> byte. Telemetry is droppable; echo is not.**
+
+Concretely:
+1. **Separate the lanes.** Terminal echo (and RPC replies / interactive events) must
+   not share a FIFO queue with sysinfo/blockstats telemetry.
+2. **Bias toward interactivity.** When both lanes are ready, the egress loop drains
+   the priority lane to empty before touching the background lane.
+3. **Telemetry yields, and may be coalesced or dropped.** A late sysinfo frame is
+   worthless — only the latest reading matters. Stale telemetry should be coalesced
+   (keep newest, drop superseded) rather than queued.
+4. **Optionally, telemetry steps aside while typing.** As the strongest expression of
+   "complete priority," the collector may skip/defer a publish for a connection that
+   had keystroke activity in the last ~150 ms.
+
+---
+
+## 4. Proposed design
+
+### Phase 1 — Split egress into priority + background lanes (the core fix)
+
+**Goal:** terminal echo and RPC replies never queue behind telemetry, and never lose
+a `select!` coin-flip to it.
+
+1. **Two receivers per connection.** Change `EventBus::register_ws` to return a
+   `(priority_rx, background_rx)` pair (or a small struct). Internally keep two
+   `UnboundedSender`s per `WindowWatchData`.
+2. **Classify at enqueue.** In `send_to_conn` / `broadcast_event`, route by event
+   type: `sysinfo` and `blockstats` → background lane; everything else (terminal
+   `blockfile` appends, `waveobj:update`, config, etc.) → priority lane. Classification
+   is a cheap match on `event.event` (constants `EVENT_SYS_INFO`, `EVENT_BLOCK_STATS`
+   already exist).
+3. **Biased drain in the egress loop** (`websocket.rs:171`):
+   ```rust
+   loop {
+       tokio::select! {
+           biased;                                   // poll in order, top-first
+           msg = socket.recv() => { ... }            // 1. incoming keystrokes
+           Some(rpc_msg) = rpc_output_rx.recv() => { ... }   // 2. RPC replies
+           Some(ev) = priority_rx.recv() => { ... }  // 3. terminal echo + interactive
+           Some(ev) = background_rx.recv() => { ... }// 4. sysinfo / blockstats (last)
+           _ = ping_interval.tick() => { ... }       // 5. ping
+       }
+   }
+   ```
+   With `biased;`, a ready keystroke or echo is always serviced before a ready
+   telemetry frame. Telemetry is only flushed when the priority lanes are momentarily
+   empty.
+
+This alone removes the head-of-line blocking and the lost coin-flip — the two
+mechanisms behind the periodic tick.
+
+### Phase 2 — Coalesce / bound the telemetry lane (kill the "grows with use" burst)
+
+Even on its own lane, a fat telemetry burst shouldn't accumulate unbounded behind a
+slow client.
+
+1. **Coalesce sysinfo to latest-only.** The background lane should keep only the most
+   recent `sysinfo` reading per scope; a new tick supersedes an unsent one. (Either a
+   1-slot "latest value" cell drained by the egress loop, or a drop-oldest dedup on
+   enqueue keyed by `event` + scope.) A dropped intermediate sysinfo frame is
+   invisible to the user — the gauge just shows the newest number.
+2. **Same for `blockstats`** — keyed per `block:<id>`.
+3. **Lower the default per-tick fan-out cost.** Pass-1 `ProcessesToUpdate::All`
+   (`sysinfo.rs:197`) is the per-tick scaling cost. Options (smallest first):
+   refresh parent links less often than the publish cadence (e.g. tree topology every
+   Nth tick, CPU/mem every tick), or scope pass-1 to the union of tracked trees plus
+   their ancestors instead of all processes. **Out of scope to redesign here** — noted
+   as a follow-up; Phases 1+2 already remove the *latency*, this only trims CPU.
+
+### Phase 3 — Frontend: telemetry renders off the interactive path (optional)
+
+Only if measurement (§6) still shows a frame cost with the popover open on many-core
+machines:
+- Gate `CpuCoresPopover` reconciliation behind `requestIdleCallback` / a low-priority
+  scheduler so a 1 Hz core-grid update can't land in the same frame as an xterm write.
+- Leave `SystemStats` (the always-visible cheap readout) as-is.
+
+### Phase 4 — "Step aside while typing" (optional, strongest guarantee)
+
+The most literal reading of "complete priority": the sysinfo collector skips a publish
+to a connection that typed in the last ~150 ms. Requires the egress side to expose a
+per-connection `last_input_at` the collector can read. **Deliberately deferred** —
+Phases 1+2 should fully resolve the symptom without coupling the collector to input
+state, and this adds a grace-timer-like heuristic the project generally avoids (cf.
+the predictive-echo "no wall-clock timers" rule). Documented as the fallback if a
+residual tick survives Phases 1–2.
+
+---
+
+## 5. Why not the simpler knobs
+
+- **Just slow the sysinfo interval (2 s) / "pause when focused."** Treats the symptom,
+  not the cause — the HOL blocking still happens, just less often, and it degrades the
+  feature the user explicitly wants to keep. Rejected as the primary fix.
+- **Just add `biased;` (no lane split).** Necessary but insufficient: terminal echo
+  and sysinfo share the *same* `event_rx` branch (§2.1), so biasing across branches
+  doesn't separate them — a sysinfo frame already ahead of the echo in that one FIFO
+  still blocks it. The lane split is what makes `biased;` effective for echo.
+- **Bound the channel / drop on backpressure.** The input channel is intentionally
+  unbounded to avoid the paste-truncation bug; we keep echo lossless and instead make
+  *telemetry* the thing that coalesces/drops (Phase 2). Correct lane to shed load.
+
+---
+
+## 6. Verification
+
+**Reproduce first (so we can prove the fix):**
+- Long-session repro: open several agent + terminal panes, let many processes run,
+  hold a key down in a terminal, and watch for a ~1 Hz hitch in the echo that
+  coincides with the sysinfo readout updating.
+- Instrument with the existing perf marks: `term-echo-render`
+  (`termwrap.ts`, WPS-arrival → xterm write callback). Record the Performance
+  timeline while typing continuously for ~30 s; look for a recurring ~1 Hz outlier in
+  the `term-echo-render` histogram and confirm it disappears after Phase 1.
+- Optional backend trace: log egress-branch selection + queue depth; confirm echo
+  frames stop being preceded by telemetry frames on the same lane.
+
+**Automated:**
+- Unit test `EventBus` lane classification: a `sysinfo`/`blockstats` event lands on
+  `background_rx`; a `blockfile`/`waveobj:update` event lands on `priority_rx`.
+- Unit test the coalescer: enqueuing two `sysinfo` frames for the same scope before a
+  drain yields only the newest.
+- `cargo check -p agentmux-srv` + existing eventbus/websocket tests green.
+
+**Acceptance:**
+- With many panes open and processes running, continuous typing shows **no** periodic
+  echo hitch correlated with the sysinfo tick (the `term-echo-render` ~1 Hz outlier is
+  gone).
+- Sysinfo gauges still update at their configured cadence (telemetry not broken, just
+  deprioritized/coalesced).
+
+---
+
+## 7. Relationship to prior terminal-latency work (not a regression)
+
+This is a *new* layer of the problem; the prior fixes stand:
+
+| Prior work | Layer it fixed | Why it doesn't cover this |
+|---|---|---|
+| PR #926 — remove `writeInFlight` guard | Frontend echo fast-path stall | Frontend write gating; unrelated to backend egress scheduling |
+| `SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30` | Frontend double-rAF frame beat | Removed a second frame gate; this is server→client queueing |
+| `docs/terminal-input-latency-report.md` | xterm write serialization | Per-write ordering; not cross-event-type priority |
+| `SPEC_TERMINAL_PREDICTIVE_LOCAL_ECHO_2026_05_31` | Hides round-trip via local echo | Predicts the echo; doesn't fix the authoritative echo being delayed by telemetry |
+
+Predictive local echo, where enabled, *masks* this for printable characters — but the
+authoritative stream (and anything prediction can't predict: control sequences, program
+output, cursor moves) still rides the contended channel. Fixing the channel benefits
+every byte, predicted or not.
+
+---
+
+## 8. Scope / files touched
+
+**Phase 1 (core):**
+- `agentmux-srv/src/backend/eventbus.rs` — two-lane `register_ws`; classify in
+  `send_to_conn` / `broadcast_event`.
+- `agentmux-srv/src/server/websocket.rs` — consume two receivers; `biased;` select
+  with priority order input → RPC → priority events → background events → ping.
+- Caller of `register_ws` is only `websocket.rs:127` (verified) — small blast radius.
+
+**Phase 2:** `eventbus.rs` (coalescing background lane); optional `sysinfo.rs` pass-1
+scoping (follow-up).
+
+**Phase 3 (optional):** `frontend/app/statusbar/CpuCoresPopover.tsx`.
+
+**Phase 4 (deferred):** per-connection `last_input_at` shared with `sysinfo.rs`.
+
+---
+
+## 9. Recommendation
+
+Ship **Phase 1** first — it directly removes both mechanisms (shared FIFO + lost
+coin-flip) behind the reported tick and is a contained, testable change with a tiny
+blast radius. Measure with `term-echo-render`. Add **Phase 2** coalescing to keep the
+fix robust as sessions grow. Treat Phases 3–4 as conditional, driven by whether any
+residual hitch survives measurement.


### PR DESCRIPTION
## Problem

In a terminal pane, after a long session, typed keystrokes echo back with a periodic stutter — the echo is "delayed by a tick" and the tick **lines up with the CPU/perf readout refreshing** (sysinfo, ~1 Hz). Invisible early, perceptible late.

## Root cause (confirmed in code)

Terminal echo output and droppable perf telemetry share **one** FIFO per-connection event channel (`EventBus::register_ws` → single `event_rx`), drained by an **unbiased** `tokio::select!` (`websocket.rs`):

1. **Same channel.** Terminal `blockfile` echo and `sysinfo`/`blockstats` telemetry both funnel through `broker.publish` → `EventBusBridge` → the one `event_rx`. A telemetry burst enqueued microseconds before an echo blocks it head-of-line.
2. **Unbiased select.** Even across branches, `select!` without `biased;` polls in random order, so a ready telemetry frame can win the coin-flip and make a keystroke wait for a `socket.send().await`.
3. **Grows with use.** The collector emits one `blockstats` event **per open block** every tick and refreshes **all** processes (`ProcessesToUpdate::All`) — both scale with session length, widening the window in which an echo lands behind telemetry.

## Fix — Phase 1

- **Two egress lanes per connection.** `register_ws` now returns `WsReceivers { priority, background }`. `EventBusBridge::send_event` classifies by `WaveEvent` type (the only spot the raw type is visible before RPC-wrapping): `sysinfo` + `blockstats` → background; everything else → priority.
- **Biased select.** The egress loop is now `biased;`, ordered: incoming keystrokes → RPC replies → agent bus → priority events (echo) → background events (telemetry) → ping. Telemetry only flushes when the priority lanes are momentarily idle, so it **can never delay a keystroke echo**.

All existing direct `broadcast_event` callers keep priority-lane behavior (none send telemetry) — tiny blast radius. The shared event-forwarding logic is factored into one `forward_event` helper used by both lanes.

This is intentionally "complete priority": under a flood of terminal output, telemetry yields and the gauges resume the instant the priority lanes drain — exactly the requested behavior.

## Not a regression

Distinct from the prior frontend typing fixes (#926 writeInFlight, double-rAF tearout, predictive echo) — those were all frontend frame-pacing; this is server→client egress scheduling. Predictive echo *masks* this for printable chars; fixing the channel benefits every byte (control sequences, program output, cursor moves).

## Tests / verification

- `cargo check -p agentmux-srv` clean.
- New `eventbus` tests: `test_lane_separation` (background send never lands on priority lane and vice versa) and `test_bridge_routes_telemetry_to_background` (bridge demotes sysinfo/blockstats, keeps blockfile on priority). All 6 eventbus tests pass.
- Manual repro/verify via the existing `term-echo-render` perf mark: record while typing continuously ~30s with many panes open; the ~1 Hz outlier correlated with the sysinfo tick should be gone.

## Follow-ups (in spec)

Phase 2 (coalesce telemetry to latest-only + trim per-tick process refresh), Phase 3 (frontend popover idle-scheduling), Phase 4 ("step aside while typing") — all documented in `docs/specs/SPEC_TERMINAL_INPUT_PRIORITY_OVER_SYSINFO_2026_06_16.md`. Phases 1+2 remove the latency; 3–4 are conditional on residual measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)