### PR TITLE
perf(layout): reduce pane reflow settle window from 220ms to 32ms

### DIFF
--- a/.changesets/1781726783-perf-layout-reduce-pane-reflow-settle-window-from-220ms-to-3-kmzz.md
+++ b/.changesets/1781726783-perf-layout-reduce-pane-reflow-settle-window-from-220ms-to-3-kmzz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(layout): reduce pane reflow settle window from 220ms to 32ms

--- a/frontend/app/platform/pane-anim.ts
+++ b/frontend/app/platform/pane-anim.ts
@@ -20,7 +20,10 @@ import { createSignal } from "solid-js";
 
 // Short settle window after the layout applies the new rect synchronously —
 // covers rAF/scheduler slack so the per-frame sampling lands on the final rect.
-const REFLOW_WINDOW_MS = 220;
+// Was 220ms when this tracked a CSS pane reflow animation; the animation was
+// removed and the placeholder rect is now final immediately, so 2 rAF frames
+// (≈32ms) is enough to let Solid's reactive flush + ResizeObserver tick settle.
+const REFLOW_WINDOW_MS = 32;
 
 // Wall-clock instant (performance.now() ms) until which the post-change settle
 // window is open. Stored in a signal so consumers can reactively start their

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -7,7 +7,7 @@ import { FLOATER_EDGE_RESIZE_BORDER } from "@/app/workspace/floater-resize";
 import { ModalLayer } from "@/element/ModalLayer";
 import { useModalLayer } from "@/element/modal-layer";
 import { registerPaneRect, unregisterPaneRect } from "@/app/platform/pane-rect-registry";
-import { paneReflowActive } from "@/app/platform/pane-anim";
+import { paneReflowActive, notifyPaneReflow } from "@/app/platform/pane-anim";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
@@ -202,6 +202,10 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
             });
             setPaneCreated(true);
             diag(`paneCreated=true`);
+            // The HWND is now live — open a fresh settle window so the
+            // per-frame loop positions it if the layout changed while the
+            // async create was in-flight (reflow window may have expired).
+            notifyPaneReflow();
             // Seed the overlay-clip short-circuit registry with the initial
             // rect; subsequent syncPosition ticks keep it current.
             registerPaneRect(model.blockId, paneRectCss());


### PR DESCRIPTION
## Summary

- The 220ms `REFLOW_WINDOW_MS` was originally tracking a CSS pane reflow animation that was removed
- The placeholder rect is now set synchronously, so there's no animation to follow frame-by-frame
- 32ms (≈2 rAF frames) is sufficient for Solid's reactive flush + ResizeObserver to settle before the per-frame HWND sampling loop stops
- This eliminates a ~188ms artificial delay on every pane open/close/split

## Test plan

- [ ] Open a new pane — browser panes should reposition correctly with no lag
- [ ] Close a pane — verify adjacent browser panes snap into position without the old ~200ms settle delay
- [ ] Resize window — steady-state `ResizeObserver` path is unaffected (no regression)
- [ ] Split a pane — HWND settles correctly within the new 32ms window

🤖 Generated with [Claude Code](https://claude.ai/claude-code)