### PR TITLE
refactor(A5): extract BlockControllerCore shared helpers; fix ACP session-id persist

### DIFF
--- a/.changesets/2026-06-18-a5-blockcontroller-core-a3f7b219.md
+++ b/.changesets/2026-06-18-a5-blockcontroller-core-a3f7b219.md
@@ -1,0 +1,26 @@
+---
+type: patch
+---
+
+refactor(A5): extract BlockControllerCore shared helpers; fix ACP session-id persist
+
+Extracts duplicated logic from the four block controllers into a new
+`blockcontroller/core.rs` module:
+
+- `apply_working_dir()` — tilde-expand, mkdir, current_dir, env-var setup
+  (replaces ~35-line copy-paste in persistent/subprocess/acp)
+- `spawn_health_watchdog()` — 5-second poll loop
+  (was duplicated twice in subprocess.rs)
+- `persist_session_id()` — persist `agent:sessionid` to block metadata
+  and broadcast `waveobj:update` so the frontend reflects the change
+- `META_SESSION_ID` — `"agent:sessionid"` constant (was magic string)
+
+Bug fix: AcpController was capturing the session ID in memory
+(`inner.session_id`) but never persisting it to block metadata or
+broadcasting the update. This broke the "My Agents" reattach path
+for ACP agents (frontend reads `block.meta["agent:sessionid"]` to
+resume with `--resume <sid>`). The fix routes ACP through
+`core::persist_session_id`, matching the careful path from
+persistent.rs and subprocess.rs.
+
+Net: –249 lines removed from the four controller files.

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -33,6 +33,7 @@ use super::{
     BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
     STATUS_RUNNING,
 };
+use super::core;
 use super::health::HealthMonitor;
 use crate::backend::eventbus::EventBus;
 use crate::backend::storage::filestore::FileStore;
@@ -205,39 +206,7 @@ impl AcpController {
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&cli_command);
         cmd.args(&cli_args);
 
-        // Working directory
-        if !working_dir.is_empty() {
-            let expanded_dir = if working_dir.starts_with("~/") || working_dir == "~" {
-                if let Some(home) = dirs::home_dir() {
-                    home.join(working_dir.trim_start_matches("~/")).to_string_lossy().to_string()
-                } else {
-                    working_dir.clone()
-                }
-            } else {
-                working_dir.clone()
-            };
-            let dir_path = std::path::Path::new(&expanded_dir);
-            if !dir_path.exists() {
-                if let Err(e) = std::fs::create_dir_all(dir_path) {
-                    tracing::warn!(
-                        block_id = %self.block_id,
-                        dir = %expanded_dir,
-                        error = %e,
-                        "failed to create working directory for ACP agent"
-                    );
-                }
-            }
-            if dir_path.exists() {
-                cmd.current_dir(&expanded_dir);
-            }
-        }
-
-        // Environment variables
-        for (k, v) in &env_vars {
-            let expanded = crate::backend::base::expand_home_dir_safe(v);
-            cmd.env(k, expanded.to_string_lossy().as_ref());
-        }
-
+        core::apply_working_dir(&mut cmd, &self.block_id, &working_dir, &env_vars);
         // On Windows: suppress console-window allocation. Without CREATE_NO_WINDOW,
         // node.exe spawned from a windowless sidecar may try to create/attach to a
         // console, causing stdout to go to that console rather than the pipe.
