### PR TITLE
fix(win32): remove owned-window z-order invariant; add floater cascade + diagnostics

### DIFF
--- a/.changesets/1781823967-fix-win32-bind-floater-cascade-to-source-window-fix-z-order--38iw.md
+++ b/.changesets/1781823967-fix-win32-bind-floater-cascade-to-source-window-fix-z-order--38iw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(win32): bind floater cascade to source window; fix z-order and multi-window regression

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -134,13 +134,15 @@ mod handlers;
 pub(crate) mod helpers;
 #[cfg(target_os = "windows")]
 mod wndproc;
+#[cfg(target_os = "windows")]
+pub(crate) use wndproc::install_main_window_floater_cascade_hook;
 
 pub use handlers::AgentMuxClient;
 
 use helpers::{js_string_literal, html_escape, backend_close_window};
 #[cfg(target_os = "windows")]
 use wndproc::{
-    install_main_window_floater_cascade_hook, install_top_level_focus_restore_hook,
+    install_top_level_focus_restore_hook,
     set_window_icon, skip_taskbar,
 };
 

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -139,7 +139,10 @@ pub use handlers::AgentMuxClient;
 
 use helpers::{js_string_literal, html_escape, backend_close_window};
 #[cfg(target_os = "windows")]
-use wndproc::{install_top_level_focus_restore_hook, set_window_icon, skip_taskbar};
+use wndproc::{
+    install_main_window_floater_cascade_hook, install_top_level_focus_restore_hook,
+    set_window_icon, skip_taskbar,
+};
 
 impl AgentMuxHandler {
     pub fn new(state: Arc<AppState>, ipc_port: u16) -> Arc<Mutex<Self>> {
@@ -518,6 +521,19 @@ impl AgentMuxHandler {
                 // Install on every top-level — both `main` and Subwindow.
                 if is_top_level_window {
                     unsafe { install_top_level_focus_restore_hook(hwnd); }
+                }
+
+                // Floater cascade hook (issue #1560): replaces the Win32
+                // owned-window z-order/minimize/destroy invariant now that
+                // floaters are unowned WS_POPUP windows. Install on all
+                // FullInstance windows (not pool, not subwindow) so that
+                // closing or minimizing any main window cascades to its floaters.
+                #[cfg(target_os = "windows")]
+                if is_top_level_window
+                    && pending_kind == WindowKind::FullInstance
+                    && !label.starts_with("window-pool-")
+                {
+                    unsafe { install_main_window_floater_cascade_hook(hwnd); }
                 }
 
                 // Subwindow? Hide from taskbar. Full instances and browser-pane

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -243,6 +243,121 @@ pub(crate) unsafe fn install_top_level_focus_restore_hook(hwnd: *mut std::ffi::c
     }
 }
 
+/// Original WndProc table for the floater cascade hook.
+/// Module-level so `cascade_hook` (an `extern "system" fn`) can access it
+/// — inner-function statics are not in scope for nested `extern fn` items.
+#[cfg(target_os = "windows")]
+static FLOATER_CASCADE_ORIGINALS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, isize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Cascade hook body — module-level so it can reference module-level statics.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn floater_cascade_wndproc(
+    hwnd: *mut std::ffi::c_void,
+    msg: u32,
+    wparam: usize,
+    lparam: isize,
+) -> isize {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CallWindowProcW, DefWindowProcW, PostMessageW, SetWindowPos, ShowWindow,
+        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE, SW_SHOWNOACTIVATE,
+        WM_ACTIVATE, WM_CLOSE, WM_DESTROY, WM_SIZE,
+    };
+    const WA_INACTIVE: usize = 0;
+    const SIZE_MINIMIZED: usize = 1;
+
+    if msg == WM_ACTIVATE {
+        if (wparam & 0xFFFF) as usize != WA_INACTIVE {
+            // Main window activated — place every floater below it in z-order.
+            // This lets the user click the main window and have it visually
+            // appear in front of the floating pane (replaces the owned-window
+            // always-on-top invariant with a cooperative z-order contract).
+            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+                SetWindowPos(
+                    fhwnd as *mut _,
+                    hwnd, // insertAfter=main → floater is placed below main
+                    0, 0, 0, 0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+                );
+            }
+        }
+    } else if msg == WM_SIZE {
+        if wparam == SIZE_MINIMIZED {
+            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+                ShowWindow(fhwnd as *mut _, SW_HIDE);
+            }
+        } else {
+            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+                ShowWindow(fhwnd as *mut _, SW_SHOWNOACTIVATE);
+            }
+        }
+    } else if msg == WM_DESTROY {
+        for fhwnd in crate::floating_pane::all_floater_hwnds() {
+            PostMessageW(fhwnd as *mut _, WM_CLOSE, 0, 0);
+        }
+    }
+
+    // Always pass through — we observe only, never short-circuit.
+    let original = FLOATER_CASCADE_ORIGINALS
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&(hwnd as usize)).copied())
+        .unwrap_or(0);
+    if original != 0 {
+        CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam)
+    } else {
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    }
+}
+
+/// Subclass a FullInstance window's WndProc to cascade lifecycle events to all
+/// active floating panes (issue #1560 — replaces the owned-window cascade that
+/// was removed when we switched to unowned `WS_POPUP` windows).
+///
+/// Handles:
+/// - `WM_ACTIVATE(active)` → z-order floaters below the main HWND
+/// - `WM_SIZE(SIZE_MINIMIZED)` → `SW_HIDE` every floater
+/// - `WM_SIZE(restored/maximized)` → `SW_SHOWNOACTIVATE` every floater
+/// - `WM_DESTROY` → `PostMessage(WM_CLOSE)` every floater
+///
+/// Idempotent: re-calling on an already-hooked HWND is a no-op.
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn install_main_window_floater_cascade_hook(
+    hwnd: *mut std::ffi::c_void,
+) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SetWindowLongPtrW, GWLP_WNDPROC};
+
+    let already_hooked = FLOATER_CASCADE_ORIGINALS
+        .lock()
+        .ok()
+        .map(|m| m.contains_key(&(hwnd as usize)))
+        .unwrap_or(false);
+    if already_hooked {
+        return;
+    }
+
+    let original = SetWindowLongPtrW(
+        hwnd,
+        GWLP_WNDPROC,
+        floater_cascade_wndproc as *const () as isize,
+    );
+    if original != 0 {
+        if let Ok(mut m) = FLOATER_CASCADE_ORIGINALS.lock() {
+            m.insert(hwnd as usize, original);
+        }
+        tracing::info!(
+            "[floater-cascade] installed cascade hook on FullInstance HWND {:p}",
+            hwnd,
+        );
+    } else {
+        tracing::warn!(
+            "[floater-cascade] SetWindowLongPtrW returned 0 for {:p} — cascade not installed",
+            hwnd,
+        );
+    }
+}
+
 /// Hide the given top-level HWND from the Windows taskbar via
 /// `ITaskbarList::DeleteTab`. The window remains fully usable — Alt-Tab still
 /// finds it, it takes focus, repaints, etc. — but the shell paints no taskbar

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -273,7 +273,7 @@ unsafe extern "system" fn floater_cascade_wndproc(
             // This lets the user click the main window and have it visually
             // appear in front of the floating pane (replaces the owned-window
             // always-on-top invariant with a cooperative z-order contract).
-            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
                 SetWindowPos(
                     fhwnd as *mut _,
                     hwnd, // insertAfter=main → floater is placed below main
@@ -284,16 +284,16 @@ unsafe extern "system" fn floater_cascade_wndproc(
         }
     } else if msg == WM_SIZE {
         if wparam == SIZE_MINIMIZED {
-            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
                 ShowWindow(fhwnd as *mut _, SW_HIDE);
             }
         } else {
-            for fhwnd in crate::floating_pane::all_floater_hwnds() {
+            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
                 ShowWindow(fhwnd as *mut _, SW_SHOWNOACTIVATE);
             }
         }
     } else if msg == WM_DESTROY {
-        for fhwnd in crate::floating_pane::all_floater_hwnds() {
+        for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
             PostMessageW(fhwnd as *mut _, WM_CLOSE, 0, 0);
         }
     }

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -304,11 +304,22 @@ unsafe extern "system" fn floater_cascade_wndproc(
         .ok()
         .and_then(|m| m.get(&(hwnd as usize)).copied())
         .unwrap_or(0);
-    if original != 0 {
+    let result = if original != 0 {
         CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam)
     } else {
         DefWindowProcW(hwnd, msg, wparam, lparam)
+    };
+
+    // Prune the map AFTER passthrough so the original proc receives WM_DESTROY.
+    // Without this, Windows HWND reuse could make install_main_window_floater_cascade_hook
+    // see already_hooked=true for a new window that happens to get the same HWND value.
+    if msg == WM_DESTROY {
+        if let Ok(mut m) = FLOATER_CASCADE_ORIGINALS.lock() {
+            m.remove(&(hwnd as usize));
+        }
     }
+
+    result
 }
 
 /// Subclass a FullInstance window's WndProc to cascade lifecycle events to all

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -1,7 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Floating-pane tear-off — the `open_floating_pane_window` IPC command.
+//! Floating-pane tear-off — the `open_floating_pane_window` IPC command and
+//! the `get_pane_debug_state` diagnostic command.
 //! Specs: `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` (Windows,
 //! issue #810) + `docs/specs/SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md`
 //! (macOS/Linux Phase A).
