### PR TITLE
fix(agent): apply model/effort changes to running persistent (Claude) agents

### DIFF
--- a/.changesets/1781652454-fix-agent-apply-model-effort-permission-changes-to-running-p-wbrq.md
+++ b/.changesets/1781652454-fix-agent-apply-model-effort-permission-changes-to-running-p-wbrq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): apply model/effort/permission changes to running persistent (Claude) agents via resume-preserving restart

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -50,6 +50,17 @@ pub struct PersistentSpawnConfig {
     pub working_dir: String,
     pub env_vars: HashMap<String, String>,
     pub session_id_field: String,
+    /// Resume flag for this provider (e.g. "--resume"), read from
+    /// `agent:resume_flag` meta. Empty = provider has no simple-flag resume.
+    /// Mirrors `SubprocessSpawnConfig::resume_flag` so a respawn (after a
+    /// runtime/model change or the picker reattach path) continues the same
+    /// conversation instead of starting fresh.
+    pub resume_flag: String,
+    /// Session id to hydrate `inner.session_id` with BEFORE spawning, when the
+    /// controller hasn't captured one yet (fresh controller after a forced
+    /// restart, or picker reattach). Read from `agent:sessionid` meta. With a
+    /// non-empty `resume_flag` this makes `--resume <sid>` land on the respawn.
+    pub session_id: String,
     /// Echoed back as `agent-message-accepted` so the frontend can promote the
     /// pending entry. Matches `CommandAgentInputData.message_id` on the AgentInput
     /// command; absent for legacy callers.
@@ -369,7 +380,36 @@ impl PersistentSubprocessController {
     fn spawn_process(&self, config: PersistentSpawnConfig) -> Result<(), String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
-        cmd.args(&config.cli_args);
+
+        // Hydrate the captured session id from the config when we don't have one
+        // yet (fresh controller after a forced restart — e.g. a /model change —
+        // or the picker reattach path). Mirrors SubprocessController::
+        // hydrate_session_id_from_config so the respawn resumes the same
+        // conversation instead of starting blank.
+        if !config.session_id.is_empty() {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.session_id.is_none() {
+                inner.session_id = Some(config.session_id.clone());
+            }
+        }
+
+        // Append `--resume <sid>` when we have a session id and the provider
+        // supports simple-flag resume — same construction as
+        // SubprocessController::spawn_turn. This is what makes a model/effort
+        // change (which respawns the persistent CLI with new flags) preserve the
+        // conversation. cli_args carries the runtime flags (model/effort/perm)
+        // already rebuilt by the frontend (useAgentCommands buildRuntimeArgs).
+        let mut spawn_args = config.cli_args.clone();
+        {
+            let inner = self.inner.lock().unwrap();
+            if let Some(ref sid) = inner.session_id {
+                if !config.resume_flag.is_empty() {
+                    spawn_args.push(config.resume_flag.clone());
+                    spawn_args.push(sid.clone());
+                }
+            }
+        }
+        cmd.args(&spawn_args);
 
         // Working directory
         if !config.working_dir.is_empty() {
@@ -450,7 +490,7 @@ impl PersistentSubprocessController {
             block_id = %self.block_id,
             pid = pid,
             cmd = %config.cli_command,
-            args = ?config.cli_args,
+            args = ?spawn_args,
             working_dir = %config.working_dir,
             "persistent process spawned"
         );

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -539,12 +539,23 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     if agent_mode == "container" {
                         return Err("container agents require a subprocess controller; this provider uses a persistent controller".to_string());
                     }
+                    // Resume parity with the subprocess path: pass the resume
+                    // flag + captured session id so a respawn (e.g. after a
+                    // /model change) continues the same conversation.
+                    let resume_flag = obj::meta_get_string(
+                        &block.meta, "agent:resume_flag", "--resume",
+                    );
+                    let persisted_session_id = obj::meta_get_string(
+                        &block.meta, "agent:sessionid", "",
+                    );
                     let config = blockcontroller::persistent::PersistentSpawnConfig {
                         cli_command,
                         cli_args,
                         working_dir,
                         env_vars,
                         session_id_field,
+                        resume_flag,
+                        session_id: persisted_session_id,
                         message_id: None,
                     };
                     persistent_ctrl.send_message(cmd.message, config)?;

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1085,12 +1085,26 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     if agent_mode == "container" {
                         return Err("container agents require a subprocess controller; this provider uses a persistent controller".to_string());
                     }
+                    // Resume support: a /model (or effort/permission) change
+                    // respawns the persistent CLI with new flags; pass the
+                    // resume flag + captured session id so the respawn continues
+                    // the same conversation. Same meta keys the subprocess path
+                    // reads below. Without this, switching model on a persistent
+                    // agent would either no-op (old behavior) or lose context.
+                    let resume_flag = crate::backend::obj::meta_get_string(
+                        &block.meta, "agent:resume_flag", "--resume",
+                    );
+                    let persisted_session_id = crate::backend::obj::meta_get_string(
+                        &block.meta, "agent:sessionid", "",
+                    );
                     let config = blockcontroller::persistent::PersistentSpawnConfig {
                         cli_command,
                         cli_args,
                         working_dir,
                         env_vars,
                         session_id_field,
+                        resume_flag,
+                        session_id: persisted_session_id,
                         message_id: cmd.message_id.clone(),
                     };
                     persistent_ctrl.send_message(cmd.message, config)?;

--- a/docs/analysis/ANALYSIS_PERSISTENT_AGENT_MODEL_SWITCH_REGRESSION_2026_06_16.md
+++ b/docs/analysis/ANALYSIS_PERSISTENT_AGENT_MODEL_SWITCH_REGRESSION_2026_06_16.md
@@ -1,0 +1,83 @@
+# ANALYSIS: Model switch silently no-ops on running Claude agents (regression)
+
+**Date:** 2026-06-16
+**Author:** Naki
+**Severity:** regression — `/model`, `/effort`, `/permission-mode` (and the inline pickers)
+silently stopped taking effect on a running Claude agent.
+**Regressing commit:** `a05060b0` (PR #1451, 2026-06-15) — *"feat(agent): answer AskUserQuestion
+via the Agent SDK control protocol"*
+
+---
+
+## 1. Symptom
+
+User changes the model (e.g. Opus → Sonnet) on a running Claude agent pane; the agent keeps
+responding on the old model. "It was working before."
+
+## 2. Root cause
+
+The model/effort/permission are passed to the agent CLI as **spawn-time flags** (`--model`,
+`--effort`, permission flags) built by `buildRuntimeArgs` from `block.meta["agent:runtime"]`.
+
+- **Subprocess controllers** (`controllerType: "subprocess"` — codex, gemini, …) spawn a *fresh
+  process per turn with `--resume`* (`providers/index.ts:75`), so a runtime change is picked up on
+  the next turn. The slash/picker handlers say *"applies to next turn"* — true here.
+- **Persistent controllers** (`controllerType: "persistent"` — Claude stream-json) spawn **one
+  process on the first message and keep it alive** across turns
+  (`backend/blockcontroller/persistent.rs:8-11`); turns just write to stdin. The frontend still
+  rewrites `cmd:args` every turn (`hooks/useAgentCommands.ts:325-333`) and the runtime handler still
+  writes `agent:runtime` (`commands/global/runtime.ts`), but **nothing restarts the live process**,
+  so the new `--model` never takes effect.
+
+`resync_controller(force=true)` (`blockcontroller/mod.rs:367-379`) *does* cleanly restart a
+controller — but no code called it on a runtime change, and the persistent controller had **no
+resume support** (no `resume_flag` in `PersistentSpawnConfig`; line 16's "auto-restart via
+session_id" was aspirational), so even a restart would have dropped the conversation.
+
+## 3. How it regressed
+
+PR #1451 / `a05060b0` (2026-06-15) flipped Claude from `subprocess` → `persistent`
+(`providers/index.ts:170`, `git blame`) to add the Agent SDK control protocol (AskUserQuestion /
+mid-turn steering). That switch silently invalidated the *"applies on next turn"* assumption the
+runtime-change path relies on — but the runtime path was never updated to restart persistent
+controllers. So model/effort/permission changes have silently no-op'd on Claude agents since
+2026-06-15.
+
+## 4. Evidence (live trace of this Naki pane)
+
+srv v0.46.0 log, block `91580ebe-5917-419b-b783-cd242ea2c9af`:
+- `21:35:38` `persistent process spawned … args=[… "--model","opus","--effort","xhigh"]` — **once**.
+- `23:04:47` `SetMeta agent:runtime`, `23:05:04`/`23:05:58` `SetMeta cmd:args` — the model change *is*
+  written to meta.
+- **No** `ControllerResync` / spawn / stop after `21:35:38`; the string `sonnet` never appears in the
+  log; the only live model token is `claude-opus-4-8`. → meta updated, live process unchanged.
+
+## 5. Fix
+
+**Frontend** (`commands/global/runtime.ts`): after writing `agent:runtime`, if the controller is
+persistent, rebuild `cmd:args` (same `buildRuntimeArgs` the per-turn path uses) and call
+`ControllerResyncCommand{forcerestart:true}`. `resync_controller` swaps in a fresh controller
+instance (no process-waiter race), and the change applies immediately.
+
+**Server — resume parity** (`blockcontroller/persistent.rs`, `server/websocket.rs`,
+`server/app_api.rs`): `PersistentSpawnConfig` gains `resume_flag` + `session_id` (read from
+`agent:resume_flag` / `agent:sessionid` meta — the same keys the subprocess path already reads).
+`spawn_process` hydrates `inner.session_id` and appends `--resume <sid>` when present — a verbatim
+mirror of `SubprocessController::spawn_turn` (subprocess.rs:364-378). So the forced restart respawns
+Claude with the new `--model` **and** resumes the same conversation (no context loss).
+
+Net: subprocess behavior is unchanged; persistent agents now apply runtime changes via a
+resume-preserving restart — restoring the pre-#1451 behavior.
+
+## 6. Testing
+
+- `cargo check -p agentmux-srv` green; `tsc --noEmit` clean for `runtime.ts`.
+- ⚠️ Needs a `task dev`/`task package` (CEF) smoke test: change `/model` on a running Claude pane →
+  confirm the next turn runs on the new model and the conversation continues (resume).
+
+## 7. Follow-ups
+
+- Consider restarting only when a *spawn-affecting* field actually changed (model/effort/permission)
+  to avoid an unnecessary respawn when the picker re-confirms the current value.
+- The slash/picker success messages still say "applies to next turn"; for persistent it now restarts
+  — wording could be tightened.

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -19,7 +19,8 @@
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
-import { getRuntimeConfig } from "../../buildRuntimeArgs";
+import { staticTabId } from "@/app/store/global";
+import { buildRuntimeArgs, getRuntimeConfig } from "../../buildRuntimeArgs";
 import type { AgentRuntimeConfig, EffortLevel, PermissionMode } from "../../types";
 import type { SlashChoice, SlashCommand, SlashCommandContext, SlashResult } from "../types";
 
@@ -44,6 +45,33 @@ async function updateRuntime(
             oref: WOS.makeORef("block", ctx.blockId),
             meta: { "agent:runtime": updated },
         });
+
+        // PERSISTENT controllers (Claude stream-json) keep ONE CLI process alive
+        // across turns, so runtime flags (model/effort/permission) baked in at
+        // spawn never change from a meta-only update — the picker would silently
+        // no-op. (Subprocess controllers re-spawn per turn, so it just works
+        // there.) Rebuild cmd:args and force a controller restart; the persistent
+        // controller now resumes via --resume so the conversation is preserved.
+        //
+        // Regression: PR #1451 (a05060b0, 2026-06-15) flipped Claude from
+        // subprocess→persistent for the Agent SDK control protocol without
+        // teaching the runtime-change path to restart persistent controllers, so
+        // /model (and the inline picker) silently stopped taking effect.
+        const prov = ctx.provider();
+        if (prov?.controllerType === "persistent") {
+            const baseArgs = prov.persistentLaunchArgs ?? prov.launchArgs;
+            const updatedArgs = buildRuntimeArgs(baseArgs, updated, prov.id);
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", ctx.blockId),
+                meta: { "cmd:args": updatedArgs },
+            });
+            await RpcApi.ControllerResyncCommand(TabRpcClient, {
+                tabid: staticTabId(),
+                blockid: ctx.blockId,
+                forcerestart: true,
+            });
+        }
+
         return { ok: true, updated };
     } catch (err: any) {
         return { ok: false, error: err?.message ?? String(err) };


### PR DESCRIPTION
## Symptom

Changing the model (e.g. Opus → Sonnet) — or effort / permission-mode — on a **running Claude agent** silently does nothing; it keeps responding on the old model. "It was working before."

## Root cause

Model/effort/permission are **spawn-time CLI flags** (`--model`, `--effort`, …) built from `block.meta["agent:runtime"]`.

- **Subprocess** controllers (codex/gemini/…) re-spawn a fresh process **per turn** with `--resume`, so a change applies next turn — the handlers' *"applies to next turn"* wording is true there.
- **Persistent** controllers (Claude stream-json) keep **one process alive** across turns (`persistent.rs`); turns just write to stdin. The frontend still rewrites `cmd:args` and `agent:runtime`, but **nothing restarts the live process**, so the new `--model` never lands.

## How it regressed

**PR #1451 (`a05060b0`, 2026-06-15)** — *"answer AskUserQuestion via the Agent SDK control protocol"* — flipped Claude from `subprocess` → `persistent` (`providers/index.ts:170`, confirmed via `git blame`). That silently invalidated the *"applies on next turn"* assumption the runtime-change path relies on, and the runtime path was never updated to restart persistent controllers. So `/model` (and the inline picker) have no-op'd on Claude since 2026-06-15.

**Live evidence** (this Naki pane, srv v0.46.0): block spawned **once** at 21:35:38 with `--model opus`; later `SetMeta agent:runtime` + `cmd:args` at 23:04–23:05, but **no respawn**, no `sonnet` anywhere in the srv log, live model still `claude-opus-4-8`.

## Fix

- **Frontend** (`commands/global/runtime.ts`): on a runtime change for a persistent controller, rebuild `cmd:args` (the same `buildRuntimeArgs` the per-turn path uses) and call `ControllerResync{forcerestart:true}`. `resync_controller` swaps in a fresh controller instance — no process-waiter race.
- **Server resume parity** (`persistent.rs` + `websocket.rs` + `app_api.rs`): `PersistentSpawnConfig` gains `resume_flag` + `session_id` (read from `agent:resume_flag` / `agent:sessionid` meta — the keys the subprocess path already reads). `spawn_process` hydrates the session id and appends `--resume <sid>` on respawn — a verbatim mirror of `SubprocessController::spawn_turn`. So the restart respawns Claude with the new `--model` **and** resumes the same conversation (no context loss).

Subprocess behavior is unchanged.

## Verification

- `cargo check -p agentmux-srv` green; `tsc --noEmit` clean for `runtime.ts`.
- ⚠️ Needs a `task dev`/`task package` (CEF) smoke test: switch `/model` on a running Claude pane → next turn runs on the new model and the conversation continues.

Analysis: `docs/analysis/ANALYSIS_PERSISTENT_AGENT_MODEL_SWITCH_REGRESSION_2026_06_16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)