@@ -338,6 +307,8 @@ impl AcpController {
         let inner_clone = self.inner.clone();
         let health_clone = self.health_monitor.clone();
         let rpc_id_clone = self.next_rpc_id.clone();
+        let wstore_clone = self.wstore.clone();
+        let event_bus_clone = self.event_bus.clone();
         // Resolve the agent's GLOBAL transcript zone once (see persistent.rs).
         let global_output_zone =
             super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
@@ -366,32 +337,39 @@ impl AcpController {
                     // Extract session ID from initialize result or session/create result
                     if let Some(result) = json.get("result") {
                         if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str()) {
-                            let mut inner = inner_clone.lock().unwrap();
-                            inner.session_id = Some(sid.to_string());
-                            tracing::info!(
-                                block_id = %block_id_stdout,
-                                session_id = %sid,
-                                "ACP session established"
-                            );
-
-                            // Flush pending prompt now that session is ready.
-                            if let Some(prompt) = inner.pending_prompt.take() {
-                                let id = rpc_id_clone.fetch_add(1, Ordering::Relaxed);
-                                let req = serde_json::json!({
-                                    "jsonrpc": "2.0",
-                                    "id": id,
-                                    "method": "session/prompt",
-                                    "params": {
-                                        "sessionId": sid,
-                                        "prompt": { "type": "text", "text": prompt },
-                                    }
-                                }).to_string();
-                                if let Some(ref tx) = inner.stdin_tx {
-                                    if tx.try_send(req).is_err() {
-                                        tracing::warn!(block_id = %block_id_stdout, "[acp] session/prompt send failed — channel full or closed");
+                            let sid_owned = sid.to_string();
+                            {
+                                let mut inner = inner_clone.lock().unwrap();
+                                inner.session_id = Some(sid_owned.clone());
+                                // Flush pending prompt now that session is ready.
+                                if let Some(prompt) = inner.pending_prompt.take() {
+                                    let id = rpc_id_clone.fetch_add(1, Ordering::Relaxed);
+                                    let req = serde_json::json!({
+                                        "jsonrpc": "2.0",
+                                        "id": id,
+                                        "method": "session/prompt",
+                                        "params": {
+                                            "sessionId": sid,
+                                            "prompt": { "type": "text", "text": prompt },
+                                        }
+                                    }).to_string();
+                                    if let Some(ref tx) = inner.stdin_tx {
+                                        if tx.try_send(req).is_err() {
+                                            tracing::warn!(block_id = %block_id_stdout, "[acp] session/prompt send failed — channel full or closed");
+                                        }
                                     }
                                 }
                             }
+                            tracing::info!(
+                                block_id = %block_id_stdout,
+                                session_id = %sid_owned,
+                                "ACP session established"
+                            );
+                            // Persist to block metadata and broadcast so the frontend's
+                            // "My Agents" reattach path can read agent:sessionid from
+                            // block.meta. ACP previously captured the ID in memory only —
+                            // this mirrors the careful path from persistent.rs / subprocess.rs.
+                            core::persist_session_id(&block_id_stdout, &sid_owned, &wstore_clone, &event_bus_clone);
                         }
                     }
 

--- a/agentmux-srv/src/backend/blockcontroller/core.rs
+++ b/agentmux-srv/src/backend/blockcontroller/core.rs
@@ -1,0 +1,166 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers used by all block controllers (persistent, subprocess, acp).
+//!
+//! Extracted to avoid copy-paste across the four controller files. Each
+//! controller keeps only its transport-specific logic (PTY / stream-json / ACP)
+//! and delegates the common mechanics here.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::health::HealthMonitor;
+use crate::backend::eventbus::EventBus;
+use crate::backend::storage::store::Store;
+
+/// Block metadata key for the persisted agent session ID.
+/// Used by the "My Agents" reattach path on the frontend: after a tab reload
+/// the picker reads `block.meta["agent:sessionid"]` and passes it as the
+/// `--resume` value so the CLI picks up the prior conversation.
+pub(crate) const META_SESSION_ID: &str = "agent:sessionid";
+
+/// Expand the working directory, create it if missing, set it on `cmd`, and
+/// apply all env-var overrides from `env_vars`.
+///
+/// Call this from each controller's spawn routine BEFORE any transport-specific
+/// `Command` flags (e.g. `CREATE_NO_WINDOW` on Windows, which must come after
+/// the env setup in some implementations).
+pub(crate) fn apply_working_dir(
+    cmd: &mut tokio::process::Command,
+    block_id: &str,
+    working_dir: &str,
+    env_vars: &HashMap<String, String>,
+) {
+    if !working_dir.is_empty() {
+        let expanded_dir = expand_home_dir(working_dir);
+        let dir_path = std::path::Path::new(&expanded_dir);
+        if !dir_path.exists() {
+            if let Err(e) = std::fs::create_dir_all(dir_path) {
+                tracing::warn!(
+                    block_id = %block_id,
+                    dir = %expanded_dir,
+                    error = %e,
+                    "failed to create working directory",
+                );
+            }
+        }
+        if dir_path.exists() {
+            cmd.current_dir(&expanded_dir);
+            // Warn loudly if the agent workspace contains a nested .git (e.g.
+            // an unintended `git clone` inside ~/.agentmux/agents/). A stale
+            // nested clone can confuse agents into reading old code and waste
+            // gigabytes of disk. Single fs::metadata call — no directory walk.
+            let looks_like_agent_workspace = expanded_dir.contains("/.agentmux/agents/")
+                || expanded_dir.contains("\\.agentmux\\agents\\");
+            if looks_like_agent_workspace {
+                let git_dir = dir_path.join(".git");
+                if git_dir.exists() {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        cwd = %expanded_dir,
+                        ".git detected inside agent workspace — this is usually \
+                         an unintended nested clone and can waste gigabytes of \
+                         disk. Clean up with: rm -rf {}/.git",
+                        expanded_dir,
+                    );
+                }
+            }
+        }
+    }
+    for (k, v) in env_vars {
+        let expanded = crate::backend::base::expand_home_dir_safe(v);
+        cmd.env(k, expanded.to_string_lossy().as_ref());
+    }
+}
+
+/// Expand a leading `~/` or bare `~` to the user's home directory.
+pub(crate) fn expand_home_dir(dir: &str) -> String {
+    if dir.starts_with("~/") || dir == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home
+                .join(dir.trim_start_matches("~/"))
+                .to_string_lossy()
+                .to_string();
+        }
+    }
+    dir.to_string()
+}
+
+/// Spawn the health-watchdog background task for a turn.
+///
+/// The watchdog polls `health_monitor.check()` every 5 s while a turn is
+/// active and exits as soon as `is_active_turn()` returns false (i.e. after
+/// the turn ends or the process exits). Duplicated verbatim in
+/// persistent.rs and subprocess.rs (twice) before this extraction.
+pub(crate) fn spawn_health_watchdog(health_monitor: &Arc<HealthMonitor>) {
+    let health = Arc::clone(health_monitor);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            if !health.is_active_turn() {
+                break;
+            }
+            health.check();
+        }
+    });
+}
+
+/// Persist a newly captured session ID to block metadata and broadcast the
+/// `waveobj:update` event so the frontend reflects the change immediately.
+///
+/// This is the "careful" path from persistent.rs and subprocess.rs. ACP was
+/// missing this step (it only set `inner.session_id` in memory) — A5 fixes it
+/// by routing ACP through this same function.
+///
+/// No-ops silently when `wstore` is `None` (e.g. in unit tests that don't wire
+/// up a store).
+pub(crate) fn persist_session_id(
+    block_id: &str,
+    sid: &str,
+    wstore: &Option<Arc<Store>>,
+    event_bus: &Option<Arc<EventBus>>,
+) {
+    let Some(ref store) = wstore else {
+        return;
+    };
+    let oref_str = format!("block:{}", block_id);
+    let mut meta_update = crate::backend::obj::MetaMapType::new();
+    meta_update.insert(
+        META_SESSION_ID.to_string(),
+        serde_json::Value::String(sid.to_string()),
+    );
+    match crate::server::service::update_object_meta(store, &oref_str, &meta_update) {
+        Err(e) => {
+            tracing::warn!(
+                block_id = %block_id,
+                error = %e,
+                "failed to persist agent:sessionid",
+            );
+        }
+        Ok(_) => {
+            let Some(ref event_bus) = event_bus else {
+                return;
+            };
+            if let Ok(updated_block) =
+                store.must_get::<crate::backend::obj::Block>(block_id)
+            {
+                let update_data = serde_json::to_value(
+                    &crate::backend::obj::WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: "block".into(),
+                        oid: block_id.to_string(),
+                        obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
+                    },
+                )
+                .ok();
+                event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+                    eventtype: "waveobj:update".to_string(),
+                    oref: oref_str,
+                    data: update_data,
+                });
+            }
+        }
+    }
+}

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -12,6 +12,7 @@
 //! - Controllers dispatch I/O between the user and the process/service
 
 pub mod acp;
