### PR TITLE
feat(agent-picker): tile-grid layout (maximize screen room)

### DIFF
--- a/.changesets/1781750214-feat-agent-picker-tile-grid.md
+++ b/.changesets/1781750214-feat-agent-picker-tile-grid.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-picker): My Agents + Templates render as a responsive tile grid filling the pane (was a 520px single column)

--- a/docs/specs/SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md
+++ b/docs/specs/SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md
@@ -1,0 +1,125 @@
+# Agent picker: tile-grid layout
+
+**Date:** 2026-06-17
+**Status:** Draft
+**Author:** naki
+**Component:** `frontend/app/view/agent/components/` (`AgentPicker`, `MyAgentsList`, `AgentCard`, `HiddenTemplatesSection`) + `frontend/app/view/agent/styles/_picker.scss`, `_recent-sessions.scss`
+
+---
+
+## 1. Problem
+
+The agent picker (shown in an agent pane before launch) lists **My Agents** then **Templates** as **single-column lists capped at `max-width: 520px` and centered** (`_picker.scss` `.agent-picker-list`, `.agent-recent-sessions` — both `flex-direction: column; max-width: 520px`). On anything wider than a phone, ~70%+ of the pane is empty margin, and the list scrolls long when there are many agents/templates.
+
+We want a **tile grid that fills the pane** — more agents visible at a glance, columns scaling with width, vertical scroll only when genuinely full.
+
+---
+
+## 2. Goal
+
+- Render **My Agents** and **Templates** as a **responsive tile grid** that uses the full pane width (no 520px cap), reflowing column count to the available space.
+- **Maximize screen room:** wide panes show many columns; the grid area scrolls vertically when it overflows ("it can get full").
+- Preserve every existing interaction: click-to-launch/reattach, modifier-force-modal, `+ New`, install ribbon/state, delete, hidden-templates section.
+- Match the app design system; reuse the existing tile-grid precedent (`accounts-gallery.scss`, the Trust Center brand tiles).
+
+---
+
+## 3. Design
+
+### 3.1 Layout — responsive CSS grid
+
+Replace the capped single-column flex lists with a grid that auto-fills:
+
+```scss
+.agent-picker {
+    // was: centered column. Now fill the pane; scroll the body, not the page.
+    padding: var(--space-4);
+    height: 100%;
+    overflow-y: auto;
+}
+
+.agent-picker-grid {                 // used by both My Agents and Templates
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min, 220px), 1fr));
+    gap: var(--space-3);
+    width: 100%;                      // no more max-width: 520px
+}
+
+.agent-picker-section-header {       // "My Agents" / "Templates"
+    grid-column: 1 / -1;             // span the full grid row
+}
+```
+
+- `auto-fill` + `minmax(220px, 1fr)` → 1 column on a narrow pane, N columns as it widens; tiles stretch to fill the row. No fixed breakpoints needed.
+- `--agent-tile-min` is a tunable token (start ~220px; tighten/loosen after eyeballing).
+- The **picker body scrolls** (`overflow-y: auto`), so the grid can "get full" and overflow gracefully. Section headers (`grid-column: 1/-1`) keep "My Agents" / "Templates" as full-width dividers between grid bands.
+- Optional very-wide guard: a generous `max-width` (e.g. 1600px) + center, so tiles don't get comically wide on ultrawide monitors. Default: no cap (the user asked to maximize room) — decide on review.
+
+### 3.2 The tile (`AgentCard` reflow)
+
+`AgentCard` is currently a **horizontal row** (28px icon + flex info column + ribbon + `+New`). Reflow to a **tile**:
+
+- Vertical, fixed-ish footprint: provider logo (larger, ~36–40px) on top or top-left, **title** (CLI blurb / display name) and **caption** beneath, install ribbon as a corner badge, `+ New` + spinner revealed on hover/focus (as today).
+- Consistent tile height (clamp the description to 1–2 lines with ellipsis) so rows align in the grid.
+- Hard corners + accent-on-hover, per the app convention and the Trust Center pattern:
+  ```scss
+  .agent-card {
+      display: flex; flex-direction: column; gap: var(--space-2);
+      padding: var(--space-3);
+      background: var(--button-secondary-bg-color, rgba(127,127,127,0.08));
+      border: 1px solid var(--border-color);
+      border-radius: 0;                 // hard corners (app convention)
+      cursor: pointer;
+      transition: background 90ms ease, border-color 90ms ease;
+      &:hover { background: var(--hover-bg-color); border-color: var(--accent-color); }
+      &--launching { /* spinner state */ }
+  }
+  ```
+  (`accounts-gallery.scss` uses the same structure with `border-radius: 8px`; we go hard-cornered to match the buttons/find-panel decision — confirm on review.)
+
+### 3.3 My Agents tiles
+
+`MyAgentsList` rows become tiles in the **same grid** (own band under a "My Agents" header), but they're *live sessions*, not "+New" templates — so the tile surfaces session affordances (last-active, status accent, reattach on click, the per-row menu/delete) rather than the install ribbon. Visually peers with the template tiles (same tile chrome) so the pane reads as one coherent grid with two labeled bands.
+
+### 3.4 Interactions (unchanged)
+
+Click → launch (template) / reattach (My Agent); modifier keys → force the launch modal; `+ New` → fresh session from a My Agent; install state/ribbon; `HiddenTemplatesSection` stays (collapsible band below, full-width). Only the **layout** changes — the handlers in `AgentPicker.tsx` / `MyAgentsList.tsx` are reused as-is.
+
+---
+
+## 4. Reference
+
+`frontend/app/view/accounts/accounts-gallery.scss` is the existing in-app tile grid (Trust Center): `display: grid` of bordered tiles, `gap`, hover → `--accent-color` border, accent count badges, `color-mix` accents. The picker grid should mirror its grid/spacing/hover structure (adjusted to hard corners) so the two galleries feel like one system.
+
+---
+
+## 5. Edge cases / details
+
+- **Empty states:** "No definitions configured" (existing) centers in the grid area; an empty My Agents band hides its header.
+- **Long names/descriptions:** clamp to fixed lines (`-webkit-line-clamp`) so tiles stay uniform.
+- **Few items:** with one template, `1fr` would stretch it across the whole row — use `justify-content: start` + `minmax(min, max)` (e.g. `minmax(220px, 320px)`) so a lone tile stays tile-sized, not pane-wide.
+- **Zoom:** the picker already honors `zoomFactor()` (`style={{ zoom }}`) — grid + tokens scale with it.
+- **Density toggle (optional, later):** a compact/comfortable switch adjusting `--agent-tile-min`.
+
+---
+
+## 6. Effort / phasing
+
+1. **Grid layout** — swap the two capped column lists for the `auto-fill` grid; full-width; body scroll; section headers span. Reuse all existing handlers. *(~1 day)*
+2. **Tile reflow** — restyle `AgentCard` from row → vertical tile (icon/title/caption/ribbon/+New), uniform height, hard corners + accent hover; bring `MyAgentsList` rows into the same tile chrome. *(~1–1.5 days)*
+3. **Polish** — lone-tile sizing, line clamping, empty states, optional very-wide cap + density toggle. *(~½ day)*
+
+Phase 1 alone delivers "fills the screen / many columns"; Phase 2 makes them proper tiles.
+
+---
+
+## 7. Key references
+
+| What | Location |
+|---|---|
+| Picker container + sections | `frontend/app/view/agent/components/AgentPicker.tsx` |
+| Template card | `frontend/app/view/agent/components/AgentCard.tsx` |
+| My Agents list | `frontend/app/view/agent/components/MyAgentsList.tsx` |
+| Hidden templates | `frontend/app/view/agent/components/HiddenTemplatesSection.tsx` |
+| Current layout (520px caps) | `frontend/app/view/agent/styles/_picker.scss`, `_recent-sessions.scss` |
+| Tile-grid precedent | `frontend/app/view/accounts/accounts-gallery.scss` |

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -11,6 +11,11 @@
         height: 100%;
         padding: var(--space-4);
         gap: var(--space-3);
