### PR TITLE
feat(agent): tool blocks stay expanded until scrolled off the top

### DIFF
--- a/.changesets/1781643855-feat-agent-tool-blocks-stay-expanded-until-scrolled-off-the--mwow.md
+++ b/.changesets/1781643855-feat-agent-tool-blocks-stay-expanded-until-scrolled-off-the--mwow.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): tool blocks stay expanded until scrolled off the top (replaces 3s collapse timer)

--- a/docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md
+++ b/docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md
@@ -1,0 +1,319 @@
+# Analysis: Scroll-Driven Tool-Block Collapse (replace the post-completion timer)
+
+**Date:** 2026-06-16
+**Author:** smike (agent)
+**Status:** Analysis / design proposal (no code yet)
+**Area:** agent-pane transcript — tool-call block expand/collapse
+**Related:** `SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md`, `SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md`, `SPEC_TOOL_BLOCK_INTERACTION_HOLD_AND_GLOB_EXPAND_2026_06_09.md`, `SPEC_AGENT_PANE_LAYOUT_REDUCER_2026_06_02.md`, `SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md`
+
+---
+
+## 1. The change requested
+
+**Today:** a tool call renders **expanded** while running, and on completion an
+auto-collapse timer fires after a few seconds, collapsing it in place — even
+while it's still on screen and the user may still be reading it.
+
+**Desired:** a tool call **stays expanded until it scrolls off the screen**, and
+collapses **as it leaves the top of the viewport** (offscreen / near the top as
+the transcript scrolls up). In other words: collapse should be driven by
+**scroll position**, not by a wall-clock timer. While a completed tool is still
+visible, it stays open; once it's scrolled past, it folds to its one-line summary
+so the history stays compact.
+
+This also aligns with a project convention seen elsewhere in the codebase: **no
+grace timers** (e.g. the predictive-echo spec's "no wall-clock timer" rule). The
+new behavior *removes* a timer rather than adding one.
+
+---
+
+## 2. How collapse works today
+
+### 2.1 The timer is 3 s, not a minute
+
+`frontend/app/view/agent/components/ToolBlock.tsx:82`
+```ts
+const POST_COMPLETION_HOLD_MS = 3000; // 1s (#988) → 5s (#1006) → 3s (2026-05-26)
+```
+Armed on the `active → inactive` status transition (ToolBlock.tsx:118-122):
+```ts
+if (isActive(prevStatus) && !isActive(s)) {
+    setPostCompletionHold(true);
+    const t = setTimeout(() => setPostCompletionHold(false), POST_COMPLETION_HOLD_MS);
+    onCleanup(() => clearTimeout(t));
+}
+```
+> **Note on the "after a minute" observation:** the committed code collapses after
+> **3 seconds**. If the running desktop build feels like ~a minute, that build is
+> off `main` (the latest Desktop portable is built from `origin/main`), or the
+> perception is of a *pinned* / hovered block staying open. Either way the
+> directive — *position-driven, not time-driven* — stands; this analysis targets
+> the committed 3 s behavior.
+
+### 2.2 The visual expansion decision (component-local)
+
+ToolBlock.tsx:138-153 — the component decides what to render:
+```ts
+const autoExpanded = () =>
+    s === "running" || s === "pending_approval" || postCompletionHold();
+const expanded = () => props.pinned || autoExpanded() || userHolding();
+```
+- `props.pinned` — persisted (survives unmount), toggled by clicking the summary row (`onClick={props.onTogglePin}`, ToolBlock.tsx:237).
+- `userHolding` — ephemeral; true while the mouse is inside an already-open block, so the timer can't collapse mid-read (ToolBlock.tsx:234-235).
+- `postCompletionHold` — ephemeral; the 3 s timer. **Lost on unmount** (i.e. when the row is virtualized away).
+
+### 2.3 The layout expansion decision (store-local) — and the divergence
+
+The virtualization layout slice computes each row's height from a **separate**
+pure mapper, `currentExpansion()`:
+
+`frontend/app/view/agent/virtualization/expansion-source.ts:50-56`
+```ts
+case "tool":
+    if (state.pinnedNodes.has(node.id)) return { open: true, via: "pin" };
+    if (node.status === "running" || node.status === "pending_approval")
+        return { open: true, via: "auto" };
+    return CLOSED;   // completed tools → collapsed height
+```
+That file's own header (expansion-source.ts:24-31) flags the gap explicitly:
+> "NOT captured here (component-local transients…): **a tool's 3 s post-completion
+> hold (`ToolBlock.postCompletionHold`)** … handled by the store-layer hold timer
+> / a click-time dispatch in the wiring layer, not by this pure mapper."
+
+**So there are two deciders that already disagree during the 3 s window:** the
+component paints the panel *expanded*, while the layout slice sizes the row as
+*collapsed*. Measurement (`ResizeObserver` → `RowMeasured`) papers over it, but the
+measured height is recorded under the *collapsed* state key, so the prefix-sum can
+be briefly wrong. **This redesign should collapse the two deciders into one
+source of truth** — exactly the "Phase 2" the layout-reducer spec anticipates.
+
+### 2.4 Per-state behavior today
+
+| Status | Expanded while…? | On completion |
+|---|---|---|
+| `running` / `pending_approval` | always | n/a |
+| `success` / `failed` | — | 3 s hold, then collapse (✗ + red border flags failures on the collapsed row) |
+| `denied` / `canceled` / `awaiting_answer` | — | collapse immediately |
+| pinned (any) | always (pin overrides) | stays expanded |
+
+Collapse state ownership: `pinnedNodes` / `collapsedNodes` are `Set<string>` in
+`documentState` (`frontend/app/view/agent/types.ts`) — **persisted, survive
+virtualization unmount**. `postCompletionHold` / `userHolding` are component
+signals — **ephemeral, reset on remount**.
+
+---
+
+## 3. The scroll/virtualization infrastructure to hook into
+
+The transcript is **hybrid-virtualized** (`SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md`):
+a virtualized head (absolute-positioned, windowed) + an unvirtualized streaming
+buffer (last ~50 nodes in normal flow). Key facts for this work:
+
+- **Every row has a known position.** `computeLayoutView` builds a prefix-sum of
+  `{ start, height }` for **all** ordered rows; the visible window is a binary-search
+  slice (`reducer.ts:windowRangeOf`). So "is row R above the viewport top?" is
+  computable as `row.start + row.height < scrollTop + threshold` for *any* row,
+  rendered or not — no DOM/IntersectionObserver needed for the virtualized head.
+- **Heights are state-keyed.** `RowHeight { collapsed?, expanded? }` — both the
+  collapsed and expanded heights are measured/estimated and stored
+  (`reducer.ts:layoutHeightFor`). Collapsing a row to a *known* height is a
+  deterministic prefix-sum change — no remeasure required.
+- **Offscreen rows unmount** (`AgentDocumentVirtualList.tsx:587-590` slices to the
+  window). This is why a scroll-off latch **cannot** live in the component — the
+  component is gone exactly when we need to record "this scrolled off."
+- **Scroll/anchor machinery already exists:** `handleScroll` toggles
+  stick-to-bottom by proximity (`anchor.ts:isNearBottom`, threshold 200 px);
+  near-top triggers paginate-older with `captureTopmostAnchor` /
+  `restoreScrollFromAnchor` to **prevent scroll jumps on prepend**
+  (`AgentDocumentVirtualList.tsx:491-575`). The same anchor primitive is what we
+  need to keep the viewport stable when a row above the fold collapses.
+- **Expansion already flows into layout via commands:** `ExpansionResolved`
+  dispatches on expansion change and triggers a relayout
+  (`AgentDocumentVirtualList.tsx:239-248`; `agent-pane-layout-store.ts:81-95`).
+
+---
+
+## 4. Proposed model: position-driven, **latched** collapse
+
+### 4.1 The rule
+
+A completed, unpinned tool is **expanded by default** and collapses **once, when
+its bottom edge scrolls above the viewport top**, then **stays collapsed (latched)**.
+
+```
+expanded(tool) =
+      tool is running | pending_approval        // live → open (unchanged)
+   || pinned(tool)                               // explicit override (unchanged)
+   || userHolding(tool)                          // mouse-inside hold (unchanged)
+   || ( completed && NOT scrolledOff(tool) )     // NEW: open until it leaves the top
+```
+
+- **Completed & still on/below the fold →** open. (Removes the 3 s timer's early
+  collapse — the user keeps reading it.)
+- **Completed & scrolled above the top →** add `tool.id` to a `scrolledOff` set →
+  collapsed, and it **stays** collapsed on scroll-back (latched).
+- **Completed off-screen above when it finished** (user had scrolled down past it
+  while it ran) → it's already above the top → collapsed immediately. Correct.
+- **Completed off-screen below** (user scrolled up; new tool finished below the
+  fold) → not above the top → stays expanded; visible & open when the user
+  returns to the bottom. Correct.
+
+### 4.2 Why **latched** (one-way), not "expanded iff currently in view"
+
+A continuously-recomputed "expanded iff visible" rule creates a **feedback loop**:
+expansion changes height → height changes the prefix-sum → that changes which rows
+are above the top → which changes expansion… potentially oscillating, and
+re-expanding on scroll-back would thrash row heights right under the user's cursor.
+
+Latching (`expanded → collapsed`, once, per node id) makes the decision
+**monotonic**: a row leaves the top at most once, collapses once, and is done.
+This kills the loop and matches the user's words ("stay expanded **until** off
+screen, **then** collapse"). Re-expanding is then an explicit click (pin), which
+is the existing affordance.
+
+### 4.3 Where the latch lives
+
+`scrolledOff` must be **pane-level persisted state**, not a component signal —
+because the row unmounts the instant it scrolls off. Natural home: a new
+`Set<string>` in `documentState` alongside `collapsedNodes` / `pinnedNodes`, fed
+into `currentExpansion()` via the existing `ExpansionInputs`. Then **one** mapper
+decides expansion for both the layout heights *and* the visual render — closing
+the §2.3 divergence.
+
+### 4.4 Single source of truth
+
+Refactor so `ToolBlock` no longer owns the expand decision:
+- Delete `POST_COMPLETION_HOLD_MS`, `postCompletionHold`, and its `createEffect`
+  (ToolBlock.tsx:82-83, 109-124).
+- Extend `currentExpansion()` (expansion-source.ts) for tools:
+  ```ts
+  case "tool":
+      if (state.pinnedNodes.has(node.id)) return { open: true, via: "pin" };
+      if (running || pending_approval)    return { open: true, via: "auto" };
+      return state.scrolledOff.has(node.id)
+          ? CLOSED
+          : { open: true, via: "auto" };   // completed-but-not-yet-scrolled-off → open
+  ```
+- `ToolBlock.expanded()` reads the resolved expansion (passed as a prop / read
+  from the same store) `|| userHolding()`. `userHolding` stays component-local
+  (it's a true transient and only matters while mounted/visible).
+
+---
+
+## 5. The hard part: scroll-height stability
+
+Collapsing a row **above** the viewport shrinks total height above `scrollTop`. If
+uncompensated, in-viewport content **jumps upward** by the height delta. Two
+regimes:
+
+1. **Stick-to-bottom engaged (active streaming, the common case).** `scrollTop`
+   is pinned to max; rows collapsing above the fold just reduce `scrollHeight`
+   and we stay pinned. **No visible jump** — this case is naturally stable.
+2. **User scrolled up reading history.** Collapsing above-fold rows *must*
+   decrement `scrollTop` by the summed collapsed-vs-expanded height delta to keep
+   the viewport visually stationary. Reuse the existing anchor primitive
+   (`captureTopmostAnchor` / `restoreScrollFromAnchor`,
+   `AgentDocumentVirtualList.tsx:491-575`): capture an anchor on a row that stays
+   in view, dispatch the collapse(s), restore scroll from the anchor's new
+   prefix-sum start. The machinery is already there for paginate-older; this is
+   the same shape.
+
+**Trigger point.** Hook the latch into the existing `handleScroll`
+(`AgentDocumentVirtualList.tsx:455`), which already runs on every scroll and has
+`scrollTop` + the layout view. On each scroll, scan rows whose
+`start + height(expanded) < scrollTop + COLLAPSE_MARGIN_PX` that are tool nodes,
+completed, unpinned, not already in `scrolledOff`; batch-add them to `scrolledOff`
+in one dispatch (one relayout), with anchor compensation per regime above.
+- Use the **expanded** height in the threshold so the decision is computed against
+  the row's pre-collapse extent (monotonic; avoids a row oscillating around the
+  boundary).
+- `COLLAPSE_MARGIN_PX`: 0 = collapse exactly when fully above the top; a small
+  positive value = "near the top" (collapse just before fully gone, a gentler
+  feel, matching "offscreen **or near the top**"). Tunable; start at 0–24 px.
+
+**Tall tools** (taller than the viewport): keying on the **bottom** edge
+(`start + height`) means a tool whose top has scrolled off but whose bottom is
+still visible stays expanded until it's *entirely* above the fold — so the user is
+never yanked mid-read. Correct by construction.
+
+---
+
+## 6. Edge cases / decisions
+
+| Case | Behavior |
+|---|---|
+| Completed tool still fully/partly visible | **Expanded** (new). The headline win. |
+| Tool scrolls entirely above the top | Collapse once, **latched**. |
+| Scroll back up to a latched tool | Stays collapsed; **click to expand** (pins). No auto-thrash. |
+| Tool finishes while already above the top | Collapsed immediately (already in `scrolledOff` criteria on next scroll/relayout). |
+| Tool finishes below the fold (user scrolled up) | Expanded; visible when user returns to bottom. |
+| Pinned tool | Always expanded; **never** auto-latched. Pin still wins. |
+| `denied` / `canceled` / `awaiting_answer` | Keep today's immediate-collapse (don't hold these open on screen). |
+| `failed` | Same as `success`: stays open while visible, collapses on scroll-off (✗ + red border on the collapsed row, unchanged). Confirm this is wanted vs "errors stay expanded." |
+| Streaming buffer rows (last ~50, in-flow near bottom) | These are at/near the bottom = visible = expanded. They only latch once they've migrated up into the prefix-sum head and crossed the top — handled uniformly by position. |
+| `userHolding` (mouse inside) when it reaches the top | Hold wins while the mouse is in; latch on the scroll after `mouseleave`. (Or: don't latch a row the pointer is inside — minor.) |
+
+**Persistence question:** should `scrolledOff` persist across reload/restore (like
+the snapshot in `SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md`)? Recommendation:
+**no** — on a fresh load, completed tools above the restored scroll position can be
+seeded as collapsed directly from their position, and anything in view renders
+expanded. Keeping `scrolledOff` session-ephemeral avoids growing a persisted set
+unboundedly and matches "collapse is a scroll artifact, not a saved preference."
+
+---
+
+## 7. Implementation sketch (files)
+
+1. **`frontend/app/view/agent/types.ts`** — add `scrolledOff: Set<string>` to
+   `DocumentState` (+ a `markScrolledOff(ids)` mutator). Widen
+   `ExpansionInputs` (expansion-source.ts:40) to include it.
+2. **`expansion-source.ts:50-56`** — completed unpinned tool: open unless in
+   `scrolledOff`. (Single source of truth; fixes the §2.3 divergence.)
+3. **`AgentDocumentVirtualList.tsx`** — in `handleScroll` (and once after relayout/
+   resize), compute newly-off-top tool rows from the layout view's prefix-sum and
+   batch-dispatch them into `scrolledOff`; wrap the dispatch in anchor
+   capture/restore when **not** stuck to bottom (reuse §5 primitives). Add
+   `COLLAPSE_MARGIN_PX`.
+4. **`ToolBlock.tsx`** — delete the timer (`82-83`, `109-124`); `expanded()` reads
+   the resolved expansion (prop/store) `|| userHolding()`. Keep pin + hover-hold.
+5. **Specs** — supersede the "post-completion hold" sections of
+   `SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md` §4.2 and note the unification as the
+   `currentExpansion` "Phase 2" the layout-reducer spec anticipated.
+
+Roughly: one new `documentState` set + mutator, a ~15-line scroll-scan with anchor
+compensation, a 3-line change in the pure mapper, and a deletion in ToolBlock.
+
+---
+
+## 8. Risks / open questions
+
+- **Scroll-jump on history scroll-up (§5 case 2)** is the main risk. The anchor
+  primitive exists but must be wired correctly; needs a running-app check (the
+  desktop build can't verify a headless diff). Easy to get subtly wrong → visible
+  jump when many rows collapse at once.
+- **Batching:** collapse all newly-off-top rows in **one** dispatch per scroll
+  frame, not one per row, to avoid N relayouts and N anchor restores.
+- **`failed` policy:** confirm errors should fold on scroll-off like successes
+  (current behavior) vs. staying expanded as a louder signal. (My default:
+  fold-on-scroll-off; the ✗/red row already flags it. Flagging for your call.)
+- **Margin feel:** `COLLAPSE_MARGIN_PX` (collapse exactly at the top vs. slightly
+  before) is a taste tune — set after seeing it live.
+- **Re-expand affordance:** latched-collapsed relies on click-to-pin to re-open. If
+  you want "scroll back up → re-expand automatically," that reintroduces the
+  feedback loop (§4.2) and is not recommended.
+
+---
+
+## 9. Recommendation
+
+Adopt the **position-driven, latched** model with a **single expansion source**
+(`currentExpansion`) and **anchor-compensated** collapse. It removes a timer
+(aligns with the no-grace-timers convention), fixes the existing dual-decider
+divergence the layout-reducer spec already wants closed, and uses infrastructure
+that already exists (prefix-sum positions, state-keyed heights, scroll anchors).
+
+Smallest correct first cut: ship the **stick-to-bottom case first** (no anchor
+math needed — the dominant case during live streaming), behind the unified
+mapper; then add the **scrolled-up anchor compensation** as the second increment.
+That sequences the only real risk (scroll-jump) into its own verifiable step. If
+you want, I can turn this into a spec + start the Phase-1 cut.

--- a/docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md
+++ b/docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Scroll-Driven Tool-Block Collapse
+
+**Date:** 2026-06-16
+**Author:** smike (agent)
+**Status:** In progress
+**Companion analysis:** `docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`
+
+## Goal
+
+A completed tool block stays **expanded while it's on screen**, and **collapses
+once it scrolls off the top** (latched). The 3 s post-completion timer
+(`ToolBlock.postCompletionHold`) is removed. Everything else — pin override,
+hover-hold, auto-expand while running/pending, immediate collapse for
+denied/canceled, the ✗/red collapsed-row treatment for failures — is unchanged.
+
+## Model
+
+A single pane-level set, `documentState.expandedTools: Set<string>` = "completed
+tools currently held open." It is the post-completion hold, made durable across
+unmount and shared by both the visual render and the virtualization layout.
+
+- **ADD** `id` when a tool transitions `active → inactive` (completes **live, on
+  screen**). This reuses `ToolBlock`'s existing transition effect (the same
+  trigger that armed the 3 s timer), so loaded-history tools — which never
+  transition this session — are never added and stay collapsed (no load-flash;
+  preserves the guard at ToolBlock.tsx:86-89).
+- **REMOVE** `id` when the tool's row has scrolled fully above the viewport top.
+  This is the latch: once removed it won't be re-added (no new run), so scrolling
+  back up leaves it collapsed (click-to-pin to re-open — "same as now").
+
+`currentExpansion` (the single layout decider, expansion-source.ts) gains:
+`if (state.expandedTools.has(id)) → { open: true, via: "auto" }`, so virtualized
+row **heights match the visual** — closing the existing component-vs-layout
+divergence the file's header documents (expansion-source.ts:24-31).
+
+`ToolBlock.expanded()` becomes `pinned || running || pending || heldOpen ||
+userHolding`, where `heldOpen = documentState.expandedTools.has(id)` (passed in
+like `pinned`).
+
+## Collapse trigger — DOM-based scan, stick-to-bottom-gated (Phase 1)
+
+In `AgentDocumentVirtualList.handleScroll`, after the `Scrolled` dispatch, when
+`stickToBottom()` is engaged, scan `documentState().expandedTools`: for each
+unpinned held tool, look up its rendered row by `data-node-id` and release it if
+its `getBoundingClientRect().bottom <= scrollRef` top (fully above the fold), or
+if it has no element (already unmounted off-screen — safety net). DOM-based so it
+works identically for virtualized and streaming-buffer rows, and is zoom-safe
+(both rects are in the same zoomed space). `expandedTools` is tiny (a few recent
+tools), so this is a handful of `querySelector`s per scroll.
+
+**Why stick-to-bottom-gated:** collapsing a row above the fold shrinks layout
+height above `scrollTop`. While pinned to bottom this is invisible (scrollHeight
+shrinks, auto-scroll stays pinned — no jump). This covers the primary scenario:
+live streaming pushes a just-completed tool up off the top → it collapses. When
+the user is scrolled up reading history, held tools above the top are simply not
+released until they return to the bottom (stick re-engages, scrolls to bottom,
+collapse is invisible) — no jump in any case.
+
+**Phase 2 (follow-up, separate commit):** relax the gate so a tool collapses when
+scrolled-down past while *not* stuck to bottom, using the existing
+`captureTopmostAnchor`/`restoreScrollFromAnchor` primitive to compensate
+`scrollTop` by the height delta. Lower priority (those tools are off-screen; only
+the scroll position, not the collapse, is visible).
+
+## Edits
+
+1. **`types.ts`** — add `expandedTools: Set<string>` to `DocumentState`.
+2. **Construction sites** — init `expandedTools: new Set()`:
+   `state.ts:137`, `useHistoryPagination.ts:276` (fresh, not persisted),
+   `expansion-source.test.ts`, `renderers.test.ts`.
+3. **`expansion-source.ts`** — widen `ExpansionInputs` with `expandedTools`; tool
+   case returns open when `expandedTools.has(id)`.
+4. **`AgentDocumentView.tsx`** — add `holdToolOpen(id)` / `releaseToolOpen(id)`
+   mutators (mirror `togglePin`); pass as `onHoldToolOpen` / `onReleaseToolOpen`.
+5. **`AgentDocumentVirtualList.tsx`** — accept the two callbacks; thread
+   `onHoldToolOpen` to rows; add the `collapseScrolledOffTools()` scan in
+   `handleScroll` (stick-gated).
+6. **`DocumentRow.tsx`** — thread `onHoldToolOpen`; pass
+   `heldOpen={documentState().expandedTools.has(id)}` + `onHoldOpen` to `ToolBlock`.
+7. **`ToolBlock.tsx`** — delete `POST_COMPLETION_HOLD_MS` + `postCompletionHold`;
+   the transition effect calls `props.onHoldOpen?.()`; `autoExpanded()` reads
+   `props.heldOpen`.
+
+## Tests
+
+- `expansion-source.test.ts` — a completed tool in `expandedTools` resolves open;
+  not in it resolves closed; pin/running still win.
+- `ToolBlock.test.tsx` — `heldOpen` renders the panel in flow; without it a
+  completed tool renders hidden.
+- Typecheck (`tsc --noEmit`) + existing agent-pane vitest suites green.
+- Live (needs running app): new tool expands, stays expanded on screen, collapses
+  after scrolling off the top while streaming; loaded history starts collapsed.
+
+## Verification commands
+
+`npx tsc -p tsconfig.json --noEmit` · `npx vitest run <touched specs>`

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -117,6 +117,30 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
         });
     };
 
