### PR TITLE
chore: release v0.46.6

### DIFF
--- a/.changesets/1781823967-fix-win32-bind-floater-cascade-to-source-window-fix-z-order--38iw.md
+++ b/.changesets/1781823967-fix-win32-bind-floater-cascade-to-source-window-fix-z-order--38iw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(win32): bind floater cascade to source window; fix z-order and multi-window regression

--- a/.changesets/1781825172-agent-pane-tab-label-now-shows-claude-code-session-topic-fro-tatv.md
+++ b/.changesets/1781825172-agent-pane-tab-label-now-shows-claude-code-session-topic-fro-tatv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-agent pane tab label now shows Claude Code session topic from OSC window-title sequences

--- a/.changesets/1781830106-feat-trust-center-accounts-tab-hard-corner-card-styling-cent-1mnf.md
+++ b/.changesets/1781830106-feat-trust-center-accounts-tab-hard-corner-card-styling-cent-1mnf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(trust-center): accounts tab — hard-corner card styling, central modal detail overlay, fix stale panel on account switch

--- a/.changesets/1781844521-fix-dnd-suppress-misleading-pool-exhaustion-warn-on-non-wind-189f.md
+++ b/.changesets/1781844521-fix-dnd-suppress-misleading-pool-exhaustion-warn-on-non-wind-189f.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dnd): suppress misleading pool-exhaustion WARN on non-Windows tearoff

--- a/.changesets/1781844523-fix-dnd-fire-redock-hover-ipc-before-arm-threshold-to-preven-jp22.md
+++ b/.changesets/1781844523-fix-dnd-fire-redock-hover-ipc-before-arm-threshold-to-preven-jp22.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dnd): fire redock hover IPC before arm threshold to prevent ghost race

--- a/.changesets/1781844526-fix-blocks-deleteblock-uses-block-s-owning-tab-instead-of-fl-zvec.md
+++ b/.changesets/1781844526-fix-blocks-deleteblock-uses-block-s-owning-tab-instead-of-fl-zvec.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(blocks): DeleteBlock uses block's owning tab instead of floating window's active tab

--- a/.changesets/1781846792-feat-memory-global-memory-bundles-seeded-from-workspace-patt-kefo.md
+++ b/.changesets/1781846792-feat-memory-global-memory-bundles-seeded-from-workspace-patt-kefo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(memory): global memory bundles seeded from workspace patterns

--- a/.changesets/1781872204-fix-memory-re-enable-automemoryenabled-so-agents-can-write-n-g007.md
+++ b/.changesets/1781872204-fix-memory-re-enable-automemoryenabled-so-agents-can-write-n-g007.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): re-enable autoMemoryEnabled so agents can write native memory

--- a/.changesets/1781873924-feat-ui-reusable-popovermenu-title-bar-right-click-rework-an-wel0.md
+++ b/.changesets/1781873924-feat-ui-reusable-popovermenu-title-bar-right-click-rework-an-wel0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ui): reusable PopoverMenu — title-bar right-click rework and More dropdown item menu fix

--- a/.changesets/1781874961-feat-agent-pane-replace-cog-overlay-with-brain-id-card-icons-c3li.md
+++ b/.changesets/1781874961-feat-agent-pane-replace-cog-overlay-with-brain-id-card-icons-c3li.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): replace cog overlay with brain+id-card icons; identity modal + memory modal Phase 1

--- a/.changesets/1781878377-feat-native-memory-add-agent-memory-list-read-file-write-fil-q7h0.md
+++ b/.changesets/1781878377-feat-native-memory-add-agent-memory-list-read-file-write-fil-q7h0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(native-memory): add agent:memory:list/read_file/write_file backend RPCs and frontend bindings (Phase 2)

--- a/.changesets/1781916950-feat-agent-persist-agent-failure-state-in-block-meta-p1-1-p1-i8he.md
+++ b/.changesets/1781916950-feat-agent-persist-agent-failure-state-in-block-meta-p1-1-p1-i8he.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): persist agent failure state in block meta (P1.1/P1.2)

--- a/.changesets/1781917499-feat-agent-inline-api-error-node-in-transcript-p1-3-z5j6.md
+++ b/.changesets/1781917499-feat-agent-inline-api-error-node-in-transcript-p1-3-z5j6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): inline API error node in transcript (P1.3)

--- a/.changesets/1781921078-feat-agent-inline-login-again-cta-on-401-403-error-nodes-rea-wshy.md
+++ b/.changesets/1781921078-feat-agent-inline-login-again-cta-on-401-403-error-nodes-rea-wshy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): inline Login Again CTA on 401/403 error nodes (reauth P2.3)

--- a/.changesets/1781921659-feat-agent-open-oauth-re-auth-in-an-in-app-browser-pane-with-ovni.md
+++ b/.changesets/1781921659-feat-agent-open-oauth-re-auth-in-an-in-app-browser-pane-with-ovni.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): open OAuth re-auth in an in-app browser pane with URL backup (reauth P2.1)

