### PR TITLE
chore(macos): scope app access to the user's folder (microphone + LAN opt-in)

### DIFF
--- a/.changesets/1781827199-chore-macos-minimize-app-access-drop-camera-mic-contacts-cal-fkav.md
+++ b/.changesets/1781827199-chore-macos-minimize-app-access-drop-camera-mic-contacts-cal-fkav.md
@@ -2,4 +2,4 @@
 type: minor
 ---
 
-chore(macos): minimize app access — drop camera/mic/contacts/calendars/location/photos entitlements; scope the editor file tree to the user's home folder
+chore(macos): scope app access to the user's folder — drop camera/contacts/calendars/location/photos entitlements; keep microphone and LAN discovery as opt-in (prompt only when the user enables them via the pane mic button / status-bar LAN switch, with NSMicrophone/NSLocalNetwork usage strings); scope the editor file tree to the user's home folder

--- a/.changesets/1781827199-chore-macos-minimize-app-access-drop-camera-mic-contacts-cal-fkav.md
+++ b/.changesets/1781827199-chore-macos-minimize-app-access-drop-camera-mic-contacts-cal-fkav.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+chore(macos): minimize app access — drop camera/mic/contacts/calendars/location/photos entitlements; scope the editor file tree to the user's home folder

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -23,8 +23,10 @@ fn scratch_session_token() -> &'static str {
 
 /// Enumerate drives/mounts to surface as editor file-tree roots alongside
 /// $HOME (via the `geteditorroots` RPC). On **macOS** this returns nothing, so