+    // Hold a tool expanded after it completes live on screen (added by
+    // ToolBlock on the active→inactive transition). Stays open until its row
+    // scrolls off the top, at which point the VirtualList calls releaseToolOpen.
+    // Replaces the old 3 s post-completion timer — see
+    // docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md.
+    const holdToolOpen = (nodeId: string): void => {
+        setDocumentState((prev) => {
+            if (prev.expandedTools.has(nodeId)) return prev; // already held — no churn
+            const expandedTools = new Set(prev.expandedTools);
+            expandedTools.add(nodeId);
+            return { ...prev, expandedTools };
+        });
+    };
+
+    // Release a held tool once it has scrolled off the top (latched collapse).
+    const releaseToolOpen = (nodeId: string): void => {
+        setDocumentState((prev) => {
+            if (!prev.expandedTools.has(nodeId)) return prev;
+            const expandedTools = new Set(prev.expandedTools);
+            expandedTools.delete(nodeId);
+            return { ...prev, expandedTools };
+        });
+    };
+
     // Header slot: loading-older banner + optional auth-url box,
     // rendered above the virtualizer inside the scroll container.
     // VirtualList's scrollMargin (=virtualContainerRef.offsetTop)
@@ -144,6 +168,8 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             scrollToBottomRef={props.scrollToBottomRef}
             onToggleCollapse={toggleCollapse}
             onTogglePin={togglePin}
