### PR TITLE
feat(agent): inline "Login Again" CTA on 401/403 error nodes (reauth P2.3)

### DIFF
--- a/.changesets/1781921078-feat-agent-inline-login-again-cta-on-401-403-error-nodes-rea-wshy.md
+++ b/.changesets/1781921078-feat-agent-inline-login-again-cta-on-401-403-error-nodes-rea-wshy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): inline Login Again CTA on 401/403 error nodes (reauth P2.3)

--- a/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
+++ b/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
@@ -1,0 +1,212 @@
+# SPEC: Re-authentication from Agent Auth Failure
+**Date:** 2026-06-20  
+**Author:** AgentA  
+**Status:** Draft  
+**Depends on:** SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md §P1.1–P1.3 (merged #1589/#1590)
+
+---
+
+## 1. Problem
+
+When an agent hits a 401/auth error the user now sees it clearly (P1.3 inline error node, P1.1/P1.2 failure banner). But clicking **Login Again** currently re-runs the full launch flow — `startLaunchFlow()` — which calls `openExternal()` to punt the OAuth URL to the system browser. The result is:
+
+- System browser opens instead of AgentMux's own browser → context switch, user may not notice
+- The URL is shown in a small text box above the composer → easy to miss
+- If the system browser doesn't open (sandbox, missing default browser, kiosk), nothing happens
+- No feedback while waiting for auth to complete
+
+**Goal:** When the user clicks **Login Again** from an auth failure, AgentMux opens the provider's OAuth flow in a first-class way — for Claude a CEF browser window with the URL shown as a fallback — and closes it automatically on success.
+
+---
+
+## 2. Scope
+
+| In scope | Out of scope |
+|---|---|
+| Claude provider re-auth on auth failure | New-identity creation (handled by pre-launch OAuth modal — SPEC_PRE_LAUNCH_OAUTH_FLOW) |
+| Other providers via their auth method | Gemini-specific auth fix (#1250 — separate issue) |
+| CTA from failure banner and inline error node | API-key-only providers (no URL to open) |
+| URL fallback display | Trust Center binding (SPEC_TRUST_CENTER_CLI_AUTH_BINDING) |
+
+Triggers considered:
+- Failure banner "Login Again" action (already wired; behavior changes)
+- Inline `agent_error` node CTA button (new in this spec)
+
+---
+
+## 3. Trigger Conditions
+
+Re-auth flow is triggered when ALL are true:
+
+1. `agentFailure.code === "auth_failure"` **or** the inline `AgentErrorNode` has `code` 401 or 403
+2. User clicks **Login Again** from either the banner or the inline error node
+
+The two surfaces share one handler — `onLoginAgain` in `agent-view.tsx`.
+
+---
+
+## 4. Current Flow (Baseline)
+
+```
+onLoginAgain
+  → status.startLaunchFlow()
+    → Phase 2: runCliLogin()
+      → spawn: claude auth login
+      → capture auth_url from stdout (2 s window)
+      → openExternal(auth_url)          ← punts to system browser
+      → show URL in auth-url box above composer
+      → poll CheckCliAuthCommand every 2 s until success or 5 min timeout
+    → Phase 3: ControllerResyncCommand  ← agent restarts
+```
+
+---
+
+## 5. New Flow
+
+```
+onLoginAgain
+  → dispatch: provider.reauthInPlace(ctx)
+    ┌─ Claude provider ─────────────────────────────────────────────┐
+    │ 1. spawn: claude auth login (same as before)                  │
+    │ 2. extract auth_url from stdout                               │
+    │ 3. open ReauthBrowserModal (CEF browser pane, see §6)         │
+    │    - loads auth_url in embedded browser                       │
+    │    - shows URL as copyable fallback below viewport            │
+    │ 4. poll CheckCliAuthCommand every 2 s                         │
+    │ 5. on success:                                                │
+    │    - close modal                                              │
+    │    - show brief "Authenticated" toast                         │
+    │    - ControllerResyncCommand → agent restarts                 │
+    │ 6. on timeout (5 min) or user closes:                         │
+    │    - close modal                                              │
+    │    - leave failure banner/error node visible                  │
+    └───────────────────────────────────────────────────────────────┘
+    ┌─ Other providers (generic) ───────────────────────────────────┐
+    │ Same path — if auth_url captured: open ReauthBrowserModal     │
+    │ If no URL (e.g. device flow, API key only): fall back to      │
+    │ existing openExternal() + URL-box behavior (no regression)    │
+    └───────────────────────────────────────────────────────────────┘
+```
+
+Key differences from baseline:
+- `openExternal()` is replaced by `ReauthBrowserModal` for providers that return a URL
+- The URL backup is shown inside the modal, not in the composer area
+- Success auto-closes the modal and restarts the agent
+- Timeout/cancel path is explicit, leaves failure state intact
+
+---
+
+## 6. ReauthBrowserModal
+
+A modal dialog with an embedded CEF browser viewport. Reuses the existing browser-pane infrastructure.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Log in to Claude                              [✕]  │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│   [  CEF browser viewport — loads auth_url  ]       │
+│   [  (https://claude.ai/oauth/authorize/…)  ]       │
+│   [                                         ]       │
+│   [  height: ~540px, width: ~480px          ]       │
+│                                                     │
+├─────────────────────────────────────────────────────┤
+│ If the browser doesn't load, open this URL:         │
+│ https://claude.ai/oauth/… [Copy]  [Open in browser] │
+└─────────────────────────────────────────────────────┘
+```
+
+- Title: `"Log in to <provider name>"` (e.g. "Log in to Claude")
+- Browser viewport occupies the modal body
+- URL fallback bar is always visible at the bottom (not hidden behind a toggle)
+- "Open in browser" calls `openExternal()` — fallback to old behavior
+- [✕] closes the modal and cancels auth (leaves failure state visible)
+- Modal is non-resizable; fixed dimensions chosen to fit Claude's consent page
+
+### While waiting
+
+A spinner overlay covers the browser until the URL loads. After load, spinner disappears.
+
+A status line at the bottom (above the URL bar) shows:
+- While polling: "Waiting for authentication…"
+- On success: "Authenticated ✓" (1.5 s, then modal closes)
+- On timeout: "Login timed out. Try again." (modal stays open, user can close)
+
+### Failure to extract URL
+
+If `auth_url` is `null` (CLI didn't print a URL within the capture window):
+- Skip the modal entirely
+- Fall back to current behavior: show a "Run `/login` to authenticate" instruction in the failure banner
+- Log a warning so we know the capture window may need tuning
+
+---
+
+## 7. Inline Error Node CTA
+
+The `AgentErrorNode` rendered by `DocumentRow.tsx` currently shows code + message only (P1.3). For `code === 401` or `code === 403`, add a CTA button:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [!] HTTP 401  Failed to authenticate. API Error:    │
+│              401 Invalid authentication credentials  │
+│                                    [Login Again →]  │
+└─────────────────────────────────────────────────────┘
+```
+
+- Button only rendered when `node.code === 401 || node.code === 403`
+- Calls the same `onLoginAgain` handler the failure banner uses
+- Styled as a small secondary button, right-aligned inside the error block
+
+This gives the user two entry points to re-auth — the persistent failure banner and the inline node — with identical behavior.
+
+---
+
+## 8. Provider Contract
+
+Each provider definition (`frontend/app/view/agent/providers/`) already has `authLoginCommand` and `requiresLoginTty`. No new fields needed — the existing `runCliLogin()` RPC returns `auth_url: Option<String>`, which drives the branching:
+
+```
+auth_url present → ReauthBrowserModal
+auth_url absent  → openExternal fallback (existing path)
+```
+
+No backend changes required for this spec.
+
+---
+
+## 9. Implementation Plan
+
+### P2.1 — ReauthBrowserModal component
+- New file: `frontend/app/view/agent/components/ReauthBrowserModal.tsx`
+- Wraps the existing CEF browser widget in a modal (reuse `ModalLayer`)
+- Props: `{ providerName: string; authUrl: string; onClose: () => void; onSuccess: () => void }`
+- Browser viewport via `<BrowserPane>` or equivalent CEF embedded renderer
+- URL fallback bar + status line
+
+### P2.2 — Launch-flow auth branch update
+- `launch-flow.ts`: after `auth_url` is captured, if present open `ReauthBrowserModal` instead of `openExternal()`
+- The existing polling loop and success/timeout handling remain; they call modal `onSuccess` / allow `onClose`
+- Gate on a `isReauthContext: boolean` param so the first-launch flow (pre-launch OAuth modal) is unchanged
+
+### P2.3 — Inline error node CTA
+- `DocumentRow.tsx`: for `agent_error` nodes with code 401/403, render a `[Login Again →]` button
+- The button calls the `onLoginAgain` prop threaded from `AgentPresentationView`
+- Thread `onLoginAgain` down through `DocumentRowProps` (add optional prop)
+
+### P2.4 — Tests
+- `ReauthBrowserModal` unit test: renders URL fallback bar, calls `onSuccess` on signal, calls `onClose` on ✕
+- `launch-flow` test: with `isReauthContext: true` and a mock `auth_url`, verify modal opens (not `openExternal`)
+- `DocumentRow` test: code 401 renders CTA button; code 200 does not
+
+---
+
+## 10. Open Questions
+
+| # | Question | Default |
+|---|---|---|
+| Q1 | Should the CEF browser in the modal share cookie store with the main window, or use an isolated profile? | Isolated — same policy as BrowserPane. |
+| Q2 | If the user completes auth in the system browser (old path from "Open in browser"), does poll detect it? | Yes — poll calls `CheckCliAuthCommand` which reads credentials on disk; it doesn't care which browser set them. |
+| Q3 | Modal width/height: 480×580 enough for Claude's consent page? | Needs a smoke test against actual claude.ai/oauth page. Adjust in P2.1. |
+| Q4 | Should auth modal be dismissible by clicking outside? | No — accidental dismissal during OAuth redirect would lose the flow. Only [✕] and success close it. |

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1050,6 +1050,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 authUrl={status.authUrl}
                 authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
+                onAgentErrorLogin={() => {
+                    log("auth", "Login Again (inline error node) — re-running the provider login flow");
+                    void status.startLaunchFlow();
+                }}
                 onLoadOlder={history.loadOlder}
                 loadingOlder={history.loadingOlder}
                 scrollCommand={scroll.command}

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -34,6 +34,9 @@ interface AgentDocumentViewProps {
     /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
     authProviderId?: string;
     onSubagentClick?: (node: SubagentLinkNode) => void;
+    /** Re-run the provider login flow — forwarded to the list so an inline
+     *  auth-error node can offer a "Login Again" CTA (SPEC_REAUTH_FROM_AUTH_ERROR §7). */
+    onAgentErrorLogin?: () => void;
     /** Called when the user scrolls near the top — load the previous page of history. */
     onLoadOlder?: () => Promise<void>;
     /** Whether an older-history load is currently in progress. */
@@ -161,6 +164,7 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             viewState={viewState}
             documentState={documentState}
             onSubagentClick={props.onSubagentClick}
+            onAgentErrorLogin={props.onAgentErrorLogin}
             onLoadOlder={props.onLoadOlder}
             loadingOlder={props.loadingOlder}
             highlightNodeId={props.highlightNodeId}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1338,4 +1338,25 @@
         color: var(--secondary-text-color);
         overflow-wrap: anywhere;
     }
+
+    // Inline re-auth CTA — only rendered for recoverable auth errors (401/403).
+    // Pushed to the right edge of the row. SPEC_REAUTH_FROM_AUTH_ERROR §7.
+    .agent-error-login-btn {
+        flex-shrink: 0;
+        margin-left: auto;
+        align-self: center;
+        padding: 2px var(--space-1-5);
+        border: 1px solid var(--error-color);
+        border-radius: 3px;
+        background: transparent;
+        color: var(--error-color);
+        font-size: 11px;
+        font-weight: 600;
+        white-space: nowrap;
+        cursor: pointer;
+
+        &:hover {
+            background: color-mix(in srgb, var(--error-color) 15%, transparent);
+        }
+    }
 }

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -77,6 +77,9 @@ export interface AgentDocumentVirtualListProps {
     /** Release a held tool once its row has scrolled off the top (latched
      *  collapse). Invoked by the scroll-off scan in `handleScroll`. */
     onReleaseToolOpen?: (id: string) => void;
+    /** Re-run the provider login flow — forwarded to each row so an inline
+     *  auth-error node can offer a "Login Again" CTA (SPEC_REAUTH_FROM_AUTH_ERROR §7). */
+    onAgentErrorLogin?: () => void;
     /**
      * Live per-pane zoom factor (the same value applied as CSS `zoom` on
      * `.agent-view` in agent-view.tsx). Normalizes the SINGLE zoomed read —
@@ -728,6 +731,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                         onToggleCollapse={props.onToggleCollapse}
                                         onTogglePin={props.onTogglePin}
                                         onHoldToolOpen={props.onHoldToolOpen}
+                                        onAgentErrorLogin={props.onAgentErrorLogin}
                                         ref={(el) => { rowEl = el; observeRow(el, row().nodeId); }}
                                         style={{
                                             position: "absolute",
@@ -789,6 +793,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                     onToggleCollapse={props.onToggleCollapse}
                                     onTogglePin={props.onTogglePin}
                                     onHoldToolOpen={props.onHoldToolOpen}
+                                    onAgentErrorLogin={props.onAgentErrorLogin}
                                 />
                             )}
                         </Key>

--- a/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
@@ -1,0 +1,89 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DocumentRow inline auth-error CTA tests (P2.3 of
+ * SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20 §7).
+ *
+ * An `agent_error` node whose `code` is an auth status (401/403) renders a
+ * "Login Again" button that drives the same re-auth flow as the failure
+ * banner. Any other code (or code 0 = non-HTTP) renders no button — those
+ * errors have no in-place fix.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DocumentRow } from "./DocumentRow";
+import type { AgentErrorNode, DocumentNode, DocumentState } from "../types";
+
+afterEach(() => cleanup());
+
+const emptyState = (): DocumentState => ({
+    collapsedNodes: new Set(),
+    pinnedNodes: new Set(),
+    expandedTools: new Set(),
+    scrollPosition: 0,
+    selectedNode: null,
+    filter: { showThinking: true } as DocumentState["filter"],
+});
+
+const errorNode = (code: number, message = "boom"): AgentErrorNode => ({
+    type: "agent_error",
+    id: "err-1",
+    code,
+    message,
+});
+
+const renderRow = (node: DocumentNode, onAgentErrorLogin?: () => void) => {
+    const [n] = createSignal<DocumentNode>(node);
+    const [state] = createSignal<DocumentState>(emptyState());
+    return render(() => (
+        <DocumentRow
+            node={n}
+            documentState={state}
+            onToggleCollapse={() => {}}
+            onTogglePin={() => {}}
+            onAgentErrorLogin={onAgentErrorLogin}
+        />
+    ));
+};
+
+describe("DocumentRow — inline auth-error CTA", () => {
+    it("renders a Login Again button for a 401 error and fires onAgentErrorLogin on click", async () => {
+        const onLogin = vi.fn();
+        renderRow(errorNode(401, "Invalid authentication credentials"), onLogin);
+
+        const btn = screen.getByRole("button", { name: /Login Again/i });
+        expect(btn).toBeInTheDocument();
+        expect(screen.getByText("HTTP 401")).toBeInTheDocument();
+
+        await userEvent.click(btn);
+        expect(onLogin).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the CTA for a 403 error too", () => {
+        renderRow(errorNode(403, "Forbidden"), vi.fn());
+        expect(screen.getByRole("button", { name: /Login Again/i })).toBeInTheDocument();
+    });
+
+    it("renders NO CTA for a non-auth error code (500)", () => {
+        renderRow(errorNode(500, "Internal error"), vi.fn());
+        expect(screen.queryByRole("button", { name: /Login Again/i })).toBeNull();
+        expect(screen.getByText("HTTP 500")).toBeInTheDocument();
+    });
+
+    it("renders NO CTA for a non-HTTP error (code 0) and shows 'Error' not 'HTTP 0'", () => {
+        renderRow(errorNode(0, "Network connection lost"), vi.fn());
+        expect(screen.queryByRole("button", { name: /Login Again/i })).toBeNull();
+        expect(screen.getByText("Error")).toBeInTheDocument();
+        expect(screen.queryByText(/HTTP 0/)).toBeNull();
+    });
+
+    it("renders NO CTA when onAgentErrorLogin is not provided, even for a 401", () => {
+        renderRow(errorNode(401), undefined);
+        expect(screen.queryByRole("button", { name: /Login Again/i })).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -39,6 +39,11 @@ export interface DocumentRowProps {
     /** Hold a tool expanded after it completes live on screen (ToolBlock calls
      *  this on the active→inactive transition). */
     onHoldToolOpen?: (id: string) => void;
+    /** Re-run the provider login flow. Threaded down so an `agent_error` node
+     *  carrying an auth status (401/403) can offer an inline "Login Again" CTA
+     *  — the same action as the failure banner. See
+     *  SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20 §7. */
+    onAgentErrorLogin?: () => void;
     /** Style applied to the wrapper element. Virtualized parent
      *  passes absolute positioning + translateY; streaming parent
      *  passes nothing (normal flow). */
@@ -128,6 +133,7 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 onTogglePin={props.onTogglePin}
                 onHoldToolOpen={props.onHoldToolOpen}
                 onSubagentClick={props.onSubagentClick}
+                onAgentErrorLogin={props.onAgentErrorLogin}
             />
         </div>
     );
@@ -142,6 +148,8 @@ interface DocumentNodeBodyProps {
     onTogglePin: (id: string) => void;
     onHoldToolOpen?: (id: string) => void;
     onSubagentClick?: (node: SubagentLinkNode) => void;
+    /** Re-run the provider login flow — drives the inline auth-error CTA. */
+    onAgentErrorLogin?: () => void;
 }
 
 /**
@@ -246,6 +254,22 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     <span class="agent-error-message">
                         {(props.node() as Extract<DocumentNode, { type: "agent_error" }>).message}
                     </span>
+                    {/* Auth errors (401 Unauthorized / 403 Forbidden) are recoverable
+                        by re-running the provider login — surface an inline CTA that
+                        drives the same flow as the failure banner. Other codes have no
+                        in-place fix, so no button. SPEC_REAUTH_FROM_AUTH_ERROR §7. */}
+                    <Show when={
+                        props.onAgentErrorLogin
+                        && [401, 403].includes((props.node() as Extract<DocumentNode, { type: "agent_error" }>).code)
+                    }>
+                        <button
+                            type="button"
+                            class="agent-error-login-btn"
+                            onClick={() => props.onAgentErrorLogin?.()}
+                        >
+                            Login Again →
+                        </button>
+                    </Show>
                 </div>
             </Show>
         </>


### PR DESCRIPTION
## What

When an agent hits an auth error, the inline `agent_error` transcript node (added in #1590) now shows a **"Login Again →"** button for recoverable auth statuses (401 Unauthorized / 403 Forbidden). Clicking it re-runs the provider login flow — the same `status.startLaunchFlow()` action the failure banner already drives.

Errors with no in-place fix (any non-auth code, and code `0` = non-HTTP network/CLI errors) render **no** button.

## Why

Closes the gap from the auth-failure-visibility work: the user can now recover from an expired Claude OAuth **directly from the error in the transcript**, not just the banner. Two entry points, identical behavior.

## How

- New optional `onAgentErrorLogin` callback threaded `agent-view.tsx → AgentDocumentView → AgentDocumentVirtualList → DocumentRow`.
- `DocumentRow` renders the CTA only when the callback is present **and** `code ∈ {401, 403}`.
- SCSS: right-aligned outlined button matching the error block's error-color theme.

## Scope

First slice of **SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20** (§7), included in this PR (rides with code per the no-doc-only-PR rule). The `ReauthBrowserModal` pieces (§6 — open OAuth in a CEF browser window with URL fallback, P2.1/P2.2) follow in a separate PR.

## Tests

`DocumentRow.test.tsx` — 5 cases: 401 renders CTA + fires callback on click; 403 renders CTA; 500 renders none; code 0 renders none + shows "Error" not "HTTP 0"; missing callback renders none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)