### PR TITLE
fix(agent): force re-login on "Login Again" instead of trusting the auth-status check (reauth P2.5)

### DIFF
--- a/.changesets/1781929749-fix-agent-force-re-login-on-login-again-instead-of-trusting--a6vg.md
+++ b/.changesets/1781929749-fix-agent-force-re-login-on-login-again-instead-of-trusting--a6vg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): force re-login on Login Again instead of trusting the auth-status check (reauth P2.5)

--- a/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
+++ b/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
@@ -260,3 +260,52 @@ one small PR.
 | Q2 | If the user completes auth in the system browser (fallback path), does poll detect it? | Yes — poll calls `CheckCliAuthCommand` which reads credentials on disk; it doesn't care which browser set them. |
 | Q3 | The OAuth pane splits the current tab — does it crowd the agent pane? | Acceptable: the split keeps both visible so the user can paste the code back. The pane can be closed/redocked normally after login. A future refinement could open it as an ephemeral/magnified pane that auto-closes on success. |
 | Q4 | Should the pane auto-close on auth success? | Not in this PR — the launch-flow doesn't track the created blockId. Tracked as a follow-up; closing it is a normal pane action meanwhile. |
+
+---
+
+## 11. The "Login Again does nothing" bug — force-login (P2.5)
+
+**Symptom (dogfood, v0.46.6):** agent 401s, user clicks **Login Again**, nothing
+happens. No browser opens, no error, no change.
+
+**Root cause (confirmed from live logs).** The click ran `startLaunchFlow()`,
+whose Phase 2 calls `CheckCliAuth`:
+
+```
+ResolveCli claude            ✓
+CheckCliAuth claude.cmd       ✓  → authenticated:true   ← FALSE POSITIVE
+needsLogin = false           → login skipped (no browser)
+ControllerResync force=false → no-op on the running persistent controller
+```
+
+`claude auth status` only confirms a credential is **present**, not **valid**.
+An expired/revoked token still reports `authenticated:true`, so the gated launch
+flow trusts it, skips login entirely, and the non-forced resync no-ops. The
+ground truth that auth is broken is the **401 itself** (which P1.3 already
+surfaces) — not the status check.
+
+**Fix.** The explicit "Login Again" actions must **force** a login, bypassing
+the status check, because the 401 already told us the token is bad:
+
+- New `forceProviderLogin()` (`flows/force-login.ts`): runs `runCliLogin`
+  unconditionally → `openOAuthBrowserPane` (§6′) → `setAuthUrl`. **Never** calls
+  `CheckCliAuth`.
+- It deliberately **omits the `CheckCliAuth` success-poll** the gated flow runs:
+  with a present-but-expired token that poll would "succeed" on the first tick
+  and reap the in-flight login CLI before the user finishes. Instead the running
+  persistent agent re-reads its credential per request, so the next message uses
+  the fresh token and clears the failure row.
+- `useAgentControllerStatus.relogin()` reads the CLI path + auth env from block
+  meta (`cmd` / `cmd:env`, written at launch) and calls the helper.
+- Both "Login Again" entry points (failure banner `onLoginAgain`, inline error
+  node `onAgentErrorLogin`) now call `relogin()` instead of `startLaunchFlow()`.
+- `/login` is refactored onto the same helper (DRY; also gains the in-app pane).
+
+`startLaunchFlow()` keeps trusting `CheckCliAuth` for **first launch**, where the
+check is reliable (genuinely no credential → it correctly returns false).
+
+**Immediate workaround (pre-fix):** typing `/login` in the agent already bypassed
+the gate (it called `runCliLogin` directly), so it was the manual unblock.
+
+**Follow-up:** force-restart / health-revalidate after login so even providers
+that cache the token in-process pick it up without a manual message resend.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -756,14 +756,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         },
         // P2 — real re-auth. An auth failure is a *CLI-provider* login lapse
         // (e.g. claude's subscription OAuth expired), not a Trust Center
