### PR TITLE
fix(editor): scratch buffer opens as plain editable text

### DIFF
--- a/.changesets/1781723223-fix-editor-scratch-plaintext.md
+++ b/.changesets/1781723223-fix-editor-scratch-plaintext.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): new scratch buffer opens as plain editable text, not a blank rendered markdown pane

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -535,7 +535,13 @@ export class EditorViewModel implements ViewModel {
                 filePath: result.file_path,
                 scratchId: result.scratch_id,
                 displayName: result.display_name,
-                language: "markdown",
+                // Plain-text scratch: an untitled buffer is for typing, not a
+                // markdown doc. The backing file is `.md` on disk (persistence
+                // detail), but treating the tab as markdown made the new
+                // styled-preview feature open a fresh scratch as a blank
+                // rendered pane. "text" → editable, no syntax-render. The user
+                // can Save As `.md` to get markdown behavior.
+                language: "text",
                 source: "system",
             });
             const opened = events.find((e) => e.type === "TabOpened" || e.type === "TabActivated");

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -95,7 +95,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     const [liveDoc, setLiveDoc] = createSignal("");
     const isMarkdown = (): boolean => model.languageAtom() === "markdown";
     const showRendered = (): boolean =>
-        isMarkdown() && !mdSourceTabs().has(model.activeIdAtom() ?? "");
+        isMarkdown() &&
+        // Never auto-render an untitled scratch buffer — it's for typing.
+        !model.activeTabAtom()?.isScratch &&
+        !mdSourceTabs().has(model.activeIdAtom() ?? "");
     const toggleMdMode = () => {
         const id = model.activeIdAtom();
         if (!id || !isMarkdown()) return;


### PR DESCRIPTION
## Problem

Opening a new editor pane creates an untitled **scratch buffer**. It was tagged `language: "markdown"` (the backing file is `{uuid}.md` on disk), so the just-merged styled-preview feature (#1522) opened a fresh, empty scratch as a **blank rendered markdown pane** instead of an editable buffer.

Reported: "when I open a new editor pane I should get a scratch file with no extension, but it's a new md."

## Fix

- **`editor-model.ts`**: the scratch tab's language is now `"text"` — an untitled buffer is for typing, not a markdown document. (The on-disk file stays `.md` for persistence/reuse; that's invisible to the user. Save As `.md` gives full markdown behavior.)
- **`editor-view.tsx`**: `showRendered()` never auto-renders a scratch tab — defensive, so a scratch is always editable even if it were markdown.

Real `.md` files still open styled; non-markdown files are unaffected.

## Notes

- `tsc`: the one error in `editor-model.ts` (rpcCall arg count) is **pre-existing** on origin/main (verified by stashing) — unrelated to this change.

## Test plan

- [ ] New editor pane → editable empty scratch (no blank rendered pane, no preview toggle).
- [ ] Type into it; Ctrl+S / Save As `.md` → becomes markdown.
- [ ] Opening a real `.md` still renders styled with the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)