### PR TITLE
fix(trust-center): bind already-authorized CLI OAuth to its brand

### DIFF
--- a/.changesets/1781570000-trust-center-cli-auth-binding.md
+++ b/.changesets/1781570000-trust-center-cli-auth-binding.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(trust-center): surface already-authorized CLI OAuth under its brand — a Claude CLI login now shows as a connected Anthropic account (and codex→OpenAI, gemini→Google, copilot→GitHub), with its live probe status, instead of being invisible

--- a/docs/specs/SPEC_TRUST_CENTER_CLI_AUTH_BINDING_2026_06_17.md
+++ b/docs/specs/SPEC_TRUST_CENTER_CLI_AUTH_BINDING_2026_06_17.md
@@ -1,0 +1,61 @@
+# SPEC: Trust Center ↔ CLI-OAuth two-way binding
+
+**Date:** 2026-06-17
+**Status:** Draft — implementation (folded into the PR)
+**Scope:** Trust Center Accounts (`frontend/app/view/accounts/**`, `frontend/app/view/identity/identity-model.ts`)
+**Related:** `SPEC_TRUST_CENTER_2026_06_15.md` (the hub), `identity/migration.rs` (Default-bundle ambient discovery), `identity/resolver.rs::probe_oauth_status`
+
+---
+
+## 1. Problem
+
+A user talking to a running Claude instance is *clearly* authorized with Anthropic — but the Trust Center shows **no** Anthropic connection. Two namespaces never met:
+
+- **Concept A — CLI-provider OAuth:** the Claude CLI's login lives at `~/.claude/.credentials.json`. At startup, `migration.rs` discovers it and creates an `IdentityAccount` with **`provider = "claude"`**, `kind = "oauth"`, `secret_ref = OAuthConfigDir { ~/.claude }`, `status` from `probe_oauth_status` (live), bound to the **Default** bundle.
+- **Concept B — Trust Center brands:** the gallery + grouping only know brand ids — `AccountProvider = github|google|aws|openai|anthropic|slack|custom|agentmux`. **`"claude"` is not in the type, not a tile, not in the `accountsByProvider` order.**
+
+So the already-authorized, already-probed `"claude"` OAuth account is **filtered out and invisible**: `accountsByProvider` (the source for both the tile count `AccountsGallery.countFor` and the connected list `AccountsTab`) drops any provider not in its brand `order`.
+
+## 2. Insight — unify the namespace at the grouping key
+
+The fix is a **display-only normalization**: a CLI-OAuth provider *is* a brand authorization. Map CLI provider → brand and group by the brand, **without** changing the account's stored `provider` (the resolver still injects env keyed by the real `"claude"` id at spawn — untouched).
+
+| CLI provider (concept A) | Trust Center brand |
+|---|---|
+| `claude` | `anthropic` |
+| `codex` | `openai` |
+| `gemini` | `google` |
+| `copilot` | `github` |
+| (`openclaw`, others) | passthrough (no brand tile yet) |
+
+`accountsByProvider` already keys the gallery tile count *and* the connected list. Normalizing its grouping key therefore surfaces the detected account **everywhere at once**:
+- the **Anthropic tile** shows "1 connected";
+- the **Connected accounts** list shows the `claude-oauth` row under the Anthropic group, with its **live status dot** (valid/expired from `probe_oauth_status`, refreshed every spawn + broadcast) — the read side of the two-way binding;
+- the per-agent identity panel groups it under Anthropic consistently.
+
+## 3. Two-way binding
+
+- **Read (this PR):** the Trust Center reflects real OS auth state. The account row is the *same* row the resolver re-probes at every agent spawn (`inject_identity_env_with_broker` → `probe_oauth_status` → upsert status → `identitybundlebindings:changed` broadcast), so the status the Trust Center shows is live, not a snapshot.
+- **Write (already wired):** the account is bound to the Default bundle, so it composes into identities/agents today; reconnect routes through the existing OAuth login flow (`auth.start` into the bundle). No new write path needed for v1.
+
+## 4. Changes
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/accounts/provider-brand.ts` *(new)* | `brandForProvider(provider): AccountProvider` — CLI-OAuth id → brand (table above), else passthrough. Single source of the mapping. |
+| `frontend/app/view/identity/identity-model.ts` | `accountsByProvider()` groups by `brandForProvider(a.provider)` instead of the raw provider. Account `provider` is unchanged; only the **grouping key** normalizes. |
+| (verify) `AccountsGallery.countFor` | unchanged — it reads `accountsByProvider().get(id)`, so it's fixed transitively. |
+
+That's the whole fix: ~1 new tiny module + a one-line key change. No backend change — the account + live status already exist.
+
+## 5. Robustness follow-ups (not in v1)
+
+- **Live ambient probe RPC** (`cli_auth_status`): for the case where the Default-bundle migration hasn't created the account (fresh machine, non-standard login), probe `~/.{authDirName}/.credentials.json` for each OAuth CLI on Trust Center open and surface detected brands even with no stored row. The migration covers the common case today; this hardens it.
+- **Brand-native reconnect:** when a brand tile's only connection is a CLI-OAuth account, its OAuth action should route to that CLI's login (`auth.start` provider=`claude`) rather than a brand-OAuth path.
+- **Logo/label:** the connected row shows the Claude logo under the Anthropic group (informative — "via Claude CLI"); optionally add a "via Claude CLI (OAuth)" sublabel.
+
+## 6. Verification
+
+- Anthropic tile shows "1 connected" when `~/.claude` OAuth exists; the Connected list shows the `claude-oauth` row under Anthropic with a live status dot.
+- Stored `provider` stays `"claude"` (agent env injection unaffected); `npm run build` + identity tests pass.
+- No regression to brand-native (concept-B) accounts — they group under their own provider as before.

--- a/frontend/app/view/accounts/provider-brand.test.ts
+++ b/frontend/app/view/accounts/provider-brand.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { brandForProvider, isCliOAuthProvider } from "./provider-brand";
+
+describe("brandForProvider", () => {
+    it("maps CLI-OAuth provider ids onto their brand", () => {
+        expect(brandForProvider("claude")).toBe("anthropic");
+        expect(brandForProvider("codex")).toBe("openai");
+        expect(brandForProvider("gemini")).toBe("google");
+        expect(brandForProvider("copilot")).toBe("github");
+    });
+
+    it("passes brand ids through unchanged", () => {
+        for (const brand of ["anthropic", "openai", "google", "github", "aws", "slack", "custom", "agentmux"]) {
+            expect(brandForProvider(brand)).toBe(brand);
+        }
+    });
+
+    it("passes unmapped providers through unchanged", () => {
+        expect(brandForProvider("openclaw")).toBe("openclaw");
+        expect(brandForProvider("kimi")).toBe("kimi");
+    });
+
+    it("flags CLI-OAuth providers, not brands", () => {
+        expect(isCliOAuthProvider("claude")).toBe(true);
+        expect(isCliOAuthProvider("copilot")).toBe(true);
+        expect(isCliOAuthProvider("anthropic")).toBe(false);
+        expect(isCliOAuthProvider("github")).toBe(false);
+    });
+});

--- a/frontend/app/view/accounts/provider-brand.ts
+++ b/frontend/app/view/accounts/provider-brand.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * provider-brand — unify the two account namespaces in the Trust Center UI.
+ *
+ * A provider-CLI OAuth login (concept A — e.g. the Claude CLI's
+ * `~/.claude/.credentials.json`, stored as an IdentityAccount with
+ * `provider = "claude"`, `kind = "oauth"`) IS an authorization for a Trust
+ * Center *brand* (concept B — `anthropic`). The two never met: the gallery and
+ * grouping only know brand ids, so a `"claude"` account was filtered out and
+ * the Anthropic tile showed nothing despite the user being logged in.
+ *
+ * `brandForProvider` maps a CLI-OAuth provider id to its brand so accounts
+ * group under the right tile. It's **display-only** — the account's stored
+ * `provider` is unchanged (the resolver still injects env keyed by the real
+ * CLI id at spawn). See SPEC_TRUST_CENTER_CLI_AUTH_BINDING_2026_06_17.md.
+ */
+
+import type { AccountProvider } from "@/app/view/identity/identity-model";
+
+/** CLI-OAuth provider id → Trust Center brand. Only providers whose login
+ *  authorizes a brand we show as a tile are mapped; everything else passes
+ *  through unchanged. */
+const CLI_PROVIDER_TO_BRAND: Record<string, AccountProvider> = {
+    claude: "anthropic",
+    codex: "openai",
+    gemini: "google",
+    copilot: "github",
+};
+
+/**
+ * Normalize an account's provider to the brand it should display under.
+ * Brand ids and unmapped providers pass through unchanged.
+ */
+export function brandForProvider(provider: string): AccountProvider {
+    return CLI_PROVIDER_TO_BRAND[provider] ?? (provider as AccountProvider);
+}
+
+/** True when `provider` is a CLI-OAuth id that maps onto a different brand. */
+export function isCliOAuthProvider(provider: string): boolean {
+    return provider in CLI_PROVIDER_TO_BRAND;
+}

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -12,6 +12,7 @@ import { createSignal, type Accessor, type Setter } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { Logger } from "@/util/logger";
+import { brandForProvider } from "@/app/view/accounts/provider-brand";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -373,11 +374,16 @@ export class IdentityViewModel implements ViewModel {
 
     // ── Derived helpers ──────────────────────────────────────────────────────
 
+    // Group by *brand*, not raw provider, so a CLI-OAuth account (e.g.
+    // provider "claude" — the Claude CLI's `~/.claude` login) surfaces under
+    // its brand tile ("anthropic"). Display-only: the account's stored
+    // `provider` is unchanged, so spawn-time env injection is unaffected.
+    // See SPEC_TRUST_CENTER_CLI_AUTH_BINDING_2026_06_17.md.
     accountsByProvider = (): Map<AccountProvider, Account[]> => {
         const map = new Map<AccountProvider, Account[]>();
         const order: AccountProvider[] = ["github", "google", "aws", "openai", "anthropic", "slack", "custom"];
         for (const p of order) {
-            const group = this.accountsAtom().filter((a) => a.provider === p);
+            const group = this.accountsAtom().filter((a) => brandForProvider(a.provider) === p);
             if (group.length > 0) map.set(p, group);
         }
         return map;

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -16,6 +16,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { OAuthConnectPanel } from "@/app/view/accounts/OAuthConnectPanel";
 import { supportsOAuth } from "@/app/view/accounts/oauth-catalog";
+import { brandForProvider, isCliOAuthProvider } from "@/app/view/accounts/provider-brand";
 import "./identity-view.scss";
 import "@/app/view/accounts/oauth-connect.scss";
 
@@ -184,7 +185,15 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
             </div>
 
             <div class="identity-detail-body">
-                <DetailField label="Provider" value={PROVIDER_LABELS[account.provider]} />
+                {/* Resolve the label via the brand so CLI-OAuth accounts
+                    (provider "claude"/"codex"/…) don't render a blank Provider
+                    field; surface "via <CLI>" so the origin is clear. */}
+                <DetailField
+                    label="Provider"
+                    value={`${PROVIDER_LABELS[brandForProvider(account.provider)] ?? account.provider}${
+                        isCliOAuthProvider(account.provider) ? ` (via ${account.provider} CLI)` : ""
+                    }`}
+                />
                 <DetailField label="Kind" value={KIND_LABELS[account.kind]} />
 
                 {/* Secret reference */}


### PR DESCRIPTION
## Problem

Talking to a running Claude instance means you're **clearly authorized with Anthropic** — yet the Trust Center showed **no** Anthropic connection.

Two namespaces never met. The Default-bundle migration discovers the ambient Claude login (`~/.claude/.credentials.json`) and stores it as an `IdentityAccount` with **`provider = "claude"`** (`kind: oauth`, `SecretRef::OAuthConfigDir`, live-probed `status`). But the Trust Center only knows **brand** ids — `"claude"` isn't in `AccountProvider`, isn't a gallery tile, and isn't in the `accountsByProvider` grouping `order` — so it was **filtered out and invisible**.

## Fix — unify the namespace at the grouping key

- **`provider-brand.ts`** — `brandForProvider()` maps CLI-OAuth ids → brands: `claude→anthropic`, `codex→openai`, `gemini→google`, `copilot→github`. **Display-only** — the account's stored `provider` is unchanged, so spawn-time env injection (keyed by the real CLI id via the resolver) is untouched.
- **`accountsByProvider()`** groups by `brandForProvider(provider)`. Since it feeds **both** the gallery tile count (`AccountsGallery.countFor`) **and** the Connected-accounts list (`AccountsTab`), the detected account now appears under its **Anthropic** tile *and* in the list with its **live status dot** — one change, fixed everywhere.

## Two-way binding
This is the **read** side: the surfaced row is the *same* one the resolver re-probes at every agent spawn (`probe_oauth_status` → status upsert → `identitybundlebindings:changed` broadcast), so the status stays live, not a snapshot. The account is already bound to the Default bundle, so it composes into identities today.

**Follow-ups (noted in the spec):** reconnect-from-tile via the existing `auth.start` flow, and an ambient live-probe RPC for machines where the migration didn't create the row.

## Verification
- `npm run build` — clean.
- `vitest` — identity + accounts pass, incl. new `provider-brand.test.ts` (4 cases).
- Stored `provider` stays `"claude"` → agent env injection unaffected; brand-native (key) accounts group as before.

Spec: `docs/specs/SPEC_TRUST_CENTER_CLI_AUTH_BINDING_2026_06_17.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)