+        // Min tile width for the My Agents / Templates grids. The grids
+        // auto-fill across the full pane width, so column count scales with
+        // the pane ("maximize screen room"). Tunable in one place.
+        // Spec: docs/specs/SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md
+        --agent-tile-min: 240px;
     }
 
     // Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md):
@@ -19,9 +24,7 @@
     // recent-sessions title visual weight so the two sections feel
     // like peers, not a heading + a free-floating grid.
     .agent-picker-templates-header {
-        max-width: 520px;
         width: 100%;
-        align-self: center;
         font-size: var(--text-sm, 0.875rem);
         font-weight: 600;
         color: color-mix(in srgb, var(--main-text-color) 70%, transparent);
@@ -30,21 +33,18 @@
         margin-top: var(--space-3);
     }
 
+    // Templates tier — a responsive tile grid that fills the pane width
+    // (was a 520px-capped single column). auto-fill + minmax reflows the
+    // column count to the pane; `align-content: start` keeps a short list
+    // top-aligned rather than stretched.
     .agent-picker-list {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2);
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min), 1fr));
+        gap: var(--space-3);
+        align-content: start;
         flex: 1;
         overflow-y: auto;
-        // Cap list width so individual cards don't stretch to an
-        // awkwardly wide pane. The flex:1 info column inside each
-        // card expands to fill the card, which left a large gap
-        // between the title text and the action buttons on wide
-        // layouts. `max-width` + `align-self: center` keeps cards
-        // readable at narrow and wide pane widths alike.
-        max-width: 520px;
         width: 100%;
-        align-self: center;
     }
 
     // Two-tier picker (Phase 2 — Q2 Decision Y: hide templates).
