### PR TITLE
feat(editor): support non-UTF-8 file encodings

### DIFF
--- a/.changesets/1781744589-feat-editor-file-encodings.md
+++ b/.changesets/1781744589-feat-editor-file-encodings.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): open and round-trip non-UTF-8 files (Windows-1252 .ini, UTF-16, Shift_JIS, …) via encoding detection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,10 +123,12 @@ dependencies = [
  "axum 0.7.9",
  "base64",
  "bollard",
+ "chardetng",
  "chrono",
  "clap",
  "crash-handler",
  "dirs",
+ "encoding_rs",
  "flate2",
  "futures-util",
  "hex",
@@ -833,6 +835,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1198,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enumflags2"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -44,6 +44,9 @@ keyring = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 mdns-sd = "0.12"
 which = "7"
+# Text encoding detection + transcoding for the editor (SPEC_EDITOR_FILE_ENCODINGS).
+encoding_rs = "0.8"
+chardetng = "0.1"
 flate2 = "1"
 sha2 = "0.10"
 hex = "0.4"

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -33,6 +33,7 @@ pub mod sysinfo;
 pub mod storage;
 pub mod subagent_watcher;
 pub mod userinput;
+pub mod text_encoding;
 pub mod base;
 pub mod obj;
 pub mod wconfig;

--- a/agentmux-srv/src/backend/text_encoding.rs
+++ b/agentmux-srv/src/backend/text_encoding.rs
@@ -34,6 +34,16 @@ pub struct DecodedFile {
 /// `chardetng` heuristic. encoding_rs always succeeds (replacement on malformed
 /// input), with `had_decode_errors` flagging low-confidence results.
 pub fn decode_file(bytes: &[u8]) -> DecodedFile {
+    // UTF-32 BOMs must be checked BEFORE UTF-16: a UTF-32LE BOM (FF FE 00 00)
+    // starts with the UTF-16LE BOM (FF FE) and would otherwise be misdecoded.
+    // encoding_rs has no UTF-32 codec, so we handle it by hand.
+    if bytes.starts_with(b"\xFF\xFE\x00\x00") {
+        return decode_utf32(&bytes[4..], false, "utf-32le", "UTF-32LE");
+    }
+    if bytes.starts_with(b"\x00\x00\xFE\xFF") {
+        return decode_utf32(&bytes[4..], true, "utf-32be", "UTF-32BE");
+    }
+
     let (enc, bom, body): (&'static Encoding, &'static str, &[u8]) =
         if bytes.starts_with(b"\xEF\xBB\xBF") {
             (UTF_8, "utf-8", &bytes[3..])
@@ -63,6 +73,55 @@ pub fn decode_file(bytes: &[u8]) -> DecodedFile {
     }
 }
 
+/// Decode UTF-32 (LE/BE) bytes by hand — encoding_rs has no UTF-32 codec.
+fn decode_utf32(body: &[u8], big_endian: bool, bom: &'static str, label: &'static str) -> DecodedFile {
+    let mut content = String::new();
+    let mut had_decode_errors = false;
+    for chunk in body.chunks(4) {
+        if chunk.len() < 4 {
+            had_decode_errors = true; // trailing partial code unit
+            break;
+        }
+        let cp = if big_endian {
+            u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
+        } else {
+            u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
+        };
+        match char::from_u32(cp) {
+            Some(c) => content.push(c),
+            None => {
+                content.push('\u{FFFD}');
+                had_decode_errors = true;
+            }
+        }
+    }
+    let line_ending = if content.contains("\r\n") { "crlf" } else { "lf" };
+    DecodedFile {
+        content,
+        encoding: label.to_string(),
+        bom,
+        line_ending,
+        had_decode_errors,
+    }
+}
+
+fn utf16_bytes(s: &str, big_endian: bool) -> Vec<u8> {
+    let mut v = Vec::with_capacity(s.len() * 2);
+    for u in s.encode_utf16() {
+        v.extend_from_slice(&if big_endian { u.to_be_bytes() } else { u.to_le_bytes() });
+    }
+    v
+}
+
+fn utf32_bytes(s: &str, big_endian: bool) -> Vec<u8> {
+    let mut v = Vec::with_capacity(s.chars().count() * 4);
+    for c in s.chars() {
+        let u = c as u32;
+        v.extend_from_slice(&if big_endian { u.to_be_bytes() } else { u.to_le_bytes() });
+    }
+    v
+}
+
 /// Encode editor text (`\n`-delimited UTF-8) back to bytes in `encoding_label`,
 /// applying `bom` and `line_ending`. Returns the bytes to write plus whether any
 /// character was unmappable in the target encoding (the caller may warn).
@@ -83,30 +142,25 @@ pub fn encode_file(
         content.to_string()
     };
 
-    let enc = if encoding_label.is_empty() {
-        UTF_8
-    } else {
-        Encoding::for_label(encoding_label.as_bytes()).unwrap_or(UTF_8)
-    };
-
-    // encoding_rs has no UTF-16 *encoder* (per the Encoding Standard its
-    // `encode()` emits UTF-8). Round-trip UTF-16 by hand so a UTF-16 file saves
-    // back as UTF-16, not UTF-8.
-    let (mut out, had_unmappable): (Vec<u8>, bool) = if enc == UTF_16LE {
-        let mut v = Vec::with_capacity(normalized.len() * 2);
-        for u in normalized.encode_utf16() {
-            v.extend_from_slice(&u.to_le_bytes());
+    // UTF-16/UTF-32 are encoded by hand: encoding_rs has no UTF-16/32 *encoder*
+    // (per the Encoding Standard its `encode()` emits UTF-8), so a UTF-16/32
+    // file would otherwise save back as UTF-8. Match on the label first; the
+    // encoding_rs fallback handles legacy single-byte/CJK encodings, where
+    // `had_unmappable` reports characters outside the target charset.
+    let (mut out, had_unmappable): (Vec<u8>, bool) = match encoding_label.to_ascii_lowercase().as_str() {
+        "utf-16le" => (utf16_bytes(&normalized, false), false),
+        "utf-16be" => (utf16_bytes(&normalized, true), false),
+        "utf-32le" => (utf32_bytes(&normalized, false), false),
+        "utf-32be" => (utf32_bytes(&normalized, true), false),
+        other => {
+            let enc = if other.is_empty() {
+                UTF_8
+            } else {
+                Encoding::for_label(other.as_bytes()).unwrap_or(UTF_8)
+            };
+            let (bytes, _enc, had_unmappable) = enc.encode(&normalized);
+            (bytes.into_owned(), had_unmappable)
         }
-        (v, false)
-    } else if enc == UTF_16BE {
-        let mut v = Vec::with_capacity(normalized.len() * 2);
-        for u in normalized.encode_utf16() {
-            v.extend_from_slice(&u.to_be_bytes());
-        }
-        (v, false)
-    } else {
-        let (bytes, _enc, had_unmappable) = enc.encode(&normalized);
-        (bytes.into_owned(), had_unmappable)
     };
 
     // Re-emit a BOM if the file had/uses one.
@@ -114,6 +168,8 @@ pub fn encode_file(
         "utf-8" => b"\xEF\xBB\xBF",
         "utf-16le" => b"\xFF\xFE",
         "utf-16be" => b"\xFE\xFF",
+        "utf-32le" => b"\xFF\xFE\x00\x00",
+        "utf-32be" => b"\x00\x00\xFE\xFF",
         _ => b"",
     };
     if !bom_bytes.is_empty() {
@@ -198,5 +254,35 @@ mod tests {
     fn unknown_label_falls_back_to_utf8() {
         let (bytes, _) = encode_file("hi", "definitely-not-an-encoding", "none", "lf");
         assert_eq!(bytes, b"hi");
+    }
+
+    #[test]
+    fn utf32le_bom_decodes_not_as_utf16() {
+        // "Hi" in UTF-32LE with BOM (FF FE 00 00) — must NOT be read as UTF-16LE.
+        let bytes = b"\xFF\xFE\x00\x00H\x00\x00\x00i\x00\x00\x00";
+        let d = decode_file(bytes);
+        assert_eq!(d.content, "Hi");
+        assert_eq!(d.bom, "utf-32le");
+        assert_eq!(d.encoding, "UTF-32LE");
+    }
+
+    #[test]
+    fn utf32_round_trips() {
+        let (bytes, _) = encode_file("Hi", "utf-32le", "utf-32le", "lf");
+        assert_eq!(&bytes[..4], b"\xFF\xFE\x00\x00");
+        let back = decode_file(&bytes);
+        assert_eq!(back.content, "Hi");
+        assert_eq!(back.bom, "utf-32le");
+    }
+
+    #[test]
+    fn unmappable_char_is_flagged_not_lossy() {
+        // An emoji can't be represented in windows-1252 → had_unmappable=true
+        // (the caller refuses the write instead of emitting NCR garbage).
+        let (_bytes, had_unmappable) = encode_file("hi 😀", "windows-1252", "none", "lf");
+        assert!(had_unmappable, "emoji in cp1252 must flag unmappable");
+        // UTF-8 represents everything → never unmappable.
+        let (_b, u8_unmappable) = encode_file("hi 😀", "UTF-8", "none", "lf");
+        assert!(!u8_unmappable);
     }
 }

--- a/agentmux-srv/src/backend/text_encoding.rs
+++ b/agentmux-srv/src/backend/text_encoding.rs
@@ -1,0 +1,202 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Text encoding detection + transcoding for the editor.
+//!
+//! The editor used to read files with `std::fs::read_to_string`, which rejects
+//! anything that isn't valid UTF-8 — so a Windows-1252 `.ini`, a UTF-16 file,
+//! Shift_JIS, etc. simply failed to open. This module reads bytes, detects the
+//! encoding (BOM → valid-UTF-8 → `chardetng` heuristic), and decodes to a Rust
+//! `String` for the editor; and re-encodes on save so files round-trip in their
+//! original encoding + BOM + line endings.
+//!
+//! Spec: docs/specs/SPEC_EDITOR_FILE_ENCODINGS_2026_06_17.md
+
+use encoding_rs::{Encoding, UTF_16BE, UTF_16LE, UTF_8};
+
+/// Result of decoding a file's bytes for the editor.
+pub struct DecodedFile {
+    /// UTF-8 text for the editor/wire (BOM stripped).
+    pub content: String,
+    /// Encoding label (WHATWG / `encoding_rs` name, e.g. "windows-1252").
+    pub encoding: String,
+    /// Byte-order-mark that was present: "none" | "utf-8" | "utf-16le" | "utf-16be".
+    pub bom: &'static str,
+    /// Detected line ending: "crlf" if any CRLF present, else "lf".
+    pub line_ending: &'static str,
+    /// True when decoding inserted U+FFFD replacements (likely wrong encoding).
+    pub had_decode_errors: bool,
+}
+
+/// Detect the encoding of `bytes` and decode to UTF-8.
+///
+/// Order: BOM (authoritative) → valid UTF-8 (keeps the common case exact) →
+/// `chardetng` heuristic. encoding_rs always succeeds (replacement on malformed
+/// input), with `had_decode_errors` flagging low-confidence results.
+pub fn decode_file(bytes: &[u8]) -> DecodedFile {
+    let (enc, bom, body): (&'static Encoding, &'static str, &[u8]) =
+        if bytes.starts_with(b"\xEF\xBB\xBF") {
+            (UTF_8, "utf-8", &bytes[3..])
+        } else if bytes.starts_with(b"\xFF\xFE") {
+            (UTF_16LE, "utf-16le", &bytes[2..])
+        } else if bytes.starts_with(b"\xFE\xFF") {
+            (UTF_16BE, "utf-16be", &bytes[2..])
+        } else if std::str::from_utf8(bytes).is_ok() {
+            (UTF_8, "none", bytes)
+        } else {
+            let mut det = chardetng::EncodingDetector::new();
+            det.feed(bytes, true);
+            // allow_utf8=true: detector may still pick UTF-8 for ASCII-heavy input.
+            (det.guess(None, true), "none", bytes)
+        };
+
+    let (cow, had_decode_errors) = enc.decode_without_bom_handling(body);
+    let content = cow.into_owned();
+    let line_ending = if content.contains("\r\n") { "crlf" } else { "lf" };
+
+    DecodedFile {
+        content,
+        encoding: enc.name().to_string(),
+        bom,
+        line_ending,
+        had_decode_errors,
+    }
+}
+
+/// Encode editor text (`\n`-delimited UTF-8) back to bytes in `encoding_label`,
+/// applying `bom` and `line_ending`. Returns the bytes to write plus whether any
+/// character was unmappable in the target encoding (the caller may warn).
+///
+/// `encoding_label` falls back to UTF-8 when unknown/empty, so existing callers
+/// that don't pass an encoding keep writing UTF-8.
+pub fn encode_file(
+    content: &str,
+    encoding_label: &str,
+    bom: &str,
+    line_ending: &str,
+) -> (Vec<u8>, bool) {
+    // Normalize to the file's line-ending convention. The editor buffer uses
+    // `\n`; collapse any stray CRLF first so we don't double-convert.
+    let normalized = if line_ending == "crlf" {
+        content.replace("\r\n", "\n").replace('\n', "\r\n")
+    } else {
+        content.to_string()
+    };
+
+    let enc = if encoding_label.is_empty() {
+        UTF_8
+    } else {
+        Encoding::for_label(encoding_label.as_bytes()).unwrap_or(UTF_8)
+    };
+
+    // encoding_rs has no UTF-16 *encoder* (per the Encoding Standard its
+    // `encode()` emits UTF-8). Round-trip UTF-16 by hand so a UTF-16 file saves
+    // back as UTF-16, not UTF-8.
+    let (mut out, had_unmappable): (Vec<u8>, bool) = if enc == UTF_16LE {
+        let mut v = Vec::with_capacity(normalized.len() * 2);
+        for u in normalized.encode_utf16() {
+            v.extend_from_slice(&u.to_le_bytes());
+        }
+        (v, false)
+    } else if enc == UTF_16BE {
+        let mut v = Vec::with_capacity(normalized.len() * 2);
+        for u in normalized.encode_utf16() {
+            v.extend_from_slice(&u.to_be_bytes());
+        }
+        (v, false)
+    } else {
+        let (bytes, _enc, had_unmappable) = enc.encode(&normalized);
+        (bytes.into_owned(), had_unmappable)
+    };
+
+    // Re-emit a BOM if the file had/uses one.
+    let bom_bytes: &[u8] = match bom {
+        "utf-8" => b"\xEF\xBB\xBF",
+        "utf-16le" => b"\xFF\xFE",
+        "utf-16be" => b"\xFE\xFF",
+        _ => b"",
+    };
+    if !bom_bytes.is_empty() {
+        let mut prefixed = Vec::with_capacity(bom_bytes.len() + out.len());
+        prefixed.extend_from_slice(bom_bytes);
+        prefixed.append(&mut out);
+        out = prefixed;
+    }
+
+    (out, had_unmappable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_ascii_is_utf8() {
+        let d = decode_file(b"hello = world\n");
+        assert_eq!(d.content, "hello = world\n");
+        assert_eq!(d.encoding, "UTF-8");
+        assert_eq!(d.bom, "none");
+        assert_eq!(d.line_ending, "lf");
+        assert!(!d.had_decode_errors);
+    }
+
+    #[test]
+    fn windows_1252_ini_decodes() {
+        // 0x92 = right single quote, 0xE9 = é in Windows-1252 — invalid UTF-8.
+        let bytes = b"name = O\x92Brien caf\xE9\r\n";
+        assert!(std::str::from_utf8(bytes).is_err(), "precondition: not UTF-8");
+        let d = decode_file(bytes);
+        assert!(d.content.contains("O\u{2019}Brien"), "got {:?}", d.content);
+        assert!(d.content.contains("caf\u{e9}"));
+        assert_eq!(d.line_ending, "crlf");
+        assert_ne!(d.encoding, "UTF-8"); // heuristic picked a legacy encoding
+    }
+
+    #[test]
+    fn utf8_bom_is_stripped_and_remembered() {
+        let d = decode_file(b"\xEF\xBB\xBFhi");
+        assert_eq!(d.content, "hi");
+        assert_eq!(d.bom, "utf-8");
+        assert_eq!(d.encoding, "UTF-8");
+    }
+
+    #[test]
+    fn utf16le_bom_decodes() {
+        // "Hi" in UTF-16LE with BOM.
+        let d = decode_file(b"\xFF\xFEH\x00i\x00");
+        assert_eq!(d.content, "Hi");
+        assert_eq!(d.bom, "utf-16le");
+    }
+
+    #[test]
+    fn windows_1252_round_trips() {
+        let original = "café — O\u{2019}Brien";
+        let (bytes, unmappable) = encode_file(original, "windows-1252", "none", "lf");
+        assert!(!unmappable);
+        assert!(std::str::from_utf8(&bytes).is_err(), "should be legacy bytes");
+        let back = decode_file(&bytes);
+        // chardetng may not name it "windows-1252" exactly, but the text must round-trip.
+        assert_eq!(back.content, original);
+    }
+
+    #[test]
+    fn utf16le_round_trips_with_bom() {
+        let (bytes, _) = encode_file("Hi", "utf-16le", "utf-16le", "lf");
+        assert_eq!(&bytes[..2], b"\xFF\xFE");
+        let back = decode_file(&bytes);
+        assert_eq!(back.content, "Hi");
+        assert_eq!(back.bom, "utf-16le");
+    }
+
+    #[test]
+    fn crlf_line_ending_applied_on_write() {
+        let (bytes, _) = encode_file("a\nb", "UTF-8", "none", "crlf");
+        assert_eq!(bytes, b"a\r\nb");
+    }
+
+    #[test]
+    fn unknown_label_falls_back_to_utf8() {
+        let (bytes, _) = encode_file("hi", "definitely-not-an-encoding", "none", "lf");
+        assert_eq!(bytes, b"hi");
+    }
+}

--- a/agentmux-srv/src/backend/text_encoding.rs
+++ b/agentmux-srv/src/backend/text_encoding.rs
@@ -56,8 +56,10 @@ pub fn decode_file(bytes: &[u8]) -> DecodedFile {
         } else {
             let mut det = chardetng::EncodingDetector::new();
             det.feed(bytes, true);
-            // allow_utf8=true: detector may still pick UTF-8 for ASCII-heavy input.
-            (det.guess(None, true), "none", bytes)
+            // guess(tld, allow_eu): allow_eu=false — don't bias toward
+            // Central-European windows-1250 (no locale signal here; biasing
+            // would misread ambiguous Western text). tld=None: no domain hint.
+            (det.guess(None, false), "none", bytes)
         };
 
     let (cow, had_decode_errors) = enc.decode_without_bom_handling(body);

--- a/agentmux-srv/src/backend/text_encoding.rs
+++ b/agentmux-srv/src/backend/text_encoding.rs
@@ -64,7 +64,7 @@ pub fn decode_file(bytes: &[u8]) -> DecodedFile {
 
     let (cow, had_decode_errors) = enc.decode_without_bom_handling(body);
     let content = cow.into_owned();
-    let line_ending = if content.contains("\r\n") { "crlf" } else { "lf" };
+    let line_ending = detect_line_ending(&content);
 
     DecodedFile {
         content,
@@ -72,6 +72,16 @@ pub fn decode_file(bytes: &[u8]) -> DecodedFile {
         bom,
         line_ending,
         had_decode_errors,
+    }
+}
+
+/// The file's line ending, from the **first** line break (what VS Code does).
+/// Using "any CRLF present" would flag a mostly-LF file as CRLF and convert all
+/// its LF lines on save.
+fn detect_line_ending(s: &str) -> &'static str {
+    match s.find('\n') {
+        Some(i) if i > 0 && s.as_bytes()[i - 1] == b'\r' => "crlf",
+        _ => "lf",
     }
 }
 
@@ -97,7 +107,7 @@ fn decode_utf32(body: &[u8], big_endian: bool, bom: &'static str, label: &'stati
             }
         }
     }
-    let line_ending = if content.contains("\r\n") { "crlf" } else { "lf" };
+    let line_ending = detect_line_ending(&content);
     DecodedFile {
         content,
         encoding: label.to_string(),
@@ -256,6 +266,15 @@ mod tests {
     fn unknown_label_falls_back_to_utf8() {
         let (bytes, _) = encode_file("hi", "definitely-not-an-encoding", "none", "lf");
         assert_eq!(bytes, b"hi");
+    }
+
+    #[test]
+    fn line_ending_uses_first_break_not_any_crlf() {
+        // Mostly-LF with a later CRLF → first break is LF → "lf"
+        // (so we don't normalize all the LF lines to CRLF on save).
+        assert_eq!(decode_file(b"a\nb\r\nc\n").line_ending, "lf");
+        assert_eq!(decode_file(b"a\r\nb\nc").line_ending, "crlf");
+        assert_eq!(decode_file(b"no breaks").line_ending, "lf");
     }
 
     #[test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1556,12 +1556,23 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     return Err("File too large (>10MB)".to_string());
                 }
 
-                let content = std::fs::read_to_string(path)
+                // Read bytes and detect the encoding (BOM → UTF-8 → heuristic),
+                // decoding to UTF-8 for the editor. This lets non-UTF-8 files
+                // (Windows-1252 .ini, UTF-16, Shift_JIS, …) open instead of
+                // erroring on read_to_string. The detected encoding/bom/line
+                // ending ride back so save round-trips the original format.
+                // See docs/specs/SPEC_EDITOR_FILE_ENCODINGS_2026_06_17.md.
+                let bytes = std::fs::read(path)
                     .map_err(|e| format!("readeditorfile: {e}"))?;
+                let decoded = crate::backend::text_encoding::decode_file(&bytes);
                 let read_only = metadata.permissions().readonly();
 
                 Ok(Some(serde_json::json!({
-                    "content": content,
+                    "content": decoded.content,
+                    "encoding": decoded.encoding,
+                    "bom": decoded.bom,
+                    "line_ending": decoded.line_ending,
+                    "had_decode_errors": decoded.had_decode_errors,
                     "read_only": read_only,
                 })))
             })
@@ -1574,7 +1585,18 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
         Box::new(|data, _ctx| {
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
-                struct Cmd { path: String, content: String }
+                struct Cmd {
+                    path: String,
+                    content: String,
+                    // Encoding to write back in (defaults preserve old UTF-8
+                    // behavior when a caller doesn't send them).
+                    #[serde(default)]
+                    encoding: Option<String>,
+                    #[serde(default)]
+                    bom: Option<String>,
+                    #[serde(default)]
+                    line_ending: Option<String>,
+                }
                 let cmd: Cmd = serde_json::from_value(data)
                     .map_err(|e| format!("writeeditorfile: {e}"))?;
 
@@ -1608,9 +1630,18 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     ));
                 }
 
-                std::fs::write(&canonical, &cmd.content)
+                // Re-encode to the file's original encoding (+ BOM + line
+                // endings) so a non-UTF-8 file round-trips instead of being
+                // silently rewritten as UTF-8. Absent fields default to UTF-8.
+                let (out_bytes, _had_unmappable) = crate::backend::text_encoding::encode_file(
+                    &cmd.content,
+                    cmd.encoding.as_deref().unwrap_or(""),
+                    cmd.bom.as_deref().unwrap_or("none"),
+                    cmd.line_ending.as_deref().unwrap_or("lf"),
+                );
+                std::fs::write(&canonical, &out_bytes)
                     .map_err(|e| format!("writeeditorfile: {e}"))?;
-                tracing::info!(path = %canonical.display(), bytes = cmd.content.len(), "editor file saved");
+                tracing::info!(path = %canonical.display(), bytes = out_bytes.len(), "editor file saved");
 
                 Ok(None)
             })

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1633,12 +1633,27 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                 // Re-encode to the file's original encoding (+ BOM + line
                 // endings) so a non-UTF-8 file round-trips instead of being
                 // silently rewritten as UTF-8. Absent fields default to UTF-8.
-                let (out_bytes, _had_unmappable) = crate::backend::text_encoding::encode_file(
+                let (out_bytes, had_unmappable) = crate::backend::text_encoding::encode_file(
                     &cmd.content,
                     cmd.encoding.as_deref().unwrap_or(""),
                     cmd.bom.as_deref().unwrap_or("none"),
                     cmd.line_ending.as_deref().unwrap_or("lf"),
                 );
+                // Refuse a lossy write: rather than silently emit
+                // numeric-character-reference replacements (corrupting the
+                // file), fail loudly so the user can save as UTF-8. The UI for
+                // an in-place "Save with Encoding → UTF-8" is Phase 3 of
+                // SPEC_EDITOR_FILE_ENCODINGS.
+                if had_unmappable {
+                    let enc = cmd
+                        .encoding
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or("its current encoding");
+                    return Err(format!(
+                        "writeeditorfile: file contains characters that can't be represented in {enc} — save it as UTF-8 instead"
+                    ));
+                }
                 std::fs::write(&canonical, &out_bytes)
                     .map_err(|e| format!("writeeditorfile: {e}"))?;
                 tracing::info!(path = %canonical.display(), bytes = out_bytes.len(), "editor file saved");

--- a/docs/specs/SPEC_EDITOR_FILE_ENCODINGS_2026_06_17.md
+++ b/docs/specs/SPEC_EDITOR_FILE_ENCODINGS_2026_06_17.md
@@ -1,0 +1,140 @@
+# Editor file encodings (beyond UTF-8)
+
+**Date:** 2026-06-17
+**Status:** Draft
+**Author:** naki
+**Component:** `agentmux-srv/src/server/websocket.rs` (`readeditorfile`/`writeeditorfile`), `frontend/app/view/editor/`
+
+---
+
+## 1. The problem (and the .ini question)
+
+**Today the editor only handles UTF-8 and fails on anything else.** The read path is:
+
+```rust
+// websocket.rs:1559 (readeditorfile)
+let content = std::fs::read_to_string(path)?;   // <- requires valid UTF-8, errors otherwise
+```
+
+`read_to_string` returns `InvalidData` ("stream did not contain valid UTF-8") for any non-UTF-8 byte sequence, so the file simply won't open. The write path is the mirror problem:
+
+```rust
+// writeeditorfile — writes the UTF-8 String as-is
+std::fs::write(path, cmd.content)   // <- always UTF-8, silently changes a non-UTF-8 file's encoding
+```
+
+So even if we made reads tolerant, saving would re-encode the file to UTF-8 and corrupt round-trips.
+
+### "If I open an .ini, what format is that?"
+
+**`.ini` has no standardized encoding — it's just text.** In practice:
+- On **Windows**, classic INI files are **ANSI / the system code page** — for Western locales that's **Windows-1252 (CP1252)**. The Win32 INI APIs (`GetPrivateProfileString`) read them as ANSI unless a UTF-16 BOM is present.
+- Modern tools may write **UTF-8** (sometimes with a BOM) or **UTF-16 LE** (with BOM).
+
+So an `.ini` you open could be CP1252, UTF-8, or UTF-16 — and the moment it contains a non-ASCII byte (a `–`, `é`, `™`, smart quote `0x92`, etc.) in CP1252, our `read_to_string` rejects it and the editor errors. Encoding can't be inferred from the extension; it must be **detected from the bytes**.
+
+We want to open (and correctly save) a **wide variety of encodings**, not just UTF-8.
+
+---
+
+## 2. How others do it (reference)
+
+- **VS Code:** Node `jschardet` (detection) + `iconv-lite` (decode/encode). Sniffs BOM first, optional heuristic guess (`files.autoGuessEncoding`), shows the encoding in the status bar, and offers **"Reopen with Encoding"** / **"Save with Encoding"**. Default via `files.encoding`.
+- **The Encoding Standard (WHATWG):** the canonical list of web-platform encodings (UTF-8/16, windows-1252, ISO-8859-*, Shift_JIS, GBK, Big5, EUC-KR/JP, KOI8, …). Implemented in Rust by **`encoding_rs`** (Firefox's encoder/decoder) — the de-facto standard for this in Rust, also used by ripgrep.
+- **Detection in Rust:** **`chardetng`** — Gecko's compact charset detector (the one Firefox ships), pairs with `encoding_rs`.
+
+We mirror VS Code's model with the Rust equivalents — **no external binary, pure crates.**
+
+---
+
+## 3. Design
+
+### 3.1 Crates (agentmux-srv)
+
+- **`encoding_rs`** — decode bytes → `String` and encode `String` → bytes for any WHATWG encoding. Lossless for round-trips of supported encodings; has a documented replacement behavior for un-encodable chars.
+- **`chardetng`** — byte-sniffing detector → an `encoding_rs::Encoding` guess (with a TLD/locale hint we can leave default).
+- (optional) `encoding_rs_io` if we later stream large files.
+
+### 3.2 Detection order (read)
+
+1. **BOM sniff** (authoritative when present): `EF BB BF` → UTF-8; `FF FE` → UTF-16 LE; `FE FF` → UTF-16 BE; `FF FE 00 00`/`00 00 FE FF` → UTF-32. Strip the BOM from the decoded text; **remember it** so save can re-emit it.
+2. **Valid UTF-8?** If the bytes are valid UTF-8, use UTF-8 (no BOM). This keeps the common case exact and fast.
+3. **Heuristic** via `chardetng` over the byte sample → best-guess encoding (e.g. windows-1252, Shift_JIS).
+4. **Fallback** to the configured default (`editor:encoding.default`, default **windows-1252** on Windows / UTF-8 elsewhere) when detection is low-confidence.
+
+Decode with `encoding_rs` (lossy=replacement on malformed input, with a `had_errors` flag surfaced to the UI as a soft warning).
+
+### 3.3 Backend API changes
+
+**`readeditorfile`** → returns encoding metadata alongside the (always-UTF-8-on-the-wire) text:
+```jsonc
+{
+  "content": "…UTF-8 text for the editor…",
+  "encoding": "windows-1252",     // detected/used label (encoding_rs name)
+  "bom": "none" | "utf-8" | "utf-16le" | "utf-16be",
+  "line_ending": "lf" | "crlf",   // detected (see §3.5)
+  "had_decode_errors": false,
+  "read_only": false
+}
+```
+Reads **bytes** (not `read_to_string`), runs §3.2, decodes to UTF-8 for transport.
+
+**`writeeditorfile`** → accepts the encoding to write back in:
+```jsonc
+{ "path", "content" /*UTF-8*/, "encoding": "windows-1252", "bom": "none", "line_ending": "crlf" }
+```
+Re-encodes `content` from UTF-8 → target encoding via `encoding_rs`, re-emits the BOM if the file had one (or the user chose one), normalizes line endings to the file's convention, then writes bytes. If a character can't be represented in the target encoding, surface a clear error/warning (offer "save as UTF-8") rather than silently dropping it.
+
+### 3.4 Per-tab encoding state (frontend)
+
+The editor model stores the file's `encoding` + `bom` + `line_ending` per tab (from the read response). Save passes them straight back so the file **round-trips in its original encoding** by default. Changing them (reopen/save-with-encoding) updates this state.
+
+### 3.5 Line endings (adjacent, include now)
+
+Encoding work naturally exposes CRLF vs LF. Detect on read, preserve on write (don't silently convert a CRLF Windows .ini to LF). Same per-tab metadata + status-bar indicator. (Editor edits in `\n`; convert at the write boundary.)
+
+### 3.6 CodeMirror interplay
+
+None required. CodeMirror always edits **decoded Unicode** (JS string). Encoding is purely a byte↔text boundary concern at read/write in the backend. The editor buffer, find, markdown preview, etc. are unaffected.
+
+---
+
+## 4. UI (mirror VS Code)
+
+- **Encoding indicator** in the editor pane (e.g. a small chip in the editor footer/status, near the LSP chip): shows `UTF-8`, `Windows-1252`, `UTF-16 LE`, plus `CRLF`/`LF`. Reflects the active tab.
+- **Reopen with Encoding** — re-decode the on-disk bytes with a chosen encoding (fixes a mis-detected file without losing data, since we re-read bytes).
+- **Save with Encoding** — convert and save in a chosen encoding (updates per-tab state).
+- A soft banner when `had_decode_errors` ("This file was decoded with replacements — it may not be <encoding>. Reopen with another encoding?").
+- **Settings:** `editor:encoding.default` (default windows-1252 on Windows, utf-8 elsewhere) and `editor:encoding.autodetect` (on by default).
+
+---
+
+## 5. Edge cases
+
+- **BOM round-trip:** preserve presence/absence; never add a BOM to a file that didn't have one unless the user asks.
+- **Binary files:** the existing "looks binary" guard stays in front of all this — encodings are for *text*.
+- **Un-encodable chars on save:** if the edited text has chars outside the target charset (e.g. typed an emoji into a CP1252 file), warn and offer UTF-8 instead of lossy-writing.
+- **Low-confidence detection:** fall back to default + flag it; the user can Reopen-with-Encoding.
+- **Large files:** the 10 MB guard stays; detection samples a bounded prefix.
+
+---
+
+## 6. Phasing
+
+1. **Stop failing (open anything).** Read bytes → BOM/UTF-8/`chardetng` detect → `encoding_rs` decode. `readeditorfile` returns `encoding`/`bom`/`line_ending`. Files that error today (ANSI `.ini`, UTF-16, Latin-1, Shift_JIS…) now open. *(~1 day)*
+2. **Round-trip save.** `writeeditorfile` re-encodes to the file's original encoding + BOM + line endings; per-tab encoding state on the frontend. No more silent UTF-8 conversion. *(~1 day)*
+3. **UI.** Encoding/line-ending indicator chip + Reopen-with-Encoding + Save-with-Encoding + decode-error banner + settings. *(~1–2 days)*
+
+Phase 1 alone fixes "my `.ini` won't open." Phases 2–3 make encodings first-class and safe to edit.
+
+---
+
+## 7. Key references
+
+| What | Location |
+|---|---|
+| Read path (strict UTF-8 today) | `agentmux-srv/src/server/websocket.rs:1559` (`readeditorfile`) |
+| Write path (always UTF-8 today) | `agentmux-srv/src/server/websocket.rs` (`writeeditorfile`, ~1571) |
+| Editor read/write callers | `frontend/app/view/editor/editor-model.ts` (`ReadEditorFileCommand`, `saveFile`/`WriteEditorFileCommand`) |
+| Crates | `encoding_rs`, `chardetng` (crates.io; pure Rust) |
+| Existing size/binary guards | `readeditorfile` 10 MB cap; editor-model binary-content refusal |

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -120,7 +120,7 @@ export class EditorViewModel implements ViewModel {
     // silently rewriting the file as UTF-8.
     private _encodingByTab = new Map<
         string,
-        { encoding: string; bom: string; lineEnding: string }
+        { encoding: string; bom: string; lineEnding: string; hadDecodeErrors: boolean }
     >();
 
     // ── Tree state (per-pane, persisted in block meta) ──────────────────
@@ -496,7 +496,15 @@ export class EditorViewModel implements ViewModel {
             encoding: result.encoding ?? "UTF-8",
             bom: result.bom ?? "none",
             lineEnding: result.line_ending ?? "lf",
+            hadDecodeErrors: result.had_decode_errors ?? false,
         });
+    }
+
+    /** True when the file was decoded with U+FFFD replacements (likely the
+     *  wrong encoding). Saving would re-encode the lossy buffer over the
+     *  original bytes, so callers must refuse the write. */
+    private _decodedWithErrors(tabId: string): boolean {
+        return this._encodingByTab.get(tabId)?.hadDecodeErrors ?? false;
     }
 
     /** Encoding fields to spread onto a WriteEditorFileCommand so the file
@@ -514,6 +522,22 @@ export class EditorViewModel implements ViewModel {
         if (this.readOnlyAtom()) return;
         const tab = this.activeTabAtom();
         if (!tab) return;
+
+        // Refuse to save a file that decoded with replacement characters
+        // (likely the wrong encoding) — re-encoding the lossy buffer would
+        // overwrite the original bytes (silent data loss), and is the symmetric
+        // counterpart to the encode-side lossy-write refusal. Recovery is
+        // Reopen-with-Encoding (Phase 3 of SPEC_EDITOR_FILE_ENCODINGS).
+        if (this._decodedWithErrors(tab.id)) {
+            dispatch(this.blockId, {
+                type: "TabContentLoadFailed",
+                tabId: tab.id,
+                error: "Save blocked: this file didn't decode cleanly (replacement characters present) — likely the wrong encoding. Reopen with the correct encoding before saving to avoid data loss.",
+                source: "system",
+            });
+            return;
+        }
+
         const content = this._contentByTab.get(tab.id) ?? "";
 
         try {

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -115,6 +115,13 @@ export class EditorViewModel implements ViewModel {
     private _contentByTab = new Map<string, string>();
     // Bump-counter signal so contentAtom re-evaluates when we mutate the Map.
     private _contentVersion = createSignal<number>(0);
+    // Detected text encoding per tab (SPEC_EDITOR_FILE_ENCODINGS), captured on
+    // read so save round-trips the original encoding/bom/line-ending instead of
+    // silently rewriting the file as UTF-8.
+    private _encodingByTab = new Map<
+        string,
+        { encoding: string; bom: string; lineEnding: string }
+    >();
 
     // ── Tree state (per-pane, persisted in block meta) ──────────────────
     private _treeExpanded = createSignal<boolean>(true);
@@ -166,6 +173,7 @@ export class EditorViewModel implements ViewModel {
             for (const ev of events) {
                 if (ev.type === "TabClosed") {
                     this._contentByTab.delete(ev.tabId);
+                    this._encodingByTab.delete(ev.tabId);
                 }
                 for (const sub of this._eventSubscribers) sub(ev);
             }
@@ -413,6 +421,7 @@ export class EditorViewModel implements ViewModel {
             }
 
             this._contentByTab.set(tabId, content);
+            this._rememberEncoding(tabId, result);
             this._contentVersion[1]((v) => v + 1);
 
             const hash = await sha256Hex(content);
@@ -476,6 +485,31 @@ export class EditorViewModel implements ViewModel {
         }
     }
 
+    /** Capture detected encoding metadata from a read result so save can
+     *  round-trip it. Missing fields default to UTF-8 (back-compat). */
+    private _rememberEncoding(
+        tabId: string,
+        result: CommandReadEditorFileResult | undefined | null,
+    ): void {
+        if (!result) return;
+        this._encodingByTab.set(tabId, {
+            encoding: result.encoding ?? "UTF-8",
+            bom: result.bom ?? "none",
+            lineEnding: result.line_ending ?? "lf",
+        });
+    }
+
+    /** Encoding fields to spread onto a WriteEditorFileCommand so the file
+     *  saves back in its original encoding. Empty (⇒ backend UTF-8 default)
+     *  when the tab's encoding is unknown. */
+    private _encodingFor(
+        tabId: string,
+    ): { encoding?: string; bom?: string; line_ending?: string } {
+        const e = this._encodingByTab.get(tabId);
+        if (!e) return {};
+        return { encoding: e.encoding, bom: e.bom, line_ending: e.lineEnding };
+    }
+
     async saveFile(): Promise<void> {
         if (this.readOnlyAtom()) return;
         const tab = this.activeTabAtom();
@@ -486,6 +520,7 @@ export class EditorViewModel implements ViewModel {
             await RpcApi.WriteEditorFileCommand(TabRpcClient, {
                 path: tab.filePath,
                 content,
+                ...this._encodingFor(tab.id),
             });
             dispatch(this.blockId, {
                 type: "ClearDirty",
@@ -553,6 +588,7 @@ export class EditorViewModel implements ViewModel {
             const fileResult = await RpcApi.ReadEditorFileCommand(TabRpcClient, { path: result.file_path });
             const content = fileResult?.content ?? "";
             this._contentByTab.set(tabId, content);
+            this._rememberEncoding(tabId, fileResult);
             this._contentVersion[1]((v) => v + 1);
             const hash = content === "" ? "" : await sha256Hex(content);
             dispatch(this.blockId, {
@@ -581,6 +617,7 @@ export class EditorViewModel implements ViewModel {
                 await RpcApi.WriteEditorFileCommand(TabRpcClient, {
                     path: tab.filePath,
                     content: liveContent,
+                    ...this._encodingFor(tab.id),
                 });
             }
             const result = await RpcApi.MoveScratchFileCommand(TabRpcClient, {
@@ -777,6 +814,7 @@ export class EditorViewModel implements ViewModel {
         _instanceHandlers.delete(this._globalHandler);
         this._eventSubscribers.clear();
         this._contentByTab.clear();
+        this._encodingByTab.clear();
         unregisterEditorPane(this.blockId);
     }
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1960,12 +1960,22 @@ declare global {
     type CommandReadEditorFileResult = {
         content: string;
         read_only: boolean;
+        // Detected text encoding (SPEC_EDITOR_FILE_ENCODINGS). Optional for
+        // back-compat; absent ⇒ treat as UTF-8.
+        encoding?: string;
+        bom?: string;
+        line_ending?: string;
+        had_decode_errors?: boolean;
     };
 
     // wshrpc.CommandWriteEditorFileData
     type CommandWriteEditorFileData = {
         path: string;
         content: string;
+        // Encoding to write back in; omit ⇒ UTF-8 (back-compat).
+        encoding?: string;
+        bom?: string;
+        line_ending?: string;
     };
 
     // wshrpc.CommandResolveCliData


### PR DESCRIPTION
## Summary

The editor only handled UTF-8 — opening a **Windows-1252 `.ini`**, a **UTF-16** file, **Shift_JIS**, Latin-1, etc. errored (`std::fs::read_to_string` → "stream did not contain valid UTF-8"), and saves always wrote UTF-8 (silently changing a file's encoding). This adds encoding detection + transcoding so a wide variety of encodings open and **round-trip**.

Spec: `docs/specs/SPEC_EDITOR_FILE_ENCODINGS_2026_06_17.md`. (And to the original question: an `.ini` has no fixed encoding — on Windows it's typically Windows-1252/ANSI, sometimes UTF-8/UTF-16; it must be detected from the bytes.)

## What changed

**Backend — `agentmux-srv/src/backend/text_encoding.rs` (new):**
- `decode_file`: BOM sniff → valid-UTF-8 → `chardetng` heuristic → decode via `encoding_rs`. Returns content + `encoding`/`bom`/`line_ending`/`had_decode_errors`.
- `encode_file`: re-encode to the target encoding + BOM + line endings. UTF-16 is encoded by hand (`encoding_rs` has no UTF-16 *encoder* per the Encoding Standard — its `encode()` emits UTF-8).
- `readeditorfile` now reads **bytes** and returns the metadata; `writeeditorfile` accepts `encoding`/`bom`/`line_ending` (absent ⇒ UTF-8, so old callers are unaffected).

**Frontend:** the editor model captures per-tab encoding on read and passes it back on save (`saveFile`/`saveFileAs`), so a non-UTF-8 file saves back in its original format instead of UTF-8. Types extended (`gotypes.d.ts`).

**Deps:** `encoding_rs` (Firefox's codec, also used by ripgrep) + `chardetng` (Firefox's detector). Pure Rust, no external binary — the Rust equivalent of VS Code's `iconv-lite` + `jschardet`.

## Tests

8 unit tests in `text_encoding.rs` (all pass): Windows-1252 `.ini` decode + round-trip, UTF-8/UTF-16 BOM handling, CRLF on write, unknown-label → UTF-8 fallback. Backend builds clean; frontend `tsc` clean (the one pre-existing `rpcCall` baseline error is unrelated).

## Test plan

- [ ] Open a Windows-1252 `.ini` with non-ASCII (`é`, smart quotes) → opens correctly (was erroring).
- [ ] Edit + save → file stays Windows-1252 (not converted to UTF-8); BOM + CRLF preserved.
- [ ] Open a UTF-16 LE file (with BOM) → opens; saves back as UTF-16 LE.
- [ ] Normal UTF-8 files unchanged.

Phase 3 (status-bar encoding indicator + Reopen/Save-with-Encoding UI) is a follow-up per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)