### PR TITLE
fix(agent-failure): surface auth 401 errors delivered as in-band assistant messages

### DIFF
--- a/.changesets/1781826736-fix-agent-failure-surface-auth-401-errors-delivered-as-in-ba-y864.md
+++ b/.changesets/1781826736-fix-agent-failure-surface-auth-401-errors-delivered-as-in-ba-y864.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-failure): surface auth 401 errors delivered as in-band assistant messages

--- a/agentmux-srv/src/agents/failure.rs
+++ b/agentmux-srv/src/agents/failure.rs
@@ -177,6 +177,8 @@ pub fn classify(
         );
     }
     if hay.contains("authentication_error")
+        || hay.contains("authentication_failed")
+        || hay.contains("invalid authentication")
         || hay.contains("invalid api key")
         || hay.contains("invalid x-api-key")
         || hay.contains("unauthorized")
@@ -372,6 +374,7 @@ fn mentions_http_status(hay: &str, code: &str) -> bool {
         format!("code {code}"),
         format!("code: {code}"),
         format!("error {code}"),
+        format!("error: {code}"),
         format!("[{code}]"),
         format!("({code})"),
     ]
@@ -500,6 +503,34 @@ mod tests {
         let f = classify(Some(2), None, "something unexpected happened", None);
         assert_eq!(f.code, FailureClass::UnknownNonZero);
         assert!(f.explain().contains("[exit 2]"));
+    }
+
+    #[test]
+    fn authentication_failed_string_is_auth() {
+        // In-band 401: claude wraps the error in a synthetic assistant message
+        // with `"error":"authentication_failed"`. The inband_text is appended
+        // to the stderr tail before classify() is called, so it must match.
+        let f = classify(
+            Some(0),
+            None,
+            "authentication_failed Failed to authenticate. API Error: 401 Invalid authentication credentials",
+            None,
+        );
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(!f.retryable);
+    }
+
+    #[test]
+    fn invalid_authentication_credentials_is_auth() {
+        let f = classify(Some(0), None, "invalid authentication credentials", None);
+        assert_eq!(f.code, FailureClass::Auth);
+    }
+
+    #[test]
+    fn api_error_colon_401_is_auth() {
+        // "API Error: 401" lowercased → "api error: 401" → matches "error: 401".
+        let f = classify(Some(0), None, "api error: 401 invalid authentication credentials", None);
+        assert_eq!(f.code, FailureClass::Auth);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -526,6 +526,12 @@ impl SubprocessController {
         // process_waiter below.
         let last_result_frame: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
         let last_result_frame_read = Arc::clone(&last_result_frame);
+        // Track in-band API errors delivered as `assistant` frames (e.g. a
+        // 401 auth failure that claude wraps in a synthetic assistant message
+        // with `"error":"authentication_failed"` and exit 0 — bypasses the
+        // `is_error` flag on the `result` frame entirely).
+        let last_inband_error: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let last_inband_error_read = Arc::clone(&last_inband_error);
         let stdout_reader_handle = tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -564,6 +570,14 @@ impl SubprocessController {
                             }
                             if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
                                 *last_result_frame_read.lock().unwrap() = Some(parsed);
+                            } else if parsed.get("type").and_then(|v| v.as_str()) == Some("assistant")
+                                && (parsed.get("isApiErrorMessage").and_then(|v| v.as_bool()).unwrap_or(false)
+                                    || parsed.get("error").is_some())
+                            {
+                                // In-band API error: 401 / auth failures arrive as a synthetic
+                                // assistant message (exit 0, is_error:false on result frame) —
+                                // capture it so the process_waiter can trip the failure gate.
+                                *last_inband_error_read.lock().unwrap() = Some(parsed);
                             }
                         }
 
@@ -668,6 +682,7 @@ impl SubprocessController {
         let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         let stderr_tail_wait = Arc::clone(&stderr_tail);
         let last_result_frame_wait = Arc::clone(&last_result_frame);
+        let last_inband_error_wait = Arc::clone(&last_inband_error);
         tokio::spawn(async move {
             // Classified failure cause, surfaced to the pane after the readers drain.
             let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
@@ -772,12 +787,31 @@ impl SubprocessController {
                     .and_then(|f| f.get("is_error"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                if exit_code != 0 || frame_is_error {
+                // Also catch in-band API errors (e.g. auth 401) delivered as
+                // synthetic assistant messages with exit 0 and is_error:false.
+                let inband_error_frame = last_inband_error_wait.lock().unwrap().clone();
+                let inband_is_api_error = inband_error_frame.is_some();
+                if exit_code != 0 || frame_is_error || inband_is_api_error {
                     let tail = stderr_tail_wait.lock().unwrap().join("\n");
+                    // Merge the in-band error text so classify() sees the
+                    // "authentication_failed" / "401" string even though it
+                    // arrived on stdout, not stderr.
+                    let inband_text = inband_error_frame.as_ref().map(|f| {
+                        let err_str = f.get("error").and_then(|v| v.as_str()).unwrap_or("");
+                        let content_text = f.pointer("/message/content/0/text")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        format!("{err_str} {content_text}")
+                    }).unwrap_or_default();
+                    let combined_tail = if inband_text.trim().is_empty() {
+                        tail
+                    } else {
+                        format!("{tail}\n{inband_text}")
+                    };
                     run_failure = Some(crate::agents::failure::classify(
                         Some(exit_code),
                         exit_signal,
-                        &tail,
+                        &combined_tail,
                         result_frame.as_ref(),
                     ));
                 }


### PR DESCRIPTION
## Summary

- Claude wraps API 401 errors as synthetic `assistant` messages (`isApiErrorMessage:true`, `error:"authentication_failed"`) and exits 0 with `is_error:false` on the `result` frame
- The agentfailure gate at `subprocess.rs` only checks `exit_code != 0 || frame_is_error` — both false for these → gate never trips → pane shows "Worked" with no error UI, no recovery row
- This was the reason Parko silently swallowed every "u there" message during the auth outage

## Changes

**`subprocess.rs`**
- Track `last_inband_error` Arc for `assistant` frames with `isApiErrorMessage:true` or `error` field set
- Trip the gate when `inband_is_api_error` (alongside the existing `exit_code != 0 || frame_is_error`)
- Merge the in-band error text (the `error` field + `message.content[0].text`) into the tail passed to `classify()` so keyword matchers see it even though it arrived on stdout, not stderr

**`failure.rs`**
- Add `"authentication_failed"` keyword to Auth class (the exact string in the `error` field)
- Add `"invalid authentication"` keyword (covers "Invalid authentication credentials" from content text)
- Add `"error: {code}"` variant to `mentions_http_status` so "API Error: 401" (lowercased → "api error: 401") matches

## Tests

3 new regression tests in `failure.rs` covering:
1. `authentication_failed` string (the `error` field value)
2. `invalid authentication credentials` (content text)
3. `api error: 401` (the colon variant that appears in real transcripts)

All verified against a live Parko agent session JSONL where the 401 pattern was confirmed.

## Test plan

- [ ] Build `agentmux-srv` and relaunch with an expired credential store (`~/.agentmux/shared/providers/claude/.credentials.json`)
- [ ] Send a message to an agent in that expired state — should now show the "Not authenticated" recovery row instead of silently completing
- [ ] `cargo test -p agentmux-srv failure` — all 26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)