### PR TITLE
feat(voice): Whisper STT engine — capture audio, transcribe via Groq

### DIFF
--- a/.changesets/1781979079-feat-voice-whisper-stt-engine-capture-audio-and-transcribe-v-licc.md
+++ b/.changesets/1781979079-feat-voice-whisper-stt-engine-capture-audio-and-transcribe-v-licc.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(voice): Whisper STT engine — capture audio and transcribe via Groq

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -35,7 +35,7 @@ portable-pty = "0.9"
 sysinfo = "0.34"
 parking_lot = "0.12"
 notify = "7"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 # OS-native secret storage (macOS Keychain / Windows Credential Manager /
 # Linux Secret Service) for Trust Center API keys. See
 # specs/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -218,6 +218,18 @@ pub struct SettingsType {
     #[serde(rename = "voice:enabled", default, skip_serializing_if = "Option::is_none")]
     pub voice_enabled: Option<bool>,
 
+    // Speech-to-text engine: "whisper" (capture audio → server STT, the default
+    // and only engine that works in CEF) or "webspeech" (browser API — dev /
+    // real-Chromium only). Absent ⇒ whisper.
+    // Spec: docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md.
+    #[serde(rename = "voice:engine", default, skip_serializing_if = "Option::is_none")]
+    pub voice_engine: Option<String>,
+
+    // Groq API key for the hosted Whisper backend. Read server-side only; never
+    // sent to the renderer. The AGENTMUX_GROQ_API_KEY env var takes precedence.
+    #[serde(rename = "voice:groqApiKey", default, skip_serializing_if = "Option::is_none")]
+    pub voice_groq_api_key: Option<String>,
+
     // -- Notification sounds --
     //
     // Spec: docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §5.1.

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -14,6 +14,7 @@ mod reactive;
 pub(crate) mod service;
 mod shell_handlers;
 mod tool_handlers;
+mod voice;
 pub(crate) mod wave_obj_bridge;
 mod websocket;
 mod drone_handlers;
