### PR TITLE
fix(agent): seed PTY size at spawn to fix initial agent-pane resize race

### DIFF
--- a/.changesets/1781651181-fix-agent-seed-pty-size-at-spawn-so-the-agent-pane-stops-hit-k1k7.md
+++ b/.changesets/1781651181-fix-agent-seed-pty-size-at-spawn-so-the-agent-pane-stops-hit-k1k7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): seed PTY size at spawn so the agent pane stops hitting 'resize to N cols failed after 3 attempts'

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -37,7 +37,7 @@ use crate::backend::eventbus::EventBus;
 use crate::backend::shellexec::{ConnInterface, ShellProc};
 use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::store::Store;
-use crate::backend::obj::{self, MetaMapType};
+use crate::backend::obj::{self, MetaMapType, RuntimeOpts};
 use crate::backend::wps;
 
 /// Cap on the out-of-order input reorder buffer (`input_seq_buf`).
@@ -314,13 +314,58 @@ impl ShellController {
             super::publish_controller_status(broker, &status);
         }
     }
+
+    /// Resolve the initial PTY geometry from the resync `rt_opts` payload.
+    ///
+    /// The agent pane is a custom UI (not xterm.js), so the PTY never receives
+    /// a `fitAddon` resize and must be born at the right width — otherwise the
+    /// first batch of agent/tool output wraps at the fallback width until a
+    /// post-spawn resize RPC lands, and that RPC races controller startup (it
+    /// can fail outright). The frontend computes cols from the pane and passes
+    /// them as `rtopts.termsize` on the `controllerresync` command (see
+    /// `usePtyWidth.ts` / `launch-flow.ts`).
+    ///
+    /// Falls back to the historical 25x200 default when `rt_opts` is absent,
+    /// unparseable, or carries the serde-default termsize (`rows==0 && cols==0`,
+    /// per `obj::is_default_term_size`). Per-field guards let a cols-only
+    /// payload keep the default row count. Each axis is clamped to `[1, 1000]`
+    /// so the `i64 → u16` cast is lossless and a bogus value cannot open a
+    /// zero-size or wrapped-size PTY.
+    /// See docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+    fn pty_size_from_rt_opts(rt_opts: &Option<serde_json::Value>) -> PtySize {
+        // Historical fallback geometry. Cols 200 keeps the agent-pane live-log
+        // from hard-wrapping at ~80 before the dynamic resize lands.
+        const DEFAULT_PTY_ROWS: u16 = 25;
+        const DEFAULT_PTY_COLS: u16 = 200;
+        let (mut rows, mut cols) = (DEFAULT_PTY_ROWS, DEFAULT_PTY_COLS);
+        if let Some(v) = rt_opts {
+            if let Ok(rt) = serde_json::from_value::<RuntimeOpts>(v.clone()) {
+                let ts = &rt.termsize;
+                // rows==0 && cols==0 is the serde default → treat as absent.
+                if !(ts.rows == 0 && ts.cols == 0) {
+                    if ts.cols > 0 {
+                        cols = ts.cols.clamp(1, 1000) as u16;
+                    }
+                    if ts.rows > 0 {
+                        rows = ts.rows.clamp(1, 1000) as u16;
+                    }
+                }
+            }
+        }
+        PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
 }
 
 impl Controller for ShellController {
     fn start(
         &self,
         block_meta: MetaMapType,
-        _rt_opts: Option<serde_json::Value>,
+        rt_opts: Option<serde_json::Value>,
         force: bool,
     ) -> Result<(), String> {
         let cmd_str_preview = Self::get_cmd_str(&block_meta);
@@ -348,13 +393,12 @@ impl Controller for ShellController {
         // Get connection info
         let conn_name = Self::get_conn_name(&block_meta);
 
-        // Update status to running and publish
+        // Update status to running.
         {
             let mut inner = self.inner.lock().unwrap();
             Self::set_status(&mut inner, STATUS_RUNNING);
             inner.conn_name = conn_name.clone();
         }
-        self.publish_status();
 
         // Create input channel. Unbounded: input must never be silently
         // dropped on burst (the paste-truncation bug). See SHELL_INPUT_CH_SIZE.
@@ -365,6 +409,15 @@ impl Controller for ShellController {
             inner.input_seq_next = 0;
             inner.input_seq_buf.clear();
         }
+
+        // Publish "running" only AFTER `input_tx` exists, so the event is a
+        // truthful readiness signal: a frontend that resizes the PTY the instant
+        // it sees "running" will not hit `send_input`'s "controller is not
+        // running" guard (which fires while `input_tx` is None). The channel is
+        // unbounded, so a resize enqueued before the input task spawns is
+        // buffered, not lost.
+        // See docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+        self.publish_status();
 
         // Check if we have a conn_factory (test/mock path)
         let has_factory = self.conn_factory.lock().unwrap().is_some();
@@ -414,19 +467,17 @@ impl Controller for ShellController {
 
         // Real PTY path.
         //
-        // Initial cols bumped to 200 (was 80) so the agent-pane live-log
-        // doesn't render hard-wrapped at ~80 chars before the frontend's
-        // dynamic resize lands (see hooks/usePtyWidth.ts and
-        // docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md). The dynamic
-        // resize coalesces over a ~150 ms debounce after mount, so the
-        // PTY uses this default for the very first batch of output.
+        // Open the PTY at the size the frontend computed from the pane (passed
+        // as `rtopts.termsize` on the resync), so the agent CLI and its tools
+        // wrap correctly from the very first byte. The earlier code always
+        // opened at a fixed 200 cols and relied on a post-spawn resize RPC to
+        // correct it — but that RPC races controller startup and could fail
+        // outright, leaving output wrapped at 200 all session. Seeding the size
+        // here removes that race; `pty_size_from_rt_opts` falls back to the
+        // historical 25x200 when no size was supplied (e.g. programmatic
+        // spawns). See docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
         let pty_system = native_pty_system();
-        let pty_size = PtySize {
-            rows: 25,
-            cols: 200,
-            pixel_width: 0,
-            pixel_height: 0,
-        };
+        let pty_size = Self::pty_size_from_rt_opts(&rt_opts);
 
         let pair = pty_system.openpty(pty_size).map_err(|e| {
             tracing::error!(block_id = %self.block_id, error = %e, "failed to open PTY");
@@ -437,7 +488,7 @@ impl Controller for ShellController {
             self.unlock_run();
             format!("failed to open PTY: {e}")
         })?;
-        tracing::info!(block_id = %self.block_id, rows = 25, cols = 200, "PTY opened");
+        tracing::info!(block_id = %self.block_id, rows = pty_size.rows, cols = pty_size.cols, "PTY opened");
 
         // Determine shell command
         let cmd_str = Self::get_cmd_str(&block_meta);
@@ -1559,6 +1610,62 @@ mod tests {
             serde_json::Value::String(cmd.to_string()),
         );
         meta
+    }
+
+    // ── pty_size_from_rt_opts ────────────────────────────────────────────
+    // Seeds the initial PTY geometry from the resync `rtopts` payload so the
+    // agent pane is born at the right width (no post-spawn resize race).
+    // See docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+
+    #[test]
+    fn pty_size_defaults_when_rt_opts_absent() {
+        let sz = ShellController::pty_size_from_rt_opts(&None);
+        assert_eq!((sz.rows, sz.cols), (25, 200));
+    }
+
+    #[test]
+    fn pty_size_defaults_when_termsize_is_serde_default() {
+        // rows==0 && cols==0 is the serde default → treat as absent.
+        let v = serde_json::json!({ "termsize": { "rows": 0, "cols": 0 } });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (25, 200));
+    }
+
+    #[test]
+    fn pty_size_honors_supplied_termsize() {
+        let v = serde_json::json!({ "termsize": { "rows": 50, "cols": 130 } });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (50, 130));
+    }
+
+    #[test]
+    fn pty_size_keeps_default_rows_for_cols_only_payload() {
+        let v = serde_json::json!({ "termsize": { "rows": 0, "cols": 130 } });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (25, 130));
+    }
+
+    #[test]
+    fn pty_size_clamps_oversized_values() {
+        let v = serde_json::json!({ "termsize": { "rows": 99999, "cols": 99999 } });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (1000, 1000));
+    }
+
+    #[test]
+    fn pty_size_defaults_on_unparseable_rt_opts() {
+        // Unknown keys deserialize to RuntimeOpts default (termsize 0/0) → fallback.
+        let v = serde_json::json!({ "totally": "unrelated" });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (25, 200));
+    }
+
+    #[test]
+    fn pty_size_ignores_non_positive_axes() {
+        // Negative axes fail the `> 0` guard and keep their default.
+        let v = serde_json::json!({ "termsize": { "rows": -5, "cols": -1 } });
+        let sz = ShellController::pty_size_from_rt_opts(&Some(v));
+        assert_eq!((sz.rows, sz.cols), (25, 200));
     }
 
     #[test]

