### PR TITLE
feat(agent): tool-result renderer registry + WebSearch cards + record tables (Phases 0–3)

### DIFF
--- a/.changesets/1781694790-refactor-agent-tool-result-renderer-registry-foundation-raw--2vn7.md
+++ b/.changesets/1781694790-refactor-agent-tool-result-renderer-registry-foundation-raw--2vn7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agent): tool-result renderer registry foundation (raw tool name + registry)

--- a/.changesets/1781694790-refactor-agent-tool-result-renderer-registry-foundation-raw--2vn7.md
+++ b/.changesets/1781694790-refactor-agent-tool-result-renderer-registry-foundation-raw--2vn7.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
-refactor(agent): tool-result renderer registry foundation (raw tool name + registry)
+feat(agent): tool-result renderer registry — rich per-tool result UIs (WebSearch cards, record tables) routed by tool name/shape instead of a closed switch

--- a/docs/specs/SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md
+++ b/docs/specs/SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md
@@ -1,0 +1,163 @@
+# SPEC: Tool-result renderer registry (rich, per-tool result UIs that scale)
+
+**Date:** 2026-06-17
+**Status:** Proposed (analysis + design; not implemented)
+**Author:** smike
+**Builds on:** `SPEC_TOOL_OUTPUT_TEE_AND_TERMINAL_RENDER_2026_06_17.md` (PR #1511 — `TerminalOutput` + `terminalText`, the first result-shape classifier)
+**Components:** `frontend/app/view/agent/stream-parser.ts`, `frontend/app/view/agent/types.ts`, `frontend/app/view/agent/components/ToolOverlayLog.tsx`, `…/components/*`
+
+---
+
+## 1. Problem
+
+Different tool calls want different result UIs, and the set of tools is **open-ended**:
+- `WebSearch` → a list of result **cards** (title / url / snippet), not a JSON blob.
+- `WebFetch` → readable page text / markdown.
+- `TodoWrite` → a checklist.
+- MCP tools (`mcp__<server>__<tool>`) → whatever that server returns — images, tables, structured records.
+- provider-specific tools we don't know about yet.
+
+Today every one of these renders as **pretty-printed JSON in a `<pre>`** (or, after PR #1511, as a terminal when the result happens to carry a string body). The `TerminalOutput` work fixed the "looks-like-a-terminal" slice; this spec generalizes the pattern so *any* tool can get a rich renderer without editing a hardcoded switch — and, crucially, so the renderer can even **tell which tool it is**.
+
+---
+
+## 2. Current architecture (verified)
+
+### 2.1 The result model cannot name the tool
+`ToolNode.tool` is a **closed 9-value union** (`types.ts:213`):
+```ts
+tool: "Read" | "Edit" | "Bash" | "Write" | "Grep" | "Glob" | "Task" | "Agent" | "Other";
+```
+Every translator *does* carry the real provider tool name (`claude-translator.ts:287` `block.tool_name`, `acp/gemini/kimi/codex-translator` `toolName`, etc.), but `stream-parser.ts:504-508` collapses anything unknown to `"Other"`:
+```ts
+private normalizeToolName(tool: string): ToolNode['tool'] {
+    const normalized = ...;
+    return knownTools.includes(normalized) ? (normalized as ToolNode['tool']) : "Other";
+}
+```
+So **the raw name is thrown away** before a `ToolNode` exists. `WebSearch`, `WebFetch`, `TodoWrite`, and every `mcp__*` tool all become `"Other"` — indistinguishable downstream.
+
+### 2.2 Rendering is a hardcoded switch over that enum
+`ToolOverlayLog.tsx:233-312` `renderToolResultBody(node)` is a `switch (node.tool)`:
+`Edit`→`DiffViewer`, `Bash`→`BashOutputViewer`, `Read`→`HighlightedCode`,
+`Grep`/`Glob`→search block + `CompactResult`, `Agent`/`Task`/**default**→`CompactResult`
+(whose expanded body is JSON, or — post #1511 — `TerminalOutput` when `terminalText(result) != null`).
+
+Because every novel tool is `"Other"`, the switch's `default` is the *only* branch they can reach. Adding a rich renderer means adding a `case` to a switch over an enum **the data can't even populate**.
+
+### 2.3 A second tool-keyed dispatch: icons
+`types.ts:602` `TOOL_ICONS: Record<string,string>` + `stream-parser.ts:463`
+`TOOL_ICONS[tool] || TOOL_ICONS.Other` pick the summary emoji. So tool identity is dispatched in **two** places (render body + icon), both keyed on the closed enum, and the per-node `summary` string is assembled in the parser.
+
+### 2.4 Prior art the registry should subsume
+- **#1511** `terminalText(result)` → `TerminalOutput` is exactly a *(classifier → renderer)* pair for one result shape. It's the seed of this design.
+- **AskUserQuestion** already renders a rich, non-JSON UI (`AgentQuestionPanel`) — but via a *node field* (`status:"awaiting_answer"` + `node.question`) and a special-case in `stream-parser.ts:311`, not through the result renderer. That's the "rich tool UI" precedent, done ad hoc.
+
+---
+
+## 3. Why it needs a rethink (not just more `case`s)
+
+1. **Open tool universe.** MCP especially means the tool set is unbounded and user-defined; a closed enum + switch can never cover it.
+2. **The data is lost at the wrong layer.** Routing is impossible because `normalizeToolName` discards the only key that matters.
+3. **Two parallel switches** (render + icon) and an ad-hoc third path (AskUserQuestion) mean every "rich tool" is bespoke wiring.
+4. **The real axis is result *shape*, not tool name.** Many tools share a shape (anything terminal-ish → `TerminalOutput`; anything list-of-records → a table; anything search-result-ish → cards). Keying purely on name misses reuse; keying purely on shape misses tool-specific polish. We want both.
+
+---
+
+## 4. Design principle
+
+> **Separate "what is this result" (classification) from "how to render it" (a registry of renderers). Key on the *real* tool name first, result *shape* second, with a graceful fallback chain. Unknown tools degrade to terminal-or-JSON, never break.**
+
+---
+
+## 5. Proposed architecture
+
+### 5.1 Preserve the raw tool name (Phase 0 — the unblocker)
+Add `toolName: string` to `ToolNode` (the exact provider name: `"WebSearch"`, `"mcp__github__search_issues"`, …). Keep the coarse `tool` enum as a *derived* "kind" for back-compat (icons, existing switch) during migration. The data already exists at `stream-parser.ts` (`event.tool` before normalization) — this is a one-field carry-through, no translator changes.
+
+### 5.2 A renderer registry
+Replace the `switch` with a registry of **matchers → renderers**:
+```
+type ToolResultRenderer = (node: ToolNode) => JSX.Element;
+type Matcher =
+  | { name: string }                         // exact: "WebSearch"
+  | { prefix: string }                       // "mcp__"
+  | { shape: (r: unknown) => boolean };      // predicate, e.g. looksLikeSearchResults
+registerToolRenderer(matcher, renderer, priority?)
+```
+`resolveToolRenderer(node)` walks: **exact name → prefix → shape predicate → fallback chain**, returning the first match. The fallback chain is the current behavior generalized:
+`registered renderer` → `terminalText` ⇒ `TerminalOutput` (#1511) → JSON `<pre>` (`CompactResult`).
+
+`renderToolResultBody` becomes a two-liner: `resolveToolRenderer(node)(node)`. The existing per-tool components (`DiffViewer`, `BashOutputViewer`, `HighlightedCode`, …) are migrated to **registrations** that produce byte-identical output — a pure refactor, no UX change.
+
+### 5.3 Reusable result-*kind* components
+Shape-driven, tool-agnostic; many tools map to one:
+- `TerminalOutput` (done) — stdout/log/plain text.
+- `CodeView` — Read / file content (wraps `HighlightedCode`).
+- `DiffView` — Edit (wraps `DiffViewer`).
+- `FileList` — Glob / file arrays.
+- **`SearchResults`** — WebSearch & friends: title / url / snippet cards. *(The first new kind; the proof of the design.)*
+- `KeyValueTable` — generic `{records:[…]}` / object-of-scalars.
+- `ImageView` — base64 / url images (MCP).
+- `ErrorView` — failed results with a message.
+
+### 5.4 Classifier helpers (the "shape" matchers)
+Small pure predicates, each tested in isolation (`terminalText` is the template):
+`looksLikeSearchResults(r)`, `looksLikeFileList(r)`, `looksLikeImage(r)`, `looksLikeRecords(r)`, … Used both as registry shape-matchers and as the fallback chain.
+
+### 5.5 Unify the second/third dispatch (later phase)
+A registry entry can optionally own its **icon** and **summary** contribution, retiring `TOOL_ICONS` + the parser's bespoke summary assembly and folding the AskUserQuestion special-case into a registered renderer (keyed on `status:"awaiting_answer"`). Out of scope for the first cut; called out so the registry is designed to grow into it.
+
+---
+
+## 6. The key fork — where structure comes from
+
+- **(A) Normalize at the translator.** Each provider maps its raw result into a typed tagged union (`{kind:"search", results:[{title,url,snippet}]}`); renderers are dumb + provider-agnostic. **Cleanest long-term**, but touches all ~6 translators and every translator must learn each kind.
+- **(B) Classify at render time.** Keep the raw result; shape predicates sniff it. **Incremental**, zero translator churn, but predicates must tolerate provider differences (a Claude `WebSearch` result shape ≠ another provider's).
+
+**Recommendation: hybrid, B-first.** Ship the registry + shape classifiers now (extends #1511 with no translator work). When a kind proves fragile across providers, normalize *that kind* at the translators (A) and switch its matcher to the tagged kind. Name-based matchers (`WebSearch`, `mcp__*`) are provider-stable and carry most of the value without any shape-sniffing.
+
+---
+
+## 7. Migration plan (incremental, each step shippable)
+
+- **Phase 0 — carry the raw name.** `ToolNode.toolName`; populate in `stream-parser.ts`. No render change. (Tiny.)
+- **Phase 1 — registry, no behavior change.** Introduce `registerToolRenderer`/`resolveToolRenderer` + the fallback chain; re-register the existing `switch` cases to produce identical output; `renderToolResultBody` → registry lookup. Snapshot/RTL tests assert parity.
+- **Phase 2 — first rich kind.** `SearchResults` + `looksLikeSearchResults`, registered for `WebSearch` (name) — the visible payoff and the design's proof.
+- **Phase 3 — breadth.** `mcp__*` prefix handling, `ImageView`/`KeyValueTable`/`FileList`, then unify icons/summary (§5.5) and fold in AskUserQuestion.
+
+Each phase is its own small PR. Phase 0+1 are a pure refactor; the user-visible win starts at Phase 2.
+
+---
+
+## 8. Relationship to PR #1511
+
+Not throwaway — the **seed**. `terminalText`→`TerminalOutput` is precisely a *(classifier, kind-renderer)* pair and slots in as the terminal entry of the fallback chain. This spec generalizes that one pair into the registry + a set of kinds.
+
+---
+
+## 9. Risks / when NOT to
+
+- **Over-abstraction.** If the tool set were closed and small, the `switch` is fine. The justification is specifically the **open** universe (MCP, web tools, provider churn). Keep the registry thin — it's a `Map` + a fallback chain, not a framework.
+- **Shape-sniffing fragility.** Mitigated by making **name matchers primary** and shape predicates the fallback; and by escalating flaky kinds to translator normalization (A).
+- **Result shape variance across providers.** Same mitigation; predicates must be defensive (typeof checks, optional fields) like `terminalText` already is.
+- **Scope creep into icons/summary.** Deliberately deferred to Phase 3 so the first cut stays small.
+
+---
+
+## 10. Open questions
+- Keep the coarse `tool` enum as a derived "kind" long-term, or replace it entirely with `toolName` + a derived kind? (Lean: keep during migration, reassess at Phase 3.)
+- Should a registered renderer also drive the **collapsed summary** (one source of truth), or is the parser-built summary good enough? (Lean: Phase 3.)
+- Where do renderers live + how do tests assert parity for Phase 1? (Lean: `components/tool-renderers/` + registration table with snapshot tests.)
+
+---
+
+## 11. Key file references
+- `frontend/app/view/agent/types.ts:213` — closed `ToolNode.tool` enum (add `toolName`)
+- `frontend/app/view/agent/types.ts:602` — `TOOL_ICONS` (second tool-keyed dispatch)
+- `frontend/app/view/agent/stream-parser.ts:504-508` — `normalizeToolName` (where the raw name is dropped)
+- `frontend/app/view/agent/stream-parser.ts:311,463` — AskUserQuestion special-case + icon pick
+- `frontend/app/view/agent/components/ToolOverlayLog.tsx:233-312` — `renderToolResultBody` switch (becomes the registry lookup)
+- `frontend/app/view/agent/components/CompactResult.tsx` — JSON/terminal fallback (becomes the chain's tail)
+- `frontend/app/view/agent/components/TerminalOutput.tsx` + `terminal-text.ts` — the seed (#1511)
+- provider translators (`claude-/codex-/acp-/gemini-/kimi-translator.ts`) — carry raw tool name; the (A) normalization site

--- a/frontend/app/view/agent/components/OutputHiddenMarker.tsx
+++ b/frontend/app/view/agent/components/OutputHiddenMarker.tsx
@@ -14,8 +14,8 @@ interface OutputHiddenMarkerProps {
     /** How many units were dropped. */
     hidden: number;
     /** Unit noun — "line" for text bodies, "block" for the chunk log,
-     *  "result" for result-card lists (search results, …). */
-    noun: "line" | "block" | "result";
+     *  "result" for result-card lists (search results, …), "row" for tables. */
+    noun: "line" | "block" | "result" | "row";
     /** "tail" hides older content (marker sits above the body); "head"
      *  hides later content (marker sits below). Default "tail". */
     from?: "head" | "tail";

--- a/frontend/app/view/agent/components/OutputHiddenMarker.tsx
+++ b/frontend/app/view/agent/components/OutputHiddenMarker.tsx
@@ -13,8 +13,9 @@ import { type JSX } from "solid-js";
 interface OutputHiddenMarkerProps {
     /** How many units were dropped. */
     hidden: number;
-    /** Unit noun — "line" for text bodies, "block" for the chunk log. */
-    noun: "line" | "block";
+    /** Unit noun — "line" for text bodies, "block" for the chunk log,
+     *  "result" for result-card lists (search results, …). */
+    noun: "line" | "block" | "result";
     /** "tail" hides older content (marker sits above the body); "head"
      *  hides later content (marker sits below). Default "tail". */
     from?: "head" | "tail";

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -25,6 +25,12 @@ import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capChars, createChunkCapper, capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { detectLanguage } from "./detectLanguage";
+import {
+    registerToolRenderer,
+    resolveToolRenderer,
+    byKind,
+    anyTool,
+} from "./tool-renderers/registry";
 
 interface ToolOverlayLogProps {
     node: ToolNode;
@@ -230,84 +236,110 @@ function ToolOverlayResult(props: { node: ToolNode }): JSX.Element {
     );
 }
 
-function renderToolResultBody(node: ToolNode): JSX.Element {
-    switch (node.tool) {
-        case "Edit":
-            return <DiffViewer params={node.params as any} result={node.result as any} />;
+// Per-tool result renderers. Each is registered with the tool-renderer registry
+// (below) so the open-ended tool universe can be routed by name/shape rather than
+// a closed switch — these are the built-in (coarse-kind) entries. The bodies are
+// the former `switch` arms verbatim; behavior is unchanged. See
+// SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md (Phase 1).
 
-        case "Bash":
-            return <BashOutputViewer params={node.params as any} result={node.result as any} />;
+function renderEdit(node: ToolNode): JSX.Element {
+    return <DiffViewer params={node.params as any} result={node.result as any} />;
+}
 
-        case "Read": {
-            const filePath = (node.params as any).file_path ?? "";
-            const content: string | undefined = (node.result as any)?.content;
-            // Head-cap file content (read top-down) so a huge Read can't bloat
-            // the conversation DOM; HighlightedCode stays simple (it injects
-            // innerHTML, so capping here is cleaner than inside it).
-            const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
-            return (
-                <div class="agent-tool-read">
-                    <div class="agent-tool-file-path">{filePath}</div>
-                    <Show
-                        when={capped}
-                        fallback={
-                            <Show when={node.result}>
-                                <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                            </Show>
-                        }
-                    >
-                        <HighlightedCode
-                            code={capped!.text}
-                            lang={detectLanguage(filePath, capped!.text.split("\n")[0])}
-                            class="agent-tool-read-content"
-                        />
-                        <Show when={capped!.hiddenLines > 0}>
-                            <OutputHiddenMarker hidden={capped!.hiddenLines} noun="line" from="head" />
-                        </Show>
-                    </Show>
-                </div>
-            );
-        }
+function renderBash(node: ToolNode): JSX.Element {
+    return <BashOutputViewer params={node.params as any} result={node.result as any} />;
+}
 
-        case "Write":
-            return (
-                <div class="agent-tool-write">
-                    <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
-                    <div class="agent-tool-write-info">
-                        {node.result && `Wrote ${(node.result as any).bytesWritten || 0} bytes`}
-                    </div>
-                </div>
-            );
-
-        case "Grep":
-        case "Glob":
-            return (
-                <div class="agent-tool-search">
-                    <div class="agent-tool-pattern">Pattern: {(node.params as any).pattern}</div>
-                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                </div>
-            );
-
-        case "Agent":
-            return (
-                <div class="agent-tool-agent">
-                    <Show when={(node.params as any).description}>
-                        <div class="agent-tool-agent-desc">{(node.params as any).description}</div>
-                    </Show>
+function renderRead(node: ToolNode): JSX.Element {
+    const filePath = (node.params as any).file_path ?? "";
+    const content: string | undefined = (node.result as any)?.content;
+    // Head-cap file content (read top-down) so a huge Read can't bloat
+    // the conversation DOM; HighlightedCode stays simple (it injects
+    // innerHTML, so capping here is cleaner than inside it).
+    const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
+    return (
+        <div class="agent-tool-read">
+            <div class="agent-tool-file-path">{filePath}</div>
+            <Show
+                when={capped}
+                fallback={
                     <Show when={node.result}>
                         <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
                     </Show>
-                </div>
-            );
+                }
+            >
+                <HighlightedCode
+                    code={capped!.text}
+                    lang={detectLanguage(filePath, capped!.text.split("\n")[0])}
+                    class="agent-tool-read-content"
+                />
+                <Show when={capped!.hiddenLines > 0}>
+                    <OutputHiddenMarker hidden={capped!.hiddenLines} noun="line" from="head" />
+                </Show>
+            </Show>
+        </div>
+    );
+}
 
-        case "Task":
-            return (
-                <div class="agent-tool-task">
-                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                </div>
-            );
+function renderWrite(node: ToolNode): JSX.Element {
+    return (
+        <div class="agent-tool-write">
+            <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
+            <div class="agent-tool-write-info">
+                {node.result && `Wrote ${(node.result as any).bytesWritten || 0} bytes`}
+            </div>
+        </div>
+    );
+}
 
-        default:
-            return <CompactResult tool={node.tool} params={node.params as any} result={node.result} />;
-    }
+function renderSearch(node: ToolNode): JSX.Element {
+    return (
+        <div class="agent-tool-search">
+            <div class="agent-tool-pattern">Pattern: {(node.params as any).pattern}</div>
+            <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+        </div>
+    );
+}
+
+function renderAgent(node: ToolNode): JSX.Element {
+    return (
+        <div class="agent-tool-agent">
+            <Show when={(node.params as any).description}>
+                <div class="agent-tool-agent-desc">{(node.params as any).description}</div>
+            </Show>
+            <Show when={node.result}>
+                <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+            </Show>
+        </div>
+    );
+}
+
+function renderTask(node: ToolNode): JSX.Element {
+    return (
+        <div class="agent-tool-task">
+            <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+        </div>
+    );
+}
+
+function renderCompactDefault(node: ToolNode): JSX.Element {
+    return <CompactResult tool={node.tool} params={node.params as any} result={node.result} />;
+}
+
+// Register the built-ins (priority 0; the catch-all sits below everything). Rich,
+// name/shape-matched renderers (WebSearch cards, mcp__* tools, …) register from
+// their own modules at a higher priority.
+registerToolRenderer({ priority: 0, label: "builtin:Edit", match: byKind("Edit"), render: renderEdit });
+registerToolRenderer({ priority: 0, label: "builtin:Bash", match: byKind("Bash"), render: renderBash });
+registerToolRenderer({ priority: 0, label: "builtin:Read", match: byKind("Read"), render: renderRead });
+registerToolRenderer({ priority: 0, label: "builtin:Write", match: byKind("Write"), render: renderWrite });
+registerToolRenderer({ priority: 0, label: "builtin:Search", match: byKind("Grep", "Glob"), render: renderSearch });
+registerToolRenderer({ priority: 0, label: "builtin:Agent", match: byKind("Agent"), render: renderAgent });
+registerToolRenderer({ priority: 0, label: "builtin:Task", match: byKind("Task"), render: renderTask });
+registerToolRenderer({ priority: -Infinity, label: "builtin:default", match: anyTool, render: renderCompactDefault });
+
+function renderToolResultBody(node: ToolNode): JSX.Element {
+    // Hard fallback to the default renderer if (somehow) nothing is registered.
+    const render = resolveToolRenderer(node) ?? renderCompactDefault;
+    return render(node);
 }

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -31,8 +31,9 @@ import {
     byKind,
     anyTool,
 } from "./tool-renderers/registry";
-// Side-effect: registers the rich, name-matched renderers (WebSearch cards, …).
+// Side-effect: registers the rich renderers (WebSearch cards, record tables, …).
 import "./tool-renderers/SearchResults";
+import "./tool-renderers/RecordTable";
 
 interface ToolOverlayLogProps {
     node: ToolNode;

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -31,6 +31,8 @@ import {
     byKind,
     anyTool,
 } from "./tool-renderers/registry";
+// Side-effect: registers the rich, name-matched renderers (WebSearch cards, …).
+import "./tool-renderers/SearchResults";
 
 interface ToolOverlayLogProps {
     node: ToolNode;

--- a/frontend/app/view/agent/components/tool-renderers/RecordTable.test.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/RecordTable.test.tsx
@@ -1,0 +1,52 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { RecordTable } from "./RecordTable";
+import { resolveToolRenderer } from "./registry";
+import type { ToolNode } from "../../types";
+
+afterEach(() => cleanup());
+
+const node = (result: unknown, over: Partial<ToolNode> = {}): ToolNode => ({
+    type: "tool",
+    id: "t1",
+    tool: "Other",
+    params: {},
+    status: "success",
+    collapsed: true,
+    summary: "x",
+    result: result as any,
+    ...over,
+});
+
+describe("RecordTable", () => {
+    it("renders a table with a header per column and a row per record", () => {
+        const { container } = render(() => (
+            <RecordTable node={node([{ name: "a", count: 1 }, { name: "b", count: 2 }])} />
+        ));
+        const table = container.querySelector(".agent-tool-record-table table");
+        expect(table).not.toBeNull();
+        expect(container.querySelectorAll("thead th").length).toBe(2);
+        expect(container.querySelectorAll("tbody tr").length).toBe(2);
+        expect(container.textContent).toContain("name");
+        expect(container.textContent).toContain("a");
+    });
+
+    it("falls back to JSON (CompactResult) for a non-record result", () => {
+        const { container } = render(() => <RecordTable node={node({ status: "done" })} />);
+        expect(container.querySelector(".agent-tool-record-table")).toBeNull();
+        expect(container.querySelector(".agent-tool-compact-result")).not.toBeNull();
+    });
+
+    it("is registered by shape for an unknown tool's record list", () => {
+        // Importing this module registered shape:record-table at priority -1
+        // (above the JSON catch-all). An unknown tool with a record list routes
+        // here rather than the JSON default.
+        const r = resolveToolRenderer(node([{ a: 1 }], { tool: "Other" }));
+        expect(r).not.toBeNull();
+        const { container } = render(() => r!(node([{ a: 1 }], { tool: "Other" })));
+        expect(container.querySelector(".agent-tool-record-table")).not.toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/tool-renderers/RecordTable.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/RecordTable.tsx
@@ -1,0 +1,68 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * RecordTable — render a top-level array of flat records as a table instead of a
+ * JSON blob. Registered by shape *below* the coarse-kind built-ins, so it only
+ * improves the otherwise-JSON unknown-tool path.
+ *
+ * See SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md §5.3 (Phase 3).
+ */
+
+import { For, Show, type JSX } from "solid-js";
+import type { ToolNode } from "../../types";
+import { CompactResult } from "../CompactResult";
+import { OutputHiddenMarker } from "../OutputHiddenMarker";
+import { byShape, registerToolRenderer } from "./registry";
+import { extractRecords, looksLikeRecords, cellText } from "./record-table";
+
+export function RecordTable(props: { node: ToolNode }): JSX.Element {
+    const data = extractRecords(props.node.result);
+    return (
+        <Show
+            when={data}
+            fallback={
+                <CompactResult
+                    tool={props.node.tool}
+                    params={props.node.params as any}
+                    result={props.node.result}
+                />
+            }
+        >
+            <div class="agent-tool-record-table">
+                <table>
+                    <thead>
+                        <tr>
+                            <For each={data!.columns}>{(c) => <th>{c}</th>}</For>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={data!.rows}>
+                            {(row) => (
+                                <tr>
+                                    <For each={data!.columns}>{(c) => <td>{cellText(row[c])}</td>}</For>
+                                </tr>
+                            )}
+                        </For>
+                    </tbody>
+                </table>
+                <Show when={data!.truncatedRows > 0}>
+                    <OutputHiddenMarker hidden={data!.truncatedRows} noun="line" from="head" />
+                </Show>
+            </div>
+        </Show>
+    );
+}
+
+RecordTable.displayName = "RecordTable";
+
+// Register by shape at priority -1: above the JSON catch-all (-Infinity) but
+// below the coarse-kind built-ins (0) and name-matched rich renderers (10), so a
+// record list from an unknown tool becomes a table while known tools are
+// untouched.
+registerToolRenderer({
+    priority: -1,
+    label: "shape:record-table",
+    match: byShape(looksLikeRecords),
+    render: (node) => <RecordTable node={node} />,
+});

--- a/frontend/app/view/agent/components/tool-renderers/RecordTable.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/RecordTable.tsx
@@ -47,7 +47,7 @@ export function RecordTable(props: { node: ToolNode }): JSX.Element {
                     </tbody>
                 </table>
                 <Show when={data!.truncatedRows > 0}>
-                    <OutputHiddenMarker hidden={data!.truncatedRows} noun="line" from="head" />
+                    <OutputHiddenMarker hidden={data!.truncatedRows} noun="row" from="head" />
                 </Show>
             </div>
         </Show>

--- a/frontend/app/view/agent/components/tool-renderers/SearchResults.test.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/SearchResults.test.tsx
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const openExternal = vi.fn();
+vi.mock("@/store/global", () => ({ getApi: () => ({ openExternal }) }));
+
+import { SearchResults } from "./SearchResults";
+import { resolveToolRenderer } from "./registry";
+import type { ToolNode } from "../../types";
+
+afterEach(() => {
+    cleanup();
+    openExternal.mockClear();
+});
+
+const node = (result: unknown, over: Partial<ToolNode> = {}): ToolNode => ({
+    type: "tool",
+    id: "t1",
+    tool: "Other",
+    toolName: "WebSearch",
+    params: {},
+    status: "success",
+    collapsed: true,
+    summary: "x",
+    result: result as any,
+    ...over,
+});
+
+describe("SearchResults", () => {
+    it("renders a card per result with title, host, snippet", () => {
+        const { container } = render(() => (
+            <SearchResults
+                node={node([
+                    { title: "AgentMux", url: "https://agentmux.ai/docs", snippet: "the docs" },
+                    { title: "Two", url: "https://two.com" },
+                ])}
+            />
+        ));
+        const cards = container.querySelectorAll(".agent-search-card");
+        expect(cards.length).toBe(2);
+        expect(container.textContent).toContain("AgentMux");
+        expect(container.textContent).toContain("agentmux.ai/docs");
+        expect(container.textContent).toContain("the docs");
+        expect(container.querySelector(".agent-tool-compact-json")).toBeNull();
+    });
+
+    it("opens the URL in the system browser on click", () => {
+        const { container } = render(() => (
+            <SearchResults node={node([{ title: "X", url: "https://x.com" }])} />
+        ));
+        fireEvent.click(container.querySelector(".agent-search-card")!);
+        expect(openExternal).toHaveBeenCalledWith("https://x.com");
+    });
+
+    it("falls back to JSON (CompactResult) when the result isn't search-shaped", () => {
+        const { container } = render(() => (
+            <SearchResults node={node({ status: "done", count: 3, items: 7 })} />
+        ));
+        expect(container.querySelector(".agent-search-card")).toBeNull();
+        expect(container.querySelector(".agent-tool-compact-result")).not.toBeNull();
+    });
+
+    it("is registered for the WebSearch tool by name", () => {
+        // Importing this module registered the web:search renderer.
+        expect(resolveToolRenderer(node([{ url: "https://a.com" }]))).not.toBeNull();
+        // ...and it routes a WebSearch node (toolName) regardless of coarse kind.
+        const r = resolveToolRenderer(node([{ url: "https://a.com" }], { tool: "Other" }));
+        expect(r).not.toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/tool-renderers/SearchResults.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/SearchResults.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SearchResults — render a WebSearch-style tool result as a list of result
+ * cards (title → opens in the system browser, host, snippet) instead of a JSON
+ * blob. The first rich result-kind to prove the renderer registry.
+ *
+ * Registered (below) for the `WebSearch` tool by name. The renderer is graceful:
+ * if the result isn't actually search-shaped it falls back to `CompactResult`
+ * (today's terminal-or-JSON view), so registering by name can never break an
+ * unexpected payload.
+ *
+ * See SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md (Phase 2).
+ */
+
+import { For, Show, type JSX } from "solid-js";
+import { getApi } from "@/store/global";
+import type { ToolNode } from "../../types";
+import { CompactResult } from "../CompactResult";
+import { MAX_TOOL_OUTPUT_LINES } from "../output-cap";
+import { OutputHiddenMarker } from "../OutputHiddenMarker";
+import { extractSearchResults, type SearchResultItem } from "./search-results";
+import { byName, registerToolRenderer } from "./registry";
+
+/** Compact host display for the card's URL line (e.g. "example.com/path"). */
+function prettyUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        const path = u.pathname === "/" ? "" : u.pathname;
+        return `${u.host}${path}`.replace(/\/$/, "");
+    } catch {
+        return url;
+    }
+}
+
+export function SearchResults(props: { node: ToolNode }): JSX.Element {
+    const items = extractSearchResults(props.node.result);
+    return (
+        <Show
+            when={items}
+            fallback={
+                <CompactResult
+                    tool={props.node.tool}
+                    params={props.node.params as any}
+                    result={props.node.result}
+                />
+            }
+        >
+            <SearchResultCards items={items!} />
+        </Show>
+    );
+}
+
+function SearchResultCards(props: { items: SearchResultItem[] }): JSX.Element {
+    const visible = (): SearchResultItem[] => props.items.slice(0, MAX_TOOL_OUTPUT_LINES);
+    const hidden = (): number => Math.max(0, props.items.length - MAX_TOOL_OUTPUT_LINES);
+    const open = (url: string): void => {
+        try {
+            getApi().openExternal(url);
+        } catch {
+            /* best-effort — opening external is non-critical */
+        }
+    };
+    return (
+        <div class="agent-tool-search-results">
+            <For each={visible()}>
+                {(it) => (
+                    <div
+                        class="agent-search-card"
+                        role="link"
+                        tabindex="0"
+                        title={it.url}
+                        onClick={() => open(it.url)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                open(it.url);
+                            }
+                        }}
+                    >
+                        <div class="agent-search-card-title">{it.title}</div>
+                        <div class="agent-search-card-url">{prettyUrl(it.url)}</div>
+                        <Show when={it.snippet}>
+                            <div class="agent-search-card-snippet">{it.snippet}</div>
+                        </Show>
+                    </div>
+                )}
+            </For>
+            <Show when={hidden() > 0}>
+                <OutputHiddenMarker hidden={hidden()} noun="line" from="head" />
+            </Show>
+        </div>
+    );
+}
+
+SearchResults.displayName = "SearchResults";
+
+// Register for WebSearch by name (priority above the coarse-kind built-ins).
+// `web_search` covers providers that lower-snake-case the tool name.
+registerToolRenderer({
+    priority: 10,
+    label: "web:search",
+    match: byName("WebSearch", "web_search"),
+    render: (node) => <SearchResults node={node} />,
+});

--- a/frontend/app/view/agent/components/tool-renderers/SearchResults.tsx
+++ b/frontend/app/view/agent/components/tool-renderers/SearchResults.tsx
@@ -88,7 +88,7 @@ function SearchResultCards(props: { items: SearchResultItem[] }): JSX.Element {
                 )}
             </For>
             <Show when={hidden() > 0}>
-                <OutputHiddenMarker hidden={hidden()} noun="line" from="head" />
+                <OutputHiddenMarker hidden={hidden()} noun="result" from="head" />
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/tool-renderers/record-table.test.ts
+++ b/frontend/app/view/agent/components/tool-renderers/record-table.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { extractRecords, looksLikeRecords, cellText } from "./record-table";
+
+describe("extractRecords", () => {
+    it("reads a top-level array of flat records, unioning column order", () => {
+        const out = extractRecords([
+            { name: "a", count: 1 },
+            { name: "b", extra: true },
+        ]);
+        expect(out?.columns).toEqual(["name", "count", "extra"]);
+        expect(out?.rows).toHaveLength(2);
+        expect(out?.truncatedRows).toBe(0);
+    });
+
+    it("rejects shapes that aren't a flat record list", () => {
+        expect(extractRecords([])).toBeNull(); // empty
+        expect(extractRecords({ a: 1 })).toBeNull(); // object, not array
+        expect(extractRecords("text")).toBeNull(); // string
+        expect(extractRecords([1, 2, 3])).toBeNull(); // scalars, not objects
+        expect(extractRecords([{ nested: { x: 1 } }])).toBeNull(); // nested object value
+        expect(extractRecords([{ arr: [1] }])).toBeNull(); // array value
+    });
+
+    it("rejects tables wider than the column cap", () => {
+        const wide: Record<string, number> = {};
+        for (let i = 0; i < 20; i++) wide[`c${i}`] = i;
+        expect(extractRecords([wide])).toBeNull();
+    });
+
+    it("caps rows and reports the truncated count", () => {
+        const many = Array.from({ length: 250 }, (_, i) => ({ i }));
+        const out = extractRecords(many);
+        expect(out?.rows).toHaveLength(200);
+        expect(out?.truncatedRows).toBe(50);
+    });
+
+    it("looksLikeRecords mirrors extract", () => {
+        expect(looksLikeRecords([{ a: 1 }])).toBe(true);
+        expect(looksLikeRecords({ a: 1 })).toBe(false);
+    });
+
+    it("cellText renders scalars and truncates long strings", () => {
+        expect(cellText(null)).toBe("");
+        expect(cellText(undefined)).toBe("");
+        expect(cellText(42)).toBe("42");
+        expect(cellText(true)).toBe("true");
+        expect(cellText("x".repeat(300))).toHaveLength(201); // 200 + ellipsis
+    });
+});

--- a/frontend/app/view/agent/components/tool-renderers/record-table.ts
+++ b/frontend/app/view/agent/components/tool-renderers/record-table.ts
@@ -1,0 +1,69 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Detect a "list of records" result — a top-level array of flat objects — so it
+ * can render as a table instead of a JSON blob. Conservative on purpose: only a
+ * top-level array whose every element is a flat object of scalar values
+ * qualifies (no nested objects/arrays, bounded column count), so it can't fire
+ * on shapes better left as JSON or handled by a named/terminal renderer.
+ *
+ * Registered by shape *below* the coarse-kind built-ins, so it only improves the
+ * otherwise-JSON unknown-tool path (mcp__*, provider-specific, …).
+ * See SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md §5.3.
+ */
+
+const MAX_COLUMNS = 12;
+const MAX_ROWS = 200;
+
+export interface RecordTableData {
+    columns: string[];
+    rows: ReadonlyArray<Record<string, unknown>>;
+    /** Rows dropped beyond MAX_ROWS. */
+    truncatedRows: number;
+}
+
+function isScalar(v: unknown): boolean {
+    return v === null || typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+}
+
+function isFlatRecord(v: unknown): v is Record<string, unknown> {
+    if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+    for (const val of Object.values(v as Record<string, unknown>)) {
+        if (!isScalar(val)) return false;
+    }
+    return true;
+}
+
+/** Extract a record table from a result, or null if it isn't a flat record list. */
+export function extractRecords(result: unknown): RecordTableData | null {
+    if (!Array.isArray(result) || result.length === 0) return null;
+    if (!result.every(isFlatRecord)) return null;
+
+    // Column order = first-seen union of keys across rows.
+    const columns: string[] = [];
+    const seen = new Set<string>();
+    for (const row of result as Record<string, unknown>[]) {
+        for (const k of Object.keys(row)) {
+            if (!seen.has(k)) {
+                seen.add(k);
+                columns.push(k);
+            }
+        }
+    }
+    if (columns.length === 0 || columns.length > MAX_COLUMNS) return null;
+
+    const rows = (result as Record<string, unknown>[]).slice(0, MAX_ROWS);
+    return { columns, rows, truncatedRows: Math.max(0, result.length - rows.length) };
+}
+
+export function looksLikeRecords(result: unknown): boolean {
+    return extractRecords(result) != null;
+}
+
+/** Render a single cell value as text (empty for null/undefined). */
+export function cellText(v: unknown): string {
+    if (v == null) return "";
+    const s = String(v);
+    return s.length > 200 ? s.slice(0, 200) + "…" : s;
+}

--- a/frontend/app/view/agent/components/tool-renderers/registry.test.ts
+++ b/frontend/app/view/agent/components/tool-renderers/registry.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    resolveFrom,
+    byKind,
+    byName,
+    byNamePrefix,
+    byShape,
+    anyTool,
+    toolNameOf,
+    type ToolRendererEntry,
+} from "./registry";
+import type { ToolNode } from "../../types";
+
+const tool = (over: Partial<ToolNode> = {}): ToolNode => ({
+    type: "tool",
+    id: "t1",
+    tool: "Other",
+    params: {},
+    status: "success",
+    collapsed: true,
+    summary: "x",
+    ...over,
+});
+
+const entry = (label: string, priority: number, match: ToolRendererEntry["match"]): ToolRendererEntry => ({
+    label,
+    priority,
+    match,
+    render: () => label as any, // identity-by-label stub
+});
+
+describe("tool-renderer registry — resolution", () => {
+    it("picks the highest-priority matching entry", () => {
+        const list = [
+            entry("default", -Infinity, anyTool),
+            entry("kind", 0, byKind("Bash")),
+            entry("name", 10, byName("Bash")),
+        ];
+        const r = resolveFrom(list, tool({ tool: "Bash", toolName: "Bash" }));
+        expect(r?.(tool())).toBe("name");
+    });
+
+    it("breaks ties by registration order (earliest wins)", () => {
+        const list = [entry("first", 5, anyTool), entry("second", 5, anyTool)];
+        expect(resolveFrom(list, tool())?.(tool())).toBe("first");
+    });
+
+    it("falls through to the catch-all when only anyTool matches", () => {
+        const list = [entry("kind", 0, byKind("Read")), entry("default", -Infinity, anyTool)];
+        expect(resolveFrom(list, tool({ tool: "Other" }))?.(tool())).toBe("default");
+    });
+
+    it("returns null when nothing matches", () => {
+        const list = [entry("kind", 0, byKind("Read"))];
+        expect(resolveFrom(list, tool({ tool: "Other" }))).toBeNull();
+    });
+});
+
+describe("tool-renderer registry — matchers", () => {
+    it("byKind matches the coarse kind", () => {
+        expect(byKind("Grep", "Glob")(tool({ tool: "Glob" }))).toBe(true);
+        expect(byKind("Grep", "Glob")(tool({ tool: "Bash" }))).toBe(false);
+    });
+
+    it("byName matches the raw provider name, falling back to kind", () => {
+        expect(byName("WebSearch")(tool({ tool: "Other", toolName: "WebSearch" }))).toBe(true);
+        // no toolName → falls back to the coarse kind
+        expect(byName("Bash")(tool({ tool: "Bash" }))).toBe(true);
+        expect(byName("WebSearch")(tool({ tool: "Other" }))).toBe(false);
+    });
+
+    it("byNamePrefix matches mcp__* tools", () => {
+        expect(byNamePrefix("mcp__")(tool({ tool: "Other", toolName: "mcp__gh__search" }))).toBe(true);
+        expect(byNamePrefix("mcp__")(tool({ tool: "Other", toolName: "WebSearch" }))).toBe(false);
+    });
+
+    it("byShape matches on the result", () => {
+        const hasResults = (r: unknown): boolean => !!r && typeof r === "object" && Array.isArray((r as any).results);
+        expect(byShape(hasResults)(tool({ result: { results: [1] } as any }))).toBe(true);
+        expect(byShape(hasResults)(tool({ result: { other: 1 } as any }))).toBe(false);
+    });
+
+    it("toolNameOf prefers toolName, falls back to kind", () => {
+        expect(toolNameOf(tool({ tool: "Other", toolName: "WebSearch" }))).toBe("WebSearch");
+        expect(toolNameOf(tool({ tool: "Bash" }))).toBe("Bash");
+    });
+});
+
+describe("tool-renderer registry — built-ins (parity)", () => {
+    it("registers all built-in renderers and routes every kind through the registry", async () => {
+        // Importing ToolOverlayLog runs the built-in registrations (module side
+        // effect). Assert the built-ins are present and resolution is total.
+        const { _registeredLabels, resolveToolRenderer } = await import("./registry");
+        await import("../ToolOverlayLog");
+        const labels = _registeredLabels();
+        for (const l of [
+            "builtin:Edit",
+            "builtin:Bash",
+            "builtin:Read",
+            "builtin:Write",
+            "builtin:Search",
+            "builtin:Agent",
+            "builtin:Task",
+            "builtin:default",
+        ]) {
+            expect(labels).toContain(l);
+        }
+        // Every kind (and an unknown tool) resolves to *some* renderer.
+        for (const k of ["Edit", "Bash", "Read", "Write", "Grep", "Glob", "Agent", "Task", "Other"] as const) {
+            expect(resolveToolRenderer(tool({ tool: k }))).not.toBeNull();
+        }
+        // An unknown provider tool (no built-in kind) still resolves (catch-all).
+        expect(resolveToolRenderer(tool({ tool: "Other", toolName: "WebSearch" }))).not.toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/tool-renderers/registry.ts
+++ b/frontend/app/view/agent/components/tool-renderers/registry.ts
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tool-result renderer registry — decouples "how a tool result renders" from a
+ * hardcoded `switch` over the closed `ToolNode.tool` enum, so rich per-tool UIs
+ * (terminal, diff, search-result cards, …) are drop-in and the open-ended tool
+ * universe (web tools, `mcp__*` tools, provider-specific) can be routed by its
+ * real name or result shape.
+ *
+ * A renderer is the highest-priority entry whose matcher accepts the node;
+ * ties break by registration order. Convention: built-in (coarse-kind) renderers
+ * register at priority 0, name-matched rich renderers above (10), shape-matched
+ * between (5), and a catch-all below (-Infinity).
+ *
+ * See docs/specs/SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md.
+ */
+
+import type { JSX } from "solid-js";
+import type { ToolNode } from "../../types";
+
+export type ToolRenderer = (node: ToolNode) => JSX.Element;
+export type ToolMatcher = (node: ToolNode) => boolean;
+
+export interface ToolRendererEntry {
+    priority: number;
+    match: ToolMatcher;
+    render: ToolRenderer;
+    /** Stable label — used for de-dup on re-register and for tests/debugging. */
+    label: string;
+}
+
+const entries: ToolRendererEntry[] = [];
+
+/**
+ * Register (or replace, by `label`) a renderer. Replacing on duplicate label
+ * keeps HMR / double-import from stacking duplicate entries.
+ */
+export function registerToolRenderer(entry: ToolRendererEntry): void {
+    const existing = entries.findIndex((e) => e.label === entry.label);
+    if (existing >= 0) entries.splice(existing, 1);
+    entries.push(entry);
+}
+
+/**
+ * Pure resolution against an explicit entry list (for tests). Highest priority
+ * wins; on a tie the earliest-registered entry wins.
+ */
+export function resolveFrom(
+    list: readonly ToolRendererEntry[],
+    node: ToolNode,
+): ToolRenderer | null {
+    let best: ToolRendererEntry | null = null;
+    for (const e of list) {
+        if (!e.match(node)) continue;
+        if (best === null || e.priority > best.priority) best = e;
+    }
+    return best ? best.render : null;
+}
+
+/**
+ * Resolve against the global registry. Returns null only when nothing matches;
+ * callers keep a hard fallback for safety (a catch-all is normally registered).
+ */
+export function resolveToolRenderer(node: ToolNode): ToolRenderer | null {
+    return resolveFrom(entries, node);
+}
+
+/** Test seam — the labels currently registered, in registration order. */
+export function _registeredLabels(): string[] {
+    return entries.map((e) => e.label);
+}
+
+// ── matcher helpers ──────────────────────────────────────────────────────────
+
+/** The tool's real provider name when carried, else the coarse kind. */
+export function toolNameOf(n: ToolNode): string {
+    return n.toolName ?? n.tool;
+}
+
+/** Match the coarse `ToolNode.tool` kind. */
+export const byKind =
+    (...kinds: ToolNode["tool"][]): ToolMatcher =>
+    (n) =>
+        kinds.includes(n.tool);
+
+/** Match the real provider tool name (falls back to the coarse kind). */
+export const byName =
+    (...names: string[]): ToolMatcher =>
+    (n) =>
+        names.includes(toolNameOf(n));
+
+/** Match a tool-name prefix — e.g. `byNamePrefix("mcp__")`. */
+export const byNamePrefix =
+    (prefix: string): ToolMatcher =>
+    (n) =>
+        toolNameOf(n).startsWith(prefix);
+
+/** Match on the result shape — e.g. `byShape(looksLikeSearchResults)`. */
+export const byShape =
+    (pred: (result: unknown) => boolean): ToolMatcher =>
+    (n) =>
+        pred(n.result);
+
+/** Always matches — for a lowest-priority catch-all. */
+export const anyTool: ToolMatcher = () => true;

--- a/frontend/app/view/agent/components/tool-renderers/registry.ts
+++ b/frontend/app/view/agent/components/tool-renderers/registry.ts
@@ -10,8 +10,11 @@
  *
  * A renderer is the highest-priority entry whose matcher accepts the node;
  * ties break by registration order. Convention: built-in (coarse-kind) renderers
- * register at priority 0, name-matched rich renderers above (10), shape-matched
- * between (5), and a catch-all below (-Infinity).
+ * register at priority 0; name-matched rich renderers above the built-ins (e.g.
+ * 10, WebSearch); shape-matched renderers sit where they should win — above the
+ * built-ins to override them, or *below* (e.g. -1, RecordTable) to only improve
+ * the otherwise-JSON unknown-tool path; a catch-all sits at the bottom
+ * (-Infinity).
  *
  * See docs/specs/SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md.
  */

--- a/frontend/app/view/agent/components/tool-renderers/search-results.test.ts
+++ b/frontend/app/view/agent/components/tool-renderers/search-results.test.ts
@@ -1,0 +1,62 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { extractSearchResults, looksLikeSearchResults } from "./search-results";
+
+describe("extractSearchResults", () => {
+    it("reads a top-level array of result objects", () => {
+        const out = extractSearchResults([
+            { title: "Example", url: "https://example.com", snippet: "hi" },
+            { title: "Two", url: "https://two.com" },
+        ]);
+        expect(out).toEqual([
+            { title: "Example", url: "https://example.com", snippet: "hi" },
+            { title: "Two", url: "https://two.com", snippet: undefined },
+        ]);
+    });
+
+    it("reads the array from results / content / items keys", () => {
+        for (const key of ["results", "content", "items", "web_search_results"]) {
+            const out = extractSearchResults({ [key]: [{ url: "https://a.com", title: "A" }] });
+            expect(out).toEqual([{ title: "A", url: "https://a.com", snippet: undefined }]);
+        }
+    });
+
+    it("tolerates field-name variants (link/uri, name/heading, description/text/page_age)", () => {
+        expect(extractSearchResults([{ link: "https://l.com", name: "N", description: "D" }])).toEqual([
+            { title: "N", url: "https://l.com", snippet: "D" },
+        ]);
+        expect(extractSearchResults([{ uri: "https://u.com", heading: "H", page_age: "2 days" }])).toEqual([
+            { title: "H", url: "https://u.com", snippet: "2 days" },
+        ]);
+    });
+
+    it("falls back title→url when no title field is present", () => {
+        expect(extractSearchResults([{ url: "https://x.com" }])).toEqual([
+            { title: "https://x.com", url: "https://x.com", snippet: undefined },
+        ]);
+    });
+
+    it("skips items without a URL and returns null when none qualify", () => {
+        expect(extractSearchResults([{ title: "no url" }, { foo: 1 }])).toBeNull();
+        // mixed: only the URL-bearing item survives
+        expect(extractSearchResults([{ title: "no url" }, { url: "https://y.com" }])).toEqual([
+            { title: "https://y.com", url: "https://y.com", snippet: undefined },
+        ]);
+    });
+
+    it("returns null for non-search results (structured, string, empty, nullish)", () => {
+        expect(extractSearchResults({ status: "done", count: 3 })).toBeNull();
+        expect(extractSearchResults("just a string")).toBeNull();
+        expect(extractSearchResults({ content: "a string body" })).toBeNull(); // content is a string, not an array
+        expect(extractSearchResults([])).toBeNull();
+        expect(extractSearchResults(null)).toBeNull();
+        expect(extractSearchResults(undefined)).toBeNull();
+    });
+
+    it("looksLikeSearchResults mirrors extract", () => {
+        expect(looksLikeSearchResults([{ url: "https://a.com" }])).toBe(true);
+        expect(looksLikeSearchResults({ a: 1 })).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/components/tool-renderers/search-results.ts
+++ b/frontend/app/view/agent/components/tool-renderers/search-results.ts
@@ -1,0 +1,69 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tolerant extraction of web-search-style results from a tool result, so
+ * `WebSearch` (and look-alike tools) can render as result cards instead of a
+ * JSON blob. Defensive by design: provider result shapes vary, so this accepts
+ * several common shapes and returns `null` for anything it doesn't recognize —
+ * the renderer then falls back to today's JSON view (no regression).
+ *
+ * See SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md §5.4.
+ */
+
+export interface SearchResultItem {
+    title: string;
+    url: string;
+    snippet?: string;
+}
+
+/** Keys whose array value may hold the result list. */
+const ARRAY_KEYS = ["results", "content", "items", "links", "data", "web_search_results"] as const;
+
+function str(v: unknown): string | null {
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+}
+
+/** Locate the array of result objects (top-level array, or under a known key). */
+function findResultArray(result: unknown): unknown[] | null {
+    if (Array.isArray(result)) return result;
+    if (result && typeof result === "object") {
+        const o = result as Record<string, unknown>;
+        for (const k of ARRAY_KEYS) {
+            if (Array.isArray(o[k])) return o[k] as unknown[];
+        }
+    }
+    return null;
+}
+
+/**
+ * Extract search-result cards, or `null` if the result isn't search-shaped. A
+ * result item must carry a URL; title/snippet are best-effort across common
+ * field names.
+ */
+export function extractSearchResults(result: unknown): SearchResultItem[] | null {
+    const arr = findResultArray(result);
+    if (!arr) return null;
+    const items: SearchResultItem[] = [];
+    for (const el of arr) {
+        if (!el || typeof el !== "object") continue;
+        const o = el as Record<string, unknown>;
+        const url = str(o.url) ?? str(o.link) ?? str(o.uri);
+        if (!url) continue; // a search result must have a URL
+        const title = str(o.title) ?? str(o.name) ?? str(o.heading) ?? url;
+        const snippet =
+            str(o.snippet) ??
+            str(o.description) ??
+            str(o.text) ??
+            str(o.content) ??
+            str(o.page_age) ??
+            undefined;
+        items.push({ title, url, snippet });
+    }
+    return items.length > 0 ? items : null;
+}
+
+/** True when the result looks like a list of web-search results. */
+export function looksLikeSearchResults(result: unknown): boolean {
+    return extractSearchResults(result) != null;
+}

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -315,6 +315,7 @@ export class ClaudeCodeStreamParser {
                     type: "tool",
                     id: event.id,
                     tool: this.normalizeToolName(event.tool),
+                    toolName: event.tool,
                     params: event.params,
                     status: "awaiting_answer",
                     collapsed: false,
@@ -334,6 +335,7 @@ export class ClaudeCodeStreamParser {
             type: "tool",
             id: event.id,
             tool: this.normalizeToolName(event.tool),
+            toolName: event.tool,
             params: event.params,
             status: "running",
             collapsed: false, // Show running tools
@@ -368,6 +370,7 @@ export class ClaudeCodeStreamParser {
             type: "tool",
             id: event.id,
             tool: this.normalizeToolName(toolName),
+            toolName,
             params,
             status: event.status,
             duration: event.duration,

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1191,3 +1191,57 @@
         }
     }
 }
+
+// Web-search result cards (SearchResults.tsx) — replaces the JSON blob for
+// WebSearch-shaped results. Each card opens its URL in the system browser.
+.agent-tool-search-results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin: var(--space-1) 0 0 0;
+    max-height: 400px;
+    overflow-y: auto;
+
+    .agent-search-card {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        padding: var(--space-1) var(--space-1-5);
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        background: var(--main-bg-color);
+        cursor: pointer;
+
+        &:hover {
+            border-color: var(--accent-color);
+        }
+    }
+
+    .agent-search-card-title {
+        color: var(--accent-color);
+        font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .agent-search-card-url {
+        color: var(--success-color);
+        font-size: 10px;
+        opacity: 0.85;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .agent-search-card-snippet {
+        color: var(--main-text-color);
+        opacity: 0.8;
+        font-size: 11px;
+        line-height: 1.4;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1192,6 +1192,45 @@
     }
 }
 
+// Record table (RecordTable.tsx) — a top-level array of flat records renders as
+// a table instead of a JSON blob (unknown-tool path).
+.agent-tool-record-table {
+    margin: var(--space-1) 0 0 0;
+    max-height: 400px;
+    overflow: auto;
+
+    table {
+        border-collapse: collapse;
+        width: 100%;
+        font-size: 11px;
+        font-family: var(--fixed-font, monospace);
+    }
+
+    th,
+    td {
+        border: 1px solid var(--border-color);
+        padding: 2px var(--space-1);
+        text-align: left;
+        vertical-align: top;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        max-width: 320px;
+    }
+
+    th {
+        position: sticky;
+        top: 0;
+        background: var(--main-bg-color);
+        color: var(--accent-color);
+        font-weight: 500;
+    }
+
+    td {
+        color: var(--main-text-color);
+        opacity: 0.9;
+    }
+}
+
 // Web-search result cards (SearchResults.tsx) — replaces the JSON blob for
 // WebSearch-shaped results. Each card opens its URL in the system browser.
 .agent-tool-search-results {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -211,6 +211,15 @@ export interface ToolNode {
     type: "tool";
     id: string;
     tool: "Read" | "Edit" | "Bash" | "Write" | "Grep" | "Glob" | "Task" | "Agent" | "Other";
+    /**
+     * The raw provider tool name (e.g. "WebSearch", "TodoWrite",
+     * "mcp__github__search_issues"). `tool` above is the coarse, closed "kind"
+     * (unknown → "Other"); `toolName` preserves the real name so the tool-result
+     * renderer registry can route the open-ended tool universe by name. Optional
+     * for back-compat with older nodes that predate the field — matchers fall
+     * back to `tool`. See SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md §5.1.
+     */
+    toolName?: string;
     params: ToolParams;
     /** Lifecycle:
      *  - `running`           — call dispatched, awaiting result


### PR DESCRIPTION
Implements `docs/specs/SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md` Phases 0–2: the architecture for rich per-tool result UIs, **plus the first one** (WebSearch).

## The problem
`ToolNode.tool` is a **closed 9-value union** (`…|"Other"`), and `stream-parser.ts:508` collapsed every unknown tool to `"Other"` — so `WebSearch`, `TodoWrite`, and all `mcp__*` tools were indistinguishable, and `renderToolResultBody`'s `switch` could only reach `default` → JSON. You couldn't `case "WebSearch"` over an enum the data can't populate.

## Phase 0 — preserve the raw tool name (no behavior change)
`ToolNode` gains optional **`toolName`** (`"WebSearch"`, `"mcp__github__search_issues"`, …); `stream-parser` sets it at the three node-construction sites. The coarse `tool` enum stays as the *kind*; matchers fall back to it when `toolName` is absent. The data already flowed from every translator — it was just dropped at `normalizeToolName`.

## Phase 1 — renderer registry (pure refactor)
`tool-renderers/registry.ts`: register `{ priority, match, render, label }`, resolve the highest-priority match (ties by registration order). Matchers `byKind`/`byName`/`byNamePrefix("mcp__")`/`byShape`/`anyTool`. `ToolOverlayLog`'s switch is migrated to **registered built-ins** — the former arms **verbatim** at priority 0 + a catch-all (`CompactResult`) — **byte-identical** output.

## Phase 2 — WebSearch result cards (the payoff)
`SearchResults` renders WebSearch results as **clickable cards** (title → `openExternal` to the system browser, host, snippet) instead of a JSON blob. Registered for `WebSearch`/`web_search` by name at priority 10. `extractSearchResults` is **tolerant** (top-level array or `results`/`content`/`items`/… arrays; `url|link|uri`, `title|name|heading`, `snippet|description|text|content|page_age`) and **gracefully falls back to today's JSON** for anything it doesn't recognize — so registering by name can never break an unexpected payload.

#1511's `terminalText`→`TerminalOutput` is the seed of this pattern and is the terminal entry of the fallback chain.

## Tests / verification
- `registry.test.ts` (10): resolution (priority/tie/catch-all/null), matchers, parity (all 8 built-ins register; every kind resolves).
- `search-results.test.ts` + `SearchResults.test.tsx` (11): classifier shapes/variants/rejections; card render + click-to-open (mocked `getApi`) + JSON fallback + registry routing.
- `tsc` + `stylelint` clean for touched files; **570 agent-view vitest pass** (no regression).
- ⚠️ Not verified headlessly: real WebSearch output in the running app. The exact result shape varies by provider; the extractor is deliberately tolerant and no-ops to JSON on unrecognized shapes, so it may need a **real-sample tune** to confirm field coverage. Needs `task dev` + an agent running WebSearch.

## Follow-ups (Phase 3)
`mcp__*` prefix renderers, more kinds (image/table/file-list), and folding in the two *other* tool-keyed dispatches (`TOOL_ICONS` + the ad-hoc AskUserQuestion panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)