--- a/.changesets/1781921692-feat-voice-red-recording-indicator-speak-to-agent-composer-g-bojt.md
+++ b/.changesets/1781921692-feat-voice-red-recording-indicator-speak-to-agent-composer-g-bojt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(voice): red recording indicator + 'Speak to <agent>' composer ghost text

--- a/.changesets/1781921941-feat-pool-enable-pre-warmed-tear-off-window-pool-for-macos-a-2vwz.md
+++ b/.changesets/1781921941-feat-pool-enable-pre-warmed-tear-off-window-pool-for-macos-a-2vwz.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pool): enable pre-warmed tear-off window pool for macOS and Linux (Phase 7)

--- a/.changesets/1781922083-feat-agent-native-memory-browser-in-the-agent-pane-brain-mod-7xjz.md
+++ b/.changesets/1781922083-feat-agent-native-memory-browser-in-the-agent-pane-brain-mod-7xjz.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): native memory browser in the agent pane brain modal

--- a/.changesets/1781922159-feat-mcp-setname-target-id-rename-any-window-tab-workspace-p-43wn.md
+++ b/.changesets/1781922159-feat-mcp-setname-target-id-rename-any-window-tab-workspace-p-43wn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(mcp): SetName target_id — rename any window/tab/workspace/pane by explicit id

--- a/.changesets/1781922315-feat-swarm-redesign-swarm-as-a-live-two-level-agent-subagent-dwap.md
+++ b/.changesets/1781922315-feat-swarm-redesign-swarm-as-a-live-two-level-agent-subagent-dwap.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): redesign Swarm as a live two-level agent/subagent tree

--- a/.changesets/1781922939-feat-agent-style-the-identity-and-memory-modal-panels-vksl.md
+++ b/.changesets/1781922939-feat-agent-style-the-identity-and-memory-modal-panels-vksl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): style the Identity and Memory modal panels

--- a/.changesets/1781923404-fix-sysinfo-throttle-chart-svg-rebuild-from-1hz-to-0-5hz-to--y3mg.md
+++ b/.changesets/1781923404-fix-sysinfo-throttle-chart-svg-rebuild-from-1hz-to-0-5hz-to--y3mg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): throttle chart SVG rebuild from 1Hz to 0.5Hz to fix sustained GPU CPU

--- a/.changesets/1781924779-feat-agent-pane-websearch-rich-result-cards-write-tool-conte-j9pr.md
+++ b/.changesets/1781924779-feat-agent-pane-websearch-rich-result-cards-write-tool-conte-j9pr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): websearch rich result cards + Write tool content view

--- a/.changesets/1781925599-feat-cef-media-permission-handler-so-voice-input-getusermedi-pnc7.md
+++ b/.changesets/1781925599-feat-cef-media-permission-handler-so-voice-input-getusermedi-pnc7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cef): media-permission handler so voice input getUserMedia is granted

--- a/.changesets/1781925931-feat-voice-actionable-mic-permission-ux-blocked-indicator-cl-d0wv.md
+++ b/.changesets/1781925931-feat-voice-actionable-mic-permission-ux-blocked-indicator-cl-d0wv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(voice): actionable mic-permission UX (blocked indicator + classified guidance)

--- a/.changesets/1781929749-fix-agent-force-re-login-on-login-again-instead-of-trusting--a6vg.md
+++ b/.changesets/1781929749-fix-agent-force-re-login-on-login-again-instead-of-trusting--a6vg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): force re-login on Login Again instead of trusting the auth-status check (reauth P2.5)

--- a/.changesets/1781950297-fix-auth-log-every-pty-login-line-and-auth-env-precedence.md
+++ b/.changesets/1781950297-fix-auth-log-every-pty-login-line-and-auth-env-precedence.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): instrument host CLI login — log every PTY line from byte 0 + auth-env precedence snapshot (host-login-capture §4)

--- a/.changesets/1781951898-feat-pool-new-window-pool-on-macos-linux-fix-stale-pool-not--psa3.md
+++ b/.changesets/1781951898-feat-pool-new-window-pool-on-macos-linux-fix-stale-pool-not--psa3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pool): new-window pool on macOS/Linux; fix stale pool_not_implemented error in drag.rs

--- a/.changesets/1781952129-feat-trust-center-global-brain-tab-ordered-workspace-section-vbm0.md
+++ b/.changesets/1781952129-feat-trust-center-global-brain-tab-ordered-workspace-section-vbm0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(trust-center): global brain tab — ordered workspace sections injected into every agent's CLAUDE.md

--- a/.changesets/1781952589-fix-auth-use-existing-claude-login-seed-from-global.md
+++ b/.changesets/1781952589-fix-auth-use-existing-claude-login-seed-from-global.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): "Use existing login" — seed an agent from a valid global Claude credential instead of a fresh OAuth (host-login-capture §5.5)