-        // service account. `startLaunchFlow` is the canonical path that
-        // re-runs that login (surfacing the OAuth URL via the auth panel) and
-        // relaunches the agent; the relaunched process then reports
-        // `controllerstatus: running`, which clears this failure row. This is
-        // the same flow the legacy AgentRetryBar's button drives.
+        // service account. We must FORCE the login rather than re-run the gated
+        // launch flow: a 401 means the token is bad, but `CheckCliAuth` still
+        // reports it present (expired-but-present false positive), so the gated
+        // flow would trust the check, skip login, and do nothing — the exact bug
+        // this fixes. `relogin()` bypasses the check and always opens the OAuth
+        // (SPEC_REAUTH_FROM_AUTH_ERROR §11). The running persistent agent
+        // re-reads its credential per request, so the next message uses the new
+        // token and clears this failure row.
         onLoginAgain: () => {
-            log("auth", "Login Again — re-running the provider login flow");
-            void status.startLaunchFlow();
+            log("auth", "Login Again — forcing a fresh provider login");
+            void status.relogin();
         },
     });
 
@@ -1051,8 +1054,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
                 onAgentErrorLogin={() => {
-                    log("auth", "Login Again (inline error node) — re-running the provider login flow");
-                    void status.startLaunchFlow();
+                    log("auth", "Login Again (inline error node) — forcing a fresh provider login");
+                    void status.relogin();
                 }}
                 onLoadOlder={history.loadOlder}
                 loadingOlder={history.loadingOlder}

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -14,7 +14,7 @@
  * is the exception. See spec §4.4 dispatcher note.
  */
 
-import { getApi } from "@/app/store/global";
+import { forceProviderLogin } from "../../flows/force-login";
 import type { SlashCommand, SlashResult } from "../types";
 
 export const loginCommand: SlashCommand = {
@@ -38,14 +38,16 @@ export const loginCommand: SlashCommand = {
                     if (typeof v === "string") authEnv[k] = v;
                 }
             }
