### PR TITLE
feat(common): A2 — extract srv/mcp/bashwrap HTTP DTOs into agentmux-common

### DIFF
--- a/.changesets/1781813004-feat-common-a2-extract-srv-mcp-bashwrap-http-dtos-into-agent-961s.md
+++ b/.changesets/1781813004-feat-common-a2-extract-srv-mcp-bashwrap-http-dtos-into-agent-961s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(common): A2 — extract srv/mcp/bashwrap HTTP DTOs into agentmux-common

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -11,6 +11,7 @@ name = "agentmux-bashwrap"
 path = "src/main.rs"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util", "time", "sync"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }

--- a/agentmux-bashwrap/src/wps_client.rs
+++ b/agentmux-bashwrap/src/wps_client.rs
@@ -13,6 +13,7 @@
 //! a `kind: "system"` chunk that surfaces the degradation to the
 //! user without aborting the command itself.
 
+use agentmux_common::api_types::WpsPublishRequest;
 use anyhow::Result;
 use serde::Serialize;
 use std::sync::Arc;
@@ -26,31 +27,6 @@ pub struct WpsClient {
     inner: Arc<reqwest::Client>,
     endpoint: String,
     auth_key: String,
-}
-
-#[derive(Serialize)]
-struct PublishRequest<'a, T: Serialize> {
-    /// WPS event name. Fixed `tool_chunk` for every streaming chunk —
-    /// the tool_use_id lives in the payload, not in the event name.
-    /// Lets the frontend open a single per-block subscription on mount
-    /// instead of per-tool subscriptions racing the tool's execution.
-    event: &'a str,
-    /// Scope filters. Always `["block:<id>"]` for tool_chunk so the
-    /// broker delivers only to the relevant pane.
-    #[serde(skip_serializing_if = "<[String]>::is_empty")]
-    scopes: &'a [String],
-    /// Per-event persistence count (kept by the broker for
-    /// replay-on-subscribe). Captures the wrapper's full output for
-    /// late subscribers when Claude buffers the tool_use stream until
-    /// after the tool runs.
-    #[serde(skip_serializing_if = "is_zero_usize")]
-    persist: usize,
-    /// Event payload. Free-form per event type.
-    data: &'a T,
-}
-
-fn is_zero_usize(n: &usize) -> bool {
-    *n == 0
 }
 
 /// How many `tool_chunk` events the broker keeps per `block:<id>`
@@ -98,14 +74,11 @@ impl WpsClient {
         block_id: Option<&str>,
         payload: &T,
     ) -> Result<()> {
-        let scopes: Vec<String> = block_id
-            .map(|b| vec![format!("block:{}", b)])
-            .unwrap_or_default();
-        let body = PublishRequest {
-            event: TOOL_CHUNK_EVENT,
-            scopes: &scopes,
+        let body = WpsPublishRequest {
+            event: TOOL_CHUNK_EVENT.to_string(),
+            scopes: block_id.map(|b| vec![format!("block:{b}")]).unwrap_or_default(),
             persist: TOOL_CHUNK_PERSIST,
-            data: payload,
+            data: serde_json::to_value(payload)?,
         };
         let url = format!("{}{}", self.endpoint, PUBLISH_PATH);
         let resp = self

--- a/agentmux-common/src/api_types.rs
+++ b/agentmux-common/src/api_types.rs
@@ -1,0 +1,184 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical HTTP request/response DTOs shared between agentmux-srv,
+//! agentmux-mcp, and agentmux-bashwrap.  Every struct here is the single
+//! source of truth for the corresponding wire shape; the three crates all
+//! import rather than redeclare these types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
+// ── WPS publish ───────────────────────────────────────────────────────────────
+
+/// `POST /agentmux/wps/publish` — shared client/server envelope.
+///
+/// Sent by `agentmux-bashwrap` and received by `agentmux-srv`.
+/// Mirrors `WaveEvent` but omits the server-populated `sender` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WpsPublishRequest {
+    pub event: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub persist: usize,
+    pub data: serde_json::Value,
+}
+
+// ── Shell ─────────────────────────────────────────────────────────────────────
+
+/// `POST /api/v1/shell/create`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellCreateRequest {
+    pub agent_block_id: String,
+    pub cmd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+}
+
+/// Response from `POST /api/v1/shell/create`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellCreateResponse {
+    pub shell_id: String,
+}
+
+/// `POST /api/v1/shell/stop`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellStopRequest {
+    pub shell_id: String,
+}
+
+/// Response from `POST /api/v1/shell/stop`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShellStopResponse {
+    pub stopped: bool,
+}
+
+// ── Inject (SendMessage + Loop) ───────────────────────────────────────────────
+
+/// `POST /agentmux/reactive/inject` — deliver a message to an agent.
+///
+/// Used by the `SendMessage` and `Loop` MCP tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InjectRequest {
+    pub target_agent: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_agent: Option<String>,
+}
+
+// ── Pane ──────────────────────────────────────────────────────────────────────
+
+/// `POST /api/v1/pane/open` — open a new pane.
+///
+/// Structurally equivalent to `rpc_types::CommandPaneOpenData` (same wire
+/// fields) so the two are interchangeable on the wire; srv deserializes into
+/// `CommandPaneOpenData`, mcp serializes from this type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneOpenRequest {
+    pub view: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub split_direction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub split_reference_block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focus: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tree_expanded: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub floating: Option<bool>,
+}
+
+/// Response from `POST /api/v1/pane/open`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneOpenResponse {
+    pub block_id: String,
+}
+
+/// `POST /api/v1/pane/title` — set a pane's display title.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneTitleRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    pub title: String,
+}
+
+// ── Tab ───────────────────────────────────────────────────────────────────────
+
+/// `POST /api/v1/tab/activate` — switch the active tab.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabActivateRequest {
+    pub tab_id: String,
+}
+
+/// `POST /api/v1/tab/new` — create a new tab in a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabNewRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// `POST /api/v1/tab/name` — rename a tab.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabNameRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    pub name: String,
+}
+
+// ── Window ────────────────────────────────────────────────────────────────────
+
+/// `POST /api/v1/window/focus` — bring a window to the foreground.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowFocusRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+}
+
+/// `POST /api/v1/window/name` — set a window's display name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowNameRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+}
+
+// ── Workspace ─────────────────────────────────────────────────────────────────
+
+/// `POST /api/v1/workspace/name` — rename a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceNameRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    pub name: String,
+}

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Shared utilities for AgentMux crates.
 
