### PR TITLE
feat(mcp): SetName target_id — rename any element by explicit id

### DIFF
--- a/.changesets/1781922159-feat-mcp-setname-target-id-rename-any-window-tab-workspace-p-43wn.md
+++ b/.changesets/1781922159-feat-mcp-setname-target-id-rename-any-window-tab-workspace-p-43wn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(mcp): SetName target_id — rename any window/tab/workspace/pane by explicit id

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -157,12 +157,13 @@ const WHOAMI_TOOL: &str = r#"{
 // See SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md §4.3 / §10.
 const SET_NAME_TOOL: &str = r#"{
   "name": "SetName",
-  "description": "Rename one of your own AgentMux UI elements. `target` selects which: \"window\" (the OS taskbar / window-title name; clamped to 64 chars), \"tab\" (the tab-bar label), \"pane\" (this conversation pane's header title), or \"workspace\" (the workspace name — also shown in the window/taskbar title when no explicit window name is set). Defaults to your own element; trimmed; non-window names clamp to 128 chars.",
+  "description": "Rename an AgentMux UI element. `target` selects which: \"window\" (the OS taskbar / window-title name; clamped to 64 chars), \"tab\" (the tab-bar label), \"pane\" (a conversation pane's header title), or \"workspace\" (the workspace name). Defaults to your own element; pass `target_id` (from Layout/WhoAmI) to rename any specific element by id. Names are trimmed; non-window names clamp to 128 chars.",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "target": { "type": "string", "enum": ["window", "tab", "pane", "workspace"], "description": "Which UI element to rename" },
-      "name": { "type": "string", "description": "The new name/title to display" }
+      "target":    { "type": "string", "enum": ["window", "tab", "pane", "workspace"], "description": "Which UI element to rename" },
+      "name":      { "type": "string", "description": "The new name/title to display" },
+      "target_id": { "type": "string", "description": "Explicit id of the element to rename (window_id / tab_id / workspace_id / block_id depending on target). Omit to default to your own." }
     },
     "required": ["target", "name"]
   }