-            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv, prov.requiresLoginTty ?? false);
-            if (url) {
-                ctx.setAuthUrl(url);
-                ctx.log("auth", "OAuth URL captured — browser should open automatically");
-                ctx.log("auth", "if it didn't, copy the URL from the box above");
-            } else {
-                ctx.log("auth", "a browser window should have opened — complete login there");
-            }
+            // Shared with the failure-banner / inline-error "Login Again" action
+            // (useAgentControllerStatus.relogin) — opens the OAuth in an in-app
+            // browser pane and surfaces the URL box. See force-login.ts.
+            await forceProviderLogin({
+                provider: prov,
+                cliPath,
+                authEnv,
+                setAuthUrl: ctx.setAuthUrl,
+                log: ctx.log,
+            });
             ctx.log("auth", "run /cost to verify authentication once logged in");
             return { kind: "ok" };
         } catch (err: any) {

--- a/frontend/app/view/agent/flows/force-login.test.ts
+++ b/frontend/app/view/agent/flows/force-login.test.ts
@@ -1,0 +1,93 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for forceProviderLogin (SPEC_REAUTH_FROM_AUTH_ERROR §11).
+ *
+ * The whole point of this helper is that it NEVER consults CheckCliAuth — it
+ * unconditionally runs the provider login. These tests pin:
+ *   - runCliLogin is called with the provider's login command + auth env;
+ *   - a captured URL is pushed to setAuthUrl AND opened via openOAuthBrowserPane;
+ *   - a null URL surfaces a warning and does not call setAuthUrl;
+ *   - CheckCliAuth is never invoked (no auth-status gate).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    runCliLogin: vi.fn(),
+    checkCliAuth: vi.fn(),
+    openPane: vi.fn(),
+}));
+
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({ runCliLogin: hub.runCliLogin, checkCliAuth: hub.checkCliAuth }),
+}));
+vi.mock("./open-oauth-pane", () => ({ openOAuthBrowserPane: hub.openPane }));
+
+import { forceProviderLogin } from "./force-login";
+
+const URL = "https://claude.ai/oauth/authorize?client_id=abc";
+const provider = { authLoginCommand: ["auth", "login"], requiresLoginTty: true } as any;
+
+beforeEach(() => {
+    hub.runCliLogin.mockReset();
+    hub.checkCliAuth.mockReset();
+    hub.openPane.mockReset().mockResolvedValue("pane");
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("forceProviderLogin", () => {
+    it("runs runCliLogin with the login command + auth env, then opens the captured URL", async () => {
+        hub.runCliLogin.mockResolvedValue(URL);
+        const setAuthUrl = vi.fn();
+        const log = vi.fn();
+
+        await forceProviderLogin({
+            provider,
+            cliPath: "C:/cli/claude.cmd",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl,
+            log,
+        });
+
+        expect(hub.runCliLogin).toHaveBeenCalledWith(
+            "C:/cli/claude.cmd",
+            ["auth", "login"],
+            { CLAUDE_CONFIG_DIR: "C:/auth" },
+            true,
+        );
+        expect(setAuthUrl).toHaveBeenCalledWith(URL);
+        expect(hub.openPane).toHaveBeenCalledWith(URL);
+    });
+
+    it("NEVER consults the auth-status check (the whole point of forcing)", async () => {
+        hub.runCliLogin.mockResolvedValue(URL);
+        await forceProviderLogin({ provider, cliPath: "x", authEnv: {}, setAuthUrl: vi.fn(), log: vi.fn() });
+        expect(hub.checkCliAuth).not.toHaveBeenCalled();
+    });
+
+    it("warns and does not set an auth URL when no URL is captured", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        const setAuthUrl = vi.fn();
+        const log = vi.fn();
+
+        await forceProviderLogin({ provider, cliPath: "x", authEnv: {}, setAuthUrl, log });
+
+        expect(setAuthUrl).not.toHaveBeenCalled();
+        expect(hub.openPane).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/browser window should have opened/i), "warn");
+    });
+
+    it("still resolves (URL set) even when the pane falls back to the system browser", async () => {
+        hub.runCliLogin.mockResolvedValue(URL);
+        hub.openPane.mockResolvedValue("external");
+        const setAuthUrl = vi.fn();
+        const log = vi.fn();
+
+        await forceProviderLogin({ provider, cliPath: "x", authEnv: {}, setAuthUrl, log });
+
+        expect(setAuthUrl).toHaveBeenCalledWith(URL);
+        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/system browser/i));
+    });
+});

