### PR TITLE
feat(agent-api): tab / pane / workspace naming verbs (Phase 2)

### DIFF
--- a/.changesets/1781715344-feat-agent-api-naming-verbs.md
+++ b/.changesets/1781715344-feat-agent-api-naming-verbs.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-api): tab/pane/workspace naming verbs — SetTabName, SetPaneTitle, SetWorkspaceName tools + /api/v1/{tab/name,pane/title,workspace/name} endpoints

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -98,6 +98,42 @@ const SET_WINDOW_NAME_TOOL: &str = r#"{
   }
 }"#;
 
+const SET_TAB_NAME_TOOL: &str = r#"{
+  "name": "SetTabName",
+  "description": "Rename your AgentMux tab (the label in the tab bar). Defaults to your own tab. Trimmed; clamped to 128 characters.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string", "description": "The tab name to display" }
+    },
+    "required": ["name"]
+  }
+}"#;
+
+const SET_PANE_TITLE_TOOL: &str = r#"{
+  "name": "SetPaneTitle",
+  "description": "Set the title of your own conversation pane (the header label on this agent pane). Trimmed; clamped to 128 characters.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "title": { "type": "string", "description": "The pane title to display" }
+    },
+    "required": ["title"]
+  }
+}"#;
+
+const SET_WORKSPACE_NAME_TOOL: &str = r#"{
+  "name": "SetWorkspaceName",
+  "description": "Rename your AgentMux workspace. The workspace name also appears in the window/taskbar title when no explicit window name is set. Defaults to your own workspace. Trimmed; clamped to 128 characters.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string", "description": "The workspace name to display" }
+    },
+    "required": ["name"]
+  }
+}"#;
+
 const OPEN_EDITOR_TOOL: &str = r#"{
   "name": "OpenEditor",
   "description": "Open a file in an AgentMux editor pane next to this conversation. Use when you want the user to see a file you're discussing or editing. Pass an absolute host path. Fire-and-forget: returns once the pane is opened.",
