### PR TITLE
refactor(agent/providers): shared ToolCorrelator for tool-call/result mapping (audit A7)

### DIFF
--- a/.changesets/1781758234-refactor-agent-providers-extract-shared-toolcorrelator-for-t-vbf9.md
+++ b/.changesets/1781758234-refactor-agent-providers-extract-shared-toolcorrelator-for-t-vbf9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agent/providers): extract shared ToolCorrelator for tool-call/result mapping (architecture audit A7)

--- a/frontend/app/view/agent/providers/acp-translator.ts
+++ b/frontend/app/view/agent/providers/acp-translator.ts
@@ -1,8 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
+import { ToolCorrelator, wrapOutput } from "./tool-correlation";
 
 /**
  * Universal translator for agents speaking the Agent Client Protocol (ACP).
@@ -21,8 +22,8 @@ import type { OutputTranslator } from "./translator";
  * See: https://github.com/agentclientprotocol/agent-client-protocol
  */
 export class AcpTranslator implements OutputTranslator {
-    // Map tool call IDs to tool names for result correlation
-    private toolNameById: Map<string, string> = new Map();
+    // Correlates tool call IDs to tool names for result resolution.
+    private tools = new ToolCorrelator();
 
     translate(rawEvent: any): StreamEvent[] {
         if (!rawEvent || typeof rawEvent !== "object") return [];
@@ -49,29 +50,23 @@ export class AcpTranslator implements OutputTranslator {
                 const toolName: string = params.toolName ?? params.name ?? "unknown";
                 const toolId: string = params.toolCallId ?? params.id ?? `tool-${Date.now()}`;
                 const toolParams: Record<string, any> = params.input ?? params.parameters ?? {};
-                this.toolNameById.set(toolId, toolName);
-                const ev: ToolCallEvent = {
-                    type: "tool_call",
-                    tool: toolName,
-                    id: toolId,
-                    params: toolParams,
-                };
-                return [ev];
+                return [this.tools.call(toolName, toolId, toolParams)];
             }
 
             case "tool_result": {
                 const toolId: string = params.toolCallId ?? params.id ?? "";
-                const toolName = this.toolNameById.get(toolId) ?? params.toolName ?? "unknown";
                 const isError = params.isError === true || params.status === "error";
                 const output = params.content ?? params.output ?? "";
-                const ev: ToolResultEvent = {
-                    type: "tool_result",
-                    tool: toolName,
-                    id: toolId,
-                    status: isError ? "failed" : "success",
-                    result: typeof output === "string" ? { output } : output,
-                };
-                return [ev];
+                // Fallback chain `map ?? params.toolName ?? "unknown"` —
+                // `a ?? (b ?? c)` is equivalent, so this preserves it.
+                return [
+                    this.tools.result(
+                        toolId,
+                        isError ? "failed" : "success",
+                        wrapOutput(output),
+                        params.toolName ?? "unknown",
+                    ),
+                ];
             }
 
             default:
@@ -81,6 +76,6 @@ export class AcpTranslator implements OutputTranslator {
     }
 
     reset(): void {
-        this.toolNameById.clear();
+        this.tools.reset();
     }
 }

--- a/frontend/app/view/agent/providers/codex-translator.ts
+++ b/frontend/app/view/agent/providers/codex-translator.ts
@@ -1,8 +1,9 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SessionStats, StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { SessionStats, StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
+import { ToolCorrelator, wrapOutput } from "./tool-correlation";
 
 /**
  * Translates Codex CLI `exec --json` NDJSON events into StreamEvent format.
@@ -27,8 +28,8 @@ import type { OutputTranslator } from "./translator";
  * The item.completed events are complete (not streaming deltas) — each carries the full content.
  */
 export class CodexTranslator implements OutputTranslator {
-    // Map call_id → function name so function_call_output can report the right tool
-    private toolNameByCallId: Map<string, string> = new Map();
+    // Correlates call_id → function name so function_call_output reports the right tool.
+    private tools = new ToolCorrelator();
 
     translate(rawEvent: any): StreamEvent[] {
         if (!rawEvent || typeof rawEvent !== "object") return [];
@@ -124,7 +125,6 @@ export class CodexTranslator implements OutputTranslator {
             case "function_call": {
                 const name: string = item.name ?? "unknown";
                 const callId: string = item.call_id ?? item.id ?? `call-${Date.now()}`;
-                this.toolNameByCallId.set(callId, name);
                 let params: Record<string, any> = {};
                 if (item.arguments) {
                     try {
@@ -133,27 +133,13 @@ export class CodexTranslator implements OutputTranslator {
                         params = { _raw: item.arguments };
                     }
                 }
-                const ev: ToolCallEvent = {
-                    type: "tool_call",
-                    tool: name,
-                    id: callId,
-                    params,
-                };
-                return [ev];
+                return [this.tools.call(name, callId, params)];
             }
 
             case "function_call_output": {
                 const callId: string = item.call_id ?? "";
-                const toolName = this.toolNameByCallId.get(callId) ?? "unknown";
                 const output = item.output ?? "";
-                const ev: ToolResultEvent = {
-                    type: "tool_result",
-                    tool: toolName,
-                    id: callId,
-                    status: "success",
-                    result: typeof output === "string" ? { output } : output,
-                };
-                return [ev];
+                return [this.tools.result(callId, "success", wrapOutput(output))];
             }
 
             case "error": {
@@ -167,6 +153,6 @@ export class CodexTranslator implements OutputTranslator {
     }
 
     reset(): void {
-        this.toolNameByCallId.clear();
+        this.tools.reset();
     }
 }

--- a/frontend/app/view/agent/providers/gemini-translator.ts
+++ b/frontend/app/view/agent/providers/gemini-translator.ts
@@ -1,8 +1,9 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SessionStats, StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { SessionStats, StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
+import { ToolCorrelator, wrapOutput } from "./tool-correlation";
 
 /**
  * Translates Gemini CLI `--output-format stream-json` events into StreamEvent format.
@@ -21,8 +22,8 @@ import type { OutputTranslator } from "./translator";
  *   - tool_use and tool_result arrive as discrete events (not streaming).
  */
 export class GeminiTranslator implements OutputTranslator {
-    // Map tool_id → tool_name so tool_result can report the right tool name
-    private toolNameById: Map<string, string> = new Map();
+    // Correlates tool_id → tool_name so tool_result reports the right tool name.
+    private tools = new ToolCorrelator();
 
     translate(rawEvent: any): StreamEvent[] {
         if (!rawEvent || typeof rawEvent !== "object") return [];
@@ -69,29 +70,14 @@ export class GeminiTranslator implements OutputTranslator {
                 const toolName: string = rawEvent.tool_name ?? "unknown";
                 const toolId: string = rawEvent.tool_id ?? `tool-${Date.now()}`;
                 const params: Record<string, any> = rawEvent.parameters ?? {};
-                this.toolNameById.set(toolId, toolName);
-                const ev: ToolCallEvent = {
-                    type: "tool_call",
-                    tool: toolName,
-                    id: toolId,
-                    params,
-                };
-                return [ev];
+                return [this.tools.call(toolName, toolId, params)];
             }
 
             case "tool_result": {
                 const toolId: string = rawEvent.tool_id ?? "";
-                const toolName = this.toolNameById.get(toolId) ?? "unknown";
                 const status: "success" | "failed" = rawEvent.status === "success" ? "success" : "failed";
                 const output = rawEvent.output ?? "";
-                const ev: ToolResultEvent = {
-                    type: "tool_result",
-                    tool: toolName,
-                    id: toolId,
-                    status,
-                    result: typeof output === "string" ? { output } : output,
-                };
-                return [ev];
+                return [this.tools.result(toolId, status, wrapOutput(output))];
             }
 
             default:
@@ -100,6 +86,6 @@ export class GeminiTranslator implements OutputTranslator {
     }
 
     reset(): void {
-        this.toolNameById.clear();
+        this.tools.reset();
     }
 }

--- a/frontend/app/view/agent/providers/kimi-translator.ts
+++ b/frontend/app/view/agent/providers/kimi-translator.ts
@@ -3,6 +3,7 @@
 
 import type { StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
+import { ToolCorrelator } from "./tool-correlation";
 
 /**
  * Translates Kimi Code CLI `--output-format stream-json` events into StreamEvent format.
@@ -20,7 +21,7 @@ import type { OutputTranslator } from "./translator";
  *   {"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{...}"}}
  */
 export class KimiTranslator implements OutputTranslator {
-    private toolNameById: Map<string, string> = new Map();
+    private tools = new ToolCorrelator();
 
     translate(rawEvent: any): StreamEvent[] {
         if (!rawEvent || typeof rawEvent !== "object") return [];
@@ -63,8 +64,7 @@ export class KimiTranslator implements OutputTranslator {
                             } catch {
                                 params = {};
                             }
-                            this.toolNameById.set(toolId, toolName);
-                            events.push({ type: "tool_call", tool: toolName, id: toolId, params });
+                            events.push(this.tools.call(toolName, toolId, params));
                         }
                     }
                 }
@@ -74,7 +74,6 @@ export class KimiTranslator implements OutputTranslator {
 
             case "tool": {
                 const toolId: string = rawEvent.tool_call_id ?? "";
-                const toolName = this.toolNameById.get(toolId) ?? "unknown";
                 const content = rawEvent.content;
                 let resultText = "";
                 if (Array.isArray(content)) {
@@ -85,13 +84,7 @@ export class KimiTranslator implements OutputTranslator {
                 } else if (typeof content === "string") {
                     resultText = content;
                 }
-                return [{
-                    type: "tool_result",
-                    tool: toolName,
-                    id: toolId,
-                    status: "success",
-                    result: { content: resultText },
-                }];
+                return [this.tools.result(toolId, "success", { content: resultText })];
             }
 
             default:
@@ -100,6 +93,6 @@ export class KimiTranslator implements OutputTranslator {
     }
 
     reset(): void {
-        this.toolNameById.clear();
+        this.tools.reset();
     }
 }

--- a/frontend/app/view/agent/providers/tool-correlation.test.ts
+++ b/frontend/app/view/agent/providers/tool-correlation.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { ToolCorrelator, wrapOutput } from "./tool-correlation";
+
+describe("ToolCorrelator", () => {
+    it("call() registers id → name and emits the agnostic tool_call", () => {
+        const t = new ToolCorrelator();
+        expect(t.call("Shell", "tc_1", { command: "ls" })).toEqual({
+            type: "tool_call",
+            tool: "Shell",
+            id: "tc_1",
+            params: { command: "ls" },
+        });
+    });
+
+    it("result() resolves the tool name from the prior call", () => {
+        const t = new ToolCorrelator();
+        t.call("Shell", "tc_1", {});
+        expect(t.result("tc_1", "success", { output: "ok" })).toEqual({
+            type: "tool_result",
+            tool: "Shell",
+            id: "tc_1",
+            status: "success",
+            result: { output: "ok" },
+        });
+    });
+
+    it("result() falls back to 'unknown' when the call was never seen", () => {
+        const t = new ToolCorrelator();
+        expect(t.result("missing", "failed", {}).tool).toBe("unknown");
+    });
+
+    it("result() honours a custom fallback name (the acp `params.toolName` case)", () => {
+        const t = new ToolCorrelator();
+        expect(t.result("missing", "success", {}, "Edit").tool).toBe("Edit");
+        // A registered name still wins over the fallback.
+        t.call("Shell", "tc_1", {});
+        expect(t.result("tc_1", "success", {}, "Edit").tool).toBe("Shell");
+    });
+
+    it("reset() forgets all correlations", () => {
+        const t = new ToolCorrelator();
+        t.call("Shell", "tc_1", {});
+        t.reset();
+        expect(t.result("tc_1", "success", {}).tool).toBe("unknown");
+    });
+});
+
+describe("wrapOutput", () => {
+    it("wraps a string as { output }", () => {
+        expect(wrapOutput("hello")).toEqual({ output: "hello" });
+        expect(wrapOutput("")).toEqual({ output: "" });
+    });
+
+    it("passes a structured object through unchanged", () => {
+        const obj = { stdout: "a", stderr: "b", exit: 0 };
+        expect(wrapOutput(obj)).toBe(obj);
+    });
+});

--- a/frontend/app/view/agent/providers/tool-correlation.ts
+++ b/frontend/app/view/agent/providers/tool-correlation.ts
@@ -1,0 +1,65 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ToolCallEvent, ToolResultEvent } from "../types";
+
+/**
+ * Shared tool-call ↔ tool-result correlation for the stream translators.
+ *
+ * Every provider's wire protocol splits a tool invocation from its later
+ * result, and the result frame typically carries only the call id — not
+ * the tool name. So each translator has to remember `id → name` when the
+ * call arrives, look it up when the result arrives, and emit the
+ * provider-agnostic `tool_call` / `tool_result` events in an identical
+ * shape. That bookkeeping (the map, its reset, and the two event
+ * literals) was copy-pasted across the codex, gemini, kimi and acp
+ * translators. Collecting it here makes "the tool name didn't resolve" a
+ * single-place fix; the genuinely provider-specific part — pulling the
+ * name / id / params out of each wire format — stays in the translators.
+ *
+ * See docs/analysis/ANALYSIS_CODEBASE_ARCHITECTURE_AUDIT_2026_06_18.md (A7).
+ */
+export class ToolCorrelator {
+    private nameById = new Map<string, string>();
+
+    /** Remember `id → name` and build the agnostic `tool_call` event. */
+    call(name: string, id: string, params: Record<string, any>): ToolCallEvent {
+        this.nameById.set(id, name);
+        return { type: "tool_call", tool: name, id, params };
+    }
+
+    /**
+     * Build the agnostic `tool_result` event, resolving the tool name
+     * from the id remembered at call time. `fallbackName` covers a
+     * result whose call was never seen (e.g. it predates a reset /
+     * reconnect, or the provider also carries the name on the result).
+     */
+    result(
+        id: string,
+        status: ToolResultEvent["status"],
+        result: any,
+        fallbackName = "unknown",
+    ): ToolResultEvent {
+        return {
+            type: "tool_result",
+            tool: this.nameById.get(id) ?? fallbackName,
+            id,
+            status,
+            result,
+        };
+    }
+
+    /** Forget all correlations (between sessions). */
+    reset(): void {
+        this.nameById.clear();
+    }
+}
+
+/**
+ * Normalise a tool's output into the `result` record used by
+ * `tool_result`: a string is wrapped as `{ output }`; anything else
+ * (already-structured output) is passed through unchanged.
+ */
+export function wrapOutput(output: any): any {
+    return typeof output === "string" ? { output } : output;
+}


### PR DESCRIPTION
## What

Implements **A7** from the architecture audit: removes the four-way duplicated tool-call ↔ tool-result correlation in the stream translators.

## Why

`codex`, `gemini`, `kimi` and `acp` each independently maintained a `toolNameById` map, registered `id → name` on a tool call, looked it up on the result, and hand-built the provider-agnostic `tool_call`/`tool_result` event literals — the same ~40-line block copy-pasted four times, differing only in **which wire fields** the name/id/params come from. That made "the tool name didn't resolve" a four-place bug.

## How

New `tool-correlation.ts`:
- **`ToolCorrelator`** — owns the `id → name` map, the `call()` / `result()` event builders, and `reset()`. `result()` resolves the name (with a fallback), so correlation lives in exactly one place.
- **`wrapOutput`** — the repeated `typeof output === "string" ? { output } : output` normalisation (codex/gemini/acp).

Each translator keeps its **own field extraction** — the genuinely provider-specific part (`call_id` vs `tool_id` vs `toolCallId`; `arguments` vs `parameters` vs `input`; etc.). Only the identical mechanics moved.

## Behaviour preserved exactly

Verified against the existing suites + a new direct unit test:
- codex's `_raw` JSON-parse fallback and `call-${Date.now()}` id prefix
- kimi's object-arg passthrough and `{ content }` result shape (not `{ output }`)
- acp's `map ?? params.toolName ?? "unknown"` fallback chain — preserved via `fallbackName`, since `a ?? b ?? c === a ?? (b ?? c)`
- gemini/codex/acp success/failed status logic

**Claude is intentionally left untouched** — its streaming `content_block` accumulation and piecewise `tool_call` emission make it genuinely distinct, not duplication (audit §4).

## Result

- Translators shrink ~40 LOC (-75/+35); the mechanics are centralised + directly tested.
- **All 6 provider suites pass** (codex/gemini/kimi/claude/index + new `tool-correlation.test.ts`). No tsc impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)