-/// the editor stays scoped to the user's home folder (no `/`, `/Volumes`, or
-/// external mounts); on Linux/Windows it exposes the filesystem root + mounts.
+/// the file-tree's roots are limited to $HOME — `/`, `/Volumes`, and external
+/// mounts aren't offered as starting points (root scoping for the tree, not a
+/// sandbox; see the note at the macOS arm). On Linux/Windows it exposes the
+/// filesystem root + mounts.
 /// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md (multi-root follow-up).
 #[cfg(target_os = "windows")]
 fn list_drives() -> Vec<serde_json::Value> {
@@ -41,11 +43,13 @@ fn list_drives() -> Vec<serde_json::Value> {
     drives
 }
 
-// macOS: keep the editor scoped to the user's own folder. HOME is added as the
-// sole root by the GetEditorRoots handler, so returning no extra drives means
-// the file tree never exposes `/`, `/Volumes`, or external/network mounts —
-// the app only ever reaches the user's home (and never triggers a TCC prompt
-// for a volume the user didn't explicitly choose).
+// macOS: scope the editor file-tree ROOTS to the user's home. HOME is the sole
+// root from GetEditorRoots, so the tree doesn't offer `/`, `/Volumes`, or
+// external mounts as starting points (no nudging the user toward volumes they
+// didn't choose). NOTE: this is root scoping, not a sandbox — listeditordir /
+// readeditorfile still serve any absolute path the frontend sends, and a
+// symlink under HOME can resolve outside it; macOS TCC remains the actual gate
+// for protected locations.
 #[cfg(target_os = "macos")]
 fn list_drives() -> Vec<serde_json::Value> {
     Vec::new()

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -21,9 +21,10 @@ fn scratch_session_token() -> &'static str {
     SCRATCH_SESSION_TOKEN.get_or_init(|| uuid::Uuid::new_v4().to_string())
 }
 
-/// Enumerate drives/mounts accessible from the current OS user.
-/// Used by the `geteditorroots` RPC so the editor file-tree exposes
-/// every reachable filesystem root, not just $HOME.
+/// Enumerate drives/mounts to surface as editor file-tree roots alongside
+/// $HOME (via the `geteditorroots` RPC). On **macOS** this returns nothing, so
+/// the editor stays scoped to the user's home folder (no `/`, `/Volumes`, or
+/// external mounts); on Linux/Windows it exposes the filesystem root + mounts.
 /// Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md (multi-root follow-up).
 #[cfg(target_os = "windows")]
 fn list_drives() -> Vec<serde_json::Value> {
@@ -368,9 +369,9 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    // geteditorroots → home + every reachable drive/mount on the system.
-    // The editor file-tree renders these as sibling top-level roots so the
-    // user can navigate to anywhere on the machine, not just inside $HOME.
+    // geteditorroots → home + (Linux/Windows) the filesystem root and mounts,
+    // rendered as sibling top-level roots. On macOS `list_drives` returns none,
+    // so the editor file-tree is scoped to $HOME only.
     // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md (multi-root follow-up)
     engine.register_handler(
         "geteditorroots",

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -40,7 +40,18 @@ fn list_drives() -> Vec<serde_json::Value> {
     drives
 }
 
-#[cfg(not(target_os = "windows"))]
+// macOS: keep the editor scoped to the user's own folder. HOME is added as the
+// sole root by the GetEditorRoots handler, so returning no extra drives means
+// the file tree never exposes `/`, `/Volumes`, or external/network mounts —
+// the app only ever reaches the user's home (and never triggers a TCC prompt
+// for a volume the user didn't explicitly choose).
+#[cfg(target_os = "macos")]
+fn list_drives() -> Vec<serde_json::Value> {
+    Vec::new()
+}
+
+// Linux (and any other non-Windows, non-macOS unix): filesystem root + mounts.
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn list_drives() -> Vec<serde_json::Value> {
     let mut drives = vec![serde_json::json!({ "name": "/", "path": "/" })];
     for mount_dir in ["/mnt", "/media", "/Volumes"] {

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -12,18 +12,14 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 
-    <!-- we add the following entitlements so that *CLI* applications can request/use these features.  this matches iTerm's permission set -->
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.personal-information.addressbook</key>
-    <true/>
-    <key>com.apple.security.personal-information.calendars</key>
-    <true/>
-    <key>com.apple.security.personal-information.location</key>
-    <true/>
-    <key>com.apple.security.personal-information.photos-library</key>
-    <true/>
+    <!-- AgentMux requests NO personal-data or device access. The hardened
+         runtime carries only the three CEF/Chromium-runtime entitlements above.
+         Camera, microphone, contacts, calendars, location, and photos
+         entitlements were removed (previously declared "to match iTerm") so the
+         app's footprint is limited to the user's own files — file access to
+         ~/.agentmux and the user's home needs no entitlement at all.
+         Consequence: a website in the browser pane, or a CLI run inside
+         AgentMux, that wants camera/mic/contacts/etc. is denied instead of
+         prompting. Re-add a specific key here if a capability is needed. -->
 </dict>
 </plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -12,14 +12,24 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 
-    <!-- AgentMux requests NO personal-data or device access. The hardened
-         runtime carries only the three CEF/Chromium-runtime entitlements above.
-         Camera, microphone, contacts, calendars, location, and photos
-         entitlements were removed (previously declared "to match iTerm") so the
-         app's footprint is limited to the user's own files — file access to
-         ~/.agentmux and the user's home needs no entitlement at all.
-         Consequence: a website in the browser pane, or a CLI run inside
-         AgentMux, that wants camera/mic/contacts/etc. is denied instead of
-         prompting. Re-add a specific key here if a capability is needed. -->
+    <!-- Microphone: OPT-IN. AgentMux only touches the mic when the user turns on
+         voice input via a pane's microphone button (Web Speech API), so the
+         macOS prompt appears then — never at launch. Paired with
+         NSMicrophoneUsageDescription in the .app Info.plist. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+
+    <!-- Intentionally NOT requested (removed; were declared "to match iTerm"):
+         camera, contacts, calendars, location, photos. AgentMux's footprint is
+         limited to the user's own files (file access to ~ needs no entitlement)
+         plus the opt-in mic above.
+         LAN discovery (mDNS) uses the macOS *Local Network* permission, driven by
+         NSLocalNetworkUsageDescription + NSBonjourServices in Info.plist — it
+         also prompts only when the user flips the "LAN discovery" switch, since
+         the mDNS daemon isn't started until then. (We do NOT add the managed
+         com.apple.developer.networking.multicast entitlement: it needs Apple
+         authorization for Developer-ID apps and would jeopardize notarization;
+         the app already ships mDNS without it.) Re-add a specific key here only
+         if a capability is genuinely needed. -->
 </dict>
 </plist>

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -225,6 +225,17 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>NSHighResolutionCapable</key><true/>
     <key>NSPrincipalClass</key><string>NSApplication</string>
     <key>LSApplicationCategoryType</key><string>public.app-category.developer-tools</string>
+    <!-- Opt-in capability prompts. These usage strings are shown ONLY if/when
+         the user turns the feature on — neither resource is touched at launch:
+         the microphone (a pane-header mic button, Web Speech API) and local
+         network / mDNS (the "LAN discovery" switch in the status bar, default
+         off). So neither prompts until the user enables it. -->
+    <key>NSMicrophoneUsageDescription</key><string>AgentMux uses the microphone only when you turn on voice input from a pane's microphone button, to transcribe what you say into that pane.</string>
+    <key>NSLocalNetworkUsageDescription</key><string>AgentMux uses your local network only when you turn on "LAN discovery" in the status bar, to find other AgentMux instances on your network.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_agentmux._tcp</string>
+    </array>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Goal
Limit AgentMux's macOS access to the user's own folder, and make the two capabilities it *does* need — **microphone** and **LAN discovery** — strictly **opt-in**: they prompt only when the user turns them on (pane-header mic button / status-bar "LAN discovery" switch), never at launch.

## Changes

**Entitlements (`build/entitlements.mac.plist`)** — now: the 3 CEF/Chromium-runtime keys **+ `com.apple.security.device.audio-input`** (mic). Removed: camera, contacts, calendars, location, photos.

**Info.plist (`scripts/package-macos.sh`)** — added `NSMicrophoneUsageDescription`, `NSLocalNetworkUsageDescription`, and `NSBonjourServices` (`_agentmux._tcp`), so the prompts have proper strings when triggered.

**Editor (`agentmux-srv/.../editor_handlers.rs`)** — macOS file tree rooted at `~` only (no `/`, `/Volumes`, `/mnt`, `/media`). Linux/Windows unchanged.

## Why no backend gating was needed (already opt-in)
- **Mic:** Web Speech API; `recognition.start()` fires only on the pane-header mic button click — no startup access (`frontend/app/hook/useVoiceInput.ts`, `MicButton.tsx`).
- **LAN:** mDNS (`mdns-sd`) is gated by `network:lan_discovery` (default **false**); the daemon is created only when the status-bar toggle calls `apply(true)` (`agentmux-srv/src/main.rs:959`, `backend/lan_discovery.rs`, `frontend/.../HostPopover.tsx`). No daemon, no prompt, at launch.

## Deliberately not added
`com.apple.developer.networking.multicast` — a managed entitlement that needs Apple authorization for Developer-ID apps and would jeopardize notarization; mDNS already ships without it. `NSLocalNetworkUsageDescription` drives the prompt.

## Verify after packaging
`codesign -d --entitlements - AgentMux.app` → 3 CEF keys + audio-input. `plutil -extract NSMicrophoneUsageDescription / NSLocalNetworkUsageDescription` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)