@@ -193,10 +229,15 @@ async fn main() {
                 let whoami: Value = serde_json::from_str(WHOAMI_TOOL).expect("static json");
                 let set_window_name: Value =
                     serde_json::from_str(SET_WINDOW_NAME_TOOL).expect("static json");
+                let set_tab_name: Value = serde_json::from_str(SET_TAB_NAME_TOOL).expect("static json");
+                let set_pane_title: Value =
+                    serde_json::from_str(SET_PANE_TITLE_TOOL).expect("static json");
+                let set_workspace_name: Value =
+                    serde_json::from_str(SET_WORKSPACE_NAME_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, set_window_name] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, set_window_name, set_tab_name, set_pane_title, set_workspace_name] }
                 })
             }
             "tools/call" => {
@@ -225,6 +266,25 @@ async fn main() {
         let _ = stdout.write_all(b"\n").await;
         let _ = stdout.flush().await;
     }
+}
+
+/// Guard for the self-scoped agent-API verbs: they need the sidecar URL +
+/// auth key to reach it, and the caller's block id to resolve "my own"
+/// tab/pane/window/workspace.
+fn require_agent_env(local_url: &str, auth_key: &str, block_id: &str) -> Result<()> {
+    if local_url.is_empty() || auth_key.is_empty() {
+        anyhow::bail!(
+            "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+             Is this agent pane opened via AgentMux?"
+        );
+    }
+    if block_id.is_empty() {
+        anyhow::bail!(
+            "neither AGENTMUX_AGENT_BUS_ID nor AGENTMUX_BLOCKID is set \
+             — cannot resolve this agent's context. Is this agent pane opened via AgentMux?"
+        );
+    }
+    Ok(())
 }
 
 async fn call_tool(
@@ -596,6 +656,59 @@ async fn call_tool(
                 .and_then(|v| v.as_str())
                 .unwrap_or(new_name);
             Ok(format!("Window name set to \"{applied}\""))
+        }
+        "SetTabName" | "SetWorkspaceName" => {
+            let new_name = arguments
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+
+            let (path, kind) = if name == "SetTabName" {
+                ("tab/name", "Tab")
+            } else {
+                ("workspace/name", "Workspace")
+            };
+            let url = format!("{}/api/v1/{path}", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&json!({ "block_id": block_id, "name": new_name }))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("set {kind} name failed: HTTP {status} — {text}");
+            }
+            Ok(format!("{kind} name set to \"{new_name}\""))
+        }
+        "SetPaneTitle" => {
+            let new_title = arguments
+                .get("title")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+
+            let url = format!("{}/api/v1/pane/title", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&json!({ "block_id": block_id, "title": new_title }))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("set pane title failed: HTTP {status} — {text}");
+            }
+            Ok(format!("Pane title set to \"{new_title}\""))
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -253,6 +253,12 @@ pub fn build_router(state: AppState) -> Router {
         // agentmux-mcp's `WhoAmI` / `SetWindowName` tools call these.
         .route("/api/v1/self", get(handle_self))
         .route("/api/v1/window/name", post(handle_window_name))
+        // Naming verbs (SPEC §4.3): rename the caller's own tab / pane / workspace
+        // (or an explicit target). agentmux-mcp's SetTabName / SetPaneTitle /
+        // SetWorkspaceName tools POST here.
+        .route("/api/v1/tab/name", post(handle_tab_name))
+        .route("/api/v1/pane/title", post(handle_pane_title))
+        .route("/api/v1/workspace/name", post(handle_workspace_name))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -735,6 +741,165 @@ async fn handle_window_name(
         return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
     }
     Json(json!({ "success": true, "window_id": window_id, "name": name })).into_response()
+}
+
+/// Trim a user-supplied name and clamp to `max` chars; `None` if empty.
+fn clean_name(raw: &str, max: usize) -> Option<String> {
+    let n: String = raw.trim().chars().take(max).collect();
+    if n.is_empty() {
+        None
+    } else {
+        Some(n)
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct TabNameRequest {
+    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the caller's
+    /// own tab when `tab_id` is omitted.
+    #[serde(default)]
+    block_id: Option<String>,
+    /// Explicit target tab; defaults to the caller's own tab.
+    #[serde(default)]
+    tab_id: Option<String>,
+    name: String,
+}
+
+/// `POST /api/v1/tab/name` — rename a tab. Defaults to the caller's own tab
+/// (resolved from `block_id`). Routes through `object.UpdateTabName`.
+async fn handle_tab_name(
+    State(state): State<AppState>,
+    Json(req): Json<TabNameRequest>,
+) -> impl IntoResponse {
+    let name = match clean_name(&req.name, 128) {
+        Some(n) => n,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({ "error": "name must not be empty" }))).into_response(),
+    };
+    let tab_id = match req.tab_id.filter(|t| !t.is_empty()) {
+        Some(t) => t,
+        None => match resolve_own(&state, req.block_id, |c| Some(c.tab_id.clone())) {
+            Ok(t) => t,
+            Err(resp) => return resp,
+        },
+    };
+    let call = crate::backend::service::WebCallType {
+        service: "object".to_string(),
+        method: "UpdateTabName".to_string(),
+        uicontext: None,
+        args: vec![json!(tab_id), json!(name)],
+    };
+    finish_name_call(&state, call, json!({ "success": true, "tab_id": tab_id, "name": name })).await
+}
+
+#[derive(serde::Deserialize)]
+struct PaneTitleRequest {
+    /// Calling agent's block id (`AGENTMUX_BLOCKID`) — the pane to title by
+    /// default. Set `block_id` to title a different pane you own.
+    #[serde(default)]
+    block_id: Option<String>,
+    title: String,
+}
+
+/// `POST /api/v1/pane/title` — set a pane's display title (`frame:title`).
+/// Targets the caller's own pane (its `block_id`). Routes through
+/// `object.UpdateObjectMeta`.
+async fn handle_pane_title(
+    State(state): State<AppState>,
+    Json(req): Json<PaneTitleRequest>,
+) -> impl IntoResponse {
+    let title = match clean_name(&req.title, 128) {
+        Some(t) => t,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({ "error": "title must not be empty" }))).into_response(),
+    };
+    let block_id = match req.block_id.filter(|b| !b.is_empty()) {
+        Some(b) => b,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({ "error": "missing block_id" }))).into_response(),
+    };
+    let call = crate::backend::service::WebCallType {
+        service: "object".to_string(),
+        method: "UpdateObjectMeta".to_string(),
+        uicontext: None,
+        args: vec![
+            json!(format!("block:{block_id}")),
+            json!({ "frame:title": title }),
+        ],
+    };
+    finish_name_call(&state, call, json!({ "success": true, "block_id": block_id, "title": title })).await
+}
+
+#[derive(serde::Deserialize)]
+struct WorkspaceNameRequest {
+    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the caller's
+    /// own workspace when `workspace_id` is omitted.
+    #[serde(default)]
+    block_id: Option<String>,
+    /// Explicit target workspace; defaults to the caller's own.
+    #[serde(default)]
+    workspace_id: Option<String>,
+    name: String,
+}
+
+/// `POST /api/v1/workspace/name` — rename a workspace. Defaults to the
+/// caller's own workspace (resolved from `block_id`). Routes through
+/// `workspace.UpdateWorkspace`.
+async fn handle_workspace_name(
+    State(state): State<AppState>,
+    Json(req): Json<WorkspaceNameRequest>,
+) -> impl IntoResponse {
+    let name = match clean_name(&req.name, 128) {
+        Some(n) => n,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({ "error": "name must not be empty" }))).into_response(),
+    };
+    let workspace_id = match req.workspace_id.filter(|w| !w.is_empty()) {
+        Some(w) => w,
+        None => match resolve_own(&state, req.block_id, |c| c.workspace_id.clone()) {
+            Ok(w) => w,
+            Err(resp) => return resp,
+        },
+    };
+    let call = crate::backend::service::WebCallType {
+        service: "workspace".to_string(),
+        method: "UpdateWorkspace".to_string(),
+        uicontext: None,
+        args: vec![json!(workspace_id), json!(name)],
+    };
+    finish_name_call(&state, call, json!({ "success": true, "workspace_id": workspace_id, "name": name })).await
+}
+
+/// Resolve a target id from the caller's own context (via `block_id`), using
+/// `pick` to select the field. Returns the route's error response on failure
+/// (missing block_id, unresolvable block, or the field is `None`).
+fn resolve_own(
+    state: &AppState,
+    block_id: Option<String>,
+    pick: impl Fn(&service::AgentContext) -> Option<String>,
+) -> Result<String, Response> {
+    let block_id = block_id.unwrap_or_default();
+    if block_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, Json(json!({ "error": "provide an explicit target id or block_id" }))).into_response());
+    }
+    let ctx = service::resolve_agent_context(&state.wstore, &block_id)
+        .map_err(|e| (StatusCode::NOT_FOUND, Json(json!({ "error": e }))).into_response())?;
+    pick(&ctx).filter(|s| !s.is_empty()).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "no such target resolved for this agent" })),
+        )
+            .into_response()
+    })
+}
+
+/// Run a naming service call and map the result to a JSON HTTP response.
+async fn finish_name_call(
+    state: &AppState,
+    call: crate::backend::service::WebCallType,
+    ok_body: serde_json::Value,
+) -> Response {
+    let result = service::run_service_call(state, &call).await;
+    if let Some(err) = result.error {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
+    }
+    Json(ok_body).into_response()
 }
 
 // ---- Auth Middleware ----

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -397,3 +397,76 @@ async fn wps_publish_omits_persist_defaults_to_zero() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 }
+
+// ---- First-class agent API (SPEC_AGENT_API_FIRST_CLASS_SURFACE) ----
+
+/// `GET /api/v1/self` resolves the seeded agent block to its tab / window /
+/// workspace. Read-only (no reducer), so it's hermetic in the test harness.
+#[tokio::test]
+async fn self_endpoint_resolves_seeded_agent() {
+    let state = test_state();
+    let wstore = state.wstore.clone();
+    let tab = wstore
+        .get_all::<crate::backend::obj::Tab>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("seeded tab");
+    let block_id = tab.blockids.first().expect("seeded agent block").clone();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/self?block_id={block_id}"))
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["block_id"], block_id);
+    assert_eq!(json["tab_id"], tab.oid);
+    assert_eq!(json["workspace_name"], "Starter workspace");
+    assert!(json["workspace_id"].is_string(), "workspace_id resolved");
+    assert!(json["window_id"].is_string(), "window_id resolved via reverse lookup");
+}
+
+/// `/api/v1/self` is auth-gated like every other route.
+#[tokio::test]
+async fn self_endpoint_requires_auth() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/self?block_id=anything")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `/api/v1/self` without a block_id is a client error, not a 500.
+#[tokio::test]
+async fn self_endpoint_missing_block_id_is_400() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/self")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn clean_name_trims_clamps_and_rejects_empty() {
+    use super::clean_name;
+    assert_eq!(clean_name("  hi  ", 64).as_deref(), Some("hi"));
+    assert_eq!(clean_name("   ", 64), None);
+    assert_eq!(clean_name("", 64), None);
+    // clamps to `max` chars (counted by char, not byte)
+    let long = "x".repeat(200);
+    assert_eq!(clean_name(&long, 64).unwrap().chars().count(), 64);
+}