+pub mod core;
 pub mod health;
 pub mod persistent;
 pub mod pidregistry;

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -31,6 +31,7 @@ use super::{
     BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
     STATUS_RUNNING,
 };
+use super::core;
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
 use crate::backend::storage::filestore::FileStore;
@@ -560,64 +561,7 @@ impl PersistentSubprocessController {
         }
         cmd.args(&spawn_args);
 
-        // Working directory
-        if !config.working_dir.is_empty() {
-            let expanded_dir = if config.working_dir.starts_with("~/") || config.working_dir == "~" {
-                if let Some(home) = dirs::home_dir() {
-                    home.join(config.working_dir.trim_start_matches("~/")).to_string_lossy().to_string()
-                } else {
-                    config.working_dir.clone()
-                }
-            } else {
-                config.working_dir.clone()
-            };
-            let dir_path = std::path::Path::new(&expanded_dir);
-            if !dir_path.exists() {
-                if let Err(e) = std::fs::create_dir_all(dir_path) {
-                    tracing::warn!(
-                        block_id = %self.block_id,
-                        dir = %expanded_dir,
-                        error = %e,
-                        "failed to create working directory"
-                    );
-                }
-            }
-            if dir_path.exists() {
-                cmd.current_dir(&expanded_dir);
-
-                // 4.2 follow-up: warn loudly if the agent's working directory
-                // contains a nested .git (typically because the agent, or the
-                // user on its behalf, cloned a repo into its cwd). A 3.5 GB
-                // nested clone was found under ~/.agentmux/agents/agentx/ in
-                // an earlier session and confused agents into reading stale
-                // pre-SolidJS code. We can't prevent the clone (the agent is
-                // an external process) so the best we can do is make it
-                // impossible to miss in the logs, with the exact cleanup
-                // command the user needs to run. Single fs::metadata call —
-                // no directory walk.
-                let looks_like_agent_workspace = expanded_dir.contains("/.agentmux/agents/")
-                    || expanded_dir.contains("\\.agentmux\\agents\\");
-                if looks_like_agent_workspace {
-                    let git_dir = dir_path.join(".git");
-                    if git_dir.exists() {
-                        tracing::warn!(
-                            block_id = %self.block_id,
-                            cwd = %expanded_dir,
-                            ".git detected inside agent workspace — this is \
-                             usually an unintended nested clone and can waste \
-                             gigabytes of disk. Clean up with: rm -rf {}/.git",
-                            expanded_dir
-                        );
-                    }
-                }
-            }
-        }
-
-        // Environment variables (with tilde expansion)
-        for (k, v) in &config.env_vars {
-            let expanded = crate::backend::base::expand_home_dir_safe(v);
-            cmd.env(k, expanded.to_string_lossy().as_ref());
-        }
+        core::apply_working_dir(&mut cmd, &self.block_id, &config.working_dir, &config.env_vars);
 
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
@@ -819,48 +763,8 @@ impl PersistentSubprocessController {
                                 session_id = %sid_string,
                                 "persistent session ID captured"
                             );
