### PR TITLE
feat(sound): ambient waiting tone when agent is blocked for user input

### DIFF
--- a/.changesets/1781951352-feat-sound-ambient-waiting-tone-when-agent-is-blocked-for-us-mub0.md
+++ b/.changesets/1781951352-feat-sound-ambient-waiting-tone-when-agent-is-blocked-for-us-mub0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(sound): ambient waiting tone when agent is blocked for user input

--- a/docs/specs/SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md
+++ b/docs/specs/SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md
@@ -1,0 +1,310 @@
+# SPEC: Agent Waiting Ambient Sound
+**Status:** Proposal  
+**Date:** 2026-06-19  
+**Area:** Notifications / Sound / Agent Pane  
+
+---
+
+## 1. Problem
+
+When an agent asks the user a question and pauses to wait for an answer, there is no auditory signal. The user may be looking at another pane, another window, or a different app entirely. A one-shot notification chime (like `agent.turn.complete`) is insufficient here because the waiting state is *sustained* — the agent remains blocked until the user responds. A looping ambient tone gives the user a continuous but non-intrusive cue that their attention is needed.
+
+---
+
+## 2. Goal
+
+Play a soft, looping ambient melody while an agent pane is in the **Idle** state and the most recent turn ended with a question directed at the user. Stop it immediately when the user begins typing or submits a message. Respect all existing sound settings (master switch, volume, focus suppression).
+
+---
+
+## 3. Scope
+
+**In scope:**
+- New sound event: `agent.waiting.for.input`
+- New looping player mode in `SoundPlayer` / new `WaitingTonePlayer`
+- New `TurnPhase` guard: entering `Idle` after a turn where the agent asked a question
+- New settings keys: master toggle + volume for the waiting sound
+- Settings template entry with user-facing comment
+- Unit tests for trigger logic and player lifecycle
+
+**Out of scope:**
+- Detecting *which* question was asked (we don't parse transcript content)
+- Visual indicator changes (separate concern)
+- Mobile / non-Chromium platforms (CEF-only for now)
+- Asset-file version of the sound (v1 is synth-only, same as rest of sound system)
+
+---
+
+## 4. Trigger Definition
+
+The ambient loop starts when **all** of the following are true:
+
+| # | Condition | Source |
+|---|-----------|--------|
+| A | `turnPhase.kind === "Done"` | `AgentPaneState.turnPhase` |
+| B | `turnPhase.outcome === "completed"` | same |
+| C | The agent's last assistant message ends with a question (heuristic: last text block ends with `?`) | transcript tail |
+| D | The composer is enabled and empty (no pending messages) | `pending.length === 0` |
+| E | The pane has not received a new user submission since condition A became true | reset signal |
+| F | `notify:sounds:enabled !== false` | settings |
+| G | `notify:sound:agent.waiting.for.input !== false` | settings |
+| H | *(Optional suppression)* pane is not the focused pane while window is active, OR `notify:sounds:suppresswhenfocused === false` | same rule as existing events |
+
+The loop **stops** when any of the following occur:
+
+- User types in the composer (first `input` event / first keydown in composer textarea)
+- User submits a message (`TurnPhase` moves to `Submitting`)
+- Agent pane is closed or navigated away
+- The ambient loop setting is toggled off at runtime
+- 5 minutes elapse with no user interaction (safety cutoff — prevents infinite loop if user walks away)
+
+**Heuristic rationale for condition C:** Parsing the full transcript for semantic question detection is heavyweight. A trailing `?` on the last text block is a strong-enough proxy for v1. The worst cases (false negative: question without `?`; false positive: rhetorical `?` mid-sentence) are acceptable polish misses, not correctness bugs. This can be upgraded to a smarter detector later without changing the rest of the spec.
+
+---
+
+## 5. Sound Design
+
+### 5.1 Character
+
+- **Type:** Looping ambient tone — *not* a one-shot notification
+- **Feel:** Expectant, gentle, non-intrusive. Think soft marimba, music-box bells, or a slow pentatonic pad.
+- **Loop:** Seamlessly crossfaded so there is no audible click or gap at the loop boundary
+- **Duration per loop:** 4–8 seconds
+- **Volume:** Independent gain node, default **0.25** (lower than turn-complete at 0.6 — the loop runs longer so it should sit further back)
+- **Fade in:** 400 ms linear ramp to full gain on start
+- **Fade out:** 600 ms linear ramp to zero on stop (prevents click on abrupt cut)
+
+### 5.2 v1 Synthesis (synth fallback, no audio file)
+
+Use the Web Audio API oscillator chain, consistent with `tool-tones-player.ts`:
+
+```
+OscillatorNode (sine, ~523 Hz — C5)
+    → GainNode (envelope: 400ms attack, sustain, 600ms release)
+    → BiquadFilterNode (lowpass, cutoff ~1200 Hz, Q 0.7 — keeps it mellow)
+    → WaitingTonePlayer masterGain
+    → AudioContext.destination
+```
+
+Play a 3-note ascending arpeggio (C5 → E5 → G5) at ~1 note/sec, pause 1 sec, repeat. Each note: 300ms on, 200ms off. This is a recognizable "waiting" pattern without being jarring.
+
+### 5.3 Future Asset (post v1)
+
+A polished audio file (`.mp3`, gapless loop, ~6 sec) can be dropped into `public/sounds/agent-waiting.mp3`. The `SoundPlayer` registry already supports asset-path loading — add `assetPath: "sounds/agent-waiting.mp3"` to the registry entry and the synth fallback is automatically bypassed when the file loads.
+
+---
+
+## 6. Architecture
+
+### 6.1 New Files
+
+```
+frontend/app/notification/sound/
+├── waiting-tone-player.ts     ← new: looping oscillator chain
+└── __tests__/
+    └── waiting-tone-player.test.ts   ← new
+```
+
+### 6.2 Changed Files
+
+| File | Change |
+|------|--------|
+| `sound-events.ts` | Add `"agent.waiting.for.input"` to `SoundEventName` union |
+| `sounds.ts` | Add registry entry for `agent.waiting.for.input` |
+| `sound-service.ts` | Add `mapAgentPaneEvent` case for waiting trigger; manage loop lifecycle |
+| `sound-player.ts` | Add `playLooping(name)` / `stopLooping(name)` methods alongside existing one-shot `play()` |
+| `agent-pane-state/types.ts` | Add `lastTurnHadQuestion: boolean` field to `AgentPaneState` |
+| `agent-pane-state/reducer.ts` | Set `lastTurnHadQuestion` on `turn-ended` by inspecting transcript tail |
+| `agent-pane-state-store.ts` | Emit new `AgentPaneEvent` `"waiting-for-input"` / `"waiting-ended"` |
+| `frontend/types/gotypes.d.ts` | Add `"notify:sound:agent.waiting.for.input"` and `"notify:sounds:waiting:volume"` to `SettingsType` |
+| `settings-template.jsonc` | Add new keys with user-facing comments |
+
+### 6.3 New AgentPaneEvents
+
+```typescript
+// In agent-pane-state/types.ts — add to AgentPaneEvent union:
+| { type: "waiting-for-input"; blockId: string }
+| { type: "waiting-ended";    blockId: string; reason: "submitted" | "typing" | "timeout" | "closed" }
+```
+
+These events flow through the existing multicast extraListeners fan-out — the sound service picks them up exactly like existing events.
+
+### 6.4 WaitingTonePlayer
+
+```typescript
+// frontend/app/notification/sound/waiting-tone-player.ts
+
+export class WaitingTonePlayer {
+    private ctx: AudioContext;
+    private masterGain: GainNode;
+    private running = false;
+    private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(ctx: AudioContext) { ... }
+
+    /** Start the looping arpeggio. Idempotent if already playing. */
+    start(volume: number): void { ... }
+
+    /** Fade out and stop. Returns a Promise that resolves after the fade. */
+    stop(): Promise<void> { ... }
+
+    private scheduleArpeggio(): void { ... }   // Recursive Web Audio scheduling
+}
+```
+
+The player is **instantiated once** inside `sound-service.ts` alongside the existing `SoundPlayer` and `ToolTonesPlayer`, sharing the same `AudioContext`.
+
+### 6.5 Sound Service Changes
+
+```typescript
+// sound-service.ts — additions to mapAgentPaneEvent():
+
+case "waiting-for-input": {
+    if (!shouldPlayWaiting(blockId)) break;
+    const vol = getSettingsKeyAtom("notify:sounds:waiting:volume")() ?? 0.25;
+    waitingPlayer.start(vol);
+    // Auto-stop after 5 min
+    waitingStopTimeout = setTimeout(() => waitingPlayer.stop(), 5 * 60 * 1000);
+    break;
+}
+
+case "waiting-ended": {
+    clearTimeout(waitingStopTimeout);
+    waitingPlayer.stop();   // graceful fade-out
+    break;
+}
+```
+
+`shouldPlayWaiting(blockId)` reuses the existing `shouldPlay()` logic (master switch, per-event setting, focus suppression) — no new gating logic needed.
+
+### 6.6 Reducer Changes
+
+```typescript
+// agent-pane-state/reducer.ts — on turn-ended with outcome "completed":
+
+const lastTurnHadQuestion = detectsQuestion(state); 
+// detectsQuestion: reads last text content block from transcript,
+// returns true if it ends with "?"
+
+nextState = { ...nextState, lastTurnHadQuestion };
+```
+
+And in `agent-pane-state-store.ts` dispatch fan-out:
+
+```typescript
+// After reducer returns, before notifying extraListeners:
+if (
+    newState.turnPhase.kind === "Idle" &&
+    newState.lastTurnHadQuestion &&
+    newState.pending.length === 0
+) {
+    extraEvents.push({ type: "waiting-for-input", blockId });
+}
+
+// When transitioning OUT of Idle (Submitting or new turn):
+if (
+    prevState.turnPhase.kind === "Idle" &&
+    newState.turnPhase.kind !== "Idle" &&
+    prevState.lastTurnHadQuestion
+) {
+    extraEvents.push({ type: "waiting-ended", blockId, reason: "submitted" });
+}
+```
+
+The `"typing"` reason for `waiting-ended` is fired from the **composer component** directly (not the reducer), since keydown events are not in the state machine:
+
+```typescript
+// AgentComposerStrip.tsx — onInput handler:
+onInput={() => {
+    if (waitingActive()) {   // local signal set when waiting-for-input fires
+        dispatchSoundEvent({ type: "waiting-ended", blockId, reason: "typing" });
+    }
+    // ... existing input handling
+}}
+```
+
+---
+
+## 7. Settings
+
+### 7.1 New Keys
+
+```typescript
+// frontend/types/gotypes.d.ts — add to SettingsType:
+"notify:sound:agent.waiting.for.input"?: boolean;   // default: true
+"notify:sounds:waiting:volume"?: number;            // default: 0.25 (0–1)
+```
+
+### 7.2 Settings Template Entry
+
+```jsonc
+// settings-template.jsonc — add under notify:sound:* block:
+
+// Play a soft looping tone while an agent is waiting for your reply.
+// Set to false to disable, or adjust "notify:sounds:waiting:volume" (0–1, default 0.25).
+"notify:sound:agent.waiting.for.input": true,
+"notify:sounds:waiting:volume": 0.25,
+```
+
+---
+
+## 8. Edge Cases & Invariants
+
+| Case | Behavior |
+|------|----------|
+| Multiple panes simultaneously waiting | Each pane manages its own loop independently. Sound service tracks one `waitingPlayer` per blockId (Map). |
+| User switches focus to waiting pane | `suppresswhenfocused` kicks in: loop fades out while pane is focused, resumes (restart from top) when focus leaves — only if `notify:sounds:suppresswhenfocused === true`. |
+| Settings toggled off mid-loop | `sound-service` subscribes to the settings signal; on change to `false`, calls `waitingPlayer.stop()` for all active blockIds. |
+| Agent pane closed mid-loop | Pane teardown emits `"closed"` event → `waiting-ended` with reason `"closed"` → `waitingPlayer.stop()`. |
+| 5-minute safety cutoff fires | `waitingPlayer.stop()` called, loop does not restart unless a new `waiting-for-input` event is emitted. |
+| Question ends in `?"` or `?'` or `?)` | `detectsQuestion` should trim trailing punctuation/quotes before checking the final char. |
+| Last assistant block is a tool result, not text | `detectsQuestion` reads only `type === "text"` blocks — tool result blocks are skipped. |
+| AudioContext suspended (browser autoplay policy) | WaitingTonePlayer checks `ctx.state` and calls `ctx.resume()` before scheduling; same pattern as existing sound system. |
+| Loop already playing when new `waiting-for-input` fires (same pane) | `WaitingTonePlayer.start()` is idempotent — no-op if already running. |
+
+---
+
+## 9. Tests
+
+### 9.1 `waiting-tone-player.test.ts`
+- `start()` schedules oscillator nodes on AudioContext mock
+- `stop()` triggers gain ramp to 0 and resolves after fade
+- `start()` is idempotent (calling twice doesn't double-schedule)
+- 5-minute auto-stop fires `stop()` (fake timers)
+
+### 9.2 `sound-service.test.ts` additions
+- `waiting-for-input` event → `waitingPlayer.start()` called with correct volume
+- `waiting-ended` event → `waitingPlayer.stop()` called
+- Master `notify:sounds:enabled = false` → `waitingPlayer.start()` not called
+- `notify:sound:agent.waiting.for.input = false` → not called
+- Focus suppression: pane focused + `suppresswhenfocused = true` → not called
+
+### 9.3 `reducer.test.ts` additions
+- `turn-ended` with `outcome = "completed"` + last text block ends with `?` → `lastTurnHadQuestion = true`
+- `turn-ended` with last text block not ending with `?` → `lastTurnHadQuestion = false`
+- `turn-ended` with `outcome = "errored"` → `lastTurnHadQuestion = false` regardless
+
+---
+
+## 10. Implementation Order
+
+1. **`waiting-tone-player.ts`** — self-contained, no dependencies, testable in isolation
+2. **Settings keys** — `gotypes.d.ts` + `settings-template.jsonc`
+3. **`sound-events.ts` + `sounds.ts`** — add event name to registry
+4. **`agent-pane-state/types.ts`** — add `lastTurnHadQuestion`, new event types
+5. **`agent-pane-state/reducer.ts`** — `detectsQuestion` + set field on `turn-ended`
+6. **`agent-pane-state-store.ts`** — emit `waiting-for-input` / `waiting-ended` events
+7. **`sound-player.ts`** — `playLooping` / `stopLooping` stubs (or delegate fully to `WaitingTonePlayer`)
+8. **`sound-service.ts`** — wire new event cases + manage player lifecycle
+9. **`AgentComposerStrip.tsx`** — fire `waiting-ended` on first keydown
+10. **Tests** for each layer
+
+---
+
+## 11. Non-Goals (Explicit)
+
+- **Voice / speech synthesis** — out of scope; this is purely a tone.
+- **Per-agent sound customization** — all agents share the same waiting sound in v1.
+- **Transcript semantic parsing** — the `?` heuristic is intentionally dumb; NLP is a follow-up.
+- **Notification badge / visual** — orthogonal, tracked separately.
+- **Desktop OS notification** — the existing notification system covers that; this spec is in-app audio only.

--- a/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
+++ b/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
@@ -99,11 +99,14 @@ describe("waiting-sound-service: startWaiting gating", () => {
         expect(__getWaitingTones().has("blk-1")).toBe(false);
     });
 
-    it("focus suppression: does not start when pane is focused + window active", () => {
+    it("focus suppression: registers player but does not start when pane is focused + window active", () => {
         focusState.focusedBlockId = "blk-1";
         focusState.windowFocused = true;
         fireWaitingForInput("blk-1");
-        expect(__getWaitingTones().has("blk-1")).toBe(false);
+        // Player is registered so focus-leave effect can resume it (spec §8).
+        const wp = __getWaitingTones().get("blk-1");
+        expect(wp).toBeDefined();
+        expect(wp?.__isRunning()).toBe(false);
     });
 
     it("focus suppression: starts when window is blurred even if pane focused", () => {

--- a/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
+++ b/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
@@ -1,0 +1,222 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Policy tests for the waiting-ambient-sound subsystem:
+ *   • sound-service startWaiting / stopWaiting gating
+ *   • reducer endsWithQuestion heuristic (via lastTurnHadQuestion)
+ *
+ * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4, §6, §9.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Module mocks ─────────────────────────────────────────────────────
+
+const settings: Record<string, unknown> = {};
+const focusState = { focusedBlockId: null as string | null, windowFocused: true };
+
+vi.mock("@/app/store/global", () => ({
+    getSettingsKeyAtom: (key: string) => () => settings[key],
+}));
+vi.mock("@/app/store/focusManager", () => ({
+    focusManager: { get blockFocusAtom() { return () => focusState.focusedBlockId; } },
+}));
+vi.mock("@/app/window/window-focus", () => ({
+    makeWindowFocusSignal: () => () => focusState.windowFocused,
+}));
+vi.mock("solid-js", () => ({
+    createRoot: (fn: (d: () => void) => () => void) => fn(() => {}),
+    createEffect: () => {},
+}));
+
+let captured: ((blockId: string, event: { type: string; [k: string]: unknown }) => void) | null = null;
+vi.mock("@/app/store/agent-pane-state-store", () => ({
+    addEventListener: (l: typeof captured) => { captured = l; return () => { captured = null; }; },
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────
+
+import {
+    __getWaitingTones,
+    __resetSoundService,
+    installSoundService,
+} from "../sound-service";
+import { __resetSoundListeners } from "../sound-events";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function fireEvent(blockId: string, event: { type: string; [k: string]: unknown }): void {
+    if (!captured) throw new Error("multicast listener not installed");
+    captured(blockId, event);
+}
+
+function fireWaitingForInput(blockId: string): void {
+    fireEvent(blockId, { type: "waiting-for-input" });
+}
+
+function fireWaitingEnded(blockId: string, reason = "submitted"): void {
+    fireEvent(blockId, { type: "waiting-ended", reason });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("waiting-sound-service: startWaiting gating", () => {
+    let startSpy: ReturnType<typeof vi.spyOn> | null = null;
+    let cleanup: () => void;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        for (const k of Object.keys(settings)) delete settings[k];
+        focusState.focusedBlockId = null;
+        focusState.windowFocused = true;
+        __resetSoundService();
+        __resetSoundListeners();
+        captured = null;
+        cleanup = installSoundService();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        cleanup();
+        startSpy?.mockRestore();
+    });
+
+    it("starts a WaitingTonePlayer on waiting-for-input", () => {
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+    });
+
+    it("master notify:sounds:enabled=false suppresses the waiting tone", () => {
+        settings["notify:sounds:enabled"] = false;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("notify:sound:agent.waiting.for.input=false suppresses the waiting tone", () => {
+        settings["notify:sound:agent.waiting.for.input"] = false;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("focus suppression: does not start when pane is focused + window active", () => {
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = true;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("focus suppression: starts when window is blurred even if pane focused", () => {
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = false;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+    });
+
+    it("focus suppression: starts for a different pane (not the focused one)", () => {
+        focusState.focusedBlockId = "blk-OTHER";
+        focusState.windowFocused = true;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+    });
+
+    it("suppresswhenfocused=false disables focus suppression", () => {
+        settings["notify:sounds:suppresswhenfocused"] = false;
+        focusState.focusedBlockId = "blk-1";
+        focusState.windowFocused = true;
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+    });
+
+    it("stopWaiting removes the player from the map", () => {
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+        fireWaitingEnded("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("waiting-ended with reason=typing also removes the player", () => {
+        fireWaitingForInput("blk-1");
+        fireWaitingEnded("blk-1", "typing");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("waiting-ended with reason=closed also removes the player", () => {
+        fireWaitingForInput("blk-1");
+        fireWaitingEnded("blk-1", "closed");
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+
+    it("multiple panes each get independent players", () => {
+        fireWaitingForInput("blk-A");
+        fireWaitingForInput("blk-B");
+        expect(__getWaitingTones().has("blk-A")).toBe(true);
+        expect(__getWaitingTones().has("blk-B")).toBe(true);
+        fireWaitingEnded("blk-A");
+        expect(__getWaitingTones().has("blk-A")).toBe(false);
+        expect(__getWaitingTones().has("blk-B")).toBe(true);
+    });
+
+    it("5-minute auto-stop clears the player", () => {
+        fireWaitingForInput("blk-1");
+        expect(__getWaitingTones().has("blk-1")).toBe(true);
+        vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+        expect(__getWaitingTones().has("blk-1")).toBe(false);
+    });
+});
+
+// ─── Reducer endsWithQuestion heuristic ───────────────────────────────
+
+describe("endsWithQuestion heuristic (via reducer)", () => {
+    // We test endsWithQuestion indirectly by importing the reducer and
+    // checking the state it produces, so no mocks needed beyond imports.
+    let update: typeof import("@/app/store/agent-pane-state/reducer").update;
+    let initialState: typeof import("@/app/store/agent-pane-state/types").initialState;
+
+    beforeAll(async () => {
+        ({ update } = await import("@/app/store/agent-pane-state/reducer"));
+        ({ initialState } = await import("@/app/store/agent-pane-state/types"));
+    });
+
+    function completedTurn(lastAssistantText?: string) {
+        const state = initialState("agent-1");
+        // Fake a streaming state so TurnEnd is valid
+        const streaming = { ...state, turnPhase: { kind: "Streaming", bufferSize: 0, toolsActive: 0, lastEventMs: 0 } } as typeof state;
+        return update(streaming, { type: "TurnEnd", stats: null, lastAssistantText });
+    }
+
+    it("sets lastTurnHadQuestion=true when text ends with ?", () => {
+        expect(completedTurn("What would you like to do?").state.lastTurnHadQuestion).toBe(true);
+    });
+
+    it("sets lastTurnHadQuestion=false when text does not end with ?", () => {
+        expect(completedTurn("I've finished the task.").state.lastTurnHadQuestion).toBe(false);
+    });
+
+    it("sets lastTurnHadQuestion=false when lastAssistantText is absent", () => {
+        expect(completedTurn(undefined).state.lastTurnHadQuestion).toBe(false);
+    });
+
+    it("handles trailing quotes before the question mark", () => {
+        expect(completedTurn("Is this correct?\"").state.lastTurnHadQuestion).toBe(true);
+    });
+
+    it("handles trailing closing parens before the question mark", () => {
+        expect(completedTurn("Ready to proceed?)").state.lastTurnHadQuestion).toBe(true);
+    });
+
+    it("sets lastTurnHadQuestion=false for non-completed outcome even with ?", () => {
+        const state = initialState("agent-1");
+        const interrupting = { ...state, turnPhase: { kind: "Interrupting", reason: "user", sigintSentAt: 0 } } as typeof state;
+        const result = update(interrupting, { type: "TurnEnd", stats: null, lastAssistantText: "Do you want me to stop?" });
+        // outcome is "stopped" → flag should be false
+        expect(result.state.lastTurnHadQuestion).toBe(false);
+    });
+
+    it("TurnReset clears lastTurnHadQuestion", () => {
+        const withQuestion = completedTurn("Should I continue?").state;
+        expect(withQuestion.lastTurnHadQuestion).toBe(true);
+        const reset = update(withQuestion, { type: "TurnReset" });
+        expect(reset.state.lastTurnHadQuestion).toBe(false);
+    });
+});

--- a/frontend/app/notification/sound/__tests__/waiting-tone-player.test.ts
+++ b/frontend/app/notification/sound/__tests__/waiting-tone-player.test.ts
@@ -1,0 +1,137 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for WaitingTonePlayer — lifecycle, idempotency, and fade
+ * scheduling. The AudioContext is stubbed with a minimal fake so we can
+ * observe method calls without actual audio output.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WaitingTonePlayer } from "../waiting-tone-player";
+
+// ── Fake AudioContext ──────────────────────────────────────────────────
+
+function makeNode() {
+    const node = {
+        connect: vi.fn().mockReturnThis(),
+        disconnect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        gain: { value: 0, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+        frequency: { value: 0, setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+        type: "sine",
+    };
+    return node;
+}
+
+function makeFakeCtx(currentTime = 0): AudioContext {
+    return {
+        currentTime,
+        state: "running",
+        resume: vi.fn().mockResolvedValue(undefined),
+        createOscillator: vi.fn(() => makeNode()),
+        createGain: vi.fn(() => makeNode()),
+        createBiquadFilter: vi.fn(() => ({ ...makeNode(), type: "lowpass", Q: { value: 0 }, frequency: { value: 0 } })),
+        destination: {},
+    } as unknown as AudioContext;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("WaitingTonePlayer", () => {
+    let ctx: AudioContext;
+    let master: GainNode;
+    let player: WaitingTonePlayer;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        ctx = makeFakeCtx();
+        master = makeNode() as unknown as GainNode;
+        player = new WaitingTonePlayer();
+        player.attach(ctx, master);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("isAttached() returns true after attach()", () => {
+        expect(player.isAttached()).toBe(true);
+    });
+
+    it("isAttached() returns false before attach()", () => {
+        expect(new WaitingTonePlayer().isAttached()).toBe(false);
+    });
+
+    it("start() sets __isRunning() to true", () => {
+        player.start();
+        expect(player.__isRunning()).toBe(true);
+    });
+
+    it("start() is idempotent — calling twice does not double-schedule", () => {
+        player.start();
+        const oscCallsBefore = (ctx.createOscillator as ReturnType<typeof vi.fn>).mock.calls.length;
+        player.start(); // second call — should no-op
+        const oscCallsAfter = (ctx.createOscillator as ReturnType<typeof vi.fn>).mock.calls.length;
+        expect(oscCallsAfter).toBe(oscCallsBefore);
+    });
+
+    it("start() schedules oscillators for the arpeggio notes", () => {
+        player.start();
+        // 3 notes per cycle → 3 oscillators + 3 gain nodes scheduled on first cycle
+        expect(ctx.createOscillator).toHaveBeenCalledTimes(3);
+    });
+
+    it("stop() sets __isRunning() to false", async () => {
+        player.start();
+        const stopPromise = player.stop();
+        vi.runAllTimers();
+        await stopPromise;
+        expect(player.__isRunning()).toBe(false);
+    });
+
+    it("stop() schedules a gain fade-out", () => {
+        player.start();
+        player.stop();
+        // The gain node's linearRampToValueAtTime should be called for fade-out
+        // (called at least once during stop: ramp to 0.0001)
+        const gainNode = (ctx.createGain as ReturnType<typeof vi.fn>).mock.results[0].value;
+        expect(gainNode.gain.linearRampToValueAtTime).toHaveBeenCalled();
+    });
+
+    it("stop() when not running resolves immediately without error", async () => {
+        await expect(player.stop()).resolves.toBeUndefined();
+    });
+
+    it("5-minute auto-stop fires stop via timeout", () => {
+        const stopSpy = vi.spyOn(player, "stop");
+        player.start();
+        vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+        // The timeout fires via sound-service, not internally; just verify
+        // the loop re-schedules correctly (no crash) for 5+ minutes.
+        expect(player.__isRunning()).toBe(true); // internal loop doesn't self-stop
+        stopSpy.mockRestore();
+    });
+
+    it("schedules a new cycle after the loop pause", () => {
+        player.start();
+        const firstOscCount = (ctx.createOscillator as ReturnType<typeof vi.fn>).mock.calls.length;
+        // Advance past one full cycle (3 notes * 500ms + 1000ms pause = 2500ms)
+        vi.advanceTimersByTime(2500);
+        const secondOscCount = (ctx.createOscillator as ReturnType<typeof vi.fn>).mock.calls.length;
+        expect(secondOscCount).toBeGreaterThan(firstOscCount);
+    });
+
+    it("setVolume() updates gainValue without starting if not running", () => {
+        player.setVolume(0.5);
+        // gain.gain.value should not have been set (no ramp scheduled pre-start)
+        expect(player.__isRunning()).toBe(false);
+    });
+
+    it("no-op before attach", () => {
+        const bare = new WaitingTonePlayer();
+        expect(() => bare.start()).not.toThrow();
+        expect(bare.__isRunning()).toBe(false);
+    });
+});

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -108,6 +108,17 @@ export function installSoundService(): () => void {
             const v = typeof vol === "number" ? vol : 0.25;
             for (const wp of waitingTones.values()) wp.setVolume(v);
         });
+        // Spec §8: if the user focuses the waiting pane while the tone is
+        // looping, fade it out reactively (not just at tone-start time).
+        createEffect(() => {
+            const focusedId = focusManager.blockFocusAtom();
+            const winFocused = windowFocused();
+            const suppressRaw = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")();
+            const shouldSuppress = suppressRaw !== false;
+            if (shouldSuppress && winFocused && focusedId) {
+                stopWaiting(focusedId);
+            }
+        });
         return dispose;
     });
 

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -111,6 +111,20 @@ export function installSoundService(): () => void {
             const v = typeof vol === "number" ? vol : 0.25;
             for (const wp of waitingTones.values()) wp.setVolume(v);
         });
+        // Spec §8: kill all active waiting tones when the master switch or
+        // the per-event toggle is turned off mid-loop. Created BEFORE the
+        // focus-resume effect so it runs first in the same reactive batch —
+        // this prevents a disabled tone from being re-started by the resume
+        // path when settings change at the same moment focus leaves the pane.
+        createEffect(() => {
+            const masterEnabled = getSettingsKeyAtom("notify:sounds:enabled")();
+            const perEventEnabled = getSettingsKeyAtom("notify:sound:agent.waiting.for.input")();
+            if (masterEnabled === false || perEventEnabled === false) {
+                for (const blockId of [...waitingTones.keys()]) {
+                    stopWaiting(blockId);
+                }
+            }
+        });
         // Spec §8: reactively suspend the waiting tone when the source pane
         // gains focus, and resume it when focus moves elsewhere.
         // "Suspend" = fade out but keep the player in waitingTones so it can
@@ -222,14 +236,10 @@ function startWaiting(blockId: string): void {
     if (replayMode) return;
     if (getSettingsKeyAtom("notify:sounds:enabled")() === false) return;
     if (getSettingsKeyAtom("notify:sound:agent.waiting.for.input")() === false) return;
-    const suppressRaw = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")();
-    const suppressWhenFocused = suppressRaw !== false; // default true
-    if (
-        suppressWhenFocused &&
-        focusManager.blockFocusAtom() === blockId &&
-        windowFocusedSignal?.()
-    ) return;
 
+    // Always create and register the player, even if the pane is currently
+    // focused. This lets the reactive focus-resume effect restart the tone
+    // when focus moves away — spec §8 "resume on unfocus."
     let wp = waitingTones.get(blockId);
     if (!wp) {
         wp = new WaitingTonePlayer();
@@ -239,17 +249,30 @@ function startWaiting(blockId: string): void {
         waitingTones.set(blockId, wp);
     }
 
-    const vol =
-        (getSettingsKeyAtom("notify:sounds:waiting:volume")() as number | undefined) ?? 0.25;
-    wp.start(vol);
-
-    // 5-minute safety cutoff
+    // 5-minute safety cutoff (arm regardless of focus state).
     const existing = waitingTimeouts.get(blockId);
     if (existing !== undefined) clearTimeout(existing);
     waitingTimeouts.set(
         blockId,
         setTimeout(() => stopWaiting(blockId), WAITING_AUTO_STOP_MS),
     );
+
+    const suppressRaw = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")();
+    const suppressWhenFocused = suppressRaw !== false;
+    if (
+        suppressWhenFocused &&
+        focusManager.blockFocusAtom() === blockId &&
+        windowFocusedSignal?.()
+    ) {
+        // Pane is currently focused — mark as suspended so the reactive
+        // focus-leave effect can restart the tone when focus moves away.
+        suspendedByFocus.add(blockId);
+        return;
+    }
+
+    const vol =
+        (getSettingsKeyAtom("notify:sounds:waiting:volume")() as number | undefined) ?? 0.25;
+    wp.start(vol);
 }
 
 function stopWaiting(blockId: string): void {

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -40,6 +40,9 @@ const player = new SoundPlayer();
 const toolTones = new ToolTonesPlayer();
 const waitingTones = new Map<string, WaitingTonePlayer>(); // blockId → player
 const waitingTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+// blockIds whose tone is temporarily faded out because the pane is focused.
+// The player stays in waitingTones so it can be restarted when focus leaves.
+const suspendedByFocus = new Set<string>();
 const lastFiredAt = new Map<SoundId, number>();
 
 const WAITING_AUTO_STOP_MS = 5 * 60 * 1000;
@@ -108,15 +111,31 @@ export function installSoundService(): () => void {
             const v = typeof vol === "number" ? vol : 0.25;
             for (const wp of waitingTones.values()) wp.setVolume(v);
         });
-        // Spec §8: if the user focuses the waiting pane while the tone is
-        // looping, fade it out reactively (not just at tone-start time).
+        // Spec §8: reactively suspend the waiting tone when the source pane
+        // gains focus, and resume it when focus moves elsewhere.
+        // "Suspend" = fade out but keep the player in waitingTones so it can
+        // be restarted from the top when focus leaves.
         createEffect(() => {
             const focusedId = focusManager.blockFocusAtom();
             const winFocused = windowFocused();
             const suppressRaw = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")();
             const shouldSuppress = suppressRaw !== false;
-            if (shouldSuppress && winFocused && focusedId) {
-                stopWaiting(focusedId);
+            const vol = (getSettingsKeyAtom("notify:sounds:waiting:volume")() as number | undefined) ?? 0.25;
+
+            const toSuspend: string[] = [];
+            const toResume: string[] = [];
+            for (const blockId of waitingTones.keys()) {
+                const suppressed = shouldSuppress && winFocused && focusedId === blockId;
+                if (suppressed && !suspendedByFocus.has(blockId)) toSuspend.push(blockId);
+                else if (!suppressed && suspendedByFocus.has(blockId)) toResume.push(blockId);
+            }
+            for (const blockId of toSuspend) {
+                void waitingTones.get(blockId)!.stop();
+                suspendedByFocus.add(blockId);
+            }
+            for (const blockId of toResume) {
+                suspendedByFocus.delete(blockId);
+                waitingTones.get(blockId)?.start(vol);
             }
         });
         return dispose;
@@ -239,6 +258,7 @@ function stopWaiting(blockId: string): void {
         clearTimeout(t);
         waitingTimeouts.delete(blockId);
     }
+    suspendedByFocus.delete(blockId);
     const wp = waitingTones.get(blockId);
     if (wp) {
         void wp.stop();
@@ -313,6 +333,7 @@ export function __resetSoundService(): void {
     for (const t of waitingTimeouts.values()) clearTimeout(t);
     waitingTimeouts.clear();
     waitingTones.clear();
+    suspendedByFocus.clear();
 }
 
 export function __getWaitingTones(): Map<string, WaitingTonePlayer> {

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -219,7 +219,11 @@ function stopWaiting(blockId: string): void {
         clearTimeout(t);
         waitingTimeouts.delete(blockId);
     }
-    waitingTones.get(blockId)?.stop();
+    const wp = waitingTones.get(blockId);
+    if (wp) {
+        void wp.stop();
+        waitingTones.delete(blockId);
+    }
 }
 
 /**

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -35,6 +35,7 @@ import { WaitingTonePlayer } from "./waiting-tone-player";
 
 let installed = false;
 let replayMode = false;
+let windowFocusedSignal: (() => boolean) | null = null;
 const player = new SoundPlayer();
 const toolTones = new ToolTonesPlayer();
 const waitingTones = new Map<string, WaitingTonePlayer>(); // blockId → player
@@ -68,6 +69,7 @@ export function installSoundService(): () => void {
     installed = true;
 
     const windowFocused = makeWindowFocusSignal();
+    windowFocusedSignal = windowFocused;
 
     // Prime AudioContext on the first user gesture, exactly once.
     // After priming, hook the tool-tones chain into the same context +
@@ -190,6 +192,13 @@ function startWaiting(blockId: string): void {
     if (replayMode) return;
     if (getSettingsKeyAtom("notify:sounds:enabled")() === false) return;
     if (getSettingsKeyAtom("notify:sound:agent.waiting.for.input")() === false) return;
+    const suppressRaw = getSettingsKeyAtom("notify:sounds:suppresswhenfocused")();
+    const suppressWhenFocused = suppressRaw !== false; // default true
+    if (
+        suppressWhenFocused &&
+        focusManager.blockFocusAtom() === blockId &&
+        windowFocusedSignal?.()
+    ) return;
 
     let wp = waitingTones.get(blockId);
     if (!wp) {
@@ -287,6 +296,7 @@ function shouldPlay(ev: SoundEvent, windowFocused: () => boolean): boolean {
 export function __resetSoundService(): void {
     installed = false;
     replayMode = false;
+    windowFocusedSignal = null;
     lastFiredAt.clear();
     toolTones.__resetCoalesce();
     for (const t of waitingTimeouts.values()) clearTimeout(t);

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -31,12 +31,17 @@ import { notify, subscribeSoundEvents, type SoundEvent } from "./sound-events";
 import { SOUNDS, type SoundId } from "./sounds";
 import { SoundPlayer } from "./sound-player";
 import { ToolTonesPlayer } from "./tool-tones-player";
+import { WaitingTonePlayer } from "./waiting-tone-player";
 
 let installed = false;
 let replayMode = false;
 const player = new SoundPlayer();
 const toolTones = new ToolTonesPlayer();
+const waitingTones = new Map<string, WaitingTonePlayer>(); // blockId → player
+const waitingTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 const lastFiredAt = new Map<SoundId, number>();
+
+const WAITING_AUTO_STOP_MS = 5 * 60 * 1000;
 
 /**
  * Toggle replay mode. While true, the bus still receives events but
@@ -74,8 +79,12 @@ export function installSoundService(): () => void {
         await player.prime();
         const ctx = player.getAudioContext();
         const master = player.getMasterGain();
-        if (ctx && master && !toolTones.isAttached()) {
-            toolTones.attach(ctx, master);
+        if (ctx && master) {
+            if (!toolTones.isAttached()) toolTones.attach(ctx, master);
+            // Attach any waiting players that were created before prime.
+            for (const wp of waitingTones.values()) {
+                if (!wp.isAttached()) wp.attach(ctx, master);
+            }
         }
     };
     document.addEventListener("pointerdown", primeOnce, onceOpts);
@@ -91,6 +100,11 @@ export function installSoundService(): () => void {
         createEffect(() => {
             const vol = getSettingsKeyAtom("notify:tooltones:volume")();
             toolTones.setVolume(typeof vol === "number" ? vol : 0.15);
+        });
+        createEffect(() => {
+            const vol = getSettingsKeyAtom("notify:sounds:waiting:volume")();
+            const v = typeof vol === "number" ? vol : 0.25;
+            for (const wp of waitingTones.values()) wp.setVolume(v);
         });
         return dispose;
     });
@@ -163,7 +177,49 @@ function mapAgentPaneEvent(blockId: string, event: AgentPaneEvent): void {
                 notify("agent.message.rejected", { sourceBlockId: blockId });
             }
             return;
+        case "waiting-for-input":
+            startWaiting(blockId);
+            return;
+        case "waiting-ended":
+            stopWaiting(blockId);
+            return;
     }
+}
+
+function startWaiting(blockId: string): void {
+    if (replayMode) return;
+    if (getSettingsKeyAtom("notify:sounds:enabled")() === false) return;
+    if (getSettingsKeyAtom("notify:sound:agent.waiting.for.input")() === false) return;
+
+    let wp = waitingTones.get(blockId);
+    if (!wp) {
+        wp = new WaitingTonePlayer();
+        const ctx = player.getAudioContext();
+        const master = player.getMasterGain();
+        if (ctx && master) wp.attach(ctx, master);
+        waitingTones.set(blockId, wp);
+    }
+
+    const vol =
+        (getSettingsKeyAtom("notify:sounds:waiting:volume")() as number | undefined) ?? 0.25;
+    wp.start(vol);
+
+    // 5-minute safety cutoff
+    const existing = waitingTimeouts.get(blockId);
+    if (existing !== undefined) clearTimeout(existing);
+    waitingTimeouts.set(
+        blockId,
+        setTimeout(() => stopWaiting(blockId), WAITING_AUTO_STOP_MS),
+    );
+}
+
+function stopWaiting(blockId: string): void {
+    const t = waitingTimeouts.get(blockId);
+    if (t !== undefined) {
+        clearTimeout(t);
+        waitingTimeouts.delete(blockId);
+    }
+    waitingTones.get(blockId)?.stop();
 }
 
 /**
@@ -229,6 +285,13 @@ export function __resetSoundService(): void {
     replayMode = false;
     lastFiredAt.clear();
     toolTones.__resetCoalesce();
+    for (const t of waitingTimeouts.values()) clearTimeout(t);
+    waitingTimeouts.clear();
+    waitingTones.clear();
+}
+
+export function __getWaitingTones(): Map<string, WaitingTonePlayer> {
+    return waitingTones;
 }
 
 export function __getSoundPlayer(): SoundPlayer {

--- a/frontend/app/notification/sound/sounds.ts
+++ b/frontend/app/notification/sound/sounds.ts
@@ -25,7 +25,8 @@ export type SoundId =
     | "agent.turn.error"
     | "agent.turn.interrupted"
     | "agent.message.accepted"
-    | "agent.message.rejected";
+    | "agent.message.rejected"
+    | "agent.waiting.for.input";
 
 export type SoundCategory = "success" | "info" | "warning" | "error";
 
@@ -84,5 +85,13 @@ export const SOUNDS: Record<SoundId, SoundDef> = {
         category: "warning",
         settingKey: "notify:sound:agent.message.rejected",
         coalesceMs: 150,
+    },
+    "agent.waiting.for.input": {
+        id: "agent.waiting.for.input",
+        label: "Agent waiting for your reply",
+        category: "info",
+        settingKey: "notify:sound:agent.waiting.for.input",
+        // No coalesceMs — the waiting player is looping, not one-shot;
+        // the service manages start/stop directly, not via the bus.
     },
 };

--- a/frontend/app/notification/sound/waiting-tone-player.ts
+++ b/frontend/app/notification/sound/waiting-tone-player.ts
@@ -1,0 +1,163 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Waiting-tone player — looping C→E→G arpeggio that plays while an agent
+ * pane is blocked waiting for user input.
+ *
+ * Spec: docs/specs/SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §5–§6.
+ *
+ * Chain:
+ *   per-note OscillatorNode → per-note envelope (GainNode)
+ *     → BiquadFilter (lowpass ~1200 Hz — keeps it mellow)
+ *     → waiting gain (settings-bound, default 0.25)
+ *     → v1 master gain
+ *     → AudioContext.destination
+ *
+ * Lifecycle: `start()` is idempotent; `stop()` fades out over 600 ms and
+ * resolves when the fade is complete. The player does NOT self-dispose the
+ * AudioContext — the context is owned by SoundPlayer.
+ */
+
+/** C5 → E5 → G5 in Hz (major triad arpeggio). */
+const ARPEGGIO_HZ = [523.25, 659.25, 783.99] as const;
+/** Duration of each note (ms). */
+const NOTE_DURATION_MS = 300;
+/** Gap between notes (ms). */
+const NOTE_GAP_MS = 200;
+/** Pause after the full triad before looping (ms). */
+const LOOP_PAUSE_MS = 1000;
+/** Fade-in ramp (s). */
+const FADE_IN_S = 0.4;
+/** Fade-out ramp (s). */
+const FADE_OUT_S = 0.6;
+/** Peak oscillator gain inside one note, before chain gain. */
+const NOTE_PEAK = 0.35;
+
+export class WaitingTonePlayer {
+    private ctx: AudioContext | null = null;
+    private masterGain: GainNode | null = null;
+    private filter: BiquadFilterNode | null = null;
+    private gain: GainNode | null = null;
+    private gainValue = 0.25;
+    private running = false;
+    private scheduleHandle: ReturnType<typeof setTimeout> | null = null;
+    /** Wall-clock time (ms) when the current loop cycle started. Used for scheduling. */
+    private cycleStartMs = 0;
+
+    /**
+     * Wire the chain into the given AudioContext and master GainNode.
+     * Must be called before `start()`. Safe to call again if the context
+     * is rebuilt — tears down and rebuilds the chain.
+     */
+    attach(ctx: AudioContext, master: GainNode): void {
+        this.ctx = ctx;
+        this.masterGain = master;
+        const filter = ctx.createBiquadFilter();
+        filter.type = "lowpass";
+        filter.frequency.value = 1200;
+        filter.Q.value = 0.7;
+        const gain = ctx.createGain();
+        gain.gain.value = 0; // start silent; fade in on start()
+        gain.connect(filter).connect(master);
+        this.filter = filter;
+        this.gain = gain;
+    }
+
+    isAttached(): boolean {
+        return this.gain != null;
+    }
+
+    setVolume(value: number): void {
+        const clamped = Math.max(0, Math.min(1, value));
+        this.gainValue = clamped;
+        // Only apply immediately if we're mid-loop (running). Otherwise
+        // start() will apply it via the fade-in ramp.
+        if (this.running && this.gain) {
+            this.gain.gain.value = clamped;
+        }
+    }
+
+    /**
+     * Start the looping arpeggio. Idempotent — no-op if already running.
+     * Fades in over FADE_IN_S seconds.
+     */
+    start(volume?: number): void {
+        if (!this.ctx || !this.gain) return;
+        if (this.running) return;
+        if (volume !== undefined) this.gainValue = Math.max(0, Math.min(1, volume));
+        this.running = true;
+
+        const ctx = this.ctx;
+        if (ctx.state === "suspended") {
+            void ctx.resume().catch(() => { /* graceful degrade */ });
+        }
+
+        // Fade in
+        const gain = this.gain;
+        gain.gain.cancelScheduledValues(ctx.currentTime);
+        gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+        gain.gain.linearRampToValueAtTime(this.gainValue, ctx.currentTime + FADE_IN_S);
+
+        this.scheduleNextCycle();
+    }
+
+    /**
+     * Fade out and stop. Returns a Promise that resolves after the fade
+     * completes. Safe to call when already stopped.
+     */
+    stop(): Promise<void> {
+        if (!this.running) return Promise.resolve();
+        this.running = false;
+        if (this.scheduleHandle !== null) {
+            clearTimeout(this.scheduleHandle);
+            this.scheduleHandle = null;
+        }
+        if (!this.ctx || !this.gain) return Promise.resolve();
+        const gain = this.gain;
+        const ctx = this.ctx;
+        gain.gain.cancelScheduledValues(ctx.currentTime);
+        gain.gain.setValueAtTime(gain.gain.value, ctx.currentTime);
+        gain.gain.linearRampToValueAtTime(0.0001, ctx.currentTime + FADE_OUT_S);
+        return new Promise((resolve) => {
+            setTimeout(resolve, FADE_OUT_S * 1000 + 50);
+        });
+    }
+
+    /** Test/dev helper. */
+    __isRunning(): boolean {
+        return this.running;
+    }
+
+    private scheduleNextCycle(): void {
+        if (!this.running) return;
+        const ctx = this.ctx!;
+        const gain = this.gain!;
+        const stepSec = (NOTE_DURATION_MS + NOTE_GAP_MS) / 1000;
+        const noteSec = NOTE_DURATION_MS / 1000;
+        const startAt = ctx.currentTime;
+
+        for (let i = 0; i < ARPEGGIO_HZ.length; i++) {
+            const at = startAt + i * stepSec;
+            const osc = ctx.createOscillator();
+            const env = ctx.createGain();
+            osc.type = "sine";
+            osc.frequency.setValueAtTime(ARPEGGIO_HZ[i], at);
+            env.gain.setValueAtTime(0.0001, at);
+            env.gain.exponentialRampToValueAtTime(NOTE_PEAK, at + 0.02);
+            env.gain.exponentialRampToValueAtTime(0.0001, at + noteSec);
+            osc.connect(env).connect(gain);
+            osc.start(at);
+            osc.stop(at + noteSec + 0.02);
+        }
+
+        // Total cycle: 3 notes + gaps + pause before loop
+        const cycleDurationMs =
+            ARPEGGIO_HZ.length * (NOTE_DURATION_MS + NOTE_GAP_MS) + LOOP_PAUSE_MS;
+
+        this.scheduleHandle = setTimeout(() => {
+            this.scheduleHandle = null;
+            this.scheduleNextCycle();
+        }, cycleDurationMs);
+    }
+}

--- a/frontend/app/notification/sound/waiting-tone-player.ts
+++ b/frontend/app/notification/sound/waiting-tone-player.ts
@@ -42,8 +42,6 @@ export class WaitingTonePlayer {
     private gainValue = 0.25;
     private running = false;
     private scheduleHandle: ReturnType<typeof setTimeout> | null = null;
-    /** Wall-clock time (ms) when the current loop cycle started. Used for scheduling. */
-    private cycleStartMs = 0;
 
     /**
      * Wire the chain into the given AudioContext and master GainNode.

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -212,7 +212,36 @@ export function dispatch(
         );
     }
 
-    for (const ev of result.events) {
+    // Synthetic waiting-for-input / waiting-ended events injected after
+    // the reducer result events — not emitted by the pure reducer because
+    // they span two state snapshots (prev vs next).
+    const extraEvents: AgentPaneEvent[] = [];
+    const prevPhase = prev.turnPhase;
+    const nextPhase = slot.state.turnPhase;
+
+    // Entering waiting state: turn just completed with a question, no pending.
+    if (
+        nextPhase.kind === "Done" &&
+        nextPhase.outcome === "completed" &&
+        slot.state.lastTurnHadQuestion &&
+        slot.state.pending.length === 0 &&
+        !(prevPhase.kind === "Done" && prevPhase.outcome === "completed" && prev.lastTurnHadQuestion)
+    ) {
+        extraEvents.push({ type: "waiting-for-input" });
+    }
+
+    // Leaving waiting state: pane was waiting and a new turn started (submitted).
+    if (
+        prevPhase.kind === "Done" &&
+        prevPhase.outcome === "completed" &&
+        prev.lastTurnHadQuestion &&
+        nextPhase.kind === "Submitting"
+    ) {
+        extraEvents.push({ type: "waiting-ended", reason: "submitted" });
+    }
+
+    const allEvents = [...result.events, ...extraEvents];
+    for (const ev of allEvents) {
         eventSink(blockId, ev);
         for (const l of extraListeners) {
             try {
@@ -229,11 +258,11 @@ export function dispatch(
         slice: "agent-pane-state",
         key: blockId,
         command,
-        events: result.events,
+        events: allEvents,
         source,
         at: Date.now(),
     });
-    return result.events;
+    return allEvents;
 }
 
 /**

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -149,6 +149,21 @@ export function registerPane(
  * `unregisterPane` from `agent-pane-registration.ts`.
  */
 export function unregisterPane(blockId: string): void {
+    // If the pane was in a waiting-for-input state, notify listeners so the
+    // sound service can stop the looping tone before the slot is gone.
+    const slot = slots.get(blockId);
+    if (
+        slot &&
+        slot.state.turnPhase.kind === "Done" &&
+        slot.state.turnPhase.outcome === "completed" &&
+        slot.state.lastTurnHadQuestion
+    ) {
+        const ev: AgentPaneEvent = { type: "waiting-ended", reason: "closed" };
+        eventSink(blockId, ev);
+        for (const l of extraListeners) {
+            try { l(blockId, ev); } catch { /* isolate */ }
+        }
+    }
     slots.delete(blockId);
 }
 
@@ -230,7 +245,7 @@ export function dispatch(
         extraEvents.push({ type: "waiting-for-input" });
     }
 
-    // Leaving waiting state: pane was waiting and a new turn started (submitted).
+    // Leaving waiting state: user submitted a new message.
     if (
         prevPhase.kind === "Done" &&
         prevPhase.outcome === "completed" &&
@@ -238,6 +253,15 @@ export function dispatch(
         nextPhase.kind === "Submitting"
     ) {
         extraEvents.push({ type: "waiting-ended", reason: "submitted" });
+    }
+
+    // Leaving waiting state: user started typing (WaitingTypingStarted clears the flag).
+    if (
+        prev.lastTurnHadQuestion &&
+        !slot.state.lastTurnHadQuestion &&
+        nextPhase.kind !== "Submitting"
+    ) {
+        extraEvents.push({ type: "waiting-ended", reason: "typing" });
     }
 
     const allEvents = [...result.events, ...extraEvents];

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -256,10 +256,12 @@ export function dispatch(
     }
 
     // Leaving waiting state: user started typing (WaitingTypingStarted clears the flag).
+    // Guard to Done→Done ensures TurnReset (Done→Idle) isn't mislabeled as "typing".
     if (
         prev.lastTurnHadQuestion &&
         !slot.state.lastTurnHadQuestion &&
-        nextPhase.kind !== "Submitting"
+        prevPhase.kind === "Done" &&
+        nextPhase.kind === "Done"
     ) {
         extraEvents.push({ type: "waiting-ended", reason: "typing" });
     }

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -388,12 +388,19 @@ export function update(
             const finishedAt = phase.kind === "Done"
                 ? phase.finishedAt
                 : nowMs;
+            const lastTurnHadQuestion =
+                outcome === "completed" && command.lastAssistantText != null
+                    ? endsWithQuestion(command.lastAssistantText)
+                    : outcome === "completed"
+                        ? state.lastTurnHadQuestion
+                        : false;
             return {
                 state: {
                     ...state,
                     sessionStats: merged,
                     currentTool: null,
                     turnTokens: null,
+                    lastTurnHadQuestion,
                     turnPhase: {
                         kind: "Done",
                         outcome,
@@ -419,6 +426,7 @@ export function update(
                     currentTool: null,
                     turnTokens: null,
                     lastContextTokens: 0,
+                    lastTurnHadQuestion: false,
                     // TurnReset is a wholesale clear → Idle. The
                     // working/stopping cascade lives entirely on
                     // turnPhase since PR G.
@@ -859,6 +867,17 @@ function bumpEvent(
  * usage (hence `||`, not `??`). Codex emits usage only on the stats
  * branch (no live tokens), so it's unaffected.
  */
+/**
+ * Returns true if the assistant's last message text ended with a question.
+ * Trims trailing whitespace and common closing punctuation (`"`, `'`, `)`)
+ * before checking the final character.
+ * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4 (heuristic C).
+ */
+function endsWithQuestion(text: string): boolean {
+    const trimmed = text.trimEnd().replace(/["')]+$/, "").trimEnd();
+    return trimmed.endsWith("?");
+}
+
 function mergeStats(
     stats: AgentPaneState["sessionStats"],
     tokens: AgentPaneState["turnTokens"],

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -388,12 +388,14 @@ export function update(
             const finishedAt = phase.kind === "Done"
                 ? phase.finishedAt
                 : nowMs;
+            // When outcome is completed and text is supplied, run the heuristic.
+            // When text is absent (tool-only or empty final block), conservatively
+            // treat it as no question — do NOT carry the prior value forward.
+            // Non-completed outcomes always clear the flag.
             const lastTurnHadQuestion =
                 outcome === "completed" && command.lastAssistantText != null
                     ? endsWithQuestion(command.lastAssistantText)
-                    : outcome === "completed"
-                        ? state.lastTurnHadQuestion
-                        : false;
+                    : false;
             return {
                 state: {
                     ...state,
@@ -790,6 +792,18 @@ export function update(
                 events: [],
             };
         }
+        case "WaitingTypingStarted": {
+            // No-op if not in the waiting state (idempotent, safe to fire
+            // on every keystroke since the store uses dispatchIfRegistered).
+            if (!state.lastTurnHadQuestion) {
+                return { state, events: [] };
+            }
+            return {
+                state: { ...state, lastTurnHadQuestion: false },
+                events: [],
+            };
+        }
+
         case "LogEntryArrived": {
             // No-op when the panel is open (user already sees the
             // entry). Increments the unread counter when closed so

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -392,8 +392,11 @@ export function update(
             // When text is absent (tool-only or empty final block), conservatively
             // treat it as no question — do NOT carry the prior value forward.
             // Non-completed outcomes always clear the flag.
-            const lastTurnHadQuestion =
-                outcome === "completed" && command.lastAssistantText != null
+            // First-done-wins: a late/duplicate TurnEnd (phase already Done)
+            // must not overwrite the flag — the initial TurnEnd was authoritative.
+            const lastTurnHadQuestion = phase.kind === "Done"
+                ? state.lastTurnHadQuestion
+                : outcome === "completed" && command.lastAssistantText != null
                     ? endsWithQuestion(command.lastAssistantText)
                     : false;
             return {

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -642,7 +642,7 @@ export type AgentPaneEvent =
      * Emitted when the waiting state ends — user submitted or started
      * typing, pane closed, or the 5-minute safety cutoff fired.
      */
-    | { type: "waiting-ended"; reason: "submitted" | "typing" | "timeout" | "closed" };
+    | { type: "waiting-ended"; reason: "submitted" | "typing" | "closed" };
 
 export interface ReducerResult {
     state: AgentPaneState;

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -509,7 +509,14 @@ export type AgentPaneCommand =
      * the strip's chevron badge updates. When the panel is already
      * open, no-op (the user sees the new entry directly).
      */
-    | { type: "LogEntryArrived" };
+    | { type: "LogEntryArrived" }
+    /**
+     * User started typing in the composer while the pane was in the
+     * waiting-for-input state. Clears `lastTurnHadQuestion` so the
+     * store can emit `waiting-ended` with reason `"typing"`.
+     * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §6.6.
+     */
+    | { type: "WaitingTypingStarted" };
 
 export type AgentPaneEvent =
     | { type: "init-ready" }

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -404,8 +404,9 @@ export type AgentPaneCommand =
           /**
            * The trimmed text of the last assistant message block, if the
            * caller can supply it cheaply. Used to set `lastTurnHadQuestion`
-           * via the trailing-`?` heuristic. Optional — absence leaves
-           * `lastTurnHadQuestion` unchanged from the prior turn.
+           * via the trailing-`?` heuristic. Optional — absence conservatively
+           * clears `lastTurnHadQuestion` (treated as no question) so a
+           * tool-only or empty final block never re-triggers the waiting tone.
            * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4.
            */
           lastAssistantText?: string;

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -251,6 +251,13 @@ export interface AgentPaneState {
     /** Resolved model id that produced `lastContextWindow` — used to re-seed the
      *  window when the user switches models mid-session (`/model`). */
     lastContextModel: string | null;
+    /**
+     * True iff the most recently completed turn ended with the agent asking
+     * a question (heuristic: last text block's trimmed content ends with `?`).
+     * Drives the waiting-ambient-sound trigger.
+     * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4.
+     */
+    lastTurnHadQuestion: boolean;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -267,6 +274,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     turnPhase: { kind: "Idle" },
     detailsOpen: false,
     composerUnreadCount: 0,
+    lastTurnHadQuestion: false,
 });
 
 /**
@@ -390,7 +398,18 @@ export type AgentPaneCommand =
      * turnTokens, and transitions the phase to Done (interrupting →
      * Done.stopped, otherwise Done.completed).
      */
-    | { type: "TurnEnd"; stats: SessionStats | null }
+    | {
+          type: "TurnEnd";
+          stats: SessionStats | null;
+          /**
+           * The trimmed text of the last assistant message block, if the
+           * caller can supply it cheaply. Used to set `lastTurnHadQuestion`
+           * via the trailing-`?` heuristic. Optional — absence leaves
+           * `lastTurnHadQuestion` unchanged from the prior turn.
+           * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4.
+           */
+          lastAssistantText?: string;
+      }
     /**
      * Truncate path: the doc was reset (or whatever caused the local
      * stream-restart). Clears all per-turn state but does NOT touch
@@ -603,7 +622,19 @@ export type AgentPaneEvent =
           queuedAt: number;
           ageMs: number;
           wasPresent: boolean;
-      };
+      }
+    /**
+     * Emitted when the pane enters the waiting-for-input state: turn
+     * completed with a question, composer empty. The sound service
+     * starts the looping ambient tone on this event.
+     * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §6.3.
+     */
+    | { type: "waiting-for-input" }
+    /**
+     * Emitted when the waiting state ends — user submitted or started
+     * typing, pane closed, or the 5-minute safety cutoff fired.
+     */
+    | { type: "waiting-ended"; reason: "submitted" | "typing" | "timeout" | "closed" };
 
 export interface ReducerResult {
     state: AgentPaneState;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1285,7 +1285,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 <AgentFooter
                     agentName={agentName()}
                     onSendMessage={handleSendMessage}
-                    onTyping={() => scrollToBottomFn?.()}
+                    onTyping={() => {
+                        scrollToBottomFn?.();
+                        // Stop the waiting-ambient tone on first keystroke.
+                        dispatchPaneIfRegistered(model.blockId, {
+                            type: "WaitingTypingStarted",
+                        });
+                    }}
                     onStopAgent={commands.stopAgent}
                     onRecallLatestQueued={commands.recallLatestHeld}
                     getCompletions={commands.completions}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1287,10 +1287,21 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onSendMessage={handleSendMessage}
                     onTyping={() => {
                         scrollToBottomFn?.();
-                        // Stop the waiting-ambient tone on first keystroke.
-                        dispatchPaneIfRegistered(model.blockId, {
-                            type: "WaitingTypingStarted",
-                        });
+                        // Guard: only dispatch while a waiting tone is active.
+                        // WaitingTypingStarted is gated on lastTurnHadQuestion in
+                        // the reducer, but dispatching on every RAF-debounced frame
+                        // would still flood recordDispatch with no-op records.
+                        const s = paneSnapshot(model.blockId);
+                        if (
+                            s != null &&
+                            s.lastTurnHadQuestion &&
+                            s.turnPhase.kind === "Done" &&
+                            s.turnPhase.outcome === "completed"
+                        ) {
+                            dispatchPaneIfRegistered(model.blockId, {
+                                type: "WaitingTypingStarted",
+                            });
+                        }
                     }}
                     onStopAgent={commands.stopAgent}
                     onRecallLatestQueued={commands.recallLatestHeld}

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -424,7 +424,23 @@ export function useAgentStream({
             // in one shot: merges live tokens into stats, clears
             // tool/tokens, and transitions the phase to Done.
             const wasStopping = getTurnPhase().kind === "Interrupting";
-            model.dispatchPane({ type: "TurnEnd", stats });
+            // Extract last assistant text for the waiting-sound heuristic.
+            // We scan backward through the current document nodes for the
+            // last markdown/text node with non-empty content.
+            const lastAssistantText = (() => {
+                const nodes = documentAtom[0]();
+                for (let i = nodes.length - 1; i >= 0; i--) {
+                    const n = nodes[i];
+                    if (
+                        n.type === "markdown" &&
+                        typeof n.content === "string"
+                    ) {
+                        return n.content;
+                    }
+                }
+                return undefined;
+            })();
+            model.dispatchPane({ type: "TurnEnd", stats, lastAssistantText });
             if (wasStopping) {
                 const interruptedNode: DocumentNode = {
                     type: "markdown",

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1406,6 +1406,8 @@ declare global {
         "notify:sound:agent.turn.interrupted"?: boolean;
         "notify:sound:agent.message.accepted"?: boolean;
         "notify:sound:agent.message.rejected"?: boolean;
+        "notify:sound:agent.waiting.for.input"?: boolean;
+        "notify:sounds:waiting:volume"?: number;
         "notify:tooltones:enabled"?: boolean;
         "notify:tooltones:volume"?: number;
         "notify:tooltones:scope"?: "all" | "focused";

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -67,6 +67,9 @@
     // "notify:sound:agent.turn.interrupted":    true,
     // "notify:sound:agent.message.accepted":    true,
     // "notify:sound:agent.message.rejected":    true,
+    // Play a soft looping tone while an agent is waiting for your reply.
+    // "notify:sound:agent.waiting.for.input":   true,
+    // "notify:sounds:waiting:volume":           0.25,  // 0–1, independent of master volume
 
     // -- Tool-call tones (subliminal per-tool "voice") --
     // "notify:tooltones:enabled":               true,

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -69,7 +69,7 @@
     // "notify:sound:agent.message.rejected":    true,
     // Play a soft looping tone while an agent is waiting for your reply.
     // "notify:sound:agent.waiting.for.input":   true,
-    // "notify:sounds:waiting:volume":           0.25,  // 0–1, independent of master volume
+    // "notify:sounds:waiting:volume":           0.25,  // 0–1, scaled by notify:sounds:volume
 
     // -- Tool-call tones (subliminal per-tool "voice") --
     // "notify:tooltones:enabled":               true,


### PR DESCRIPTION
## Summary

- Plays a soft, looping C→E→G major-triad arpeggio (via Web Audio oscillators) while an agent pane is waiting for the user to reply after asking a question
- Stops immediately on the first keypress or message submit; 5-minute safety auto-stop if the user walks away
- Fully settings-controlled: `notify:sound:agent.waiting.for.input` (toggle) + `notify:sounds:waiting:volume` (default 0.25, independent of master volume)

## What changed

| File | Change |
|------|--------|
| `frontend/app/notification/sound/waiting-tone-player.ts` | **New** — looping Web Audio arpeggio player with fade-in/out |
| `frontend/app/notification/sound/sound-service.ts` | Wire `WaitingTonePlayer`, handle `waiting-for-input` / `waiting-ended` events, reactive volume setting |
| `frontend/app/notification/sound/sounds.ts` | Add `agent.waiting.for.input` to `SoundId` union + registry |
| `frontend/app/store/agent-pane-state/types.ts` | Add `lastTurnHadQuestion: boolean` to state, `lastAssistantText?` to `TurnEnd` command, two new `AgentPaneEvent` variants |
| `frontend/app/store/agent-pane-state/reducer.ts` | Set `lastTurnHadQuestion` on `TurnEnd` via `endsWithQuestion()` heuristic; clear on `TurnReset` |
| `frontend/app/store/agent-pane-state-store.ts` | Emit synthetic `waiting-for-input` / `waiting-ended` events after reducer runs |
| `frontend/app/view/agent/useAgentStream.ts` | Extract last markdown node text and pass as `lastAssistantText` to `TurnEnd` |
| `frontend/types/gotypes.d.ts` | Two new settings keys |
| `settings-template.jsonc` | User-facing commented entries for the new settings |
| `docs/specs/SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md` | Full spec |

## Test plan

- [ ] Ask an agent a question that ends with `?` — waiting tone starts after agent replies
- [ ] Start typing in the composer — tone stops immediately
- [ ] Submit a message — tone stops
- [ ] Set `"notify:sound:agent.waiting.for.input": false` in settings.json — tone does not play
- [ ] Set `"notify:sounds:enabled": false` — tone does not play
- [ ] `"notify:sounds:waiting:volume": 0.5` — tone plays at higher volume
- [ ] Agent replies without a `?` — tone does not play
- [ ] Multiple agent panes simultaneously asking questions — each has an independent loop
- [ ] 5-minute idle — tone auto-stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)