### PR TITLE
feat(host+ui): low-memory warning banner driven by mem_pressure

### DIFF
--- a/.changesets/1781651220-feat-host-ui-low-memory-warning-banner-driven-by-mem-pressur-6pd8.md
+++ b/.changesets/1781651220-feat-host-ui-low-memory-warning-banner-driven-by-mem-pressur-6pd8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host+ui): low-memory warning banner driven by mem_pressure

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -815,8 +815,10 @@ fn main() {
     macos_menu::install_menu_bar(app_state.clone());
 
     // Start memory heartbeat — logs system/process memory stats every 20s.
-    // Provides forensic data if the process later crashes from OOM / VA exhaustion.
-    memory_heartbeat::start();
+    // Provides forensic data if the process later crashes from OOM / VA
+    // exhaustion, and drives the debounced mem_pressure level + low-memory
+    // banner (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.A/§5.F).
+    memory_heartbeat::start(app_state.clone());
 
     // Phase B.6 (post-fix): publish port:token AFTER CEF init so a
     // second launcher only forwards `open_new_window` when we're

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -43,7 +43,7 @@ pub fn commit_free_mb() -> u64 {
 /// Spawn a background thread that logs memory stats at a fixed interval.
 /// Also refreshes the log pointer file on UTC date rollover.
 /// Runs for the lifetime of the process — no shutdown signal needed.
-pub fn start() {
+pub fn start(state: std::sync::Arc<crate::state::AppState>) {
     std::thread::Builder::new()
         .name("mem-heartbeat".into())
         .spawn(move || {
@@ -53,9 +53,12 @@ pub fn start() {
                 std::thread::sleep(Duration::from_secs(20));
                 log_memory_stats();
                 // Feed the debounced memory-pressure tracker from the just-
-                // sampled commit-free; log only on a level transition (the
-                // observability foundation the proactive-shedding responses
-                // will read — SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.A).
+                // sampled commit-free; on a level transition, log it AND push
+                // the new level to the frontend low-memory banner
+                // (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.A/§5.F). The
+                // emit is posted to the CEF UI thread (this is a background
+                // thread); the banner shows on Warn/Critical and clears on the
+                // return to Normal.
                 let free = commit_free_mb();
                 if let Some(level) = pressure.observe(free) {
                     tracing::warn!(
@@ -64,6 +67,7 @@ pub fn start() {
                         commit_free_mb = free,
                         "system memory pressure changed"
                     );
+                    crate::ui_tasks::post_memory_pressure(&state, level.as_str(), free);
                 }
                 refresh_log_pointer(&mut last_date);
             }

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -60,14 +60,26 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
                 // thread); the banner shows on Warn/Critical and clears on the
                 // return to Normal.
                 let free = commit_free_mb();
-                if let Some(level) = pressure.observe(free) {
+                let transition = pressure.observe(free);
+                let level_now = pressure.level();
+                if let Some(level) = transition {
                     tracing::warn!(
                         target: "mem_pressure",
                         level = level.as_str(),
                         commit_free_mb = free,
                         "system memory pressure changed"
                     );
-                    crate::ui_tasks::post_memory_pressure(&state, level.as_str(), free);
+                }
+                // Push to the banner on a transition (to show or clear it), AND
+                // re-assert a steady non-Normal level each tick so a window
+                // opened or reloaded mid-episode catches up within one heartbeat
+                // rather than staying silent until the next transition (reagent
+                // #1501 P2 — the CustomEvent channel has no replay-on-subscribe).
+                // Idempotent on existing windows (the frontend dedups an
+                // unchanged level and a re-assert never un-dismisses); a steady
+                // Normal stays silent, so there's no traffic in the common case.
+                if transition.is_some() || level_now != crate::memory_pressure::PressureLevel::Normal {
+                    crate::ui_tasks::post_memory_pressure(&state, level_now.as_str(), free);
                 }
                 refresh_log_pointer(&mut last_date);
             }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -81,6 +81,39 @@ pub fn post_close_window(state: &Arc<AppState>, label: &str) {
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Memory-pressure → frontend banner event ────────────────────────────────
+
+wrap_task! {
+    pub struct EmitMemoryPressureTask {
+        state: Arc<AppState>,
+        level: String,
+        commit_free_mb: u64,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let payload = serde_json::json!({
+                "level": self.level,
+                "commit_free_mb": self.commit_free_mb,
+            });
+            crate::events::emit_event_to_top_level_windows(
+                &self.state,
+                "memory-pressure",
+                &payload,
+            );
+        }
+    }
+}
+
+/// Push a memory-pressure level transition to the frontend banner. Callable
+/// from ANY thread (the memory heartbeat runs on a background std::thread); the
+/// emit itself (CEF JS execution) must run on the UI thread, so it's wrapped in
+/// a posted task. SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F.
+pub fn post_memory_pressure(state: &Arc<AppState>, level: &str, commit_free_mb: u64) {
+    let mut task = EmitMemoryPressureTask::new(state.clone(), level.to_string(), commit_free_mb);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Minimize ─────────────────────────────────────────────────────────────
 
 wrap_task! {

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -30,6 +30,7 @@ import { PerfHud } from "@/perf/hud";
 import { DiagPanel } from "./devtools/diag-panel";
 import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
+import { MemoryPressureBanner } from "./notification/memory-pressure-banner";
 import { BundleManagerElsewhereBanner } from "./modals/bundle-manager-modal";
 
 import "./app.scss";
@@ -423,6 +424,10 @@ const AppInner = () => {
                     bundles. */}
                 <Show when={!IS_FLOATING_PANE}>
                     <BundleManagerElsewhereBanner />
+                    {/* Low-memory warning banner — app-wide, non-modal,
+                        dismissible. Driven by the host's mem_pressure level
+                        (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F). */}
+                    <MemoryPressureBanner />
                 </Show>
                 <Show
                     when={IS_FLOATING_PANE}

--- a/frontend/app/notification/memory-pressure-banner.scss
+++ b/frontend/app/notification/memory-pressure-banner.scss
@@ -1,0 +1,48 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Low-memory warning banner (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F).
+// App-wide, non-modal, dismissible. Token-driven; no raw hex except the warning
+// fallback (no --warning-color token guaranteed across themes).
+
+.memory-pressure-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1-5) var(--space-3);
+    flex: 0 0 auto;
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    border-bottom: 1px solid var(--border-color);
+    // Warn: amber-tinted; Critical: error-tinted (overridden below).
+    background: color-mix(in srgb, var(--warning-color, #d89614) 18%, var(--main-bg-color));
+
+    &--critical {
+        background: color-mix(in srgb, var(--error-color) 22%, var(--main-bg-color));
+    }
+
+    &-icon {
+        flex: 0 0 auto;
+        font-size: var(--text-md);
+    }
+
+    &-text {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    &-dismiss {
+        flex: 0 0 auto;
+        background: transparent;
+        border: none;
+        color: var(--secondary-text-color);
+        cursor: var(--cursor-interactive);
+        font-size: var(--text-md);
+        line-height: 1;
+        padding: 0 var(--space-1);
+
+        &:hover {
+            color: var(--main-text-color);
+        }
+    }
+}

--- a/frontend/app/notification/memory-pressure-banner.test.ts
+++ b/frontend/app/notification/memory-pressure-banner.test.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { severity, shouldShow, type PressureLevel } from "./memory-pressure-banner";
+
+describe("memory-pressure banner — severity", () => {
+    it("orders normal < warn < critical", () => {
+        expect(severity("normal")).toBe(0);
+        expect(severity("warn")).toBe(1);
+        expect(severity("critical")).toBe(2);
+    });
+});
+
+describe("memory-pressure banner — shouldShow", () => {
+    const notDismissed: PressureLevel = "normal";
+
+    it("hides at normal regardless of dismissal", () => {
+        expect(shouldShow("normal", "normal")).toBe(false);
+        expect(shouldShow("normal", "warn")).toBe(false);
+    });
+
+    it("shows on warn/critical when not dismissed", () => {
+        expect(shouldShow("warn", notDismissed)).toBe(true);
+        expect(shouldShow("critical", notDismissed)).toBe(true);
+    });
+
+    it("stays hidden after dismissing at the same level", () => {
+        expect(shouldShow("warn", "warn")).toBe(false);
+        expect(shouldShow("critical", "critical")).toBe(false);
+    });
+
+    it("re-shows when pressure escalates past the dismissed level", () => {
+        // Dismissed at warn, then escalates to critical → show again.
+        expect(shouldShow("critical", "warn")).toBe(true);
+    });
+
+    it("stays hidden when pressure de-escalates below the dismissed level", () => {
+        // Dismissed at critical, drops to warn → still hidden (less severe).
+        expect(shouldShow("warn", "critical")).toBe(false);
+    });
+});

--- a/frontend/app/notification/memory-pressure-banner.tsx
+++ b/frontend/app/notification/memory-pressure-banner.tsx
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * MemoryPressureBanner — a non-modal, dismissible, app-wide banner that warns
+ * the user when the host detects low system memory, BEFORE the cliff.
+ * SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F.
+ *
+ * The host (`memory_heartbeat` → `mem_pressure`, #1494) emits a `memory-pressure`
+ * event carrying the debounced level on every transition; this renders a warning
+ * (Warn) / error (Critical) banner and clears it when the level returns to
+ * normal. It is **purely informational** — the user (closing a window or another
+ * app) is the most reliable lever; the banner never touches renderers or windows.
+ *
+ * Dismiss is sticky per *severity*: dismissing at Warn keeps it hidden until
+ * pressure escalates to Critical or a fresh episode begins (level returns to
+ * Normal then rises again), so it can't nag while the user is already acting.
+ *
+ * The show/dismiss decision is a pure function (`shouldShow`) so it's unit-tested
+ * without a renderer. End-to-end the banner can be exercised from DevTools:
+ *   window.dispatchEvent(new CustomEvent('agentmux-event',
+ *     { detail: { event: 'memory-pressure', payload: { level: 'warn' } } }))
+ */
+
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
+import { listenEvent } from "@/app/platform/ipc";
+import "./memory-pressure-banner.scss";
+
+export type PressureLevel = "normal" | "warn" | "critical";
+
+interface MemoryPressurePayload {
+    level: PressureLevel;
+    commit_free_mb?: number;
+}
+
+/** Ordinal severity, so escalation (warn→critical) can re-show a dismissed banner. */
+export function severity(level: PressureLevel): number {
+    return level === "critical" ? 2 : level === "warn" ? 1 : 0;
+}
+
+/** Show the banner iff there is pressure AND it is more severe than the level the
+ *  user last dismissed at. (`dismissedAt === "normal"` means "not dismissed".) */
+export function shouldShow(level: PressureLevel, dismissedAt: PressureLevel): boolean {
+    return severity(level) > 0 && severity(level) > severity(dismissedAt);
+}
+
+const MESSAGE: Record<Exclude<PressureLevel, "normal">, string> = {
+    warn: "System memory is running low. Closing some windows or other applications will keep AgentMux responsive.",
+    critical:
+        "System memory is critically low — an out-of-memory crash is imminent. Close some windows or other apps now to keep your work safe.",
+};
+
+export const MemoryPressureBanner = () => {
+    const [level, setLevel] = createSignal<PressureLevel>("normal");
+    // The level at which the user last dismissed; "normal" = not dismissed.
+    const [dismissedAt, setDismissedAt] = createSignal<PressureLevel>("normal");
+
+    onMount(() => {
+        let unsub: (() => void) | undefined;
+        void listenEvent<MemoryPressurePayload>("memory-pressure", (p) => {
+            const next: PressureLevel = p?.level ?? "normal";
+            setLevel(next);
+            // A return to Normal ends the episode → re-arm so the next episode
+            // shows even if the user had dismissed the previous one.
+            if (next === "normal") setDismissedAt("normal");
+        }).then((u) => {
+            unsub = u;
+        });
+        onCleanup(() => unsub?.());
+    });
+
+    const visible = () => shouldShow(level(), dismissedAt());
+
+    return (
+        <Show when={visible()}>
+            <div
+                class={`memory-pressure-banner memory-pressure-banner--${level()}`}
+                role="status"
+                aria-live="polite"
+            >
+                <span class="memory-pressure-banner-icon" aria-hidden="true">
+                    {level() === "critical" ? "⚠" : "▲"}
+                </span>
+                <span class="memory-pressure-banner-text">
+                    {level() === "critical" ? MESSAGE.critical : MESSAGE.warn}
+                </span>
+                <button
+                    class="memory-pressure-banner-dismiss"
+                    type="button"
+                    title="Dismiss"
+                    aria-label="Dismiss low-memory warning"
+                    onClick={() => setDismissedAt(level())}
+                >
+                    ×
+                </button>
+            </div>
+        </Show>
+    );
+};
+
+MemoryPressureBanner.displayName = "MemoryPressureBanner";


### PR DESCRIPTION
## Why

`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16` §5.F — the **user-facing half** of the merged detection (#1494). It warns the user *before* the memory cliff instead of after, so they can free memory (the single most reliable lever — close a window or another app) while it still helps. On 2026-06-16 commit-free sat near zero for ~20 min with **no signal** before the host OOM-crashed; this surfaces exactly that.

Tracked in [Discussion #943](https://github.com/agentmuxai/agentmux/discussions/943); the lowest-risk slice of the memory-pressure response set.

## What

**Host** (`agentmux-cef`): on a `mem_pressure` level transition the heartbeat posts a `memory-pressure` event (level + `commit_free_mb`) to the frontend via the existing `emit_event_to_top_level_windows` (the same path `pool:promote` uses), wrapped in a UI-thread task (`ui_tasks::post_memory_pressure`) because the heartbeat runs on a background `std::thread`. `memory_heartbeat::start` now takes the `AppState`.

**UI**: a non-modal, dismissible, **app-wide** banner (`memory-pressure-banner.tsx`, mounted in `app.tsx` next to the existing `BundleManagerElsewhereBanner`):
- amber on **Warn** (< 1 GB commit-free), error-tinted on **Critical** (< 512 MB), cleared on the return to Normal.
- **Dismiss is sticky per severity** — dismissing at Warn keeps it hidden until pressure escalates to Critical or a fresh episode begins, so it never nags while the user is already acting.

## Risk

**Purely informational** — unlike the warm-pool drain / CDP purge, this response *never touches renderers or windows*. It only renders a banner. That's why it's the safe first response to ship.

## Verification

- `cargo build -p agentmux-cef` ✓ · `task build:frontend` ✓ · `tsc` clean on touched files.
- **6 unit tests** over the pure show/dismiss/escalation logic (`shouldShow` / `severity`).
- The banner renders independently of real pressure — exercisable from DevTools:
  ```js
  window.dispatchEvent(new CustomEvent('agentmux-event', { detail: { event: 'memory-pressure', payload: { level: 'warn' } } }))
  ```
- The host-emit-at-threshold is established by #1494's tested tracker; the full under-real-pressure path is observable in the wild (per the deferred-verification decision in Discussion #943).

🤖 Generated with [Claude Code](https://claude.com/claude-code)