--- a/frontend/app/view/agent/flows/force-login.ts
+++ b/frontend/app/view/agent/flows/force-login.ts
@@ -1,0 +1,70 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * forceProviderLogin — run a provider OAuth login UNCONDITIONALLY, bypassing
+ * the `CheckCliAuth` status check.
+ *
+ * Why bypass the check: `claude auth status` (and equivalents) only confirm a
+ * credential is PRESENT, not that it's still VALID. An expired/revoked token
+ * still reports "authenticated", so the agent 401s on every real API call while
+ * the status check insists everything is fine (the false-positive that made
+ * "Login Again" do nothing — SPEC_REAUTH_FROM_AUTH_ERROR §11). When the user
+ * explicitly asks to re-login (the failure banner / inline-error "Login Again",
+ * or the `/login` command) we KNOW the token is bad, so we must force a fresh
+ * OAuth instead of trusting the check.
+ *
+ * Opens the OAuth in an in-app browser pane (with the system browser as a
+ * fallback) and surfaces the URL via `setAuthUrl` so the auth box appears above
+ * the composer with the URL + paste-the-code input. The running persistent
+ * agent re-reads its credential per request, so it picks up the fresh token on
+ * the next message — no controller restart required.
+ *
+ * Deliberately does NOT run the `CheckCliAuth` success-poll the gated launch
+ * flow uses: with a present-but-expired token the poll would "succeed" on the
+ * first tick and reap the in-flight login CLI before the user finishes.
+ */
+
+import { getApi } from "@/app/store/global";
+import { openOAuthBrowserPane } from "./open-oauth-pane";
+import type { ProviderDefinition } from "../providers";
+import type { LogFn } from "../types";
+
+export interface ForceLoginParams {
+    provider: Pick<ProviderDefinition, "authLoginCommand" | "requiresLoginTty">;
+    /** Resolved CLI path (from block meta `cmd`, set at launch). */
+    cliPath: string;
+    /** Auth env (e.g. CLAUDE_CONFIG_DIR) — from block meta `cmd:env`. */
+    authEnv: Record<string, string>;
+    setAuthUrl: (url: string | null) => void;
+    log: LogFn;
+}
+
+export async function forceProviderLogin(p: ForceLoginParams): Promise<void> {
+    const { provider, cliPath, authEnv, setAuthUrl, log } = p;
+    log("auth", "re-login: forcing a fresh OAuth (bypassing the auth-status check)…");
+
+    const url = await getApi().runCliLogin(
+        cliPath,
+        provider.authLoginCommand,
+        authEnv,
+        provider.requiresLoginTty ?? false,
+    );
+
+    if (url) {
+        setAuthUrl(url);
+        const opened = await openOAuthBrowserPane(url);
+        if (opened === "pane") {
+            log("auth", "opened login in an in-app browser pane — complete login there");
+        } else if (opened === "external") {
+            log("auth", "opened login in your system browser — complete login there");
+        } else {
+            log("auth", "could not open a browser; copy the URL from the box above and open it manually", "warn");
+        }
+        log("auth", "after you finish, just send your message again — the agent will use the new token");
+    } else {
+        // No URL captured (some providers don't print one); the CLI may have
+        // opened its own browser. Leave the user to complete it manually.
+        log("auth", "a browser window should have opened — complete login there", "warn");
+    }
+}

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -34,8 +34,9 @@
  */
 
 import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
-import { getApi } from "@/app/store/global";
+import { getApi, getBlockMetaKeyAtom } from "@/app/store/global";
 import { runLaunchFlow } from "../flows/launch-flow";
+import { forceProviderLogin } from "../flows/force-login";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -64,6 +65,15 @@ export interface UseAgentControllerStatus {
     isLoading: Accessor<boolean>;
     loginWaiting: Accessor<boolean>;
     startLaunchFlow: () => Promise<void>;
+    /**
+     * Force a provider re-login, bypassing the auth-status check. Wired to the
+     * failure-banner / inline-error "Login Again" actions: a 401 means the token
+     * is bad even though `CheckCliAuth` still reports it present, so re-running
+     * the gated launch flow would trust the lying check and skip the very login
+     * the user needs. This always opens the OAuth. See
+     * SPEC_REAUTH_FROM_AUTH_ERROR §11.
+     */
+    relogin: () => Promise<void>;
     cancelLogin: () => void;
 }
 
@@ -137,6 +147,46 @@ export function useAgentControllerStatus(
         }
     };
 
