### PR TITLE
fix(agent-pane): choose host/container at template instantiation; drop bogus template runtime badge

### DIFF
--- a/.changesets/1781822953-fix-agent-pane-pick-host-container-when-creating-from-a-temp-da2a.md
+++ b/.changesets/1781822953-fix-agent-pane-pick-host-container-when-creating-from-a-temp-da2a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): pick host/container when creating from a template; drop bogus runtime badge on templates

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1425,6 +1425,13 @@ pub struct CommandAgentDefCreateFromTemplateData {
     /// Same semantics as `identity_id` above.
     #[serde(default)]
     pub memory_id: String,
+    /// Runtime to persist on the cloned definition: "host" or
+    /// "container". Empty/absent → keep the template's `agent_type`.
+    /// Runtime is chosen at instantiation time, not a property of the
+    /// template, so the clone records the user's pick rather than
+    /// inheriting the (now container-defaulted) template value.
+    #[serde(default)]
+    pub agent_type: String,
 }
 
 /// Response for `agentdefcreatefromtemplate`. The frontend uses

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -309,6 +309,15 @@ pub const COMMAND_FORK_AGENT_DEFINITION_SUGGEST: &str = "forkagentdefinitionsugg
 /// launch. Rejects non-template ids + duplicate user-agent names.
 pub const COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE: &str = "agentdefcreatefromtemplate";
 
