### PR TITLE
feat(cef): media-permission handler to grant mic for voice input

### DIFF
--- a/.changesets/1781925599-feat-cef-media-permission-handler-so-voice-input-getusermedi-pnc7.md
+++ b/.changesets/1781925599-feat-cef-media-permission-handler-so-voice-input-getusermedi-pnc7.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(cef): media-permission handler so voice input getUserMedia is granted

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -59,6 +59,17 @@ wrap_client! {
                 None
             }
         }
+
+        fn permission_handler(&self) -> Option<PermissionHandler> {
+            // Microphone (getUserMedia) access for voice input. ONLY the main app
+            // client gets a handler — browser panes load arbitrary web content, so
+            // auto-granting them media access would hand the mic to any site with no
+            // prompt. For panes we return None → CEF's default Alloy handling (deny).
+            if self.is_browser_pane {
+                return None;
+            }
+            Some(AgentMuxPermissionHandler::new())
+        }
     }
 }
 
@@ -423,6 +434,74 @@ wrap_request_handler! {
             inner.on_auth_credentials(
                 browser, origin_url, is_proxy, host, port, realm, scheme, callback,
             )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PermissionHandler — microphone (getUserMedia) access for voice input
+// ---------------------------------------------------------------------------
+//
+// AgentMux runs the Alloy runtime for all non-devtools windows (app.rs:
+// RuntimeStyle::ALLOY). Under Alloy, CEF's DEFAULT handling of a media-access
+// request is to DENY — so without this handler every getUserMedia({audio:true})
+// (the Web Speech API today, and the MediaRecorder capture for server-side STT
+// in #1591) is rejected with NotAllowedError, surfacing as the "Voice input
+// unavailable" toast.
+//
+// We grant only the AUDIO-capture bits the page requested and implicitly deny
+// everything else (camera, desktop capture). Per the CEF contract, for a
+// getUserMedia request `allowed_permissions` must match `required_permissions`:
+// granting only the audio subset means a combined audio+video request is denied
+// as a whole (we never want camera), while an audio-only request — AgentMux's
+// only case — is granted exactly. Only ever installed on the main app client
+// (see `permission_handler` getter above); browser panes never reach here.
+//
+// OS-level permission (Windows Privacy / macOS TCC) is a SEPARATE layer handled
+// in the frontend via getUserMedia error classification + a settings deep-link.
+// See SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md §Phase 4 and #1591.
+
+// cef_media_access_permission_types_t bitmask values (ABI-stable in CEF).
+const CEF_MEDIA_PERMISSION_DEVICE_AUDIO_CAPTURE: u32 = 1 << 0;
+const CEF_MEDIA_PERMISSION_DESKTOP_AUDIO_CAPTURE: u32 = 1 << 2;
+
+wrap_permission_handler! {
+    struct AgentMuxPermissionHandler;
+
+    impl PermissionHandler {
+        fn on_request_media_access_permission(
+            &self,
+            _browser: Option<&mut Browser>,
+            _frame: Option<&mut Frame>,
+            requesting_origin: Option<&CefString>,
+            requested_permissions: u32,
+            callback: Option<&mut MediaAccessCallback>,
+        ) -> ::std::os::raw::c_int {
+            let audio_bits = CEF_MEDIA_PERMISSION_DEVICE_AUDIO_CAPTURE
+                | CEF_MEDIA_PERMISSION_DESKTOP_AUDIO_CAPTURE;
+            let allowed = requested_permissions & audio_bits;
+            let origin = requesting_origin.map(|s| s.to_string()).unwrap_or_default();
+            match callback {
+                Some(cb) => {
+                    tracing::info!(
+                        target: "voice",
+                        %origin,
+                        requested = requested_permissions,
+                        allowed,
+                        "granting audio media-access permission"
+                    );
+                    cb.cont(allowed);
+                    1 // handled
+                }
+                None => {
+                    tracing::warn!(
+                        target: "voice",
+                        %origin,
+                        "media-access request had no callback — deferring to default"
+                    );
+                    0 // not handled — CEF default (deny under Alloy)
+                }
+            }
         }
     }
 }

--- a/docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md
+++ b/docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md
@@ -184,11 +184,67 @@ This avoids the original PR's "last-focused" ambiguity: the user always sees whi
 - Settings toggle: `voice:enabled` (default true) to fully hide the buttons globally
 - Long-press / right-click: language picker (defer if not requested)
 
-### Phase 4 (deferred) — server-side STT
+### Phase 4 — server-side STT + mic-permission flow (REVISED 2026-06-20)
 
-- Replace `webkitSpeechRecognition` with an Anthropic/OpenAI/Whisper server-side path
-- Same `getVoiceSession()` API, just a different implementation under the hood
-- Better accuracy + works in non-Chromium browsers, at the cost of latency + API key + cost
+> **Critical revision.** Live testing on CEF revealed the Web Speech API is
+> **non-viable in AgentMux's runtime**, so Phase 4 is no longer a "nice to have"
+> — it's the only path that can actually transcribe. Full diagnosis +
+> external sources: working report `agentmux-voice-permissions-report.md`;
+> tracking issue #1591.
+
+**Why Web Speech API can't work here (three stacked blockers, all code-confirmed):**
+
+1. **No CEF media-permission handler** → Chromium denies the mic by default
+   under the Alloy runtime (AgentMux uses `RuntimeStyle::ALLOY` for all
+   non-devtools windows, `app.rs`) → `getUserMedia`/Web Speech `not-allowed`.
+2. **The Web Speech service is closed-source and bound to genuine Chrome
+   builds** → `webkitSpeechRecognition` returns `service-not-allowed` **even
+   with `GOOGLE_API_KEY` + client id/secret + Cloud Speech enabled**. Broken in
+   embedded Chromium (CEF/Electron) for years; CEF maintainers don't support it.
+3. **`disable-background-networking` + `disable-component-update`**
+   (`app.rs:722-723`) → also forecloses the network speech path and the
+   on-device SODA model.
+
+Fixing permissions alone only moves the error `not-allowed` → `service-not-allowed`.
+**The engine must be capture-and-send.**
+
+#### 4a. CEF mic-permission handler (foundation — landed)
+
+`agentmux-cef/src/client/handlers.rs`: a `wrap_permission_handler!` block
+implementing `on_request_media_access_permission`, registered via the
+`permission_handler()` getter on the **main app client only** (browser panes
+load untrusted web content → never auto-granted; they return `None` → default
+deny). Grants the audio-capture bits the page requested (`DEVICE_AUDIO_CAPTURE |
+DESKTOP_AUDIO_CAPTURE`), implicitly denying camera/desktop-video. This unblocks
+`getUserMedia({audio:true})` — the shared prerequisite for the Whisper capture
+below. (`cargo check -p agentmux-cef` clean.)
+
+#### 4b. OS-permission UX (frontend)
+
+The CEF grant is layer A; the **OS** mic permission (Windows Privacy / macOS
+TCC, see #1580) is layer B. Replace the single "Voice input unavailable" toast
+with a stateful flow that classifies the `getUserMedia` failure:
+`NotAllowedError` → actionable panel + deep-link to OS mic settings + a
+"blocked" mic-button state; `NotFoundError` → "no microphone detected";
+`SecurityError`/other → generic. Distinct messages, not one toast.
+
+#### 4c. Whisper capture+send engine
+
+Behind the existing `getVoiceSession()` singleton, swap the engine: capture with
+`MediaRecorder` (webm/opus) + VAD chunking → `agentmux-srv` STT backend (local
+whisper.cpp default for privacy/offline; **Groq** hosted option — ~9× cheaper
+than OpenAI, fast enough that chunk latency is negligible). No streaming →
+`setInterim` degrades to a "…transcribing" spinner. Keys stay server-side.
+
+#### 4d. Gate the dead Web Speech engine
+
+In CEF builds, the Web Speech engine must not present a working-looking mic that
+can't transcribe — gate it behind `getVoiceSession()` so only a real engine
+(whisper) drives the button.
+
+> **Anthropic note:** the Claude API has **no** audio/transcription modality
+> (text/image/PDF only), so there is no "Anthropic STT path." Claude's only role
+> is an optional post-transcription cleanup pass (agent pane only, opt-in).
 
 ---
 


### PR DESCRIPTION
## Summary

Voice input shows **"Voice input unavailable"** because the CEF client has **no permission handler**. Under the **Alloy runtime** (used for all non-devtools windows — `app.rs` `RuntimeStyle::ALLOY`), CEF **denies media access by default**, so every `getUserMedia({audio:true})` is rejected with `NotAllowedError`. This is the first of the three stacked blockers found in the voice diagnosis (full write-up + sources tracked in #1591).

This PR adds the missing handler:

- A `wrap_permission_handler!` block in `client/handlers.rs` implementing `on_request_media_access_permission`, registered via a new `permission_handler()` getter on the **main app client only**.
- Grants the **audio-capture** bits the page requested (`DEVICE_AUDIO_CAPTURE | DESKTOP_AUDIO_CAPTURE`); implicitly denies camera/desktop-video (per CEF's `allowed_permissions` must-match-`required_permissions` contract, a combined audio+video request is denied as a whole — AgentMux only ever requests audio).

### Security
Browser panes load **arbitrary web content** — they return `None` from the getter (→ CEF default deny), so only the trusted app origin is ever auto-granted the mic. No untrusted page can grab the mic without a prompt.

## Scope / what this does NOT do

This unblocks `getUserMedia` at the **CEF layer**. Two separate layers remain, tracked in #1591:
- **OS permission** (Windows Privacy / macOS TCC) — frontend error-classification + settings deep-link (next PR).
- **Transcription engine** — the Web Speech API **cannot work in CEF** (closed-source Google speech service, bound to genuine Chrome builds → `service-not-allowed` even with API keys). The real engine is **capture-and-send to Whisper** (`MediaRecorder` → `agentmux-srv` STT). This handler is the shared prerequisite (Whisper needs `getUserMedia` too).

Spec `SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md` §Phase 4 revised with the full diagnosis.

## Test plan

- [x] `cargo check -p agentmux-cef` — clean.
- [ ] Build + run; click the agent-pane mic → OS mic prompt appears (first time) instead of immediate "unavailable". (Note: full transcription still requires the Whisper engine from #1591 — Web Speech will now reach `service-not-allowed`, the expected second blocker.)
- [ ] Confirm a browser pane does **not** get auto-granted mic access.

## Notes

- API verified against `cef 148.3.0+148.0.9` bindings (`on_request_media_access_permission`, `MediaAccessCallback::cont(allowed_permissions: u32)`, `permission_handler` client getter).
- Changeset: `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)