### PR TITLE
feat(host): proactive --disable-gpu at startup under critically-low commit

### DIFF
--- a/.changesets/1781649131-feat-host-proactive-disable-gpu-at-startup-when-commit-is-cr-we0r.md
+++ b/.changesets/1781649131-feat-host-proactive-disable-gpu-at-startup-when-commit-is-cr-we0r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): proactive --disable-gpu at startup when commit is critically low

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -535,10 +535,35 @@ wrap_app! {
     impl App {
         fn on_before_command_line_processing(
             &self,
-            _process_type: Option<&CefString>,
+            process_type: Option<&CefString>,
             command_line: Option<&mut CommandLine>,
         ) {
             if let Some(cmd) = command_line {
+                // Proactive memory-pressure guard (SPEC_MEMORY_PRESSURE_
+                // SUPERVISION_2026_06_16 §5.H): if the system is already
+                // critically low on commit at launch, start in software
+                // rendering. The GPU process is a large commit consumer, and on
+                // a starved system spawning it can push commit over the edge and
+                // OOM the host before first paint — the 2026-06-16 failure mode
+                // under several concurrent instances. Browser process only (only
+                // it decides whether to spawn the GPU process); reuses the same
+                // `disable-gpu` switch as the launcher's degraded-relaunch rung.
+                // On non-Windows `commit_free_mb()` is u64::MAX, so this never
+                // fires there (commit-limit exhaustion is a Windows concern).
+                const STARTUP_DISABLE_GPU_FLOOR_MB: u64 = 512;
+                if process_type.is_none() {
+                    let free = crate::memory_heartbeat::commit_free_mb();
+                    if free < STARTUP_DISABLE_GPU_FLOOR_MB {
+                        tracing::warn!(
+                            target: "mem_pressure",
+                            commit_free_mb = free,
+                            floor_mb = STARTUP_DISABLE_GPU_FLOOR_MB,
+                            "commit critically low at startup — launching with --disable-gpu (software rendering)"
+                        );
+                        cmd.append_switch(Some(&CefString::from("disable-gpu")));
+                    }
+                }
+
                 // Prevent empty browser on visibility change (CEF #3638).
                 //
                 // Also disable MediaRouter: Chromium's Cast/DIAL device


### PR DESCRIPTION
## Why

`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16` §5.H, building on the merged P0 (#1493, memory-aware *relaunch*) and the merged detection foundation (#1494). On a **fresh** launch the GPU process spawns unconditionally; when commit is already critically low (the 2026-06-16 condition — several instances + dev tooling saturating the commit pool), that GPU process can be the allocation that tips commit over the edge and OOM-aborts the host before first paint.

## What

In `on_before_command_line_processing` (**browser process only** — only it decides whether to spawn the GPU process), probe `memory_heartbeat::commit_free_mb()`; if below **512 MB**, append `disable-gpu` (software rendering) and log a `mem_pressure` warn line.

- Reuses the exact switch the launcher's degraded-relaunch rung already uses, so the software-rendering path is proven.
- On non-Windows `commit_free_mb()` is `u64::MAX` → never fires (commit-limit exhaustion is a Windows concern).
- Complements #1493: that adds `--disable-gpu` only on a degraded *relaunch*; this is the proactive *first-launch* guard.

Low-risk: a single conditional that reuses an already-exercised flag; no change to the multi-process model or window/renderer lifecycle. `cargo build -p agentmux-cef` green.

## Sequence note

This is the last of the **blind-safe** memory-pressure slices. The remaining responses (warm-pool drain, CDP renderer purge, low-memory banner, Job-Object soft limit, full Reopen dialog) mutate delicate CEF window/renderer/launcher internals and need a smoke under **real** memory pressure before merge — they won't be blind-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)