### PR TITLE
fix(mcp): prefer AGENTMUX_BLOCKID over AGENTMUX_AGENT_BUS_ID for shell scope

### DIFF
--- a/.changesets/1781976316-fix-mcp-prefer-agentmux-blockid-over-agentmux-agent-bus-id-f-5j8a.md
+++ b/.changesets/1781976316-fix-mcp-prefer-agentmux-blockid-over-agentmux-agent-bus-id-f-5j8a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(mcp): prefer AGENTMUX_BLOCKID over AGENTMUX_AGENT_BUS_ID for shell scope

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -12,17 +12,15 @@
 //! conversation as a `ShellNode` row without blocking the agent.
 //!
 //! Env vars (inherited from agentmux-srv's agent env injection):
-//!   AGENTMUX_LOCAL_URL   — sidecar HTTP base URL
-//!   AGENTMUX_AUTH_KEY    — X-AuthKey header secret
-//!   AGENTMUX_AGENT_BUS_ID — block UUID for event scoping (preferred)
-//!   AGENTMUX_BLOCKID      — block UUID, used as the fallback source for the
-//!                           bus id. websocket.rs reliably injects this onto the
-//!                           agent process env (it holds exactly the block UUID
-//!                           the MCP server needs), and the MCP subprocess —
-//!                           spawned by the agent CLI — inherits it. The
-//!                           production `.mcp.json` path never injects
-//!                           AGENTMUX_AGENT_BUS_ID, so this fallback is what
-//!                           makes the Shell tool functional.
+//!   AGENTMUX_LOCAL_URL    — sidecar HTTP base URL
+//!   AGENTMUX_AUTH_KEY     — X-AuthKey header secret
+//!   AGENTMUX_BLOCKID      — block UUID for shell event scoping (preferred).
+//!                           Injected by agent_handlers.rs into every persistent
+//!                           subprocess env; inherited by this MCP subprocess.
+//!   AGENTMUX_AGENT_BUS_ID — MuxBus routing identifier (fallback only).
+//!                           Often set to the agent type string (e.g. "claude")
+//!                           in .mcp.json, NOT the block UUID — do not use it
+//!                           as the shell scope unless AGENTMUX_BLOCKID is absent.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -217,18 +217,23 @@ async fn main() {
     let local_url = std::env::var("AGENTMUX_LOCAL_URL").unwrap_or_default();
     let auth_key = std::env::var("AGENTMUX_AUTH_KEY").unwrap_or_default();
     // The "bus id" is the agent's block UUID, used to scope shell events to the
-    // conversation pane. AGENTMUX_AGENT_BUS_ID is the preferred source, but the
-    // production .mcp.json path never injects it (build_mcp_config is called with
-    // an empty bus id and build_config_files_with_bus has no call site). Fall
-    // back to AGENTMUX_BLOCKID, which holds the same block UUID and is reliably
-    // set on the agent process env (websocket.rs) and inherited by this MCP
-    // subprocess. Without this fallback the Shell tool always bailed.
+    // AGENTMUX_BLOCKID is the canonical block UUID injected by agent_handlers.rs
+    // into the persistent subprocess env. It is what the frontend subscribes to
+    // for shell_node_create events (`block:<uuid>`), so it MUST be used here.
+    //
+    // AGENTMUX_AGENT_BUS_ID is the MuxBus routing identifier — a different
+    // concept. In existing .mcp.json files it is often set to "claude" (the
+    // agent type, not the block UUID), which was accidentally being used as the
+    // shell scope and caused shell_node_create to publish under `block:claude`
+    // instead of the real pane UUID — making the ActivityDock never receive
+    // shell events. Prefer AGENTMUX_BLOCKID; fall back to AGENTMUX_AGENT_BUS_ID
+    // only for older deployments that pre-date AGENTMUX_BLOCKID injection.
     let block_id = {
-        let bus = std::env::var("AGENTMUX_AGENT_BUS_ID").unwrap_or_default();
-        if bus.is_empty() {
-            std::env::var("AGENTMUX_BLOCKID").unwrap_or_default()
+        let blockid = std::env::var("AGENTMUX_BLOCKID").unwrap_or_default();
+        if blockid.is_empty() {
+            std::env::var("AGENTMUX_AGENT_BUS_ID").unwrap_or_default()
         } else {
-            bus
+            blockid
         }
     };
 

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -214,7 +214,6 @@ const LOOP_STOP_TOOL: &str = r#"{
 async fn main() {
     let local_url = std::env::var("AGENTMUX_LOCAL_URL").unwrap_or_default();
     let auth_key = std::env::var("AGENTMUX_AUTH_KEY").unwrap_or_default();
-    // The "bus id" is the agent's block UUID, used to scope shell events to the
     // AGENTMUX_BLOCKID is the canonical block UUID injected by agent_handlers.rs
     // into the persistent subprocess env. It is what the frontend subscribes to
     // for shell_node_create events (`block:<uuid>`), so it MUST be used here.


### PR DESCRIPTION
## Root Cause

The `block_id` used by `agentmux-mcp` for `shell/create` requests was resolved in the wrong order:

```rust
// Before (broken):
let bus = std::env::var("AGENTMUX_AGENT_BUS_ID").unwrap_or_default();
if bus.is_empty() { AGENTMUX_BLOCKID } else { bus }
```

`AGENTMUX_AGENT_BUS_ID` is set in every agent's `.mcp.json` as the MuxBus routing identifier — typically `"claude"` (the agent type, not a block UUID). Because it's non-empty, agentmux-mcp used it as `agent_block_id` in shell create requests. The backend then published `shell_node_create` under `block:claude` instead of `block:<real-pane-uuid>`. The frontend subscribes to `block:<real-uuid>` and never received the event — **the ActivityDock stayed empty for all persistent (stream-json) Claude Code agent panes**.

## Fix

Flip the priority: read `AGENTMUX_BLOCKID` first (the canonical block UUID injected by `agent_handlers.rs` into every persistent subprocess env), falling back to `AGENTMUX_AGENT_BUS_ID` only for older deployments that pre-date the block ID injection.

```rust
// After (fixed):
let blockid = std::env::var("AGENTMUX_BLOCKID").unwrap_or_default();
if blockid.is_empty() { AGENTMUX_AGENT_BUS_ID } else { blockid }
```

## Test plan

- [ ] Ask a Claude Code agent to run a long-running shell (`ping -n 15 localhost`)
- [ ] Verify the ActivityDock appears **above the composer** while the shell is running
- [ ] Verify the dock row shows the shell command title and running status
- [ ] Verify the dock auto-hides 3s after the shell exits
- [ ] Verify `muxlog srv grep shell.create` shows the real block UUID (not `"claude"`) in the `block_id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)