### PR TITLE
fix(term): enable reverse-wraparound so Backspace crosses soft-wrapped lines

### DIFF
--- a/.changesets/1781691242-fix-term-enable-reverse-wraparound-so-backspace-crosses-soft-2fn6.md
+++ b/.changesets/1781691242-fix-term-enable-reverse-wraparound-so-backspace-crosses-soft-2fn6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): enable reverse-wraparound so Backspace crosses soft-wrapped lines

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -124,6 +124,25 @@ export class TermWrap {
         //   even when no PTY output is arriving. Focus/blur listeners re-enable blink only
         //   for the active pane.
         this.terminal = new Terminal({ ...options, cursorBlink: false, scrollOnUserInput: false, smoothScrollDuration: 0 });
+        // Reverse-wraparound (DECSET ?45): Backspace at column 0 of a soft-wrapped
+        // line moves to the END of the previous row, matching real terminals.
+        // bash/readline emits a bare BS (0x08) for the cross-wrap delete and relies
+        // on the terminal honoring reverse-wrap (xterm-256color has no `bw`). xterm.js
+        // defaults this mode OFF — so on a raw PTY (Linux/macOS) backspacing across a
+        // wrap is stuck at col 0. (Windows is unaffected: ConPTY re-renders with
+        // absolute cursor positioning, so the bare BS never reaches xterm.js.) The
+        // enabled branch only wraps when the row is genuinely `isWrapped`, so hard
+        // line breaks are never crossed. We assert it here AND re-assert on RIS reset.
+        this.terminal.write("\x1b[?45h");
+        // A full reset (RIS, `ESC c` — e.g. `reset` / `tput reset`) restores DEC
+        // private modes to defaults, turning reverse-wrap back OFF. Re-assert it
+        // immediately after, so a reset doesn't silently reintroduce the stuck-
+        // backspace bug. Returning false lets xterm run its built-in RIS first;
+        // the microtask then re-applies the mode once that synchronous parse ends.
+        this.terminal.parser.registerEscHandler({ final: "c" }, () => {
+            queueMicrotask(() => this.terminal.write("\x1b[?45h"));
+            return false;
+        });
         this.fitAddon = new FitAddon();
         this.serializeAddon = new SerializeAddon();
         this.searchAddon = new SearchAddon();


### PR DESCRIPTION
## Problem
On **Linux/macOS**, pressing **Backspace at column 0 of a soft-wrapped row** does nothing — the cursor is stuck and won't delete back into the previous row. **Windows is fine.**

## Root cause (evidence-based)
- Captured from a PTY: bash/readline emits a **bare `BS` (`0x08`) + `CSI K`** for the cross-wrap delete — identical bytes to a same-line backspace. It relies on the terminal doing **reverse-wraparound** (`infocmp xterm-256color` confirms **no `bw`** capability).
- xterm.js v6 gates reverse-wraparound behind **DEC private mode 45**, default **OFF**. Its `backspace()` clamps at column 0 when the mode is off:
  ```js
  backspace(){ if(!decPrivateModes.reverseWraparound) return _restrictCursor(), x>0 && x--, true; ... }
  ```
- **Platform split:** on a raw PTY (Linux/macOS) the bare `0x08` reaches xterm.js and clamps. On Windows, **ConPTY re-renders with absolute cursor positioning**, so xterm.js never receives the bare BS — it just works.

## Fix
`frontend/app/view/term/termwrap.ts`: assert `\x1b[?45h` (DECSET reverse-wraparound) on terminal init, and **re-assert after RIS** (`reset`/`tput reset` clears DEC private modes). xterm.js's enabled branch only wraps when the row is genuinely `isWrapped`, so **hard line breaks are never crossed**. No effect on Windows (ConPTY path doesn't need it).

## Verification
Confirmed in a live dev terminal on Linux: Backspace across a soft wrap now pulls the cursor up to the end of the previous row. Frontend-only; type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)