### PR TITLE
fix(ui): rename "block" to "pane" in user-facing help pane, context menu, and crash UI

### DIFF
--- a/.changesets/1781803358-fix-ui-rename-block-to-pane-in-user-facing-help-pane-context-r6mq.md
+++ b/.changesets/1781803358-fix-ui-rename-block-to-pane-in-user-facing-help-pane-context-r6mq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): rename block to pane in user-facing help pane, context menu, and crash UI

--- a/frontend/app/block/BlockErrorBoundary.tsx
+++ b/frontend/app/block/BlockErrorBoundary.tsx
@@ -191,7 +191,7 @@ function BlockErrorFallback(props: {
                     <strong>{errName()}:</strong> {errMessage()}
                 </div>
                 <div class="block-error-fallback-meta">
-                    block <code>{shortId()}</code>
+                    pane <code>{shortId()}</code>
                     <Show when={props.viewType}>
                         {" · view "}
                         <code>{props.viewType}</code>

--- a/frontend/app/block/pane-actions.ts
+++ b/frontend/app/block/pane-actions.ts
@@ -207,10 +207,10 @@ export function buildPaneContextMenu(
         { type: "separator" },
         ...buildReplaceSubmenu(blockData),
         {
-            label: opts.magnified ? "Un-Magnify Block" : "Magnify Block",
+            label: opts.magnified ? "Un-Magnify Pane" : "Magnify Pane",
             click: opts.onMagnifyToggle,
         },
-        { label: "Close Block", click: opts.onClose },
+        { label: "Close Pane", click: opts.onClose },
         // Inspect Element — opens CEF DevTools focused on whatever was
         // under the right-click. Only appears when `inspectAt` was supplied
         // (call sites that don't capture click coords don't get the entry).

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -109,7 +109,7 @@ const QuickTips = (): JSX.Element => {
                             <i class="fa-solid fa-sharp fa-window-maximize fa-fw" />
                         </IconBox>
                         <div class="flex flex-col gap-0.5 flex-1">
-                            <span class="text-[15px]">Maximize a Block</span>
+                            <span class="text-[15px]">Maximize a Pane</span>
                             <KeyBinding keyDecl="Cmd:m" />
                         </div>
                     </div>
@@ -126,14 +126,14 @@ const QuickTips = (): JSX.Element => {
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-cog fa-fw" />
                         </IconBox>
-                        <span class="text-[15px]">Block Settings</span>
+                        <span class="text-[15px]">Pane Settings</span>
                     </div>
                     <div class="flex items-center gap-3 p-2 rounded-md hover:bg-white/5 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-xmark-large fa-fw" />
                         </IconBox>
                         <div class="flex flex-col gap-0.5 flex-1">
-                            <span class="text-[15px]">Close Block</span>
+                            <span class="text-[15px]">Close Pane</span>
                             <KeyBinding keyDecl="Cmd:w" />
                         </div>
                     </div>
@@ -156,7 +156,7 @@ const QuickTips = (): JSX.Element => {
                             <KeyBinding keyDecl="Cmd:t" />
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
-                            <span class="text-[15px]">New Terminal Block</span>
+                            <span class="text-[15px]">New Terminal Pane</span>
                             <KeyBinding keyDecl="Cmd:n" />
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
@@ -185,14 +185,14 @@ const QuickTips = (): JSX.Element => {
 
                     <div class="flex flex-col gap-1.5">
                         <div class="text-sm text-accent-400 font-semibold uppercase tracking-wide mb-1">
-                            Block Navigation (Ctrl-Shift)
+                            Pane Navigation (Ctrl-Shift)
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
-                            <span class="text-[15px]">Navigate Between Blocks</span>
+                            <span class="text-[15px]">Navigate Between Panes</span>
                             <KeyBinding keyDecl="Ctrl:Shift:Arrows" />
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
-                            <span class="text-[15px]">Focus Nth Block</span>
+                            <span class="text-[15px]">Focus Nth Pane</span>
                             <KeyBinding keyDecl="Ctrl:Shift:Digit" />
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
@@ -203,7 +203,7 @@ const QuickTips = (): JSX.Element => {
 
                     <div class="flex flex-col gap-1.5">
                         <div class="text-sm text-accent-400 font-semibold uppercase tracking-wide mb-1">
-                            Split Blocks
+                            Split Panes
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
                             <span class="text-[15px]">Split Right</span>


### PR DESCRIPTION
## Summary

- **Help pane** (`quicktips.tsx`): 8 strings changed — Maximize a Pane, Pane Settings, Close Pane, New Terminal Pane, Pane Navigation (section header), Navigate Between Panes, Focus Nth Pane, Split Panes (section header)
- **Context menu** (`pane-actions.ts`): Magnify Pane / Un-Magnify Pane, Close Pane
- **Crash UI** (`BlockErrorBoundary.tsx`): "pane \`<id>\`" instead of "block \`<id>\`" in the error fallback metadata line

Internal code identifiers (`blockId`, `blockData`, CSS class names like `.block-error-fallback`) are unchanged — this is purely user-visible label text.

`agent-app-api.md` in the docs also has stale "block" references, but that page is queued for a full rewrite in Sprint 2.

## Test plan

- [ ] Open Help pane — confirm all labels say "Pane" not "Block"
- [ ] Right-click a pane header — confirm context menu says "Magnify Pane" and "Close Pane"
- [ ] Trigger a pane crash (via DevTools `throw new Error()`) — confirm error UI says "pane \`abc1234\`"

🤖 Generated with [Claude Code](https://claude.com/claude-code)