+    // Guard against double-firing while a re-login's runCliLogin RPC is in
+    // flight (the user double-clicks "Login Again"). Separate from flowRunning
+    // — relogin must work even when the gated flow believes it already finished.
+    let reloginInFlight = false;
+    const relogin = async () => {
+        if (reloginInFlight) return;
+        const prov = opts.provider();
+        if (!prov) {
+            opts.log("auth", "re-login: no active provider", "warn");
+            return;
+        }
+        // The CLI path + auth env are written to block meta at launch; reuse
+        // them instead of re-resolving (the agent is already running, so the
+        // CLI is installed). If `cmd` is missing the agent never launched —
+        // fall back to the full launch flow.
+        const cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
+        if (!cliPath) {
+            opts.log("auth", "re-login: CLI not resolved yet — running the full launch flow instead", "warn");
+            void startLaunchFlow();
+            return;
+        }
+        const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
+        const authEnv: Record<string, string> = {};
+        if (envMeta && typeof envMeta === "object") {
+            for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
+                if (typeof v === "string") authEnv[k] = v;
+            }
+        }
+        reloginInFlight = true;
+        setLoginWaiting(true);
+        try {
+            await forceProviderLogin({ provider: prov, cliPath, authEnv, setAuthUrl, log: opts.log });
+        } catch (err: any) {
+            opts.log("auth", `re-login failed: ${err?.message ?? String(err)}`, "error");
+        } finally {
+            reloginInFlight = false;
+            setLoginWaiting(false);
+        }
+    };
+
     const cancelLogin = () => {
         loginCancelled = true;
         getApi().cancelCliLogin().catch(() => {});
@@ -166,6 +216,7 @@ export function useAgentControllerStatus(
         isLoading,
         loginWaiting,
         startLaunchFlow,
+        relogin,
         cancelLogin,
     };
 }


### PR DESCRIPTION
## The bug

Dogfooding v0.46.6: an agent 401s, the user clicks **Login Again**, and **nothing happens** — no browser, no error, no change.

## Root cause (confirmed from live logs)

The click ran `startLaunchFlow()`, whose Phase 2 trusts `CheckCliAuth`:

```
ResolveCli claude            ✓
CheckCliAuth claude.cmd       ✓  → authenticated:true   ← FALSE POSITIVE
needsLogin = false           → login skipped (no browser opens)
ControllerResync force=false → no-op on the running persistent controller
```

`claude auth status` only confirms a credential is **present**, not **valid**. An expired/revoked token still reports `authenticated:true`, so the gated flow trusts it, skips login, and the non-forced resync no-ops. The **401 itself** is the ground truth that auth is broken (and P1.3 already surfaces it) — not the status check.

## Fix

The explicit "Login Again" actions now **force** a login, bypassing the check (the 401 already told us the token is bad):

- **New `forceProviderLogin()`** (`flows/force-login.ts`): runs `runCliLogin` unconditionally → `openOAuthBrowserPane` (in-app browser pane, #1594) → `setAuthUrl`. **Never** calls `CheckCliAuth`.
  - Deliberately **omits the status-check success-poll** the gated flow uses: with a present-but-expired token that poll would "succeed" on the first tick and reap the in-flight login CLI before the user finishes.
- **`useAgentControllerStatus.relogin()`** reads the CLI path + auth env from block meta (`cmd` / `cmd:env`, written at launch) and calls the helper.
- Both **"Login Again" entry points** (failure banner `onLoginAgain`, inline error node `onAgentErrorLogin`) call `relogin()` instead of `startLaunchFlow()`.
- **`/login` refactored** onto the same helper (DRY; also gains the in-app pane).

`startLaunchFlow()` keeps trusting `CheckCliAuth` for **first launch**, where it's reliable (genuinely no credential → correctly returns false). The running persistent agent re-reads its credential per request, so the next message uses the fresh token and clears the failure row.

## Verification

- Diagnosed live on a dev build (logs in spec §11); `/login` was the manual workaround (it already bypassed the gate).
- `tsc` clean, `task build:frontend` green.
- `force-login.test.ts` — 4 cases: runs `runCliLogin` with the right args + opens the URL; **never** calls the auth-status check; warns + no `setAuthUrl` on a null URL; resolves on system-browser fallback.

## Series

P1.1/P1.2 (#1589) · P1.3 (#1590) · P2.3 inline CTA (#1592) · P2.1 browser pane (#1594) · **P2.5 force-login (this PR)** · Spec: `SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md` §11

## Follow-up (noted in spec)

Force-restart / health-revalidate after login so providers that cache the token in-process pick it up without a manual message resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)