### PR TITLE
docs(agent-api): first-class agent API surface spec + window-naming report

### DIFF
--- a/docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md
+++ b/docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md
@@ -1,0 +1,93 @@
+# Can an agent set the window/taskbar name? (e.g. "Starter Workspace")
+
+**Date:** 2026-06-17
+**Question:** Does the agent-facing app API have a binding to set the OS window name as it appears in the taskbar, so an agent can launch `task dev` with a recognizable name for easy ID?
+**Short answer:** **No binding exists for agents today.** The native taskbar-title plumbing is fully implemented, but the only way to drive it is a frontend-reactive meta key (`window:displayname`) set over the WebSocket RPC by the in-app UI. There is **no MCP tool, no HTTP `/api/v1` endpoint, and no launch-time flag/env var.** Adding one is small — see §5.
+
+---
+
+## 1. How the taskbar title actually works (verified)
+
+The native window caption (what Windows shows in the taskbar) is **derived from the HTML `document.title`**, one-directionally, frontend → host:
+
+1. **Frontend computes** `document.title` reactively in `installWindowTitleEffect()` (`frontend/app-init.ts` ~L675–750, ~L877).
+   Format (`frontend/util/window-title.ts`):
+   ```
+   {Window Name} - {Tab Name} - AgentMux
+   ```
+   **Window Name** is a 3-tier fallback (`resolveWindowName`, window-title.ts:33-39):
+   1. `WaveWindow.meta["window:displayname"]` (user-set, ≤64 chars)
+   2. assigned `workspace.name`
+   3. positional `"Window N"`
+
+2. **CEF mirrors it to the OS.** When `document.title` changes, CEF fires `on_title_change`, which sets the native caption (`agentmux-cef/src/client/mod.rs:205-243`):
+   - macOS/Linux: `window.set_title(...)` (CEF Views)
+   - **Windows: `SetWindowTextW(hwnd, …)`** (L224-243) — this is the taskbar text. Guarded to skip when CEF passes `None` (reagent P1 #876).
+
+So **the binding to the taskbar exists and works** — it's just keyed entirely off `document.title`, which is computed in the renderer.
+
+## 2. Where "Starter workspace" comes from
+
+It's the hardcoded **default workspace name** created on first DB init:
+`agentmux-srv/src/backend/wcore/mod.rs:85` → `create_workspace(store, "Starter workspace")`.
+
+Because Window Name falls back to the workspace name (tier 2), a window with no explicit `window:displayname` and the default workspace shows **"Starter workspace - <tab> - AgentMux"** in the taskbar. That's why you see it.
+
+## 3. How the name is set today (and by whom)
+
+`window:displayname` is written **only** from the frontend UI, via the generic object-meta RPC:
+
+- `ObjectService.UpdateObjectMeta(makeORef("window", id), { "window:displayname": name })`
+  - InstancePanel rename: double-click a window row or **F2** (`frontend/app/statusbar/InstancePanel.tsx:226, 492`)
+- `UpdateObjectMeta` is a **backend service call routed through the reducer** (`agentmux-srv/src/server/service.rs:311`), reached via `WOS.callBackendService("object", "UpdateObjectMeta", …)` — i.e. over the **WebSocket `/ws` RPC**, not a REST endpoint.
+
+## 4. What the agent API exposes today — and the gap
+
+Agents talk to their sidecar with `AGENTMUX_LOCAL_URL` + `X-AuthKey`. The surface:
+
+| Channel | Available to agents | Window-naming capability |
+|---|---|---|
+| **MCP tools** (`agentmux-mcp`): Shell, ShellStop, OpenEditor, SendMessage, DiscoverAgents | yes | ❌ none touch window/title |
+| **HTTP `/api/v1/*`** (shell/create, shell/stop, pane/open) and `/agentmux/*` (reactive, discovery) | yes | ❌ no `window`/`meta`/`rename`/`title` route exists (grep of all `.route(` = none) |
+| **WebSocket `/ws`** RPC incl. `setmeta` / `UpdateObjectMeta` | technically auth-gated, but this is the **frontend's** channel; agents have no client for it | ⚠️ could set `window:displayname` *if* it had the window ID and a WS client |
+
+**Two structural problems for the "name my `task dev`" use case even via `/ws`:**
+1. **No agent client for the WS RPC** — agents use the MCP/HTTP surface, not the SolidJS `ObjectService`.
+2. **`task dev` spawns a *separate* AgentMux instance** — its own sidecar, own `auth_key`, own window IDs. An agent running in instance A cannot reach instance B's sidecar to set B's window name. The name has to be applied **by the new instance, at its own startup.**
+
+**Conclusion:** there is no quick path today. The natural channel for "launch `task dev` already named" is **launch-time configuration the new instance reads about itself**, not a cross-instance RPC.
+
+## 5. Recommended implementation (smallest thing that fits the goal)
+
+**Option A — launch-time env var `AGENTMUX_WINDOW_NAME` (recommended).**
+Ride it on the command the agent already runs:
+```bash
+AGENTMUX_WINDOW_NAME="PR-1503 repro" task dev
+```
+On window init, if the env var is set, seed `window:displayname` on the window object before `installWindowTitleEffect` first runs. Two viable wiring points:
+- **Backend startup** (`wcore`): when creating/attaching the window, if `AGENTMUX_WINDOW_NAME` is set, write it into the window meta. Pro: one place, persists; works for first-launch and is read by the same reactive effect.
+- **Frontend init** (`app-init.ts`): read the value (exposed by the host) and call `UpdateObjectMeta` once at boot. Pro: reuses the exact path the UI uses.
+
+Effort: ~½ day. No new API surface, no cross-instance concerns, composes with `task dev`. **Best fit for the stated goal.**
+
+**Option B — MCP `SetWindowName` tool + HTTP `POST /api/v1/window/name`.**
+Lets a *running* agent rename *its own* instance's window at runtime (needs the window ID; resolvable since the sidecar knows its windows). Pro: also useful outside dev. Con: does **not** by itself solve "launch `task dev` pre-named" because of the separate-instance problem in §4 — you'd still want Option A for that. Effort: ~1 day (new route + reducer call + MCP tool + tests).
+
+**Option C — `task dev` convenience flag.**
+e.g. `task dev -- --name "X"` that just sets `AGENTMUX_WINDOW_NAME` for the child. Thin sugar on Option A. Effort: ~1 hr once A exists.
+
+**Suggested path:** ship **A** (covers the dev-window ID use case directly), optionally add **C** as sugar. Add **B** later only if agents need to rename running windows generally.
+
+## 6. Key file references
+
+| What | File:line |
+|---|---|
+| Title format + 3-tier resolution | `frontend/util/window-title.ts:11-55` |
+| Reactive `document.title` effect | `frontend/app-init.ts` ~675-750, ~877 |
+| Native caption set (Win32 `SetWindowTextW`) | `agentmux-cef/src/client/mod.rs:205-243` |
+| Default "Starter workspace" name | `agentmux-srv/src/backend/wcore/mod.rs:85` |
+| Rename UI (writes `window:displayname`) | `frontend/app/statusbar/InstancePanel.tsx:226,492` |
+| `UpdateObjectMeta` reducer route (WS RPC) | `agentmux-srv/src/server/service.rs:311` |
+| Window-meta host commands (no displayname setter) | `agentmux-cef/src/commands/window/meta.rs` |
+| HTTP router (no window/title route) | `agentmux-srv/src/server/mod.rs` (`.route(` set) |
+| MCP tools (no window tool) | `agentmux-mcp/src/main.rs` |

--- a/docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md
+++ b/docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md
@@ -38,7 +38,7 @@ Because Window Name falls back to the workspace name (tier 2), a window with no 
 `window:displayname` is written **only** from the frontend UI, via the generic object-meta RPC:
 
 - `ObjectService.UpdateObjectMeta(makeORef("window", id), { "window:displayname": name })`
-  - InstancePanel rename: double-click a window row or **F2** (`frontend/app/statusbar/InstancePanel.tsx:226, 492`)
+  - InstancePanel rename: double-click a window row or **F2** (`frontend/app/statusbar/InstancePanel.tsx:226`)
 - `UpdateObjectMeta` is a **backend service call routed through the reducer** (`agentmux-srv/src/server/service.rs:311`), reached via `WOS.callBackendService("object", "UpdateObjectMeta", …)` — i.e. over the **WebSocket `/ws` RPC**, not a REST endpoint.
 
 ## 4. What the agent API exposes today — and the gap
@@ -86,7 +86,7 @@ e.g. `task dev -- --name "X"` that just sets `AGENTMUX_WINDOW_NAME` for the chil
 | Reactive `document.title` effect | `frontend/app-init.ts` ~675-750, ~877 |
 | Native caption set (Win32 `SetWindowTextW`) | `agentmux-cef/src/client/mod.rs:205-243` |
 | Default "Starter workspace" name | `agentmux-srv/src/backend/wcore/mod.rs:85` |
-| Rename UI (writes `window:displayname`) | `frontend/app/statusbar/InstancePanel.tsx:226,492` |
+| Rename UI (writes `window:displayname`) | `frontend/app/statusbar/InstancePanel.tsx:226` |
 | `UpdateObjectMeta` reducer route (WS RPC) | `agentmux-srv/src/server/service.rs:311` |
 | Window-meta host commands (no displayname setter) | `agentmux-cef/src/commands/window/meta.rs` |
 | HTTP router (no window/title route) | `agentmux-srv/src/server/mod.rs` (`.route(` set) |

--- a/docs/specs/SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md
+++ b/docs/specs/SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md
@@ -1,0 +1,205 @@
+# Agent API: First-Class Surface (naming, layout, identity, introspection)
+
+**Date:** 2026-06-17
+**Status:** Draft
+**Author:** naki
+**Related:**
+- `docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md` (the window-naming finding that triggered this)
+- `docs/specs/SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md` (#1497 — floating pane / collapse_tree, the most recent API add)
+- `docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md` (title resolution)
+
+---
+
+## 1. Premise
+
+Agents running inside AgentMux are **first-class actors**, not guests. They should be able to shape their own workspace the way a human can: name things, open/close/focus panes and tabs, and introspect the layout they live in. Today the surface is ad-hoc (5 MCP tools) on top of a powerful-but-undocumented generic gateway. Since we're already extending the API (window naming was the immediate ask), this spec defines a **coherent first-class periphery** and the conventions future additions follow.
+
+This spec is deliberately scoped to abilities whose **backend already exists** — we are surfacing and hardening, not building new subsystems.
+
+---
+
+## 2. What exists today (verified)
+
+### 2.1 Two transports, one auth
+
+Agents get `AGENTMUX_LOCAL_URL` (sidecar base) + `AGENTMUX_AUTH_KEY` (`X-AuthKey`). Every route except `GET /` is auth-gated (`mod.rs` `auth_middleware`).
+
+- **MCP tools** (`agentmux-mcp/src/main.rs`) — the ergonomic surface agents actually reach for: `Shell`, `ShellStop`, `OpenEditor`, `SendMessage`, `DiscoverAgents`. Each is a thin POST to a sidecar route.
+- **`POST /agentmux/service`** (`service.rs::handle_service`) — a **generic gateway** to the same reducer/service layer the frontend uses. Body is `WebCallType { service, method, args }`; it runs `dispatch_service(...)` and **broadcasts resulting `WaveObjUpdate`s to the event bus** so the UI reflects agent-driven changes live.
+
+### 2.2 The gateway already exposes 47 methods
+
+`dispatch_service` (`service.rs`) handles, among others:
+
+| Domain | Methods (service.method) |
+|---|---|
+| **Object/meta** | `object.UpdateObjectMeta`, `object.UpdateTabName`, `object.UpdateObject`, `object.CreateBlock`, `object.DeleteBlock`, `object.GetObject(s)` |
+| **Workspace/tab** | `workspace.CreateTab`, `CloseTab`, `SetActiveTab`, `ReorderTab`, `MoveTabToWorkspace`, `MoveBlockToTab`, `PromoteBlockToTab`, `TearOffBlock`, `TearOffTab`, `RedockFloatingPane`, `RestoreTornOffTab`, `CreateWorkspace`, `DeleteWorkspace`, `UpdateWorkspace`, `ListWorkspaces`, `GetWorkspace` |
+| **Window** | `window.CreateWindow`, `CloseWindow`, `GetWindow`, `SetWindowPosAndSize`, `SwitchWorkspace`, `client.FocusWindow` |
+| **Agent/other** | `agent.define`, `subagent.*`, `history.*`, `block.GetControllerStatus`, `userinput.SendUserInputResponse` |
+
+**Implication:** the abilities the user wants (set window name, tab name, workspace name, manage tabs/panes) are **already reachable over HTTP today** via `object.UpdateObjectMeta` (e.g. `window:displayname`, `frame:title`, `tab:color`), `object.UpdateTabName`, and `workspace.UpdateWorkspace`.
+
+### 2.3 So what's actually missing
+
+The gap is **not transport** — it's that the gateway is **unergonomic, undiscoverable, unscoped, and unsafe** for agent use:
+
+1. **No self-context.** To rename "my tab" an agent must already know its `tab_id`, `window_id`, `workspace_id`, and the `oref` envelope format. It only has `AGENTMUX_BLOCKID` / `AGENTMUX_AGENT_ID`. There is no "who/where am I" call.
+2. **No verbs.** Agents must hand-craft reducer calls (`object.UpdateObjectMeta` with the right meta key) — implementation detail leakage. No MCP tools wrap them, so in practice agents never discover them.
+3. **No safety model.** `window.CloseWindow` and `workspace.DeleteWorkspace` are as reachable as a rename. Nothing distinguishes a benign self-scoped rename from a destructive global op.
+4. **The launch-time naming case is unsolved.** `task dev` spawns a *separate* instance with its own sidecar/window; no env/flag seeds its name (see the window-naming report §4–5).
+
+---
+
+## 3. Goals / Non-goals
+
+**Goals**
+- Give agents a small, **discoverable, ergonomic, self-scoped** set of first-class verbs for naming, layout, and introspection.
+- Establish **conventions** (self-context defaulting, capability tiers, MCP-tool-wraps-REST-wraps-gateway) so future API growth is consistent.
+- Solve the **launch-time naming** case for `task dev` and any spawned instance.
+
+**Non-goals**
+- No new rendering/window subsystems — we wrap existing `dispatch_service` methods.
+- No remote/cross-instance control (an agent only acts on **its own** instance; cross-instance stays muxbus messaging).
+- Not exposing every one of the 47 methods — only the curated, safe subset below.
+
+---
+
+## 4. Design
+
+### 4.1 Layering convention
+
+```
+MCP tool  (ergonomic, agent-facing, self-defaulting)
+   └── REST verb  /api/v1/...   (clean, typed, documented)
+          └── dispatch_service  (existing reducer/service layer)
+```
+
+New abilities are added as a **REST verb** (typed, testable) plus a **thin MCP tool** that defaults the target to the agent's own context. The verb internally calls the existing `dispatch_service` method — no reducer changes.
+
+### 4.2 Self-context (foundation — build first)
+
+**`GET /api/v1/self`** → resolves the calling agent's place in the tree from `AGENTMUX_BLOCKID`:
+
+```json
+{
+  "agent_id": "naki",
+  "block_id": "…",          "block_title": "naki",
+  "tab_id": "…",            "tab_name": "Work",
+  "window_id": "…",         "window_name": "Starter workspace",
+  "workspace_id": "…",      "workspace_name": "Starter workspace"
+}
+```
+
+MCP tool **`WhoAmI`** (no args) returns the same. Every other verb below accepts an optional explicit target but **defaults to the relevant id from self-context**, so the common case ("name my window") is a one-arg call.
+
+### 4.3 Naming / identity verbs (the immediate ask)
+
+All default their target to self-context; all are non-destructive.
+
+| MCP tool | REST | Underlying call | Notes |
+|---|---|---|---|
+| `SetWindowName(name)` | `POST /api/v1/window/name` | `object.UpdateObjectMeta(window, {"window:displayname": name})` | drives taskbar title (≤64 chars, see title spec) |
+| `SetTabName(name, tab_id?)` | `POST /api/v1/tab/name` | `object.UpdateTabName` | tab label |
+| `SetPaneTitle(title, block_id?)` | `POST /api/v1/pane/title` | `object.UpdateObjectMeta(block, {"frame:title": title})` | own pane title; complements `OpenEditor(title:)` |
+| `SetWorkspaceName(name)` | `POST /api/v1/workspace/name` | `workspace.UpdateWorkspace` | |
+
+### 4.4 Launch-time naming (solves the `task dev` case)
+
+Add startup env vars read by the **new instance** about **itself** (no cross-instance RPC):
+
+- `AGENTMUX_WINDOW_NAME` → seeds `window:displayname` on the instance's window at init.
+- `AGENTMUX_WORKSPACE_NAME` → seeds the starter workspace name (overrides the hardcoded `"Starter workspace"`, `wcore/mod.rs:85`) when a fresh DB is initialized.
+
+Usage becomes:
+```bash
+AGENTMUX_WINDOW_NAME="repro #1503" task dev
+```
+Optionally add `task dev -- --name "X"` sugar that just exports the env for the child. Wiring point: backend window init seeds the meta before `installWindowTitleEffect` first runs (frontend title effect already reacts to it).
+
+### 4.5 Layout / navigation verbs (high value, low cost)
+
+Self-defaulting, reversible:
+
+| MCP tool | REST | Underlying call |
+|---|---|---|
+| `FocusPane(block_id?)` / `FocusTab(tab_id)` / `FocusWindow(window_id?)` | `POST /api/v1/{pane,tab,window}/focus` | `client.FocusWindow`, `workspace.SetActiveTab` |
+| `NewTab(name?)` | `POST /api/v1/tab/new` | `workspace.CreateTab` (+ `UpdateTabName`) |
+| `SetActiveTab(tab_id)` | `POST /api/v1/tab/activate` | `workspace.SetActiveTab` |
+
+`OpenEditor` (incl. `floating`, `collapse_tree`) and `Shell` already cover pane creation.
+
+### 4.6 Introspection verbs (read-only, always safe)
+
+| MCP tool | REST | Underlying call |
+|---|---|---|
+| `ListTabs()` / `ListWindows()` / `ListWorkspaces()` | `GET /api/v1/{tabs,windows,workspaces}` | `client.GetTab`, `window.GetWindow`, `workspace.ListWorkspaces` |
+| `GetLayout()` | `GET /api/v1/layout` | composed read: windows → tabs → blocks tree |
+
+(`DiscoverAgents` already covers the agent inventory.)
+
+### 4.7 User-signal verb (candidate — confirm an event sink exists)
+
+`Notify(message, level?)` → surface a transient toast/log line to the human (not another agent — that's `SendMessage`). Wire to the existing event bus (`wps/publish` already exists). Include only if a frontend toast consumer exists or is cheap to add; otherwise defer.
+
+---
+
+## 5. Safety / capability model
+
+Self-scoped, reversible ops (naming, focus, new tab, introspection) are **allowed by default**. Destructive or global ops are **gated**:
+
+- **Tier 0 (default, ungated):** all of §4.2, §4.3, §4.5 (create/focus/rename), §4.6 (reads).
+- **Tier 1 (gated):** `CloseTab` of a tab the agent doesn't own, `CloseWindow`, `DeleteWorkspace`, moving *other* agents' panes. Gate behind an explicit capability flag (e.g. `agent:caps` block meta or a sidecar setting) and **default off**.
+- **Never:** cross-instance control; killing processes the agent didn't spawn (already enforced by I3 / kill-by-PID rules).
+
+The raw `/agentmux/service` gateway stays available (it's how the verbs are implemented) but is treated as **internal/advanced** — the curated verbs are the supported, documented surface. Consider gating the destructive `dispatch_service` methods behind the same Tier-1 capability so the gateway can't be used to bypass the verb-level policy.
+
+Every verb's resulting `WaveObjUpdate` already broadcasts to the event bus (existing `handle_service` behavior), so the UI and other windows stay consistent with agent-driven changes.
+
+---
+
+## 6. Implementation plan
+
+**Phase 1 — Foundation + the ask**
+1. `GET /api/v1/self` + `WhoAmI` MCP tool (self-context resolver: block_id → tab → window → workspace).
+2. `SetWindowName` / `SetTabName` / `SetPaneTitle` / `SetWorkspaceName` (REST verbs + MCP tools, self-defaulting).
+3. `AGENTMUX_WINDOW_NAME` / `AGENTMUX_WORKSPACE_NAME` launch-time seeding.
+
+**Phase 2 — Layout & introspection**
+4. `FocusPane/Tab/Window`, `NewTab`, `SetActiveTab`.
+5. `ListTabs/Windows/Workspaces`, `GetLayout`.
+
+**Phase 3 — Safety & polish**
+6. Capability tiers; gate Tier-1 ops; document the gateway as advanced.
+7. `Notify` (if event sink confirmed).
+
+Each phase ships independently; Phase 1 alone delivers the requested window naming as a first-class, discoverable ability.
+
+---
+
+## 7. Testing
+
+- **Unit (sidecar):** each REST verb maps args → correct `dispatch_service` call and rejects bad targets; self-context resolves block_id → tab/window/workspace; Tier-1 gate denies when capability off.
+- **MCP:** `tools/list` includes the new tools; each tool defaults target from self-context when omitted.
+- **Launch-time:** `AGENTMUX_WINDOW_NAME=X task dev` → taskbar shows `X - … - AgentMux` (manual CEF smoke, like floating-pane).
+- **Regression:** existing `OpenEditor` (incl. `floating`/`collapse_tree`) and `Shell`/`SendMessage` unaffected.
+
+---
+
+## 8. Open questions
+
+1. **Capability storage** — block meta (`agent:caps`) vs. a sidecar setting vs. per-agent-definition field? Per-definition is most aligned with "agents are first-class entities."
+2. **`window:displayname` for a multi-window instance** — `SetWindowName` defaults to the agent's own window; confirm self-context resolves the right window when the agent pane was torn off.
+3. **Does a toast/notification consumer exist** in the frontend today, or is `Notify` net-new UI (then defer to its own spec)?
+4. **Naming collisions / validation** — clamp lengths (window ≤64), strip control chars; reject empty (mirror the `SendMessage`/`OpenEditor` guards).
+
+---
+
+## 9. Appendix — floating-pane editor API status (checked 2026-06-17)
+
+Requested alongside this spec. **Verdict: working as of `main`.**
+
+- Shipped in **#1497** (`73ce2ec3`, 2026-06-16) — "feat(pane.open): OpenEditor collapse_tree + floating-pane support".
+- Full path verified end-to-end: `OpenEditor{floating:true}` → `POST /api/v1/pane/open` → `app_api.rs::open_pane()` floating branch (~L911) → `open_pane_floating()` (~L1011-1186) reuses the `tear_off_block` saga → publishes scoped `openfloatingpane` WPS event → `frontend/app/store/global.ts:307-344` → host `open_floating_pane_window` (`agentmux-cef/src/commands/floating_pane.rs:81-231`) → chromeless `FloatingPaneWorkspace`.
+- **Known limitations (by design, not bugs):** Windows = owned floating panes only (Phase 1, no cross-window redock); macOS/Linux = Phase A frameless windows. If the source window isn't in `state.windows`, the floater silently no-ops (logged) — safe.
+- **Gap:** no automated test — the cross-process CEF path requires a manual smoke (the spec for #1497 calls this out). Recommend adding a smoke step to the verification checklist; full automation needs a CEF build harness.


### PR DESCRIPTION
## Summary

Captures the approved design for extending the **agent-facing API** so agents are first-class actors that can name, navigate, and introspect their own workspace — triggered by the immediate ask: let an agent set the window/taskbar name (e.g. for a named `task dev`).

Two docs:
- **`docs/specs/SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md`** — the spec.
- **`docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md`** — the supporting research.

## Key findings (verified against code)

- **`POST /agentmux/service` is already a generic authenticated gateway** to the same reducer/service layer the frontend uses — exposing **47 service.method pairs** today, including `object.UpdateObjectMeta` (→ `window:displayname`, `frame:title`), `object.UpdateTabName`, and `workspace.UpdateWorkspace`. So the *transport* to naming already exists for agents.
- The native taskbar title is driven by `document.title` → `SetWindowTextW` (`agentmux-cef/src/client/mod.rs:205-243`), keyed off the `window:displayname` meta (3-tier fallback in `frontend/util/window-title.ts`). "Starter workspace" is just the default workspace name (`wcore/mod.rs:85`) showing through.
- **The real gap is ergonomics/discoverability/safety**, plus no launch-time naming for a spawned `task dev` instance (separate sidecar/window).

## What the spec proposes

- **Self-context** (`GET /api/v1/self` + `WhoAmI`) — resolves the agent's block→tab→window→workspace so every verb can default to "my own X".
- **Naming verbs** — `SetWindowName`, `SetTabName`, `SetPaneTitle`, `SetWorkspaceName`.
- **Launch-time naming** — `AGENTMUX_WINDOW_NAME` / `AGENTMUX_WORKSPACE_NAME` env seeding.
- **Layout/navigation + introspection** verbs.
- **Capability-tier safety model** (self-scoped/reversible allowed by default; destructive ops gated, off by default).
- Layering convention: MCP tool → REST verb → existing `dispatch_service`.

Phased; **Phase 1 delivers window naming**. Implementation of the window-naming slice follows in a separate PR.

## Appendix

§9 confirms the **floating-pane editor API (#1497) works end-to-end** (full path traced); the only gap is no automated test (manual CEF smoke required).

## Note

Docs-only PR (no code, no version-affecting change), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)