### PR TITLE
fix(layout): pane resize on Linux — drive resize from window pointermove

### DIFF
--- a/.changesets/1781825760-fix-layout-pane-resize-on-linux-drive-resize-from-window-poi-j1lb.md
+++ b/.changesets/1781825760-fix-layout-pane-resize-on-linux-drive-resize-from-window-poi-j1lb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): pane resize on Linux — drive resize from window pointermove instead of the unstable CEF pointerId

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -685,37 +685,67 @@ interface ResizeHandleComponentProps {
 
 const ResizeHandle = (props: ResizeHandleComponentProps) => {
     let resizeHandleRef: HTMLDivElement | undefined;
-    const [trackingPointer, setTrackingPointer] = createSignal<number | undefined>(undefined);
 
-    const handlePointerMove = throttle(10, (event: PointerEvent) => {
-        if (trackingPointer() === event.pointerId) {
-            const { clientX, clientY } = event;
-            props.layoutModel.onResizeMove(props.resizeHandleProps, clientX, clientY);
-        }
-    });
+    // CEF/Chromium on Linux (Wayland) does NOT keep a stable PointerEvent.pointerId
+    // across a press → drag: the pointerdown arrives as one id (e.g. 1) but the
+    // subsequent pointermove events arrive as a *different* id (e.g. 2), and
+    // setPointerCapture() does not reliably route those moves once the cursor
+    // leaves the thin handle. The pointerId-match + onGotPointerCapture approach
+    // used on win32/darwin therefore never fires onResizeMove here — verified via
+    // logging: every move logged `tracking=1 id=2 match=false`, so the guard was
+    // always false and the divider never moved.
+    //
+    // Fix: don't depend on pointerId or pointer-capture routing. Arm on pointerdown
+    // and listen for moves on `window`, which receives every pointermove regardless
+    // of pointerId or whether the cursor is still over the handle. End on the
+    // primary-button release (pointerup/pointercancel, or buttons going to 0).
+    let teardown: (() => void) | null = null;
 
     function onPointerDown(event: PointerEvent) {
-        resizeHandleRef?.setPointerCapture(event.pointerId);
+        if (event.button !== 0 || teardown) return; // primary button, not already resizing
+        // Keep the press from also starting a tile tear-off or native window drag.
+        event.preventDefault();
+        // Best-effort capture: helps keep moves flowing over native panes on
+        // platforms where capture works; on Linux/CEF the unstable id makes it
+        // unreliable, which is why the window listeners below drive the resize.
+        try {
+            resizeHandleRef?.setPointerCapture(event.pointerId);
+        } catch {
+            /* ignore — capture is best-effort */
+        }
+
+        const onMove = throttle(10, (e: PointerEvent) => {
+            if (!teardown) return; // trailing throttle call after release
+            if ((e.buttons & 1) === 0) {
+                teardown(); // primary button released without a pointerup reaching us
+                return;
+            }
+            props.layoutModel.onResizeMove(props.resizeHandleProps, e.clientX, e.clientY);
+        });
+        const onUp = () => teardown?.();
+
+        teardown = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+            window.removeEventListener("pointercancel", onUp);
+            onMove.cancel();
+            teardown = null;
+            props.layoutModel.onResizeEnd();
+        };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+        window.addEventListener("pointercancel", onUp);
     }
 
-    function onPointerCapture(event: PointerEvent) {
-        setTrackingPointer(event.pointerId);
-    }
-
-    const onPointerRelease = debounce(30, (event: PointerEvent) => {
-        setTrackingPointer(undefined);
-        props.layoutModel.onResizeEnd();
-    });
+    onCleanup(() => teardown?.());
 
     return (
         <div
             ref={resizeHandleRef}
             class={clsx("resize-handle", `flex-${props.resizeHandleProps.flexDirection}`)}
             onPointerDown={onPointerDown}
-            onGotPointerCapture={onPointerCapture}
-            onLostPointerCapture={onPointerRelease}
             style={props.resizeHandleProps.transform as JSX.CSSProperties}
-            onPointerMove={handlePointerMove}
         >
             <div class="line" />
         </div>


### PR DESCRIPTION
## Problem
Dragging a pane divider to resize does nothing on **Linux**. Works on Windows/macOS.

## Root cause
On Linux/CEF (Wayland), `PointerEvent.pointerId` is **not stable across a press → drag**: the `pointerdown` arrives as one id (e.g. `1`) but the subsequent `pointermove` events arrive as a *different* id (e.g. `2`), and `setPointerCapture(1)` does not route those `id=2` moves once the cursor leaves the thin handle.

The shared `ResizeHandle` guarded each move with `trackingPointer() === event.pointerId` (with `trackingPointer` set from `onGotPointerCapture`). On Linux that comparison is **always false**, so `onResizeMove` never fires. win32/darwin work because their `pointerId` stays consistent.

Verified by instrumenting the handler — every move logged:
```
[resize-dbg] pointerdown id=1 → setPointerCapture OK id=1
[resize-dbg] pointermove tracking=1 id=2 match=false buttons=1   (×many)
```

## Fix
Stop depending on `pointerId` and pointer-capture routing on Linux. The handle now:
- arms on `pointerdown` (primary button) and `preventDefault()`s to stop the press also starting a tear-off/native window drag,
- attaches `pointermove`/`pointerup`/`pointercancel` listeners to **`window`** — which receive every move regardless of `pointerId` or whether the cursor is still over the thin handle — driving `onResizeMove` while the primary button is held,
- tears down on release (or when `buttons` goes to 0).

`setPointerCapture` is kept best-effort (helps over native panes on platforms where it works). **`TileLayout.win32.tsx` / `TileLayout.darwin.tsx` are unchanged.**

## Verification
Built locally (`task dev`) on Linux/CEF. After the fix, dragging a divider resizes smoothly; the log confirms `onResizeMove` firing throughout the drag (`id=2 buttons=1`, 99× in one drag).

## Scope
- One focused hunk in `frontend/layout/lib/TileLayout.linux.tsx` (the `ResizeHandle` component) + a `patch` changeset.
- No backend or shared-type changes.

## Test plan
- [ ] Linux: drag horizontal and vertical pane dividers — panes resize.
- [ ] Linux: pane tear-off / rearrange still works (drag behavior unchanged).
- [ ] Windows / macOS: resize unaffected (files untouched).