### PR TITLE
fix(floater): dwell gate for redock ghost + retry on back-to-back tear-off

### DIFF
--- a/.changesets/1781781025-fix-floater-dwell-gate-for-redock-ghost-retry-on-back-to-bac-n07u.md
+++ b/.changesets/1781781025-fix-floater-dwell-gate-for-redock-ghost-retry-on-back-to-bac-n07u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floater): dwell gate for redock ghost + retry on back-to-back tear-off

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -161,6 +161,16 @@ function installFloatingRedockHoverListener(): void {
         }
     };
 
+    // Dwell gate — mirrors the 180ms gate in floating-pane-workspace.tsx.
+    // On Windows, Win32BeginMoveTask emits floating-redock:hover-state every
+    // 50ms unconditionally; without this gate the ghost appears immediately on
+    // cursor entry. On non-Windows the floater's IPC is already gated so the
+    // event only arrives after 180ms — the gate here is a no-op there but
+    // keeps both paths in sync if the upstream constant changes.
+    const REDOCK_DWELL_MS = 180;
+    let dwellTarget: string | null = null;
+    let dwellSince = 0;
+
     fireAndForget(async () => {
         const { listenEvent } = await import("@/app/platform/ipc");
         const { determineDropDirection } = await import("@/layout/lib/utils");
@@ -170,10 +180,25 @@ function installFloatingRedockHoverListener(): void {
             cursor_x?: number;
             cursor_y?: number;
         }>("floating-redock:hover-state", (payload) => {
-            if (!payload || payload.target_label !== myLabel) {
+            const newTarget = payload?.target_label ?? null;
+            if (!payload || newTarget !== myLabel) {
+                // Target changed away from us or cleared — reset dwell and hide ghost.
+                if (dwellTarget !== null) {
+                    dwellTarget = null;
+                    dwellSince = 0;
+                }
                 clearPlaceholder();
                 return;
             }
+            // Cursor is over our window. Start or continue dwell clock.
+            const now = performance.now();
+            if (dwellTarget !== myLabel) {
+                dwellTarget = myLabel;
+                dwellSince = now;
+            }
+            // Ghost only appears after the dwell has elapsed.
+            if (now - dwellSince < REDOCK_DWELL_MS) return;
+
             const cursorX = payload.cursor_x;
             const cursorY = payload.cursor_y;
             if (typeof cursorX !== "number" || typeof cursorY !== "number") {

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -53,6 +53,7 @@ import { fireAndForget } from "@/util/util";
 import { scheduleRevealLift } from "@/store/tab-reveal";
 import { installLauncherEventBridge } from "@/util/launcher-events";
 import { installSrvEventBridge } from "@/util/srv-events";
+import { REDOCK_DWELL_MS } from "@/app/workspace/floating-pane-constants";
 import {
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
@@ -167,7 +168,6 @@ function installFloatingRedockHoverListener(): void {
     // cursor entry. On non-Windows the floater's IPC is already gated so the
     // event only arrives after 180ms — the gate here is a no-op there but
     // keeps both paths in sync if the upstream constant changes.
-    const REDOCK_DWELL_MS = 180;
     let dwellTarget: string | null = null;
     let dwellSince = 0;
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -162,12 +162,16 @@ function installFloatingRedockHoverListener(): void {
         }
     };
 
-    // Dwell gate — mirrors the 180ms gate in floating-pane-workspace.tsx.
-    // On Windows, Win32BeginMoveTask emits floating-redock:hover-state every
-    // 50ms unconditionally; without this gate the ghost appears immediately on
-    // cursor entry. On non-Windows the floater's IPC is already gated so the
-    // event only arrives after 180ms — the gate here is a no-op there but
-    // keeps both paths in sync if the upstream constant changes.
+    // Dwell gate for the redock ghost.
+    // On Windows, Win32BeginMoveTask emits floating-redock:hover-state every 50ms
+    // with no dwell awareness — we must gate the ghost ourselves to 180ms.
+    // On non-Windows, the floater's onMouseMove path already waits REDOCK_DWELL_MS
+    // before calling update_floating_redock_hover, so the first event arrives at
+    // ~T=180ms; applying our own 180ms clock on top would delay to ~T=360ms and
+    // would never fire if the cursor is held still (no further mousemoves = no
+    // further events). Set ghostDwellMs=0 on non-Windows so the ghost appears on
+    // the first event (already pre-gated by the floater).
+    const ghostDwellMs = isWindows() ? REDOCK_DWELL_MS : 0;
     let dwellTarget: string | null = null;
     let dwellSince = 0;
 
@@ -196,8 +200,8 @@ function installFloatingRedockHoverListener(): void {
                 dwellTarget = myLabel;
                 dwellSince = now;
             }
-            // Ghost only appears after the dwell has elapsed.
-            if (now - dwellSince < REDOCK_DWELL_MS) return;
+            // Ghost only appears after the dwell has elapsed (0 on non-Windows).
+            if (now - dwellSince < ghostDwellMs) return;
 
             const cursorX = payload.cursor_x;
             const cursorY = payload.cursor_y;

--- a/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
@@ -216,11 +216,32 @@ async function performTearOff(
                 screenY,
             });
         } catch (e) {
-            Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
-                error: String(e),
-                blockId: payload.blockId,
-            });
-            return;
+            const msg = String(e);
+            if (msg.includes("currently closing")) {
+                await new Promise<void>((r) => setTimeout(r, 350));
+                try {
+                    await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+                        pane_id: payload.blockId,
+                        workspace_id: newWsId,
+                        x: screenX,
+                        y: screenY,
+                        width: floaterWidth,
+                        height: floaterHeight,
+                    });
+                } catch (e2) {
+                    Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {
+                        error: String(e2),
+                        blockId: payload.blockId,
+                    });
+                    return;
+                }
+            } else {
+                Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
+                    error: msg,
+                    blockId: payload.blockId,
+                });
+                return;
+            }
         }
 
         // IPC succeeded → drop the docked node so the pane doesn't render twice.

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -230,12 +230,34 @@ async function performTearOff(
                 height: floaterHeight,
             });
         } catch (err) {
-            Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
-                error: String(err),
-                blockId: payload.blockId,
-                newWsId,
-            });
-            return;
+            const msg = String(err);
+            if (msg.includes("currently closing")) {
+                await new Promise<void>((r) => setTimeout(r, 350));
+                try {
+                    await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+                        pane_id: payload.blockId,
+                        workspace_id: newWsId,
+                        x: screenX,
+                        y: screenY,
+                        width: floaterWidth,
+                        height: floaterHeight,
+                    });
+                } catch (e2) {
+                    Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {
+                        error: String(e2),
+                        blockId: payload.blockId,
+                        newWsId,
+                    });
+                    return;
+                }
+            } else {
+                Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
+                    error: msg,
+                    blockId: payload.blockId,
+                    newWsId,
+                });
+                return;
+            }
         }
 
         // IPC succeeded → drop the docked layout node so the pane

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -296,15 +296,40 @@ async function performTearOff(
                 screenY,
             });
         } catch (e) {
-            Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
-                error: String(e),
-                blockId: payload.blockId,
-            });
-            // TODO(phase-5): undo TearOffBlock here to avoid an orphaned
-            // workspace if the host couldn't create the floating window.
-            // For now we leave the new workspace in place; it's reachable
-            // via the workspace switcher and the user can close it.
-            return;
+            const msg = String(e);
+            // The first tear-off auto-closes the source tab, which briefly sets
+            // BrowserPaneLifecycle::Closing and makes any_browser_pane_closing()
+            // true in open_floating_pane_window. A 350ms one-shot retry covers
+            // the typical 100–200ms closing window so back-to-back tear-offs work.
+            if (msg.includes("currently closing")) {
+                await new Promise<void>((r) => setTimeout(r, 350));
+                try {
+                    await invokeCommand<{ window_label: string }>("open_floating_pane_window", {
+                        pane_id: payload.blockId,
+                        workspace_id: newWsId,
+                        x: screenX,
+                        y: screenY,
+                        width: floaterWidth,
+                        height: floaterHeight,
+                    });
+                } catch (e2) {
+                    Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {
+                        error: String(e2),
+                        blockId: payload.blockId,
+                    });
+                    return;
+                }
+            } else {
+                Logger.error("dnd:cross", "open_floating_pane_window failed — leaving pane docked", {
+                    error: msg,
+                    blockId: payload.blockId,
+                });
+                // TODO(phase-5): undo TearOffBlock here to avoid an orphaned
+                // workspace if the host couldn't create the floating window.
+                // For now we leave the new workspace in place; it's reachable
+                // via the workspace switcher and the user can close it.
+                return;
+            }
         }
         // IPC succeeded → safe to drop the docked node so the pane
         // doesn't render twice.