@@ -256,6 +257,11 @@ pub fn build_router(state: AppState) -> Router {
         // shares the exact pane.open logic with the WebSocket RPC handler
         // (app_api::open_pane). See ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.
         .route("/api/v1/pane/open", post(handle_pane_open))
+        // Voice speech-to-text: the renderer POSTs mic audio (one
+        // silence-bounded utterance per request); we forward to a Whisper
+        // backend and return the transcript. Key stays server-side.
+        // See SPEC_VOICE_STT_ENGINE_2026_06_20.md and #1591.
+        .route("/api/v1/voice/transcribe", post(voice::handle_voice_transcribe))
         // First-class agent API (SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md).
         // `GET /api/v1/self?block_id=` resolves the caller's place in the tree;
         // `POST /api/v1/window/name` sets the window display name (taskbar title).

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -1,0 +1,180 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Voice speech-to-text endpoint — `POST /api/v1/voice/transcribe`.
+//!
+//! The renderer captures mic audio (getUserMedia → MediaRecorder, gated by the
+//! CEF permission handler #1602) and POSTs each silence-bounded utterance here
+//! as a raw audio body. We forward it to a Whisper backend and return the
+//! transcript. The API key stays server-side — the renderer never sees it.
+//!
+//! Web Speech API can't transcribe in CEF (closed-source Google service,
+//! Chrome-build-bound), so this capture-and-send path is the real engine. See
+//! docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md and #1591.
+//!
+//! PR 1 ships the Groq hosted backend (whisper-large-v3-turbo) as free
+//! functions; the pluggable `SttBackend` trait + local whisper.cpp land in PR 2.
+
+use axum::{
+    body::Bytes,
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use serde_json::json;
+
+use super::AppState;
+
+const GROQ_TRANSCRIBE_URL: &str = "https://api.groq.com/openai/v1/audio/transcriptions";
+const GROQ_MODEL: &str = "whisper-large-v3-turbo";
+
+#[derive(serde::Deserialize)]
+pub(super) struct TranscribeQuery {
+    /// MIME type of the posted audio (e.g. "audio/webm"). Defaults to webm.
+    mime: Option<String>,
+    /// Optional BCP-47 language hint (e.g. "en"); improves accuracy + latency.
+    lang: Option<String>,
+}
+
+/// `POST /api/v1/voice/transcribe?mime=audio/webm&lang=en` — body is raw audio.
+/// → 200 `{ "text": "..." }` · 400 empty body · 501 no backend configured ·
+///   502 upstream error.
+pub(super) async fn handle_voice_transcribe(
+    State(_state): State<AppState>,
+    Query(q): Query<TranscribeQuery>,
+    body: Bytes,
+) -> impl IntoResponse {
+    if body.is_empty() {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "empty audio body" })))
+            .into_response();
+    }
+
+    let mime = q.mime.unwrap_or_else(|| "audio/webm".to_string());
+    let lang = q.lang.filter(|l| !l.trim().is_empty());
+
+    let Some(key) = resolve_groq_key() else {
+        // Mirrors the frontend's `service-not-allowed` UX (#1603): voice isn't
+        // configured in this build yet.
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(json!({
+                "error": "no STT backend configured — set voice:groqApiKey in \
+                          settings.json or the AGENTMUX_GROQ_API_KEY env var"
+            })),
+        )
+            .into_response();
+    };
+
+    match transcribe_groq(&key, body, &mime, lang.as_deref()).await {
+        Ok(text) => Json(json!({ "text": text })).into_response(),
+        Err(e) => {
+            tracing::warn!(target: "voice", "transcription failed: {e}");
+            (StatusCode::BAD_GATEWAY, Json(json!({ "error": e }))).into_response()
+        }
+    }
+}
+
+/// Resolve the Groq API key, server-side only:
+///   1. `AGENTMUX_GROQ_API_KEY` env var
+///   2. settings.json key `voice:groqApiKey`
+fn resolve_groq_key() -> Option<String> {
+    if let Ok(k) = std::env::var("AGENTMUX_GROQ_API_KEY") {
+        let k = k.trim().to_string();
+        if !k.is_empty() {
+            return Some(k);
+        }
+    }
+    let path = crate::backend::base::get_wave_config_dir().join("settings.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    v.get("voice:groqApiKey")
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// File extension matching the posted MIME, so Groq's content sniffing accepts
+/// the multipart `file` part.
+fn mime_ext(mime: &str) -> &'static str {
+    let m = mime.to_ascii_lowercase();
+    if m.contains("webm") {
+        "webm"
+    } else if m.contains("ogg") {
+        "ogg"
+    } else if m.contains("wav") {
+        "wav"
+    } else if m.contains("mp4") || m.contains("m4a") {
+        "m4a"
+    } else if m.contains("mpeg") || m.contains("mp3") {
+        "mp3"
+    } else if m.contains("flac") {
+        "flac"
+    } else {
+        "webm"
+    }
+}
+
+/// POST the audio to Groq's OpenAI-compatible transcription endpoint and return
+/// the transcript text. ~$0.0007/min, ~216× real-time.
+async fn transcribe_groq(
+    key: &str,
+    audio: Bytes,
+    mime: &str,
+    lang: Option<&str>,
+) -> Result<String, String> {
+    let part = reqwest::multipart::Part::bytes(audio.to_vec())
+        .file_name(format!("audio.{}", mime_ext(mime)))
+        .mime_str(mime)
+        .map_err(|e| format!("invalid mime: {e}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .text("model", GROQ_MODEL)
+        .text("response_format", "json")
+        .part("file", part);
+    if let Some(l) = lang {
+        form = form.text("language", l.to_string());
+    }
+
+    let resp = reqwest::Client::new()
+        .post(GROQ_TRANSCRIBE_URL)
+        .bearer_auth(key)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+
+    let status = resp.status();
+    let text_body = resp
+        .text()
+        .await
+        .map_err(|e| format!("reading response: {e}"))?;
+
+    if !status.is_success() {
+        // Don't leak the key; cap the upstream body in the message.
+        let snippet: String = text_body.chars().take(300).collect();
+        return Err(format!("groq {}: {}", status.as_u16(), snippet));
+    }
+
+    let v: serde_json::Value =
+        serde_json::from_str(&text_body).map_err(|e| format!("parsing response: {e}"))?;
+    Ok(v.get("text")
+        .and_then(|t| t.as_str())
+        .unwrap_or_default()
+        .trim()
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mime_ext_maps_common_types() {
+        assert_eq!(mime_ext("audio/webm;codecs=opus"), "webm");
+        assert_eq!(mime_ext("audio/ogg"), "ogg");
+        assert_eq!(mime_ext("audio/wav"), "wav");
+        assert_eq!(mime_ext("audio/mp4"), "m4a");
+        assert_eq!(mime_ext("audio/mpeg"), "mp3");
+        assert_eq!(mime_ext("application/octet-stream"), "webm"); // fallback
+    }
+}

--- a/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
+++ b/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
@@ -1,0 +1,132 @@
+# SPEC: Voice STT engine — capture-and-send to Whisper
+
+**Date:** 2026-06-20
+**Author:** Claude (Opus 4.8)
+**Status:** In progress (PR 1)
+**Tracking:** #1591 §4c/4d. Builds on the merged foundation: CEF mic-permission
+handler (#1602) + actionable permission UX (#1603). Supersedes the Web Speech
+engine, which **cannot transcribe in CEF** (closed-source Google speech service,
+Chrome-build-bound — see `agentmux-voice-permissions-report.md`).
+
+---
+
+## 1. Goal
+
+Make voice input actually transcribe in packaged AgentMux builds by replacing
+the (dead-in-CEF) Web Speech recognizer with a **capture-and-send** pipeline:
+the renderer captures mic audio and sends it to `agentmux-srv`, which calls a
+Whisper backend and returns text. The existing per-pane plumbing
+(`getVoiceSession()` singleton, `PaneVoiceHandle`, `MicButton`, the red recording
+indicator, "Speak to <agent>" ghost text) is **reused unchanged** — only the
+engine behind `getVoiceSession()` swaps.
+
+## 2. Architecture
+
+```
+ renderer (pane)                         agentmux-srv                    Whisper
+ ───────────────                         ────────────                    ───────
+ getUserMedia(audio)                     POST /api/v1/voice/transcribe
+   → MediaRecorder ──(webm/opus blob)──▶  (authed, raw audio body)  ──▶  Groq /
+   → VAD: cut on silence                  SttBackend::transcribe()        OpenAI /
+   ◀──────────── { "text": "..." } ◀──    returns transcript              whisper.cpp
+   → PaneVoiceHandle.appendFinal(text)
+```
+
+- **No streaming** (no Whisper variant streams): each silence-bounded utterance
+  is one request/response. `setInterim` degrades to a "…transcribing" spinner.
+- **Key stays server-side.** The renderer never sees the API key; it only POSTs
+  audio to the local srv, which holds the key. This is why capture goes through
+  srv rather than the renderer calling Groq directly.
+- **CEF mic grant (#1602) is the prerequisite** — `getUserMedia({audio:true})`
+  only works because of that handler.
+
+## 3. Server: `SttBackend` trait + endpoint
+
+New module `agentmux-srv/src/backend/voice/` (or `server/voice.rs` for the route).
+
+```rust
+#[async_trait] // or hand-rolled async fn
+pub trait SttBackend: Send + Sync {
+    /// Transcribe one audio clip (webm/opus/mp3/wav bytes) → text.
+    async fn transcribe(&self, audio: Bytes, mime: &str, lang: Option<&str>)
+        -> Result<String, SttError>;
+    fn id(&self) -> &'static str;
+}
+```
+
+**Endpoint** (axum, in `authed_routes`):
+```
+POST /api/v1/voice/transcribe?mime=audio/webm&lang=en
+body: raw audio bytes (axum::body::Bytes)
+→ 200 { "text": "..." }   |   501 { "error": "no STT backend configured" }
+```
+Mirrors the existing `handle_*` pattern: `State(AppState)`, `Bytes` body (same
+extractor `service.rs` uses), `Json<Value>` response. Auth-gated like the other
+`/api/v1/*` routes.
+
+### 3.1 Backends
+- **`GroqBackend`** (PR 1) — `reqwest` multipart POST to
+  `https://api.groq.com/openai/v1/audio/transcriptions`, model
+  `whisper-large-v3-turbo`. ~$0.0007/min, ~216× real-time. `reqwest` is already
+  a dependency.
+- **`OpenAiBackend`** (later) — same OpenAI-compatible shape, `gpt-4o-transcribe`.
+- **`LocalWhisperBackend`** (PR 2) — `whisper-rs` (whisper.cpp) with a model
+  fetched on-demand to the config dir. Default for privacy/offline. ~0 MB ship.
+
+### 3.2 Backend selection + key (server-side)
+Resolved once at request time from, in order:
+1. env `AGENTMUX_GROQ_API_KEY` (and future `AGENTMUX_OPENAI_API_KEY`)
+2. settings.json key `voice:groqApiKey` (read from `get_wave_config_dir()/settings.json`)
+
+`voice:engine` setting selects the backend (`groq` | `openai` | `whisper-local`;
+default `whisper-local` once PR 2 lands, `groq` in PR 1). If no key/engine is
+configured, the endpoint returns `501` and the frontend shows the
+`service-not-allowed`-style "not configured" guidance (reuses #1603's toast).
+
+## 4. Frontend: capture engine
+
+New `frontend/app/hook/voice/whisperEngine.ts`, selected by `getVoiceSession()`
+based on the `voice:engine` setting. Implements the same `VoiceSession` shape
+(`isListening`, `currentTargetId`, `lastError`, `toggleListening`, `registerPane`).
+
+- `getUserMedia({audio:true})` → `MediaRecorder` (webm/opus).
+- **VAD:** a Web Audio `AnalyserNode` tracks RMS; on speech→silence (~800 ms)
+  or a max-segment timer (~10 s), `recorder.stop()` finalizes a valid webm blob,
+  POST it to `/api/v1/voice/transcribe`, then `start()` a fresh recorder.
+- On 200 → `activeHandle.appendFinal(text + " ")`. While a segment is in flight
+  → `activeHandle.setInterim("…")` (spinner; terminal pane no-ops as today).
+- Errors map to the existing `lastError` codes so #1603's UX applies:
+  `getUserMedia` `NotAllowedError`→`not-allowed`, `NotFoundError`→`audio-capture`,
+  endpoint `501`/network → `service-not-allowed`.
+
+## 5. Gate the dead Web Speech engine (§4d)
+
+`getVoiceSession()` picks the engine from `voice:engine`:
+- `webspeech` only if explicitly set AND `webkitSpeechRecognition` exists (escape
+  hatch for non-CEF/dev browsers).
+- otherwise the Whisper engine.
+In CEF, default to the Whisper engine so the mic never presents a working-looking
+button backed by a recognizer that can't run.
+
+## 6. Security
+- API key never enters the renderer (server-side resolve only).
+- Endpoint is auth-gated (`authed_routes`). Mic capture is gated to the trusted
+  app origin by the CEF handler (#1602) — browser panes can't capture.
+- Audio is sent to the configured provider (Groq/OpenAI) for hosted backends;
+  the local whisper.cpp backend (PR 2) keeps audio fully on-device. Document the
+  provider egress in settings.
+
+## 7. Phasing
+- **PR 1 (this):** `SttBackend` trait + `GroqBackend` + `/api/v1/voice/transcribe`
+  + frontend `whisperEngine.ts` (MediaRecorder+VAD) + `voice:engine` setting +
+  gate Web Speech. ~0 MB ship, ~600–800 LOC.
+- **PR 2:** `LocalWhisperBackend` (whisper-rs) + on-demand model download +
+  default engine → `whisper-local`.
+- **PR 3 (optional):** Claude post-transcription cleanup pass (agent pane only).
+
+## 8. Verification
+- `cargo check -p agentmux-srv` (endpoint + Groq backend).
+- `task build:frontend` (capture engine + gating).
+- Live: set `voice:groqApiKey`, click mic → OS prompt → speak → text appears in
+  composer; confirm key never appears in renderer; confirm browser pane can't
+  capture.

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createSignalAtom, type SignalAtom } from "@/util/util";
+import { getSettingsKeyAtom } from "@/app/store/global";
+import { createWhisperVoiceSession } from "./whisperVoiceEngine";
 
 export interface PaneVoiceHandle {
     appendFinal: (text: string) => void;
@@ -26,7 +28,7 @@ export interface VoiceSession {
 
 const RESTART_DELAY_MS = 100;
 
-function createVoiceSession(): VoiceSession {
+function createWebSpeechVoiceSession(): VoiceSession {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
     const isListening = createSignalAtom(false);
     const currentTargetId = createSignalAtom<string | null>(null);
@@ -146,6 +148,19 @@ function createVoiceSession(): VoiceSession {
 let _session: VoiceSession | null = null;
 
 export function getVoiceSession(): VoiceSession {
-    if (!_session) _session = createVoiceSession();
+    if (_session) return _session;
+    // Engine selection (SPEC_VOICE_STT_ENGINE_2026_06_20.md §5): the Web Speech
+    // recognizer can't transcribe in CEF (closed-source Google service), so it's
+    // used ONLY when explicitly opted into via `voice:engine: "webspeech"` AND
+    // the API exists (dev / real-Chromium). Otherwise the Whisper
+    // capture-and-send engine, which is the default everywhere.
+    const engine = getSettingsKeyAtom("voice:engine")();
+    const hasWebSpeech =
+        typeof window !== "undefined" &&
+        !!((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition);
+    _session =
+        engine === "webspeech" && hasWebSpeech
+            ? createWebSpeechVoiceSession()
+            : createWhisperVoiceSession();
     return _session;
 }

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -83,6 +83,16 @@ export function createWhisperVoiceSession(): VoiceSession {
     let silenceStart = 0;
     let segmentStart = 0;
 
+    // Serialize transcription so utterances are applied in spoken order.
+    // Capture keeps running concurrently (recorder restarts immediately); only
+    // the network call + appendFinal are chained — Groq latency varies, so
+    // POSTing concurrently could resolve out of order and scramble the composer
+    // text during continuous speech (reagent P1 #1623).
+    let postChain: Promise<void> = Promise.resolve();
+    const enqueuePost = (blob: Blob) => {
+        postChain = postChain.then(() => postSegment(blob)).catch(() => {});
+    };
+
     type BlobChunk = Blob;
 
     const fail = (code: string) => {
@@ -150,8 +160,10 @@ export function createWhisperVoiceSession(): VoiceSession {
             const blob = new Blob(chunks, { type: mime });
             chunks = [];
             // Only transcribe clips that contained speech and weren't blips.
+            // Enqueued (not awaited) so the next recorder starts immediately,
+            // but applied strictly in order — see enqueuePost above.
             if (sawSpeech && dur >= MIN_SEGMENT_MS) {
-                void postSegment(blob);
+                enqueuePost(blob);
             }
             // Restart for the next utterance while still listening.
             if (isListening()) startRecorder();

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -1,0 +1,265 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Whisper capture-and-send voice engine.
+ *
+ * The Web Speech API can't transcribe in CEF (closed-source Google service,
+ * Chrome-build-bound), so this engine captures mic audio with getUserMedia +
+ * MediaRecorder, cuts it into silence-bounded utterances (a small Web-Audio
+ * VAD), and POSTs each clip to `agentmux-srv` (`/api/v1/voice/transcribe`),
+ * which calls Whisper and returns text. The API key stays server-side.
+ *
+ * Implements the same `VoiceSession` shape as the Web Speech engine so
+ * `getVoiceSession()` can pick between them with the rest of the per-pane
+ * plumbing (MicButton, red indicator, "Speak to <agent>" ghost text) unchanged.
+ *
+ * Spec: docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md · tracking #1591.
+ */
+
+import { createSignalAtom } from "@/util/util";
+import { getWebServerEndpoint } from "@/util/endpoints";
+import { getApi } from "@/app/store/app-api";
+import type { PaneVoiceHandle, VoiceSession } from "./useVoiceInput";
+
+// VAD tuning. RMS below SILENCE_RMS for >= SILENCE_MS after speech ends an
+// utterance; a hard cap keeps any single clip small (Whisper isn't streaming,
+// so shorter clips = lower latency). LEVEL_POLL_MS samples the analyser — a
+// periodic read is inherent to Web-Audio level metering, not a workaround.
+const SILENCE_RMS = 0.012;
+const SILENCE_MS = 800;
+const MAX_SEGMENT_MS = 12_000;
+const MIN_SEGMENT_MS = 350; // drop blips with no real speech
+const LEVEL_POLL_MS = 100;
+
+/** Pick the best MediaRecorder mime the runtime supports (opus preferred). */
+function pickMime(): string {
+    const candidates = [
+        "audio/webm;codecs=opus",
+        "audio/webm",
+        "audio/ogg;codecs=opus",
+        "audio/mp4",
+    ];
+    for (const m of candidates) {
+        if (typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported(m)) {
+            return m;
+        }
+    }
+    return "audio/webm";
+}
+
+export function createWhisperVoiceSession(): VoiceSession {
+    const isListening = createSignalAtom(false);
+    const currentTargetId = createSignalAtom<string | null>(null);
+    const lastError = createSignalAtom<string | null>(null);
+
+    const available =
+        typeof navigator !== "undefined" &&
+        !!navigator.mediaDevices?.getUserMedia &&
+        typeof MediaRecorder !== "undefined";
+
+    if (!available) {
+        return {
+            isListening,
+            currentTargetId,
+            lastError,
+            isAvailable: () => false,
+            toggleListening: () => {},
+            registerPane: () => {},
+        };
+    }
+
+    let activeHandle: PaneVoiceHandle | null = null;
+    let stream: MediaStream | null = null;
+    let recorder: MediaRecorder | null = null;
+    let audioCtx: AudioContext | null = null;
+    let analyser: AnalyserNode | null = null;
+    let levelTimer: number | null = null;
+    let chunks: BlobChunk[] = [];
+    let mime = "audio/webm";
+
+    // VAD state
+    let sawSpeech = false;
+    let silenceStart = 0;
+    let segmentStart = 0;
+
+    type BlobChunk = Blob;
+
+    const fail = (code: string) => {
+        lastError._set(code);
+        window.dispatchEvent(new CustomEvent("voice-input-error", { detail: code }));
+        void stopCapture();
+    };
+
+    const postSegment = async (blob: Blob) => {
+        if (blob.size === 0) return;
+        const handle = activeHandle;
+        if (!handle) return;
+        handle.setInterim("…"); // non-streaming: spinner-ish placeholder
+        try {
+            const base = getWebServerEndpoint();
+            const url = `${base}/api/v1/voice/transcribe?mime=${encodeURIComponent(mime)}&lang=${encodeURIComponent(
+                (navigator.language || "").split("-")[0] || "",
+            )}`;
+            const resp = await fetch(url, {
+                method: "POST",
+                headers: { "X-AuthKey": getApi()?.getAuthKey?.() ?? "", "Content-Type": mime },
+                body: blob,
+            });
+            handle.setInterim("");
+            if (resp.status === 501) {
+                fail("service-not-allowed"); // backend not configured
+                return;
+            }
+            if (!resp.ok) {
+                // Transient upstream error — surface once, keep the session alive.
+                lastError._set("service-not-allowed");
+                window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
+                return;
+            }
+            const data = (await resp.json()) as { text?: string };
+            const text = (data.text || "").trim();
+            if (text) handle.appendFinal(text);
+        } catch {
+            handle.setInterim("");
+            // Network/host error — surface as service-unavailable.
+            lastError._set("service-not-allowed");
+            window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
+        }
+    };
+
+    /** Stop the current recorder; its onstop posts the accumulated clip. */
+    const cutSegment = () => {
+        if (recorder && recorder.state !== "inactive") {
+            recorder.stop(); // → onstop builds blob + posts + restarts (if listening)
+        }
+    };
+
+    const startRecorder = () => {
+        if (!stream) return;
+        chunks = [];
+        sawSpeech = false;
+        silenceStart = 0;
+        segmentStart = Date.now();
+        recorder = new MediaRecorder(stream, { mimeType: mime });
+        recorder.ondataavailable = (e) => {
+            if (e.data && e.data.size > 0) chunks.push(e.data);
+        };
+        recorder.onstop = () => {
+            const dur = Date.now() - segmentStart;
+            const blob = new Blob(chunks, { type: mime });
+            chunks = [];
+            // Only transcribe clips that contained speech and weren't blips.
+            if (sawSpeech && dur >= MIN_SEGMENT_MS) {
+                void postSegment(blob);
+            }
+            // Restart for the next utterance while still listening.
+            if (isListening()) startRecorder();
+        };
+        recorder.start();
+    };
+
+    const pollLevel = () => {
+        if (!analyser) return;
+        const buf = new Uint8Array(analyser.fftSize);
+        analyser.getByteTimeDomainData(buf);
+        let sum = 0;
+        for (let i = 0; i < buf.length; i++) {
+            const v = (buf[i] - 128) / 128;
+            sum += v * v;
+        }
+        const rms = Math.sqrt(sum / buf.length);
+
+        const now = Date.now();
+        if (rms >= SILENCE_RMS) {
+            sawSpeech = true;
+            silenceStart = 0;
+        } else if (sawSpeech) {
+            if (silenceStart === 0) silenceStart = now;
+            else if (now - silenceStart >= SILENCE_MS) {
+                cutSegment(); // utterance boundary
+                return;
+            }
+        }
+        // Hard cap so a long monologue still gets transcribed in chunks.
+        if (now - segmentStart >= MAX_SEGMENT_MS && sawSpeech) {
+            cutSegment();
+        }
+    };
+
+    const stopCapture = async () => {
+        isListening._set(false);
+        currentTargetId._set(null);
+        if (levelTimer != null) {
+            clearInterval(levelTimer);
+            levelTimer = null;
+        }
+        if (recorder && recorder.state !== "inactive") {
+            try {
+                recorder.onstop = null as any; // don't restart on a deliberate stop
+                recorder.stop();
+            } catch {
+                /* ignore */
+            }
+        }
+        recorder = null;
+        if (audioCtx) {
+            try { await audioCtx.close(); } catch { /* ignore */ }
+            audioCtx = null;
+        }
+        analyser = null;
+        if (stream) {
+            stream.getTracks().forEach((t) => t.stop());
+            stream = null;
+        }
+        activeHandle?.setInterim("");
+    };
+
+    const startCapture = async () => {
+        try {
+            stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (e: any) {
+            const name = e?.name || "";
+            if (name === "NotAllowedError" || name === "SecurityError") {
+                fail("not-allowed");
+            } else if (name === "NotFoundError" || name === "OverconstrainedError") {
+                fail("audio-capture");
+            } else {
+                fail("service-not-allowed");
+            }
+            return;
+        }
+        mime = pickMime();
+        lastError._set(null);
+        isListening._set(true);
+
+        audioCtx = new AudioContext();
+        const src = audioCtx.createMediaStreamSource(stream);
+        analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 2048;
+        src.connect(analyser);
+
+        startRecorder();
+        levelTimer = window.setInterval(pollLevel, LEVEL_POLL_MS);
+    };
+
+    const toggleListening = () => {
+        if (isListening()) {
+            void stopCapture();
+        } else {
+            void startCapture();
+        }
+    };
+
+    return {
+        isListening,
+        currentTargetId,
+        lastError,
+        isAvailable: () => true,
+        toggleListening,
+        registerPane: (blockId, handle) => {
+            activeHandle = handle;
+            currentTargetId._set(blockId);
+        },
+    };
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1401,6 +1401,8 @@ declare global {
         "conn:*"?: boolean;
         "network:lan_discovery"?: boolean;
         "voice:enabled"?: boolean;
+        "voice:engine"?: string;
+        "voice:groqApiKey"?: string;
         "notify:*"?: boolean;
         "notify:sounds:enabled"?: boolean;
         "notify:sounds:volume"?: number;

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -76,6 +76,15 @@
     // "notify:tooltones:volume":                0.15,
     // "notify:tooltones:scope":                 "all",  // "all" or "focused"
 
+    // -- Voice input (speech-to-text) --
+    // "voice:enabled":     true,        // show the per-pane mic button (default true)
+    // "voice:engine":      "whisper",   // "whisper" (capture→server STT, default) or
+    //                                   // "webspeech" (browser API — does NOT work in
+    //                                   // packaged CEF builds; dev/Chromium only)
+    // "voice:groqApiKey":  "gsk_...",   // Groq key for the hosted Whisper backend.
+    //                                   // Read server-side only (never sent to the UI).
+    //                                   // Or set the AGENTMUX_GROQ_API_KEY env var.
+
     // -- Other --
     // "widget:icononly":           false,
     // "blockheader:showblockids": false,


### PR DESCRIPTION
## Summary

Makes voice input **actually transcribe**. The Web Speech API can't run in CEF (closed-source Google speech service, Chrome-build-bound — see #1591), so this replaces it with a **capture-and-send** pipeline behind the existing `getVoiceSession()` singleton. All per-pane plumbing — `MicButton`, the red recording indicator, "Speak to <agent>" ghost text (#1593), permission UX (#1603) — is reused unchanged.

Builds on the merged foundation: CEF mic-permission handler (#1602) + actionable permission UX (#1603). Spec: `docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md`.

## Server (`agentmux-srv`)
- **`POST /api/v1/voice/transcribe`** (authed): raw audio body → Groq `whisper-large-v3-turbo` → `{ "text": ... }`.
- **Key stays server-side** — resolved from `AGENTMUX_GROQ_API_KEY` env or `settings.json` `voice:groqApiKey`; never sent to the renderer. Returns **501** when unconfigured (maps to the existing "not available" toast).
- Adds the `multipart` feature to `reqwest`.

## Frontend
- **`whisperVoiceEngine.ts`** — `getUserMedia` → `MediaRecorder`; a small Web-Audio (RMS) VAD cuts silence-bounded utterances, POSTs each clip, calls `appendFinal`. Non-streaming, so `setInterim` shows a spinner. `getUserMedia` errors map to the existing `lastError` codes so #1603's UX applies.
- **`getVoiceSession()`** selects the engine: **Whisper by default**; Web Speech only when `voice:engine: "webspeech"` **and** the API exists (dev/Chromium escape hatch) — so CEF never shows a working-looking mic it can't back (§4d gating).
- `settings-template.jsonc` documents `voice:engine` / `voice:groqApiKey`.

## Cost / footprint
- **~0 MB** added to the build (HTTP only — `reqwest` already present). Groq `whisper-large-v3-turbo` is ~$0.0007/min, ~216× real-time.
- Local whisper.cpp (offline, no key) is the **PR-2** follow-up (#1591 §4c).

## Test plan
- [x] `cargo check -p agentmux-srv` — clean.
- [x] `task build:frontend` — clean.
- [ ] Set `voice:groqApiKey` (or `AGENTMUX_GROQ_API_KEY`), click the agent-pane mic → OS prompt → speak → text appears in the composer.
- [ ] No key set → 501 → "voice transcription unavailable" toast (honest).
- [ ] Confirm the key never appears in the renderer; confirm a browser pane can't capture (CEF handler gates it).

## Notes
- PR-2: `LocalWhisperBackend` (whisper-rs) + on-demand model download; refactor the Groq free-functions into the `SttBackend` trait then.
- Changeset: `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)