### PR TITLE
chore: release v0.46.3

### DIFF
--- a/.changesets/1781717402-fix-agent-show-in-progress-when-streaming-resumes-after-a-st-t08o.md
+++ b/.changesets/1781717402-fix-agent-show-in-progress-when-streaming-resumes-after-a-st-t08o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): show 'in progress' when streaming resumes after a stream drop; quiet Esc on idle

--- a/.changesets/1781726783-perf-layout-reduce-pane-reflow-settle-window-from-220ms-to-3-kmzz.md
+++ b/.changesets/1781726783-perf-layout-reduce-pane-reflow-settle-window-from-220ms-to-3-kmzz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-perf(layout): reduce pane reflow settle window from 220ms to 32ms

--- a/.changesets/1781744589-feat-editor-file-encodings.md
+++ b/.changesets/1781744589-feat-editor-file-encodings.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): open and round-trip non-UTF-8 files (Windows-1252 .ini, UTF-16, Shift_JIS, …) via encoding detection

--- a/.changesets/1781746754-feat-mcp-consolidate-layout-naming-verbs.md
+++ b/.changesets/1781746754-feat-mcp-consolidate-layout-naming-verbs.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): consolidate layout/introspection + naming verbs — `Layout(query)` replaces GetLayout/ListWindows/ListWorkspaces/ListTabs and `SetName(target,name)` replaces SetWindowName/SetTabName/SetPaneTitle/SetWorkspaceName (17→11 MCP tools). WhoAmI and the SetActiveTab/NewTab/FocusWindow navigation verbs are unchanged; every REST endpoint and capability is preserved. Cuts the per-turn MCP tool-definition footprint (see agent-pane latency report §3) while keeping the surface discoverable.

--- a/.changesets/1781747957-fix-agent-askuserquestion-dead-air-resume.md
+++ b/.changesets/1781747957-fix-agent-askuserquestion-dead-air-resume.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): auto-resume after AskUserQuestion on persistent (Claude) panes. When a turn ends while a question is still parked, the CLI abandons the pending tool_use and the answer's control_response is silently dropped — the agent stalls ("dead air"). `answer_question` now arms a short post-answer check: if no stdout activity follows the control_response, the answer is re-delivered as a directive follow-up user message so the turn resumes. Gated on output activity, so it is mutually exclusive with a real resume and never double-delivers. Mirrors the one-shot controllers' existing message fallback (SPEC_ASK_USER_QUESTION §9/§10.1).

--- a/.changesets/1781750214-feat-agent-picker-tile-grid.md
+++ b/.changesets/1781750214-feat-agent-picker-tile-grid.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-picker): My Agents + Templates render as a responsive tile grid filling the pane (was a 520px single column)

--- a/.changesets/1781750799-fix-agent-dead-air-fallback-hardening.md
+++ b/.changesets/1781750799-fix-agent-dead-air-fallback-hardening.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): harden the AskUserQuestion dead-air fallback (codex review on #1536). Snapshot stdout activity *before* sending the answer (not after), and count *every* stdout frame — including control frames the reader skips for health monitoring — via a dedicated `stdout_seq` counter. A resume whose first activity is a tool-permission round-trip is no longer mistaken for "no activity" (which would have spuriously re-delivered the answer). Happy path unchanged.

--- a/.changesets/1781750944-fix-accounts-agentmux-provider-visibility-stale-agent-count-status-ctas.md
+++ b/.changesets/1781750944-fix-accounts-agentmux-provider-visibility-stale-agent-count-status-ctas.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(accounts): fix agentmux provider visibility, remove stale assigned_agents UI, add status CTAs

--- a/.changesets/1781751731-feat-editor-find-panel-refine.md
+++ b/.changesets/1781751731-feat-editor-find-panel-refine.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(editor): refine the find panel — tight spacing, hard corners, accent-tinted controls

--- a/.changesets/1781752186-fix-tabbar-hamburger-spacing.md
+++ b/.changesets/1781752186-fix-tabbar-hamburger-spacing.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): uniform spacing/separator between the hamburger and the first tab

--- a/.changesets/1781752660-chore-agent-pane-remove-dead-streamstalled-streaming-idle-wa-sgxk.md
+++ b/.changesets/1781752660-chore-agent-pane-remove-dead-streamstalled-streaming-idle-wa-sgxk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(agent-pane): remove dead StreamStalled streaming-idle watchdog (emitted but never dispatched; drops its dead sound + setting)