+/// Returns whether a usable container runtime is reachable RIGHT NOW —
+/// i.e. the Docker daemon answers a `ping`, not merely that the `docker`
+/// CLI is on PATH. Used by the create-from-template modal to decide
+/// whether to offer/default the container runtime; a binary-only check
+/// would false-positive when Docker is installed but the daemon is
+/// stopped, steering the user into a container agent that can't start.
+/// Response: `{ "available": bool }`.
+pub const COMMAND_CONTAINER_RUNTIME_AVAILABLE: &str = "containerruntimeavailable";
+
 /// Two-tier picker (Phase 2 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
 /// Q2 Decision Y). Set the `user_hidden` flag on a seeded template so
 /// it disappears from the default `+ New from template` list. Idempotent;

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -456,6 +456,19 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .duration_since(UNIX_EPOCH)
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
+                // Runtime is the user's instantiation-time choice, not a
+                // template property. When supplied, the clone records it
+                // (and the matching `environment`); empty falls back to
+                // the template's value for back-compat with older callers.
+                let chosen_agent_type = match cmd.agent_type.trim() {
+                    "host" | "container" => cmd.agent_type.trim().to_string(),
+                    _ => template.agent_type.clone(),
+                };
+                let chosen_environment = if chosen_agent_type == "container" {
+                    "docker".to_string()
+                } else {
+                    "local".to_string()
+                };
                 let mut new_def = AgentDefinition {
                     id: uuid::Uuid::new_v4().to_string(),
                     // agent_def_insert derives a unique slug from the
@@ -477,8 +490,8 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     restart_on_crash: template.restart_on_crash,
                     idle_timeout_minutes: template.idle_timeout_minutes,
                     created_at: now,
-                    agent_type: template.agent_type.clone(),
-                    environment: template.environment.clone(),
+                    agent_type: chosen_agent_type,
+                    environment: chosen_environment,
                     agent_bus_id: String::new(),
                     is_seeded: 0,
                     accounts: String::new(),

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -19,6 +19,7 @@ use crate::backend::rpc_types::{
     COMMAND_RESEED_AGENTS,
     // Two-tier picker — Phase 1 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md)
     COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE,
+    COMMAND_CONTAINER_RUNTIME_AVAILABLE,
     CommandAgentDefCreateFromTemplateData, AgentDefCreateFromTemplateResult,
     CommandListAgentDefinitionsData,
     // Two-tier picker — Phase 2 (SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md
@@ -532,6 +533,30 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "agentdefcreatefromtemplate: cloned template into user agent"
                 );
                 Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // containerruntimeavailable → does the Docker DAEMON answer a ping
+    // right now? Returns `{ available: bool }`. The create-from-template
+    // modal uses this to gate/default the container runtime. Distinct
+    // from `resolvecli docker`, which only confirms the CLI binary is on
+    // PATH — that false-positives when Docker is installed but the daemon
+    // is stopped, steering users into a container agent that can't start
+    // (codex P1 on #1576). `None` manager (Docker absent at startup) →
+    // false; `Some` → live `check_available()` ping so a daemon that
+    // came up or went down since launch is reflected.
+    let container_manager_cra = state.container_manager.clone();
+    engine.register_handler(
+        COMMAND_CONTAINER_RUNTIME_AVAILABLE,
+        Box::new(move |_data, _ctx| {
+            let cm = container_manager_cra.clone();
+            Box::pin(async move {
+                let available = match cm {
+                    Some(mgr) => mgr.check_available().await.is_ok(),
+                    None => false,
+                };
+                Ok(Some(serde_json::json!({ "available": available })))
             })
         }),
     );

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -215,7 +215,7 @@ export function renderRequest(
                         // (spec note on CreateFromTemplateRequest) so
                         // `submitting()` covers both RPC steps and ESC
                         // / backdrop dismiss stay blocked end-to-end.
-                        onSubmit={async ({ name, identityId, memoryId }) => {
+                        onSubmit={async ({ name, identityId, memoryId, agentType }) => {
                             setSubmitting(true);
                             try {
                                 const resp = await RpcApi.AgentDefCreateFromTemplateCommand(
@@ -225,6 +225,10 @@ export function renderRequest(
                                         name,
                                         identity_id: identityId,
                                         memory_id: memoryId,
+                                        // Persist the chosen runtime on the
+                                        // new user-owned definition so later
+                                        // reattach/auto-continue uses it too.
+                                        agent_type: agentType,
                                     },
                                 );
                                 await req.onCreatedAndLaunch(
@@ -232,6 +236,7 @@ export function renderRequest(
                                     resp.identity_id,
                                     resp.memory_id,
                                     name,
+                                    agentType,
                                 );
                                 setSubmitting(false);
                                 api.close();

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -254,6 +254,10 @@ export interface CreateFromTemplateRequest {
         identityId: string,
         memoryId: string,
         name: string,
+        /** Runtime the user picked in the modal. The launch override
+         *  uses this directly instead of re-reading the (template-
+         *  derived) `agent_type`, so the choice actually takes effect. */
+        agentType: "host" | "container",
     ) => Promise<void>;
 }
 

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -580,6 +580,9 @@ class RpcApiType {
             name: string;
             identity_id?: string;
             memory_id?: string;
+            /** Runtime to persist on the cloned definition ("host" |
+             *  "container"). Omitted → backend keeps the template's. */
+            agent_type?: string;
         },
         opts?: RpcOpts,
     ): Promise<{ definition_id: string; identity_id: string; memory_id: string }> {

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -589,6 +589,20 @@ class RpcApiType {
         return client.rpcCall("agentdefcreatefromtemplate", data, opts);
     }
 
+    // command "containerruntimeavailable" [call]
+    //
+    // True only when the Docker daemon answers a live ping — NOT merely
+    // that the `docker` CLI is on PATH (which `resolvecli` checks). Used
+    // by the create-from-template modal to gate/default the container
+    // runtime so a daemon-down box doesn't get steered into a container
+    // agent that can't start.
+    ContainerRuntimeAvailableCommand(
+        client: RpcClient,
+        opts?: RpcOpts,
+    ): Promise<{ available: boolean }> {
+        return client.rpcCall("containerruntimeavailable", {}, opts);
+    }
+
     // command "createagent" [call]
     CreateAgentDefinitionCommand(client: RpcClient, data: CommandCreateAgentDefinitionData, opts?: RpcOpts): Promise<AgentDefinition> {
         return client.rpcCall("createagent", data, opts);

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -22,7 +22,6 @@
 import { createMemo, onMount, Show, type JSX } from "solid-js";
 import { ProviderLogo } from "@/element/ProviderLogo";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
-import { RuntimeBadge } from "./RuntimeBadge";
 
 interface AgentCardProps {
     agent: AgentDefinition;
@@ -124,9 +123,11 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
                 <span class="agent-card-title">{title()}</span>
                 <span class="agent-card-caption">{caption()}</span>
             </span>
-            <Show when={props.agent.agent_type === "host" || props.agent.agent_type === "container"}>
-                <RuntimeBadge runtime={props.agent.agent_type} size="sm" />
-            </Show>
+            {/* No runtime badge here. A template is runtime-agnostic —
+                the host/container choice is made when you instantiate it
+                (in the create-from-template modal), not a property of the
+                template itself. The badge belongs on a launched session
+                (MyAgentsList), where the runtime is concrete. */}
             <Show when={props.installed === false}>
                 <span class="agent-card-install-ribbon" aria-hidden="true">
                     Click to install

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -21,9 +21,9 @@ vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListIdentityBundlesCommand: vi.fn(),
         ListMemoriesCommand: vi.fn(),
-        // Mount-time Docker probe (drives the host/container dropdown).
-        // Default rejects → no sandbox available → host-only.
-        ResolveCliCommand: vi.fn(),
+        // Mount-time daemon probe (drives the host/container dropdown).
+        // Default → no reachable runtime → host-only.
+        ContainerRuntimeAvailableCommand: vi.fn(),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -61,8 +61,8 @@ beforeEach(async () => {
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
         { id: "mem-notes", name: "Notes", is_blank: false } as any,
     ]);
-    // Default: no container runtime resolvable → host-only.
-    vi.mocked(RpcApi.ResolveCliCommand).mockRejectedValue(new Error("not found"));
+    // Default: Docker daemon not reachable → host-only.
+    vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: false });
 });
 
 afterEach(() => cleanup());
@@ -142,10 +142,7 @@ describe("AgentCreateFromTemplateModalPanel", () => {
     });
 
     it("defaults to container when Docker is available and the template suggests it", async () => {
-        vi.mocked(RpcApi.ResolveCliCommand).mockResolvedValue({
-            cli_path: "/usr/bin/docker",
-            version: "27.0",
-        } as any);
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: true });
         const containerTemplate = { ...template, agent_type: "container" } as AgentDefinition;
         const onSubmit = vi.fn().mockResolvedValue(undefined);
         render(() => (

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -21,6 +21,9 @@ vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListIdentityBundlesCommand: vi.fn(),
         ListMemoriesCommand: vi.fn(),
+        // Mount-time Docker probe (drives the host/container dropdown).
+        // Default rejects → no sandbox available → host-only.
+        ResolveCliCommand: vi.fn(),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -58,6 +61,8 @@ beforeEach(async () => {
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
         { id: "mem-notes", name: "Notes", is_blank: false } as any,
     ]);
+    // Default: no container runtime resolvable → host-only.
+    vi.mocked(RpcApi.ResolveCliCommand).mockRejectedValue(new Error("not found"));
 });
 
 afterEach(() => cleanup());
@@ -110,6 +115,55 @@ describe("AgentCreateFromTemplateModalPanel", () => {
         // bundle each.
         expect(args.identityId).toBe("id-work");
         expect(args.memoryId).toBe("mem-notes");
+        // No Docker → runtime defaults to host (never a mode that
+        // can't actually start).
+        expect(args.agentType).toBe("host");
+    });
+
+    it("disables the container option when no Docker runtime is found", async () => {
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={vi.fn().mockResolvedValue(undefined)}
+                onCancel={vi.fn()}
+            />
+        ));
+        // Let the mount-time Docker probe settle (rejects in beforeEach).
+        await flush();
+        await flush();
+        const select = screen.getByTestId(
+            "create-from-template-runtime-select",
+        ) as HTMLSelectElement;
+        const containerOpt = Array.from(select.options).find(
+            (o) => o.value === "container",
+        )!;
+        expect(containerOpt.disabled).toBe(true);
+        expect(select.value).toBe("host");
+    });
+
+    it("defaults to container when Docker is available and the template suggests it", async () => {
+        vi.mocked(RpcApi.ResolveCliCommand).mockResolvedValue({
+            cli_path: "/usr/bin/docker",
+            version: "27.0",
+        } as any);
+        const containerTemplate = { ...template, agent_type: "container" } as AgentDefinition;
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={containerTemplate}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        // Wait for the probe to resolve and the default-pick effect to run.
+        const select = screen.getByTestId(
+            "create-from-template-runtime-select",
+        ) as HTMLSelectElement;
+        await waitFor(() => expect(select.value).toBe("container"));
+        const containerOpt = Array.from(select.options).find(
+            (o) => o.value === "container",
+        )!;
+        expect(containerOpt.disabled).toBe(false);
     });
 
     it("surfaces an error from onSubmit", async () => {

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -80,25 +80,20 @@ export const AgentCreateFromTemplateModalPanel = (
     );
     const canPickContainer = () => containerSupported() && dockerAvailable() === true;
 
-    // Probe for a usable container runtime the same way the launch flow
-    // gates container agents (flows/launch-flow.ts Phase 0). ResolveCli
-    // throws when the docker CLI can't be resolved → no sandbox.
+    // Probe for a usable container runtime: ask the backend whether the
+    // Docker DAEMON answers a ping right now — not just whether the
+    // `docker` CLI is on PATH. A binary-only check (resolvecli) would
+    // false-positive when Docker is installed but the daemon is stopped,
+    // re-creating the exact trap this modal exists to avoid: defaulting
+    // to a container agent that then can't start (codex P1 on #1576).
+    // Any failure → treat as unavailable (host-only), the safe fallback.
     onMount(() => {
         void (async () => {
             try {
-                await RpcApi.ResolveCliCommand(
-                    TabRpcClient,
-                    {
-                        provider_id: "docker",
-                        cli_command: "docker",
-                        npm_package: "",
-                        pinned_version: "",
-                        windows_install_command: "",
-                        unix_install_command: "",
-                    },
-                    { timeout: 10000 },
-                );
-                setDockerAvailable(true);
+                const r = await RpcApi.ContainerRuntimeAvailableCommand(TabRpcClient, {
+                    timeout: 10000,
+                });
+                setDockerAvailable(r?.available === true);
             } catch {
                 setDockerAvailable(false);
             }

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -69,7 +69,8 @@ export const AgentCreateFromTemplateModalPanel = (
     // agent always actually starts; container can never be the silent
     // default on a box without Docker (the bug this fixes).
     const [runtime, setRuntime] = createSignal<"host" | "container">("host");
-    // undefined = still probing; true/false = Docker CLI resolved or not.
+    // undefined = still probing; true/false = Docker daemon answered the
+    // ping (ContainerRuntimeAvailableCommand) or not — NOT a CLI-on-PATH check.
     const [dockerAvailable, setDockerAvailable] = createSignal<boolean | undefined>(undefined);
     // Once the user touches the dropdown we stop auto-defaulting so the
     // Docker-probe result can't yank their choice out from under them.

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -27,11 +27,16 @@ import { createEffect, createMemo, createSignal, For, onMount, Show, type JSX } 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { getCliCatalogEntry } from "../defaults/cli-catalog";
 
 export interface CreateFromTemplateFormData {
     name: string;
     identityId: string;
     memoryId: string;
+    /** Where the new agent runs. Chosen here at instantiation time —
+     *  it is NOT a property of the template (a template is runtime-
+     *  agnostic). "container" requires a reachable Docker runtime. */
+    agentType: "host" | "container";
 }
 
 interface AgentCreateFromTemplateModalPanelProps {
@@ -55,6 +60,66 @@ export const AgentCreateFromTemplateModalPanel = (
     const [memories, setMemories] = createSignal<Memory[]>([]);
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
+
+    // ── Runtime (host vs container) ────────────────────────────────
+    // Runtime is decided HERE, when instantiating the template — it's
+    // not a property of the template. The container option is only
+    // offered when (a) the CLI can run in a container and (b) Docker is
+    // actually reachable on this machine. We default to host so the new
+    // agent always actually starts; container can never be the silent
+    // default on a box without Docker (the bug this fixes).
+    const [runtime, setRuntime] = createSignal<"host" | "container">("host");
+    // undefined = still probing; true/false = Docker CLI resolved or not.
+    const [dockerAvailable, setDockerAvailable] = createSignal<boolean | undefined>(undefined);
+    // Once the user touches the dropdown we stop auto-defaulting so the
+    // Docker-probe result can't yank their choice out from under them.
+    let runtimeTouched = false;
+
+    const containerSupported = createMemo(
+        () => getCliCatalogEntry(props.template.provider)?.containerSupported ?? true,
+    );
+    const canPickContainer = () => containerSupported() && dockerAvailable() === true;
+
+    // Probe for a usable container runtime the same way the launch flow
+    // gates container agents (flows/launch-flow.ts Phase 0). ResolveCli
+    // throws when the docker CLI can't be resolved → no sandbox.
+    onMount(() => {
+        void (async () => {
+            try {
+                await RpcApi.ResolveCliCommand(
+                    TabRpcClient,
+                    {
+                        provider_id: "docker",
+                        cli_command: "docker",
+                        npm_package: "",
+                        pinned_version: "",
+                        windows_install_command: "",
+                        unix_install_command: "",
+                    },
+                    { timeout: 10000 },
+                );
+                setDockerAvailable(true);
+            } catch {
+                setDockerAvailable(false);
+            }
+        })();
+    });
+
+    // Default-pick the runtime once the probe lands: honour the
+    // template's suggested mode when container is genuinely usable,
+    // otherwise fall back to host. Never auto-selects a mode that can't
+    // run. Skipped once the user has made an explicit choice.
+    createEffect(() => {
+        if (runtimeTouched) return;
+        setRuntime(
+            canPickContainer() && props.template.agent_type === "container" ? "container" : "host",
+        );
+    });
+
+    const pickRuntime = (v: "host" | "container") => {
+        runtimeTouched = true;
+        setRuntime(v);
+    };
 
     // Load bundle lists on mount. Bindings are stored on the
     // db_agent_instances row at launch time; the empty string sentinel
@@ -108,6 +173,7 @@ export const AgentCreateFromTemplateModalPanel = (
                 name: name().trim(),
                 identityId: identityId(),
                 memoryId: memoryId(),
+                agentType: runtime(),
             });
             // Layer unmounts via close-on-success. Reset is defensive.
             setSubmitting(false);
@@ -148,6 +214,39 @@ export const AgentCreateFromTemplateModalPanel = (
                         disabled={submitting()}
                         data-testid="create-from-template-name-input"
                     />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Runtime</span>
+                    <select
+                        class="agent-new-bundle-modal-input"
+                        value={runtime()}
+                        onChange={(e) =>
+                            pickRuntime(e.currentTarget.value as "host" | "container")}
+                        disabled={submitting()}
+                        data-testid="create-from-template-runtime-select"
+                    >
+                        <option value="host">On this computer (host)</option>
+                        <option value="container" disabled={!canPickContainer()}>
+                            In a safe sandbox (container)
+                            {canPickContainer() ? "" : " — Docker not detected"}
+                        </option>
+                    </select>
+                    <Show when={runtime() === "host"}>
+                        <span class="agent-new-bundle-modal-hint">
+                            Runs directly on your machine with full access to your files,
+                            environment, and credentials.
+                        </span>
+                    </Show>
+                    <Show when={runtime() === "container"}>
+                        <span class="agent-new-bundle-modal-hint">
+                            Isolated Docker sandbox — the agent only sees its workspace.
+                        </span>
+                    </Show>
+                    <Show when={!containerSupported()}>
+                        <span class="agent-new-bundle-modal-hint">
+                            {props.template.name} can only run on the host.
+                        </span>
+                    </Show>
                 </label>
                 <label class="agent-new-bundle-modal-field">
                     <span class="agent-new-bundle-modal-label">Identity</span>

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -314,11 +314,16 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         await waitFor(() => expect(modalLayerOpen).toHaveBeenCalled());
 
         const req = modalLayerOpen.mock.calls[0][0];
+        // Pass an explicit runtime (5th arg) — the modal always supplies
+        // it; exercise the threading so the stub + override carry the
+        // user's pick rather than silently falling back (reagent P2 on
+        // #1576).
         await req.onCreatedAndLaunch(
             "new-def-id",
             "id-work",
             "mem-notes",
             "Mary",
+            "container",
         );
         expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1);
         const [stubAgent, overrides] = model.launchAgentDefinition.mock.calls[0];
@@ -326,6 +331,11 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(stubAgent.name).toBe("Mary");
         expect(stubAgent.is_seeded).toBe(0);
         expect(stubAgent.parent_id).toBe("tpl-claude");
+        // The chosen runtime is threaded onto both the stub definition
+        // and the launch override (not read from the template's type).
+        expect(stubAgent.agent_type).toBe("container");
+        expect(overrides.agentType).toBe("container");
+        expect(overrides.environment).toBe("docker");
         expect(overrides.identityId).toBe("id-work");
         expect(overrides.memoryId).toBe("mem-notes");
         expect(overrides.instanceName).toBe("Mary");

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -482,7 +482,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             kind: "create-from-template" as const,
             template,
             originBlockId: props.model.blockId,
-            onCreatedAndLaunch: async (newDefId, identityIdSel, memoryIdSel, name) => {
+            onCreatedAndLaunch: async (newDefId, identityIdSel, memoryIdSel, name, agentType) => {
                 // The new definition is user-owned and carries the
                 // template's provider + cmd config. Build an
                 // AgentDefinition stub good enough for the launch flow
@@ -508,12 +508,17 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         parent_id: template.id,
                         slug: "",
                         working_directory: "",
+                        // Reflect the runtime the user picked in the
+                        // modal, not the template's — the template is
+                        // runtime-agnostic and the backend persisted this
+                        // choice on the new row.
+                        agent_type: agentType,
+                        environment: agentType === "container" ? "docker" : "local",
                     };
                     await props.model.launchAgentDefinition(stubAgent, {
                         instanceName: name,
-                        agentType: (template.agent_type as "host" | "container") || "host",
-                        environment:
-                            template.agent_type === "container" ? "docker" : "local",
+                        agentType,
+                        environment: agentType === "container" ? "docker" : "local",
                         identityId: identityIdSel,
                         memoryId: memoryIdSel,
                         // No `continueOfInstanceId` — the new definition


### PR DESCRIPTION
**Follow-up to #1573** — a correction to the host/container differentiation feature, stacked on its branch.

## The problem (found while dogfooding 0.46.4 on a Windows box with no Docker)

Two symptoms reported by the user, one root cause:

1. **"agents not responding"** — their seeded agents were all `agent_type = "container"`, and container agents spawn via the Docker socket API. With no Docker daemon (`Docker daemon not reachable; container agent panes will fail to start` in the srv log), the container never starts, so the agent never comes alive to answer.
2. **"can't create a host agent — it's hard-coded to container"** — of the agent-create paths, only the full launch modal exposes a host/container radio. The **+ New from template** path inherits the template's `agent_type` (now `container`) with **no host escape hatch**.

The conceptual error #1573 introduced: it treats **runtime (host vs container) as a property of the template**. It isn't. A "Claude" / "Codex" template is a CLI you can run *either* way. Stamping `agent_type="container"` on templates and badging the template cards is what produced both the mislabeling and the Docker-less container trap.

## The fix — move the choice to instantiation time

- **`AgentCard`**: remove the `RuntimeBadge` from template cards (templates are runtime-agnostic). The badge stays on **My Agents** (`MyAgentsList`), where a launched session has a concrete runtime.
- **`AgentCreateFromTemplateModal`**: add a **Docker-aware host/container dropdown**.
  - Defaults to **host** so the new agent always actually starts.
  - The **container** option is only enabled when the CLI supports containers *and* a Docker runtime is resolvable (same `ResolveCli` probe the launch flow gates on).
  - When Docker **is** present and the template suggests container, it defaults to container — so #1573's secure-by-default intent is preserved where it can actually work. Never auto-selects a runtime that can't run.
- **Threading**: the chosen runtime flows `onSubmit → onCreatedAndLaunch → launch override`, and is **persisted on the cloned definition** (`agentdefcreatefromtemplate` gains an `agent_type` field) so later reattach / auto-continue uses the runtime the user actually picked, not the template's.

## Tests / smoke
- `AgentCreateFromTemplateModal.test.tsx` +2: container option disabled when no Docker; defaults to container when Docker available + container template. Existing modal + `AgentPicker` suites green (6/6, 9/9).
- `cargo check -p agentmux-srv` clean.
- `tsc` shows no new errors in touched files (repo builds via Vite).

## Note / open question for @parko
The seeded templates still carry `agent_type` in the DB — now used only as the modal's **Docker-gated default suggestion**, which is the right role for it. If you'd rather templates store no runtime at all, that's a separate seed change (gen-seed.js + schemaVersion bump) we can do on your branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)