### PR TITLE
feat(trust-center): accounts tab — hard-corner cards, central detail modal

### DIFF
--- a/.changesets/1781830106-feat-trust-center-accounts-tab-hard-corner-card-styling-cent-1mnf.md
+++ b/.changesets/1781830106-feat-trust-center-accounts-tab-hard-corner-card-styling-cent-1mnf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(trust-center): accounts tab — hard-corner card styling, central modal detail overlay, fix stale panel on account switch

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -94,6 +94,22 @@
     color: var(--secondary-text-color);
 }
 
+// ── AccountsManager layout (gallery + scrollable accounts list) ───────────────
+// Makes identity-body a flex column so the gallery takes its natural height
+// and the connected-accounts section fills the remaining space.
+.accounts-manager-body {
+    display: flex;
+    flex-direction: column;
+}
+
+.accounts-manager-list-section {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
 // ── Tile-click chooser (OAuth / Key) ──────────────────────────────────────────
 .accounts-chooser-overlay {
     position: fixed;

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-3, 12px);
+    padding: var(--space-2);
 
     .accounts-gallery-grid {
         display: grid;
@@ -24,16 +25,15 @@
         padding: var(--space-3, 12px) var(--space-2, 8px);
         background: var(--button-secondary-bg-color, rgba(127, 127, 127, 0.08));
         border: 1px solid var(--border-color);
-        border-radius: 8px;
+        border-radius: 0;
         color: inherit;
         font-family: inherit;
         cursor: pointer;
-        transition: background 90ms ease, border-color 90ms ease, transform 90ms ease;
+        transition: background 90ms ease, border-color 90ms ease;
 
         &:hover {
             background: var(--hover-bg-color);
             border-color: var(--accent-color);
-            transform: translateY(-1px);
         }
 
         &:focus-visible {

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -77,7 +77,7 @@ export function AccountsManager(): JSX.Element {
                 {/* Connected accounts (manage existing). Shown when there is any
                     stored account OR an AgentMux Cloud session is connected.
                     accounts-manager-list-section is flex:1 so it fills remaining
-                    height below the gallery, letting AccountsTab's height:100% work. */}
+                    height below the gallery. */}
                 <Show when={model.accountsAtom().length > 0 || agentMuxConnected()}>
                     <div class="accounts-manager-list-section">
                         <div class="accounts-connected-heading">Connected accounts</div>

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -67,7 +67,7 @@ export function AccountsManager(): JSX.Element {
                 </button>
             </div>
 
-            <div class="identity-body">
+            <div class="identity-body accounts-manager-body">
                 {/* Brand-tile landing: pick a service → OAuth / Key, or AgentMux. */}
                 <AccountsGallery
                     model={model}
@@ -75,44 +75,48 @@ export function AccountsManager(): JSX.Element {
                     onAgentMux={() => setMuxPanelOpen(true)}
                 />
                 {/* Connected accounts (manage existing). Shown when there is any
-                    stored account OR an AgentMux Cloud session is connected. */}
+                    stored account OR an AgentMux Cloud session is connected.
+                    accounts-manager-list-section is flex:1 so it fills remaining
+                    height below the gallery, letting AccountsTab's height:100% work. */}
                 <Show when={model.accountsAtom().length > 0 || agentMuxConnected()}>
-                    <div class="accounts-connected-heading">Connected accounts</div>
-                    {/* AgentMux Cloud — read-only projected row (singleton
-                        session, not a stored IdentityAccount). Clicking it opens
-                        the connect panel, where Disconnect lives. */}
-                    <Show when={agentMuxConnected()}>
-                        <div class="identity-accounts-list">
-                            <div class="identity-group">
-                                <div class="identity-group-header">AgentMux</div>
-                                <div
-                                    class="identity-account-row"
-                                    onClick={() => setMuxPanelOpen(true)}
-                                    title="Manage AgentMux Cloud connection"
-                                >
-                                    <span class="identity-provider-badge provider-agentmux">
-                                        <ProviderLogo provider="agentmux" size={16} />
-                                    </span>
-                                    <span class="identity-account-name">
-                                        {muxbus.status()?.email || "AgentMux Cloud"}
-                                    </span>
-                                    <div class="identity-row-meta">
-                                        <span class="identity-display-name">
-                                            AgentMux Cloud
-                                            <Show when={!muxbus.status()?.valid}> · token expired</Show>
+                    <div class="accounts-manager-list-section">
+                        <div class="accounts-connected-heading">Connected accounts</div>
+                        {/* AgentMux Cloud — read-only projected row (singleton
+                            session, not a stored IdentityAccount). Clicking it opens
+                            the connect panel, where Disconnect lives. */}
+                        <Show when={agentMuxConnected()}>
+                            <div class="identity-accounts-list">
+                                <div class="identity-group">
+                                    <div class="identity-group-header">AgentMux</div>
+                                    <div
+                                        class="identity-account-row"
+                                        onClick={() => setMuxPanelOpen(true)}
+                                        title="Manage AgentMux Cloud connection"
+                                    >
+                                        <span class="identity-provider-badge provider-agentmux">
+                                            <ProviderLogo provider="agentmux" size={16} />
                                         </span>
+                                        <span class="identity-account-name">
+                                            {muxbus.status()?.email || "AgentMux Cloud"}
+                                        </span>
+                                        <div class="identity-row-meta">
+                                            <span class="identity-display-name">
+                                                AgentMux Cloud
+                                                <Show when={!muxbus.status()?.valid}> · token expired</Show>
+                                            </span>
+                                        </div>
+                                        <span
+                                            class={muxStatusDot()}
+                                            title={muxbus.status()?.valid ? "valid" : "expired"}
+                                        />
                                     </div>
-                                    <span
-                                        class={muxStatusDot()}
-                                        title={muxbus.status()?.valid ? "valid" : "expired"}
-                                    />
                                 </div>
                             </div>
-                        </div>
-                    </Show>
-                    <Show when={model.accountsAtom().length > 0}>
-                        <AccountsTab model={model} />
-                    </Show>
+                        </Show>
+                        <Show when={model.accountsAtom().length > 0}>
+                            <AccountsTab model={model} />
+                        </Show>
+                    </div>
                 </Show>
             </div>
 

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -472,6 +472,7 @@ export class IdentityViewModel implements ViewModel {
     };
 
     openEditForm = (account: Account): void => {
+        this.setSelectedAccount(null); // close detail modal before opening form
         this.setEditingAccount(account);
         this.setAddPreset(null);
         this.setFormError(null);

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -17,6 +17,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { OAuthConnectPanel } from "@/app/view/accounts/OAuthConnectPanel";
 import { supportsOAuth } from "@/app/view/accounts/oauth-catalog";
 import { brandForProvider, isCliOAuthProvider } from "@/app/view/accounts/provider-brand";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/app/element/modal";
 import "./identity-view.scss";
 import "@/app/view/accounts/oauth-connect.scss";
 
@@ -101,42 +102,53 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
     const groups = () => model.accountsByProvider();
 
     return (
-        <div class="identity-accounts-layout">
-            <div class="identity-accounts-list">
-                <Show
-                    when={model.accountsAtom().length > 0}
-                    fallback={
-                        <div class="identity-empty">
-                            <p>No accounts configured.</p>
-                            <button class="identity-empty-add" onClick={() => model.openAddForm()}>
-                                + Add your first account
-                            </button>
-                        </div>
-                    }
-                >
-                    <For each={[...groups().entries()]}>
-                        {([provider, accounts]) => (
-                            <div class="identity-group">
-                                <div class="identity-group-header">{PROVIDER_LABELS[provider]}</div>
-                                <For each={accounts}>
-                                    {(account) => (
-                                        <AccountRow
-                                            account={account}
-                                            selected={model.selectedAccountAtom()?.id === account.id}
-                                            onClick={() => model.setSelectedAccount(account)}
-                                        />
-                                    )}
-                                </For>
+        <>
+            <div class="identity-accounts-layout">
+                <div class="identity-accounts-list">
+                    <Show
+                        when={model.accountsAtom().length > 0}
+                        fallback={
+                            <div class="identity-empty">
+                                <p>No accounts configured.</p>
+                                <button class="identity-empty-add" onClick={() => model.openAddForm()}>
+                                    + Add your first account
+                                </button>
                             </div>
-                        )}
-                    </For>
-                </Show>
+                        }
+                    >
+                        <For each={[...groups().entries()]}>
+                            {([provider, accounts]) => (
+                                <div class="identity-group">
+                                    <div class="identity-group-header">{PROVIDER_LABELS[provider]}</div>
+                                    <For each={accounts}>
+                                        {(account) => (
+                                            <AccountRow
+                                                account={account}
+                                                selected={model.selectedAccountAtom()?.id === account.id}
+                                                onClick={() => model.setSelectedAccount(account)}
+                                            />
+                                        )}
+                                    </For>
+                                </div>
+                            )}
+                        </For>
+                    </Show>
+                </div>
             </div>
 
-            <Show when={model.selectedAccountAtom() !== null}>
-                <AccountDetail model={model} account={model.selectedAccountAtom()!} />
-            </Show>
-        </div>
+            {/* Central detail overlay — keyed so switching accounts remounts the content */}
+            <Modal
+                open={model.selectedAccountAtom() !== null}
+                onClose={() => model.setSelectedAccount(null)}
+                scope="window"
+                size="md"
+                showCloseButton
+            >
+                <Show when={model.selectedAccountAtom()} keyed>
+                    {(account) => <AccountDetail model={model} account={account} />}
+                </Show>
+            </Modal>
+        </>
     );
 }
 
@@ -161,30 +173,27 @@ function AccountRow(props: { account: Account; selected: boolean; onClick: () =>
     );
 }
 
-// ── Account detail panel ─────────────────────────────────────────────────────
+// ── Account detail panel (rendered inside <Modal>) ───────────────────────────
 
 function AccountDetail({ model, account }: { model: IdentityViewModel; account: Account }): JSX.Element {
     return (
-        <div class="identity-detail">
-            <div class="identity-detail-header">
-                <span class={`identity-provider-badge provider-${account.provider}`}>
-                    <ProviderLogo provider={account.provider} size={16} />
-                </span>
-                <div class="identity-detail-title">
-                    <span class="identity-detail-name">{account.name}</span>
-                    <Show when={account.display_name}>
-                        <span class="identity-detail-subname">{account.display_name}</span>
-                    </Show>
+        <>
+            <ModalHeader title={account.name} />
+            <ModalBody>
+                <div class="identity-detail-meta-row">
+                    <span class={`identity-provider-badge provider-${account.provider}`}>
+                        <ProviderLogo provider={account.provider} size={14} />
+                    </span>
+                    <span class="identity-detail-meta-label">
+                        <Show when={account.display_name}>
+                            <span class="identity-detail-subname">{account.display_name}</span>
+                        </Show>
+                    </span>
+                    <span class={`${STATUS_DOT[account.status] ?? STATUS_DOT["unknown"]} detail-status`} title={account.status} />
+                    <span class="identity-detail-status-text" data-status={account.status}>{account.status}</span>
                 </div>
-                <span class={`${STATUS_DOT[account.status] ?? STATUS_DOT["unknown"]} detail-status`} title={account.status}>
-                    {account.status}
-                </span>
-            </div>
 
-            <div class="identity-detail-body">
-                {/* Resolve the label via the brand so CLI-OAuth accounts
-                    (provider "claude"/"codex"/…) don't render a blank Provider
-                    field; surface "via <CLI>" so the origin is clear. */}
+                {/* Resolve the label via the brand so CLI-OAuth accounts surface "via <CLI>". */}
                 <DetailField
                     label="Provider"
                     value={`${PROVIDER_LABELS[brandForProvider(account.provider)] ?? account.provider}${
@@ -193,7 +202,6 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                 />
                 <DetailField label="Kind" value={KIND_LABELS[account.kind]} />
 
-                {/* Secret reference */}
                 <div class="identity-detail-section">Secret</div>
                 <DetailField label="Backend" value={account.secret_ref.backend} />
                 <Show when={account.secret_ref.env_var}>
@@ -213,7 +221,6 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                     <DetailField label="Key" value={account.context.masked_tail ?? "••••••••"} />
                 </Show>
 
-                {/* Context fields */}
                 <Show when={account.context.github_username}>
                     <div class="identity-detail-section">GitHub</div>
                     <DetailField label="Username" value={account.context.github_username!} />
@@ -241,24 +248,17 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                     <DetailField label="Notes" value={account.context.description!} />
                 </Show>
 
-                {/* Agent assignments are managed via identity bundles — see Identities tab */}
                 <div class="identity-detail-section">Agents</div>
                 <span class="identity-detail-empty">Assigned via Identities tab</span>
 
                 <DetailField label="Created" value={new Date(account.created_at).toLocaleString()} />
-            </div>
-
-            <div class="identity-detail-actions">
-                {/* Reauth: expired non-OAuth accounts only. OAuth reauth goes through
-                    OAuthConnectPanel which needs the existing accountId threaded through
-                    (not yet wired); opening the edit form here would create a duplicate. */}
+            </ModalBody>
+            <ModalFooter>
                 <Show when={account.status === "expired" && account.kind !== "oauth"}>
                     <button class="identity-btn identity-btn-primary" onClick={() => model.openEditForm(account)}>
                         Reauth
                     </button>
                 </Show>
-                {/* Validate: keychain only. plaintext_dev routes through handleSubmit →
-                    updateAccount with no verify call, so it cannot clear unknown status. */}
                 <Show when={account.status === "unknown" && account.secret_ref.backend === "keychain"}>
                     <button class="identity-btn identity-btn-primary" onClick={() => model.openEditForm(account)}>
                         Validate…
@@ -277,8 +277,8 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                 >
                     Delete
                 </button>
-            </div>
-        </div>
+            </ModalFooter>
+        </>
     );
 }
 

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -8,11 +8,14 @@
 .identity-accounts-layout {
     flex: 1;
     min-height: 0;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
 }
 
 .identity-accounts-list {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: var(--space-2);
     min-width: 0;

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -6,15 +6,15 @@
 // ── Accounts layout (list + detail) ──────────────────────────────────────────
 
 .identity-accounts-layout {
-    display: flex;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
 }
 
 .identity-accounts-list {
     flex: 1;
     overflow-y: auto;
-    padding: var(--space-2) 0;
+    padding: var(--space-2);
     min-width: 0;
 
     &::-webkit-scrollbar-thumb {
@@ -30,7 +30,7 @@
 }
 
 .identity-group-header {
-    padding: var(--space-1) var(--space-3);
+    padding: var(--space-1) 0;
     font-size: 10px;
     font-weight: 600;
     letter-spacing: 0.08em;
@@ -44,18 +44,26 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    padding: var(--space-1-5) var(--space-3);
+    padding: var(--space-1-5) var(--space-2);
     cursor: pointer;
-    transition: background 0.1s;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    margin-bottom: var(--space-1);
+    transition: background 0.1s, border-color 0.1s;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
 
     &:hover {
-        background: var(--hover-bg-color);
+        border-color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 8%, transparent);
     }
 
     &.selected {
-        background: var(--highlight-bg-color);
-        border-left: 2px solid var(--accent-color);
-        padding-left: 10px;
+        border-color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 8%, transparent);
     }
 }
 

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -1,57 +1,35 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Detail panel + action buttons.
+// Account detail content (rendered inside the unified Modal overlay).
 
-// ── Detail panel ──────────────────────────────────────────────────────────────
+// ── Meta row (provider badge + display name + status dot + status text) ──────
 
-.identity-detail {
-    width: 280px;
-    flex-shrink: 0;
-    border-left: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
-.identity-detail-header {
+.identity-detail-meta-row {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    padding: 10px var(--space-3);
-    border-bottom: 1px solid var(--border-color);
-    flex-shrink: 0;
+    margin-bottom: var(--space-3);
 }
 
-.identity-detail-title {
+// Spacer that takes up remaining width so the status dot + text stay right-end
+.identity-detail-meta-label {
     flex: 1;
-    display: flex;
-    flex-direction: column;
     min-width: 0;
-}
-
-.identity-detail-name {
-    font-weight: 600;
-    font-size: 13px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .identity-detail-subname {
     font-size: 11px;
     color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.identity-detail-body {
-    flex: 1;
-    overflow-y: auto;
-    padding: var(--space-2) var(--space-3);
-
-    &::-webkit-scrollbar-thumb {
-        background: var(--scrollbar-thumb-color);
-        border-radius: 0;
-    }
+.identity-detail-status-text {
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    text-transform: capitalize;
 }
 
 .identity-detail-section {

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -85,14 +85,6 @@
     color: var(--main-text-color);
 }
 
-.identity-detail-actions {
-    display: flex;
-    gap: var(--space-2);
-    padding: 10px var(--space-3);
-    border-top: 1px solid var(--border-color);
-    flex-shrink: 0;
-}
-
 // ── Buttons ───────────────────────────────────────────────────────────────────
 
 .identity-btn {

--- a/frontend/app/view/identity/styles/_header.scss
+++ b/frontend/app/view/identity/styles/_header.scss
@@ -66,6 +66,9 @@
 
 .identity-body {
     flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

- **Hard-corner account rows**: Account cards now match the agent-template design language — bordered, accent-colour hover/selected states, no border-radius, consistent spacing
- **Central detail modal**: Clicking an account opens a window-scoped `<Modal>` centred overlay instead of the side-panel foldout that clipped on overflow and didn't update on account switch
- **Stale-panel fix**: `<Show keyed>` remounts `AccountDetail` when switching between accounts, so stale destructured props can't survive a selection change
- **Status indicator**: Status dot and text are now separate elements — dot was visually distorted when the status string was placed inside the 7×7px circle
- **Layout overflow fix**: `accounts-manager-list-section` is `flex:1` so the account list fills the remaining height below the gallery without causing overflow

## Test plan

- [ ] Open Trust Center → Accounts tab
- [ ] Click any connected GitHub account — centred modal opens with correct detail
- [ ] Click a different account — modal content updates (not stale)
- [ ] ESC / backdrop click closes the modal
- [ ] Account rows show hard-corner bordered style matching agent-template cards
- [ ] Status dot renders as a small circle; status text renders beside it (no distortion)
- [ ] No layout overflow or distortion in the accounts list section

🤖 Generated with [Claude Code](https://claude.com/claude-code)