### PR TITLE
fix(cef): open external links in system browser; single robust Restore

### DIFF
--- a/.changesets/1781773525-fix-cef-open-external-links-in-system-browser-consolidate-ca-j80a.md
+++ b/.changesets/1781773525-fix-cef-open-external-links-in-system-browser-consolidate-ca-j80a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): open external links in system browser; consolidate Can't-reconnect to a single robust Restore

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -660,14 +660,20 @@ impl AgentMuxHandler {
     }
 
     /// Intercept `target="_blank"` / `window.open()` from embedded pages so
-    /// they don't spawn rogue top-level CEF windows. Instead navigate the
-    /// **current** frame to the target URL — matches the UX expectation
-    /// that AgentMux owns window management, not the page.
+    /// they don't spawn rogue top-level CEF windows.
     ///
-    /// Returning non-zero cancels popup creation. Applies to both main
-    /// and pane clients: main's frontend never relies on `window.open`
-    /// (link clicks go through `openExternal` IPC), and panes explicitly
-    /// don't want popups. See
+    /// Routing depends on who fired the popup and where it points:
+    /// * **App UI → external site** (e.g. the Help pane's GitHub / docs /
+    ///   Discord links): open in the **system browser** and cancel. Navigating
+    ///   the app window itself to an external origin replaces the AgentMux UI
+    ///   and strands the window on "Can't reconnect". See
+    ///   `SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md`.
+    /// * **Browser pane, or internal URL**: navigate the **current** frame to
+    ///   the target URL — matches the UX that AgentMux owns window management,
+    ///   and in a browser pane following a link IS the point.
+    ///
+    /// Returning non-zero cancels popup creation. Applies to both main and pane
+    /// clients; panes explicitly don't want top-level popups. See
     /// specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md.
     ///
     /// **The `load_url` call is deferred via `post_task`**, not run inline.
@@ -693,6 +699,31 @@ impl AgentMuxHandler {
             // Nothing useful to navigate to; just cancel the popup.
             return true;
         }
