### PR TITLE
feat(tear-off): resize mother window when tearing off a full-height pane

### DIFF
--- a/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
+++ b/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(tear-off): resize mother window when tearing off a full-height pane column

--- a/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
+++ b/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tear-off): resize mother window when tearing off a full-height pane column

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -234,10 +234,19 @@ pub fn open_floating_pane_window(
         crate::floating_pane::post_create_floating_window(state, &parsed, &window_label, parent_main_hwnd);
 
         // Mother-window resize: if the pane spanned the full column height,
-        // shrink the source window so remaining panes keep their pixel sizes.
+        // shrink the SOURCE window so remaining panes keep their pixel sizes.
+        // Gate on a direct label→HWND resolution (NOT parent_main_hwnd, which
+        // may be a FullInstance fallback for an unrelated window when
+        // source_window_label failed to resolve). Consistent with the non-Windows
+        // path which also gates on source_window_label resolving.
         if let Some(new_w_dip) = parsed.mother_resize_to_width {
-            if parent_main_hwnd != 0 {
-                crate::ui_tasks::post_resize_mother_window_win32(state, parent_main_hwnd, new_w_dip);
+            if let Some(src_hwnd) = parsed
+                .source_window_label
+                .as_deref()
+                .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
+                .filter(|&h| h != 0)
+            {
+                crate::ui_tasks::post_resize_mother_window_win32(state, src_hwnd, new_w_dip);
             }
         }
 

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -226,6 +226,18 @@ pub fn open_floating_pane_window(
             parsed.height,
             parent_main_hwnd,
         ) {
+            // Pool fast path — apply mother resize before returning (same gate
+            // as the cold path below: direct label resolution only).
+            if let Some(new_w_dip) = parsed.mother_resize_to_width {
+                if let Some(src_hwnd) = parsed
+                    .source_window_label
+                    .as_deref()
+                    .and_then(|lbl| state.window_hwnds.lock().get(lbl).copied())
+                    .filter(|&h| h != 0)
+                {
+                    crate::ui_tasks::post_resize_mother_window_win32(state, src_hwnd, new_w_dip);
+                }
+            }
             return Ok(serde_json::to_value(OpenFloatingPaneResponse {
                 window_label: pool_label,
             }).unwrap_or_default());
@@ -267,6 +279,13 @@ pub fn open_floating_pane_window(
             parsed.height,
             0, // parent_hwnd: unused on non-Windows
         ) {
+            // Pool fast path — apply mother resize before returning (same gate
+            // as the cold path below: both fields must be Some).
+            if let (Some(new_w_dip), Some(src_label)) =
+                (parsed.mother_resize_to_width, parsed.source_window_label.as_deref())
+            {
+                crate::ui_tasks::post_resize_mother_window(state, src_label, new_w_dip);
+            }
             return Ok(serde_json::to_value(OpenFloatingPaneResponse {
                 window_label: pool_label,
             }).unwrap_or_default());

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -71,6 +71,18 @@ pub struct OpenFloatingPaneArgs {
     /// Optional for back-compat; callers should always provide it.
     #[serde(default)]
     pub source_window_label: Option<String>,
+    /// If present, resize the mother window to this width (in CSS/DIP px)
+    /// after the floating pane is created. Set only when the torn-off pane
+    /// spans the full height of the layout container (a top-to-bottom column),
+    /// so the mother shrinks by exactly the pane's column width and remaining
+    /// panes keep their absolute sizes. Absent for partial-height panes.
+    ///
+    /// The host converts this DIP value to physical pixels on Windows using
+    /// the source window's monitor DPI (`GetDpiForMonitor(MonitorFromPoint)`).
+    /// On macOS/Linux it is passed directly to CEF `set_bounds`.
+    /// See `SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md`.
+    #[serde(default)]
+    pub mother_resize_to_width: Option<i32>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -220,6 +232,15 @@ pub fn open_floating_pane_window(
         }
 
         crate::floating_pane::post_create_floating_window(state, &parsed, &window_label, parent_main_hwnd);
+
+        // Mother-window resize: if the pane spanned the full column height,
+        // shrink the source window so remaining panes keep their pixel sizes.
+        if let Some(new_w_dip) = parsed.mother_resize_to_width {
+            if parent_main_hwnd != 0 {
+                crate::ui_tasks::post_resize_mother_window_win32(state, parent_main_hwnd, new_w_dip);
+            }
+        }
+
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }
 
@@ -311,6 +332,14 @@ pub fn open_floating_pane_window(
             parsed.height,
             true, // frameless — secondary windows use the custom title bar
         );
+
+        // Mother-window resize: if the pane spanned the full column height,
+        // shrink the source window so remaining panes keep their pixel sizes.
+        if let (Some(new_w_dip), Some(src_label)) =
+            (parsed.mother_resize_to_width, parsed.source_window_label.as_deref())
+        {
+            crate::ui_tasks::post_resize_mother_window(state, src_label, new_w_dip);
+        }
 
         Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
     }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1661,3 +1661,115 @@ unsafe fn find_main_render_widget(
     EnumChildWindows(root, Some(cb), &mut finder as *mut _ as isize);
     if finder.found.is_null() { None } else { Some(finder.found) }
 }
+
+// ── Mother-window resize after pane tear-off ──────────────────────────────
+//
+// When a full-height pane is torn off (top-to-bottom column), the mother
+// window shrinks by the pane's column width so remaining panes keep their
+// absolute pixel sizes.
+//
+// Spec: docs/specs/SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
+
+/// Resize the mother window to `new_w_dip` on macOS/Linux via CEF Views
+/// `set_bounds`. Width is in CSS/DIP pixels (same coordinate space as the
+/// floater args); height is read from the current bounds and preserved.
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct ResizeMotherWindowTask {
+        state: Arc<AppState>,
+        label: String,
+        new_w_dip: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let Some(window) = get_window_on_ui(&self.state, &self.label) else {
+                tracing::warn!(
+                    label = %self.label,
+                    "[tear-off] ResizeMotherWindowTask: source window not found (already closed?)"
+                );
+                return;
+            };
+            let old = window.bounds();
+            window.set_bounds(Some(&cef::Rect {
+                x: old.x,
+                y: old.y,
+                width: self.new_w_dip,
+                height: old.height,
+            }));
+            tracing::info!(
+                label = %self.label,
+                old_w = old.width,
+                new_w = self.new_w_dip,
+                "[tear-off] mother window resized after pane tear-off"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn post_resize_mother_window(state: &Arc<AppState>, label: &str, new_w_dip: i32) {
+    let mut task = ResizeMotherWindowTask::new(state.clone(), label.to_string(), new_w_dip);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+/// Resize the mother window to `new_w_dip` on Windows via Win32 `SetWindowPos`.
+/// `new_w_dip` is in CSS/DIP pixels; this function converts to physical pixels
+/// using the source window's monitor DPI before calling `SetWindowPos`.
+/// Must be called with the source window's HWND (already resolved in
+/// `open_floating_pane_window` as `parent_main_hwnd`).
+#[cfg(target_os = "windows")]
+wrap_task! {
+    pub struct ResizeMotherWindowWin32Task {
+        state: Arc<AppState>,
+        hwnd: isize,
+        new_w_dip: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            use windows_sys::Win32::Foundation::POINT;
+            use windows_sys::Win32::Graphics::Gdi::{MonitorFromPoint, MONITOR_DEFAULTTONEAREST};
+            use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+            use windows_sys::Win32::UI::WindowsAndMessaging::{
+                GetWindowRect, SetWindowPos, SWP_NOMOVE, SWP_NOACTIVATE, SWP_NOZORDER,
+            };
+
+            unsafe {
+                let hwnd = self.hwnd as windows_sys::Win32::Foundation::HWND;
+                let mut wr = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
+                GetWindowRect(hwnd, &mut wr);
+                let current_h = wr.bottom - wr.top;
+                let pt = POINT { x: wr.left, y: wr.top };
+                let monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+                let mut dpi_x: u32 = 0;
+                let mut dpi_y: u32 = 0;
+                let hr = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+                let dpi_scale = if hr != 0 || dpi_x == 0 { 1.0f32 } else { dpi_x as f32 / 96.0 };
+                let new_w_px = (self.new_w_dip as f32 * dpi_scale).round() as i32;
+                let ok = SetWindowPos(
+                    hwnd,
+                    std::ptr::null_mut(),
+                    0, 0,
+                    new_w_px,
+                    current_h,
+                    SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE,
+                );
+                tracing::info!(
+                    hwnd = self.hwnd,
+                    new_w_dip = self.new_w_dip,
+                    new_w_px,
+                    dpi_scale,
+                    ok = (ok != 0),
+                    "[tear-off] mother window resized after pane tear-off (Win32)"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn post_resize_mother_window_win32(state: &Arc<AppState>, hwnd: isize, new_w_dip: i32) {
+    let mut task = ResizeMotherWindowWin32Task::new(state.clone(), hwnd, new_w_dip);
+    post_task(ThreadId::UI, Some(&mut task));
+}

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1716,8 +1716,9 @@ pub fn post_resize_mother_window(state: &Arc<AppState>, label: &str, new_w_dip: 
 /// Resize the mother window to `new_w_dip` on Windows via Win32 `SetWindowPos`.
 /// `new_w_dip` is in CSS/DIP pixels; this function converts to physical pixels
 /// using the source window's monitor DPI before calling `SetWindowPos`.
-/// Must be called with the source window's HWND (already resolved in
-/// `open_floating_pane_window` as `parent_main_hwnd`).
+/// `hwnd` is resolved directly from `source_window_label` in
+/// `open_floating_pane_window` (not the cascade-hook fallback `parent_main_hwnd`)
+/// so the resize always targets the actual source window.
 #[cfg(target_os = "windows")]
 wrap_task! {
     pub struct ResizeMotherWindowWin32Task {

--- a/docs/specs/SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
+++ b/docs/specs/SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
@@ -1,0 +1,343 @@
+# Pane Tear-Off — Mother Window Resize
+
+**Date:** 2026-06-20
+**Status:** Proposed
+**Issue:** TBD
+**Extends:** `SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` (Windows), `SPEC_MACOS_FLOATING_PANE_TEAROFF_2026_05_29.md` (macOS/Linux)
+
+---
+
+## 1. Problem
+
+When a pane is torn off, the mother window keeps its full size. The remaining panes
+reflow to fill the vacated space, which changes their sizes unexpectedly. The tear-off
+feels like a "move" rather than a "split."
+
+The intended UX: tearing a pane off should feel like physically splitting the window
+along the pane's boundary. The mother shrinks to exactly the space its remaining
+content occupies; the floater takes the pane's original footprint. Remaining panes do
+not change size.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- Panes that span the full height of the layout container (top-to-bottom columns). These
+  represent a clean vertical split — removing one shrinks the mother window horizontally.
+- Cross-platform: Windows, macOS, Linux.
+
+**Out of scope / no-op:**
+- Panes that share vertical space with at least one sibling at the same row level (i.e.,
+  the pane does NOT reach both the top and bottom of the layout container). The mother
+  window is unchanged; remaining siblings reflow normally into the vacated slot. This is
+  the existing behavior and it is intentionally preserved — a pane that shares a row with
+  others cannot cleanly "split off" a column.
+- Tab tear-off (spawns a new full instance — out of scope).
+- Single-pane layouts (one leaf = the entire window; nothing to shrink to).
+- The mother window would shrink below `MIN_MOTHER_WIDTH = 400` CSS px. Clamp to
+  `MIN_MOTHER_WIDTH` in that case (no resize if clamping would still make the window
+  too small to be usable).
+- Magnified-node layouts (one pane covers the others — geometry detection unreliable;
+  skip resize when `magnifiedNodeId` is set).
+
+---
+
+## 3. Full-Height Detection
+
+A pane **spans full height** when its CSS DIP rect (as reported by
+`getBoundingClientRect`) touches both the top and bottom of the layout container,
+within a 2 px tolerance to absorb sub-pixel rounding:
+
+```typescript
+const EPSILON_PX = 2;
+
+function spansFullHeight(paneRect: DOMRect, containerRect: DOMRect): boolean {
+    return (
+        paneRect.top - containerRect.top <= EPSILON_PX &&
+        containerRect.bottom - paneRect.bottom <= EPSILON_PX
+    );
+}
+```
+
+`containerRect` is the bounding rect of the `TileLayout` display container (the element
+whose ref is `model.displayContainerRef`). This excludes the title bar, tab strip, and
+status bar — only the pane grid area matters.
+
+The `paneRect` is obtained by:
+```typescript
+const el = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
+const paneRect = el?.getBoundingClientRect();
+```
+
+This MUST be called before `TearOffBlock` (identical timing constraint to
+`measureSourcePaneSize` which already runs first).
+
+---
+
+## 4. New Mother Resize Width Computation
+
+When `spansFullHeight` is true:
+
+```typescript
+const newMotherWidthCss = Math.round(
+    containerRect.width - paneRect.width
+);
+const belowMinimum = newMotherWidthCss < MIN_MOTHER_WIDTH;
+```
+
+`newMotherWidthCss` is in CSS DIP pixels (same coordinate space as the floater
+`width`/`height` parameters already sent to the host). The gap between panes (the resize
+handle overlay) is part of the pane's own `getBoundingClientRect` footprint on whichever
+side it absorbs it, so no gap adjustment is needed — the panes are flex-contiguous at
+the CSS level.
+
+If `belowMinimum` is true, omit `mother_resize_to_width` from the IPC (treat as
+no-resize path).
+
+---
+
+## 5. IPC Changes
+
+### 5.1 `open_floating_pane_window` — new optional field
+
+Add to `OpenFloatingPaneArgs` (both the TypeScript call sites and the Rust struct):
+
+```rust
+/// New mother-window width in CSS/DIP pixels after the pane is torn off.
+/// Present only when the pane spans the full height of the layout container
+/// AND the resulting width would be ≥ MIN_MOTHER_WIDTH (400 CSS px).
+/// Absent = no resize (partial-height pane, single pane, or too-narrow result).
+#[serde(default)]
+pub mother_resize_to_width: Option<i32>,
+```
+
+On Windows, the host converts this DIP value to physical pixels using the
+**source window's** monitor DPI (same `MonitorFromPoint` + `GetDpiForMonitor` pattern
+used for the floater's `width`/`height` conversion, but using the source window's
+current top-left position rather than the cursor position).
+
+### 5.2 TypeScript call sites
+
+`CrossWindowDragMonitor.win32.tsx` and `CrossWindowDragMonitor.linux.tsx` — both call
+`open_floating_pane_window` in `performTearOff`. Before that call, add the detection and
+pass `mother_resize_to_width` when appropriate:
+
+```typescript
+// Snapshot BEFORE TearOffBlock (DOM element still present).
+const containerEl = props.layoutModel.displayContainerRef.current;
+const containerRect = containerEl?.getBoundingClientRect();
+const paneEl = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
+const paneRect = paneEl?.getBoundingClientRect();
+const motherResizeWidth =
+    containerRect && paneRect && spansFullHeight(paneRect, containerRect)
+        ? Math.round(containerRect.width - paneRect.width)
+        : undefined;
+const motherResizeWidthSafe =
+    motherResizeWidth != null && motherResizeWidth >= MIN_MOTHER_WIDTH
+        ? motherResizeWidth
+        : undefined;
+
+// ... then later in the invokeCommand call:
+await invokeCommand("open_floating_pane_window", {
+    pane_id: payload.blockId,
+    workspace_id: newWsId,
+    x: screenX,
+    y: screenY,
+    width: floaterWidth,
+    height: floaterHeight,
+    source_window_label: sourceWindowLabel,
+    mother_resize_to_width: motherResizeWidthSafe,  // NEW
+});
+```
+
+The `props.layoutModel` reference is available on the `CrossWindowDragMonitor`
+component via the standard `getLayoutModelForStaticTab()` call that already exists
+in these files (see line 348 of `.win32.tsx`). The snapshot must happen before
+`TearOffBlock` (the pane is removed from the layout tree at that point).
+
+---
+
+## 6. Host Implementation
+
+### 6.1 Rust struct update (`commands/floating_pane.rs`)
+
+```rust
+pub struct OpenFloatingPaneArgs {
+    // ... existing fields ...
+    #[serde(default)]
+    pub mother_resize_to_width: Option<i32>,
+}
+```
+
+### 6.2 Apply the resize after the floating pane IPC returns
+
+The resize is applied at the very end of `open_floating_pane_window`, after the floating
+pane creation IPC has been posted but before returning the response. The source window
+resize is posted to the UI thread so it runs on the next frame (same pattern as
+`promote_pool_window`'s `wrap_task!`).
+
+#### Windows (`#[cfg(target_os = "windows")]`)
+
+```rust
+if let Some(target_dip_w) = parsed.mother_resize_to_width {
+    if let Some(source_label) = parsed.source_window_label.as_deref() {
+        if let Some(&source_hwnd) = state.window_hwnds.lock().get(source_label) {
+            // Convert DIP → physical px using the source window's monitor.
+            let dpi_scale: f32 = unsafe {
+                use windows_sys::Win32::Foundation::POINT;
+                use windows_sys::Win32::Graphics::Gdi::{MonitorFromPoint, MONITOR_DEFAULTTONEAREST};
+                use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+                use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect;
+                let mut wr = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
+                GetWindowRect(source_hwnd as *mut _, &mut wr);
+                let pt = POINT { x: wr.left, y: wr.top };
+                let monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+                let mut dpi_x: u32 = 0;
+                let mut dpi_y: u32 = 0;
+                let hr = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+                if hr != 0 || dpi_x == 0 { 1.0 } else { dpi_x as f32 / 96.0 }
+            };
+            let new_w_px = (target_dip_w as f32 * dpi_scale).round() as i32;
+            crate::ui_tasks::post_resize_window_width(state, source_hwnd as isize, new_w_px);
+        }
+    }
+}
+```
+
+`post_resize_window_width` posts a UI-thread task that calls:
+```rust
+// ui_tasks.rs
+unsafe {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SetWindowPos, SWP_NOMOVE, SWP_NOZORDER, SWP_NOACTIVATE,
+    };
+    // Preserve current height; only shrink width.
+    let mut wr = std::mem::zeroed::<windows_sys::Win32::Foundation::RECT>();
+    windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect(hwnd as *mut _, &mut wr);
+    let current_h = wr.bottom - wr.top;
+    SetWindowPos(
+        hwnd as *mut _,
+        std::ptr::null_mut(),
+        0, 0,
+        new_w_px,
+        current_h,
+        SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE,
+    );
+}
+```
+
+#### macOS/Linux (`#[cfg(not(target_os = "windows"))]`)
+
+CEF Views `set_bounds` runs on the UI thread. Post via `wrap_task!`:
+
+```rust
+if let Some(target_dip_w) = parsed.mother_resize_to_width {
+    if let Some(source_label) = parsed.source_window_label.as_deref() {
+        let label = source_label.to_string();
+        let state_clone = state.clone();
+        crate::ui_tasks::post_set_window_width(state_clone, label, target_dip_w);
+    }
+}
+```
+
+`post_set_window_width` wraps a UI task that looks up the CEF `Window` by label
+(via `cef::WindowDelegate`'s stored label → window map, or the existing
+`state.cef_windows` map if one exists), reads its current bounds, and calls
+`window.set_bounds(Some(&Rect { x: old_x, y: old_y, width: target_dip_w, height: old_h }))`.
+
+On macOS, CEF Views handles the `NSWindow` resize natively. On Linux (X11/Wayland via
+GTK), CEF Views `set_bounds` calls through to `gtk_window_resize`. Both are tested
+via the existing `set_bounds` usage in the pool-promote path (see `ui_tasks.rs:849`).
+
+---
+
+## 7. Layout Side Effect: Flex-Ratio Preservation
+
+When the mother window shrinks by exactly the pane's width, the remaining panes'
+**CSS pixel widths are preserved without any additional layout action**:
+
+- Before: panes B (300 px) and C (500 px) in a 800 px column (after A's 400 px is
+  removed). Their flex ratios: B = 300/800 = 37.5%, C = 500/800 = 62.5%.
+- After mother resize to 800 px: layout container is now 800 px. Flex ratios unchanged.
+  B = 300 px, C = 500 px. ✓
+
+This holds for any ratio because the remaining panes' proportional sizes are
+unchanged relative to the new container. The layout model already handles this
+correctly — no additional flex recalculation is needed.
+
+---
+
+## 8. Platform Coordinate Summary
+
+| Platform | `mother_resize_to_width` unit | Host converts? | API |
+|---|---|---|---|
+| Windows | CSS/DIP px (same as floater w/h) | Yes: × (source monitor DPI / 96) | `SetWindowPos` with `SWP_NOMOVE \| SWP_NOZORDER \| SWP_NOACTIVATE` |
+| macOS | CSS/DIP px | No | CEF Views `window.set_bounds()` on UI thread |
+| Linux | CSS/DIP px | No | CEF Views `window.set_bounds()` on UI thread |
+
+---
+
+## 9. Edge Cases and Guards
+
+| Case | Behavior |
+|---|---|
+| Single-pane layout | `containerRect.width - paneRect.width ≈ 0` → below `MIN_MOTHER_WIDTH` → no resize |
+| Pane is partial-height (shares a row) | `spansFullHeight` returns false → no resize; siblings expand to fill |
+| Resulting width < `MIN_MOTHER_WIDTH` (400 px) | Omit `mother_resize_to_width` → no resize |
+| `source_window_label` absent or unresolved | Log warn, skip resize silently; floater still opens normally |
+| `magnifiedNodeId` set | Skip detection entirely (add `if (layoutModel?.treeState.magnifiedNodeId) return` before the resize measurement) |
+| Multiple monitors (different DPI) | Windows: DPI lookup uses source window's monitor (not cursor monitor) via `GetWindowRect` + `MonitorFromPoint` |
+| Window already at minimum size | `SetWindowPos`/`set_bounds` no-ops at the OS level; no crash risk |
+| Rapid back-to-back tear-offs | Each invocation of `open_floating_pane_window` carries its own `mother_resize_to_width`; resize tasks are independent, last one wins |
+| macOS fullscreen | CEF `set_bounds` in fullscreen is a no-op; acceptable — fullscreen pane tears don't need a resize |
+
+---
+
+## 10. Testing Checklist
+
+- [ ] **2-column layout, left pane torn off** — mother shrinks by left pane width; right pane keeps exact pixel width
+- [ ] **2-column layout, right pane torn off** — same, mirrored
+- [ ] **3-column layout, center pane torn off** — center pane spans full height → mother shrinks by center pane width; outer two panes keep their widths
+- [ ] **Horizontal split (2 rows)** — each pane is half-height → `spansFullHeight` = false → no resize
+- [ ] **Mixed layout** (one tall left column, two stacked right panes) — left pane → full-height → mother shrinks; either right pane → partial-height → no resize
+- [ ] **Single pane** — no resize (min width guard)
+- [ ] **Narrow result (< 400 px)** — no resize
+- [ ] **Windows HiDPI** — tear on a 150% DPI monitor: floater is correct size, mother shrinks to correct physical width
+- [ ] **Cross-DPI** — source window on 100% monitor, cursor on 150% monitor: floater uses 150% DPI, mother resize uses 100% DPI (source window's monitor, independent)
+- [ ] **macOS** — same layout scenarios; CEF Views `set_bounds` path exercised
+- [ ] **Linux** — same layout scenarios
+- [ ] **Retry path (H.7 gate)** — `open_floating_pane_window` retried after 350 ms; `mother_resize_to_width` persists through the retry (it's in the args object, not re-measured)
+- [ ] **Pool path** — when pool promotes instead of cold-spawning, the mother resize still fires (it's in `open_floating_pane_window` args; the pool path is a fast-path INSIDE that handler, not a bypass)
+
+---
+
+## 11. Files to Change
+
+| File | Change |
+|---|---|
+| `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` | Add `spansFullHeight` detection before `TearOffBlock`; pass `mother_resize_to_width` |
+| `frontend/app/drag/CrossWindowDragMonitor.linux.tsx` | Same (Linux/macOS share this path) |
+| `frontend/app/drag/tear-off-pool-helper.ts` | Export `MIN_MOTHER_WIDTH`, `spansFullHeight` helper |
+| `agentmux-cef/src/commands/floating_pane.rs` | Add `mother_resize_to_width: Option<i32>` to `OpenFloatingPaneArgs`; call resize task |
+| `agentmux-cef/src/ui_tasks.rs` | Add `post_resize_window_width` (Windows) and `post_set_window_width` (non-Windows) |
+
+No changes to `agentmux-srv`, the layout reducer, or the floating pane pool. The resize
+is purely a host-side window-management operation triggered at tear-off time.
+
+---
+
+## 12. Open Questions
+
+1. **Animation** — should the mother resize animate (slide) or snap? Initial proposal:
+   snap (instant `SetWindowPos` / `set_bounds`). The floater appears at the same time,
+   creating the visual illusion of the pane physically detaching. An animation could
+   conflict with the OS window-resize animation on Windows 11.
+
+2. **macOS CEF Window lookup** — the non-Windows path needs a label → CEF `Window`
+   map. Verify that `state.cef_windows` (or equivalent) exists and is populated for
+   all top-level windows; if not, a new map is needed (similar to `window_hwnds`).
+
+3. **Wayland** — `gtk_window_resize` behavior under Wayland compositors varies. The
+   `set_bounds` path is already used for pool-promote on Linux; if it works there, it
+   should work here.

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -140,7 +140,7 @@ async function handleCrossWindowDragEnd(
             await performCrossWindowDrop(dragType, dragPayloadForApi, workspace.oid, activeTabId);
             await api.completeCrossDrag(dragId, targetWindow, cursorPoint.x, cursorPoint.y);
         } else if (!targetWindow) {
-            await performTearOff(dragType, dragPayloadForApi, workspace.oid, activeTabId, cursorPoint.x, cursorPoint.y);
+            await performTearOff(dragType, dragPayloadForApi, workspace.oid, activeTabId, cursorPoint.x, cursorPoint.y, sourceWindow);
             await api.completeCrossDrag(dragId, null, cursorPoint.x, cursorPoint.y);
         } else {
             await api.cancelCrossDrag(dragId);
@@ -163,7 +163,8 @@ async function performTearOff(
     sourceWsId: string,
     sourceTabId: string,
     screenX: number,
-    screenY: number
+    screenY: number,
+    sourceWindowLabel: string | null = null,
 ) {
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
@@ -230,6 +231,7 @@ async function performTearOff(
                 y: screenY,
                 width: floaterWidth,
                 height: floaterHeight,
+                source_window_label: sourceWindowLabel,
                 mother_resize_to_width: motherResizeToWidth,
             });
             Logger.info("dnd:cross", "floating pane spawned (linux)", {
@@ -239,6 +241,7 @@ async function performTearOff(
                 screenY,
                 width: floaterWidth,
                 height: floaterHeight,
+                sourceWindowLabel,
                 motherResizeToWidth,
             });
         } catch (err) {
@@ -253,6 +256,7 @@ async function performTearOff(
                         y: screenY,
                         width: floaterWidth,
                         height: floaterHeight,
+                        source_window_label: sourceWindowLabel,
                         mother_resize_to_width: motherResizeToWidth,
                     });
                 } catch (e2) {

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -11,7 +11,7 @@
 import { atoms, getApi } from "@/store/global";
 import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
-import { openTearOffWindow, measureSourcePaneSize } from "./tear-off-pool-helper";
+import { openTearOffWindow, measureSourcePaneSize, measureMotherResize } from "./tear-off-pool-helper";
 import { getTabGrabOffset } from "@/app/tab/tab-grab-offset";
 import { invokeCommand } from "@/app/platform/ipc";
 import { onCleanup, onMount } from "solid-js";
@@ -192,6 +192,11 @@ async function performTearOff(
         const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
             payload.blockId,
         );
+        // Compute mother window resize: if the pane spans the full height of
+        // the layout container (top-to-bottom column), the mother shrinks by
+        // the pane's width so remaining panes keep their sizes unchanged.
+        // SPEC: SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
+        const motherResizeToWidth = measureMotherResize(payload.blockId);
 
         const newWsId = await WorkspaceService.TearOffBlock(
             payload.blockId,
@@ -220,6 +225,7 @@ async function performTearOff(
                 y: screenY,
                 width: floaterWidth,
                 height: floaterHeight,
+                mother_resize_to_width: motherResizeToWidth,
             });
             Logger.info("dnd:cross", "floating pane spawned (linux)", {
                 blockId: payload.blockId,
@@ -228,6 +234,7 @@ async function performTearOff(
                 screenY,
                 width: floaterWidth,
                 height: floaterHeight,
+                motherResizeToWidth,
             });
         } catch (err) {
             const msg = String(err);
@@ -241,6 +248,7 @@ async function performTearOff(
                         y: screenY,
                         width: floaterWidth,
                         height: floaterHeight,
+                        mother_resize_to_width: motherResizeToWidth,
                     });
                 } catch (e2) {
                     Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -195,8 +195,13 @@ async function performTearOff(
         // Compute mother window resize: if the pane spans the full height of
         // the layout container (top-to-bottom column), the mother shrinks by
         // the pane's width so remaining panes keep their sizes unchanged.
+        // Skip when a pane is magnified — layout container dimensions are
+        // misleading in that mode (spec §9).
         // SPEC: SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
-        const motherResizeToWidth = measureMotherResize(payload.blockId);
+        const layoutModelForResize = getLayoutModelForStaticTab();
+        const motherResizeToWidth = layoutModelForResize?.treeState?.magnifiedNodeId
+            ? undefined
+            : measureMotherResize(payload.blockId);
 
         const newWsId = await WorkspaceService.TearOffBlock(
             payload.blockId,

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -265,8 +265,13 @@ async function performTearOff(
         // mother shrinks by exactly the pane's column width so remaining panes
         // keep their sizes unchanged. Absent when the pane is in a horizontal
         // split or the remaining width would be < MIN_MOTHER_WIDTH.
+        // Skip when a pane is magnified — the layout container dimensions are
+        // misleading in that mode (spec §9).
         // SPEC: SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
-        const motherResizeToWidth = measureMotherResize(payload.blockId);
+        const layoutModelForResize = getLayoutModelForStaticTab();
+        const motherResizeToWidth = layoutModelForResize?.treeState?.magnifiedNodeId
+            ? undefined
+            : measureMotherResize(payload.blockId);
 
         const newWsId = await WorkspaceService.TearOffBlock(
             payload.blockId,

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -25,7 +25,7 @@ import { WorkspaceService } from "@/app/store/services";
 import { getLayoutModelForStaticTab, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "@/layout/index";
 import { invokeCommand } from "@/app/platform/ipc";
 import { Logger } from "@/util/logger";
-import { openTearOffWindow, measureSourcePaneSize } from "./tear-off-pool-helper";
+import { openTearOffWindow, measureSourcePaneSize, measureMotherResize } from "./tear-off-pool-helper";
 import { getTabGrabOffset } from "@/app/tab/tab-grab-offset";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
@@ -260,6 +260,13 @@ async function performTearOff(
         const { width: floaterWidth, height: floaterHeight } = measureSourcePaneSize(
             payload.blockId,
         );
+        // Compute the mother window's new width if the pane spans the full
+        // height of the layout container (top-to-bottom column). If so, the
+        // mother shrinks by exactly the pane's column width so remaining panes
+        // keep their sizes unchanged. Absent when the pane is in a horizontal
+        // split or the remaining width would be < MIN_MOTHER_WIDTH.
+        // SPEC: SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md
+        const motherResizeToWidth = measureMotherResize(payload.blockId);
 
         const newWsId = await WorkspaceService.TearOffBlock(
             payload.blockId,
@@ -299,12 +306,14 @@ async function performTearOff(
                 width: floaterWidth,
                 height: floaterHeight,
                 source_window_label: sourceWindowLabel,
+                mother_resize_to_width: motherResizeToWidth,
             });
             Logger.info("dnd:cross", "floating pane spawned", {
                 blockId: payload.blockId,
                 newWsId,
                 screenX,
                 screenY,
+                motherResizeToWidth,
             });
         } catch (e) {
             const msg = String(e);
@@ -323,6 +332,7 @@ async function performTearOff(
                         width: floaterWidth,
                         height: floaterHeight,
                         source_window_label: sourceWindowLabel,
+                        mother_resize_to_width: motherResizeToWidth,
                     });
                 } catch (e2) {
                     Logger.error("dnd:cross", "open_floating_pane_window failed after retry", {

--- a/frontend/app/drag/tear-off-pool-helper.ts
+++ b/frontend/app/drag/tear-off-pool-helper.ts
@@ -1,5 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Mother-window resize on pane tear-off
+// (SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md)
 
 /**
  * Shared tear-off helper: try the warm pool first, fall back to the
@@ -23,6 +26,14 @@ import type { getApi } from "@/store/global";
 import { Logger } from "@/util/logger";
 
 type Api = ReturnType<typeof getApi>;
+
+// Minimum CSS pixel width the mother window must retain after a pane tear-off
+// resize. Below this the remaining layout would be too narrow to be useful.
+export const MIN_MOTHER_WIDTH = 400;
+
+// Tolerance in CSS px for deciding whether a pane's edge aligns with the
+// layout container's edge (sub-pixel rounding, scrollbar gutters, etc.).
+const FULL_HEIGHT_EPSILON_PX = 2;
 
 // Default floater size when the source pane element can't be measured
 // (e.g. it already unmounted). Used by every platform's pane tear-off.
@@ -58,6 +69,53 @@ export function measureSourcePaneSize(blockId: string): { width: number; height:
         width: Math.max(MIN_FLOATER_WIDTH, Math.round(rect.width)),
         height: Math.max(MIN_FLOATER_HEIGHT, Math.round(rect.height)),
     };
+}
+
+/**
+ * Compute the CSS/DIP pixel width the mother window should shrink to after
+ * tearing off the pane identified by `blockId`.
+ *
+ * Returns a width in CSS pixels when ALL of the following hold:
+ *   1. The pane element is found in the DOM (must be called BEFORE TearOffBlock).
+ *   2. The pane spans the full height of its layout container (top-to-bottom
+ *      column — a clean vertical split).
+ *   3. The remaining width would be ≥ MIN_MOTHER_WIDTH (400 CSS px).
+ *
+ * Returns `undefined` when:
+ *   - The pane element is missing (unmounted early).
+ *   - The pane is in a horizontal split (shares height with siblings) — no resize.
+ *   - The remaining width would be too narrow.
+ *
+ * The value is passed as `mother_resize_to_width` in `open_floating_pane_window`.
+ * The host converts it to physical pixels on Windows (using the source window's
+ * monitor DPI) and applies it via `SetWindowPos` / CEF `set_bounds`.
+ *
+ * MUST be called BEFORE `TearOffBlock` — that mutation removes the pane from
+ * the layout tree and unmounts its DOM element.
+ */
+export function measureMotherResize(blockId: string): number | undefined {
+    const paneEl = document.querySelector(`[data-blockid="${blockId}"]`) as HTMLElement | null;
+    if (!paneEl) return undefined;
+
+    // Resolve the layout display container — the immediate parent grid div.
+    // TileLayout renders: <div class="tile-layout"><div class="display-container">…
+    // The pane node's DOM element is a descendant of display-container.
+    const containerEl = paneEl.closest(".display-container") as HTMLElement | null;
+    if (!containerEl) return undefined;
+
+    const paneRect = paneEl.getBoundingClientRect();
+    const containerRect = containerEl.getBoundingClientRect();
+
+    // Full-height check: pane must reach from container top to container bottom.
+    const spansFullHeight =
+        paneRect.top - containerRect.top <= FULL_HEIGHT_EPSILON_PX &&
+        containerRect.bottom - paneRect.bottom <= FULL_HEIGHT_EPSILON_PX;
+
+    if (!spansFullHeight) return undefined;
+
+    // Single-pane layout guard: nothing left after resize.
+    const newWidth = Math.round(containerRect.width - paneRect.width);
+    return newWidth >= MIN_MOTHER_WIDTH ? newWidth : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When a pane spans the full height of its layout container (a top-to-bottom column), tearing it off now **shrinks the mother window** by that pane's column width. Remaining panes keep their pixel sizes — it's a clean vertical split, not a relayout.
- If the pane shares vertical space with siblings (horizontal split) — no resize; existing behaviour preserved.
- Guard: if the resulting mother width would be < 400 CSS px, no resize.

## Design

**Full-height detection** (`tear-off-pool-helper.ts::measureMotherResize`):
- Reads `paneEl.getBoundingClientRect()` and its `display-container` ancestor — **before `TearOffBlock`** (DOM still intact).
- Full-height = `paneRect.top ≈ containerTop && paneRect.bottom ≈ containerBottom` (2 px epsilon).
- Passes `mother_resize_to_width` (CSS/DIP px) in `open_floating_pane_window`.

**Host resize (`ui_tasks.rs`)**:
- **Windows** (`ResizeMotherWindowWin32Task`): `SetWindowPos(SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE)` with DIP→physical px via `GetDpiForMonitor(MonitorFromPoint(source_window_top_left))`.
- **macOS/Linux** (`ResizeMotherWindowTask`): CEF Views `window.set_bounds()` on the UI thread, width replaced, height preserved.

## Files changed

| File | Change |
|---|---|
| `frontend/app/drag/tear-off-pool-helper.ts` | `measureMotherResize()` helper + `MIN_MOTHER_WIDTH` |
| `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` | Call `measureMotherResize`; pass `mother_resize_to_width` |
| `frontend/app/drag/CrossWindowDragMonitor.linux.tsx` | Same (covers Linux + macOS) |
| `agentmux-cef/src/commands/floating_pane.rs` | New `mother_resize_to_width` field; dispatch resize task |
| `agentmux-cef/src/ui_tasks.rs` | `ResizeMotherWindowTask` (non-Win) + `ResizeMotherWindowWin32Task` (Win) |
| `docs/specs/SPEC_PANE_TEAROFF_MOTHER_RESIZE_2026_06_20.md` | Full spec |

## Test plan

- [ ] 2-column layout → tear off left/right pane → mother shrinks by that column's width; sibling stays same pixel width
- [ ] 3-column → tear off center (full height) → mother shrinks; outer two columns unchanged
- [ ] Horizontal split (2 rows) → each pane is partial-height → no resize
- [ ] Mixed layout (tall left + two stacked right) → left pane: resize; either right pane: no resize
- [ ] Single pane → no resize (min-width guard)
- [ ] Narrow result (< 400 px) → no resize
- [ ] Windows HiDPI (150%) → floater correct size, mother shrinks to correct physical width
- [ ] Cross-DPI (source 100%, cursor 150%) → floater uses 150% DPI, mother resize uses source monitor DPI independently
- [ ] macOS / Linux → CEF `set_bounds` path exercised
- [ ] Retry path (H.7 gate) → `mother_resize_to_width` persists through retry (baked into args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)