### PR TITLE
fix(agent): auto-resume after AskUserQuestion on persistent panes (dead-air fix)

### DIFF
--- a/.changesets/1781747957-fix-agent-askuserquestion-dead-air-resume.md
+++ b/.changesets/1781747957-fix-agent-askuserquestion-dead-air-resume.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): auto-resume after AskUserQuestion on persistent (Claude) panes. When a turn ends while a question is still parked, the CLI abandons the pending tool_use and the answer's control_response is silently dropped — the agent stalls ("dead air"). `answer_question` now arms a short post-answer check: if no stdout activity follows the control_response, the answer is re-delivered as a directive follow-up user message so the turn resumes. Gated on output activity, so it is mutually exclusive with a real resume and never double-delivers. Mirrors the one-shot controllers' existing message fallback (SPEC_ASK_USER_QUESTION §9/§10.1).

--- a/agentmux-srv/src/backend/blockcontroller/health.rs
+++ b/agentmux-srv/src/backend/blockcontroller/health.rs
@@ -223,6 +223,14 @@ impl HealthMonitor {
         self.inner.lock().unwrap().active_turn
     }
 
+    /// `Instant` of the most recent stdout line (meaningful or not). Used by the
+    /// AskUserQuestion dead-air fallback (`persistent.rs::answer_question`) to
+    /// detect whether the turn resumed after an answer was delivered: if this is
+    /// unchanged a few seconds later, no output arrived and the turn stalled.
+    pub fn last_output_at(&self) -> Instant {
+        self.inner.lock().unwrap().last_output_ts
+    }
+
     /// Periodic health check — call this every ~5 seconds while a turn is active.
     pub fn check(&self) {
         self.evaluate_and_transition();

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -153,6 +153,42 @@ pub struct PersistentSubprocessController {
     health_monitor: Arc<HealthMonitor>,
 }
 
+/// How long to wait after delivering an AskUserQuestion answer before assuming
+/// the turn did not resume and re-delivering the answer as a follow-up message.
+/// See `answer_question` and SPEC_ASK_USER_QUESTION_2026_06_15.md §10.1.
+const ANSWER_RESUME_FALLBACK_MS: u64 = 4000;
+
+/// Compose the directive follow-up message used by the AskUserQuestion dead-air
+/// fallback. `answers` maps each question's text to the selected label(s) or free
+/// text (the same object delivered in the control_response). The message is
+/// deliberately directive so the model resumes the task instead of treating it
+/// as a no-op (the "user sent an empty message" failure mode).
+fn build_answer_resume_message(answers: &serde_json::Value) -> String {
+    let mut out = String::from(
+        "[AgentMux] Your earlier question was answered, but the turn had already ended, \
+         so the answer is delivered here as a follow-up. Resume the task you were working \
+         on using this answer — do not wait for further input:\n",
+    );
+    match answers.as_object() {
+        Some(map) if !map.is_empty() => {
+            for (question, answer) in map {
+                let rendered = match answer {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Array(items) => items
+                        .iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    other => other.to_string(),
+                };
+                out.push_str(&format!("\n• {question}: {rendered}"));
+            }
+        }
+        _ => out.push_str(&format!("\nAnswer: {answers}")),
+    }
+    out
+}
+
 impl PersistentSubprocessController {
     pub fn new(
         tab_id: String,
@@ -340,13 +376,60 @@ impl PersistentSubprocessController {
                 "request_id": request_id,
                 "response": {
                     "behavior": "allow",
-                    "updatedInput": { "questions": questions, "answers": answers },
+                    "updatedInput": { "questions": questions, "answers": answers.clone() },
                     "toolUseID": tool_use_id,
                 }
             }
         });
         tx.try_send(control_response.to_string())
-            .map_err(|e| format!("control_response send failed: {e}"))
+            .map_err(|e| format!("control_response send failed: {e}"))?;
+
+        // Dead-air safety net. The CLI *abandons* a pending AskUserQuestion
+        // tool_use if its turn already ended, silently dropping the
+        // control_response above — the model then sees an empty message and
+        // stalls (SPEC_ASK_USER_QUESTION_2026_06_15.md §9/§10.1; the dead-air
+        // report). If no stdout activity appears shortly after the answer, the
+        // turn did not resume, so re-deliver the answer as a normal follow-up
+        // user turn — the same resilience the one-shot controllers already use.
+        // Gated on output activity, so it is mutually exclusive with a real
+        // resume and never double-delivers.
+        let inner = Arc::clone(&self.inner);
+        let health = Arc::clone(&self.health_monitor);
+        let block_id = self.block_id.clone();
+        let before_output = health.last_output_at();
+        let resume_msg = build_answer_resume_message(&answers);
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(ANSWER_RESUME_FALLBACK_MS)).await;
+            // Any stdout line since the answer means the turn resumed — nothing to do.
+            if health.last_output_at() != before_output {
+                return;
+            }
+            let line = serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": resume_msg }
+            })
+            .to_string();
+            let stdin_tx = { inner.lock().unwrap().stdin_tx.clone() };
+            match stdin_tx {
+                Some(stdin_tx) if stdin_tx.try_send(line).is_ok() => {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        tool_use_id = %tool_use_id,
+                        fallback_ms = ANSWER_RESUME_FALLBACK_MS,
+                        "AskUserQuestion answer did not resume the turn — re-delivered as a follow-up message (dead-air fallback)"
+                    );
+                }
+                Some(_) => tracing::warn!(
+                    block_id = %block_id,
+                    "AskUserQuestion dead-air fallback: stdin send failed"
+                ),
+                None => tracing::warn!(
+                    block_id = %block_id,
+                    "AskUserQuestion dead-air fallback skipped: process not running"
+                ),
+            }
+        });
+        Ok(())
     }
 
     /// Push a raw NDJSON line to the live stdin (used to emit control_responses
