### PR TITLE
security(cef): enable renderer sandbox on macOS and Linux (#1374 Phase 1+2)

### DIFF
--- a/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
+++ b/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
@@ -1,3 +1,4 @@
 ---
 type: patch
----security(cef): enable renderer sandbox on macOS and Linux (issue #1374)
+---
+security(cef): enable renderer sandbox on macOS and Linux (issue #1374)

--- a/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
+++ b/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
@@ -1,0 +1,3 @@
+---
+type: patch
+---security(cef): enable renderer sandbox on macOS and Linux (issue #1374)

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -11,8 +11,11 @@ name = "agentmux-cef"
 path = "src/main.rs"
 
 [features]
-default = []
-# Enable sandbox mode (requires bootstrap.exe on Windows)
+# Sandbox ON by default for macOS (Seatbelt/libcef_sandbox.dylib) and Linux
+# (kernel namespace isolation). Windows sandbox is Phase 3 (DLL wrapper +
+# bootstrap.exe, issue #1374) and remains unconditionally disabled at runtime
+# via the cfg!(target_os = "windows") guard even when this feature is active.
+default = ["sandbox"]
 sandbox = ["cef/sandbox"]
 # Opt-in for dev_authfile unit tests that touch the filesystem and Win32 ACL APIs
 test-authfile = []
@@ -25,7 +28,6 @@ test-authfile = []
 patched-libcef = []
 
 [package.metadata.cef.bundle]
-# No helper needed without sandbox
 resources_path = "resources"
 
 [dependencies]

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -627,6 +627,23 @@ wrap_app! {
                         let oz_val = CefString::from(platform.as_str());
                         cmd.append_switch_with_value(Some(&oz_key), Some(&oz_val));
                     }
+
+                    // Linux sandbox: use kernel namespace isolation instead of the setuid
+                    // chrome-sandbox binary. On kernels ≥3.8 without user-namespace
+                    // restrictions (standard distro default), Chromium's namespace
+                    // sandbox is equivalent to the SUID path in practice.
+                    // If the environment doesn't support user namespaces (older kernel,
+                    // Docker with --security-opt=no-new-privileges, nested VM), set
+                    // AGENTMUX_UNSAFE_NOSANDBOX=1 to fall back to no_sandbox=1.
+                    #[cfg(feature = "sandbox")]
+                    {
+                        let suppress = std::env::var("AGENTMUX_UNSAFE_NOSANDBOX")
+                            .map(|v| v.trim() == "1")
+                            .unwrap_or(false);
+                        if !suppress {
+                            cmd.append_switch(Some(&CefString::from("disable-setuid-sandbox")));
+                        }
+                    }
                 }
 
                 // ── ANGLE backend precedence (capability-probed) ─────────────

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -230,6 +230,28 @@ fn main() {
     let type_switch = CefString::from("type");
     let is_browser_process = cmd_line.has_switch(Some(&type_switch)) != 1;
 
+    // Runtime escape hatch — AGENTMUX_UNSAFE_NOSANDBOX=1 disables the renderer
+    // sandbox regardless of build features. Intended for known-incompatible
+    // environments (nested VM, Docker without user namespaces, macOS SIP issues).
+    // Tracing isn't up yet; the browser-process path below re-reads this to emit
+    // a warn! once the subscriber is initialized.
+    let force_no_sandbox = std::env::var("AGENTMUX_UNSAFE_NOSANDBOX")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false);
+
+    // macOS: initialize Seatbelt sandbox context for renderer/GPU/utility subprocesses
+    // before CefExecuteProcess. The Sandbox holds the opaque context pointer; Drop
+    // calls cef_sandbox_destroy, so keep it alive until process exit.
+    // The browser process does not need (or want) this context — only subprocesses.
+    #[cfg(all(target_os = "macos", feature = "sandbox"))]
+    let _macos_sandbox = if !is_browser_process && !force_no_sandbox {
+        let mut s = cef::sandbox::Sandbox::new();
+        s.initialize(args.as_main_args());
+        Some(s)
+    } else {
+        None
+    };
+
     // Execute subprocess if applicable (exits here for non-browser processes).
     let ret = execute_process(
         Some(args.as_main_args()),
@@ -661,8 +683,26 @@ fn main() {
     let cef_log_path = log_dir.join("cef-debug.log");
     let cef_log_file = CefString::from(cef_log_path.to_str().unwrap_or(""));
 
+    if force_no_sandbox {
+        tracing::warn!(
+            "AGENTMUX_UNSAFE_NOSANDBOX=1: renderer sandbox disabled. \
+             Only use in environments where namespace/Seatbelt sandbox is known-incompatible."
+        );
+    }
+
+    // Sandbox active on macOS (Seatbelt via libcef_sandbox.dylib) and Linux
+    // (kernel namespace isolation) when built with `--features sandbox` (the default).
+    // Windows sandbox is Phase 3 (DLL wrapper + bootstrap.exe). See issue #1374.
+    let no_sandbox: i32 = if cfg!(any(not(feature = "sandbox"), target_os = "windows"))
+        || force_no_sandbox
+    {
+        1
+    } else {
+        0
+    };
+
     let settings = Settings {
-        no_sandbox: 1,
+        no_sandbox,
         // ARGB: alpha=0 → SK_AlphaTRANSPARENT → triggers the transparency
         // cascade in the patched libcef.so (see cef commits b921ffe18 +
         // 68e0dc668). The CSS layer's rgba(_,_,_,<1) body bg then composites

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -196,7 +196,34 @@ fn main() {
     // Tracing is initialized after the subprocess check below — browser process
     // gets dual file+stderr output; subprocesses exit before tracing is needed.
 
+    // Escape hatch — read once here so both macOS subprocess sandbox init
+    // (below) and the browser-process Settings construction share the same value.
+    let force_no_sandbox = std::env::var("AGENTMUX_UNSAFE_NOSANDBOX")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false);
+
+    // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
+    // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
+    //   1. cef_sandbox_initialize     ← here, before dlopen
+    //   2. LoadInHelper / _library    ← CEF framework loaded within the sandbox
+    //   3. CefExecuteProcess
+    // Subprocess mode is detected from raw argv (--type=…) because cef::Args
+    // cannot be parsed until after the framework is loaded. Browser process
+    // skips this entirely — the host process is unsandboxed by design.
+    #[cfg(all(target_os = "macos", feature = "sandbox"))]
+    let _macos_sandbox = if std::env::args().any(|a| a.starts_with("--type="))
+        && !force_no_sandbox
+    {
+        let raw = cef::args::Args::new();
+        let mut s = cef::sandbox::Sandbox::new();
+        s.initialize(raw.as_main_args());
+        Some(s)
+    } else {
+        None
+    };
+
     // macOS: load the CEF framework library explicitly.
+    // For subprocesses this load happens within the Seatbelt policy established above.
     #[cfg(target_os = "macos")]
     let _library = {
         let exe = std::env::current_exe().unwrap();
@@ -229,28 +256,6 @@ fn main() {
     // for child processes. If --type is present, this is a subprocess.
     let type_switch = CefString::from("type");
     let is_browser_process = cmd_line.has_switch(Some(&type_switch)) != 1;
-
-    // Runtime escape hatch — AGENTMUX_UNSAFE_NOSANDBOX=1 disables the renderer
-    // sandbox regardless of build features. Intended for known-incompatible
-    // environments (nested VM, Docker without user namespaces, macOS SIP issues).
-    // Tracing isn't up yet; the browser-process path below re-reads this to emit
-    // a warn! once the subscriber is initialized.
-    let force_no_sandbox = std::env::var("AGENTMUX_UNSAFE_NOSANDBOX")
-        .map(|v| v.trim() == "1")
-        .unwrap_or(false);
-
-    // macOS: initialize Seatbelt sandbox context for renderer/GPU/utility subprocesses
-    // before CefExecuteProcess. The Sandbox holds the opaque context pointer; Drop
-    // calls cef_sandbox_destroy, so keep it alive until process exit.
-    // The browser process does not need (or want) this context — only subprocesses.
-    #[cfg(all(target_os = "macos", feature = "sandbox"))]
-    let _macos_sandbox = if !is_browser_process && !force_no_sandbox {
-        let mut s = cef::sandbox::Sandbox::new();
-        s.initialize(args.as_main_args());
-        Some(s)
-    } else {
-        None
-    };
 
     // Execute subprocess if applicable (exits here for non-browser processes).
     let ret = execute_process(

--- a/docs/specs/SPEC_CEF_SANDBOX_2026_06_20.md
+++ b/docs/specs/SPEC_CEF_SANDBOX_2026_06_20.md
@@ -1,0 +1,314 @@
+# SPEC: Enable CEF Renderer Sandbox
+**Status:** Approved for implementation
+**Issue:** #1374
+**Date:** 2026-06-20
+**Author:** AgentMux Engineering
+
+---
+
+## 1. Problem
+
+`no_sandbox: 1` is hardcoded unconditionally in the `Settings` struct at
+`agentmux-cef/src/main.rs:665`. This disables the Chromium renderer sandbox on
+every platform in every build (debug, release, portable). A compromised renderer
+process — e.g. via a malicious URL loaded in a browser pane — runs with the same
+OS privileges as the host, which inherits the shell environment: `AWS_SECRET_*`,
+`GITHUB_TOKEN`, `AGENTMUX_AUTH_KEY`, full filesystem access. `CEF_ARCHITECTURE.md:975`
+already documents the risk explicitly.
+
+Browser panes accept arbitrary URLs (`browser_pane_navigate` has no allowlist),
+so the threat is real and the blast radius is maximal.
+
+This compounds PR #1373 (`ipc_token` hardening): a sandbox escape sits in front
+of the already-powerful local IPC surface.
+
+---
+
+## 2. Goals
+
+- Remove `no_sandbox: 1` and enable the appropriate sandbox on each platform.
+- Ship in three sequential PRs (one per platform tier) so the macOS/Linux fixes
+  land quickly without waiting for the harder Windows work.
+- Provide a runtime escape hatch (`AGENTMUX_UNSAFE_NOSANDBOX=1`) that can be set
+  by operators for known-incompatible environments (e.g. nested VM, Docker), with
+  a mandatory log warning.
+- Keep each PR shippable and bisectable.
+
+## 3. Non-goals
+
+- URL allowlist for browser panes (tracked separately; useful defence-in-depth
+  but orthogonal to sandbox).
+- GPU process sandboxing hardening — that's independent of renderer sandbox.
+- Changing the CEF version or the patched-libcef fork.
+
+---
+
+## 4. Background: how the cef-rs 148 sandbox works per platform
+
+### 4.1 macOS
+
+The cef-rs crate exposes `cef::sandbox::Sandbox` (in `sandbox.rs`). It
+dynamically loads `libcef_sandbox.dylib` from the framework bundle and calls
+`cef_sandbox_initialize(argc, argv)` before any other code in the subprocess
+helper path. The resulting opaque context pointer must be kept alive until
+program exit (the `Drop` impl calls `cef_sandbox_destroy`).
+
+**What exists already:**
+- Separate helper app bundle (`AgentMux Helper.app`) is set up and bundled ✓
+- `resolve_browser_subprocess_path()` correctly points CEF at the helper ✓
+
+**What is missing:**
+- `cef::sandbox::Sandbox::new()` + `.initialize(&args)` called at the very start
+  of the subprocess branch (before `execute_process`). Currently the subprocess
+  branch passes `null_ptr` as `sandbox_info` to `execute_process` and
+  `initialize`.
+
+### 4.2 Linux
+
+Linux uses the Zygote process model with seccomp-BPF + kernel namespace
+isolation. No setuid helper or extra init call is needed on kernels ≥3.8 when
+the namespace sandbox is used. The correct flags are:
+
+- `--disable-setuid-sandbox` — tells Chromium not to look for a setuid
+  `chrome-sandbox` binary and fall back to the namespace sandbox instead.
+- Do **not** pass `--no-sandbox` (that would disable all isolation).
+- Do **not** pass `--no-zygote` (the Zygote handles sandboxed forking).
+
+**What exists already:** nothing extra is needed in the Rust code beyond removing
+`no_sandbox: 1` from `Settings`.
+
+**What is missing:**
+- `no_sandbox: 1` is set globally (removes all isolation).
+- `--disable-setuid-sandbox` is not explicitly added to the CEF command line
+  (should be added so Chromium doesn't abort looking for a missing SUID helper).
+
+### 4.3 Windows
+
+Windows sandbox is the most complex. The cef-rs 148 `sandbox` feature implements
+the **DLL wrapper pattern**: the Rust crate is compiled as a `cdylib`, and the
+CEF-provided `bootstrap.exe` acts as the real launcher — it initializes
+`cef_sandbox_info_t` before any user code, then loads and calls into the DLL.
+
+**What exists already:**
+- `sandbox = ["cef/sandbox"]` feature defined in `agentmux-cef/Cargo.toml:16` ✓
+- `bootstrap.exe` present in the CEF distribution ✓
+- The `cef/build_util/win` bundle tool knows to copy `bootstrap.exe` and link
+  against `cef_sandbox.lib` when `sandbox` feature is active ✓
+
+**What is missing:**
+- `[[lib]]` target with `crate-type = ["cdylib"]` in `agentmux-cef/Cargo.toml`
+  (currently only a `[[bin]]` target exists).
+- A `lib.rs` entry point that exports `DllMain` / the expected CEF bootstrap
+  symbols so `bootstrap.exe` can find them.
+- `bootstrap.exe` bundled into `dist/cef-dev/runtime/` and `task bundle` output.
+- The entire host `main()` restructured to be callable as a DLL export.
+
+This is effort-L and ships as a dedicated PR (Phase 3).
+
+---
+
+## 5. Implementation plan
+
+### Phase 1 — macOS sandbox (this PR first)
+
+**File: `agentmux-cef/src/main.rs`**
+
+1. Add `#[cfg(all(target_os = "macos", feature = "sandbox"))]` import of
+   `cef::sandbox::Sandbox`.
+
+2. At the very top of `main()`, before `Args::new()`, initialize the sandbox
+   context on macOS subprocess paths:
+
+```rust
+#[cfg(all(target_os = "macos", feature = "sandbox"))]
+let mut _sandbox = {
+    let mut s = cef::sandbox::Sandbox::new();
+    // Must be called before execute_process.
+    // Safe: Args::new() hasn't been called yet; no CEF heap in use.
+    let args = cef::args::Args::new();
+    s.initialize(args.as_main_args());
+    s
+};
+```
+
+3. Change `no_sandbox` to be conditional:
+
+```rust
+let settings = Settings {
+    #[cfg(not(feature = "sandbox"))]
+    no_sandbox: 1,
+    // ...
+};
+```
+
+4. Update `agentmux-cef/Cargo.toml` `[features]`:
+   ```toml
+   default = ["sandbox"]
+   sandbox = ["cef/sandbox"]
+   ```
+   (Enable by default; `--no-default-features` opts out for special builds.)
+
+5. Add escape hatch: if `AGENTMUX_UNSAFE_NOSANDBOX=1` is set at runtime, log a
+   `tracing::warn!` and proceed with `no_sandbox: 1` regardless of feature flag.
+   This is checked at runtime inside `main()` before `initialize()`.
+
+**Taskfile / bundle:**
+
+The macOS helper app bundle is already correct. No Taskfile change needed for
+Phase 1.
+
+**Cargo.toml:**
+
+Add `libloading` to dependencies (required by `cef::sandbox::Sandbox` on macOS):
+```toml
+[target.'cfg(target_os = "macos")'.dependencies]
+libloading = "0.8"
+```
+
+(Check if `cef/sandbox` feature already pulls it transitively — if so, omit.)
+
+---
+
+### Phase 2 — Linux sandbox (can land same PR as Phase 1 or separate)
+
+**File: `agentmux-cef/src/app.rs`** (`on_before_command_line_processing`)
+
+Add to the Linux section:
+
+```rust
+#[cfg(target_os = "linux")]
+{
+    // Use kernel namespace sandbox instead of setuid chrome-sandbox.
+    // This works on kernels ≥3.8 without a privileged helper binary.
+    cmd_line.append_switch(Some(&CefString::from("disable-setuid-sandbox")));
+}
+```
+
+**File: `agentmux-cef/src/main.rs`**
+
+Same `no_sandbox` conditional as Phase 1 (shared change).
+
+**No Taskfile changes needed** — `chrome-sandbox` binary is not required when
+namespace sandbox is active.
+
+---
+
+### Phase 3 — Windows sandbox (dedicated PR, effort-L)
+
+**Overview:** restructure the crate to build as both `[[bin]]` (sandbox-off,
+existing path) and `[[lib]]` (sandbox-on, new path). The DLL export surface
+matches what `bootstrap.exe` calls.
+
+**File: `agentmux-cef/Cargo.toml`**
+
+```toml
+[[bin]]
+name = "agentmux-cef"
+path = "src/main.rs"
+# Built when sandbox feature is NOT active (all non-Windows or sandbox-off)
+
+[lib]
+name = "agentmux_cef"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+# Built when sandbox feature IS active on Windows
+```
+
+**New file: `agentmux-cef/src/lib.rs`**
+
+Export the `DllMain`-equivalent entry point that `bootstrap.exe` calls:
+
+```rust
+#[cfg(all(target_os = "windows", feature = "sandbox"))]
+#[no_mangle]
+pub extern "C" fn agentmux_cef_main(
+    instance: *mut std::ffi::c_void,
+    sandbox_info: *mut std::ffi::c_void,
+) -> i32 {
+    crate::main_impl(sandbox_info)
+}
+```
+
+The existing `main()` body becomes `main_impl(sandbox_info: *mut c_void)` which
+receives the already-initialized sandbox info from `bootstrap.exe`.
+
+**Taskfile:** add `bootstrap.exe` copy step to `bundle:windows` and
+`build:cef-dev` tasks.
+
+**`cef_sandbox.lib` linking:** the `cef/sandbox` build_util feature already
+handles this via `cargo:rustc-link-lib=static=cef_sandbox` in the build script.
+
+---
+
+## 6. Escape hatch
+
+In `main()` (browser process path only), before `initialize()`:
+
+```rust
+let force_no_sandbox = std::env::var("AGENTMUX_UNSAFE_NOSANDBOX")
+    .map(|v| v == "1")
+    .unwrap_or(false);
+if force_no_sandbox {
+    tracing::warn!(
+        "AGENTMUX_UNSAFE_NOSANDBOX=1 set — renderer sandbox DISABLED. \
+         This should only be used in known-incompatible environments."
+    );
+    settings.no_sandbox = 1;
+}
+```
+
+Document in `settings-template.jsonc` and `CEF_ARCHITECTURE.md`.
+
+---
+
+## 7. Testing
+
+### Per platform
+
+| Test | macOS | Linux | Windows |
+|------|-------|-------|---------|
+| App starts, browser pane renders | ✓ | ✓ | ✓ (Phase 3) |
+| Renderer process visible in task manager with restricted token | - | - | ✓ |
+| `chrome://sandbox` shows renderer Sandbox=Yes | ✓ | ✓ | ✓ |
+| Agent panes, terminal panes unaffected | ✓ | ✓ | ✓ |
+| Tear-off / float pane redock works | ✓ | ✓ | ✓ |
+| `AGENTMUX_UNSAFE_NOSANDBOX=1` falls back gracefully | ✓ | ✓ | ✓ |
+| `task dev` works without sandbox feature | ✓ | ✓ | ✓ |
+
+### Regression signals
+
+- GPU process crash (same symptoms as #778) — if sandbox forces GPU isolation
+  that the driver doesn't support, browser panes go black. Mitigated by the
+  existing `--disable-gpu` dev-mode flag (issue #778).
+- Namespace sandbox failure on Linux (older kernel / Docker without user
+  namespaces) — escape hatch covers this.
+
+---
+
+## 8. Rollout
+
+- Phase 1+2 (macOS + Linux): ship together, `default = ["sandbox"]` means sandbox
+  is ON by default in `task dev` and `task package`. If issues arise, set
+  `AGENTMUX_UNSAFE_NOSANDBOX=1` at the OS level.
+- Phase 3 (Windows): separate PR; sandbox OFF by default until tested end-to-end.
+  Flip `default = ["sandbox"]` in a follow-up once Windows path is verified.
+
+---
+
+## 9. Files changed (Phases 1+2)
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/main.rs` | Sandbox init on macOS, conditional `no_sandbox`, escape hatch |
+| `agentmux-cef/src/app.rs` | `--disable-setuid-sandbox` on Linux |
+| `agentmux-cef/Cargo.toml` | `default = ["sandbox"]`, `libloading` dep (macOS) |
+| `docs/CEF_ARCHITECTURE.md` | Document sandbox status + escape hatch |
+
+## 10. Files changed (Phase 3, Windows)
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/Cargo.toml` | Add `[lib]` cdylib target |
+| `agentmux-cef/src/lib.rs` | New — DLL export entry point |
+| `agentmux-cef/src/main.rs` | Refactor body into `main_impl(sandbox_info)` |
+| `Taskfile.yml` | Bundle `bootstrap.exe`, `agentmux_cef.dll` |


### PR DESCRIPTION
## Summary

- **Removes `no_sandbox: 1`** that has unconditionally disabled CEF renderer sandboxing since the first POC commit (5d0be0bf, March 2026). A compromised renderer was running with full host privileges — shell env (`AWS_SECRET_*`, `GITHUB_TOKEN`, `AGENTMUX_AUTH_KEY`), filesystem, and the local IPC surface.
- **Phase 1 (macOS):** `cef::sandbox::Sandbox::new()` + `.initialize(args)` called in the subprocess path before `CefExecuteProcess`, activating Seatbelt policy via `libcef_sandbox.dylib`. The opaque context pointer is held by `_macos_sandbox` until process exit (Drop calls `cef_sandbox_destroy`).
- **Phase 2 (Linux):** `--disable-setuid-sandbox` appended in `on_before_command_line_processing` so Chromium uses kernel namespace isolation (kernels ≥3.8) instead of aborting looking for a missing SUID `chrome-sandbox` binary.
- **`default = ["sandbox"]`** — sandbox is ON by default in `task dev`, `task package`, and CI. Opt out with `--no-default-features`.
- **Windows** remains `no_sandbox=1` at runtime via `cfg!(target_os = "windows")` guard; Phase 3 (DLL wrapper + `bootstrap.exe`) is tracked separately.
- **Escape hatch:** `AGENTMUX_UNSAFE_NOSANDBOX=1` skips both macOS Seatbelt init and the namespace sandbox flag, with a `tracing::warn!` logged once the subscriber is up.

## Test plan

- [ ] macOS: `task dev` → open a browser pane → `chrome://sandbox` shows Renderer Sandbox=active
- [ ] macOS: agent panes, terminal panes, tear-off unaffected
- [ ] macOS: `AGENTMUX_UNSAFE_NOSANDBOX=1 task dev` → warn in log → `chrome://sandbox` shows sandbox=off
- [ ] Linux: `task dev` → `chrome://sandbox` shows namespace sandbox
- [ ] Linux: app starts without SUID chrome-sandbox binary
- [ ] `cargo check -p agentmux-cef --no-default-features` — compiles (sandbox-off path)
- [ ] `cargo check -p agentmux-cef` — compiles (sandbox-on path, confirmed locally)
- [ ] Windows CI — builds without regression (runtime path guarded)

## Files changed

| File | Change |
|------|--------|
| `agentmux-cef/Cargo.toml` | `default = ["sandbox"]` |
| `agentmux-cef/src/main.rs` | Seatbelt init (macOS), conditional `no_sandbox`, escape hatch warn |
| `agentmux-cef/src/app.rs` | `--disable-setuid-sandbox` on Linux |
| `docs/specs/SPEC_CEF_SANDBOX_2026_06_20.md` | Full spec (3-phase plan, escape hatch, test matrix) |

Closes #1374 (Phases 1+2). Phase 3 (Windows) tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)