### PR TITLE
feat(pool): Windows pane tear-off pool (P3)

### DIFF
--- a/.changesets/1781955118-feat-pool-pane-tear-off-pool-on-macos-linux-floating-pool-uu-ft4c.md
+++ b/.changesets/1781955118-feat-pool-pane-tear-off-pool-on-macos-linux-floating-pool-uu-ft4c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(pool): pane tear-off pool on macOS/Linux — floating-pool-{uuid} pre-warmed frameless windows

--- a/.changesets/1781956729-feat-pool-windows-pane-tear-off-pool-ws-popup-pre-warmed-flo-07i8.md
+++ b/.changesets/1781956729-feat-pool-windows-pane-tear-off-pool-ws-popup-pre-warmed-flo-07i8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(pool): Windows pane tear-off pool — WS_POPUP pre-warmed floating-pool windows

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -534,6 +534,7 @@ impl AgentMuxHandler {
                 if is_top_level_window
                     && pending_kind == WindowKind::FullInstance
                     && !label.starts_with("window-pool-")
+                    && !label.starts_with("floating-pool-")
                 {
                     unsafe { install_main_window_floater_cascade_hook(hwnd); }
                 }

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -662,8 +662,11 @@ impl AgentMuxHandler {
         //   so emit_event_to_window doesn't race the listener install.
         if label == "main" {
             crate::commands::window_pool::init_pool(&self.state);
+            crate::commands::window_pool::init_pane_pool(&self.state);
         } else if label.starts_with("window-pool-") {
             crate::commands::window_pool::register_pool_window(&self.state, &label);
+        } else if label.starts_with("floating-pool-") {
+            crate::commands::window_pool::register_pane_pool_window(&self.state, &label);
         }
     }
 
@@ -865,6 +868,8 @@ impl AgentMuxHandler {
             // the pool would never refill.
             if lbl.starts_with("window-pool-") {
                 crate::commands::window_pool::on_pool_window_destroyed(&self.state, lbl);
+            } else if lbl.starts_with("floating-pool-") {
+                crate::commands::window_pool::on_pane_pool_window_destroyed(&self.state, lbl);
             }
             // Phase B.4 — mirror the close to the launcher. Skip
             // browser-pane child HWNDs (never reported as open).
@@ -1330,7 +1335,7 @@ impl AgentMuxHandler {
         let browser_label = browser_cloned.as_mut().and_then(|b| self.window_label_for(b));
         let is_pool_window = browser_label
             .as_deref()
-            .map_or(false, |l| l.starts_with("window-pool-"));
+            .map_or(false, |l| l.starts_with("window-pool-") || l.starts_with("floating-pool-"));
 
         if !is_pool_window {
             if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -563,7 +563,7 @@ impl AgentMuxHandler {
         // pool windows (they're not user-visible until promoted; the
         // pool->user transition gets its own report in a follow-up).
         // No-op if launcher IPC isn't connected (`task dev` mode).
-        if is_top_level_window && !label.starts_with("window-pool-") {
+        if is_top_level_window && !label.starts_with("window-pool-") && !label.starts_with("floating-pool-") {
             // Phase B.5 (window_meta step d) — kind/parent come
             // from the pending entry we popped at the top of this
             // fn, not a window_meta lookup.

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -307,6 +307,18 @@ pub fn pool_window_ready(
     Ok(serde_json::Value::Null)
 }
 
+pub fn pane_pool_window_ready(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing label".to_string())?;
+    super::window_pool::mark_pane_pool_window_renderer_ready(state, label);
+    Ok(serde_json::Value::Null)
+}
+
 /// Phase 6 — promote a pre-warmed pool window for tear-off.
 /// Returns the promoted window's label, or an error string if the
 /// pool was empty (caller should fall back to open_window_at_position).

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -205,6 +205,22 @@ pub fn open_floating_pane_window(
 
     #[cfg(not(target_os = "windows"))]
     {
+        // Pane pool fast path — promote a pre-warmed frameless pool window
+        // instead of spawning a cold CEF window (~3s → ~30ms).
+        if let Some(pool_label) = crate::commands::window_pool::promote_pane_pool_window(
+            state,
+            &parsed.pane_id,
+            parsed.workspace_id.as_deref().unwrap_or(""),
+            parsed.x,
+            parsed.y,
+            parsed.width,
+            parsed.height,
+        ) {
+            return Ok(serde_json::to_value(OpenFloatingPaneResponse {
+                window_label: pool_label,
+            }).unwrap_or_default());
+        }
+
         // Phase A (SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md): create a
         // frameless top-level window via the SAME CEF Views path the regular
         // tear-off uses (`open_window_at_position` →

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -199,6 +199,26 @@ pub fn open_floating_pane_window(
                 fallback
             }
         };
+        // Pane pool fast path (Windows): promote a pre-warmed WS_POPUP pane pool
+        // window. `width` and `height` are already DPI-converted to physical
+        // pixels by the block above. `parent_main_hwnd` is passed so the cascade
+        // hook is registered at promote time (deferred from spawn because the
+        // parent was unknown when the pool window was pre-warmed).
+        if let Some(pool_label) = crate::commands::window_pool::promote_pane_pool_window(
+            state,
+            &parsed.pane_id,
+            parsed.workspace_id.as_deref().unwrap_or(""),
+            parsed.x,
+            parsed.y,
+            parsed.width,
+            parsed.height,
+            parent_main_hwnd,
+        ) {
+            return Ok(serde_json::to_value(OpenFloatingPaneResponse {
+                window_label: pool_label,
+            }).unwrap_or_default());
+        }
+
         crate::floating_pane::post_create_floating_window(state, &parsed, &window_label, parent_main_hwnd);
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }
@@ -215,6 +235,7 @@ pub fn open_floating_pane_window(
             parsed.y,
             parsed.width,
             parsed.height,
+            0, // parent_hwnd: unused on non-Windows
         ) {
             return Ok(serde_json::to_value(OpenFloatingPaneResponse {
                 window_label: pool_label,

--- a/agentmux-cef/src/commands/orphan_reconcile.rs
+++ b/agentmux-cef/src/commands/orphan_reconcile.rs
@@ -248,14 +248,17 @@ fn ui_thread_reconcile(state: &Arc<AppState>) {
         .keys()
         .cloned()
         .collect();
-    let pool_queue: HashSet<String> = state
-        .host_state
-        .lock()
-        .pool
-        .queue
-        .iter()
-        .cloned()
-        .collect();
+    let pool_queue: HashSet<String> = {
+        let st = state.host_state.lock();
+        st.pool
+            .queue
+            .iter()
+            .cloned()
+            .chain(st.pane_pool.queue.iter().cloned())
+            .collect()
+    };
+    // unpromoted_pool_labels_snapshot covers both tab pool (window-pool-*) and
+    // pane pool (floating-pool-*) unpromoted sets.
     let unpromoted_pool: HashSet<String> = state.unpromoted_pool_labels_snapshot();
 
     // Probe HWND status for every non-pane top-level browser. Panes

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -56,14 +56,44 @@ fn pool_hwnd_cache() -> &'static Mutex<HashMap<String, usize>> {
     POOL_HWND_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// HWND cache for pane pool windows. Separate from `POOL_HWND_CACHE` because
+/// pane pool windows are WS_POPUP + WS_EX_TOOLWINDOW (unowned, no taskbar entry)
+/// and their outer HWND must be cached before the CEF child browser is created
+/// (same reason as `POOL_HWND_CACHE` — `window_handle()` goes null after load).
+#[cfg(target_os = "windows")]
+static PANE_POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn pane_pool_hwnd_cache() -> &'static Mutex<HashMap<String, usize>> {
+    PANE_POOL_HWND_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Store the outer WS_POPUP HWND for a pane pool window. Called from
+/// `floating_pane::CreatePanePoolWindowWin32Task` after `CreateWindowExW`
+/// and before `browser_host_create_browser` fires.
+#[cfg(target_os = "windows")]
+pub(crate) fn cache_pane_pool_hwnd(label: &str, hwnd: usize) {
+    pane_pool_hwnd_cache()
+        .lock()
+        .unwrap()
+        .insert(label.to_string(), hwnd);
+}
+
+/// Pop (and remove) the outer HWND for a pane pool label (promote or destroy path).
+#[cfg(target_os = "windows")]
+fn take_pane_pool_hwnd(label: &str) -> Option<usize> {
+    pane_pool_hwnd_cache().lock().unwrap().remove(label)
+}
+
 /// Target pool size. See module-level comment for rationale.
 pub const POOL_TARGET_SIZE: usize = 2;
 
 /// Pool windows are spawned at this off-screen position so they
 /// don't appear on the user's desktop while pre-painting. On
 /// promote they're moved to the cursor and shown.
-const POOL_OFFSCREEN_X: i32 = -32000;
-const POOL_OFFSCREEN_Y: i32 = -32000;
+pub(crate) const POOL_OFFSCREEN_X: i32 = -32000;
+pub(crate) const POOL_OFFSCREEN_Y: i32 = -32000;
 const POOL_WIDTH: i32 = 1200;
 const POOL_HEIGHT: i32 = 800;
 /// Pixels above the cursor where the title bar sits — matches
@@ -1056,8 +1086,8 @@ pub fn promote_pool_window_for_new_window(
 /// Target size for the pane pool. One pre-warmed window covers the common
 /// burst; two would add ~75 MB RSS with minimal additional benefit.
 pub const PANE_POOL_TARGET_SIZE: usize = 1;
-const PANE_POOL_WIDTH: i32 = 900;
-const PANE_POOL_HEIGHT: i32 = 600;
+pub(crate) const PANE_POOL_WIDTH: i32 = 900;
+pub(crate) const PANE_POOL_HEIGHT: i32 = 600;
 
 /// Spawn a single pre-warmed frameless pane window. Follows the same
 /// single-flight + refill chain pattern as `spawn_pool_window`.
@@ -1120,17 +1150,27 @@ pub fn spawn_pane_pool_window(state: &Arc<AppState>) {
 
     tracing::info!(target: "pool:pane", label = %label, "[pane-pool] spawning pane pool window");
 
-    // frameless=true — pane windows require this at creation time.
-    crate::ui_tasks::post_create_window(
-        state,
-        &url,
-        &label,
-        POOL_OFFSCREEN_X,
-        POOL_OFFSCREEN_Y,
-        PANE_POOL_WIDTH,
-        PANE_POOL_HEIGHT,
-        true,
-    );
+    // On Windows: create a WS_POPUP + WS_EX_TOOLWINDOW window (same type as the
+    // cold-path `post_create_floating_window`) so promote can reuse the same Win32
+    // HWND without re-creating the window at tear-off time.
+    // On non-Windows: use CEF Views frameless window.
+    #[cfg(target_os = "windows")]
+    {
+        crate::floating_pane::post_create_pane_pool_window_win32(state, &label, &url);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        crate::ui_tasks::post_create_window(
+            state,
+            &url,
+            &label,
+            POOL_OFFSCREEN_X,
+            POOL_OFFSCREEN_Y,
+            PANE_POOL_WIDTH,
+            PANE_POOL_HEIGHT,
+            true,
+        );
+    }
 }
 
 /// Called once at startup (when main window registers) to seed the pane pool.
@@ -1181,6 +1221,12 @@ pub fn on_pane_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("floating-pool-") {
         return;
     }
+    // Drop the cached outer HWND so the map can't grow unbounded. Idempotent —
+    // fine if the entry is already absent (double-destroy or failure path).
+    #[cfg(target_os = "windows")]
+    {
+        pane_pool_hwnd_cache().lock().unwrap().remove(label);
+    }
     let dispatch = state.host_dispatch(
         crate::reducer::HostCommand::PanePoolWindowDestroyedBeforePromote {
             label: label.to_string(),
@@ -1200,8 +1246,7 @@ pub fn on_pane_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     }
 }
 
-/// Orphan cleanup for failed pane pool promotes (non-Windows).
-#[cfg(not(target_os = "windows"))]
+/// Orphan cleanup for failed pane pool promotes.
 fn cleanup_failed_pane_promote_orphan(state: &Arc<AppState>, label: &str) {
     state.host_dispatch(
         crate::reducer::HostCommand::UnregisterBrowser {
@@ -1219,11 +1264,12 @@ fn cleanup_failed_pane_promote_orphan(state: &Arc<AppState>, label: &str) {
 
 /// Pop a pane pool window and show it as a floating pane at the drop target.
 ///
+/// `parent_hwnd`: the FullInstance HWND that triggered the tear-off (for cascade
+/// hook binding on Windows). Pass 0 on non-Windows — it is unused there.
+///
 /// macOS / Linux: CEF Views `set_bounds` + `show` + `pool:pane-promote`.
-/// Windows: always returns `None` (cold-path fallback). The Win32 floating
-/// pane creation path (`post_create_floating_window`) is separate from the
-/// CEF Views path used by pane pool windows; a dedicated Win32 promote path
-/// is tracked in `SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md` §3.5.
+/// Windows: Win32 `SetWindowPos` + `ShowWindow` on the outer WS_POPUP HWND
+/// cached by `CreatePanePoolWindowWin32Task`, then `pool:pane-promote` event.
 pub fn promote_pane_pool_window(
     state: &Arc<AppState>,
     pane_id: &str,
@@ -1232,15 +1278,99 @@ pub fn promote_pane_pool_window(
     y: i32,
     width: i32,
     height: i32,
+    parent_hwnd: isize,
 ) -> Option<String> {
     #[cfg(target_os = "windows")]
     {
-        let _ = (state, pane_id, workspace_id, x, y, width, height);
-        return None;
+        use windows_sys::Win32::Foundation::HWND;
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            IsWindow, SetWindowPos, ShowWindow, HWND_TOP, SW_SHOWNORMAL,
+        };
+
+        let dispatch = state.host_dispatch(
+            crate::reducer::HostCommand::PopAndPromoteFrontPanePoolWindow,
+        );
+        let label = dispatch.promoted_pane_pool_label?;
+
+        tracing::info!(
+            target: "pool:pane",
+            label = %label,
+            pane_id = %pane_id,
+            workspace_id = %workspace_id,
+            x, y, width, height,
+            "[pane-pool] promoting pane pool window (Windows)"
+        );
+
+        let outer_hwnd = match take_pane_pool_hwnd(&label) {
+            Some(h) => h,
+            None => {
+                tracing::error!(
+                    target: "pool:pane",
+                    label = %label,
+                    "[pane-pool] no cached HWND for promoted label — orphan cleanup"
+                );
+                cleanup_failed_pane_promote_orphan(state, &label);
+                return None;
+            }
+        };
+
+        // Verify the HWND is still alive before touching it.
+        let alive = unsafe { IsWindow(outer_hwnd as HWND) } != 0;
+        if !alive {
+            tracing::error!(
+                target: "pool:pane",
+                label = %label,
+                hwnd = format!("0x{:x}", outer_hwnd),
+                "[pane-pool] cached HWND is no longer a live OS window — orphan cleanup"
+            );
+            cleanup_failed_pane_promote_orphan(state, &label);
+            return None;
+        }
+
+        // `width` and `height` arrive pre-DPI-converted (physical pixels) from
+        // `open_floating_pane_window`'s Windows block. `x` and `y` are in the
+        // same coordinate space as `CreateWindowExW` (physical screen coords).
+        unsafe {
+            let ok = SetWindowPos(outer_hwnd as HWND, HWND_TOP, x, y, width, height, 0);
+            if ok == 0 {
+                let err = windows_sys::Win32::Foundation::GetLastError();
+                tracing::error!(
+                    target: "pool:pane",
+                    label = %label,
+                    last_err = %err,
+                    "[pane-pool] SetWindowPos failed"
+                );
+            }
+            let _ = ShowWindow(outer_hwnd as HWND, SW_SHOWNORMAL);
+        }
+
+        // Bind this floater to the source window's cascade hook. Deferred from
+        // spawn time because the parent HWND is only known at tear-off.
+        crate::floating_pane::register_floater_hwnd(
+            label.clone(),
+            outer_hwnd as isize,
+            parent_hwnd,
+        );
+
+        // Tell the renderer to bootstrap pane + workspace.
+        crate::events::emit_event_to_window(
+            state,
+            &label,
+            "pool:pane-promote",
+            &serde_json::json!({
+                "paneId": pane_id,
+                "workspaceId": workspace_id,
+            }),
+        );
+
+        spawn_pane_pool_window(state);
+
+        return Some(label);
     }
 
     #[cfg(not(target_os = "windows"))]
     {
+        let _ = parent_hwnd; // unused on non-Windows
         let dispatch = state.host_dispatch(
             crate::reducer::HostCommand::PopAndPromoteFrontPanePoolWindow,
         );

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1050,3 +1050,226 @@ pub fn promote_pool_window_for_new_window(
         Some(label)
     }
 }
+
+// ── Pane pool (floating-pool-{uuid}, frameless=true) ─────────────────────
+
+/// Target size for the pane pool. One pre-warmed window covers the common
+/// burst; two would add ~75 MB RSS with minimal additional benefit.
+pub const PANE_POOL_TARGET_SIZE: usize = 1;
+const PANE_POOL_WIDTH: i32 = 900;
+const PANE_POOL_HEIGHT: i32 = 600;
+
+/// Spawn a single pre-warmed frameless pane window. Follows the same
+/// single-flight + refill chain pattern as `spawn_pool_window`.
+pub fn spawn_pane_pool_window(state: &Arc<AppState>) {
+    if state.is_quitting() {
+        return;
+    }
+    if state.any_browser_pane_closing() {
+        tracing::warn!(
+            target: "wfr:gate",
+            "[pane-pool] spawn_pane_pool_window deferred — pane is mid-close (H.7 invariant)"
+        );
+        return;
+    }
+    if state.pane_pool_queue_size() >= PANE_POOL_TARGET_SIZE {
+        tracing::debug!(
+            target: "pool:pane",
+            current = %state.pane_pool_queue_size(),
+            target = %PANE_POOL_TARGET_SIZE,
+            "[pane-pool] spawn skipped — pool at target size"
+        );
+        return;
+    }
+
+    let window_id = uuid::Uuid::new_v4();
+    let label = format!("floating-pool-{}", window_id.simple());
+
+    let dispatch = state.host_dispatch(
+        crate::reducer::HostCommand::PanePoolWindowSpawnStart { label: label.clone() },
+    );
+    if !dispatch.pane_pool_spawn_proceeding {
+        return;
+    }
+
+    let ipc_port = *state.ipc_port.lock();
+    let ipc_token = &state.ipc_token;
+    let url = match super::window::resolve_frontend_base_url(ipc_port) {
+        Ok(base_url) => {
+            let sep = if base_url.contains('?') { "&" } else { "?" };
+            format!(
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}&pane-pool=1",
+                base_url, sep, ipc_port, ipc_token, label
+            )
+        }
+        Err(e) => {
+            tracing::error!(error = %e, label = %label, "[pane-pool] frontend assets unavailable");
+            super::window::assets_missing_data_url(&e)
+        }
+    };
+
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: label.clone(),
+                kind: WindowKind::FullInstance,
+                parent_instance_id: None,
+            },
+        },
+    );
+
+    tracing::info!(target: "pool:pane", label = %label, "[pane-pool] spawning pane pool window");
+
+    // frameless=true — pane windows require this at creation time.
+    crate::ui_tasks::post_create_window(
+        state,
+        &url,
+        &label,
+        POOL_OFFSCREEN_X,
+        POOL_OFFSCREEN_Y,
+        PANE_POOL_WIDTH,
+        PANE_POOL_HEIGHT,
+        true,
+    );
+}
+
+/// Called once at startup (when main window registers) to seed the pane pool.
+pub fn init_pane_pool(state: &Arc<AppState>) {
+    if state.pane_pool_queue_size() >= PANE_POOL_TARGET_SIZE {
+        return;
+    }
+    spawn_pane_pool_window(state);
+}
+
+/// Called from `on_after_created` for `floating-pool-*` labels.
+/// Logs the registration; queue insertion waits for the frontend's
+/// `pane_pool_window_ready` IPC so we don't race the listener install.
+pub fn register_pane_pool_window(_state: &Arc<AppState>, label: &str) {
+    if !label.starts_with("floating-pool-") {
+        return;
+    }
+    tracing::debug!(
+        target: "pool:pane",
+        label = %label,
+        "[pane-pool] browser registered, awaiting renderer-ready signal"
+    );
+}
+
+/// Called by the `pane_pool_window_ready` IPC command when the frontend
+/// has installed its `pool:pane-promote` listener and is ready to receive.
+pub fn mark_pane_pool_window_renderer_ready(state: &Arc<AppState>, label: &str) {
+    if !label.starts_with("floating-pool-") {
+        return;
+    }
+    let dispatch = state.host_dispatch(
+        crate::reducer::HostCommand::PanePoolWindowReady { label: label.to_string() },
+    );
+    let pool_size = dispatch.pane_pool_size_after.unwrap_or(0);
+    tracing::info!(
+        target: "pool:pane",
+        label = %label,
+        pool_size,
+        "[pane-pool] renderer ready, enqueued"
+    );
+    if pool_size < PANE_POOL_TARGET_SIZE {
+        spawn_pane_pool_window(state);
+    }
+}
+
+/// Called from `on_before_close` for `floating-pool-*` labels.
+pub fn on_pane_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
+    if !label.starts_with("floating-pool-") {
+        return;
+    }
+    let dispatch = state.host_dispatch(
+        crate::reducer::HostCommand::PanePoolWindowDestroyedBeforePromote {
+            label: label.to_string(),
+        },
+    );
+    let needs_refill = dispatch
+        .pane_pool_size_after
+        .map(|n| n < PANE_POOL_TARGET_SIZE)
+        .unwrap_or(false);
+    tracing::warn!(
+        target: "pool:pane",
+        label = %label,
+        "[pane-pool] pool window destroyed before promote"
+    );
+    if needs_refill {
+        spawn_pane_pool_window(state);
+    }
+}
+
+/// Orphan cleanup for failed pane pool promotes (non-Windows).
+#[cfg(not(target_os = "windows"))]
+fn cleanup_failed_pane_promote_orphan(state: &Arc<AppState>, label: &str) {
+    state.host_dispatch(
+        crate::reducer::HostCommand::UnregisterBrowser {
+            label: label.to_string(),
+        },
+    );
+    state.window_meta.lock().remove(label);
+    spawn_pane_pool_window(state);
+    tracing::warn!(
+        target: "pool:pane",
+        label = %label,
+        "[pane-pool] orphan cleaned up — refilled"
+    );
+}
+
+/// Pop a pane pool window and show it as a floating pane at the drop target.
+///
+/// macOS / Linux: CEF Views `set_bounds` + `show` + `pool:pane-promote`.
+/// Windows: always returns `None` (cold-path fallback). The Win32 floating
+/// pane creation path (`post_create_floating_window`) is separate from the
+/// CEF Views path used by pane pool windows; a dedicated Win32 promote path
+/// is tracked in `SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md` §3.5.
+pub fn promote_pane_pool_window(
+    state: &Arc<AppState>,
+    pane_id: &str,
+    workspace_id: &str,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+) -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = (state, pane_id, workspace_id, x, y, width, height);
+        return None;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let dispatch = state.host_dispatch(
+            crate::reducer::HostCommand::PopAndPromoteFrontPanePoolWindow,
+        );
+        let label = dispatch.promoted_pane_pool_label?;
+
+        tracing::info!(
+            target: "pool:pane",
+            label = %label,
+            pane_id = %pane_id,
+            workspace_id = %workspace_id,
+            x, y, width, height,
+            "[pane-pool] promoting pane pool window"
+        );
+
+        if state.get_browser(&label).is_none() {
+            tracing::warn!(
+                target: "pool:pane",
+                label = %label,
+                "[pane-pool] browser not in state — orphan cleanup"
+            );
+            cleanup_failed_pane_promote_orphan(state, &label);
+            return None;
+        }
+
+        crate::ui_tasks::post_promote_pane_pool_window(
+            state, &label, pane_id, workspace_id, x, y, width, height,
+        );
+        spawn_pane_pool_window(state);
+
+        Some(label)
+    }
+}

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -82,8 +82,26 @@ pub(crate) fn cache_pane_pool_hwnd(label: &str, hwnd: usize) {
 
 /// Pop (and remove) the outer HWND for a pane pool label (promote or destroy path).
 #[cfg(target_os = "windows")]
-fn take_pane_pool_hwnd(label: &str) -> Option<usize> {
+pub(crate) fn take_pane_pool_hwnd(label: &str) -> Option<usize> {
     pane_pool_hwnd_cache().lock().unwrap().remove(label)
+}
+
+/// Clean up after a pane pool window that failed during creation (before it
+/// ever became a usable pool slot). Unlike `on_pane_pool_window_destroyed`,
+/// this does NOT trigger a refill spawn — creation failures are likely
+/// persistent (Win32 error, driver issue) and re-spawning immediately would
+/// cause an infinite respawn loop: create → fail → cleanup → spawn → fail.
+/// The pool stays empty and the cold path handles the next tear-off request.
+#[cfg(target_os = "windows")]
+pub(crate) fn cleanup_failed_pane_pool_creation(state: &Arc<AppState>, label: &str) {
+    take_pane_pool_hwnd(label);
+    state.host_dispatch(
+        crate::reducer::HostCommand::PanePoolWindowDestroyedBeforePromote {
+            label: label.to_string(),
+        },
+    );
+    // Deliberately skip spawn_pane_pool_window — creation failure may be
+    // persistent; caller should dequeue PendingWindowCreation separately.
 }
 
 /// Target pool size. See module-level comment for rationale.

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -419,9 +419,11 @@ wrap_task! {
                         error = %e,
                         "[pane-pool] create_popup failed (Windows)"
                     );
-                    // Reducer cleanup + refill via on_pane_pool_window_destroyed,
-                    // then dequeue the pending-creation entry.
-                    crate::commands::window_pool::on_pane_pool_window_destroyed(
+                    // Clean up reducer state without triggering a refill spawn.
+                    // HWND was not cached yet (create_popup failed before that step).
+                    // on_pane_pool_window_destroyed must NOT be used here — it triggers
+                    // spawn_pane_pool_window which would re-enter this failure → loop.
+                    crate::commands::window_pool::cleanup_failed_pane_pool_creation(
                         &self.state, &self.label,
                     );
                     dequeue();
@@ -481,14 +483,17 @@ wrap_task! {
                     label = %self.label,
                     "[pane-pool] browser_host_create_browser returned 0 (Windows)"
                 );
-                // Destroy the outer HWND (no browser to close it for us),
-                // clean up reducer + HWND cache, dequeue pending creation.
+                // Destroy the outer HWND (no browser to close it for us).
                 unsafe {
                     use windows_sys::Win32::UI::WindowsAndMessaging::DestroyWindow;
                     DestroyWindow(outer_hwnd as *mut std::ffi::c_void);
                 }
-                // on_pane_pool_window_destroyed removes from HWND cache + handles reducer.
-                crate::commands::window_pool::on_pane_pool_window_destroyed(
+                // Remove from window_hwnds (inserted above before browser creation).
+                self.state.window_hwnds.lock().remove(&self.label);
+                // Clean up reducer + HWND cache without triggering a refill spawn.
+                // on_pane_pool_window_destroyed must NOT be used here — it triggers
+                // spawn_pane_pool_window which would re-enter this failure → loop.
+                crate::commands::window_pool::cleanup_failed_pane_pool_creation(
                     &self.state, &self.label,
                 );
                 dequeue();

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -380,6 +380,143 @@ pub fn post_create_floating_window(
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+/// Pre-warmed pane pool window task (Windows). Creates a WS_POPUP +
+/// WS_EX_TOOLWINDOW window at the off-screen pool position and embeds a
+/// CEF child browser. The outer HWND is cached in `PANE_POOL_HWND_CACHE`
+/// before `browser_host_create_browser` fires so `promote_pane_pool_window`
+/// has a reliable handle even after CEF nulls `window_handle()` post-load.
+///
+/// Differs from `CreateFloatingWindowTask`:
+///   1. No `register_floater_hwnd` — parent HWND unknown at spawn; deferred to promote.
+///   2. Offscreen position + pane pool dimensions; window is hidden after create_popup.
+///   3. URL carries `?pane-pool=1`; frontend defers init until `pool:pane-promote`.
+wrap_task! {
+    pub(crate) struct CreatePanePoolWindowWin32Task {
+        state: Arc<AppState>,
+        label: String,
+        url: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let dequeue = || {
+                self.state.host_dispatch(
+                    crate::reducer::HostCommand::DequeuePendingWindowCreation,
+                );
+            };
+
+            let outer_hwnd = match create_popup(
+                &self.label,
+                crate::commands::window_pool::POOL_OFFSCREEN_X,
+                crate::commands::window_pool::POOL_OFFSCREEN_Y,
+                crate::commands::window_pool::PANE_POOL_WIDTH,
+                crate::commands::window_pool::PANE_POOL_HEIGHT,
+            ) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::error!(
+                        label = %self.label,
+                        error = %e,
+                        "[pane-pool] create_popup failed (Windows)"
+                    );
+                    // Reducer cleanup + refill via on_pane_pool_window_destroyed,
+                    // then dequeue the pending-creation entry.
+                    crate::commands::window_pool::on_pane_pool_window_destroyed(
+                        &self.state, &self.label,
+                    );
+                    dequeue();
+                    return;
+                }
+            };
+
+            // create_popup ends with SW_SHOWNOACTIVATE — hide immediately so the
+            // offscreen WS_POPUP doesn't appear in Alt+Tab while pre-warming.
+            unsafe {
+                use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+                let _ = ShowWindow(outer_hwnd as *mut std::ffi::c_void, SW_HIDE);
+            }
+
+            // Cache the outer HWND before browser creation. CEF's window_handle()
+            // returns null after page load (same issue as tab pool, diagnosed
+            // 2026-05-06); the cache is the only reliable source at promote time.
+            crate::commands::window_pool::cache_pane_pool_hwnd(&self.label, outer_hwnd as usize);
+
+            // Register in window_hwnds so promote_pane_pool_window can reach
+            // the outer HWND via state.window_hwnds if needed.
+            self.state
+                .window_hwnds
+                .lock()
+                .insert(self.label.clone(), outer_hwnd as isize);
+
+            // Embed CEF browser as WS_CHILD of the outer WS_POPUP.
+            let rect = Rect {
+                x: 0,
+                y: 0,
+                width: crate::commands::window_pool::PANE_POOL_WIDTH,
+                height: crate::commands::window_pool::PANE_POOL_HEIGHT,
+            };
+            let handler = crate::client::AgentMuxHandler::new_with_browser_pane(
+                self.state.clone(),
+                0,
+                true,
+            );
+            let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
+            let url_cef = CefString::from(self.url.as_str());
+            let settings = BrowserSettings::default();
+            let parent_hwnd = sys::HWND(outer_hwnd as *mut _);
+            let mut window_info = WindowInfo::default().set_as_child(parent_hwnd, &rect);
+            window_info.runtime_style = RuntimeStyle::ALLOY;
+
+            let result = browser_host_create_browser(
+                Some(&window_info),
+                client.as_mut(),
+                Some(&url_cef),
+                Some(&settings),
+                None,
+                None,
+            );
+
+            if result == 0 {
+                tracing::error!(
+                    label = %self.label,
+                    "[pane-pool] browser_host_create_browser returned 0 (Windows)"
+                );
+                // Destroy the outer HWND (no browser to close it for us),
+                // clean up reducer + HWND cache, dequeue pending creation.
+                unsafe {
+                    use windows_sys::Win32::UI::WindowsAndMessaging::DestroyWindow;
+                    DestroyWindow(outer_hwnd as *mut std::ffi::c_void);
+                }
+                // on_pane_pool_window_destroyed removes from HWND cache + handles reducer.
+                crate::commands::window_pool::on_pane_pool_window_destroyed(
+                    &self.state, &self.label,
+                );
+                dequeue();
+            }
+        }
+    }
+}
+
+/// Post `CreatePanePoolWindowWin32Task` to the CEF UI thread.
+///
+/// Called by `spawn_pane_pool_window` on Windows instead of
+/// `ui_tasks::post_create_window` so the pool window is a WS_POPUP +
+/// WS_EX_TOOLWINDOW — the same window type as `post_create_floating_window`.
+/// This ensures `promote_pane_pool_window` can reuse the same HWND without
+/// re-creating the window at tear-off time.
+pub(crate) fn post_create_pane_pool_window_win32(
+    state: &Arc<AppState>,
+    label: &str,
+    url: &str,
+) {
+    let mut task = CreatePanePoolWindowWin32Task::new(
+        state.clone(),
+        label.to_string(),
+        url.to_string(),
+    );
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 /// Minimal query-string escaping for the pane id. Encodes the small
 /// set of characters that would break query-string parsing. Avoids
 /// pulling in a `url`/`urlencoding` dependency for a single-call site.

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -322,6 +322,7 @@ async fn route_command(
         "open_window_at_position" => commands::drag::open_window_at_position(state, args),
         "tear_off_pool_promote" => commands::drag::tear_off_pool_promote(state, args),
         "pool_window_ready" => commands::drag::pool_window_ready(state, args),
+        "pane_pool_window_ready" => commands::drag::pane_pool_window_ready(state, args),
         "tear_off_sc_move_handshake" => {
             // Wrap in spawn_blocking — the handler polls state.browsers
             // for up to 2s waiting for the destination window's HWND to

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -34,9 +34,9 @@ use cef::Browser;
 
 use crate::state::{
     BrowserHandle, BrowserKind, CompletedCreation, CreationPhase, DragSession, EffectKind,
-    InFlightCreation, BrowserPaneEntry, BrowserPaneLifecycle, PaneWindowState, PendingWindowCreation,
-    PoolState, QuitReason, QuitState, TopLevelCreationOutcome, TopLevelCreationRequest,
-    TopLevelCreationState, TopLevelSource, WindowPlacement,
+    InFlightCreation, BrowserPaneEntry, BrowserPaneLifecycle, PanePoolState, PaneWindowState,
+    PendingWindowCreation, PoolState, QuitReason, QuitState, TopLevelCreationOutcome,
+    TopLevelCreationRequest, TopLevelCreationState, TopLevelSource, WindowPlacement,
 };
 
 /// Capacity of `TopLevelCreationState.history` ring buffer. Configurable
@@ -104,6 +104,10 @@ pub struct HostState {
     /// `window_pool` / `unpromoted_pool_labels` fields on AppState.
     pub pool: PoolState,
 
+    /// Pane pool state — pre-warmed frameless floating-pane windows
+    /// (`floating-pool-{uuid}`). Mirrors `pool` but for the pane pool.
+    pub pane_pool: PanePoolState,
+
     /// H.5 — quit lifecycle. Replaces the deleted
     /// `AppState.is_quitting: AtomicBool`.
     pub quit_state: QuitState,
@@ -168,6 +172,7 @@ impl Default for HostState {
             browsers: HashMap::new(),
             active_drag: None,
             pool: PoolState::default(),
+            pane_pool: PanePoolState::default(),
             quit_state: QuitState::default(),
             top_level_creation: TopLevelCreationState::default(),
             window_opacities: HashMap::new(),
@@ -346,6 +351,19 @@ pub enum HostCommand {
     /// Drain all pool windows on shutdown. Idempotent.
     PoolDrainAll,
 
+    // ── Pane pool (floating-pool-{uuid}, frameless=true) ────────────────
+    /// Pane pool window spawn started. Adds label to pane_pool.unpromoted
+    /// and sets respawn_in_flight=true (single-flight semaphore).
+    PanePoolWindowSpawnStart { label: String },
+    /// Frontend signalled pane pool window renderer ready. Move from
+    /// unpromoted to queue; clear respawn_in_flight.
+    PanePoolWindowReady { label: String },
+    /// Pane pool window destroyed before promote (renderer crash, OS close).
+    PanePoolWindowDestroyedBeforePromote { label: String },
+    /// Atomic pop+promote front of pane pool queue.
+    /// Returns promoted label via `DispatchOutput::promoted_pane_pool_label`.
+    PopAndPromoteFrontPanePoolWindow,
+
     // ── H.5 — quit lifecycle ────────────────────────────────────────────
 
     /// Transition Running → Draining. Suppresses pool refills, awaits
@@ -498,6 +516,19 @@ impl std::fmt::Debug for HostCommand {
                 .finish(),
             HostCommand::PopAndPromoteFrontPoolWindow => f.write_str("PopAndPromoteFrontPoolWindow"),
             HostCommand::PoolDrainAll => f.write_str("PoolDrainAll"),
+            HostCommand::PanePoolWindowSpawnStart { label } => f
+                .debug_struct("PanePoolWindowSpawnStart")
+                .field("label", label)
+                .finish(),
+            HostCommand::PanePoolWindowReady { label } => f
+                .debug_struct("PanePoolWindowReady")
+                .field("label", label)
+                .finish(),
+            HostCommand::PanePoolWindowDestroyedBeforePromote { label } => f
+                .debug_struct("PanePoolWindowDestroyedBeforePromote")
+                .field("label", label)
+                .finish(),
+            HostCommand::PopAndPromoteFrontPanePoolWindow => f.write_str("PopAndPromoteFrontPanePoolWindow"),
             HostCommand::BeginDrain { reason } => f
                 .debug_struct("BeginDrain")
                 .field("reason", reason)
@@ -814,6 +845,11 @@ pub struct DispatchOutput {
     pub pool_size_after: Option<usize>,
     pub pool_destroyed_was_unpromoted: bool,
     pub promoted_pool_label: Option<String>,
+    // Pane pool fields (parallel to tab pool above)
+    pub pane_pool_spawn_proceeding: bool,
+    pub pane_pool_size_after: Option<usize>,
+    pub pane_pool_destroyed_was_unpromoted: bool,
+    pub promoted_pane_pool_label: Option<String>,
 }
 
 // Manual Debug — `cef::Browser` doesn't impl Debug.
@@ -849,6 +885,7 @@ impl std::fmt::Debug for DispatchOutput {
 /// function takes only `&mut HostState` and produces no I/O.
 mod browsers;
 mod drag;
+mod pane_pool;
 mod pane_window;
 mod panes;
 mod pool;
@@ -904,6 +941,13 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         HostCommand::PromotePoolWindow { label } => pool::handle_promote_pool_window(state, label),
         HostCommand::PopAndPromoteFrontPoolWindow => pool::handle_pop_and_promote_front_pool_window(state),
         HostCommand::PoolDrainAll => pool::handle_pool_drain_all(state),
+        // Pane pool
+        HostCommand::PanePoolWindowSpawnStart { label } => pane_pool::handle_pane_pool_spawn_start(state, label),
+        HostCommand::PanePoolWindowReady { label } => pane_pool::handle_pane_pool_ready(state, label),
+        HostCommand::PanePoolWindowDestroyedBeforePromote { label } => {
+            pane_pool::handle_pane_pool_destroyed_before_promote(state, label)
+        }
+        HostCommand::PopAndPromoteFrontPanePoolWindow => pane_pool::handle_pop_and_promote_front_pane_pool_window(state),
         // H.5 quit
         HostCommand::BeginDrain { reason } => quit::handle_begin_drain(state, reason),
         HostCommand::ConfirmDrained => quit::handle_confirm_drained(state),

--- a/agentmux-cef/src/reducer/pane_pool.rs
+++ b/agentmux-cef/src/reducer/pane_pool.rs
@@ -1,0 +1,81 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pane pool reducer handlers — mirrors reducer/pool.rs for the
+//! `floating-pool-{uuid}` frameless window pool.
+
+use crate::state::*;
+use super::{DispatchOutput, HostState};
+
+pub(super) fn handle_pane_pool_spawn_start(state: &mut HostState, label: String) -> DispatchOutput {
+    if state.quit_state != QuitState::Running {
+        return DispatchOutput {
+            pane_pool_spawn_proceeding: false,
+            ..Default::default()
+        };
+    }
+    if state.pane_pool.respawn_in_flight {
+        return DispatchOutput {
+            pane_pool_spawn_proceeding: false,
+            ..Default::default()
+        };
+    }
+    state.pane_pool.unpromoted.insert(label);
+    state.pane_pool.respawn_in_flight = true;
+    DispatchOutput {
+        pane_pool_spawn_proceeding: true,
+        ..Default::default()
+    }
+}
+
+pub(super) fn handle_pane_pool_ready(state: &mut HostState, label: String) -> DispatchOutput {
+    if !state.pane_pool.unpromoted.remove(&label) {
+        return DispatchOutput {
+            pane_pool_size_after: Some(state.pane_pool.queue.len()),
+            ..Default::default()
+        };
+    }
+    if !state.pane_pool.queue.iter().any(|l| l == &label) {
+        state.pane_pool.queue.push_back(label.clone());
+    }
+    state.pane_pool.respawn_in_flight = false;
+    let queue_len_after = state.pane_pool.queue.len();
+    DispatchOutput {
+        pane_pool_size_after: Some(queue_len_after),
+        ..Default::default()
+    }
+}
+
+pub(super) fn handle_pane_pool_destroyed_before_promote(state: &mut HostState, label: String) -> DispatchOutput {
+    let was_unpromoted = state.pane_pool.unpromoted.remove(&label);
+    let queue_len_before = state.pane_pool.queue.len();
+    state.pane_pool.queue.retain(|l| l != &label);
+    let was_in_queue = state.pane_pool.queue.len() < queue_len_before;
+    state.pane_pool.respawn_in_flight = false;
+    let queue_len_after = state.pane_pool.queue.len();
+    DispatchOutput {
+        pane_pool_destroyed_was_unpromoted: was_unpromoted || was_in_queue,
+        pane_pool_size_after: Some(queue_len_after),
+        ..Default::default()
+    }
+}
+
+pub(super) fn handle_pop_and_promote_front_pane_pool_window(state: &mut HostState) -> DispatchOutput {
+    let label = match state.pane_pool.queue.pop_front() {
+        Some(l) => l,
+        None => return DispatchOutput::default(),
+    };
+    state.pane_pool.unpromoted.remove(&label);
+    // Mark the BrowserHandle as no longer a pool window.
+    if let Some(handle) = state.browsers.get_mut(&label) {
+        if let BrowserKind::TopLevel { is_pool } = &mut handle.kind {
+            *is_pool = false;
+        }
+    }
+    let queue_len_after = state.pane_pool.queue.len();
+    DispatchOutput {
+        promoted_pane_pool_label: Some(label),
+        pane_pool_size_after: Some(queue_len_after),
+        ..Default::default()
+    }
+}

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1063,14 +1063,17 @@ impl AppState {
     /// pool drift while the warm pool is idle and ready.
     pub fn host_counts_snapshot(&self) -> (u32, u32) {
         let st = self.host_state.lock();
+        // `host_counts_snapshot` feeds the launcher's event-sourced pool mirror.
+        // Pane pool emits NO launcher events (report_pool_window_added/removed/promoted),
+        // so including pane_pool.* here would cause permanent DriftDetected{Pool}.
+        // Only the tab pool (window-pool-*) participates in launcher mirror accounting.
+        // See user_visibility_snapshot for the app-exit gate (which correctly includes pane pool).
         let pool_inventory: std::collections::HashSet<&str> = st
             .pool
             .unpromoted
             .iter()
             .map(String::as_str)
             .chain(st.pool.queue.iter().map(String::as_str))
-            .chain(st.pane_pool.unpromoted.iter().map(String::as_str))
-            .chain(st.pane_pool.queue.iter().map(String::as_str))
             .collect();
         let pool = pool_inventory.len() as u32;
         let windows = st

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1076,10 +1076,18 @@ impl AppState {
             .chain(st.pool.queue.iter().map(String::as_str))
             .collect();
         let pool = pool_inventory.len() as u32;
+        // Also exclude floating-pool-* (pane pool windows) from the windows count.
+        // On Windows (this branch) they are excluded from report_window_opened at
+        // client/mod.rs:566, so the launcher mirror does not count them either.
+        // Without this filter, host_windows > launcher_windows → DriftDetected{Windows}.
         let windows = st
             .browsers
             .keys()
-            .filter(|k| !k.starts_with("browser-pane-") && !pool_inventory.contains(k.as_str()))
+            .filter(|k| {
+                !k.starts_with("browser-pane-")
+                    && !k.starts_with("floating-pool-")
+                    && !pool_inventory.contains(k.as_str())
+            })
             .count() as u32;
         (windows, pool)
     }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -270,6 +270,16 @@ pub struct PoolState {
     pub respawn_in_flight: bool,
 }
 
+/// Pre-warmed pane (floating) window pool state.
+/// Mirrors `PoolState` but for `floating-pool-{uuid}` frameless windows.
+#[derive(Default, Clone, Debug)]
+#[allow(dead_code)]
+pub struct PanePoolState {
+    pub queue: std::collections::VecDeque<String>,
+    pub unpromoted: std::collections::HashSet<String>,
+    pub respawn_in_flight: bool,
+}
+
 // ── Quit state (H.5) ─────────────────────────────────────────────────────
 
 /// Host process quit lifecycle. Replaces `is_quitting: AtomicBool` at
@@ -1094,6 +1104,10 @@ impl AppState {
     /// whether to bootstrap more pool windows.
     pub fn pool_queue_size(&self) -> usize {
         self.host_state.lock().pool.queue.len()
+    }
+
+    pub fn pane_pool_queue_size(&self) -> usize {
+        self.host_state.lock().pane_pool.queue.len()
     }
 
     /// Atomic snapshot for user-visibility filtering: pool inventory

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1069,6 +1069,8 @@ impl AppState {
             .iter()
             .map(String::as_str)
             .chain(st.pool.queue.iter().map(String::as_str))
+            .chain(st.pane_pool.unpromoted.iter().map(String::as_str))
+            .chain(st.pane_pool.queue.iter().map(String::as_str))
             .collect();
         let pool = pool_inventory.len() as u32;
         let windows = st
@@ -1079,17 +1081,16 @@ impl AppState {
         (windows, pool)
     }
 
-    /// Snapshot of unpromoted pool labels. Used by orphan
-    /// reconciliation and the pool-count report after spawning a
-    /// new pool slot. Caller can `.contains()` against the set or
-    /// iterate.
+    /// Snapshot of unpromoted pool labels — both tab pool (`window-pool-*`)
+    /// and pane pool (`floating-pool-*`). Used by orphan reconciliation and
+    /// the pool-count report after spawning a new pool slot.
     pub fn unpromoted_pool_labels_snapshot(&self) -> std::collections::HashSet<String> {
-        self.host_state
-            .lock()
-            .pool
+        let st = self.host_state.lock();
+        st.pool
             .unpromoted
             .iter()
             .cloned()
+            .chain(st.pane_pool.unpromoted.iter().cloned())
             .collect()
     }
 
@@ -1121,9 +1122,11 @@ impl AppState {
     /// user window. Atomic snapshot eliminates the gap.
     ///
     /// Returns:
-    /// - `pool_inventory`: labels in `pool.unpromoted` ∪ `pool.queue`
-    ///   (host-internal, no user UI yet — exclude from user-visible
-    ///   filters and from launcher-event dispatch).
+    /// - `pool_inventory`: labels in `pool.unpromoted` ∪ `pool.queue` ∪
+    ///   `pane_pool.unpromoted` ∪ `pane_pool.queue` — all host-internal
+    ///   pool windows (both tab pool `window-pool-*` and pane pool
+    ///   `floating-pool-*`) that have no user UI yet; exclude from
+    ///   user-visible filters and from launcher-event dispatch.
     /// - `browsers`: every label → Browser pair currently registered
     ///   (cheap clone — `Browser` is a CEF refcounted wrapper).
     pub fn user_visibility_snapshot(&self) -> (
@@ -1137,6 +1140,8 @@ impl AppState {
             .iter()
             .cloned()
             .chain(st.pool.queue.iter().cloned())
+            .chain(st.pane_pool.unpromoted.iter().cloned())
+            .chain(st.pane_pool.queue.iter().cloned())
             .collect();
         let browsers: Vec<(String, Browser)> = st
             .browsers

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -990,6 +990,98 @@ pub fn post_promote_pool_window_for_new_window(
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Promote pane pool window (macOS / Linux) ──────────────────────────────
+//
+// Repositions a floating-pool-{uuid} frameless window from its off-screen
+// holding position to the drop-target bounds and emits pool:pane-promote so
+// the renderer mounts FloatingPaneWorkspace with the given paneId+workspaceId.
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct PromotePanePoolWindowTask {
+        state: Arc<AppState>,
+        label: String,
+        pane_id: String,
+        workspace_id: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let Some(window) = get_window_on_ui(&self.state, &self.label) else {
+                tracing::warn!(
+                    target: "pool:pane",
+                    label = %self.label,
+                    "[pane-pool] window not found on UI thread — pool window may have closed"
+                );
+                return;
+            };
+
+            window.set_bounds(Some(&cef::Rect {
+                x: self.x,
+                y: self.y,
+                width: self.width,
+                height: self.height,
+            }));
+            window.show();
+
+            tracing::info!(
+                target: "pool:pane",
+                label = %self.label,
+                x = self.x,
+                y = self.y,
+                width = self.width,
+                height = self.height,
+                "[pane-pool] window repositioned + shown"
+            );
+
+            crate::events::emit_event_to_window(
+                &self.state,
+                &self.label,
+                "pool:pane-promote",
+                &serde_json::json!({
+                    "paneId": self.pane_id,
+                    "workspaceId": self.workspace_id,
+                }),
+            );
+
+            tracing::info!(
+                target: "pool:pane",
+                label = %self.label,
+                pane_id = %self.pane_id,
+                workspace_id = %self.workspace_id,
+                "[pane-pool] pool:pane-promote emitted — renderer will mount FloatingPaneWorkspace"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn post_promote_pane_pool_window(
+    state: &Arc<AppState>,
+    label: &str,
+    pane_id: &str,
+    workspace_id: &str,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+) {
+    let mut task = PromotePanePoolWindowTask::new(
+        state.clone(),
+        label.to_string(),
+        pane_id.to_string(),
+        workspace_id.to_string(),
+        x,
+        y,
+        width,
+        height,
+    );
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Get window absolute position (DIP) — blocking UI-thread read ──────────
 //
 // CEF Views `window.bounds()` must run on the UI thread, but

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -557,11 +557,18 @@ export async function initApp() {
             // wait for either `pool:promote` (tear-off, injects workspaceId) or
             // `pool:new-window` (Cmd+N, no workspaceId → fresh workspace).
             // initHostNewWindow branches on workspaceId presence automatically.
-            const { isPoolMode, awaitPoolPromote } = await import("@/app/init/pool");
+            const { isPoolMode, awaitPoolPromote, isPanePoolMode, awaitPanePoolPromote } = await import("@/app/init/pool");
             if (isPoolMode()) {
                 getApi().sendLog("[initApp] pool mode — deferring init until pool:promote or pool:new-window");
                 await awaitPoolPromote();
                 getApi().sendLog("[initApp] pool event received — bootstrapping workspace");
+                await initHostNewWindow();
+            } else if (isPanePoolMode()) {
+                // Pane pool: wait for pool:pane-promote which injects floatingPaneId+workspaceId
+                // into the URL, then initHostNewWindow reattaches and wave renders FloatingPaneWorkspace.
+                getApi().sendLog("[initApp] pane-pool mode — deferring init until pool:pane-promote");
+                await awaitPanePoolPromote();
+                getApi().sendLog("[initApp] pool:pane-promote received — bootstrapping floating pane");
                 await initHostNewWindow();
             } else {
                 // Check if this is a new window or the main window

--- a/frontend/app/init/pool.ts
+++ b/frontend/app/init/pool.ts
@@ -14,10 +14,16 @@
 //
 // Spec: docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26 §4.5
 
-/** True when the current renderer was spawned as a pool window. */
+/** True when the current renderer was spawned as a tab/new-window pool window. */
 export function isPoolMode(): boolean {
     if (typeof window === "undefined") return false;
     return new URLSearchParams(window.location.search).get("pool") === "1";
+}
+
+/** True when the current renderer was spawned as a pane pool window. */
+export function isPanePoolMode(): boolean {
+    if (typeof window === "undefined") return false;
+    return new URLSearchParams(window.location.search).get("pane-pool") === "1";
 }
 
 /**
@@ -77,6 +83,50 @@ export async function awaitPoolPromote(): Promise<void> {
         } catch (e) {
             cleanup();
             reject(new Error(`pool_window_ready signal failed: ${e}`));
+        }
+    });
+}
+
+/**
+ * Wait for the host's `pool:pane-promote` event.
+ *
+ * Injects `floatingPaneId` and `workspaceId` into the URL and removes
+ * `pane-pool=1`, then resolves. `initHostNewWindow` reattaches the workspace
+ * (workspaceId present) and the wave renderer mounts `FloatingPaneWorkspace`
+ * because `floatingPaneId` is in the URL — same code path as the cold-start
+ * floating pane URL `?floatingPaneId=X&workspaceId=Y`.
+ *
+ * Race contract: both listeners are installed before `pane_pool_window_ready`
+ * signals the host, so the promote event cannot arrive before we are ready.
+ */
+export async function awaitPanePoolPromote(): Promise<void> {
+    const { listenEvent } = await import("@/app/platform/ipc");
+    const { invokeCommand } = await import("@/app/platform/ipc");
+    const { getApi } = await import("@/store/global");
+
+    return new Promise<void>(async (resolve, reject) => {
+        let unsub: (() => void) | undefined;
+        const cleanup = () => { unsub?.(); };
+
+        unsub = await listenEvent<{ paneId: string; workspaceId: string }>(
+            "pool:pane-promote",
+            (payload) => {
+                cleanup();
+                const url = new URL(window.location.href);
+                url.searchParams.set("floatingPaneId", payload.paneId);
+                url.searchParams.set("workspaceId", payload.workspaceId);
+                url.searchParams.delete("pane-pool");
+                window.history.replaceState({}, "", url.toString());
+                resolve();
+            },
+        );
+
+        try {
+            const label = await getApi().getWindowLabel();
+            await invokeCommand("pane_pool_window_ready", { label });
+        } catch (e) {
+            cleanup();
+            reject(new Error(`pane_pool_window_ready signal failed: ${e}`));
         }
     });
 }

--- a/frontend/app/init/pool.ts
+++ b/frontend/app/init/pool.ts
@@ -114,7 +114,13 @@ export async function awaitPanePoolPromote(): Promise<void> {
                 cleanup();
                 const url = new URL(window.location.href);
                 url.searchParams.set("floatingPaneId", payload.paneId);
-                url.searchParams.set("workspaceId", payload.workspaceId);
+                // Match cold-path contract: omit workspaceId when empty so
+                // initHostNewWindow's `if (tearOffWsId)` guard is not triggered
+                // with a blank value. In practice workspaceId is always present
+                // for a pane tear-off, but guard defensively.
+                if (payload.workspaceId) {
+                    url.searchParams.set("workspaceId", payload.workspaceId);
+                }
                 url.searchParams.delete("pane-pool");
                 window.history.replaceState({}, "", url.toString());
                 resolve();


### PR DESCRIPTION
## Summary

Implements the pre-warmed pane pool on Windows, completing pane tear-off pool coverage across all three platforms.

**Why WS_POPUP, not CEF Views frameless?** On Windows, pane pool windows must be created as `WS_POPUP + WS_EX_TOOLWINDOW` (the same type as the cold-path `post_create_floating_window`) rather than the CEF Views frameless window used by macOS/Linux. The cascade hook system (min/restore/destroy) and the unowned-popup Z-ordering fix (issue #1560) are specific to `WS_POPUP`; a CEF Views frameless window would not have these properties and would produce different visual behavior at promote time.

## Coverage after this PR

| Operation | Windows | macOS | Linux |
|-----------|---------|-------|-------|
| Tab tear-off | ✅ pool | ✅ pool | ✅ pool |
| New window (Cmd/Ctrl+N) | ✅ pool (#1609) | ✅ pool | ✅ pool |
| Pane tear-off | ✅ pool (this PR) | ✅ pool (#1610) | ✅ pool (#1610) |

## Architecture

- **`CreatePanePoolWindowWin32Task`** (new, `floating_pane.rs`): Runs on CEF UI thread. Calls `create_popup` at (-32000, -32000) → immediately `ShowWindow(SW_HIDE)` → caches outer HWND in `PANE_POOL_HWND_CACHE` → inserts in `window_hwnds` → `browser_host_create_browser(set_as_child)`.
  - `register_floater_hwnd` is **deferred** to promote time (parent HWND unknown at spawn).
- **`PANE_POOL_HWND_CACHE`** (new, `window_pool.rs`): Windows-only static for outer `WS_POPUP` HWND — same rationale as `POOL_HWND_CACHE` (CEF's `window_handle()` goes null after page load).
- **`spawn_pane_pool_window` (Windows)**: Dispatches to `post_create_pane_pool_window_win32` instead of `post_create_window`.
- **`promote_pane_pool_window` (Windows)**: Gets `label` from reducer pop → outer HWND from cache → `IsWindow` liveness check → `SetWindowPos` + `ShowWindow(SW_SHOWNORMAL)` → `register_floater_hwnd` (cascade hook, now deferred) → `emit_event_to_window("pool:pane-promote", {paneId, workspaceId})` → refill spawn.
- **`open_floating_pane_window` (Windows)**: Pool-first path added before `post_create_floating_window`; `width`/`height` are already DPI-converted physical pixels at the call site, `parent_main_hwnd` is passed for cascade binding.

## Depends on

- #1610 (pane tear-off pool macOS/Linux) — shares the reducer arms, frontend `awaitPanePoolPromote`, `on_pane_pool_window_destroyed`, state changes. This PR should merge after #1610.

## Test plan

- [ ] Windows: drag pane out → appears in ~30ms; no cold-path spawn in host log
- [ ] Windows: `muxlog host 'pool:pane'` shows `[pane-pool] promoting pane pool window (Windows)` + refill spawn
- [ ] Windows: pane pool refills after consume — `[pane-pool] spawning pane pool window` fires
- [ ] Windows: promoted pane pool window is WS_POPUP (no taskbar entry while idle; appears normally after promote)
- [ ] Windows: minimize main window → pane floater minimizes (cascade hook registered at promote time)
- [ ] Windows: close main window → pane floater also closes (cascade hook WM_DESTROY)
- [ ] Windows: rapid back-to-back pane tears gracefully cold-path (pool exhausted)
- [ ] Windows: tab tear-off still works (separate POOL_HWND_CACHE, no interference)
- [ ] macOS/Linux: pane tear-off still uses CEF Views path (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)