@@ -1035,6 +1118,31 @@ mod send_input_tests {
         let c = controller();
         let res = c.send_input(BlockInputUnion::resize(TermSize { rows: 25, cols: 117 }), None);
         assert!(res.is_ok(), "termsize resize should be a no-op Ok, got {res:?}");
+    }
+
+    // The AskUserQuestion dead-air fallback re-delivers the answer as a directive
+    // follow-up message; the rendering must surface each Q/A so the model can
+    // resume with the decision in context. See SPEC_ASK_USER_QUESTION §10.1.
+    #[test]
+    fn answer_resume_message_renders_qa_pairs() {
+        let answers = serde_json::json!({
+            "Pick a color": "blue",
+            "Pick toppings": ["cheese", "olives"],
+        });
+        let msg = build_answer_resume_message(&answers);
+        assert!(msg.contains("Resume the task"), "must be directive: {msg}");
+        assert!(msg.contains("Pick a color: blue"), "string answer: {msg}");
+        assert!(
+            msg.contains("Pick toppings: cheese, olives"),
+            "multi-select joins labels: {msg}"
+        );
+    }
+
+    #[test]
+    fn answer_resume_message_handles_non_object() {
+        let msg = build_answer_resume_message(&serde_json::json!("just text"));
+        assert!(msg.contains("Resume the task"), "still directive: {msg}");
+        assert!(msg.contains("Answer: "), "non-object falls back: {msg}");
     }
 
     // Raw keystrokes are genuinely unsupported on a persistent controller —

--- a/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md
@@ -530,3 +530,19 @@ tool_use can't consume.)
   "answer later" affordance keeps it pending; no silent drop.
 
 No blocking unknowns remain for Phase 1.
