### PR TITLE
fix(toolchain): docker/git/node show as not installed on Windows

### DIFF
--- a/.changesets/1781807290-fix-toolchain-detect-docker-git-node-on-windows-where-lookup-pb2t.md
+++ b/.changesets/1781807290-fix-toolchain-detect-docker-git-node-on-windows-where-lookup-pb2t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(toolchain): detect docker/git/node on Windows — where lookup now uses bare command name so .exe tools are found via PATHEXT

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -508,8 +508,12 @@ pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 /// `docker.exe`, `git.exe`, `node.exe` AND `npm.cmd` — previously the
 /// hard-coded `.cmd` suffix caused all `.exe`-based tools (docker, git,
 /// node) to report as not installed even when present on PATH.
-/// `make_cli_cmd` then handles `.cmd` vs `.exe` invocation correctly based
-/// on the extension of the path returned here.
+///
+/// `where` can return multiple lines (e.g. Node.js ships both an extensionless
+/// `npm` Unix shell script and `npm.cmd` on Windows). We filter to the first
+/// line whose extension `make_cli_cmd` can actually spawn (.exe / .cmd / .bat).
+/// Taking the raw first line would yield the extensionless entry, which
+/// `Command::new` cannot run on Windows without a shell.
 pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
     let which_result = if cfg!(windows) {
         let mut probe = tokio::process::Command::new("where");
@@ -526,7 +530,17 @@ pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
     if let Ok(out) = which_result {
         if out.status.success() {
             let stdout_str = String::from_utf8_lossy(&out.stdout);
-            let path = stdout_str.lines().next().unwrap_or("").trim();
+            #[cfg(windows)]
+            let path: &str = stdout_str
+                .lines()
+                .map(str::trim)
+                .find(|l| {
+                    let lo = l.to_lowercase();
+                    lo.ends_with(".exe") || lo.ends_with(".cmd") || lo.ends_with(".bat")
+                })
+                .unwrap_or("");
+            #[cfg(not(windows))]
+            let path: &str = stdout_str.lines().next().unwrap_or("").trim();
             if !path.is_empty() && std::path::Path::new(path).exists() {
                 return Some(path.to_string());
             }

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -502,15 +502,18 @@ pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 ///
 /// Uses `where` on Windows and `which` on Unix. Returns the absolute path
 /// if the command is found and exists, otherwise `None`.
+///
+/// On Windows we pass the bare command name (no `.cmd` suffix) so that
+/// `where` resolves the correct extension via PATHEXT. This correctly finds
+/// `docker.exe`, `git.exe`, `node.exe` AND `npm.cmd` — previously the
+/// hard-coded `.cmd` suffix caused all `.exe`-based tools (docker, git,
+/// node) to report as not installed even when present on PATH.
+/// `make_cli_cmd` then handles `.cmd` vs `.exe` invocation correctly based
+/// on the extension of the path returned here.
 pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
-    let path_cmd = if cfg!(windows) {
-        format!("{}.cmd", cli_command)
-    } else {
-        cli_command.to_string()
-    };
     let which_result = if cfg!(windows) {
         let mut probe = tokio::process::Command::new("where");
-        probe.arg(&path_cmd);
+        probe.arg(cli_command);
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt;
@@ -518,7 +521,7 @@ pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
         }
         probe.output().await
     } else {
-        tokio::process::Command::new("which").arg(&path_cmd).output().await
+        tokio::process::Command::new("which").arg(cli_command).output().await
     };
     if let Ok(out) = which_result {
         if out.status.success() {


### PR DESCRIPTION
## Summary

- `resolve_cli_on_path()` in `cli_handlers.rs` was appending `.cmd` to every command name on Windows before calling `where`. This works for `npm` (which genuinely ships as `npm.cmd`) but silently breaks detection for `docker`, `git`, and `node` — all of which install as `.exe` files.
- `where docker.cmd` returns nothing even with Docker Desktop fully installed → toolchain manager reports Docker as not installed.
- Fix: pass the bare command name to `where`. Windows resolves the correct extension via PATHEXT and returns the full path including extension (`.exe` or `.cmd`). `make_cli_cmd()` already branches on the extension to handle native `.exe` spawn vs `.cmd` wrapper unwrapping, so invocation is unaffected.

**Affected tools on Windows (all now fixed):** `docker`, `git`, `node`  
**Unaffected:** `npm` (still found as `npm.cmd`, `make_cli_cmd` continues to unwrap it correctly)

## Test plan

- [ ] Open Toolchain Manager on Windows with Docker Desktop installed — Docker should show version + path (was: "not installed")
- [ ] Same for Git for Windows and Node.js
- [ ] npm detection still works (finds `npm.cmd`, version reported correctly)
- [ ] On macOS/Linux — no change to `which` path, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)