### PR TITLE
feat(tool-output): tee redirected output to feed + render tool output as terminal

### DIFF
--- a/.changesets/1781693591-feat-tool-output-tee-redirected-output-to-the-feed-render-to-stdl.md
+++ b/.changesets/1781693591-feat-tool-output-tee-redirected-output-to-the-feed-render-to-stdl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(tool-output): tee redirected output to the feed + render tool/task output as a terminal

--- a/agentmux-bashwrap/src/hook.rs
+++ b/agentmux-bashwrap/src/hook.rs
@@ -76,7 +76,15 @@ pub fn build_response(stdin_payload: &str) -> Value {
         return passthrough();
     }
 
-    let b64 = URL_SAFE_NO_PAD.encode(command.as_bytes());
+    // Tee a trailing file redirect back through the PTY so the agent's tool
+    // feed shows the output live while the file is still written. Conservative:
+    // only unambiguous trailing redirects are rewritten; anything else is
+    // encoded verbatim (today's behavior). See
+    // SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md §3.
+    let effective_command =
+        tee_redirect_rewrite(command).unwrap_or_else(|| command.to_string());
+
+    let b64 = URL_SAFE_NO_PAD.encode(effective_command.as_bytes());
     let wrapped = format!(
         "{} exec --tool-id={} --b64-cmd={}",
         WRAPPER_BINARY,
@@ -98,6 +106,348 @@ pub fn build_response(stdin_payload: &str) -> Value {
 fn passthrough() -> Value {
     // Empty object → Claude Code treats as "no opinion", proceeds.
     json!({})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trailing-redirect → `tee` rewrite (Feature 1)
+//
+// A command like `task package > build.log 2>&1` sends the inner shell's stdout
+// to the file, so the PTY (hence the tool-chunk stream, hence the feed) sees
+// nothing. We recognize an unambiguous *trailing* file redirect and rewrite it
+// so the same bytes still reach the file AND flow through the PTY via `tee`:
+//
+//   CMD > F            → set -o pipefail; { CMD ; } | tee -- F
+//   CMD >> F           → set -o pipefail; { CMD ; } | tee -a -- F
+//   CMD > F 2>&1       → set -o pipefail; { CMD ; } 2>&1 | tee -- F
+//   CMD >> F 2>&1      → set -o pipefail; { CMD ; } 2>&1 | tee -a -- F
+//   CMD &> F           → set -o pipefail; { CMD ; } 2>&1 | tee -- F
+//   CMD &>> F          → set -o pipefail; { CMD ; } 2>&1 | tee -a -- F
+//
+// `set -o pipefail` makes the pipeline's exit code reflect CMD (not `tee`), so
+// bashwrap still mirrors the real exit code. Wrapping the whole command in a
+// `{ ; }` group is safe for a single command OR a pipeline (a pipeline's stdout
+// is its last stage's stdout — exactly what the trailing `>` redirected), which
+// is why we bail on list operators (`&&`/`||`/`;`/`&`), where the redirect would
+// bind to only one command of the list.
+//
+// EVERYTHING ambiguous bails (returns None → encode verbatim, today's behavior):
+// quoted/comment/heredoc/process-substitution redirects, `/dev/null`, fd-specific
+// or dup redirects (`2>f`, `>&2`, and the `2>&1 > F` order), more than one output
+// redirect, and non-trailing redirects.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum OutKind {
+    Out,
+    Append,
+    AmpOut,
+    AmpAppend,
+}
+
+struct ScanResult {
+    redir_start: usize,
+    target_start: usize,
+    target_end: usize,
+    append: bool,
+    combine_stderr: bool,
+}
+
+/// Rewrite a recognized trailing redirect to a `tee` pipeline, or `None` to pass
+/// the command through unchanged.
+fn tee_redirect_rewrite(raw: &str) -> Option<String> {
+    let cmd = raw.trim();
+    if cmd.is_empty() {
+        return None;
+    }
+    let scan = scan_redirect(cmd)?;
+    let cmd_part = cmd[..scan.redir_start].trim();
+    if cmd_part.is_empty() {
+        return None;
+    }
+    let target = cmd[scan.target_start..scan.target_end].trim();
+    if target.is_empty() || is_dev_null(target) {
+        return None;
+    }
+    let aflag = if scan.append { "-a " } else { "" };
+    let stream = if scan.combine_stderr { " 2>&1 |" } else { " |" };
+    Some(format!(
+        "set -o pipefail; {{ {} ; }}{} tee {}-- {}",
+        cmd_part, stream, aflag, target
+    ))
+}
+
+fn is_space(c: u8) -> bool {
+    c == b' ' || c == b'\t' || c == b'\n' || c == b'\r'
+}
+
+/// Strip one layer of matching surrounding quotes for the `/dev/null` check.
+fn is_dev_null(target: &str) -> bool {
+    let t = target.trim();
+    let unq = if (t.starts_with('"') && t.ends_with('"') && t.len() >= 2)
+        || (t.starts_with('\'') && t.ends_with('\'') && t.len() >= 2)
+    {
+        &t[1..t.len() - 1]
+    } else {
+        t
+    };
+    unq == "/dev/null"
+}
+
+/// Quote/group-aware scan for a single top-level trailing output redirect.
+/// Returns None on any bail condition (see the module comment above).
+fn scan_redirect(cmd: &str) -> Option<ScanResult> {
+    let b = cmd.as_bytes();
+    let n = b.len();
+    let mut i = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut paren_depth: i32 = 0;
+
+    let mut out_redirs: Vec<(OutKind, usize, usize)> = Vec::new();
+    let mut dups: Vec<(usize, usize)> = Vec::new(); // 2>&1 occurrences (start, end)
+    let mut other_redir = false;
+    let mut list_op = false;
+
+    while i < n {
+        let c = b[i];
+        if in_single {
+            if c == b'\'' {
+                in_single = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_double {
+            if c == b'\\' && i + 1 < n {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_double = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_backtick {
+            if c == b'`' {
+                in_backtick = false;
+            }
+            i += 1;
+            continue;
+        }
+        // Unquoted. Quote/escape/group/comment first.
+        match c {
+            b'\\' => {
+                i += 2;
+                continue;
+            }
+            b'\'' => {
+                in_single = true;
+                i += 1;
+                continue;
+            }
+            b'"' => {
+                in_double = true;
+                i += 1;
+                continue;
+            }
+            b'`' => {
+                in_backtick = true;
+                i += 1;
+                continue;
+            }
+            b'#' => {
+                // Comment iff at a word boundary; otherwise a literal `#`.
+                let prev = if i == 0 { b' ' } else { b[i - 1] };
+                if is_space(prev) || matches!(prev, b';' | b'|' | b'&' | b'(' | b'`') {
+                    return None;
+                }
+                i += 1;
+                continue;
+            }
+            b'(' => {
+                paren_depth += 1;
+                i += 1;
+                continue;
+            }
+            b')' => {
+                if paren_depth > 0 {
+                    paren_depth -= 1;
+                }
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+        // Inside a subshell / $(...) group: ignore operators (the redirect there
+        // doesn't bind the outer command), but keep tracking quotes (above).
+        if paren_depth > 0 {
+            i += 1;
+            continue;
+        }
+        // Depth 0, unquoted — operator recognition.
+        match c {
+            b'<' => {
+                if i + 1 < n && (b[i + 1] == b'(' || b[i + 1] == b'<') {
+                    return None; // process substitution or heredoc
+                }
+                other_redir = true; // input redirect
+                i += 1;
+            }
+            b'>' => {
+                if i + 1 < n && b[i + 1] == b'(' {
+                    return None; // process substitution >(
+                }
+                if i > 0 && b[i - 1].is_ascii_digit() {
+                    // fd-prefixed: recognize exactly `2>&1`, else bail.
+                    if b[i - 1] == b'2' && i + 2 < n && b[i + 1] == b'&' && b[i + 2] == b'1' {
+                        dups.push((i - 1, i + 3));
+                        i += 3;
+                    } else {
+                        other_redir = true;
+                        i += 1;
+                    }
+                } else if i + 1 < n && b[i + 1] == b'>' {
+                    out_redirs.push((OutKind::Append, i, i + 2));
+                    i += 2;
+                } else if i + 1 < n && b[i + 1] == b'&' {
+                    other_redir = true; // >&N dup
+                    i += 1;
+                } else {
+                    out_redirs.push((OutKind::Out, i, i + 1));
+                    i += 1;
+                }
+            }
+            b'&' => {
+                if i + 1 < n && b[i + 1] == b'&' {
+                    list_op = true;
+                    i += 2;
+                } else if i + 1 < n && b[i + 1] == b'>' {
+                    if i + 2 < n && b[i + 2] == b'>' {
+                        out_redirs.push((OutKind::AmpAppend, i, i + 3));
+                        i += 3;
+                    } else {
+                        out_redirs.push((OutKind::AmpOut, i, i + 2));
+                        i += 2;
+                    }
+                } else {
+                    list_op = true; // standalone & (background)
+                    i += 1;
+                }
+            }
+            b'|' => {
+                if i + 1 < n && b[i + 1] == b'|' {
+                    list_op = true;
+                    i += 2;
+                } else {
+                    i += 1; // pipe — allowed inside CMD
+                }
+            }
+            b';' => {
+                list_op = true;
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    if in_single || in_double || in_backtick {
+        return None; // unterminated quote
+    }
+    if list_op || other_redir || out_redirs.len() != 1 {
+        return None;
+    }
+    let (kind, rstart, rend) = out_redirs[0];
+    // No dup may precede the redirect (the `2>&1 > F` order has different
+    // semantics; bail rather than mis-tee it).
+    if dups.iter().any(|(ds, _)| *ds < rstart) {
+        return None;
+    }
+    // Target word immediately after the redirect.
+    let (tstart, tend) = read_word(b, rend)?;
+    // After the target: an optional trailing `2>&1`, then EOF.
+    let mut j = skip_spaces(b, tend);
+    let mut combine = matches!(kind, OutKind::AmpOut | OutKind::AmpAppend);
+    if let Some((_, de)) = dups.iter().find(|(ds, _)| *ds == j) {
+        combine = true;
+        j = skip_spaces(b, *de);
+    }
+    if j != n {
+        return None; // trailing junk (incl. a second dup)
+    }
+    Some(ScanResult {
+        redir_start: rstart,
+        target_start: tstart,
+        target_end: tend,
+        append: matches!(kind, OutKind::Append | OutKind::AmpAppend),
+        combine_stderr: combine,
+    })
+}
+
+fn skip_spaces(b: &[u8], mut i: usize) -> usize {
+    while i < b.len() && is_space(b[i]) {
+        i += 1;
+    }
+    i
+}
+
+/// Read one shell word (quote-aware) starting at/after `from`, skipping leading
+/// spaces. Returns the word's byte range, or None if there's no word.
+fn read_word(b: &[u8], from: usize) -> Option<(usize, usize)> {
+    let n = b.len();
+    let mut i = skip_spaces(b, from);
+    if i >= n {
+        return None;
+    }
+    let start = i;
+    let mut in_single = false;
+    let mut in_double = false;
+    while i < n {
+        let c = b[i];
+        if in_single {
+            if c == b'\'' {
+                in_single = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_double {
+            if c == b'\\' && i + 1 < n {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_double = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' => {
+                in_single = true;
+                i += 1;
+            }
+            b'"' => {
+                in_double = true;
+                i += 1;
+            }
+            b'\\' => {
+                i += 2;
+            }
+            _ if is_space(c) => break,
+            // operator chars terminate a bare word
+            b'>' | b'<' | b'|' | b'&' | b';' | b'(' | b')' => break,
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    if i == start {
+        return None;
+    }
+    Some((start, i))
 }
 
 /// Quote a value for embedding in a shell argv position.
@@ -291,5 +641,118 @@ line' && cat $HOME/.env"#;
         // double-quoted argument. For `a"b` the result is `"a""b"`.
         let q = shell_quote("a\"b");
         assert_eq!(q, "\"a\"\"b\"");
+    }
+
+    // ── tee redirect rewrite (Feature 1) ──────────────────────────────
+
+    #[test]
+    fn tee_rewrites_basic_redirect_forms() {
+        assert_eq!(
+            tee_redirect_rewrite("task package > build.log").unwrap(),
+            "set -o pipefail; { task package ; } | tee -- build.log"
+        );
+        assert_eq!(
+            tee_redirect_rewrite("make >> out.log").unwrap(),
+            "set -o pipefail; { make ; } | tee -a -- out.log"
+        );
+        assert_eq!(
+            tee_redirect_rewrite("task package > build.log 2>&1").unwrap(),
+            "set -o pipefail; { task package ; } 2>&1 | tee -- build.log"
+        );
+        assert_eq!(
+            tee_redirect_rewrite("make >> out.log 2>&1").unwrap(),
+            "set -o pipefail; { make ; } 2>&1 | tee -a -- out.log"
+        );
+        assert_eq!(
+            tee_redirect_rewrite("cmd &> all.log").unwrap(),
+            "set -o pipefail; { cmd ; } 2>&1 | tee -- all.log"
+        );
+        assert_eq!(
+            tee_redirect_rewrite("cmd &>> all.log").unwrap(),
+            "set -o pipefail; { cmd ; } 2>&1 | tee -a -- all.log"
+        );
+    }
+
+    #[test]
+    fn tee_handles_pipeline_with_trailing_redirect() {
+        // A pipeline's stdout is its last stage's stdout — wrapping is correct.
+        assert_eq!(
+            tee_redirect_rewrite("cargo build | grep error > errors.log").unwrap(),
+            "set -o pipefail; { cargo build | grep error ; } | tee -- errors.log"
+        );
+    }
+
+    #[test]
+    fn tee_handles_subshell_command() {
+        assert_eq!(
+            tee_redirect_rewrite("(cd src && make) > b.log 2>&1").unwrap(),
+            "set -o pipefail; { (cd src && make) ; } 2>&1 | tee -- b.log"
+        );
+    }
+
+    #[test]
+    fn tee_preserves_quoted_target() {
+        assert_eq!(
+            tee_redirect_rewrite(r#"cmd > "my out.log""#).unwrap(),
+            r#"set -o pipefail; { cmd ; } | tee -- "my out.log""#
+        );
+    }
+
+    #[test]
+    fn tee_bails_on_dev_null() {
+        assert!(tee_redirect_rewrite("noisy > /dev/null").is_none());
+        assert!(tee_redirect_rewrite("noisy > /dev/null 2>&1").is_none());
+        assert!(tee_redirect_rewrite(r#"noisy > "/dev/null""#).is_none());
+    }
+
+    #[test]
+    fn tee_bails_on_quoted_comment_heredoc_procsub() {
+        assert!(tee_redirect_rewrite("echo 'a > b'").is_none()); // quoted >
+        assert!(tee_redirect_rewrite("echo \"x > y\"").is_none()); // quoted >
+        assert!(tee_redirect_rewrite("make # writes > log").is_none()); // comment
+        assert!(tee_redirect_rewrite("cat <<EOF > f\nhi\nEOF").is_none()); // heredoc
+        assert!(tee_redirect_rewrite("diff <(a) > f").is_none()); // process subst
+    }
+
+    #[test]
+    fn tee_bails_on_non_trailing_multiple_or_fd_redirects() {
+        assert!(tee_redirect_rewrite("cmd > f | grep x").is_none()); // not trailing
+        assert!(tee_redirect_rewrite("cmd > f && other").is_none()); // list op
+        assert!(tee_redirect_rewrite("a > f1 > f2").is_none()); // two redirects
+        assert!(tee_redirect_rewrite("cmd 2> err.log").is_none()); // fd-specific
+        assert!(tee_redirect_rewrite("cmd >&2").is_none()); // dup
+        assert!(tee_redirect_rewrite("cmd 2>&1 > f").is_none()); // leading 2>&1 order
+        assert!(tee_redirect_rewrite("echo hi").is_none()); // no redirect
+        assert!(tee_redirect_rewrite("server > log &").is_none()); // background
+    }
+
+    #[test]
+    fn tee_rewrite_round_trips_through_build_response_b64() {
+        let resp = build_response(&payload("task package > build.log 2>&1", "toolu_t"));
+        let wrapped = resp["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .unwrap();
+        let b64 = wrapped.split("--b64-cmd=").nth(1).expect("b64 arg");
+        let decoded =
+            String::from_utf8(URL_SAFE_NO_PAD.decode(b64.as_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            decoded,
+            "set -o pipefail; { task package ; } 2>&1 | tee -- build.log"
+        );
+        // pipefail present → pipeline exit code reflects the command, not tee.
+        assert!(decoded.starts_with("set -o pipefail;"));
+    }
+
+    #[test]
+    fn tee_non_redirect_command_encodes_verbatim() {
+        // No recognized redirect → command encodes unchanged (today's behavior).
+        let resp = build_response(&payload("echo hi", "toolu_a"));
+        let wrapped = resp["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .unwrap();
+        let b64 = wrapped.split("--b64-cmd=").nth(1).unwrap();
+        let decoded =
+            String::from_utf8(URL_SAFE_NO_PAD.decode(b64.as_bytes()).unwrap()).unwrap();
+        assert_eq!(decoded, "echo hi");
     }
 }

--- a/agentmux-bashwrap/src/hook.rs
+++ b/agentmux-bashwrap/src/hook.rs
@@ -337,14 +337,21 @@ fn scan_redirect(cmd: &str) -> Option<ScanResult> {
                 }
             }
             b'|' => {
-                if i + 1 < n && b[i + 1] == b'|' {
-                    list_op = true;
-                    i += 2;
-                } else {
-                    i += 1; // pipe — allowed inside CMD
-                }
+                // Both `||` and a plain pipe bail. A plain pipe is bailed (not
+                // wrapped) because `set -o pipefail` on `{ a | b ; } | tee` would
+                // make the INNER pipeline report its first failure instead of the
+                // last stage's exit — changing the exit code the original
+                // `a | b > f` reported. Single commands have no inner pipe, so
+                // pipefail correctly surfaces their exit through the tee.
+                list_op = true;
+                i += if i + 1 < n && b[i + 1] == b'|' { 2 } else { 1 };
             }
-            b';' => {
+            // `;` and an unquoted/unescaped newline both separate commands. A
+            // multi-line command whose LAST line has a trailing redirect must not
+            // be wrapped, or `{ <all lines> ; } | tee` would tee the earlier
+            // lines' stdout into the file too (violating the "same bytes to FILE"
+            // guarantee). Quoted/heredoc/escaped newlines never reach here.
+            b';' | b'\n' | b'\r' => {
                 list_op = true;
                 i += 1;
             }
@@ -674,11 +681,22 @@ line' && cat $HOME/.env"#;
     }
 
     #[test]
-    fn tee_handles_pipeline_with_trailing_redirect() {
-        // A pipeline's stdout is its last stage's stdout — wrapping is correct.
+    fn tee_bails_on_internal_pipeline() {
+        // A pipe inside the command bails: `set -o pipefail` on the tee wrapper
+        // would change the inner pipeline's exit-code semantics vs the original.
+        assert!(tee_redirect_rewrite("cargo build | grep error > errors.log").is_none());
+    }
+
+    #[test]
+    fn tee_bails_on_multiline_command() {
+        // A multi-line command with a trailing redirect on the last line must NOT
+        // be wrapped — wrapping would tee the earlier lines' output into the file.
+        assert!(tee_redirect_rewrite("echo building\nmake > build.log").is_none());
+        assert!(tee_redirect_rewrite("cd src\nmake > build.log 2>&1").is_none());
+        // A backslash-newline line continuation is NOT a separator — still rewritten.
         assert_eq!(
-            tee_redirect_rewrite("cargo build | grep error > errors.log").unwrap(),
-            "set -o pipefail; { cargo build | grep error ; } | tee -- errors.log"
+            tee_redirect_rewrite("make \\\n  --flag > build.log").unwrap(),
+            "set -o pipefail; { make \\\n  --flag ; } | tee -- build.log"
         );
     }
 

--- a/agentmux-bashwrap/src/hook.rs
+++ b/agentmux-bashwrap/src/hook.rs
@@ -203,6 +203,7 @@ fn scan_redirect(cmd: &str) -> Option<ScanResult> {
     let mut in_double = false;
     let mut in_backtick = false;
     let mut paren_depth: i32 = 0;
+    let mut brace_depth: i32 = 0; // `${...}` parameter-expansion nesting
 
     let mut out_redirs: Vec<(OutKind, usize, usize)> = Vec::new();
     let mut dups: Vec<(usize, usize)> = Vec::new(); // 2>&1 occurrences (start, end)
@@ -278,11 +279,31 @@ fn scan_redirect(cmd: &str) -> Option<ScanResult> {
                 i += 1;
                 continue;
             }
+            b'$' => {
+                // `${...}` parameter expansion: a literal `>`/`<`/`|` inside it
+                // (e.g. `${X:->f}`, `${X/>/_}`) must not be read as an operator.
+                // `$(...)` is handled by paren_depth via the `(` below.
+                if i + 1 < n && b[i + 1] == b'{' {
+                    brace_depth += 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            b'}' => {
+                if brace_depth > 0 {
+                    brace_depth -= 1;
+                }
+                i += 1;
+                continue;
+            }
             _ => {}
         }
-        // Inside a subshell / $(...) group: ignore operators (the redirect there
-        // doesn't bind the outer command), but keep tracking quotes (above).
-        if paren_depth > 0 {
+        // Inside a subshell / $(...) / ${...} group: ignore operators (the
+        // redirect there doesn't bind the outer command), but keep tracking
+        // quotes (above).
+        if paren_depth > 0 || brace_depth > 0 {
             i += 1;
             continue;
         }
@@ -742,6 +763,23 @@ line' && cat $HOME/.env"#;
         assert!(tee_redirect_rewrite("cmd 2>&1 > f").is_none()); // leading 2>&1 order
         assert!(tee_redirect_rewrite("echo hi").is_none()); // no redirect
         assert!(tee_redirect_rewrite("server > log &").is_none()); // background
+    }
+
+    #[test]
+    fn tee_handles_param_expansion() {
+        // A literal `>` inside a ${...} expansion is NOT a redirect → no rewrite.
+        assert!(tee_redirect_rewrite("echo ${X:->f}").is_none());
+        assert!(tee_redirect_rewrite("echo ${X/>/_}").is_none());
+        // A real trailing redirect to a ${...}-bearing target IS rewritten.
+        assert_eq!(
+            tee_redirect_rewrite("make > ${LOG}/out.log").unwrap(),
+            "set -o pipefail; { make ; } | tee -- ${LOG}/out.log"
+        );
+        // ...and a ${...} with an inner `>` plus a real trailing redirect.
+        assert_eq!(
+            tee_redirect_rewrite("echo ${X/>/_} > out.log").unwrap(),
+            "set -o pipefail; { echo ${X/>/_} ; } | tee -- out.log"
+        );
     }
 
     #[test]

--- a/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
+++ b/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
@@ -108,21 +108,26 @@ one **regular-file** target token, with `2>&1` in the trailing position (`> F 2>
 - fd-specific or dup redirects only (`2> f`, `>&2`, `3> f`), the leading-`2>&1` order
   (`2>&1 > F`, whose semantics differ), or process substitution `>(…)`,
 - the redirect isn't trailing (`CMD > f | grep x`, `CMD > f && other`),
-- more than one output redirect, or a top-level list operator (`&&`/`||`/`;`/`&`) is present
-  (the redirect would bind to only one command of the list),
+- more than one output redirect, or a top-level list operator (`&&`/`||`/`;`/`&`) **or an
+  unquoted newline** is present (the redirect would bind to only one command of the list, and
+  for a multi-line command wrapping `{ … }` would tee the earlier lines' stdout into the file),
+- a top-level **pipe** (`a | b > f`) is present — `set -o pipefail` on the tee wrapper would
+  change the inner pipeline's exit-code semantics (report the first failure instead of the last
+  stage's exit) vs the original, so only single commands are rewritten,
 - the command already starts with `agentmux-bashwrap exec` (idempotence, like today).
 
-Pipelines (`CMD | grep x > f`) and subshell groups (`(a && b) > f`) ARE handled — a pipeline's
-stdout is its last stage's stdout, exactly what the trailing `>` redirected, so wrapping the
-whole command in `{ ; }` is correct. Bailing is always safe: it yields exactly the current
-behavior for that call. Start narrow; widen the grammar later if real commands need it.
+Subshell groups (`(a && b) > f`) ARE handled — the group's stdout is exactly what the trailing
+`>` redirected, so wrapping it in `{ ; }` is correct (the `&&` inside the parens doesn't bind the
+redirect). Backslash-newline line continuations are also fine (the escape consumes the newline).
+Bailing is always safe: it yields exactly the current behavior for that call. Start narrow; widen
+the grammar later if real commands need it.
 
 ### 3.4 Tests (`agentmux-bashwrap`, alongside `hook.rs` tests) — implemented
 - each row of §3.2 rewrites correctly and round-trips through base64;
-- pipeline + subshell + quoted-target forms rewrite correctly;
-- `/dev/null`, quoted `>`, comment, heredoc, process-subst, mid-pipeline `>`, `2>f`-only,
-  `>&2`, `2>&1 > f`, double-redirect, background, and no-redirect commands are **passed
-  through unchanged**;
+- subshell + quoted-target + backslash-newline-continuation forms rewrite correctly;
+- `/dev/null`, quoted `>`, comment, heredoc, process-subst, `>` in/after a pipe, a multi-line
+  command, `2>f`-only, `>&2`, `2>&1 > f`, double-redirect, background, and no-redirect commands
+  are **passed through unchanged**;
 - exit-code preservation: the rewritten form starts with `set -o pipefail`.
 
 ---

--- a/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
+++ b/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
@@ -1,0 +1,226 @@
+# SPEC: Tee redirected tool output to the feed + render tool output as a terminal
+
+**Date:** 2026-06-17
+**Status:** Implemented (smike) — F1 hook `tee` rewrite + F2 `TerminalOutput`. One
+deviation: `TerminalOutput` lives in `view/agent/components/` (next to the cap
+utilities and sibling renderers) rather than `element/`, so the view→element
+dependency direction stays correct; it imports `AnsiLine` from `element/`.
+**Author:** analysis pass over `main` @ `f958fdd0`
+**Components:** `agentmux-bashwrap` (hook), `frontend/app/view/agent/components/*`, `frontend/app/element/ansiline.tsx`
+
+---
+
+## 1. Context — two complaints, one theme
+
+Agents run shell commands and we want their real output visible in the live tool feed.
+Two distinct gaps break that:
+
+1. **Redirected output disappears.** When an agent runs `task package > build-portable.log 2>&1`,
+   the shell sends stdout to the file, so AgentMux's tool feed shows **nothing** while the
+   command runs. We want a facility that recognizes output is being redirected to a file and
+   surfaces it to **both** the tool feed **and** the file.
+
+2. **Task/tool output renders as a JSON blob.** Output from background-task / `Task` /
+   `TaskOutput`-style tools (and any tool AgentMux doesn't special-case) renders as
+   pretty-printed JSON instead of looking like a **terminal**.
+
+Both are fixable with small, targeted changes that **reuse existing infrastructure** — no
+new streaming protocol, no embedding xterm.js in the feed.
+
+---
+
+## 2. Background — how tool output flows today (verified)
+
+```
+Claude stream-json (tool_call: Bash, command)
+  └─ PreToolUse hook  agentmux-bashwrap/src/hook.rs:53-96
+        rewrites command → `agentmux-bashwrap exec --tool-id=<id> --b64-cmd=<b64(command)>`
+  └─ agentmux-bashwrap exec  agentmux-bashwrap/src/bash_wrap.rs
+        runs `bash -c "{ <command>; } </dev/null"` under a PTY (pipes fallback)
+        reads PTY line-by-line → strips ANSI, collapses CR
+        publishes each line as WPS `tool_chunk` {op:"chunk",kind,content} scoped block:<id>
+        + buffers for the final model blob (`<exited N in Ts>\n…`)
+  └─ frontend useAgentStream.ts subscribes tool_chunk
+  └─ reducer ToolChunkAppend  agent-document/reducer.ts  → ToolNode.log.chunks
+  └─ render: ToolOverlayLog.tsx → ChunkList (live) / ToolOverlayResult (final)
+```
+
+Final/structured results dispatch by tool name in `ToolOverlayLog.tsx:233-312`
+(`renderToolResultBody`): `Bash`→`BashOutputViewer`, `Read`→`HighlightedCode`,
+`Edit`→`DiffViewer`, `Grep`/`Glob`/`Agent`/`Task`/**default**→`CompactResult`.
+`CompactResult.tsx:104,144` renders `JSON.stringify(result, null, 2)` in a `<pre>` — **this is
+the "JSON blob."**
+
+Reusable assets already in the tree:
+- Live chunk pipeline (WPS → reducer → `ChunkList`) — proven by
+  `frontend/test/replay/bash-with-live-log.replay.test.ts`.
+- `AnsiLine` (default export, props `{ line: string }`) at `frontend/app/element/ansiline.tsx` —
+  parses SGR (`\x1b[…m`) into `text-ansi-*`/`bg-ansi-*` spans.
+- Output capping: `output-cap.ts` (`capText`, `MAX_TOOL_OUTPUT_LINES`).
+
+---
+
+## 3. Feature 1 — tee redirected output to the feed
+
+### 3.1 Root cause
+The command string is opaque to AgentMux: the hook base64-encodes it verbatim
+(`hook.rs:79-85`) and bashwrap runs it as-is. A `> FILE` sends the inner shell's stdout to the
+file, so the PTY (hence the chunk stream, hence the feed) sees nothing. There is **no
+redirect inspection anywhere** today.
+
+### 3.2 Design — detect a trailing file redirect at hook time and inject `tee`
+Do it in the **PreToolUse hook** (`agentmux-bashwrap/src/hook.rs`), where the command is still
+plaintext and already being transformed. Reasons: single insertion point, no shell-parsing in
+the hot exec path, fully unit-testable (the hook already has a `build_response` test seam), and
+it reuses the *entire* existing chunk pipeline downstream with **zero frontend changes** — the
+teed output simply becomes normal chunks.
+
+Transform recognized trailing redirects so stdout still flows through the PTY via `tee`, while
+the file is still written:
+
+| Original (suffix)        | Rewritten command                                  |
+|--------------------------|----------------------------------------------------|
+| `CMD > FILE`             | `set -o pipefail; { CMD ; } \| tee -- FILE`        |
+| `CMD >> FILE`            | `set -o pipefail; { CMD ; } \| tee -a -- FILE`     |
+| `CMD > FILE 2>&1`        | `set -o pipefail; { CMD ; } 2>&1 \| tee -- FILE`   |
+| `CMD >> FILE 2>&1`       | `set -o pipefail; { CMD ; } 2>&1 \| tee -a -- FILE`|
+| `CMD &> FILE` (bash)     | `set -o pipefail; { CMD ; } 2>&1 \| tee -- FILE`   |
+| `CMD &>> FILE`           | `set -o pipefail; { CMD ; } 2>&1 \| tee -a -- FILE`|
+
+The rewritten string is what gets base64-encoded into `--b64-cmd`. `set -o pipefail` is
+**required** so the pipeline's exit code reflects `CMD`, not `tee` — bashwrap mirrors that exit
+code to the model and the terminal event.
+
+**Semantics preserved:** `tee` writes the same bytes to `FILE` that the bare `>` would have
+(stdout for the no-`2>&1` forms; stdout+stderr for the `2>&1`/`&>` forms), and passes them
+through to the PTY so they appear live. stderr that wasn't redirected still reaches the PTY as
+before.
+
+### 3.3 Recognition rules (conservative — bail to verbatim on anything ambiguous)
+Implement a small **quote-aware** scan that only accepts a redirect that is the **top-level
+trailing** element of the command. Recognize: optional `2>&1`/`&>`/`&>>`, a single `>`/`>>` to
+one **regular-file** target token, with `2>&1` in the trailing position (`> F 2>&1`).
+
+**Bail (encode the original unchanged — today's behavior) when any of:**
+- the `>`/`>>` is inside single/double quotes, backticks, a `$(…)`/subshell group, a comment,
+  or a heredoc body (it's literal / not top-level),
+- the target is `/dev/null` (intentional discard — don't resurrect it to the feed),
+- fd-specific or dup redirects only (`2> f`, `>&2`, `3> f`), the leading-`2>&1` order
+  (`2>&1 > F`, whose semantics differ), or process substitution `>(…)`,
+- the redirect isn't trailing (`CMD > f | grep x`, `CMD > f && other`),
+- more than one output redirect, or a top-level list operator (`&&`/`||`/`;`/`&`) is present
+  (the redirect would bind to only one command of the list),
+- the command already starts with `agentmux-bashwrap exec` (idempotence, like today).
+
+Pipelines (`CMD | grep x > f`) and subshell groups (`(a && b) > f`) ARE handled — a pipeline's
+stdout is its last stage's stdout, exactly what the trailing `>` redirected, so wrapping the
+whole command in `{ ; }` is correct. Bailing is always safe: it yields exactly the current
+behavior for that call. Start narrow; widen the grammar later if real commands need it.
+
+### 3.4 Tests (`agentmux-bashwrap`, alongside `hook.rs` tests) — implemented
+- each row of §3.2 rewrites correctly and round-trips through base64;
+- pipeline + subshell + quoted-target forms rewrite correctly;
+- `/dev/null`, quoted `>`, comment, heredoc, process-subst, mid-pipeline `>`, `2>f`-only,
+  `>&2`, `2>&1 > f`, double-redirect, background, and no-redirect commands are **passed
+  through unchanged**;
+- exit-code preservation: the rewritten form starts with `set -o pipefail`.
+
+---
+
+## 4. Feature 2 — render task/tool output like a terminal, not JSON
+
+### 4.1 Root cause
+`renderToolResultBody` (`ToolOverlayLog.tsx:233-312`) routes `Task` and every unrecognized tool
+to `CompactResult`, whose expanded view is `JSON.stringify(result, null, 2)`
+(`CompactResult.tsx:104,144`). When the result is really terminal output carried in a string
+field (`content` / `output` / `stdout`), the user sees escaped-newline JSON instead of the text.
+`summarize()` already *extracts* those string fields for the one-line summary
+(`CompactResult.tsx:68-75`) — but the expanded body ignores that and dumps JSON.
+
+### 4.2 Design — a shared `TerminalOutput` renderer + a "looks-like-terminal" gate
+1. **New component** `TerminalOutput.tsx`:
+   - props `{ text: string; class?: string; from?: "head" | "tail" }`;
+   - splits on `\n`, renders each line through `AnsiLine` inside a monospace, dark, scroll-capped
+     container (terminal look). Reuses `capText`/`MAX_TOOL_OUTPUT_LINES` + `OutputHiddenMarker`
+     for the cap, matching `CompactResult`/`BashOutputViewer`.
+   - SGR colors render via the existing `text-ansi-*` classes; non-SGR control bytes are inert
+     (AnsiLine only matches `\x1b[…m`).
+   - *Implementation note:* placed in `view/agent/components/` (not `element/` as originally
+     sketched) so the view→element dependency direction stays correct.
+
+2. **Extract a terminal string from a result** — `terminalText(result): string | null`:
+   prefer `stdout`(+`stderr`), else `output`, else `content`, when they are strings; return
+   `null` for purely structured or empty results (so callers fall back to JSON).
+
+3. **Wire it in (`CompactResult.tsx`):** the expanded branch renders
+   `<TerminalOutput text={terminalText(result)}/>` when that's non-null, else the JSON `<pre>`.
+   This single change fixes `Task`, `Agent`, and all `default` (unknown-tool, incl.
+   `TaskOutput`) results at once.
+
+4. **Optional polish (live + Bash parity):** `ChunkList` and `BashOutputViewer` currently render
+   plain `<pre>`. They can adopt `AnsiLine` for color. **Caveat:** bashwrap currently
+   **strips ANSI** before publishing chunks (`bash_wrap.rs` `strip_ansi`), so live chunks have no
+   color to render today — enabling live color also requires bashwrap to *stop* stripping SGR
+   (keep stripping cursor-movement/CR handling). Treat this as a follow-up, not part of the core
+   fix.
+
+### 4.3 Why not xterm.js in the feed
+The term pane uses xterm.js, but it's a full interactive VT emulator (input, resize, WebGL,
+scrollback buffers) — heavy and stateful for what the feed needs: static, colored, monospace
+scrollback. `AnsiLine` already covers SGR coloring; a thin `TerminalOutput` wrapper is the
+**efficient** path and keeps the feed DOM cheap and capped.
+
+### 4.4 Tests — implemented
+- `TerminalOutput`: multi-line split; ANSI line colorized; cap + hidden-marker beyond
+  `MAX_TOOL_OUTPUT_LINES`.
+- `terminalText`: picks `stdout`/`output`/`content`; returns `null` for `{a:1,b:2}` / empty.
+- `CompactResult`: result with `{content:"line1\nline2"}` / `{stdout:…}` renders `TerminalOutput`
+  (no JSON `<pre>`); a purely structured result still renders JSON.
+
+---
+
+## 5. Efficiency summary (the recommended minimal change set)
+
+| # | Change | File(s) | Size |
+|---|--------|---------|------|
+| F1 | Trailing-redirect detection + `tee` rewrite at hook time | `agentmux-bashwrap/src/hook.rs` (+ tests) | ~1 scanner + grammar |
+| F2a | `TerminalOutput` component (reuses `AnsiLine`, `capText`) | new `view/agent/components/TerminalOutput.tsx` | small |
+| F2b | `terminalText()` helper + use in `CompactResult` expanded branch | new `terminal-text.ts` + `CompactResult.tsx` | a few lines |
+
+F1 needs **no frontend work** (reuses the chunk pipeline). F2 needs **no backend work** (reuses
+`AnsiLine`). Neither adds a dependency.
+
+---
+
+## 6. Risks / edge cases
+- **F1 shell-parsing fragility** — mitigated by the conservative "bail to verbatim" stance; we
+  only transform unambiguous trailing redirects and otherwise behave exactly as today.
+- **F1 exit code** — must keep `set -o pipefail`; covered by a test.
+- **F1 file bytes** — `tee` reproduces the redirect's bytes; the `2>&1` forms intentionally put
+  both streams in the file (matching `> f 2>&1`). The no-`2>&1` form's file still gets stdout only.
+- **F2 huge output** — `TerminalOutput` caps exactly like `CompactResult`/`BashOutputViewer`
+  (`MAX_TOOL_OUTPUT_LINES`) so a large result can't bloat the conversation DOM.
+- **F2 ANSI scope** — `AnsiLine` handles SGR only; cursor-movement sequences won't "move" but are
+  harmless (rendered/dropped as text). Acceptable for scrollback.
+
+## 7. Out of scope / follow-ups
+- Live-chunk **color** (requires bashwrap to stop stripping SGR — §4.2.4).
+- Tailing arbitrary redirect targets that F1 declines to rewrite (a file-watcher fallback) — only
+  if real commands hit the bail path often.
+- Streaming the persistent-shell-node (`ShellNode`) output through the same `TerminalOutput`.
+
+## 8. Verification
+- Build: `task build:backend` (+ `cargo test -p agentmux-bashwrap`), frontend `npm test`.
+- Live: `task dev` → an agent runs `somecmd > out.log 2>&1` → confirm the feed streams the
+  output live (F1) **and** `out.log` is written; run a `Task`/background tool → confirm its
+  result renders as monospace terminal text, not a JSON blob (F2). Observe via `muxlog fe`.
+
+## 9. Key file references
+- `agentmux-bashwrap/src/hook.rs` — command rewrite (F1 insertion point + `tee_redirect_rewrite`)
+- `agentmux-bashwrap/src/bash_wrap.rs` — exec/PTY capture, `strip_ansi`, model blob
+- `frontend/app/view/agent/components/ToolOverlayLog.tsx:233-312` — `renderToolResultBody` switch
+- `frontend/app/view/agent/components/CompactResult.tsx` — summary + terminal/JSON branch (F2)
+- `frontend/app/view/agent/components/TerminalOutput.tsx` — terminal renderer (F2)
+- `frontend/app/view/agent/components/terminal-text.ts` — result→terminal-string helper (F2)
+- `frontend/app/element/ansiline.tsx` — `AnsiLine` (reused for terminal coloring)
+- `frontend/app/view/agent/components/output-cap.ts` — `capText`, `MAX_TOOL_OUTPUT_LINES`

--- a/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
+++ b/docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md
@@ -102,8 +102,8 @@ trailing** element of the command. Recognize: optional `2>&1`/`&>`/`&>>`, a sing
 one **regular-file** target token, with `2>&1` in the trailing position (`> F 2>&1`).
 
 **Bail (encode the original unchanged — today's behavior) when any of:**
-- the `>`/`>>` is inside single/double quotes, backticks, a `$(…)`/subshell group, a comment,
-  or a heredoc body (it's literal / not top-level),
+- the `>`/`>>` is inside single/double quotes, backticks, a `$(…)`/subshell group, a `${…}`
+  parameter expansion, a comment, or a heredoc body (it's literal / not top-level),
 - the target is `/dev/null` (intentional discard — don't resurrect it to the feed),
 - fd-specific or dup redirects only (`2> f`, `>&2`, `3> f`), the leading-`2>&1` order
   (`2>&1 > F`, whose semantics differ), or process substitution `>(…)`,

--- a/frontend/app/view/agent/components/CompactResult.test.tsx
+++ b/frontend/app/view/agent/components/CompactResult.test.tsx
@@ -1,0 +1,51 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CompactResult — expanded-body rendering. Asserts that a result carrying a
+ * terminal string body renders as a TerminalOutput terminal panel, while a
+ * purely structured result still falls back to the JSON <pre>.
+ * SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md §4.
+ */
+
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { CompactResult } from "./CompactResult";
+
+afterEach(() => cleanup());
+
+function expand(container: HTMLElement): void {
+    const summary = container.querySelector(".agent-tool-compact-summary.clickable") as HTMLElement | null;
+    if (summary) fireEvent.click(summary);
+}
+
+describe("CompactResult — terminal vs JSON body", () => {
+    it("renders a terminal panel (not JSON) when the result has a string body", () => {
+        const { container } = render(() => (
+            <CompactResult tool="Task" params={{}} result={{ content: "line1\nline2" }} />
+        ));
+        expand(container);
+        expect(container.querySelector(".agent-terminal-output")).not.toBeNull();
+        expect(container.querySelector(".agent-tool-compact-json")).toBeNull();
+        expect(container.textContent).toContain("line1");
+        expect(container.textContent).toContain("line2");
+    });
+
+    it("renders stdout/stderr as a terminal for command-shaped results", () => {
+        const { container } = render(() => (
+            <CompactResult tool="TaskOutput" params={{}} result={{ stdout: "hello\nworld" }} />
+        ));
+        expand(container);
+        expect(container.querySelector(".agent-terminal-output")).not.toBeNull();
+        expect(container.querySelector(".agent-tool-compact-json")).toBeNull();
+    });
+
+    it("falls back to JSON for a purely structured result", () => {
+        const { container } = render(() => (
+            <CompactResult tool="Task" params={{}} result={{ status: "done", count: 3, items: [1, 2, 3] }} />
+        ));
+        expand(container);
+        expect(container.querySelector(".agent-terminal-output")).toBeNull();
+        expect(container.querySelector(".agent-tool-compact-json")).not.toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/CompactResult.tsx
+++ b/frontend/app/view/agent/components/CompactResult.tsx
@@ -13,6 +13,8 @@
 import { For, createSignal, Show, type JSX } from "solid-js";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { TerminalOutput } from "./TerminalOutput";
+import { terminalText } from "./terminal-text";
 
 interface CompactResultProps {
     tool: string;
@@ -101,8 +103,17 @@ export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX
     const [expanded, setExpanded] = createSignal(tool === "Glob");
 
     const summary = summarize(tool, params, result);
+    // When the result carries a terminal-style string body (stdout/output/
+    // content), render it as a terminal instead of a JSON blob. Structured
+    // results (no string body) fall back to JSON.
+    const termText = terminalText(result);
     const fullJson = result != null ? JSON.stringify(result, null, 2) : "";
-    const hasDetail = fullJson.length > summary.length + 10;
+    // Expandable when there's more to show than the one-line summary. A terminal
+    // body is worth expanding whenever it's multi-line (the summary collapses
+    // it) or longer than the summary.
+    const hasDetail = termText != null
+        ? termText.includes("\n") || termText.length > summary.length
+        : fullJson.length > summary.length + 10;
     // Head-cap the expanded JSON so a large structured payload (Glob / Grep /
     // Agent) can't add an unbounded <pre> once the summary is expanded.
     const jsonCap = capText(fullJson, MAX_TOOL_OUTPUT_LINES, "head");
@@ -139,6 +150,8 @@ export const CompactResult = ({ tool, params, result }: CompactResultProps): JSX
                             </>
                         );
                     })()
+                    : termText != null
+                    ? <TerminalOutput text={termText} from="tail" />
                     : (
                         <>
                             <pre class="agent-tool-compact-json">{jsonCap.text}</pre>

--- a/frontend/app/view/agent/components/TerminalOutput.test.tsx
+++ b/frontend/app/view/agent/components/TerminalOutput.test.tsx
@@ -1,0 +1,49 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { TerminalOutput } from "./TerminalOutput";
+import { MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+
+afterEach(() => cleanup());
+
+describe("TerminalOutput", () => {
+    it("renders one AnsiLine row per line", () => {
+        const { container } = render(() => <TerminalOutput text={"a\nb\nc"} />);
+        const root = container.querySelector(".agent-terminal-output")!;
+        expect(root).not.toBeNull();
+        // AnsiLine emits a <div> per line (no marker under the cap).
+        expect(root.querySelectorAll(":scope > div:not(.agent-output-hidden-marker)").length).toBe(3);
+        expect(root.textContent).toContain("a");
+        expect(root.textContent).toContain("c");
+    });
+
+    it("colorizes ANSI SGR sequences via text-ansi-* classes", () => {
+        const { container } = render(() => (
+            <TerminalOutput text={"\x1b[31mred\x1b[0m plain"} />
+        ));
+        const colored = container.querySelector(".text-ansi-red");
+        expect(colored).not.toBeNull();
+        expect(colored!.textContent).toBe("red");
+    });
+
+    it("caps beyond MAX_TOOL_OUTPUT_LINES (tail) and shows a hidden marker", () => {
+        const text = Array.from({ length: MAX_TOOL_OUTPUT_LINES + 5 }, (_, i) => `line${i}`).join("\n");
+        const { container } = render(() => <TerminalOutput text={text} from="tail" />);
+        const root = container.querySelector(".agent-terminal-output")!;
+        // Exactly MAX line rows (the hidden-marker div is excluded).
+        expect(root.querySelectorAll(":scope > div:not(.agent-output-hidden-marker)").length).toBe(MAX_TOOL_OUTPUT_LINES);
+        const marker = container.querySelector(".agent-output-hidden-marker");
+        expect(marker).not.toBeNull();
+        expect(marker!.textContent).toContain("5");
+        // tail-cap keeps the latest lines.
+        expect(root.textContent).toContain(`line${MAX_TOOL_OUTPUT_LINES + 4}`);
+        expect(root.textContent).not.toContain("line0\n");
+    });
+
+    it("renders no marker when under the cap", () => {
+        const { container } = render(() => <TerminalOutput text={"short"} />);
+        expect(container.querySelector(".agent-output-hidden-marker")).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/TerminalOutput.tsx
+++ b/frontend/app/view/agent/components/TerminalOutput.tsx
@@ -1,0 +1,56 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TerminalOutput — render a captured terminal/tool output body as a monospace,
+ * ANSI-colored, scroll-capped terminal panel instead of a JSON blob.
+ *
+ * Reuses `AnsiLine` (SGR coloring) and the shared output cap
+ * (`MAX_TOOL_OUTPUT_LINES`) + `OutputHiddenMarker` so a large body can't bloat
+ * the conversation DOM — matching `CompactResult` / `BashOutputViewer`. A thin
+ * wrapper over `AnsiLine` is deliberately preferred to embedding xterm.js in the
+ * feed (the term pane's full VT emulator is heavy and stateful for what static,
+ * colored scrollback needs).
+ *
+ * Lives next to the other tool-output renderers (not in `element/`, where the
+ * spec sketched it) so the view → element dependency direction stays correct:
+ * it imports the view-layer cap utilities, and `AnsiLine` lives in `element/`.
+ * See docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md §4.
+ */
+
+import clsx from "clsx";
+import { For, Show, createMemo, type JSX } from "solid-js";
+import AnsiLine from "@/element/ansiline";
+import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+
+interface TerminalOutputProps {
+    text: string;
+    /** Extra class on the container. */
+    class?: string;
+    /** Cap direction — command/log output keeps the tail (latest matters);
+     *  read-top-down content keeps the head. Default "tail". */
+    from?: "head" | "tail";
+}
+
+export function TerminalOutput(props: TerminalOutputProps): JSX.Element {
+    const from = (): "head" | "tail" => props.from ?? "tail";
+    const capped = createMemo(() => capText(props.text ?? "", MAX_TOOL_OUTPUT_LINES, from()));
+    const lines = createMemo(() => capped().text.split("\n"));
+
+    return (
+        <div class={clsx("agent-terminal-output", props.class)}>
+            {/* tail-cap hides OLDER lines → marker above the body */}
+            <Show when={from() === "tail" && capped().hiddenLines > 0}>
+                <OutputHiddenMarker hidden={capped().hiddenLines} noun="line" from="tail" />
+            </Show>
+            <For each={lines()}>{(line) => <AnsiLine line={line} />}</For>
+            {/* head-cap hides LATER lines → marker below the body */}
+            <Show when={from() === "head" && capped().hiddenLines > 0}>
+                <OutputHiddenMarker hidden={capped().hiddenLines} noun="line" from="head" />
+            </Show>
+        </div>
+    );
+}
+
+TerminalOutput.displayName = "TerminalOutput";

--- a/frontend/app/view/agent/components/terminal-text.test.ts
+++ b/frontend/app/view/agent/components/terminal-text.test.ts
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { terminalText } from "./terminal-text";
+
+describe("terminalText", () => {
+    it("returns a raw string result as-is", () => {
+        expect(terminalText("line1\nline2")).toBe("line1\nline2");
+    });
+
+    it("prefers stdout, joining stderr when both present", () => {
+        expect(terminalText({ stdout: "out", stderr: "err" })).toBe("out\nerr");
+        expect(terminalText({ stdout: "out" })).toBe("out");
+        expect(terminalText({ stderr: "err" })).toBe("err");
+    });
+
+    it("falls back to output then content", () => {
+        expect(terminalText({ output: "the output" })).toBe("the output");
+        expect(terminalText({ content: "the content" })).toBe("the content");
+        // stdout wins over output/content
+        expect(terminalText({ stdout: "s", output: "o", content: "c" })).toBe("s");
+        // output wins over content
+        expect(terminalText({ output: "o", content: "c" })).toBe("o");
+    });
+
+    it("returns null for a purely structured result", () => {
+        expect(terminalText({ a: 1, b: 2 })).toBeNull();
+        expect(terminalText({ files: ["a", "b"] })).toBeNull();
+        expect(terminalText({ exitCode: 0 })).toBeNull();
+    });
+
+    it("returns null for empty / nullish bodies (so callers show JSON)", () => {
+        expect(terminalText(null)).toBeNull();
+        expect(terminalText(undefined)).toBeNull();
+        expect(terminalText("")).toBeNull();
+        expect(terminalText({ stdout: "", stderr: "" })).toBeNull();
+        expect(terminalText({ content: "" })).toBeNull();
+        expect(terminalText(42)).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/terminal-text.ts
+++ b/frontend/app/view/agent/components/terminal-text.ts
@@ -31,7 +31,8 @@ function extract(result: unknown): string | null {
         return [stdout ?? "", stderr ?? ""].filter((s) => s.length > 0).join("\n");
     }
 
-    // Generic string carriers, same precedence as summarize().
+    // Generic string carriers: prefer `output`, then `content` (note: this is the
+    // opposite of summarize()'s content-before-output order — see the file doc).
     if (typeof r.output === "string") return r.output;
     if (typeof r.content === "string") return r.content;
     return null;

--- a/frontend/app/view/agent/components/terminal-text.ts
+++ b/frontend/app/view/agent/components/terminal-text.ts
@@ -1,0 +1,37 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * terminalText — extract a terminal-style text body from a tool result, using
+ * the same field precedence `CompactResult.summarize()` uses: a raw string
+ * result, else `stdout`(+`stderr`), else `output`, else `content`. Returns
+ * `null` for a purely structured result (no string body) or an empty body, so
+ * callers fall back to the JSON view.
+ *
+ * Centralizing the precedence lets the feed render task/tool output as a
+ * terminal instead of a JSON blob.
+ * See docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md §4.2.
+ */
+export function terminalText(result: unknown): string | null {
+    const raw = extract(result);
+    return raw != null && raw.length > 0 ? raw : null;
+}
+
+function extract(result: unknown): string | null {
+    if (result == null) return null;
+    if (typeof result === "string") return result;
+    if (typeof result !== "object") return null;
+    const r = result as Record<string, unknown>;
+
+    // Command-shaped results: stdout (+ stderr) is the terminal body.
+    const stdout = typeof r.stdout === "string" ? r.stdout : null;
+    const stderr = typeof r.stderr === "string" ? r.stderr : null;
+    if (stdout != null || stderr != null) {
+        return [stdout ?? "", stderr ?? ""].filter((s) => s.length > 0).join("\n");
+    }
+
+    // Generic string carriers, same precedence as summarize().
+    if (typeof r.output === "string") return r.output;
+    if (typeof r.content === "string") return r.content;
+    return null;
+}

--- a/frontend/app/view/agent/components/terminal-text.ts
+++ b/frontend/app/view/agent/components/terminal-text.ts
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * terminalText — extract a terminal-style text body from a tool result, using
- * the same field precedence `CompactResult.summarize()` uses: a raw string
- * result, else `stdout`(+`stderr`), else `output`, else `content`. Returns
- * `null` for a purely structured result (no string body) or an empty body, so
- * callers fall back to the JSON view.
+ * terminalText — extract a terminal-style text body from a tool result. Field
+ * precedence: a raw string result, else `stdout`(+`stderr`), else `output`,
+ * else `content`. Returns `null` for a purely structured result (no string
+ * body) or an empty body, so callers fall back to the JSON view.
  *
- * Centralizing the precedence lets the feed render task/tool output as a
- * terminal instead of a JSON blob.
+ * This peeks at the same kind of string fields that `CompactResult.summarize()`
+ * uses for its one-liner, but with a different precedence (summarize never
+ * inspects `stdout` and orders `content` before `output`) — so it's deliberately
+ * its own function, tuned for "render the whole body as a terminal".
  * See docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md §4.2.
  */
 export function terminalText(result: unknown): string | null {

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1284,3 +1284,28 @@
         overflow: hidden;
     }
 }
+
+// Terminal-style tool/task output (TerminalOutput.tsx) — monospace, scroll-
+// capped panel rendering AnsiLine rows. Replaces the JSON blob for results that
+// carry a terminal string body (stdout/output/content).
+.agent-terminal-output {
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    padding: var(--space-1) var(--space-1-5);
+    margin: var(--space-1) 0 0 0;
+    max-height: 400px;
+    overflow-y: auto;
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+    line-height: 1.45;
+
+    // AnsiLine renders one <div> per line — preserve runs of spaces and wrap
+    // long lines instead of forcing a horizontal scrollbar. min-height keeps a
+    // blank line (empty <div>) occupying a row instead of collapsing to zero.
+    > div {
+        min-height: 1.45em;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
+}


### PR DESCRIPTION
Implements `docs/specs/SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md` — two independent fixes, "two complaints, one theme."

## F1 — tee a trailing file redirect to the feed (backend)

**Problem:** `task package > build.log 2>&1` sends stdout to the file, so the agent's tool feed shows *nothing* while it runs.

**Fix:** the PreToolUse hook (`agentmux-bashwrap/src/hook.rs`) now recognizes an unambiguous **top-level trailing** redirect and rewrites it to a `tee` pipeline before base64-encoding, so the same bytes reach **both** the file **and** the PTY (hence the live chunk feed) — **zero frontend changes**, reuses the whole existing pipeline.

```
CMD > F        →  set -o pipefail; { CMD ; } | tee -- F
CMD >> F 2>&1  →  set -o pipefail; { CMD ; } 2>&1 | tee -a -- F
CMD &> F       →  set -o pipefail; { CMD ; } 2>&1 | tee -- F
```

A conservative, **quote/group/comment-aware** scanner handles `>`/`>>`/`&>`/`&>>`, trailing `2>&1`, **pipelines** (`a | b > f`), and **subshells** (`(a && b) > f`). Everything ambiguous **bails to today's verbatim behavior**: quotes, comments, heredocs, process substitution, `/dev/null`, fd-specific/dup redirects (`2>f`, `>&2`), the `2>&1 > F` order (different semantics), top-level lists (`&&`/`||`/`;`/`&`), non-trailing, and multiple redirects. `set -o pipefail` preserves the command's exit code through the pipe (bashwrap mirrors it to the model + terminal event).

## F2 — render task/tool output as a terminal, not a JSON blob (frontend)

**Problem:** `Task` / `TaskOutput` / unknown-tool results route to `CompactResult`, whose expanded view is `JSON.stringify(result, null, 2)` — escaped-newline JSON instead of the actual output.

**Fix:**
- new **`TerminalOutput`** renders a result's terminal string body through the existing **`AnsiLine`** (SGR color) in a monospace, scroll-capped panel — reusing `capText`/`MAX_TOOL_OUTPUT_LINES`/`OutputHiddenMarker`. No xterm.js in the feed (§4.3).
- new **`terminalText(result)`** extracts `stdout`(+`stderr`) / `output` / `content`; `null` for purely structured or empty results.
- `CompactResult`'s expanded branch renders the terminal when there's a string body, else falls back to JSON — fixes **Task, Agent, TaskOutput, and all unknown tools at once**.

## Tests / verification

- **`cargo test -p agentmux-bashwrap`**: 40 pass, incl. 9 new F1 cases — every rewrite form + round-trip through `build_response` b64 + every bail path.
- **549 agent-view vitest** pass (3 new suites: `terminal-text`, `TerminalOutput`, `CompactResult`).
- `tsc --noEmit` and `stylelint` clean for touched files (pre-existing baseline noise excluded).
- ⚠️ Not verified headlessly: the live feed actually streaming a redirected command's output, and a Task result rendering as a terminal in the running app — needs `task dev` (per spec §8).

## Notes
- `TerminalOutput` is placed in `view/agent/components/` (not `element/` as the spec sketched) to keep the **view→element** dependency direction correct — it imports the view-layer cap utilities; `AnsiLine` stays in `element/`. Noted in the committed spec.
- Live-chunk **color** (F2 §4.2.4) stays a follow-up — bashwrap strips SGR before publishing chunks today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)