### PR TITLE
feat(editor): branded empty state with shortcuts

### DIFF
--- a/.changesets/1781723951-feat-editor-empty-state.md
+++ b/.changesets/1781723951-feat-editor-empty-state.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): empty editor shows a faded brain mark + key shortcuts instead of a path input

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -47,32 +47,6 @@
     }
 }
 
-.editor-tree-path-input {
-    display: flex;
-    gap: var(--space-1);
-    padding: var(--space-1) var(--space-1-5);
-    border-top: 1px solid var(--border-color);
-    background: var(--block-bg-color);
-
-    .editor-open-input {
-        flex: 1;
-        min-width: 0;
-        width: auto;
-        padding: var(--space-1) var(--space-1-5);
-        font-size: 11px;
-    }
-
-    .editor-open-btn {
-        padding: var(--space-1) var(--space-2);
-        font-size: 11px;
-
-        &:disabled {
-            opacity: 0.4;
-            cursor: not-allowed;
-        }
-    }
-}
-
 // ── File tree ───────────────────────────────────────────────────────────────
 
 .file-tree {
@@ -393,61 +367,75 @@
     min-width: 180px;
 }
 
-.editor-open-prompt {
+// ── Empty editor (no file open) ──────────────────────────────────────
+// Faded brain mark watermark + the best few shortcuts, centered.
+
+.editor-empty {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     height: 100%;
-    gap: var(--space-3);
-    color: var(--secondary-text-color);
+    gap: var(--space-5);
     padding: var(--space-4);
+    color: var(--secondary-text-color);
+    user-select: none;
 }
 
-.editor-open-label {
-    font-size: 14px;
+.editor-empty-logo {
+    width: 132px;
+    height: 132px;
+    opacity: 0.12;
+
+    svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+    }
 }
 
-.editor-open-hint {
+.editor-empty-shortcuts {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    gap: var(--space-2) var(--space-5);
+}
+
+.editor-empty-shortcut {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: 12px;
+}
+
+.editor-empty-keys {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+
+    kbd {
+        display: inline-block;
+        min-width: 16px;
+        padding: 1px 6px;
+        font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+        font-size: 11px;
+        line-height: 16px;
+        text-align: center;
+        color: var(--main-text-color);
+        background: var(--secondary-bg-color, var(--block-bg-color));
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+    }
+}
+
+.editor-empty-label {
+    opacity: 0.8;
+}
+
+.editor-empty-hint {
     font-size: 11px;
-    opacity: 0.6;
+    opacity: 0.55;
     text-align: center;
     max-width: 320px;
-}
-
-.editor-open-row {
-    display: flex;
-    gap: var(--space-2);
-}
-
-.editor-open-input {
-    width: 350px;
-    padding: var(--space-1-5) 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 0;
-    background: var(--form-element-bg-color);
-    color: var(--main-text-color);
-    font-family: var(--termfontfamily, "JetBrains Mono", monospace);
-    font-size: 13px;
-
-    &:focus {
-        outline: none;
-        border-color: var(--accent-color);
-    }
-}
-
-.editor-open-btn {
-    padding: var(--space-1-5) var(--space-4);
-    border: 1px solid var(--border-color);
-    border-radius: 0;
-    background: var(--accent-color);
-    color: var(--main-text-color);
-    cursor: pointer;
-    font-size: 13px;
-
-    &:hover {
-        opacity: 0.9;
-    }
 }
 
 .editor-loading {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -15,6 +15,7 @@ import { search } from "@codemirror/search";
 import { lintGutter } from "@codemirror/lint";
 import { editorTheme } from "./editor-theme";
 import { Markdown } from "@/app/element/markdown";
+import brainLogoSvg from "@/app/asset/logo-brain.svg?raw";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { settingsAtom } from "@/store/global";
@@ -76,7 +77,17 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     let containerRef: HTMLDivElement | undefined;
     let rootRef: HTMLDivElement | undefined;
     let cmView: EditorView | null = null;
-    const [fileInput, setFileInput] = createSignal("");
+
+    // Platform-aware modifier glyph for the empty-state shortcut hints.
+    const isMac = /mac/i.test(navigator.platform || navigator.userAgent || "");
+    const MOD = isMac ? "⌘" : "Ctrl";
+    // The handful of shortcuts worth surfacing on the empty editor.
+    const emptyShortcuts: { keys: string[]; label: string }[] = [
+        { keys: [MOD, "S"], label: "Save" },
+        { keys: [MOD, "F"], label: "Find" },
+        { keys: [MOD, "⇧", "V"], label: "Toggle .md preview" },
+        { keys: [MOD, "+ / −"], label: "Zoom" },
+    ];
 
     // ── Markdown rendered/source view ────────────────────────────────────────
     // Markdown files open in the styled <Markdown> renderer by default; a
@@ -478,13 +489,30 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         cmView = null;
     });
 
-    const handleOpenFile = () => {
-        const path = fileInput().trim();
-        if (path) {
-            void model.openFile(path);
-            setFileInput("");
-        }
-    };
+    // Empty-editor state — faded brain mark + the best few shortcuts. Shown
+    // in the main column whenever no file is open (replaces the old path
+    // input; the file tree is the way to open files).
+    const EmptyEditor = () => (
+        <div class="editor-empty">
+            {/* eslint-disable-next-line solid/no-innerhtml */}
+            <div class="editor-empty-logo" innerHTML={brainLogoSvg} aria-hidden="true" />
+            <div class="editor-empty-shortcuts">
+                {emptyShortcuts.map((s) => (
+                    <div class="editor-empty-shortcut">
+                        <span class="editor-empty-keys">
+                            {s.keys.map((k) => (
+                                <kbd>{k}</kbd>
+                            ))}
+                        </span>
+                        <span class="editor-empty-label">{s.label}</span>
+                    </div>
+                ))}
+            </div>
+            <Show when={!model.treeExpandedAtom()}>
+                <div class="editor-empty-hint">Open the file tree (chevron) to browse files.</div>
+            </Show>
+        </div>
+    );
 
     // ── Save As flow (scratch tabs) ───────────────────────────────────
     const [saveAsTabId, setSaveAsTabId] = createSignal<string | null>(null);
@@ -678,27 +706,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         onNewEntryCancel={() => setNewEntry(null)}
                         onStartRename={(path) => setRenamingPath(path)}
                     />
-                    <Show when={!model.filePathAtom()}>
-                        <div class="editor-tree-path-input">
-                            <input
-                                class="editor-open-input"
-                                type="text"
-                                placeholder="/path/to/file.ts"
-                                value={fileInput()}
-                                onInput={(e) => setFileInput(e.currentTarget.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") handleOpenFile();
-                                }}
-                            />
-                            <button
-                                class="editor-open-btn"
-                                onClick={handleOpenFile}
-                                disabled={!fileInput().trim()}
-                            >
-                                Open
-                            </button>
-                        </div>
-                    </Show>
                 </div>
                 <div
                     class="editor-tree-resize-handle"
@@ -806,31 +813,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         // to load — the centered error panel takes the body.
                         !(model.errorAtom() && model.activeTabAtom() && !model.activeTabAtom()?.contentLoaded)
                     }
