### PR TITLE
fix(agent-pane): control-bar model/effort changes apply to running Claude

### DIFF
--- a/.changesets/1781572000-fix-control-bar-model-apply.md
+++ b/.changesets/1781572000-fix-control-bar-model-apply.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): model/effort/permission picked in the control-bar dropdown now applies to a running Claude agent — previously only the /model slash command did (the GUI write was meta-only and silently no-op'd for persistent controllers)

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -16,11 +16,8 @@
  * (current)`, and Enter is a no-op confirmation.
  */
 
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
-import * as WOS from "@/app/store/wos";
-import { staticTabId } from "@/app/store/global";
-import { buildRuntimeArgs, getRuntimeConfig } from "../../buildRuntimeArgs";
+import { getRuntimeConfig } from "../../buildRuntimeArgs";
+import { applyRuntimeChange } from "../../runtime-apply";
 import type { AgentRuntimeConfig, EffortLevel, PermissionMode } from "../../types";
 import type { SlashChoice, SlashCommand, SlashCommandContext, SlashResult } from "../types";
 
@@ -41,37 +38,11 @@ async function updateRuntime(
     const current = getRuntimeConfig(ctx.block()?.meta);
     const updated: AgentRuntimeConfig = { ...current, ...patch };
     try {
-        await RpcApi.SetMetaCommand(TabRpcClient, {
-            oref: WOS.makeORef("block", ctx.blockId),
-            meta: { "agent:runtime": updated },
-        });
-
-        // PERSISTENT controllers (Claude stream-json) keep ONE CLI process alive
-        // across turns, so runtime flags (model/effort/permission) baked in at
-        // spawn never change from a meta-only update — the picker would silently
-        // no-op. (Subprocess controllers re-spawn per turn, so it just works
-        // there.) Rebuild cmd:args and force a controller restart; the persistent
-        // controller now resumes via --resume so the conversation is preserved.
-        //
-        // Regression: PR #1451 (a05060b0, 2026-06-15) flipped Claude from
-        // subprocess→persistent for the Agent SDK control protocol without
-        // teaching the runtime-change path to restart persistent controllers, so
-        // /model (and the inline picker) silently stopped taking effect.
-        const prov = ctx.provider();
-        if (prov?.controllerType === "persistent") {
-            const baseArgs = prov.persistentLaunchArgs ?? prov.launchArgs;
-            const updatedArgs = buildRuntimeArgs(baseArgs, updated, prov.id);
-            await RpcApi.SetMetaCommand(TabRpcClient, {
-                oref: WOS.makeORef("block", ctx.blockId),
-                meta: { "cmd:args": updatedArgs },
-            });
-            await RpcApi.ControllerResyncCommand(TabRpcClient, {
-                tabid: staticTabId(),
-                blockid: ctx.blockId,
-                forcerestart: true,
-            });
-        }
-
+        // Persist + (for persistent Claude) rebuild cmd:args & force-restart so
+        // the change applies to the running agent. Shared with the GUI control
+        // bar via applyRuntimeChange — the persistent rebuild/restart used to
+        // live only here (#1503), so the dropdown silently no-op'd.
+        await applyRuntimeChange(ctx.blockId, ctx.provider(), updated);
         return { ok: true, updated };
     } catch (err: any) {
         return { ok: false, error: err?.message ?? String(err) };

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -16,6 +16,8 @@ import * as WOS from "@/app/store/wos";
 import type { AgentRuntimeConfig, PermissionMode, ModelChoice, EffortLevel } from "../types";
 import { DEFAULT_RUNTIME_CONFIG } from "../types";
 import { getRuntimeConfig } from "../buildRuntimeArgs";
+import { applyRuntimeChange } from "../runtime-apply";
+import { getProvider } from "../providers";
 
 interface AgentControlBarProps {
     blockId: string;
@@ -73,14 +75,14 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
     };
 
     const updateRuntime = async (patch: Partial<AgentRuntimeConfig>) => {
-        const current = runtime();
-        const updated = { ...current, ...patch };
-        const oref = WOS.makeORef("block", blockId);
+        const updated = { ...runtime(), ...patch };
         try {
-            await RpcApi.SetMetaCommand(TabRpcClient, {
-                oref,
-                meta: { "agent:runtime": updated },
-            });
+            // Persist + (for persistent Claude) rebuild args & force-restart so
+            // the change applies to the running agent. Previously this wrote
+            // only `agent:runtime` meta, which silently no-op'd for persistent
+            // Claude — picking Opus/Sonnet here didn't take effect. Now shared
+            // with the /model slash path via applyRuntimeChange.
+            await applyRuntimeChange(blockId, getProvider(providerId), updated);
         } catch {
             // Silently ignore — settings will retry on next change
         }

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * applyRuntimeChange — the single way to apply a runtime config change
+ * (model / effort / permission) so it takes effect on the live agent.
+ *
+ * Persistent controllers (Claude stream-json) keep ONE CLI process alive
+ * across turns, so the model/effort/permission flags are baked in at spawn —
+ * a meta-only `agent:runtime` write silently no-ops for them. We therefore
+ * rebuild `cmd:args` (via the same `buildRuntimeArgs`) and force a controller
+ * restart; the persistent controller resumes via `--resume`, preserving the
+ * conversation. Subprocess controllers re-spawn per turn, so the meta write
+ * alone is enough there.
+ *
+ * Shared by the `/model`·`/effort`·`/mode` slash commands
+ * (`commands/global/runtime.ts`) AND the GUI control-bar dropdowns
+ * (`components/AgentControlBar.tsx`). Previously the persistent rebuild+restart
+ * lived only in the slash path (#1503), so the GUI dropdown silently failed to
+ * change the model on a running Claude agent — this helper unifies both.
+ */
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import * as WOS from "@/app/store/wos";
+import { staticTabId } from "@/app/store/global";
+import { buildRuntimeArgs } from "./buildRuntimeArgs";
+import type { AgentRuntimeConfig } from "./types";
+import type { ProviderDefinition } from "./providers";
+
+/**
+ * Persist `updated` to `agent:runtime` and, for persistent controllers, rebuild
+ * `cmd:args` + force-restart so the change applies to the running agent. May
+ * throw on RPC failure — callers decide how to surface it.
+ */
+export async function applyRuntimeChange(
+    blockId: string,
+    provider: ProviderDefinition | undefined,
+    updated: AgentRuntimeConfig,
+): Promise<void> {
+    const oref = WOS.makeORef("block", blockId);
+    await RpcApi.SetMetaCommand(TabRpcClient, {
+        oref,
+        meta: { "agent:runtime": updated },
+    });
+
+    if (provider?.controllerType === "persistent") {
+        const baseArgs = provider.persistentLaunchArgs ?? provider.launchArgs;
+        const updatedArgs = buildRuntimeArgs(baseArgs, updated, provider.id);
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref,
+            meta: { "cmd:args": updatedArgs },
+        });
+        await RpcApi.ControllerResyncCommand(TabRpcClient, {
+            tabid: staticTabId(),
+            blockid: blockId,
+            forcerestart: true,
+        });
+    }
+}


### PR DESCRIPTION
## Verification finding

Verifying "**does setting the model (Sonnet/Opus) work in AgentMux**" surfaced a real gap:

| Path | Applies to a *running* Claude agent? |
|------|--------------------------------------|
| Launch-time `--model` (`buildRuntimeArgs`) | ✅ (10/10 unit tests) |
| Slash `/model` | ✅ — #1503 rebuilds `cmd:args` + restarts the persistent controller |
| **GUI control-bar Opus/Sonnet dropdown** | ❌ **silently no-op'd** |

#1503 (which fixed the #1451 subprocess→persistent regression) patched the **slash** path in `commands/global/runtime.ts`, but the **control-bar dropdown** has its *own* `updateRuntime` that only wrote `agent:runtime` meta. For a **persistent** (Claude stream-json) controller the model/effort are baked in at spawn, so a meta-only write never changes the live process — picking Opus/Sonnet in the dropdown did nothing until the next respawn.

## Fix — one shared apply path
- **`runtime-apply.ts::applyRuntimeChange`** (new): write `agent:runtime`, and for persistent controllers rebuild `cmd:args` (`buildRuntimeArgs`) + `ControllerResyncCommand({ forcerestart })` (resumes via `--resume`, conversation preserved).
- `commands/global/runtime.ts` (`/model`·`/effort`·`/mode`) now calls the shared helper — de-duplicates the inline #1503 logic.
- `AgentControlBar.updateRuntime` calls `applyRuntimeChange(getProvider(providerId), …)` instead of the meta-only write — **fixes the dropdown**.

## Verification
- `npm run build` — clean.
- `vitest buildRuntimeArgs.test.ts` — 10/10 (`--model opus/sonnet`, `--effort` skipped on haiku, codex namespace, stale-flag strip).
- Subprocess providers unaffected (meta write only; they respawn per turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)