+            onHoldToolOpen={holdToolOpen}
+            onReleaseToolOpen={releaseToolOpen}
             zoomFactor={props.zoomFactor}
             blockId={props.blockId}
             layoutView={props.layoutView}

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -14,6 +14,7 @@
 
 import { cleanup, fireEvent, render } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
 
 import { ToolBlock } from "./ToolBlock";
 import type { ToolNode } from "../types";
@@ -71,6 +72,37 @@ describe("ToolBlock — panel mode", () => {
         const panel = container.querySelector(".agent-tool-panel");
         expect(panel).not.toBeNull();
         expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(true);
+    });
+
+    it("heldOpen (completed, held after live completion) → panel is in-flow", () => {
+        // The scroll-driven post-completion hold: a completed tool held open
+        // renders expanded until its row scrolls off the top.
+        const { container } = render(() => (
+            <ToolBlock node={baseTool} pinned={false} heldOpen={true} onTogglePin={() => {}} />
+        ));
+        const panel = container.querySelector(".agent-tool-panel");
+        expect(panel).not.toBeNull();
+        expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(true);
+        expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(false);
+    });
+
+    it("calls onHoldOpen once when a running tool completes (active→inactive)", () => {
+        const onHoldOpen = vi.fn();
+        const [node, setNode] = createSignal<ToolNode>({ ...baseTool, status: "running" });
+        render(() => (
+            <ToolBlock node={node()} pinned={false} onTogglePin={() => {}} onHoldOpen={onHoldOpen} />
+        ));
+        expect(onHoldOpen).not.toHaveBeenCalled(); // still running
+        setNode({ ...baseTool, status: "success" }); // completes live
+        expect(onHoldOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call onHoldOpen for an already-completed tool on mount (loaded history)", () => {
+        const onHoldOpen = vi.fn();
+        render(() => (
+            <ToolBlock node={baseTool} pinned={false} onTogglePin={() => {}} onHoldOpen={onHoldOpen} />
+        ));
+        expect(onHoldOpen).not.toHaveBeenCalled();
     });
 
     // ── Hover is not a trigger ────────────────────────────────────────

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -55,8 +55,17 @@ interface ToolBlockProps {
     node: ToolNode;
     /** User has clicked to pin this tool block open. */
     pinned: boolean;
+    /**
+     * Held expanded after completing live on screen (`documentState.expandedTools`).
+     * Set by `onHoldOpen` on completion; cleared by the pane's scroll-off scan
+     * once the row leaves the top — the scroll-driven replacement for the old
+     * 3 s post-completion timer.
+     */
+    heldOpen?: boolean;
     /** Toggle the pinned state (called on click of the collapsed row). */
     onTogglePin: () => void;
+    /** Mark this tool held-open — called once on its active→inactive transition. */
+    onHoldOpen?: () => void;
     /** Opens the tool's overlay content in a dedicated pane. */
     onOpenInPane?: () => void;
 }
@@ -72,36 +81,17 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
 };
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
-    // Stays true for POST_COMPLETION_HOLD_MS after a running tool
-    // completes so the user can read the final output line before the
-    // panel collapses.
-    // - Originally 1s (#988).
-    // - Bumped to 5s in #1006 — too tight to finish reading.
-    // - Dropped to 3s 2026-05-26 — 5s felt too long during live
-    //   conversation; user wants it punchier.
-    const POST_COMPLETION_HOLD_MS = 3000;
-    const [postCompletionHold, setPostCompletionHold] = createSignal(false);
-    // Gate the post-completion hold on a real active → inactive
-    // TRANSITION (not on a status-value snapshot). The earlier draft
-    // simply checked `s !== "running" && ...` which fired on mount
-    // for already-completed tools — loaded transcripts would briefly
-    // auto-expand every completed tool row on initial render
-    // (codex P1 round 2 on #988).
+    // A tool stays expanded after completing live until its row scrolls off the
+    // top — the "post-completion hold" now lives in `documentState.expandedTools`
+    // (read via props.heldOpen) instead of a 3 s timer. Here we just detect the
+    // active → inactive TRANSITION and mark the tool held-open via onHoldOpen.
     //
