### PR TITLE
feat(pool): Windows new-window pool

### DIFF
--- a/.changesets/1781954433-feat-pool-windows-new-window-pool-reuse-promote-pool-window--d6nz.md
+++ b/.changesets/1781954433-feat-pool-windows-new-window-pool-reuse-promote-pool-window--d6nz.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(pool): Windows new-window pool — reuse promote_pool_window with physical-pixel anchor

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -245,9 +245,9 @@ pub fn open_new_window(state: &Arc<AppState>) -> Result<serde_json::Value, Strin
     }
 
     // Pool-first path — instant show with no renderer-spawn latency (~3s saved).
-    // On macOS/Linux, promotes a pre-warmed pool window via CEF Views set_bounds+show
-    // and emits pool:new-window so the renderer creates a fresh workspace.
-    // On Windows, returns None (TODO: dedicated Win32 physical-pixel path).
+    // On macOS/Linux, emits pool:new-window (no workspaceId → fresh workspace).
+    // On Windows, delegates to promote_pool_window with workspace_id="" and physical-pixel
+    // anchor (bypassing DIP→physical DPI double-conversion; see promote_pool_window_for_new_window).
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
     if let Some(label) = crate::commands::window_pool::promote_pool_window_for_new_window(

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -996,9 +996,9 @@ fn cleanup_failed_promote_orphan_cross_platform(state: &Arc<AppState>, label: &s
 ///
 /// macOS / Linux: emits `pool:new-window` (no workspaceId).
 /// Windows: delegates to `promote_pool_window` with `workspace_id=""`. The
-/// frontend's `awaitPoolPromote` receives `pool:promote { workspaceId: "" }`,
-/// skips the workspaceId URL injection (empty string is falsy), and
-/// `initHostNewWindow` falls through to the fresh-workspace path. Position is
+/// frontend's `awaitPoolPromote` receives `pool:promote { workspaceId: "" }` and
+/// sets `?workspaceId=` (empty string) in the URL; `initHostNewWindow` reads the
+/// param as falsy and falls through to the fresh-workspace path. Position is
 /// passed as the tab anchor so it feeds directly to `SetWindowPos` without the
 /// cursor-centering offset math. Width/height pass as `None` so the function
 /// uses the hardcoded `POOL_WIDTH/POOL_HEIGHT` defaults (1200×800) — this

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -991,16 +991,21 @@ fn cleanup_failed_promote_orphan_cross_platform(state: &Arc<AppState>, label: &s
 /// Pop a pool window for a new top-level window (Cmd+N, File → New Window).
 ///
 /// Reuses the tab tear-off pool. No workspace_id — the frontend creates a fresh
-/// workspace via `pool:new-window` (see `frontend/app/init/pool.ts`). The absence
-/// of a `workspaceId` URL param causes `initHostNewWindow` to take the "create
-/// fresh workspace" branch rather than the "reattach existing workspace" branch.
+/// workspace via the absence of `?workspaceId=` in the URL, which causes
+/// `initHostNewWindow` to take the "create fresh workspace" branch.
 ///
-/// macOS / Linux: full implementation — CEF Views `set_bounds` + `show` at the
-/// cascade-offset position, then `pool:new-window`.
-/// Windows: always returns `None` (cold-path fallback). `get_offset_position` on
-/// Windows returns PHYSICAL pixels (from `GetWindowRect`), while `promote_pool_window`'s
-/// DPI conversion assumes DIP/CSS inputs from the frontend. A dedicated Win32 path
-/// is tracked in `SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md` §4.
+/// macOS / Linux: emits `pool:new-window` (no workspaceId).
+/// Windows: delegates to `promote_pool_window` with `workspace_id=""`. The
+/// frontend's `awaitPoolPromote` receives `pool:promote { workspaceId: "" }`,
+/// skips the workspaceId URL injection (empty string is falsy), and
+/// `initHostNewWindow` falls through to the fresh-workspace path. Position is
+/// passed as the tab anchor so it feeds directly to `SetWindowPos` without the
+/// cursor-centering offset math. Width/height pass as `None` so the function
+/// uses the hardcoded `POOL_WIDTH/POOL_HEIGHT` defaults (1200×800) — this
+/// avoids double-applying the DIP→physical DPI conversion: `get_offset_position`
+/// and `get_secondary_window_size` on Windows already return physical pixels
+/// (from `GetWindowRect`/`GetMonitorInfoW`), but `promote_pool_window` only
+/// runs `to_physical()` when `width.is_some()`. Passing `None` skips it.
 pub fn promote_pool_window_for_new_window(
     state: &Arc<AppState>,
     pos_x: i32,
@@ -1010,9 +1015,21 @@ pub fn promote_pool_window_for_new_window(
 ) -> Option<String> {
     #[cfg(target_os = "windows")]
     {
-        // TODO(pool-new-window-win32): implement with a dedicated Win32 path.
-        let _ = (state, pos_x, pos_y, width, height);
-        return None;
+        // Width/height intentionally passed as None (use POOL_WIDTH/POOL_HEIGHT defaults)
+        // to avoid double-DPI-converting the already-physical pixels from GetWindowRect.
+        // pos_x/pos_y passed as the tab anchor so SetWindowPos places the window there
+        // directly without the cursor-centering arithmetic.
+        let _ = (width, height); // used only on non-Windows path
+        return promote_pool_window(
+            state,
+            "",           // empty workspace_id → frontend creates fresh workspace
+            pos_x,
+            pos_y,
+            None,         // width: skip DPI conversion, use POOL_WIDTH default
+            None,         // height: skip DPI conversion, use POOL_HEIGHT default
+            Some(pos_x),  // tab_anchor_x: physical px placed directly in SetWindowPos
+            Some(pos_y),  // tab_anchor_y
+        );
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

Removes the Windows cold-path stub in `promote_pool_window_for_new_window` and wires it to the existing `promote_pool_window` function. New window (Cmd+N / File → New Window) is now pool-accelerated on all three platforms.

**The DPI problem and how it's solved:**
- `get_offset_position()` and `get_secondary_window_size()` on Windows return **physical pixels** (`GetWindowRect` / `GetMonitorInfoW`)
- `promote_pool_window`'s `to_physical()` conversion only runs when `width.is_some()` — passing `None` skips it and falls back to the `POOL_WIDTH=1200` / `POOL_HEIGHT=800` constants without double-scaling
- `pos_x/pos_y` pass as `tab_anchor_x/y` so they feed directly into `SetWindowPos` bypassing the cursor-centering `screen_x - win_w / 2` formula

**Fresh workspace via empty workspaceId:**
- `workspace_id=""` → host emits `pool:promote { workspaceId: "" }` (Windows reuses the existing promote event vs macOS/Linux `pool:new-window`)
- `awaitPoolPromote` in `pool.ts` receives it, calls `url.searchParams.set("workspaceId", "")` — empty string is falsy, so `initHostNewWindow` takes the "create fresh workspace" branch ✓

## Coverage after this PR

| Operation | Windows | macOS | Linux |
|-----------|---------|-------|-------|
| Tab tear-off | ✅ pool | ✅ pool | ✅ pool |
| New window (Cmd+N) | ✅ pool (this PR) | ✅ pool | ✅ pool |
| Pane tear-off | cold path | cold path | cold path |

## Test plan

- [ ] Windows: Cmd+N / File → New Window — second window appears instantly (~30ms), no `[create-window] task entered UI thread` cold-path log
- [ ] Windows: `muxlog host 'pool:new-window\|pool:promote'` shows promote + refill; fresh workspace (no existing tabs) opens
- [ ] Windows: back-to-back Cmd+N (pool exhausted) gracefully cold-paths
- [ ] Windows: tab tear-off still works (promote_pool_window path unchanged)
- [ ] macOS/Linux: no regression (cfg-gated, code path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)