### PR TITLE
feat(trust-center): global brain tab

### DIFF
--- a/.changesets/1781952129-feat-trust-center-global-brain-tab-ordered-workspace-section-vbm0.md
+++ b/.changesets/1781952129-feat-trust-center-global-brain-tab-ordered-workspace-section-vbm0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): global brain tab — ordered workspace sections injected into every agent's CLAUDE.md

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -253,7 +253,7 @@ fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<usize, 
         .as_millis() as i64;
 
     let mut created = 0usize;
-    for mem_def in &manifest.memories {
+    for (idx, mem_def) in manifest.memories.iter().enumerate() {
         if existing_ids.contains(&mem_def.id) {
             continue;
         }
@@ -269,6 +269,9 @@ fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<usize, 
             context_files: "[]".to_string(),
             mcp_servers: "[]".to_string(),
             skills: "[]".to_string(),
+            // Seed initial global-brain order by manifest position so seeded
+            // sections start in a deterministic order; users reorder later.
+            sort_order: idx as i64,
             created_at: now,
             updated_at: now,
         };

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -274,6 +274,9 @@ pub const COMMAND_LIST_MEMORIES: &str = "listmemories";
 pub const COMMAND_GET_MEMORY: &str = "getmemory";
 pub const COMMAND_UPSERT_MEMORY: &str = "upsertmemory";
 pub const COMMAND_DELETE_MEMORY: &str = "deletememory";
+/// v9 — set the global-brain section order. `ids` is the full ordered list
+/// of global bundle ids; each row's `sort_order` becomes its index.
+pub const COMMAND_REORDER_GLOBAL_BRAIN: &str = "reorderglobalbrain";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";
@@ -1868,6 +1871,13 @@ pub struct CommandGetMemoryData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandDeleteMemoryData {
     pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandReorderGlobalBrainData {
+    /// Full ordered list of global bundle ids. Each id's `sort_order`
+    /// becomes its position in this list.
+    pub ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/agentmux-srv/src/backend/storage/memory_bundles.rs
+++ b/agentmux-srv/src/backend/storage/memory_bundles.rs
@@ -50,6 +50,13 @@ pub struct Memory {
     /// JSON-encoded array of skill IDs.
     #[serde(default = "default_json_array_string")]
     pub skills: String,
+    /// Explicit ordering within the Trust Center global brain. Lower sorts
+    /// first; this is the order sections inject into CLAUDE.md at launch.
+    /// Only meaningful for `is_global` bundles; 0 for the rest. Owned by the
+    /// `reorderglobalbrain` RPC — `bundle_memory_upsert` never overwrites it
+    /// on conflict, so editing a bundle via the regular form keeps its place.
+    #[serde(default)]
+    pub sort_order: i64,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -58,12 +65,27 @@ fn default_json_array_string() -> String {
     "[]".to_string()
 }
 
+/// Format global brain bundles into the block injected into an agent's
+/// CLAUDE.md. Each non-empty section gets a `# [Workspace] <name>` heading so
+/// Claude can tell injected workspace rules apart from the agent's own config;
+/// sections are separated by a `---` rule. Bundles arrive already ordered by
+/// `bundle_memory_list_global` (sort_order). Returns an empty string when no
+/// section has instructions.
+pub fn format_global_brain_block(bundles: &[Memory]) -> String {
+    bundles
+        .iter()
+        .filter(|b| !b.instructions.trim().is_empty())
+        .map(|b| format!("# [Workspace] {}\n\n{}", b.name, b.instructions))
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n")
+}
+
 impl Store {
     pub fn bundle_memory_list(&self) -> Result<Vec<Memory>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
-                    context_files, mcp_servers, skills, created_at, updated_at
+                    context_files, mcp_servers, skills, sort_order, created_at, updated_at
              FROM db_memory_bundles
              ORDER BY is_blank ASC, is_global DESC, updated_at DESC",
         )?;
@@ -75,16 +97,18 @@ impl Store {
         Ok(out)
     }
 
-    /// Returns only the global bundles (`is_global = 1`), ordered by name.
-    /// Called at agent launch to inject workspace-wide rules into every agent.
+    /// Returns only the global bundles (`is_global = 1`), in explicit
+    /// `sort_order` (then name as a stable tiebreak). Called at agent launch
+    /// to inject workspace-wide rules into every agent in the order the user
+    /// arranged them in the Trust Center Brain tab.
     pub fn bundle_memory_list_global(&self) -> Result<Vec<Memory>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
-                    context_files, mcp_servers, skills, created_at, updated_at
+                    context_files, mcp_servers, skills, sort_order, created_at, updated_at
              FROM db_memory_bundles
              WHERE is_global = 1
-             ORDER BY name ASC",
+             ORDER BY sort_order ASC, name ASC",
         )?;
         let iter = stmt.query_map([], map_memory_row)?;
         let mut out = Vec::new();
@@ -98,7 +122,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
-                    context_files, mcp_servers, skills, created_at, updated_at
+                    context_files, mcp_servers, skills, sort_order, created_at, updated_at
              FROM db_memory_bundles WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], map_memory_row);
@@ -112,10 +136,14 @@ impl Store {
     pub fn bundle_memory_upsert(&self, memory: &Memory) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
+            // sort_order is deliberately NOT in the ON CONFLICT update set:
+            // it is owned by `bundle_memory_reorder`, so editing a bundle
+            // through the regular Memory form never disturbs its position in
+            // the global brain.
             "INSERT INTO db_memory_bundles
                 (id, name, description, is_blank, is_global, provider, model, instructions,
-                 context_files, mcp_servers, skills, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                 context_files, mcp_servers, skills, sort_order, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -139,6 +167,7 @@ impl Store {
                 memory.context_files,
                 memory.mcp_servers,
                 memory.skills,
+                memory.sort_order,
                 memory.created_at,
                 memory.updated_at,
             ],
@@ -165,6 +194,27 @@ impl Store {
         let rows = conn.execute("DELETE FROM db_memory_bundles WHERE id = ?1", params![id])?;
         Ok(rows > 0)
     }
+
+    /// Assign `sort_order` to the given bundle ids in the order supplied
+    /// (position 0, 1, 2, …). Drives the Trust Center global brain ordering,
+    /// which in turn controls CLAUDE.md injection order. Ids not present in
+    /// the table are skipped silently (a concurrently-deleted section is not
+    /// an error). Runs in a single transaction so a partial reorder never
+    /// lands. Returns the number of rows updated.
+    pub fn bundle_memory_reorder(&self, ordered_ids: &[String]) -> Result<usize, StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut updated = 0usize;
+        {
+            let mut stmt =
+                tx.prepare("UPDATE db_memory_bundles SET sort_order = ?1 WHERE id = ?2")?;
+            for (idx, id) in ordered_ids.iter().enumerate() {
+                updated += stmt.execute(params![idx as i64, id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(updated)
+    }
 }
 
 fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
@@ -180,7 +230,8 @@ fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         context_files: row.get(8)?,
         mcp_servers: row.get(9)?,
         skills: row.get(10)?,
-        created_at: row.get(11)?,
-        updated_at: row.get(12)?,
+        sort_order: row.get(11)?,
+        created_at: row.get(12)?,
+        updated_at: row.get(13)?,
     })
 }

--- a/agentmux-srv/src/backend/storage/memory_bundles.rs
+++ b/agentmux-srv/src/backend/storage/memory_bundles.rs
@@ -57,7 +57,13 @@ pub struct Memory {
     /// on conflict, so editing a bundle via the regular form keeps its place.
     #[serde(default)]
     pub sort_order: i64,
+    // created_at / updated_at are server-owned: the upsert handler stamps
+    // created_at = now when 0 and always overwrites updated_at with now. They
+    // default on input so partial upserts (e.g. a "new section" that only
+    // sends id/name/instructions) deserialize cleanly. (reagent P0 on #1608)
+    #[serde(default)]
     pub created_at: i64,
+    #[serde(default)]
     pub updated_at: i64,
 }
 

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -41,7 +41,10 @@ use super::error::StoreError;
 ///        Cognito PKCE tokens (access, refresh, id) + expiry + user email
 ///   v8 — db_memory_bundles.is_global: global-tier flag for Trust Center
 ///        bundles injected into every agent's CLAUDE.md at launch
-pub const OBJECT_SCHEMA_VERSION: i64 = 8;
+///   v9 — db_memory_bundles.sort_order: explicit ordering for the Trust
+///        Center global brain (controls CLAUDE.md injection order). Existing
+///        rows default to 0; the Brain tab assigns positions via reorder.
+pub const OBJECT_SCHEMA_VERSION: i64 = 9;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -249,6 +252,7 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             context_files TEXT NOT NULL DEFAULT '[]',
             mcp_servers   TEXT NOT NULL DEFAULT '[]',
             skills        TEXT NOT NULL DEFAULT '[]',
+            sort_order    INTEGER NOT NULL DEFAULT 0,
             created_at    INTEGER NOT NULL DEFAULT 0,
             updated_at    INTEGER NOT NULL DEFAULT 0
         );
@@ -446,6 +450,7 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         "ALTER TABLE db_agents ADD COLUMN container_volumes TEXT NOT NULL DEFAULT '[]'",
         "ALTER TABLE db_agents ADD COLUMN container_name TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE db_memory_bundles ADD COLUMN is_global INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_memory_bundles ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -27,5 +27,5 @@ pub use error::StoreError;
 #[allow(unused_imports)]
 pub use history::AgentHistory;
 pub use identities::{AgentIdentityLink, Identity, IdentityAccount, IdentityBinding, SecretRef};
-pub use memory_bundles::Memory;
+pub use memory_bundles::{format_global_brain_block, Memory};
 pub use skills::AgentSkill;

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -1506,6 +1506,7 @@ mod tests {
             context_files: "[]".to_string(),
             mcp_servers: "[]".to_string(),
             skills: "[]".to_string(),
+            sort_order: 0,
             created_at: 100,
             updated_at: 100,
         };
@@ -1526,6 +1527,63 @@ mod tests {
         // Delete the user memory.
         assert!(store.bundle_memory_delete("mem-coder").unwrap());
         assert_eq!(store.bundle_memory_list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_global_brain_order_and_format() {
+        let store = make_store();
+
+        let mk = |id: &str, name: &str, order: i64| Memory {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: true,
+            provider: String::new(),
+            model: String::new(),
+            instructions: format!("rules for {name}"),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: order,
+            created_at: 0,
+            updated_at: 0,
+        };
+        // Insert out of order: B at 0, A at 1.
+        store.bundle_memory_upsert(&mk("g-a", "Alpha", 1)).unwrap();
+        store.bundle_memory_upsert(&mk("g-b", "Beta", 0)).unwrap();
+
+        // list_global orders by sort_order: Beta (0) then Alpha (1).
+        let g = store.bundle_memory_list_global().unwrap();
+        assert_eq!(
+            g.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["g-b", "g-a"]
+        );
+
+        // Reorder to [Alpha, Beta].
+        let updated = store
+            .bundle_memory_reorder(&["g-a".to_string(), "g-b".to_string()])
+            .unwrap();
+        assert_eq!(updated, 2);
+        let g = store.bundle_memory_list_global().unwrap();
+        assert_eq!(
+            g.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["g-a", "g-b"]
+        );
+
+        // Editing a bundle via upsert must NOT disturb its sort_order.
+        let mut edited = g[0].clone();
+        edited.instructions = "edited".to_string();
+        edited.sort_order = 999; // upsert ON CONFLICT ignores this
+        store.bundle_memory_upsert(&edited).unwrap();
+        let g = store.bundle_memory_list_global().unwrap();
+        assert_eq!(g[0].id, "g-a", "edit must keep position");
+        assert_eq!(g[0].sort_order, 0, "sort_order owned by reorder, not upsert");
+
+        // The injection block carries [Workspace] headings in order.
+        let block = super::super::format_global_brain_block(&g);
+        let expected = "# [Workspace] Alpha\n\nedited\n\n---\n\n# [Workspace] Beta\n\nrules for Beta";
+        assert_eq!(block, expected);
     }
 
     // ---- Registry parallel-write mirror (PR A) ----

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -76,11 +76,11 @@ use crate::backend::rpc_types::{
     COMMAND_BIND_IDENTITY_ACCOUNT, COMMAND_UNBIND_IDENTITY_ACCOUNT,
     COMMAND_LIST_IDENTITY_BINDINGS,
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
-    COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY,
+    COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
     CommandGetIdentityBundleData, CommandDeleteIdentityBundleData,
     CommandBindIdentityAccountData, CommandUnbindIdentityAccountData,
     CommandListIdentityBindingsData,
-    CommandGetMemoryData, CommandDeleteMemoryData,
+    CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::{AgentDefinition, AgentContent, AgentSkill};
 use crate::backend::storage::store::{
@@ -2972,6 +2972,31 @@ fn register_v7_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_REORDER_GLOBAL_BRAIN,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandReorderGlobalBrainData = serde_json::from_value(data)
+                    .map_err(|e| format!("reorderglobalbrain: {e}"))?;
+                let updated = wstore
+                    .bundle_memory_reorder(&cmd.ids)
+                    .map_err(|e| format!("reorderglobalbrain: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(json!({ "updated": updated })))
+            })
+        }),
+    );
 }
 
 pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -3736,6 +3761,7 @@ mod recent_sessions_tests {
             context_files: "[]".to_string(),
             mcp_servers: "[]".to_string(),
             skills: "[]".to_string(),
+            sort_order: 0,
             created_at: 0,
             updated_at: 0,
         };

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2324,24 +2324,20 @@ fn write_agent_config_files(
         }
     }
 