+
+---
+
+## 11. Amendment — persistent dead-air fallback (2026-06-17)
+
+**Author:** Claude (claude-2) · **Status:** Implemented (branch `fix/askuserquestion-dead-air-resume`)
+
+**Symptom (observed in a live pane).** After a user answered an `AskUserQuestion`, the agent produced no output and did no work until manually nudged. Diagnosis in `agentmux-askuserquestion-dead-air-report.md`.
+
+**Root cause.** §9/§10.1 already document it for one-shot agents: *when a turn ends while the question is still parked, the CLI abandons the pending tool_use*, so the answer's `control_response` is silently dropped and the model sees an empty message. Phase 1 (persistent) assumed the turn always stays alive until the answer arrives — but if it ends first (the CLI's own turn-end while blocked, a stream hiccup, etc.), `answer_question` had **no recovery**: it fired the `control_response` and returned. (`proc_status` can't detect this — it tracks the *process*, which stays alive across turns, not the turn boundary, which lives in the stdout stream.)
+
+**Fix.** Give the **persistent** path the same resilience the one-shot path already has (§9 Phase 2): after sending the `control_response`, `answer_question` snapshots `HealthMonitor::last_output_at()` and arms a short check (`ANSWER_RESUME_FALLBACK_MS`, 4 s). If **no stdout line** has arrived by then, the turn did not resume → re-deliver the answer as a **directive follow-up user message** (`build_answer_resume_message`) on the live stdin, so the agent resumes with the decision in context. Because it is gated on output activity, it is **mutually exclusive** with a real resume and can never double-deliver. The directive wording ("Resume the task… do not wait for further input") also defends against the secondary failure where a vague "continue" nudge is read as a no-op.
+
+**Scope.** `agentmux-srv/src/backend/blockcontroller/persistent.rs` (`answer_question` + `build_answer_resume_message` + tests) and a `last_output_at()` getter on `HealthMonitor` (`health.rs`). No protocol or frontend change; the happy path (turn still live → `control_response` consumed) is byte-for-byte unchanged.
+
+**Follow-ups (not in this change):** the 4 s window is a heuristic that wants a live-smoke tune (the cross-process timing can't be unit-tested, like the §10 CEF smokes); and the §5 "suspend stall watchdog while a question is parked" idea remains optional (the watchdog is non-destructive, so it's cosmetic, not a turn-killer).


### PR DESCRIPTION
## Summary

Fixes a reliability bug where a Claude (persistent) agent **stalls with no output after the user answers an `AskUserQuestion`** — "dead air" — until manually nudged. Diagnosed live; full write-up in `agentmux-askuserquestion-dead-air-report.md`.

## Root cause

`AskUserQuestion` blocks the model's turn; the answer is delivered as a `control_response` that should resume the same turn. But — already documented for one-shot agents in `SPEC_ASK_USER_QUESTION_2026_06_15.md` §9/§10.1 — **when a turn ends while the question is still parked, the CLI abandons the pending tool_use and the `control_response` is silently dropped** (the model "sees an empty message"). Phase 1 (persistent) had **no recovery**: `answer_question` fired the `control_response` and returned. `proc_status` can't detect this — it tracks the *process* (alive across turns), not the *turn* boundary (which lives in the stdout stream).

## Fix

Give the persistent path the same resilience the one-shot path already has (§9 Phase 2). After sending the `control_response`, `answer_question` snapshots `HealthMonitor::last_output_at()` and arms a short check (`ANSWER_RESUME_FALLBACK_MS` = 4s). If **no stdout line** arrives by then, the turn didn't resume → re-deliver the answer as a **directive follow-up user message** (`build_answer_resume_message`) on the live stdin, so the agent resumes with the decision in context.

**Safe by construction:** gated on output activity → **mutually exclusive** with a real resume, so it can never double-deliver. The happy path (turn still live → `control_response` consumed) is byte-for-byte unchanged. The directive wording ("Resume the task… do not wait for further input") also defends against the secondary failure where a vague "continue" nudge is read as a no-op.

## Scope

- `agentmux-srv/src/backend/blockcontroller/persistent.rs` — `answer_question` fallback + `build_answer_resume_message` + tests
- `agentmux-srv/src/backend/blockcontroller/health.rs` — `last_output_at()` getter
- `docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md` — §11 amendment

No protocol or frontend change.

## Test plan

- [x] `cargo check -p agentmux-srv` — clean (only pre-existing warnings)
- [x] `cargo test -p agentmux-srv` — green (new: `answer_resume_message_renders_qa_pairs`, `answer_resume_message_handles_non_object`; existing blockcontroller/health suites unaffected — 84 passed)
- [ ] **Live smoke (needs a real pane):** ask a question, answer it, confirm the turn resumes; force the dead-air case (answer after the turn ends) and confirm the follow-up message re-delivers exactly once. The 4s window is a heuristic that may want tuning under real timing — like the §10 cross-process smokes, it can't be unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)