-                            {
-                                let mut inner = inner_read.lock().unwrap();
-                                inner.session_id = Some(sid_string.clone());
-                            }
-                            // Persist to block metadata (same pattern as subprocess.rs)
-                            if let Some(ref store) = wstore_read {
-                                let oref_str = format!("block:{}", block_id_read);
-                                let mut meta_update =
-                                    crate::backend::obj::MetaMapType::new();
-                                meta_update.insert(
-                                    "agent:sessionid".to_string(),
-                                    serde_json::Value::String(sid_string),
-                                );
-                                if let Err(e) = crate::server::service::update_object_meta(
-                                    store, &oref_str, &meta_update,
-                                ) {
-                                    tracing::warn!(
-                                        block_id = %block_id_read,
-                                        error = %e,
-                                        "failed to persist agent:sessionid"
-                                    );
-                                } else if let Some(ref event_bus) = event_bus_read {
-                                    if let Ok(updated_block) = store.must_get::<crate::backend::obj::Block>(&block_id_read) {
-                                        let update_data = serde_json::to_value(
-                                            &crate::backend::obj::WaveObjUpdate {
-                                                updatetype: "update".into(),
-                                                otype: "block".into(),
-                                                oid: block_id_read.clone(),
-                                                obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
-                                            },
-                                        )
-                                        .ok();
-                                        event_bus.broadcast_event(
-                                            &crate::backend::eventbus::WSEventType {
-                                                eventtype: "waveobj:update".to_string(),
-                                                oref: oref_str,
-                                                data: update_data,
-                                            },
-                                        );
-                                    }
-                                }
-                            }
+                            inner_read.lock().unwrap().session_id = Some(sid_string.clone());
+                            core::persist_session_id(&block_id_read, &sid_string, &wstore_read, &event_bus_read);
                         }
                     }
                 }
