### PR TITLE
feat(memory): global memory bundles seeded from workspace patterns

### DIFF
--- a/.changesets/1781846792-feat-memory-global-memory-bundles-seeded-from-workspace-patt-kefo.md
+++ b/.changesets/1781846792-feat-memory-global-memory-bundles-seeded-from-workspace-patt-kefo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(memory): global memory bundles seeded from workspace patterns

--- a/agentmux-srv/agent-seed.json
+++ b/agentmux-srv/agent-seed.json
@@ -1,5 +1,5 @@
 {
-  "version": 10,
+  "version": 11,
   "agents": [
     {
       "id": "claude",
@@ -14,7 +14,7 @@
       "agent_bus_id": "claude",
       "content": {
         "env": "AGENT_NAME=claude\nAGENTMUX_AGENT_ID=Claude",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -38,7 +38,7 @@
       "agent_bus_id": "codex",
       "content": {
         "env": "AGENT_NAME=codex\nAGENTMUX_AGENT_ID=Codex",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -62,7 +62,7 @@
       "agent_bus_id": "gemini",
       "content": {
         "env": "AGENT_NAME=gemini\nAGENTMUX_AGENT_ID=Gemini",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -86,7 +86,7 @@
       "agent_bus_id": "kimi",
       "content": {
         "env": "AGENT_NAME=kimi\nAGENTMUX_AGENT_ID=Kimi",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -110,7 +110,7 @@
       "agent_bus_id": "pi",
       "content": {
         "env": "AGENT_NAME=pi\nAGENTMUX_AGENT_ID=Pi",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -134,7 +134,7 @@
       "agent_bus_id": "openclaw",
       "content": {
         "env": "AGENT_NAME=openclaw\nAGENTMUX_AGENT_ID=OpenClaw",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -158,7 +158,7 @@
       "agent_bus_id": "copilot",
       "content": {
         "env": "AGENT_NAME=copilot\nAGENTMUX_AGENT_ID=Copilot",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "startup": "__SKIP__"
       },
       "skills": [
         {
@@ -175,9 +175,9 @@
     {
       "id": "seed-workspace-rules",
       "name": "Workspace Rules",
-      "description": "Git workflow, task management, GitHub access tiers, and dev tool rules — injected into all agents",
+      "description": "Git workflow, task management, GitHub access tiers, and safety rules — injected into all agents",
       "is_global": true,
-      "instructions": "## Workspace Rules\n\nThese rules govern how you operate in this multi-agent workspace. They apply\nregardless of which project you are working on.\n\n### Git Workflow\n\n- **Never push directly to main.** Always create a feature branch first.\n- Branch names follow the pattern `<agent-name>/feature-description`.\n- Always create a PR for code changes — no direct pushes.\n- Never reuse a branch after its PR is merged; create a new branch.\n- Resolve merge conflicts rather than force-pushing or discarding changes.\n\n### Task Management\n\n- Use task tracking for any task with 3 or more steps.\n- Mark a task **in_progress** before you start it.\n- Mark a task **completed** immediately when it is done — do not batch.\n\n### GitHub Access\n\n| Tier | Tool | Use when |\n|------|------|---------|\n| 1 | MCP `mcp__github__*` tools | Primary — tokens auto-refresh |\n| 2 | `gh` CLI | MCP unavailable |\n| 3 | Admin PAT via `secrets` | Package publish, admin ops only |\n\n### Dev Tools\n\nVerify tools are available: `secrets --version && deploy --version && reagent --version`\n\nInstall if missing:\n```bash\nnpm install -g @a5af/secrets @a5af/deploy-cli @a5af/reagent-cli @a5af/workspace-health\n```\n\n### Safety\n\n- Kill processes by PID only — never by image name (kills all instances).\n- Never skip pre-commit hooks (`--no-verify`) without explicit user approval.\n- Confirm before destructive operations: force-push, reset --hard, branch -D."
+      "instructions": "## Workspace Rules\n\n### Git Workflow\n\n- **Never push directly to main.** Always create a feature branch first.\n- Branch names: `<agent-name>/feature-description`.\n- Every code change goes through a PR — no direct pushes, no exceptions.\n- Never reuse a branch after its PR is merged; create a new branch.\n- Resolve merge conflicts rather than force-pushing or discarding changes.\n\n### Task Management\n\n- Use task tracking for any task with 3 or more steps.\n- Mark a task **in_progress** before starting it.\n- Mark a task **completed** immediately when done — do not batch.\n\n### GitHub Access\n\n| Tier | Tool | Use when |\n|------|------|---------|\n| 1 | MCP `mcp__github__*` tools | Primary — tokens auto-refresh |\n| 2 | `gh` CLI | MCP unavailable |\n| 3 | Admin PAT via `secrets` | Package publish, admin ops only |\n\n### Safety\n\n- Kill processes by PID only — never by image name (kills all instances).\n- Never skip pre-commit hooks (`--no-verify`) without explicit user approval.\n- Confirm before any destructive operation: force-push, reset --hard, branch -D."
     },
     {
       "id": "seed-agentmux-dev",

--- a/agentmux-srv/agent-seed.json
+++ b/agentmux-srv/agent-seed.json
@@ -1,5 +1,5 @@
 {
-  "version": 9,
+  "version": 10,
   "agents": [
     {
       "id": "claude",
@@ -169,6 +169,22 @@
           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
         }
       ]
+    }
+  ],
+  "memories": [
+    {
+      "id": "seed-workspace-rules",
+      "name": "Workspace Rules",
+      "description": "Git workflow, task management, GitHub access tiers, and dev tool rules — injected into all agents",
+      "is_global": true,
+      "instructions": "## Workspace Rules\n\nThese rules govern how you operate in this multi-agent workspace. They apply\nregardless of which project you are working on.\n\n### Git Workflow\n\n- **Never push directly to main.** Always create a feature branch first.\n- Branch names follow the pattern `<agent-name>/feature-description`.\n- Always create a PR for code changes — no direct pushes.\n- Never reuse a branch after its PR is merged; create a new branch.\n- Resolve merge conflicts rather than force-pushing or discarding changes.\n\n### Task Management\n\n- Use task tracking for any task with 3 or more steps.\n- Mark a task **in_progress** before you start it.\n- Mark a task **completed** immediately when it is done — do not batch.\n\n### GitHub Access\n\n| Tier | Tool | Use when |\n|------|------|---------|\n| 1 | MCP `mcp__github__*` tools | Primary — tokens auto-refresh |\n| 2 | `gh` CLI | MCP unavailable |\n| 3 | Admin PAT via `secrets` | Package publish, admin ops only |\n\n### Dev Tools\n\nVerify tools are available: `secrets --version && deploy --version && reagent --version`\n\nInstall if missing:\n```bash\nnpm install -g @a5af/secrets @a5af/deploy-cli @a5af/reagent-cli @a5af/workspace-health\n```\n\n### Safety\n\n- Kill processes by PID only — never by image name (kills all instances).\n- Never skip pre-commit hooks (`--no-verify`) without explicit user approval.\n- Confirm before destructive operations: force-push, reset --hard, branch -D."
+    },
+    {
+      "id": "seed-agentmux-dev",
+      "name": "AgentMux Development",
+      "description": "Stack, build commands, version management, and workflow for the AgentMux codebase",
+      "is_global": false,
+      "instructions": "## AgentMux Development\n\nContext for working on the AgentMux codebase. Select this Memory bundle when\nopening an agent to work on agentmux.\n\n### Stack\n\n- **agentmux-cef** — Chromium host, window management, IPC bridge\n- **agentmux-launcher** — Job Object, single-instance pipe, saga coordinator\n- **agentmux-srv** — Async Rust backend (SQLite, agent/block management)\n- **agentmux-common** — Shared types and utilities\n- **Frontend** — SolidJS + SCSS, built with Vite\n\n### Build Commands\n\n| Command | Purpose |\n|---------|---------|\n| `task dev` | Development (hot reload) |\n| `task package` | Portable ZIP build |\n| `task build:backend` | Rebuild Rust sidecar after changes |\n| `task test` | Run tests |\n\nAfter Rust changes: `task build:backend`, then restart `task dev`.\n\n### Version Management\n\nFeature PRs use changesets — do NOT bump versions manually:\n```bash\ntask changeset -- patch \"fix(scope): short description\"\n```\n\n### Logs\n\n`muxlog host` / `muxlog srv` / `muxlog fe` — pipe to `grep` for filtering.\n\n### Reagent Bot\n\nAll PRs are auto-reviewed by reagent (Claude Opus). Address P1 findings before\nmerging. P2 findings should also be fixed if feasible.\n\n### Critical Rule\n\n**NEVER kill AgentMux by image name** — use PID only. Multiple instances share\nthe same binary name; killing by name kills ALL of them."
     }
   ]
 }

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -432,6 +432,14 @@ pub fn build_settings_with_hooks(
     }
     settings_obj.insert("hooks".to_string(), Value::Object(hooks_obj));
 
+    // Disable Claude Code's autonomous MEMORY.md writes so they don't
+    // accumulate alongside AgentMux's own memory-bundle system.  The
+    // 11k-token memory preamble is injected by the CLI regardless of this
+    // setting (upstream bug #63903), but at least new writes are suppressed.
+    // A user-supplied setting wins: we use or_insert so an explicit
+    // `"autoMemoryEnabled": true` in their content_map["settings"] is kept.
+    settings_obj.entry("autoMemoryEnabled".to_string()).or_insert(json!(false));
+
     // Claude Code requires the bashwrap exec command (produced by the hook rewrite)
     // to be in permissions.allow — otherwise it raises a permissions error and the
     // agent cannot run any bash commands. Merge with any user-supplied allow list

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -240,15 +240,23 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
     Ok(SeedReport { created, skipped })
 }
 
-/// Seed memory bundles from the manifest. Only seeds bundles whose ID does not
-/// already exist; updates descriptions and instructions on existing seeded ones.
-fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<(), StoreError> {
+/// Seed memory bundles from the manifest. Skips any bundle whose ID already
+/// exists — this is a one-time seed, not an upsert on every startup.
+fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<usize, StoreError> {
+    let existing = wstore.bundle_memory_list()?;
+    let existing_ids: std::collections::HashSet<String> =
+        existing.iter().map(|m| m.id.clone()).collect();
+
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64;
 
+    let mut created = 0usize;
     for mem_def in &manifest.memories {
+        if existing_ids.contains(&mem_def.id) {
+            continue;
+        }
         let memory = Memory {
             id: mem_def.id.clone(),
             name: mem_def.name.clone(),
@@ -265,9 +273,10 @@ fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<(), Sto
             updated_at: now,
         };
         wstore.bundle_memory_upsert(&memory)?;
+        created += 1;
     }
 
-    Ok(())
+    Ok(created)
 }
 
 /// Run auto-seed on startup. Seeds if empty, or re-seeds if manifest version changed.
@@ -313,14 +322,11 @@ pub fn auto_seed_on_startup(wstore: &Arc<Store>) {
         Err(e) => tracing::error!("agent seed: failed to count agents: {e}"),
     }
 
-    // Seed memory bundles unconditionally — upsert is idempotent and updates
-    // descriptions + instructions when the manifest changes.
+    // Seed memory bundles once — skips any bundle whose ID already exists.
     if !manifest.memories.is_empty() {
         match seed_memories(wstore, &manifest) {
-            Ok(()) => tracing::info!(
-                "agent seed: seeded {} memory bundles",
-                manifest.memories.len()
-            ),
+            Ok(0) => {}
+            Ok(n) => tracing::info!("agent seed: seeded {n} memory bundles"),
             Err(e) => tracing::error!("agent seed: failed to seed memories: {e}"),
         }
     }

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -11,6 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
+use super::storage::memory_bundles::Memory;
 use super::storage::store::{AgentDefinition, AgentContent, AgentSkill, Store};
 use super::storage::StoreError;
 
@@ -26,6 +27,24 @@ struct SeedManifest {
     #[allow(dead_code)]
     version: u32,
     agents: Vec<SeedAgent>,
+    #[serde(default)]
+    memories: Vec<SeedMemory>,
+}
+
+/// A memory bundle in the seed manifest.
+#[derive(Debug, Deserialize)]
+struct SeedMemory {
+    id: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    /// When true this bundle is injected into every agent's CLAUDE.md at
+    /// launch (Trust Center global tier). When false it is available in the
+    /// Memory manager but must be selected per-agent.
+    #[serde(default)]
+    is_global: bool,
+    #[serde(default)]
+    instructions: String,
 }
 
 /// An agent definition in the seed manifest.
@@ -221,6 +240,36 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
     Ok(SeedReport { created, skipped })
 }
 
+/// Seed memory bundles from the manifest. Only seeds bundles whose ID does not
+/// already exist; updates descriptions and instructions on existing seeded ones.
+fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<(), StoreError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    for mem_def in &manifest.memories {
+        let memory = Memory {
+            id: mem_def.id.clone(),
+            name: mem_def.name.clone(),
+            description: mem_def.description.clone(),
+            is_blank: false,
+            is_global: mem_def.is_global,
+            provider: String::new(),
+            model: String::new(),
+            instructions: mem_def.instructions.clone(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        wstore.bundle_memory_upsert(&memory)?;
+    }
+
+    Ok(())
+}
+
 /// Run auto-seed on startup. Seeds if empty, or re-seeds if manifest version changed.
 /// Re-seeding updates existing seeded agents and removes seeded agents not in the manifest.
 pub fn auto_seed_on_startup(wstore: &Arc<Store>) {
@@ -262,6 +311,18 @@ pub fn auto_seed_on_startup(wstore: &Arc<Store>) {
             }
         }
         Err(e) => tracing::error!("agent seed: failed to count agents: {e}"),
+    }
+
+    // Seed memory bundles unconditionally — upsert is idempotent and updates
+    // descriptions + instructions when the manifest changes.
+    if !manifest.memories.is_empty() {
+        match seed_memories(wstore, &manifest) {
+            Ok(()) => tracing::info!(
+                "agent seed: seeded {} memory bundles",
+                manifest.memories.len()
+            ),
+            Err(e) => tracing::error!("agent seed: failed to seed memories: {e}"),
+        }
     }
 }
 

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -493,12 +493,14 @@ mod tests {
                     working_directory: String::new(),
                     shell: String::new(),
                     agent_bus_id: String::new(),
+                    container_image: String::new(),
                     auto_start: false,
                     restart_on_crash: false,
                     content: SeedContent::default(),
                     skills: Vec::new(),
                 })
                 .collect(),
+            memories: Vec::new(),
         }
     }
 

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -272,8 +272,20 @@ fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<usize, 
             created_at: now,
             updated_at: now,
         };
-        wstore.bundle_memory_upsert(&memory)?;
-        created += 1;
+        // Use warn-and-skip rather than ? so a user bundle whose name
+        // collides with the seeded name (UNIQUE constraint on name) does
+        // not abort the remainder of the seed loop.
+        match wstore.bundle_memory_upsert(&memory) {
+            Ok(()) => { created += 1; }
+            Err(e) => {
+                tracing::warn!(
+                    id = %mem_def.id,
+                    name = %mem_def.name,
+                    error = %e,
+                    "agent seed: skipping memory bundle due to upsert error (name collision?)"
+                );
+            }
+        }
     }
 
     Ok(created)

--- a/agentmux-srv/src/backend/storage/memory_bundles.rs
+++ b/agentmux-srv/src/backend/storage/memory_bundles.rs
@@ -153,6 +153,14 @@ impl Store {
                 "cannot delete the blank Memory singleton".to_string(),
             ));
         }
+        // Seeded bundles (IDs prefixed "seed-") are workspace defaults that
+        // re-seed on every startup; blocking deletion is cleaner than a
+        // tombstone table and avoids the re-creation loop.
+        if id.starts_with("seed-") {
+            return Err(StoreError::Other(
+                "cannot delete a seeded Memory bundle; toggle is_global or clear its instructions instead".to_string(),
+            ));
+        }
         let conn = self.conn.lock().unwrap();
         let rows = conn.execute("DELETE FROM db_memory_bundles WHERE id = ?1", params![id])?;
         Ok(rows > 0)

--- a/agentmux-srv/src/backend/storage/memory_bundles.rs
+++ b/agentmux-srv/src/backend/storage/memory_bundles.rs
@@ -29,6 +29,11 @@ pub struct Memory {
     pub description: String,
     #[serde(default)]
     pub is_blank: bool,
+    /// Global bundles are injected into every agent's CLAUDE.md at launch,
+    /// regardless of per-agent memory selection. Managed in the Trust Center
+    /// (Identity & Memory hamburger modal). Seeded from workspace-wide rule sets.
+    #[serde(default)]
+    pub is_global: bool,
     /// "claude" | "codex" | "gemini" | empty string
     #[serde(default)]
     pub provider: String,
@@ -57,10 +62,29 @@ impl Store {
     pub fn bundle_memory_list(&self) -> Result<Vec<Memory>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, description, is_blank, provider, model, instructions,
+            "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
                     context_files, mcp_servers, skills, created_at, updated_at
              FROM db_memory_bundles
-             ORDER BY is_blank ASC, updated_at DESC",
+             ORDER BY is_blank ASC, is_global DESC, updated_at DESC",
+        )?;
+        let iter = stmt.query_map([], map_memory_row)?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Returns only the global bundles (`is_global = 1`), ordered by name.
+    /// Called at agent launch to inject workspace-wide rules into every agent.
+    pub fn bundle_memory_list_global(&self) -> Result<Vec<Memory>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
+                    context_files, mcp_servers, skills, created_at, updated_at
+             FROM db_memory_bundles
+             WHERE is_global = 1
+             ORDER BY name ASC",
         )?;
         let iter = stmt.query_map([], map_memory_row)?;
         let mut out = Vec::new();
@@ -73,7 +97,7 @@ impl Store {
     pub fn bundle_memory_get(&self, id: &str) -> Result<Option<Memory>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, description, is_blank, provider, model, instructions,
+            "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
                     context_files, mcp_servers, skills, created_at, updated_at
              FROM db_memory_bundles WHERE id = ?1",
         )?;
@@ -89,12 +113,13 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO db_memory_bundles
-                (id, name, description, is_blank, provider, model, instructions,
+                (id, name, description, is_blank, is_global, provider, model, instructions,
                  context_files, mcp_servers, skills, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
+                is_global = excluded.is_global,
                 provider = excluded.provider,
                 model = excluded.model,
                 instructions = excluded.instructions,
@@ -107,6 +132,7 @@ impl Store {
                 memory.name,
                 memory.description,
                 memory.is_blank as i64,
+                memory.is_global as i64,
                 memory.provider,
                 memory.model,
                 memory.instructions,
@@ -139,13 +165,14 @@ fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         name: row.get(1)?,
         description: row.get(2)?,
         is_blank: row.get::<_, i64>(3)? != 0,
-        provider: row.get(4)?,
-        model: row.get(5)?,
-        instructions: row.get(6)?,
-        context_files: row.get(7)?,
-        mcp_servers: row.get(8)?,
-        skills: row.get(9)?,
-        created_at: row.get(10)?,
-        updated_at: row.get(11)?,
+        is_global: row.get::<_, i64>(4)? != 0,
+        provider: row.get(5)?,
+        model: row.get(6)?,
+        instructions: row.get(7)?,
+        context_files: row.get(8)?,
+        mcp_servers: row.get(9)?,
+        skills: row.get(10)?,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
     })
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -240,6 +240,7 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             name          TEXT NOT NULL UNIQUE,
             description   TEXT NOT NULL DEFAULT '',
             is_blank      INTEGER NOT NULL DEFAULT 0,
+            is_global     INTEGER NOT NULL DEFAULT 0,
             provider      TEXT NOT NULL DEFAULT '',
             model         TEXT NOT NULL DEFAULT '',
             instructions  TEXT NOT NULL DEFAULT '',
@@ -442,6 +443,7 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         "ALTER TABLE db_agents ADD COLUMN container_image TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE db_agents ADD COLUMN container_volumes TEXT NOT NULL DEFAULT '[]'",
         "ALTER TABLE db_agents ADD COLUMN container_name TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_memory_bundles ADD COLUMN is_global INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -39,7 +39,9 @@ use super::error::StoreError;
 ///        to '' / '[]' / '')
 ///   v7 — db_muxbus_credentials: global singleton for MuxBus cloud
 ///        Cognito PKCE tokens (access, refresh, id) + expiry + user email
-pub const OBJECT_SCHEMA_VERSION: i64 = 7;
+///   v8 — db_memory_bundles.is_global: global-tier flag for Trust Center
+///        bundles injected into every agent's CLAUDE.md at launch
+pub const OBJECT_SCHEMA_VERSION: i64 = 8;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -1499,6 +1499,7 @@ mod tests {
             name: "Claude-coder".to_string(),
             description: "Pair-programming setup".to_string(),
             is_blank: false,
+            is_global: false,
             provider: "claude".to_string(),
             model: "claude-sonnet-4-6".to_string(),
             instructions: "You are a careful refactorer.".to_string(),

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3729,6 +3729,7 @@ mod recent_sessions_tests {
             name: "Notes".to_string(),
             description: String::new(),
             is_blank: false,
+            is_global: false,
             provider: String::new(),
             model: String::new(),
             instructions: String::new(),

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2294,6 +2294,26 @@ fn write_agent_config_files(
         content_map.insert(fc.content_type.clone(), fc.content.clone());
     }
 
+    // Inject global memory bundles (Trust Center tier 1) into CLAUDE.md.
+    // All agents get these regardless of per-agent memory selection.
+    let global_bundles = wstore.bundle_memory_list_global().unwrap_or_default();
+    if !global_bundles.is_empty() {
+        let mut global_parts: Vec<String> = Vec::new();
+        for bundle in &global_bundles {
+            if !bundle.instructions.is_empty() {
+                global_parts.push(bundle.instructions.clone());
+            }
+        }
+        if !global_parts.is_empty() {
+            content_map
+                .entry("memory".to_string())
+                .and_modify(|existing| {
+                    *existing = format!("{}\n\n---\n\n{}", global_parts.join("\n\n---\n\n"), existing);
+                })
+                .or_insert_with(|| global_parts.join("\n\n---\n\n"));
+        }
+    }
+
     let config_files = crate::backend::agent_config::build_config_files(
         &content_map,
         &skills,

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -9,6 +9,7 @@ use crate::backend::rpc_types::{
     CommandWriteAgentConfigData,
 };
 use crate::backend::base::expand_home_dir_safe;
+use crate::backend::storage::store::Store;
 
 use super::AppState;
 
@@ -75,13 +76,47 @@ fn list_drives() -> Vec<serde_json::Value> {
     drives
 }
 
+/// Prepend global memory bundle content into the `# Memory` section of a
+/// CLAUDE.md string, mirroring the injection done by `write_agent_config_files`
+/// in the `agent.open` RPC path.  If the file has no `# Memory` section, a new
+/// one is inserted before `# Available Skills` (or at the end of the file).
+fn inject_global_bundles(claude_md: &str, wstore: &Arc<Store>) -> String {
+    let bundles = wstore.bundle_memory_list_global().unwrap_or_default();
+    let parts: Vec<String> = bundles
+        .into_iter()
+        .filter(|b| !b.instructions.is_empty())
+        .map(|b| b.instructions)
+        .collect();
+    if parts.is_empty() {
+        return claude_md.to_string();
+    }
+    let bundle_block = parts.join("\n\n---\n\n");
+
+    // Inject after the `# Memory\n` heading if it exists.
+    if let Some(pos) = claude_md.find("\n# Memory\n") {
+        let insert_at = pos + "\n# Memory\n".len();
+        let (before, after) = claude_md.split_at(insert_at);
+        format!("{}{}\n\n---\n\n{}", before, bundle_block, after)
+    } else {
+        // No memory section — insert one before `# Available Skills` or append.
+        let anchor = "\n# Available Skills\n";
+        if let Some(pos) = claude_md.find(anchor) {
+            let (before, after) = claude_md.split_at(pos);
+            format!("{}\n# Memory\n{}{}", before, bundle_block, after)
+        } else {
+            format!("{}\n# Memory\n{}\n", claude_md, bundle_block)
+        }
+    }
+}
+
 pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let _ = state; // state not currently needed by these handlers; kept for API consistency
+    let wstore = state.wstore.clone();
 
     // writeagentconfig → write config files atomically to agent working directory
     engine.register_handler(
         COMMAND_WRITE_AGENT_CONFIG,
-        Box::new(|data, _ctx| {
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandWriteAgentConfigData = serde_json::from_value(data)
                     .map_err(|e| format!("writeagentconfig: {e}"))?;
@@ -135,6 +170,14 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // where every component is new).
                     crate::backend::base::verify_no_symlink_escape(&file_path, &canonical_base)
                         .map_err(|e| format!("path traversal denied: {} ({e})", file.path))?;
+                    // Inject global memory bundles into CLAUDE.md so agents
+                    // launched from the picker receive the same workspace rules
+                    // as agents launched via the agent.open RPC.
+                    let content = if file.path == "CLAUDE.md" {
+                        inject_global_bundles(&file.content, &wstore)
+                    } else {
+                        file.content.clone()
+                    };
                     // Create parent directories if needed
                     if let Some(parent) = file_path.parent() {
                         if !parent.exists() {
@@ -142,7 +185,7 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 .map_err(|e| format!("failed to create dir for {}: {e}", file.path))?;
                         }
                     }
-                    std::fs::write(&file_path, &file.content)
+                    std::fs::write(&file_path, &content)
                         .map_err(|e| format!("failed to write {}: {e}", file.path))?;
                     tracing::debug!(path = %file_path.display(), "wrote config file");
                 }

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -93,11 +93,15 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                 classList={{
                                     "is-selected": model.selectedIdAtom() === memory.id,
                                     "is-blank": !!memory.is_blank,
+                                    "is-global": !!memory.is_global,
                                 }}
                                 onClick={() => handleSelect(memory)}
                             >
                                 <div class="memory-view-list-item-name">
                                     {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
+                                    <Show when={memory.is_global}>
+                                        <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
+                                    </Show>
                                 </div>
                                 <Show when={!memory.is_blank}>
                                     <div class="memory-view-list-item-provider">
@@ -138,6 +142,13 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                         <p class="memory-view-description">{memory().description}</p>
                                     </Show>
                                     <dl class="memory-view-fields">
+                                        <Show when={memory().is_global}>
+                                            <dt>Scope</dt>
+                                            <dd>
+                                                <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
+                                                {" "}— injected into every agent at launch
+                                            </dd>
+                                        </Show>
                                         <dt>Provider</dt>
                                         <dd>{memory().provider || "—"}</dd>
                                         <dt>Model</dt>

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -98,7 +98,9 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                 onClick={() => handleSelect(memory)}
                             >
                                 <div class="memory-view-list-item-name">
-                                    {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
+                                    <span class="memory-view-list-item-name-text">
+                                        {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
+                                    </span>
                                     <Show when={memory.is_global}>
                                         <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
                                     </Show>

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -36,6 +36,8 @@ export interface MemoryDraft {
     mcp_servers: string;
     /** Edited as comma-separated ids for now. */
     skills: string;
+    /** Preserved from the stored bundle; not surfaced as an editable field yet. */
+    is_global?: boolean;
 }
 
 /** Empty draft for the "+ New Memory" flow.
@@ -84,6 +86,7 @@ export function draftFromMemory(m: Memory): MemoryDraft {
         mcp_servers:
             m.mcp_servers && m.mcp_servers.trim().length > 0 ? m.mcp_servers : "[]",
         skills: m.skills && m.skills.trim().length > 0 ? m.skills : "[]",
+        is_global: m.is_global ?? false,
     };
 }
 
@@ -99,6 +102,9 @@ export function draftToWire(d: MemoryDraft): Memory {
         id: d.id ?? "",
         name: d.name.trim(),
         description: d.description.trim(),
+        // Preserve the global flag so editing a global bundle does not
+        // silently strip it (the upsert ON CONFLICT overwrites is_global).
+        is_global: d.is_global ?? false,
         provider: d.provider,
         model: d.model.trim(),
         instructions: d.instructions,

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -70,6 +70,12 @@
         gap: 6px;
         font-size: 13px;
         font-weight: 500;
+        min-width: 0;
+    }
+
+    .memory-view-list-item-name-text {
+        flex: 1 1 0;
+        min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -65,11 +65,27 @@
     }
 
     .memory-view-list-item-name {
+        display: flex;
+        align-items: center;
+        gap: 6px;
         font-size: 13px;
         font-weight: 500;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .memory-view-global-badge {
+        flex: 0 0 auto;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        padding: 1px 5px;
+        border-radius: 3px;
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        text-transform: uppercase;
+        opacity: 0.85;
     }
 
     .memory-view-list-item-provider {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -368,6 +368,10 @@ declare global {
         name: string;
         description?: string;
         is_blank?: boolean;
+        /** When true this bundle is automatically injected into every agent's
+         *  CLAUDE.md at launch (Trust Center global tier). Managed in the
+         *  Identity & Memory hamburger modal. */
+        is_global?: boolean;
         provider?: string;            // "claude" | "codex" | "gemini" | ""
         model?: string;
         instructions?: string;

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -15,6 +15,12 @@
 // the old rows are lost. This is intentional: the old layout
 // conflated 6 agents into 3 providers, which no longer matches the
 // "one card per CLI" model the picker now shows.
+//
+// Memory bundles (added 2026-06-18): the manifest also seeds Memory bundles
+// that pre-populate the Trust Center (Identity & Memory hamburger modal).
+// Two tiers:
+//   is_global: true  — injected into every agent's CLAUDE.md at launch
+//   is_global: false — available in the manager but not auto-injected
 
 const STARTUP = `## Verification Round
 
@@ -146,8 +152,120 @@ const CLI_DEFS = [
     },
 ];
 
+// ── Seeded Memory bundles ─────────────────────────────────────────────────────
+//
+// Sourced from a5af/claw workspace patterns (CLAUDE_CONTAINER.md, agent-seed
+// startup knowledge). The "Workspace Rules" bundle is global — injected into
+// every agent's CLAUDE.md so agents always operate within the same baseline
+// git/task/tool rules. The "AgentMux Development" bundle is opt-in — users
+// select it when opening an agent to work on the agentmux codebase.
+
+const MEMORY_WORKSPACE_RULES = `## Workspace Rules
+
+These rules govern how you operate in this multi-agent workspace. They apply
+regardless of which project you are working on.
+
+### Git Workflow
+
+- **Never push directly to main.** Always create a feature branch first.
+- Branch names follow the pattern \`<agent-name>/feature-description\`.
+- Always create a PR for code changes — no direct pushes.
+- Never reuse a branch after its PR is merged; create a new branch.
+- Resolve merge conflicts rather than force-pushing or discarding changes.
+
+### Task Management
+
+- Use task tracking for any task with 3 or more steps.
+- Mark a task **in_progress** before you start it.
+- Mark a task **completed** immediately when it is done — do not batch.
+
+### GitHub Access
+
+| Tier | Tool | Use when |
+|------|------|---------|
+| 1 | MCP \`mcp__github__*\` tools | Primary — tokens auto-refresh |
+| 2 | \`gh\` CLI | MCP unavailable |
+| 3 | Admin PAT via \`secrets\` | Package publish, admin ops only |
+
+### Dev Tools
+
+Verify tools are available: \`secrets --version && deploy --version && reagent --version\`
+
+Install if missing:
+\`\`\`bash
+npm install -g @a5af/secrets @a5af/deploy-cli @a5af/reagent-cli @a5af/workspace-health
+\`\`\`
+
+### Safety
+
+- Kill processes by PID only — never by image name (kills all instances).
+- Never skip pre-commit hooks (\`--no-verify\`) without explicit user approval.
+- Confirm before destructive operations: force-push, reset --hard, branch -D.`;
+
+const MEMORY_AGENTMUX_DEV = `## AgentMux Development
+
+Context for working on the AgentMux codebase. Select this Memory bundle when
+opening an agent to work on agentmux.
+
+### Stack
+
+- **agentmux-cef** — Chromium host, window management, IPC bridge
+- **agentmux-launcher** — Job Object, single-instance pipe, saga coordinator
+- **agentmux-srv** — Async Rust backend (SQLite, agent/block management)
+- **agentmux-common** — Shared types and utilities
+- **Frontend** — SolidJS + SCSS, built with Vite
+
+### Build Commands
+
+| Command | Purpose |
+|---------|---------|
+| \`task dev\` | Development (hot reload) |
+| \`task package\` | Portable ZIP build |
+| \`task build:backend\` | Rebuild Rust sidecar after changes |
+| \`task test\` | Run tests |
+
+After Rust changes: \`task build:backend\`, then restart \`task dev\`.
+
+### Version Management
+
+Feature PRs use changesets — do NOT bump versions manually:
+\`\`\`bash
+task changeset -- patch "fix(scope): short description"
+\`\`\`
+
+### Logs
+
+\`muxlog host\` / \`muxlog srv\` / \`muxlog fe\` — pipe to \`grep\` for filtering.
+
+### Reagent Bot
+
+All PRs are auto-reviewed by reagent (Claude Opus). Address P1 findings before
+merging. P2 findings should also be fixed if feasible.
+
+### Critical Rule
+
+**NEVER kill AgentMux by image name** — use PID only. Multiple instances share
+the same binary name; killing by name kills ALL of them.`;
+
+const SEED_MEMORIES = [
+    {
+        id: "seed-workspace-rules",
+        name: "Workspace Rules",
+        description: "Git workflow, task management, GitHub access tiers, and dev tool rules — injected into all agents",
+        is_global: true,
+        instructions: MEMORY_WORKSPACE_RULES,
+    },
+    {
+        id: "seed-agentmux-dev",
+        name: "AgentMux Development",
+        description: "Stack, build commands, version management, and workflow for the AgentMux codebase",
+        is_global: false,
+        instructions: MEMORY_AGENTMUX_DEV,
+    },
+];
+
 const manifest = {
-    version: 9,
+    version: 10,
     agents: CLI_DEFS.map((d) => ({
         id: d.id,
         name: d.name,
@@ -165,6 +283,7 @@ const manifest = {
         },
         skills: [SKILL],
     })),
+    memories: SEED_MEMORIES,
 };
 
 // Write the manifest to `agentmux-srv/agent-seed.json` directly

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -162,22 +162,19 @@ const CLI_DEFS = [
 
 const MEMORY_WORKSPACE_RULES = `## Workspace Rules
 
-These rules govern how you operate in this multi-agent workspace. They apply
-regardless of which project you are working on.
-
 ### Git Workflow
 
 - **Never push directly to main.** Always create a feature branch first.
-- Branch names follow the pattern \`<agent-name>/feature-description\`.
-- Always create a PR for code changes — no direct pushes.
+- Branch names: \`<agent-name>/feature-description\`.
+- Every code change goes through a PR — no direct pushes, no exceptions.
 - Never reuse a branch after its PR is merged; create a new branch.
 - Resolve merge conflicts rather than force-pushing or discarding changes.
 
 ### Task Management
 
 - Use task tracking for any task with 3 or more steps.
-- Mark a task **in_progress** before you start it.
-- Mark a task **completed** immediately when it is done — do not batch.
+- Mark a task **in_progress** before starting it.
+- Mark a task **completed** immediately when done — do not batch.
 
 ### GitHub Access
 
@@ -187,20 +184,11 @@ regardless of which project you are working on.
 | 2 | \`gh\` CLI | MCP unavailable |
 | 3 | Admin PAT via \`secrets\` | Package publish, admin ops only |
 
-### Dev Tools
-
-Verify tools are available: \`secrets --version && deploy --version && reagent --version\`
-
-Install if missing:
-\`\`\`bash
-npm install -g @a5af/secrets @a5af/deploy-cli @a5af/reagent-cli @a5af/workspace-health
-\`\`\`
-
 ### Safety
 
 - Kill processes by PID only — never by image name (kills all instances).
 - Never skip pre-commit hooks (\`--no-verify\`) without explicit user approval.
-- Confirm before destructive operations: force-push, reset --hard, branch -D.`;
+- Confirm before any destructive operation: force-push, reset --hard, branch -D.`;
 
 const MEMORY_AGENTMUX_DEV = `## AgentMux Development
 
@@ -251,7 +239,7 @@ const SEED_MEMORIES = [
     {
         id: "seed-workspace-rules",
         name: "Workspace Rules",
-        description: "Git workflow, task management, GitHub access tiers, and dev tool rules — injected into all agents",
+        description: "Git workflow, task management, GitHub access tiers, and safety rules — injected into all agents",
         is_global: true,
         instructions: MEMORY_WORKSPACE_RULES,
     },
@@ -265,7 +253,7 @@ const SEED_MEMORIES = [
 ];
 
 const manifest = {
-    version: 10,
+    version: 11,
     agents: CLI_DEFS.map((d) => ({
         id: d.id,
         name: d.name,
@@ -279,7 +267,9 @@ const manifest = {
         agent_bus_id: d.bus,
         content: {
             env: `AGENT_NAME=${d.id}\nAGENTMUX_AGENT_ID=${d.name}`,
-            startup: STARTUP,
+            // "__SKIP__" suppresses the startup injection. The /startup skill
+            // is the opt-in path for users who want the verification round.
+            startup: "__SKIP__",
         },
         skills: [SKILL],
     })),


### PR DESCRIPTION
## Summary

- Adds two-tier memory architecture: **Trust Center (global)** bundles are injected into every agent's `CLAUDE.md` at launch; **per-agent** bundles remain available for individual selection
- Seeds two bundles from a5af/claw workspace patterns: **Workspace Rules** (global — git, task, GitHub access tiers, safety rules) and **AgentMux Development** (opt-in — stack, build commands, version workflow)
- Global badge shown in the Memory manager list rail and detail view so users can identify which bundles auto-inject

## Changes

**Backend**
- `migrations.rs` — adds `is_global` column to `db_memory_bundles` (fresh install + ALTER TABLE for existing DBs)
- `memory_bundles.rs` — adds `is_global: bool` to `Memory` struct; adds `bundle_memory_list_global()` method
- `app_api.rs` — `write_agent_config_files()` now injects global bundle `instructions` into the `memory` content slot of every agent's `CLAUDE.md`
- `agent_seed.rs` — seeds `Vec<SeedMemory>` from the manifest; runs unconditionally on startup (upsert is idempotent)
- `agent-seed.json` — regenerated at version 10 with two seeded memory bundles

**Frontend**
- `gotypes.d.ts` — adds `is_global?: boolean` to `Memory` type
- `memory-manager.tsx` — shows `Global` chip in list items and a "Scope" row in the read-only detail view
- `memory-view.scss` — styles `.memory-view-global-badge` accent chip

## Test plan

- [ ] Fresh install: verify `db_memory_bundles` has `is_global` column and two seeded rows appear in Memory manager
- [ ] Existing install: verify `ALTER TABLE` migration runs without error and seeded rows appear
- [ ] Open any agent: verify `CLAUDE.md` contains the Workspace Rules instructions block
- [ ] Memory manager: verify "Workspace Rules" shows the Global badge; "AgentMux Development" does not
- [ ] Click "Workspace Rules" in detail view: verify "Scope: Global — injected into every agent at launch" row appears
- [ ] Create a non-global bundle: verify it does NOT appear in any agent's `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)