### PR TITLE
feat(agent-api): first-class window naming (Phase 1)

### DIFF
--- a/.changesets/1781713903-feat-agent-api-window-naming.md
+++ b/.changesets/1781713903-feat-agent-api-window-naming.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-api): first-class window naming — WhoAmI/SetWindowName tools, /api/v1/self + /api/v1/window/name endpoints, AGENTMUX_WINDOW_NAME launch seeding

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -77,6 +77,27 @@ const DISCOVER_AGENTS_TOOL: &str = r#"{
   }
 }"#;
 
+const WHOAMI_TOOL: &str = r#"{
+  "name": "WhoAmI",
+  "description": "Return your own place in the AgentMux UI: your block (pane), tab, window, and workspace ids plus their names. Use it to discover the targets for naming/layout verbs (e.g. before SetWindowName). Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const SET_WINDOW_NAME_TOOL: &str = r#"{
+  "name": "SetWindowName",
+  "description": "Set the name of your AgentMux window as it appears in the OS taskbar / window title (e.g. \"Starter Workspace\" → a label you choose). Defaults to your own window. Useful for making an instance easy to identify. Name is trimmed and clamped to 64 characters.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string", "description": "The window display name to show in the taskbar / title bar" }
+    },
+    "required": ["name"]
+  }
+}"#;
+
 const OPEN_EDITOR_TOOL: &str = r#"{
   "name": "OpenEditor",
   "description": "Open a file in an AgentMux editor pane next to this conversation. Use when you want the user to see a file you're discussing or editing. Pass an absolute host path. Fire-and-forget: returns once the pane is opened.",