@@ -894,17 +798,7 @@ impl PersistentSubprocessController {
         // Emits `agenthealth` WPS events when the process stalls (30 s) or
         // dies (120 s) without producing meaningful output, giving the
         // frontend enough signal to show a "not responding" warning.
-        let health_watchdog = Arc::clone(&self.health_monitor);
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
-            loop {
-                interval.tick().await;
-                if !health_watchdog.is_active_turn() {
-                    break;
-                }
-                health_watchdog.check();
-            }
-        });
+        core::spawn_health_watchdog(&self.health_monitor);
 
         // Spawn process waiter task
         let block_id_wait = self.block_id.clone();

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -30,6 +30,7 @@ use super::{
     BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
     STATUS_RUNNING,
 };
+use super::core;
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
 use crate::backend::storage::filestore::FileStore;
@@ -399,43 +400,7 @@ impl SubprocessController {
             const CREATE_NO_WINDOW: u32 = 0x0800_0000;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
-        if !config.working_dir.is_empty() {
-            // Expand ~ to home directory (cross-platform)
-            let expanded_dir = if config.working_dir.starts_with("~/") || config.working_dir == "~" {
-                if let Some(home) = dirs::home_dir() {
-                    home.join(config.working_dir.trim_start_matches("~/")).to_string_lossy().to_string()
-                } else {
-                    config.working_dir.clone()
-                }
-            } else {
-                config.working_dir.clone()
-            };
-            // Create directory if it doesn't exist
-            let dir_path = std::path::Path::new(&expanded_dir);
-            if !dir_path.exists() {
-                if let Err(e) = std::fs::create_dir_all(dir_path) {
-                    tracing::warn!(
-                        block_id = %self.block_id,
-                        dir = %expanded_dir,
-                        error = %e,
-                        "failed to create working directory, using current dir"
-                    );
-                } else {
-                    tracing::info!(
-                        block_id = %self.block_id,
-                        dir = %expanded_dir,
-                        "created working directory"
-                    );
-                }
-            }
-            if dir_path.exists() {
-                cmd.current_dir(&expanded_dir);
-            }
-        }
-        for (k, v) in &config.env_vars {
-            let expanded = crate::backend::base::expand_home_dir_safe(v);
-            cmd.env(k, expanded.to_string_lossy().as_ref());
-        }
+        core::apply_working_dir(&mut cmd, &self.block_id, &config.working_dir, &config.env_vars);
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
@@ -628,46 +593,7 @@ impl SubprocessController {
                                         session_id = %sid_string,
                                         "captured session id"
                                     );
-
-                                    // Persist session_id to block metadata
-                                    if let Some(ref store) = wstore_read {
-                                        let oref_str = format!("block:{}", block_id_read);
-                                        let mut meta_update =
-                                            crate::backend::obj::MetaMapType::new();
-                                        meta_update.insert(
-                                            "agent:sessionid".to_string(),
-                                            serde_json::Value::String(sid_string),
-                                        );
-                                        if let Err(e) = crate::server::service::update_object_meta(
-                                            store, &oref_str, &meta_update,
-                                        ) {
-                                            tracing::warn!(
-                                                block_id = %block_id_read,
-                                                error = %e,
-                                                "failed to persist agent:sessionid"
-                                            );
-                                        } else if let Some(ref event_bus) = event_bus_read {
-                                            // Broadcast metadata update to frontend
-                                            if let Ok(updated_block) = store.must_get::<crate::backend::obj::Block>(&block_id_read) {
-                                                let update_data = serde_json::to_value(
-                                                    &crate::backend::obj::WaveObjUpdate {
-                                                        updatetype: "update".into(),
-                                                        otype: "block".into(),
-                                                        oid: block_id_read.clone(),
-                                                        obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
-                                                    },
-                                                )
-                                                .ok();
-                                                event_bus.broadcast_event(
-                                                    &crate::backend::eventbus::WSEventType {
-                                                        eventtype: "waveobj:update".to_string(),
-                                                        oref: oref_str,
-                                                        data: update_data,
-                                                    },
-                                                );
-                                            }
-                                        }
-                                    }
+                                    core::persist_session_id(&block_id_read, &sid_string, &wstore_read, &event_bus_read);
                                 }
                             }
                         }
