### PR TITLE
fix(srv): harden error paths — poison-tolerant mutex, log silent drops, guard take().unwrap() (A15)

### DIFF
--- a/.changesets/1781776672392-fix-srv-error-hardening-94e3c9878898.md
+++ b/.changesets/1781776672392-fix-srv-error-hardening-94e3c9878898.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Harden srv error paths: poison-tolerant mutex in rpc/engine, log silent channel drops, guard unguarded take().unwrap() in subprocess/persistent/acp controllers with proper Err returns

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -267,8 +267,10 @@ impl AcpController {
         );
 
         let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
-        let stdin = child.stdin.take().unwrap();
-        let stdout = child.stdout.take().unwrap();
+        let stdin = child.stdin.take()
+            .ok_or_else(|| format!("[acp] stdin not captured for block {}", self.block_id))?;
+        let stdout = child.stdout.take()
+            .ok_or_else(|| format!("[acp] stdout not captured for block {}", self.block_id))?;
         let stderr = child.stderr.take();
 
         // Drain stderr with explicit error/EOF logging
@@ -385,7 +387,9 @@ impl AcpController {
                                     }
                                 }).to_string();
                                 if let Some(ref tx) = inner.stdin_tx {
-                                    let _ = tx.try_send(req);
+                                    if tx.try_send(req).is_err() {
+                                        tracing::warn!(block_id = %block_id_stdout, "[acp] session/prompt send failed — channel full or closed");
+                                    }
                                 }
                             }
                         }
