### PR TITLE
fix(sysinfo): throttle chart SVG rebuild to fix sustained GPU/renderer CPU

### DIFF
--- a/.changesets/1781923404-fix-sysinfo-throttle-chart-svg-rebuild-from-1hz-to-0-5hz-to--y3mg.md
+++ b/.changesets/1781923404-fix-sysinfo-throttle-chart-svg-rebuild-from-1hz-to-0-5hz-to--y3mg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sysinfo): throttle chart SVG rebuild from 1Hz to 0.5Hz to fix sustained GPU CPU

--- a/frontend/app/view/sysinfo/sysinfo-plot.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-plot.tsx
@@ -138,7 +138,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
             x: {
                 grid: true,
                 label: "time",
-                tickFormat: (d: number) => `${dayjs.unix(d / 1000).format("h:mm:ss A")}`,
+                tickFormat: (d: number) => dayjs.unix(d / 1000).format("h:mm A"),
                 domain: [minX, maxX],
             },
             y: { label: labelY, domain: [minY, maxY] },

--- a/frontend/app/view/sysinfo/sysinfo-view.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-view.tsx
@@ -4,7 +4,7 @@
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import clsx from "clsx";
-import { createEffect, createMemo, For, onCleanup, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 
 import type { SysinfoViewModel } from "./sysinfo-model";
@@ -68,9 +68,25 @@ function SysinfoView(props: SysinfoViewProps): JSX.Element {
     );
 }
 
+// Chart rebuild interval. The chart shows 5-min history so a 2s lag is
+// imperceptible, but the full 1Hz SVG rebuild (font hinting + Temporal
+// API for every axis tick) caused ~13% sustained GPU process CPU.
+const CHART_UPDATE_INTERVAL_MS = 2000;
+
 function SysinfoViewInner(props: SysinfoViewProps): JSX.Element {
     const { model } = props;
-    const plotData = createMemo(() => model.dataAtom());
+
+    // Throttle chart data to avoid rebuilding the SVG on every sysinfo
+    // event (default 1Hz). At 1Hz, full SVG recreation forced font
+    // hinting + Temporal date formatting for every x-axis label each
+    // second, causing ~13% sustained GPU process CPU. This throttle
+    // reduces repaints to ~0.5Hz while the status-bar stats still
+    // update at the full sysinfo rate (cheap text DOM updates).
+    const [plotData, setPlotData] = createSignal(model.dataAtom());
+    onMount(() => {
+        const id = setInterval(() => setPlotData(model.dataAtom()), CHART_UPDATE_INTERVAL_MS);
+        onCleanup(() => clearInterval(id));
+    });
     const yvals = createMemo(() => model.metrics());
     const plotMeta = createMemo(() => model.plotMetaAtom());
     const targetLen = createMemo(() => model.numPoints() + 1);


### PR DESCRIPTION
## Root cause

The sysinfo chart was rebuilding its entire Observable Plot SVG every second (on every sysinfo event at 1Hz). Profiling the stable build after 24h of uptime revealed:

- **GPU process (13.4% CPU sustained)**: `CA::Transaction::commit()` / `CA::Layer::commit_if_needed()` fired on every sysinfo update — the compositor committing the freshly rebuilt SVG layer on every tick
- **Renderer Compositor thread (6.9% CPU)**: `fontations_ffi BridgeHintingInstance` — font hinting for the x-axis tick labels every second; `temporal_rs_PlainTime_millisecond` — Temporal API date formatting for those labels

With `"h:mm:ss A"` format every label was unique per second, making glyph-cache reuse impossible. The full SVG tear-down + rebuild + font rasterization ran at 1Hz in perpetuity.

## Fix

**`sysinfo-view.tsx`**: Replace the reactive `createMemo(() => model.dataAtom())` (fires on every sysinfo event) with a `createSignal` + `setInterval(2000)` throttle. The chart updates every 2 seconds instead of every second. The 5-minute history chart makes a 2s lag imperceptible.

The status-bar `SystemStats` component is unaffected — it subscribes to sysinfo events directly and does cheap text-only DOM updates (no SVG, no font hinting), so it still refreshes at full 1Hz.

**`sysinfo-plot.tsx`**: Change x-axis `tickFormat` from `"h:mm:ss A"` to `"h:mm A"`. Shorter strings, and labels repeat once per minute allowing the browser to reuse cached glyph bitmaps. The interactive hover tooltip keeps second precision (renders only on user mouse movement, not continuously).

## Expected impact

- GPU process CPU: ~13% → <5%
- Renderer CPU: ~7% → <3%
- Total sustained AgentMux idle CPU: ~20% → <8% on two open windows

## Test plan

- [ ] Open AgentMux with sysinfo pane visible
- [ ] Verify chart still updates (refreshes every ~2s)
- [ ] Verify x-axis shows `h:mm` format (no seconds on ticks)
- [ ] Hover over data points — confirm tooltip still shows `h:mm:ss A` with full precision
- [ ] Let run for 5+ minutes and confirm Activity Monitor shows reduced GPU Helper CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)