@@ -731,18 +657,7 @@ impl SubprocessController {
             }
         });
 
-        // Spawn health watchdog (checks every 5s while turn is active)
-        let health_watchdog = Arc::clone(&self.health_monitor);
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
-            loop {
-                interval.tick().await;
-                if !health_watchdog.is_active_turn() {
-                    break;
-                }
-                health_watchdog.check();
-            }
-        });
+        core::spawn_health_watchdog(&self.health_monitor);
 
         // Spawn process_waiter task
         let inner_wait = Arc::clone(&self.inner);
@@ -1125,19 +1040,7 @@ impl SubprocessController {
             // check(), so without this a container turn gets no Stalled/Dead
             // detection. Self-terminates when the turn ends — completion calls
             // health_monitor.set_exited(), which clears the active-turn flag.
-            {
-                let health_watchdog = Arc::clone(&health_monitor);
-                tokio::spawn(async move {
-                    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
-                    loop {
-                        interval.tick().await;
-                        if !health_watchdog.is_active_turn() {
-                            break;
-                        }
-                        health_watchdog.check();
-                    }
-                });
-            }
+            core::spawn_health_watchdog(&health_monitor);
 
             let crate::backend::container::ExecSession { exec_id, mut input, output } = exec_session;
 
@@ -1365,32 +1268,7 @@ impl SubprocessController {
                 let changed = SubprocessController::record_captured_session_id_inner(inner, sid);
                 if changed {
                     tracing::info!(block_id = %block_id, session_id = %sid, "container exec: captured session id");
-                    if let Some(ref store) = wstore {
-                        let oref_str = format!("block:{}", block_id);
-                        let mut meta_update = crate::backend::obj::MetaMapType::new();
-                        meta_update.insert("agent:sessionid".to_string(), serde_json::Value::String(sid.to_string()));
-                        if let Err(e) = crate::server::service::update_object_meta(store, &oref_str, &meta_update) {
-                            tracing::warn!(block_id = %block_id, error = %e, "failed to persist agent:sessionid");
-                        } else if let Some(ref bus) = event_bus {
-                            if let Ok(updated_block) = store.must_get::<crate::backend::obj::Block>(block_id) {
-                                let update_data = serde_json::to_value(
-                                    &crate::backend::obj::WaveObjUpdate {
-                                        updatetype: "update".into(),
-                                        otype: "block".into(),
-                                        oid: block_id.to_string(),
-                                        obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
-                                    },
-                                ).ok();
-                                bus.broadcast_event(
-                                    &crate::backend::eventbus::WSEventType {
-                                        eventtype: "waveobj:update".to_string(),
-                                        oref: oref_str,
-                                        data: update_data,
-                                    },
-                                );
-                            }
-                        }
-                    }
+                    core::persist_session_id(block_id, sid, &wstore, &event_bus);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Extracts ~250 lines of copy-pasted spawn/health/session-id logic from `persistent.rs`, `subprocess.rs`, and `acp.rs` into a new `blockcontroller/core.rs` module
- **Bug fix**: `AcpController` captured `session_id` in memory only — it never persisted it to `block.meta["agent:sessionid"]` or broadcast the `waveobj:update`. This broke the "My Agents" reattach path for ACP agents. Fix routes ACP through `core::persist_session_id`, matching the careful path from persistent.rs/subprocess.rs.
- Part of the A1–A15 architecture refactor board (PR #1546)

### New shared helpers in `core.rs`
| Helper | Replaces |
|--------|---------|
| `apply_working_dir()` | ~35-line tilde-expand + mkdir + env-var block in 3 files |
| `spawn_health_watchdog()` | 10-line loop duplicated 3× (subprocess twice) |
| `persist_session_id()` | ~40-line meta-write + broadcast in persistent + subprocess; newly added to acp |
| `META_SESSION_ID` | `"agent:sessionid"` magic string (6 occurrences) |

## Test plan
- [ ] `cargo check -p agentmux-srv` passes (verified: 0 errors, existing warnings only)
- [ ] ACP agent turn: session ID now appears in `block.meta["agent:sessionid"]` after first turn
- [ ] "My Agents" reattach path works for ACP agents (reads sessionid → passes `--resume`)
- [ ] Persistent and subprocess agents: no regression in session-id capture behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)