### PR TITLE
feat(linux): session-aware startup splash (X11 + Wayland)

### DIFF
--- a/.changesets/1781973703-feat-linux-session-aware-startup-splash-x11-wayland-backends-vtbt.md
+++ b/.changesets/1781973703-feat-linux-session-aware-startup-splash-x11-wayland-backends-vtbt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(linux): session-aware startup splash (X11 + Wayland backends)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "smithay-client-toolkit",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -102,6 +103,7 @@ dependencies = [
  "uuid",
  "windows-sys 0.59.0",
  "winres",
+ "x11rb",
 ]
 
 [[package]]
@@ -715,6 +717,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +755,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "polling 3.11.0",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -1058,6 +1106,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "data-encoding"
@@ -1526,6 +1580,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -2289,6 +2353,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
@@ -2361,7 +2434,7 @@ dependencies = [
  "libc",
  "log",
  "mach2",
- "memmap2",
+ "memmap2 0.9.10",
  "memoffset 0.9.1",
  "minidump-common",
  "nix 0.29.0",
@@ -3604,6 +3677,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.10",
+ "pkg-config",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4449,6 +4550,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,6 +5222,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,6 +5262,26 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xkbcommon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
+dependencies = [
+ "libc",
+ "memmap2 0.8.0",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1301,13 +1301,13 @@ impl AgentMuxHandler {
             }
         }
 
-        // macOS analogue of the Win32 splash signal: the launcher owns the
-        // native splash (see agentmux-launcher/src/splash_mac.rs) and passes a
-        // ready-file path via AGENTMUX_SPLASH_READY_FILE. Creating the file is
-        // the cross-process "first frame painted" signal the launcher polls for
-        // before tearing the splash down. Fire-and-forget; absent var => no
+        // macOS/Linux analogue of the Win32 splash signal: the launcher owns the
+        // native splash (see agentmux-launcher/src/splash_mac.rs and splash_linux/)
+        // and passes a ready-file path via AGENTMUX_SPLASH_READY_FILE. Creating the
+        // file is the cross-process "first frame painted" signal the launcher polls
+        // for before tearing the splash down. Fire-and-forget; absent var => no
         // launcher splash (e.g. dev:standalone), so this is a no-op.
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
                 if !path.is_empty() {

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -100,12 +100,28 @@ windows-sys = { version = "0.59", features = [
 # libc surface we need; tokio's process_group handles the spawn side.
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Session-aware Linux startup splash (SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20).
+# X11 backend: a software-drawn override-redirect splash window (pixmap blit,
+# no GPU). Pure-Rust RustConnection over libxcb; present on every X11 stack.
+x11rb = "0.13"
+# Wayland backend: a software-drawn (wl_shm) xdg_toplevel splash for native-
+# Wayland sessions (the default since #1611). No GPU/EGL. wayland-client is used
+# via sctk's reexport so the protocol versions can't skew.
+smithay-client-toolkit = "0.19"
+
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
 # Decode the splash brain logo at compile time. The PNG (RGBA, transparent
 # background) lives at `resources/brain.png`; build.rs decodes it to raw
 # BGRA bytes that splash.rs `include_bytes!`-s — no runtime PNG decoder
 # in the launcher binary.
+png = "0.17"
+
+[target.'cfg(target_os = "linux")'.build-dependencies]
+# Same compile-time brain.png decode as Windows, but emitting straight RGBA8
+# (brain_rgba.bin) for the Linux X11/Wayland splash backends. Keeps a PNG
+# decoder out of the launcher runtime binary.
 png = "0.17"
 
 [dev-dependencies]

--- a/agentmux-launcher/build.rs
+++ b/agentmux-launcher/build.rs
@@ -105,4 +105,45 @@ fn main() {
         let dims_path = std::path::Path::new(&out_dir).join("brain_dims.rs");
         std::fs::write(&dims_path, dims_rs).expect("write brain_dims.rs");
     }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Decode the brain logo PNG (RGBA, transparent background) to raw
+        // *straight* (non-pre-multiplied) RGBA8 bytes for the Linux splash
+        // backends (X11 pixmap + Wayland wl_shm). The backends alpha-blend the
+        // brain over the solid backdrop themselves each frame, so they need the
+        // un-pre-multiplied source. Decoding at compile time keeps a PNG decoder
+        // out of the launcher runtime binary (mirrors the Windows arm above).
+        let png_path = std::path::Path::new("resources/brain.png");
+        println!("cargo:rerun-if-changed={}", png_path.display());
+        let f = std::fs::File::open(png_path).expect("resources/brain.png not found");
+        let decoder = png::Decoder::new(f);
+        let mut reader = decoder.read_info().expect("png header");
+        let info = reader.info().clone();
+        assert_eq!(
+            info.color_type,
+            png::ColorType::Rgba,
+            "splash brain.png must be RGBA (transparent background)"
+        );
+        assert_eq!(
+            info.bit_depth,
+            png::BitDepth::Eight,
+            "splash brain.png must be 8-bit"
+        );
+        let mut buf = vec![0u8; reader.output_buffer_size()];
+        reader.next_frame(&mut buf).expect("png decode");
+
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        let rgba_path = std::path::Path::new(&out_dir).join("brain_rgba.bin");
+        std::fs::write(&rgba_path, &buf).expect("write brain_rgba.bin");
+
+        // Same brain_dims.rs the X11/Wayland backends `include!`, in lockstep
+        // with the actual PNG size.
+        let dims_rs = format!(
+            "pub const BRAIN_W: i32 = {};\npub const BRAIN_H: i32 = {};\n",
+            info.width, info.height
+        );
+        let dims_path = std::path::Path::new(&out_dir).join("brain_dims.rs");
+        std::fs::write(&dims_path, dims_rs).expect("write brain_dims.rs");
+    }
 }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -37,6 +37,8 @@ mod saga;
 mod splash;
 #[cfg(target_os = "macos")]
 mod splash_mac;
+#[cfg(target_os = "linux")]
+mod splash_linux;
 mod srv_spawner;
 mod state;
 mod wrr;
@@ -108,6 +110,15 @@ fn main() {
 
     #[cfg(not(target_os = "macos"))]
     {
+        // Linux: paint the splash before any heavy work (mirrors the macOS path,
+        // but on its own thread since neither X11 nor Wayland needs the main
+        // thread). spawn() sets AGENTMUX_SPLASH_READY_FILE so the host — spawned
+        // later inside launcher_main — inherits it and signals first paint.
+        // Windows keeps spawning its splash inside launcher_main (event-name
+        // model). See splash_linux/.
+        #[cfg(target_os = "linux")]
+        splash_linux::spawn();
+
         tokio::runtime::Runtime::new()
             .expect("failed to build Tokio runtime")
             .block_on(launcher_main());

--- a/agentmux-launcher/src/splash_linux/mod.rs
+++ b/agentmux-launcher/src/splash_linux/mod.rs
@@ -1,0 +1,172 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session-aware Linux startup splash.
+//!
+//! The launcher is up in milliseconds; `agentmux-cef` *is* the multi-second cold
+//! start (CEF init + GPU channel + page load). This paints a pulsing brain logo
+//! over a dark backdrop in that gap — the Linux analogue of `splash.rs` (Win32)
+//! and `splash_mac.rs` (Cocoa).
+//!
+//! The backend mirrors the host's ozone choice (`agentmux-cef/src/app.rs`): an
+//! X11 splash for X11 / XWayland sessions, a Wayland splash for native-Wayland
+//! sessions — so the splash always speaks the same display protocol as the host.
+//!
+//! Dismiss protocol is the macOS one: `spawn()` sets `AGENTMUX_SPLASH_READY_FILE`
+//! (the host inherits it and writes the file on first paint); the splash thread
+//! polls for that file and tears down, with a safety timeout for a host that
+//! crashes before painting.
+//!
+//! Spec: docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md
+
+mod wayland;
+mod x11;
+
+use std::time::Duration;
+
+// ── Shared look (matches splash_mac.rs / splash.rs) ─────────────────────────
+/// Opaque dark backdrop RGB(26, 26, 31) = #1A1A1F.
+pub(crate) const BG_R: u8 = 0x1A;
+pub(crate) const BG_G: u8 = 0x1A;
+pub(crate) const BG_B: u8 = 0x1F;
+/// Backdrop padding around the brain, in px.
+pub(crate) const PADDING: i32 = 28;
+/// ~60 fps animation tick.
+pub(crate) const FRAME_MS: u64 = 16;
+const FADE_IN_S: f32 = 0.2;
+const PULSE_HZ: f32 = 1.1;
+const PULSE_MIN: f32 = 0.73;
+const PULSE_MAX: f32 = 1.0;
+/// Self-dismiss if the host never signals first paint (crash before frame).
+pub(crate) const DISMISS_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Brain logo as straight (non-pre-multiplied) RGBA8, emitted by build.rs.
+pub(crate) static BRAIN_RGBA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/brain_rgba.bin"));
+include!(concat!(env!("OUT_DIR"), "/brain_dims.rs")); // pub const BRAIN_W / BRAIN_H (i32)
+
+enum Session {
+    Wayland,
+    X11,
+}
+
+/// Mirror the host's ozone selection (`agentmux-cef/src/app.rs`): an explicit
+/// `AGENTMUX_OZONE_PLATFORM` wins; otherwise native Wayland when `WAYLAND_DISPLAY`
+/// is set; otherwise X11. Keeping this in lockstep guarantees splash and host
+/// never end up on different display protocols.
+fn detect() -> Session {
+    if let Ok(forced) = std::env::var("AGENTMUX_OZONE_PLATFORM") {
+        match forced.as_str() {
+            "wayland" => return Session::Wayland,
+            "x11" => return Session::X11,
+            _ => {}
+        }
+    }
+    let on_wayland = std::env::var("WAYLAND_DISPLAY")
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if on_wayland {
+        Session::Wayland
+    } else {
+        Session::X11
+    }
+}
+
+/// Minimum on-screen time before the splash is allowed to dismiss, so a fast
+/// cold start can't produce a sub-perceptible flash (worse than no splash).
+/// Overridable via `AGENTMUX_SPLASH_HOLD_MS` — also handy for eyeballing the
+/// splash during testing (e.g. `AGENTMUX_SPLASH_HOLD_MS=3000`).
+pub(crate) fn min_hold() -> Duration {
+    std::env::var("AGENTMUX_SPLASH_HOLD_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_millis(450))
+}
+
+/// Pulse alpha in 0..=1 for elapsed seconds since the splash appeared: a linear
+/// ramp 0→1 over `FADE_IN_S`, then a `PULSE_HZ` sine between `PULSE_MIN..PULSE_MAX`
+/// (the backdrop stays opaque; only the brain's alpha breathes). Shared by both
+/// backends.
+pub(crate) fn pulse_alpha(t: f32) -> f32 {
+    if t < FADE_IN_S {
+        return t / FADE_IN_S;
+    }
+    let s = (((t - FADE_IN_S) * std::f32::consts::TAU * PULSE_HZ).sin() + 1.0) * 0.5;
+    PULSE_MIN + s * (PULSE_MAX - PULSE_MIN)
+}
+
+/// Composite one frame into a 4-byte-per-pixel buffer: fill the dark backdrop,
+/// then alpha-blend the brain (centered) at `alpha` strength. Pixel byte order
+/// is given by `bgr`: `true` writes B,G,R,X (X11 depth-24 / Wayland ARGB on LE),
+/// `false` writes R,G,B,X. Shared by both backends.
+pub(crate) fn render_frame(buf: &mut [u8], w: i32, h: i32, alpha: f32, bgr: bool) {
+    let (c0, c2) = if bgr { (BG_B, BG_R) } else { (BG_R, BG_B) };
+    for px in buf.chunks_exact_mut(4) {
+        px[0] = c0;
+        px[1] = BG_G;
+        px[2] = c2;
+        px[3] = 0xFF;
+    }
+    let ox = (w - BRAIN_W) / 2;
+    let oy = (h - BRAIN_H) / 2;
+    for by in 0..BRAIN_H {
+        let dy = oy + by;
+        if dy < 0 || dy >= h {
+            continue;
+        }
+        for bx in 0..BRAIN_W {
+            let dx = ox + bx;
+            if dx < 0 || dx >= w {
+                continue;
+            }
+            let si = ((by * BRAIN_W + bx) * 4) as usize;
+            let sr = BRAIN_RGBA[si] as f32;
+            let sg = BRAIN_RGBA[si + 1] as f32;
+            let sb = BRAIN_RGBA[si + 2] as f32;
+            let a = (BRAIN_RGBA[si + 3] as f32 / 255.0) * alpha;
+            let di = ((dy * w + dx) * 4) as usize;
+            let (b0, b2) = if bgr { (sb, sr) } else { (sr, sb) };
+            buf[di] = (buf[di] as f32 * (1.0 - a) + b0 * a) as u8;
+            buf[di + 1] = (buf[di + 1] as f32 * (1.0 - a) + sg * a) as u8;
+            buf[di + 2] = (buf[di + 2] as f32 * (1.0 - a) + b2 * a) as u8;
+        }
+    }
+}
+
+/// Spawn the startup splash. Sets `AGENTMUX_SPLASH_READY_FILE` (inherited by the
+/// host, which writes it on first paint) and runs the matching backend on a
+/// dedicated thread, so the launcher's main thread continues to start srv + host.
+/// The thread self-terminates on first-paint or the safety timeout. Best-effort:
+/// any failure (no display, protocol error) just means no splash — the launcher
+/// is unaffected.
+pub fn spawn() {
+    let ready_file =
+        std::env::temp_dir().join(format!("agentmux-splash-ready-{}", std::process::id()));
+    let _ = std::fs::remove_file(&ready_file);
+    // Set before any host is spawned so the host inherits it (same trick as
+    // splash_mac.rs). Safe: the launcher is single-threaded at this point.
+    std::env::set_var("AGENTMUX_SPLASH_READY_FILE", &ready_file);
+
+    match detect() {
+        Session::X11 => {
+            std::thread::Builder::new()
+                .name("agentmux-splash".into())
+                .spawn(move || {
+                    if let Err(e) = x11::run(&ready_file) {
+                        eprintln!("[splash] x11 backend disabled: {e}");
+                    }
+                })
+                .ok();
+        }
+        Session::Wayland => {
+            std::thread::Builder::new()
+                .name("agentmux-splash".into())
+                .spawn(move || {
+                    if let Err(e) = wayland::run(&ready_file) {
+                        eprintln!("[splash] wayland backend disabled: {e}");
+                    }
+                })
+                .ok();
+        }
+    }
+}

--- a/agentmux-launcher/src/splash_linux/wayland.rs
+++ b/agentmux-launcher/src/splash_linux/wayland.rs
@@ -1,0 +1,227 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wayland splash backend — a software-drawn (`wl_shm`) `xdg_toplevel` showing
+//! the pulsing brain, for native-Wayland sessions (the default since #1611).
+//!
+//! Wayland deliberately denies clients window positioning and "always on top",
+//! and GNOME/Mutter does not implement `wlr-layer-shell`, so this is a
+//! best-effort splash: a borderless `xdg_toplevel` the compositor places (Mutter
+//! centers small toplevels) and which we dismiss the instant the host paints.
+//! No GPU/EGL — a shared-memory buffer we blit each frame. See
+//! docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md §3, §6.
+
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use smithay_client_toolkit::{
+    compositor::{CompositorHandler, CompositorState},
+    delegate_compositor, delegate_output, delegate_registry, delegate_shm, delegate_xdg_shell,
+    delegate_xdg_window,
+    output::{OutputHandler, OutputState},
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+    shell::{
+        xdg::{
+            window::{Window, WindowConfigure, WindowDecorations, WindowHandler},
+            XdgShell,
+        },
+        WaylandSurface,
+    },
+    shm::{slot::SlotPool, Shm, ShmHandler},
+};
+use smithay_client_toolkit::reexports::client::{
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_shm, wl_surface},
+    Connection, QueueHandle,
+};
+
+use super::{min_hold, pulse_alpha, render_frame, BRAIN_H, BRAIN_W, DISMISS_TIMEOUT, PADDING};
+
+pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
+    let conn = Connection::connect_to_env()?;
+    let (globals, mut event_queue) = registry_queue_init::<SplashState>(&conn)?;
+    let qh = event_queue.handle();
+
+    let compositor = CompositorState::bind(&globals, &qh)?;
+    let shm = Shm::bind(&globals, &qh)?;
+    let xdg_shell = XdgShell::bind(&globals, &qh)?;
+
+    let w = (BRAIN_W + PADDING * 2) as u32;
+    let h = (BRAIN_H + PADDING * 2) as u32;
+
+    let surface = compositor.create_surface(&qh);
+    let window = xdg_shell.create_window(surface, WindowDecorations::None, &qh);
+    window.set_title("AgentMux");
+    // Match the host's app_id so the compositor associates the two.
+    window.set_app_id("ai.agentmux.AgentMux");
+    window.set_min_size(Some((w, h)));
+    window.set_max_size(Some((w, h)));
+    window.commit();
+
+    let pool = SlotPool::new((w * h * 4) as usize, &shm)?;
+
+    let mut state = SplashState {
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
+        shm,
+        pool,
+        window,
+        width: w,
+        height: h,
+        start: Instant::now(),
+        min_hold: min_hold(),
+        ready_file: ready_file.to_path_buf(),
+        exit: false,
+    };
+
+    while !state.exit {
+        event_queue.blocking_dispatch(&mut state)?;
+    }
+    Ok(())
+}
+
+struct SplashState {
+    registry_state: RegistryState,
+    output_state: OutputState,
+    shm: Shm,
+    pool: SlotPool,
+    window: Window,
+    width: u32,
+    height: u32,
+    start: Instant,
+    min_hold: Duration,
+    ready_file: PathBuf,
+    exit: bool,
+}
+
+impl SplashState {
+    fn should_dismiss(&self) -> bool {
+        let elapsed = self.start.elapsed();
+        (self.ready_file.exists() && elapsed >= self.min_hold) || elapsed >= DISMISS_TIMEOUT
+    }
+
+    /// Paint one frame and request the next frame callback, or set `exit` once
+    /// the dismiss condition is met. Driven by the compositor's frame callbacks
+    /// (which also pace the ~60 fps pulse).
+    fn draw(&mut self, qh: &QueueHandle<Self>) {
+        if self.should_dismiss() {
+            self.exit = true;
+            return;
+        }
+
+        let (w, h) = (self.width as i32, self.height as i32);
+        let stride = w * 4;
+        let (buffer, canvas) = match self
+            .pool
+            .create_buffer(w, h, stride, wl_shm::Format::Argb8888)
+        {
+            Ok(b) => b,
+            Err(_) => {
+                self.exit = true;
+                return;
+            }
+        };
+
+        let alpha = pulse_alpha(self.start.elapsed().as_secs_f32());
+        // wl_shm ARGB8888 is native-endian 0xAARRGGBB → bytes B,G,R,A on LE.
+        render_frame(canvas, w, h, alpha, /* bgr = */ true);
+
+        let surface = self.window.wl_surface();
+        surface.damage_buffer(0, 0, w, h);
+        surface.frame(qh, surface.clone());
+        let _ = buffer.attach_to(surface);
+        self.window.commit();
+    }
+}
+
+impl CompositorHandler for SplashState {
+    fn scale_factor_changed(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_surface::WlSurface,
+        _: i32,
+    ) {
+    }
+    fn transform_changed(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_surface::WlSurface,
+        _: wl_output::Transform,
+    ) {
+    }
+    fn frame(
+        &mut self,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+        _: &wl_surface::WlSurface,
+        _: u32,
+    ) {
+        self.draw(qh);
+    }
+    fn surface_enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_surface::WlSurface,
+        _: &wl_output::WlOutput,
+    ) {
+    }
+    fn surface_leave(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_surface::WlSurface,
+        _: &wl_output::WlOutput,
+    ) {
+    }
+}
+
+impl WindowHandler for SplashState {
+    fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &Window) {
+        self.exit = true;
+    }
+    fn configure(
+        &mut self,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+        _: &Window,
+        _: WindowConfigure,
+        _: u32,
+    ) {
+        // First (and every) configure: (re)paint, which kicks the frame loop.
+        self.draw(qh);
+    }
+}
+
+impl OutputHandler for SplashState {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+    fn new_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_output::WlOutput) {}
+    fn update_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_output::WlOutput) {}
+    fn output_destroyed(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_output::WlOutput) {}
+}
+
+impl ShmHandler for SplashState {
+    fn shm_state(&mut self) -> &mut Shm {
+        &mut self.shm
+    }
+}
+
+impl ProvidesRegistryState for SplashState {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+    registry_handlers![OutputState];
+}
+
+delegate_compositor!(SplashState);
+delegate_output!(SplashState);
+delegate_xdg_shell!(SplashState);
+delegate_xdg_window!(SplashState);
+delegate_shm!(SplashState);
+delegate_registry!(SplashState);

