### PR TITLE
feat(pane.open): OpenEditor collapse_tree + floating-pane support

### DIFF
--- a/.changesets/1781649151-feat-pane-open-openeditor-collapse-tree-floating-pane-suppor-oazj.md
+++ b/.changesets/1781649151-feat-pane-open-openeditor-collapse-tree-floating-pane-suppor-oazj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(pane.open): OpenEditor collapse_tree + floating-pane support

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -76,7 +76,9 @@ const OPEN_EDITOR_TOOL: &str = r#"{
     "properties": {
       "file":  { "type": "string", "description": "Absolute path to the file to open" },
       "title": { "type": "string", "description": "Optional tab/pane title (defaults to the file name)" },
-      "split": { "type": "string", "enum": ["right", "left", "down", "up"], "description": "Where to place the new pane relative to this agent pane (default: right)" }
+      "split": { "type": "string", "enum": ["right", "left", "down", "up"], "description": "Where to place the new pane relative to this agent pane (default: right). Ignored when floating is true." },
+      "collapse_tree": { "type": "boolean", "description": "Open the editor with its file-tree sidebar collapsed (just the file, no explorer). Default: false (tree expanded)." },
+      "floating": { "type": "boolean", "description": "Open the file in a floating window (a chromeless pane over the app) instead of a docked split. Default: false." }
     },
     "required": ["file"]
   }
@@ -349,6 +351,15 @@ async fn call_tool(
             }
             if let Some(title) = arguments.get("title").and_then(|v| v.as_str()) {
                 body["title"] = json!(title);
+            }
+            // `collapse_tree: true` → open with the file-tree sidebar collapsed.
+            // Maps to the editor's `tree_expanded` meta (collapsed == not expanded).
+            if arguments.get("collapse_tree").and_then(|v| v.as_bool()) == Some(true) {
+                body["tree_expanded"] = json!(false);
+            }
+            // `floating: true` → open in a floating window instead of a docked split.
+            if arguments.get("floating").and_then(|v| v.as_bool()) == Some(true) {
+                body["floating"] = json!(true);
             }
 
             let resp = client

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -931,6 +931,19 @@ pub struct CommandPaneOpenData {
     pub split_direction: Option<String>,
     pub split_reference_block_id: Option<String>,
     pub focus: Option<bool>,
+    /// `editor` only: initial file-tree sidebar state. `Some(false)` opens the
+    /// editor with its tree collapsed (just the file, no explorer). Written to
+    /// `block.meta["editor:tree_expanded"]`, which the frontend `EditorViewModel`
+    /// restores on init. Absent / `Some(true)` → the frontend default (expanded).
+    pub tree_expanded: Option<bool>,
+    /// `Some(true)` opens the pane as a floating window instead of a docked
+    /// split. The block is created then moved into a fresh floating workspace
+    /// via the `tear_off_block` saga; the launcher broadcasts an
+    /// `openfloatingpane` directive scoped to the source window, whose frontend
+    /// calls the host `open_floating_pane_window` command to materialize the OS
+    /// window. `split_direction` / `split_reference_block_id` are ignored when
+    /// floating. See docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md.
+    pub floating: Option<bool>,
 }
 
 /// Response from pane.open.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -893,7 +893,15 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
     // Resolve tab
     let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
 
-    // Create block
+    // Floating path (SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16):
+    // create the block in a fresh floating workspace (via reducer CreateBlock +
+    // the existing tear_off_block saga) and signal the source window's frontend
+    // to materialize the chromeless OS window — srv can't open windows itself.
+    if cmd.floating == Some(true) {
+        return open_pane_floating(state, &wstore, &event_bus, cmd.view, tab_id, meta).await;
+    }
+
+    // Create block (docked path)
     let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
         .map_err(|e| format!("pane.open: create_block: {e}"))?;
     let block_id = block.oid.clone();
@@ -982,6 +990,190 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
     })
 }
 
