### PR TITLE
fix(agent-pane): clip persistent-shell panel so collapsed build log doesn't paint behind the conversation

### DIFF
--- a/.changesets/1781648965-fix-agent-pane-clip-persistent-shell-panel-so-collapsed-buil-yswl.md
+++ b/.changesets/1781648965-fix-agent-pane-clip-persistent-shell-panel-so-collapsed-buil-yswl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): clip persistent-shell panel so collapsed build log doesn't paint behind the conversation

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -26,6 +26,43 @@
     50%       { border-left-color: color-mix(in srgb, var(--term-bright-green) 35%, transparent); }
 }
 
+// The persistent-shell log reuses the `.agent-tool-panel` markup
+// (PersistentShellBlock.tsx) but lives under `.agent-shell-block`, NOT
+// `.agent-tool-block`. The container + collapse-clip rules in
+// _document-nodes.scss are scoped to `.agent-tool-block .agent-tool-panel`,
+// so they never reach the shell's panel. Without the clip the "hidden"
+// (collapsed) panel isn't bounded: the full build log lays out at natural
+// height inside a row the virtualizer sized at SHELL_COLLAPSED_PX (32px,
+// renderers.ts), so it overflows and paints across the absolutely-positioned
+// rows below it — the "build shows on a layer behind the conversation" bug.
+// Mirror the tool-block panel rules here, scoped to the shell block.
+.agent-shell-block .agent-tool-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    max-height: 50vh;
+    overflow: hidden;
+    transition:
+        max-height 120ms cubic-bezier(0.4, 0, 0.2, 1),
+        padding 120ms cubic-bezier(0.4, 0, 0.2, 1),
+        margin 120ms cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 100ms ease-out,
+        content-visibility 120ms allow-discrete;
+
+    // Collapsed: clip to zero so the row matches its 32px estimate. Body
+    // stays in the DOM (content-visibility, not display:none) so the
+    // virtualizer keeps a stable subtree and the 120ms shrink can animate.
+    &--hidden {
+        max-height: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        margin-top: 0;
+        margin-bottom: 0;
+        opacity: 0;
+        content-visibility: hidden;
+    }
+}
+
 .agent-shell-summary {
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
## Symptom

In an agent pane, a long-running shell's output (e.g. a `task dev` build streamed into a **persistent shell node**) renders **garbled, on a layer behind the conversation**, instead of staying contained in the collapsed node.

## Root cause — CSS scope mismatch

`PersistentShellBlock` reuses the `.agent-tool-panel` markup (`PersistentShellBlock.tsx:136`), but the panel's containment + collapse-clip rules are **scoped to `.agent-tool-block`** (`_document-nodes.scss:276`, `&--hidden` at `:310`). The shell renders that panel under **`.agent-shell-block`**, so the rules never match — the collapsed panel is never clipped and lays out at full content height.

Proof of the gap: before this PR, the entire frontend had exactly two `.agent-tool-panel` selectors, both under `.agent-tool-block`:
```
_document-nodes.scss:276   .agent-tool-panel        (inside .agent-tool-block)
_responsive.scss:58        .agent-tool-panel        (inside the tool-block subtree)
```
The shared *slot* styles (`.agent-tool-overlay`, `.agent-tool-overlay-log`) are global, which is why the log **text** is styled but the **container** is not.

## Why "full height" → "layer behind"

- Collapsed shell is estimated at `SHELL_COLLAPSED_PX = 32` (`renderers.ts:166/291`) — valid only if the panel clips to ~0.
- Rows are absolutely positioned by prefix-sum offset (`AgentDocumentVirtualList.tsx:733-737`).
- Heights reconcile **asynchronously** via a measure-RO keyed by expansion state (`:671-673`, `inFlowState` `store/agent-pane-layout/types.ts:142`; "contributes only when in-flow" `:122-128`).

While a noisy shell streams, the DOM grows faster than the recorded measurement (the explicitly-named **"measurement race"**, `perf-probe.ts:37`), so the unclipped log overflows its 32px slot and paints across the absolutely-positioned rows below it. At steady state the collapsed shell instead shows its **entire** log (collapse visually broken). Both vanish once the panel clips.

## Fix

Add `.agent-shell-block .agent-tool-panel` rules in `_shell-node.scss` mirroring the tool-block panel: bounds (`display:flex`, `max-height:50vh`, `overflow:hidden`) + the `--hidden` zero-clip (`content-visibility:hidden`, so the body stays mounted and the virtualizer keeps a stable subtree). Scoped to the shell block — **cannot regress tool blocks**. Restores the validity of the 32px collapsed estimate; the expanded panel is bounded with internal scroll. One file, CSS only.

## Verification

- ✅ Root cause proven statically (full enumeration of `.agent-tool-panel` selectors).
- ✅ Compiles into the bundle (`agent-view.scss` `@use "styles/shell-node"`); hot-reloaded in `task dev` with no SCSS/Vite errors.
- ⚠️ Not visually screenshot-confirmed from the authoring environment. Suggested manual check: spawn a noisy long-running shell, let it stream, scroll it up into the virtualized head, confirm the collapsed row stays one line with no bleed-through; pin it and confirm the expanded panel scrolls internally.

## Not done (out of scope)
No version bump (changeset workflow — `patch`). No behavior change to tool blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)