### PR TITLE
feat(voice): actionable mic-permission UX (blocked indicator + classified guidance)

### DIFF
--- a/.changesets/1781925931-feat-voice-actionable-mic-permission-ux-blocked-indicator-cl-d0wv.md
+++ b/.changesets/1781925931-feat-voice-actionable-mic-permission-ux-blocked-indicator-cl-d0wv.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(voice): actionable mic-permission UX (blocked indicator + classified guidance)

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -789,20 +789,48 @@ function installWindowTitleEffect(windowId: string): void {
 function installVoiceInputErrorListener(): void {
     window.addEventListener("voice-input-error", (e: Event) => {
         const detail = (e as CustomEvent<string>).detail;
+
+        // Platform-specific path to the OS microphone privacy setting, so the
+        // "blocked" guidance is actionable rather than generic.
+        const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent);
+        const micSettingsPath = isMac
+            ? "System Settings ▸ Privacy & Security ▸ Microphone"
+            : "Settings ▸ Privacy & security ▸ Microphone";
+
+        // Classify the recognition error into an actionable message. Distinct
+        // causes need distinct guidance — a single "unavailable" toast left the
+        // user with no idea whether to fix permissions, plug in a mic, or wait
+        // for a feature. See SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md §Phase 4.
+        let title = "Voice input unavailable";
         let message: string | null = null;
-        if (detail === "not-allowed") {
-            message = "Microphone permission denied. Enable it in browser settings to use voice input.";
-        } else if (detail === "service-not-allowed") {
-            message = "Voice service unavailable. Check browser settings.";
+        switch (detail) {
+            case "not-allowed":
+                title = "Microphone access blocked";
+                message =
+                    `Enable microphone access for AgentMux in ${micSettingsPath}, ` +
+                    `then click the mic again.`;
+                break;
+            case "audio-capture":
+                title = "No microphone detected";
+                message = "Connect a microphone and click the mic again.";
+                break;
+            case "service-not-allowed":
+                title = "Voice transcription unavailable";
+                message =
+                    "Speech recognition isn't available in this build yet. " +
+                    "Server-side transcription is in progress.";
+                break;
+            default:
+                return; // non-fatal / unknown — no toast
         }
-        if (message == null) return;
+
         pushNotification({
             icon: "fa-microphone-slash",
-            title: "Voice input unavailable",
+            title,
             message,
             timestamp: new Date().toISOString(),
             type: "error",
-            expiration: Date.now() + 10000,
+            expiration: Date.now() + 12000,
         });
     });
 }

--- a/frontend/app/element/MicButton.scss
+++ b/frontend/app/element/MicButton.scss
@@ -18,6 +18,14 @@
             animation: mic-pulse 1.4s ease-in-out infinite;
         }
     }
