### PR TITLE
feat(muxbus): unified agent-discovery endpoint + DiscoverAgents tool

### DIFF
--- a/.changesets/1781651198-feat-muxbus-unified-agent-discovery-endpoint-discoveragents--wzms.md
+++ b/.changesets/1781651198-feat-muxbus-unified-agent-discovery-endpoint-discoveragents--wzms.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): unified agent-discovery endpoint + DiscoverAgents tool (host/LAN/WAN, addressable flag)

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -68,6 +68,15 @@ const SEND_MESSAGE_TOOL: &str = r#"{
   }
 }"#;
 
+const DISCOVER_AGENTS_TOOL: &str = r#"{
+  "name": "DiscoverAgents",
+  "description": "List the agents and instances reachable from here across the muxbus delivery tiers (host, LAN, cloud), so you can pick a valid target before SendMessage. Returns JSON: host.addressable (agents reachable right now via local delivery), host.agents (this host's agent directory, each with an `addressable` flag), lan (LAN peers and the agents on them), and wan.subscribed_agents (cloud-subscribed agents). Addressing is by agent name, case-insensitive. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
 const OPEN_EDITOR_TOOL: &str = r#"{
   "name": "OpenEditor",
   "description": "Open a file in an AgentMux editor pane next to this conversation. Use when you want the user to see a file you're discussing or editing. Pass an absolute host path. Fire-and-forget: returns once the pane is opened.",
