### PR TITLE
chore(release): add --as <type> override to force a specific bump

### DIFF
--- a/.changesets/1781625491-chore-release-add-as-type-override-to-force-a-specific-versi-nmfk.md
+++ b/.changesets/1781625491-chore-release-add-as-type-override-to-force-a-specific-versi-nmfk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(release): add --as <type> override to force a specific version bump (e.g. patch even when minor changesets are queued)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ git push -u origin agenta/release-vX.Y.Z
 
 The release script picks the highest bump type across pending changesets (major > minor > patch), runs `scripts/bump-wrapper.sh`, appends to `VERSION_HISTORY.md`, and deletes the consumed changesets.
 
+**Forcing a bump type:** pass `--as <patch|minor|major>` to override the computed type — e.g. `task release -- --as patch` ships a patch even while `minor` changesets are queued. The override still consumes and changelogs every pending changeset (the higher-typed changes just ship under the forced version), and the script prints a loud `WARNING` when you force a bump *lower* than the changesets request. Use it when you want a deliberate patch release and accept that queued `minor` work rides along under that patch.
+
 ### Background
 
 `@a5af/bump-cli` is still installed and used internally by the release script. The `.bump.json` config now targets only the workspace root (`Cargo.toml` + `package.json` + lockfiles) thanks to Phase 1's workspace-version-inheritance — see `docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,19 +24,33 @@ set -euo pipefail
 
 DRY_RUN=0
 FORCE_TYPE=""
+FORCE_SET=0   # whether --as/--bump was passed (so an empty value still errors)
+# Each branch consumes its own args — no loop-bottom `shift`, which under
+# `set -euo pipefail` would abort cryptically when `--as` is the final token
+# (the in-branch shift empties $@, then a second shift fails).
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)        DRY_RUN=1 ;;
-        --as|--bump)      shift; FORCE_TYPE="${1:-}" ;;
-        --as=*|--bump=*)  FORCE_TYPE="${1#*=}" ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --as|--bump)
+            FORCE_SET=1
+            FORCE_TYPE="${2:-}"          # empty if no value follows → caught below
+            shift 2 2>/dev/null || shift  # consume flag (+value); tolerate missing value
+            ;;
+        --as=*|--bump=*)
+            FORCE_SET=1
+            FORCE_TYPE="${1#*=}"          # empty for `--as=` → caught below
+            shift
+            ;;
         *)
             echo "ERROR: unknown argument '$1' (expected --dry-run and/or --as <patch|minor|major>)." >&2
             exit 1
             ;;
     esac
-    shift
 done
-if [[ -n "$FORCE_TYPE" ]]; then
+if (( FORCE_SET )); then
     case "$FORCE_TYPE" in
         patch|minor|major) ;;
         *)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,15 +9,41 @@
 # commits the staged changes and opens a release PR.
 #
 # Usage:
-#   scripts/release.sh [--dry-run]
+#   scripts/release.sh [--dry-run] [--as <patch|minor|major>]
+#
+# By default the bump type is the HIGHEST among the pending changesets
+# (major > minor > patch). `--as <type>` forces a specific bump regardless —
+# e.g. `--as patch` ships a patch release even while `minor` changesets are
+# queued. This intentionally under-claims: the higher-typed changesets are
+# still consumed and listed in VERSION_HISTORY, just under the forced version.
+# The script warns loudly when the override is lower than the computed type.
 #
 # RFC #857 Phase 2 / spec docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md.
 
 set -euo pipefail
 
 DRY_RUN=0
-if [[ "${1:-}" == "--dry-run" ]]; then
-    DRY_RUN=1
+FORCE_TYPE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)        DRY_RUN=1 ;;
+        --as|--bump)      shift; FORCE_TYPE="${1:-}" ;;
+        --as=*|--bump=*)  FORCE_TYPE="${1#*=}" ;;
+        *)
+            echo "ERROR: unknown argument '$1' (expected --dry-run and/or --as <patch|minor|major>)." >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+if [[ -n "$FORCE_TYPE" ]]; then
+    case "$FORCE_TYPE" in
+        patch|minor|major) ;;
+        *)
+            echo "ERROR: --as must be one of patch|minor|major (got '$FORCE_TYPE')." >&2
+            exit 1
+            ;;
+    esac
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -54,6 +80,22 @@ for f in "${CHANGESETS[@]}"; do
             ;;
     esac
 done
+
+# Apply an explicit override (`--as <type>`), if given. The computed type is
+# kept so we can warn when the override under-claims (e.g. forcing patch while
+# minor changesets are pending). The higher-typed changesets are still consumed
+# and changelogged — only the version number is forced lower.
+if [[ -n "$FORCE_TYPE" ]]; then
+    rank() { case "$1" in patch) echo 0 ;; minor) echo 1 ;; major) echo 2 ;; *) echo 0 ;; esac; }
+    if [[ "$FORCE_TYPE" != "$RELEASE_TYPE" ]]; then
+        echo "NOTE: --as overrides the computed bump '$RELEASE_TYPE' with '$FORCE_TYPE'." >&2
+        if (( $(rank "$FORCE_TYPE") < $(rank "$RELEASE_TYPE") )); then
+            echo "WARNING: forcing a LOWER bump than the changesets request — some" >&2
+            echo "         ${RELEASE_TYPE}-level change(s) will ship under a $FORCE_TYPE version." >&2
+        fi
+    fi
+    RELEASE_TYPE="$FORCE_TYPE"
+fi
 
 echo "Release type: $RELEASE_TYPE" >&2
 


### PR DESCRIPTION
## Why
`scripts/release.sh` computes the release bump as the **highest** type among pending changesets (major > minor > patch). With ~37 changesets queued (14 `minor` + 23 `patch`) on `main`, a release is forced to **minor (0.47.0)** — there's currently **no way to cut a deliberate patch** even when you want one.

## What
Adds an opt-in override to `release.sh`:

```bash
task release -- --as patch     # force a patch even while minors are queued
task release -- --as minor      # or any of patch|minor|major  (--bump is an alias)
```

- **Default behavior unchanged** — no flag = highest-type computation as before.
- The override **still consumes and changelogs every pending changeset**; only the version *number* is forced. The higher-typed changes ride along under the forced version (a deliberate under-claim).
- Prints a loud **`WARNING`** when you force a bump *lower* than the changesets request, so it can never happen silently.
- Validates input (`--as bogus` and unknown args error out).

## Validation (`--dry-run`, no mutation)
| Invocation | Result |
|---|---|
| `release.sh --dry-run` | `Release type: minor` (unchanged default) |
| `release.sh --dry-run --as patch` | `NOTE` + `WARNING: forcing a LOWER bump…` → `Release type: patch` |
| `release.sh --dry-run --as=minor` | silent (matches computed) → `minor` |
| `release.sh --as bogus` | `ERROR: --as must be one of patch\|minor\|major` |
| `release.sh --frobnicate` | `ERROR: unknown argument` |

## Notes
- Script + `CLAUDE.md` doc update + changeset (patch).
- Semver caveat is intentional and documented: forcing patch while minors are queued means those features ship under a patch version. For a continuously-shipped app that's a valid choice; the warning keeps it deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)