-    // Background on the older self-loop bug (round 1): reading
-    // `postCompletionHold()` inside the same effect that wrote to it
-    // made the effect a subscriber of its own write; the synchronous
-    // re-run disposed the previous owner and ran the just-registered
-    // `onCleanup(() => clearTimeout(t))` BEFORE the timer could fire,
-    // leaving the panel auto-expanded forever after the first
-    // completion. Both bugs are fixed here: track only
-    // `props.node.status`, and gate on a transition by comparing
-    // against `prevStatus` captured outside the reactive scope.
-    //
-    // prevNodeId guards against <Index> slot-position state leakage:
-    // when a streaming-buffer cap-advance replaces the node at this
-    // slot position with a different node, the old prevStatus must not
-    // be treated as a transition baseline for the incoming node.
+    // Gate on a real TRANSITION (not a status-value snapshot): firing on mount
+    // for an already-completed tool would auto-expand every row of a loaded
+    // transcript (codex P1 round 2 on #988). prevNodeId guards <Index>
+    // slot-position state leakage — when a streaming-buffer cap-advance swaps the
+    // node at this slot, the old prevStatus must not seed the incoming node's
+    // transition baseline.
     let prevStatus: string = props.node.status;
     let prevNodeId: string = props.node.id;
     const isActive = (s: string): boolean =>
