### PR TITLE
feat(ui): reusable PopoverMenu + title-bar right-click rework + More dropdown fix

### DIFF
--- a/.changesets/1781873924-feat-ui-reusable-popovermenu-title-bar-right-click-rework-an-wel0.md
+++ b/.changesets/1781873924-feat-ui-reusable-popovermenu-title-bar-right-click-rework-an-wel0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(ui): reusable PopoverMenu — title-bar right-click rework and More dropdown item menu fix

--- a/docs/specs/SPEC_TITLEBAR_CONTEXTMENU_REWORK_2026_06_19.md
+++ b/docs/specs/SPEC_TITLEBAR_CONTEXTMENU_REWORK_2026_06_19.md
@@ -1,0 +1,231 @@
+# Spec: Title Bar Context Menu Rework & Reusable PopoverMenu
+
+**Date:** 2026-06-19  
+**Status:** Approved — implementing  
+**Scope:** `frontend/app/element/popover-menu.tsx` (new), `frontend/app/element/popover-menu.scss` (new), `frontend/app/window/titlebar-context-menu.tsx` (new), `frontend/app/window/window-header.tsx`, `frontend/app/window/action-widgets.tsx`, `frontend/app/menu/base-menus.ts`
+
+---
+
+## 1. Problems Being Fixed
+
+### 1a. Title bar right-click — wrong items + native-menu close-on-widget-toggle
+
+Right-clicking the window drag bar calls `ContextMenuModel.showContextMenu()` → `getApi().showContextMenu()` (native OS menu). Two issues:
+
+1. **Wrong top-level item.** `AgentMux v{version}` is a dev detail. Users expect actions there.
+2. **Widget checkboxes close the menu on every click.** Native OS menus always dismiss on any item click. Multi-select is impossible without reopening.
+
+### 1b. More dropdown — closes when right-clicking an item
+
+`MoreDropdown.handleItemContextMenu` (`action-widgets.tsx:216`) calls `onClose()` explicitly before showing the native context menu. The More dropdown closes the instant the user right-clicks a widget. After dismissing the item context menu, the More dropdown is gone.
+
+---
+
+## 2. Desired Behaviour
+
+### Title bar right-click
+
+```
+New Window                    ← closes menu
+New Tab                       ← closes menu
+──────────────────────────────
+Pin Widgets ▾                 ← section header; click toggles collapse; never closes menu
+  ☑ Agent
+  ☑ Swarm
+  ☑ Drone
+  ☑ Warden
+  □ Terminal
+  □ Editor
+  □ Browser
+  □ Sysinfo
+  □ Help
+──────────────────────────────
+□ Icon Only                   ← closes menu (single toggle, interaction complete)
+```
+
+### More dropdown item right-click
+
+```
+New Window                    ← closes item menu + closes More dropdown
+──────────────────────────────
+Pin to bar / Unpin from bar   ← closes item menu; More dropdown stays open
+```
+
+---
+
+## 3. Architecture: Reusable `PopoverMenu`
+
+### Why not native menus
+
+`getApi().showContextMenu()` wraps the platform native context menu. Every item click — including checkboxes — unconditionally dismisses the menu before the JS callback fires. No suppression hook exists.
+
+### `PopoverMenu` component
+
+**New:** `frontend/app/element/popover-menu.tsx` + `popover-menu.scss`
+
+A cursor-positioned SolidJS component rendered into a `<Portal mount={document.body}>`. Gives full per-item control over whether clicking closes it.
+
+**Reuses existing styles** — `.menu`, `.menu-item`, `.menu-item-icon`, `.menu-item-check`, `.menu-divider` from `flyoutmenu.scss` are applied directly. `popover-menu.scss` adds only the section-header and indented-children styles.
+
+#### Item types
+
+```ts
+type PopoverMenuActionItem = {
+    type?: "normal" | "checkbox";
+    label: string;
+    checked?: boolean;
+    disabled?: boolean;
+    keepOpen?: boolean;   // true → click does NOT close the popover
+    click: () => void;
+};
+type PopoverMenuSeparator = { type: "separator" };
+type PopoverMenuSection   = {
+    type: "section";
+    label: string;
+    defaultOpen?: boolean;   // default true
+    items: PopoverMenuActionItem[];
+};
+type PopoverMenuItem = PopoverMenuActionItem | PopoverMenuSeparator | PopoverMenuSection;
+```
+
+#### Props
+
+```ts
+interface PopoverMenuProps {
+    items: PopoverMenuItem[];
+    pos: { x: number; y: number };   // client px; clamped to viewport on mount
+    onClose: () => void;
+}
+```
+
+#### Behaviour
+
+- Renders with class `"menu popover-menu"` (inherits `.menu` chrome from `flyoutmenu.scss`).
+- Calls `usePaneOverlay(() => menuEl)` — required so the floating card cuts through native CEF browser-pane HWNDs.
+- Calls `assertMenuInPaintableArea(el, "popover-menu")` in the mount RAF — dev-only guard.
+- Outside-click: `mousedown` listener in capture phase. Ignores clicks inside `menuEl`.
+- Keyboard: `Escape` → `onClose()`.
+- Item click with `keepOpen: false` (default) → calls `item.click()` then `onClose()`.
+- Item click with `keepOpen: true` → calls `item.click()` only.
+- Section header click → toggles `open` signal. **Never calls `onClose()`**.
+
+#### Cross-component click coordination (no registry needed)
+
+`PopoverMenu` renders with class `.popover-menu`. The More dropdown's outside-click handler — which uses capture-phase `mousedown` — gets one extra guard line mirroring the pattern already used by `flyoutmenu.tsx`:
+
+```ts
+// flyoutmenu.tsx pattern (existing):
+const el = target instanceof Element ? target : (target as Node).parentElement;
+if (el?.closest(".menu, .sub-menu")) return;
+
+// More dropdown extension (new):
+if (el?.closest(".popover-menu")) return;
+```
+
+No global registry module needed.
+
+---
+
+## 4. Implementation Plan
+
+### 4a. `frontend/app/element/popover-menu.tsx` (new)
+
+- Portal-rendered, cursor-positioned (not anchor-relative like `popover.tsx`).
+- Three sub-renderers: `PopoverMenuItemView` (action/checkbox), `PopoverMenuSectionView` (expandable), separator.
+- Section view owns a local `createSignal(open)` initialized from `defaultOpen ?? true`.
+- Viewport clamping: after first paint `requestAnimationFrame` reads `getBoundingClientRect()` and adjusts `left`/`top`.
+
+### 4b. `frontend/app/element/popover-menu.scss` (new)
+
+Uses `@use "./menu-frame"` and `@use "./flyoutmenu.scss"` for item chrome. Adds:
+- `.popover-menu-section-header` — cursor pointer, slightly muted text, chevron left-side
+- `.popover-menu-section-items` — left-padding indent for child items
+
+### 4c. `frontend/app/window/titlebar-context-menu.tsx` (new)
+
+Thin wrapper that builds `PopoverMenuItem[]` from `fullConfig` and renders `<PopoverMenu>`.
+
+Widget checkboxes: `keepOpen: true`, `type: "checkbox"`.  
+New Window / New Tab / Icon Only: `keepOpen: false` (default).  
+Icon Only closes because the interaction is complete after one toggle.  
+New Tab calls `WorkspaceService.CreateTab(ws()?.oid ?? "", "", true, false)`.  
+New Window calls `getApi().openNewWindow()`.
+
+### 4d. `frontend/app/window/window-header.tsx`
+
+Replace `handleContextMenu` / `ContextMenuModel.showContextMenu` with a `createSignal(menuOpen)` + `<Show>/<Portal>/<TitleBarContextMenu>`.
+
+### 4e. `frontend/app/window/action-widgets.tsx` — two changes
+
+**In `MoreDropdown.handleItemContextMenu` (line 198–217):**
+1. Remove `onClose()` at line 216.
+2. Replace `ContextMenuModel.showContextMenu()` with a `PopoverMenu` signal rendered from `ActionWidgets` JSX.
+
+**Signal in `ActionWidgets`:**
+```ts
+const [itemMenuState, setItemMenuState] = createSignal<{
+    pos: { x: number; y: number };
+    shortName: string;
+} | null>(null);
+```
+
+Pass `onItemContextMenu` down to `MoreDropdown`. Item menu items:
+- **New Window** → `setItemMenuState(null); closeMore(); getApi().openNewWindow()`
+- **Pin/Unpin** → `setItemMenuState(null); pin/unpinWidget(...)` (More stays open)
+
+**In More dropdown outside-click handler (line 315–321):**
+```ts
+const el = t instanceof Element ? t : (t as Node).parentElement;
+if (el?.closest(".popover-menu")) return;  // ← add this guard
+```
+
+### 4f. `frontend/app/menu/base-menus.ts`
+
+Verify no remaining callers, then remove `createTabBarBaseMenu()` and `createTabBarMenu()`.  
+`createWidgetsMenu()` — keep if called elsewhere, otherwise remove.
+
+---
+
+## 5. Files Changed
+
+| File | Change |
+|---|---|
+| `frontend/app/element/popover-menu.tsx` | **New** — reusable `PopoverMenu` component |
+| `frontend/app/element/popover-menu.scss` | **New** — section-header + indent styles only; item chrome inherited from flyoutmenu.scss |
+| `frontend/app/window/titlebar-context-menu.tsx` | **New** — title-bar-specific menu wrapper |
+| `frontend/app/window/window-header.tsx` | Replace native context menu with `TitleBarContextMenu` portal |
+| `frontend/app/window/action-widgets.tsx` | Fix More item context menu: remove `onClose()`, use `PopoverMenu` signal, guard outside-click |
+| `frontend/app/menu/base-menus.ts` | Remove dead exports |
+
+---
+
+## 6. Platform Notes
+
+Affects **all platforms** (macOS, Windows, Linux) equally.
+
+**Visual trade-off for review:** native menus had per-platform OS chrome. The custom `PopoverMenu` looks the same everywhere, consistent with the app's design language. Intentional.
+
+**Windows hit-testing:** `PopoverMenu` renders in `<Portal mount={document.body}>` outside the header DOM — no conflict with `data-drag-region` hit-testing. Any future backdrop overlay must carry `data-drag-region="false"`.
+
+---
+
+## 7. Edge Cases
+
+| Case | Handling |
+|---|---|
+| Right-click while title-bar menu already open | `setMenuOpen(false)` + new pos + `setMenuOpen(true)` — moves the menu |
+| Right-click More item while item menu already open | Signal update replaces `itemMenuState`; old `PopoverMenu` unmounts, new one mounts |
+| App loses focus while popover open | `visibilitychange` listener → `onClose()` |
+| Widget list empty | Omit "Pin Widgets" section and its separator |
+| `CreateTab` called with no workspace | Guard `if (!ws()?.oid) return;` |
+| `handleBarContextMenu` (empty bar right-click → "Icon Only") | Keep as native menu — single-action, close-on-click is correct |
+| `handlePinnedContextMenu` (right-click pinned widget slot) | Keep as native menu — not in scope |
+
+---
+
+## 8. Not in Scope
+
+- Keyboard navigation (arrow keys, Enter) within `PopoverMenu`.
+- Drag-to-reorder inside Pin Widgets list.
+- Version string — removed; lives in hamburger → About.
+- `handleBarContextMenu` and `handlePinnedContextMenu` — single-action native menus, correct as-is.