+/// Floating-pane branch of `open_pane`. The block already exists in
+/// `source_tab_id`'s blockids (created by the caller, with no layout node).
+/// This moves it into a fresh floating workspace via the `tear_off_block`
+/// saga, sets up the new tab's layout, broadcasts the new WaveObjs, and asks
+/// the source window's frontend to materialize the chromeless floating OS
+/// window via the host `open_floating_pane_window` command (srv cannot open
+/// windows itself). See docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md.
+async fn open_pane_floating(
+    state: &AppState,
+    wstore: &Store,
+    event_bus: &crate::backend::eventbus::EventBus,
+    view: String,
+    source_tab_id: String,
+    meta: MetaMapType,
+) -> Result<PaneOpenResult, String> {
+    use agentmux_common::ipc::{Command, Event};
+
+    // Source workspace from the reducer's canonical tab→workspace map.
+    let source_ws_id = {
+        let s = state.srv_state.lock().await;
+        s.tabs
+            .get(&source_tab_id)
+            .map(|t| t.workspace_id.clone())
+            .ok_or_else(|| format!("pane.open: floating: tab {source_tab_id} not in reducer state"))?
+    };
+
+    // Create the block through the reducer (NOT wcore-direct) so it lands in
+    // `state.blocks` — the `tear_off_block` saga's pre-condition checks the
+    // reducer-canonical block map. The `BlockCreated` event also carries the
+    // meta, which `persist_subscriber::apply_block_created` writes into the
+    // wstore Block so the editor renders with its file + tree state. We skip
+    // layout placement, so the block never renders docked before the saga
+    // moves it into the floating workspace (no flash).
+    let meta_val = serde_json::to_value(&meta)
+        .map_err(|e| format!("pane.open: floating: meta serialize: {e}"))?;
+    let create_events = crate::server::service::dispatch_to_reducer(
+        state,
+        Command::CreateBlock {
+            tab_id: source_tab_id.clone(),
+            meta: meta_val,
+        },
+    )
+    .await;
+    if let Some(msg) = create_events.iter().find_map(|e| match e {
+        Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    }) {
+        return Err(format!("pane.open: floating: CreateBlock: {msg}"));
+    }
+    let block_id = create_events
+        .iter()
+        .find_map(|e| match e {
+            Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| "pane.open: floating: CreateBlock emitted no BlockCreated".to_string())?;
+    for ev in &create_events {
+        if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, wstore) {
+            tracing::warn!("pane.open: floating: CreateBlock wstore apply failed: {e}");
+        }
+    }
+    crate::server::service::publish_events(state, &create_events);
+
+    // Tear the block off into a fresh floating workspace + tab (reuses the
+    // exact saga the drag tear-off uses: CreateWorkspace → CreateTab → MoveBlock).
+    let saga_val = crate::sagas::tear_off_block::run(
+        state,
+        block_id.clone(),
+        source_tab_id.clone(),
+        source_ws_id.clone(),
+    )
+    .await?;
+    let new_ws_id = saga_val
+        .get("new_workspace_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let new_tab_id = saga_val
+        .get("new_tab_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if new_ws_id.is_empty() || new_tab_id.is_empty() {
+        return Err("pane.open: floating: tear_off_block returned empty ids".to_string());
+    }
+
+    // Make the moved block the new tab's single root node so it renders.
+    if let Err(e) =
+        crate::server::service::setup_torn_off_block_layout(wstore, &new_tab_id, &block_id)
+    {
+        tracing::warn!(
+            new_tab = %new_tab_id,
+            "pane.open: floating: layout setup failed: {e} (block moved but layout malformed)"
+        );
+    }
+
+    // Broadcast the new workspace + layout + tab + block so any frontend syncs
+    // its WaveObj cache (mirrors the docked path + the tear-off DnD handler).
+    {
+        let mut updates: Vec<obj::WaveObjUpdate> = Vec::new();
+        if let Ok(ws) = wstore.must_get::<Workspace>(&new_ws_id) {
+            updates.push(obj::WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "workspace".into(),
+                oid: new_ws_id.clone(),
+                obj: Some(obj::wave_obj_to_value(&ws)),
+            });
+        }
+        if let Ok(t) = wstore.must_get::<Tab>(&new_tab_id) {
+            if let Ok(layout) = wstore.must_get::<obj::LayoutState>(&t.layoutstate) {
+                updates.push(obj::WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: "layout".into(),
+                    oid: t.layoutstate.clone(),
+                    obj: Some(obj::wave_obj_to_value(&layout)),
+                });
+            }
+            updates.push(obj::WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "tab".into(),
+                oid: new_tab_id.clone(),
+                obj: Some(obj::wave_obj_to_value(&t)),
+            });
+        }
+        if let Ok(b) = wstore.must_get::<Block>(&block_id) {
+            updates.push(obj::WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "block".into(),
+                oid: block_id.clone(),
+                obj: Some(obj::wave_obj_to_value(&b)),
+            });
+        }
+        for update in &updates {
+            let oref = format!("{}:{}", update.otype, update.oid);
+            if let Ok(data) = serde_json::to_value(update) {
+                event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+                    eventtype: "waveobj:update".to_string(),
+                    oref,
+                    data: Some(data),
+                });
+            }
+        }
+    }
+
+    // Ask the source window's frontend to open the floating OS window — scoped
+    // to that window (mirrors the window-scoped `userinput` event) so exactly
+    // one window acts. The frontend handler calls the host
+    // `open_floating_pane_window` command.
+    let window_id = {
+        let s = state.srv_state.lock().await;
+        s.windows
+            .iter()
+            .find(|(_, w)| w.workspace_id == source_ws_id)
+            .map(|(id, _)| id.clone())
+    };
+    match window_id {
+        Some(win) => {
+            state.broker.publish(crate::backend::wps::WaveEvent {
+                event: "openfloatingpane".to_string(),
+                scopes: vec![win],
+                sender: String::new(),
+                persist: 0,
+                data: Some(json!({
+                    "block_id": block_id,
+                    "workspace_id": new_ws_id,
+                })),
+            });
+        }
+        None => {
+            tracing::warn!(
+                source_ws = %source_ws_id,
+                "pane.open: floating: no window mapped to source workspace — floater not opened"
+            );
+        }
+    }
+
+    Ok(PaneOpenResult {
+        block_id,
+        tab_id: new_tab_id,
+        view,
+        created: true,
+    })
+}
+
 /// Build the metadata map for a pane.open request, validating required args.
 fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, String> {
     let mut meta = MetaMapType::new();
@@ -992,6 +1184,13 @@ fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, String> {
                 .ok_or_else(|| "MISSING_ARG: view=editor requires 'file'".to_string())?;
             meta.insert("view".to_string(), json!("editor"));
             meta.insert("file".to_string(), json!(file));
+            // Optional initial file-tree state. Only write when explicitly
+            // requested; absent leaves the frontend default (expanded). The
+            // frontend collapses iff this is literally `false`
+            // (EditorViewModel restore: `meta["editor:tree_expanded"] === false`).
+            if let Some(expanded) = cmd.tree_expanded {
+                meta.insert("editor:tree_expanded".to_string(), json!(expanded));
+            }
         }
         "term" => {
             meta.insert("view".to_string(), json!("term"));

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2500,7 +2500,7 @@ async fn compensate_via_reducer(
 /// wcore-direct and not reducer-routed. Best-effort: a failure here
 /// leaves the new tab with the moved block but a malformed layout;
 /// the user-visible symptom is an empty render in the new window.
-fn setup_torn_off_block_layout(
+pub(crate) fn setup_torn_off_block_layout(
     store: &Store,
     new_tab_id: &str,
     block_id: &str,

--- a/docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md
+++ b/docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md
@@ -1,0 +1,168 @@
+# SPEC: OpenEditor — collapsed file-tree + floating-pane support
+
+**Date:** 2026-06-16
+**Status:** In progress
+**Author:** Naki
+**Repo HEAD at analysis:** `bb255fda`
+**Related:** [[SPEC_FLOATING_PANE_TEAROFF_2026_05_11]], [[SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29]],
+[[SPEC_FLOATING_PANE_REDOCK_2026-05-27]], `docs/retro/saga-coordinator-location-analysis-2026-04-30.md`
+
+---
+
+## 1. Goal
+
+Extend the `OpenEditor` MCP tool (and the underlying `pane.open` RPC / `POST /api/v1/pane/open`)
+so an agent can open a file:
+
+1. **with the file-tree sidebar collapsed** (just the file, no explorer), and
+2. **in a floating pane** (a chromeless window over the source instance), instead of a docked split.
+
+Both must **reuse the existing systems** — the editor's `editor:tree_expanded` meta and the
+existing floating-pane tear-off pipeline — not invent parallel machinery.
+
+---
+
+## 2. How the relevant systems work (verified)
+
+### 2.1 Editor file-tree state is meta-driven
+`EditorViewModel` restores tree state from `block.meta` on init
+(`frontend/app/view/editor/editor-model.ts:39,266-268`):
+
+```ts
+const META_TREE_EXPANDED = "editor:tree_expanded"; // default true
+if (meta?.[META_TREE_EXPANDED] === false) this._treeExpanded[1](false);
+```
+
+So opening collapsed = write `block.meta["editor:tree_expanded"] = false` at create time. **No
+frontend change needed.**
+
+### 2.2 The reducer is a pure state machine; it does not open OS windows
+`reducer.rs::update(&mut State, Command) -> Vec<Event>` (no I/O). `CreateWindow{window_id,
+workspace_id}` only registers a window↔workspace mapping and emits `SrvWindowOpened`
+(`reducer/window.rs:16-48`). Events fan out to SQLite (`persist_subscriber`) + the event bus
+(`publish_events`).
+
+### 2.3 Floating panes are frontend-orchestrated tear-offs
+A floating pane is a **chromeless `WS_POPUP` window owned by the source main window**, sharing the
+same sidecar / data dir / reducer state (`agentmux-cef/src/commands/floating_pane.rs:4-24`). The
+tear-off flow (drag path, `service.rs:1873` + `CrossWindowDragMonitor.*`):
+
+1. Frontend → srv RPC `workspace/TearOffBlock` → `sagas::tear_off_block::run`
+   (`CreateWorkspace` → `CreateTab` → `MoveBlock`) → `setup_torn_off_block_layout` → returns
+   `new_workspace_id`.
+2. Frontend → **host** command `open_floating_pane_window{pane_id, workspace_id, x, y, width,
+   height}` (`floating_pane.rs:81`) — opens the OS window; its docstring already anticipates
+   *"the frontend **or an agent**"* invoking it.
+3. The floater boots with `?floatingPaneId=<id>&workspaceId=<ws>`, renders
+   `<FloatingPaneWorkspace>` (`app.tsx:377`), and calls `WindowService.CreateWindow(null, wsId)`.
+
+**srv cannot open an OS window** — only the host can, and only the frontend invokes host commands.
+So a programmatic float needs a srv→frontend directive.
+
+### 2.4 srv→frontend directive channel (scoped pub/sub)
+`frontend/app/store/global.ts:259` `initGlobalEventSubs` subscribes via `waveEventSubscribe(
+{eventType, handler, scope?})` (`store/wps.ts`). `scope` becomes a `SubscriptionRequest.scopes`
+entry; srv broadcasts `WSEventType{eventtype, oref, data}` (`backend/eventbus.rs:43,158`) and the
+bus routes by `eventtype` + `oref`-vs-`scope`. The existing `userinput` sub is **scoped to
+`windowId`** — the exact pattern we reuse to target one window.
+
+---
+
+## 3. Design
+
+### 3.1 Collapsed tree (DONE)
+- `OpenEditor` tool: new `collapse_tree: boolean` → `pane.open` body `tree_expanded: false`.
+- `CommandPaneOpenData.tree_expanded: Option<bool>` (`backend/rpc_types.rs`).
+- `build_pane_meta` (editor arm): writes `editor:tree_expanded` when present (`app_api.rs`).
+- Frontend already honors it. Compiles (srv + mcp `cargo check` green).
+
+### 3.2 Floating pane (server-owns, flashless)
+
+`OpenEditor(floating: true)` → `pane.open` body `floating: true`.
+
+`CommandPaneOpenData` gains `floating: Option<bool>`. In `open_pane`, when `floating == Some(true)`,
+it delegates to `open_pane_floating`:
+
+1. Resolve the source workspace from the reducer's `state.tabs[tab].workspace_id`.
+2. **Create the block via the reducer** `Command::CreateBlock{tab_id, meta}` (NOT `wcore::create_block`)
+   — the `tear_off_block` saga's pre-condition checks the reducer-canonical `state.blocks` map, and
+   only the reducer command populates it. The emitted `BlockCreated` event also carries the meta,
+   which `persist_subscriber::apply_block_created` writes into the wstore Block (so the editor renders
+   with its file + tree state). We apply the events to wstore + `publish_events`. **No layout
+   placement is enqueued**, so the block never renders docked (no flash).
+3. Run `sagas::tear_off_block::run(state, block_id, source_tab_id, source_ws_id)` →
+   `CreateWorkspace`→`CreateTab`→`MoveBlock` → `{new_workspace_id, new_tab_id}`, then
+   `service::setup_torn_off_block_layout` (now `pub(crate)`) makes the block the new tab's root.
+4. Broadcast `waveobj:update` for the new workspace/tab/layout/block on the event bus (mirrors the
+   docked path + the tear-off DnD handler) so other frontends' WaveObj caches sync.
+5. Resolve the **source window**: `state.windows` entry whose `workspace_id == source_ws_id` →
+   `window_id`. Publish a scoped directive via the WPS broker:
+   `broker.publish(WaveEvent{ event: "openfloatingpane", scopes: [window_id],
+   data: {block_id, workspace_id: new_workspace_id} })`. (Scoped delivery goes through the broker, not
+   `event_bus.broadcast_event` which is unfiltered.) Transient directive — no new reducer `Event`.
+6. Return `PaneOpenResult{ block_id, tab_id: new_tab_id, view, created: true }`.
+
+Frontend (`initGlobalEventSubs`, scoped to `windowId`):
+
+```ts
+{ eventType: "openfloatingpane", scope: initOpts.windowId, handler: (event) => {
+    const { block_id, workspace_id } = event.data;
+    // geometry computed frontend-side (srv has no cursor): centered default size
+    invokeCommand("open_floating_pane_window", {
+        pane_id: block_id, workspace_id, x, y, width, height,
+    });
+}}
+```
+
+The new floater window boots → `?floatingPaneId&workspaceId` → `FloatingPaneWorkspace` renders the
+editor. **No new window machinery** — reuses `tear_off_block` (saga), `open_floating_pane_window`
+(host), `FloatingPaneWorkspace` (renderer), and the scoped-event channel.
+
+### 3.3 Why server-owns over docked-then-tear-off
+Alternative: open docked, then have the frontend call `TearOffBlock` + `open_floating_pane_window`
+(literal drag-path replay). Rejected: it flashes the pane docked first and splits the orchestration
+across two round-trips. Server-owns keeps the reducer-state move atomic in one `open_pane` call
+(the architecture's contract: srv owns reducer state via sagas; frontend owns the OS-window spawn).
+
+---
+
+## 4. File-by-file change list
+
+| File | Change | Status |
+|---|---|---|
+| `agentmux-mcp/src/main.rs` | `collapse_tree` + `floating` tool params → body fields | ✅ done |
+| `agentmux-srv/src/backend/rpc_types.rs` | `CommandPaneOpenData.tree_expanded` + `.floating` | ✅ done |
+| `agentmux-srv/src/server/app_api.rs` | `build_pane_meta` tree key; `open_pane` floating branch + `open_pane_floating` (reducer CreateBlock + tear_off_block saga + window resolution + scoped broker directive) | ✅ done |
+| `agentmux-srv/src/server/service.rs` | `setup_torn_off_block_layout` → `pub(crate)` | ✅ done |
+| `frontend/app/store/global.ts` | `openfloatingpane` subscription (scope=windowId) → host `open_floating_pane_window` | ✅ done |
+| `.changesets/` | `feat(pane.open): OpenEditor collapse_tree + floating-pane support` | ✅ done |
+
+No new host command, no new reducer `Event` variant, no new saga. `cargo check -p agentmux-srv
+-p agentmux-mcp` green; `tsc --noEmit` clean for `global.ts`. **Floating still needs a CEF-build
+smoke test** (the srv→frontend→host cross-process path can't be unit-tested).
+
+---
+
+## 5. Testing
+
+- **Collapsed tree:** `OpenEditor(file, collapse_tree:true)` → editor opens with tree hidden;
+  toggling still works (meta round-trips). `cargo check -p agentmux-srv -p agentmux-mcp` (green).
+- **Floating:** `OpenEditor(file, floating:true)` → a chromeless floating window appears showing the
+  editor; the source window is unchanged; closing the floater behaves like a torn-off pane.
+  Requires a full `task package` / `task dev` (CEF) build to smoke — the cross-process path can't be
+  unit-tested.
+- **Regression:** plain `OpenEditor(file)` unchanged (docked split); `split`/`title` unaffected.
+
+---
+
+## 6. Risks / open items
+
+- **Window resolution** (source workspace → `window_id`) relies on the main window being registered
+  in `state.windows` via `CreateWindow` (it is, per `app-init.ts:282`). If a window is missing from
+  the map, the directive won't route — fall back is "no floater opens" (safe, logged), not a crash.
+- **Geometry**: srv has no cursor, so the frontend picks a default size/position (centered). Could
+  later accept `x/y/width/height` hints on the tool.
+- **Scope id parity**: frontend `initOpts.windowId` must equal the reducer's `window_id` for the
+  source window (same id used by the working `userinput` scoped sub — reused deliberately).
+- Floating panes are subordinate (owned) windows on Windows; macOS/Linux Phase A is a frameless CEF
+  window (redock is a follow-up per the macOS spec). Behavior matches the existing drag tear-off.

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -304,6 +304,44 @@ export function initGlobalEventSubs(initOpts: AgentMuxInitOpts) {
                 setLanDiscoveryErrorAtom(String(errMsg));
             },
         },
+        {
+            // Server-initiated floating pane (e.g. OpenEditor(floating:true)).
+            // srv creates the block + tears it into a fresh floating workspace,
+            // then broadcasts this directive scoped to the source window — srv
+            // can't open OS windows, so the window's frontend calls the host
+            // `open_floating_pane_window` command (same as a drag tear-off).
+            // See docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md.
+            eventType: "openfloatingpane",
+            scope: initOpts.windowId,
+            handler: (event) => {
+                const data = event.data as { block_id?: string; workspace_id?: string };
+                if (!data?.block_id || !data?.workspace_id) return;
+                void (async () => {
+                    try {
+                        const { invokeCommand } = await import("@/app/platform/ipc");
+                        // width/height are DIP on all platforms; x/y are physical
+                        // px on Windows, DIP on macOS/Linux (see floating_pane.rs).
+                        // Center a default-sized floater over the current window.
+                        const dpr = window.devicePixelRatio || 1;
+                        const isWindows = /Windows/i.test(navigator.userAgent);
+                        const width = Math.max(600, Math.min(1200, Math.round(window.innerWidth * 0.5)));
+                        const height = Math.max(400, Math.min(900, Math.round(window.innerHeight * 0.6)));
+                        const cssX = window.screenX + Math.max(0, (window.outerWidth - width) / 2);
+                        const cssY = window.screenY + Math.max(0, (window.outerHeight - height) / 2);
+                        await invokeCommand("open_floating_pane_window", {
+                            pane_id: data.block_id,
+                            workspace_id: data.workspace_id,
+                            x: isWindows ? Math.round(cssX * dpr) : Math.round(cssX),
+                            y: isWindows ? Math.round(cssY * dpr) : Math.round(cssY),
+                            width,
+                            height,
+                        });
+                    } catch (e) {
+                        console.error("[openfloatingpane] failed to open floating window", e);
+                    }
+                })();
+            },
+        },
     );
 }
 


### PR DESCRIPTION
## What

Extends the `OpenEditor` MCP tool (and the underlying `pane.open` RPC / `POST /api/v1/pane/open`) with two options:

- **`collapse_tree`** — open the editor with its file-tree sidebar collapsed (just the file, no explorer). Writes `editor:tree_expanded=false` into block meta; the frontend `EditorViewModel` already restores it on init, so **no frontend change**.
- **`floating`** — open the file in a floating window instead of a docked split, reusing the existing tear-off floating-pane pipeline.

## How (floating)

srv can't open OS windows — only the host can, driven by the frontend. So `open_pane_floating`:

1. Creates the block via the **reducer `CreateBlock`** (not `wcore::create_block`) so it lands in `state.blocks` — the `tear_off_block` saga's precondition checks the reducer-canonical block map; `BlockCreated` also mirrors meta into the wstore Block so the editor renders. **Layout placement is skipped** so it never renders docked (no flash).
2. Runs the existing **`tear_off_block` saga** (`CreateWorkspace`→`CreateTab`→`MoveBlock`) into a fresh floating workspace + `setup_torn_off_block_layout`.
3. Broadcasts `waveobj:update`s, then publishes a **window-scoped `openfloatingpane` directive via the WPS broker**.
4. The source window's frontend (`global.ts`, scoped to `windowId` like `userinput`) handles it and calls the existing host command **`open_floating_pane_window`** → `FloatingPaneWorkspace`.

No new host command, reducer `Event` variant, or saga.

## Verification

- `cargo check -p agentmux-srv -p agentmux-mcp` — green.
- `tsc --noEmit` — clean for `global.ts` (project-wide pre-existing TS errors untouched).
- ⚠️ The **floating** srv→frontend→host cross-process path still needs a `task package`/`task dev` (CEF) **smoke test** — it can't be unit-tested.

Spec: `docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)