--- a/frontend/app/workspace/floating-pane-constants.ts
+++ b/frontend/app/workspace/floating-pane-constants.ts
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared redock dwell/velocity constants consumed by both the floater drag
+ * handler (floating-pane-workspace.tsx) and the main-window ghost listener
+ * (app-init.ts). Single source of truth so both sides gate at the same
+ * threshold.
+ */
+
+/** Milliseconds the cursor must hover over a target before redock arms. */
+export const REDOCK_DWELL_MS = 180;
+
+/** CSS-px/s above which cursor motion cancels the dwell clock. */
+export const REDOCK_VELOCITY_PX_PER_S = 400;

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -50,6 +50,7 @@ import { atoms, getApi } from "@/store/global";
 import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 
+import { REDOCK_DWELL_MS, REDOCK_VELOCITY_PX_PER_S } from "./floating-pane-constants";
 import "./floating-pane-workspace.scss";
 
 /**
@@ -193,8 +194,6 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // stays near the same target window for REDOCK_DWELL_MS ms at
         // ≤ REDOCK_VELOCITY_PX_PER_S CSS-px/s. All vars hoisted to drag scope so
         // a second drag never inherits state from the first.
-        const REDOCK_DWELL_MS = 180;
-        const REDOCK_VELOCITY_PX_PER_S = 400;
         let hoverArmed = false;
         // Preserves arm state across the Windows mouseup/window_drag_ended race:
         // onMouseUp sets pendingRedockArmed=hoverArmed before clearing hoverArmed,


### PR DESCRIPTION
## Summary

- **Bug 1 — redock ghost delay**: `installFloatingRedockHoverListener` in `app-init.ts` now gates the ghost placeholder behind 180ms of continuous hover over the same target window, matching `REDOCK_DWELL_MS` already enforced by the floater for the actual drop. On Windows, `Win32BeginMoveTask` fires `floating-redock:hover-state` every 50ms with no dwell — the ghost was appearing immediately on cursor entry and surprising users who just wanted to reposition the floater.

- **Bug 3 — second tear-off silently drops**: All three `CrossWindowDragMonitor` variants (win32, darwin, linux) now retry `open_floating_pane_window` once after 350ms when the error message contains `"currently closing"`. Root cause: the first tear-off auto-closes its source tab (`service.rs:2182`), briefly setting `BrowserPaneLifecycle::Closing`, which makes `any_browser_pane_closing()` return true and rejects any concurrent `open_floating_pane_window` call. The 350ms window covers the typical 100–200ms tab-close lifecycle.

## Out of scope (tracked separately)

Bug 2 — floater Z-order always above main window — is a Win32 owned-window invariant and requires removing the owner relationship + manual minimize/restore/destroy cascade. Filed as a separate issue.

## Test plan

- [ ] Drag floating pane quickly across main window border — ghost should NOT appear (< 180ms pass-through)
- [ ] Hold cursor over main window for > 180ms with floater being dragged — ghost should appear and snap correctly on drop
- [ ] Tear off a pane, then immediately tear off a second pane — both should produce floating windows (no silent drop)
- [ ] Non-"currently closing" IPC failures still log and bail (no retry loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)