--- a/.changesets/1781754556-test-rpc-add-frontend-backend-rpc-command-contract-guard-arc-ooae.md
+++ b/.changesets/1781754556-test-rpc-add-frontend-backend-rpc-command-contract-guard-arc-ooae.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(rpc): add frontend<->backend RPC command contract guard (architecture audit A1)

--- a/.changesets/1781758234-refactor-agent-providers-extract-shared-toolcorrelator-for-t-vbf9.md
+++ b/.changesets/1781758234-refactor-agent-providers-extract-shared-toolcorrelator-for-t-vbf9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(agent/providers): extract shared ToolCorrelator for tool-call/result mapping (architecture audit A7)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "dirs",
  "serde",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.46.2"
+version = "0.46.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.46.2"
+version = "0.46.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,22 @@
 # AgentMux Version History
 
+## 0.46.3 — 2026-06-18
+
+- fix(agent): show 'in progress' when streaming resumes after a stream drop; quiet Esc on idle
+- perf(layout): reduce pane reflow settle window from 220ms to 32ms
+- feat(editor): open and round-trip non-UTF-8 files (Windows-1252 .ini, UTF-16, Shift_JIS, …) via encoding detection
+- feat(mcp): consolidate layout/introspection + naming verbs — `Layout(query)` replaces GetLayout/ListWindows/ListWorkspaces/ListTabs and `SetName(target,name)` replaces SetWindowName/SetTabName/SetPaneTitle/SetWorkspaceName (17→11 MCP tools). WhoAmI and the SetActiveTab/NewTab/FocusWindow navigation verbs are unchanged; every REST endpoint and capability is preserved. Cuts the per-turn MCP tool-definition footprint (see agent-pane latency report §3) while keeping the surface discoverable.
+- fix(agent): auto-resume after AskUserQuestion on persistent (Claude) panes. When a turn ends while a question is still parked, the CLI abandons the pending tool_use and the answer's control_response is silently dropped — the agent stalls ("dead air"). `answer_question` now arms a short post-answer check: if no stdout activity follows the control_response, the answer is re-delivered as a directive follow-up user message so the turn resumes. Gated on output activity, so it is mutually exclusive with a real resume and never double-delivers. Mirrors the one-shot controllers' existing message fallback (SPEC_ASK_USER_QUESTION §9/§10.1).
+- feat(agent-picker): My Agents + Templates render as a responsive tile grid filling the pane (was a 520px single column)
+- fix(agent): harden the AskUserQuestion dead-air fallback (codex review on #1536). Snapshot stdout activity *before* sending the answer (not after), and count *every* stdout frame — including control frames the reader skips for health monitoring — via a dedicated `stdout_seq` counter. A resume whose first activity is a tool-permission round-trip is no longer mistaken for "no activity" (which would have spuriously re-delivered the answer). Happy path unchanged.
+- fix(accounts): fix agentmux provider visibility, remove stale assigned_agents UI, add status CTAs
+- feat(editor): refine the find panel — tight spacing, hard corners, accent-tinted controls
+- fix(tabbar): uniform spacing/separator between the hamburger and the first tab
+- chore(agent-pane): remove dead StreamStalled streaming-idle watchdog (emitted but never dispatched; drops its dead sound + setting)
+- test(rpc): add frontend<->backend RPC command contract guard (architecture audit A1)
+- refactor(agent/providers): extract shared ToolCorrelator for tool-call/result mapping (architecture audit A7)
+
+
 ## 0.46.2 — 2026-06-17
 
 - fix(trust-center): surface already-authorized CLI OAuth under its brand — a Claude CLI login now shows as a connected Anthropic account (and codex→OpenAI, gemini→Google, copilot→GitHub), with its live probe status, instead of being invisible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.46.2",
+      "version": "0.46.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Bumps version 0.46.2 → 0.46.3 (forced patch — changesets include feat entries held for a dedicated minor release)
- Consumes 13 pending changesets from recent merged PRs (#1523, #1531, #1533, #1535, #1536, #1537, #1538, #1539, #1540, #1541, #1542, #1544, #1545)
- Updates VERSION_HISTORY.md

## Test plan
- [ ] VERSION_HISTORY.md top entry matches 0.46.3
- [ ] All .changesets/ entries removed
- [ ] package.json, Cargo.toml, package-lock.json, Cargo.lock all at 0.46.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)