### PR TITLE
fix(auth): host CLI login capture for Claude Code v2.1.x — instrument + seed-from-global

### DIFF
--- a/.changesets/1781950297-fix-auth-log-every-pty-login-line-and-auth-env-precedence.md
+++ b/.changesets/1781950297-fix-auth-log-every-pty-login-line-and-auth-env-precedence.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): instrument host CLI login — log every PTY line from byte 0 + auth-env precedence snapshot (host-login-capture §4)

--- a/.changesets/1781952589-fix-auth-use-existing-claude-login-seed-from-global.md
+++ b/.changesets/1781952589-fix-auth-use-existing-claude-login-seed-from-global.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): "Use existing login" — seed an agent from a valid global Claude credential instead of a fresh OAuth (host-login-capture §5.5)

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -446,6 +446,34 @@ pub async fn run_cli_login(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    // §4 instrumentation (SPEC_HOST_CLI_LOGIN_CAPTURE): snapshot the
+    // auth-precedence env keys the child will see. A stray ANTHROPIC_API_KEY
+    // (precedence #3) overrides subscription OAuth (#6) and, if it belongs to a
+    // disabled/expired org, yields the "loggedIn but 401" symptom we're chasing.
+    // "override" = passed explicitly in auth_env; "inherited" = present in the
+    // host process env the child inherits; "absent" = neither. NAMES/STATES
+    // ONLY — values are never logged.
+    {
+        let source = |k: &str| -> &'static str {
+            if auth_env.contains_key(k) {
+                "override"
+            } else if std::env::var(k).is_ok() {
+                "inherited"
+            } else {
+                "absent"
+            }
+        };
+        tracing::info!(
+            target: "login_pty",
+            cli = %cli_path,
+            requires_tty,
+            anthropic_api_key = source("ANTHROPIC_API_KEY"),
+            anthropic_auth_token = source("ANTHROPIC_AUTH_TOKEN"),
+            claude_code_oauth_token = source("CLAUDE_CODE_OAUTH_TOKEN"),
+            "run_cli_login: auth-env precedence snapshot"
+        );
+    }
+
     // Supersede any in-progress login so we never accumulate orphaned
     // `auth login` children (one per attempt — the confirmed leak). cancel_cli_login
     // kills both transports (pipe oneshot + PTY kill-by-PID) and is idempotent —
