### PR TITLE
feat(agent): style the Identity and Memory modal panels

### DIFF
--- a/.changesets/1781922939-feat-agent-style-the-identity-and-memory-modal-panels-vksl.md
+++ b/.changesets/1781922939-feat-agent-style-the-identity-and-memory-modal-panels-vksl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): style the Identity and Memory modal panels

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -20,6 +20,8 @@ import { AgentIdentityModalPanel } from "@/app/view/agent/components/AgentIdenti
 import { AgentMemoryModalPanel } from "@/app/view/agent/components/AgentMemoryModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
+import "@/app/view/agent/components/AgentMemoryModal.scss";
+import "@/app/view/agent/components/AgentIdentityModal.scss";
 import "@/app/view/browser/components/BrowserAuthModal.scss";
 
 import type { ModalLayerApi, ModalLayerRequest } from "./modal-layer";

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -1,0 +1,13 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// The inner AgentIdentityPanel content is fully styled by _identity-panel.scss.
+// This file only handles the modal body wrapper and the shared footer/button
+// which live in AgentMemoryModal.scss (both imported via modal-dispatch.tsx).
+
+.agent-identity-modal-body {
+    display: flex;
+    flex-direction: column;
+    min-width: 440px;
+    max-width: 560px;
+}

--- a/frontend/app/view/agent/components/AgentMemoryModal.scss
+++ b/frontend/app/view/agent/components/AgentMemoryModal.scss
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.agent-memory-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 440px;
+    max-width: 560px;
+}
+
+.agent-memory-modal-coming-soon {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    border: 1px solid var(--border-color);
+}
+
+.agent-memory-modal-heading {
+    margin: 0;
+    font-size: var(--text-md);
+    font-weight: var(--font-weight-medium);
+    color: var(--main-text-color);
+}
+
+.agent-memory-modal-desc {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: var(--leading-normal);
+}
+
+.agent-memory-modal-path-label {
+    margin: 0;
+    font-size: var(--text-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--secondary-text-color);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.agent-memory-modal-path {
+    display: block;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    font-family: monospace;
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    word-break: break-all;
+    user-select: all;
+}
+
+.agent-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+}
+
+.agent-modal-done-btn {
+    padding: var(--space-1-5) var(--space-4);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--button-text-color);
+    background: var(--accent-color);
+    border: none;
+    border-radius: 0;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--accent-color) 85%, var(--main-text-color));
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-focus-ring);
+    }
+}


### PR DESCRIPTION
## What

Adds the SCSS for the Agent **Identity** and **Memory** modal panels and wires both stylesheets into `modal-dispatch.tsx`. The component `.tsx` panels already shipped to main but were rendering **unstyled** (no stylesheet imported).

## Files

- `AgentMemoryModal.scss` — body layout, coming-soon block, heading/desc/path rows, **and the shared** `.agent-modal-footer` / `.agent-modal-done-btn` used by both panels.
- `AgentIdentityModal.scss` — body wrapper only (the inner identity panel content is styled by the existing `_identity-panel.scss`).
- `modal-dispatch.tsx` — two `import "...scss"` lines so the stylesheets load.

## Verification

- `tsc --noEmit` clean
- `task build:frontend` green (SCSS compiles, imports resolve)
- Every class defined in the two SCSS files is referenced by its component (no dead styles); shared footer/button classes confirmed used by both `AgentIdentityModal.tsx` and `AgentMemoryModal.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)