### PR TITLE
feat(editor): empty-state brain mark as large background watermark

### DIFF
--- a/.changesets/1781724170-feat-editor-empty-logo-watermark.md
+++ b/.changesets/1781724170-feat-editor-empty-logo-watermark.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): empty-editor brain mark enlarged into a centered background watermark

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -391,7 +391,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     width: min(70%, 560px);
-    opacity: 0.05;
+    opacity: 0.1;
     pointer-events: none;
     z-index: 0;
 

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -371,6 +371,7 @@
 // Faded brain mark watermark + the best few shortcuts, centered.
 
 .editor-empty {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -378,23 +379,32 @@
     height: 100%;
     gap: var(--space-5);
     padding: var(--space-4);
+    overflow: hidden;
     color: var(--secondary-text-color);
     user-select: none;
 }
 
+// Large faded brain mark behind everything — a background watermark.
 .editor-empty-logo {
-    width: 132px;
-    height: 132px;
-    opacity: 0.12;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(70%, 560px);
+    opacity: 0.05;
+    pointer-events: none;
+    z-index: 0;
 
     svg {
         width: 100%;
-        height: 100%;
+        height: auto;
         display: block;
     }
 }
 
 .editor-empty-shortcuts {
+    position: relative;
+    z-index: 1;
     display: grid;
     grid-template-columns: repeat(2, auto);
     gap: var(--space-2) var(--space-5);
@@ -432,6 +442,8 @@
 }
 
 .editor-empty-hint {
+    position: relative;
+    z-index: 1;
     font-size: 11px;
     opacity: 0.55;
     text-align: center;


### PR DESCRIPTION
## Summary

Follow-up to #1527: the empty-editor brain mark is now a **large, centered background watermark** rather than a small icon stacked above the shortcuts.

- `.editor-empty-logo`: absolutely centered, `width: min(70%, 560px)`, `opacity: 0.05`, `pointer-events: none`, `z-index: 0`.
- The shortcut chips and hint sit on top (`z-index: 1`); `.editor-empty` is `position: relative; overflow: hidden` so the watermark is clipped to the pane.

## Checks

- `stylelint`: no new violations (base and branch both report the file's pre-existing grandfathered set; my rules use theme tokens / allowed values only).
- `tsc`: unchanged (SCSS-only change).

## Test plan

- [ ] Empty editor → large faded brain fills the pane as a backdrop, shortcuts legible on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)