@@ -169,10 +190,13 @@ async fn main() {
                 let send_message: Value = serde_json::from_str(SEND_MESSAGE_TOOL).expect("static json");
                 let discover_agents: Value =
                     serde_json::from_str(DISCOVER_AGENTS_TOOL).expect("static json");
+                let whoami: Value = serde_json::from_str(WHOAMI_TOOL).expect("static json");
+                let set_window_name: Value =
+                    serde_json::from_str(SET_WINDOW_NAME_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, set_window_name] }
                 })
             }
             "tools/call" => {
@@ -490,6 +514,88 @@ async fn call_tool(
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
 
             Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "WhoAmI" => {
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+            if block_id.is_empty() {
+                anyhow::bail!(
+                    "neither AGENTMUX_AGENT_BUS_ID nor AGENTMUX_BLOCKID is set \
+                     — cannot resolve this agent's pane. Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/self", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&[("block_id", block_id)])
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("self lookup failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "SetWindowName" => {
+            let new_name = arguments
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+            if block_id.is_empty() {
+                anyhow::bail!(
+                    "neither AGENTMUX_AGENT_BUS_ID nor AGENTMUX_BLOCKID is set \
+                     — cannot resolve this agent's window. Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/window/name", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&json!({ "block_id": block_id, "name": new_name }))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("set window name failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            let applied = result
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(new_name);
+            Ok(format!("Window name set to \"{applied}\""))
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -85,7 +85,24 @@ pub fn ensure_initial_data(store: &Store) -> Result<bool, StoreError> {
     let ws = create_workspace(store, "Starter workspace")?;
 
     // Create window pointing to workspace
-    let win = create_window(store, &ws.oid)?;
+    let mut win = create_window(store, &ws.oid)?;
+
+    // Seed the window's display name (drives the OS/taskbar title) from
+    // AGENTMUX_WINDOW_NAME if the launcher/caller set it. This lets an agent
+    // bring up a recognizable instance, e.g. `AGENTMUX_WINDOW_NAME="repro #1503"
+    // task dev`. Only applies to a fresh instance's first window (this
+    // initial-data path); the runtime `SetWindowName` verb renames later.
+    // See SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md §4.4.
+    if let Ok(name) = std::env::var("AGENTMUX_WINDOW_NAME") {
+        let name = name.trim();
+        if !name.is_empty() {
+            win.meta.insert(
+                "window:displayname".to_string(),
+                serde_json::json!(name.chars().take(64).collect::<String>()),
+            );
+            store.update(&mut win)?;
+        }
+    }
 
     // Update client with window ID
     client.windowids.push(win.oid.clone());

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use axum::{
     body::Body,
-    extract::{Request, State},
+    extract::{Query, Request, State},
     http::{header, Method, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
@@ -247,6 +247,12 @@ pub fn build_router(state: AppState) -> Router {
         // shares the exact pane.open logic with the WebSocket RPC handler
         // (app_api::open_pane). See ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.
         .route("/api/v1/pane/open", post(handle_pane_open))
+        // First-class agent API (SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md).
+        // `GET /api/v1/self?block_id=` resolves the caller's place in the tree;
+        // `POST /api/v1/window/name` sets the window display name (taskbar title).
+        // agentmux-mcp's `WhoAmI` / `SetWindowName` tools call these.
+        .route("/api/v1/self", get(handle_self))
+        .route("/api/v1/window/name", post(handle_window_name))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -636,6 +642,99 @@ async fn handle_pane_open(
             (status, Json(json!({ "error": e }))).into_response()
         }
     }
+}
+
+#[derive(serde::Deserialize)]
+struct SelfQuery {
+    /// Block UUID of the calling agent pane (its `AGENTMUX_BLOCKID`).
+    block_id: Option<String>,
+}
+
+/// `GET /api/v1/self?block_id=<id>` — resolve the calling agent's place in the
+/// object tree (block → tab → window → workspace, with their names). The
+/// sidecar serves many agents, so the caller identifies itself by its block id
+/// (the MCP `WhoAmI` tool passes `AGENTMUX_BLOCKID`). Naming verbs reuse the
+/// same resolver to default their target to the agent's own context.
+async fn handle_self(
+    State(state): State<AppState>,
+    Query(q): Query<SelfQuery>,
+) -> impl IntoResponse {
+    let block_id = q.block_id.unwrap_or_default();
+    if block_id.is_empty() {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "missing block_id" }))).into_response();
+    }
+    match service::resolve_agent_context(&state.wstore, &block_id) {
+        Ok(ctx) => Json(serde_json::to_value(&ctx).unwrap_or_default()).into_response(),
+        Err(e) => (StatusCode::NOT_FOUND, Json(json!({ "error": e }))).into_response(),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct WindowNameRequest {
+    /// Block UUID of the calling agent pane (`AGENTMUX_BLOCKID`); used to
+    /// resolve the caller's own window when `window_id` is omitted.
+    #[serde(default)]
+    block_id: Option<String>,
+    /// New display name; drives the OS/taskbar title. Trimmed; clamped to 64.
+    name: String,
+    /// Explicit target window. Defaults to the caller's own window.
+    #[serde(default)]
+    window_id: Option<String>,
+}
+
+/// `POST /api/v1/window/name` — set a window's display name
+/// (`window:displayname`), which the frontend turns into the OS/taskbar title.
+/// Defaults to the caller's own window (resolved from `block_id`). Routes
+/// through the same `object.UpdateObjectMeta` service path the InstancePanel
+/// rename uses, so persistence + live-title update are identical.
+/// agentmux-mcp's `SetWindowName` tool POSTs here.
+async fn handle_window_name(
+    State(state): State<AppState>,
+    Json(req): Json<WindowNameRequest>,
+) -> impl IntoResponse {
+    // window:displayname is documented as ≤64 chars (window-title.ts).
+    let name: String = req.name.trim().chars().take(64).collect();
+    if name.is_empty() {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "name must not be empty" }))).into_response();
+    }
+
+    let window_id = match req.window_id.filter(|w| !w.is_empty()) {
+        Some(w) => w,
+        None => {
+            let block_id = req.block_id.unwrap_or_default();
+            if block_id.is_empty() {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": "provide window_id or block_id" }))).into_response();
+            }
+            match service::resolve_agent_context(&state.wstore, &block_id) {
+                Ok(ctx) => match ctx.window_id {
+                    Some(w) => w,
+                    None => {
+                        return (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({ "error": "no live window for this agent (tab not attached to a window)" })),
+                        )
+                            .into_response()
+                    }
+                },
+                Err(e) => return (StatusCode::NOT_FOUND, Json(json!({ "error": e }))).into_response(),
+            }
+        }
+    };
+
+    let call = crate::backend::service::WebCallType {
+        service: "object".to_string(),
+        method: "UpdateObjectMeta".to_string(),
+        uicontext: None,
+        args: vec![
+            json!(format!("window:{window_id}")),
+            json!({ "window:displayname": name }),
+        ],
+    };
+    let result = service::run_service_call(&state, &call).await;
+    if let Some(err) = result.error {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
+    }
+    Json(json!({ "success": true, "window_id": window_id, "name": name })).into_response()
 }
 
 // ---- Auth Middleware ----

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -17,12 +17,21 @@ pub(super) async fn handle_service(
     State(state): State<AppState>,
     body: axum::body::Bytes,
 ) -> Json<WebReturnType> {
-    let service_start = std::time::Instant::now();
     let call: WebCallType = match serde_json::from_slice(&body) {
         Ok(c) => c,
         Err(e) => return Json(WebReturnType::error(format!("invalid request body: {e}"))),
     };
-    let result = dispatch_service(&state, &call).await;
+    Json(run_service_call(&state, &call).await)
+}
+
+/// Dispatch a service call and broadcast any resulting `WaveObjUpdate`s to the
+/// event bus — the shared core of `handle_service`. Factored out so the typed
+/// first-class agent-API verbs (e.g. `/api/v1/window/name`) get byte-identical
+/// persistence + broadcast to a raw `/agentmux/service` call without
+/// re-implementing it. See SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md.
+pub(crate) async fn run_service_call(state: &AppState, call: &WebCallType) -> WebReturnType {
+    let service_start = std::time::Instant::now();
+    let result = dispatch_service(state, call).await;
     let elapsed = service_start.elapsed();
     tracing::info!(
         "[http-perf] {}.{}: {:.2}ms",
@@ -54,7 +63,73 @@ pub(super) async fn handle_service(
         }
     }
 
-    Json(result)
+    result
+}
+
+/// The agent pane's place in the object tree, resolved from its block id.
+/// Powers `GET /api/v1/self` and lets naming verbs default to "my own X".
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct AgentContext {
+    pub block_id: String,
+    pub block_title: String,
+    pub tab_id: String,
+    pub tab_name: String,
+    pub window_id: Option<String>,
+    pub window_name: String,
+    pub workspace_id: Option<String>,
+    pub workspace_name: String,
+}
+
+/// Walk block → tab → workspace → window from an agent pane's block id.
+///
+/// Tabs carry no parent reference, so the workspace and window are found by
+/// reverse lookup: the workspace whose `tabids`/`pinnedtabids` contains the
+/// tab, then the window assigned that workspace. `window_id`/`workspace_id`
+/// are `None` when the tab isn't attached to a live window (e.g. a torn-off
+/// tab mid-transition) — callers should treat that as "no window to name".
+pub(crate) fn resolve_agent_context(store: &Store, block_id: &str) -> Result<AgentContext, String> {
+    let block = store
+        .get::<Block>(block_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("block not found: {block_id}"))?;
+    let block_title = meta_get_string(&block.meta, "frame:title", "");
+    let tab_id = block.parentoref.strip_prefix("tab:").unwrap_or("").to_string();
+    let tab = store
+        .get::<Tab>(&tab_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("tab not found for block {block_id}"))?;
+
+    let mut workspace_id = None;
+    let mut workspace_name = String::new();
+    let mut window_id = None;
+    let mut window_name = String::new();
+
+    if let Ok(workspaces) = store.get_all::<Workspace>() {
+        if let Some(ws) = workspaces
+            .into_iter()
+            .find(|w| w.tabids.contains(&tab_id) || w.pinnedtabids.contains(&tab_id))
+        {
+            workspace_name = ws.name.clone();
+            workspace_id = Some(ws.oid.clone());
+            if let Ok(windows) = store.get_all::<Window>() {
+                if let Some(win) = windows.into_iter().find(|w| w.workspaceid == ws.oid) {
+                    window_name = meta_get_string(&win.meta, "window:displayname", "");
+                    window_id = Some(win.oid);
+                }
+            }
+        }
+    }
+
+    Ok(AgentContext {
+        block_id: block_id.to_string(),
+        block_title,
+        tab_id,
+        tab_name: tab.name,
+        window_id,
+        window_name,
+        workspace_id,
+        workspace_name,
+    })
 }
 
 async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
@@ -2622,3 +2697,42 @@ fn wstore_workspace_exists(
 // vs wcore-direct tab ops). It will be reintroduced in E.2c.3
 // when tabs migrate into the reducer and pinned/active state is
 // authoritative there. (reagent + codex P1 #615.)
+
+#[cfg(test)]
+mod agent_context_tests {
+    use super::resolve_agent_context;
+    use crate::backend::obj::Tab;
+    use crate::backend::storage::store::Store;
+    use crate::backend::wcore;
+
+    // `ensure_initial_data` seeds one workspace ("Starter workspace") with a
+    // window and an initial tab holding a default agent block. The resolver
+    // must walk that agent block back up to its tab, workspace, and window.
+    #[test]
+    fn resolves_block_to_tab_workspace_and_window() {
+        let store = Store::open_in_memory().unwrap();
+        wcore::ensure_initial_data(&store).unwrap();
+
+        let tab = store
+            .get_all::<Tab>()
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("seeded tab");
+        let block_id = tab.blockids.first().expect("seeded agent block").clone();
+
+        let ctx = resolve_agent_context(&store, &block_id).expect("resolves context");
+        assert_eq!(ctx.tab_id, tab.oid);
+        assert_eq!(ctx.workspace_name, "Starter workspace");
+        assert!(ctx.workspace_id.is_some(), "workspace should resolve");
+        assert!(ctx.window_id.is_some(), "window should resolve via reverse lookup");
+    }
+
+    #[test]
+    fn unknown_block_errors() {
+        let store = Store::open_in_memory().unwrap();
+        wcore::ensure_initial_data(&store).unwrap();
+        let err = resolve_agent_context(&store, "does-not-exist").unwrap_err();
+        assert!(err.contains("block not found"), "unexpected error: {err}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **window-naming slice** of the first-class agent API spec (#1515 / `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md`). Agents can now name their own AgentMux window (the OS/taskbar title), and a launched instance can be pre-named.

Built on the existing `object.UpdateObjectMeta` service path that the in-app InstancePanel rename already uses, so persistence + live-title update are identical and proven.

## What's added

**Sidecar**
- **`GET /api/v1/self?block_id=`** — resolves the caller's place in the object tree (block → tab → window → workspace, with names). Tabs carry no parent ref, so workspace/window are found by reverse lookup (workspace whose `tabids` holds the tab; window assigned that workspace). This is the foundation for self-scoped verbs.
- **`POST /api/v1/window/name`** — sets `window:displayname` (→ `document.title` → `SetWindowTextW`/taskbar). Defaults to the caller's own window via `block_id`; name trimmed + clamped to 64. Routes through a shared `run_service_call` (factored out of `handle_service`) so it dispatches + broadcasts exactly like a raw `/agentmux/service` call.

**MCP tools** (`agentmux-mcp`)
- **`WhoAmI`** — returns your block/tab/window/workspace ids + names (calls `/api/v1/self` with `AGENTMUX_BLOCKID`).
- **`SetWindowName(name)`** — sets your window's taskbar name (POSTs `/api/v1/window/name`).

**Launch-time**
- **`AGENTMUX_WINDOW_NAME`** seeds `window:displayname` at fresh-instance window creation, e.g.:
  ```bash
  AGENTMUX_WINDOW_NAME="repro #1503" task dev
  ```
  Applies to a fresh instance's first window (the `task dev` / portable case); the `SetWindowName` verb renames at runtime. (Note: on a *reused* per-branch dev data dir the name persists from first creation rather than re-seeding — runtime `SetWindowName` covers re-labeling.)

## Tests

- `resolve_agent_context` walks a `ensure_initial_data`-seeded tree to the correct tab/workspace/window; unknown block errors. (`cargo test -p agentmux-srv agent_context_tests` — 2 passing.)
- Both crates build clean (`cargo build -p agentmux-srv -p agentmux-mcp`).

## Test plan

- [ ] `WhoAmI` from an agent returns its real tab/window/workspace names.
- [ ] `SetWindowName("X")` → taskbar title becomes `X - <tab> - AgentMux` live.
- [ ] `AGENTMUX_WINDOW_NAME="Y" task dev` on a fresh data dir → window opens named `Y`.
- [ ] Existing `OpenEditor`/`Shell`/`SendMessage`/`DiscoverAgents` unaffected; `tools/list` now includes `WhoAmI` + `SetWindowName`.

Follows the spec's layering: MCP tool → REST verb → existing `dispatch_service`. Phase 2 (tab/pane/workspace naming, layout, introspection) is a fast-follow on the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)