@@ -689,30 +690,51 @@ async fn call_tool(
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
-            require_agent_env(local_url, auth_key, block_id)?;
+            let target_id = arguments
+                .get("target_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+            // block_id is only needed for own-context resolution; when
+            // target_id is explicit we can reach any element without it.
+            if target_id.is_none() && block_id.is_empty() {
+                anyhow::bail!(
+                    "neither AGENTMUX_AGENT_BUS_ID nor AGENTMUX_BLOCKID is set \
+                     — pass target_id to name a specific element, or open this \
+                     agent in an AgentMux pane to default to your own."
+                );
+            }
 
             // window/tab/workspace POST {"name": …} to /…/name; pane POSTs
             // {"title": …} to /pane/title. `label` and `resp_field` are the
             // human-facing echo and the response key used to surface the
             // server-applied value (e.g. a window name clamped to 64 chars).
+            let own_block = if block_id.is_empty() { None } else { Some(block_id.to_string()) };
             let (path, label, resp_field, body) = match target {
                 "window" => ("window/name", "Window name", "name", serde_json::to_value(WindowNameRequest {
-                    block_id: Some(block_id.to_string()),
+                    block_id: own_block,
                     name: new_name.to_string(),
-                    window_id: None,
+                    window_id: target_id,
                 })?),
                 "tab" => ("tab/name", "Tab name", "name", serde_json::to_value(TabNameRequest {
-                    block_id: Some(block_id.to_string()),
-                    tab_id: None,
+                    block_id: own_block,
+                    tab_id: target_id,
                     name: new_name.to_string(),
                 })?),
                 "workspace" => ("workspace/name", "Workspace name", "name", serde_json::to_value(WorkspaceNameRequest {
-                    block_id: Some(block_id.to_string()),
-                    workspace_id: None,
+                    block_id: own_block,
+                    workspace_id: target_id,
                     name: new_name.to_string(),
                 })?),
                 "pane" => ("pane/title", "Pane title", "title", serde_json::to_value(PaneTitleRequest {
-                    block_id: Some(block_id.to_string()),
+                    block_id: target_id.or(own_block),
                     title: new_name.to_string(),
                 })?),
                 other => anyhow::bail!(

--- a/docs/specs/SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md
+++ b/docs/specs/SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md
@@ -1,0 +1,93 @@
+# SPEC: `SetName` explicit target-id parameter
+
+**Date:** 2026-06-19
+**Status:** Implementing
+**Author:** smike
+**Related:** `agentmux-mcp/src/main.rs` (SetName tool), `agentmux-common::api_types` (WindowNameRequest etc.)
+
+---
+
+## 1. Problem
+
+`SetName` currently resolves the target element from the calling agent's own context
+(its `AGENTMUX_BLOCKID`). This means an agent can only rename *its own* window, tab,
+workspace, or pane — it cannot target another element even when it knows the ID.
+
+Combined with `Layout` (which already returns `window_id`, `tab_id`, `workspace_id`
+for every element in the instance), the missing piece is a way to pass an explicit ID
+through to the rename endpoint.
+
+**Use case (motivating example):**
+
+```
+// Discover all windows
+Layout(query: "windows")
+→ [{ window_id: "88b2e33c-...", name: "" }, ...]
+
+// Name a specific one
+SetName(target: "window", name: "Dev", target_id: "88b2e33c-...")
+```
+
+---
+
+## 2. Design
+
+Add a single optional `target_id` string parameter to `SetName`. When present it is
+forwarded as the explicit id field in the matching request struct; when absent the
+existing own-context resolution (from `block_id`) is used unchanged.
+
+| `target`    | `target_id` maps to          | Endpoint |
+|-------------|------------------------------|----------|
+| `window`    | `WindowNameRequest.window_id` | `POST /api/v1/window/name` |
+| `tab`       | `TabNameRequest.tab_id`       | `POST /api/v1/tab/name` |
+| `workspace` | `WorkspaceNameRequest.workspace_id` | `POST /api/v1/workspace/name` |
+| `pane`      | `PaneTitleRequest.block_id`   | `POST /api/v1/pane/title` |
+
+The srv-side request structs (`WindowNameRequest`, `TabNameRequest`, etc.) already
+have these fields — all defined in `agentmux-common::api_types` as of A2 (#1575).
+No srv changes needed.
+
+**Auth guard change:** when `target_id` is provided the agent's own `block_id` is no
+longer required (we know the target directly). The check is relaxed to only require
+`block_id` when `target_id` is absent.
+
+---
+
+## 3. Schema change (mcp SETNAME_TOOL)
+
+```json
+{
+  "name": "SetName",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "target":    { "type": "string", "enum": ["window","tab","pane","workspace"] },
+      "name":      { "type": "string" },
+      "target_id": {
+        "type": "string",
+        "description": "Explicit id of the element to rename (window_id / tab_id / workspace_id / block_id). Omit to default to your own."
+      }
+    },
+    "required": ["target", "name"]
+  }
+}
+```
+
+---
+
+## 4. Acceptance criteria
+
+- `SetName(target:"window", name:"X")` — still renames own window (no regression).
+- `SetName(target:"window", name:"X", target_id:"<window_id>")` — renames that specific window.
+- Same for `tab`, `workspace`, `pane`.
+- `cargo check -p agentmux-mcp` green; existing 4 mcp tests pass.
+- Works end-to-end: `Layout → window_id → SetName(target_id)` renames the right window.
+
+---
+
+## 5. Files changed
+
+| File | Change |
+|------|--------|
+| `agentmux-mcp/src/main.rs` | Add `target_id` to `SETNAME_TOOL` schema; extract in handler; pass through |
+| `docs/specs/SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md` | This file |


### PR DESCRIPTION
## Summary

- Adds optional `target_id` parameter to the `SetName` MCP tool
- When provided, `target_id` is forwarded as the explicit ID in the matching request struct (window_id / tab_id / workspace_id / block_id), allowing agents to rename any UI element they know the ID of
- No srv changes needed — `WindowNameRequest`, `TabNameRequest`, `WorkspaceNameRequest` already have these fields (A2 / #1575)
- Auth guard relaxed: `block_id` (own context) is only required when `target_id` is absent

## Use case

```
// Discover all windows
Layout(query: "windows")
→ [{ window_id: "88b2e33c-...", name: "" }, ...]

// Name a specific one
SetName(target: "window", name: "Dev", target_id: "88b2e33c-...")
```

## Test plan

- [ ] `cargo check -p agentmux-mcp` clean ✅
- [ ] `cargo test -p agentmux-mcp` — 4/4 pass ✅
- [ ] `SetName(target:"window", name:"X")` — own window rename still works (no regression)
- [ ] `SetName(target:"window", name:"X", target_id:"<id>")` — specific window renamed
- [ ] Same for `tab`, `workspace`, `pane`
- [ ] End-to-end: `Layout → window_id → SetName(target_id)` renames the right window

## Spec

`docs/specs/SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)