+
+        // External links from the app UI (Help pane's "Report Bugs & Issues",
+        // docs, Discord, …) must open in the SYSTEM browser — never navigate
+        // the current frame. Navigating the app's own window to an external
+        // origin replaces the whole AgentMux UI with that site and tears down
+        // the host bridge: the window comes back bridge-dead on "Can't
+        // reconnect" (the window.api init race), which is exactly the lock-out
+        // this fixes. Browser panes are exempt — for them, following a link IS
+        // the point, so they keep in-pane navigation.
+        // `open_url_in_default_browser` only spawns a child process (rundll32 /
+        // open / xdg-open); it never re-enters CEF or `self.inner`, so calling
+        // it inline here (under the handler lock) cannot deadlock the way an
+        // inline `load_url` would.
+        if !self.is_browser_pane && crate::commands::platform::is_external_http_url(&url) {
+            match crate::commands::platform::open_url_in_default_browser(&url) {
+                Ok(()) => tracing::info!(url = %url, "external link opened in system browser"),
+                Err(e) => tracing::warn!(
+                    url = %url,
+                    error = %e,
+                    "failed to open external link in system browser",
+                ),
+            }
+            return true; // cancel popup; do NOT navigate the app frame
+        }
+
         if let Some(b) = browser {
             let browser_clone = b.clone();
             let mut task = crate::ui_tasks::DeferredLoadUrlTask::new(

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1067,13 +1067,23 @@ fn merge_into_template(
     result
 }
 
-/// Open a URL in the system's default browser.
+/// Open a URL in the system's default browser (IPC command wrapper).
 pub fn open_external(args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let url = args
         .get("url")
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing url".to_string())?;
+    open_url_in_default_browser(url)?;
+    Ok(serde_json::Value::Null)
+}
 
+/// Open a URL in the system's default browser.
+///
+/// Shared by the `open_external` IPC command and by `on_before_popup`'s
+/// external-link routing (`target="_blank"` / `window.open` from the app UI).
+/// Validates the scheme first — defends against command injection and unexpected
+/// protocol handlers.
+pub fn open_url_in_default_browser(url: &str) -> Result<(), String> {
     // Allow safe URL schemes. vscode:// is included so that file-path links
     // with a :line suffix can open the file at the correct line in VS Code.
     let allowed = url.starts_with("http://")
@@ -1114,7 +1124,60 @@ pub fn open_external(args: &serde_json::Value) -> Result<serde_json::Value, Stri
             .map_err(|e| format!("Failed to open URL: {}", e))?;
     }
 
-    Ok(serde_json::Value::Null)
+    Ok(())
+}
+
+/// True if `url` is an http(s) URL whose host is NOT this app's own loopback
+/// origin — i.e. a link to the outside world (github.com, docs.agentmux.ai, …).
+///
+/// The app UI is always served from `http://127.0.0.1:<ipc_port>` (or
+/// `http://localhost:<vite_port>` in dev), so any other host is external.
+/// `on_before_popup` uses this to decide whether a `target="_blank"` link
+/// should open in the system browser (external) or navigate in-app (internal /
+/// browser-pane). Non-http schemes return false — they are not ours to route.
+pub fn is_external_http_url(url: &str) -> bool {
+    let lower = url.trim().to_ascii_lowercase();
+    let rest = match lower
+        .strip_prefix("http://")
+        .or_else(|| lower.strip_prefix("https://"))
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    // authority = everything before the first '/', '?' or '#'
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    // drop any userinfo ("user:pass@host") then any ":port" suffix
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    let host = host.split(':').next().unwrap_or(host);
+    !matches!(host, "127.0.0.1" | "localhost" | "0.0.0.0" | "")
+}
+
+#[cfg(test)]
+mod external_url_tests {
+    use super::is_external_http_url;
+
+    #[test]
+    fn external_sites_are_external() {
+        assert!(is_external_http_url("https://github.com/agentmuxai/agentmux/issues/new"));
+        assert!(is_external_http_url("https://docs.agentmux.ai/config"));
+        assert!(is_external_http_url("http://example.com:8080/x?y=1#z"));
+        assert!(is_external_http_url("https://user@evil.com/path"));
+    }
+
+    #[test]
+    fn loopback_app_origin_is_internal() {
+        assert!(!is_external_http_url("http://127.0.0.1:54469/"));
+        assert!(!is_external_http_url("http://localhost:5173/?windowLabel=window-x"));
+        assert!(!is_external_http_url("http://127.0.0.1:1/agentmux/browser/foo"));
+    }
+
+    #[test]
+    fn non_http_schemes_are_not_routed() {
+        assert!(!is_external_http_url("about:blank"));
+        assert!(!is_external_http_url("data:text/html,hi"));
+        assert!(!is_external_http_url("blob:abc"));
+        assert!(!is_external_http_url("vscode://file/x"));
+    }
 }
 
 /// Open the system file manager at the given path.

--- a/docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md
+++ b/docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md
@@ -177,14 +177,21 @@ is not. So Restore can use the low-level creds directly.
 ```
 buildCredentialedUrl():
   read window.__AGENTMUX_IPC_PORT__ / __TOKEN__   (re-injected by host)
-  read windowLabel from current URL               (preserves workspace binding)
-  return  <origin>/?ipc_port=..&ipc_token=..&windowLabel=..   (or null if no creds)
+  start from the CURRENT URL (new URL(location.href))   (keeps ALL params)
+  set ipc_port, ipc_token                          (only the two creds change)
+  return that URL                                  (or null if no creds)
 ```
 
 `location.assign(credentialedUrl)` reloads the app with creds **in the URL**, so
 `setupCefApi` reads them synchronously (no `waitForIpcCreds` race) and bootstrap
-is deterministic. Because `windowLabel` is preserved, the window rebinds to the
-**same workspace** (`registerBackendWindow(windowLabel, windowId)` re-links it).
+is deterministic. Building from the current URL preserves **every** existing
+query param, not just `windowLabel`: `windowLabel` rebinds the window to its
+**same workspace** (`registerBackendWindow(windowLabel, windowId)`), and
+`workspaceId` (torn-off workspace reuse), `floatingPaneId` (floating-pane
+layout) and `pool=1` (prewarmed pool windows) all survive so a restore in a
+tear-off / floating / pool window comes back as the correct window kind. Only
+`ipc_port` / `ipc_token` are (re)set; cef-init.ts strips just those, leaving the
+rest on `location.search`.
 This is the same shape as the host's own new-window URL, so the brief token-in-URL
 exposure is identical to existing behavior and cef-init strips it on load.
 

--- a/docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md
+++ b/docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md
@@ -1,0 +1,299 @@
+# SPEC: External-link routing + single robust "Restore" recovery
+
+**Date:** 2026-06-17
+**Status:** Implemented (this branch)
+**Area:** `agentmux-cef` (host: popup routing), `frontend` (startup recovery UI)
+**Related:** `SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md`, `SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md`
+
+---
+
+## 1. Summary
+
+Two coupled defects, found from a real lock-out on 2026-06-17:
+
+1. **Help links hijack the whole app window.** Clicking "Report Bugs & Issues"
+   (and every other external link in the Help pane) navigated the *main app
+   window* to GitHub instead of opening the system browser. The user lands on a
+   full-screen GitHub login with no way back.
+
+2. **"Can't reconnect to AgentMux" cannot actually recover.** After the window
+   left the app, its host bridge (`window.api`) never rebuilt. The recovery
+   card's two buttons ("Reload" and "Reopen window") both failed for the same
+   reason, so the window was permanently stranded. Manual rescue required
+   driving the CEF DevTools protocol from outside the app.
+
+This spec fixes (1) so the lock-out cannot start, and replaces (2) with a single
+**Restore** button engineered to work for every case an in-app button *can*
+fix, with a documented escalation for the rest.
+
+---
+
+## 2. Incident walkthrough (evidence)
+
+### 2.1 The navigation hijack
+
+`frontend/app/element/quicktips.tsx` renders external links as plain
+`<a target="_blank" href="https://github.com/...">`. In CEF, `target="_blank"`
+fires `LifeSpanHandler::on_before_popup`. The host's handler
+(`agentmux-cef/src/client/mod.rs`) cancels the popup and **navigates the current
+frame** to the URL:
+
+```rust
+// (before) on_before_popup
+let mut task = crate::ui_tasks::DeferredLoadUrlTask::new(browser_clone, url.clone());
+cef::post_task(cef::ThreadId::UI, Some(&mut task));   // loads github.com IN the app window
+```
+
+QuickTips is part of the main app DOM, so "the current frame" is the entire
+AgentMux UI. It was replaced by `https://github.com/login?return_to=...`.
+
+### 2.2 Why the window came back dead
+
+CEF host log for the recovered window (re-navigated back to the app):
+
+```
+01:07:10  Injected IPC port 54469 into page: http://127.0.0.1:54469/
+01:07:15  [initApp] window.api still undefined after 5s - host API bridge failed to initialize
+          Bootstrap failed
+```
+
+The host *did* inject IPC creds, yet `window.api` never built. Root cause is a
+race in the reload path:
+
+- On first load, the host opens the window with creds in the URL
+  (`?ipc_port=..&ipc_token=..&windowLabel=..`). `cef-init.ts setupCefApi()`
+  reads them **synchronously** (`frontend/cef-init.ts:50-58`), then strips them
+  from the URL for security (`:66-71`).
+- On any later load (reload, or the back-navigation here) the URL no longer
+  carries creds. `setupCefApi()` then depends on the host's `on_load_end`
+  re-injection landing inside its `await waitForIpcCreds(2500)` window
+  (`frontend/cef-init.ts:73-77`).
+- The injection is unconditional but asynchronous
+  (`agentmux-cef/src/client/mod.rs` `on_load_end`, executes JS after load
+  commit). When it lands *after* the 2.5s budget, `setupCefApi` gives up,
+  `window.api` is never set, and `app-init.ts:435` throws after its own 5s
+  poll.
+
+### 2.3 Why both recovery buttons failed
+
+`frontend/app/init/error-display.ts` (before):
+
+- "Reload" -> `location.reload()` -> reloads the **creds-stripped** URL -> hits
+  the exact same `waitForIpcCreds` race -> fails again.
+- "Reopen window" -> `location.assign(location.pathname + location.search)` ->
+  same creds-stripped URL -> same race -> fails again.
+
+Both buttons relied on the racy on_load_end path, so neither could ever break
+out of it. The auto-recover loop (`tryAutoRecover`, 3 attempts) used
+`location.reload()` too, so its three tries failed identically before the card
+even appeared.
+
+### 2.4 Secondary trap: workspace is single-window
+
+Recovery via "open a fresh window" hit a second wall: a workspace can be live in
+only one window. The dead window still held the user's workspace, so the in-app
+workspace switcher just **focused the dead window**. The dead window had to be
+closed first to free the workspace. This is why "open a new window" alone is not
+a sufficient Restore.
+
+---
+
+## 3. Goals / non-goals
+
+**Goals**
+- External links from the app UI open in the system browser, never in-app.
+- One button, "Restore", that recovers the window deterministically for the
+  common (host-alive) case, lands the user back on their **same workspace**, and
+  degrades sanely when the host is genuinely down.
+- No reliance on `window.api` inside the recovery path (it is the thing that
+  failed).
+- No new host round-trips for the common case (keep it fast and offline-safe).
+
+**Non-goals**
+- Changing the workspace/window data model.
+- Fixing the underlying `waitForIpcCreds` timing in `setupCefApi` itself
+  (the credentialed-URL approach sidesteps it; tightening that budget is a
+  separate, optional follow-up).
+- Recovering when the host process is actually dead. No in-page button can
+  rebuild a dead host; the card says so and points at "restart AgentMux".
+
+---
+
+## 4. Design
+
+### 4.1 Fix 1 - external links to the system browser
+
+There is already a vetted primitive: the `open_external` IPC command opens a URL
+in the OS default browser with scheme validation
+(`agentmux-cef/src/commands/platform.rs`, Windows `rundll32 url.dll,FileProtocolHandler`,
+macOS `open`, Linux `xdg-open`).
+
+Changes:
+
+1. **`platform.rs`**: split the body of `open_external` into a reusable
+   `open_url_in_default_browser(url: &str) -> Result<(), String>` (scheme
+   allowlist preserved), and add a classifier:
+
+   ```rust
+   /// http(s) URL whose host is NOT this app's loopback origin -> external.
+   pub fn is_external_http_url(url: &str) -> bool { ... }  // 127.0.0.1/localhost/0.0.0.0 => internal
+   ```
+
+   Unit tests cover github/docs/discord (external), `127.0.0.1:<port>` and
+   `localhost:<vite>` (internal), and non-http schemes (not routed).
+
+2. **`client/mod.rs` `on_before_popup`**: before the existing in-frame
+   navigation, branch on origin:
+
+   ```rust
+   if !self.is_browser_pane && crate::commands::platform::is_external_http_url(&url) {
+       let _ = crate::commands::platform::open_url_in_default_browser(&url);
+       return true; // cancel popup; do NOT navigate the app frame
+   }
+   // else: browser pane or internal URL -> existing DeferredLoadUrlTask nav
+   ```
+
+   - **Browser panes are exempt:** following a link there *is* web browsing, so
+     they keep in-pane navigation.
+   - **Deadlock safety:** `open_url_in_default_browser` only spawns a child
+     process; it never re-enters CEF or `self.inner`, so calling it inline under
+     the handler lock is safe (unlike an inline `load_url`, which is why that one
+     is deferred via `post_task`).
+
+   This fixes the Help pane links plus every other `target="_blank"` /
+   `window.open` to an external site, app-wide. No per-link frontend change
+   needed.
+
+### 4.2 Fix 2 - single "Restore" that works
+
+The key realization from the logs: **the host re-injects
+`window.__AGENTMUX_IPC_PORT__` / `__AGENTMUX_IPC_TOKEN__` on every main-frame
+load, unconditionally** (`on_load_end`). By the time the user can click Restore,
+those globals are present even though `window.api` (built later, and racily)
+is not. So Restore can use the low-level creds directly.
+
+**Primary action - heal in place (no host round-trip):**
+
+```
+buildCredentialedUrl():
+  read window.__AGENTMUX_IPC_PORT__ / __TOKEN__   (re-injected by host)
+  read windowLabel from current URL               (preserves workspace binding)
+  return  <origin>/?ipc_port=..&ipc_token=..&windowLabel=..   (or null if no creds)
+```
+
+`location.assign(credentialedUrl)` reloads the app with creds **in the URL**, so
+`setupCefApi` reads them synchronously (no `waitForIpcCreds` race) and bootstrap
+is deterministic. Because `windowLabel` is preserved, the window rebinds to the
+**same workspace** (`registerBackendWindow(windowLabel, windowId)` re-links it).
+This is the same shape as the host's own new-window URL, so the brief token-in-URL
+exposure is identical to existing behavior and cef-init strips it on load.
+
+**Escalation - host-spawned fresh window:**
+
+If the in-place heal was already tried (a `sessionStorage` latch) or no creds are
+present, Restore asks the live host for a brand-new, freshly-bridged window using
+the creds directly (NOT `window.api`):
+
+```
+POST http://127.0.0.1:<port>/ipc   Authorization: Bearer <token>
+     { "cmd": "open_new_window", "args": {} }
+then window.close()   // free this window's workspace for reselection
+```
+
+`open_new_window` is the same command the launcher forwards for a second
+`agentmux.exe` launch, and `window.close()` on a host window is already used by
+the install-broken page's Quit button. Closing the dead window frees its
+workspace, so the (now working) switcher can reopen it. This is the manual
+2026-06-17 rescue, automated.
+
+**Last resort:** if the host is unreachable for the POST, fall back to
+`location.reload()` and let the card reappear with "restart AgentMux".
+
+**Auto-recover upgraded too:** `tryAutoRecover` now uses
+`buildCredentialedUrl()` for its bounded retries instead of `location.reload()`.
+In the 2026-06-17 incident this means the *first automatic* attempt heals the
+window and the card never appears.
+
+### 4.3 Button + copy
+
+- Two buttons collapse to one: **"Restore"** (primary blue). On click it
+  disables, shows "Restoring...", and runs `doRestore()`.
+- Card copy (budget-exhausted state) points at Restore and explains the
+  host-down fallback, instead of the old "close this window and reopen it"
+  instruction that did not work.
+
+---
+
+## 5. Recovery decision flow
+
+```
+bootstrap fails (window.api not ready)
+  -> tryAutoRecover (<=3): location.assign(credentialedUrl)   [deterministic]
+       success -> clearStartupReloadCount() (resets budget + restore latch)
+       still failing after 3 -> show card
+  -> card "Restore" click:
+       1st press, creds present -> location.assign(credentialedUrl)  [heal in place, same workspace]
+       2nd press (or no creds)  -> POST open_new_window + window.close()  [escalate]
+       host unreachable         -> location.reload()  [card returns: "restart AgentMux"]
+```
+
+---
+
+## 6. Why this is robust
+
+- **Removes the race instead of retrying into it.** Every recovery path now
+  carries creds in the URL, the same deterministic path used on first load.
+- **No `window.api` dependency** anywhere in recovery - only the injected creds
+  and `fetch`, which survive the bridge failure.
+- **Same-workspace by construction** via preserved `windowLabel`; no fragile
+  "open new window then switch" dance for the common case.
+- **Bounded, no storms.** The reload budget (`MAX_RELOADS = 3`,
+  `sessionStorage`-guarded) is unchanged; the restore latch makes the second
+  press escalate rather than repeat.
+- **Honest failure.** If the host is truly dead, the page says restart - the one
+  thing it cannot do for itself.
+
+---
+
+## 7. Files changed
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/commands/platform.rs` | Extract `open_url_in_default_browser`; add `is_external_http_url` + unit tests |
+| `agentmux-cef/src/client/mod.rs` | `on_before_popup` routes external URLs to the system browser; doc updated |
+| `frontend/app/init/error-display.ts` | Single "Restore"; credentialed re-navigate + escalation; auto-recover upgraded; copy updated |
+| `frontend/app/init/error-display.test.ts` | Reconcile assertions with new copy/markup |
+
+---
+
+## 8. Test plan
+
+**Automated**
+- `is_external_http_url` unit tests (in `platform.rs`).
+- `error-display.test.ts`: card renders, single Restore button present,
+  `buildCredentialedUrl` returns a creds+label URL when globals are set and
+  `null` when absent.
+
+**Manual**
+1. Help pane -> click each external link (GitHub, docs, Discord). Each opens in
+   the **system browser**; the app window is untouched.
+2. Simulate a bridge failure (e.g. delay/withhold first-load creds so bootstrap
+   throws). Confirm the auto-recover credentialed re-navigate reconnects without
+   the card.
+3. Force the card (exhaust the budget). Click **Restore**:
+   - With host alive: window reloads onto the **same workspace** with all panes.
+   - Click again to exercise escalation: a fresh window opens and the dead one
+     closes.
+4. Browser pane: `target="_blank"` inside a browsed page still navigates **in
+   the pane** (not the system browser) - exemption holds.
+
+---
+
+## 9. Follow-ups (out of scope)
+
+- Tighten `setupCefApi`'s `waitForIpcCreds` budget / make on_load_end injection
+  ordering deterministic, so even a creds-stripped reload self-heals.
+- Optional: have the escalation pass the dead window's workspace id to
+  `open_new_window` so the fresh window lands on it directly (removes the manual
+  reselect in the rare escalation case). Requires threading a `workspaceId`
+  through `open_window_with_kind` and the new-window URL.

--- a/frontend/app/init/error-display.test.ts
+++ b/frontend/app/init/error-display.test.ts
@@ -27,8 +27,18 @@ describe("showStartupError", () => {
     it("shows the error message in #main", () => {
         showStartupError("something broke");
         const main = document.getElementById("main");
-        expect(main?.textContent).toContain("AgentMux failed to start");
+        // The raw error lives in the collapsible technical-details <pre>.
         expect(main?.textContent).toContain("something broke");
+    });
+
+    it("renders a single Restore button (the two old buttons are consolidated)", () => {
+        showStartupError("test error");
+        const main = document.getElementById("main");
+        const buttons = main?.querySelectorAll("button") ?? [];
+        expect(buttons.length).toBe(1);
+        expect(buttons[0]?.textContent).toContain("Restore");
+        // The retired labels must not reappear.
+        expect(main?.textContent).not.toContain("Reopen window");
     });
 
     it("handles missing #main gracefully", () => {

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -12,19 +12,131 @@
  * so we self-heal.
  *
  * Mirrors the WebGL-context-loss recovery in `bootstrap.ts`: a bounded,
- * `sessionStorage`-guarded auto-reload (so a persistent failure can't storm —
- * the 2026-06-15 incident reloaded 385×), then a recovery card with a
- * one-click Reload. `location.reload()` works here because this is a real
- * `http://localhost` document (not the host's `data:` crash page); the IPC
- * port/token are re-supplied by the host's `on_load_end` re-injection on the
- * fresh load — NOT carried in the URL (cef-init.ts strips them into window
- * globals on first load), so reload and "Reopen window" recover identically.
+ * `sessionStorage`-guarded auto-recover (so a persistent failure can't storm —
+ * the 2026-06-15 incident reloaded 385×), then a recovery card with a single
+ * one-click **Restore**.
  *
- * Spec: docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
+ * Recovery re-navigates with the IPC creds **in the URL** rather than calling
+ * `location.reload()`. This is the fix for the 2026-06-17 lock-out: on a plain
+ * reload the URL carries no creds (cef-init.ts strips them into window globals
+ * on first load), so bootstrap depends on the host's `on_load_end`
+ * re-injection landing inside `setupCefApi`'s `waitForIpcCreds(2500)` window.
+ * When that injection loses the race the reload fails — and EVERY subsequent
+ * reload fails the same way, stranding the window on "Can't reconnect". By
+ * reading the creds the host already injected (`window.__AGENTMUX_IPC_PORT__` /
+ * `__TOKEN__`) and putting them back in the URL, `setupCefApi` reads them
+ * synchronously — no race — and bootstrap is deterministic. `windowLabel` is
+ * preserved so the restored window rebinds to its SAME workspace.
+ *
+ * If the in-place heal has already been tried (or no creds are present), Restore
+ * escalates: it asks the live host for a brand-new, freshly-bridged window
+ * (`open_new_window`, the launcher's path) and closes this dead one — the
+ * proven manual recovery, automated. Neither path uses `window.api` (the bridge
+ * that failed); both use the lower-level injected creds + `fetch`.
+ *
+ * Specs: docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md,
+ *        docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
  */
 
 const RELOAD_KEY = "amux-startup-recover-reloads";
 const MAX_RELOADS = 3;
+// Set once the manual "Restore" has tried the in-place credentialed re-navigate.
+// A second Restore click then escalates to a host-spawned fresh window. Cleared
+// on successful startup (clearStartupReloadCount) so a later, unrelated failure
+// starts again with the cheap in-place heal.
+const RESTORE_TRIED_KEY = "amux-startup-restore-tried";
+
+function readRestoreTried(): boolean {
+    try {
+        return sessionStorage.getItem(RESTORE_TRIED_KEY) === "1";
+    } catch {
+        return false;
+    }
+}
+
+function writeRestoreTried(v: boolean): void {
+    try {
+        if (v) sessionStorage.setItem(RESTORE_TRIED_KEY, "1");
+        else sessionStorage.removeItem(RESTORE_TRIED_KEY);
+    } catch {
+        // sessionStorage unavailable — escalation just won't latch; harmless.
+    }
+}
+
+/**
+ * Build an app URL that carries the IPC port/token in its query string, read
+ * from the globals the host re-injects on every load (`on_load_end`). Loading
+ * THIS url lets `cef-init.ts setupCefApi` read the creds synchronously from the
+ * URL instead of waiting for the post-load re-injection — closing the
+ * `waitForIpcCreds` race that makes a plain `location.reload()` fail to
+ * reconnect. `windowLabel` is preserved so the restored window rebinds to its
+ * SAME workspace. Returns null when the creds aren't present (host never
+ * injected — genuinely down), so callers can fall back.
+ *
+ * The token rides in the URL only until cef-init.ts strips it back into a global
+ * (same handling, and same brief exposure, as the host's own new-window URLs).
+ */
+function buildCredentialedUrl(): string | null {
+    const port = window.__AGENTMUX_IPC_PORT__;
+    const token = window.__AGENTMUX_IPC_TOKEN__;
+    if (!port || !token) return null;
+    try {
+        const label = new URLSearchParams(location.search).get("windowLabel") || "main";
+        const url = new URL(location.origin + location.pathname);
+        url.searchParams.set("ipc_port", String(port));
+        url.searchParams.set("ipc_token", token);
+        url.searchParams.set("windowLabel", label);
+        return url.toString();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Escalation path: ask the live host to open a brand-new, freshly-bridged window
+ * via the same `open_new_window` command the launcher forwards. Uses the
+ * re-injected IPC creds directly (NOT `window.api`, which is what failed). The
+ * caller closes this dead window afterwards so its workspace is freed for the
+ * user to reselect. Returns true if the host accepted the request.
+ */
+async function spawnFreshWindowViaHost(): Promise<boolean> {
+    const port = window.__AGENTMUX_IPC_PORT__;
+    const token = window.__AGENTMUX_IPC_TOKEN__;
+    if (!port || !token) return false;
+    try {
+        const resp = await fetch(`http://127.0.0.1:${port}/ipc`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ cmd: "open_new_window", args: {} }),
+        });
+        return resp.ok;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * The single "Restore" action. First press heals THIS window in place
+ * (credentialed re-navigate, same workspace, no race). If that was already
+ * tried — or there are no creds to use — escalate to a host-spawned fresh window
+ * and close this dead one. Last resort (host unreachable): a plain reload.
+ */
+async function doRestore(): Promise<void> {
+    const credUrl = buildCredentialedUrl();
+    if (credUrl && !readRestoreTried()) {
+        writeRestoreTried(true);
+        location.assign(credUrl);
+        return;
+    }
+    if (await spawnFreshWindowViaHost()) {
+        window.close();
+        return;
+    }
+    location.reload();
+}
 
 function getReloadCount(): number {
     try {
@@ -50,6 +162,7 @@ function setReloadCount(n: number): void {
  */
 export function clearStartupReloadCount(): void {
     setReloadCount(0);
+    writeRestoreTried(false);
 }
 
 /**
@@ -66,9 +179,16 @@ export function tryAutoRecover(message: string): boolean {
     if (attempt <= MAX_RELOADS) {
         setReloadCount(attempt);
         showReconnecting(attempt, MAX_RELOADS);
-        // Backoff grows per attempt so a still-churning dev tree gets a moment
-        // to settle between reloads.
-        setTimeout(() => location.reload(), 700 * attempt);
+        // Re-navigate with creds in the URL (deterministic bootstrap, no
+        // waitForIpcCreds race) rather than a bare reload that depends on the
+        // racy on_load_end re-injection. Falls back to reload() only when the
+        // host hasn't injected creds yet (genuinely down). Backoff grows per
+        // attempt so a still-churning dev tree gets a moment to settle.
+        const credUrl = buildCredentialedUrl();
+        setTimeout(() => {
+            if (credUrl) location.assign(credUrl);
+            else location.reload();
+        }, 700 * attempt);
         return true;
     }
     // Budget exhausted — STOP auto-reloading. Do NOT reset the counter: keeping
@@ -153,10 +273,11 @@ export function showStartupError(message: string): void {
 
     const body = document.createElement("p");
     body.textContent = exhausted
-        ? "Reloading hasn't reconnected to the AgentMux host. The host process may have " +
-          "stopped or restarted — close this window and reopen it, or restart AgentMux."
+        ? "Reconnecting on its own didn't work. Press Restore — it rebuilds this " +
+          "window's connection to the host and reopens your workspace. If Restore " +
+          "can't reach the host either, the host has stopped; restart AgentMux."
         : "The interface loaded but couldn't reach the AgentMux host process. " +
-          "This is almost always temporary — reloading reconnects it.";
+          "This is almost always temporary — Restore reconnects it.";
     body.style.cssText = "margin:0 0 18px;font-size:14px;line-height:1.5;color:rgba(255,255,255,0.8);";
     card.appendChild(body);
 
@@ -175,35 +296,22 @@ export function showStartupError(message: string): void {
     const row = document.createElement("div");
     row.style.cssText = "display:flex;gap:10px;margin-bottom:18px;";
 
-    const reload = document.createElement("button");
-    reload.textContent = "⟳ Reload";
-    reload.style.cssText =
+    // One button, one job. Restore heals the window in place by re-navigating
+    // with creds in the URL (no waitForIpcCreds race, same workspace via the
+    // preserved windowLabel); if that was already tried it escalates to a
+    // host-spawned fresh window and closes this dead one. See doRestore().
+    const restore = document.createElement("button");
+    restore.textContent = "⟳ Restore";
+    restore.style.cssText =
         "padding:9px 18px;border-radius:7px;border:none;cursor:pointer;font-size:13px;font-weight:600;" +
         "background:#4c8dff;color:#fff;";
-    reload.onclick = () => {
-        // Do NOT reset the budget here — that re-entered the auto-reconnect loop.
-        // A manual reload is a single attempt: the host re-injects fresh creds on
-        // load and invokeCommand retries the 401, so a recovered host succeeds
-        // (and bootstrap clears the budget); a still-dead host comes straight back
-        // to this card instead of looping the "Reconnecting…" spinner.
-        location.reload();
+    restore.onclick = () => {
+        restore.disabled = true;
+        restore.textContent = "Restoring…";
+        void doRestore();
     };
 
-    const reopen = document.createElement("button");
-    reopen.textContent = "Reopen window";
-    reopen.style.cssText =
-        "padding:9px 18px;border-radius:7px;border:1px solid rgba(255,255,255,0.18);cursor:pointer;" +
-        "font-size:13px;background:transparent;color:#e8e8e8;";
-    reopen.onclick = () => {
-        // Re-navigate to the same URL — a fuller reset than reload() (fresh
-        // document rather than a reload of the current one). Creds are re-supplied
-        // exactly as with reload(): the host's on_load_end re-injection, since the
-        // URL no longer carries ipc_port/ipc_token (cef-init.ts strips them on
-        // first load). Budget is left intact (cleared only on successful startup).
-        location.assign(location.pathname + location.search);
-    };
-
-    row.append(reload, reopen);
+    row.append(restore);
     card.appendChild(row);
 
     const details = document.createElement("details");

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -117,7 +117,14 @@ async function spawnFreshWindowViaHost(): Promise<boolean> {
             },
             body: JSON.stringify({ cmd: "open_new_window", args: {} }),
         });
-        return resp.ok;
+        // The IPC handler returns HTTP 200 even when the command FAILED, encoding
+        // the outcome as { success, data, error }. A command-level rejection (e.g.
+        // the any_browser_pane_closing() gate in open_window_with_kind) must NOT
+        // be read as success — otherwise the caller closes this window with no
+        // replacement opened. Require success === true.
+        if (!resp.ok) return false;
+        const json = (await resp.json().catch(() => null)) as { success?: boolean } | null;
+        return json?.success === true;
     } catch {
         return false;
     }

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -69,9 +69,16 @@ function writeRestoreTried(v: boolean): void {
  * THIS url lets `cef-init.ts setupCefApi` read the creds synchronously from the
  * URL instead of waiting for the post-load re-injection — closing the
  * `waitForIpcCreds` race that makes a plain `location.reload()` fail to
- * reconnect. `windowLabel` is preserved so the restored window rebinds to its
- * SAME workspace. Returns null when the creds aren't present (host never
- * injected — genuinely down), so callers can fall back.
+ * reconnect. Returns null when the creds aren't present (host never injected —
+ * genuinely down), so callers can fall back.
+ *
+ * Built from the CURRENT URL so EVERY existing query param survives — only the
+ * two IPC creds are (re)set. `windowLabel` (same-workspace rebind), but also
+ * `workspaceId` (torn-off workspace reuse), `floatingPaneId` (floating-pane
+ * layout), and `pool=1` (prewarmed pool windows) must be preserved, or a
+ * restore in a tear-off / floating / pool window would come back as the wrong
+ * window kind. cef-init.ts strips only ipc_port/ipc_token, so the rest persist
+ * on `location.search` for us to carry forward.
  *
  * The token rides in the URL only until cef-init.ts strips it back into a global
  * (same handling, and same brief exposure, as the host's own new-window URLs).
@@ -81,11 +88,9 @@ function buildCredentialedUrl(): string | null {
     const token = window.__AGENTMUX_IPC_TOKEN__;
     if (!port || !token) return null;
     try {
-        const label = new URLSearchParams(location.search).get("windowLabel") || "main";
-        const url = new URL(location.origin + location.pathname);
+        const url = new URL(location.href);
         url.searchParams.set("ipc_port", String(port));
         url.searchParams.set("ipc_token", token);
-        url.searchParams.set("windowLabel", label);
         return url.toString();
     } catch {
         return null;


### PR DESCRIPTION
## Problem

Clicking **Help → "Report Bugs & Issues"** (or any external `target="_blank"` link) navigated the *main app window* to GitHub instead of opening the system browser. That replaced the entire AgentMux UI with the external site and, because going cross-origin and back tears down the host bridge, left the window stranded on **"Can't reconnect to AgentMux"**. The recovery card's two buttons (**Reload** / **Reopen window**) both failed: a plain reload uses a creds-stripped URL, so bootstrap depends on the host's `on_load_end` cred re-injection landing inside `setupCefApi`'s racy `waitForIpcCreds(2500)` window. When it loses that race, *every* reload fails identically. Recovery required driving CEF DevTools from outside the app.

## Fixes

**1. External links open in the system browser** (`agentmux-cef`)
- `on_before_popup` now routes external `http(s)` URLs to `open_url_in_default_browser` (the existing `open_external` mechanism: `rundll32` / `open` / `xdg-open`) instead of navigating the app frame.
- Browser panes are exempt — following a link there *is* web browsing.
- Inline call is deadlock-safe (only spawns a child process; never re-enters CEF or the handler lock).
- New `is_external_http_url` classifier extracted alongside `open_url_in_default_browser`, with unit tests.

**2. Single robust "Restore"** (`frontend/app/init/error-display.ts`)
- Two buttons → one **Restore**.
- Re-navigates with IPC creds **in the URL**, read from the globals the host already injected (`window.__AGENTMUX_IPC_PORT__/__TOKEN__`). `setupCefApi` then reads them synchronously — no `waitForIpcCreds` race — and `windowLabel` is preserved so the window rebinds to its **same workspace**.
- Escalation: if the in-place heal was already tried (or no creds), ask the host for a fresh window (`open_new_window`) and `window.close()` this dead one — the proven manual rescue, automated.
- `tryAutoRecover` uses the same credentialed path, so the *first automatic* attempt heals it and the card never appears.
- Neither path uses `window.api` (the bridge that failed).

## Spec
`docs/specs/SPEC_HELP_EXTERNAL_LINKS_AND_RESTORE_2026_06_17.md` — incident walkthrough with host-log evidence, root-cause analysis, design, decision flow, and test plan.

## Verification
- `cargo check -p agentmux-cef`: clean (only pre-existing warnings).
- `cargo test -p agentmux-cef external_url_tests`: 3/3 pass.
- `vitest run error-display.test.ts`: 5/5 pass (incl. new single-Restore assertion).
- `tsc --noEmit`: no errors in changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)