### PR TITLE
fix(agent-pane): persistent controllers accept the stop signal (SIGINT/SIGTERM)

### DIFF
--- a/.changesets/1781662115-fix-agent-pane-persistent-controllers-accept-sigint-sigterm--hp3p.md
+++ b/.changesets/1781662115-fix-agent-pane-persistent-controllers-accept-sigint-sigterm--hp3p.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): persistent controllers accept SIGINT/SIGTERM so Stop/Esc interrupts Claude (stream-json) agents instead of failing with 'does not accept raw input'

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -957,7 +957,29 @@ impl Controller for PersistentSubprocessController {
         self.get_status_snapshot()
     }
 
-    fn send_input(&self, _input: BlockInputUnion, _seq: Option<u64>) -> Result<(), String> {
+    fn send_input(&self, input: BlockInputUnion, _seq: Option<u64>) -> Result<(), String> {
+        // Persistent controllers have no PTY and don't take raw keystrokes —
+        // user messages go through send_message(). But the agent-pane Stop
+        // button / Esc delivers an *interrupt* as a signal via
+        // `ControllerInputCommand({signame:"SIGINT"})` (see useAgentCommands
+        // `stopAgent`). Without handling it here, stopping a persistent (e.g.
+        // Claude stream-json) agent failed with "does not accept raw input".
+        // Route the interrupt to the same kill path `stop()` uses, mirroring
+        // SubprocessController. The session_id is retained, so the next message
+        // resumes the conversation.
+        if let Some(sig) = input.sig_name.as_deref() {
+            if sig == "SIGINT" || sig == "SIGTERM" {
+                tracing::info!(
+                    block_id = %self.block_id,
+                    sig = %sig,
+                    "persistent controller: received signal, stopping current process"
+                );
+                return self.stop_process(true);
+            }
+            return Err(format!(
+                "persistent controller: unsupported signal {sig} (only SIGINT/SIGTERM)"
+            ));
+        }
         Err("persistent controller does not accept raw input; use send_message()".to_string())
     }
 


### PR DESCRIPTION
## Bug

Stopping a **Claude agent** (any persistent-controller agent) always fails with:

> stop failed: persistent controller does not accept raw input; use send_message()

## Root cause

The Stop button / Esc sends an interrupt as a **SIGINT signal** via `ControllerInputCommand({signame:"SIGINT"})` (`useAgentCommands.ts:494`), which the backend turns into `BlockInputUnion::signal("SIGINT")` and routes to `controller.send_input()` (`websocket.rs:2316`).

- `SubprocessController::send_input` handles `SIGINT`/`SIGTERM` → `stop_subprocess(true)` ✓
- `PersistentSubprocessController::send_input` rejected **all** input → `Err("… does not accept raw input; use send_message()")` ✗

The signal case was never wired, even though the persistent controller owns a working kill path (`stop_process(true)`, used by its `stop()`).

## Fix

Handle `SIGINT`/`SIGTERM` in `PersistentSubprocessController::send_input` by routing to `stop_process(true)` — the same path `stop()` uses, mirroring `SubprocessController`. Raw (non-signal) input is still rejected. The `session_id` is retained, so the next message resumes the conversation (kill-the-turn semantics, matching subprocess).

## Verification

`cargo check -p agentmux-srv` — clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)