### PR TITLE
feat(agent-api): introspection verbs (Phase 2)

### DIFF
--- a/.changesets/1781716072-feat-agent-api-introspection.md
+++ b/.changesets/1781716072-feat-agent-api-introspection.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-api): introspection verbs — GetLayout, ListWindows, ListWorkspaces, ListTabs tools + /api/v1/{layout,windows,workspaces,tabs} read endpoints

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -77,6 +77,42 @@ const DISCOVER_AGENTS_TOOL: &str = r#"{
   }
 }"#;
 
+const GET_LAYOUT_TOOL: &str = r#"{
+  "name": "GetLayout",
+  "description": "Get the AgentMux UI tree: every window with its workspace, tabs, and panes (block_id, view, title), and which tab is active. Use it to see what's around you before naming or focusing things. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const LIST_WINDOWS_TOOL: &str = r#"{
+  "name": "ListWindows",
+  "description": "List all AgentMux windows (window_id, display name, assigned workspace). Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const LIST_WORKSPACES_TOOL: &str = r#"{
+  "name": "ListWorkspaces",
+  "description": "List all AgentMux workspaces (workspace_id, name, tab count, active tab). Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const LIST_TABS_TOOL: &str = r#"{
+  "name": "ListTabs",
+  "description": "List tabs (tab_id, name, pane count) in your own workspace by default. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
 const WHOAMI_TOOL: &str = r#"{
   "name": "WhoAmI",
   "description": "Return your own place in the AgentMux UI: your block (pane), tab, window, and workspace ids plus their names. Use it to discover the targets for naming/layout verbs (e.g. before SetWindowName). Takes no arguments.",
@@ -234,10 +270,16 @@ async fn main() {
                     serde_json::from_str(SET_PANE_TITLE_TOOL).expect("static json");
                 let set_workspace_name: Value =
                     serde_json::from_str(SET_WORKSPACE_NAME_TOOL).expect("static json");
+                let get_layout: Value = serde_json::from_str(GET_LAYOUT_TOOL).expect("static json");
+                let list_windows: Value =
+                    serde_json::from_str(LIST_WINDOWS_TOOL).expect("static json");
+                let list_workspaces: Value =
+                    serde_json::from_str(LIST_WORKSPACES_TOOL).expect("static json");
+                let list_tabs: Value = serde_json::from_str(LIST_TABS_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, set_window_name, set_tab_name, set_pane_title, set_workspace_name] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, set_window_name, set_tab_name, set_pane_title, set_workspace_name, get_layout, list_windows, list_workspaces, list_tabs] }
                 })
             }
             "tools/call" => {
@@ -709,6 +751,40 @@ async fn call_tool(
                 anyhow::bail!("set pane title failed: HTTP {status} — {text}");
             }
             Ok(format!("Pane title set to \"{new_title}\""))
+        }
+        "GetLayout" | "ListWindows" | "ListWorkspaces" | "ListTabs" => {
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+            let path = match name {
+                "GetLayout" => "layout",
+                "ListWindows" => "windows",
+                "ListWorkspaces" => "workspaces",
+                _ => "tabs",
+            };
+            let url = format!("{}/api/v1/{path}", local_url.trim_end_matches('/'));
+            let mut reqb = client.get(&url).header("X-AuthKey", auth_key);
+            // ListTabs scopes to the caller's own workspace when we know it.
+            if name == "ListTabs" && !block_id.is_empty() {
+                reqb = reqb.query(&[("block_id", block_id)]);
+            }
+            let resp = reqb
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("{name} failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
         }
         _ => anyhow::bail!("unknown tool: {name}"),
     }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -259,6 +259,13 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tab/name", post(handle_tab_name))
         .route("/api/v1/pane/title", post(handle_pane_title))
         .route("/api/v1/workspace/name", post(handle_workspace_name))
+        // Introspection verbs (SPEC §4.6): read-only views of the UI tree so an
+        // agent can see what's around it. agentmux-mcp's GetLayout / ListWindows
+        // / ListWorkspaces / ListTabs tools GET these.
+        .route("/api/v1/layout", get(handle_layout))
+        .route("/api/v1/windows", get(handle_list_windows))
+        .route("/api/v1/workspaces", get(handle_list_workspaces))
+        .route("/api/v1/tabs", get(handle_list_tabs))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -900,6 +907,47 @@ async fn finish_name_call(
         return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
     }
     Json(ok_body).into_response()
