### PR TITLE
fix(agent-pane): persistent controller no-ops termsize resize

### DIFF
--- a/.changesets/1781692991-fix-persistent-controller-termsize-noop.md
+++ b/.changesets/1781692991-fix-persistent-controller-termsize-noop.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): persistent controller accepts termsize resize as a no-op so the agent pane stops logging spurious "resize to N cols failed" warnings

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -980,7 +980,21 @@ impl Controller for PersistentSubprocessController {
                 "persistent controller: unsupported signal {sig} (only SIGINT/SIGTERM)"
             ));
         }
-        Err("persistent controller does not accept raw input; use send_message()".to_string())
+        // Raw keystrokes are genuinely unsupported — user messages go through
+        // send_message(), not the PTY input channel.
+        if input.input_data.is_some() {
+            return Err(
+                "persistent controller does not accept raw input; use send_message()".to_string(),
+            );
+        }
+        // Term resize / other benign input types: accepted no-op. A persistent
+        // controller has no PTY, so there is nothing to resize — but the agent
+        // pane's `usePtyWidth` hook sends a `termsize` on every running turn
+        // (it can't tell a PTY-backed controller from a PTY-less one). Returning
+        // an error here surfaced a spurious "resize to N cols failed" warning in
+        // the agent pane's activity log. Mirror SubprocessController, which
+        // already no-ops termsize. See AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+        Ok(())
     }
 
     fn controller_type(&self) -> &str {
@@ -993,5 +1007,47 @@ impl Controller for PersistentSubprocessController {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod send_input_tests {
+    use super::*;
+    use crate::backend::obj::TermSize;
+
+    fn controller() -> PersistentSubprocessController {
+        PersistentSubprocessController::new(
+            "tab".to_string(),
+            "block".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    // A persistent controller has no PTY, but the agent pane's usePtyWidth hook
+    // sends a termsize resize on every running turn. It must be accepted as a
+    // no-op, not rejected — otherwise the pane logs a spurious "resize to N cols
+    // failed" warning. See AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
+    #[test]
+    fn termsize_resize_is_accepted_noop() {
+        let c = controller();
+        let res = c.send_input(BlockInputUnion::resize(TermSize { rows: 25, cols: 117 }), None);
+        assert!(res.is_ok(), "termsize resize should be a no-op Ok, got {res:?}");
+    }
+
+    // Raw keystrokes are genuinely unsupported on a persistent controller —
+    // user messages go through send_message(), so they must still be rejected.
+    #[test]
+    fn raw_input_is_still_rejected() {
+        let c = controller();
+        let err = c
+            .send_input(BlockInputUnion::data(b"ls\n".to_vec()), None)
+            .unwrap_err();
+        assert!(
+            err.contains("does not accept raw input"),
+            "raw input should be rejected, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The agent pane still logs `resize to <N> cols failed ...` in its activity log — even after #1505 ("seed PTY size at spawn"). #1505 fixed the **ShellController** path (the only code that emits `"controller is not running"`), but **Claude/Codex agents don't use it**.

## Root cause

Agent panes run on the **PersistentController** (`controllerType: "persistent"`, e.g. Claude `--input-format stream-json`) — verified live: the sidecar logs `persistent controller registered (spawns on first message)`. Persistent controllers **have no PTY**.

`usePtyWidth` can't tell a PTY-backed controller from a PTY-less one, so it sends a `termsize` resize via `ControllerInputCommand` on every running turn:

- `SubprocessController::send_input` already treats `termsize` as an accepted no-op (`subprocess.rs:1482`).
- `PersistentController::send_input` had **no such branch** — it rejected *all* non-signal input with `Err("persistent controller does not accept raw input; use send_message()")`.

`usePtyWidth` doesn't classify that string as retryable, so it logged a one-shot `resize to N cols failed (not retryable): ...` warning in the pane's "aux bar" on every turn.

## Fix

Mirror `SubprocessController`: reject only raw `input_data`; accept `termsize`/other benign inputs as a no-op. A persistent controller has no PTY, so there is nothing to resize — the resize is meaningless, not an error.

## Tests

Added `send_input_tests` in `persistent.rs`:
- `termsize_resize_is_accepted_noop` — a `termsize` resize returns `Ok`
- `raw_input_is_still_rejected` — raw keystrokes still error

Both pass (`cargo test -p agentmux-srv send_input_tests`).

## Test plan

- [ ] Open a Claude (persistent) agent pane, send a message, confirm no `resize to N cols failed` warning appears in the activity log
- [ ] Stop button / Esc (SIGINT) still interrupts a running persistent turn
- [ ] Sending a normal message still works (routes via `send_message`, not `send_input`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)