### PR TITLE
feat(launcher): memory-aware host relaunch — wait out system OOM instead of crash-looping (P0)

### DIFF
--- a/.changesets/1781646427-feat-launcher-memory-aware-host-relaunch-wait-out-system-oom-y7do.md
+++ b/.changesets/1781646427-feat-launcher-memory-aware-host-relaunch-wait-out-system-oom-y7do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): memory-aware host relaunch — wait out system OOM instead of crash-looping

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -72,6 +72,10 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    # GlobalMemoryStatusEx / MEMORYSTATUSEX — the launcher's commit-free probe
+    # for memory-aware host relaunch (mem_supervisor.rs;
+    # SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16).
+    "Win32_System_SystemInformation",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_ErrorReporting",
     "Win32_System_Diagnostics_ToolHelp",

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -1018,7 +1018,44 @@ async fn run_unix(
                              memory to recover before relaunch",
                             code, commit_free
                         ));
-                        if !mem_supervisor::await_commit_recovery(log).await {
+                        // Race the commit-recovery wait against shutdown + srv
+                        // death so the supervisor stays responsive during the
+                        // (up to OOM_RELAUNCH_DEADLINE) wait — without this the
+                        // SIGINT/SIGTERM + srv arms are starved for the whole
+                        // wait (reagent P2). Mirrors the outer select! arms.
+                        let recovered = tokio::select! {
+                            r = mem_supervisor::await_commit_recovery(log) => r,
+                            srv_status = srv_child.wait() => {
+                                use std::os::unix::process::ExitStatusExt;
+                                match srv_status {
+                                    Ok(s) => {
+                                        let group_shutdown = matches!(
+                                            s.signal(),
+                                            Some(sig) if sig == libc::SIGINT || sig == libc::SIGTERM || sig == libc::SIGHUP
+                                        );
+                                        if s.success() || group_shutdown {
+                                            log("srv exited as part of shutdown (during OOM wait) — shutting down");
+                                            break 0;
+                                        }
+                                        log(&format!(
+                                            "srv exited UNEXPECTEDLY during OOM wait with code {} — terminating launcher",
+                                            s.code().unwrap_or(1)
+                                        ));
+                                    }
+                                    Err(e) => log(&format!("FATAL: srv wait failed during OOM wait: {}", e)),
+                                }
+                                break 1;
+                            }
+                            _ = next_signal(&mut sigint) => {
+                                log("received SIGINT during OOM wait — shutting down");
+                                break 0;
+                            }
+                            _ = next_signal(&mut sigterm) => {
+                                log("received SIGTERM during OOM wait — shutting down");
+                                break 0;
+                            }
+                        };
+                        if !recovered {
                             show_fatal_dialog(
                                 mem_supervisor::OOM_GIVEUP_TITLE,
                                 mem_supervisor::OOM_GIVEUP_BODY,
@@ -1600,7 +1637,24 @@ async fn run_windows(
                         ));
                         // Commit-gated, backed-off wait. Relaunching into a
                         // starved system just re-OOMs; waiting is the only lever.
-                        if !mem_supervisor::await_commit_recovery(log).await {
+                        // Race it against srv death so the supervisor isn't blind
+                        // to a concurrent srv exit during the wait (reagent P2).
+                        // run_windows has no signal arms (shutdown flows via the
+                        // host/srv), so srv is the only concurrent event here.
+                        let recovered = tokio::select! {
+                            r = mem_supervisor::await_commit_recovery(log) => r,
+                            srv_status = srv_child.wait() => {
+                                match srv_status {
+                                    Ok(s) => log(&format!(
+                                        "srv exited UNEXPECTEDLY during OOM wait with code {} — terminating launcher",
+                                        s.code().unwrap_or(1)
+                                    )),
+                                    Err(e) => log(&format!("FATAL: srv wait failed during OOM wait: {}", e)),
+                                }
+                                break 1;
+                            }
+                        };
+                        if !recovered {
                             show_fatal_dialog(
                                 mem_supervisor::OOM_GIVEUP_TITLE,
                                 mem_supervisor::OOM_GIVEUP_BODY,

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -30,6 +30,7 @@ mod event_log;
 mod hash;
 mod host_pipe;
 mod ipc;
+mod mem_supervisor;
 mod reducer;
 mod saga;
 #[cfg(target_os = "windows")]
@@ -945,6 +946,9 @@ async fn run_unix(
     // 5. Supervised wait loop — host crash budget mirrors run_windows.
     log("entering supervised host + srv wait (unix)");
     let mut host_restarts: Vec<std::time::Instant> = Vec::new();
+    // Separate budget for system-OOM host exits (memory-aware relaunch); see
+    // mem_supervisor + SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.
+    let mut oom_restarts: Vec<std::time::Instant> = Vec::new();
     let mut last_abnormal_code: Option<i32> = None;
     let mut host_degraded = false;
     let exit_code = loop {
@@ -980,35 +984,87 @@ async fn run_unix(
                     log("CEF host exited cleanly (code 0) — shutting down");
                     break 0;
                 }
-                let now = std::time::Instant::now();
-                host_restarts.retain(|t| now.duration_since(*t) < HOST_RESTART_WINDOW);
-                if host_restarts.len() >= HOST_RESTART_BUDGET {
-                    log(&format!(
-                        "CEF host exited abnormally (code {}); restart budget exhausted \
-                         ({} in {}s) — giving up",
-                        code,
-                        host_restarts.len(),
-                        HOST_RESTART_WINDOW.as_secs()
-                    ));
-                    break code;
-                }
-                host_restarts.push(now);
-                if last_abnormal_code == Some(code) {
-                    host_degraded = true;
-                }
-                last_abnormal_code = Some(code);
-                log(&format!(
-                    "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
-                    code,
-                    host_restarts.len(),
-                    HOST_RESTART_BUDGET,
-                    if host_degraded { ", degraded: --disable-gpu" } else { "" }
-                ));
-                match spawn_host_unix(real_exe, args, &srv_result, &host_env, host_degraded) {
-                    Some(c) => host_child = c,
-                    None => {
-                        log("host relaunch failed to spawn — giving up");
-                        break code;
+                // Classify system-OOM (wait it out) vs a genuine host fault
+                // (existing fast budget), mirroring run_windows. SPEC_MEMORY_
+                // PRESSURE_SUPERVISION_2026_06_16 §5.B. On Linux a kernel-OOM-kill
+                // arrives as a SIGKILL (code 1 here) and is caught by the low-
+                // commit reading (SPEC §9.4).
+                let commit_free = mem_supervisor::commit_free_mb();
+                match mem_supervisor::classify_host_exit(code, commit_free) {
+                    mem_supervisor::HostExitClass::SystemOom => {
+                        let now = std::time::Instant::now();
+                        if mem_supervisor::budget_exhausted(
+                            &mut oom_restarts,
+                            now,
+                            mem_supervisor::OOM_RESTART_WINDOW,
+                            mem_supervisor::OOM_RESTART_BUDGET,
+                        ) {
+                            log(&format!(
+                                "CEF host hit system OOM (code {}, {} MB commit-free); OOM restart \
+                                 budget exhausted ({} in {}s) — giving up",
+                                code,
+                                commit_free,
+                                mem_supervisor::OOM_RESTART_BUDGET,
+                                mem_supervisor::OOM_RESTART_WINDOW.as_secs()
+                            ));
+                            show_fatal_dialog(
+                                mem_supervisor::OOM_GIVEUP_TITLE,
+                                mem_supervisor::OOM_GIVEUP_BODY,
+                            );
+                            break code;
+                        }
+                        log(&format!(
+                            "CEF host hit system OOM (code {}, {} MB commit-free) — waiting for \
+                             memory to recover before relaunch",
+                            code, commit_free
+                        ));
+                        if !mem_supervisor::await_commit_recovery(log).await {
+                            show_fatal_dialog(
+                                mem_supervisor::OOM_GIVEUP_TITLE,
+                                mem_supervisor::OOM_GIVEUP_BODY,
+                            );
+                            break code;
+                        }
+                        match spawn_host_unix(real_exe, args, &srv_result, &host_env, true) {
+                            Some(c) => host_child = c,
+                            None => {
+                                log("host relaunch failed to spawn — giving up");
+                                break code;
+                            }
+                        }
+                    }
+                    mem_supervisor::HostExitClass::Abnormal => {
+                        let now = std::time::Instant::now();
+                        host_restarts.retain(|t| now.duration_since(*t) < HOST_RESTART_WINDOW);
+                        if host_restarts.len() >= HOST_RESTART_BUDGET {
+                            log(&format!(
+                                "CEF host exited abnormally (code {}); restart budget exhausted \
+                                 ({} in {}s) — giving up",
+                                code,
+                                host_restarts.len(),
+                                HOST_RESTART_WINDOW.as_secs()
+                            ));
+                            break code;
+                        }
+                        host_restarts.push(now);
+                        if last_abnormal_code == Some(code) {
+                            host_degraded = true;
+                        }
+                        last_abnormal_code = Some(code);
+                        log(&format!(
+                            "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
+                            code,
+                            host_restarts.len(),
+                            HOST_RESTART_BUDGET,
+                            if host_degraded { ", degraded: --disable-gpu" } else { "" }
+                        ));
+                        match spawn_host_unix(real_exe, args, &srv_result, &host_env, host_degraded) {
+                            Some(c) => host_child = c,
+                            None => {
+                                log("host relaunch failed to spawn — giving up");
+                                break code;
+                            }
+                        }
                     }
                 }
             }
@@ -1487,6 +1543,9 @@ async fn run_windows(
     // degraded mode (job == None) only.
     log("entering supervised host + srv wait");
     let mut host_restarts: Vec<std::time::Instant> = Vec::new();
+    // Separate budget for system-OOM host exits (memory-aware relaunch); see
+    // mem_supervisor + SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.
+    let mut oom_restarts: Vec<std::time::Instant> = Vec::new();
     let mut last_abnormal_code: Option<i32> = None;
     let mut host_degraded = false;
     let exit_code = loop {
@@ -1503,51 +1562,120 @@ async fn run_windows(
                     log("CEF host exited cleanly (code 0) — shutting down");
                     break 0;
                 }
-                // Abnormal exit — relaunch within the crash budget.
-                let now = std::time::Instant::now();
-                host_restarts.retain(|t| now.duration_since(*t) < HOST_RESTART_WINDOW);
-                if host_restarts.len() >= HOST_RESTART_BUDGET {
-                    log(&format!(
-                        "CEF host exited abnormally (code {}); restart budget exhausted \
-                         ({} in {}s) — giving up",
-                        code,
-                        host_restarts.len(),
-                        HOST_RESTART_WINDOW.as_secs()
-                    ));
-                    break code;
-                }
-                host_restarts.push(now);
-                // Crash classification + retry ladder (spec §7): a crash that
-                // reproduces the previous abnormal exit code is deterministic —
-                // step down to a degraded (--disable-gpu) relaunch so the retry
-                // isn't "the same thing again". Degraded is sticky; the ladder
-                // only steps down.
-                if last_abnormal_code == Some(code) {
-                    host_degraded = true;
-                }
-                last_abnormal_code = Some(code);
-                log(&format!(
-                    "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
-                    code,
-                    host_restarts.len(),
-                    HOST_RESTART_BUDGET,
-                    if host_degraded { ", degraded: --disable-gpu" } else { "" }
-                ));
-                match spawn_host_supervised(
-                    real_exe,
-                    args,
-                    &srv_result,
-                    &host_env,
-                    &pipe_path,
-                    job.is_some(),
-                    job_handle,
-                    splash_event_name.as_deref(),
-                    host_degraded,
-                ) {
-                    Some(c) => host_child = c,
-                    None => {
-                        log("host relaunch failed to spawn — giving up");
-                        break code;
+                // Classify: a *system-OOM* exit (the OS ran out of commit) is
+                // transient and must be WAITED OUT, not hammered into the same
+                // wall on the fast wedged-host budget — that just re-OOMs and
+                // burns the budget into a silent give-up
+                // (docs/retro/retro-oom-crash-2026-06-16.md,
+                // SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.B). A genuine
+                // host fault still takes the existing path below, unchanged.
+                let commit_free = mem_supervisor::commit_free_mb();
+                match mem_supervisor::classify_host_exit(code, commit_free) {
+                    mem_supervisor::HostExitClass::SystemOom => {
+                        let now = std::time::Instant::now();
+                        if mem_supervisor::budget_exhausted(
+                            &mut oom_restarts,
+                            now,
+                            mem_supervisor::OOM_RESTART_WINDOW,
+                            mem_supervisor::OOM_RESTART_BUDGET,
+                        ) {
+                            log(&format!(
+                                "CEF host hit system OOM (code {}, {} MB commit-free); OOM restart \
+                                 budget exhausted ({} in {}s) — giving up",
+                                code,
+                                commit_free,
+                                mem_supervisor::OOM_RESTART_BUDGET,
+                                mem_supervisor::OOM_RESTART_WINDOW.as_secs()
+                            ));
+                            show_fatal_dialog(
+                                mem_supervisor::OOM_GIVEUP_TITLE,
+                                mem_supervisor::OOM_GIVEUP_BODY,
+                            );
+                            break code;
+                        }
+                        log(&format!(
+                            "CEF host hit system OOM (code {}, {} MB commit-free) — waiting for \
+                             memory to recover before relaunch",
+                            code, commit_free
+                        ));
+                        // Commit-gated, backed-off wait. Relaunching into a
+                        // starved system just re-OOMs; waiting is the only lever.
+                        if !mem_supervisor::await_commit_recovery(log).await {
+                            show_fatal_dialog(
+                                mem_supervisor::OOM_GIVEUP_TITLE,
+                                mem_supervisor::OOM_GIVEUP_BODY,
+                            );
+                            break code;
+                        }
+                        // Relaunch degraded: the GPU process is a large commit
+                        // consumer, so skip straight to software rendering for an
+                        // OOM relaunch (SPEC §5.B.4).
+                        match spawn_host_supervised(
+                            real_exe,
+                            args,
+                            &srv_result,
+                            &host_env,
+                            &pipe_path,
+                            job.is_some(),
+                            job_handle,
+                            splash_event_name.as_deref(),
+                            true, // disable_gpu
+                        ) {
+                            Some(c) => host_child = c,
+                            None => {
+                                log("host relaunch failed to spawn — giving up");
+                                break code;
+                            }
+                        }
+                    }
+                    mem_supervisor::HostExitClass::Abnormal => {
+                        // Abnormal exit — relaunch within the crash budget.
+                        let now = std::time::Instant::now();
+                        host_restarts.retain(|t| now.duration_since(*t) < HOST_RESTART_WINDOW);
+                        if host_restarts.len() >= HOST_RESTART_BUDGET {
+                            log(&format!(
+                                "CEF host exited abnormally (code {}); restart budget exhausted \
+                                 ({} in {}s) — giving up",
+                                code,
+                                host_restarts.len(),
+                                HOST_RESTART_WINDOW.as_secs()
+                            ));
+                            break code;
+                        }
+                        host_restarts.push(now);
+                        // Crash classification + retry ladder (spec §7): a crash that
+                        // reproduces the previous abnormal exit code is deterministic —
+                        // step down to a degraded (--disable-gpu) relaunch so the retry
+                        // isn't "the same thing again". Degraded is sticky; the ladder
+                        // only steps down.
+                        if last_abnormal_code == Some(code) {
+                            host_degraded = true;
+                        }
+                        last_abnormal_code = Some(code);
+                        log(&format!(
+                            "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
+                            code,
+                            host_restarts.len(),
+                            HOST_RESTART_BUDGET,
+                            if host_degraded { ", degraded: --disable-gpu" } else { "" }
+                        ));
+                        match spawn_host_supervised(
+                            real_exe,
+                            args,
+                            &srv_result,
+                            &host_env,
+                            &pipe_path,
+                            job.is_some(),
+                            job_handle,
+                            splash_event_name.as_deref(),
+                            host_degraded,
+                        ) {
+                            Some(c) => host_child = c,
+                            None => {
+                                log("host relaunch failed to spawn — giving up");
+                                break code;
+                            }
+                        }
                     }
                 }
             }

--- a/agentmux-launcher/src/mem_supervisor.rs
+++ b/agentmux-launcher/src/mem_supervisor.rs
@@ -1,0 +1,254 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Memory-pressure-aware host supervision — P0 of
+//! `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`.
+//!
+//! The launcher's host-relaunch ladder (`HOST_RESTART_BUDGET`) is otherwise
+//! memory-blind: on a *system out-of-memory* host crash it relaunches straight
+//! back into the same commit-starved condition, burns the budget in seconds, and
+//! gives up — a silent vanish (see `docs/retro/retro-oom-crash-2026-06-16.md`).
+//!
+//! This module adds the discrimination: a system-OOM exit is waited out (commit-
+//! gated, backed-off relaunch on a *separate*, longer OOM budget), while a
+//! genuine host fault still trips the fast wedged-host budget + degraded ladder
+//! unchanged. The decision logic here is pure and unit-tested; the platform
+//! commit probe and the backoff wait are thin wrappers over the OS.
+
+use std::time::{Duration, Instant};
+
+/// Chromium's intentional out-of-memory abort code (`base::win::kOomExceptionCode`,
+/// raised non-continuably via `KERNELBASE!RaiseException` when an allocation
+/// fails). It surfaces as the host's exit code; `ExitStatus::code()` returns it
+/// as an `i32`, so the unsigned `0xE000_0008` reads back as `-536_870_904`.
+pub const CHROMIUM_OOM_EXIT_CODE: i32 = 0xE000_0008u32 as i32;
+
+/// Minimum commit-free (available page file) headroom, in MB, before it is safe
+/// to (re)launch a CEF host without it instantly re-OOMing. A fresh host +
+/// renderer commits on the order of a few hundred MB; 512 leaves margin. Shared
+/// starting point with the renderer spec's `RESUME_FLOOR` (SPEC §6).
+pub const RESUME_FLOOR_MB: u64 = 512;
+
+/// Restart budget for *system-OOM* host exits — larger and longer than the
+/// wedged-host `HOST_RESTART_BUDGET` (3 / 60 s), because transient system
+/// pressure is the OS's problem, not a host bug, and recovery can legitimately
+/// take minutes (SPEC §5.B / §6).
+pub const OOM_RESTART_BUDGET: usize = 5;
+pub const OOM_RESTART_WINDOW: Duration = Duration::from_secs(600);
+
+/// Commit-gated relaunch backoff: while commit-free is below `RESUME_FLOOR_MB`,
+/// wait this long and re-probe, doubling each time up to the cap. Relaunching
+/// into a starved system just re-OOMs, so waiting is the only thing that works.
+pub const BACKOFF_START: Duration = Duration::from_secs(2);
+pub const BACKOFF_CAP: Duration = Duration::from_secs(30);
+
+/// Hard ceiling on how long to wait for commit to recover before giving up (and
+/// showing the honest "out of memory" dialog rather than waiting forever).
+pub const OOM_RELAUNCH_DEADLINE: Duration = Duration::from_secs(300);
+
+/// User-facing copy for the graceful give-up dialog (SPEC §5.C). Shown via the
+/// launcher's `show_fatal_dialog` (a renderer-free Win32 `MessageBoxW`) so the
+/// crash is never a silent vanish.
+pub const OOM_GIVEUP_TITLE: &str = "AgentMux — out of memory";
+pub const OOM_GIVEUP_BODY: &str = "AgentMux ran low on system memory and couldn't recover this window.\n\n\
+Your panes, agents, and sign-ins are saved. Close some other apps or AgentMux windows to free memory, then reopen AgentMux to restore your session.";
+
+/// Classification of an abnormal (non-zero, non-clean-shutdown) host exit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostExitClass {
+    /// The OS was out of commit — transient and unavoidable. Wait it out on the
+    /// separate OOM budget; do NOT consume the wedged-host budget.
+    SystemOom,
+    /// A genuine host fault (bug, GPU-process cascade, …). Use the existing fast
+    /// wedged-host budget + degraded ladder, unchanged.
+    Abnormal,
+}
+
+/// Classify an abnormal host exit. OOM is identified two ways, deliberately
+/// defensive — Chromium sometimes surfaces an OOM as a generic crash code rather
+/// than the exact OOM exception (electron#40426):
+///   1. the exact Chromium OOM exit code, OR
+///   2. *any* abnormal exit taken while commit-free was already below the resume
+///      floor — the OS was out of memory, so whatever died, died of it.
+pub fn classify_host_exit(exit_code: i32, commit_free_mb: u64) -> HostExitClass {
+    if exit_code == CHROMIUM_OOM_EXIT_CODE || commit_free_mb < RESUME_FLOOR_MB {
+        HostExitClass::SystemOom
+    } else {
+        HostExitClass::Abnormal
+    }
+}
+
+/// Next backoff duration: double `prev`, capped at `BACKOFF_CAP`.
+pub fn next_backoff(prev: Duration) -> Duration {
+    (prev * 2).min(BACKOFF_CAP)
+}
+
+/// Crash-budget bookkeeping, factored out so it is unit-testable. Retains only
+/// restarts within `window` of `now`; if the surviving count is already at
+/// `budget`, returns `true` (exhausted — caller gives up) WITHOUT recording.
+/// Otherwise records `now` and returns `false`. Matches the existing inline
+/// wedged-host budget semantics (check-before-push).
+pub fn budget_exhausted(
+    restarts: &mut Vec<Instant>,
+    now: Instant,
+    window: Duration,
+    budget: usize,
+) -> bool {
+    restarts.retain(|t| now.duration_since(*t) < window);
+    if restarts.len() >= budget {
+        return true;
+    }
+    restarts.push(now);
+    false
+}
+
+/// Available commit (page file) in MB. The OS commit pool is process-global, so
+/// the launcher reads it directly — no shared memory with the host's heartbeat
+/// is needed. Returns `u64::MAX` if the probe fails, so a probe failure can never
+/// *gate* a relaunch (fail open).
+#[cfg(target_os = "windows")]
+pub fn commit_free_mb() -> u64 {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    let mut s: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    s.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    // SAFETY: `s` is a correctly-sized, zeroed MEMORYSTATUSEX with dwLength set.
+    if unsafe { GlobalMemoryStatusEx(&mut s) } == 0 {
+        return u64::MAX;
+    }
+    s.ullAvailPageFile / (1024 * 1024)
+}
+
+/// Linux commit proxy: `MemAvailable` from `/proc/meminfo`. The kernel OOM-killer
+/// (a SIGKILL) is the real OOM signal here; the abnormal-exit-plus-low-commit
+/// reading together approximate it (SPEC §9.4 open question).
+#[cfg(target_os = "linux")]
+pub fn commit_free_mb() -> u64 {
+    if let Ok(s) = std::fs::read_to_string("/proc/meminfo") {
+        for line in s.lines() {
+            if let Some(rest) = line.strip_prefix("MemAvailable:") {
+                if let Some(kb) = rest.split_whitespace().next().and_then(|n| n.parse::<u64>().ok()) {
+                    return kb / 1024;
+                }
+            }
+        }
+    }
+    u64::MAX
+}
+
+/// macOS has no cheap commit figure; fail open until a platform probe lands.
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn commit_free_mb() -> u64 {
+    u64::MAX
+}
+
+/// Wait for system commit to recover above `RESUME_FLOOR_MB`, probing with
+/// exponential backoff (`BACKOFF_START` → `BACKOFF_CAP`). Returns `true` once
+/// recovered, or `false` if `OOM_RELAUNCH_DEADLINE` elapses first (the caller
+/// then gives up gracefully). `log` is the launcher's logger, threaded in so the
+/// wait is observable in the launcher log.
+pub async fn await_commit_recovery(log: impl Fn(&str)) -> bool {
+    let start = Instant::now();
+    let mut backoff = BACKOFF_START;
+    loop {
+        let free = commit_free_mb();
+        if free >= RESUME_FLOOR_MB {
+            log(&format!(
+                "commit recovered: {} MB free (>= {} MB floor) — relaunching host",
+                free, RESUME_FLOOR_MB
+            ));
+            return true;
+        }
+        if start.elapsed() >= OOM_RELAUNCH_DEADLINE {
+            log(&format!(
+                "commit still low ({} MB free) after {}s — giving up host relaunch",
+                free,
+                OOM_RELAUNCH_DEADLINE.as_secs()
+            ));
+            return false;
+        }
+        log(&format!(
+            "system out of commit ({} MB free, need {} MB) — waiting {}s before re-check",
+            free,
+            RESUME_FLOOR_MB,
+            backoff.as_secs()
+        ));
+        tokio::time::sleep(backoff).await;
+        backoff = next_backoff(backoff);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oom_exit_code_roundtrips_to_known_signed_value() {
+        // Documents the i32 value the launcher will actually compare against.
+        assert_eq!(CHROMIUM_OOM_EXIT_CODE, -536_870_904);
+    }
+
+    #[test]
+    fn exact_oom_code_is_system_oom_even_with_headroom() {
+        // The exact Chromium OOM code is OOM regardless of the commit reading,
+        // which may already have recovered by the time we sample it.
+        assert_eq!(
+            classify_host_exit(CHROMIUM_OOM_EXIT_CODE, 8192),
+            HostExitClass::SystemOom
+        );
+    }
+
+    #[test]
+    fn abnormal_code_with_low_commit_is_system_oom() {
+        // OOM misreported as a generic crash code — the low commit reading still
+        // catches it (the OS was out of memory).
+        assert_eq!(
+            classify_host_exit(1, RESUME_FLOOR_MB - 1),
+            HostExitClass::SystemOom
+        );
+    }
+
+    #[test]
+    fn abnormal_code_with_headroom_is_a_host_bug() {
+        // A genuine crash with memory available → existing fast wedged-host path.
+        assert_eq!(classify_host_exit(1, RESUME_FLOOR_MB), HostExitClass::Abnormal);
+        assert_eq!(classify_host_exit(-1, 16_384), HostExitClass::Abnormal);
+    }
+
+    #[test]
+    fn backoff_doubles_then_caps() {
+        assert_eq!(next_backoff(Duration::from_secs(2)), Duration::from_secs(4));
+        assert_eq!(next_backoff(Duration::from_secs(4)), Duration::from_secs(8));
+        // 16 → 32 capped to 30.
+        assert_eq!(next_backoff(Duration::from_secs(16)), Duration::from_secs(30));
+        // Stays at the cap.
+        assert_eq!(next_backoff(Duration::from_secs(30)), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn budget_allows_up_to_n_then_exhausts() {
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut r = Vec::new();
+        assert!(!budget_exhausted(&mut r, now, window, 3));
+        assert!(!budget_exhausted(&mut r, now, window, 3));
+        assert!(!budget_exhausted(&mut r, now, window, 3));
+        // Fourth within the window → exhausted, and it is NOT recorded.
+        assert!(budget_exhausted(&mut r, now, window, 3));
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    fn budget_forgets_restarts_outside_the_window() {
+        let base = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut r = Vec::new();
+        for _ in 0..3 {
+            let _ = budget_exhausted(&mut r, base, window, 3);
+        }
+        assert!(budget_exhausted(&mut r, base, window, 3)); // exhausted at base
+        // A restart well past the window prunes the stale entries → room again.
+        let later = base + Duration::from_secs(120);
+        assert!(!budget_exhausted(&mut r, later, window, 3));
+        assert_eq!(r.len(), 1);
+    }
+}

--- a/docs/retro/retro-oom-crash-2026-06-16.md
+++ b/docs/retro/retro-oom-crash-2026-06-16.md
@@ -1,0 +1,259 @@
+# Retro / Post-mortem — AgentMux OOM crash (2026-06-16)
+
+**Status:** root cause confirmed · recovery gaps identified · recommendations below
+**Author:** AgentA
+**Date:** 2026-06-16
+**Severity:** P1 — the live dogfood session was lost (hard crash, no graceful exit)
+
+---
+
+## 1. Executive summary
+
+The AgentMux instance we were working in — the **v0.44.1 local portable**
+(`local-main-b28b7a`, build `gc7df50a6`) — **hard-crashed at 07:33:16 local
+(14:33:16 UTC)**. The crash was an **out-of-memory abort inside the CEF/Chromium
+host process**, not a logic bug in AgentMux code.
+
+Windows Error Reporting recorded the faulting process raising exception
+**`0xe0000008`** — Chromium's intentional, non-continuable *out-of-memory*
+exception code (`base::win::kOomExceptionCode`) — through
+`KERNELBASE!RaiseException`. Chromium raises this deliberately when an allocation
+fails; it is the allocator's "I cannot get memory, abort now" signal.
+
+The machine had **32 GB of RAM but its system commit limit (page file + RAM) was
+exhausted**. All session we had been hitting `errno 1455`
+(`ERROR_COMMITMENT_LIMIT`) on builds — the same condition. The exhaustion was
+driven by **several AgentMux instances running at once** plus a **1.3 GB Vite dev
+server** plus **repeated production builds** (each esbuild/Go worker needing
+~1–2 GB). When the commit pool ran dry, the next allocation in the v0.44.1
+Chromium host failed and Chromium aborted the process.
+
+AgentMux already has a **host-crash relaunch ladder** (3 restarts / 60 s,
+escalating to `--disable-gpu`). The gap is that **the ladder is memory-blind**:
+it relaunches straight back into the same starved condition, and nothing warns
+the user or sheds load *before* the OOM. The result is a hard crash that reads,
+to the user, as "AgentMux just disappeared."
+
+---
+
+## 2. Timeline (2026-06-16, local time)
+
+| Time | Event |
+|------|-------|
+| (all morning) | Active dogfood session in the **v0.44.1 portable** (`agentmux-0.44.1+gc7df50a6` on the Desktop). Simultaneously: a `task dev` instance for branch `agenta/agent-failure-recovery-ui`, a `0.46.0` local build, and a long-running **Vite dev server (PID 10376, ~1.3 GB RSS)**. |
+| ~07:2x–07:33 | Repeated **production frontend builds** attempted; each failed with `runtime: VirtualAlloc … errno=1455` / `fatal error: out of memory` and `fork: retry: Resource temporarily unavailable` — direct evidence the **system commit limit was exhausted**. |
+| **07:33:15** | The crashed instance's backend `srv-events.log` stops writing (`channels/local-main-b28b7a-…/versions/0.44.1/data/srv-events.log`). |
+| **07:33:16** | **CEF host `agentmux-0.44.1.exe` (PID 3796 / `0xed4`) crashes** — exception `0xe0000008`, faulting module `KERNELBASE.dll`, fault offset `0x25369`. (WER Event ID 1000.) |
+| 07:33:53–54 | Windows Error Reporting writes the `APPCRASH` reports and a **minidump** (`…\WER\Temp\WERD071.tmp.mdmp`). (Event ID 1001 ×2.) |
+| ~07:33–08:02 | The instance's `cef-debug.log` continues to grow to ~164 MB until ~08:02, consistent with the **launcher relaunch ladder firing** and the host coming back up — but the backend `srv-events.log` never resumes, so the relaunched host likely had a degraded/headless backend. |
+| (now) | Memory has fully recovered: 25.7 GB physical free, 7.9 GB committed of a 65.4 GB limit. The pressure was transient and load-driven. |
+
+---
+
+## 3. Root cause
+
+### 3.1 The crash itself — Chromium OOM abort
+
+WER (authoritative):
+
+```
+Faulting application name: agentmux-0.44.1.exe, version: 0.0.0.0, time stamp: 0x6a2d9e2e
+Faulting module name:      KERNELBASE.dll, version: 10.0.19041.7417
+Exception code:            0xe0000008
+Fault offset:              0x0000000000025369
+Faulting process id:       0xed4   (3796)
+Faulting application path:  …\agentmux-0.44.1+gc7df50a6.20260613T180900.363-x64-portable\runtime\agentmux-0.44.1.exe
+```
+
+`0xe0000008` decodes as a **customer-defined** SEH code (top nibble `E` → severity
+ERROR + customer bit set). It is **not** an access violation (`0xC0000005`) or a
+C++/CLR throw (`0xE06D7363` / `0xE0434352`). It is **Chromium's `kOomExceptionCode`**:
+when PartitionAlloc / the Chromium allocator cannot satisfy a request, Chromium
+calls `RaiseException(0xE0000008, EXCEPTION_NONCONTINUABLE, …)` from inside
+`base::internal::OnNoMemory*`. That call lives in `KERNELBASE.dll` — exactly the
+faulting module reported. **This is a deliberate OOM abort, not memory
+corruption.** A crash dump is available if deeper analysis is wanted
+(`%ProgramData%\Microsoft\Windows\WER\Temp\WERD071.tmp.mdmp`, may be GC'd).
+
+### 3.2 Why memory ran out — load, not a leak
+
+The host did not leak; the *system* ran out of committable memory. Concurrent
+consumers at crash time:
+
+- **Multiple AgentMux instances** — the v0.44.1 portable **and** the
+  `agent-failure-recovery-ui` `task dev` instance **and** a `0.46.0` build, each a
+  full launcher + host + multiple CEF subprocesses (browser/GPU/renderer/utility)
+  + an `agentmux-srv`. CEF/Chromium is memory-heavy per instance.
+- **A 1.3 GB Vite dev server** (PID 10376, `vite --port 5287`) left running from
+  hot-reload testing, ballooned over a long session.
+- **Repeated `task build:frontend` runs**, each spawning Go/esbuild workers that
+  need ~1–2 GB; these were *themselves* OOM-failing with `errno 1455`.
+
+32 GB RAM was nominally plenty, but the **commit limit** (RAM + page file) is the
+real ceiling, and it was saturated. The first instance to ask for memory and lose
+was the v0.44.1 Chromium host.
+
+> Note: this is fundamentally a **dev-machine load pattern** (N instances + Vite +
+> builds), not a defect a normal end user would hit with a single instance. The
+> recommendations below still apply because (a) dogfooding *is* this load pattern,
+> and (b) end users on smaller/older machines can hit per-instance OOM, and the
+> *graceful-handling* gaps are the same.
+
+---
+
+## 4. What recovery already exists today
+
+AgentMux is not defenceless against a host crash — the launcher
+(`agentmux-launcher/src/main.rs`) implements:
+
+- **Host-crash relaunch ladder** — `HOST_RESTART_BUDGET = 3` relaunches within a
+  `HOST_RESTART_WINDOW = 60 s` window. On the second attempt it steps into a
+  **degraded `--disable-gpu`** (software-rendering) rung; budget exhausted → it
+  logs `restart budget exhausted` and gives up. (Both the Windows and Unix
+  supervisors share this; lines ~949–1010 and ~1491–1549.)
+- **Splash re-dismissal on relaunch** so a host that died pre-first-frame doesn't
+  leave a stuck splash.
+- **srv crash monitor** — the backend spawns a crash monitor that writes minidumps
+  to `C:\CrashDumps\agentmuxsrv` (`[crash-handler] crash monitor spawned …`).
+- **Persisted state** — the workspace (panes/layout) lives in the channel's
+  `objects.db`; **agents and auth are global** (cross-channel work #1387–#1393).
+  So a *successful* relaunch can reload the workspace; the durable data is not
+  lost in a crash.
+
+For this incident, the growing `cef-debug.log` after 07:33 suggests the ladder
+**did** fire and bring a host back — but the backend `srv-events.log` never
+resumed, so recovery was partial at best.
+
+---
+
+## 5. Why it wasn't graceful — the gaps
+
+1. **The relaunch ladder is memory-blind.** It relaunches the host *immediately*
+   into the **same** commit-exhausted condition. Under sustained pressure that
+   means crash → relaunch → crash → … until the 3-restart budget is burned, then
+   "give up" — converting a recoverable transient into a permanent down. There is
+   no check of available commit before relaunching and no backoff to let memory
+   recover.
+
+2. **No pre-OOM awareness or graceful degradation.** Nothing watches system memory
+   pressure. AgentMux runs full-speed into the wall: no "memory is low, pausing
+   non-essential renderers / agents" step, no flush-and-checkpoint before the
+   abort, no clean teardown. Chromium's OOM abort is the *first* signal anything
+   is wrong.
+
+3. **No user-facing crash/recovery signal.** From the user's seat the window just
+   vanished. There is no "AgentMux recovered from a crash and restored your
+   session" (or "couldn't recover — here's your data") affordance. Recovery, when
+   it happens, is silent and unverifiable to the user.
+
+4. **Multi-instance memory has no shared budget.** Each instance is independently
+   greedy; nothing coordinates total footprint across instances, and nothing
+   accounts for co-resident dev tooling (Vite, esbuild). On a dogfood box this is
+   the dominant failure mode.
+
+5. **Backend/host recovery aren't coupled.** The host relaunched but the srv
+   stopped logging at 07:33:15 and didn't visibly resume — a relaunched host with
+   a dead/oom'd backend is a half-recovered, confusing state rather than a clean
+   restore-or-fail.
+
+6. **No OOM caps inside Chromium.** The host doesn't pass renderer memory limits
+   / `--js-flags` heap caps / process-count limits, so a single instance's
+   Chromium can grow until the *system* (not Chromium) refuses — the worst place
+   to hit the limit.
+
+---
+
+## 6. Recommendations (prioritized)
+
+> These are now designed in
+> **`docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`** (host/instance-level
+> memory-pressure supervision + graceful degradation), which complements the
+> existing renderer-level `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`.
+
+### P0 — make recovery memory-aware (turn the hard crash into a graceful one)
+
+- **Gate the relaunch ladder on available commit.** Before each relaunch, read
+  `GlobalMemoryStatusEx` (Windows) / `/proc/meminfo` (Linux). If commit headroom
+  is below a threshold, **back off with exponential delay** instead of
+  immediately respawning into the wall, and **don't count memory-starved retries
+  against the 3-restart budget** (or use a separate, longer window for OOM-class
+  exits). Distinguish the OOM exit code (`0xe0000008`) from other abnormal exits
+  so the supervisor can apply OOM-specific backoff.
+- **On budget-exhaustion, fail *gracefully*:** show a real window/dialog —
+  "AgentMux ran out of memory and couldn't recover. Your panes, agents and auth
+  are saved; reopen to restore." — rather than a silent disappearance. The data
+  is in `objects.db`, so this is a messaging gap, not a data-loss one.
+
+### P1 — degrade before the wall, not at it
+
+- **Add a lightweight memory-pressure monitor** (in the launcher or srv) that
+  samples commit headroom. On a low-water mark, **proactively shed load**: pause
+  idle agent subprocesses, drop the warm window pool, ask renderers to free
+  caches (`Page.clearMemoryCache` / `--purge-memory-on-low`), and surface a
+  non-blocking "low memory" banner so the user can close things *before* a crash.
+- **Checkpoint on pressure**: flush any unsaved UI/session state to `objects.db`
+  when pressure is detected, so even a subsequent hard OOM restores cleanly.
+
+### P1 — verify and harden session restore
+
+- **Confirm the relaunch path actually restores the workspace** (panes + agents)
+  from `objects.db` after a host crash, end-to-end, and add a smoke test for
+  "kill host → relaunch → same panes". Today we *believe* it restores; this
+  incident shows we don't *verify* it.
+- **Couple host+backend recovery**: if the srv died too, the relaunched host
+  should detect the dead backend and respawn/reconnect it (or fail loudly),
+  instead of coming up half-wired.
+
+### P2 — cap Chromium's appetite so it fails inside its own budget
+
+- Pass renderer memory limits / `--js-flags="--max-old-space-size=…"` /
+  `--renderer-process-limit` so a runaway instance hits a *Chromium-level* cap
+  (recoverable: kill one renderer) before it hits the *system* commit limit
+  (unrecoverable: whole-host abort).
+- Consider starting in `--disable-gpu` automatically when commit headroom is
+  already low at launch (skip straight to the degraded rung).
+
+### P2 — operational / dogfooding guidance
+
+- **Don't run N instances + Vite + prod builds on one box.** Prefer a **headless
+  CDP probe** over a GUI dev for verification (already a noted preference); stop
+  stale `task dev` Vite servers (they balloon — PID 10376 was 1.3 GB); don't run
+  `task build:frontend` while multiple instances + dev are live.
+- **Prune accumulated per-build channels** (`channels/local-*`) — each carries a
+  data dir + cef-cache and they accumulate; live ones also hold memory.
+- Add a `muxlog`/doctor command that reports current commit headroom and the
+  number of live AgentMux instances, so pressure is visible before it bites.
+
+---
+
+## 7. Evidence appendix
+
+**Crash (WER, Application log, 2026-06-16):**
+- Event 1000 — faulting app `agentmux-0.44.1.exe` PID `0xed4` (3796), module
+  `KERNELBASE.dll`, exception `0xe0000008`, offset `0x25369`,
+  report id `4896b060-77c0-4e7b-a000-c5648e3c2db3`.
+- Event 1001 ×2 — `APPCRASH`, fault bucket `1813149519630564525` (type 4);
+  minidump `…\WER\Temp\WERD071.tmp.mdmp`.
+
+**Crashed instance data dir:**
+`~/.agentmux/channels/local-main-b28b7a-20260613T180900/versions/0.44.1/`
+(`data/srv-events.log` last write 07:33:15; `logs/cef-debug.log` grew to ~164 MB
+until ~08:02).
+
+**Memory-pressure evidence (this session):** repeated
+`runtime: VirtualAlloc of N bytes failed with errno=1455` / `fatal error: out of
+memory` from `task build:frontend`; `bash: fork: retry: Resource temporarily
+unavailable`.
+
+**Co-resident load at crash time:** v0.44.1 portable host (PID 3796), the
+`agenta/agent-failure-recovery-ui` `task dev` instance, a `0.46.0` build, and a
+Vite dev server (PID 10376, `vite --port 5287`, ~1.3 GB).
+
+**Existing recovery code:** `agentmux-launcher/src/main.rs`
+(`HOST_RESTART_BUDGET = 3`, `HOST_RESTART_WINDOW = 60s`, `--disable-gpu` degraded
+rung, "restart budget exhausted" give-up); srv crash monitor →
+`C:\CrashDumps\agentmuxsrv`.
+
+**Decode of `0xe0000008`:** Chromium `base::win::kOomExceptionCode`, raised
+non-continuably from `base::internal::OnNoMemory*` via
+`KERNELBASE!RaiseException` — a deliberate out-of-memory abort.

--- a/docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md
+++ b/docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md
@@ -1,0 +1,446 @@
+# Memory-Pressure Supervision & Graceful Degradation (host / instance level)
+
+**Status:** proposed — no PR yet
+**Date:** 2026-06-16
+**Author:** AgentA
+**Motivating incident:** `docs/retro/retro-oom-crash-2026-06-16.md`
+**Complements (does not replace):** `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`
+
+---
+
+## 1. Scope — and how this differs from the renderer spec
+
+AgentMux already has a **renderer-level** memory-aware recovery design
+(`SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`, Phase 1a shipped in PR #1229):
+when a *renderer subprocess* OOM-terminates, the host discriminates
+"OOM-under-pressure" from "wedged renderer", pauses instead of crash-looping, and
+auto-resumes when commit frees. That spec is correct and stays authoritative for
+**everything below the browser process**.
+
+But that spec **explicitly scopes out** (its §9) the two layers the 2026-06-16
+crash exposed:
+
+> *"The host-level crash-budget relaunch (`spawn_host_supervised`,
+> `HOST_RESTART_BUDGET`) and the GPU retry ladder … — unchanged (different
+> layer)."*
+> *"Cross-process global coordination between AgentMux instances (e.g. a shared
+> total-memory budget across instances) — out of scope."*
+
+This spec owns exactly those layers:
+
+| Layer | Owner |
+|---|---|
+| A renderer subprocess OOMs; the browser process survives | **`SPEC_GATED_RENDERER_RECOVERY`** (renderer pause/resume) |
+| The **browser/host process itself** OOMs → whole window/instance dies → launcher relaunches | **THIS SPEC** (memory-aware host supervision) |
+| **Proactive, instance-wide** shedding before *any* process OOMs | **THIS SPEC** (CDP purge + Job-Object soft limit) — extends the renderer spec's §6.D |
+| **Multi-instance / system** commit exhaustion | **THIS SPEC** (system signal + cross-instance awareness) |
+| Graceful **give-up** when relaunch can't recover | **THIS SPEC** (host-native "session saved, reopen to restore") |
+
+One sentence: *the renderer spec keeps a renderer crash invisible; this spec keeps
+a **host** crash recoverable and, better, keeps memory pressure from reaching the
+cliff in the first place — across the whole instance and with awareness that other
+instances exist.*
+
+---
+
+## 2. The incident (summary; full retro linked above)
+
+On 2026-06-16 07:33:16 the v0.44.1 portable's **CEF host process** (PID 3796)
+raised Chromium's intentional OOM exception **`0xe0000008`**
+(`base::win::kOomExceptionCode`, via `KERNELBASE!RaiseException`) under **system
+commit-limit exhaustion** (`errno 1455` / `ERROR_COMMITMENT_LIMIT`). Driver: three
+AgentMux instances + a 1.3 GB Vite dev server + repeated builds saturating the
+commit pool. The launcher's relaunch ladder (`HOST_RESTART_BUDGET = 3` / 60 s)
+relaunched **into the same starved condition** — memory-blind — and the user's
+session vanished with no signal.
+
+`0xe0000008` is reported on the **process that lost the allocation race**, which
+under CEF's shared exe name can be the *browser* process (whole instance dies) or
+a *renderer* (renderer spec's domain). This spec hardens the case the renderer
+spec leaves open and reduces how often *either* fires.
+
+---
+
+## 3. Best-practices grounding (researched 2026-06)
+
+**Detection (Windows).**
+- `GlobalMemoryStatusEx` gives commit usage by polling — **already sampled** by
+  `agentmux-cef/src/memory_heartbeat.rs` (every 20 s) and exposed as the
+  `COMMIT_FREE_MB` atomic + synchronous `commit_free_mb()` probe.
+- `CreateMemoryResourceNotification(LowMemoryResourceNotification)` +
+  `QueryMemoryResourceNotification` give an **event-driven, system-wide** "memory
+  is low" signal (non-blocking; reflects the *system*, ignores job limits).
+- **Job Object notification limits** (`JobObjectNotificationLimitInformation` /
+  `…2` via `SetInformationJobObject`) deliver a **soft**
+  `JOB_OBJECT_MSG_NOTIFICATION_LIMIT` to the **job creator's** I/O completion
+  port when the job crosses a memory threshold — *without killing anything*.
+  Caveat (Old New Thing, 2025-12-29): a process **cannot** get a handle to its
+  own enclosing job, so only the *creator* can monitor it. **AgentMux's launcher
+  creates Job Object J0** (it owns the handle), so the launcher is the one process
+  legitimately able to watch the whole instance's footprint. Hard limits
+  (`JOBOBJECT_EXTENDED_LIMIT_INFORMATION.ProcessMemoryLimit` / `JobMemoryLimit`)
+  *terminate* on breach — too blunt; we prefer the soft notification.
+
+**Relief without killing (Chromium/CEF).**
+- `base::MemoryPressureListener::SimulatePressureNotification(level)` broadcasts a
+  MODERATE/CRITICAL pressure signal; V8, Blink, and discardable-memory caches
+  respond by purging. Exposed over the **Chrome DevTools Protocol** as
+  `Memory.simulatePressureNotification({level:"critical"})` and
+  `Memory.forciblyPurgeJavaScriptMemory()` (purges V8 / simulates OomIntervention).
+  AgentMux **already runs a `remote_debugging_port`** (`CefSettings` in
+  `agentmux-cef/src/main.rs:651-696`), so the host can drive these against its own
+  renderers — instance-wide shedding **without** discarding any renderer.
+
+**Proactive eviction (precedent).** Electron's `render-process-gone` reasons
+include **`memory-eviction`** — "process *proactively* terminated to prevent a
+future OOM" — alongside `oom`. That is precisely the posture here: act *before*
+the cliff. (Two cited caveats we must respect: OOM is sometimes misreported as
+`crashed` not `oom` — classify defensively; and `--js-flags=--max-old-space-size`
+bounds only the V8 old space, **not** total renderer commit — a heap cap is
+necessary-not-sufficient.)
+
+Sources are listed in §13.
+
+---
+
+## 4. Design principles (inherited)
+
+From `SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md`: the supervisor is
+**passive, bounded, free-rides on persistence that already happens, and is loud
+about every action.** We **cannot allocate our way out of system OOM** — so the
+levers are only: (a) *delay* relaunch until the OS has commit, (b) *shed our own*
+committed memory, (c) *tell the user* honestly, (d) *never lose durable state*
+(it already lives in srv's SQLite; `persist_subscriber.rs` writes on every change,
+so committed workspace state is already crash-durable).
+
+---
+
+## 5. Design
+
+### 5.A — One memory signal, readable by the launcher (foundation)
+
+`memory_heartbeat.rs` already computes commit-free and publishes `COMMIT_FREE_MB`
+**within the host process**. The launcher is a *separate* process and cannot read
+that atomic, yet the launcher is where host relaunch is decided. So:
+
+1. **Launcher-side probe.** Add a tiny `commit_free_mb()` to the launcher
+   (one `GlobalMemoryStatusEx` call; `/proc/meminfo` on Linux), mirroring the
+   host helper. The launcher needs no shared memory — the OS commit figure is
+   global. This is the gate for §5.B.
+2. **Keep one definition of the thresholds** (`RESUME_FLOOR`, `WARN_FLOOR`, …) in
+   `agentmux-common` so host (renderer spec) and launcher (this spec) agree.
+
+> No new measurement framework — both layers read the same OS counter the
+> heartbeat already reads.
+
+### 5.B — Memory-aware host relaunch (the core P0 fix)
+
+Today (`agentmux-launcher/src/main.rs`, Windows `run_windows` ~1492-1565, Unix
+`run_unix` ~945-1013): on abnormal host exit, relaunch immediately, up to
+`HOST_RESTART_BUDGET = 3` within `HOST_RESTART_WINDOW = 60 s`; second try steps to
+`--disable-gpu`; budget exhausted → give up. **This is memory-blind.** Changes:
+
+1. **Classify OOM-class host exits.** Treat exit code `0xe0000008`
+   (`kOomExceptionCode`, surfaced as `STATUS`-style `3758096392` / `i32 -536870904`)
+   — and, defensively, the generic abnormal exit *while* `commit_free_mb()` was
+   below `RESUME_FLOOR` at exit time — as **`HostExit::SystemOom`**, distinct from
+   `HostExit::Abnormal` (a genuine host bug). (Mirrors the renderer spec's §5
+   discrimination, one layer up. Honors the "oom-misreported-as-crashed" caveat by
+   falling back to the commit reading.)
+2. **Commit-gated, backed-off relaunch for `SystemOom`.** Before relaunching an
+   OOM-class exit, probe `commit_free_mb()`. If below `RESUME_FLOOR`, **wait**
+   (exponential backoff `RELAUNCH_BACKOFF`: 2 s → 4 s → 8 s → … cap 30 s),
+   re-probing, until commit recovers *or* a wall-clock ceiling
+   (`OOM_RELAUNCH_DEADLINE`, e.g. 5 min) elapses. Relaunching into a starved
+   system just re-OOMs and burns the budget; waiting is the only thing that works.
+3. **Separate OOM restart budget.** OOM-class relaunches draw from
+   `OOM_RESTART_BUDGET` (a larger/longer window — e.g. 5 within 10 min), **not**
+   the wedged-host `HOST_RESTART_BUDGET`. A deterministic *host bug* still trips
+   the small fast budget; transient *system* OOM does not. (Exactly the
+   renderer-spec discrimination — don't let the OS's problem look like our bug.)
+4. **`--disable-gpu` earlier for OOM.** The GPU process is a large commit consumer;
+   for `SystemOom` relaunches, step to `--disable-gpu` on the **first** retry
+   (skip the rung-1 GPU attempt that will likely re-OOM).
+
+### 5.C — Graceful give-up (no more silent vanish)
+
+When relaunch genuinely cannot recover (`OOM_RELAUNCH_DEADLINE` hit, or
+`OOM_RESTART_BUDGET` exhausted), the launcher must **not** just `process::exit`.
+It paints a **host-native, renderer-free dialog** — reusing the layered-window
+machinery `agentmux-launcher/src/splash.rs` already owns (the same fallback the
+renderer spec's §6.C uses for its overlay) — saying:
+
+> *"AgentMux ran low on memory and couldn't recover this window. Your panes,
+> agents and sign-ins are saved. [Reopen] [Quit]"*
+
+"Reopen" re-execs the launcher once commit is back (it can gate on
+`commit_free_mb()` too). Durable state is intact in `objects.db`, so reopening
+restores the workspace — the loss is the live window, not the work. This converts
+the worst-case (silent disappearance) into an honest, recoverable prompt.
+
+### 5.D — Proactive, instance-wide shedding (prevention; extends renderer §6.D)
+
+The renderer spec's §6.D sheds by **discarding** background browser-pane / hidden-
+window renderers (frees commit, recreate on focus). This spec adds the
+**non-destructive, instance-wide** lever and the **whole-instance trigger**:
+
+1. **CDP purge.** When `commit_free_mb()` crosses `WARN_FLOOR`, the host drives its
+   own `remote_debugging_port`: `Memory.simulatePressureNotification("critical")`
+   then `Memory.forciblyPurgeJavaScriptMemory()` across live targets. V8/Blink/
+   discardable caches free memory **without** discarding any renderer (no flicker,
+   no reload). Cheap, reversible, first thing to try.
+2. **Drain the warm pool.** `agentmux-cef/src/commands/window_pool.rs`
+   (`POOL_TARGET_SIZE = 2`, ~50-150 MB each) holds spare renderers purely for
+   tear-off latency. Under `WARN_FLOOR`, **drain to 0** and suspend refill
+   (`spawn_pool_window` already has a quit-state skip guard to reuse); restore the
+   pool when commit recovers above `WARN_FLOOR + hysteresis`. This is pure upside:
+   pool windows are invisible and reconstructible.
+3. **Pause idle agent subprocesses.** An idle agent CLI between turns holds commit.
+   Under pressure, the srv can `SIGSTOP`/suspend (Windows: `NtSuspendProcess` /
+   suspend threads) idle agent subprocesses and resume on the next turn. (Gated;
+   never suspend a streaming turn. Detail TBD — see §9.)
+
+### 5.E — Whole-instance soft ceiling via Job Object J0 (prevention trigger)
+
+The launcher owns Job Object J0 around the whole instance. Set
+`JobObjectNotificationLimitInformation(2)` with a **soft** commit/working-set
+threshold so the launcher receives a `JOB_OBJECT_MSG_NOTIFICATION_LIMIT` on its
+completion port when *this instance's aggregate* footprint crosses a budget — a
+per-instance early warning that no per-process probe gives. On that notification
+the launcher asks the host (over the existing host pipe) to run §5.D shedding and
+shows the §5.F banner. (Soft, not hard — we degrade, we don't let the OS kill.)
+This is the one mechanism that bounds a *single instance's* greed; combined with
+§5.F it also makes the multi-instance case visible.
+
+### 5.F — User-facing signals (honest, non-modal)
+
+Reuse the existing notification infra — `frontend/app/notification/`
+(`usenotification.tsx`, toast bubbles) and `frontend/app/errors/ErrorBanner.tsx`,
+driven from srv via the wave pub/sub (`agentmux-srv/src/backend/wps.rs`):
+
+- At `WARN_FLOOR` / on a Job-Object soft-limit hit: a **non-modal** banner —
+  *"System memory is low — AgentMux freed caches and paused idle agents. Closing
+  some windows or other apps will help."* (Actionable, dismissible.)
+- The §5.C give-up dialog is the only modal, and only when recovery failed.
+- Surface **how many AgentMux instances are live** in the warning when >1 (see
+  §5.G) so the user knows the real lever is "close another instance."
+
+### 5.G — Cross-instance awareness (visibility, not control)
+
+A shared *enforced* budget across instances is genuinely hard (no central
+coordinator; isolation invariants I1-I6 forbid cross-instance lifecycle handles).
+So scope this to **awareness**:
+
+- A `muxlog`/doctor command reports **current commit-free + count of live
+  AgentMux instances** (enumerate by the per-instance pipe / data dir), so pressure
+  and its cause are visible *before* a crash.
+- The §5.F banner names the instance count. The honest message under multi-instance
+  pressure is "you're running N AgentMuxes; close one," and we should say so.
+- *Optional, deferred:* an advisory shared counter (a named file/section under
+  `~/.agentmux/`) where each instance writes its commit footprint, so each can
+  back off proactively when the *aggregate* is high. Advisory only — it must never
+  become a cross-instance lifecycle dependency (I2/I3/I4). Likely a later phase.
+
+### 5.H — Cap Chromium's appetite (defense in depth)
+
+In `agentmux-cef/src/app.rs::on_before_command_line_processing` (536-729) add,
+behind tunables:
+- `--js-flags=--max-old-space-size=<N>` per-renderer V8 old-space cap (necessary
+  but **not** sufficient — see §3 caveat; pair with §5.D).
+- `--renderer-process-limit=<N>` to bound renderer process count (fewer, shared
+  renderers under pressure).
+- Consider launching `--disable-gpu` automatically when `commit_free_mb()` is
+  already below `WARN_FLOOR` at startup (skip straight to the degraded rung).
+
+The goal: make a runaway hit a **Chromium-level** cap (recoverable: one renderer)
+before the **system** commit limit (unrecoverable: a process abort).
+
+---
+
+## 6. Thresholds & constants (tunable; shared in `agentmux-common`)
+
+| Constant | Initial | Meaning |
+|---|---|---|
+| `RESUME_FLOOR` | 512 MB commit-free | Min headroom to (re)launch a process without instant re-OOM (shared w/ renderer spec) |
+| `WARN_FLOOR` | 1 GB commit-free | Trigger §5.D shedding + §5.F banner |
+| `RELAUNCH_BACKOFF` | 2→4→8…cap 30 s | OOM-class host relaunch backoff while commit < `RESUME_FLOOR` |
+| `OOM_RELAUNCH_DEADLINE` | 5 min | Give up (→ §5.C dialog) if commit never recovers |
+| `OOM_RESTART_BUDGET` / window | 5 / 10 min | OOM-class relaunch budget (separate from `HOST_RESTART_BUDGET` 3/60 s) |
+| `POOL_DRAIN_BELOW` | `WARN_FLOOR` | Drain warm pool below this; refill above `WARN_FLOOR + 256 MB` (hysteresis) |
+| `JOB_SOFT_LIMIT` | e.g. 4 GB commit | Per-instance soft notification limit on J0 (tunable per machine class) |
+| `HOST_RESTART_BUDGET` / window | 3 / 60 s (**unchanged**) | Wedged-**host** backstop, still applies to non-OOM abnormal exits |
+
+All commit-free numbers must be validated against real machines (§10); the table
+is a starting point, not a measurement.
+
+---
+
+## 7. Host-supervisor state machine (launcher; new arm)
+
+```
+        ┌──────────┐  host healthy
+        │  Running │◀───────────────────────────────────────────┐
+        └────┬─────┘                                             │
+   abnormal  │                                                   │ relaunch ok
+   exit      ▼                                                   │
+     ┌───────────────┐  code==0xe0000008 OR (abnormal &          │
+     │  classify     │  commit_free < RESUME_FLOOR at exit)      │
+     └──┬─────────┬──┘                                           │
+        │SystemOom│ else Abnormal                                │
+        ▼         ▼                                              │
+ ┌────────────┐ ┌──────────────────────┐                        │
+ │ commit-gate│ │ existing path:       │                        │
+ │ + backoff  │ │ HOST_RESTART_BUDGET  │── over budget ──▶ give-up (host-native)
+ │ (OOM budget│ │ 3/60s, --disable-gpu │                  §5.C dialog
+ │  5/10min)  │ └──────────────────────┘                        │
+ └──┬──────┬──┘                                                  │
+    │commit│ deadline / OOM budget exhausted                    │
+    │≥floor│ ───────────────────────────────▶ give-up (§5.C)    │
+    ▼      ▼                                                     │
+   relaunch (--disable-gpu) ─────────────────────────────────────┘
+```
+
+`Running → Abnormal → existing budget path` is **unchanged** for genuine host
+bugs. `SystemOom` is the **new** commit-gated arm that waits out the OS instead of
+hammering it, and ends in an honest dialog rather than a silent exit.
+
+---
+
+## 8. Phasing
+
+- **P0 — memory-aware host relaunch + graceful give-up (§5.A, §5.B, §5.C).**
+  Highest value, smallest surface: the launcher gains a `commit_free_mb()` probe,
+  OOM-class exit classification, commit-gated backed-off relaunch on a separate
+  OOM budget, and a host-native give-up dialog. Directly converts the 2026-06-16
+  failure (memory-blind relaunch → silent vanish) into (wait-then-recover → or
+  honest, restorable prompt). No frontend or CEF changes required.
+- **P1 — proactive shedding + banner (§5.D CDP purge + warm-pool drain, §5.F
+  banner).** Reduces how often P0 fires. CDP purge and pool-drain are
+  non-destructive and ship first; idle-agent suspension follows once the
+  streaming-turn guard is designed.
+- **P2 — instance soft ceiling + system signal + awareness (§5.E Job-Object
+  notification limit, system `CreateMemoryResourceNotification`, §5.G doctor/banner
+  instance count).** Per-instance budget + multi-instance visibility.
+- **P3 — Chromium caps (§5.H)** and the optional advisory cross-instance counter.
+
+Each phase is independently valuable and shippable; P0 alone closes the incident.
+
+---
+
+## 9. Open questions
+
+1. **Idle-agent suspension (§5.D.3)** — suspending a CLI subprocess mid-stream
+   would corrupt a turn. Need a precise "agent is idle between turns" signal from
+   the block controller, and a resume-before-next-turn guarantee. Defer until that
+   signal is specced.
+2. **`JOB_SOFT_LIMIT` default** — should it be a fraction of physical RAM, of the
+   commit limit, or fixed? Likely `min(4 GB, 0.25 × physical)` — validate.
+3. **Reopen UX (§5.C)** — does "Reopen" re-exec the same labeled portable, and how
+   does it interact with the single-instance pipe if a sibling is up? Probably
+   "Reopen" should just relaunch *this* instance's data dir.
+4. **OOM exit-code portability** — `0xe0000008` is Chromium/Windows-specific;
+   Linux/macOS OOM surfaces differently (SIGKILL from the kernel OOM killer / Mach
+   `EXC_RESOURCE`). The commit-reading fallback (§5.B.1) covers those, but confirm
+   the Linux path classifies a kernel-OOM-killed host as `SystemOom`.
+
+---
+
+## 10. Testing
+
+- **Unit (launcher):** table-drive `(exit_code, commit_free_at_exit)` →
+  `{SystemOom | Abnormal}`; assert `SystemOom` does **not** consume
+  `HOST_RESTART_BUDGET`; assert backoff re-probes and only relaunches above
+  `RESUME_FLOOR`; assert `OOM_RELAUNCH_DEADLINE` / `OOM_RESTART_BUDGET` route to
+  the give-up dialog.
+- **Fault injection:** a debug switch making the host exit with `0xe0000008`, and a
+  stubbed `commit_free_mb()` provider, to exercise the gated-relaunch loop without
+  real pressure.
+- **Soak (the real condition):** shrink the page file, launch 2-3 instances + a
+  build to exhaust commit, confirm: (a) the host **waits** instead of crash-looping
+  relaunch, (b) warm pool drains + CDP purge fires at `WARN_FLOOR`, (c) the banner
+  names the instance count, (d) on continued exhaustion the give-up dialog appears
+  (not a silent exit) and "Reopen" restores the workspace from `objects.db`.
+- **Anti-flap:** oscillate commit around `RESUME_FLOOR`; assert no relaunch thrash
+  and no OOM-budget exhaustion from oscillation alone.
+- **Regression:** a non-OOM abnormal host exit (commit healthy) still uses the
+  unchanged `HOST_RESTART_BUDGET` fast path and trips give-up after 3/60 s.
+
+---
+
+## 11. Out of scope / unchanged
+
+- **Renderer-subprocess OOM pause/resume** — owned by
+  `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` (§6.B/§6.C). This spec does not
+  touch `on_render_process_terminated`.
+- **Raising the OS commit limit** — system-managed; impossible from a process.
+- **Freeing *other* applications' memory** — impossible.
+- **Enforced cross-instance memory budget** — out (only advisory awareness, §5.G);
+  enforcement would violate isolation invariants I2/I3/I4.
+- **The renderer crash budget, recovery page, and draft persistence** (renderer
+  spec §6.E) — unchanged.
+
+---
+
+## 12. Risks
+
+- **Backoff too conservative → window stays down longer than needed.** Mitigated
+  by short initial backoff (2 s) + immediate relaunch the instant commit clears
+  `RESUME_FLOOR`; the deadline only bounds the pathological never-recovers case.
+- **Job-Object notification false-positives** on machines with huge page files
+  (commit "free" but RAM thrashing). The Job-Object limit is per-instance commit,
+  not system RAM; tune `JOB_SOFT_LIMIT` and treat it as advisory (drives shedding,
+  not kills).
+- **CDP purge cost** — `forciblyPurgeJavaScriptMemory` triggers GC pauses; gate it
+  to `WARN_FLOOR` crossings (not steady-state) and rate-limit.
+- **`--max-old-space-size` false security** — it does **not** bound total renderer
+  commit (§3 caveat #2); never rely on it alone — it pairs with §5.D shedding.
+- **Give-up dialog under true exhaustion** — must be renderer-free (layered-window,
+  reuse `splash.rs`) precisely because a renderer may not start; same constraint
+  the renderer spec's §6.C overlay already solved.
+
+---
+
+## 13. Cross-references & sources
+
+**Internal (do not duplicate):**
+- `docs/retro/retro-oom-crash-2026-06-16.md` — the motivating incident.
+- `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` — the renderer-level layer this
+  complements (renderer pause/resume; §6.D shedding this extends instance-wide;
+  §6.C native overlay this reuses for give-up).
+- `SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md` — the stability mandate +
+  host-level supervisor + `HOST_RESTART_BUDGET` ladder this makes memory-aware.
+- `SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md` — the renderer recovery page.
+- `SPEC_MULTI_INSTANCE_ISOLATION_HARDENING_2026_06_03.md` — invariants I1-I6 that
+  constrain §5.G cross-instance work.
+- `docs/MEMORY_HEARTBEAT_SPEC.md` — the heartbeat + `commit_free_mb()` this reads.
+
+**Integration points (from codebase survey):**
+- Launcher supervisor: `agentmux-launcher/src/main.rs` (Windows ~1082-1581, Unix
+  ~689-1070; budget `283-284`; `--disable-gpu` in `spawn_host_supervised` 294-374).
+- Memory signal: `agentmux-cef/src/memory_heartbeat.rs` (`COMMIT_FREE_MB` 15-41,
+  `GlobalMemoryStatusEx` 109-177).
+- CEF flags: `agentmux-cef/src/app.rs::on_before_command_line_processing` 536-729;
+  `CefSettings`/`remote_debugging_port` `agentmux-cef/src/main.rs` 651-696.
+- Wave pub/sub: `agentmux-srv/src/backend/wps.rs`. Notifications:
+  `frontend/app/notification/`, `frontend/app/errors/ErrorBanner.tsx`.
+- Persistence: `agentmux-srv/src/persist_subscriber.rs` (on-change SQLite writes),
+  `objects.db` (`agentmux-srv/src/main.rs:375`).
+- Warm pool: `agentmux-cef/src/commands/window_pool.rs` (`POOL_TARGET_SIZE` 60,
+  `spawn_pool_window` 86-150).
+- srv crash dumps: `agentmux-srv/src/crash_monitor.rs` (no host equivalent → WER).
+
+**External best-practices (researched 2026-06):**
+- Windows memory detection (system + job): *The Old New Thing*, "How can I detect
+  that the system is running low on memory? Or that my job is running low on
+  memory?" (2025-12-29).
+- `QueryMemoryResourceNotification` / `CreateMemoryResourceNotification` /
+  `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` — Microsoft Learn (Win32 memoryapi/winnt).
+- Chrome DevTools Protocol **Memory** domain — `simulatePressureNotification`,
+  `forciblyPurgeJavaScriptMemory`, `setPressureNotificationsSuppressed`
+  (chromedevtools.github.io).
+- Chromium `base::MemoryPressureListener::SimulatePressureNotification`
+  (chromium.googlesource.com base/memory).
+- Electron `render-process-gone` reasons incl. `oom` / `memory-eviction`
+  (electronjs.org RenderProcessGoneDetails) + heap-cap caveat (electron#37214) +
+  oom-misreported-as-crashed caveat (electron#40426).
+```

--- a/docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md
+++ b/docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md
@@ -153,6 +153,11 @@ Today (`agentmux-launcher/src/main.rs`, Windows `run_windows` ~1492-1565, Unix
    re-probing, until commit recovers *or* a wall-clock ceiling
    (`OOM_RELAUNCH_DEADLINE`, e.g. 5 min) elapses. Relaunching into a starved
    system just re-OOMs and burns the budget; waiting is the only thing that works.
+   The wait must stay **interruptible** — it races against the supervisor's
+   shutdown signals (SIGINT/SIGTERM) and srv-death, so a Ctrl+C / quit / backend
+   crash during the wait is serviced promptly rather than blocked for up to
+   `OOM_RELAUNCH_DEADLINE` (a `select!`-arm-blocking regression reagent caught on
+   the P0 PR).
 3. **Separate OOM restart budget.** OOM-class relaunches draw from
    `OOM_RESTART_BUDGET` (a larger/longer window — e.g. 5 within 10 min), **not**
    the wedged-host `HOST_RESTART_BUDGET`. A deterministic *host bug* still trips


### PR DESCRIPTION
## Why

`docs/retro/retro-oom-crash-2026-06-16.md`: the v0.44.1 host hard-crashed with Chromium's intentional OOM exception **`0xe0000008`** under **system commit-limit exhaustion** (`errno 1455`). The launcher's relaunch ladder (`HOST_RESTART_BUDGET` 3/60s) is **memory-blind** — it relaunched straight back into the same starved condition, burned the budget in seconds, and the user's window vanished with no signal.

This is **P0** of `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md` — the **host/instance-level** complement to the existing renderer-level `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` (whose §9 explicitly leaves the host-relaunch layer out of scope).

## What

**New `mem_supervisor` module (pure + unit-tested):**
- `classify_host_exit()` splits a **system-OOM** exit from a genuine host fault. OOM is detected two ways (defensive — Chromium sometimes reports OOM as a generic crash, per electron#40426): the exact `0xe0000008` exit code, **or** *any* abnormal exit taken while commit-free was already below `RESUME_FLOOR`.
- `commit_free_mb()` probe (`GlobalMemoryStatusEx` on Windows, `/proc/meminfo` on Linux, fail-open elsewhere), `next_backoff()` (exp, capped 30s), `budget_exhausted()` windowed budget, `await_commit_recovery()` (wait until commit clears the floor, 5-min deadline).

**Both supervisor loops (`run_windows` / `run_unix`) gain a `SystemOom` arm:**
- **Commit-gated, backed-off relaunch** drawn from a **separate** OOM budget (`OOM_RESTART_BUDGET` 5 / 10 min) — *not* the wedged-host budget. Relaunching into a starved system just re-OOMs; waiting is the only lever.
- Relaunch **degraded** (`--disable-gpu`) since the GPU process is a large commit consumer.
- The existing wedged-host **`Abnormal` path is byte-for-byte unchanged** — a deterministic host bug still trips the fast 3/60s budget + degraded ladder exactly as before.

**Graceful give-up (no more silent vanish):** on OOM-budget exhaustion or the recovery deadline, show the **renderer-free** Win32 give-up dialog (reusing the existing `show_fatal_dialog`) — *"out of memory; your panes, agents and sign-ins are saved — reopen to restore"* — instead of a bare `process::exit`.

## Isolation invariants (I1–I6)

No change to Job Object creation/assignment, pipe/event naming, or cross-instance contact. The new arm only adds a *delay* + a *separate budget* + a *dialog* around the existing relaunch; it spawns the host the same way (`spawn_host_supervised` / `spawn_host_unix`) under the same J0. Blast radius unchanged.

## Tests / verification

- 7 `mem_supervisor` unit tests (classification incl. the exact-code and low-commit cases, backoff doubling+cap, budget window prune). `cargo build` + `cargo test -p agentmux-launcher` green.
- Adds `Win32_System_SystemInformation` to the launcher's `windows-sys` features (for `GlobalMemoryStatusEx`); `Cargo.lock` unchanged (feature-only).

## Follow-ups (later phases in the spec, not this PR)

P1 proactive shedding (CDP `Memory.simulatePressureNotification`/`forciblyPurgeJavaScriptMemory` + warm-pool drain) · P2 Job-Object soft memory limit + cross-instance awareness · the full interactive **Reopen** dialog (P0 ships the minimal honest `MessageBox`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)