### PR TITLE
feat(editor): refine find/replace panel to match design system

### DIFF
--- a/.changesets/1781726109-feat-editor-find-panel-theme.md
+++ b/.changesets/1781726109-feat-editor-find-panel-theme.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(editor): style the find/replace panel to match the app design system (tokens, themed inputs/buttons/toggles)

--- a/frontend/app/view/editor/editor-theme.ts
+++ b/frontend/app/view/editor/editor-theme.ts
@@ -66,6 +66,83 @@ const editorChromeTheme = EditorView.theme(
             border: "1px solid var(--border-color)",
             color: "var(--main-text-color)",
         },
+
+        // ── Find/replace panel — refined to match the app design system ──
+        // (tokens from theme.scss; mirrors the look of element/search.scss).
+        ".cm-panels.cm-panels-top": {
+            borderBottom: "1px solid var(--border-color)",
+        },
+        ".cm-panel.cm-search": {
+            position: "relative",
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: "6px",
+            padding: "7px 32px 7px 10px",
+            fontFamily: "inherit",
+            fontSize: "12px",
+        },
+        ".cm-panel.cm-search label": {
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "4px",
+            margin: "0",
+            color: "var(--secondary-text-color)",
+            fontSize: "11px",
+            textTransform: "none",
+            cursor: "pointer",
+        },
+        ".cm-panel.cm-search input[type=checkbox]": {
+            accentColor: "var(--accent-color)",
+            margin: "0",
+            cursor: "pointer",
+        },
+        ".cm-textfield": {
+            backgroundColor: "var(--form-element-bg-color)",
+            color: "var(--main-text-color)",
+            border: "1px solid var(--border-color)",
+            borderRadius: "4px",
+            padding: "3px 8px",
+            fontSize: "12px",
+            fontFamily: "inherit",
+        },
+        ".cm-textfield:focus": {
+            outline: "none",
+            borderColor: "var(--accent-color)",
+        },
+        ".cm-button": {
+            backgroundColor: "transparent",
+            backgroundImage: "none",
+            color: "var(--secondary-text-color)",
+            border: "1px solid var(--border-color)",
+            borderRadius: "4px",
+            padding: "2px 9px",
+            fontSize: "11px",
+            cursor: "pointer",
+        },
+        ".cm-button:hover": {
+            backgroundColor: "var(--hover-bg-color)",
+            color: "var(--main-text-color)",
+        },
+        ".cm-button:active": {
+            backgroundColor: "var(--hover-bg-color)",
+        },
+        ".cm-search button[name=close]": {
+            position: "absolute",
+            top: "6px",
+            right: "8px",
+            padding: "0 4px",
+            border: "none",
+            background: "transparent",
+            color: "var(--secondary-text-color)",
+            fontSize: "16px",
+            lineHeight: "1",
+            cursor: "pointer",
+        },
+        ".cm-search button[name=close]:hover": {
+            color: "var(--main-text-color)",
+            backgroundColor: "transparent",
+        },
     },
     { dark: true },
 );


### PR DESCRIPTION
## Summary

The editor's find panel (now reachable via Ctrl+F, #1529) used CodeMirror's default unstyled chrome. This restyles it to match the AgentMux design system, echoing `frontend/app/element/search.scss` and using `theme.scss` tokens.

Styled via the editor CodeMirror theme (`editor-theme.ts`) so the rules apply cleanly to CM's panel DOM — correct cascade, no specificity fights with app SCSS.

- **Panel:** themed padding/gap, `border-bottom: var(--border-color)`.
- **Inputs** (`.cm-textfield`): `--form-element-bg-color` + `--border-color`, 4px radius, **accent border on focus**.
- **Buttons** (`.cm-button`): subtle transparent + `--border-color`, `--hover-bg-color` on hover (drops CM's default gradient).
- **Toggle labels** (match case / regexp / by word): `--secondary-text-color`, small.
- **Checkboxes:** `accent-color: var(--accent-color)`.
- **Close (✕):** borderless icon button, top-right, hover → `--main-text-color`.

(Match highlights `.cm-searchMatch` were already themed with the accent color.)

## Checks

- `tsc`: clean (string-valued theme object).

## Test plan

- [ ] Ctrl+F → panel matches app styling (themed field, accent focus ring, subtle buttons, accent checkboxes, themed ✕).
- [ ] Find/replace, regex/case/word toggles still function.
- [ ] Match highlights use the accent color.

Note: applies to newly-built editor instances — reload the dev window (or reopen the file) to see it on an already-open editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)