--- a/agentmux-launcher/src/splash_linux/x11.rs
+++ b/agentmux-launcher/src/splash_linux/x11.rs
@@ -1,0 +1,151 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! X11 splash backend — a software-drawn, override-redirect window showing the
+//! pulsing brain over a dark backdrop, dismissed when the host writes the
+//! ready-file (or after the safety timeout). Used for X11 and XWayland sessions.
+//!
+//! No GPU: we composite each frame into an off-screen pixmap (depth-24 BGRX) and
+//! `CopyArea` it to the window at ~60 fps. Window placement, `override_redirect`,
+//! and EWMH splash/above/skip-taskbar hints give a proper splash under any X11
+//! window manager and under XWayland.
+
+use std::error::Error;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::ConnectionExt as _;
+use x11rb::protocol::xproto::{
+    AtomEnum, CreateGCAux, CreateWindowAux, EventMask, ImageFormat, PropMode, Window, WindowClass,
+};
+use x11rb::wrapper::ConnectionExt as _;
+
+use super::{
+    pulse_alpha, render_frame, BRAIN_H, BRAIN_W, DISMISS_TIMEOUT, FRAME_MS, PADDING,
+};
+
+pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
+    let (conn, screen_num) = x11rb::connect(None)?;
+    let screen = &conn.setup().roots[screen_num];
+    let root = screen.root;
+    let depth = screen.root_depth; // typically 24
+    let visual = screen.root_visual;
+
+    let w = (BRAIN_W + PADDING * 2) as u16;
+    let h = (BRAIN_H + PADDING * 2) as u16;
+    // Center on the X screen. (RANDR primary-monitor centering is P3 polish.)
+    let x = (((screen.width_in_pixels as i32) - w as i32) / 2).max(0) as i16;
+    let y = (((screen.height_in_pixels as i32) - h as i32) / 2).max(0) as i16;
+
+    let win = conn.generate_id()?;
+    let win_aux = CreateWindowAux::new()
+        .override_redirect(1)
+        .background_pixel(screen.black_pixel)
+        .event_mask(EventMask::EXPOSURE);
+    conn.create_window(
+        depth,
+        win,
+        root,
+        x,
+        y,
+        w,
+        h,
+        0,
+        WindowClass::INPUT_OUTPUT,
+        visual,
+        &win_aux,
+    )?;
+
+    set_ewmh_hints(&conn, win)?;
+
+    let gc = conn.generate_id()?;
+    conn.create_gc(gc, win, &CreateGCAux::new())?;
+    let pixmap = conn.generate_id()?;
+    conn.create_pixmap(depth, pixmap, win, w, h)?;
+
+    conn.map_window(win)?;
+    conn.flush()?;
+
+    let start = Instant::now();
+    let min_hold = super::min_hold();
+    // BGRX, 4 bytes/pixel (depth-24 pixmaps are 32 bpp on every modern server).
+    let mut buf = vec![0u8; w as usize * h as usize * 4];
+
+    loop {
+        let elapsed = start.elapsed();
+        // Dismiss once the host has painted AND we've shown for the minimum hold,
+        // or unconditionally at the safety timeout (host crashed before paint).
+        if (ready_file.exists() && elapsed >= min_hold) || elapsed >= DISMISS_TIMEOUT {
+            break;
+        }
+
+        let alpha = pulse_alpha(start.elapsed().as_secs_f32());
+        render_frame(&mut buf, w as i32, h as i32, alpha, /* bgr = */ true);
+
+        // PutImage in horizontal strips so no single request exceeds the server's
+        // max request size (a full ~312×312 BGRX frame is ~380 KB, over the
+        // 256 KB non-BIG-REQUESTS limit — strips keep us portable either way).
+        let row_bytes = w as usize * 4;
+        let strip_rows = (200_000 / row_bytes).max(1) as u16;
+        let mut row = 0u16;
+        while row < h {
+            let rows = strip_rows.min(h - row);
+            let off = row as usize * row_bytes;
+            let len = rows as usize * row_bytes;
+            conn.put_image(
+                ImageFormat::Z_PIXMAP,
+                pixmap,
+                gc,
+                w,
+                rows,
+                0,
+                row as i16,
+                0,
+                depth,
+                &buf[off..off + len],
+            )?;
+            row += rows;
+        }
+        conn.copy_area(pixmap, win, gc, 0, 0, 0, 0, w, h)?;
+        conn.flush()?;
+
+        // Drain and ignore events so the connection's read buffer can't stall.
+        while let Ok(Some(_)) = conn.poll_for_event() {}
+
+        std::thread::sleep(Duration::from_millis(FRAME_MS));
+    }
+
+    let _ = conn.destroy_window(win);
+    let _ = conn.free_pixmap(pixmap);
+    let _ = conn.free_gc(gc);
+    let _ = conn.flush();
+    Ok(())
+}
+
+/// Best-effort EWMH hints (harmless under `override_redirect`, helpful if a WM
+/// still considers them): mark the window as a splash, ask for above + no
+/// taskbar/pager entry.
+fn set_ewmh_hints<C: Connection>(conn: &C, win: Window) -> Result<(), Box<dyn Error>> {
+    let atom = |name: &[u8]| -> Result<u32, Box<dyn Error>> {
+        Ok(conn.intern_atom(false, name)?.reply()?.atom)
+    };
+
+    let wm_type = atom(b"_NET_WM_WINDOW_TYPE")?;
+    let wm_type_splash = atom(b"_NET_WM_WINDOW_TYPE_SPLASH")?;
+    conn.change_property32(PropMode::REPLACE, win, wm_type, AtomEnum::ATOM, &[wm_type_splash])?;
+
+    let wm_state = atom(b"_NET_WM_STATE")?;
+    let above = atom(b"_NET_WM_STATE_ABOVE")?;
+    let skip_taskbar = atom(b"_NET_WM_STATE_SKIP_TASKBAR")?;
+    let skip_pager = atom(b"_NET_WM_STATE_SKIP_PAGER")?;
+    conn.change_property32(
+        PropMode::REPLACE,
+        win,
+        wm_state,
+        AtomEnum::ATOM,
+        &[above, skip_taskbar, skip_pager],
+    )?;
+
+    Ok(())
+}

