### PR TITLE
feat(agent): default new panes to sonnet + high effort

### DIFF
--- a/.changesets/1781722170-feat-agent-default-new-panes-to-sonnet-high-effort-instead-o-vnkn.md
+++ b/.changesets/1781722170-feat-agent-default-new-panes-to-sonnet-high-effort-instead-o-vnkn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): default new panes to sonnet + high effort instead of opus + xhigh

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -598,11 +598,11 @@ export interface AgentRuntimeConfig {
 
 export const DEFAULT_RUNTIME_CONFIG: AgentRuntimeConfig = {
     permissionMode: "bypass",
-    // Default to Opus (the `claude` CLI resolves `--model opus` to the current
-    // Opus, i.e. Opus 4.8) at xhigh effort — the coding/agentic sweet spot and
-    // Claude Code's own default. effort is Claude-only and works on Opus/Sonnet.
-    model: "opus",
-    effort: "xhigh",
+    // Sonnet at high effort — faster default for routine/conversational turns.
+    // Use the model picker or /model opus to escalate to Opus for complex work.
+    // See docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md §2.1.
+    model: "sonnet",
+    effort: "high",
 };
 
 /**

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -600,7 +600,6 @@ export const DEFAULT_RUNTIME_CONFIG: AgentRuntimeConfig = {
     permissionMode: "bypass",
     // Sonnet at high effort — faster default for routine/conversational turns.
     // Use the model picker or /model opus to escalate to Opus for complex work.
-    // See docs/retros/RETRO_MODEL_SLASH_CMD_STUCK_2026_06_17.md §2.1.
     model: "sonnet",
     effort: "high",
 };


### PR DESCRIPTION
## Summary

- Changes `DEFAULT_RUNTIME_CONFIG` in `types.ts` from `opus + xhigh` to `sonnet + high`
- Based on latency investigation (`agentmux-pane-latency-report.md §2.1`): effort level is the dominant latency driver, and `xhigh` causes routine conversational turns to overthink
- Users escalate to Opus/xhigh via `/model`, `/effort`, or the control-bar picker

## Test plan

- [ ] New agent pane opens with Sonnet + High shown in the control bar
- [ ] `/model opus` and `/effort xhigh` escalate correctly
- [ ] Existing panes with saved runtime meta are unaffected (meta overrides the default)
- [ ] No regression on codex/gemini/other providers (default only applies when no model meta is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)