@@ -112,33 +102,27 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         if (id !== prevNodeId) {
             prevNodeId = id;
             prevStatus = s;
-            setPostCompletionHold(false);
             return;
         }
         if (isActive(prevStatus) && !isActive(s)) {
-            setPostCompletionHold(true);
-            const t = setTimeout(() => setPostCompletionHold(false), POST_COMPLETION_HOLD_MS);
-            onCleanup(() => clearTimeout(t));
+            props.onHoldOpen?.();
         }
         prevStatus = s;
     });
 
-    // Auto-expand while the tool is actively running (or awaiting
-    // approval). Terminal states (success OR failure) get the 5s
-    // post-completion hold then collapse. Pin still wins as an
-    // explicit override (so the user can keep a completed tool
-    // expanded). Hover keeps working as a peek affordance for
-    // collapsed (completed) tools — successes and failures alike.
+    // Auto-expand while the tool is actively running (or awaiting approval), and
+    // keep a completed tool expanded while it's held open (props.heldOpen — set
+    // on completion, cleared when the row scrolls off the top). Pin still wins as
+    // an explicit override. Success and failure behave identically (the ✗ icon +
+    // red border-left at the collapsed row flag the failure).
     //
-    // Per SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4.2 — Phase B.
-    // The 2026-05-24 user feedback removed `failed` from the
-    // always-expanded set; failed-collapses-after-5s mirrors the
-    // success path, and the ✗ icon + red border-left at the
-    // collapsed row continue to flag the failure.
+    // Per SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4.2 and
+    // docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md — the 3 s
+    // post-completion timer was replaced by scroll-position-driven collapse.
     const autoExpanded = (): boolean => {
         const s = props.node.status;
         return s === "running" || s === "pending_approval"
-            || postCompletionHold();
+            || !!props.heldOpen;
     };
     // Hover-to-peek was removed in SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28
     // — expansion is now driven exclusively by pin + active-state auto-

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -133,8 +133,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // collapsed into a single in-flow panel.
     //
     // Exception: if the user's mouse is inside an already-expanded block,
