### PR TITLE
fix(editor): markdown preview fully hides the source

### DIFF
--- a/.changesets/1781723528-fix-editor-md-preview-opaque.md
+++ b/.changesets/1781723528-fix-editor-md-preview-opaque.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): markdown preview fully hides the source underneath (was a dim bleed-through)

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -574,7 +574,10 @@
     inset: 0;
     z-index: 1;
     overflow: auto;
-    background: var(--block-bg-color);
+    // Opaque surface — --block-bg-color is rgba(0,0,0,0.5), which let the
+    // CodeMirror source bleed through (a dim ghost) behind the preview. Use
+    // the solid block surface so the source is fully hidden.
+    background: var(--block-bg-solid-color);
     // Center the rendered doc with comfortable reading measure, scaled by
     // the same per-pane zoom CodeMirror uses.
     padding: calc(16px * var(--editor-zoom, 1)) calc(24px * var(--editor-zoom, 1));


### PR DESCRIPTION
## Problem

In markdown preview mode the CodeMirror source bled through as a dim ghost behind the rendered content — the overlay used `--block-bg-color`, which is `rgba(0, 0, 0, 0.5)` (50% transparent).

## Fix

Switch the `.editor-md-preview` overlay background to `--block-bg-solid-color` (`rgb(0,0,0)` — the opaque block surface already used by the editor's autocomplete tooltip). The source is now fully hidden behind the preview.

## Test plan

- [ ] Open a `.md`, confirm no dim source text shows behind the rendered preview.
- [ ] Toggle to source and back — still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)