@@ -15,9 +16,9 @@
 //! and the frontend renders `<FloatingPaneWorkspace>` (chromeless).
 //!
 //! Platform primitive differs by OS:
-//! - **Windows**: a raw `WS_POPUP + WS_EX_TOOLWINDOW` HWND OWNED by the source
-//!   main window (no taskbar/Alt-Tab entry; minimizes/restores/destroys with
-//!   its owner), CEF browser embedded — see `crate::floating_pane`.
+//! - **Windows**: an unowned `WS_POPUP + WS_EX_TOOLWINDOW` HWND (no taskbar/
+//!   Alt-Tab entry; cascade managed by `install_main_window_floater_cascade_hook`
+//!   in `client/wndproc.rs`), CEF browser embedded — see `crate::floating_pane`.
 //! - **macOS / Linux** (Phase A): a frameless CEF Views window created via the
 //!   same `ui_tasks::post_create_window(frameless=true)` path the regular
 //!   tear-off uses, with `&floatingPaneId=` injected into the URL. Owned-window
@@ -228,4 +229,42 @@ pub fn open_floating_pane_window(
 
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }
+}
+
+/// Diagnostic snapshot of active floater state — called by the frontend on
+/// every tear-off attempt (before + after) to enable structured logging and
+/// to surface intermittent failures without requiring a host-side repro.
+///
+/// Returns JSON:
+/// ```json
+/// {
+///   "floaters": [{"label": "floating-abc", "hwnd": 12345678}],
+///   "any_browser_pane_closing": false,
+///   "pool_queue_size": 2,
+///   "pending_window_creations": 0
+/// }
+/// ```
+pub fn get_pane_debug_state(state: &Arc<AppState>) -> serde_json::Value {
+    #[cfg(target_os = "windows")]
+    let floaters: Vec<serde_json::Value> = crate::floating_pane::floater_debug_snapshot()
+        .into_iter()
+        .map(|(label, hwnd)| serde_json::json!({ "label": label, "hwnd": hwnd }))
+        .collect();
+    #[cfg(not(target_os = "windows"))]
+    let floaters: Vec<serde_json::Value> = vec![];
+
+    let any_closing = state.any_browser_pane_closing();
+    let pool_queue = state.pool_queue_size();
+    let pending = state
+        .host_state
+        .lock()
+        .pending_window_creations
+        .len();
+
+    serde_json::json!({
+        "floaters": floaters,
+        "any_browser_pane_closing": any_closing,
+        "pool_queue_size": pool_queue,
+        "pending_window_creations": pending,
+    })
 }

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 
-use crate::state::AppState;
+use crate::state::{AppState, WindowKind};
 
 #[derive(Debug, Deserialize)]
 pub struct OpenFloatingPaneArgs {
@@ -157,13 +157,48 @@ pub fn open_floating_pane_window(
 
     #[cfg(target_os = "windows")]
     {
-        // Resolve source window → parent HWND so the cascade hook can restrict
-        // min/restore/destroy to only the floaters belonging to that window.
-        let parent_main_hwnd: isize = parsed
-            .source_window_label
-            .as_deref()
-            .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
-            .unwrap_or(0);
+        // Resolve source window → parent HWND so the cascade hook restricts
+        // min/restore/destroy to only this window's floaters.
+        // Primary lookup: label → HWND directly.
+        // Fallback: first FullInstance window in window_meta (covers old
+        // frontend clients that predate source_window_label, and the rare
+        // race where the label isn't in window_hwnds yet).
+        let parent_main_hwnd: isize = {
+            let direct = parsed
+                .source_window_label
+                .as_deref()
+                .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
+                .unwrap_or(0);
+            if direct != 0 {
+                direct
+            } else {
+                let fallback_label: Option<String> = state
+                    .window_meta
+                    .lock()
+                    .values()
+                    .find(|m| m.kind == WindowKind::FullInstance)
+                    .map(|m| m.label.clone());
+                let fallback = fallback_label
+                    .as_deref()
+                    .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
+                    .unwrap_or(0);
+                if fallback == 0 {
+                    tracing::warn!(
+                        source_label = ?parsed.source_window_label,
+                        "[floating-pane] could not resolve parent main HWND; \
+                         floater will not cascade on minimize/destroy (orphan risk)",
+                    );
+                } else {
+                    tracing::debug!(
+                        source_label = ?parsed.source_window_label,
+                        fallback,
+                        "[floating-pane] source_window_label unresolved; \
+                         using FullInstance fallback HWND for cascade binding",
+                    );
+                }
+                fallback
+            }
+        };
         crate::floating_pane::post_create_floating_window(state, &parsed, &window_label, parent_main_hwnd);
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -65,6 +65,12 @@ pub struct OpenFloatingPaneArgs {
     /// - **macOS/Linux**: passed through unscaled — CEF Views sizes in DIP.
     pub width: i32,
     pub height: i32,
+    /// Window label of the FullInstance window initiating the tear-off.
+    /// Used on Windows to bind the new floater to its parent's cascade hook
+    /// so that minimize/restore/destroy only affects that window's floaters.
+    /// Optional for back-compat; callers should always provide it.
+    #[serde(default)]
+    pub source_window_label: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -151,7 +157,14 @@ pub fn open_floating_pane_window(
 
     #[cfg(target_os = "windows")]
     {
-        crate::floating_pane::post_create_floating_window(state, &parsed, &window_label);
+        // Resolve source window → parent HWND so the cascade hook can restrict
+        // min/restore/destroy to only the floaters belonging to that window.
+        let parent_main_hwnd: isize = parsed
+            .source_window_label
+            .as_deref()
+            .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
+            .unwrap_or(0);
+        crate::floating_pane::post_create_floating_window(state, &parsed, &window_label, parent_main_hwnd);
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -810,6 +810,13 @@ pub fn promote_pool_window(
             );
         }
         let _ = ShowWindow(raw_hwnd, SW_SHOW);
+
+        // Pool windows skip the cascade-hook install in on_after_created
+        // (gated on !label.starts_with("window-pool-")) because they are
+        // hidden off-screen at creation time. Install it here after the
+        // window is visible and promoted so floaters torn from this window
+        // follow its minimize/restore/destroy.
+        crate::client::install_main_window_floater_cascade_hook(raw_hwnd);
     }
 
     // Phase B.7.3.3 — the launcher's typed events drive the

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -1,19 +1,38 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Win32-native owned-window creator for floating panes. Phase 1 of
+//! Win32-native unowned popup creator for floating panes. Phase 1 of
 //! issue #810 (floating-pane tear-off).
 //!
 //! This module is intentionally Windows-only and intentionally
 //! separate from `crate::ui_tasks` (which posts the standard CEF Views
 //! top-level windows). A floating pane is a *raw* `WS_POPUP` HWND with
-//! `WS_EX_TOOLWINDOW`, owner = source main window. CEF Views does not
-//! expose tool-window / owner semantics in a way that lets us achieve
-//! the no-taskbar + minimize-cascade behavior the spec requires, so we
-//! drop down to `CreateWindowExW` and then embed a CEF browser inside
-//! the resulting HWND via `WindowInfo::set_as_child` — the same
-//! mechanism the browser-pane creation path uses
-//! (`browser_pane/creation.rs`).
+//! `WS_EX_TOOLWINDOW` and **no Win32 owner** (null parent). CEF Views
+//! does not expose tool-window semantics, so we drop down to
+//! `CreateWindowExW` and embed a CEF browser inside the resulting HWND
+//! via `WindowInfo::set_as_child` — the same mechanism the browser-pane
+//! creation path uses (`browser_pane/creation.rs`).
+//!
+//! ## Why no owner (issue #1560)
+//!
+//! The original design used the main window as the Win32 owner, which
+//! gave minimize/restore/destroy cascade for free. However, Win32's
+//! owned-window invariant — owned windows are ALWAYS z-above their owner
+//! and cannot be pushed below with `SetWindowPos` — meant the floater
+//! was permanently stuck above the main window even after the user
+//! activated the main window. The fix is to remove the owner and handle
+//! the cascade explicitly:
+//!
+//! - **Taskbar/Alt+Tab hiding**: `WS_EX_TOOLWINDOW` (already set, not
+//!   ownership-derived).
+//! - **Minimize/restore cascade**: handled by
+//!   `install_main_window_floater_cascade_hook` in `client/wndproc.rs`,
+//!   which intercepts `WM_SIZE` on the main window and
+//!   shows/hides all registered floaters.
+//! - **Destroy cascade**: same hook intercepts `WM_DESTROY`.
+//! - **Z-order on activation**: the hook intercepts `WM_ACTIVATE` on the
+//!   main window and calls `SetWindowPos(floater, main_hwnd, ...)` to
+//!   place each floater below main, so clicking main brings it to front.
 //!
 //! See issue #810 / `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`
 //! for the full design and phase plan.
@@ -38,11 +57,54 @@
 
 #![cfg(target_os = "windows")]
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
 
 use cef::*;
 
 use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Global floater HWND registry — used by the main-window cascade hook to
+// minimize/restore/destroy/z-order floaters without the owned-window
+// invariant. Keyed by window label ("floating-<uuid>"), value is the raw
+// outer HWND as isize (Send-safe). Populated at floater creation, removed
+// on WM_DESTROY in floating_pane_wndproc.
+// ---------------------------------------------------------------------------
+static ACTIVE_FLOATER_HWNDS: LazyLock<Mutex<HashMap<String, isize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) fn register_floater_hwnd(label: String, hwnd: isize) {
+    if let Ok(mut m) = ACTIVE_FLOATER_HWNDS.lock() {
+        m.insert(label, hwnd);
+    }
+}
+
+/// Called from `floating_pane_wndproc` on WM_DESTROY and from the cascade
+/// hook on explicit close; reverse-scans by HWND value since the wndproc
+/// doesn't have the label in scope.
+pub(crate) fn unregister_floater_by_hwnd(hwnd: isize) {
+    if let Ok(mut m) = ACTIVE_FLOATER_HWNDS.lock() {
+        m.retain(|_, v| *v != hwnd);
+    }
+}
+
+/// Snapshot of all active floater HWNDs. Used by the cascade hook and the
+/// diagnostic command.
+pub(crate) fn all_floater_hwnds() -> Vec<isize> {
+    ACTIVE_FLOATER_HWNDS
+        .lock()
+        .map(|m| m.values().copied().collect())
+        .unwrap_or_default()
+}
+
+/// Snapshot for the `get_pane_debug_state` diagnostic command.
+pub(crate) fn floater_debug_snapshot() -> Vec<(String, isize)> {
+    ACTIVE_FLOATER_HWNDS
+        .lock()
+        .map(|m| m.iter().map(|(l, h)| (l.clone(), *h)).collect())
+        .unwrap_or_default()
+}
 
 /// Return the Win32 window-class name for floating panes, suffixed with
 /// the launcher-supplied `AGENTMUX_IPC_HASH` (= `hash(data_dir, version)`)
@@ -104,33 +166,10 @@ wrap_task! {
                 );
             };
 
-            // Use the MAIN window as owner, not whichever top-level happens
-            // to be focused at tear-off time. On Win32, destroying an owner
-            // window cascades to all owned windows — if a secondary window
-            // (Window B) were the owner, closing Window B would destroy the
-            // floater. Using the main window means the floater survives closing
-            // any secondary window and is only destroyed with the whole app.
-            let owner_hwnd_raw = unsafe {
-                let h = crate::commands::window::find_main_window();
-                if h.is_null() {
-                    // Fallback: take whatever top-level is visible
-                    crate::commands::window::find_own_top_level_window()
-                } else {
-                    h
-                }
-            };
-            if owner_hwnd_raw.is_null() {
-                tracing::error!(
-                    pane_id = %self.pane_id,
-                    label = %self.window_label,
-                    "[floating-pane] cannot find main HWND — aborting floater creation",
-                );
-                dequeue();
-                return;
-            }
-
-            let outer_hwnd = match create_owned_popup(
-                owner_hwnd_raw,
+            // No Win32 owner — see module doc §"Why no owner (issue #1560)".
+            // Minimize/restore/destroy cascade is handled by
+            // install_main_window_floater_cascade_hook (client/wndproc.rs).
+            let outer_hwnd = match create_popup(
                 &self.window_label,
                 self.x,
                 self.y,
@@ -173,6 +212,12 @@ wrap_task! {
                 .window_hwnds
                 .lock()
                 .insert(self.window_label.clone(), outer_hwnd as isize);
+            // Register in the global cascade registry so the main-window
+            // WM_ACTIVATE/WM_SIZE/WM_DESTROY hook can reach this floater.
+            crate::floating_pane::register_floater_hwnd(
+                self.window_label.clone(),
+                outer_hwnd as isize,
+            );
 
             // CEF embed — the browser is a WS_CHILD of the outer HWND.
             let rect = Rect {
@@ -455,6 +500,11 @@ unsafe extern "system" fn floating_pane_wndproc(
         // cascades the resize to the frontend's inner render-widget children.
         // (Terminal/agent floaters have a single child, so bottom-most == that
         // child — unchanged.) Falls through to DefWindowProcW afterwards.
+        // Unregister from the cascade registry so the main-window hook no
+        // longer tries to show/hide/z-order a destroyed HWND.
+        WM_DESTROY => {
+            crate::floating_pane::unregister_floater_by_hwnd(hwnd as isize);
+        }
         WM_SIZE => {
             // Walk the sibling Z-order from topmost (GW_CHILD) to the
             // bottom-most direct child = the frontend browser.
@@ -485,13 +535,14 @@ unsafe extern "system" fn floating_pane_wndproc(
     DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 
-/// CreateWindowExW wrapper that produces the owned `WS_POPUP +
+/// CreateWindowExW wrapper that produces an unowned `WS_POPUP +
 /// WS_EX_TOOLWINDOW` HWND used as the floating-pane outer shell.
+/// No Win32 owner — cascade behavior is implemented in the main-window
+/// WndProc hook (`install_main_window_floater_cascade_hook`).
 ///
 /// The class is registered once per process; subsequent calls reuse
 /// the registered atom.
-fn create_owned_popup(
-    owner_hwnd_raw: *mut std::ffi::c_void,
+fn create_popup(
     window_label: &str,
     x: i32,
     y: i32,
@@ -585,7 +636,7 @@ fn create_owned_popup(
             y,
             width,
             height,
-            owner_hwnd_raw as HWND,
+            std::ptr::null_mut(), // no owner — see module doc §"Why no owner"
             std::ptr::null_mut(),
             windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(std::ptr::null()),
             std::ptr::null(),

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -67,34 +67,46 @@ use crate::state::AppState;
 // ---------------------------------------------------------------------------
 // Global floater HWND registry — used by the main-window cascade hook to
 // minimize/restore/destroy/z-order floaters without the owned-window
-// invariant. Keyed by window label ("floating-<uuid>"), value is the raw
-// outer HWND as isize (Send-safe). Populated at floater creation, removed
-// on WM_DESTROY in floating_pane_wndproc.
+// invariant. Keyed by window label ("floating-<uuid>"); value is
+// (floater_hwnd, parent_main_hwnd), both as isize (Send-safe).
+// The parent_main_hwnd binding lets the cascade hook in wndproc.rs filter
+// to ONLY the floaters that belong to the window sending the message —
+// prevents closing a secondary full window from destroying floaters that
+// belong to a different window. Populated at floater creation, removed on
+// WM_DESTROY in floating_pane_wndproc.
 // ---------------------------------------------------------------------------
-static ACTIVE_FLOATER_HWNDS: LazyLock<Mutex<HashMap<String, isize>>> =
+static ACTIVE_FLOATER_HWNDS: LazyLock<Mutex<HashMap<String, (isize, isize)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-pub(crate) fn register_floater_hwnd(label: String, hwnd: isize) {
+/// Register a floater. `parent_hwnd` is the HWND of the FullInstance main
+/// window that spawned this floater — used by the cascade hook to restrict
+/// min/restore/destroy operations to only that window's floaters.
+pub(crate) fn register_floater_hwnd(label: String, floater_hwnd: isize, parent_hwnd: isize) {
     if let Ok(mut m) = ACTIVE_FLOATER_HWNDS.lock() {
-        m.insert(label, hwnd);
+        m.insert(label, (floater_hwnd, parent_hwnd));
     }
 }
 
-/// Called from `floating_pane_wndproc` on WM_DESTROY and from the cascade
-/// hook on explicit close; reverse-scans by HWND value since the wndproc
-/// doesn't have the label in scope.
+/// Called from `floating_pane_wndproc` on WM_DESTROY; reverse-scans by
+/// floater HWND value since the wndproc doesn't have the label in scope.
 pub(crate) fn unregister_floater_by_hwnd(hwnd: isize) {
     if let Ok(mut m) = ACTIVE_FLOATER_HWNDS.lock() {
-        m.retain(|_, v| *v != hwnd);
+        m.retain(|_, (fh, _)| *fh != hwnd);
     }
 }
 
-/// Snapshot of all active floater HWNDs. Used by the cascade hook and the
-/// diagnostic command.
-pub(crate) fn all_floater_hwnds() -> Vec<isize> {
+/// Floater HWNDs whose parent main window matches `parent_hwnd`. Used by the
+/// cascade hook — only fires on the floaters belonging to the activating /
+/// minimizing / destroying window, not the entire global set.
+pub(crate) fn floater_hwnds_for_parent(parent_hwnd: isize) -> Vec<isize> {
     ACTIVE_FLOATER_HWNDS
         .lock()
-        .map(|m| m.values().copied().collect())
+        .map(|m| {
+            m.values()
+                .filter(|(_, ph)| *ph == parent_hwnd)
+                .map(|(fh, _)| *fh)
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -102,7 +114,7 @@ pub(crate) fn all_floater_hwnds() -> Vec<isize> {
 pub(crate) fn floater_debug_snapshot() -> Vec<(String, isize)> {
     ACTIVE_FLOATER_HWNDS
         .lock()
-        .map(|m| m.iter().map(|(l, h)| (l.clone(), *h)).collect())
+        .map(|m| m.iter().map(|(l, (fh, _))| (l.clone(), *fh)).collect())
         .unwrap_or_default()
 }
 
@@ -132,27 +144,22 @@ wrap_task! {
         y: i32,
         width: i32,
         height: i32,
+        // HWND of the FullInstance main window that initiated the tear-off.
+        // 0 if the caller didn't provide a source_window_label (back-compat).
+        parent_main_hwnd: isize,
     }
 
     impl Task {
         fn execute(&self) {
             // Runs on the CEF UI thread.
             //
-            //   1. Find the source main window's HWND (we own this).
-            //   2. CreateWindowExW with WS_EX_TOOLWINDOW + WS_POPUP +
-            //      owner HWND. That's what gives us no taskbar / no
-            //      Alt-Tab and the minimize / restore / destroy cascade.
+            //   1. CreateWindowExW with WS_EX_TOOLWINDOW + WS_POPUP (no owner
+            //      — see module doc §"Why no owner (issue #1560)").
+            //   2. Register in ACTIVE_FLOATER_HWNDS keyed by parent_main_hwnd
+            //      so the cascade hook affects only this window's floaters.
             //   3. Embed a CEF browser inside via `set_as_child` —
             //      same pattern as `browser_pane/creation.rs:109`.
 
-            // TODO(phase-6, codex P2 on #811): With multiple main
-            // windows in the same process (future tab-tear-off-to-same-
-            // process scenarios, sub-windows, etc.), `find_own_top_level_window`
-            // returns the FIRST visible window of this process, which
-            // may not be the source of the tear-off. The right fix is
-            // an API change to thread the source window's label/HWND
-            // through `OpenFloatingPaneArgs`. Today (Phase 1) there's
-            // exactly one main window per process, so this is harmless.
             // Every early-return from execute() AFTER the host's
             // `post_create_floating_window` enqueued a
             // `PendingWindowCreation` must dispatch
@@ -214,9 +221,13 @@ wrap_task! {
                 .insert(self.window_label.clone(), outer_hwnd as isize);
             // Register in the global cascade registry so the main-window
             // WM_ACTIVATE/WM_SIZE/WM_DESTROY hook can reach this floater.
+            // parent_main_hwnd binds this floater to its source window so
+            // the hook only cascades its own floaters (not those of other
+            // full-instance windows in the same process).
             crate::floating_pane::register_floater_hwnd(
                 self.window_label.clone(),
                 outer_hwnd as isize,
+                self.parent_main_hwnd,
             );
 
             // CEF embed — the browser is a WS_CHILD of the outer HWND.
@@ -292,6 +303,7 @@ pub fn post_create_floating_window(
     state: &Arc<AppState>,
     args: &crate::commands::floating_pane::OpenFloatingPaneArgs,
     window_label: &str,
+    parent_main_hwnd: isize,
 ) {
     // Compose the URL the floating window's CEF browser will load. The
     // frontend's cef-init detects `floatingPaneId` and routes to the
@@ -362,6 +374,7 @@ pub fn post_create_floating_window(
         args.y,
         args.width,
         args.height,
+        parent_main_hwnd,
     );
     post_task(ThreadId::UI, Some(&mut task));
 }
@@ -480,6 +493,11 @@ unsafe extern "system" fn floating_pane_wndproc(
             // we don't map any zone to HTCAPTION here. Fall through to
             // HTCLIENT so clicks reach CEF and the JS handler.
         }
+        // Unregister from the cascade registry so the main-window hook no
+        // longer tries to show/hide/z-order a destroyed HWND.
+        WM_DESTROY => {
+            crate::floating_pane::unregister_floater_by_hwnd(hwnd as isize);
+        }
         // Resize the floater's FRONTEND browser (header + layout) to fill the
         // client area on every outer-window resize (maximize / restore, and
         // future edge-resize). CEF `set_as_child` browsers don't self-resize,
@@ -500,11 +518,6 @@ unsafe extern "system" fn floating_pane_wndproc(
         // cascades the resize to the frontend's inner render-widget children.
         // (Terminal/agent floaters have a single child, so bottom-most == that
         // child — unchanged.) Falls through to DefWindowProcW afterwards.
-        // Unregister from the cascade registry so the main-window hook no
-        // longer tries to show/hide/z-order a destroyed HWND.
-        WM_DESTROY => {
-            crate::floating_pane::unregister_floater_by_hwnd(hwnd as isize);
-        }
         WM_SIZE => {
             // Walk the sibling Z-order from topmost (GW_CHILD) to the
             // bottom-most direct child = the frontend browser.

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -95,15 +95,16 @@ pub(crate) fn unregister_floater_by_hwnd(hwnd: isize) {
     }
 }
 
-/// Floater HWNDs whose parent main window matches `parent_hwnd`. Used by the
-/// cascade hook — only fires on the floaters belonging to the activating /
-/// minimizing / destroying window, not the entire global set.
+/// Floater HWNDs whose parent main window matches `parent_hwnd`, plus any
+/// floaters registered with parent=0 (unresolved source, legacy callers).
+/// Used by the cascade hook — parent=0 floaters are claimed by whichever
+/// window fires the hook first, preventing them from becoming permanent orphans.
 pub(crate) fn floater_hwnds_for_parent(parent_hwnd: isize) -> Vec<isize> {
     ACTIVE_FLOATER_HWNDS
         .lock()
         .map(|m| {
             m.values()
-                .filter(|(_, ph)| *ph == parent_hwnd)
+                .filter(|(_, ph)| *ph == parent_hwnd || *ph == 0)
                 .map(|(fh, _)| *fh)
                 .collect()
         })

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -235,12 +235,18 @@ async fn route_command(
         }
         "open_floating_pane_window" => {
             // Floating-pane tear-off — a chromeless window showing just the
-            // torn-off pane. Windows: a subordinate WS_POPUP+WS_EX_TOOLWINDOW
-            // HWND owned by the source window. macOS/Linux (Phase A): a
-            // frameless CEF Views window with ?floatingPaneId= in the URL.
+            // torn-off pane. Windows: unowned WS_POPUP+WS_EX_TOOLWINDOW HWND
+            // with explicit cascade hook. macOS/Linux (Phase A): a frameless
+            // CEF Views window with ?floatingPaneId= in the URL.
             // Specs: SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md +
             // SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md.
             commands::floating_pane::open_floating_pane_window(state, args)
+        }
+        "get_pane_debug_state" => {
+            // Diagnostic snapshot: active floaters, pane-closing gate, pool
+            // queue size, pending window creations. Called by the frontend
+            // before/after every tear-off to surface intermittent failures.
+            Ok(commands::floating_pane::get_pane_debug_state(state))
         }
         "get_instance_number" => Ok(commands::window::get_instance_number(state, args)),
         "register_backend_window" => Ok(commands::window::register_backend_window(state, args)),

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -297,6 +297,7 @@ async function performTearOff(
                 y: screenY,
                 width: floaterWidth,
                 height: floaterHeight,
+                source_window_label: windowLabelRef,
             });
             Logger.info("dnd:cross", "floating pane spawned", {
                 blockId: payload.blockId,
@@ -320,6 +321,7 @@ async function performTearOff(
                         y: screenY,
                         width: floaterWidth,
                         height: floaterHeight,
+                        source_window_label: windowLabelRef,
                     });
                 } catch (e2) {
                     Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -272,6 +272,15 @@ async function performTearOff(
             });
             return;
         }
+        // Diagnostic snapshot before the IPC so intermittent failures can
+        // be correlated with pane-closing state or pool exhaustion.
+        invokeCommand("get_pane_debug_state", {}).then((snap) => {
+            Logger.info("dnd:cross", "tear-off pre-flight state", {
+                blockId: payload.blockId,
+                ...snap,
+            });
+        }).catch(() => {});
+
         // CRITICAL: invoke the IPC FIRST, then mutate the layout on
         // success. If we delete the layout node up front and the IPC
         // fails (e.g. the H.7 mid-close gate in

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -208,7 +208,7 @@ async function handleCrossWindowDragEnd(
             await performCrossWindowDrop(dragType, dragPayloadForApi, workspace.oid, activeTabId);
             await api.completeCrossDrag(dragId, targetWindow, cursorPoint.x, cursorPoint.y);
         } else if (!targetWindow) {
-            await performTearOff(dragType, dragPayloadForApi, workspace.oid, activeTabId, cursorPoint.x, cursorPoint.y, grabOffsetSnapshot);
+            await performTearOff(dragType, dragPayloadForApi, workspace.oid, activeTabId, cursorPoint.x, cursorPoint.y, grabOffsetSnapshot, sourceWindow);
             await api.completeCrossDrag(dragId, null, cursorPoint.x, cursorPoint.y);
             try { await api.releaseDragCapture(); } catch {}
         } else {
@@ -236,6 +236,7 @@ async function performTearOff(
     screenX: number,
     screenY: number,
     grabOffsetSnapshot: ReturnType<typeof getTabGrabOffset> = null,
+    sourceWindowLabel: string | null = null,
 ) {
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
@@ -272,9 +273,9 @@ async function performTearOff(
             });
             return;
         }
-        // Diagnostic snapshot before the IPC so intermittent failures can
-        // be correlated with pane-closing state or pool exhaustion.
-        invokeCommand("get_pane_debug_state", {}).then((snap) => {
+        // Diagnostic snapshot — awaited so it captures state before the IPC
+        // starts (a fire-and-forget races the IPC and may read post-start state).
+        await invokeCommand("get_pane_debug_state", {}).then((snap) => {
             Logger.info("dnd:cross", "tear-off pre-flight state", {
                 blockId: payload.blockId,
                 ...snap,
@@ -297,7 +298,7 @@ async function performTearOff(
                 y: screenY,
                 width: floaterWidth,
                 height: floaterHeight,
-                source_window_label: windowLabelRef,
+                source_window_label: sourceWindowLabel,
             });
             Logger.info("dnd:cross", "floating pane spawned", {
                 blockId: payload.blockId,
@@ -321,7 +322,7 @@ async function performTearOff(
                         y: screenY,
                         width: floaterWidth,
                         height: floaterHeight,
-                        source_window_label: windowLabelRef,
+                        source_window_label: sourceWindowLabel,
                     });
                 } catch (e2) {
                     Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {


### PR DESCRIPTION
## Summary

- **Removes Win32 owned-window relationship** from floating panes. The owned-window invariant forces owned windows permanently above their owner — it cannot be overridden with `SetWindowPos`. Floaters are now created as unowned `WS_POPUP + WS_EX_TOOLWINDOW` windows.
- **Adds explicit cascade hook** (`install_main_window_floater_cascade_hook` in `client/wndproc.rs`) that subclasses the main window's WndProc to replicate owned-window behaviour manually: floaters are placed below the main window on `WM_ACTIVATE`, hidden/shown on minimize/restore (`WM_SIZE`), and closed on `WM_DESTROY`.
- **Global floater HWND registry** (`ACTIVE_FLOATER_HWNDS` in `floating_pane.rs`) tracks every live floater; populated at creation, pruned on `WM_DESTROY` in `floating_pane_wndproc`.
- **`get_pane_debug_state` IPC command** — returns `any_browser_pane_closing`, `pool_queue_size`, `pending_window_creations`, and active floater HWNDs for structured diagnostics.
- **Pre-flight diagnostic logging** in `CrossWindowDragMonitor.win32.tsx` calls `get_pane_debug_state` before every `open_floating_pane_window` so intermittent tear-off failures can be correlated with pane-closing state in the frontend log.

Closes #1560.

## Test plan

- [ ] Tear off a pane — main window should come to foreground when clicked; floater should sit below it
- [ ] Minimize main window — floaters should hide; restore should bring them back
- [ ] Close main window — floaters should close
- [ ] Back-to-back tear-offs still work (retry path from PR #1559 unaffected)
- [ ] Check frontend logs on a failed tear-off: pre-flight snapshot should show `any_browser_pane_closing: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)