+}
+
+/// `GET /api/v1/layout` — read-only window → workspace → tab → pane tree.
+async fn handle_layout(State(state): State<AppState>) -> impl IntoResponse {
+    Json(service::agent_layout(&state.wstore))
+}
+
+/// `GET /api/v1/windows` — flat list of windows.
+async fn handle_list_windows(State(state): State<AppState>) -> impl IntoResponse {
+    Json(service::agent_windows(&state.wstore))
+}
+
+/// `GET /api/v1/workspaces` — flat list of workspaces.
+async fn handle_list_workspaces(State(state): State<AppState>) -> impl IntoResponse {
+    Json(service::agent_workspaces(&state.wstore))
+}
+
+#[derive(serde::Deserialize)]
+struct ListTabsQuery {
+    /// Limit to this workspace's tabs. Omit (or pass `block_id`) for all tabs.
+    #[serde(default)]
+    workspace_id: Option<String>,
+    /// Calling agent's block id — scopes to the caller's own workspace when
+    /// `workspace_id` is omitted.
+    #[serde(default)]
+    block_id: Option<String>,
+}
+
+/// `GET /api/v1/tabs` — flat list of tabs, optionally scoped to a workspace
+/// (explicit `workspace_id`, or the caller's own via `block_id`).
+async fn handle_list_tabs(
+    State(state): State<AppState>,
+    Query(q): Query<ListTabsQuery>,
+) -> impl IntoResponse {
+    let ws_id = q.workspace_id.filter(|w| !w.is_empty()).or_else(|| {
+        q.block_id
+            .filter(|b| !b.is_empty())
+            .and_then(|b| service::resolve_agent_context(&state.wstore, &b).ok())
+            .and_then(|ctx| ctx.workspace_id)
+    });
+    Json(service::agent_tabs(&state.wstore, ws_id.as_deref()))
 }
 
 // ---- Auth Middleware ----

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -80,6 +80,133 @@ pub(crate) struct AgentContext {
     pub workspace_name: String,
 }
 