@@ -500,9 +504,11 @@ impl AcpController {
         // Queue the handshake messages
         let inner = self.inner.lock().unwrap();
         if let Some(ref tx) = inner.stdin_tx {
-            let _ = tx.try_send(init_req);
-            let _ = tx.try_send(init_notification);
-            let _ = tx.try_send(session_req);
+            for (label, msg) in [("initialize", init_req), ("initialized", init_notification), ("session/create", session_req)] {
+                if tx.try_send(msg).is_err() {
+                    tracing::error!(block_id = %self.block_id, method = label, "[acp] handshake message dropped — channel full or closed; agent will not start");
+                }
+            }
         }
 
         Ok(())
@@ -539,8 +545,11 @@ impl Controller for AcpController {
             if let Some(ref tx) = inner.stdin_tx {
                 let shutdown = self.make_request("shutdown", serde_json::json!({}));
                 let exit = self.make_notification("exit", serde_json::json!({}));
-                let _ = tx.try_send(shutdown);
-                let _ = tx.try_send(exit);
+                for (label, msg) in [("shutdown", shutdown), ("exit", exit)] {
+                    if tx.try_send(msg).is_err() {
+                        tracing::debug!(block_id = %self.block_id, method = label, "[acp] shutdown message dropped — process likely already gone");
+                    }
+                }
             }
         }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -662,8 +662,10 @@ impl PersistentSubprocessController {
         }
 
         let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
-        let stdin = child.stdin.take().unwrap();
-        let stdout = child.stdout.take().unwrap();
+        let stdin = child.stdin.take()
+            .ok_or_else(|| format!("[persistent] stdin not captured for block {}", self.block_id))?;
+        let stdout = child.stdout.take()
+            .ok_or_else(|| format!("[persistent] stdout not captured for block {}", self.block_id))?;
         let stderr = child.stderr.take();
 
         // Drain stderr in background — log lines for debugging

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -487,10 +487,13 @@ impl SubprocessController {
             inner.kill_tx = Some(kill_tx);
         }
 
-        // Take ownership of stdin/stdout
-        let stdin = child.stdin.take().unwrap();
-        let stdout = child.stdout.take().unwrap();
-        let stderr = child.stderr.take().unwrap();
+        // Take ownership of stdin/stdout (piped via Stdio::piped() in spawn config).
+        let stdin = child.stdin.take()
+            .ok_or_else(|| format!("[subprocess] stdin not captured for block {}", self.block_id))?;
+        let stdout = child.stdout.take()
+            .ok_or_else(|| format!("[subprocess] stdout not captured for block {}", self.block_id))?;
+        let stderr = child.stderr.take()
+            .ok_or_else(|| format!("[subprocess] stderr not captured for block {}", self.block_id))?;
 
         // Write user message to stdin, then close it.
         // CRITICAL: This must complete BEFORE the child's stdin timeout

--- a/agentmux-srv/src/backend/rpc/engine.rs
+++ b/agentmux-srv/src/backend/rpc/engine.rs
@@ -192,6 +192,14 @@ pub struct WshRpcEngine {
 }
 
 impl WshRpcEngine {
+    /// Lock `inner`, recovering from mutex poison instead of propagating
+    /// the panic. A poisoned mutex means a previous handler panicked while
+    /// holding the lock — the data is still consistent for our purposes
+    /// (inserts/removes on HashMaps), so recovery is safe here.
+    fn lock_inner(&self) -> std::sync::MutexGuard<'_, EngineInner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Create a new RPC engine.
     /// Returns the engine and a receiver for outgoing messages.
     pub fn new() -> (Arc<Self>, mpsc::UnboundedReceiver<RpcMessage>) {
@@ -211,7 +219,7 @@ impl WshRpcEngine {
 
     /// Register a call handler (single request → single response).
     pub fn register_handler(&self, command: &str, handler: CommandHandler) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner
             .handlers
             .insert(command.to_string(), Handler::Call(handler));
@@ -220,7 +228,7 @@ impl WshRpcEngine {
     /// Register a streaming handler (single request → stream of responses).
     #[allow(dead_code)]
     pub fn register_stream_handler(&self, command: &str, handler: StreamHandler) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner
             .handlers
             .insert(command.to_string(), Handler::Stream(handler));
@@ -229,21 +237,21 @@ impl WshRpcEngine {
     /// Set the authentication token.
     #[allow(dead_code)]
     pub fn set_auth_token(&self, token: &str) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner.auth_token = token.to_string();
     }
 
     /// Get the authentication token.
     #[allow(dead_code)]
     pub fn get_auth_token(&self) -> String {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.auth_token.clone()
     }
 
     /// Set the RPC context.
     #[allow(dead_code)]
     pub fn set_rpc_context(&self, ctx: RpcContext) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner.rpc_context = Some(ctx);
     }
 
@@ -305,7 +313,7 @@ impl WshRpcEngine {
         let (resp_tx, resp_rx) = mpsc::channel(RESP_CH_SIZE);
 
         {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = self.lock_inner();
             inner
                 .pending_responses
                 .insert(req_id.clone(), resp_tx);
@@ -361,7 +369,9 @@ impl WshRpcEngine {
     // ---- Internal ----
 
     fn send_output(&self, msg: RpcMessage) {
-        let _ = self.output_tx.send(msg);
+        if self.output_tx.send(msg).is_err() {
+            tracing::warn!("[rpc-engine] output channel closed — message dropped");
+        }
     }
 
     async fn handle_request(self: Arc<Self>, msg: RpcMessage) {
@@ -382,14 +392,14 @@ impl WshRpcEngine {
 
         // Register the active handler
         if !msg.reqid.is_empty() {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = self.lock_inner();
             inner
                 .active_handlers
                 .insert(msg.reqid.clone(), handler.clone());
         }
 
         let rpc_context = {
-            let inner = self.inner.lock().unwrap();
+            let inner = self.lock_inner();
             inner.rpc_context.clone().unwrap_or_default()
         };
 
@@ -400,7 +410,7 @@ impl WshRpcEngine {
         let has_call;
         let has_stream;
         {
-            let inner = self.inner.lock().unwrap();
+            let inner = self.lock_inner();
             match inner.handlers.get(&command) {
                 Some(Handler::Call(_)) => {
                     has_call = true;
@@ -432,7 +442,7 @@ impl WshRpcEngine {
             // Create the future while holding the lock, then drop the lock before awaiting.
             let handler_start = std::time::Instant::now();
             let fut = {
-                let inner = self.inner.lock().unwrap();
+                let inner = self.lock_inner();
                 match inner.handlers.get(&command) {
                     Some(Handler::Call(h)) => h(data.clone(), rpc_context.clone()),
                     _ => Box::pin(async { Err("handler disappeared".to_string()) }),
@@ -458,7 +468,7 @@ impl WshRpcEngine {
         } else {
             // Stream handler: same pattern — build future under lock, await outside.
             let fut = {
-                let inner = self.inner.lock().unwrap();
+                let inner = self.lock_inner();
                 match inner.handlers.get(&command) {
                     Some(Handler::Stream(h)) => h(data.clone(), rpc_context.clone()),
                     _ => Box::pin(async { Err("handler disappeared".to_string()) }),
@@ -504,20 +514,22 @@ impl WshRpcEngine {
     }
 
     fn handle_response(&self, msg: RpcMessage) {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         if let Some(tx) = inner.pending_responses.get(&msg.resid) {
             let is_done = !msg.cont;
-            let _ = tx.try_send(msg.clone());
+            if tx.try_send(msg.clone()).is_err() {
+                tracing::warn!(resid = %msg.resid, "[rpc-engine] response channel full/closed — reply dropped");
+            }
             if is_done {
                 drop(inner);
-                let mut inner = self.inner.lock().unwrap();
+                let mut inner = self.lock_inner();
                 inner.pending_responses.remove(&msg.resid);
             }
         }
     }
 
     fn handle_cancel_request(&self, req_id: &str) {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         if let Some(handler) = inner.active_handlers.get(req_id) {
             handler.cancel();
         }
@@ -527,7 +539,7 @@ impl WshRpcEngine {
         if req_id.is_empty() {
             return;
         }
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner.active_handlers.remove(req_id);
     }
 }


### PR DESCRIPTION
## Summary

Addresses A15 from the architecture refactor tracking board (`docs/analysis/TRACKING_ARCHITECTURE_REFACTOR_A1_A15_2026_06_18.md`).

- **`rpc/engine.rs`** — add `lock_inner()` helper that recovers from mutex poison via `unwrap_or_else(|e| e.into_inner())`, replacing all 15 `lock().unwrap()` call sites. Also logs when the output channel is closed (`send_output`) and when a response channel is full or closed (`handle_response`).
- **`subprocess.rs`, `persistent.rs`, `acp.rs`** — replace `child.stdin/stdout.take().unwrap()` with `.ok_or_else(...)` so a missing pipe returns `Err` instead of panicking the Tokio task.
- **`acp.rs`** — log `warn`/`error` when `try_send` silently drops ACP handshake messages (`initialize`, `initialized`, `session/create`) or shutdown messages (`shutdown`, `exit`). ACP agents that fail to start will now appear in logs.

## Test plan

- [ ] `cargo check -p agentmux-srv` passes (no new errors) ✅ (36s, 66 pre-existing warnings)
- [ ] Start an ACP agent, observe normal startup in logs
- [ ] Kill an ACP agent mid-run, confirm graceful stop path logs debug (not error)
- [ ] Confirm no panic under `lock_inner()` usage in a normal run

🤖 Generated with [Claude Code](https://claude.com/claude-code)