@@ -52,9 +52,7 @@
     // under the templates tier, hidden entirely when no templates are
     // hidden (zero footprint by default).
     .agent-picker-hidden-templates {
-        max-width: 520px;
         width: 100%;
-        align-self: center;
         display: flex;
         flex-direction: column;
         gap: var(--space-2);
@@ -139,10 +137,15 @@
 
     .agent-card {
         position: relative;                // anchor for absolutely-positioned actions
+        // Tile layout: logo + title + caption stacked, uniform height so the
+        // grid rows align. (Was a horizontal row.) Extra bottom padding
+        // leaves room for the corner install ribbon / "+ New" affordance.
         display: flex;
-        align-items: center;
-        gap: var(--space-3);
-        padding: var(--space-3) 14px;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-2);
+        min-height: 92px;
+        padding: var(--space-3) var(--space-3) var(--space-4);
         border: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
         border-radius: 0;
@@ -271,15 +274,17 @@
             align-items: center;
             justify-content: center;
             flex-shrink: 0;
-            width: 28px;
-            height: 28px;
+            width: 32px;
+            height: 32px;
         }
 
         .agent-card-info {
             display: flex;
             flex-direction: column;
             gap: var(--space-0-5);
-            flex: 1;
+            // Tile: the info block spans the card width (was flex:1 in the
+            // old horizontal row) so title/caption ellipsis against the tile.
+            width: 100%;
             min-width: 0;
         }
 

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -39,7 +39,10 @@
     // top-aligned rather than stretched.
     .agent-picker-list {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min), 1fr));
+        // min(tile-min, 100%) so a pane narrower than the tile floor (tiled
+        // multi-pane layouts) collapses to one full-width column instead of
+        // forcing a 240px track that overflows/clips.
+        grid-template-columns: repeat(auto-fill, minmax(min(var(--agent-tile-min), 100%), 1fr));
         gap: var(--space-3);
         align-content: start;
         flex: 1;

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -10,10 +10,8 @@
     .agent-recent-sessions {
         display: flex;
         flex-direction: column;
-        gap: var(--space-1);
-        max-width: 520px;
+        gap: var(--space-2);
         width: 100%;
-        align-self: center;
         // Hard cap so the list doesn't swallow the picker when the
         // user has 20 active sessions. Internal scroll instead.
         max-height: 40vh;
@@ -56,9 +54,12 @@
         list-style: none;
         padding: 0;
         margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-1);
+        // Tile grid matching the templates tier — sessions flow across the
+        // full pane width instead of a single 520px column.
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min, 240px), 1fr));
+        gap: var(--space-2);
+        align-content: start;
         overflow-y: auto;
         // Scroll containment so wheeling inside the list doesn't
         // spill into the picker-list below once we hit the boundary.

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -57,7 +57,9 @@
         // Tile grid matching the templates tier — sessions flow across the
         // full pane width instead of a single 520px column.
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min, 240px), 1fr));
+        // min(..., 100%) so a sub-tile-width pane collapses to one column
+        // instead of overflowing (matches .agent-picker-list).
+        grid-template-columns: repeat(auto-fill, minmax(min(var(--agent-tile-min, 240px), 100%), 1fr));
         gap: var(--space-2);
         align-content: start;
         overflow-y: auto;


### PR DESCRIPTION
## Summary

The agent picker showed **My Agents** and **Templates** as single columns capped at `max-width: 520px` and centered — most of the pane was empty. Both are now **responsive tile grids that fill the pane** (Phase 1+2 of `SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md`).

- `.agent-picker-list` (Templates) and `.agent-recent-sessions-list` (My Agents) → `display: grid; grid-template-columns: repeat(auto-fill, minmax(var(--agent-tile-min, 240px), 1fr))`. Column count scales with pane width (1 → many); the body scrolls when full.
- Dropped the 520px caps + `align-self: center` on the lists/headers/hidden-templates.
- `.agent-card` reflowed from a horizontal **row → vertical tile** (logo / title / caption stacked, uniform `min-height`; corner install-ribbon and hover `+ New` unchanged).
- `--agent-tile-min` token on `.agent-picker` for one-place tuning of tile width / column density.

**SCSS-only** — existing markup and all handlers (launch/reattach, modifier-force-modal, `+New`, install state, hidden templates, delete) are reused as-is.

## Checks

- `stylelint`: no new violations (the 9 reported are the file's pre-existing grandfathered hex colors in the install ribbon / session styles — untouched).
- No TS changes.

## Test plan

- [ ] Open the picker on a wide pane → multiple columns of tiles, fills the width.
- [ ] Narrow the pane → reflows to fewer/one column.
- [ ] Many templates/sessions → grid scrolls (doesn't overflow the pane).
- [ ] Click-to-launch/reattach, `+New`, install ribbon, hidden templates, delete all still work.

Open decision (flagged in spec): tiles use hard corners (app convention); the Trust Center gallery uses 8px — easy to switch if you prefer rounded. Phase 3 (lone-tile sizing, line-clamp, density toggle, ultrawide cap) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)