### PR DESCRIPTION
## Summary

Completes the **naming verbs** from `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md` §4.3, extending the merged window-naming slice (#1516) with the same pattern. Agents can now rename their own tab, pane, and workspace.

| MCP tool | REST | Underlying service call |
|---|---|---|
| `SetTabName(name)` | `POST /api/v1/tab/name` | `object.UpdateTabName` |
| `SetPaneTitle(title)` | `POST /api/v1/pane/title` | `object.UpdateObjectMeta(block, {frame:title})` |
| `SetWorkspaceName(name)` | `POST /api/v1/workspace/name` | `workspace.UpdateWorkspace` |

Each **defaults its target to the caller's own** tab/pane/workspace (resolved from `block_id` via the shared `resolve_agent_context` added in #1516), with an optional explicit target id. All route through the shared `run_service_call`, so persistence + event broadcast are identical to the in-app rename paths (and live-update the UI).

Helpers added: `clean_name` (trim + 128-char clamp + empty rejection) and `resolve_own` (explicit-or-self target resolution, returns the route's error response on failure).

## Tests

- `self_endpoint_resolves_seeded_agent` — `GET /api/v1/self` resolves block → tab/workspace/window end-to-end through the router.
- `self_endpoint_requires_auth` (401) and `self_endpoint_missing_block_id_is_400`.
- `clean_name_trims_clamps_and_rejects_empty` — trim, char-count clamp, empty→None.
- All pass; both crates build clean.

The write endpoints route through the reducer (hydrated at runtime, not in the hermetic test harness), so they're covered by the manual test plan below — matching #1516's approach.

## Test plan

- [ ] `SetTabName("X")` → tab label updates live.
- [ ] `SetPaneTitle("Y")` → this pane's header updates.
- [ ] `SetWorkspaceName("Z")` → workspace renamed (and window/taskbar title when no explicit window name set).
- [ ] Missing/empty name → client error, not 500.
- [ ] `tools/list` now includes `SetTabName` / `SetPaneTitle` / `SetWorkspaceName`.

Next (Phase 2 cont.): layout/navigation (focus, new tab) + introspection (list tabs/windows) verbs, then the capability-tier safety model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)