+
+    // Blocked: a fatal error is outstanding (permission denied, no device, or
+    // the recognition service is unavailable). Muted, no pulse — signals the
+    // mic can't be used until the user resolves it (see the button tooltip).
+    &.mic-blocked .wave-iconbutton {
+        color: var(--error-color, var(--color-error, #e5484d));
+        opacity: 0.65;
+    }
 }
 
 @keyframes mic-pulse {

--- a/frontend/app/element/MicButton.tsx
+++ b/frontend/app/element/MicButton.tsx
@@ -24,6 +24,25 @@ export function MicButton(props: MicButtonProps): JSX.Element {
     // Active iff this pane owns the current voice session.
     const isActiveHere = () => voice.isListening() && voice.currentTargetId() === props.blockId;
 
+    // Blocked iff a fatal error is outstanding and nothing is currently
+    // listening — surfaces a muted "slash" mic so the user sees voice is
+    // unavailable (mic permission denied, no device, or the recognition
+    // service is unavailable) rather than a silently dead button. Cleared on
+    // the next successful start (useVoiceInput resets lastError).
+    const isBlocked = () => !voice.isListening() && voice.lastError() != null;
+    const blockedTitle = () => {
+        switch (voice.lastError()) {
+            case "not-allowed":
+                return "Microphone blocked — enable mic access in your OS privacy settings, then click again";
+            case "audio-capture":
+                return "No microphone detected";
+            case "service-not-allowed":
+                return "Voice transcription unavailable in this build";
+            default:
+                return "Voice input unavailable";
+        }
+    };
+
     const handleClick = () => {
         // Snapshot pre-click state — registerPane below will overwrite
         // currentTargetId, so we need to know whether THIS pane already
@@ -52,12 +71,17 @@ export function MicButton(props: MicButtonProps): JSX.Element {
 
     return (
         <Show when={voice.isAvailable() && voiceEnabled() !== false}>
-            <div class="mic-button-wrap" classList={{ "mic-active": isActiveHere() }}>
+            <div
+                class="mic-button-wrap"
+                classList={{ "mic-active": isActiveHere(), "mic-blocked": isBlocked() }}
+            >
                 <ToggleIconButton
                     decl={{
                         elemtype: "toggleiconbutton",
-                        icon: "regular@microphone",
-                        title: props.paneTitle ?? "Voice input (Ctrl+Shift+V)",
+                        icon: isBlocked() ? "regular@microphone-slash" : "regular@microphone",
+                        title: isBlocked()
+                            ? blockedTitle()
+                            : (props.paneTitle ?? "Voice input (Ctrl+Shift+V)"),
                         active: activeAtom,
                     }}
                 />

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -14,6 +14,11 @@ export interface VoiceSession {
      *  pane is targeted). Each pane's mic button reads this to determine
      *  whether *it* owns the active session — multi-pane safe. */
     currentTargetId: SignalAtom<string | null>;
+    /** Last fatal recognition error code (e.g. "not-allowed",
+     *  "audio-capture", "service-not-allowed"), or null when none / cleared.
+     *  Mic buttons read this to render a "blocked" affordance; cleared when a
+     *  session starts successfully. */
+    lastError: SignalAtom<string | null>;
     isAvailable: () => boolean;
     toggleListening: () => void;
     registerPane: (blockId: string, handle: PaneVoiceHandle) => void;
@@ -25,11 +30,13 @@ function createVoiceSession(): VoiceSession {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
     const isListening = createSignalAtom(false);
     const currentTargetId = createSignalAtom<string | null>(null);
+    const lastError = createSignalAtom<string | null>(null);
 
     if (!SR) {
         return {
             isListening,
             currentTargetId,
+            lastError,
             isAvailable: () => false,
             toggleListening: () => {},
             registerPane: () => {},
@@ -73,8 +80,16 @@ function createVoiceSession(): VoiceSession {
     };
 
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-        if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        // Fatal errors that should stop the session and surface guidance:
+        //   not-allowed         — mic permission denied (OS or CEF layer)
+        //   service-not-allowed — recognition service unavailable (the Web
+        //                         Speech backend doesn't work in CEF; #1591)
+        //   audio-capture       — no microphone device present
+        const FATAL = ["not-allowed", "service-not-allowed", "audio-capture"];
+        if (FATAL.includes(event.error)) {
             isListening._set(false);
+            currentTargetId._set(null);
+            lastError._set(event.error);
             window.dispatchEvent(new CustomEvent("voice-input-error", { detail: event.error }));
         }
         // "no-speech" and "aborted" are non-fatal; onend auto-restarts.
@@ -106,6 +121,9 @@ function createVoiceSession(): VoiceSession {
             try {
                 recognition.start();
                 isListening._set(true);
+                // A fresh start clears any prior blocked/error state so the
+                // mic button drops its "blocked" affordance on retry.
+                lastError._set(null);
             } catch {
                 // Race with onend auto-restart — ignore.
             }
@@ -115,6 +133,7 @@ function createVoiceSession(): VoiceSession {
     return {
         isListening,
         currentTargetId,
+        lastError,
         isAvailable: () => true,
         toggleListening,
         registerPane: (blockId, handle) => {


### PR DESCRIPTION
## Summary

Replaces the single generic **"Voice input unavailable"** toast with a stateful, actionable flow so the user knows *what's wrong* and *what to do*. Part of the voice-input permission work tracked in #1591; pairs with the CEF media-permission handler (#1602).

- **`useVoiceInput.ts`** — adds a `lastError` `SignalAtom`, set on fatal recognition errors (`not-allowed` / `service-not-allowed` / `audio-capture`) and cleared on the next successful start. Fatal errors also clear the pane target.
- **`MicButton.tsx` / `.scss`** — when blocked (error outstanding and not listening), the mic shows a muted **microphone-slash** icon (`mic-blocked`) with a cause-specific tooltip, instead of a silently dead button.
- **`app-init.ts`** — classifies the error into distinct, actionable toasts:
  - `not-allowed` → "Microphone access blocked — enable it in **{OS} ▸ Privacy ▸ Microphone}**, then click the mic again" (platform-aware path: Windows vs macOS).
  - `audio-capture` → "No microphone detected."
  - `service-not-allowed` → honest "Voice transcription unavailable in this build yet" (the Web Speech engine can't run in CEF — the real cause; server-side STT is #1591).

## Why

The old code showed one vague toast for every failure, leaving the user unsure whether to fix permissions, plug in a mic, or wait for a feature. See `SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md` §Phase 4.

## Scope

Frontend-only. The CEF `getUserMedia` grant (so `not-allowed` stops happening once OS permission is given) is **#1602**. The transcription engine itself (Whisper capture+send) is the larger **#1591**.

## Test plan

- [x] `task build:frontend` — clean.
- [ ] Deny mic at the OS level → mic shows blocked (slash) icon + toast names the OS settings path.
- [ ] No mic device → "No microphone detected".
- [ ] Retry after granting → `lastError` clears, blocked state drops.

## Notes
- Changeset: `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)