-    // Inject global memory bundles (Trust Center tier 1) into CLAUDE.md.
-    // All agents get these regardless of per-agent memory selection.
+    // Inject global memory bundles (Trust Center global brain) into CLAUDE.md.
+    // All agents get these regardless of per-agent memory selection. Each
+    // section carries a `# [Workspace] <name>` heading (see
+    // format_global_brain_block) so the rules are attributable to the
+    // workspace and ordered per the Brain tab's sort_order.
     let global_bundles = wstore.bundle_memory_list_global().unwrap_or_default();
-    if !global_bundles.is_empty() {
-        let mut global_parts: Vec<String> = Vec::new();
-        for bundle in &global_bundles {
-            if !bundle.instructions.is_empty() {
-                global_parts.push(bundle.instructions.clone());
-            }
-        }
-        if !global_parts.is_empty() {
-            content_map
-                .entry("memory".to_string())
-                .and_modify(|existing| {
-                    *existing = format!("{}\n\n---\n\n{}", global_parts.join("\n\n---\n\n"), existing);
-                })
-                .or_insert_with(|| global_parts.join("\n\n---\n\n"));
-        }
+    let global_block = crate::backend::storage::format_global_brain_block(&global_bundles);
+    if !global_block.is_empty() {
+        content_map
+            .entry("memory".to_string())
+            .and_modify(|existing| {
+                *existing = format!("{global_block}\n\n---\n\n{existing}");
+            })
+            .or_insert(global_block);
     }
 
     let config_files = crate::backend::agent_config::build_config_files(

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -82,15 +82,10 @@ fn list_drives() -> Vec<serde_json::Value> {
 /// one is inserted before `# Available Skills` (or at the end of the file).
 fn inject_global_bundles(claude_md: &str, wstore: &Arc<Store>) -> String {
     let bundles = wstore.bundle_memory_list_global().unwrap_or_default();
-    let parts: Vec<String> = bundles
-        .into_iter()
-        .filter(|b| !b.instructions.is_empty())
-        .map(|b| b.instructions)
-        .collect();
-    if parts.is_empty() {
+    let bundle_block = crate::backend::storage::format_global_brain_block(&bundles);
+    if bundle_block.is_empty() {
         return claude_md.to_string();
     }
-    let bundle_block = parts.join("\n\n---\n\n");
 
     // Inject after the `# Memory\n` heading if it exists.
     if let Some(pos) = claude_md.find("\n# Memory\n") {

--- a/docs/specs/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md
+++ b/docs/specs/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md
@@ -1,7 +1,7 @@
 # Trust Center — Global Brain
 
 **Date:** 2026-06-19  
-**Status:** Draft  
+**Status:** Implemented (2026-06-20) — Option A (sort_order column); Brain tab added alongside the existing Accounts / Identities / Memories rail.  
 **Relates to:** `SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md`, `SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md`
 
 ---

--- a/frontend/app/modals/bundle-manager-modal.tsx
+++ b/frontend/app/modals/bundle-manager-modal.tsx
@@ -49,6 +49,7 @@ import {
 import { IdentityManager } from "@/app/view/identity/identity-manager";
 import { MemoryManager } from "@/app/view/memory/memory-manager";
 import { AccountsManager } from "@/app/view/accounts/accounts-manager";
+import { GlobalBrainManager } from "@/app/view/brain/global-brain-manager";
 import "./bundle-manager-modal.scss";
 
 /**
@@ -58,7 +59,7 @@ import "./bundle-manager-modal.scss";
 export const SINGLETON_KIND_BUNDLE_MANAGER: SingletonKind = "bundle-manager";
 
 /** Which section the left rail currently shows. */
-type BundleSection = "accounts" | "identities" | "memories";
+type BundleSection = "accounts" | "identities" | "brain" | "memories";
 
 /**
  * Resolve a window *label* to its human display name ("Window N", the
@@ -93,10 +94,14 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
 
     const handleClose = () => props.close();
 
+    // "Brain" (global brain — the brain icon) is distinct from "Memories"
+    // (the full bundle library, now layer-group) so the brain icon means one
+    // thing only. See SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.
     const rail: { id: BundleSection; label: string; icon: string }[] = [
         { id: "accounts", label: "Accounts", icon: "key" },
         { id: "identities", label: "Identities", icon: "id-card" },
-        { id: "memories", label: "Memories", icon: "brain" },
+        { id: "brain", label: "Brain", icon: "brain" },
+        { id: "memories", label: "Memories", icon: "layer-group" },
     ];
 
     return (
@@ -144,6 +149,12 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
                         classList={{ "is-hidden": section() !== "identities" }}
                     >
                         <IdentityManager />
+                    </div>
+                    <div
+                        class="bundle-manager-pane"
+                        classList={{ "is-hidden": section() !== "brain" }}
+                    >
+                        <GlobalBrainManager />
                     </div>
                     <div
                         class="bundle-manager-pane"

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -917,6 +917,16 @@ class RpcApiType {
         return client.rpcCall("deletememory", data, opts);
     }
 
+    // command "reorderglobalbrain" [call] — set global-brain section order.
+    // `ids` is the full ordered list of global bundle ids.
+    ReorderGlobalBrainCommand(
+        client: RpcClient,
+        data: { ids: string[] },
+        opts?: RpcOpts,
+    ): Promise<{ updated: number }> {
+        return client.rpcCall("reorderglobalbrain", data, opts);
+    }
+
     // ── Pre-launch OAuth (spec: SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md)
 
     // command "auth.start"

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -88,12 +88,6 @@ export const GlobalBrainManager = (): JSX.Element => {
             </Show>
 
             <div class="global-brain-sections">
-                <Show when={model.editingIdAtom() === NEW_SECTION_ID}>
-                    <div class="global-brain-section is-editing">
-                        <SectionEditor model={model} isNew={true} />
-                    </div>
-                </Show>
-
                 <For each={model.sectionsAtom()}>
                     {(section, i) => (
                         <div
@@ -153,6 +147,14 @@ export const GlobalBrainManager = (): JSX.Element => {
                         </div>
                     )}
                 </For>
+
+                {/* New-section draft renders at the END — saveEdit appends it
+                    to the order, so its draft position matches where it lands. */}
+                <Show when={model.editingIdAtom() === NEW_SECTION_ID}>
+                    <div class="global-brain-section is-editing">
+                        <SectionEditor model={model} isNew={true} />
+                    </div>
+                </Show>
 
                 <Show when={model.sectionsAtom().length === 0 && model.editingIdAtom() === null}>
                     <div class="global-brain-empty">

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -1,0 +1,203 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// GlobalBrainManager — the Trust Center "Brain" tab. Presents the
+// workspace-wide global brain (is_global Memory bundles) as an ordered list
+// of editable sections that compose into every agent's CLAUDE.md at launch.
+//
+// Context-free: owns its own GlobalBrainViewModel and drives off the
+// bundle_* RPCs. Spec: SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.
+
+import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { GlobalBrainViewModel, NEW_SECTION_ID } from "./global-brain-model";
+import "./global-brain.scss";
+
+/** Inline editor card shared by the "new section" and "edit section" flows. */
+function SectionEditor(props: { model: GlobalBrainViewModel; isNew: boolean }): JSX.Element {
+    const { model } = props;
+    return (
+        <div class="global-brain-editor">
+            <label class="global-brain-field">
+                <span class="global-brain-field-label">Name</span>
+                <input
+                    class="global-brain-input"
+                    type="text"
+                    value={model.draftNameAtom()}
+                    onInput={(e) => model.setDraftName(e.currentTarget.value)}
+                    placeholder="e.g. Coding Standards"
+                />
+            </label>
+            <label class="global-brain-field">
+                <span class="global-brain-field-label">Content</span>
+                <textarea
+                    class="global-brain-textarea"
+                    rows={8}
+                    value={model.draftInstructionsAtom()}
+                    onInput={(e) => model.setDraftInstructions(e.currentTarget.value)}
+                    placeholder="Markdown injected into every agent's CLAUDE.md under a # [Workspace] heading."
+                    spellcheck={false}
+                />
+            </label>
+            <div class="global-brain-editor-actions">
+                <button
+                    class="global-brain-btn"
+                    disabled={model.savingAtom()}
+                    onClick={() => model.cancelEdit()}
+                >
+                    Cancel
+                </button>
+                <button
+                    class="global-brain-btn global-brain-btn-primary"
+                    disabled={model.savingAtom() || !model.draftNameAtom().trim()}
+                    onClick={() => void model.saveEdit()}
+                >
+                    {model.savingAtom() ? "Saving…" : props.isNew ? "Add section" : "Save"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export const GlobalBrainManager = (): JSX.Element => {
+    const model = new GlobalBrainViewModel();
+    onCleanup(() => model.dispose());
+
+    const [promoteValue, setPromoteValue] = createSignal("");
+
+    const handlePromote = (id: string) => {
+        if (!id) return;
+        void model.promote(id);
+        setPromoteValue("");
+    };
+
+    return (
+        <div class="global-brain">
+            <p class="global-brain-intro">
+                Every agent inherits these sections at launch. They compose into the
+                agent's <code>CLAUDE.md</code> in order, each under a{" "}
+                <code># [Workspace]</code> heading.
+            </p>
+
+            <div class="global-brain-restart-note">
+                Changes take effect when agents restart. Running agents keep the version
+                from their last launch.
+            </div>
+
+            <Show when={model.errorAtom()}>
+                <div class="global-brain-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div class="global-brain-sections">
+                <Show when={model.editingIdAtom() === NEW_SECTION_ID}>
+                    <div class="global-brain-section is-editing">
+                        <SectionEditor model={model} isNew={true} />
+                    </div>
+                </Show>
+
+                <For each={model.sectionsAtom()}>
+                    {(section, i) => (
+                        <div
+                            class="global-brain-section"
+                            classList={{ "is-editing": model.editingIdAtom() === section.id }}
+                        >
+                            <Show
+                                when={model.editingIdAtom() === section.id}
+                                fallback={
+                                    <div class="global-brain-section-row">
+                                        <div class="global-brain-section-main">
+                                            <span class="global-brain-section-name">
+                                                {section.name}
+                                            </span>
+                                            <Show when={section.description}>
+                                                <span class="global-brain-section-desc">
+                                                    {section.description}
+                                                </span>
+                                            </Show>
+                                        </div>
+                                        <div class="global-brain-section-actions">
+                                            <button
+                                                class="global-brain-icon-btn"
+                                                title="Move up"
+                                                disabled={i() === 0}
+                                                onClick={() => void model.move(section.id, -1)}
+                                            >
+                                                ↑
+                                            </button>
+                                            <button
+                                                class="global-brain-icon-btn"
+                                                title="Move down"
+                                                disabled={i() === model.sectionsAtom().length - 1}
+                                                onClick={() => void model.move(section.id, 1)}
+                                            >
+                                                ↓
+                                            </button>
+                                            <button
+                                                class="global-brain-btn"
+                                                onClick={() => model.startEdit(section)}
+                                            >
+                                                Edit
+                                            </button>
+                                            <button
+                                                class="global-brain-btn global-brain-btn-danger"
+                                                title="Remove from the global brain (keeps the bundle)"
+                                                onClick={() => void model.remove(section.id)}
+                                            >
+                                                Remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            >
+                                <SectionEditor model={model} isNew={false} />
+                            </Show>
+                        </div>
+                    )}
+                </For>
+
+                <Show when={model.sectionsAtom().length === 0 && model.editingIdAtom() === null}>
+                    <div class="global-brain-empty">
+                        No global sections yet. Add one to give every agent shared context.
+                    </div>
+                </Show>
+            </div>
+
+            <div class="global-brain-add-bar">
+                <button
+                    class="global-brain-btn global-brain-btn-primary"
+                    disabled={model.editingIdAtom() === NEW_SECTION_ID}
+                    onClick={() => model.startNew()}
+                >
+                    + New section
+                </button>
+                <Show when={model.candidatesAtom().length > 0}>
+                    <select
+                        class="global-brain-promote-select"
+                        value={promoteValue()}
+                        onChange={(e) => handlePromote(e.currentTarget.value)}
+                    >
+                        <option value="">Promote existing bundle…</option>
+                        <For each={model.candidatesAtom()}>
+                            {(c) => <option value={c.id}>{c.name}</option>}
+                        </For>
+                    </select>
+                </Show>
+            </div>
+
+            <div class="global-brain-preview">
+                <button
+                    class="global-brain-preview-toggle"
+                    onClick={() => model.setShowPreview(!model.showPreviewAtom())}
+                >
+                    {model.showPreviewAtom() ? "▾" : "▸"} Combined CLAUDE.md preview
+                </button>
+                <Show when={model.showPreviewAtom()}>
+                    <pre class="global-brain-preview-content">
+                        {model.previewAtom() || "(no content — sections have no instructions yet)"}
+                    </pre>
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+GlobalBrainManager.displayName = "GlobalBrainManager";

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -106,7 +106,8 @@ export class GlobalBrainViewModel {
         this.setDraftInstructions(section.instructions ?? "");
     }
 
-    /** Open a blank "new section" editor at the top of the list. */
+    /** Open a blank "new section" editor at the end of the list — where
+     *  saveEdit appends the saved section, so the draft sits where it lands. */
     startNew(): void {
         this.setError(null);
         this.setEditingId(NEW_SECTION_ID);

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -1,0 +1,219 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// GlobalBrainViewModel — drives the Trust Center "Brain" tab: the
+// workspace-wide global brain that every agent inherits at launch.
+//
+// A "section" is a Memory bundle with is_global=true. The global brain is
+// the ordered list of those sections; their instructions concatenate into
+// each agent's CLAUDE.md at launch (backend: format_global_brain_block).
+// Section order is the sort_order column, mutated via reorderglobalbrain.
+//
+// This model is block-free (same shape as MemoryViewModel) and drives off
+// the bundle_* RPCs. Mutations refresh the list afterwards; it does not
+// subscribe to memories:changed (matching MemoryViewModel — the manager is
+// the only writer in practice).
+//
+// Spec: SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+/** Sentinel editingId for the unsaved "new section" draft. */
+export const NEW_SECTION_ID = "__new__";
+
+/** Mirror of the backend format_global_brain_block — keep in sync so the
+ *  preview matches exactly what lands in CLAUDE.md. */
+export function formatGlobalBrainBlock(sections: Memory[]): string {
+    return sections
+        .filter((s) => (s.instructions ?? "").trim().length > 0)
+        .map((s) => `# [Workspace] ${s.name}\n\n${s.instructions}`)
+        .join("\n\n---\n\n");
+}
+
+export class GlobalBrainViewModel {
+    private _all = createSignal<Memory[]>([]);
+    /** Every bundle (global + per-agent), used to derive sections + candidates. */
+    allAtom: Accessor<Memory[]> = this._all[0];
+    private setAll = this._all[1];
+
+    private _editingId = createSignal<string | null>(null);
+    editingIdAtom: Accessor<string | null> = this._editingId[0];
+    private setEditingId = this._editingId[1];
+
+    private _draftName = createSignal<string>("");
+    draftNameAtom: Accessor<string> = this._draftName[0];
+    setDraftName = this._draftName[1];
+
+    private _draftInstructions = createSignal<string>("");
+    draftInstructionsAtom: Accessor<string> = this._draftInstructions[0];
+    setDraftInstructions = this._draftInstructions[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    private setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    private _showPreview = createSignal<boolean>(false);
+    showPreviewAtom: Accessor<boolean> = this._showPreview[0];
+    setShowPreview = this._showPreview[1];
+
+    /** Global sections, in injection order (sort_order, then name). */
+    sectionsAtom: Accessor<Memory[]>;
+    /** Non-global, non-blank bundles eligible to promote into the brain. */
+    candidatesAtom: Accessor<Memory[]>;
+    /** Combined CLAUDE.md preview block. */
+    previewAtom: Accessor<string>;
+
+    constructor() {
+        this.sectionsAtom = createMemo(() =>
+            this.allAtom()
+                .filter((m) => m.is_global && !m.is_blank)
+                .sort(
+                    (a, b) =>
+                        (a.sort_order ?? 0) - (b.sort_order ?? 0) ||
+                        a.name.localeCompare(b.name),
+                ),
+        );
+        this.candidatesAtom = createMemo(() =>
+            this.allAtom()
+                .filter((m) => !m.is_global && !m.is_blank)
+                .sort((a, b) => a.name.localeCompare(b.name)),
+        );
+        this.previewAtom = createMemo(() => formatGlobalBrainBlock(this.sectionsAtom()));
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.ListMemoriesCommand(TabRpcClient, {});
+            this.setAll(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load global brain: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Open the inline editor for an existing section. */
+    startEdit(section: Memory): void {
+        this.setError(null);
+        this.setEditingId(section.id);
+        this.setDraftName(section.name);
+        this.setDraftInstructions(section.instructions ?? "");
+    }
+
+    /** Open a blank "new section" editor at the top of the list. */
+    startNew(): void {
+        this.setError(null);
+        this.setEditingId(NEW_SECTION_ID);
+        this.setDraftName("");
+        this.setDraftInstructions("");
+    }
+
+    cancelEdit(): void {
+        this.setEditingId(null);
+        this.setDraftName("");
+        this.setDraftInstructions("");
+        this.setError(null);
+    }
+
+    /** Persist the current draft. Creates a new global section (appended to
+     *  the end of the order) or updates the section being edited. */
+    async saveEdit(): Promise<void> {
+        const name = this.draftNameAtom().trim();
+        if (!name) {
+            this.setError("Section name is required.");
+            return;
+        }
+        const editingId = this.editingIdAtom();
+        if (editingId === null) return;
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const instructions = this.draftInstructionsAtom();
+            if (editingId === NEW_SECTION_ID) {
+                const saved = await RpcApi.UpsertMemoryCommand(TabRpcClient, {
+                    id: "",
+                    name,
+                    is_global: true,
+                    instructions,
+                });
+                // Append the new section to the end of the order.
+                const order = [...this.sectionsAtom().map((s) => s.id), saved.id];
+                await RpcApi.ReorderGlobalBrainCommand(TabRpcClient, { ids: order });
+            } else {
+                const existing = this.allAtom().find((m) => m.id === editingId);
+                if (!existing) {
+                    this.setError("Section no longer exists.");
+                    return;
+                }
+                await RpcApi.UpsertMemoryCommand(TabRpcClient, {
+                    ...existing,
+                    name,
+                    instructions,
+                    is_global: true,
+                });
+            }
+            await this.refresh();
+            this.cancelEdit();
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    /** Promote an existing non-global bundle into the brain, appended last. */
+    async promote(id: string): Promise<void> {
+        const bundle = this.allAtom().find((m) => m.id === id);
+        if (!bundle) return;
+        this.setError(null);
+        try {
+            await RpcApi.UpsertMemoryCommand(TabRpcClient, { ...bundle, is_global: true });
+            const order = [...this.sectionsAtom().map((s) => s.id), id];
+            await RpcApi.ReorderGlobalBrainCommand(TabRpcClient, { ids: order });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Promote failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Remove a section from the brain (clears is_global). The bundle itself
+     *  is kept — it stays available in the Memories tab. */
+    async remove(id: string): Promise<void> {
+        const bundle = this.allAtom().find((m) => m.id === id);
+        if (!bundle) return;
+        this.setError(null);
+        try {
+            await RpcApi.UpsertMemoryCommand(TabRpcClient, { ...bundle, is_global: false });
+            if (this.editingIdAtom() === id) this.cancelEdit();
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Remove failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Move a section one slot earlier/later and persist the new order. */
+    async move(id: string, dir: -1 | 1): Promise<void> {
+        const ids = this.sectionsAtom().map((s) => s.id);
+        const i = ids.indexOf(id);
+        const j = i + dir;
+        if (i === -1 || j < 0 || j >= ids.length) return;
+        [ids[i], ids[j]] = [ids[j], ids[i]];
+        this.setError(null);
+        try {
+            await RpcApi.ReorderGlobalBrainCommand(TabRpcClient, { ids });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Reorder failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -1,0 +1,273 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Styles for the Trust Center "Brain" tab (GlobalBrainManager). Renders
+// inside the bundle-manager pane, which provides the scroll container.
+
+.global-brain {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    overflow-y: auto;
+    height: 100%;
+    min-width: 0;
+}
+
+.global-brain-intro {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.5;
+
+    code {
+        font-family: var(--fixed-font, monospace);
+        font-size: 0.92em;
+        color: var(--main-text-color);
+    }
+}
+
+.global-brain-restart-note {
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    border-left: 2px solid var(--accent-color);
+}
+
+.global-brain-error {
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-sm);
+}
+
+// ── Section list ─────────────────────────────────────────────────────────────
+
+.global-brain-sections {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+}
+
+.global-brain-section {
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+
+    &.is-editing {
+        border-color: var(--accent-color);
+    }
+}
+
+.global-brain-section-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1-5) var(--space-2);
+}
+
+.global-brain-section-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.global-brain-section-name {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--main-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.global-brain-section-desc {
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.global-brain-section-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-shrink: 0;
+}
+
+.global-brain-empty {
+    padding: var(--space-3);
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    font-style: italic;
+    border: 1px dashed var(--border-color);
+}
+
+// ── Inline editor ────────────────────────────────────────────────────────────
+
+.global-brain-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2);
+}
+
+.global-brain-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.global-brain-field-label {
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--secondary-text-color);
+}
+
+.global-brain-input,
+.global-brain-textarea {
+    width: 100%;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.global-brain-textarea {
+    resize: vertical;
+    font-family: var(--fixed-font, monospace);
+}
+
+.global-brain-editor-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+}
+
+// ── Add bar ──────────────────────────────────────────────────────────────────
+
+.global-brain-add-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.global-brain-promote-select {
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    cursor: pointer;
+}
+
+// ── Preview ──────────────────────────────────────────────────────────────────
+
+.global-brain-preview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    border-top: 1px solid var(--border-color);
+    padding-top: var(--space-2);
+}
+
+.global-brain-preview-toggle {
+    align-self: flex-start;
+    padding: var(--space-1) 0;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: var(--text-sm);
+    cursor: pointer;
+
+    &:hover {
+        color: var(--main-text-color);
+    }
+}
+
+.global-brain-preview-content {
+    margin: 0;
+    padding: var(--space-2);
+    max-height: 240px;
+    overflow: auto;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs);
+    color: var(--main-text-color);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+// ── Buttons ──────────────────────────────────────────────────────────────────
+
+.global-brain-btn {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-sm);
+    border-radius: 0;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: pointer;
+    transition: opacity 0.1s;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+
+    &.global-brain-btn-primary {
+        background: var(--accent-color);
+        color: var(--button-text-color);
+        border-color: var(--accent-color);
+
+        &:hover:not(:disabled) {
+            opacity: 0.85;
+        }
+    }
+
+    &.global-brain-btn-danger {
+        color: var(--error-color);
+        border-color: color-mix(in srgb, var(--error-color) 40%, transparent);
+    }
+}
+
+.global-brain-icon-btn {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -381,6 +381,10 @@ declare global {
         mcp_servers?: string;
         /** JSON-encoded array of skill IDs. */
         skills?: string;
+        /** Explicit ordering within the Trust Center global brain (controls
+         *  CLAUDE.md injection order). Only meaningful for is_global bundles;
+         *  0 otherwise. Owned by the reorderglobalbrain RPC. */
+        sort_order?: number;
         created_at: number;
         updated_at: number;
     };


### PR DESCRIPTION
## What

Implements **SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md** — a **Brain** tab in the Trust Center that surfaces the workspace-wide *global brain*: the `is_global` Memory bundles that inject into every agent's `CLAUDE.md` at launch. Today those bundles are buried in a flat list with no ordering and no focused view; this gives them a first-class surface as ordered, editable sections.

## Two brains, clarified

- **Trust Center → Brain tab** (this PR): workspace scope — human-authored rules every agent inherits.
- **Agent pane → Brain modal** (#1600): agent scope — Claude's autonomous native memory.

The brain icon now means the global brain only; the existing **Memories** rail (full bundle library) moved to a `layer-group` icon.

## Backend

- **Schema v9**: `db_memory_bundles.sort_order` (flat DDL + idempotent additive ALTER).
- `Memory.sort_order`; `bundle_memory_list_global()` orders by `sort_order, name`; new `bundle_memory_reorder()` in a single transaction. Upsert **never** overwrites `sort_order` on conflict — reorder owns it, so editing a bundle via the regular form keeps its place.
- `reorderglobalbrain` RPC.
- `format_global_brain_block()` helper — each section gets a `# [Workspace] <name>` heading + `---` separator so Claude can attribute injected workspace rules. Used at **both** injection sites (`app_api` write path + `editor_handlers` preview), replacing the previous heading-less concatenation.
- `test_global_brain_order_and_format` covers ordering, reorder, edit-keeps-position, and the exact injected block format. All 16 storage/migration tests pass.

## Frontend

- `GlobalBrainViewModel` + `GlobalBrainManager` + scss: ordered section list with inline editor, move up/down, remove (clears `is_global`, keeps the bundle), "+ New section", "promote existing bundle", and a combined-CLAUDE.md preview.
- `Memory.sort_order` type + `ReorderGlobalBrainCommand` binding.
- Brain rail item wired into `BundleManagerModal`.

## Verification

- `cargo build` + storage/migration tests green (16 passed).
- `tsc` clean for all touched files (31 pre-existing unrelated errors remain).
- `stylelint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)