### PR TITLE
fix(agent): slash commands no longer lock the pane after use

### DIFF
--- a/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
+++ b/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
@@ -1,3 +1,4 @@
 ---
 type: patch
----fix(agent): slash commands no longer lock the pane after use
+---
+fix(agent): slash commands no longer lock the pane after use

--- a/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
+++ b/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): slash commands no longer lock the pane after use; drop forcerestart from model/effort changes

--- a/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
+++ b/.changesets/1781717077-fix-agent-slash-commands-no-longer-lock-the-pane-after-use-d-pthz.md
@@ -1,5 +1,3 @@
 ---
 type: patch
----
-
-fix(agent): slash commands no longer lock the pane after use; drop forcerestart from model/effort changes
+---fix(agent): slash commands no longer lock the pane after use

--- a/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
+++ b/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
@@ -84,7 +84,7 @@ The only reason to `forcerestart` would be to apply a change to an actively-stre
 
 ## Immediate fixes (this PR)
 
-### Fix 1: TurnReset on handled slash commands (useAgentCommands.ts)
+### Fix 1 (the actual fix): TurnReset on handled slash commands (useAgentCommands.ts)
 
 ```typescript
 if (trimmed.startsWith("/")) {
@@ -100,19 +100,13 @@ if (trimmed.startsWith("/")) {
 
 Mirrors the bang-command fix exactly.
 
-### Fix 2: Drop `forcerestart` from `applyRuntimeChange` (runtime-apply.ts)
+### `forcerestart` is still required
 
-```typescript
-// Before: kills the process, risks mid-turn corruption, races on status
-await RpcApi.ControllerResyncCommand(TabRpcClient, {
-    tabid: staticTabId(), blockid: blockId, forcerestart: true,
-});
-
-// After: just write cmd:args — next spawn picks them up automatically
-// (no resync call at all; the meta write is enough)
-```
-
-This simplifies `applyRuntimeChange` to two SetMetaCommand calls and nothing else for persistent controllers.
+The `forcerestart` call in `applyRuntimeChange` must be kept. The persistent controller
+stays alive between turns and never re-reads `cmd:args` on its own — killing it and
+letting `send_message` respawn with the new flags is the only way to apply a model/effort
+change without waiting for an unrelated crash or user restart. The stuck-pane bug was
+caused by the missing `TurnReset`, not by the `forcerestart` itself.
 
 ---
 

--- a/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
+++ b/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
@@ -1,0 +1,147 @@
+# Retro: `/model` (and all slash commands) leave the pane stuck after use
+
+**Date:** 2026-06-17  
+**Severity:** P1 — slash commands lock the input for ~30 seconds every time  
+**Affected:** Every `/model`, `/effort`, `/permission-mode`, `/bypass`, `/plan`, `/runtime` call  
+**Root cause:** `TurnStart` dispatched before slash command processing; `TurnReset` never dispatched for the slash path
+
+---
+
+## Timeline
+
+| PR | What it tried to fix | What it missed |
+|---|---|---|
+| #1503 | `/model` slash command didn't apply to persistent (Claude) controller — meta write silently no-ops for persistent; added `forcerestart` to rebuild `cmd:args` + kill/respawn | GUI control bar still used the old meta-only path |
+| #1517 | Extracted `applyRuntimeChange` shared helper; GUI control bar now calls it too | `TurnReset` missing on slash path — the UI lock bug was pre-existing and unnoticed |
+| Today | `TurnReset` bug surfaced when user tries `/model` in the live dev session | |
+
+---
+
+## Root cause
+
+`handleSendMessage` in `agent-view.tsx` dispatches `TurnStart` **before** calling `sendMessage`:
+
+```typescript
+// agent-view.tsx
+if (!wasAlreadyWorking) {
+    dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
+}
+return commands.sendMessage(message, wasAlreadyWorking);
+```
+
+Inside `sendMessage` (useAgentCommands.ts), the slash command path:
+
+```typescript
+if (trimmed.startsWith("/")) {
+    const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
+    if (outcome.kind === "handled") return;  // ← returns without TurnReset
+}
+```
+
+Returns early without resetting the turn. The pane stays in "Submitting" state until the 30-second `TurnStart` watchdog fires. The user sees a locked input box for 30 seconds.
+
+The `!` bang-command path fixed this exact problem earlier and documents it clearly:
+
+```typescript
+// bang path — the fix that slash is missing
+if (!wasAlreadyWorking) {
+    opts.model.dispatchPane({ type: "TurnReset" }, "system");
+}
+```
+
+The slash path should have gotten the same treatment but didn't.
+
+---
+
+## Why it keeps biting us
+
+**The coupling is fragile.** `TurnStart` is dispatched by `handleSendMessage` (agent-view.tsx) before it knows whether a real turn will happen. `TurnReset` is the responsibility of any path that intercepts and short-circuits. This is an implicit contract with no compiler enforcement.
+
+Right now there are three exit paths from `sendMessage` that bypass the real agent turn:
+1. `!cmd` (bang) — **has TurnReset** ✓
+2. `/cmd` (slash) — **missing TurnReset** ✗ ← this bug
+3. `initPhase === InitPending` early-bail — returns early without reset; the `TurnStart` suppression in the reducer handles this case implicitly (the `TurnStart` is swallowed by `InitPending`, not queued), so it doesn't produce a UI lock but it's a subtle reliance on reducer internals
+
+**The pattern breaks silently.** New intercept paths (or refactors) will repeat this mistake unless the invariant is enforced rather than documented.
+
+---
+
+## Cascading confusion from `forcerestart`
+
+A secondary issue that made model-setting feel flaky even before today's lock bug:
+
+`applyRuntimeChange` calls `ControllerResyncCommand` with `forcerestart: true` for persistent (Claude) controllers. This kills the live process and waits for the next message to respawn. The intent was "apply the change immediately," but:
+
+1. The persistent controller re-reads `cmd:args` on **every spawn** anyway — the new model is already baked in at next spawn without a forcerestart.
+2. `forcerestart` kills the process synchronously (well, sends an async kill signal) but only publishes `STATUS_DONE` from the synchronous `stop()` call on the old controller. The background task's kill arm (the one that does the actual `child.kill().await`) does NOT publish a broker status update — so there's a window where the frontend has seen DONE but the backend hasn't confirmed it.
+3. If the agent was mid-response when `/model` was called, the forcerestart kills a streaming turn, leaving the blockfile with a partial response and no `turn_end` event. The next message then resumes from an inconsistent state.
+
+The safer fix for `applyRuntimeChange` is to **drop the forcerestart entirely**. Just write the meta. The next natural respawn (user's next message) will pick up the new `cmd:args`. The model change "applies to next turn" — exactly as the success message already says.
+
+The only reason to `forcerestart` would be to apply a change to an actively-streaming turn, but that's not a supported operation (you'd need to cancel the turn first). "Applies to next turn" is the correct semantic and doesn't need a forcerestart to deliver it.
+
+---
+
+## Immediate fixes (this PR)
+
+### Fix 1: TurnReset on handled slash commands (useAgentCommands.ts)
+
+```typescript
+if (trimmed.startsWith("/")) {
+    const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
+    if (outcome.kind === "handled") {
+        if (!wasAlreadyWorking) {
+            opts.model.dispatchPane({ type: "TurnReset" }, "system");
+        }
+        return;
+    }
+}
+```
+
+Mirrors the bang-command fix exactly.
+
+### Fix 2: Drop `forcerestart` from `applyRuntimeChange` (runtime-apply.ts)
+
+```typescript
+// Before: kills the process, risks mid-turn corruption, races on status
+await RpcApi.ControllerResyncCommand(TabRpcClient, {
+    tabid: staticTabId(), blockid: blockId, forcerestart: true,
+});
+
+// After: just write cmd:args — next spawn picks them up automatically
+// (no resync call at all; the meta write is enough)
+```
+
+This simplifies `applyRuntimeChange` to two SetMetaCommand calls and nothing else for persistent controllers.
+
+---
+
+## Structural recommendation
+
+**Invert the coupling.** Instead of `handleSendMessage` dispatching `TurnStart` pre-emptively and every intercept path being responsible for `TurnReset`, let `sendMessage` own the full lifecycle:
+
+```typescript
+// Proposed: agent-view.tsx
+return commands.sendMessage(message);  // no TurnStart here
+
+// In sendMessage: dispatch TurnStart only when we know a real turn is happening
+if (slash handled || bang handled) return;  // no TurnStart ever dispatched
+dispatchPane({ type: "TurnStart", at: Date.now() }, "user");
+// ... proceed to real turn
+```
+
+This makes the invariant impossible to violate: `TurnStart` can only happen on a real turn path. The early-return paths never see it. 
+
+The tradeoff is a small perceived-latency regression on the "submitting" indicator (fires 1 RPC round-trip later), but correctness trumps that.
+
+This structural fix is tracked as a follow-up; Fix 1 above is the minimum for the immediate regression.
+
+---
+
+## Checklist
+
+- [x] Root cause confirmed in code (agent-view.tsx:688-691, useAgentCommands.ts:300-303)
+- [ ] Fix 1: TurnReset on slash path
+- [ ] Fix 2: Drop forcerestart from applyRuntimeChange
+- [ ] Changeset added
+- [ ] Structural inversion tracked (follow-up issue)

--- a/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
+++ b/docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md
@@ -66,19 +66,17 @@ Right now there are three exit paths from `sendMessage` that bypass the real age
 
 ---
 
-## Cascading confusion from `forcerestart`
+## Why `forcerestart` is required (and not the bug)
 
-A secondary issue that made model-setting feel flaky even before today's lock bug:
+`applyRuntimeChange` calls `ControllerResyncCommand` with `forcerestart: true` for persistent (Claude) controllers. This is necessary — **not** the bug.
 
-`applyRuntimeChange` calls `ControllerResyncCommand` with `forcerestart: true` for persistent (Claude) controllers. This kills the live process and waits for the next message to respawn. The intent was "apply the change immediately," but:
+The persistent controller keeps **one Claude process alive across all turns**. It does not respawn between turns; `send_message` only spawns on `!self.is_running()`. Writing `cmd:args` to meta has no effect on the already-running process. The only way to apply a model/effort change immediately is to kill the current process so that the next `send_message` spawns fresh with the new flags.
 
-1. The persistent controller re-reads `cmd:args` on **every spawn** anyway — the new model is already baked in at next spawn without a forcerestart.
-2. `forcerestart` kills the process synchronously (well, sends an async kill signal) but only publishes `STATUS_DONE` from the synchronous `stop()` call on the old controller. The background task's kill arm (the one that does the actual `child.kill().await`) does NOT publish a broker status update — so there's a window where the frontend has seen DONE but the backend hasn't confirmed it.
-3. If the agent was mid-response when `/model` was called, the forcerestart kills a streaming turn, leaving the blockfile with a partial response and no `turn_end` event. The next message then resumes from an inconsistent state.
+Two known rough edges with forcerestart that are acceptable:
+- The background kill arm in `persistent.rs` does not publish a broker `STATUS_DONE` event (only the synchronous `stop()` call does). This is benign — the frontend sees DONE from the synchronous path and the async arm's omission is redundant.
+- If called mid-streaming turn, the partial response stays in the blockfile with no `turn_end`. The pane recovers via `TurnReset` (slash path) or has no outstanding `TurnStart` at all (UI dropdown path).
 
-The safer fix for `applyRuntimeChange` is to **drop the forcerestart entirely**. Just write the meta. The next natural respawn (user's next message) will pick up the new `cmd:args`. The model change "applies to next turn" — exactly as the success message already says.
-
-The only reason to `forcerestart` would be to apply a change to an actively-streaming turn, but that's not a supported operation (you'd need to cancel the turn first). "Applies to next turn" is the correct semantic and doesn't need a forcerestart to deliver it.
+The stuck-pane bug was caused entirely by the missing `TurnReset`, not by `forcerestart`.
 
 ---
 
@@ -135,7 +133,6 @@ This structural fix is tracked as a follow-up; Fix 1 above is the minimum for th
 ## Checklist
 
 - [x] Root cause confirmed in code (agent-view.tsx:688-691, useAgentCommands.ts:300-303)
-- [ ] Fix 1: TurnReset on slash path
-- [ ] Fix 2: Drop forcerestart from applyRuntimeChange
-- [ ] Changeset added
+- [x] Fix: TurnReset on slash path (useAgentCommands.ts)
+- [x] Changeset added
 - [ ] Structural inversion tracked (follow-up issue)

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -299,7 +299,16 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
 
         if (trimmed.startsWith("/")) {
             const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
-            if (outcome.kind === "handled") return;
+            if (outcome.kind === "handled") {
+                // TurnStart was dispatched by handleSendMessage before sendMessage
+                // was called. Reset it so the pane returns to Idle — no real agent
+                // turn was initiated, only a client-side command. Mirrors the bang
+                // command's finally-TurnReset above.
+                if (!wasAlreadyWorking) {
+                    opts.model.dispatchPane({ type: "TurnReset" }, "system");
+                }
+                return;
+            }
         }
 
         // Init guard (issue #728 gap 1, codex P2 on PR #742). The

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -298,7 +298,17 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
 
         if (trimmed.startsWith("/")) {
-            const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
+            let outcome;
+            try {
+                outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
+            } catch {
+                // dispatchSlashCommand threw — reset TurnStart so the pane
+                // doesn't stay locked for the 30s watchdog window.
+                if (!wasAlreadyWorking) {
+                    opts.model.dispatchPane({ type: "TurnReset" }, "system");
+                }
+                return;
+            }
             if (outcome.kind === "handled") {
                 // TurnStart was dispatched by handleSendMessage before sendMessage
                 // was called. Reset it so the pane returns to Idle — no real agent
@@ -309,6 +319,8 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 }
                 return;
             }
+            // outcome.kind === "passthrough" — fall through to the real turn;
+            // TurnStart stays active because an actual agent turn is about to happen.
         }
 
         // Init guard (issue #728 gap 1, codex P2 on PR #742). The

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -5,33 +5,35 @@
  * applyRuntimeChange — the single way to apply a runtime config change
  * (model / effort / permission) so it takes effect on the live agent.
  *
- * Persistent controllers (Claude stream-json) keep ONE CLI process alive
- * across turns, so the model/effort/permission flags are baked in at spawn —
- * a meta-only `agent:runtime` write silently no-ops for them. We therefore
- * rebuild `cmd:args` (via the same `buildRuntimeArgs`) and force a controller
- * restart; the persistent controller resumes via `--resume`, preserving the
- * conversation. Subprocess controllers re-spawn per turn, so the meta write
- * alone is enough there.
+ * For persistent controllers (Claude stream-json), flags are baked in at spawn
+ * time, so we also rebuild `cmd:args` — the next turn's spawn picks them up.
+ * We do NOT forcerestart: "applies to next turn" is the correct semantic, and
+ * a forcerestart creates a kill-race and can corrupt a streaming turn.
  *
  * Shared by the `/model`·`/effort`·`/mode` slash commands
  * (`commands/global/runtime.ts`) AND the GUI control-bar dropdowns
- * (`components/AgentControlBar.tsx`). Previously the persistent rebuild+restart
- * lived only in the slash path (#1503), so the GUI dropdown silently failed to
- * change the model on a running Claude agent — this helper unifies both.
+ * (`components/AgentControlBar.tsx`).
  */
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
-import { staticTabId } from "@/app/store/global";
 import { buildRuntimeArgs } from "./buildRuntimeArgs";
 import type { AgentRuntimeConfig } from "./types";
 import type { ProviderDefinition } from "./providers";
 
 /**
  * Persist `updated` to `agent:runtime` and, for persistent controllers, rebuild
- * `cmd:args` + force-restart so the change applies to the running agent. May
- * throw on RPC failure — callers decide how to surface it.
+ * `cmd:args` so the change applies at next spawn. May throw on RPC failure —
+ * callers decide how to surface it.
+ *
+ * We intentionally do NOT forcerestart here. Persistent controllers re-read
+ * `cmd:args` on every spawn, so the new model/effort/permission is already
+ * baked in for the next turn — which is exactly what "applies to next turn"
+ * means. A forcerestart would kill a potentially-streaming turn, leave the
+ * blockfile with a partial response, and create a status-update race between
+ * the old controller's async kill task and the new controller registration.
+ * See docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md.
  */
 export async function applyRuntimeChange(
     blockId: string,
@@ -50,11 +52,6 @@ export async function applyRuntimeChange(
         await RpcApi.SetMetaCommand(TabRpcClient, {
             oref,
             meta: { "cmd:args": updatedArgs },
-        });
-        await RpcApi.ControllerResyncCommand(TabRpcClient, {
-            tabid: staticTabId(),
-            blockid: blockId,
-            forcerestart: true,
         });
     }
 }

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -6,9 +6,14 @@
  * (model / effort / permission) so it takes effect on the live agent.
  *
  * For persistent controllers (Claude stream-json), flags are baked in at spawn
- * time, so we also rebuild `cmd:args` — the next turn's spawn picks them up.
- * We do NOT forcerestart: "applies to next turn" is the correct semantic, and
- * a forcerestart creates a kill-race and can corrupt a streaming turn.
+ * time. The process stays alive between turns and never re-reads cmd:args on
+ * its own, so we rebuild cmd:args AND forcerestart — killing the idle process
+ * so the next send_message spawns with the new flags.
+ *
+ * forcerestart is safe when the agent is idle (STATUS_DONE). If triggered
+ * mid-turn the streaming turn is interrupted; the partial response stays in the
+ * blockfile but the pane recovers via TurnReset (slash path) or has no
+ * TurnStart outstanding (UI dropdown path).
  *
  * Shared by the `/model`·`/effort`·`/mode` slash commands
  * (`commands/global/runtime.ts`) AND the GUI control-bar dropdowns
@@ -18,22 +23,15 @@
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
+import { staticTabId } from "@/app/store/global";
 import { buildRuntimeArgs } from "./buildRuntimeArgs";
 import type { AgentRuntimeConfig } from "./types";
 import type { ProviderDefinition } from "./providers";
 
 /**
  * Persist `updated` to `agent:runtime` and, for persistent controllers, rebuild
- * `cmd:args` so the change applies at next spawn. May throw on RPC failure —
- * callers decide how to surface it.
- *
- * We intentionally do NOT forcerestart here. Persistent controllers re-read
- * `cmd:args` on every spawn, so the new model/effort/permission is already
- * baked in for the next turn — which is exactly what "applies to next turn"
- * means. A forcerestart would kill a potentially-streaming turn, leave the
- * blockfile with a partial response, and create a status-update race between
- * the old controller's async kill task and the new controller registration.
- * See docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md.
+ * `cmd:args` + forcerestart so the change applies immediately. May throw on RPC
+ * failure — callers decide how to surface it.
  */
 export async function applyRuntimeChange(
     blockId: string,
@@ -52,6 +50,11 @@ export async function applyRuntimeChange(
         await RpcApi.SetMetaCommand(TabRpcClient, {
             oref,
             meta: { "cmd:args": updatedArgs },
+        });
+        await RpcApi.ControllerResyncCommand(TabRpcClient, {
+            tabid: staticTabId(),
+            blockid: blockId,
+            forcerestart: true,
         });
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 1 — pane stuck for 30s after any slash command:** \`handleSendMessage\` dispatches \`TurnStart\` before calling \`sendMessage\`. The slash command path returned \`"handled"\` without dispatching \`TurnReset\`, leaving the pane in Submitting state until the watchdog fired. Fix: add \`TurnReset\` on the handled path (and a \`try/catch\` reset on the throw path) in \`useAgentCommands.ts\`, mirroring the existing bang-command fix.

- **\`forcerestart\` is kept** — persistent controllers keep one Claude process alive across all turns and never re-read \`cmd:args\` without being respawned. The forcerestart is required to apply a model/effort change immediately. The stuck-pane bug was caused entirely by the missing \`TurnReset\`, not by the forcerestart itself.

Retro: \`docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md\`

## Test plan

- [ ] Type \`/model sonnet\` in any Claude agent pane → input unlocks immediately after the success message (no 30s lock)
- [ ] Type \`/effort high\` — same: no lock
- [ ] Type \`/runtime\` — same
- [ ] After \`/model opus\`, send a message — Claude responds using Opus (verify in the control bar label)
- [ ] Model change mid-idle (agent not streaming): next turn uses the new model
- [ ] No regression: GUI control bar Opus/Sonnet dropdown still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)