### PR TITLE
feat(voice): red recording indicator + "Speak to <agent>" composer ghost text

### DIFF
--- a/.changesets/1781921692-feat-voice-red-recording-indicator-speak-to-agent-composer-g-bojt.md
+++ b/.changesets/1781921692-feat-voice-red-recording-indicator-speak-to-agent-composer-g-bojt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(voice): red recording indicator + 'Speak to <agent>' composer ghost text

--- a/frontend/app/element/MicButton.scss
+++ b/frontend/app/element/MicButton.scss
@@ -2,8 +2,10 @@
     display: flex;
     align-items: center;
 
+    // Active = recording. Red is the universal "live mic" convention, so the
+    // indicator deliberately diverges from the accent color used elsewhere.
     &.mic-active .wave-iconbutton {
-        color: var(--color-primary, var(--accent-color));
+        color: var(--error-color, var(--color-error, #e5484d));
         position: relative;
 
         &::after {
@@ -11,7 +13,7 @@
             position: absolute;
             inset: -3px;
             border-radius: 50%;
-            border: 1.5px solid var(--color-primary, var(--accent-color));
+            border: 1.5px solid var(--error-color, var(--color-error, #e5484d));
             opacity: 0.6;
             animation: mic-pulse 1.4s ease-in-out infinite;
         }

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
-import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { markEnd, markStart } from "@/perf";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
@@ -232,6 +232,22 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         const p = autocompletePrefix();
         if (p === null || !props.getCompletions) return [];
         return props.getCompletions(p);
+    });
+
+    // Composer ghost text. While voice is listening AND this pane owns the
+    // session, switch to "Speak to <agent>…" so it's obvious transcription is
+    // live and routed here (the mic button also shows a red recording ring).
+    // Otherwise the normal "Send message to <agent>…" prompt. Reactive: reads
+    // the voice singleton's SignalAtoms so it flips the instant the mic toggles
+    // or retargets to another pane.
+    const voice = getVoiceSession();
+    const placeholder = createMemo(() => {
+        const vm = props.viewModel;
+        const listeningHere =
+            !!vm && voice.isListening() && voice.currentTargetId() === vm.blockId;
+        return listeningHere
+            ? `Speak to ${props.agentName}...`
+            : `Send message to ${props.agentName}...`;
     });
 
     // IME composition state — true between compositionstart and compositionend.
@@ -536,7 +552,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 <textarea
                     ref={textareaRef}
                     class="agent-input"
-                    placeholder={`Send message to ${props.agentName}...`}
+                    placeholder={placeholder()}
                     onKeyDown={handleKeyDown}
                     onInput={handleInput}
                     onCompositionStart={() => {


### PR DESCRIPTION
## Summary

Makes the already-shipped Web Speech API voice input **visibly active**, so it's obvious when a click on the mic has started transcription and which pane it's routed to. No engine change — server-side STT stays tracked in #1591.

- **Red recording indicator** (`MicButton.scss`): the active mic icon + pulse ring now use `--error-color` (themed red) instead of the accent color — the universal "live mic" convention.
- **Reactive composer ghost text** (`AgentFooter.tsx`): while the voice session is listening **and** this pane owns it, the placeholder reads `Speak to <agent>...`; otherwise the normal `Send message to <agent>...`. Driven by the `isListening` / `currentTargetId` signals on the voice singleton, keyed on `vm.blockId` (the same id `MicButton` registers via `blockframe.tsx`), so it flips the instant the mic toggles or retargets to another pane.

## Behavior

1. Click the mic in a pane's frame header → red pulsing ring + placeholder becomes **"Speak to Claude…"**.
2. Web Speech API transcribes into the composer (interim preview, final folded in — existing wiring).
3. Click again, or the mic on another pane → indicator clears, placeholder reverts.

## Test plan

- [ ] Click the agent-pane mic → icon turns red + pulses; placeholder shows "Speak to <agent>…"
- [ ] Speak → text appears in the composer
- [ ] Click mic again → red clears, placeholder back to "Send message to <agent>…"
- [ ] Click the mic on a second pane → first pane's red clears, second pane goes red + "Speak to …"
- [ ] Deny mic permission → existing error toast still fires (unchanged)

## Notes

- Frontend builds clean (`task build:frontend`, ✓ in ~13s).
- `--error-color` is themed (e.g. `#f7768e` tokyo-night), with `var(--color-error, #e5484d)` fallbacks.
- Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)