### PR TITLE
fix(agent): DiffViewer skips synthetic diff for failed/denied Edit calls

### DIFF
--- a/.changesets/1781781620-fix-agent-diffviewer-skips-synthetic-diff-for-failed-denied--pwow.md
+++ b/.changesets/1781781620-fix-agent-diffviewer-skips-synthetic-diff-for-failed-denied--pwow.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): DiffViewer skips synthetic diff for failed/denied Edit calls

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -114,17 +114,27 @@ function parseDiffLines(diff: string): DiffLine[] {
 interface DiffViewerProps {
     params: EditParams;
     result?: EditResult;
+    /** ToolNode.status — gates the params fallback. Only synthesise a diff
+     *  when the edit actually applied. For failed/denied edits the params
+     *  reflect the *intended* change, not what happened, so showing them
+     *  as a diff would mislead. Defaults to "success" when omitted. */
+    status?: string;
 }
 
 export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
     const rawDiff = () => {
         // Prefer the pre-computed diff from result (populated by some providers).
-        // Fall back to computing from params — Claude's translator returns a
-        // plain-text string, so result.diff is absent in the current pipeline.
         if (props.result?.diff) return props.result.diff;
-        const p = props.params;
-        if (p && (p.old_string != null || p.new_string != null)) {
-            return buildDiffFromParams(p.old_string ?? "", p.new_string ?? "");
+        // Fall back to computing from params only for successful edits.
+        // For failed/denied nodes params reflect the *intended* change —
+        // synthesising a diff would show what was supposed to happen, not
+        // what did, misleading the user. (Codex P2 on PR #1561.)
+        const succeeded = (props.status ?? "success") === "success";
+        if (succeeded) {
+            const p = props.params;
+            if (p && (p.old_string != null || p.new_string != null)) {
+                return buildDiffFromParams(p.old_string ?? "", p.new_string ?? "");
+            }
         }
         return undefined;
     };

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -246,7 +246,7 @@ function ToolOverlayResult(props: { node: ToolNode }): JSX.Element {
 // SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md (Phase 1).
 
 function renderEdit(node: ToolNode): JSX.Element {
-    return <DiffViewer params={node.params as any} result={node.result as any} />;
+    return <DiffViewer params={node.params as any} result={node.result as any} status={node.status} />;
 }
 
 function renderBash(node: ToolNode): JSX.Element {


### PR DESCRIPTION
## Summary

Addresses Codex P2 on #1561.

- **Problem:** The params-based diff fallback in `DiffViewer` ran for any completed Edit node regardless of `status`. For failed/denied edits the params contain the *intended* `old_string`/`new_string` (what the agent tried to do) — showing that as a diff implies the edit applied when it didn't.
- **Fix:** Added a `status` prop to `DiffViewer`; the params fallback is gated on `status === "success"`. `renderEdit` in `ToolOverlayLog` passes `node.status`. Failed/denied edits fall through to the existing "No diff available" empty state.
- No change to the happy path — successful edits still show the LCS diff as before.

## Test plan

- [ ] Successful Edit: expand panel shows the syntax-highlighted diff
- [ ] Failed Edit (e.g. `old_string` not found): expand panel shows "No diff available" + file path — no misleading synthetic diff
- [ ] Denied Edit: same as failed — no diff shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)