--- a/docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md
+++ b/docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md
@@ -1,0 +1,266 @@
+# SPEC: Session-aware Linux startup splash (X11 + Wayland)
+
+**Date:** 2026-06-20
+**Status:** Draft / proposed
+**Owner:** launcher / Linux platform
+**Supersedes the splash portion of:** [`SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md`](./SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md) Workstream B (X11-only assumption)
+**Builds on:** [`SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31.md`](./SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31.md) (dismiss protocol, threading precedent)
+
+---
+
+## 0. TL;DR
+
+Linux is the only platform with **no startup splash** — the launcher spawns `srv` + the CEF host and the user stares at a blank desktop for the ~1–3 s of `srv` handshake + CEF init before the host paints its first frame. Windows (`splash.rs`, Win32) and macOS (`splash_mac.rs`, Cocoa) both paint a pulsing brain logo in that window; Linux falls straight through to `splash_event_name = None` (`agentmux-launcher/src/main.rs:1356`).
+
+The previously-specced Linux plan (Workstream B) was **X11-only**, justified because the host was pinned to `--ozone-platform=x11`. **That pin was just removed** — [PR #1611] made **native Wayland the default** when `WAYLAND_DISPLAY` is present (`agentmux-cef/src/app.rs:599`). The old spec explicitly said to **skip the splash on native-Wayland hosts**, which now means *no splash on the common GNOME/Wayland path* — the opposite of the goal.
+
+This spec replaces that with a **session-aware, dual-backend splash** in the launcher:
+
+| Session (mirrors host ozone) | Splash backend | Fidelity |
+| --- | --- | --- |
+| X11, or `AGENTMUX_OZONE_PLATFORM=x11` (XWayland) | **`splash_x11`** via `x11rb` — `override_redirect` + EWMH `_NET_WM_WINDOW_TYPE_SPLASH` + RANDR centering | Full (positioned, on-top, no taskbar) |
+| Wayland (default when `WAYLAND_DISPLAY` set) | **`splash_wayland`** via `smithay-client-toolkit` + `wl_shm` xdg_toplevel | Degraded but present (compositor-placed, no forced on-top) |
+
+Both share one dismiss protocol (the macOS `AGENTMUX_SPLASH_READY_FILE` file signal), one asset pipeline (`brain.png` → `build.rs`), and one animation curve.
+
+---
+
+## 1. Goals / non-goals
+
+### Goals
+- A branded splash (pulsing brain on dark backdrop) covering the launcher→`srv`→host→CEF-first-frame gap on Linux, on **both** X11 and native-Wayland sessions — GNOME/Mutter being the primary target.
+- Reuse, not reinvent: same dismiss protocol, asset pipeline, animation params, and launcher integration shape as Windows/macOS.
+- No GPU dependency (software draw only) — the launcher is a tiny binary that must paint *before* the CEF/GPU stack exists.
+- Graceful degradation and clean teardown: a host that crashes before first frame must not leave a stuck splash.
+
+### Non-goals
+- Pixel-perfect parity of placement/stacking on Wayland (the protocol forbids it — see §3).
+- A `wlr-layer-shell` implementation (unavailable on GNOME — see §3.1).
+- Covering the *dev-mode* Vite module-load lag — that's a dev-only artifact, not the shipped cold-start gap. (The packaged AppImage already loads fast.)
+- Multi-window / per-monitor splashes; one splash on the primary/active output.
+
+---
+
+## 2. Motivation & the new Wayland wrinkle
+
+The launcher is up in milliseconds; `agentmux-cef` *is* the multi-second cold start (CEF init, GPU channel, page load). A splash can only be painted by a process that is alive *before* CEF — i.e. the launcher, in its own process. This is exactly why Windows/macOS put the splash there, and why a host-side / HTML splash **cannot** cover the gap (CEF can't paint until it's initialized).
+
+Until #1611 the Linux host ran XWayland (`--ozone-platform=x11`) to dodge the CEF 146 native-Wayland frame-stall bug. Workstream B leaned on that: an X11 splash matched an X11 host, and `AGENTMUX_OZONE_PLATFORM=wayland` (the rare regression-test path) simply skipped the splash.
+
+CEF 148 fixed the native-Wayland bug (verified: no `OnTrancheFlags Not implemented`, no `DidNotProduceFrame`, smooth typing), so #1611 flipped the default to **native Wayland on Wayland sessions**. Consequently:
+
+- On a GNOME/Wayland desktop (now the default), the host is a **native-Wayland** client. An XWayland splash would float as a *foreign* X11 surface over a Wayland host, and the old spec's rule would skip it entirely → **no splash for most users**.
+- To show a splash on that path we need a **native-Wayland** splash — which runs into Wayland's deliberate UX constraints (§3).
+
+The splash backend must therefore track the **same** session decision the host makes, so splash and host always speak the same display protocol.
+
+---
+
+## 3. Research findings (Wayland/GNOME feasibility)
+
+### 3.1 GNOME/Mutter does not support `wlr-layer-shell`
+`wlr-layer-shell` is the wlroots/KDE protocol for stacked, screen-edge-locked overlay surfaces (what panels/launchers/splashes use). **Mutter does not implement it and GNOME has declined to** (open since [mutter#973], [gnome-shell#1141]). `gtk4-layer-shell` / `gtk-layer-shell` exist but are thin wrappers over that protocol — so they work on sway/Hyprland/KDE/COSMIC, **not GNOME**. The clean "always-on-top overlay" mechanism is therefore **off the table for our primary target**.
+
+### 3.2 Wayland forbids client-controlled positioning and stacking — by design
+Wayland intentionally does **not** expose absolute window position to clients, and there is **no client-side "always on top."** "Throughout the design of Wayland the approach has been for the client to make requests and the server to make the final decisions." A standalone `xdg_toplevel` therefore:
+- **Cannot self-center** — the compositor places it. (Mutter places small new toplevels roughly centered on the work area, which is acceptable for a splash.)
+- **Cannot force itself above** the host window — best effort only.
+- **Cannot avoid the taskbar/overview** the way EWMH `_NET_WM_STATE_SKIP_TASKBAR` does on X11 (no equivalent without extension protocols).
+
+These are accepted degradations on Wayland, not bugs to fix.
+
+### 3.3 `smithay-client-toolkit` + `wl_shm` is the viable software path
+The sctk `simple_window` example shows the minimal flow: `Connection::connect_to_env()` → `registry_queue_init()` binds `wl_compositor`/`wl_shm`/`xdg_wm_base` (`CompositorState`, `Shm`, `XdgShell`) → `XdgShell::create_window()` for an xdg_toplevel → `SlotPool` allocates an **ARGB8888** `wl_shm` buffer → draw raw pixels into the canvas → damage + `commit`; redraw on the `frame` callback (~16 ms). Decorations are requested via `WindowDecorations` (we request **none**). Core draw is ~50 LOC; a full minimal toplevel with handler boilerplate is ~450 LOC. **No GPU** — pure shared-memory software blit, exactly what the launcher needs.
+
+### 3.4 Precedent
+Electron went Wayland-native (CSD via `ClientFrameViewLinux`), but there is **no established native pre-init splash pattern** on Wayland — Chromium/Electron apps generally accept CSD and have no cold-start splash. So we are slightly off the beaten path; the degradations in §3.2 are inherent, and we design around them rather than expecting a polished overlay.
+
+**Conclusion:** keep the full-fidelity **X11** splash for X11/XWayland sessions, add a **best-effort native-Wayland** splash (sctk + `wl_shm`) for Wayland sessions, and share everything else.
+
+---
+
+## 4. Architecture
+
+```
+launcher main()  (ms-fast, pre-CEF)
+   │
+   ├─ session = detect()            // mirrors agentmux-cef/src/app.rs ozone logic
+   │     AGENTMUX_OZONE_PLATFORM set? → that
+   │     else WAYLAND_DISPLAY set?   → "wayland"
+   │     else                         → "x11"
+   │
+   ├─ splash = match session {
+   │     "wayland" => splash_wayland::spawn(dir_hash),   // sctk + wl_shm, own thread
+   │     _         => splash_x11::spawn(dir_hash),       // x11rb, own thread
+   │   }   // → Option<SplashHandle { ready_file: PathBuf }>
+   │
+   ├─ spawn srv + host  (host env gets AGENTMUX_SPLASH_READY_FILE = splash.ready_file)
+   │
+   └─ host paints first frame → writes ready_file (on_load_end)
+         → splash thread polls the file, fades out (~160 ms), tears the surface down
+         → safety timeout (10 s) dismisses if the host never signals (crash before paint)
+```
+
+Key choices:
+- **Threaded model (like Windows), not main-thread (like macOS).** Neither X11 (x11rb/xcb) nor Wayland (sctk) requires the main thread, so each backend owns a **dedicated thread** with its own display connection + event loop. `spawn()` returns a lightweight `SplashHandle`. This avoids the macOS CFRunLoop-on-main dance and keeps `main()` free to start the supervisor immediately.
+- **One dismiss protocol for all of Linux:** the macOS **`AGENTMUX_SPLASH_READY_FILE`** file signal (§6). Simpler than Windows named events and already implemented host-side; Linux just needs the host's `cfg` gate widened.
+- **Splash backend == host backend, always.** Because both read the same env/`WAYLAND_DISPLAY`, an X11 host gets an X11 splash and a Wayland host gets a Wayland splash — never a cross-protocol mismatch.
+
+---
+
+## 5. Backend A — X11 (`splash_x11.rs`)
+
+Essentially Workstream B of the prior spec, retained for X11 and XWayland sessions where we get full control.
+
+- **Window:** `create_window` with `override_redirect = 1` (no WM decoration/management), `SPLASH_SIZE × SPLASH_SIZE`, centered on the **primary** output via RANDR (`xrandr` `GetMonitors`, pick `primary`).
+- **EWMH hints** (best-effort, harmless under `override_redirect`): `_NET_WM_WINDOW_TYPE = _NET_WM_WINDOW_TYPE_SPLASH`, `_NET_WM_STATE = {_NET_WM_STATE_ABOVE, _NET_WM_STATE_SKIP_TASKBAR, _NET_WM_STATE_SKIP_PAGER}`.
+- **Paint:** one `Pixmap` sized to the window; each tick, software alpha-blend the brain RGBA over the solid backdrop into the pixmap, then `CopyArea` to the window. ~60 Hz (16 ms).
+- **Pulse curve:** shared (§8).
+- **Dismiss:** poll `AGENTMUX_SPLASH_READY_FILE`; on signal, fade alpha→0 over ~160 ms, then unmap + destroy + close the connection. 10 s safety timeout.
+- **Crate:** `x11rb` `0.13`, `default-features = false`, features `["randr"]` (add `xinerama` only if multi-GPU monitor enumeration needs it). Pure `libxcb` (present on every X11 stack).
+
+---
+
+## 6. Backend B — Wayland (`splash_wayland.rs`)
+
+New. Best-effort native-Wayland splash for the now-default path.
+
+- **Connection/thread:** dedicated thread; `Connection::connect_to_env()`, `registry_queue_init()`, bind `CompositorState` / `Shm` / `XdgShell`.
+- **Surface:** `XdgShell::create_window(surface, WindowDecorations::None, &qh)`; `set_title("AgentMux")`, `set_app_id("ai.agentmux.AgentMux")` — **same app_id as the host** so Mutter groups/associates them and is more likely to stack the splash with the app. Set a fixed `min`/`max` size = `SPLASH_SIZE` so the compositor gives us exactly that (a splash is non-resizable).
+- **Buffer/draw:** `SlotPool` → **ARGB8888** `wl_shm` buffer; blit the dark backdrop + alpha-modulated brain each `frame` callback (~16 ms); `damage` + `commit`. (Note: `wl_shm` ARGB is **pre-multiplied** straight-alpha per Wayland — match the backdrop opaque and the brain alpha-pulsed.)
+- **Placement / stacking — accepted limitations (§3.2):** we cannot center or force-on-top. We rely on Mutter's default centered placement for small toplevels and on dismissing *the instant* the host paints (so the two-window overlap window is sub-frame in practice). Document this as expected.
+- **Taskbar/overview:** the splash may flash briefly in the overview/alt-tab. Mitigations: minimal lifetime + matching `app_id`; if a suitable hint protocol is available at impl time (e.g. `xdg-toplevel-tag-v1`), set it, but do **not** depend on it.
+- **Dismiss:** identical file-poll + fade + teardown as X11.
+- **Crates:** `smithay-client-toolkit` (pulls `wayland-client`, `wayland-protocols`). Software-only; no GPU/EGL.
+
+> **Decision call-out (§12-A):** the Wayland backend is intentionally "good enough," not pixel-perfect. If review decides the degradations aren't worth it for v1, ship X11-only and have Wayland sessions *skip* the splash (the prior behavior) — but that leaves the default desktop splash-less, which defeats the motivation.
+
+---
+
+## 7. Shared — dismiss protocol & host signaling
+
+Reuse the **macOS file mechanism** verbatim:
+
+- Launcher (`splash_*::spawn`) creates `std::env::temp_dir().join(format!("agentmux-splash-ready-{}", std::process::id()))`, returns it in `SplashHandle`.
+- Launcher threads it into the host env as **`AGENTMUX_SPLASH_READY_FILE`** (see §10 — `spawn_host_unix` must learn to set it).
+- Host writes the file on first paint. The existing code in `agentmux-cef/src/client/mod.rs:1310` is gated `#[cfg(target_os = "macos")]`; **widen to `#[cfg(any(target_os = "macos", target_os = "linux"))]`** (the one-character change the prior spec noted). The Windows `AGENTMUX_SPLASH_EVENT` branch is untouched.
+- Splash thread polls `ready_file.exists()` on its tick; on hit → fade + teardown.
+- **Safety timeout: 10 s** (mirror `splash_mac.rs` `DISMISS_TIMEOUT`). If the host crashes before first paint, the splash self-dismisses cleanly; the launcher's supervisor independently handles the crash/restart. On a restart, the same ready-file path is reused so a late first-frame still dismisses a splash left pending.
+
+---
+
+## 8. Shared — assets, `build.rs`, animation
+
+### Asset
+`agentmux-launcher/resources/brain.png` — 256×256 RGBA8 transparent PNG (already in tree; macOS embeds it directly, Windows decodes it in `build.rs`).
+
+### `build.rs`
+Currently `#[cfg(target_os = "windows")]`-only (emits pre-multiplied **BGRA** `brain_bgra.bin` + `brain_dims.rs`). Add a `#[cfg(target_os = "linux")]` arm:
+- Decode `brain.png` → **straight RGBA8** → emit `brain_rgba.bin` (X11 pixmap wants native RGBA; the Wayland path converts RGBA→pre-multiplied ARGB at blit time, or emit a second pre-multiplied buffer if cheaper).
+- Emit the shared `brain_dims.rs` (`BRAIN_W`, `BRAIN_H` consts).
+- ~30 LOC; no runtime PNG decoder dependency.
+
+### Layout & animation (shared constants, match macOS feel)
+- Backdrop: opaque **RGB(26, 26, 31)** = `#1A1A1F`.
+- Brain display size and padding: follow the macOS convention (brain 150 px, 35 px padding → 220×220, 16 px corner radius where the backend supports rounding; X11 `override_redirect` can use a shaped/rounded pixmap, Wayland uses a rounded ARGB blit). Sizing constants live in one shared module.
+- Pulse: fade-in 0→peak over **200 ms**, then **1.1 Hz** sine; alpha range matches the platform's compositing (macOS 0.73–1.0; for software ARGB use the same normalized 0.73–1.0 on the brain, backdrop stays opaque). ~60 fps (16 ms ticks).
+
+---
+
+## 9. Launcher integration & the `spawn_host_unix` gap
+
+- **Session dispatch** in `main.rs` replaces the current `#[cfg(not(target_os="windows"))] let splash_event_name = None;` with a Linux arm that runs `detect()` and calls the matching `splash_*::spawn`. macOS keeps its existing early-show path; Windows keeps `spawn_splash`. Introduce a small enum so the host-spawn path is platform-agnostic:
+  ```rust
+  enum SplashDismiss { None, WindowsEvent(String), ReadyFile(PathBuf) }
+  ```
+- **`spawn_host_unix` must set the splash env.** The Explore audit confirms the Unix host-spawn path currently does **not** export `AGENTMUX_SPLASH_READY_FILE` (nor `AGENTMUX_HOME`/`AGENTMUX_LAUNCHER_PIPE` — those are separate A1 work). Add: when `SplashDismiss::ReadyFile(p)` is present, set `AGENTMUX_SPLASH_READY_FILE = p` on the host `Command`. This is the **prerequisite** that makes any Linux splash dismiss.
+- **Supervisor flow:** the splash thread is independent of the supervisor; it dies on signal or timeout. No change to crash/restart/OOM-`disable_gpu` ladders.
+- **AppImage timing:** `AppRun` execs the launcher; splash `spawn` should run immediately after single-instance acquisition, before `srv` spawn, so the brain appears within ~50 ms of AppRun (per the prior spec's acceptance bar).
+
+---
+
+## 10. Dependencies
+
+```toml
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = { version = "0.13", default-features = false, features = ["randr"] }
+smithay-client-toolkit = "0.19"   # pulls wayland-client + wayland-protocols
+```
+
+- Both are **software-only** (X11 `Pixmap` / Wayland `wl_shm`); no EGL/GPU, no new C deps beyond `libxcb` (X11) and `libwayland-client` (present in any Wayland session).
+- Binary-size budget: x11rb ≈ +150 KB stripped; sctk + wayland-client ≈ +250–400 KB stripped. Acceptable for a launcher; both are `cfg(linux)`-gated so Windows/macOS are unaffected.
+- Feature-flag both backends behind a `linux-splash` cargo feature if we want a no-splash build for headless/CI.
+
+---
+
+## 11. Phasing
+
+| Phase | Deliverable | Notes |
+| --- | --- | --- |
+| **P0** | Dismiss plumbing | Widen `client/mod.rs` cfg to include linux; teach `spawn_host_unix` to set `AGENTMUX_SPLASH_READY_FILE`; `build.rs` Linux arm emits `brain_rgba.bin`; shared constants module. **No visible splash yet** — but everything downstream depends on this. |
+| **P1** | `splash_x11.rs` | Full-fidelity X11 splash; verify on an X11 session and via `AGENTMUX_OZONE_PLATFORM=x11` (XWayland). |
+| **P2** | `splash_wayland.rs` | sctk + `wl_shm` toplevel; verify on GNOME/Wayland (the default). Accept §3.2 degradations. |
+| **P3** | Polish | Rounded corners, fade-out tuning, `app_id` grouping, optional taskbar-hint protocol if available, multi-monitor primary-output selection. |
+
+P1 and P2 are independent after P0 and can land in either order; P2 is the higher-value one given native Wayland is the default.
+
+---
+
+## 12. Decision points (need a call before/within implementation)
+
+- **(A) Wayland fidelity vs. scope.** Ship the best-effort Wayland splash (recommended — it's the default desktop) accepting compositor placement + no forced on-top, **or** ship X11-only and skip on Wayland (simpler, but splash-less for most users)?
+- **(B) Single dual-backend module vs. two files.** `splash_x11.rs` + `splash_wayland.rs` behind a `splash_linux` dispatcher (recommended) vs. one large file.
+- **(C) Binary size.** Accept ~+0.4 MB for sctk on the launcher, or gate the Wayland backend behind a feature that distro packagers can drop?
+- **(D) Rounded corners on Wayland.** Worth the per-pixel alpha mask, or square is fine for v1?
+
+---
+
+## 13. Testing & acceptance criteria
+
+X11 session (or `AGENTMUX_OZONE_PLATFORM=x11`):
+- [ ] Brain appears within ~50 ms of AppRun, centered on the primary monitor, above other windows, not in the taskbar.
+- [ ] Smooth 1.1 Hz pulse; fades out within ~200 ms of host first frame.
+- [ ] Multi-monitor: centered on the primary output.
+
+Wayland session (GNOME/Mutter, default):
+- [ ] Brain appears within ~50 ms, roughly centered (compositor-placed), pulsing smoothly.
+- [ ] Dismisses within ~200 ms of host first frame; no lingering surface; minimal/no taskbar-overview flash.
+- [ ] No protocol errors in the launcher log; `wl_shm` buffer released cleanly on teardown.
+
+Both:
+- [ ] **Host crash before first paint** → splash self-dismisses at the 10 s timeout, no zombie window, supervisor still restarts the host.
+- [ ] `AGENTMUX_OZONE_PLATFORM` override routes the splash to the matching backend (forced x11 → X11 splash even on a Wayland session via XWayland; forced wayland → Wayland splash).
+- [ ] Windows/macOS splash behavior unchanged (no regressions from the shared refactor).
+- [ ] `--features no/linux-splash` (if added) builds and runs splash-less.
+
+---
+
+## 14. Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+| --- | --- | --- |
+| Wayland splash not on-top / placed oddly on some Mutter versions | Medium | Accept (§3.2); dismiss on first frame so overlap is sub-perceptible; matching `app_id`. |
+| Splash flashes in GNOME overview/alt-tab | Medium | Minimal lifetime; optional tag protocol; document as known v1 limitation. |
+| Two Wayland clients (launcher + host) confuse the compositor | Low | Independent connections, standard pattern; splash torn down as host maps. |
+| sctk API churn (0.19→) | Low–Med | Pin version; the surface/`wl_shm` path is stable; thin usage. |
+| `wl_shm` pre-multiplied-alpha mistakes (dark fringing) | Med | Pre-multiply at blit; unit-test a few pixels; compare against macOS render. |
+| Binary-size creep on the launcher | Low | `cfg(linux)`-gate; optional feature flag (§12-C). |
+| Non-GNOME Wayland (KDE/wlroots) behaves differently | Low | xdg_toplevel + `wl_shm` is universal; layer-shell explicitly **not** used so no wlroots-only dependency. |
+
+---
+
+## 15. References
+
+Codebase:
+- `agentmux-launcher/src/splash.rs` (Windows), `splash_mac.rs` (macOS), `main.rs:1354–1357` (gating), `build.rs` (asset embed)
+- `agentmux-cef/src/client/mod.rs:1310` (macOS ready-file write), `app.rs:599–637` (ozone/session selection — mirror for `detect()`)
+- `resources/brain.png` (256×256 RGBA)
+- Prior specs: `SPEC_LAUNCHER_LINUX_PACKAGED_AND_SPLASH_2026_06_05.md` (Workstream B), `SPEC_LAUNCHER_MACOS_PACKAGED_AND_SPLASH_2026_05_31.md`
+
+External research:
+- GNOME/Mutter declines `wlr-layer-shell`: <https://gitlab.gnome.org/GNOME/mutter/-/issues/973>, <https://gitlab.gnome.org/GNOME/gnome-shell/-/work_items/1141>
+- `wlr-layer-shell` protocol (wlroots/KDE only): <https://wayland.app/protocols/wlr-layer-shell-unstable-v1>
+- Wayland window positioning is compositor-controlled (no client placement/always-on-top): <https://canonical-mir.readthedocs-hosted.com/stable/explanation/window-positions-under-wayland/>, <https://wayland-book.com/xdg-shell-basics/xdg-toplevel.html>
+- sctk software-rendered window example: <https://github.com/Smithay/client-toolkit/blob/master/examples/simple_window.rs>
+- gtk4-layer-shell (works on wlroots/KDE, not GNOME): <https://github.com/wmww/gtk4-layer-shell>
+- Electron Wayland-native (CSD; no native splash precedent): <https://www.electronjs.org/blog/tech-talk-wayland>


### PR DESCRIPTION
## What
Adds a Linux startup splash — the Linux analogue of the Windows (`splash.rs`) and macOS (`splash_mac.rs`) splashes — a pulsing brain on a dark backdrop that covers the launcher→srv→host→CEF-first-frame cold-start gap. Linux previously fell straight through to `splash_event_name = None`.

## Design — session-aware, dual backend
The splash backend **mirrors the host's ozone choice** (`agentmux-cef/src/app.rs`), so splash and host always speak the same display protocol:

- **X11 / XWayland** (or `AGENTMUX_OZONE_PLATFORM=x11`) → `splash_linux/x11.rs` (`x11rb`): `override_redirect` window, EWMH `_NET_WM_WINDOW_TYPE_SPLASH` + above + skip-taskbar/pager, software pixmap blit (strip `PutImage` → `CopyArea`), ~60 fps pulse. Full fidelity.
- **native Wayland** (the default since #1611) → `splash_linux/wayland.rs` (`smithay-client-toolkit` + `wl_shm`): a best-effort borderless `xdg_toplevel`. GNOME/Mutter doesn't implement `wlr-layer-shell` and Wayland forbids client placement / always-on-top, so the **compositor** places it (Mutter centers small toplevels) and it's dismissed the instant the host paints.

Full rationale + research in `docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md`.

## Shared infrastructure
- **Dismiss protocol:** reuses the macOS `AGENTMUX_SPLASH_READY_FILE` mechanism — the launcher `set_var`s it (host inherits), the host writes it on first paint (`client/mod.rs` `cfg` widened `macos` → `macos`/`linux`), the splash thread polls + tears down. 10 s safety timeout for a host that crashes before painting.
- **Assets:** `build.rs` decodes `brain.png` → straight RGBA8 (`brain_rgba.bin` + `brain_dims.rs`), no runtime PNG decoder.
- **Min hold:** `AGENTMUX_SPLASH_HOLD_MS` (default 450 ms) so a fast cold start can't produce a sub-perceptible flash.
- Threaded model (like Windows), not main-thread (like macOS) — neither X11 nor Wayland needs the main thread.

## Testing
Built locally (AppImage, CEF 148) and validated end-to-end on a **GNOME/Wayland VM**:
- **X11 backend** (`AGENTMUX_OZONE_PLATFORM=x11`): visually confirmed — pulsing brain, centered, dismisses on first paint. Ready-file written, no backend error.
- **Wayland backend** (native default): cold-started, sctk splash ran with no error, host painted → dismiss fired.

## Scope / caveats
- New `cfg(linux)` deps: `x11rb` (no GPU; pure-Rust over libxcb) and `smithay-client-toolkit` (no GPU/EGL; `wl_shm`). Windows/macOS untouched.
- Wayland fidelity is best-effort by protocol design (no forced centering/on-top on GNOME) — documented, not a bug.
- Validated on one compositor (GNOME/Mutter) + VM GPU so far; broader compositor/hardware testing welcome.

## Test plan
- [ ] X11 session: centered, on-top, not in taskbar; dismisses on first paint.
- [ ] Wayland session (GNOME): appears, roughly centered, dismisses on first paint.
- [ ] Host crash before paint → splash self-dismisses at the 10 s timeout.
- [ ] `AGENTMUX_OZONE_PLATFORM` override routes to the matching backend.
- [ ] Windows/macOS splash unchanged.