--- a/docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md
+++ b/docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md
@@ -1,0 +1,291 @@
+# Agent-Pane PTY Resize Race — "resize to N cols failed after 3 attempts"
+
+**Date:** 2026-06-16
+**Status:** Implemented 2026-06-16 (Layers A+B+C below). See changeset `.changesets/1781651181-fix-agent-seed-pty-size-at-spawn-*.md`.
+**Component:** `frontend/app/view/agent/hooks/usePtyWidth.ts` ↔ `agentmux-srv/src/backend/blockcontroller/shell.rs`
+**Related:** `docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md` (the dynamic-resize feature this race lives inside)
+
+---
+
+## 1. Symptom
+
+When a **new agent pane loads**, the activity log occasionally shows:
+
+```
+[pty] resize to 77 cols failed: controller is not running (retrying in 500ms)
+[pty] resize to 77 cols failed: controller is not running (retrying in 1000ms)
+[pty] resize to 77 cols failed after 3 attempts: controller is not running
+```
+
+It is logged at **`warn` level — not fatal**. The visible consequence: the PTY keeps its
+fallback width (see §3) instead of the pane's real width, so the agent CLI and its child
+tools (`git`, `ls`, `claude`) wrap output at the wrong column count until the user manually
+resizes the pane (which fires a fresh, now-succeeding send).
+
+---
+
+## 2. What the code is *trying* to do
+
+The agent pane is a **custom UI, not an xterm.js terminal**, so the PTY hosting the agent CLI
+never receives a `fitAddon`-style resize. `usePtyWidth` compensates:
+
+1. A `ResizeObserver` watches the pane element.
+2. Pixel width → columns: `floor((width − 16px) / (fontSize × 0.6))`, floored at `MIN_COLS = 40`.
+3. Debounced by `DEBOUNCE_MS = 150` so a drag emits one RPC per gesture.
+4. Sends `RpcApi.ControllerInputCommand` with `termsize: { rows, cols }`.
+
+The backend routes that to `master.resize(...)` on the PTY. ("77 cols" is just the computed
+width for the current pane.)
+
+---
+
+## 3. Root cause — a **two-layer** startup race
+
+The code comment in `usePtyWidth.ts` blames *controller-not-yet-registered*. That is real, but
+the trace shows a **second, deeper** ordering bug that makes even "wait for the controller to be
+running" insufficient.
+
+### Layer A — the PTY is born at the wrong size (the actual root cause)
+
+`ShellController::start()` opens the PTY with a **hardcoded default**, never the real width:
+
+```rust
+// agentmux-srv/src/backend/blockcontroller/shell.rs:424
+let pty_size = PtySize { rows: 25, cols: 200, pixel_width: 0, pixel_height: 0 };
+let pair = pty_system.openpty(pty_size) ...;   // shell.rs:431
+```
+
+The comment at `shell.rs:420-422` even concedes: *"the PTY uses this default for the very first
+batch of output."* So the resize RPC is **the only mechanism** that ever corrects the width — and
+it runs *after* spawn, across a process boundary, on a debounce timer. Every byte the agent emits
+before that resize lands is wrapped at 200 cols. **If the resize fails (Layer B), the width is
+simply never corrected for that session.** The entire design hinges on a post-spawn resize
+winning a race it sometimes loses.
+
+### Layer B — `"running"` is published *before* the input channel exists
+
+`send_input` rejects with the exact error string when the input channel is absent:
+
+```rust
+// shell.rs (send_input)
+let tx = match &inner.input_tx {
+    Some(tx) => tx.clone(),
+    None => return Err("controller is not running".to_string()),
+};
+```
+
+But inside `start()` the status broadcast happens **before** `input_tx` is created — verified
+directly:
+
+```rust
+// shell.rs:354  set_status(RUNNING)
+// shell.rs:357  self.publish_status();        // ← broadcasts controllerstatus = "running"
+// shell.rs:361  let (input_tx, input_rx) = mpsc::unbounded_channel();
+// shell.rs:364  inner.input_tx = Some(input_tx);   // ← only NOW can send_input succeed
+```
+
+The actual `master.resize(...)` runs even later, in the spawned input-drain loop:
+
+```rust
+// shell.rs:915-922
+if let Some(ref size) = input.term_size {
+    let pty_size = PtySize { rows: size.rows as u16, cols: size.cols as u16, .. };
+    if let Err(e) = master.resize(pty_size) { ... }
+}
+```
+
+**Consequence:** a frontend that (sensibly) waited for the `controllerstatus: "running"` event and
+*then* sent the resize could **still** hit the `None` branch, because `"running"` is published in
+the window between `set_status` and `input_tx = Some(..)`. The `input_tx` channel is *unbounded*,
+so once it exists a queued resize is safe even before the drain loop starts — but there is **no
+event that fires at the moment `input_tx` becomes available.**
+
+### Timeline
+
+```
+T0     frontend: launch-flow Phase 3 → ControllerResyncCommand RPC
+T0+ε   backend:  register_controller()  → controller visible in registry
+T0+ε   backend:  start(): set_status(RUNNING)
+T0+ε   backend:  publish_status()  ──────────────►  "running" event in flight
+T0+ε   backend:  input_tx = Some(..)        ← gap: send_input fails if hit before here
+T0+ε   backend:  openpty(200×25); spawn child; spawn input-drain loop
+...
+T0+150ms frontend: usePtyWidth debounce fires → ControllerInputCommand({termsize})
+T0+150ms backend:  send_input(): input_tx None?  → "controller is not running"
+```
+
+### Current retry behavior (the backstop that sometimes runs out)
+
+```
+attempt 1: ~T0+150ms          (debounce)
+attempt 2: +500ms  → ~T0+650ms
+attempt 3: +1000ms → ~T0+1650ms
+fail:      "resize to N cols failed after 3 attempts"
+```
+
+A fixed **~1.65 s** window with **no jitter**. On a busy machine (cold agent CLI spawn, auth,
+Tokio scheduling pressure) the controller's input path can come up later than that, and all three
+attempts land in the dead window.
+
+### Key file references
+
+| What | File:line | Verified |
+|---|---|---|
+| Hardcoded spawn size `200×25` | `shell.rs:424-426` | ✅ direct |
+| `openpty` | `shell.rs:431` | ✅ direct |
+| `set_status(RUNNING)` | `shell.rs:354` | ✅ direct |
+| `publish_status()` (before input_tx) | `shell.rs:357` | ✅ direct |
+| `input_tx = Some(..)` | `shell.rs:361-367` | ✅ direct |
+| `master.resize()` in drain loop | `shell.rs:915-922` | ✅ direct (grep) |
+| `"controller is not running"` | `shell.rs` (send_input) | trace |
+| `controllerinput` RPC handler | `websocket.rs:751-759` | trace + grep |
+| `send_input` dispatch | `blockcontroller/mod.rs:271-276` | trace |
+| `resync_controller` (register ~407, start ~408) | `blockcontroller/mod.rs:334-409` | trace |
+| `EVENT_CONTROLLER_STATUS = "controllerstatus"` | `blockcontroller/mod.rs:459-473`, `wps.rs` | trace |
+| Frontend status subscribe | `useControllerStatusEvents.ts:22-40` | trace |
+| Launch Phase 3 `ControllerResyncCommand` | `flows/launch-flow.ts:277-299` | trace |
+| `send`/retry/backoff | `usePtyWidth.ts:91-118` | ✅ direct |
+| Initial debounced send | `usePtyWidth.ts:136-140` | ✅ direct |
+
+> Line numbers marked "trace" come from an automated code trace and may drift by a few lines; the
+> "verified" rows were read directly for this report.
+
+---
+
+## 4. Best practices (researched)
+
+### 4.1 The canonical fix: **set the size at spawn, don't race a post-spawn resize**
+
+This is the strongest and most consistent finding. PTY libraries are explicitly designed to take
+the size up front:
+
+- **node-pty**: `pty.spawn(shell, [], { cols: 80, rows: 30, ... })` — size is a spawn argument;
+  `resize()` is only for *later* changes. ([node-pty](https://github.com/microsoft/node-pty))
+- **creack/pty (Go)**: `StartWithAttrs` "will resize the pty to the specified size **before**
+  starting the command if a size is provided" — precisely to avoid the startup race.
+  ([creack/pty](https://pkg.go.dev/github.com/creack/pty))
+- **`portable-pty`** (the crate AgentMux uses) takes `PtySize` in `openpty()` — AgentMux just
+  hardcodes it to `200×25` instead of using the known pane width.
+
+The matching failure mode is documented: if you spawn at a default size and resize ~tens of ms
+later, the child may not have installed its `SIGWINCH` handler yet and **the resize is silently
+lost**; `bash` keeps `COLUMNS=80` until `checkwinsize` fires (only after external commands, not
+builtins), so it "never self-corrects."
+([R. Koucha — SIGWINCH](http://www.rkoucha.fr/tech_corner/sigwinch.html))
+
+A **near-identical real-world bug and fix** exists: *hermes-ide #113* — "PTY/xterm column mismatch
+causes garbled history navigation and stale remnants." Their fix is the template for ours:
+1. `create_session` accepts `initial_rows`/`initial_cols`; the **frontend estimates dimensions
+   from window size + font settings** and passes them in.
+2. **Re-send resize on `shell_ready`** as a safety net.
+3. **NaN/`isFinite()` guard** before using proposed dimensions.
+([hermes-ide #113](https://github.com/hermes-hq/hermes-ide/issues/113))
+
+xterm.js maintainers note the async resize race "cannot be avoided completely, but can be narrowed
+to a small buffer window" — seeding at spawn is what narrows it.
+([xterm.js #1914](https://github.com/xtermjs/xterm.js/issues/1914))
+
+### 4.2 Readiness signal vs. retry/backoff
+
+- **No universal winner.** Event-driven readiness is precise but introduces ordering hazards that
+  must be guarded with conditional state checks (the classic PostgreSQL startup-signal race).
+  ([Event-Driven.io](https://event-driven.io/en/dealing_with_race_conditions_in_eda_using_read_models/))
+- **Retry must be disciplined:** bounded, *failure-classified* (retry transient like
+  "not running"; never retry permanent errors), and **jittered** to avoid synchronized retry
+  storms. ([AWS Builders' Library](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/))
+- **Most resilient designs combine both:** a signal-aware consumer backed by bounded, jittered
+  retries — exactly the shape we want here (seed at spawn → gate on a *true* ready signal →
+  bounded jittered retry as a backstop).
+
+### 4.3 Frontend dimension hygiene
+
+- Guard `proposeDimensions()`/computed cols against `NaN` and non-positive values — `NaN < 10` is
+  `false`, so naive floors don't catch it. `usePtyWidth.computeCols` is mostly safe
+  (`Math.floor`, `Math.max(1, ..)`, `MIN_COLS` floor) but `readFontSizePx` should keep its finite
+  check. ([hermes-ide #113](https://github.com/hermes-hq/hermes-ide/issues/113))
+- Coalesce drag resizes (already done via the 150 ms debounce). ([xterm.js #1914](https://github.com/xtermjs/xterm.js/issues/1914))
+
+---
+
+## 5. Recommended fix (layered)
+
+Implement in order; **(A) alone eliminates the symptom for the common case.** (B) and (C) make the
+remaining edge cases correct and quiet.
+
+### (A) Seed the PTY size at spawn — *primary fix*
+
+The frontend already knows the width at launch (Phase 3 runs after the pane element exists, and
+`computeCols` is pure). Thread the initial cols/rows down to `openpty`:
+
+- **Frontend** (`flows/launch-flow.ts:277-299`): before `ControllerResyncCommand`, compute
+  `{rows, cols}` from the pane element (reuse `usePtyWidth`'s `computeCols`/`readFontSizePx`,
+  exported via `__test__`) and pass them into the resync — either through `rt_opts` or as
+  `term:rows`/`term:cols` block-meta keys.
+- **Backend** (`shell.rs:320-431`): `start()` currently **ignores** its options arg (note the
+  `_rt_opts` underscore). Read `rows`/`cols` from there (or from `block_meta`), clamp to sane
+  bounds, and use them for `pty_size` instead of the hardcoded `200×25`. Fall back to the default
+  when absent (headless/programmatic spawns).
+
+Result: the PTY is **born at the right width**; the post-spawn resize becomes a *correction for
+later changes*, not a load-bearing race.
+
+### (B) Make `"running"` a truthful readiness signal — *correctness*
+
+Move `self.publish_status()` (`shell.rs:357`) to **after** `inner.input_tx = Some(..)`
+(`shell.rs:367`). Because `input_tx` is unbounded, a resize sent the instant `"running"` arrives is
+then guaranteed to enqueue safely (it drains when the loop starts). This closes Layer B with a
+two-line move.
+
+> ⚠️ Audit consumers of `controllerstatus: "running"` first. Today it means "process status set to
+> running"; after the move it means "running **and** ready for input." `useControllerStatusEvents`
+> only logs on `"running"`, so the risk is low — but confirm nothing treats the earlier semantics
+> as "process is alive" for liveness/timeout purposes.
+
+Then, in `usePtyWidth`, **gate the initial send on the `controllerstatus: "running"` event** (via
+the existing `waveEventSubscribe` pattern used by `useControllerStatusEvents.ts:22-40`) instead of
+firing blindly at `mount + 150 ms`. User-driven `ResizeObserver` sends remain immediate.
+
+### (C) Harden the retry backstop — *defense in depth*
+
+Once (A)+(B) land, retries should rarely fire. Keep them as a backstop but:
+- **Classify:** only retry on transient errors (`"controller is not running"` / `"no controller
+  for block"`); do **not** retry permanent failures.
+- **Jitter:** add randomized jitter to the 500/1000 ms steps to avoid synchronized retries when
+  many panes mount together. (Scripts can't call `Math.random()` in workflows, but app runtime
+  can — use `Math.random()` here.)
+- Optionally widen to ~3–4 attempts with a small cap; with (A)+(B) this is belt-and-suspenders.
+
+### Why not "just widen the backoff"?
+
+It's the option the original comment reaches for, but it only shrinks the dead window — it never
+closes it, it adds latency before the correct width appears, and it leaves the PTY at 200 cols for
+the whole retry window on every cold start. (A) removes the race; widening only manages it.
+
+---
+
+## 6. Suggested change set
+
+| Order | File | Change |
+|---|---|---|
+| A1 | `frontend/app/view/agent/hooks/usePtyWidth.ts` | Export a reusable `computeColsForElement(el)`; keep `computeCols` pure. |
+| A2 | `frontend/app/view/agent/flows/launch-flow.ts` | Compute `{rows, cols}` pre-resync; pass via `rt_opts`/block-meta to `ControllerResyncCommand`. |
+| A3 | `agentmux-srv/src/backend/blockcontroller/shell.rs` | Read rows/cols from options/meta in `start()`; clamp; use for `pty_size` (replace hardcoded `200×25`); default-fallback. |
+| B1 | `agentmux-srv/src/backend/blockcontroller/shell.rs` | Move `publish_status()` (357) to after `input_tx = Some(..)` (367). |
+| B2 | `frontend/app/view/agent/hooks/usePtyWidth.ts` | Gate the *initial* send on the `controllerstatus:"running"` event; keep observer-driven sends immediate. |
+| C1 | `frontend/app/view/agent/hooks/usePtyWidth.ts` | Classify retryable errors; add jitter; small cap. |
+
+Tests: extend `usePtyWidth` `__test__` unit checks (cols math + NaN guard); add a backend test
+that `start()` honors a passed-in size and that `"running"` is published only after `input_tx`
+exists.
+
+---
+
+## 7. References
+
+- node-pty — spawn-time `cols`/`rows`: https://github.com/microsoft/node-pty
+- creack/pty — resize-before-start: https://pkg.go.dev/github.com/creack/pty
+- R. Koucha, "Playing with SIGWINCH" — lost-signal-at-startup: http://www.rkoucha.fr/tech_corner/sigwinch.html
+- hermes-ide #113 — near-identical PTY/column mismatch bug + fix: https://github.com/hermes-hq/hermes-ide/issues/113
+- xterm.js #1914 — resize roundtrip race, "narrow not eliminate": https://github.com/xtermjs/xterm.js/issues/1914
+- AWS Builders' Library — timeouts, retries, backoff, jitter: https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/
+- Event-Driven.io — race conditions in EDA / guarded transitions: https://event-driven.io/en/dealing_with_race_conditions_in_eda_using_read_models/

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -45,7 +45,7 @@ import { useInSessionSearch } from "./hooks/useInSessionSearch";
 import { useScrollToNode } from "./hooks/useScrollToNode";
 import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
 import { useProcessCount } from "./hooks/useProcessCount";
-import { usePtyWidth } from "./hooks/usePtyWidth";
+import { usePtyWidth, computeTermSizeFromEl } from "./hooks/usePtyWidth";
 import { useSubagentEvents } from "./hooks/useSubagentEvents";
 import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useAgentCommands } from "./hooks/useAgentCommands";
@@ -506,6 +506,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         return out;
     };
 
+    // Root element ref — declared before useAgentControllerStatus so its
+    // getInitialTermSize closure can read the laid-out pane width when the
+    // launch flow's Phase-3 resync runs (the ref is assigned during render,
+    // before onMount fires). Also consumed by dropAttach + usePtyWidth below.
+    let rootRef: HTMLDivElement | undefined;
+
     const status = useAgentControllerStatus({
         blockId: model.blockId,
         provider,
@@ -524,6 +530,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             });
         },
         onReady: () => onReadyFn?.(),
+        getInitialTermSize: () => computeTermSizeFromEl(rootRef),
     });
 
     onMount(() => {
@@ -851,8 +858,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Persistence is owned by the universal zoom framework — see the
     // note below where the inline handlers were removed.
-
-    let rootRef: HTMLDivElement | undefined;
 
     // File-drop attach. Drop a file onto the agent pane → copy it into the
     // agent's CWD AND splice `@filename` into the composer at the caret, so

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -52,6 +52,13 @@ export interface LaunchFlowOptions {
     authEnv?: Record<string, string>;
     /** Called once when login is confirmed — append a success message to the chat. */
     onLoginSuccess?: (email: string | null) => void;
+    /**
+     * Returns the pane's current `{rows, cols}` (or undefined if not laid out
+     * yet). Used to seed the PTY size on the Phase-3 resync so the agent CLI is
+     * born at the right width, avoiding the post-spawn resize race. See
+     * docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+     */
+    getInitialTermSize?: () => { rows: number; cols: number } | undefined;
 }
 
 export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
@@ -277,10 +284,17 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
     // Phase 3: Controller Registration
     log("controller", "registering subprocess controller...");
     try {
+        // Seed the PTY at the pane's current width so the agent CLI wraps
+        // correctly from its first byte — the backend opens the PTY at this
+        // size (shell.rs `pty_size_from_rt_opts`), avoiding the post-spawn
+        // resize race. Omitted when the pane isn't laid out yet; the live
+        // ResizeObserver in usePtyWidth corrects any later change.
+        const initialTermSize = opts.getInitialTermSize?.();
         await RpcApi.ControllerResyncCommand(TabRpcClient, {
             tabid: staticTabId(),
             blockid: blockId,
             forcerestart: false,
+            ...(initialTermSize ? { rtopts: { termsize: initialTermSize } } : {}),
         });
         const rts = await BlockService.GetControllerStatus(blockId);
         const status = rts?.shellprocstatus ?? "init";

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -48,6 +48,11 @@ export interface UseAgentControllerStatusOptions {
     onLoginSuccess?: (email: string | null) => void;
     /** Called once when the launch flow completes successfully and the agent is ready to receive messages. */
     onReady?: () => void;
+    /**
+     * Returns the pane's current `{rows, cols}` (or undefined if not laid out
+     * yet). Forwarded to the launch flow to seed the PTY size at spawn.
+     */
+    getInitialTermSize?: () => { rows: number; cols: number } | undefined;
 }
 
 export interface UseAgentControllerStatus {
@@ -115,6 +120,7 @@ export function useAgentControllerStatus(
                 setLoginWaiting,
                 authEnv,
                 onLoginSuccess: opts.onLoginSuccess,
+                getInitialTermSize: opts.getInitialTermSize,
             });
             if (result === "success") {
                 setAgentReady(true);

--- a/frontend/app/view/agent/hooks/usePtyWidth.test.ts
+++ b/frontend/app/view/agent/hooks/usePtyWidth.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * usePtyWidth — cols math + the initial-resize readiness gate.
+ *
+ * The gate is the heart of the PTY-resize race fix
+ * (docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md): a resize must NOT
+ * be sent before the controller can accept input, or it fails with "controller
+ * is not running" (the "failed after 3 attempts" warning). So sends are
+ * deferred until the controller is "running" (or already running on re-mount),
+ * coalescing the latest width; transient failures retry, permanent ones don't.
+ */
+
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+    // Set per-test so each can control the resize RPC + status probe.
+    rpc: undefined as unknown as ReturnType<typeof vi.fn>,
+    getStatus: undefined as unknown as ReturnType<typeof vi.fn>,
+}));
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { ControllerInputCommand: (...args: unknown[]) => hub.rpc(...args) },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/services", () => ({
+    BlockService: { GetControllerStatus: (...args: unknown[]) => hub.getStatus(...args) },
+}));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+vi.mock("@/app/store/wos", () => ({ makeORef: (a: string, b: string) => `${a}:${b}` }));
+
+import { usePtyWidth, __test__ } from "./usePtyWidth";
+
+const { DEBOUNCE_MS } = __test__;
+
+// ── Pure helpers ─────────────────────────────────────────────────────────
+
+describe("computeCols", () => {
+    it("converts width→cols using the padding + monospace ratio", () => {
+        // cell = 15 * 0.6 = 9; usable = 800 - 16 = 784; floor(784 / 9) = 87.
+        expect(__test__.computeCols(800, 15)).toBe(87);
+    });
+    it("floors at MIN_COLS for a very narrow pane", () => {
+        expect(__test__.computeCols(50, 15)).toBe(__test__.MIN_COLS);
+    });
+});
+
+describe("computeTermSizeFromEl", () => {
+    it("returns rows=25 + cols≥MIN for a laid-out element", () => {
+        const el = document.createElement("div");
+        Object.defineProperty(el, "clientWidth", { value: 800, configurable: true });
+        const ts = __test__.computeTermSizeFromEl(el);
+        expect(ts?.rows).toBe(25);
+        expect(ts?.cols).toBeGreaterThanOrEqual(__test__.MIN_COLS);
+    });
+    it("returns undefined when absent or not yet laid out", () => {
+        expect(__test__.computeTermSizeFromEl(undefined)).toBeUndefined();
+        const el = document.createElement("div");
+        Object.defineProperty(el, "clientWidth", { value: 0, configurable: true });
+        expect(__test__.computeTermSizeFromEl(el)).toBeUndefined();
+    });
+});
+
+describe("isRetryableResizeError", () => {
+    it("treats controller-not-ready errors as transient", () => {
+        expect(__test__.isRetryableResizeError("controller is not running")).toBe(true);
+        expect(__test__.isRetryableResizeError("no controller for block abc")).toBe(true);
+    });
+    it("treats other errors as permanent", () => {
+        expect(__test__.isRetryableResizeError("malformed termsize")).toBe(false);
+        expect(__test__.isRetryableResizeError("")).toBe(false);
+    });
+});
+
+// ── Readiness gate + retry (integration) ───────────────────────────────────
+
+describe("usePtyWidth readiness gate", () => {
+    let el: HTMLDivElement;
+    let roCb: (() => void) | undefined;
+
+    // Flush a few microtask ticks so onMount + the GetControllerStatus probe
+    // (a resolved-promise .then chain) settle.
+    const settle = async () => {
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+    };
+    const fire = (type: string, data: unknown) => {
+        const h = hub.handlers.get(type);
+        if (!h) throw new Error(`no "${type}" handler — usePtyWidth onMount did not run`);
+        h({ data });
+    };
+    const mount = () => usePtyWidth({ blockId: "b", elementRef: () => el, log: () => {} });
+
+    beforeEach(() => {
+        hub.handlers.clear();
+        hub.rpc = vi.fn().mockResolvedValue(undefined);
+        hub.getStatus = vi.fn().mockResolvedValue({ shellprocstatus: "init" });
+        vi.useFakeTimers();
+        el = document.createElement("div");
+        Object.defineProperty(el, "clientWidth", { value: 800, configurable: true });
+        roCb = undefined;
+        // Stub ResizeObserver: capture the callback so a resize can be simulated.
+        (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+            constructor(cb: () => void) {
+                roCb = cb;
+            }
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        };
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it("defers the initial resize until the controller reports 'running'", async () => {
+        await createRoot(async (dispose) => {
+            mount();
+            await settle(); // onMount + probe (status: init → not ready)
+            roCb?.(); // at-mount ResizeObserver delivery
+            await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+            expect(hub.rpc).not.toHaveBeenCalled(); // deferred — not running yet
+
+            fire("controllerstatus", { shellprocstatus: "running" });
+            expect(hub.rpc).toHaveBeenCalledTimes(1); // flushed on running
+            dispose();
+        });
+    });
+
+    it("sends immediately when the controller is already running (re-mount)", async () => {
+        hub.getStatus = vi.fn().mockResolvedValue({ shellprocstatus: "running" });
+        await createRoot(async (dispose) => {
+            mount();
+            await settle(); // probe → already running → ready
+            roCb?.();
+            await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+            expect(hub.rpc).toHaveBeenCalledTimes(1);
+            dispose();
+        });
+    });
+
+    it("retries a transient 'controller is not running' failure, then succeeds", async () => {
+        hub.getStatus = vi.fn().mockResolvedValue({ shellprocstatus: "running" });
+        hub.rpc = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("controller is not running"))
+            .mockResolvedValueOnce(undefined);
+        await createRoot(async (dispose) => {
+            mount();
+            await settle();
+            roCb?.();
+            await vi.advanceTimersByTimeAsync(DEBOUNCE_MS); // attempt 1 → rejects
+            expect(hub.rpc).toHaveBeenCalledTimes(1);
+            await vi.advanceTimersByTimeAsync(700); // jittered backoff (≤600ms) → retry
+            expect(hub.rpc).toHaveBeenCalledTimes(2);
+            dispose();
+        });
+    });
+
+    it("does not retry a permanent failure", async () => {
+        hub.getStatus = vi.fn().mockResolvedValue({ shellprocstatus: "running" });
+        hub.rpc = vi.fn().mockRejectedValue(new Error("some permanent error"));
+        await createRoot(async (dispose) => {
+            mount();
+            await settle();
+            roCb?.();
+            await vi.advanceTimersByTimeAsync(DEBOUNCE_MS); // attempt 1 → rejects (permanent)
+            expect(hub.rpc).toHaveBeenCalledTimes(1);
+            await vi.advanceTimersByTimeAsync(2000);
+            expect(hub.rpc).toHaveBeenCalledTimes(1); // no retry
+            dispose();
+        });
+    });
+});

--- a/frontend/app/view/agent/hooks/usePtyWidth.ts
+++ b/frontend/app/view/agent/hooks/usePtyWidth.ts
@@ -11,25 +11,31 @@
  * their output at whatever cols the PTY was opened with (80) and
  * the captured live-log shows hard wraps that don't match the pane.
  *
- * The backend (`shell.rs`) already accepts `termsize: { rows, cols }`
- * on incoming `controllerinput` messages and forwards it to
- * `master.resize(...)`. This hook supplies the value:
+ * The backend (`shell.rs`) accepts `termsize: { rows, cols }` on incoming
+ * `controllerinput` messages and forwards it to `master.resize(...)`, and
+ * also seeds the PTY at that size on spawn (`rtopts.termsize` on the resync;
+ * see launch-flow.ts). This hook supplies the value for *changes*:
  *
  *   1. Attaches a `ResizeObserver` to the supplied container ref.
  *   2. Converts width-in-pixels to cols using the computed monospace
  *      cell width (`font-size × ~0.6`).
  *   3. Debounces by `DEBOUNCE_MS` so a drag-resize emits at most one
  *      RPC per gesture.
- *   4. Sends `RpcApi.ControllerInputCommand` with `termsize`.
+ *   4. Defers the send until the controller is ready to accept input
+ *      ("running"), then sends `RpcApi.ControllerInputCommand` with
+ *      `termsize` — so a resize never races the per-turn PTY spawn.
  *
- * Caveat (documented in
- * `docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md`): lines already
- * in the live-log buffer stay wrapped at whatever cols was active
- * when they were captured. Only NEW output reflows.
+ * Caveats: (a) lines already in the live-log buffer stay wrapped at the cols
+ * active when they were captured — only NEW output reflows
+ * (`docs/analysis/AGENT_PANE_PTY_WRAP_2026_05_23.md`); (b) the initial-resize
+ * race and its fix are in `docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md`.
  */
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { BlockService } from "@/app/store/services";
+import { waveEventSubscribe } from "@/app/store/wps";
+import * as WOS from "@/app/store/wos";
 import { onCleanup, onMount, type Accessor } from "solid-js";
 
 export interface UsePtyWidthOpts {
@@ -66,6 +72,36 @@ function readFontSizePx(el: HTMLElement): number {
     return 15; // matches the SCSS fallback for --termfontsize.
 }
 
+/**
+ * Compute a `{rows, cols}` TermSize from an element's current width using the
+ * same monospace math as the live resize path. Returns undefined when the
+ * element is absent or not yet laid out (`clientWidth <= 0`) so callers omit
+ * the value rather than send a bogus size.
+ *
+ * Used to seed the PTY at spawn via the resync `rtopts.termsize`
+ * (`launch-flow.ts` Phase 3 → `shell.rs::pty_size_from_rt_opts`), so the agent
+ * CLI is born at the right width instead of relying on a post-spawn resize that
+ * races controller startup. See
+ * docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+ */
+export function computeTermSizeFromEl(
+    el: HTMLElement | undefined,
+): { rows: number; cols: number } | undefined {
+    if (!el) return undefined;
+    const width = el.clientWidth;
+    if (width <= 0) return undefined;
+    return { rows: DEFAULT_ROWS, cols: computeCols(width, readFontSizePx(el)) };
+}
+
+/**
+ * Only resize failures caused by the controller not yet (or no longer) being
+ * able to accept input are worth retrying. Anything else (malformed RPC, etc.)
+ * is permanent — retrying just spams the activity log.
+ */
+function isRetryableResizeError(msg: string): boolean {
+    return msg.includes("controller is not running") || msg.includes("no controller for block");
+}
+
 export function usePtyWidth(opts: UsePtyWidthOpts): void {
     onMount(() => {
         const el = opts.elementRef();
@@ -76,20 +112,30 @@ export function usePtyWidth(opts: UsePtyWidthOpts): void {
         let lastCols = -1;
         let timer: ReturnType<typeof setTimeout> | undefined;
 
-        // codex P1 on #986: the controller can be unregistered at first
-        // mount (launcher async-spawns it AFTER `startLaunchFlow` runs),
-        // so the initial `controllerinput` send fails with "controller is
-        // not running" and `lastCols` was being set BEFORE the RPC
-        // resolved — meaning we'd never retry the same width and the PTY
-        // stayed at the fallback 200 for the whole session unless the
-        // user manually resized the pane.
+        // Readiness gate. The backend's `send_input` rejects a resize with
+        // "controller is not running" until the controller's input channel
+        // exists, and for an agent pane the process is per-turn — so the PTY
+        // can only accept a resize while a turn is live ("running"). Sending
+        // before that (e.g. the at-mount ResizeObserver delivery during the
+        // launch-flow spawn) is what produced the spurious "failed after 3
+        // attempts" warning. So we DEFER sends until the controller is ready,
+        // coalesce the latest pending width, and flush on "running". `lastCols`
+        // is still set only AFTER the RPC resolves, so a failed send is retried.
         //
-        // Fix: only mark `lastCols` AFTER the RPC succeeds. Retry up to 2
-        // times on failure with a short backoff so the controller has a
-        // chance to come up. A user-driven resize remains independent —
-        // each new width attempts a fresh send.
+        // The initial width is normally already correct: the launch flow seeds
+        // the PTY at spawn via `rtopts.termsize` (launch-flow.ts), so this send
+        // is a correction, not the thing that fixes wrap.
+        // See docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+        let controllerReady = false;
+        let pendingCols: number | null = null;
+
         const send = (cols: number, retriesLeft: number = 2) => {
             if (cols === lastCols) return;
+            // Not live yet — stash the latest width; flushed on "running".
+            if (!controllerReady) {
+                pendingCols = cols;
+                return;
+            }
             RpcApi.ControllerInputCommand(TabRpcClient, {
                 blockid: opts.blockId,
                 termsize: { rows: DEFAULT_ROWS, cols },
@@ -99,8 +145,11 @@ export function usePtyWidth(opts: UsePtyWidthOpts): void {
                 })
                 .catch((err: unknown) => {
                     const msg = err instanceof Error ? err.message : String(err);
-                    if (retriesLeft > 0) {
-                        const delay = (3 - retriesLeft) * 500;
+                    // Only controller-not-ready races are transient; jitter the
+                    // backoff so many panes mounting together don't retry in
+                    // lockstep. Layer A makes this path non-load-bearing.
+                    if (retriesLeft > 0 && isRetryableResizeError(msg)) {
+                        const delay = (3 - retriesLeft) * 400 + Math.floor(Math.random() * 200);
                         opts.log?.(
                             "pty",
                             `resize to ${cols} cols failed: ${msg} (retrying in ${delay}ms)`,
@@ -108,9 +157,12 @@ export function usePtyWidth(opts: UsePtyWidthOpts): void {
                         );
                         setTimeout(() => send(cols, retriesLeft - 1), delay);
                     } else {
+                        // Either the retry budget is spent or the error is
+                        // permanent — say which, so the log isn't misleading.
+                        const reason = isRetryableResizeError(msg) ? "after 3 attempts" : "(not retryable)";
                         opts.log?.(
                             "pty",
-                            `resize to ${cols} cols failed after 3 attempts: ${msg}`,
+                            `resize to ${cols} cols failed ${reason}: ${msg}`,
                             "warn",
                         );
                     }
@@ -126,25 +178,62 @@ export function usePtyWidth(opts: UsePtyWidthOpts): void {
             send(computeCols(width, fontSize));
         };
 
+        const markReady = () => {
+            controllerReady = true;
+            if (pendingCols != null && pendingCols !== lastCols) {
+                const cols = pendingCols;
+                pendingCols = null;
+                send(cols);
+            }
+        };
+
         const observer = new ResizeObserver(() => {
             if (timer) clearTimeout(timer);
             timer = setTimeout(compute, DEBOUNCE_MS);
         });
+        // observe() delivers an initial notification with the current size, so
+        // the at-mount width is captured here (deferred via the gate above) —
+        // no separate initial timer needed.
         observer.observe(el);
 
-        // Fire once after mount so the agent gets the right cols before
-        // its first tool invocation, not just after the user resizes.
-        // Use the same debounced path so this initial value can be
-        // coalesced with any layout-driven ResizeObserver burst at mount.
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(compute, DEBOUNCE_MS);
+        // Flush on each turn's spawn: "running" now fires only after the input
+        // channel is ready (shell.rs). Clear readiness on "done" so a resize
+        // made while the agent is idle is coalesced and re-applied when the
+        // next turn starts, rather than failing against a dead PTY.
+        const unsubStatus = waveEventSubscribe({
+            eventType: "controllerstatus",
+            scope: WOS.makeORef("block", opts.blockId),
+            handler: (event) => {
+                const status = (event as any)?.data?.shellprocstatus;
+                if (status === "running") markReady();
+                else if (status === "done") controllerReady = false;
+            },
+        });
+
+        // Re-mount path: the controller may already be running, in which case
+        // the event above won't re-fire — probe once so a pending resize flushes.
+        BlockService.GetControllerStatus(opts.blockId)
+            .then((rts) => {
+                if (rts?.shellprocstatus === "running") markReady();
+            })
+            .catch(() => {
+                // status unknown — the subscription covers the fresh-launch path.
+            });
 
         onCleanup(() => {
             if (timer) clearTimeout(timer);
             observer.disconnect();
+            unsubStatus();
         });
     });
 }
 
 // Export internals for unit tests / sanity checks.
-export const __test__ = { computeCols, CELL_WIDTH_RATIO, MIN_COLS, DEBOUNCE_MS };
+export const __test__ = {
+    computeCols,
+    computeTermSizeFromEl,
+    isRetryableResizeError,
+    CELL_WIDTH_RATIO,
+    MIN_COLS,
+    DEBOUNCE_MS,
+};


### PR DESCRIPTION
## Problem

Loading a new agent pane intermittently logged **`resize to N cols failed after 3 attempts`** (`[pty]`, warn). The agent pane is a custom UI (not xterm.js), so `usePtyWidth` pushes the pane width to the PTY over `controllerinput` — but the initial send raced controller startup and rejected with "controller is not running". Two root causes:

- **`ShellController::start()` opened the PTY at a hardcoded `200x25`** and relied on a post-spawn resize RPC to correct it. That RPC races the controller coming up and can fail outright → the agent CLI / tools wrap at 200 cols for the whole session.
- **`publish_status()` broadcast `"running"` before `input_tx` existed**, so even a frontend that waited for the `"running"` event could still hit the reject.

## Fix

- **Seed the PTY at spawn** using the existing `rtopts.termsize` plumbing (the resync command already carries `rtopts` end-to-end). `launch-flow` Phase 3 computes the pane size and the backend opens the PTY at it (`pty_size_from_rt_opts`, clamped, fallback `200x25`). The post-spawn resize is now a correction, not a load-bearing race.
- **Make `"running"` truthful**: move `publish_status()` to after `input_tx` is set.
- **Gate the frontend initial send** on readiness (`controllerstatus: "running"` + a one-shot `GetControllerStatus` probe for re-mounts), coalescing the latest width and clearing readiness on `"done"` (the agent process is per-turn). Retries are now classified (only controller-not-ready is retried) and jittered.

## Tests
- `pty_size_from_rt_opts` unit tests (absent / serde-default / honored / cols-only / clamp / garbage).
- New `usePtyWidth.test.ts`: cols math, readiness gate (defer→flush, already-running re-mount), retry classification.
- `useAgentFailure.test.ts` re-run green — the `publish_status` move preserves `running`/`done` event ordering.

## Verification
- ✅ `task dev` builds (backend + host + bundle) and launches.
- ⏳ Live before/after (PTY opens at pane width, no warning) not yet captured — needs an agent pane opened in the running app; can attach once confirmed.

## Notes / follow-ups
- The runtime-resize path (`shell.rs`) still does an unchecked `i64 as u16` cast — independent hardening.
- Only the launch-flow resync passes `termsize`; other resync callers (restart paths) could too.

Analysis: `docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
