### PR TITLE
feat(macos): bundle id follows channel + unix open_new_window forward

### DIFF
--- a/.changesets/1781778889-feat-macos-channel-scoped-bundle-id-reopen-opens-new-window--c8gh.md
+++ b/.changesets/1781778889-feat-macos-channel-scoped-bundle-id-reopen-opens-new-window--c8gh.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(macos): bundle id follows the build channel + wire the unix open_new_window forward (fixes the cross-version "not responding" dialog; `open -n`/CLI relaunch opens a new window). A kAEReopenApplication handler for plain double-click is included but currently inert — Chromium owns the event — with the NSApp-delegate swizzle tracked as a follow-up.

--- a/agentmux-cef/src/macos_menu.rs
+++ b/agentmux-cef/src/macos_menu.rs
@@ -119,6 +119,81 @@ unsafe fn make_target() -> Id {
     msg(msg(cls as Id, sel(b"alloc\0")), sel(b"init\0"))
 }
 
+// AppState handle for the kAEReopenApplication handler (a bare C function with
+// no captured env — same pattern as MENU_STATE above).
+static REOPEN_STATE: OnceLock<Arc<AppState>> = OnceLock::new();
+
+/// `handleAEReopen:withReplyEvent:` — fires when macOS re-activates the
+/// already-running app (Finder/Dock double-click, `open` without `-n`, or a
+/// LaunchServices reactivation triggered by launching another build with the
+/// same bundle id). We answer kAEReopenApplication by opening a new window —
+/// matching the Windows relaunch-forwards-`open_new_window` behavior. Without a
+/// handler the reopen Apple Event goes unanswered: a plain double-click is a
+/// silent no-op, and a same-bundle-id reactivation makes LaunchServices report
+/// the app "not responding". See SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
+unsafe extern "C" fn ae_reopen(_self: Id, _cmd: Sel, _event: Id, _reply: Id) {
+    match REOPEN_STATE.get() {
+        // open_new_window is non-blocking: it enqueues + posts to the CEF UI
+        // thread, so invoking it from the AppKit main thread is safe.
+        Some(state) => match crate::commands::window::open_new_window(state) {
+            Ok(_) => tracing::info!("ae-reopen: opened a new window"),
+            Err(e) => tracing::warn!(error = %e, "ae-reopen: open_new_window failed"),
+        },
+        None => tracing::warn!("ae-reopen fired before REOPEN_STATE was set"),
+    }
+}
+
+/// Register the kAEReopenApplication handler with NSAppleEventManager. Raw
+/// libobjc, mirrors `make_target`. Must run on the main thread after
+/// `cef::initialize` (NSApplication + the AE manager exist by then).
+/// Re-registering just replaces the handler, so a single call is enough.
+pub fn install_reopen_handler(state: Arc<AppState>) {
+    let _ = REOPEN_STATE.set(state);
+    unsafe {
+        let name = b"AgentMuxReopenTarget\0";
+        let mut cls = class(name);
+        if cls.is_null() {
+            cls = objc_allocateClassPair(class(b"NSObject\0"), name.as_ptr() as *const c_char, 0);
+            // -(void)handleAEReopen:(id)event withReplyEvent:(id)reply  →  "v@:@@"
+            let imp: unsafe extern "C" fn(Id, Sel, Id, Id) = ae_reopen;
+            class_addMethod(
+                cls,
+                sel(b"handleAEReopen:withReplyEvent:\0"),
+                imp as usize,
+                b"v@:@@\0".as_ptr() as *const c_char,
+            );
+            objc_registerClassPair(cls);
+        }
+        // Leaked on purpose: the handler target lives for the process lifetime.
+        let target = msg(msg(cls as Id, sel(b"alloc\0")), sel(b"init\0"));
+
+        let mgr = msg(
+            class(b"NSAppleEventManager\0") as Id,
+            sel(b"sharedAppleEventManager\0"),
+        );
+        if mgr.is_null() {
+            tracing::warn!("ae-reopen: NSAppleEventManager unavailable; handler not installed");
+            return;
+        }
+        // FourCharCodes: kCoreEventClass = 'aevt', kAEReopenApplication = 'rapp'.
+        const K_CORE_EVENT_CLASS: u32 = 0x6165_7674;
+        const K_AE_REOPEN_APPLICATION: u32 = 0x7261_7070;
+        // [mgr setEventHandler:target andSelector:@selector(handleAEReopen:withReplyEvent:)
+        //      forEventClass:kCoreEventClass andEventID:kAEReopenApplication]
+        let set_handler: extern "C" fn(Id, Sel, Id, Sel, u32, u32) =
+            std::mem::transmute(objc_msgSend as *const c_void);
+        set_handler(
+            mgr,
+            sel(b"setEventHandler:andSelector:forEventClass:andEventID:\0"),
+            target,
+            sel(b"handleAEReopen:withReplyEvent:\0"),
+            K_CORE_EVENT_CLASS,
+            K_AE_REOPEN_APPLICATION,
+        );
+        tracing::info!("ae-reopen: installed kAEReopenApplication handler");
+    }
+}
+
 unsafe fn new_menu(title: &str) -> Id {
     let alloc = msg(class(b"NSMenu\0") as Id, sel(b"alloc\0"));
     msg_id(alloc, sel(b"initWithTitle:\0"), nsstr(title))

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -814,6 +814,14 @@ fn main() {
     #[cfg(target_os = "macos")]
     macos_menu::install_menu_bar(app_state.clone());
 
+    // kAEReopenApplication handler — a plain re-launch / Dock click opens a new
+    // window (Windows-parity) instead of a silent no-op, and a same-bundle-id
+    // reactivation no longer leaves LaunchServices reporting "not responding".
+    // After menu install (NSApplication + the AppleEvent manager exist by now).
+    // SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
+    #[cfg(target_os = "macos")]
+    macos_menu::install_reopen_handler(app_state.clone());
+
     // Start memory heartbeat — logs system/process memory stats every 20s.
     // Provides forensic data if the process later crashes from OOM / VA
     // exhaustion, and drives the debounced mem_pressure level + low-memory

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -502,7 +502,11 @@ async fn next_signal(s: &mut Option<tokio::signal::unix::Signal>) {
 /// site comment. Two-launcher concurrent stale-cleanup would otherwise
 /// produce two live launchers for one data dir.
 #[cfg(not(target_os = "windows"))]
-fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
+fn bind_socket_with_recovery(
+    socket_path: &str,
+    data_dir: &std::path::Path,
+    dir_hash: &str,
+) -> tokio::net::UnixListener {
     use std::os::unix::io::AsRawFd as _;
 
     // Fast path: bind without contention.
@@ -583,13 +587,14 @@ fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
     // or a stale file?
     match std::os::unix::net::UnixStream::connect(socket_path) {
         Ok(_) => {
-            // Real second-instance. Exit cleanly so the existing
-            // launcher's window gets focus (Phase-2 arg-forwarding
-            // is a separate PR).
+            // Real second-instance. Forward an `open_new_window` request to the
+            // already-running launcher's host (Windows-parity — main.rs:1292),
+            // then exit cleanly. SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
             eprintln!(
                 "AgentMux is already running for this data directory.\n\nSocket: {}",
                 socket_path
             );
+            forward_open_new_window_or_log(data_dir, dir_hash);
             log(&format!(
                 "[ipc] second-instance detected — existing launcher owns {}",
                 socket_path
@@ -622,6 +627,7 @@ fn bind_socket_with_recovery(socket_path: &str) -> tokio::net::UnixListener {
                         "AgentMux is already running for this data directory.\n\nSocket: {}",
                         socket_path
                     );
+                    forward_open_new_window_or_log(data_dir, dir_hash);
                     log(&format!(
                         "[ipc] post-recovery bind lost the race to a fresh launcher on {} — exiting as second instance",
                         socket_path
@@ -779,7 +785,7 @@ async fn run_unix(
     // tiny, and leaving it lets the next launcher reuse it without a
     // create-race. (Stale-lock-file scenarios are bounded: flock(2)
     // is auto-released on process exit even for SIGKILL.)
-    let first_socket = bind_socket_with_recovery(&socket_path);
+    let first_socket = bind_socket_with_recovery(&socket_path, &paths.data_dir, &dir_hash);
 
     // Broadcast bus for reducer-emitted events. Same capacity (1024)
     // and rationale as the Windows path.
@@ -1988,6 +1994,25 @@ fn forward_open_new_window(data_dir: &std::path::Path, dir_hash: &str) -> Result
     let mut sink = [0u8; 64];
     let _ = stream.read(&mut sink);
     Ok(())
+}
+
+/// Best-effort `open_new_window` forward for the unix second-instance path.
+/// Unlike the Windows path (which pops a dialog on a fatal forward), unix just
+/// logs and lets the caller exit 0: the existing instance is alive (its socket
+/// answered our connect probe), so a transient/fatal forward failure shouldn't
+/// block — at worst the relaunch is a silent no-op instead of a new window.
+/// SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
+#[cfg(not(target_os = "windows"))]
+fn forward_open_new_window_or_log(data_dir: &std::path::Path, dir_hash: &str) {
+    match forward_open_new_window(data_dir, dir_hash) {
+        Ok(()) => log("forwarded open_new_window to existing instance"),
+        Err(ForwardError::Transient(reason)) => {
+            log(&format!("open_new_window forward transient (host mid-startup?): {}", reason))
+        }
+        Err(ForwardError::Fatal(reason)) => {
+            log(&format!("open_new_window forward failed: {}", reason))
+        }
+    }
 }
 
 /// Show a modal error dialog before the launcher exits. Used for

--- a/docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md
+++ b/docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md
@@ -1,0 +1,86 @@
+# SPEC: macOS Launch Coherence — Channel-Scoped Bundle ID, Reopen Handler, Unix Window Forward
+
+- **Date:** 2026-06-18
+- **Status:** Proposed → implementation in progress
+- **Owner decision:** bundle id follows the channel; the default/release channel `stable` is suffixed explicitly (`ai.agentmux.cef.stable`).
+
+---
+
+## 1. Symptoms (observed testing release DMGs side by side)
+
+While running 0.44.1 / 0.45.0 / 0.46.1 / 0.46.3 simultaneously on macOS:
+
+1. **"You can't open AgentMux because it is not responding"** when double-clicking a build while a *different* version is already running.
+2. **Double-clicking a running build opens no second window** (expected: relaunch → new window, the Windows behavior).
+3. **Version leakage on disk** — dozens of stale `ai.agentmux.app.v*`, `ai.agentmux.cef.v*`, `com.agentmuxhq.*` dirs in `~/Library/Application Support` and `~/Library/Caches`.
+
+---
+
+## 2. Root causes
+
+### A. One constant bundle identifier → LaunchServices collision
+`scripts/package-macos.sh:58` → `BUNDLE_ID="ai.agentmux.cef"`, constant across every version **and** channel (helpers at `:171`, main app at `:207`). macOS LaunchServices keys app identity on `CFBundleIdentifier`. With one id for all builds, double-clicking build B while build A runs makes LaunchServices **reactivate A** (send it the reopen Apple Event) instead of launching B.
+
+### B. No reopen handler
+No `applicationShouldHandleReopen:` / `kAEReopenApplication` handler exists in `agentmux-cef` or `agentmux-launcher` (only `setActivationPolicy`, `agentmux-cef/src/main.rs:1419-1461`). So the reactivation from (A) has nothing to answer it → LaunchServices times out → **"not responding."** A normal double-click of the running app also produces no new window.
+
+### C. Unix `open_new_window` forward is not wired (Windows-only)
+The relaunch → new-window forward **is implemented, but only on Windows**:
+- **Unix second-instance path:** `agentmux-launcher/src/main.rs:585-597` detects the running instance via the unix socket and `std::process::exit(0)`. Comment: *"Phase-2 arg-forwarding is a separate PR."* No forward.
+- **Windows path:** `main.rs:1292` calls `forward_open_new_window(&paths.data_dir, &dir_hash)`.
+- **The forward itself is platform-agnostic:** `forward_open_new_window` (`main.rs:1935`) reads `ipc-port-<dir_hash>` and HTTP-POSTs `{"cmd":"open_new_window"}` to `127.0.0.1:<port>/ipc`. No Windows APIs.
+- **Host endpoint is cross-platform:** `agentmux-cef/src/ipc.rs:225` → `"open_new_window" => commands::window::open_new_window(state)`.
+- **In-app affordance already uses it:** `frontend/app/statusbar/InstancePanel.tsx:527` ("+ Open another window") → same endpoint. (This is the current macOS workaround.)
+
+### D. Disk leakage — wipe script is Windows-only
+`scripts/wipe-old-data-dirs.sh` shells out to `powershell.exe`; it has never run on macOS. **Out of scope here** (tracked separately).
+
+---
+
+## 3. The two attach layers (must agree)
+
+A "new window" / relaunch resolves to a running instance at two independent layers:
+
+- **OS layer — `CFBundleIdentifier`:** LaunchServices decides which *process* a double-click / reopen routes to.
+- **Launcher layer — data dir:** instance key is `channels/<channel>/versions/<version>/`; `runtime/ipc-port` lives there (`agentmux-common/src/data_paths.rs:192-202`); the single-instance socket and the `open_new_window` forward both attach by this key.
+
+Today the OS layer is a **constant** while the launcher layer is **per-(channel, version)**. They disagree, so the OS can route a double-click to the wrong-channel (or a hung) process — the source of symptoms 1 & 2.
+
+---
+
+## 4. Decision: bundle id follows the channel
+
+`CFBundleIdentifier = ai.agentmux.cef.<channel>`, derived from the **same** channel the binary is compiled with — `AGENTMUX_BUILD_CHANNEL_DEFAULT` (compile-time `option_env!`, default `"stable"`, `data_paths.rs:55-57`; `"default"` is a synonym for `"stable"`, `:458`). `scripts/package.sh:151` already exports `$CHANNEL` into `AGENTMUX_BUILD_CHANNEL_DEFAULT` for the cargo build; `package-macos.sh` reads the same value for the Info.plist. **Single source of truth** → the OS identity and the runtime channel cannot drift apart.
+
+- **Default/release channel `stable` → `ai.agentmux.cef.stable`** (explicit suffix — uniform scheme, no bare special-case).
+- `dev` → `ai.agentmux.cef.dev`.
+- local builds → `ai.agentmux.cef.local-<branch>-<hash>-<build-id>` (sanitized to the bundle-id charset: `[A-Za-z0-9-.]`).
+- Helpers inherit the suffix automatically via `${BUNDLE_ID}.helper[.type]` (`package-macos.sh:171`).
+
+### What this fixes / doesn't
+- **Cross-channel:** dev/local builds become **distinct macOS apps** → double-click-launchable side by side with a running stable, no `open -n`. Local builds already carry a per-build hash *in the channel*, so every local build is its own app for free.
+- **Same channel, different versions** (stable 0.45.0 vs 0.46.3): still share `ai.agentmux.cef.stable` **by design**. Running two stable *releases* at once stays an `open -n` operation — intentional (avoids per-release Dock-app sprawl, which is what created the data-dir explosion in the first place).
+
+### Migration consequence of `.stable`
+Existing stable installs report `ai.agentmux.cef` today. Switching to `ai.agentmux.cef.stable` is a **one-time app-identity change**: on the next stable update macOS treats it as a new app → previously-granted permissions (notifications, screen recording, accessibility), login items, and default-app associations reset **once**; LaunchServices may keep a duplicate registration until the stale one is pruned. Accepted by the owner in exchange for a uniform, drift-proof scheme.
+
+---
+
+## 5. Fix plan (one branch / PR)
+
+1. **`scripts/package-macos.sh`** — derive `BUNDLE_ID="ai.agentmux.cef.${CHANNEL}"` from `${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}`, sanitized; app / helpers / entitlements inherit it. (Attach target = right process.)
+2. **Reopen handler (Rust/AppKit, `agentmux-cef`)** — on `applicationShouldHandleReopen:` / `kAEReopenApplication`, POST `open_new_window` to self. Fixes "not responding" **and** makes a plain double-click open a window. (Attach action.)
+3. **Unix forward (`agentmux-launcher/src/main.rs:585`)** — call `forward_open_new_window` before exiting, mirroring the Windows path, for the `open -n` / CLI route.
+
+(1) makes the OS route to the correct instance; (2) makes the instance actually open a window when reactivated; (3) covers the explicit new-process route.
+
+---
+
+## 6. Out of scope (tracked separately)
+- macOS port of `wipe-old-data-dirs.sh` (symptom 3 — disk leakage cleanup).
+
+## 7. Status (verified on-device 2026-06-18)
+
+- **#1 channel-scoped bundle id — ✅ verified.** A `.stable` build launches alongside a running `ai.agentmux.cef` 0.45.0 with **no "not responding"**; LaunchServices registers it as a distinct app, and helpers inherit `…stable.helper.*`.
+- **#3 unix `open_new_window` forward — ✅ verified.** `open -n` of a second instance opens a new window in the running instance, and the second launcher forwards then exits.
+- **#2 reopen handler — ⚠️ inert, deferred.** The raw `NSAppleEventManager` registration installs but never fires: **Chromium owns `kAEReopenApplication`** and re-registers after our handler, so a plain Finder/Dock double-click never reaches it. The effective fix is to **swizzle the NSApp delegate's `applicationShouldHandleReopen:hasVisibleWindows:`** — the Chromium-proof pattern the accessibility governor already uses (`agentmux-cef/src/main.rs`). Tracked as a follow-up. Meanwhile a second window is available via `open -n` (#3) or the in-app status-bar **"+ Open another window"**.

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -55,7 +55,18 @@ CERT="${MACOS_SIGN_CERT:-$(security find-identity -v -p codesigning 2>/dev/null 
         | awk -F'"' '/Developer ID Application/ {print $2; exit}')}"
 [ -n "$CERT" ] || { echo "❌ No 'Developer ID Application' identity in the keychain (and MACOS_SIGN_CERT unset)." >&2; exit 1; }
 ENTITLEMENTS="$REPO_ROOT/build/entitlements.mac.plist"
-BUNDLE_ID="ai.agentmux.cef"
+# Bundle id follows the build CHANNEL so LaunchServices' app identity matches the
+# runtime data-dir channel (~/.agentmux/channels/<channel>/…). The channel is the
+# SAME value compiled into the binaries via AGENTMUX_BUILD_CHANNEL_DEFAULT
+# (agentmux-common/src/data_paths.rs; default "stable"), so the OS identity and the
+# launcher's per-(channel,version) instance key can't drift apart. dev/local builds
+# thus become distinct macOS apps (double-click-launchable beside a running stable);
+# only two stable RELEASES still share an id (by design — avoids per-release sprawl).
+# Sanitize to the bundle-id charset [A-Za-z0-9.-].
+# See docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
+CHANNEL="${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}"
+CHANNEL_ID="$(printf '%s' "$CHANNEL" | tr -C 'A-Za-z0-9.-' '-' | tr '[:upper:]' '[:lower:]')"
+BUNDLE_ID="ai.agentmux.cef.${CHANNEL_ID}"
 NOTARIZE="${NOTARIZE:-1}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-notarytool}"
 SRV="dist/bin/agentmux-srv-${VERSION}-darwin.${ARCH}"


### PR DESCRIPTION
## What & why

On macOS every build shipped a constant `CFBundleIdentifier` (`ai.agentmux.cef`), so LaunchServices couldn't tell versions/channels apart. Double-clicking one build while another ran reactivated the *other* instance and hung → **"AgentMux is not responding"**, and a relaunch never opened a new window (the `open_new_window` forward was Windows-only). Full analysis: `docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md`.

Two "attach layers" must agree — LaunchServices (`CFBundleIdentifier`) and the launcher (`channels/<channel>/versions/<version>/` data dir). They didn't. This aligns them.

## Changes

1. **`scripts/package-macos.sh` — bundle id follows the channel.** `BUNDLE_ID="ai.agentmux.cef.${CHANNEL}"` from `${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}` (the same channel compiled into the binaries), sanitized; helpers/app inherit it. ✅ **verified** — a `.stable` build launches next to a running 0.45.0 with no "not responding".
2. **`agentmux-launcher` — wire the unix `open_new_window` forward.** The second-instance path in `run_unix` / `bind_socket_with_recovery` now calls `forward_open_new_window` (mirroring the Windows pipe path) before exiting. ✅ **verified** — `open -n` of a second instance opens a new window; the second launcher forwards + exits.
3. **`agentmux-cef` — `kAEReopenApplication` handler.** ⚠️ **Included but currently inert.** Chromium owns the reopen AppleEvent and re-registers after our raw `NSAppleEventManager` handler, so a plain double-click never reaches it. The working fix is to swizzle the NSApp delegate's `applicationShouldHandleReopen:` (the pattern the a11y governor already uses) — tracked as a follow-up (spec §7). **Reviewers: keep this as documented scaffolding, or strip it and land the swizzle separately?**

## Verification (on-device, Apple Silicon)
- Notarized `.stable` DMG launches with no "not responding" alongside a running `ai.agentmux.cef` instance; LaunchServices registers it as a distinct app.
- `open -n` second instance → new window in the running instance; 2nd launcher exits.
- Reopen handler logs `installed` but never `fired` → confirms #3 is inert.

## Scope / safety
- macOS-only: `package-macos.sh` + `#[cfg(not(windows))]` launcher path + `#[cfg(target_os="macos")]` host code. Windows/Linux unaffected.
- Upholds isolation invariants I1–I6 (the forward is the only cross-instance contact, side-effect-free).
- One-time identity note: stable's id moves `ai.agentmux.cef` → `ai.agentmux.cef.stable`; existing installs reset macOS permission grants once on update (spec §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)