### PR TITLE
feat(trust-center): rename Memory bundles to Presets (provider-agnostic)

### DIFF
--- a/.changesets/1781975234-feat-trust-center-rename-memory-bundles-to-presets-presets-a-jrgq.md
+++ b/.changesets/1781975234-feat-trust-center-rename-memory-bundles-to-presets-presets-a-jrgq.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(trust-center): rename Memory bundles to Presets; presets are provider-agnostic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ These views exist in the codebase but are **not** widget-bar entries — do not 
 | Surface | How it's reached |
 |---|---|
 | **Identity** | Tab inside an Agent pane (cog → settings panel → Identity tab). The `view: "identity"` registration and `IdentityPaneViewModel` exist for `pane.open` RPC and right-click menu paths; no widget-bar entry. |
-| **Memory** | Tab inside an Agent pane (cog → settings panel → Memory tab). Same shape as Identity — view registered for programmatic access only. Replaces the old Forge concept. The `block.tsx` migration shim still redirects `view: "forge"` blocks to `view: "agent"` for backward compatibility. |
+| **Presets** | Trust Center tab (hamburger → Identity & Memory → Presets) + the `view: "memory"` pane (registered for programmatic access only; the `viewType` string stays `"memory"` as a persisted key). A "preset" is the agent's provider-agnostic config bundle — instructions + context files + MCP servers + skills (NOT provider/model; those belong to the agent). Backend names stay `db_memory_bundles` / `bundle_memory_*`. Distinct from the brain (native memory). The `block.tsx` shim still redirects `view: "forge"` → `view: "agent"`. |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in the user's default editor. |
 | **DevTools** | View ▸ Toggle DevTools (macOS native menu bar) or the hamburger menu on other platforms; also the `dev:devtools` command. Toggles Chromium DevTools — does not open a pane. It is **not** a widget (no `defwidget@devtools`). |
 | **Subagent** | Spawned by clicking a sub-agent in the Swarm pane's overview. Not a top-level pane type the user opens directly. |

--- a/docs/specs/SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md
+++ b/docs/specs/SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md
@@ -106,15 +106,49 @@ The native memory backend RPCs are complete. The UI is a placeholder. Users can'
 
 ### 4.1 Core principle: rename to separate the concepts
 
-| Current name | Proposed name | Why |
-|---|---|---|
-| Memory bundle (`db_memory_bundles`) | **Bundle** | It's a config preset, not memory. "Bundle" is already used in `BundleManagerModal`. |
-| Memory tab (Trust Center) | **Bundles tab** | Consistent with the rename |
-| Memory pane (`view: "memory"`) | **Bundles pane** | Same |
-| `MemoryViewModel` | `BundleViewModel` | Same |
-| Brain icon (Trust Center sidebar, `viewIcon`) | Remove or change to grid/preset icon | Reserve the brain icon for native memory only |
+The user-facing name is **Presets** (decided 2026-06-20). "Bundle" was the
+original proposal but is ambiguous in the live taxonomy — Identities are also
+"bundles" (`IdentityBundle`), and the rail already names tabs by their domain
+("Identities", not "Identity Bundles"). "Presets" is a distinct domain noun for
+"reusable agent config." The internal type stays `Memory` / `db_memory_bundles`
+(backend names unchanged); only user-facing strings change.
 
