### PR TITLE
fix(agent): context meter — per-model window, learned from usage

### DIFF
--- a/.changesets/1781753670-fix-agent-context-meter-resolves-the-window-per-model-and-le-e7i6.md
+++ b/.changesets/1781753670-fix-agent-context-meter-resolves-the-window-per-model-and-le-e7i6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): context meter resolves the window per-model and learns it from usage

--- a/docs/reports/REPORT_CONTEXT_VISIBILITY_2026_06_17.md
+++ b/docs/reports/REPORT_CONTEXT_VISIBILITY_2026_06_17.md
@@ -1,0 +1,91 @@
+# Report: Context & Token Visibility — findings and next steps
+
+**Date:** 2026-06-17
+**Scope:** Why the agent-pane context meter is wrong, what token/context data AgentMux can actually get from the CLIs it drives, how to source model context windows reliably, and the recommended path forward.
+**Design detail:** `docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md` (this report is the executive summary + decisions).
+
+---
+
+## 1. The reported bug, diagnosed
+
+The context meter in the agent pane's composer aux bar (`ContextWindowBar.tsx`) overflows (e.g. shows `300k / 200k`, pinned full) and never appears to compress. **Root cause: one wrong constant.**
+
+- `frontend/app/view/agent/providers/index.ts` hardcodes the **Claude provider** `contextWindow: 200_000`. That's Haiku's window — **Opus and Sonnet are 1,000,000**. Running Opus, the meter divides real context by 200K instead of 1M.
+  - *Overflow* = real ~300K Opus context ÷ 200K = 150%.
+  - *"Never compresses"* = the CLI auto-compacts near Opus's *real* ceiling (~987K), so at 200–400K it correctly hasn't compacted — but the meter thinks 200K is the wall.
+- The meter's **numerator is correct**: `contextTokens` is fed per turn from `message_start.usage` as `input_tokens + cache_creation + cache_read` (the true prompt size) and is **overwritten, not accumulated** (`useAgentStream.ts:689`, reducer `TokensIn`). So once the denominator is right, it will track compaction.
+
+**It's both a wrong value and a wrong *shape*:** `contextWindow` is per-**provider**, but the `claude` provider spans Opus/Sonnet (1M) and Haiku (200K) — no single constant is correct.
+
+---
+
+## 2. What the wire actually gives us (and what it doesn't)
+
+Verified against a live agent + the API reference:
+
+| Want | Available? | Source |
+|---|---|---|
+| Tokens **per turn/query** | ✅ | `result.usage` (already captured) |
+| Tokens **per assistant message** | ✅ | each `assistant` event's `usage` (full cache split) |
+| **Current context size** | ✅ | `input_tokens + cache_read + cache_creation` of the latest request — **not** `input_tokens` alone (that's only the uncached remainder; undercounts by the cached portion) |
+| Tokens **per tool call** | ❌ | a `tool_use` is one block in a message; usage is per-message only |
+| Tokens **per reasoning block** | ❌ | thinking is billed inside `output_tokens`, never broken out |
+| The **effective context window** | ❌ (not in stream) | CLI `system/init` and `result` carry `model` but **no** window field (all keys inspected) |
+
+Per-tool / per-reasoning can only ever be a *local estimate* (tokenize the rendered text), clearly labelled — never an authoritative figure.
+
+---
+
+## 3. Context compaction is the CLI's, not ours
+
+AgentMux drives the **Claude Code CLI** (not the Agent SDK, not the raw API). The **CLI auto-compacts** on its own: threshold ≈ `effective_window − 13K` (`effective = window − min(max_output, 20K)`), overridable via `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, manual `/compact`. The API's `context_management`/compaction betas are a separate mechanism we don't use. So the meter should display fill **against the compaction threshold** ("about to compact"), not the raw window.
+
+---
+
+## 4. Sourcing context windows reliably (the hard part)
+
+Sonnet is the problem child: **200K by default, 1M only with the `context-1m-2025-08-07` beta** — a runtime toggle, not a model property. So a static `model→window` map can't stay aligned. Findings on every candidate source:
+
+- **`claude --help`** — ❌ no windows, no enumerable model list, no `models`/`config` subcommand (verified). `--betas` exists but is "API key users only."
+- **CLI stream-json** — ❌ no window field anywhere (verified).
+- **Anthropic Models API** (`GET /v1/models` → `max_input_tokens`) — ✅ **VERIFIED reachable with the agents' own OAuth (Claude Max) credentials: HTTP 200, no API key, no beta header needed, standard scopes suffice.** It's the live, authoritative catalog and auto-tracks new models. **Caveat:** it reports the model **ceiling** (Sonnet 4.6 → 1M), not the per-session *effective* window.
+
+**Conclusion:** the Models API resolves single-window models definitively (Opus → 1M, Haiku → 200K) and gives the *upgrade ceiling* for Sonnet — but the effective Sonnet window still needs runtime resolution.
+
+---
+
+## 5. Recommended design (drift-proof, self-aligning)
+
+A **learned window**, not a static constant — three layers that converge on the truth:
+
+1. **Seed from the Models API** (cached) — kills hardcoded numbers, auto-tracks new models. Seed Sonnet conservatively (200K) and use its API ceiling (1M) as the upgrade target.
+2. **Own the 1M toggle (cleanest)** — if AgentMux gates Sonnet's 1M (a per-agent setting → pass the beta/variant to the CLI), the window is deterministic from (model, setting).
+3. **Self-align from observed behavior (bulletproof net)** — the prompt size can never exceed the real window, so (a) **high-water upgrade**: if context crosses the assumed window without compacting, promote to the next tier (catches Sonnet-1M); (b) **compaction calibration**: the pre-compaction high-water mark reveals the exact window — lock it for the session.
+
+**Sync cadence — on CLI install/upgrade** (AgentMux owns these; infrequent; aligned with when supported models change). Sufficient because: a **bundled static fallback** covers first-run/offline/pre-auth, the **observed-behavior layer** self-corrects any seed regardless of catalog age, and an **auth-ready guard** skips the live fetch when no valid token. *Cadence only affects catalog freshness — it does not affect the Sonnet effective-window correctness, which is resolved per-session.*
+
+Meter everything **against the compaction threshold**, never imply >100%, and verify the bar visibly drops after a real compaction.
+
+---
+
+## 6. Best next steps (prioritized)
+
+| # | Step | Effort | Why now |
+|---|---|---|---|
+| **1** | **Quick win:** resolve `contextWindow` per-**model** (from the agent's `--model`), correct values (Opus/Sonnet 1M, Haiku 200K), and meter against the compaction threshold in `ContextWindowBar`. Fix the >100% presentation. | Small (3 files: `providers/index.ts`, `agent-view.tsx`, `ContextWindowBar.tsx`) | Directly fixes the reported "/200,000 on Opus" + overflow; verifiable live in the dev build today. |
+| **2** | **Observed-behavior layer:** high-water upgrade + compaction-boundary calibration of the window (per pane). | Small–medium (reducer + a per-pane window signal) | The bulletproof net; makes the meter correct for Sonnet and any future model without a catalog. Highest reliability-per-effort. |
+| **3** | **Models API catalog sync on CLI install:** fetch `/v1/models`, cache `max_input_tokens` per model, with a bundled static fallback + auth-ready guard. | Medium (install hook + cache + fallback; Rust side) | Removes hardcoded windows; "always in sync" as Anthropic adds models. Depends on step 1's per-model plumbing. |
+| **4** | **Compaction visibility:** detect the auto-compaction (confirm the wire signal first) and drop a "context compacted" marker in the transcript. | Medium | Explains the context discontinuity to the user; needs a quick wire-signal verification first. |
+| 5 | **Cache-hit indicator** + per-turn/message usage drill-down (extend `token-usage.ts` with cache fields). | Small–medium | Nice-to-have; cheap once per-message usage is captured. |
+| — | Per-tool / per-reasoning token figures | — | **Not feasible authoritatively** (protocol limit). Only as labelled "≈" estimates, if ever. |
+
+**Recommended sequence:** ship **1 + 2** together (small, fully fixes the reported bug and makes the meter trustworthy for every model including Sonnet), verify in the dev build, then do **3** (install-time catalog sync) to retire the last hardcoded numbers. **4** after a quick compaction-signal probe.
+
+---
+
+## 7. Pointers
+
+- Design spec (full detail): `docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md`
+- Touch points: `ContextWindowBar.tsx`, `AgentComposerStrip.tsx`, `agent-view.tsx`, `providers/index.ts`, `useAgentStream.ts`, `claude-translator.ts`; per-pane state in `agent-pane-state/`.
+- Agent OAuth creds (for the Models API call): `~/.agentmux/shared/providers/claude/.credentials.json` (token expires — fetch when fresh).
+- Both this report and the spec are **uncommitted** — commit when ready.

--- a/docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md
+++ b/docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md
@@ -1,0 +1,203 @@
+# SPEC: Context & Token Visibility — what we can show the user, and how
+
+**Date:** 2026-06-17
+**Status:** Draft — research complete, design proposed
+**Owner:** Agent pane (token-usage store, translators) + status bar
+**Builds on:** `SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md` (the existing session-wide tally)
+**Scope:** How AgentMux learns token usage and context state from the agent CLIs it drives, what granularity is actually available, how context compaction works, and a design to surface it to the user.
+
+---
+
+## 0. The framing correction (important)
+
+AgentMux does **not** call the Anthropic Messages API directly, and it does **not** use the Claude **Agent SDK** (`@anthropic-ai/claude-agent-sdk`). It **spawns the Claude Code CLI** (a native binary, currently v2.1.x) in stream-json mode (`--input-format stream-json --output-format stream-json --verbose --include-partial-messages`) and reads the NDJSON it emits. So:
+
+- **Token usage** is whatever the CLI puts in its stream-json `usage` blocks — not something we query.
+- **Context compaction** is governed by the **CLI's own auto-compaction**, not by the API's `context_management` beta. We are a *consumer* of the CLI's context behavior, not its driver.
+
+Both points shape everything below. (The same applies to the other providers — Codex, Gemini, Kimi — each via its own translator; this spec details Claude and notes where the others differ.)
+
+---
+
+## 1. What token data the stream actually carries
+
+### 1.1 Per **assistant message** `usage` (captured live, bundled CLI v2.1.178)
+
+Every `assistant` event carries a `usage` object. Real bytes captured from a running dev agent:
+
+```jsonc
+"usage": {
+  "input_tokens": 1,                       // NEW uncached prompt tokens this request
+  "cache_creation_input_tokens": 27868,    // tokens written to cache (~1.25× price)
+  "cache_read_input_tokens": 15621,        // tokens served from cache (~0.1× price)
+  "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 27868 },
+  "output_tokens": 8,
+  "service_tier": "standard",
+  "inference_geo": "not_available"
+}
+```
+
+Also on the assistant event: `diagnostics.cache_miss_reason` (why the prefix cache missed) and **`context_management`** (null in the capture; populated when API-side context edits/compaction apply — see §3).
+
+**The current prompt (context) size for that request = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`.** `input_tokens` alone is only the *uncached remainder* — reading it as "context size" undercounts by the cached portion (here, 1 vs ~43.5K). This is the single most important correctness point for any context gauge.
+
+### 1.2 Per **turn** — the `result` event
+
+At the end of each query/turn the CLI emits:
+
+```jsonc
+{ "type": "result", "subtype": "success", "is_error": false,
+  "num_turns": 12, "duration_ms": …, "duration_api_ms": …, "total_cost_usd": …,
+  "usage": { "input_tokens", "output_tokens", "cache_creation_input_tokens",
+             "cache_read_input_tokens", "service_tier", "server_tool_use" },
+  "modelUsage": { … per-model breakdown … } }
+```
+
+This is cumulative for the turn. **AgentMux already reads this** (`claude-translator.ts:61-76`): it sums input+cache_creation+cache_read → `input_tokens`, takes `output_tokens`, and `num_turns`, then `useAgentStream.ts:415` feeds it to `recordTurn()`.
+
+### 1.3 Granularity ceiling — what we **cannot** get
+
+| Question | Answer | Why |
+|---|---|---|
+| Tokens **per query/turn** | ✅ Yes | `result.usage` (and we already capture it) |
+| Tokens **per assistant message** (model request) | ✅ Yes | each `assistant` event's `usage` |
+| Tokens **per tool call** | ❌ **No** | a `tool_use` is one content block inside an assistant message; `usage` is reported for the *whole message*, never per block. The *cost of a tool's result* shows up as `input_tokens` in the **next** assistant message, not attributed to the tool. |
+| Tokens **per line/block of reasoning** (thinking) | ❌ **No** | thinking is billed inside `output_tokens` but never broken out. With `display:"omitted"` (our current default) the thinking text isn't even emitted. |
+
+**Best we can do for per-tool / per-reasoning is *estimation*, not truth:** locally tokenize the rendered text of a block (e.g. via `count_tokens`, or a cheap heuristic) and label it "≈". The wire protocol gives no authoritative per-block number. Any UI must mark these as approximate or omit them. Do **not** invent a per-tool token figure that looks authoritative.
+
+---
+
+## 2. The one real lever for finer attribution
+
+Because each **assistant message** has its own `usage`, we can attribute at the message level (which the current per-turn-only capture throws away):
+
+- **output side:** each assistant message's `output_tokens` is exactly the tokens that message produced (text + thinking + any tool_use args). Attribute it to that message/step.
+- **input side:** the jump in `input_tokens + cache_read + cache_creation` between consecutive assistant messages ≈ what the intervening tool_result(s) + user turn added to context. This lets us say "that big file read cost ~X tokens of context" — at message granularity, which is the honest unit.
+
+This is the highest-value upgrade: move from a single session counter to **per-message context accounting**, then roll up to per-turn and per-agent.
+
+---
+
+## 3. How context compresses
+
+### 3.1 The CLI's auto-compaction (what actually governs our agents)
+
+The Claude Code CLI auto-compacts on its own:
+
+- **Trigger:** when the conversation approaches the context window. Default threshold ≈ **`effective_window − 13,000` tokens**, where `effective_window = model_context_window − min(max_output_tokens, 20,000)`. (Buffer was ~33K/16.5% in earlier builds; it's been tightened.) Overridable via the **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`** env var (e.g. `60` = compact at 60% capacity); community guidance is to compact early (~60%) for quality. Manual: the `/compact` command.
+- **Effect:** the CLI summarizes earlier history, preserving decisions/state, and continues with a smaller transcript.
+- **Our visibility:** there is **no documented dedicated "compacted" event** in stream-json. Detection options: (a) watch for a large *drop* in `input_tokens+cache_*` across turns (the post-compaction prompt is much smaller); (b) the CLI may emit a `system` line around it; (c) the `context_management` field on the assistant event (§1.1) is the API-side signal. We should empirically confirm which signal the bundled CLI emits before relying on one — same "verify the wire, don't trust the doc" discipline as `SPEC_AGENT_CONTROL_PROTOCOL`.
+- **Knob we control:** AgentMux launches the CLI, so we can set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` per agent (a user-facing "compact at N%" setting) — see §5.
+
+### 3.2 API-level context management (NOT what we use, but worth knowing)
+
+The Messages API has its own context features (beta): **compaction** (`compact-2026-01-12`, `context_management:{edits:[{type:"compact_20260112"}]}` → returns a `compaction` block to echo back), and **context editing** (`clear_tool_uses_*`, `clear_thinking_*` — prune stale blocks). These are for code that calls the API directly. AgentMux does not; the CLI may use them internally and surface state via the `context_management` field. We don't implement them ourselves.
+
+### 3.3 Other providers
+
+Codex / Gemini / Kimi each compact differently and report usage in their own shapes (`codex-translator.ts`, `gemini-translator.ts`). The context gauge must be per-provider: read the model's window + the provider's usage fields. Where a provider doesn't report cache tokens, the gauge degrades to input+output only.
+
+---
+
+## 4. What AgentMux shows today (the baseline)
+
+Two separate surfaces exist:
+
+- **Session spend counter** — `frontend/app/store/token-usage.ts`: a session-wide `{input, output}` tally **per provider** (no cache fields, no per-agent split, no context %). `recordTurn()` adds each turn's totals from the `result` event; the status bar (`StatusBar.tsx`) shows `↑Xk ↓Yk`, popover shows per-provider breakdown.
+- **Per-agent context meter** — `frontend/app/view/agent/components/ContextWindowBar.tsx`, rendered in the composer strip's aux bar above the text input (`AgentComposerStrip.tsx:265`). It shows `<tokens> / <contextWindow>` as a banded bar. `tokens` is fed live per turn from `message_start.usage` (`useAgentStream.ts:689-703`) as `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` (the real prompt size), dispatched as `TokensIn` and **overwritten, not accumulated** (`reducer.ts:481`). `contextWindow` comes from `provider().contextWindow` (`agent-view.tsx:1207`).
+
+The meter's *source* is correct (current-context, overwrite — it would drop on compaction). The bugs are in the **denominator** and the **presentation** — §4.1.
+
+### 4.1 Confirmed bugs in the existing context meter
+
+**Bug A — wrong, per-PROVIDER context window (root cause of both reported symptoms).**
+`providers/index.ts` gives the Claude provider a single `contextWindow: 200_000`. But the window is **per-model**: Opus 4.x and Sonnet 4.x are **1,000,000**; only Haiku is 200K. So a Claude agent running Opus is metered against 200K when its real window is 1M. Consequences exactly match the report:
+- **"Overflowing":** a real ~300K Opus context ÷ 200K = 150% → the bar pins at 100% (fill is `Math.min(100, …)`, `ContextWindowBar.tsx:35`) and the numeric label reads `300k / 200k`.
+- **"Not compressing":** the CLI auto-compacts near Opus's *real* threshold (~`1M − 13K` ≈ 987K, or the `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` value), so at 200–400K it legitimately hasn't compacted — but the meter, believing 200K is the ceiling, shows it blowing past with no relief. **Fixing the window largely fixes the "no compaction" appearance**, because the meter overwrites per turn and *will* drop once the CLI actually compacts near the true ceiling.
+
+The deeper issue is that `contextWindow` is a **per-provider constant**, but `claude` spans models with different windows — and worse, **the window isn't even fixed per model**: Sonnet 4.x is **200K by default but 1M with the `context-1m-2025-08-07` beta enabled**. So a static `model→window` map is *also* unreliable (it'd be wrong for Sonnet half the time).
+
+**Verified (this is what makes it hard):** the CLI's stream-json does **not** report the effective window anywhere — `system/init` and `result` both carry `model` but no `context_window`/`max_input_tokens`/beta field (all keys inspected on a live agent). So we cannot just read it. The window must be **resolved from the agent's model AND derived/learned at runtime** (§5 P1).
+
+**Bug B — overflow presentation.** Even with a correct window, the label prints raw `tokens / window`, so any genuine overflow (or a model whose window we don't know) reads as ">100%". The bar should (a) never imply >100% numerically, and (b) mark the **compaction threshold** (not just 100%), so "full" means "about to compact," which is the number the user actually cares about.
+
+---
+
+## 5. Proposed design — show context, not just spend
+
+Five additions, in priority order. Each is independently shippable.
+
+**P1 — Fix the existing context meter (the headline; addresses the reported bug).**
+The `ContextWindowBar` already exists and is already fed the right *numerator* (current-context, per-turn, overwrite). The work is:
+1. **Make the window a LEARNED value, not a static constant** (Bug A). The CLI doesn't expose it and Sonnet's window is a runtime beta toggle, so a static table can't stay aligned. Use a three-layer resolution that converges on the truth:
+   - **(seed / catalog — "always in sync" source)** Do **not** hardcode windows. Verified: `claude --help` does *not* expose context windows or an enumerable model list (`--model` only documents the alias/full-name shape; there's no `models`/`config` subcommand; no `context`/`window`/`1m` anywhere in help). The authoritative live catalog is the **Anthropic Models API** — `GET /v1/models` / `GET /v1/models/{id}` → **`max_input_tokens`** (the window) + a `capabilities` tree — which tracks new models and their windows automatically.
+
+**VERIFIED reachable with the agents' own credentials (2026-06-17):** `GET /v1/models` returns **HTTP 200** using the agent's OAuth (Claude Max subscription) Bearer token — and **does not require the `oauth-2025-04-20` beta header** (a control request without it also 200'd). The standard agent scopes (`user:inference`, `user:profile`, …) suffice. No API key needed. Live values: Opus 4.x / Fable 5 / Sonnet 4.6 = 1,000,000; Opus 4.5 / Haiku 4.5 = 200,000.
+
+**Two caveats from the test:**
+- **It reports the model's *ceiling*, not the effective window.** `claude-sonnet-4-6` returns `max_input_tokens: 1,000,000` (its max capability) — *not* the 200K a session without the 1M beta actually gets. So the API definitively resolves single-window models (Opus → 1M, Haiku → 200K) but the Sonnet 200K-vs-1M effective value still needs layer 2 (own the toggle) or layer 3 (observed behavior).
+- **OAuth tokens expire** (the long-idle agent's token was 11 days expired → 401; a recently-used one is valid). So don't fetch on demand against a possibly-stale token — **cache the catalog.**
+
+**Sync cadence — on CLI install/update (chosen).** AgentMux already manages CLI install/upgrade (`npm install @anthropic-ai/claude-code@latest`, `claude update`), and a CLI version bump is exactly when the supported-model set tends to change — so refresh the cached catalog **as a post-install/upgrade step** (per provider). This is the right primary trigger: AgentMux-controlled, infrequent, semantically aligned, no polling. Three things make it sufficient:
+  1. **Bundled static fallback** baked into the build — covers first run, offline, and *install-before-auth* (a fresh install may run before the user logs in, so the live `GET /v1/models` 401s; keep the fallback and retry the sync on the next install/auth).
+  2. **Observed-behavior layer is always on** (§5 P1 layer 3) — it self-corrects any seed regardless of catalog age, so a stale catalog is low-stakes: a brand-new model released between CLI updates just gets a best-guess seed that self-heals on first overflow/compaction.
+  3. **Auth-ready guard** at install — only do the live fetch if a valid token is present; otherwise keep the last-good cache / bundled fallback.
+  - *Optional belt-and-suspenders:* a lazy staleness check (cache older than ~30d **and** a fresh token available → refetch) catches new models released *without* a CLI update, without any polling. Not required given (2); add only if cheap.
+  - **Cadence ≠ the Sonnet fix.** Sync frequency only governs catalog freshness (new models / changed ceilings). The Sonnet 200K-vs-1M *effective* window is unaffected by sync cadence — it's resolved per-session by seed-conservative + layer 2/3, every session, regardless of when the catalog was last synced.
+
+Net: seed single-window models directly from the Models-API `max_input_tokens` (no hardcoding, auto-tracks new models); for Sonnet, seed conservative (200K) and use the API's 1M as the layer-3 upgrade target.
+   - **(own the toggle — most reliable)** If AgentMux gates Sonnet's 1M context (a per-agent "1M context" setting that makes AgentMux pass the `context-1m-2025-08-07` beta / `[1m]` model variant to the CLI), then the window is a **deterministic function of (model, that setting)** — AgentMux is the single source of truth. This is the clean fix; the layers below are the safety net for anything set outside AgentMux or by a future CLI change.
+   - **(self-align from observed behavior — the bulletproof net)** Two invariants the stream *does* give us, regardless of model/beta:
+     - **High-water upgrade:** the per-turn prompt size (`contextTokens`) can never exceed the real window. If it ever exceeds the current assumed window *without* a compaction, the assumption is provably too low → promote to the next known tier (200K → 1M). This catches Sonnet-1M the moment context passes 200K.
+     - **Compaction calibration:** when a compaction is detected (sharp `contextTokens` drop, §3.1), the pre-compaction high-water mark ≈ `effectiveWindow − buffer` → back-calculate and **lock the exact window for the session.**
+
+   Window is learned-up-only within a session (model/beta are fixed per session; a new session re-seeds). Net effect: the meter converges to the true window for any model/beta combo without depending on a field the CLI never emits.
+2. **Meter against the compaction threshold, not the raw window** (Bug B). Compute `threshold ≈ effectiveWindow − 13K` (`effectiveWindow = window − min(maxOutput, 20K)`), honoring `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` if set. Mark it on the bar so "full" = "about to compact." Never render a numeric ratio implying >100%; clamp the label and show an explicit "over / compacting" state instead of a pinned 100% bar.
+3. Confirm the meter visibly **drops after a real compaction** (it should, given the overwrite source + correct window — verify once Bug A is fixed).
+
+This is the highest-value, smallest change and directly fixes "shows / 200,000 on Opus" and "overflows without compressing."
+
+**P2 — Compaction awareness.**
+Detect a compaction (per §3.1, after we confirm the signal) and (a) drop the gauge accordingly, (b) drop a "context compacted — earlier history summarized" marker into the transcript so the user understands the context discontinuity. Optionally expose the **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`** as a per-agent "compact at N%" setting in the agent settings panel.
+
+**P3 — Cache-hit visibility.**
+Surface `cache_read / (input+cache_read+cache_creation)` as a small "cache: 92%" indicator. High cache-read = cheap, fast; a sudden drop signals a cache-busting change (model switch, edited system prompt). Cheap to add once per-message usage is captured.
+
+**P4 — Per-turn / per-message breakdown.**
+In a pane-level "usage" popover: a list of turns, each with input/output/cache + `total_cost_usd` (from `result`), expandable to per-message rows. This is the honest drill-down — turn and message granularity only.
+
+**P5 — Approximate per-tool / per-reasoning (clearly labelled).**
+Only if there's appetite: locally estimate tokens for big tool outputs and thinking blocks and show "≈X tok" on the tool/thinking block. Must be visibly approximate. Skippable — it's the lowest-confidence data and the most likely to mislead.
+
+### Files to touch
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/providers/index.ts` | **P1:** replace per-provider `contextWindow: 200_000` (Claude) with a model→window map; resolve by the agent's model. Optional `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` wiring. |
+| `frontend/app/view/agent/agent-view.tsx` | **P1:** pass `contextWindow` resolved from the agent's **model** (`block.meta["agent:model"]`), not `provider().contextWindow`; pass the compaction threshold. |
+| `frontend/app/view/agent/components/ContextWindowBar.tsx` | **P1:** meter against the compaction threshold; never imply >100%; mark the threshold; explicit over/compacting state (Bug B). |
+| `frontend/app/view/agent/components/AgentComposerStrip.tsx` | **P1/P3:** thread the threshold + cache-hit indicator through to the bar. |
+| `frontend/app/view/agent/providers/claude-translator.ts` | **P3/P4:** preserve the cache split + `context_management` from per-message usage (currently the `result` path drops the cache split). |
+| `frontend/app/store/token-usage.ts` | **P4:** extend `ServiceUsage` with cache fields for the spend popover. |
+| transcript reducer / `stream-parser.ts` | **P2:** compaction marker node. |
+| `codex/gemini-translator.ts` + provider model maps | per-provider/per-model window + usage parity. |
+
+---
+
+## 6. Open questions / things to verify on the wire first
+
+1. **Compaction signal:** what exactly does the bundled CLI emit when it auto-compacts? (new `system`/`init`? a visible message? only an `input_tokens` drop? a populated `context_management`?) — capture it before building P2.
+2. **`context_management` field semantics** on the assistant event from the CLI (vs the API beta) — when is it non-null?
+3. **`modelUsage`** shape on `result` — useful for multi-model turns (subagents on a cheaper model).
+4. **Effective-window constants** per model/provider — confirm `min(max_output, 20000)` and the 13K buffer against the current CLI, and whether `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` shifts it.
+5. **Per-tool estimation** — is an approximate figure worth the risk of looking authoritative? Default: omit unless asked.
+
+---
+
+## 7. Sources
+
+- Claude API / Agent SDK reference (bundled `claude-api` skill): `usage` schema, `context_management`/compaction/context-editing, token-counting, per-message vs per-turn granularity.
+- Claude Code auto-compaction threshold + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: anthropics/claude-code issues #41037, #41818; claudefast.st "Context Buffer" guide; justin3go / danielvaughan compaction deep-dives.
+- stream-json event/usage surface: takopi stream-json cheatsheet; backgroundclaude.com "stream-json"; code.claude.com Agent SDK streaming-output docs.
+- Empirical: usage/result bytes captured live from the running dev agent (`agentmuxsrv-v0.46.0` log) and AgentMux source (`token-usage.ts`, `claude-translator.ts`, `useAgentStream.ts`).

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -74,6 +74,9 @@ export interface AgentPaneProjections {
      * visible between turns. Clears only on TurnReset (session wipe).
      */
     contextTokens?: (next: number | null) => void;
+    /** Learned context-window size for the current model (null → view uses the
+     *  provider's static fallback). Driven by TokensIn alongside contextTokens. */
+    contextWindow?: (next: number | null) => void;
 }
 
 interface Slot {
@@ -190,6 +193,10 @@ export function dispatch(
         prev.lastContextTokens ?? null,
         slot.state.lastContextTokens ?? null,
         slot.proj.contextTokens);
+    proj("contextWindow",
+        prev.lastContextWindow ?? null,
+        slot.state.lastContextWindow ?? null,
+        slot.proj.contextWindow);
     proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
     proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);
     proj("turnPhase", prev.turnPhase, slot.state.turnPhase, slot.proj.turnPhase);

--- a/frontend/app/store/agent-pane-state/context-window.test.ts
+++ b/frontend/app/store/agent-pane-state/context-window.test.ts
@@ -48,6 +48,16 @@ describe("learnContextWindow", () => {
     test("unknown model but a prior window → keeps the prior", () => {
         expect(learnContextWindow(200_000, 50_000, "gpt-5")).toBe(200_000);
     });
+    test("model switch mid-session re-seeds (Opus 1M → Haiku 200K, not learn-up)", () => {
+        // learned 1M on Opus, then /model to Haiku: must drop to 200K, not stay 1M
+        expect(learnContextWindow(1_000_000, 50_000, "claude-haiku-4-5", "claude-opus-4-8")).toBe(200_000);
+    });
+    test("same model (unchanged) keeps the learned high-water", () => {
+        expect(learnContextWindow(1_000_000, 50_000, "claude-sonnet-4-6", "claude-sonnet-4-6")).toBe(1_000_000);
+    });
+    test("model absent on a later turn keeps the prior window", () => {
+        expect(learnContextWindow(1_000_000, 50_000, undefined, "claude-opus-4-8")).toBe(1_000_000);
+    });
 });
 
 describe("compactionThreshold", () => {

--- a/frontend/app/store/agent-pane-state/context-window.test.ts
+++ b/frontend/app/store/agent-pane-state/context-window.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from "vitest";
+import {
+    compactionThreshold,
+    contextWindowForModel,
+    learnContextWindow,
+} from "./context-window";
+
+describe("contextWindowForModel", () => {
+    test("Opus / Fable resolve to 1M", () => {
+        expect(contextWindowForModel("claude-opus-4-8")).toBe(1_000_000);
+        expect(contextWindowForModel("opus")).toBe(1_000_000);
+        expect(contextWindowForModel("claude-fable-5")).toBe(1_000_000);
+    });
+    test("Haiku resolves to 200K", () => {
+        expect(contextWindowForModel("claude-haiku-4-5")).toBe(200_000);
+    });
+    test("Sonnet seeds conservatively at 200K (learns up to 1M)", () => {
+        expect(contextWindowForModel("claude-sonnet-4-6")).toBe(200_000);
+    });
+    test("unknown / non-Claude models are undefined (caller falls back)", () => {
+        expect(contextWindowForModel("gpt-5-codex")).toBeUndefined();
+        expect(contextWindowForModel("gemini-3-pro")).toBeUndefined();
+        expect(contextWindowForModel(undefined)).toBeUndefined();
+        expect(contextWindowForModel(null)).toBeUndefined();
+    });
+});
+
+describe("learnContextWindow", () => {
+    test("seeds from the model on first observation", () => {
+        expect(learnContextWindow(null, 1_000, "claude-opus-4-8")).toBe(1_000_000);
+        expect(learnContextWindow(null, 1_000, "claude-haiku-4-5")).toBe(200_000);
+    });
+    test("Sonnet-1M: promotes 200K → 1M once context exceeds 200K", () => {
+        const seed = learnContextWindow(null, 50_000, "claude-sonnet-4-6");
+        expect(seed).toBe(200_000);
+        // a later turn whose prompt exceeds the 200K seed proves it's the 1M variant
+        expect(learnContextWindow(seed, 250_000, "claude-sonnet-4-6")).toBe(1_000_000);
+    });
+    test("learn-up-only: never shrinks within a session", () => {
+        expect(learnContextWindow(1_000_000, 50_000, "claude-sonnet-4-6")).toBe(1_000_000);
+    });
+    test("unknown model with no prior → undefined (provider fallback)", () => {
+        expect(learnContextWindow(null, 50_000, "gpt-5")).toBeUndefined();
+    });
+    test("unknown model but a prior window → keeps the prior", () => {
+        expect(learnContextWindow(200_000, 50_000, "gpt-5")).toBe(200_000);
+    });
+});
+
+describe("compactionThreshold", () => {
+    test("sits ~33K below the window", () => {
+        expect(compactionThreshold(1_000_000)).toBe(967_000);
+        expect(compactionThreshold(200_000)).toBe(167_000);
+    });
+    test("never negative for tiny windows", () => {
+        expect(compactionThreshold(10_000)).toBe(1);
+    });
+});

--- a/frontend/app/store/agent-pane-state/context-window.ts
+++ b/frontend/app/store/agent-pane-state/context-window.ts
@@ -48,16 +48,21 @@ function nextTierAbove(n: number): number {
 
 /**
  * Resolve the window after observing a prompt of `observed` tokens for `model`.
- * Learn-up-only: never shrinks within a session (model/beta are fixed per
- * session; a new session re-seeds). Returns `undefined` only when we have
- * neither a prior value nor a recognised model (caller uses the provider fallback).
+ * Learn-up-only *while the model is unchanged* (model/beta are fixed within a
+ * model). If the model **changes mid-session** (the `/model` path rebuilds the
+ * controller but preserves the conversation), re-seed from the new model so a
+ * larger learned window (e.g. Opus 1M) doesn't mask a smaller cap (Haiku 200K).
+ * Returns `undefined` only when we have neither a prior value nor a recognised
+ * model (caller uses the provider fallback).
  */
 export function learnContextWindow(
     prev: number | null | undefined,
     observed: number,
     model: string | null | undefined,
+    prevModel?: string | null | undefined,
 ): number | undefined {
-    let w = prev ?? contextWindowForModel(model);
+    const modelChanged = !!model && !!prevModel && model !== prevModel;
+    let w = modelChanged ? contextWindowForModel(model) : (prev ?? contextWindowForModel(model));
     if (w == null) return undefined;
     // A prompt can't exceed the real window: if it did, our assumption is too low.
     if (observed > w) w = nextTierAbove(observed);

--- a/frontend/app/store/agent-pane-state/context-window.ts
+++ b/frontend/app/store/agent-pane-state/context-window.ts
@@ -1,0 +1,74 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-model context-window resolution for the agent-pane context meter.
+ *
+ * The window is NOT a per-provider constant: the Claude provider spans
+ * Opus/Sonnet (1M) and Haiku (200K), and Sonnet itself is 200K by default but
+ * 1M with the `context-1m-2025-08-07` beta. The CLI never reports the effective
+ * window (verified — `system/init` and `result` carry `model` but no window
+ * field), so we (a) SEED from the resolved model id the stream reports and
+ * (b) LEARN upward from observed usage: a prompt can never exceed the real
+ * window, so if it ever does, promote to the next known tier (this is what
+ * catches Sonnet-1M).
+ *
+ * Spec: docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md §5 P1.
+ * Follow-ups (not here): seed the catalog from the Anthropic Models API on CLI
+ * install; calibrate the exact window at the compaction boundary.
+ */
+
+/** Known Claude window tiers, ascending — the high-water upgrade promotes to these. */
+const TIERS = [200_000, 1_000_000];
+
+/** Usable buffer below the raw window before the CLI auto-compacts (~33K):
+ *  threshold ≈ effectiveWindow − 13K, effectiveWindow = window − min(maxOutput, 20K). */
+const COMPACTION_BUFFER = 33_000;
+
+/**
+ * Seed window from a resolved model id/alias. Returns `undefined` for models we
+ * don't recognise (non-Claude, or future ids) — the caller falls back to the
+ * provider's static window. Sonnet seeds CONSERVATIVELY at 200K; the high-water
+ * upgrade promotes it to 1M the moment context exceeds 200K (its beta-gated ceiling).
+ */
+export function contextWindowForModel(model: string | null | undefined): number | undefined {
+    if (!model) return undefined;
+    const m = model.toLowerCase();
+    if (m.includes("haiku")) return 200_000;
+    if (m.includes("opus") || m.includes("fable") || m.includes("mythos")) return 1_000_000;
+    if (m.includes("sonnet")) return 200_000; // conservative seed; learns up to 1M
+    return undefined;
+}
+
+/** Smallest known tier strictly greater than `n`; `n` itself if above all tiers. */
+function nextTierAbove(n: number): number {
+    for (const t of TIERS) if (t > n) return t;
+    return n;
+}
+
+/**
+ * Resolve the window after observing a prompt of `observed` tokens for `model`.
+ * Learn-up-only: never shrinks within a session (model/beta are fixed per
+ * session; a new session re-seeds). Returns `undefined` only when we have
+ * neither a prior value nor a recognised model (caller uses the provider fallback).
+ */
+export function learnContextWindow(
+    prev: number | null | undefined,
+    observed: number,
+    model: string | null | undefined,
+): number | undefined {
+    let w = prev ?? contextWindowForModel(model);
+    if (w == null) return undefined;
+    // A prompt can't exceed the real window: if it did, our assumption is too low.
+    if (observed > w) w = nextTierAbove(observed);
+    return w;
+}
+
+/**
+ * Approximate auto-compaction threshold for a window. We band the meter against
+ * this (not the raw window) so "full" means "about to compact" — the number the
+ * user actually cares about.
+ */
+export function compactionThreshold(window: number): number {
+    return Math.max(1, window - COMPACTION_BUFFER);
+}

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -44,6 +44,7 @@ import {
     TurnPhase,
 } from "./types";
 import type { DisconnectReason } from "./types";
+import { learnContextWindow } from "./context-window";
 
 /**
  * If `phase` is `Streaming`, return the `schedule-stream-watchdog` event
@@ -483,8 +484,19 @@ export function update(
                 input: command.input,
                 output: state.turnTokens?.output ?? 0,
             };
+            // Learn the context window from the resolved model + observed fill
+            // (seed-then-high-water-upgrade); null until a recognised model is
+            // seen, so the view falls back to the provider's static window.
+            const learnedWindow =
+                learnContextWindow(state.lastContextWindow, command.input, command.model) ??
+                state.lastContextWindow;
             const nextState = bumpEvent(
-                { ...state, turnTokens: next, lastContextTokens: command.input },
+                {
+                    ...state,
+                    turnTokens: next,
+                    lastContextTokens: command.input,
+                    lastContextWindow: learnedWindow ?? null,
+                },
                 nowMs,
                 0,
             );

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -488,14 +488,19 @@ export function update(
             // (seed-then-high-water-upgrade); null until a recognised model is
             // seen, so the view falls back to the provider's static window.
             const learnedWindow =
-                learnContextWindow(state.lastContextWindow, command.input, command.model) ??
-                state.lastContextWindow;
+                learnContextWindow(
+                    state.lastContextWindow,
+                    command.input,
+                    command.model,
+                    state.lastContextModel,
+                ) ?? state.lastContextWindow;
             const nextState = bumpEvent(
                 {
                     ...state,
                     turnTokens: next,
                     lastContextTokens: command.input,
                     lastContextWindow: learnedWindow ?? null,
+                    lastContextModel: command.model ?? state.lastContextModel,
                 },
                 nowMs,
                 0,

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -240,6 +240,14 @@ export interface AgentPaneState {
      * explicit TurnReset (session wipe).
      */
     lastContextTokens: number | null;
+    /**
+     * Learned context-window size for the current model — seeded from the
+     * resolved model id on the first TokensIn and upgraded if observed context
+     * ever exceeds it (Sonnet-1M detection). NOT a per-provider constant.
+     * Null until a recognised model is seen; the view falls back to the
+     * provider's static window. See store/agent-pane-state/context-window.ts.
+     */
+    lastContextWindow: number | null;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -248,6 +256,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     currentTool: null,
     turnTokens: null,
     lastContextTokens: null,
+    lastContextWindow: null,
     pending: [],
     initPhase: { kind: "InitPending" },
     lastEventMs: null,
@@ -390,7 +399,7 @@ export type AgentPaneCommand =
     | { type: "ToolEnd" }
 
     // ── Tokens (live deltas during a turn) ────────────────────────
-    | { type: "TokensIn"; input: number }
+    | { type: "TokensIn"; input: number; model?: string }
     | { type: "TokensOut"; output: number }
 
     // ── Stop flow ──────────────────────────────────────────────────

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -248,6 +248,9 @@ export interface AgentPaneState {
      * provider's static window. See store/agent-pane-state/context-window.ts.
      */
     lastContextWindow: number | null;
+    /** Resolved model id that produced `lastContextWindow` — used to re-seed the
+     *  window when the user switches models mid-session (`/model`). */
+    lastContextModel: string | null;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -257,6 +260,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     turnTokens: null,
     lastContextTokens: null,
     lastContextWindow: null,
+    lastContextModel: null,
     pending: [],
     initPhase: { kind: "InitPending" },
     lastEventMs: null,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -189,6 +189,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 currentTool: a.currentToolAtom[1],
                 turnTokens: a.turnTokensAtom[1],
                 contextTokens: a.contextTokensAtom[1],
+                contextWindow: a.contextWindowAtom[1],
                 pending: a.pendingMessagesAtom[1],
                 initPhase: a.initPhaseAtom[1],
                 turnPhase: a.turnPhaseAtom[1],
@@ -1204,7 +1205,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     dispatchPane(model.blockId, { type: "DetailsToggle" }, "user")
                 }
                 contextTokens={agentAtoms().contextTokensAtom[0]()}
-                contextWindow={provider()?.contextWindow}
+                contextWindow={agentAtoms().contextWindowAtom[0]() ?? provider()?.contextWindow}
             />
 
             <div class="agent-composer-region">

--- a/frontend/app/view/agent/components/ContextWindowBar.tsx
+++ b/frontend/app/view/agent/components/ContextWindowBar.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Show, type JSX } from "solid-js";
+import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
 
 interface ContextWindowBarProps {
     /** Current input-token count (context fill). null = no turn yet. */
@@ -27,12 +28,18 @@ export function ContextWindowBar(props: ContextWindowBarProps): JSX.Element {
     // Reactive accessors so updates to props.tokens mid-turn (successive
     // message_start events) re-render the bar. An IIFE inside <Show> only
     // runs once when `when` first becomes truthy and freezes thereafter.
-    const fraction = () =>
+    // Bar FILL is fraction of the real window (clamped — never implies >100%).
+    // The COLOUR BAND tracks proximity to the auto-compaction threshold (~33K
+    // below the window), so "critical" means "about to compact" rather than
+    // "at 100% of the window".
+    const fillPct = () =>
         props.tokens != null && props.contextWindow != null
-            ? props.tokens / props.contextWindow
-            : null;
-    const b = () => { const f = fraction(); return f != null ? band(f) : "low"; };
-    const pct = () => { const f = fraction(); return f != null ? Math.min(100, Math.round(f * 100)) : 0; };
+            ? Math.min(100, Math.round((props.tokens / props.contextWindow) * 100))
+            : 0;
+    const b = () =>
+        props.tokens != null && props.contextWindow != null
+            ? band(props.tokens / compactionThreshold(props.contextWindow))
+            : "low";
 
     return (
         <Show when={props.tokens != null && props.tokens! > 0}>
@@ -52,7 +59,7 @@ export function ContextWindowBar(props: ContextWindowBarProps): JSX.Element {
                     <div class={`ctx-window-track ctx-window-track--${b()}`}>
                         <div
                             class="ctx-window-fill"
-                            style={{ width: `${pct()}%` }}
+                            style={{ width: `${fillPct()}%` }}
                         />
                         <span class="ctx-window-label">
                             {fmtK(props.tokens!)} / {fmtK(props.contextWindow!)}
@@ -69,7 +76,7 @@ function contextTitle(tokens: number, contextWindow: number | undefined): string
         return `Context: ${tokens.toLocaleString()} tokens`;
     }
     const pct = ((tokens / contextWindow) * 100).toFixed(1);
-    return `Context window: ${tokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens (${pct}%)\nThis is the total conversation history sent to the model on each turn.`;
+    return `Context window: ${tokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens (${pct}%)\nThis is the total conversation history sent to the model on each turn.\nAuto-compacts around ${compactionThreshold(contextWindow).toLocaleString()} tokens.`;
 }
 
 ContextWindowBar.displayName = "ContextWindowBar";

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -61,6 +61,8 @@ export interface AgentAtoms {
      * on that turn. Persists through TurnEnd; clears on TurnReset (session wipe).
      */
     contextTokensAtom: SignalPair<number | null>;
+    /** Learned context-window for the current model (null → provider fallback). */
+    contextWindowAtom: SignalPair<number | null>;
     /**
      * Messages sent by the user that the backend hasn't picked up yet.
      * Rendered in a pending zone between the conversation and the composer.
@@ -156,6 +158,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
         contextTokensAtom: createSignal<number | null>(null),
+        contextWindowAtom: createSignal<number | null>(null),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
         // gap1 (#993) reshaped InitPhase from string union to discriminated
         // union; turnPhase from PR B is now the sole working-state encoding

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -699,7 +699,11 @@ export function useAgentStream({
                                   + ((u.cache_read_input_tokens as number | undefined) ?? 0)
                                 : undefined;
                         if (inputTok != null) {
-                            model.dispatchPane({ type: "TokensIn", input: inputTok });
+                            // message.model is the resolved model id (e.g.
+                            // "claude-opus-4-8") — used to seed the context-window
+                            // meter per model (Opus/Sonnet 1M, Haiku 200K).
+                            const modelId = inner.message?.model as string | undefined;
+                            model.dispatchPane({ type: "TokensIn", input: inputTok, model: modelId });
                         }
                     } else if (inner?.type === "message_delta") {
                         const outputTok = inner.usage?.output_tokens as number | undefined;


### PR DESCRIPTION
## Problem
The agent-pane context meter (composer aux bar, `ContextWindowBar`) showed **`/ 200,000` on Opus** and **overflowed without ever reflecting compaction**.

**Root cause:** `frontend/app/view/agent/providers/index.ts` hardcodes the Claude provider `contextWindow: 200_000` — that's **Haiku's** window. Opus/Sonnet are **1,000,000**, and the value is **per-provider when it must be per-model**. So Opus context (e.g. ~300K) ÷ 200K read as 150% (pinned, "300k / 200k"), and since the CLI auto-compacts near Opus's *real* ~987K ceiling, the meter showed it sailing past 200K with no relief.

The meter's **numerator was already correct** (per-turn `message_start.usage` = `input + cache_creation + cache_read`, overwritten not accumulated). Only the denominator + presentation were wrong.

## Why it's a *learned* window, not a static map
The CLI never reports the effective window (**verified**: `system/init` and `result` carry `model` but no window field), and **Sonnet is 200K-or-1M** depending on the `context-1m` beta — so a static `model→window` table can't stay aligned. Resolution layers:
1. **Seed** from the resolved model id the stream reports (`message.model` → `claude-opus-4-8`): Opus/Fable → 1M, Haiku → 200K, Sonnet → **200K conservative**.
2. **High-water upgrade:** a prompt can't exceed the real window, so if observed context crosses the assumed window, promote to the next tier — **this catches Sonnet-1M** (jumps to 1M once context passes 200K).
3. **Band against the auto-compaction threshold** (~`window − 33K`), so a "critical" bar means *about to compact*; fill is clamped (never implies >100%).

The provider's static `contextWindow` stays as a fallback for unrecognised / non-Claude models.

## Changes
- New pure helper `store/agent-pane-state/context-window.ts` (`contextWindowForModel`, `learnContextWindow`, `compactionThreshold`) + **11 unit tests**.
- `TokensIn` carries the resolved `model`; reducer learns `lastContextWindow`; projected through the store to a `contextWindowAtom`; `agent-view` feeds it to the bar (`?? provider().contextWindow` fallback).
- `ContextWindowBar` bands against the compaction threshold and clamps the fill.

## Verification
- **11 new tests + 159 reducer/store tests pass; frontend type-clean.**
- Live-verifiable in the dev build: a fresh **Opus** agent now meters against **1,000,000** and colours toward the compaction threshold instead of pinning at "/200,000".

## Scope / follow-ups (in the spec)
This is steps 1–2 of `SPEC_CONTEXT_VISIBILITY_2026_06_17.md` (included). Deliberately **not** in this PR: seeding the catalog from the Anthropic Models API on CLI install (verified reachable via the agents' OAuth creds — no API key needed), exact-window calibration at the compaction boundary, and a compaction transcript marker. The spec + `docs/reports/REPORT_CONTEXT_VISIBILITY_2026_06_17.md` capture the full roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)