-    // we hold it open until they leave so the post-completion timer can't
-    // collapse it mid-read.
+    // we hold it open until they leave so a scroll-off collapse can't fold it
+    // mid-read.
     const [userHolding, setUserHolding] = createSignal(false);
     const expanded = () => props.pinned || autoExpanded() || userHolding();
 

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -10,9 +10,11 @@
  *     duration + (while streaming) the live-tail line. Applies to ALL
  *     terminated statuses.
  *   - Auto-expand: `running` and `pending_approval` keep the panel open
- *     in flow. After a terminal transition the panel stays open for
- *     POST_COMPLETION_HOLD_MS so the user can finish reading, then
- *     collapses.
+ *     in flow. After a terminal transition the panel stays open while the
+ *     tool is held (`props.heldOpen`, backed by `documentState.expandedTools`)
+ *     — i.e. while it's still on screen — and collapses once its row scrolls
+ *     off the top. This replaced the old fixed post-completion timer; see
+ *     docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md.
  *   - Click summary: pins the expanded state. Clicking again unpins.
  *   - Hover: nothing happens. No browser-native tooltip, no panel
  *     expand, no time popup. The hover-to-peek model from the prior

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -275,6 +275,9 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                                 documentState: {
                                     collapsedNodes: new Set<string>(ds.collapsedNodeIds ?? []),
                                     pinnedNodes: new Set<string>(ds.pinnedNodeIds ?? []),
+                                    // Not persisted — scroll-driven hold starts empty so
+                                    // restored history renders collapsed.
+                                    expandedTools: new Set<string>(),
                                     scrollPosition: typeof ds.scrollPosition === "number" ? ds.scrollPosition : 0,
                                     filter: ds.filter ?? DEFAULT_FILTER_STATE,
                                 },

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -136,6 +136,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         documentStateAtom: createSignal<DocumentState>({
             collapsedNodes: new Set<string>(),
             pinnedNodes: new Set<string>(),
+            expandedTools: new Set<string>(),
             scrollPosition: 0,
             selectedNode: null,
             filter: {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -527,6 +527,15 @@ export interface DocumentState {
      * docs/specs/tool-collapse.md.
      */
     pinnedNodes: Set<string>;
+    /**
+     * Tool nodes currently held EXPANDED after completing live on screen. A
+     * completed tool is added here on its active→inactive transition and removed
+     * once its row scrolls off the top of the viewport (latched collapse) —
+     * replacing the old 3 s post-completion timer. Loaded-history tools never
+     * transition this session, so they're never added and render collapsed.
+     * See docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md.
+     */
+    expandedTools: Set<string>;
     scrollPosition: number;
     selectedNode: string | null; // For keyboard navigation
     filter: FilterState;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -71,6 +71,12 @@ export interface AgentDocumentVirtualListProps {
     scrollToBottomRef?: (fn: () => void) => void;
     onToggleCollapse: (id: string) => void;
     onTogglePin: (id: string) => void;
+    /** Hold a tool expanded after it completes live on screen (ToolBlock calls
+     *  this on the active→inactive transition). */
+    onHoldToolOpen?: (id: string) => void;
+    /** Release a held tool once its row has scrolled off the top (latched
+     *  collapse). Invoked by the scroll-off scan in `handleScroll`. */
+    onReleaseToolOpen?: (id: string) => void;
     /**
      * Live per-pane zoom factor (the same value applied as CSS `zoom` on
      * `.agent-view` in agent-view.tsx). Normalizes the SINGLE zoomed read —
@@ -366,6 +372,10 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 // when this microtask was queued and when it fires.
                 if (!props.viewState.stickToBottom()) return;
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+                // New content may have pushed a held-open tool above the top
+                // without a user scroll event — collapse it now (pinned to
+                // bottom, so no visible jump).
+                collapseScrolledOffTools();
             });
         }
     });
@@ -452,6 +462,30 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (cmd) untrack(() => scrollToNode(cmd.nodeId));
     });
 
+    // Release (latched-collapse) any held-open tool whose row has scrolled fully
+    // above the viewport top. DOM-based so it works uniformly for virtualized
+    // and streaming-buffer rows and is zoom-safe (both rects share the zoomed
+    // space). `expandedTools` is tiny (a few recently-completed tools), so this
+    // is a handful of lookups per scroll. Pinned tools are skipped — pin wins.
+    const collapseScrolledOffTools = (): void => {
+        const release = props.onReleaseToolOpen;
+        if (!release || !scrollRef) return;
+        const ds = props.documentState();
+        if (ds.expandedTools.size === 0) return;
+        const containerTop = scrollRef.getBoundingClientRect().top;
+        for (const id of ds.expandedTools) {
+            if (ds.pinnedNodes.has(id)) continue;
+            const el = scrollRef.querySelector(
+                `[data-node-id="${id}"]`,
+            ) as HTMLElement | null;
+            // No element → not rendered → already off-screen (unmounted): release
+            // as a safety net. Otherwise release once it's fully above the top.
+            if (!el || el.getBoundingClientRect().bottom <= containerTop) {
+                release(id);
+            }
+        }
+    };
+
     const handleScroll = (): void => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
@@ -467,6 +501,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 viewportPx: clientHeight,
             });
             dispatchScrollMargin();
+        }
+
+        // Collapse held-open tools that have scrolled off the top (latched).
+        // Gated on stick-to-bottom: collapsing a row above the fold shrinks
+        // layout height above scrollTop, which is invisible while pinned to the
+        // bottom (no jump) — the primary live-streaming case. The scrolled-up /
+        // anchor-compensated case is a documented Phase 2 follow-up.
+        if (props.viewState.stickToBottom()) {
+            collapseScrolledOffTools();
         }
 
         // Engage stick when user scrolls back near bottom; disengage
@@ -684,6 +727,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                         highlightNodeId={props.highlightNodeId}
                                         onToggleCollapse={props.onToggleCollapse}
                                         onTogglePin={props.onTogglePin}
+                                        onHoldToolOpen={props.onHoldToolOpen}
                                         ref={(el) => { rowEl = el; observeRow(el, row().nodeId); }}
                                         style={{
                                             position: "absolute",
@@ -744,6 +788,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                     highlightNodeId={props.highlightNodeId}
                                     onToggleCollapse={props.onToggleCollapse}
                                     onTogglePin={props.onTogglePin}
+                                    onHoldToolOpen={props.onHoldToolOpen}
                                 />
                             )}
                         </Key>

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -37,6 +37,9 @@ export interface DocumentRowProps {
     highlightNodeId?: Accessor<string | null>;
     onToggleCollapse: (id: string) => void;
     onTogglePin: (id: string) => void;
+    /** Hold a tool expanded after it completes live on screen (ToolBlock calls
+     *  this on the active→inactive transition). */
+    onHoldToolOpen?: (id: string) => void;
     /** Style applied to the wrapper element. Virtualized parent
      *  passes absolute positioning + translateY; streaming parent
      *  passes nothing (normal flow). */
@@ -131,6 +134,7 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 onOpenInPane={onOpenInPane}
                 onToggleCollapse={props.onToggleCollapse}
                 onTogglePin={props.onTogglePin}
+                onHoldToolOpen={props.onHoldToolOpen}
                 onSubagentClick={props.onSubagentClick}
             />
             <NodeHoverStrip
@@ -151,6 +155,7 @@ interface DocumentNodeBodyProps {
     onOpenInPane?: () => void;
     onToggleCollapse: (id: string) => void;
     onTogglePin: (id: string) => void;
+    onHoldToolOpen?: (id: string) => void;
     onSubagentClick?: (node: SubagentLinkNode) => void;
 }
 
@@ -192,7 +197,9 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                 <ToolBlock
                     node={props.node() as Extract<DocumentNode, { type: "tool" }>}
                     pinned={props.documentState().pinnedNodes.has(props.node().id)}
+                    heldOpen={props.documentState().expandedTools.has(props.node().id)}
                     onTogglePin={() => props.onTogglePin(props.node().id)}
+                    onHoldOpen={() => props.onHoldToolOpen?.(props.node().id)}
                     onOpenInPane={props.onOpenInPane}
                 />
             </Show>

--- a/frontend/app/view/agent/virtualization/expansion-source.test.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.test.ts
@@ -12,9 +12,14 @@ import type {
     UserMessageNode,
 } from "../types";
 
-const inputs = (collapsed: string[] = [], pinned: string[] = []): ExpansionInputs => ({
+const inputs = (
+    collapsed: string[] = [],
+    pinned: string[] = [],
+    expandedTools: string[] = [],
+): ExpansionInputs => ({
     collapsedNodes: new Set(collapsed),
     pinnedNodes: new Set(pinned),
+    expandedTools: new Set(expandedTools),
 });
 
 const tool = (id: string, status: ToolNode["status"]): ToolNode => ({
@@ -52,6 +57,13 @@ describe("currentExpansion — parity with the per-kind expansion rules", () => 
         it("pin wins over both terminal-collapsed and running-auto", () => {
             expect(currentExpansion(tool("t", "success"), inputs([], ["t"]))).toEqual({ open: true, via: "pin" });
             expect(currentExpansion(tool("t", "running"), inputs([], ["t"]))).toEqual({ open: true, via: "pin" });
+        });
+        it("a completed tool held in expandedTools stays open (scroll-driven hold)", () => {
+            // Held open after live completion → expanded until it scrolls off.
+            expect(currentExpansion(tool("t", "success"), inputs([], [], ["t"]))).toEqual({ open: true, via: "auto" });
+            expect(currentExpansion(tool("t", "failed"), inputs([], [], ["t"]))).toEqual({ open: true, via: "auto" });
+            // A different held id does not open this tool.
+            expect(currentExpansion(tool("t", "success"), inputs([], [], ["other"]))).toEqual({ open: false });
         });
     });
 

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -21,14 +21,17 @@
  * `pending_approval` tool maps to `{ open: true, via: "auto" }`, matching what
  * actually renders.
  *
- * NOT captured here (component-local transients, not derivable from a node /
- * `documentState`, that Phase 2 moves into the slice via commands):
- *   - a tool's 3 s post-completion hold (`ToolBlock.postCompletionHold`)
+ * The tool's post-completion hold IS captured here now, via `expandedTools`: a
+ * completed tool stays open while held (added on live completion, removed when
+ * its row scrolls off the top), so heights track the visual. This replaced the
+ * old 3 s `ToolBlock` timer — see
+ * docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md.
+ *
+ * Still NOT captured here (a genuinely component-local transient):
  *   - a user's expand CLICK on a canceled-thinking block (`MarkdownBlock.expanded`).
  *     NOTE the canceled block's collapsed *default* IS captured below (it's
- *     `metadata.canceled`); only the click that overrides it is component-local.
- * Until then these are handled by the store-layer hold timer / a click-time
- * `UserExpanded` dispatch in the wiring layer, not by this pure mapper.
+ *     `metadata.canceled`); only the click that overrides it is component-local,
+ *     handled by a click-time dispatch in the wiring layer, not this pure mapper.
  */
 
 import type { Expansion } from "@/app/store/agent-pane-layout/types";

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -34,10 +34,14 @@
 import type { Expansion } from "@/app/store/agent-pane-layout/types";
 import type { DocumentNode, DocumentState } from "../types";
 
-/** The only `documentState` the mapping depends on — the two collapse/pin
- *  sets. Narrowed from the full `DocumentState` so the dependency is explicit
- *  (a full `DocumentState` still satisfies it at the call site). */
-export type ExpansionInputs = Pick<DocumentState, "collapsedNodes" | "pinnedNodes">;
+/** The only `documentState` the mapping depends on — the collapse/pin sets plus
+ *  the scroll-driven `expandedTools` hold. Narrowed from the full
+ *  `DocumentState` so the dependency is explicit (a full `DocumentState` still
+ *  satisfies it at the call site). */
+export type ExpansionInputs = Pick<
+    DocumentState,
+    "collapsedNodes" | "pinnedNodes" | "expandedTools"
+>;
 
 const OPEN_DEFAULT: Expansion = { open: true, via: "default" };
 const CLOSED: Expansion = { open: false };
@@ -48,11 +52,15 @@ export function currentExpansion(
 ): Expansion {
     switch (node.type) {
         case "tool":
-            // pin wins; otherwise a live tool is auto-expanded.
+            // pin wins; otherwise a live tool is auto-expanded. A completed tool
+            // stays open while held in `expandedTools` (added on live completion,
+            // removed once it scrolls off the top — the scroll-driven replacement
+            // for the old 3 s post-completion timer).
             if (state.pinnedNodes.has(node.id)) return { open: true, via: "pin" };
             if (node.status === "running" || node.status === "pending_approval") {
                 return { open: true, via: "auto" };
             }
+            if (state.expandedTools.has(node.id)) return { open: true, via: "auto" };
             return CLOSED;
 
         case "agent_message":

--- a/frontend/app/view/agent/virtualization/renderers.test.ts
+++ b/frontend/app/view/agent/virtualization/renderers.test.ts
@@ -28,6 +28,7 @@ import {
 const baseDocState = (): DocumentState => ({
     collapsedNodes: new Set<string>(),
     pinnedNodes: new Set<string>(),
+    expandedTools: new Set<string>(),
     scrollPosition: 0,
     selectedNode: null,
     filter: {


### PR DESCRIPTION
## What

Replaces the 3 s post-completion auto-collapse on agent-pane tool blocks with **scroll-position-driven collapse**: a completed tool stays **expanded while it's on screen** and collapses once it **scrolls off the top** of the transcript. Everything else is unchanged — pin override, hover-hold, auto-expand while running/pending, immediate collapse for denied/canceled, and the ✗/red collapsed-row treatment for failures.

## Why

The 3 s timer collapsed tools while you were still reading them. Position-driven collapse keeps a tool open exactly as long as it's visible, and folds it only once it's out of view — and it removes a wall-clock timer (the codebase's "no grace timers" convention).

## How

A pane-level `documentState.expandedTools` set is the post-completion hold, durable across virtualization unmount and shared by **both** the visual render and the layout-slice height decision — closing the component-vs-layout divergence that `expansion-source.ts` already documented as a known gap.

- **Add** the id on `ToolBlock`'s `active → inactive` transition (the same trigger that armed the old timer), so loaded-history tools — which never transition this session — are never added and stay collapsed (no load-flash; preserves the existing guard).
- **Release** the id in `AgentDocumentVirtualList` once the row's bottom edge has scrolled above the viewport top — DOM-based (`data-node-id` + `getBoundingClientRect`), zoom-safe, works for both virtualized and streaming-buffer rows. **Latched**: once released it won't re-add, so scrolling back up leaves it collapsed (click to pin to re-open).
- `currentExpansion()` returns open while held, so virtualized row heights track the visual.

### Phase 1 (this PR) vs Phase 2

The release is **gated on stick-to-bottom**, where collapsing a row above the fold causes no scroll jump — the primary live-streaming case ("new tool completes → more output → it scrolls off the top → collapses"). The scrolled-up case (collapse while reading history, needing `captureTopmostAnchor`/`restoreScrollFromAnchor` compensation) is a documented **Phase 2** follow-up; those tools are off-screen so only scroll position, not the collapse, would be visible.

## Tests / verification

- New `expansion-source` cases (held tool resolves open; pin/running still win); new `ToolBlock` tests (`heldOpen` renders in-flow; `onHoldOpen` fires once on completion and **never** on already-completed mount).
- `tsc -p tsconfig.json --noEmit`: **no new errors** (confirmed the only matches in touched-area, `ActivityDock.tsx`, are a pre-existing baseline — they error identically on `main`).
- **511** agent-view vitest tests pass.
- ⚠️ Not verifiable headlessly: the actual on-screen feel (expand → stays while visible → collapses off the top while streaming). Needs a running app.

## Docs

- Plan: `docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`
- Analysis: `docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)