--- a/frontend/app/element/popover-menu.scss
+++ b/frontend/app/element/popover-menu.scss
@@ -1,0 +1,37 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// PopoverMenu — cursor-positioned popover that stays open on keepOpen item clicks.
+// Item chrome (`.menu`, `.menu-item`, `.menu-divider`, `.menu-item-check`) is
+// inherited from flyoutmenu.scss. Only section-specific styles live here.
+
+.popover-menu {
+    // z-index matches other flyout surfaces
+    z-index: var(--z-flyout-menu);
+
+    // Spacer for non-checkbox action items — keeps labels left-aligned with
+    // checkbox items that have the fa-check icon in the same slot.
+    .menu-item-icon-spacer {
+        width: 14px;
+        margin-right: var(--space-1);
+        flex-shrink: 0;
+    }
+}
+
+.popover-menu-section-header {
+    cursor: pointer;
+    color: var(--secondary-text-color, rgb(from var(--main-text-color) r g b / 0.65));
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+
+    .menu-item-icon {
+        opacity: 0.6;
+        font-size: 10px;
+    }
+}
+
+.popover-menu-section-items {
+    // Indent child items under the section header
+    padding-left: var(--space-2);
+}

--- a/frontend/app/element/popover-menu.tsx
+++ b/frontend/app/element/popover-menu.tsx
@@ -1,0 +1,186 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { assertMenuInPaintableArea } from "@/app/util/menu-position";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import clsx from "clsx";
+import { createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+
+import "./popover-menu.scss";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type PopoverMenuActionItem = {
+    type?: "normal" | "checkbox";
+    label: string;
+    checked?: boolean;
+    disabled?: boolean;
+    /** When true, clicking this item does not close the popover. Default false. */
+    keepOpen?: boolean;
+    click: () => void;
+};
+
+export type PopoverMenuSeparator = { type: "separator" };
+
+export type PopoverMenuSection = {
+    type: "section";
+    label: string;
+    /** Whether the section starts expanded. Default true. */
+    defaultOpen?: boolean;
+    items: PopoverMenuActionItem[];
+};
+
+export type PopoverMenuItem = PopoverMenuActionItem | PopoverMenuSeparator | PopoverMenuSection;
+
+export interface PopoverMenuProps {
+    items: PopoverMenuItem[];
+    /** Cursor position in client px. Clamped to viewport on mount. */
+    pos: { x: number; y: number };
+    onClose: () => void;
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+const PopoverMenu = (props: PopoverMenuProps): JSX.Element => {
+    const [menuEl, setMenuEl] = createSignal<HTMLDivElement | null>(null);
+    const [left, setLeft] = createSignal(props.pos.x);
+    const [top, setTop]   = createSignal(props.pos.y);
+
+    // Required: cuts a transparent clip through any CEF browser-pane HWND
+    // behind this popover so the DOM renders above native pane content.
+    usePaneOverlay(menuEl);
+
+    const registerMenu = (el: HTMLDivElement) => {
+        setMenuEl(el);
+        requestAnimationFrame(() => {
+            if (!(el instanceof Element)) return;
+            const r = el.getBoundingClientRect();
+            setLeft(Math.min(props.pos.x, window.innerWidth  - r.width  - 8));
+            setTop( Math.min(props.pos.y, window.innerHeight - r.height - 8));
+            // Dev-only guard: logs if the menu falls outside the paintable area.
+            assertMenuInPaintableArea(el, "popover-menu");
+        });
+    };
+
+    const close = () => props.onClose();
+
+    const handleMouseDown = (e: MouseEvent) => {
+        const t = e.target as Node;
+        if (menuEl()?.contains(t)) return;
+        close();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") close();
+    };
+
+    const handleVisibilityChange = () => {
+        if (document.hidden) close();
+    };
+
+    onMount(() => {
+        document.addEventListener("mousedown",        handleMouseDown, true);
+        document.addEventListener("keydown",          handleKeyDown);
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+    });
+
+    onCleanup(() => {
+        document.removeEventListener("mousedown",        handleMouseDown, true);
+        document.removeEventListener("keydown",          handleKeyDown);
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+    });
+
+    return (
+        <Portal mount={document.body}>
+            <div
+                ref={registerMenu}
+                class="menu popover-menu"
+                style={{ position: "fixed", left: `${left()}px`, top: `${top()}px` }}
+                data-pane-overlay
+            >
+                <For each={props.items}>
+                    {(item) => <PopoverMenuItemRenderer item={item} onClose={close} />}
+                </For>
+            </div>
+        </Portal>
+    );
+};
+
+// ── Item renderers ─────────────────────────────────────────────────────────
+
+const PopoverMenuItemRenderer = (props: {
+    item: PopoverMenuItem;
+    onClose: () => void;
+}): JSX.Element => {
+    const { item } = props;
+
+    if (item.type === "separator") {
+        return <div class="menu-divider" aria-hidden="true" />;
+    }
+
+    if (item.type === "section") {
+        return <PopoverMenuSectionRenderer section={item} onClose={props.onClose} />;
+    }
+
+    // Normal / checkbox action item
+    const handleClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        if (item.disabled) return;
+        item.click();
+        if (!item.keepOpen) props.onClose();
+    };
+
+    return (
+        <div
+            class={clsx("menu-item popover-menu-action", { disabled: item.disabled })}
+            onClick={handleClick}
+        >
+            <Show when={item.type === "checkbox"} fallback={<span class="menu-item-icon-spacer" />}>
+                <i
+                    class={clsx(
+                        "fa-solid fa-fw menu-item-icon menu-item-check",
+                        { "fa-check": item.checked === true },
+                    )}
+                />
+            </Show>
+            <span class="label">{item.label}</span>
+        </div>
+    );
+};
+
+const PopoverMenuSectionRenderer = (props: {
+    section: PopoverMenuSection;
+    onClose: () => void;
+}): JSX.Element => {
+    const [open, setOpen] = createSignal(props.section.defaultOpen ?? true);
+
+    const handleHeaderClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        setOpen((v) => !v);
+        // Intentionally does NOT call onClose — section collapse is not an action.
+    };
+
+    return (
+        <div class="popover-menu-section">
+            <div class="menu-item popover-menu-section-header" onClick={handleHeaderClick}>
+                <i
+                    class={clsx(
+                        "fa-solid fa-fw menu-item-icon",
+                        open() ? "fa-chevron-down" : "fa-chevron-right",
+                    )}
+                />
+                <span class="label">{props.section.label}</span>
+            </div>
+            <Show when={open()}>
+                <div class="popover-menu-section-items">
+                    <For each={props.section.items}>
+                        {(item) => <PopoverMenuItemRenderer item={item} onClose={props.onClose} />}
+                    </For>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+export { PopoverMenu };

--- a/frontend/app/menu/base-menus.ts
+++ b/frontend/app/menu/base-menus.ts
@@ -1,95 +1,6 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getApi } from "@/store/global";
-import { writeText as clipboardWriteText } from "@/util/clipboard";
-import { MenuBuilder } from "./menu-builder";
-
-/**
- * Create the base tabbar context menu.
- * Includes: Version info
- */
-export function createTabBarBaseMenu(): MenuBuilder {
-    const menu = new MenuBuilder();
-    const aboutDetails = getApi().getAboutModalDetails();
-    const version = aboutDetails.version;
-
-    menu.add({
-        label: `AgentMux v${version}`,
-        click: () => {
-            clipboardWriteText(version);
-            getApi().sendLog(`Version ${version} copied to clipboard`);
-        },
-    });
-
-    return menu;
-}
-
-function getPinnedKeys(settings: Record<string, any>, widgets: Record<string, any>): string[] {
-    const pinned: string[] | undefined = settings["widget:pinned"];
-    if (pinned !== undefined) return pinned;
-    return Object.entries(widgets)
-        .filter(([, w]: any) => w["display:pinned"])
-        .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
-        .map(([key]) => key.replace("defwidget@", ""));
-}
-
-/**
- * Create the widgets menu section.
- * Shows: pinned status (checkbox), icon-only toggle.
- */
-export function createWidgetsMenu(fullConfig: any): MenuBuilder {
-    const menu = new MenuBuilder();
-    if (!fullConfig?.widgets) return menu;
-
-    const widgets = fullConfig.widgets || {};
-    const settings = fullConfig.settings || {};
-    const iconOnly = settings["widget:icononly"] ?? false;
-    const pinnedKeys = new Set(getPinnedKeys(settings, widgets));
-
-    const widgetEntries = Object.entries(widgets)
-        .filter(([key]) => key.startsWith("defwidget@"))
-        .sort((a: any, b: any) => (a[1]["display:order"] ?? 0) - (b[1]["display:order"] ?? 0));
-
-    if (widgetEntries.length > 0) {
-        menu.section("Pinned in bar");
-        widgetEntries.forEach(([widgetKey, widgetConfig]: [string, any]) => {
-            const shortName = widgetKey.replace("defwidget@", "");
-            const label = widgetConfig.label || shortName;
-            const isPinned = pinnedKeys.has(shortName);
-            menu.add({
-                label,
-                type: "checkbox" as const,
-                checked: isPinned,
-                click: async () => {
-                    const { RpcApi } = await import("@/app/store/rpc-api");
-                    const { TabRpcClient } = await import("@/app/store/rpc-util");
-                    const currentPinned = getPinnedKeys(settings, widgets);
-                    const next = isPinned
-                        ? currentPinned.filter((k) => k !== shortName)
-                        : [...currentPinned, shortName];
-                    await RpcApi.SetConfigCommand(TabRpcClient, { "widget:pinned": next } as any);
-                },
-            });
-        });
-
-        menu.separator();
-    }
-
-    menu.add({
-        label: "Icon Only",
-        type: "checkbox" as const,
-        checked: iconOnly,
-        click: async () => {
-            const { RpcApi } = await import("@/app/store/rpc-api");
-            const { TabRpcClient } = await import("@/app/store/rpc-util");
-            await RpcApi.SetConfigCommand(TabRpcClient, { "widget:icononly": !iconOnly } as any);
-        },
-    });
-
-    return menu;
-}
-
 /**
  * Theme list shown in the hamburger menu Theme submenu. Order matters
  * for muscle memory — don't reshuffle. Ids must match the schema enum
@@ -107,12 +18,3 @@ export const THEME_OPTIONS: ReadonlyArray<{ id: string; label: string }> = [
     { id: "gruvbox", label: "Gruvbox" },
 ];
 
-/**
- * Create the complete tabbar (right-click) menu. Theme + Opacity live
- * in the hamburger now (frontend/app/tab/tabbar.tsx); this right-click
- * menu keeps only the AgentMux version line and the widget bar
- * controls (show/icon-only).
- */
-export function createTabBarMenu(fullConfig: any): MenuBuilder {
-    return createTabBarBaseMenu().merge(createWidgetsMenu(fullConfig));
-}

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -316,7 +316,7 @@ const ActionWidgets = (): JSX.Element => {
         {
             label: "New Window",
             click: () => {
-                setItemMenuState(null);
+                // Item menu closes via keepOpen:false → onClose; More must be closed explicitly.
                 closeMore();
                 fireAndForget(async () => getApi().openNewWindow());
             },
@@ -326,14 +326,13 @@ const ActionWidgets = (): JSX.Element => {
             ? {
                 label: "Unpin from bar",
                 click: () => {
-                    setItemMenuState(null);
                     unpinWidget(shortName, settings(), wmap());
+                    // Item menu closes via keepOpen:false → onClose; More stays open.
                 },
             }
             : {
                 label: "Pin to bar",
                 click: () => {
-                    setItemMenuState(null);
                     pinWidget(shortName, settings(), wmap());
                 },
             },
@@ -519,6 +518,7 @@ const ActionWidgets = (): JSX.Element => {
 
     const handleBarContextMenu = (e: MouseEvent) => {
         e.preventDefault();
+        e.stopPropagation(); // prevent bubbling to window-header onContextMenu (opens TitleBarContextMenu)
         ContextMenuModel.showContextMenu(
             [
                 {

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -13,6 +13,7 @@
  */
 
 import { Tooltip } from "@/app/element/tooltip";
+import { PopoverMenu, type PopoverMenuItem } from "@/app/element/popover-menu";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -137,6 +138,7 @@ ActionWidget.displayName = "ActionWidget";
 const MoreDropdown = ({
     widgets,
     onClose,
+    onItemContextMenu,
     anchor,
     settings,
     wmap,
@@ -144,6 +146,7 @@ const MoreDropdown = ({
 }: {
     widgets: () => { key: string; widget: WidgetConfigType }[];
     onClose: () => void;
+    onItemContextMenu: (pos: { x: number; y: number }, key: string) => void;
     anchor: () => HTMLElement | null;
     settings: () => Record<string, any>;
     wmap: () => Record<string, WidgetConfigType>;
@@ -198,22 +201,10 @@ const MoreDropdown = ({
     const handleItemContextMenu = (e: MouseEvent, key: string) => {
         e.preventDefault();
         e.stopPropagation();
-        const shortName = key.replace("defwidget@", "");
-        ContextMenuModel.showContextMenu(
-            [
-                { label: "New Window", click: () => {
-                    fireAndForget(async () => {
-                        await getApi().openNewWindow();
-                    });
-                }},
-                { type: "separator" },
-                getPinnedKeys(settings(), wmap()).includes(shortName)
-                    ? { label: "Unpin from bar", click: () => unpinWidget(shortName, settings(), wmap()) }
-                    : { label: "Pin to bar", click: () => pinWidget(shortName, settings(), wmap()) },
-            ],
-            e
-        );
-        onClose();
+        // Delegate to ActionWidgets — the item popover is rendered there so it
+        // can stay open independently of this dropdown. onClose() is NOT called
+        // here; the More dropdown remains visible while the item menu is open.
+        onItemContextMenu({ x: e.clientX, y: e.clientY }, key);
     };
 
     return (
@@ -309,12 +300,54 @@ const ActionWidgets = (): JSX.Element => {
 
     const closeMore = () => setMoreOpen(false);
 
-    // Close on outside click — ignore clicks inside button or dropdown
+    // Item context menu — rendered independently so the More dropdown stays open
+    // while the user interacts with pin/unpin. itemMenuState drives a PopoverMenu
+    // in the JSX below; null means closed.
+    const [itemMenuState, setItemMenuState] = createSignal<{
+        pos: { x: number; y: number };
+        shortName: string;
+    } | null>(null);
+
+    const handleItemContextMenu = (pos: { x: number; y: number }, key: string) => {
+        setItemMenuState({ pos, shortName: key.replace("defwidget@", "") });
+    };
+
+    const buildItemMenuItems = (shortName: string): PopoverMenuItem[] => [
+        {
+            label: "New Window",
+            click: () => {
+                setItemMenuState(null);
+                closeMore();
+                fireAndForget(async () => getApi().openNewWindow());
+            },
+        },
+        { type: "separator" },
+        getPinnedKeys(settings(), wmap()).includes(shortName)
+            ? {
+                label: "Unpin from bar",
+                click: () => {
+                    setItemMenuState(null);
+                    unpinWidget(shortName, settings(), wmap());
+                },
+            }
+            : {
+                label: "Pin to bar",
+                click: () => {
+                    setItemMenuState(null);
+                    pinWidget(shortName, settings(), wmap());
+                },
+            },
+    ];
+
+    // Close on outside click — ignore clicks inside button, dropdown, or any
+    // open popover-menu (e.g. the item context menu rendered by handleItemContextMenu).
     createEffect(() => {
         if (!moreOpen()) return;
         const handler = (e: MouseEvent) => {
             const t = e.target as Node;
             if (moreButtonRef?.contains(t) || moreDropdownRef?.contains(t)) return;
+            const el = t instanceof Element ? t : (t as Node).parentElement;
+            if (el?.closest(".popover-menu")) return;
             setMoreOpen(false);
         };
         document.addEventListener("mousedown", handler, true);
@@ -632,6 +665,7 @@ const ActionWidgets = (): JSX.Element => {
                     <MoreDropdown
                         widgets={() => [...clippedPinnedWidgets(), ...moreWidgets()]}
                         onClose={closeMore}
+                        onItemContextMenu={handleItemContextMenu}
                         anchor={() => moreButtonRef ?? null}
                         settings={settings}
                         wmap={wmap}
@@ -639,6 +673,14 @@ const ActionWidgets = (): JSX.Element => {
                     />
                 </Show>
             </Portal>
+
+            <Show when={itemMenuState() !== null}>
+                <PopoverMenu
+                    pos={itemMenuState()!.pos}
+                    onClose={() => setItemMenuState(null)}
+                    items={buildItemMenuItems(itemMenuState()!.shortName)}
+                />
+            </Show>
         </>
     );
 };

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -10,7 +10,11 @@ import { createSignal, type JSX } from "solid-js";
 
 function getPinnedKeys(settings: Record<string, any>, widgets: Record<string, any>): string[] {
     const pinned: string[] | undefined = settings["widget:pinned"];
-    if (pinned !== undefined) return pinned;
+    if (pinned !== undefined) {
+        // Filter out stale keys that no longer exist in the widget map to avoid
+        // writing ghost entries back to the server on each toggle.
+        return pinned.filter((shortName) => widgets[`defwidget@${shortName}`] != null);
+    }
     return Object.entries(widgets)
         .filter(([, w]: any) => w["display:pinned"])
         .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
@@ -59,7 +63,6 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
         items.push({
             label: "New Window",
             click: () => {
-                props.onClose();
                 fireAndForget(async () => getApi().openNewWindow());
             },
         });
@@ -67,7 +70,6 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
         items.push({
             label: "New Tab",
             click: () => {
-                props.onClose();
                 createTab();
             },
         });
@@ -101,7 +103,6 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
             label: "Icon Only",
             checked: iconOnly(),
             click: () => {
-                props.onClose();
                 toggleIconOnly();
             },
         });

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -4,9 +4,9 @@
 import { PopoverMenu, type PopoverMenuItem } from "@/app/element/popover-menu";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { atoms, createTab, getApi } from "@/store/global";
+import { createTab, getApi } from "@/store/global";
 import { fireAndForget } from "@/util/util";
-import { type JSX } from "solid-js";
+import { createSignal, type JSX } from "solid-js";
 
 function getPinnedKeys(settings: Record<string, any>, widgets: Record<string, any>): string[] {
     const pinned: string[] | undefined = settings["widget:pinned"];
@@ -28,14 +28,21 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
     const widgets  = (): Record<string, any> => props.fullConfig?.widgets  ?? {};
     const iconOnly = (): boolean => settings()["widget:icononly"] ?? false;
 
-    const pinnedKeys = (): Set<string> => new Set(getPinnedKeys(settings(), widgets()));
+    // Optimistic local state for pinned keys. Initialized lazily from server
+    // config on first read. Each toggle updates this immediately so rapid
+    // checkbox clicks chain off the already-updated list rather than
+    // re-reading stale settings() and overwriting each other.
+    const [localPinned, setLocalPinned] = createSignal<string[] | null>(null);
+    const effectivePinned = (): string[] => localPinned() ?? getPinnedKeys(settings(), widgets());
+    const pinnedKeys = (): Set<string> => new Set(effectivePinned());
 
     const toggleWidget = (shortName: string) => {
+        const current = effectivePinned();
+        const next = pinnedKeys().has(shortName)
+            ? current.filter((k) => k !== shortName)
+            : [...current, shortName];
+        setLocalPinned(next); // optimistic — drives UI immediately
         fireAndForget(async () => {
-            const current = getPinnedKeys(settings(), widgets());
-            const next = pinnedKeys().has(shortName)
-                ? current.filter((k) => k !== shortName)
-                : [...current, shortName];
             await RpcApi.SetConfigCommand(TabRpcClient, { "widget:pinned": next } as any);
         });
     };

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -1,0 +1,108 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PopoverMenu, type PopoverMenuItem } from "@/app/element/popover-menu";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { atoms, createTab, getApi } from "@/store/global";
+import { fireAndForget } from "@/util/util";
+import { type JSX } from "solid-js";
+
+function getPinnedKeys(settings: Record<string, any>, widgets: Record<string, any>): string[] {
+    const pinned: string[] | undefined = settings["widget:pinned"];
+    if (pinned !== undefined) return pinned;
+    return Object.entries(widgets)
+        .filter(([, w]: any) => w["display:pinned"])
+        .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
+        .map(([key]) => key.replace("defwidget@", ""));
+}
+
+interface TitleBarContextMenuProps {
+    pos: { x: number; y: number };
+    fullConfig: any;
+    onClose: () => void;
+}
+
+const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
+    const settings = (): Record<string, any> => props.fullConfig?.settings ?? {};
+    const widgets  = (): Record<string, any> => props.fullConfig?.widgets  ?? {};
+    const iconOnly = (): boolean => settings()["widget:icononly"] ?? false;
+
+    const pinnedKeys = (): Set<string> => new Set(getPinnedKeys(settings(), widgets()));
+
+    const toggleWidget = (shortName: string) => {
+        fireAndForget(async () => {
+            const current = getPinnedKeys(settings(), widgets());
+            const next = pinnedKeys().has(shortName)
+                ? current.filter((k) => k !== shortName)
+                : [...current, shortName];
+            await RpcApi.SetConfigCommand(TabRpcClient, { "widget:pinned": next } as any);
+        });
+    };
+
+    const toggleIconOnly = () => {
+        fireAndForget(async () => {
+            await RpcApi.SetConfigCommand(TabRpcClient, { "widget:icononly": !iconOnly() } as any);
+        });
+    };
+
+    const buildItems = (): PopoverMenuItem[] => {
+        const items: PopoverMenuItem[] = [];
+
+        items.push({
+            label: "New Window",
+            click: () => {
+                props.onClose();
+                fireAndForget(async () => getApi().openNewWindow());
+            },
+        });
+
+        items.push({
+            label: "New Tab",
+            click: () => {
+                props.onClose();
+                createTab();
+            },
+        });
+
+        const widgetEntries = Object.entries(widgets())
+            .filter(([key]) => key.startsWith("defwidget@"))
+            .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
+
+        if (widgetEntries.length > 0) {
+            items.push({ type: "separator" });
+            items.push({
+                type: "section",
+                label: "Pin Widgets",
+                defaultOpen: true,
+                items: widgetEntries.map(([key, cfg]: [string, any]) => {
+                    const shortName = key.replace("defwidget@", "");
+                    return {
+                        type: "checkbox" as const,
+                        label: cfg.label ?? shortName,
+                        checked: pinnedKeys().has(shortName),
+                        keepOpen: true,
+                        click: () => toggleWidget(shortName),
+                    };
+                }),
+            });
+        }
+
+        items.push({ type: "separator" });
+        items.push({
+            type: "checkbox",
+            label: "Icon Only",
+            checked: iconOnly(),
+            click: () => {
+                props.onClose();
+                toggleIconOnly();
+            },
+        });
+
+        return items;
+    };
+
+    return <PopoverMenu items={buildItems()} pos={props.pos} onClose={props.onClose} />;
+};
+
+export { TitleBarContextMenu };

--- a/frontend/app/window/window-header.tsx
+++ b/frontend/app/window/window-header.tsx
@@ -1,18 +1,17 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ContextMenuModel } from "@/app/store/contextmenu";
 import { TabBar } from "@/app/tab/tabbar";
 import { WindowDrag } from "@/element/windowdrag";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { atoms } from "@/store/global";
-import { type JSX } from "solid-js";
-import { createTabBarMenu } from "@/app/menu/base-menus";
+import { createSignal, type JSX, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { TitleBarContextMenu } from "@/app/window/titlebar-context-menu";
 import { SystemStatus } from "@/app/window/system-status";
 import { WindowControlsLeft } from "@/app/window/window-controls.platform";
 import { HamburgerMenu } from "@/app/window/hamburger-menu";
 import { isMacOS } from "@/util/platformutil";
-import { Show } from "solid-js";
 import "./window-header.platform.scss";
 
 
@@ -27,11 +26,13 @@ const WindowHeader = (props: WindowHeaderProps): JSX.Element => {
     const fullConfig = atoms.fullConfigAtom;
     const { dragProps } = useWindowDrag();
 
-    // Handle window header context menu
+    const [menuOpen, setMenuOpen] = createSignal(false);
+    const [menuPos,  setMenuPos]  = createSignal({ x: 0, y: 0 });
+
     const handleContextMenu = (e: MouseEvent) => {
         e.preventDefault();
-        const menu = createTabBarMenu(fullConfig());
-        ContextMenuModel.showContextMenu(menu.build(), e);
+        setMenuPos({ x: e.clientX, y: e.clientY });
+        setMenuOpen(true);
     };
 
     return (
@@ -56,6 +57,16 @@ const WindowHeader = (props: WindowHeaderProps): JSX.Element => {
                 Windows/Linux it stays in the tab strip (see TabBar). */}
             <Show when={isMacOS()}>
                 <HamburgerMenu position="right" />
+            </Show>
+
+            <Show when={menuOpen()}>
+                <Portal mount={document.body}>
+                    <TitleBarContextMenu
+                        pos={menuPos()}
+                        fullConfig={fullConfig()}
+                        onClose={() => setMenuOpen(false)}
+                    />
+                </Portal>
             </Show>
         </div>
     );

--- a/frontend/app/window/window-header.tsx
+++ b/frontend/app/window/window-header.tsx
@@ -6,7 +6,6 @@ import { WindowDrag } from "@/element/windowdrag";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { atoms } from "@/store/global";
 import { createSignal, type JSX, Show } from "solid-js";
-import { Portal } from "solid-js/web";
 import { TitleBarContextMenu } from "@/app/window/titlebar-context-menu";
 import { SystemStatus } from "@/app/window/system-status";
 import { WindowControlsLeft } from "@/app/window/window-controls.platform";
@@ -31,6 +30,7 @@ const WindowHeader = (props: WindowHeaderProps): JSX.Element => {
 
     const handleContextMenu = (e: MouseEvent) => {
         e.preventDefault();
+        e.stopPropagation(); // prevent bubbling to app-level onContextMenu (clipboard/URL menu)
         setMenuPos({ x: e.clientX, y: e.clientY });
         setMenuOpen(true);
     };
@@ -59,14 +59,14 @@ const WindowHeader = (props: WindowHeaderProps): JSX.Element => {
                 <HamburgerMenu position="right" />
             </Show>
 
+            {/* PopoverMenu (inside TitleBarContextMenu) already renders into
+                a Portal — no extra Portal wrapper needed here. */}
             <Show when={menuOpen()}>
-                <Portal mount={document.body}>
-                    <TitleBarContextMenu
-                        pos={menuPos()}
-                        fullConfig={fullConfig()}
-                        onClose={() => setMenuOpen(false)}
-                    />
-                </Portal>
+                <TitleBarContextMenu
+                    pos={menuPos()}
+                    fullConfig={fullConfig()}
+                    onClose={() => setMenuOpen(false)}
+                />
             </Show>
         </div>
     );


### PR DESCRIPTION
## Summary

- **New `PopoverMenu` component** (`frontend/app/element/popover-menu.tsx`) — cursor-positioned SolidJS popover that replaces native OS context menus where per-item close control is needed. Items declare `keepOpen: true` to suppress close (e.g. checkboxes in a multi-select flow). Supports inline expandable sections. Reuses `.menu`/`.menu-item` chrome from `flyoutmenu.scss`. Calls `usePaneOverlay` (CEF pane clip) and `assertMenuInPaintableArea` (dev guard). Closes on outside `mousedown`, `Escape`, `visibilitychange`.

- **Title bar right-click reworked** — replaces `ContextMenuModel.showContextMenu` (native OS menu) with a `TitleBarContextMenu` portal. New structure: `New Window` | `New Tab` | separator | `Pin Widgets ▾` (checkbox list, stays open on toggle) | separator | `Icon Only`. Version string removed.

- **More dropdown item right-click fixed** — `action-widgets.tsx:216` called `onClose()` before showing the item context menu, collapsing the More dropdown immediately on right-click. Fixed by moving the item menu to a `PopoverMenu` signal rendered from `ActionWidgets`. `Pin/Unpin` closes only the item menu; `New Window` closes both. More dropdown outside-click handler guards against `.popover-menu` clicks.

- **`base-menus.ts` cleaned up** — `createTabBarBaseMenu`, `createWidgetsMenu`, `createTabBarMenu` removed (no remaining callers). `THEME_OPTIONS` kept.

## Test plan

- [ ] Right-click the window drag bar — menu shows `New Window`, `New Tab`, `Pin Widgets` (expanded), `Icon Only`; no version string
- [ ] Toggle multiple widgets in `Pin Widgets` — menu stays open between toggles; widget bar updates reactively
- [ ] Click `Icon Only` — menu closes
- [ ] Click `New Window` / `New Tab` — menu closes, action fires
- [ ] Click outside the menu — closes normally
- [ ] Press `Escape` — closes
- [ ] Open More dropdown → right-click a widget item — More dropdown stays open while item context menu appears
- [ ] Click `Pin to bar` / `Unpin from bar` in item menu — item menu closes, More dropdown stays open, widget moves
- [ ] Click `New Window` in item menu — both item menu and More dropdown close
- [ ] All platforms: macOS, Windows, Linux (frontend-only change, all platforms affected equally)

Spec: `docs/specs/SPEC_TITLEBAR_CONTEXTMENU_REWORK_2026_06_19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)