-**Result:** "brain" = one thing only: Claude's autonomous native memory. "Bundle" = config preset. No ambiguity.
+| Surface | New user-facing name | Notes |
+|---|---|---|
+| Memory tab (Trust Center rail) | **Presets** | rail: Accounts · Identities · Brain · Presets |
+| Per-item label | **Preset** | "+ New Preset", "Edit Preset" |
+| Memory pane (`view: "memory"`) | **Presets** summary | `viewType = "memory"` string stays (persisted block key) |
+| `viewIcon` (was `brain`) | `sliders` / `cubes` | reserve the brain icon for native memory only |
+
+**Internal symbols stay** (`MemoryViewModel`, `MemoryDraft`, `memory-*.tsx`,
+`memory-view-*` CSS, `db_memory_bundles`, `bundle_memory_*`, `listmemories`).
+Renaming the persisted `view: "memory"` key or the RPC/table names is pure churn
+with a migration/compat cost and no user benefit; the backend already keeps the
+`Memory` type name, so the frontend class staying `MemoryViewModel` is consistent.
+
+**Result:** "brain" = one thing only (Claude's autonomous native memory);
+"Presets" = provider-agnostic config. No ambiguity.
+
+### 4.1a Presets are provider-agnostic (decided 2026-06-20)
+
+A preset is the agent's reusable, **provider-agnostic** capability pack:
+instructions + context files + MCP servers + skills. It does NOT carry a
+provider or model.
+
+- **Provider + model belong to the agent.** `AgentDefinition.provider` is the
+  CLI (claude/codex/gemini); the model rides in `AgentDefinition.provider_flags`
+  as `--model <x>`. The agent is the single source of truth for what runs.
+- The `Memory` bundle's `provider` and `model` fields are **vestigial** — stored
+  and editable today, but never read at launch (only `instructions`, context,
+  MCP, and skills are consumed). They are a duplicate of provider that does
+  nothing.
+
+**Action (cosmetic + cleanup, low risk — the fields are vestigial):**
+- Remove the **Provider** and **Model** fields from the Presets editor
+  (`memory-manager.tsx`) and from `MemoryDraft` / the wire.
+- Leave the `db_memory_bundles.provider` / `.model` columns in place,
+  deprecated (written empty) — no migration, no launch path touched.
+- A preset can then be paired with an agent of any provider.
 
 ### 4.2 Resolve or commit to Identity Bundles
 
@@ -240,19 +274,30 @@ The backend is done. The UI gap is the only thing preventing the brain icon from
 
 Empty state: "No memory files yet. Claude creates this folder when it first saves a fact. [+ Create MEMORY.md]"
 
-### Priority 2 — Rename Memory → Bundles
+### Priority 2 — Rename Memory → Presets + strip provider/model
 
-**Scope:** cosmetic rename, no schema migration needed.
+**Scope:** user-facing rename + removal of two vestigial fields. No schema
+migration. See §4.1 and §4.1a for the decisions.
 
-Files affected:
-- `frontend/app/view/memory/memory-model.ts` → keep filename, rename exports: `MemoryViewModel` → `BundleViewModel`, `MemoryDraft` → `BundleDraft`
-- `frontend/app/view/memory/memory-manager.tsx` → rename component references
-- `frontend/app/view/memory/memory-view.scss` → rename CSS classes from `memory-view-*` to `bundle-view-*`
-- Trust Center tab label: "Memory" → "Bundles"
-- `viewIcon` in MemoryViewModel: change from `"brain"` to `"cubes"` (or `"layer-group"`) so brain = only native memory
-- `CLAUDE.md` "Not widgets" table: update "Memory" row
+User-facing rename (strings only — internal symbols stay, see §4.1):
+- Trust Center rail label: "Memories" → **"Presets"**
+- `memory-manager.tsx` strings: "+ New Memory" → "+ New Preset", "Edit Memory" /
+  "New Memory" → "Edit Preset" / "New Preset", "Select a Memory bundle…" →
+  "Select a preset…", confirm/empty/error copy → "preset"
+- `memory-model.ts`: `viewText` / `viewName` "Memory" → "Presets";
+  `viewIcon` `"brain"` → `"sliders"` (reserve brain for native memory)
+- `memory-view.tsx` + `bundle-summary.tsx`: standalone pane label "Memory" →
+  "Presets" (extend `BundleSummaryPanel` kind to render "Presets")
+- `CLAUDE.md` "Not widgets" table: update the "Memory" row
 
-Backend: no changes needed — the table and RPC names can stay (`db_memory_bundles`, `listmemories`, etc.) since they're internal; only the UI-visible names change.
+Provider-agnostic cleanup (§4.1a):
+- Remove the **Provider** and **Model** form fields + the `provider` / `model`
+  keys from `MemoryDraft` and `draftToWire`
+- Leave `db_memory_bundles.provider` / `.model` columns deprecated (written
+  empty); the launch path never read them, so nothing breaks
+
+Backend: no changes needed — the table and RPC names stay (`db_memory_bundles`,
+`listmemories`, etc.); only UI strings and the two form fields change.
 
 ### Priority 3 — Migrate identity assignment to v6 junction table
 

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -32,7 +32,7 @@ export function requestLabel(req: ModalLayerRequest): string {
         case "new-identity":
             return "New Identity";
         case "new-memory":
-            return "New Memory";
+            return "New Preset";
         case "agent-prereqs":
             return `Install required tools for ${req.agent.name}`;
         case "install-agent":

--- a/frontend/app/modals/bundle-manager-modal.tsx
+++ b/frontend/app/modals/bundle-manager-modal.tsx
@@ -101,7 +101,7 @@ export const BundleManagerModal = (props: ModalCloseProps): JSX.Element => {
         { id: "accounts", label: "Accounts", icon: "key" },
         { id: "identities", label: "Identities", icon: "id-card" },
         { id: "brain", label: "Brain", icon: "brain" },
-        { id: "memories", label: "Memories", icon: "layer-group" },
+        { id: "memories", label: "Presets", icon: "sliders" },
     ];
 
     return (

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -808,9 +808,9 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                         <legend class="agent-launch-modal-label">Profile</legend>
                         <span class="agent-launch-modal-hint">
                             A Profile groups the agent's <strong>Identity</strong> (credentials
-                            for Claude, Codex, GitHub, AWS, …) with its <strong>Memory</strong>
-                            (notes, instructions, project context). Both are required —
-                            pick existing bundles or create new ones below.
+                            for Claude, Codex, GitHub, AWS, …) with its <strong>Preset</strong>
+                            (instructions, context, MCP servers, skills). Both are required —
+                            pick existing ones or create new ones below.
                         </span>
 
                         <div class="agent-launch-modal-bundle-row">
@@ -889,7 +889,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                          */}
 
                         <div class="agent-launch-modal-bundle-row">