+pub mod api_types;
 mod cli;
 pub mod data_paths;
 pub mod errors;

--- a/agentmux-mcp/Cargo.toml
+++ b/agentmux-mcp/Cargo.toml
@@ -11,6 +11,7 @@ name = "agentmux-mcp"
 path = "src/main.rs"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "time"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -29,6 +29,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use agentmux_common::api_types::{
+    InjectRequest, PaneOpenRequest, PaneOpenResponse, ShellCreateRequest, ShellCreateResponse,
+    ShellStopRequest, ShellStopResponse, TabActivateRequest, TabNameRequest, TabNewRequest,
+    WindowFocusRequest, WindowNameRequest, WorkspaceNameRequest, PaneTitleRequest,
+};
 use anyhow::Result;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -393,29 +398,27 @@ async fn call_tool(
                 .get("title")
                 .and_then(|v| v.as_str())
                 .unwrap_or(cmd);
-            let cwd = arguments.get("cwd").and_then(|v| v.as_str());
-            let env = arguments.get("env").cloned();
+            let cwd = arguments.get("cwd").and_then(|v| v.as_str()).map(str::to_string);
+            let env = arguments
+                .get("env")
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
 
             let url = format!(
                 "{}/api/v1/shell/create",
                 local_url.trim_end_matches('/')
             );
-            let mut body = json!({
-                "agent_block_id": block_id,
-                "cmd": cmd,
-                "title": title,
-            });
-            if let Some(cwd) = cwd {
-                body["cwd"] = json!(cwd);
-            }
-            if let Some(env) = env {
-                body["env"] = env;
-            }
+            let req = ShellCreateRequest {
+                agent_block_id: block_id.to_string(),
+                cmd: cmd.to_string(),
+                title: Some(title.to_string()),
+                cwd,
+                env,
+            };
 
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&body)
+                .json(&req)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -426,16 +429,12 @@ async fn call_tool(
                 anyhow::bail!("shell/create failed: HTTP {status} — {text}");
             }
 
-            let result: Value = resp
+            let result: ShellCreateResponse = resp
                 .json()
                 .await
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
-            let shell_id = result
-                .get("shell_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
 
-            Ok(shell_id.to_string())
+            Ok(result.shell_id)
         }
         "ShellStop" => {
             let shell_id = arguments
@@ -454,7 +453,7 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&json!({ "shell_id": shell_id }))
+                .json(&ShellStopRequest { shell_id: shell_id.to_string() })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -465,12 +464,11 @@ async fn call_tool(
                 anyhow::bail!("shell/stop failed: HTTP {status} — {text}");
             }
 
