### PR TITLE
feat(trust-center): add AgentMux Cloud account to the Accounts gallery

### DIFF
--- a/.changesets/1781660786-feat-trust-center-add-agentmux-cloud-as-a-virtual-first-clas-mx7n.md
+++ b/.changesets/1781660786-feat-trust-center-add-agentmux-cloud-as-a-virtual-first-clas-mx7n.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): add AgentMux Cloud as a virtual first-class account in the Accounts gallery (brain-alternate logo, reuses the existing muxbus PKCE sign-in)

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -47,6 +47,11 @@ export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
 
         if (p === "muxcode" || p === "mux-code" || p === "mux_code") return { html: brainSvg };
 
+        // AgentMux's own brand mark — the brain-alternate logo. `brainSvg`
+        // (@/app/asset/logo-brain.svg) is byte-identical to the source
+        // frontend/logos/agentmux-logo-brain-alternate.svg.
+        if (p === "agentmux") return { html: brainSvg };
+
         // Handcrafted multi-color Slack mark (the package ships only a mono
         // variant; the brand is recognized by its four colors).
         if (p === "slack") {

--- a/frontend/app/view/accounts/AccountsGallery.tsx
+++ b/frontend/app/view/accounts/AccountsGallery.tsx
@@ -15,15 +15,37 @@ import type { AccountKind, AccountProvider, IdentityViewModel } from "@/app/view
 import { SERVICE_CATALOG, modeLabel, type AuthMode, type ServiceTile } from "./accounts-catalog";
 import "./accounts-gallery.scss";
 
-export function AccountsGallery({ model }: { model: IdentityViewModel }): JSX.Element {
+export function AccountsGallery(props: {
+    model: IdentityViewModel;
+    /** True when an AgentMux Cloud session is connected — drives the agentmux
+     *  tile's "1 connected" badge (projected, not a stored IdentityAccount). */
+    agentMuxConnected?: () => boolean;
+    /** Open the dedicated AgentMux connect panel instead of the OAuth/Key
+     *  chooser. Required for the agentmux tile to do anything. */
+    onAgentMux?: () => void;
+}): JSX.Element {
+    const model = props.model;
     const [chooser, setChooser] = createSignal<ServiceTile | null>(null);
 
-    const countFor = (id: AccountProvider): number => model.accountsByProvider().get(id)?.length ?? 0;
+    const countFor = (id: AccountProvider): number => {
+        if (id === "agentmux") return props.agentMuxConnected?.() ? 1 : 0;
+        return model.accountsByProvider().get(id)?.length ?? 0;
+    };
 
     const pick = (tile: ServiceTile, mode: AuthMode) => {
         const kind: AccountKind = mode === "oauth" ? "oauth" : tile.keyKind;
         setChooser(null);
         model.openAddFormFor(tile.id, kind);
+    };
+
+    const openTile = (tile: ServiceTile) => {
+        // AgentMux Cloud is a singleton session, not a per-credential account —
+        // open its dedicated connect panel rather than the OAuth/Key chooser.
+        if (tile.id === "agentmux") {
+            props.onAgentMux?.();
+            return;
+        }
+        setChooser(tile);
     };
 
     return (
@@ -37,7 +59,7 @@ export function AccountsGallery({ model }: { model: IdentityViewModel }): JSX.El
                                 type="button"
                                 class="account-tile"
                                 classList={{ "account-tile--connected": n() > 0 }}
-                                onClick={() => setChooser(tile)}
+                                onClick={() => openTile(tile)}
                                 aria-label={`${tile.displayName} — ${n()} connected, add account`}
                             >
                                 <Show when={n() > 0}>

--- a/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
+++ b/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
@@ -1,0 +1,277 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentMux Cloud connect — the single, shared implementation of the AgentMux
+ * Cloud sign-in (Cognito hosted-UI PKCE). Backed by the `muxbus.login /
+ * .status / .disconnect` RPCs and the singleton credential store
+ * (`db_muxbus_credentials`, one global row). AgentMux Cloud is one app-wide
+ * session — NOT a pluralizable IdentityAccount — so it never goes through the
+ * generic service-OAuth path (`oauth_client.rs` / `account.oauth.*`).
+ *
+ * Two consumers share this module so there is exactly one implementation:
+ *   - `MuxBusConnectSection` — the per-agent identity panel (AgentIdentityPanel).
+ *   - `AgentMuxConnectPanel` — the Trust Center → Accounts gallery tile.
+ *
+ * The gallery additionally projects the signed-in session into the connected
+ * list as a read-only row; that projection lives in `accounts-manager.tsx` and
+ * reads the same controller (`useMuxBusStatus`) so connect/disconnect refresh
+ * the tile, the row, and the panel together.
+ *
+ * See SPEC_TRUST_CENTER_2026_06_15.md and muxbus/pkce.rs.
+ */
+
+import { createSignal, onMount, Show, type Accessor, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { ProviderLogo } from "@/element/ProviderLogo";
+
+// Production Cognito config — set after deployment.
+// Override with VITE_MUXBUS_COGNITO_DOMAIN / VITE_MUXBUS_CLIENT_ID at build time.
+const MUXBUS_COGNITO_DOMAIN =
+    (import.meta.env.VITE_MUXBUS_COGNITO_DOMAIN as string | undefined) ??
+    "https://muxbus-auth-prod.auth.us-east-1.amazoncognito.com";
+const MUXBUS_CLIENT_ID =
+    (import.meta.env.VITE_MUXBUS_CLIENT_ID as string | undefined) ?? "";
+
+export interface MuxBusStatus {
+    connected: boolean;
+    email: string;
+    cognitoDomain: string;
+    expiresAt: number;
+    valid: boolean;
+}
+
+const DISCONNECTED: MuxBusStatus = {
+    connected: false,
+    email: "",
+    cognitoDomain: "",
+    expiresAt: 0,
+    valid: false,
+};
+
+/**
+ * Shared reactive controller for the AgentMux Cloud session. One instance is
+ * the single source of truth for any UI that needs connection state — pass the
+ * same controller to the gallery tile, the read-only row, and the connect
+ * panel so a connect/disconnect updates all of them.
+ */
+export interface MuxBusController {
+    status: Accessor<MuxBusStatus | null>;
+    loading: Accessor<boolean>;
+    error: Accessor<string | null>;
+    /** Re-pull `muxbus.status`. Treats any error as "disconnected". */
+    refresh: () => Promise<void>;
+    /** Run the browser PKCE login (blocks up to 5 min), then refresh. */
+    connect: () => Promise<void>;
+    /** Clear stored credentials, then refresh. */
+    disconnect: () => Promise<void>;
+    /** False when no built-in client id is baked into this build. */
+    isConfigured: () => boolean;
+}
+
+export function useMuxBusStatus(): MuxBusController {
+    const [status, setStatus] = createSignal<MuxBusStatus | null>(null);
+    const [loading, setLoading] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const refresh = async () => {
+        try {
+            setStatus(await RpcApi.MuxBusStatusCommand(TabRpcClient));
+        } catch {
+            // no credentials or server not reachable — treat as disconnected
+            setStatus({ ...DISCONNECTED });
+        }
+    };
+
+    const connect = async () => {
+        if (!MUXBUS_CLIENT_ID) {
+            setError("AgentMux client ID not configured (contact AgentMux team).");
+            return;
+        }
+        setError(null);
+        setLoading(true);
+        try {
+            const result = await RpcApi.MuxBusLoginCommand(TabRpcClient, {
+                cognitoDomain: MUXBUS_COGNITO_DOMAIN,
+                clientId: MUXBUS_CLIENT_ID,
+            });
+            if (result.success) {
+                await refresh();
+            } else {
+                setError(result.error ?? "Login failed.");
+            }
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const disconnect = async () => {
+        setError(null);
+        setLoading(true);
+        try {
+            await RpcApi.MuxBusDisconnectCommand(TabRpcClient);
+            await refresh();
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const isConfigured = () => MUXBUS_CLIENT_ID !== "";
+
+    return { status, loading, error, refresh, connect, disconnect, isConfigured };
+}
+
+/** Human-readable local expiry, or null when not connected. */
+function expiryLabel(status: MuxBusStatus | null): string | null {
+    if (!status?.connected) return null;
+    return new Date(status.expiresAt * 1000).toLocaleString();
+}
+
+/**
+ * Per-agent identity panel section (unchanged UI). Owns its own controller so
+ * the agent panel keeps working independently of the Trust Center tab.
+ */
+export const MuxBusConnectSection = (): JSX.Element => {
+    const muxbus = useMuxBusStatus();
+    onMount(() => void muxbus.refresh());
+    const { status, loading, error } = muxbus;
+
+    return (
+        <div class="agent-identity-muxbus">
+            <div class="agent-identity-section-title">AgentMux Cloud</div>
+            <Show
+                when={status()?.connected}
+                fallback={
+                    <div class="agent-identity-muxbus-row">
+                        <span class="agent-identity-none">Not connected</span>
+                        <button
+                            class="agent-identity-new-btn"
+                            disabled={loading()}
+                            onClick={() => void muxbus.connect()}
+                        >
+                            {loading() ? "Connecting…" : "Connect"}
+                        </button>
+                    </div>
+                }
+            >
+                <div class="agent-identity-muxbus-row">
+                    <div class="agent-identity-muxbus-info">
+                        <span class="agent-identity-account-name">{status()!.email}</span>
+                        <Show when={!status()!.valid}>
+                            <span class="agent-identity-muxbus-expired"> (token expired)</span>
+                        </Show>
+                        <Show when={expiryLabel(status())}>
+                            <span class="agent-identity-muxbus-expiry"> · expires {expiryLabel(status())}</span>
+                        </Show>
+                    </div>
+                    <button
+                        class="agent-identity-unassign-btn"
+                        disabled={loading()}
+                        title="Disconnect from AgentMux Cloud"
+                        onClick={() => void muxbus.disconnect()}
+                    >
+                        Disconnect
+                    </button>
+                </div>
+            </Show>
+            <Show when={error()}>
+                <div class="agent-identity-error">{error()}</div>
+            </Show>
+        </div>
+    );
+};
+
+MuxBusConnectSection.displayName = "MuxBusConnectSection";
+
+/**
+ * Trust Center → Accounts gallery connect panel. Renders in the existing
+ * accounts-chooser modal shell (no new SCSS). Uses the controller owned by
+ * `AccountsManager` so the tile/row/panel stay in sync.
+ */
+export function AgentMuxConnectPanel(props: {
+    muxbus: MuxBusController;
+    onClose: () => void;
+}): JSX.Element {
+    const { muxbus } = props;
+    return (
+        <div
+            class="accounts-chooser-overlay"
+            onClick={(e) => e.target === e.currentTarget && props.onClose()}
+        >
+            <div class="accounts-chooser" role="dialog" aria-label="Connect AgentMux">
+                <div class="accounts-chooser-header">
+                    <span class="account-tile-logo">
+                        <ProviderLogo provider="agentmux" size={20} />
+                    </span>
+                    <span class="accounts-chooser-title">Connect AgentMux</span>
+                    <button
+                        type="button"
+                        class="accounts-chooser-close"
+                        onClick={() => props.onClose()}
+                        aria-label="Close"
+                    >
+                        ✕
+                    </button>
+                </div>
+                <div class="accounts-chooser-modes">
+                    <Show when={muxbus.error()}>
+                        <div class="identity-form-error">{muxbus.error()}</div>
+                    </Show>
+
+                    <Show
+                        when={muxbus.isConfigured()}
+                        fallback={
+                            <div class="oauth-byo-note">
+                                ⓘ AgentMux Cloud sign-in isn’t configured in this build (client ID
+                                missing). Contact the AgentMux team.
+                            </div>
+                        }
+                    >
+                        <Show
+                            when={muxbus.status()?.connected}
+                            fallback={
+                                <>
+                                    <div class="oauth-byo-note">
+                                        ⓘ Sign in to AgentMux Cloud in your browser — one account per
+                                        install, no key to manage.
+                                    </div>
+                                    <div class="identity-key-actions">
+                                        <button
+                                            class="identity-btn identity-btn-primary"
+                                            disabled={muxbus.loading()}
+                                            onClick={() => void muxbus.connect()}
+                                        >
+                                            {muxbus.loading() ? "Connecting…" : "Connect with AgentMux"}
+                                        </button>
+                                    </div>
+                                </>
+                            }
+                        >
+                            <div class="oauth-byo-note">
+                                Connected as{" "}
+                                <strong>{muxbus.status()!.email || "AgentMux Cloud"}</strong>
+                                <Show when={!muxbus.status()!.valid}> (token expired)</Show>
+                            </div>
+                            <div class="identity-key-actions">
+                                <button
+                                    class="identity-btn identity-btn-secondary"
+                                    disabled={muxbus.loading()}
+                                    onClick={() => void muxbus.disconnect()}
+                                >
+                                    Disconnect
+                                </button>
+                            </div>
+                        </Show>
+                    </Show>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+AgentMuxConnectPanel.displayName = "AgentMuxConnectPanel";

--- a/frontend/app/view/accounts/accounts-catalog.ts
+++ b/frontend/app/view/accounts/accounts-catalog.ts
@@ -28,6 +28,11 @@ export interface ServiceTile {
 }
 
 export const SERVICE_CATALOG: ServiceTile[] = [
+    // AgentMux Cloud — the flagship brand. A singleton browser sign-in (Cognito
+    // PKCE), not a per-credential OAuth/Key account: the gallery intercepts its
+    // tile click to open a dedicated connect panel, so `authModes`/`keyKind`
+    // below are inert placeholders kept only to satisfy the ServiceTile shape.
+    { id: "agentmux", displayName: "AgentMux", authModes: ["oauth"], keyKind: "api_key", blurb: "AgentMux Cloud sign-in" },
     { id: "github", displayName: "GitHub", authModes: ["oauth", "key"], keyKind: "pat", blurb: "Repos, Actions, PRs" },
     { id: "google", displayName: "Google", authModes: ["oauth"], keyKind: "api_key", blurb: "Workspace, Cloud" },
     // AWS OAuth (IAM Identity Center / OIDC device) isn't wired in the backend

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -12,12 +12,22 @@
 // composes the already-built `AccountsTab` + `AccountForm` so styling and the
 // add/edit/delete lifecycle come for free. Identity-bundle and Memory
 // management remain in their own Trust Center tabs.
+//
+// AgentMux Cloud is also surfaced here as a "virtual first-class account": it
+// is a single app-wide session (the `muxbus.*` singleton), NOT a pluralizable
+// IdentityAccount, so it is not stored in `db_identity_accounts`. Instead this
+// tab projects the live `muxbus.status` into the gallery tile count and a
+// read-only connected row, and drives connect/disconnect through the shared
+// `useMuxBusStatus` controller. Scoped to this tab only — the per-agent
+// identity panel is unaffected.
 
-import { onCleanup, Show, type JSX } from "solid-js";
+import { createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { BlockNodeModel } from "@/app/block/blocktypes";
 import { IdentityViewModel } from "@/app/view/identity/identity-model";
 import { AccountsTab, AccountForm } from "@/app/view/identity/identity-view";
+import { ProviderLogo } from "@/element/ProviderLogo";
 import { AccountsGallery } from "./AccountsGallery";
+import { AgentMuxConnectPanel, useMuxBusStatus } from "./AgentMuxConnectPanel";
 import "@/app/view/identity/identity-view.scss";
 
 export function AccountsManager(): JSX.Element {
@@ -28,6 +38,21 @@ export function AccountsManager(): JSX.Element {
     // bodies run a single time).
     const model = new IdentityViewModel("trust-center:accounts", {} as BlockNodeModel);
     onCleanup(() => model.dispose());
+
+    // Shared AgentMux Cloud session controller — single source of truth for the
+    // tile count, the read-only row, and the connect panel.
+    const muxbus = useMuxBusStatus();
+    onMount(() => void muxbus.refresh());
+
+    const [muxPanelOpen, setMuxPanelOpen] = createSignal(false);
+    const agentMuxConnected = () => muxbus.status()?.connected === true;
+
+    const muxStatusDot = (): string => {
+        const s = muxbus.status();
+        if (s?.connected && s.valid) return "status-dot status-valid";
+        if (s?.connected) return "status-dot status-expired";
+        return "status-dot status-unknown";
+    };
 
     return (
         <div class="identity-view">
@@ -43,18 +68,60 @@ export function AccountsManager(): JSX.Element {
             </div>
 
             <div class="identity-body">
-                {/* Brand-tile landing: pick a service → OAuth / Key. */}
-                <AccountsGallery model={model} />
-                {/* Connected accounts (manage existing). Gated on having any —
-                    the gallery above is the empty/landing state. */}
-                <Show when={model.accountsAtom().length > 0}>
+                {/* Brand-tile landing: pick a service → OAuth / Key, or AgentMux. */}
+                <AccountsGallery
+                    model={model}
+                    agentMuxConnected={agentMuxConnected}
+                    onAgentMux={() => setMuxPanelOpen(true)}
+                />
+                {/* Connected accounts (manage existing). Shown when there is any
+                    stored account OR an AgentMux Cloud session is connected. */}
+                <Show when={model.accountsAtom().length > 0 || agentMuxConnected()}>
                     <div class="accounts-connected-heading">Connected accounts</div>
-                    <AccountsTab model={model} />
+                    {/* AgentMux Cloud — read-only projected row (singleton
+                        session, not a stored IdentityAccount). Clicking it opens
+                        the connect panel, where Disconnect lives. */}
+                    <Show when={agentMuxConnected()}>
+                        <div class="identity-accounts-list">
+                            <div class="identity-group">
+                                <div class="identity-group-header">AgentMux</div>
+                                <div
+                                    class="identity-account-row"
+                                    onClick={() => setMuxPanelOpen(true)}
+                                    title="Manage AgentMux Cloud connection"
+                                >
+                                    <span class="identity-provider-badge provider-agentmux">
+                                        <ProviderLogo provider="agentmux" size={16} />
+                                    </span>
+                                    <span class="identity-account-name">
+                                        {muxbus.status()?.email || "AgentMux Cloud"}
+                                    </span>
+                                    <div class="identity-row-meta">
+                                        <span class="identity-display-name">
+                                            AgentMux Cloud
+                                            <Show when={!muxbus.status()?.valid}> · token expired</Show>
+                                        </span>
+                                    </div>
+                                    <span
+                                        class={muxStatusDot()}
+                                        title={muxbus.status()?.valid ? "valid" : "expired"}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </Show>
+                    <Show when={model.accountsAtom().length > 0}>
+                        <AccountsTab model={model} />
+                    </Show>
                 </Show>
             </div>
 
             <Show when={model.formOpenAtom()}>
                 <AccountForm model={model} />
+            </Show>
+
+            <Show when={muxPanelOpen()}>
+                <AgentMuxConnectPanel muxbus={muxbus} onClose={() => setMuxPanelOpen(false)} />
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentIdentityPanel.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityPanel.tsx
@@ -14,7 +14,7 @@
  * through the existing AccountForm via identityModel.openAddForm().
  */
 
-import { createMemo, createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { AccountForm } from "@/app/view/identity/identity-view";
 import { ProviderLogo } from "@/element/ProviderLogo";
 import {
@@ -25,8 +25,7 @@ import {
     PROVIDER_LABELS,
     serializeAgentAccounts,
 } from "@/app/view/identity/identity-model";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
+import { MuxBusConnectSection } from "@/app/view/accounts/AgentMuxConnectPanel";
 
 const ALL_PROVIDERS: AccountProvider[] = ["github", "google", "aws", "openai", "anthropic", "slack", "custom"];
 
@@ -184,128 +183,3 @@ AgentIdentityPanel.displayName = "AgentIdentityPanel";
 
 /** Serialize AgentAccounts to the JSON string stored on AgentDefinition. */
 export { serializeAgentAccounts };
-
-// ── MuxBus Cloud Section ──────────────────────────────────────────────────────
-
-// Production Cognito config — set after deployment.
-// Override with VITE_MUXBUS_COGNITO_DOMAIN / VITE_MUXBUS_CLIENT_ID at build time.
-const MUXBUS_COGNITO_DOMAIN =
-    (import.meta.env.VITE_MUXBUS_COGNITO_DOMAIN as string | undefined) ??
-    "https://muxbus-auth-prod.auth.us-east-1.amazoncognito.com";
-const MUXBUS_CLIENT_ID =
-    (import.meta.env.VITE_MUXBUS_CLIENT_ID as string | undefined) ?? "";
-
-interface MuxBusStatus {
-    connected: boolean;
-    email: string;
-    expiresAt: number;
-    valid: boolean;
-}
-
-export const MuxBusConnectSection = (): JSX.Element => {
-    const [status, setStatus] = createSignal<MuxBusStatus | null>(null);
-    const [loading, setLoading] = createSignal(false);
-    const [error, setError] = createSignal<string | null>(null);
-
-    const refreshStatus = async () => {
-        try {
-            const s = await RpcApi.MuxBusStatusCommand(TabRpcClient);
-            setStatus(s);
-        } catch {
-            // no credentials or server not reachable — treat as disconnected
-            setStatus({ connected: false, email: "", expiresAt: 0, valid: false });
-        }
-    };
-
-    onMount(() => {
-        void refreshStatus();
-    });
-
-    const handleConnect = async () => {
-        if (!MUXBUS_CLIENT_ID) {
-            setError("MuxBus client ID not configured (contact AgentMux team).");
-            return;
-        }
-        setError(null);
-        setLoading(true);
-        try {
-            const result = await RpcApi.MuxBusLoginCommand(TabRpcClient, {
-                cognitoDomain: MUXBUS_COGNITO_DOMAIN,
-                clientId: MUXBUS_CLIENT_ID,
-            });
-            if (result.success) {
-                await refreshStatus();
-            } else {
-                setError(result.error ?? "Login failed.");
-            }
-        } catch (e) {
-            setError(String(e));
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const handleDisconnect = async () => {
-        setError(null);
-        setLoading(true);
-        try {
-            await RpcApi.MuxBusDisconnectCommand(TabRpcClient);
-            await refreshStatus();
-        } catch (e) {
-            setError(String(e));
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const expiryLabel = () => {
-        const s = status();
-        if (!s?.connected) return null;
-        const exp = new Date(s.expiresAt * 1000);
-        return exp.toLocaleString();
-    };
-
-    return (
-        <div class="agent-identity-muxbus">
-            <div class="agent-identity-section-title">AgentMux Cloud</div>
-            <Show
-                when={status()?.connected}
-                fallback={
-                    <div class="agent-identity-muxbus-row">
-                        <span class="agent-identity-none">Not connected</span>
-                        <button
-                            class="agent-identity-new-btn"
-                            disabled={loading()}
-                            onClick={() => void handleConnect()}
-                        >
-                            {loading() ? "Connecting…" : "Connect"}
-                        </button>
-                    </div>
-                }
-            >
-                <div class="agent-identity-muxbus-row">
-                    <div class="agent-identity-muxbus-info">
-                        <span class="agent-identity-account-name">{status()!.email}</span>
-                        <Show when={!status()!.valid}>
-                            <span class="agent-identity-muxbus-expired"> (token expired)</span>
-                        </Show>
-                        <Show when={expiryLabel()}>
-                            <span class="agent-identity-muxbus-expiry"> · expires {expiryLabel()}</span>
-                        </Show>
-                    </div>
-                    <button
-                        class="agent-identity-unassign-btn"
-                        disabled={loading()}
-                        title="Disconnect from AgentMux Cloud"
-                        onClick={() => void handleDisconnect()}
-                    >
-                        Disconnect
-                    </button>
-                </div>
-            </Show>
-            <Show when={error()}>
-                <div class="agent-identity-error">{error()}</div>
-            </Show>
-        </div>
-    );
-};

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -15,7 +15,7 @@ import { Logger } from "@/util/logger";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type AccountProvider = "github" | "openai" | "aws" | "anthropic" | "google" | "slack" | "custom";
+export type AccountProvider = "github" | "openai" | "aws" | "anthropic" | "google" | "slack" | "custom" | "agentmux";
 export type AccountKind = "pat" | "role" | "api_key" | "env_ref" | "oauth";
 export type AccountStatus = "valid" | "expired" | "invalid" | "unknown" | "checking";
 export type IdentityTab = "accounts" | "assignments";
@@ -115,6 +115,7 @@ export const PROVIDER_LABELS: Record<AccountProvider, string> = {
     google: "Google",
     slack: "Slack",
     custom: "Custom",
+    agentmux: "AgentMux",
 };
 
 export const PROVIDER_COLORS: Record<AccountProvider, string> = {
@@ -125,6 +126,7 @@ export const PROVIDER_COLORS: Record<AccountProvider, string> = {
     google: "#e8f0fe",
     slack: "#f3e8fd",
     custom: "#f1f5f9",
+    agentmux: "#ede9fe",
 };
 
 export const KIND_LABELS: Record<AccountKind, string> = {


### PR DESCRIPTION
## What

Surfaces **AgentMux** as a first-class option in the Trust Center → Accounts gallery, with the **brain-alternate logo**, connecting via the AgentMux Cloud sign-in that's already built (Cognito hosted-UI PKCE — `muxbus.login`/`.status`/`.disconnect` + `muxbus/pkce.rs`).

## Why this shape — "virtual first-class account"

AgentMux Cloud is a **singleton session**, not a pluralizable credential: one global row (`db_muxbus_credentials WHERE id='global'`) drives `cloud_subscriber.rs` (one WS) and `MUXBUS_TOKEN` injection into every agent spawn. Forcing it into a generic bindable `IdentityAccount` (via `identity/oauth_client.rs` / `account.oauth.*`) would create **two token stores for the same session**.

So instead: reuse the singleton flow, add a brand tile, and **project** the signed-in session into the connected list as a **read-only** row. A single shared `useMuxBusStatus()` controller is the source of truth for the tile count, the row, and the connect panel — so connect/disconnect refresh all three reactively.

## Changes (frontend-only)

- **New** `frontend/app/view/accounts/AgentMuxConnectPanel.tsx` — shared `useMuxBusStatus` controller + the moved `MuxBusConnectSection` (one implementation, two call sites) + the gallery connect panel (reuses existing chooser/SCSS classes).
- `identity-model.ts` — `agentmux` added to `AccountProvider` + the `PROVIDER_LABELS`/`PROVIDER_COLORS` maps.
- `ProviderLogo.tsx` — `agentmux` → brain-alternate (`brainSvg`, byte-identical to `agentmux-logo-brain-alternate.svg`).
- `accounts-catalog.ts` — AgentMux tile (first in the grid).
- `AccountsGallery.tsx` — intercepts the AgentMux tile click → dedicated panel; projects the "1 connected" badge from `muxbus.status`.
- `accounts-manager.tsx` — owns the controller, renders the read-only projected row, mounts the panel.
- `AgentIdentityPanel.tsx` — imports the shared section (−130 lines).

Scoped to the Trust Center tab: `agentmux` is kept out of `accountsByProvider()`/`ALL_PROVIDERS`, so the per-agent identity panel and assignments matrix are unaffected. No `agentmux-srv`, DB, or cloud changes.

## Known prerequisite (separate)

End-to-end sign-in needs `VITE_MUXBUS_CLIENT_ID` set to the deployed Cognito `DesktopClient` id, and that client's callback URLs must match the desktop loopback redirect. Until then the panel shows a "not configured" state; the tile, panel states, and projected row all render regardless.

## Verification

`tsc --noEmit` typecheck: baseline 31 pre-existing errors vs. with-this-PR 31 — **identical error sets, zero regressions**, none in any touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)