-                    fallback={
-                        <Show when={!model.treeExpandedAtom()}>
-                            <div class="editor-open-prompt">
-                                <div class="editor-open-label">Open a file</div>
-                                <div class="editor-open-row">
-                                    <input
-                                        class="editor-open-input"
-                                        type="text"
-                                        placeholder="/path/to/file.ts"
-                                        value={fileInput()}
-                                        onInput={(e) => setFileInput(e.currentTarget.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === "Enter") handleOpenFile();
-                                        }}
-                                    />
-                                    <button class="editor-open-btn" onClick={handleOpenFile}>
-                                        Open
-                                    </button>
-                                </div>
-                                <div class="editor-open-hint">
-                                    Show the file tree from the header chevron to browse your files.
-                                </div>
-                            </div>
-                        </Show>
-                    }
+                    fallback={<EmptyEditor />}
                 >
                     <div class="editor-body-wrap">
                         <div class="editor-codemirror" ref={containerRef} />


### PR DESCRIPTION
## Summary

Replaces the editor's empty state (no file open) — previously a `/path/to/file.ts` text input + Open button — with a clean branded welcome: a **faded AgentMux brain mark** centered, with the most useful shortcuts laid out beneath it.

Shown in the main editor body whenever no file is open (regardless of tree state). When the tree is collapsed, a small hint points to the chevron to browse files. The file tree is the way to open files, so the redundant path input is removed from both the tree column and the main body.

**Shortcuts shown** (platform-aware ⌘/Ctrl):
- `S` — Save
- `F` — Find
- `⇧ V` — Toggle .md preview
- `+ / −` — Zoom

## Cleanup

Removes the now-unused `fileInput` signal, `handleOpenFile`, and the `.editor-open-*` / `.editor-tree-path-input` styles. Reuses the existing `logo-brain.svg` asset (inline, faded to 0.12 opacity). Net **-1** stylelint violation.

## Checks

- `tsc`: no new errors in the changed file (the pre-existing `rpcCall` arg-count error is unrelated).
- `stylelint`: 13 → 12 problems; the new `.editor-empty*` rules add none (theme tokens only).

## Test plan

- [ ] New editor pane / close all files → faded brain + 4 shortcut chips, centered; no path input.
- [ ] Tree collapsed → hint to open the tree appears.
- [ ] Open a file from the tree → editor body shows normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)