@@ -690,12 +718,11 @@ async fn run_cli_login_pty(
         use std::io::BufRead;
         let mut reader = std::io::BufReader::new(reader);
         // Wrap the oneshot in an Option so we send the URL exactly once and then
-        // keep reading. Before the URL: scan for it. After: keep draining and LOG
-        // every line — the CLI's `Paste code here >` prompt and, crucially, its
-        // response to the code delivered via set_provider_auth (success vs. an
-        // "invalid code" / error). Without this the host discarded that output,
-        // so a failed login was a black box. Draining also keeps the CLI from
-        // blocking on a full PTY output buffer.
+        // keep reading. We LOG every line from the first byte AND scan for an
+        // OAuth URL until one is found — the CLI's `Paste code here >` prompt
+        // and, crucially, its response to the code delivered via
+        // set_provider_auth (success vs. an "invalid code" / error). Draining
+        // also keeps the CLI from blocking on a full PTY output buffer.
         let mut url_tx = Some(url_tx);
         let mut line = String::new();
         loop {
@@ -703,16 +730,23 @@ async fn run_cli_login_pty(
             match reader.read_line(&mut line) {
                 Ok(0) => break, // EOF
                 Ok(_) => {
+                    // Log EVERY PTY line from the first byte (§4 of
+                    // SPEC_HOST_CLI_LOGIN_CAPTURE). Before this, lines were only
+                    // logged AFTER a URL was captured, so a login that never
+                    // printed a URL (Claude Code v2.1.x — the URL is clipboard-
+                    // on-`c`, not a stdout line) was a black box: we couldn't
+                    // tell capture-miss from no-browser from a silent exit.
+                    let t = line.trim_end();
+                    if !t.trim().is_empty() {
+                        tracing::info!(target: "login_pty", "[login-pty] {}", t);
+                    }
+                    // Still capture an OAuth URL for providers that DO print one
+                    // (Codex/Gemini/OpenClaw); a no-op for Claude v2.1.x.
                     if let Some(tx) = url_tx.take() {
                         if let Some(u) = extract_url(&line) {
                             let _ = tx.send(Some(u));
                         } else {
                             url_tx = Some(tx); // not the URL line yet
-                        }
-                    } else {
-                        let t = line.trim_end();
-                        if !t.trim().is_empty() {
-                            tracing::info!(target: "login_pty", "[login-pty] {}", t);
                         }
                     }
                 }

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -364,6 +364,130 @@ pub async fn set_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) 
     Ok(serde_json::Value::Null)
 }
 
+/// Seed an agent's ISOLATED provider auth dir from the user's GLOBAL CLI login.
+///
+/// The reliable recovery when the host can't drive a provider's OAuth TUI
+/// (Claude Code v2.1.x opens its own browser + localhost callback and never
+/// prints a scrapeable URL — see `SPEC_HOST_CLI_LOGIN_CAPTURE` §5.5): if the
+/// user already has a valid GLOBAL Claude login, copy it verbatim into the
+/// agent's isolated dir, which the spawned CLI reads via `CLAUDE_CONFIG_DIR`.
+/// The copy keeps its `refreshToken`, so the isolated session keeps refreshing.
+///
+/// - GLOBAL source: `$CLAUDE_CONFIG_DIR/.credentials.json` when the user set
+///   that in their own shell env (the host inherits it), else
+///   `~/.claude/.credentials.json` (Anthropic's documented default). This is the
+///   user's real login — NOT the agent's isolated dir, which is the destination.
+/// - ISOLATED destination: `~/.agentmux/shared/providers/<provider>/.credentials.json`
+///   (`state.user_home_dir` + `shared/providers/<provider>`), matching
+///   `ensure_auth_dir`.
+///
+/// Validity is gated HERE (the frontend can't read the global dir): we only
+/// seed when `claudeAiOauth.expiresAt` is in the future — mirrors
+/// `agentmux-srv` `identity::resolver::probe_oauth_status`. Returns
+/// `{ seeded, status, expiresAt }` so the UI can explain a no-op without ever
+/// seeing token material — `status`: `seeded` | `missing` | `expired`.
+pub fn seed_provider_auth_from_global(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let provider = args
+        .get("provider")
+        .or_else(|| args.get("provider_id"))
+        .or_else(|| args.get("providerId"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("claude");
+
+    // Only Claude has both a documented global location and a credential shape
+    // we can validate. Reject others explicitly rather than copy blind.
+    if provider != "claude" {
+        return Err(format!(
+            "seed-from-global is only supported for 'claude' (got '{provider}')"
+        ));
+    }
+
+    // GLOBAL source — the user's own login. Honour a user-level
+    // CLAUDE_CONFIG_DIR (the host inherits it) else the documented `~/.claude`.
+    let global_dir = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))
+        .ok_or_else(|| "Could not resolve the global Claude config dir".to_string())?;
+    let global_cred = global_dir.join(".credentials.json");
+
+    let contents = match std::fs::read_to_string(&global_cred) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::info!(
+                target: "login_pty",
+                path = %global_cred.to_string_lossy(),
+                "seed_provider_auth_from_global: no global credential to seed"
+            );
+            return Ok(serde_json::json!({ "seeded": false, "status": "missing" }));
+        }
+    };
+
+    // Validate non-expired before seeding (claude shape: claudeAiOauth.expiresAt, ms).
+    let json: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|_| "Global Claude credential is not valid JSON".to_string())?;
+    let expires_at_ms = json
+        .get("claudeAiOauth")
+        .and_then(|o| o.get("expiresAt"))
+        .and_then(|v| v.as_i64())
+        .or_else(|| json.get("expiresAt").and_then(|v| v.as_i64()));
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    if let Some(exp) = expires_at_ms {
+        if exp <= now_ms {
+            tracing::info!(
+                target: "login_pty",
+                expires_at = exp,
+                "seed_provider_auth_from_global: global credential expired — not seeding"
+            );
+            return Ok(
+                serde_json::json!({ "seeded": false, "status": "expired", "expiresAt": exp }),
+            );
+        }
+    }
+
+    // ISOLATED destination — the same path `ensure_auth_dir` builds.
+    let home = state
+        .user_home_dir
+        .lock()
+        .clone()
+        .ok_or_else(|| "User home dir not initialized yet".to_string())?;
+    let dest_dir = std::path::PathBuf::from(home)
+        .join("shared")
+        .join("providers")
+        .join(provider);
+    std::fs::create_dir_all(&dest_dir)
+        .map_err(|e| format!("Failed to create isolated auth dir: {e}"))?;
+    let dest_cred = dest_dir.join(".credentials.json");
+
+    // Write verbatim via temp + rename so a concurrent reader (the agent's CLI)
+    // never sees a half-written credential.
+    let tmp = dest_dir.join(".credentials.json.seed-tmp");
+    std::fs::write(&tmp, contents.as_bytes())
+        .map_err(|e| format!("Failed to write seeded credential: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    std::fs::rename(&tmp, &dest_cred)
+        .map_err(|e| format!("Failed to finalize seeded credential: {e}"))?;
+
+    tracing::info!(
+        target: "login_pty",
+        provider,
+        dest = %dest_cred.to_string_lossy(),
+        "seed_provider_auth_from_global: seeded isolated dir from valid global login"
+    );
+    Ok(serde_json::json!({ "seeded": true, "status": "seeded", "expiresAt": expires_at_ms }))
+}
+
 /// Clear auth token for a provider.
 pub fn clear_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let provider = args

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -358,6 +358,9 @@ async fn route_command(
         "get_cli_path" => commands::providers::get_cli_path(state, args),
         "check_nodejs_available" => commands::providers::check_nodejs_available().await,
         "ensure_auth_dir" => commands::platform::ensure_auth_dir(state, args),
+        "seed_provider_auth_from_global" => {
+            commands::providers::seed_provider_auth_from_global(state, args)
+        }
         "run_cli_login" => commands::platform::run_cli_login(state.clone(), args).await,
         "cancel_cli_login" => commands::platform::cancel_cli_login(state),
         "ensure_settings_file" => commands::platform::ensure_settings_file(state),

--- a/docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md
+++ b/docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md
@@ -1,0 +1,232 @@
+# SPEC: Host-side CLI login capture is broken for Claude Code v2.1.183
+**Date:** 2026-06-20
+**Author:** AgentA
+**Status:** Draft — revised 2026-06-20 after upstream-docs research + code re-read
+**Related:** SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20 (frontend force-login, merged #1604)
+
+---
+
+## 1. Symptom
+
+After the frontend force-login fix (#1604), clicking **Login Again** correctly
+calls `run_cli_login` (confirmed in logs). But **no browser opens and no OAuth URL
+box appears**. The agent stays un-authenticated.
+
+## 2. Root cause
+
+`run_cli_login` / `run_cli_login_pty` (`agentmux-cef/src/commands/platform.rs`)
+spawns the provider login (`claude auth login`) in a PTY and **scrapes each output
+line for an OAuth URL** via `extract_url`, with a 15 s cap. For Claude Code CLI
+**v2.1.183** this never fires:
+
+```
+run_cli_login: spawned (PTY), waiting for OAuth URL  cli=…claude.cmd  pid=…
+run_cli_login_pty: no auth URL captured within 15s          ← every time
+```
+
+Evidence gathered 2026-06-20 (repro) + 2026-06-20 (upstream-docs research):
+- `claude auth login --help` exposes no URL-printing / headless flag
+  (`--claudeai | --console | --email | --sso` only).
+- Run in a **non-TTY pipe**, `claude auth login` prints **nothing** to stdout
+  (exits on timeout) — it's a TTY-interactive TUI.
+- In a **real terminal** it opens its own browser and runs a **localhost OAuth
+  callback server** — it does NOT emit a plain `https://…` URL line for the host
+  to scrape. Per upstream docs, the URL only materialises when the user **presses
+  `c` to copy the login URL to the clipboard** — so there is *no printable URL
+  line for `extract_url` to match* on this CLI version. This is the real reason
+  the scrape model is obsolete, not an ANSI-stripping gap: `extract_url` already
+  strips CSI/OSC-8 (`platform.rs:805`).
+
+Two distinct failures stack here:
+- **(A) URL not captured** → host can't open a browser (this spec). Confirmed
+  cause: the URL is clipboard-on-`c`, never a stdout line.
+- **(B) localhost callback unreachable** when the user logged in manually — made
+  worse by *competing* login processes (host PTY attempt + diagnostic probes)
+  leaving stale tabs whose callback servers had died. A clean single attempt is
+  the precondition for any callback to land. This is the **inherent weakness of
+  the RFC 8252 loopback-redirect flow** in sandboxed/non-default-browser contexts
+  — see §3.5.
+
+Orthogonal, already understood (SPEC_REAUTH §11): `claude auth status` reports
+`loggedIn:true` for an **expired** token (checks presence, not validity) — so it
+can't be used to gate OR to confirm a login. **New hypothesis to rule out in §4:**
+upstream docs state that a stray `ANTHROPIC_API_KEY` in the environment *takes
+precedence over* subscription OAuth (auth precedence #3 > #6) and, if the key
+belongs to a disabled/expired org, produces exactly this "looks logged in but
+401s" symptom. The agent env may be leaking one in.
+
+## 3. Why the old model worked before
+
+Earlier Claude CLI builds printed the OAuth URL as a plain line; `extract_url`
+caught it, the host opened the browser (or, post-#1594, an in-app pane) and polled
+`auth status` for completion. v2.1.183 moved to a self-driving TUI (opens its own
+browser, runs its own callback, copies the URL to the clipboard on `c`), breaking
+both the capture and the host-opens-the-browser assumption.
+
+## 3.5 Research findings (upstream docs, 2026-06-20)
+
+Anthropic now documents **three officially-supported auth paths that do not
+require scraping a URL** ([code.claude.com/docs/en/authentication](https://code.claude.com/docs/en/authentication.md)).
+This reframes the whole fix: stop fighting the transport, adopt a supported path.
+
+1. **`claude setup-token` → `CLAUDE_CODE_OAUTH_TOKEN`** — the documented headless
+   path. `claude setup-token` runs OAuth once and **prints a one-year token to
+   stdout** (it saves nothing). Capture stdout, write the token into the agent's
+   isolated env as `CLAUDE_CODE_OAUTH_TOKEN`. Precedence #5 — above subscription
+   `/login` (#6), so it bypasses the un-driveable `auth login` TUI entirely.
+   Caveats: requires Pro/Max/Team/Enterprise; **inference-only** (no Remote
+   Control); **`--bare` ignores it**.
+2. **Paste-the-code fallback (v2.1+)** — when the browser callback can't reach
+   localhost (the docs explicitly name **WSL2, SSH, containers** — our PTY case),
+   the CLI shows a login code in the browser and prompts
+   **`Paste code here if prompted`** on stdin. This is the designed-for-sandbox
+   path and the robust answer to failure (B). **Our infra already supports it:**
+   `set_provider_auth` writes a code into `cli_login_stdin` over both pipe and PTY
+   (`CliLoginStdin::write_line`, `platform.rs:373`). The missing piece is getting
+   the user *to* the auth URL (open it host-side, or send `c` and read the
+   clipboard) and surfacing the paste box.
+3. **Env-var / credential precedence** — order is Bedrock/Vertex/Foundry →
+   `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` →
+   `CLAUDE_CODE_OAUTH_TOKEN` → subscription `/login`. Credentials live in
+   `~/.claude/.credentials.json` (mode 0600; under `CLAUDE_CONFIG_DIR` when set;
+   macOS uses Keychain). This **confirms §5.5 (seed-from-global)** as the
+   industry-standard recovery — upstream issue #7100's recommended remote-auth
+   method is literally "copy the credential file."
+
+Standards context: Claude's flow (loopback redirect + PKCE) is exactly what
+[RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html) mandates for native apps;
+the loopback's known failure mode is "callback can't reach localhost," and the
+standard mitigation is the manual code-paste fallback — i.e. path 2, not forcing
+a subprocess browser-open (old §5.3).
+
+## 4. Required first step — INSTRUMENT (don't design blind)
+
+`run_cli_login_pty` only logs PTY lines **after** a URL is seen (target
+`login_pty`, `platform.rs:713`); the pre-URL scan silently consumes everything.
+We never see what `claude auth login` actually prints **before** the
+(never-captured) URL. Before committing to a fix, log **every** PTY line from the
+first byte, plus the child's exit code (already logged) and the auth-related env
+keys present. Capture one real run. That tells us definitively whether claude:
+  (a) prints a URL we're failing to match (→ unlikely given §2, but cheap to rule out),
+  (b) opens its own browser + shows a paste prompt (→ path 2 / §5.1), or
+  (c) silently does nothing in the host's PTY env (→ path 1 `setup-token` / §5.3).
+
+Also assert in this step: **is `ANTHROPIC_API_KEY` present in the agent env?**
+(§2 new hypothesis). Log the *names* of auth-related env keys (never values).
+
+Implemented in this spec's first code slice (see §8).
+
+## 5. Fix options (ranked, revised after §3.5)
+
+### 5.1 `setup-token` capture → `CLAUDE_CODE_OAUTH_TOKEN` (NEW — preferred)
+Change Claude's `login_args` from `["auth", "login"]` to `["setup-token"]`. Run it
+in the PTY (still needs a TTY + browser for the one-time OAuth), but instead of
+scraping a URL, **capture the token line it prints to stdout**, then write it into
+the agent's isolated provider env / a place the agent's spawn env reads as
+`CLAUDE_CODE_OAUTH_TOKEN`. Robust: it's the documented headless contract, and
+completion is the token's *arrival*, not a fragile status poll. Pairs with §5.2
+for the browser-open and §5.5 as the no-OAuth fallback.
+
+### 5.2 Drive the paste-code flow (NEW — interactive fallback)
+Stop scraping. Host opens the auth URL itself (obtain it by sending `c` to the PTY
+and reading the clipboard, or — simpler — let claude open its own browser), the
+user authorises, the browser shows a code, the user pastes it into the existing
+auth box, and `set_provider_auth` forwards it to the child over the *already-wired*
+`CliLoginStdin`. Detect completion by the credential's `expiresAt` advancing (NOT
+`loggedIn:true`, which lies). This is the RFC 8252-sanctioned fallback and reuses
+infra we already ship.
+
+### 5.3 Status-transition poll (completion detector, not a driver)
+Snapshot the credential's `expiresAt` (or its absence), then poll
+`auth status --json` until a **new** credential appears — detect login by
+`expiresAt` advancing. Keep as the *completion signal* layered onto 5.1/5.2; it
+does not by itself make a browser open, so it is not a standalone fix (the
+2026-06-20 repro showed no browser opened from the host's spawn).
+
+### 5.4 logout-then-login (needed regardless)
+A stale/expired-but-present credential makes `claude auth login` / `setup-token`
+prompt/skip instead of starting a clean OAuth. For an explicit re-login, run
+`auth logout` first (host-side, in the isolated `CLAUDE_CONFIG_DIR`) so the OAuth
+always starts clean. Also `unset ANTHROPIC_API_KEY` for the child if §4 shows one
+leaking (§2). Pairs with whichever capture fix lands.
+
+### 5.5 "Use my existing login" — seed from global (ship now, low risk)
+The reliable 2026-06-20 recovery was copying `~/.claude/.credentials.json` into the
+agent's isolated dir (`~/.agentmux/shared/providers/claude/.credentials.json`).
+Add an explicit button/flow: when a global Claude login exists and is valid
+(`expiresAt` in the future), offer "Use my existing Claude login" which copies the
+credential (incl. `refreshToken`, so it keeps refreshing). This is the documented
+"seed isolated creds from global" pattern (cf. PR #1283) and the upstream-#7100
+recommended remote-auth method — unblocks users even if the OAuth capture is never
+fixed. Caveat: global and isolated then share a `refreshToken`; if Anthropic
+rotates refresh tokens, one side can stale the other — acceptable as a recovery
+path, document it.
+
+### 5.6 `extract_url` fix — DROPPED
+The old §5.2. `extract_url` already strips CSI/OSC-8 (`platform.rs:805`); the
+problem is not an unmatched URL but **no URL line at all** (clipboard-on-`c`).
+Keep `extract_url` for the providers that *do* print a URL (Codex/Gemini/OpenClaw),
+but it is a dead end for Claude v2.1.x.
+
+## 6. Recommendation
+
+1. **Now:** ship **5.5** (seed-from-global button) as the reliable recovery — it
+   needs no URL capture and works today.
+2. **Now (this PR):** land the **§4 instrumentation** so a real run can be
+   captured (small, safe, permanent-quality logging).
+3. **Next:** capture one real `claude auth login` / `setup-token` run on a host
+   build; confirm (a)/(b)/(c) and whether `ANTHROPIC_API_KEY` is leaking.
+4. **Then:** implement **5.1 (`setup-token`)** as the primary capture — fall back
+   to **5.2 (paste-code)** for the interactive case; layer **5.3** as the
+   completion detector and fold in **5.4** for clean re-login.
+5. Old §5.3 (force a subprocess browser-open) and old §5.2 (`extract_url` rework)
+   are **dropped** for Claude — superseded by the supported paths above.
+
+## 7. Test plan
+
+- Reproduce by invalidating the isolated credential (expire `expiresAt` + corrupt
+  `refreshToken`) so the agent 401s with `auth status` still `loggedIn:true`.
+- Assert: failure banner + inline 401 node appear (regression guard on the merged
+  visibility work).
+- Assert: §4 instrumentation logs every PTY line from byte 0 + the auth-env key
+  names for one real run.
+- Assert (5.1): a completed `setup-token` run yields a token, and an agent spawned
+  with `CLAUDE_CODE_OAUTH_TOKEN` set authenticates on its next turn.
+- Assert (5.2): the paste box appears, a pasted code reaches the child, and a
+  completed login writes a credential with an advanced `expiresAt`.
+- Assert (5.5): seeds a valid credential when a global login exists.
+
+## 8. Implementation log
+
+- **2026-06-20 — slice 1 (§4 instrumentation):** `run_cli_login_pty` now logs
+  every PTY line from the first byte (not just after a URL), and both spawn paths
+  log the *names* of auth-related env keys present in `auth_env`
+  (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`) so the
+  precedence hypothesis (§2) is checkable from logs. Names only — never values.
+  Target `login_pty`, visible via `muxlog host grep login-pty`.
+  Verified: `cargo check -p agentmux-cef` green (1m50s) after clearing a
+  partial-CEF-extraction build blocker (see memory `CEF extraction race vs
+  Windows file scanners`). Not yet smoke-tested against a live login run (needs a
+  host build + interactive OAuth — §4's capture step).
+
+- **2026-06-20 — slice 2 (§5.5 ship-now recovery): "Use my existing Claude login".**
+  New host IPC command `seed_provider_auth_from_global`
+  (`agentmux-cef/src/commands/providers.rs` + `ipc.rs`): reads the user's GLOBAL
+  Claude credential (`$CLAUDE_CONFIG_DIR` if the host inherits one, else
+  `~/.claude/.credentials.json`), validates `claudeAiOauth.expiresAt` is in the
+  future (mirrors `agentmux-srv` `identity::resolver::probe_oauth_status`), and
+  copies it verbatim — incl. `refreshToken`, so the isolated session keeps
+  refreshing — into the agent's isolated dir
+  (`~/.agentmux/shared/providers/claude/.credentials.json`) via temp+rename.
+  Returns `{ seeded, status: seeded|missing|expired, expiresAt }` (no token
+  material). Frontend: `seedProviderAuthFromGlobal` API
+  (`cef-api.ts`/`custom.d.ts`), a `seedGlobalLogin` flow, `useGlobalLogin` on
+  `useAgentControllerStatus`, and a "Use existing login" 🌐 action beside
+  "Login Again" on the 401/403 failure CTA (`failure-accessory.ts` +
+  `useAgentFailure` + `agent-view.tsx`). No restart needed — the running agent
+  re-reads its credential per request. Verified: `cargo check -p agentmux-cef`
+  green; `vitest` 18/18 on the two affected suites (incl. a new CTA assertion);
+  `tsc --noEmit` clean for every touched file (31 pre-existing errors are all in
+  unrelated files). NOT yet wired into the PRE-LAUNCH auth panel (the srv
+  `auth.*` state-machine path) — tracked as a follow-up. Live smoke (real
+  expired isolated cred + valid global) still pending.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -768,6 +768,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             log("auth", "Login Again — forcing a fresh provider login");
             void status.relogin();
         },
+        // Seed-from-global recovery: copy the user's existing valid global
+        // Claude login into this agent instead of a fresh OAuth — the reliable
+        // path for Claude Code v2.1.x's un-scrapeable login TUI (§5.5). The
+        // agent re-reads its credential per request, so the next message clears
+        // this failure row with no restart.
+        onUseExistingLogin: () => {
+            log("auth", "Use existing login — seeding from your global Claude login");
+            void status.useGlobalLogin();
+        },
     });
 
     // Deliver queued-while-busy ("send now") messages at the next tool-call

--- a/frontend/app/view/agent/failure/failure-accessory.test.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.test.ts
@@ -21,11 +21,12 @@ const mkView = (overrides: Partial<FailureViewState> = {}): FailureViewState => 
 });
 
 const mkActions = (): FailureActions & { _calls: Record<keyof FailureActions, number> } => {
-    const _calls = { retry: 0, loginAgain: 0, trustCenter: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
+    const _calls = { retry: 0, loginAgain: 0, useExistingLogin: 0, trustCenter: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
     return {
         _calls,
         retry: vi.fn(() => void _calls.retry++),
         loginAgain: vi.fn(() => void _calls.loginAgain++),
+        useExistingLogin: vi.fn(() => void _calls.useExistingLogin++),
         trustCenter: vi.fn(() => void _calls.trustCenter++),
         newSession: vi.fn(() => void _calls.newSession++),
         toggleDetails: vi.fn(() => void _calls.toggleDetails++),
@@ -72,6 +73,13 @@ describe("failureToRow", () => {
         expect(login?.primary).toBe(true);
         login?.onClick();
         expect(on._calls.loginAgain).toBe(1);
+
+        // Seed-from-global recovery sits alongside Login Again (not primary).
+        const useExisting = action(row, "Use existing login");
+        expect(useExisting).toBeTruthy();
+        expect(useExisting?.primary).toBeFalsy();
+        useExisting?.onClick();
+        expect(on._calls.useExistingLogin).toBe(1);
 
         const trust = action(row, "Trust Center → Accounts");
         expect(trust).toBeTruthy();

--- a/frontend/app/view/agent/failure/failure-accessory.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.ts
@@ -23,6 +23,8 @@ export interface FailureActions {
     retry: () => void;
     /** Re-authenticate this agent's provider account (auth failures). */
     loginAgain: () => void;
+    /** Seed from the user's existing valid global Claude login (no fresh OAuth). */
+    useExistingLogin: () => void;
     /** Open Trust Center → Accounts. */
     trustCenter: () => void;
     /** Start a fresh agent session — recovery for a context-window overflow,
@@ -99,6 +101,7 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
         case "auth":
             actions.push(
                 { glyph: "🔑", label: "Login Again", title: "Re-authenticate this agent", primary: true, onClick: on.loginAgain },
+                { glyph: "🌐", label: "Use existing login", title: "Copy your existing valid global Claude login into this agent (no re-OAuth)", onClick: on.useExistingLogin },
                 trustCenter,
             );
             break;

--- a/frontend/app/view/agent/flows/seed-global-login.ts
+++ b/frontend/app/view/agent/flows/seed-global-login.ts
@@ -1,0 +1,40 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * seedGlobalLogin — "Use my existing Claude login": copy the user's already-
+ * valid GLOBAL Claude credential into this agent's ISOLATED auth dir, instead
+ * of driving a fresh OAuth.
+ *
+ * The reliable recovery for Claude Code v2.1.x, whose self-driving login TUI
+ * the host can't scrape a URL from (SPEC_HOST_CLI_LOGIN_CAPTURE §5.5). The host
+ * command `seed_provider_auth_from_global` validates the global credential's
+ * expiry and copies it verbatim (incl. its `refreshToken`, so the isolated
+ * session keeps refreshing) into `~/.agentmux/shared/providers/claude/`.
+ *
+ * Like force-login, no controller restart is needed: the running persistent
+ * agent re-reads its credential per request, so the next message uses the
+ * seeded token and clears the failure row.
+ *
+ * Returns true when a credential was seeded; false (with a logged reason) when
+ * there's no global login or it's also expired — the caller should then fall
+ * back to "Login Again".
+ */
+
+import { getApi } from "@/app/store/global";
+import type { LogFn } from "../types";
+
+export async function seedGlobalLogin(providerId: string, log: LogFn): Promise<boolean> {
+    log("auth", "Use existing login — copying your global Claude login into this agent…");
+    const res = await getApi().seedProviderAuthFromGlobal(providerId);
+    if (res?.seeded) {
+        log("auth", "copied your existing login — just send your message again");
+        return true;
+    }
+    if (res?.status === "expired") {
+        log("auth", "your global Claude login is also expired — use “Login Again” to re-authenticate", "warn");
+    } else {
+        log("auth", "no valid global Claude login found — use “Login Again” to authenticate", "warn");
+    }
+    return false;
+}

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -37,6 +37,7 @@ import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 import { getApi, getBlockMetaKeyAtom } from "@/app/store/global";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { forceProviderLogin } from "../flows/force-login";
+import { seedGlobalLogin } from "../flows/seed-global-login";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -74,6 +75,14 @@ export interface UseAgentControllerStatus {
      * SPEC_REAUTH_FROM_AUTH_ERROR §11.
      */
     relogin: () => Promise<void>;
+    /**
+     * "Use my existing login" — seed this agent's isolated auth dir from the
+     * user's already-valid GLOBAL Claude login instead of a fresh OAuth, the
+     * reliable recovery for Claude Code v2.1.x's un-scrapeable login TUI
+     * (SPEC_HOST_CLI_LOGIN_CAPTURE §5.5). Like relogin, no restart is needed —
+     * the running agent re-reads its credential per request.
+     */
+    useGlobalLogin: () => Promise<void>;
     cancelLogin: () => void;
 }
 
@@ -187,6 +196,28 @@ export function useAgentControllerStatus(
         }
     };
 
+    // "Use my existing login" — seed the isolated dir from the global Claude
+    // login instead of a fresh OAuth (SPEC_HOST_CLI_LOGIN_CAPTURE §5.5). Guarded
+    // against double-fire like relogin; the running agent re-reads its
+    // credential per request, so a successful seed needs no restart.
+    let seedInFlight = false;
+    const useGlobalLogin = async () => {
+        if (seedInFlight) return;
+        const prov = opts.provider();
+        if (!prov) {
+            opts.log("auth", "use existing login: no active provider", "warn");
+            return;
+        }
+        seedInFlight = true;
+        try {
+            await seedGlobalLogin(prov.id, opts.log);
+        } catch (err: any) {
+            opts.log("auth", `use existing login failed: ${err?.message ?? String(err)}`, "error");
+        } finally {
+            seedInFlight = false;
+        }
+    };
+
     const cancelLogin = () => {
         loginCancelled = true;
         getApi().cancelCliLogin().catch(() => {});
@@ -217,6 +248,7 @@ export function useAgentControllerStatus(
         loginWaiting,
         startLaunchFlow,
         relogin,
+        useGlobalLogin,
         cancelLogin,
     };
 }

--- a/frontend/app/view/agent/hooks/useAgentFailure.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.test.ts
@@ -56,7 +56,7 @@ const hasRetryCountdown = (ui: UseAgentFailureResult) =>
     (ui.row()?.actions ?? []).some((a) => a.label === "Retry now (5s)");
 
 const mkUI = (onRetry: () => void): UseAgentFailureResult =>
-    useAgentFailure({ blockId: "b", onRetry, onLoginAgain() {}, onTrustCenter() {}, onNewSession() {} });
+    useAgentFailure({ blockId: "b", onRetry, onLoginAgain() {}, onUseExistingLogin() {}, onTrustCenter() {}, onNewSession() {} });
 
 describe("useAgentFailure P1.2 — persisted meta seed on mount", () => {
     beforeEach(() => {

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -33,6 +33,8 @@ export interface UseAgentFailureOptions {
     onRetry: () => void;
     /** Re-authenticate this agent's provider account (P2). */
     onLoginAgain: () => void;
+    /** Seed this agent from the user's existing global Claude login (§5.5). */
+    onUseExistingLogin: () => void;
     /** Open Trust Center → Accounts. */
     onTrustCenter: () => void;
     /** Start a fresh agent session (context-window overflow recovery). */
@@ -185,6 +187,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
             {
                 retry: doRetry,
                 loginAgain: opts.onLoginAgain,
+                useExistingLogin: opts.onUseExistingLogin,
                 trustCenter: opts.onTrustCenter,
                 newSession: opts.onNewSession,
                 toggleDetails: () => setExpanded((v) => !v),

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -183,6 +183,7 @@ declare global {
         ensureAuthDir: (providerId: string) => Promise<string>;
         runCliLogin: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>, requiresTty?: boolean) => Promise<string | null>;
         cancelCliLogin: () => Promise<void>;
+        seedProviderAuthFromGlobal: (providerId: string) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (
             dragType: "pane" | "tab",

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -609,6 +609,12 @@ export function buildCefApi(): AppApi {
         cancelCliLogin: async () => {
             await invokeCommand("cancel_cli_login");
         },
+        seedProviderAuthFromGlobal: async (providerId: string) => {
+            return await invokeCommand<{ seeded: boolean; status: string; expiresAt?: number | null }>(
+                "seed_provider_auth_from_global",
+                { providerId },
+            );
+        },
 
         listen: async (event: string, callback: (event: any) => void) => {
             const unlisten = await listenEvent(event, callback);


### PR DESCRIPTION
Follow-up to #1604. Spec: `docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md`.

## Problem
Claude Code CLI **v2.1.183** turned `claude auth login` into a self-driving TUI: it opens its own browser + localhost OAuth callback and **copies the login URL to the clipboard on `c`** — it no longer prints a scrapeable `https://…` line. The host's PTY `extract_url` scrape (`run_cli_login_pty`) therefore never fires, so after the #1604 force-login fix, **"Login Again" calls `run_cli_login` but no browser/URL box appears**. (`extract_url` already strips ANSI/OSC-8, so this is *not* a parsing gap — there is simply no URL to scrape.)

Research against the current Anthropic docs surfaced three officially-supported, non-scrape paths (`setup-token` → `CLAUDE_CODE_OAUTH_TOKEN`, the v2.1 paste-code fallback, and the env/credential precedence rules). This PR lands the two pieces that don't require an interactive capture run.

## Slice 1 — §4 instrumentation
- `run_cli_login_pty` now logs **every PTY line from the first byte** (was: only *after* a URL was captured, so a login that never prints a URL was a total black box).
- Both spawn paths log an **auth-env precedence snapshot** — `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` = `override|inherited|absent` (names/states only, never values) — to check the "loggedIn but 401" precedence hypothesis (a stray `ANTHROPIC_API_KEY` overrides subscription OAuth). Visible via `muxlog host grep login-pty`.

## Slice 2 — §5.5 "Use my existing Claude login" (ship-now recovery)
- New host IPC command **`seed_provider_auth_from_global`**: reads the user's GLOBAL Claude credential (`$CLAUDE_CONFIG_DIR` if the host inherits one, else `~/.claude/.credentials.json`), validates `claudeAiOauth.expiresAt` is in the future (mirrors `agentmux-srv` `identity::resolver::probe_oauth_status`), and copies it verbatim — incl. `refreshToken` — into the agent's isolated dir (`~/.agentmux/shared/providers/claude/.credentials.json`) via temp+rename. Returns `{ seeded, status: seeded|missing|expired, expiresAt }` with **no token material**.
- Frontend: `seedProviderAuthFromGlobal` API, a `seedGlobalLogin` flow, `useGlobalLogin` on `useAgentControllerStatus`, and a 🌐 **"Use existing login"** action beside "Login Again" on the 401/403 failure CTA. No controller restart — the running agent re-reads its credential per request, so the next message clears the failure row.

## Verification
- `cargo check -p agentmux-cef` — clean
- `vitest` — **18/18** on the two affected suites (incl. a new CTA assertion)
- `tsc --noEmit` — **zero errors in any touched file** (pre-existing errors are all in unrelated files)

## Scoped out (tracked in the spec)
- Pre-launch auth panel integration (that path goes through the srv `auth.*` state machine, not the host `runCliLogin`/failure-CTA path).
- Live smoke test (needs a real expired isolated cred + valid global on a host build).
- **5.1 (`setup-token`) / 5.2 (paste-code)** OAuth-capture fixes — sequenced *after* a §4 instrumented capture run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)