### PR TITLE
feat(ui): thin scrollbars everywhere except agent-pane main and terminal

### DIFF
--- a/.changesets/1781744050-feat-ui-thin-scrollbars-everywhere-except-agent-main-and-terminal-6956.md
+++ b/.changesets/1781744050-feat-ui-thin-scrollbars-everywhere-except-agent-main-and-terminal-6956.md
@@ -1,0 +1,12 @@
+---
+type: patch
+---
+
+feat(ui): thin scrollbars everywhere except the agent-pane main scroll and terminal
+
+Make half-width (7px) the default for all native scrollbars and OverlayScrollbars
+(`--os-size`), and keep full-width (14px) only on the two primary reading
+surfaces: the agent conversation (`.agent-document`) and the terminal (xterm's
+own overlay scrollbar, already sized independently). Drops the now-redundant
+hard-coded `width: 14px` from the command-palette and identity panels so they
+follow the thin default.

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -70,7 +70,20 @@ a.plain-link {
     cursor: var(--cursor-default);
 }
 
+// Scrollbar SIZE policy: thin (half-width) everywhere by default, full-width
+// only on the two primary reading surfaces — the agent conversation
+// (`.agent-document`, overridden below) and the terminal (xterm's own overlay
+// scrollbar, sized independently in view/term/term.scss). Tool-call logs, list
+// panes, modals, etc. all get the thin default.
 *::-webkit-scrollbar {
+    width: 7px;
+    height: 7px;
+}
+
+// Full-width exception: the agent pane's main conversation scroll. More specific
+// than the universal rule above, so it wins on size only (cursor/colour still
+// come from the shared rules).
+.agent-document::-webkit-scrollbar {
     width: 14px;
     height: 14px;
 }
@@ -111,6 +124,9 @@ a.plain-link {
     --os-handle-bg: var(--scrollbar-thumb-color);
     --os-handle-bg-hover: var(--scrollbar-thumb-hover-color);
     --os-handle-bg-active: var(--scrollbar-thumb-active-color);
+    // OverlayScrollbars (markdown blocks, TOC, etc.) are never the main agent or
+    // terminal scroll, so they follow the thin default (library default is 10px).
+    --os-size: 7px;
 }
 
 .os-scrollbar-handle {

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -70,9 +70,6 @@
     flex: 1;
     padding: var(--space-1) 0;
 
-    &::-webkit-scrollbar {
-        width: 14px;
-    }
     &::-webkit-scrollbar-track {
         background: transparent;
     }

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -17,9 +17,6 @@
     padding: var(--space-2) 0;
     min-width: 0;
 
-    &::-webkit-scrollbar {
-        width: 14px;
-    }
     &::-webkit-scrollbar-thumb {
         background: var(--scrollbar-thumb-color);
         border-radius: 0;

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -48,9 +48,6 @@
     overflow-y: auto;
     padding: var(--space-2) var(--space-3);
 
-    &::-webkit-scrollbar {
-        width: 14px;
-    }
     &::-webkit-scrollbar-thumb {
         background: var(--scrollbar-thumb-color);
         border-radius: 0;

--- a/frontend/app/view/identity/styles/_form-overlay.scss
+++ b/frontend/app/view/identity/styles/_form-overlay.scss
@@ -57,9 +57,6 @@
     flex-direction: column;
     gap: var(--space-2);
 
-    &::-webkit-scrollbar {
-        width: 14px;
-    }
     &::-webkit-scrollbar-thumb {
         background: var(--scrollbar-thumb-color);
         border-radius: 0;


### PR DESCRIPTION
## What

Make **half-width (7px)** the default for scrollbars, and keep **full-width (14px)** only on the two primary reading surfaces:

- **Agent pane main conversation** (`.agent-document`) — stays full.
- **Terminal** — xterm's own overlay scrollbar, already sized independently (`view/term/term.scss`), so no change needed.

Everything else — tool-call logs, the agents list, command palette, identity panels, markdown code/TOC blocks — now gets the thin scrollbar.

## How

- `app.scss`: global `*::-webkit-scrollbar` width/height **14px → 7px**; new `.agent-document::-webkit-scrollbar { 14px }` exception (more specific than the universal rule, so it wins on size only); `.os-scrollbar { --os-size: 7px }` for OverlayScrollbars (library default was 10px).
- Removed the redundant hard-coded `width: 14px` from `command-palette.scss` and the three identity panels (`_accounts`/`_detail`/`_form-overlay`) so they inherit the new thin default instead of restating the old magic number.
- `patch` changeset; no version bump.

## Verification

- Confirmed in `task dev` (HMR): agent main + terminal stay full; tool logs, agents list, command palette, identity panels, markdown blocks are now thin.
- Mechanical: only two webkit-scrollbar widths remain (global 7 / agent-document 14); `--os-size: 7px` set; `scripts/check-scrollbar-cursor.sh` green; touched files lint clean (aside from the unrelated pre-existing `z-index:9999` at `app.scss:48`).

Follow-up to #1513 (scrollbar cursor fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)