+/// Read-only snapshot of the window → workspace → tab → pane tree, for agent
+/// introspection (`GET /api/v1/layout`). Pure wstore reads — no reducer, so
+/// it's hermetic and safe. Lookups use linear scans (a handful of objects).
+pub(crate) fn agent_layout(store: &Store) -> serde_json::Value {
+    let windows = store.get_all::<Window>().unwrap_or_default();
+    let workspaces = store.get_all::<Workspace>().unwrap_or_default();
+    let tabs = store.get_all::<Tab>().unwrap_or_default();
+    let blocks = store.get_all::<Block>().unwrap_or_default();
+
+    let panes_of = |tab: &Tab| -> Vec<serde_json::Value> {
+        tab.blockids
+            .iter()
+            .filter_map(|bid| blocks.iter().find(|b| &b.oid == bid))
+            .map(|b| {
+                json!({
+                    "block_id": b.oid,
+                    "view": meta_get_string(&b.meta, "view", ""),
+                    "title": meta_get_string(&b.meta, "frame:title", ""),
+                })
+            })
+            .collect()
+    };
+
+    let windows_json: Vec<serde_json::Value> = windows
+        .iter()
+        .map(|w| {
+            let ws = workspaces.iter().find(|x| x.oid == w.workspaceid);
+            let tabs_json: Vec<serde_json::Value> = ws
+                .map(|ws| {
+                    // Pinned tabs render first, then the regular tab order.
+                    ws.pinnedtabids
+                        .iter()
+                        .chain(ws.tabids.iter())
+                        .filter_map(|tid| tabs.iter().find(|t| &t.oid == tid))
+                        .map(|t| {
+                            json!({
+                                "tab_id": t.oid,
+                                "name": t.name,
+                                "active": ws.activetabid == t.oid,
+                                "panes": panes_of(t),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            json!({
+                "window_id": w.oid,
+                "name": meta_get_string(&w.meta, "window:displayname", ""),
+                "workspace_id": w.workspaceid,
+                "workspace_name": ws.map(|x| x.name.clone()).unwrap_or_default(),
+                "tabs": tabs_json,
+            })
+        })
+        .collect();
+
+    json!({ "windows": windows_json })
+}
+
+/// Flat list of all windows (id, display name, assigned workspace).
+pub(crate) fn agent_windows(store: &Store) -> serde_json::Value {
+    let workspaces = store.get_all::<Workspace>().unwrap_or_default();
+    let windows: Vec<serde_json::Value> = store
+        .get_all::<Window>()
+        .unwrap_or_default()
+        .iter()
+        .map(|w| {
+            let ws_name = workspaces
+                .iter()
+                .find(|x| x.oid == w.workspaceid)
+                .map(|x| x.name.clone())
+                .unwrap_or_default();
+            json!({
+                "window_id": w.oid,
+                "name": meta_get_string(&w.meta, "window:displayname", ""),
+                "workspace_id": w.workspaceid,
+                "workspace_name": ws_name,
+            })
+        })
+        .collect();
+    json!({ "windows": windows })
+}
+
+/// Flat list of all workspaces (id, name, tab count, active tab).
+pub(crate) fn agent_workspaces(store: &Store) -> serde_json::Value {
+    let workspaces: Vec<serde_json::Value> = store
+        .get_all::<Workspace>()
+        .unwrap_or_default()
+        .iter()
+        .map(|w| {
+            json!({
+                "workspace_id": w.oid,
+                "name": w.name,
+                "tab_count": w.tabids.len() + w.pinnedtabids.len(),
+                "active_tab_id": w.activetabid,
+            })
+        })
+        .collect();
+    json!({ "workspaces": workspaces })
+}
+
+/// Flat list of tabs (id, name, pane count). When `workspace_id` is given,
+/// only that workspace's tabs are returned.
+pub(crate) fn agent_tabs(store: &Store, workspace_id: Option<&str>) -> serde_json::Value {
+    let workspaces = store.get_all::<Workspace>().unwrap_or_default();
+    let scope: Option<Vec<String>> = workspace_id.map(|wid| {
+        workspaces
+            .iter()
+            .find(|w| w.oid == wid)
+            .map(|w| w.pinnedtabids.iter().chain(w.tabids.iter()).cloned().collect())
+            .unwrap_or_default()
+    });
+    let tabs: Vec<serde_json::Value> = store
+        .get_all::<Tab>()
+        .unwrap_or_default()
+        .iter()
+        .filter(|t| scope.as_ref().map(|ids| ids.contains(&t.oid)).unwrap_or(true))
+        .map(|t| {
+            json!({
+                "tab_id": t.oid,
+                "name": t.name,
+                "pane_count": t.blockids.len(),
+            })
+        })
+        .collect();
+    json!({ "tabs": tabs })
+}
+
 /// Walk block → tab → workspace → window from an agent pane's block id.
 ///
 /// Tabs carry no parent reference, so the workspace and window are found by

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -470,3 +470,54 @@ fn clean_name_trims_clamps_and_rejects_empty() {
     let long = "x".repeat(200);
     assert_eq!(clean_name(&long, 64).unwrap().chars().count(), 64);
 }
+
+/// `GET /api/v1/layout` returns the seeded window → workspace → tab → pane
+/// tree. Read-only, hermetic.
+#[tokio::test]
+async fn layout_endpoint_returns_seeded_tree() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/layout")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let windows = json["windows"].as_array().expect("windows array");
+    assert_eq!(windows.len(), 1, "one seeded window");
+    let win = &windows[0];
+    assert_eq!(win["workspace_name"], "Starter workspace");
+    let tabs = win["tabs"].as_array().expect("tabs array");
+    assert!(!tabs.is_empty(), "seeded tab present");
+    // The seeded tab carries the default agent/sysinfo/swarm panes.
+    let panes = tabs[0]["panes"].as_array().expect("panes array");
+    assert!(panes.iter().any(|p| p["view"] == "agent"), "agent pane present");
+}
+
+/// Introspection list endpoints are auth-gated and return their wrapper keys.
+#[tokio::test]
+async fn introspection_lists_return_collections() {
+    for (path, key) in [
+        ("/api/v1/windows", "windows"),
+        ("/api/v1/workspaces", "workspaces"),
+        ("/api/v1/tabs", "tabs"),
+    ] {
+        let app = test_router();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(path)
+            .header("X-AuthKey", "test-secret-key")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "{path}");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json[key].is_array(), "{path} should return a {key} array");
+        assert!(!json[key].as_array().unwrap().is_empty(), "{path} non-empty");
+    }
+}


### PR DESCRIPTION
## Summary

Adds read-only introspection so an agent can see the UI tree it lives in (SPEC §4.6). All endpoints are **pure wstore reads — no reducer**, so they're hermetic and safe.

| MCP tool | REST | Returns |
|---|---|---|
| `GetLayout` | `GET /api/v1/layout` | window → workspace → tab → pane tree (panes carry block_id/view/title; active tab flagged) |
| `ListWindows` | `GET /api/v1/windows` | flat windows (id, display name, workspace) |
| `ListWorkspaces` | `GET /api/v1/workspaces` | flat workspaces (id, name, tab count, active tab) |
| `ListTabs` | `GET /api/v1/tabs` | tabs (id, name, pane count), scoped to the caller's workspace via `block_id` or explicit `workspace_id` |

## Tests

- `layout_endpoint_returns_seeded_tree` — `/api/v1/layout` returns the one seeded window/workspace with the default agent pane present.
- `introspection_lists_return_collections` — `/windows`, `/workspaces`, `/tabs` each return a non-empty array under their wrapper key.
- Both crates build clean.

## Test plan

- [ ] `GetLayout` from an agent shows all windows/tabs/panes with correct active flags.
- [ ] `ListTabs` scopes to the caller's workspace.
- [ ] `tools/list` now includes the 4 new tools.

Next/last: layout-navigation verbs (FocusWindow/Tab, NewTab, SetActiveTab) + finalize the safety posture, completing the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)