-                            <span class="agent-launch-modal-bundle-row-label">Memory</span>
+                            <span class="agent-launch-modal-bundle-row-label">Preset</span>
                             <Show
                                 when={hasUserMemories()}
                                 fallback={
@@ -908,7 +908,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                                 : "Coming soon"
                                         }
                                     >
-                                        + New memory bundle...
+                                        + New preset...
                                     </button>
                                 }
                             >
@@ -917,10 +917,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     value={memoryId()}
                                     onChange={(e) => setMemoryId(e.currentTarget.value)}
                                     disabled={submitting() || continueLocksMemory()}
-                                    aria-label="Memory bundle"
+                                    aria-label="Preset"
                                 >
                                     <Show when={!memoryId()}>
-                                        <option value="" disabled>— Pick a memory —</option>
+                                        <option value="" disabled>— Pick a preset —</option>
                                     </Show>
                                     <For each={(memories() ?? []).filter((m) => !m.is_blank)}>
                                         {(memory) => (
@@ -939,10 +939,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     }
                                     title={
                                         props.onRequestNewMemory
-                                            ? "New memory bundle..."
+                                            ? "New preset..."
                                             : "Coming soon"
                                     }
-                                    aria-label="New memory bundle"
+                                    aria-label="New preset"
                                 >
                                     +
                                 </button>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -875,16 +875,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                         </div>
 
                         {/*
-                         * Memory dropdown — companion to Identity.
+                         * Preset dropdown — companion to Identity.
                          * The wire selection rides through to the
                          * backend via `memoryId` on LaunchOverrides;
                          * the spawn-time content-injection layer
-                         * (provider override, instructions, context
-                         * files, MCP servers, skills) ships in PR-F.4
-                         * and will start consuming the selection.
-                         * Until then, picking a non-blank Memory is
-                         * visible UX scaffolding that records the
-                         * user's intent without changing runtime
+                         * (instructions, context files, MCP servers,
+                         * skills — presets are provider-agnostic) ships
+                         * in PR-F.4 and will start consuming the
+                         * selection. Until then, picking a non-blank
+                         * preset is visible UX scaffolding that records
+                         * the user's intent without changing runtime
                          * behavior.
                          */}
 

--- a/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
@@ -89,9 +89,9 @@ export const AgentNewMemoryModalPanel = (
     return (
         <>
             <header class="modal-panel-header">
-                <h2 class="modal-panel-title">New Memory</h2>
+                <h2 class="modal-panel-title">New Preset</h2>
                 <p class="modal-panel-description">
-                    A Memory holds text the agent reads at launch — notes,
+                    A preset holds text the agent reads at launch — notes,
                     project context, style guides, instructions.
                 </p>
             </header>
@@ -116,7 +116,7 @@ export const AgentNewMemoryModalPanel = (
                     <input
                         type="text"
                         class="agent-new-bundle-modal-input"
-                        placeholder="What's this Memory for?"
+                        placeholder="What's this preset for?"
                         value={description()}
                         onInput={(e) => setDescription(e.currentTarget.value)}
                         onKeyDown={onKeyDown}
@@ -134,7 +134,7 @@ export const AgentNewMemoryModalPanel = (
                                 onChange={() => setSeedMode("empty")}
                                 disabled={submitting()}
                             />
-                            <span>Start empty — add files later from the Memory pane</span>
+                            <span>Start empty — add files later from the Presets pane</span>
                         </label>
                         <label class="agent-new-bundle-modal-radio">
                             <input

--- a/frontend/app/view/bundle-summary.tsx
+++ b/frontend/app/view/bundle-summary.tsx
@@ -32,21 +32,24 @@ import { openBundleManager } from "@/app/modals/bundle-manager-modal";
 import "./bundle-summary.scss";
 
 interface BundleSummaryPanelProps {
-    /** "Identity" | "Memory" — drives the heading + copy. */
-    kind: "Identity" | "Memory";
+    /** "Identity" | "Preset" — drives the heading + copy. */
+    kind: "Identity" | "Preset";
 }
 
 export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element => {
-    const lowerPlural = props.kind === "Identity" ? "identities" : "memories";
+    // Identity items are still called "bundles"; presets are not (they are
+    // provider-agnostic config presets). Compute the display strings per kind.
+    const title = props.kind === "Identity" ? "Identity bundles" : "Presets";
+    const lowerPlural = props.kind === "Identity" ? "identities" : "presets";
 
     return (
         <div class="bundle-summary">
             <div class="bundle-summary-inner">
-                <h2 class="bundle-summary-title">{props.kind} bundles</h2>
+                <h2 class="bundle-summary-title">{title}</h2>
                 <p class="bundle-summary-body">
-                    {props.kind} bundles are app-wide data, shared across every
-                    agent and window. They are now created, edited, and deleted
-                    in one place — the <strong>Identity &amp; Memory</strong>{" "}
+                    {title} are app-wide data, shared across every agent and
+                    window. They are now created, edited, and deleted in one
+                    place — the <strong>Identity &amp; Memory</strong>{" "}
                     manager, opened from the hamburger menu.
                 </p>
                 <p class="bundle-summary-body bundle-summary-hint">

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -60,10 +60,10 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
     const handleCancel = () => model.cancelDraft();
 
     const handleDelete = (id: string) => {
-        // Confirm via the most boring possible dialog. Memory bundles can
-        // be referenced by running instances; deletion is an explicit user
+        // Confirm via the most boring possible dialog. Presets can be
+        // referenced by running instances; deletion is an explicit user
         // intent we don't want to fast-path.
-        const ok = window.confirm("Delete this Memory bundle? Running instances continue with their snapshot, but new launches won't see it.");
+        const ok = window.confirm("Delete this preset? Running instances continue with their snapshot, but new launches won't see it.");
         if (!ok) return;
         void model.deleteMemory(id);
     };
@@ -82,7 +82,7 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
             <div class="memory-view-rail">
                 <div class="memory-view-rail-header">
                     <button class="memory-view-new-btn" onClick={handleNew}>
-                        + New Memory
+                        + New Preset
                     </button>
                 </div>
                 <ul class="memory-view-list">
@@ -105,9 +105,12 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                         <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
                                     </Show>
                                 </div>
-                                <Show when={!memory.is_blank}>
+                                {/* Subtitle shows the description now that presets
+                                    are provider-agnostic (§4.1a). Class name kept
+                                    to avoid CSS churn. */}
+                                <Show when={!memory.is_blank && memory.description}>
                                     <div class="memory-view-list-item-provider">
-                                        {memory.provider || "no provider"}
+                                        {memory.description}
                                     </div>
                                 </Show>
                             </li>
@@ -128,11 +131,12 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                             when={model.selectedAtom()}
                             fallback={
                                 <div class="memory-view-empty">
-                                    <p>Select a Memory bundle from the list, or create a new one.</p>
+                                    <p>Select a preset from the list, or create a new one.</p>
                                     <p class="memory-view-empty-hint">
-                                        A Memory holds an agent's CLI choice, model, system instructions,
-                                        context files, MCP servers, and skills. Pick one at launch time
-                                        alongside an Identity to compose an agent instance.
+                                        A preset holds an agent's system instructions, context
+                                        files, MCP servers, and skills. It is provider-agnostic —
+                                        the CLI and model belong to the agent. Pick one at launch
+                                        time alongside an Identity to compose an agent instance.
                                     </p>
                                 </div>
                             }
@@ -151,10 +155,6 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                                 {" "}— injected into every agent at launch
                                             </dd>
                                         </Show>
-                                        <dt>Provider</dt>
-                                        <dd>{memory().provider || "—"}</dd>
-                                        <dt>Model</dt>
-                                        <dd>{memory().model || "—"}</dd>
                                         <dt>Instructions</dt>
                                         <dd class="memory-view-instructions-readonly">
                                             <pre>{memory().instructions || "(none)"}</pre>
@@ -190,7 +190,7 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                             }}
                         >
                             <h2 class="memory-view-form-title">
-                                {draft().id ? "Edit Memory" : "New Memory"}
+                                {draft().id ? "Edit Preset" : "New Preset"}
                             </h2>
 
                             <label class="memory-view-field">
@@ -218,33 +218,9 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                                 />
                             </label>
 
-                            <label class="memory-view-field">
-                                <span class="memory-view-field-label">Provider</span>
-                                <select
-                                    class="memory-view-input"
-                                    value={draft().provider}
-                                    onChange={(e) =>
-                                        updateDraft("provider", e.currentTarget.value)
-                                    }
-                                >
-                                    <option value="">(none — vanilla shell)</option>
-                                    <option value="claude">Claude Code</option>
-                                    <option value="codex">Codex CLI</option>
-                                    <option value="gemini">Gemini CLI</option>
-                                    <option value="qwen">Qwen Code</option>
-                                </select>
-                            </label>
-
-                            <label class="memory-view-field">
-                                <span class="memory-view-field-label">Model</span>
-                                <input
-                                    class="memory-view-input"
-                                    type="text"
-                                    value={draft().model}
-                                    onInput={(e) => updateDraft("model", e.currentTarget.value)}
-                                    placeholder="e.g. claude-sonnet-4-6"
-                                />
-                            </label>
+                            {/* Provider + model intentionally omitted: presets are
+                                provider-agnostic; the CLI + model belong to the
+                                agent. See SPEC_MEMORY_IDENTITY_ARCH §4.1a. */}
 
                             <label class="memory-view-field">
                                 <span class="memory-view-field-label">Instructions</span>

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -1,12 +1,15 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Memory pane — first-class management of Memory bundles.
+// Presets pane — first-class management of presets (memory bundles).
+// User-facing name is "Presets"; the type/table stay `Memory` /
+// `db_memory_bundles` (SPEC_MEMORY_IDENTITY_ARCH §4.1).
 //
-// A Memory bundle is the agent's personality + capability stack:
-// provider/CLI choice, model, system instructions, context files, MCP
-// servers, skills. Bundles are reusable across many agent instances —
-// pick one in the launch modal alongside an Identity bundle.
+// A preset is the agent's provider-agnostic capability stack:
+// system instructions, context files, MCP servers, skills. Provider/model
+// are NOT part of a preset — they belong to the agent (§4.1a). Presets are
+// reusable across many agent instances — pick one in the launch modal
+// alongside an Identity bundle.
 //
 // This module is the ViewModel for `view: "memory"` panes. It owns the
 // list of memories, the currently-selected one, and the in-flight edit
@@ -27,8 +30,9 @@ export interface MemoryDraft {
     id?: string;
     name: string;
     description: string;
-    provider: string;          // "" | "claude" | "codex" | "gemini"
-    model: string;
+    // provider/model intentionally absent: a preset is provider-agnostic.
+    // The CLI provider + model belong to the agent (AgentDefinition.provider
+    // + provider_flags), not the preset. See SPEC_MEMORY_IDENTITY_ARCH §4.1a.
     instructions: string;
     /** Edited as `[{ path, content }]`; serialized to JSON on save. */
     context_files: Array<{ path: string; content: string }>;
@@ -40,7 +44,7 @@ export interface MemoryDraft {
     is_global?: boolean;
 }
 
-/** Empty draft for the "+ New Memory" flow.
+/** Empty draft for the "+ New Preset" flow.
  *
  *  All JSON-array fields default to `"[]"` (not `""`). The backend's
  *  `db_memory_bundles.skills` column is JSON-encoded; a literal `""` would
@@ -51,8 +55,6 @@ export function emptyDraft(): MemoryDraft {
         id: undefined,
         name: "",
         description: "",
-        provider: "",
-        model: "",
         instructions: "",
         context_files: [],
         mcp_servers: "[]",
@@ -75,8 +77,6 @@ export function draftFromMemory(m: Memory): MemoryDraft {
         id: m.id,
         name: m.name,
         description: m.description ?? "",
-        provider: m.provider ?? "",
-        model: m.model ?? "",
         instructions: m.instructions ?? "",
         context_files,
         // Both JSON-array fields use the same empty-string-aware
@@ -105,8 +105,10 @@ export function draftToWire(d: MemoryDraft): Memory {
         // Preserve the global flag so editing a global bundle does not
         // silently strip it (the upsert ON CONFLICT overwrites is_global).
         is_global: d.is_global ?? false,
-        provider: d.provider,
-        model: d.model.trim(),
+        // provider/model are deprecated on presets (provider-agnostic, §4.1a).
+        // Write empty so the ON CONFLICT update clears any stale legacy value.
+        provider: "",
+        model: "",
         instructions: d.instructions,
         context_files: JSON.stringify(d.context_files),
         mcp_servers: d.mcp_servers || "[]",
@@ -123,9 +125,10 @@ export class MemoryViewModel implements ViewModel {
     blockId: string;
     nodeModel: BlockNodeModel | null;
 
-    viewIcon: Accessor<string> = () => "brain";
+    // "sliders" (not "brain") — the brain icon is reserved for native memory.
+    viewIcon: Accessor<string> = () => "sliders";
     viewName: Accessor<string>;
-    viewText: Accessor<string | HeaderElem[]> = () => "Memory";
+    viewText: Accessor<string | HeaderElem[]> = () => "Presets";
     noPadding: Accessor<boolean> = () => false;
 
     get viewComponent(): ViewComponent {
@@ -172,7 +175,7 @@ export class MemoryViewModel implements ViewModel {
             : () => undefined;
         this.viewName = createMemo(() => {
             const block = this.blockAtom();
-            return (block?.meta?.["frame:title"] as string) ?? "Memory";
+            return (block?.meta?.["frame:title"] as string) ?? "Presets";
         });
         this.selectedAtom = createMemo(() => {
             const id = this.selectedIdAtom();
@@ -191,7 +194,7 @@ export class MemoryViewModel implements ViewModel {
             this.setMemories(list);
             this.setError(null);
         } catch (e) {
-            this.setError(`Failed to load memories: ${(e as Error).message ?? e}`);
+            this.setError(`Failed to load presets: ${(e as Error).message ?? e}`);
         }
     }
 
@@ -212,7 +215,7 @@ export class MemoryViewModel implements ViewModel {
      *  banner showing alongside the new edit form). Reagent P2 (#747). */
     startEdit(memory: Memory): void {
         if (memory.is_blank) {
-            this.setError("The blank Memory is system-managed and cannot be edited.");
+            this.setError("The blank preset is system-managed and cannot be edited.");
             return;
         }
         this.setError(null);
@@ -234,7 +237,7 @@ export class MemoryViewModel implements ViewModel {
         const draft = this.draftAtom();
         if (!draft) return;
         if (!draft.name.trim()) {
-            this.setError("Memory name is required.");
+            this.setError("Preset name is required.");
             return;
         }
         this.setSaving(true);
@@ -247,7 +250,7 @@ export class MemoryViewModel implements ViewModel {
             // OBJECT IDENTITY (=== draft) rather than `!== null`. The
             // user can replace the draft mid-flight by:
             //   - clicking another list item   → cancelDraft → null
-            //   - clicking "+ New Memory"      → startNew → fresh draft
+            //   - clicking "+ New Preset"      → startNew → fresh draft
             //   - clicking the Edit button     → startEdit → other draft
             // All three cases must skip the post-save navigation. Only
             // identity-equal-to-our-snapshot means the user is still
@@ -272,7 +275,7 @@ export class MemoryViewModel implements ViewModel {
     async deleteMemory(id: string): Promise<void> {
         const target = this.memoriesAtom().find((m) => m.id === id);
         if (target?.is_blank) {
-            this.setError("The blank Memory is system-managed and cannot be deleted.");
+            this.setError("The blank preset is system-managed and cannot be deleted.");
             return;
         }
         this.setError(null);

--- a/frontend/app/view/memory/memory-view.tsx
+++ b/frontend/app/view/memory/memory-view.tsx
@@ -25,5 +25,5 @@ interface MemoryViewProps {
 }
 
 export const MemoryView = (_props: MemoryViewProps): JSX.Element => {
-    return <BundleSummaryPanel kind="Memory" />;
+    return <BundleSummaryPanel kind="Preset" />;
 };


### PR DESCRIPTION
## What

Two linked cleanups from `SPEC_MEMORY_IDENTITY_ARCH` §4.1 / §4.1a:

1. **Rename** the memory-bundle concept to **Presets** in the UI, so "Memory" / "Brain" now refer *only* to native memory (the agent's learned facts). "Bundles" was rejected as the name because Identities are also bundles — "Presets" is an unambiguous domain noun.

2. **Strip provider/model** from presets. A preset is the agent's *provider-agnostic* capability stack — instructions + context files + MCP servers + skills. The CLI provider + model belong to the **agent** (`AgentDefinition.provider` / `provider_flags`) and were **never read off the memory bundle at launch** (verified — the fields were vestigial), so removing the form fields changes no runtime behavior.

## Scope: user-facing only

Internal symbols, the persisted `view: "memory"` key, and the backend names (`db_memory_bundles`, `bundle_memory_*`, `listmemories`) are **unchanged** — renaming them is churn with a migration/compat cost and no user benefit, and the backend deliberately keeps the `Memory` type name.

## Changes

- **Trust Center rail**: "Memories" → **"Presets"** (sliders icon; brain stays reserved for native memory)
- **Presets editor** (`memory-manager.tsx`): "New/Edit Preset", updated copy, **removed the Provider + Model form fields** and the read-only Provider/Model rows; rail subtitle now shows the description
- **memory-model.ts**: `viewText`/`viewName`/`viewIcon`, error strings; dropped `provider`/`model` from `MemoryDraft` / `emptyDraft` / `draftFromMemory` / `draftToWire` (wire sends empty so ON CONFLICT clears stale values)
- **bundle-summary.tsx**: renders "Presets" (kind union `Identity | Preset`)
- **Launch + new flows** (`AgentLaunchModal`, `AgentNewMemoryModal`, `modal-dispatch`): the launch picker row and creation modal now say "Preset" end-to-end. (`agent-memory` modal label stays "Memory — <agent>" — that's native memory, now unambiguous.)
- **Spec §4.1/§4.1a + CLAUDE.md** updated.

## Verification

- `tsc` clean for all touched files (31 pre-existing unrelated errors remain; dropping provider/model from the draft type would surface any stray reference — none).
- No backend changes; no schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)