-            let result: Value = resp
+            let result: ShellStopResponse = resp
                 .json()
                 .await
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
-            let stopped = result.get("stopped").and_then(|v| v.as_bool()).unwrap_or(false);
-            Ok(if stopped {
+            Ok(if result.stopped {
                 format!("stopped shell {shell_id}")
             } else {
                 format!("shell {shell_id} was not running (unknown or already exited)")
@@ -497,35 +495,43 @@ async fn call_tool(
                 .unwrap_or("right");
 
             let url = format!("{}/api/v1/pane/open", local_url.trim_end_matches('/'));
-            let mut body = json!({
-                "view": "editor",
-                "file": file,
-                "focus": true,
-            });
             // Place the editor relative to the calling agent pane when we know
             // its block id (AGENTMUX_BLOCKID); otherwise the sidecar inserts it
             // at the tab root.
-            if !block_id.is_empty() {
-                body["split_direction"] = json!(split);
-                body["split_reference_block_id"] = json!(block_id);
-            }
-            if let Some(title) = arguments.get("title").and_then(|v| v.as_str()) {
-                body["title"] = json!(title);
-            }
-            // `collapse_tree: true` → open with the file-tree sidebar collapsed.
-            // Maps to the editor's `tree_expanded` meta (collapsed == not expanded).
-            if arguments.get("collapse_tree").and_then(|v| v.as_bool()) == Some(true) {
-                body["tree_expanded"] = json!(false);
-            }
-            // `floating: true` → open in a floating window instead of a docked split.
-            if arguments.get("floating").and_then(|v| v.as_bool()) == Some(true) {
-                body["floating"] = json!(true);
-            }
+            let (split_direction, split_reference_block_id) = if block_id.is_empty() {
+                (None, None)
+            } else {
+                (Some(split.to_string()), Some(block_id.to_string()))
+            };
+            let req = PaneOpenRequest {
+                view: "editor".to_string(),
+                file: Some(file.to_string()),
+                focus: Some(true),
+                split_direction,
+                split_reference_block_id,
+                title: arguments.get("title").and_then(|v| v.as_str()).map(str::to_string),
+                // `collapse_tree: true` → open with the file-tree sidebar collapsed.
+                // Maps to the editor's `tree_expanded` meta (collapsed == not expanded).
+                tree_expanded: if arguments.get("collapse_tree").and_then(|v| v.as_bool()) == Some(true) {
+                    Some(false)
+                } else {
+                    None
+                },
+                // `floating: true` → open in a floating window instead of a docked split.
+                floating: if arguments.get("floating").and_then(|v| v.as_bool()) == Some(true) {
+                    Some(true)
+                } else {
+                    None
+                },
+                url: None,
+                cwd: None,
+                tab_id: None,
+            };
 
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&body)
+                .json(&req)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -536,16 +542,12 @@ async fn call_tool(
                 anyhow::bail!("pane.open failed: HTTP {status} — {text}");
             }
 
-            let result: Value = resp
+            let result: PaneOpenResponse = resp
                 .json()
                 .await
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
-            let block = result
-                .get("block_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
 
-            Ok(format!("Opened {file} in editor pane (block {block})"))
+            Ok(format!("Opened {file} in editor pane (block {})", result.block_id))
         }
         "SendMessage" => {
             let to = arguments
@@ -574,18 +576,16 @@ async fn call_tool(
                 "{}/agentmux/reactive/inject",
                 local_url.trim_end_matches('/')
             );
-            let mut body = json!({
-                "target_agent": to,
-                "message": message,
-            });
-            if let Some(src) = source_agent {
-                body["source_agent"] = json!(src);
-            }
+            let req = InjectRequest {
+                target_agent: to.to_string(),
+                message: message.to_string(),
+                source_agent,
+            };
 
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&body)
+                .json(&req)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -692,19 +692,34 @@ async fn call_tool(
             require_agent_env(local_url, auth_key, block_id)?;
 
             // window/tab/workspace POST {"name": …} to /…/name; pane POSTs
-            // {"title": …} to /pane/title. `label` is the human-facing echo.
-            let (path, field, label) = match target {
-                "window" => ("window/name", "name", "Window name"),
-                "tab" => ("tab/name", "name", "Tab name"),
-                "workspace" => ("workspace/name", "name", "Workspace name"),
-                "pane" => ("pane/title", "title", "Pane title"),
+            // {"title": …} to /pane/title. `label` and `resp_field` are the
+            // human-facing echo and the response key used to surface the
+            // server-applied value (e.g. a window name clamped to 64 chars).
+            let (path, label, resp_field, body) = match target {
+                "window" => ("window/name", "Window name", "name", serde_json::to_value(WindowNameRequest {
+                    block_id: Some(block_id.to_string()),
+                    name: new_name.to_string(),
+                    window_id: None,
+                })?),
+                "tab" => ("tab/name", "Tab name", "name", serde_json::to_value(TabNameRequest {
+                    block_id: Some(block_id.to_string()),
+                    tab_id: None,
+                    name: new_name.to_string(),
+                })?),
+                "workspace" => ("workspace/name", "Workspace name", "name", serde_json::to_value(WorkspaceNameRequest {
+                    block_id: Some(block_id.to_string()),
+                    workspace_id: None,
+                    name: new_name.to_string(),
+                })?),
+                "pane" => ("pane/title", "Pane title", "title", serde_json::to_value(PaneTitleRequest {
+                    block_id: Some(block_id.to_string()),
+                    title: new_name.to_string(),
+                })?),
                 other => anyhow::bail!(
                     "invalid target '{other}' — expected one of: window, tab, pane, workspace"
                 ),
             };
             let url = format!("{}/api/v1/{path}", local_url.trim_end_matches('/'));
-            let mut body = json!({ "block_id": block_id });
-            body[field] = json!(new_name);
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
@@ -719,12 +734,11 @@ async fn call_tool(
             }
             // Surface the server-applied value (e.g. a window name clamped to 64
             // chars) when the endpoint echoes it back; fall back to the request.
-            // Restores the pre-consolidation SetWindowName behavior generically.
             let applied = resp
                 .json::<Value>()
                 .await
                 .ok()
-                .and_then(|v| v.get(field).and_then(|s| s.as_str()).map(str::to_string))
+                .and_then(|v| v.get(resp_field).and_then(|s| s.as_str()).map(str::to_string))
                 .unwrap_or_else(|| new_name.to_string());
             Ok(format!("{label} set to \"{applied}\""))
         }
@@ -783,7 +797,7 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&json!({ "tab_id": tab_id }))
+                .json(&TabActivateRequest { tab_id: tab_id.to_string() })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -801,7 +815,11 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&json!({ "block_id": block_id, "name": name }))
+                .json(&TabNewRequest {
+                    block_id: Some(block_id.to_string()),
+                    workspace_id: None,
+                    name: if name.is_empty() { None } else { Some(name.to_string()) },
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -823,7 +841,10 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&json!({ "block_id": block_id, "window_id": window_id }))
+                .json(&WindowFocusRequest {
+                    block_id: Some(block_id.to_string()),
+                    window_id: if window_id.is_empty() { None } else { Some(window_id.to_string()) },
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -893,17 +914,15 @@ async fn call_tool(
                     tokio::time::sleep(interval).await;
                 }
                 loop {
-                    let mut body = json!({
-                        "target_agent": task_target,
-                        "message": prompt,
-                    });
-                    if let Some(src) = &task_source {
-                        body["source_agent"] = json!(src);
-                    }
+                    let req = InjectRequest {
+                        target_agent: task_target.clone(),
+                        message: prompt.clone(),
+                        source_agent: task_source.clone(),
+                    };
                     let _ = task_client
                         .post(&url)
                         .header("X-AuthKey", &task_auth)
-                        .json(&body)
+                        .json(&req)
                         .send()
                         .await;
                     tokio::time::sleep(interval).await;

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -47,6 +47,11 @@ use crate::backend::history::HistoryService;
 use crate::backend::subagent_watcher::SubagentWatcher;
 use crate::backend::wconfig;
 use crate::backend::wps::Broker;
+use agentmux_common::api_types::{
+    PaneTitleRequest, ShellCreateRequest, ShellCreateResponse, ShellStopRequest,
+    TabActivateRequest, TabNameRequest, TabNewRequest, WindowFocusRequest, WindowNameRequest,
+    WorkspaceNameRequest, WpsPublishRequest,
+};
 
 // ---- AppState ----
 
@@ -437,34 +442,6 @@ async fn stub_501() -> impl IntoResponse {
     )
 }
 
-/// Wire shape for `POST /agentmux/wps/publish`. Mirrors `WaveEvent`
-/// but keeps the field set narrow for what `agentmux-bashwrap`
-/// actually needs (no `sender`).
-#[derive(serde::Deserialize)]
-struct WpsPublishRequest {
-    /// WPS event name. We use a fixed `tool_chunk` for every
-    /// streaming chunk (the tool_use_id lives in the payload), but
-    /// the handler is general-purpose.
-    event: String,
-    /// Optional scope filters (e.g. `["block:<id>"]`) so only
-    /// subscribers watching that block receive the event.
-    #[serde(default)]
-    scopes: Vec<String>,
-    /// Per-scope event ring size. Lets late subscribers replay
-    /// events that landed before they subscribed. agentmux-bashwrap
-    /// sets this to 1024 for `tool_chunk` so the frontend's
-    /// subscription (installed on pane mount) picks up chunks that
-    /// flew before Claude's stream-json caught up enough to surface
-    /// the tool_use_id. Zero (or omitted) disables persistence —
-    /// pure fan-out. See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §6.
-    #[serde(default)]
-    persist: usize,
-    /// Free-form payload. For tool_chunk events this is the
-    /// `{op, kind, content, timestamp}` shape from
-    /// `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
-    data: serde_json::Value,
-}
-
 /// Auth-gated WPS publish endpoint
 /// (SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §3.2). `agentmux-bashwrap`
 /// POSTs here while running a Bash command; we forward to the
@@ -482,28 +459,6 @@ async fn handle_wps_publish(
     };
     state.broker.publish(event);
     (StatusCode::OK, Json(json!({"ok": true})))
-}
-
-// ---- Shell create ----
-
-#[derive(serde::Deserialize)]
-struct ShellCreateRequest {
-    /// Block UUID of the agent pane that launched the shell.
-    /// Events will be scoped to `block:<agent_block_id>` so only
-    /// that pane's subscription receives them.
-    agent_block_id: String,
-    cmd: String,
-    #[serde(default)]
-    cwd: Option<String>,
-    #[serde(default)]
-    title: Option<String>,
-    #[serde(default)]
-    env: Option<std::collections::HashMap<String, String>>,
-}
-
-#[derive(serde::Serialize)]
-struct ShellCreateResponse {
-    shell_id: String,
 }
 
 /// `POST /api/v1/shell/create` — start a persistent background shell.
@@ -619,13 +574,6 @@ async fn handle_shell_create(
     (StatusCode::OK, Json(ShellCreateResponse { shell_id }))
 }
 
-// ---- Shell stop ----
-
-#[derive(serde::Deserialize)]
-struct ShellStopRequest {
-    shell_id: String,
-}
-
 /// `POST /api/v1/shell/stop` — stop a running persistent shell.
 ///
 /// Called by `agentmux-mcp`'s `ShellStop` tool. Tree-kills the shell's
@@ -689,19 +637,6 @@ async fn handle_self(
         Ok(ctx) => Json(serde_json::to_value(&ctx).unwrap_or_default()).into_response(),
         Err(e) => (StatusCode::NOT_FOUND, Json(json!({ "error": e }))).into_response(),
     }
-}
-
-#[derive(serde::Deserialize)]
-struct WindowNameRequest {
-    /// Block UUID of the calling agent pane (`AGENTMUX_BLOCKID`); used to
-    /// resolve the caller's own window when `window_id` is omitted.
-    #[serde(default)]
-    block_id: Option<String>,
-    /// New display name; drives the OS/taskbar title. Trimmed; clamped to 64.
-    name: String,
-    /// Explicit target window. Defaults to the caller's own window.
-    #[serde(default)]
-    window_id: Option<String>,
 }
 
 /// `POST /api/v1/window/name` — set a window's display name
@@ -769,18 +704,6 @@ fn clean_name(raw: &str, max: usize) -> Option<String> {
     }
 }
 
-#[derive(serde::Deserialize)]
-struct TabNameRequest {
-    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the caller's
-    /// own tab when `tab_id` is omitted.
-    #[serde(default)]
-    block_id: Option<String>,
-    /// Explicit target tab; defaults to the caller's own tab.
-    #[serde(default)]
-    tab_id: Option<String>,
-    name: String,
-}
-
 /// `POST /api/v1/tab/name` — rename a tab. Defaults to the caller's own tab
 /// (resolved from `block_id`). Routes through `object.UpdateTabName`.
 async fn handle_tab_name(
@@ -805,15 +728,6 @@ async fn handle_tab_name(
         args: vec![json!(tab_id), json!(name)],
     };
     finish_name_call(&state, call, json!({ "success": true, "tab_id": tab_id, "name": name })).await
-}
-
-#[derive(serde::Deserialize)]
-struct PaneTitleRequest {
-    /// Calling agent's block id (`AGENTMUX_BLOCKID`) — the pane to title by
-    /// default. Set `block_id` to title a different pane you own.
-    #[serde(default)]
-    block_id: Option<String>,
-    title: String,
 }
 
 /// `POST /api/v1/pane/title` — set a pane's display title (`frame:title`).
@@ -841,18 +755,6 @@ async fn handle_pane_title(
         ],
     };
     finish_name_call(&state, call, json!({ "success": true, "block_id": block_id, "title": title })).await
-}
-
-#[derive(serde::Deserialize)]
-struct WorkspaceNameRequest {
-    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the caller's
-    /// own workspace when `workspace_id` is omitted.
-    #[serde(default)]
-    block_id: Option<String>,
-    /// Explicit target workspace; defaults to the caller's own.
-    #[serde(default)]
-    workspace_id: Option<String>,
-    name: String,
 }
 
 /// `POST /api/v1/workspace/name` — rename a workspace. Defaults to the
@@ -959,12 +861,6 @@ async fn handle_list_tabs(
     Json(service::agent_tabs(&state.wstore, ws_id.as_deref()))
 }
 
-#[derive(serde::Deserialize)]
-struct TabActivateRequest {
-    /// Tab to switch to (required).
-    tab_id: String,
-}
-
 /// `POST /api/v1/tab/activate` — make `tab_id` the active tab in its
 /// workspace. Routes through `workspace.SetActiveTab`.
 async fn handle_tab_activate(
@@ -986,20 +882,6 @@ async fn handle_tab_activate(
         args: vec![json!(ws_id), json!(tab_id)],
     };
     finish_name_call(&state, call, json!({ "success": true, "tab_id": tab_id })).await
-}
-
-#[derive(serde::Deserialize)]
-struct TabNewRequest {
-    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the workspace
-    /// the new tab is created in when `workspace_id` is omitted.
-    #[serde(default)]
-    block_id: Option<String>,
-    /// Explicit target workspace; defaults to the caller's own.
-    #[serde(default)]
-    workspace_id: Option<String>,
-    /// Optional tab name; the backend auto-generates `tab{N}` when empty.
-    #[serde(default)]
-    name: Option<String>,
 }
 
 /// `POST /api/v1/tab/new` — create (and activate) a new tab in the caller's
@@ -1025,17 +907,6 @@ async fn handle_tab_new(
         args: vec![json!(workspace_id), json!(name), json!(true)],
     };
     finish_name_call(&state, call, json!({ "success": true, "workspace_id": workspace_id })).await
-}
-
-#[derive(serde::Deserialize)]
-struct WindowFocusRequest {
-    /// Calling agent's block id (`AGENTMUX_BLOCKID`); resolves the caller's
-    /// own window when `window_id` is omitted.
-    #[serde(default)]
-    block_id: Option<String>,
-    /// Explicit target window; defaults to the caller's own.
-    #[serde(default)]
-    window_id: Option<String>,
 }
 
 /// `POST /api/v1/window/focus` — bring a window to the foreground. Defaults to


### PR DESCRIPTION
## Summary

- Creates `agentmux-common::api_types` with 14 canonical HTTP request/response DTOs shared across all three crates
- Removes 11 locally-defined structs from `agentmux-srv/src/server/mod.rs` (WpsPublishRequest, ShellCreate/Response, ShellStop, TabActivate, TabNew, WindowFocus, WindowName, TabName, PaneTitle, WorkspaceName)
- Replaces all `json!` literal request bodies in `agentmux-mcp/src/main.rs` with typed struct construction (Shell, ShellStop, OpenEditor, SendMessage, SetActiveTab, NewTab, FocusWindow, SetName, Loop)
- Replaces `agentmux-bashwrap`'s local generic `PublishRequest<'a, T>` with the shared `WpsPublishRequest`
- Adds `agentmux-common` as a dependency to `agentmux-mcp` and `agentmux-bashwrap` (both previously depended on nothing shared)

Closes A2 from the architecture refactor program (#1549).

## Test plan

- [x] `cargo check -p agentmux-common -p agentmux-mcp -p agentmux-bashwrap -p agentmux-srv` — green
- [x] `cargo test -p agentmux-mcp` — 4/4 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)