@@ -156,10 +165,12 @@ async fn main() {
                 let shell_stop: Value = serde_json::from_str(SHELL_STOP_TOOL).expect("static json");
                 let open_editor: Value = serde_json::from_str(OPEN_EDITOR_TOOL).expect("static json");
                 let send_message: Value = serde_json::from_str(SEND_MESSAGE_TOOL).expect("static json");
+                let discover_agents: Value =
+                    serde_json::from_str(DISCOVER_AGENTS_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents] }
                 })
             }
             "tools/call" => {
@@ -439,6 +450,35 @@ async fn call_tool(
                     .unwrap_or("unknown error");
                 anyhow::bail!("Message delivery failed: {err}")
             }
+        }
+        "DiscoverAgents" => {
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/agentmux/discovery", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("discovery failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -126,6 +126,15 @@ impl CloudSubscriber {
     pub fn reload_token(&self) {
         let _ = self.ctrl_tx.send(CtrlMsg::ReloadToken);
     }
+
+    /// Snapshot of the agents this sidecar has subscribed to the cloud relay
+    /// (Tier-4), sorted for stable output. Empty when no MUXBUS_TOKEN is set
+    /// (cloud disabled). Read-only; used by the discovery endpoint.
+    pub fn subscribed_agents(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.agents.lock().unwrap().iter().cloned().collect();
+        v.sort();
+        v
+    }
 }
 
 // ── Background loop ───────────────────────────────────────────────────────────

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -226,6 +226,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/docsite/*path", get(files::handle_docsite))
         .route("/schema/*path", get(files::handle_schema))
         .route("/api/lan-instances", get(handle_lan_instances))
+        .route("/agentmux/discovery", get(handle_discovery))
         .route("/agentmux/diag/sagas", get(handle_diag_sagas))
         // Streaming-bash wrapper publish endpoint
         // (SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §4.3). agentmux-bashwrap
@@ -332,6 +333,67 @@ async fn handle_diag_sagas(State(state): State<AppState>) -> Json<serde_json::Va
 
 async fn handle_lan_instances(State(state): State<AppState>) -> Json<serde_json::Value> {
     Json(json!(state.lan_discovery.get_instances()))
+}
+
+/// `GET /agentmux/discovery` — a unified, agent-facing view of what exists and
+/// what is reachable across the muxbus delivery tiers, so an agent can resolve a
+/// target before sending. Aggregates:
+///   - `host.addressable`: the authoritative Tier-1/2 reachable set
+///     (`reactive_handler.list_agents()` — every entry has a live block_id).
+///   - `host.agents`: this host's agent directory (SQLite `instance_list`),
+///     each flagged `addressable` iff its name is in the reachable set.
+///   - `lan`: Tier-3 mDNS peers (each `LanInstance` carries its own `agents`).
+///   - `wan.subscribed_agents`: Tier-4 cloud subscriptions (empty when no token).
+/// Addressing is case-insensitive (registration lowercases the key). Authed like
+/// the other reactive routes; agents reach it via AGENTMUX_LOCAL_URL + X-AuthKey.
+/// See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
+async fn handle_discovery(State(state): State<AppState>) -> Json<serde_json::Value> {
+    use std::collections::HashSet;
+
+    // Tier-1/2 reachable set — the authoritative "addressable" answer.
+    let reachable = state.reactive_handler.list_agents();
+    let addressable: HashSet<String> =
+        reachable.iter().map(|a| a.agent_id.to_lowercase()).collect();
+
+    // Host directory (live SQLite instances), each flagged against the
+    // reachable set. Hidden ("forgotten") rows are excluded.
+    let instances = state.wstore.instance_list(None, None).unwrap_or_default();
+    let agents: Vec<serde_json::Value> = instances
+        .into_iter()
+        .filter(|i| !i.display_hidden)
+        .map(|i| {
+            let is_addressable = !i.instance_name.is_empty()
+                && addressable.contains(&i.instance_name.to_lowercase());
+            json!({
+                "name": i.instance_name,
+                "id": i.id,
+                "definition_id": i.definition_id,
+                "block_id": i.block_id,
+                "status": i.status,
+                "working_directory": i.working_directory,
+                "addressable": is_addressable,
+            })
+        })
+        .collect();
+
+    let wan_agents = crate::muxbus::cloud_subscriber::get_global_subscriber()
+        .map(|s| s.subscribed_agents())
+        .unwrap_or_default();
+
+    let lan = state.lan_discovery.get_instances();
+    let version = state.version.clone();
+    let local_url = state.local_web_url.clone();
+
+    Json(json!({
+        "host": {
+            "version": version,
+            "local_url": local_url,
+            "addressable": reachable,
+            "agents": agents,
+        },
+        "lan": lan,
+        "wan": { "subscribed_agents": wan_agents },
+    }))
 }
 
 async fn stub_501() -> impl IntoResponse {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -348,30 +348,36 @@ async fn handle_lan_instances(State(state): State<AppState>) -> Json<serde_json:
 /// the other reactive routes; agents reach it via AGENTMUX_LOCAL_URL + X-AuthKey.
 /// See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
 async fn handle_discovery(State(state): State<AppState>) -> Json<serde_json::Value> {
-    use std::collections::HashSet;
-
-    // Tier-1/2 reachable set — the authoritative "addressable" answer.
+    // Tier-1/2 reachable set — the authoritative "addressable" answer. Keep the
+    // live block_id per name (lowercased) so an addressable row can surface its
+    // real delivery block; the SQLite directory below does not carry one.
     let reachable = state.reactive_handler.list_agents();
-    let addressable: HashSet<String> =
-        reachable.iter().map(|a| a.agent_id.to_lowercase()).collect();
+    let reachable_block: std::collections::HashMap<String, String> = reachable
+        .iter()
+        .map(|a| (a.agent_id.to_lowercase(), a.block_id.clone()))
+        .collect();
 
-    // Host directory (live SQLite instances), each flagged against the
-    // reachable set. Hidden ("forgotten") rows are excluded.
+    // Host directory (live SQLite instances). `instance_list` already excludes
+    // hidden (user_hidden = 0) and template rows in SQL, and the consolidated
+    // path leaves block_id/status empty (agents.rs) — so addressability AND the
+    // live block_id come from the reachable set above. `block_id` is null for a
+    // known-but-unreachable agent; the always-empty `status` is omitted.
     let instances = state.wstore.instance_list(None, None).unwrap_or_default();
     let agents: Vec<serde_json::Value> = instances
         .into_iter()
-        .filter(|i| !i.display_hidden)
         .map(|i| {
-            let is_addressable = !i.instance_name.is_empty()
-                && addressable.contains(&i.instance_name.to_lowercase());
+            let live_block = if i.instance_name.is_empty() {
+                None
+            } else {
+                reachable_block.get(&i.instance_name.to_lowercase()).cloned()
+            };
             json!({
                 "name": i.instance_name,
                 "id": i.id,
                 "definition_id": i.definition_id,
-                "block_id": i.block_id,
-                "status": i.status,
                 "working_directory": i.working_directory,
-                "addressable": is_addressable,
+                "addressable": live_block.is_some(),
+                "block_id": live_block,
             })
         })
         .collect();


### PR DESCRIPTION
Follow-up to #1499 (persistent-agent delivery). Together they close the "directory ≠ delivery registry" gap: an agent can now *see* what exists and what's actually reachable, and (with #1499) persistent panes are reachable.

## What
A unified, agent-facing discovery surface across the muxbus tiers.

### `GET /agentmux/discovery` (authed)
```jsonc
{
  "host": {
    "version": "0.46.0",
    "local_url": "http://127.0.0.1:PORT",
    "addressable": [ /* reactive_handler.list_agents() — Tier-1/2 reachable NOW (carries block_id) */ ],
    "agents":      [ { "name": "...", "id": "...", "definition_id": "...",
                       "working_directory": "...",
                       "addressable": true,
                       "block_id": "blk_..." /* live block when addressable, else null */ } ]
  },
  "lan": [ /* LanInstance[] — Tier-3 mDNS peers + their agents */ ],
  "wan": { "subscribed_agents": [ /* Tier-4 cloud subscriptions */ ] }
}
```
- **`host.addressable`** is the authoritative reachable set (every entry has a live `block_id`).
- **`host.agents`** is this host's directory (SQLite `instance_list`), each flagged `addressable` iff its name is in the reachable set (case-insensitive). `block_id` is sourced from the reachable set — the real live delivery block when addressable, `null` otherwise. (The consolidated `instance_list` path doesn't carry block_id/status, so those aren't faked here.)
- Registered in the authed route block next to `/api/lan-instances`; agents reach it via `AGENTMUX_LOCAL_URL` + `X-AuthKey`.

### `DiscoverAgents` MCP tool
First-class tool in `agentmux-mcp` (mirrors `SendMessage`): GETs the endpoint and returns the JSON, so an agent can enumerate valid targets *before* `SendMessage` instead of guessing.

### Plumbing
One new public accessor — `CloudSubscriber::subscribed_agents()` (read-only snapshot). No AppState changes.

## Why
This is the gap that made testing muxbus painful: `Naki` was visible in "My Agents" (directory) yet `SendMessage → Naki` returned `agent not found` (delivery registry). `DiscoverAgents` surfaces that distinction directly via the `addressable` flag.

## Verification
- ✅ `cargo check -p agentmux-srv -p agentmux-mcp` clean.
- ✅ reagent P1/P2 addressed (block_id now live-or-null, dead hidden-filter removed).
- ⚠️ Live response not captured from the authoring env. Once running: `curl -s -H "X-AuthKey: $AGENTMUX_AUTH_KEY" "$AGENTMUX_LOCAL_URL/agentmux/discovery" | jq`. With #1499 also merged, persistent panes show `addressable: true`.

## Notes
- Design doc (`SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.md`) lands with #1499.
- Known upstream gap (out of scope): `LanInstance.agents` is currently populated empty on the advertise/resolve path, so LAN peers list but their agent arrays may be empty until that's filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)