--- a/.changesets/1781954433-feat-pool-windows-new-window-pool-reuse-promote-pool-window--d6nz.md
+++ b/.changesets/1781954433-feat-pool-windows-new-window-pool-reuse-promote-pool-window--d6nz.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pool): Windows new-window pool — reuse promote_pool_window with physical-pixel anchor

--- a/.changesets/1781955205-fix-linux-prefer-native-wayland-ozone-on-cef-148-instead-of--o0wn.md
+++ b/.changesets/1781955205-fix-linux-prefer-native-wayland-ozone-on-cef-148-instead-of--o0wn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux): prefer native Wayland ozone on CEF 148 instead of forcing XWayland

--- a/.changesets/1781957910-fix-agent-move-activity-dock-below-conversation-above-compos-gdng.md
+++ b/.changesets/1781957910-fix-agent-move-activity-dock-below-conversation-above-compos-gdng.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): move activity dock below conversation, above composer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.46.5"
+version = "0.46.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.46.5"
+version = "0.46.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,42 @@
 # AgentMux Version History
 
+## 0.46.6 — 2026-06-20
+
+- fix(win32): bind floater cascade to source window; fix z-order and multi-window regression
+- agent pane tab label now shows Claude Code session topic from OSC window-title sequences
+- feat(trust-center): accounts tab — hard-corner card styling, central modal detail overlay, fix stale panel on account switch
+- fix(dnd): suppress misleading pool-exhaustion WARN on non-Windows tearoff
+- fix(dnd): fire redock hover IPC before arm threshold to prevent ghost race
+- fix(blocks): DeleteBlock uses block's owning tab instead of floating window's active tab
+- feat(memory): global memory bundles seeded from workspace patterns
+- fix(memory): re-enable autoMemoryEnabled so agents can write native memory
+- feat(ui): reusable PopoverMenu — title-bar right-click rework and More dropdown item menu fix
+- feat(agent-pane): replace cog overlay with brain+id-card icons; identity modal + memory modal Phase 1
+- feat(native-memory): add agent:memory:list/read_file/write_file backend RPCs and frontend bindings (Phase 2)
+- feat(agent): persist agent failure state in block meta (P1.1/P1.2)
+- feat(agent): inline API error node in transcript (P1.3)
+- feat(agent): inline Login Again CTA on 401/403 error nodes (reauth P2.3)
+- feat(agent): open OAuth re-auth in an in-app browser pane with URL backup (reauth P2.1)
+- feat(voice): red recording indicator + 'Speak to <agent>' composer ghost text
+- feat(pool): enable pre-warmed tear-off window pool for macOS and Linux (Phase 7)
+- feat(agent): native memory browser in the agent pane brain modal
+- feat(mcp): SetName target_id — rename any window/tab/workspace/pane by explicit id
+- feat(swarm): redesign Swarm as a live two-level agent/subagent tree
+- feat(agent): style the Identity and Memory modal panels
+- fix(sysinfo): throttle chart SVG rebuild from 1Hz to 0.5Hz to fix sustained GPU CPU
+- feat(agent-pane): websearch rich result cards + Write tool content view
+- feat(cef): media-permission handler so voice input getUserMedia is granted
+- feat(voice): actionable mic-permission UX (blocked indicator + classified guidance)
+- fix(agent): force re-login on Login Again instead of trusting the auth-status check (reauth P2.5)
+- fix(auth): instrument host CLI login — log every PTY line from byte 0 + auth-env precedence snapshot (host-login-capture §4)
+- feat(pool): new-window pool on macOS/Linux; fix stale pool_not_implemented error in drag.rs
+- feat(trust-center): global brain tab — ordered workspace sections injected into every agent's CLAUDE.md
+- fix(auth): "Use existing login" — seed an agent from a valid global Claude credential instead of a fresh OAuth (host-login-capture §5.5)
+- feat(pool): Windows new-window pool — reuse promote_pool_window with physical-pixel anchor
+- fix(linux): prefer native Wayland ozone on CEF 148 instead of forcing XWayland
+- fix(agent): move activity dock below conversation, above composer
+
+
 ## 0.46.5 — 2026-06-18
 
 - feat(mcp): Loop + LoopStop tools — recurring prompt injection (Claude /loop analogue)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.46.5",
+  "version": "0.46.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.46.5",
+      "version": "0.46.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.46.5",
+  "version": "0.46.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Forced **patch** release (`task release -- --as patch`) consuming **34 pending changesets**.

- **0.46.5 → 0.46.6**
- All 5 version locations agree at 0.46.6 (package.json, package-lock.json root, Cargo.toml `[workspace.package]`, Cargo.lock workspace members, VERSION_HISTORY.md top) — verified via `git show HEAD:<file>` before push.
- Override note: some `minor`-level (feat) changesets ship under this patch per the explicit `--as patch` override.

Commit contains **only** version files + the 34 consumed changeset deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)