### PR TITLE
feat(voice): offline whisper.cpp backend (whisper-local engine)

### DIFF
--- a/.changesets/1781982267-feat-voice-offline-whisper-cpp-backend-whisper-local-engine-2qdr.md
+++ b/.changesets/1781982267-feat-voice-offline-whisper-cpp-backend-whisper-local-engine-2qdr.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(voice): offline whisper.cpp backend (whisper-local engine)

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -230,6 +230,14 @@ pub struct SettingsType {
     #[serde(rename = "voice:groqApiKey", default, skip_serializing_if = "Option::is_none")]
     pub voice_groq_api_key: Option<String>,
 
+    // Local whisper.cpp backend (voice:engine = "whisper-local"). Both are
+    // user-provided paths in v1 (auto-download is a follow-up). Env overrides:
+    // AGENTMUX_WHISPER_CLI / AGENTMUX_WHISPER_MODEL.
+    #[serde(rename = "voice:whisperCliPath", default, skip_serializing_if = "Option::is_none")]
+    pub voice_whisper_cli_path: Option<String>,
+    #[serde(rename = "voice:whisperModelPath", default, skip_serializing_if = "Option::is_none")]
+    pub voice_whisper_model_path: Option<String>,
+
     // -- Notification sounds --
     //
     // Spec: docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md §5.1.

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -253,13 +253,16 @@ async fn transcribe_local_whisper(
         return Err(NotConfigured(format!("whisper model not found at {model}")));
     }
 
-    // Write the WAV body to a unique temp file. Use a monotonic-ish unique name
-    // (nanos + a counter) — the sidecar handles many requests.
+    // Write the WAV body to a unique temp file. Timestamp alone can collide
+    // under concurrent requests (coarse Windows SystemTime granularity), so add
+    // a process-global atomic counter to guarantee uniqueness.
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let wav_path = std::env::temp_dir().join(format!("agentmux-voice-{ts}.wav"));
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let wav_path = std::env::temp_dir().join(format!("agentmux-voice-{ts}-{seq}.wav"));
     std::fs::write(&wav_path, &audio).map_err(|e| Upstream(format!("temp write: {e}")))?;
 
     // whisper-cli: -nt no timestamps, -np no progress prints → transcript on

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -272,11 +272,27 @@ async fn transcribe_local_whisper(
     if let Some(l) = lang {
         cmd.arg("-l").arg(l);
     }
+    // Bound the run: a wedged CLI (corrupt model, pathological input) must not
+    // block the HTTP handler forever. kill_on_drop ensures the timed-out child
+    // is reaped when the timeout future drops it.
+    cmd.kill_on_drop(true);
+    const WHISPER_TIMEOUT_SECS: u64 = 120;
 
-    let output = cmd.output().await;
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(WHISPER_TIMEOUT_SECS),
+        cmd.output(),
+    )
+    .await;
     let _ = std::fs::remove_file(&wav_path); // best-effort cleanup
 
-    let output = output.map_err(|e| Upstream(format!("spawn whisper-cli: {e}")))?;
+    let output = match output {
+        Err(_) => {
+            return Err(Upstream(format!(
+                "whisper-cli timed out after {WHISPER_TIMEOUT_SECS}s"
+            )))
+        }
+        Ok(r) => r.map_err(|e| Upstream(format!("spawn whisper-cli: {e}")))?,
+    };
     if !output.status.success() {
         let err: String = String::from_utf8_lossy(&output.stderr).chars().take(300).collect();
         return Err(Upstream(format!(

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -3,17 +3,20 @@
 //
 //! Voice speech-to-text endpoint — `POST /api/v1/voice/transcribe`.
 //!
-//! The renderer captures mic audio (getUserMedia → MediaRecorder, gated by the
-//! CEF permission handler #1602) and POSTs each silence-bounded utterance here
-//! as a raw audio body. We forward it to a Whisper backend and return the
-//! transcript. The API key stays server-side — the renderer never sees it.
+//! The renderer captures mic audio (getUserMedia, gated by the CEF permission
+//! handler #1602) and POSTs each silence-bounded utterance here; we forward it
+//! to the configured Whisper backend and return the transcript. Keys/paths stay
+//! server-side — the renderer never sees them.
 //!
-//! Web Speech API can't transcribe in CEF (closed-source Google service,
-//! Chrome-build-bound), so this capture-and-send path is the real engine. See
+//! Web Speech API can't transcribe in CEF (closed-source Google service), so
+//! this capture-and-send path is the real engine. See
 //! docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md and #1591.
 //!
-//! PR 1 ships the Groq hosted backend (whisper-large-v3-turbo) as free
-//! functions; the pluggable `SttBackend` trait + local whisper.cpp land in PR 2.
+//! Backends (selected by the `voice:engine` setting):
+//!   * "groq" (default) — hosted whisper-large-v3-turbo; renderer sends webm.
+//!   * "whisper-local"  — offline whisper.cpp via a local `whisper-cli`
+//!                        subprocess; renderer sends 16 kHz mono WAV. Opt-in,
+//!                        configured via settings/env; needs a model file.
 
 use axum::{
     body::Bytes,
@@ -38,7 +41,7 @@ pub(super) struct TranscribeQuery {
 
 /// `POST /api/v1/voice/transcribe?mime=audio/webm&lang=en` — body is raw audio.
 /// → 200 `{ "text": "..." }` · 400 empty body · 501 no backend configured ·
-///   502 upstream error.
+///   502 upstream/subprocess error.
 pub(super) async fn handle_voice_transcribe(
     State(_state): State<AppState>,
     Query(q): Query<TranscribeQuery>,
@@ -51,47 +54,94 @@ pub(super) async fn handle_voice_transcribe(
 
     let mime = q.mime.unwrap_or_else(|| "audio/webm".to_string());
     let lang = q.lang.filter(|l| !l.trim().is_empty());
+    let settings = read_settings_json();
+    let engine = resolve_engine(&settings);
 
-    let Some(key) = resolve_groq_key() else {
-        // Mirrors the frontend's `service-not-allowed` UX (#1603): voice isn't
-        // configured in this build yet.
-        return (
-            StatusCode::NOT_IMPLEMENTED,
-            Json(json!({
-                "error": "no STT backend configured — set voice:groqApiKey in \
-                          settings.json or the AGENTMUX_GROQ_API_KEY env var"
-            })),
-        )
-            .into_response();
+    let result = if engine == "whisper-local" {
+        transcribe_local_whisper(body, lang.as_deref(), &settings).await
+    } else {
+        match resolve_groq_key(&settings) {
+            Some(key) => transcribe_groq(&key, body, &mime, lang.as_deref()).await,
+            None => Err(NotConfigured(
+                "Groq backend not configured — set voice:groqApiKey in settings.json \
+                 or the AGENTMUX_GROQ_API_KEY env var"
+                    .to_string(),
+            )),
+        }
     };
 
-    match transcribe_groq(&key, body, &mime, lang.as_deref()).await {
+    match result {
         Ok(text) => Json(json!({ "text": text })).into_response(),
-        Err(e) => {
-            tracing::warn!(target: "voice", "transcription failed: {e}");
-            (StatusCode::BAD_GATEWAY, Json(json!({ "error": e }))).into_response()
+        Err(NotConfigured(msg)) => {
+            // Mirrors the frontend's `service-not-allowed` UX (#1603): voice
+            // isn't usable in this build/config yet.
+            (StatusCode::NOT_IMPLEMENTED, Json(json!({ "error": msg }))).into_response()
+        }
+        Err(Upstream(msg)) => {
+            tracing::warn!(target: "voice", "transcription failed: {msg}");
+            (StatusCode::BAD_GATEWAY, Json(json!({ "error": msg }))).into_response()
         }
     }
 }
 
-/// Resolve the Groq API key, server-side only:
-///   1. `AGENTMUX_GROQ_API_KEY` env var
-///   2. settings.json key `voice:groqApiKey`
-fn resolve_groq_key() -> Option<String> {
+/// Transcription failure: distinguishes "not configured" (→ 501, surfaced as the
+/// frontend's "unavailable" guidance) from a real upstream/runtime error (→ 502).
+enum SttError {
+    NotConfigured(String),
+    Upstream(String),
+}
+use SttError::{NotConfigured, Upstream};
+
+// ── Config resolution (server-side only) ────────────────────────────────────
+
+/// Read settings.json once; `None` if absent/unparseable.
+fn read_settings_json() -> Option<serde_json::Value> {
+    let path = crate::backend::base::get_wave_config_dir().join("settings.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn settings_str(settings: &Option<serde_json::Value>, key: &str) -> Option<String> {
+    settings
+        .as_ref()?
+        .get(key)
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// `voice:engine` — "groq" (default) or "whisper-local". Env override:
+/// `AGENTMUX_VOICE_ENGINE`.
+fn resolve_engine(settings: &Option<serde_json::Value>) -> String {
+    std::env::var("AGENTMUX_VOICE_ENGINE")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| settings_str(settings, "voice:engine"))
+        .unwrap_or_else(|| "groq".to_string())
+}
+
+/// Groq key: `AGENTMUX_GROQ_API_KEY` env, else settings.json `voice:groqApiKey`.
+fn resolve_groq_key(settings: &Option<serde_json::Value>) -> Option<String> {
     if let Ok(k) = std::env::var("AGENTMUX_GROQ_API_KEY") {
         let k = k.trim().to_string();
         if !k.is_empty() {
             return Some(k);
         }
     }
-    let path = crate::backend::base::get_wave_config_dir().join("settings.json");
-    let content = std::fs::read_to_string(path).ok()?;
-    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
-    v.get("voice:groqApiKey")
-        .and_then(|x| x.as_str())
+    settings_str(settings, "voice:groqApiKey")
+}
+
+/// Env-first, then settings.json, for a path-valued config key.
+fn resolve_path(settings: &Option<serde_json::Value>, env: &str, key: &str) -> Option<String> {
+    std::env::var(env)
+        .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+        .or_else(|| settings_str(settings, key))
 }
+
+// ── Groq backend (hosted) ───────────────────────────────────────────────────
 
 /// File extension matching the posted MIME, so Groq's content sniffing accepts
 /// the multipart `file` part.
@@ -114,18 +164,17 @@ fn mime_ext(mime: &str) -> &'static str {
     }
 }
 
-/// POST the audio to Groq's OpenAI-compatible transcription endpoint and return
-/// the transcript text. ~$0.0007/min, ~216× real-time.
+/// POST the audio to Groq's OpenAI-compatible transcription endpoint.
 async fn transcribe_groq(
     key: &str,
     audio: Bytes,
     mime: &str,
     lang: Option<&str>,
-) -> Result<String, String> {
+) -> Result<String, SttError> {
     let part = reqwest::multipart::Part::bytes(audio.to_vec())
         .file_name(format!("audio.{}", mime_ext(mime)))
         .mime_str(mime)
-        .map_err(|e| format!("invalid mime: {e}"))?;
+        .map_err(|e| Upstream(format!("invalid mime: {e}")))?;
 
     let mut form = reqwest::multipart::Form::new()
         .text("model", GROQ_MODEL)
@@ -141,27 +190,99 @@ async fn transcribe_groq(
         .multipart(form)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| Upstream(format!("request failed: {e}")))?;
 
     let status = resp.status();
     let text_body = resp
         .text()
         .await
-        .map_err(|e| format!("reading response: {e}"))?;
+        .map_err(|e| Upstream(format!("reading response: {e}")))?;
 
     if !status.is_success() {
-        // Don't leak the key; cap the upstream body in the message.
         let snippet: String = text_body.chars().take(300).collect();
-        return Err(format!("groq {}: {}", status.as_u16(), snippet));
+        return Err(Upstream(format!("groq {}: {}", status.as_u16(), snippet)));
     }
 
     let v: serde_json::Value =
-        serde_json::from_str(&text_body).map_err(|e| format!("parsing response: {e}"))?;
+        serde_json::from_str(&text_body).map_err(|e| Upstream(format!("parsing response: {e}")))?;
     Ok(v.get("text")
         .and_then(|t| t.as_str())
         .unwrap_or_default()
         .trim()
         .to_string())
+}
+
+// ── Local whisper.cpp backend (offline, opt-in) ─────────────────────────────
+
+/// Transcribe via a local `whisper-cli` (whisper.cpp) subprocess. The renderer
+/// sends 16 kHz mono WAV for this engine, so we write the body to a temp `.wav`
+/// and run the CLI. Fully offline; nothing leaves the machine.
+///
+/// Config (env-first):
+///   * binary — `AGENTMUX_WHISPER_CLI`  / settings `voice:whisperCliPath`
+///   * model  — `AGENTMUX_WHISPER_MODEL` / settings `voice:whisperModelPath`
+///
+/// On-demand model/binary download is a follow-up (#1591); for now both paths
+/// are user-provided. Missing config → NotConfigured (501).
+async fn transcribe_local_whisper(
+    audio: Bytes,
+    lang: Option<&str>,
+    settings: &Option<serde_json::Value>,
+) -> Result<String, SttError> {
+    let cli = resolve_path(settings, "AGENTMUX_WHISPER_CLI", "voice:whisperCliPath").ok_or_else(
+        || {
+            NotConfigured(
+                "local whisper not configured — set voice:whisperCliPath (path to whisper-cli) \
+                 in settings.json or AGENTMUX_WHISPER_CLI"
+                    .to_string(),
+            )
+        },
+    )?;
+    let model = resolve_path(settings, "AGENTMUX_WHISPER_MODEL", "voice:whisperModelPath")
+        .ok_or_else(|| {
+            NotConfigured(
+                "local whisper not configured — set voice:whisperModelPath (path to a GGML model) \
+                 in settings.json or AGENTMUX_WHISPER_MODEL"
+                    .to_string(),
+            )
+        })?;
+    if !std::path::Path::new(&cli).exists() {
+        return Err(NotConfigured(format!("whisper-cli not found at {cli}")));
+    }
+    if !std::path::Path::new(&model).exists() {
+        return Err(NotConfigured(format!("whisper model not found at {model}")));
+    }
+
+    // Write the WAV body to a unique temp file. Use a monotonic-ish unique name
+    // (nanos + a counter) — the sidecar handles many requests.
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let wav_path = std::env::temp_dir().join(format!("agentmux-voice-{ts}.wav"));
+    std::fs::write(&wav_path, &audio).map_err(|e| Upstream(format!("temp write: {e}")))?;
+
+    // whisper-cli: -nt no timestamps, -np no progress prints → transcript on
+    // stdout; logs go to stderr.
+    let mut cmd = tokio::process::Command::new(&cli);
+    cmd.arg("-m").arg(&model).arg("-f").arg(&wav_path).arg("-nt").arg("-np");
+    if let Some(l) = lang {
+        cmd.arg("-l").arg(l);
+    }
+
+    let output = cmd.output().await;
+    let _ = std::fs::remove_file(&wav_path); // best-effort cleanup
+
+    let output = output.map_err(|e| Upstream(format!("spawn whisper-cli: {e}")))?;
+    if !output.status.success() {
+        let err: String = String::from_utf8_lossy(&output.stderr).chars().take(300).collect();
+        return Err(Upstream(format!(
+            "whisper-cli exited {}: {}",
+            output.status.code().unwrap_or(-1),
+            err
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[cfg(test)]
@@ -176,5 +297,12 @@ mod tests {
         assert_eq!(mime_ext("audio/mp4"), "m4a");
         assert_eq!(mime_ext("audio/mpeg"), "mp3");
         assert_eq!(mime_ext("application/octet-stream"), "webm"); // fallback
+    }
+
+    #[test]
+    fn engine_defaults_to_groq() {
+        assert_eq!(resolve_engine(&None), "groq");
+        let s = serde_json::json!({ "voice:engine": "whisper-local" });
+        assert_eq!(resolve_engine(&Some(s)), "whisper-local");
     }
 }

--- a/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
+++ b/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
@@ -70,8 +70,16 @@ extractor `service.rs` uses), `Json<Value>` response. Auth-gated like the other
   `whisper-large-v3-turbo`. ~$0.0007/min, ~216× real-time. `reqwest` is already
   a dependency.
 - **`OpenAiBackend`** (later) — same OpenAI-compatible shape, `gpt-4o-transcribe`.
-- **`LocalWhisperBackend`** (PR 2) — `whisper-rs` (whisper.cpp) with a model
-  fetched on-demand to the config dir. Default for privacy/offline. ~0 MB ship.
+- **`LocalWhisperBackend`** (PR 2, shipped) — offline whisper.cpp via a local
+  **`whisper-cli` subprocess** (not in-process whisper-rs — avoids a bindgen /
+  libclang / C++ build in the sidecar). The renderer sends **16 kHz mono WAV**
+  for this engine (whisper-cli reads WAV natively, no ffmpeg), captured via
+  Web-Audio PCM (`AudioContext({sampleRate:16000})` + `ScriptProcessor`). Both
+  the CLI binary and GGML model are **user-provided paths** in v1
+  (`voice:whisperCliPath` / `voice:whisperModelPath`, or `AGENTMUX_WHISPER_CLI`
+  / `AGENTMUX_WHISPER_MODEL`); missing config → 501. Bundled binary +
+  on-demand model download is the **PR-3** follow-up. Fully offline — audio
+  never leaves the machine. ~0 MB ship.
 
 ### 3.2 Backend selection + key (server-side)
 Resolved once at request time from, in order:

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -194,7 +194,11 @@ export function createWhisperVoiceSession(): VoiceSession {
             if (silenceStart === 0) silenceStart = now;
             else if (now - silenceStart >= SILENCE_MS) return true;
         }
-        return now - segmentStart >= MAX_SEGMENT_MS && sawSpeech;
+        // Hard cap fires regardless of sawSpeech so the WAV-mode PCM buffer
+        // can't grow unbounded under sustained sub-threshold input — a
+        // speechless cut just discards + resets (postSegment/cut are gated on
+        // sawSpeech). webm mode is bounded by MediaRecorder internally.
+        return now - segmentStart >= MAX_SEGMENT_MS;
     };
 
     const resetSegment = () => {

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -5,14 +5,20 @@
  * Whisper capture-and-send voice engine.
  *
  * The Web Speech API can't transcribe in CEF (closed-source Google service,
- * Chrome-build-bound), so this engine captures mic audio with getUserMedia +
- * MediaRecorder, cuts it into silence-bounded utterances (a small Web-Audio
- * VAD), and POSTs each clip to `agentmux-srv` (`/api/v1/voice/transcribe`),
- * which calls Whisper and returns text. The API key stays server-side.
+ * Chrome-build-bound), so this engine captures mic audio, cuts it into
+ * silence-bounded utterances (a small Web-Audio VAD), and POSTs each clip to
+ * `agentmux-srv` (`/api/v1/voice/transcribe`), which calls Whisper and returns
+ * text. The API key / model path stays server-side.
+ *
+ * Two capture modes, chosen by the `voice:engine` setting so each backend gets
+ * audio it can decode without a server-side decoder:
+ *   - **groq** (default): MediaRecorder → webm/opus (Groq decodes server-side).
+ *   - **whisper-local**: Web-Audio PCM → 16 kHz mono WAV (whisper.cpp's
+ *     `whisper-cli` reads WAV natively; no ffmpeg needed).
  *
  * Implements the same `VoiceSession` shape as the Web Speech engine so
- * `getVoiceSession()` can pick between them with the rest of the per-pane
- * plumbing (MicButton, red indicator, "Speak to <agent>" ghost text) unchanged.
+ * `getVoiceSession()` swaps engines with the rest of the per-pane plumbing
+ * (MicButton, red indicator, "Speak to <agent>" ghost text) unchanged.
  *
  * Spec: docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md · tracking #1591.
  */
@@ -20,17 +26,19 @@
 import { createSignalAtom } from "@/util/util";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { getApi } from "@/app/store/app-api";
+import { getSettingsKeyAtom } from "@/app/store/global";
 import type { PaneVoiceHandle, VoiceSession } from "./useVoiceInput";
 
 // VAD tuning. RMS below SILENCE_RMS for >= SILENCE_MS after speech ends an
 // utterance; a hard cap keeps any single clip small (Whisper isn't streaming,
-// so shorter clips = lower latency). LEVEL_POLL_MS samples the analyser — a
-// periodic read is inherent to Web-Audio level metering, not a workaround.
+// so shorter clips = lower latency). LEVEL_POLL_MS samples the analyser in webm
+// mode — a periodic read is inherent to Web-Audio level metering, not a hack.
 const SILENCE_RMS = 0.012;
 const SILENCE_MS = 800;
 const MAX_SEGMENT_MS = 12_000;
 const MIN_SEGMENT_MS = 350; // drop blips with no real speech
 const LEVEL_POLL_MS = 100;
+const WAV_SAMPLE_RATE = 16_000; // whisper.cpp requires 16 kHz mono
 
 /** Pick the best MediaRecorder mime the runtime supports (opus preferred). */
 function pickMime(): string {
@@ -48,6 +56,35 @@ function pickMime(): string {
     return "audio/webm";
 }
 
+/** Encode mono Float32 PCM as a 16-bit WAV blob at the given sample rate. */
+function encodeWav(samples: Float32Array, sampleRate: number): Blob {
+    const buffer = new ArrayBuffer(44 + samples.length * 2);
+    const view = new DataView(buffer);
+    const writeStr = (off: number, s: string) => {
+        for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
+    };
+    writeStr(0, "RIFF");
+    view.setUint32(4, 36 + samples.length * 2, true);
+    writeStr(8, "WAVE");
+    writeStr(12, "fmt ");
+    view.setUint32(16, 16, true); // PCM fmt chunk size
+    view.setUint16(20, 1, true); // PCM
+    view.setUint16(22, 1, true); // mono
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true); // byte rate (mono, 16-bit)
+    view.setUint16(32, 2, true); // block align
+    view.setUint16(34, 16, true); // bits per sample
+    writeStr(36, "data");
+    view.setUint32(40, samples.length * 2, true);
+    let off = 44;
+    for (let i = 0; i < samples.length; i++) {
+        const s = Math.max(-1, Math.min(1, samples[i]));
+        view.setInt16(off, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+        off += 2;
+    }
+    return new Blob([view], { type: "audio/wav" });
+}
+
 export function createWhisperVoiceSession(): VoiceSession {
     const isListening = createSignalAtom(false);
     const currentTargetId = createSignalAtom<string | null>(null);
@@ -56,7 +93,7 @@ export function createWhisperVoiceSession(): VoiceSession {
     const available =
         typeof navigator !== "undefined" &&
         !!navigator.mediaDevices?.getUserMedia &&
-        typeof MediaRecorder !== "undefined";
+        typeof AudioContext !== "undefined";
 
     if (!available) {
         return {
@@ -69,31 +106,37 @@ export function createWhisperVoiceSession(): VoiceSession {
         };
     }
 
+    // Capture mode is fixed for the session: whisper-local → WAV, else webm.
+    const isLocal = getSettingsKeyAtom("voice:engine")() === "whisper-local";
+
     let activeHandle: PaneVoiceHandle | null = null;
     let stream: MediaStream | null = null;
-    let recorder: MediaRecorder | null = null;
     let audioCtx: AudioContext | null = null;
-    let analyser: AnalyserNode | null = null;
-    let levelTimer: number | null = null;
-    let chunks: BlobChunk[] = [];
     let mime = "audio/webm";
 
-    // VAD state
+    // webm mode
+    let recorder: MediaRecorder | null = null;
+    let analyser: AnalyserNode | null = null;
+    let levelTimer: number | null = null;
+    let chunks: Blob[] = [];
+
+    // wav mode
+    let processor: ScriptProcessorNode | null = null;
+    let pcm: Float32Array[] = [];
+
+    // shared VAD state
     let sawSpeech = false;
     let silenceStart = 0;
     let segmentStart = 0;
 
     // Serialize transcription so utterances are applied in spoken order.
-    // Capture keeps running concurrently (recorder restarts immediately); only
-    // the network call + appendFinal are chained — Groq latency varies, so
-    // POSTing concurrently could resolve out of order and scramble the composer
-    // text during continuous speech (reagent P1 #1623).
+    // Capture keeps running concurrently; only the network call + appendFinal
+    // are chained — Groq/whisper latency varies, so POSTing concurrently could
+    // resolve out of order and scramble the composer text (reagent P1 #1623).
     let postChain: Promise<void> = Promise.resolve();
     const enqueuePost = (blob: Blob) => {
         postChain = postChain.then(() => postSegment(blob)).catch(() => {});
     };
-
-    type BlobChunk = Blob;
 
     const fail = (code: string) => {
         lastError._set(code);
@@ -122,7 +165,6 @@ export function createWhisperVoiceSession(): VoiceSession {
                 return;
             }
             if (!resp.ok) {
-                // Transient upstream error — surface once, keep the session alive.
                 lastError._set("service-not-allowed");
                 window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
                 return;
@@ -132,25 +174,37 @@ export function createWhisperVoiceSession(): VoiceSession {
             if (text) handle.appendFinal(text);
         } catch {
             handle.setInterim("");
-            // Network/host error — surface as service-unavailable.
             lastError._set("service-not-allowed");
             window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
         }
     };
 
-    /** Stop the current recorder; its onstop posts the accumulated clip. */
-    const cutSegment = () => {
-        if (recorder && recorder.state !== "inactive") {
-            recorder.stop(); // → onstop builds blob + posts + restarts (if listening)
+    // VAD applied to a fresh RMS reading; returns true when the utterance should
+    // be cut. Shared by both modes.
+    const vadShouldCut = (rms: number): boolean => {
+        const now = Date.now();
+        if (rms >= SILENCE_RMS) {
+            sawSpeech = true;
+            silenceStart = 0;
+        } else if (sawSpeech) {
+            if (silenceStart === 0) silenceStart = now;
+            else if (now - silenceStart >= SILENCE_MS) return true;
         }
+        return now - segmentStart >= MAX_SEGMENT_MS && sawSpeech;
     };
+
+    const resetSegment = () => {
+        sawSpeech = false;
+        silenceStart = 0;
+        segmentStart = Date.now();
+    };
+
+    // ── webm mode (MediaRecorder + AnalyserNode VAD) ─────────────────────────
 
     const startRecorder = () => {
         if (!stream) return;
         chunks = [];
-        sawSpeech = false;
-        silenceStart = 0;
-        segmentStart = Date.now();
+        resetSegment();
         recorder = new MediaRecorder(stream, { mimeType: mime });
         recorder.ondataavailable = (e) => {
             if (e.data && e.data.size > 0) chunks.push(e.data);
@@ -159,13 +213,7 @@ export function createWhisperVoiceSession(): VoiceSession {
             const dur = Date.now() - segmentStart;
             const blob = new Blob(chunks, { type: mime });
             chunks = [];
-            // Only transcribe clips that contained speech and weren't blips.
-            // Enqueued (not awaited) so the next recorder starts immediately,
-            // but applied strictly in order — see enqueuePost above.
-            if (sawSpeech && dur >= MIN_SEGMENT_MS) {
-                enqueuePost(blob);
-            }
-            // Restart for the next utterance while still listening.
+            if (sawSpeech && dur >= MIN_SEGMENT_MS) enqueuePost(blob);
             if (isListening()) startRecorder();
         };
         recorder.start();
@@ -180,24 +228,40 @@ export function createWhisperVoiceSession(): VoiceSession {
             const v = (buf[i] - 128) / 128;
             sum += v * v;
         }
-        const rms = Math.sqrt(sum / buf.length);
-
-        const now = Date.now();
-        if (rms >= SILENCE_RMS) {
-            sawSpeech = true;
-            silenceStart = 0;
-        } else if (sawSpeech) {
-            if (silenceStart === 0) silenceStart = now;
-            else if (now - silenceStart >= SILENCE_MS) {
-                cutSegment(); // utterance boundary
-                return;
-            }
-        }
-        // Hard cap so a long monologue still gets transcribed in chunks.
-        if (now - segmentStart >= MAX_SEGMENT_MS && sawSpeech) {
-            cutSegment();
+        if (vadShouldCut(Math.sqrt(sum / buf.length))) {
+            if (recorder && recorder.state !== "inactive") recorder.stop();
         }
     };
+
+    // ── wav mode (ScriptProcessor PCM @ 16 kHz) ──────────────────────────────
+
+    const cutWavSegment = () => {
+        const dur = Date.now() - segmentStart;
+        const total = pcm.reduce((n, c) => n + c.length, 0);
+        const merged = new Float32Array(total);
+        let off = 0;
+        for (const c of pcm) {
+            merged.set(c, off);
+            off += c.length;
+        }
+        pcm = [];
+        if (sawSpeech && dur >= MIN_SEGMENT_MS && merged.length > 0) {
+            enqueuePost(encodeWav(merged, WAV_SAMPLE_RATE));
+        }
+        resetSegment();
+    };
+
+    const onAudioProcess = (e: AudioProcessingEvent) => {
+        const input = e.inputBuffer.getChannelData(0);
+        // Copy (the buffer is reused by the engine).
+        pcm.push(new Float32Array(input));
+        let sum = 0;
+        for (let i = 0; i < input.length; i++) sum += input[i] * input[i];
+        if (vadShouldCut(Math.sqrt(sum / input.length))) cutWavSegment();
+        // Leave outputBuffer silent (don't write it) → no mic echo to speakers.
+    };
+
+    // ── lifecycle ────────────────────────────────────────────────────────────
 
     const stopCapture = async () => {
         isListening._set(false);
@@ -208,18 +272,27 @@ export function createWhisperVoiceSession(): VoiceSession {
         }
         if (recorder && recorder.state !== "inactive") {
             try {
-                recorder.onstop = null as any; // don't restart on a deliberate stop
+                recorder.onstop = null as any; // don't restart on deliberate stop
                 recorder.stop();
             } catch {
                 /* ignore */
             }
         }
         recorder = null;
+        if (processor) {
+            try {
+                processor.onaudioprocess = null as any;
+                processor.disconnect();
+            } catch {
+                /* ignore */
+            }
+            processor = null;
+        }
+        analyser = null;
         if (audioCtx) {
             try { await audioCtx.close(); } catch { /* ignore */ }
             audioCtx = null;
         }
-        analyser = null;
         if (stream) {
             stream.getTracks().forEach((t) => t.stop());
             stream = null;
@@ -232,35 +305,40 @@ export function createWhisperVoiceSession(): VoiceSession {
             stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         } catch (e: any) {
             const name = e?.name || "";
-            if (name === "NotAllowedError" || name === "SecurityError") {
-                fail("not-allowed");
-            } else if (name === "NotFoundError" || name === "OverconstrainedError") {
-                fail("audio-capture");
-            } else {
-                fail("service-not-allowed");
-            }
+            if (name === "NotAllowedError" || name === "SecurityError") fail("not-allowed");
+            else if (name === "NotFoundError" || name === "OverconstrainedError") fail("audio-capture");
+            else fail("service-not-allowed");
             return;
         }
-        mime = pickMime();
         lastError._set(null);
         isListening._set(true);
 
-        audioCtx = new AudioContext();
-        const src = audioCtx.createMediaStreamSource(stream);
-        analyser = audioCtx.createAnalyser();
-        analyser.fftSize = 2048;
-        src.connect(analyser);
-
-        startRecorder();
-        levelTimer = window.setInterval(pollLevel, LEVEL_POLL_MS);
+        if (isLocal) {
+            mime = "audio/wav";
+            // Force 16 kHz so captured PCM is whisper-ready (no resampling).
+            audioCtx = new AudioContext({ sampleRate: WAV_SAMPLE_RATE });
+            const src = audioCtx.createMediaStreamSource(stream);
+            processor = audioCtx.createScriptProcessor(4096, 1, 1);
+            processor.onaudioprocess = onAudioProcess;
+            src.connect(processor);
+            processor.connect(audioCtx.destination); // required for onaudioprocess to fire
+            pcm = [];
+            resetSegment();
+        } else {
+            mime = pickMime();
+            audioCtx = new AudioContext();
+            const src = audioCtx.createMediaStreamSource(stream);
+            analyser = audioCtx.createAnalyser();
+            analyser.fftSize = 2048;
+            src.connect(analyser);
+            startRecorder();
+            levelTimer = window.setInterval(pollLevel, LEVEL_POLL_MS);
+        }
     };
 
     const toggleListening = () => {
-        if (isListening()) {
-            void stopCapture();
-        } else {
-            void startCapture();
-        }
+        if (isListening()) void stopCapture();
+        else void startCapture();
     };
 
     return {

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -90,10 +90,17 @@ export function createWhisperVoiceSession(): VoiceSession {
     const currentTargetId = createSignalAtom<string | null>(null);
     const lastError = createSignalAtom<string | null>(null);
 
+    // Capture mode is fixed for the session: whisper-local → WAV, else webm.
+    const isLocal = getSettingsKeyAtom("voice:engine")() === "whisper-local";
+
+    // Both modes need getUserMedia + AudioContext; the webm (groq) path also
+    // needs MediaRecorder. Gate on exactly what the chosen mode uses so a
+    // runtime missing a primitive degrades gracefully instead of throwing.
     const available =
         typeof navigator !== "undefined" &&
         !!navigator.mediaDevices?.getUserMedia &&
-        typeof AudioContext !== "undefined";
+        typeof AudioContext !== "undefined" &&
+        (isLocal || typeof MediaRecorder !== "undefined");
 
     if (!available) {
         return {
@@ -105,9 +112,6 @@ export function createWhisperVoiceSession(): VoiceSession {
             registerPane: () => {},
         };
     }
-
-    // Capture mode is fixed for the session: whisper-local → WAV, else webm.
-    const isLocal = getSettingsKeyAtom("voice:engine")() === "whisper-local";
 
     let activeHandle: PaneVoiceHandle | null = null;
     let stream: MediaStream | null = null;
@@ -313,26 +317,33 @@ export function createWhisperVoiceSession(): VoiceSession {
         lastError._set(null);
         isListening._set(true);
 
-        if (isLocal) {
-            mime = "audio/wav";
-            // Force 16 kHz so captured PCM is whisper-ready (no resampling).
-            audioCtx = new AudioContext({ sampleRate: WAV_SAMPLE_RATE });
-            const src = audioCtx.createMediaStreamSource(stream);
-            processor = audioCtx.createScriptProcessor(4096, 1, 1);
-            processor.onaudioprocess = onAudioProcess;
-            src.connect(processor);
-            processor.connect(audioCtx.destination); // required for onaudioprocess to fire
-            pcm = [];
-            resetSegment();
-        } else {
-            mime = pickMime();
-            audioCtx = new AudioContext();
-            const src = audioCtx.createMediaStreamSource(stream);
-            analyser = audioCtx.createAnalyser();
-            analyser.fftSize = 2048;
-            src.connect(analyser);
-            startRecorder();
-            levelTimer = window.setInterval(pollLevel, LEVEL_POLL_MS);
+        // Building the audio graph can throw — e.g. a runtime that rejects the
+        // forced 16 kHz AudioContext rate. Catch it so the mic stream is closed
+        // and isListening doesn't get stuck true (fail → stopCapture).
+        try {
+            if (isLocal) {
+                mime = "audio/wav";
+                // Force 16 kHz so captured PCM is whisper-ready (no resampling).
+                audioCtx = new AudioContext({ sampleRate: WAV_SAMPLE_RATE });
+                const src = audioCtx.createMediaStreamSource(stream);
+                processor = audioCtx.createScriptProcessor(4096, 1, 1);
+                processor.onaudioprocess = onAudioProcess;
+                src.connect(processor);
+                processor.connect(audioCtx.destination); // required for onaudioprocess to fire
+                pcm = [];
+                resetSegment();
+            } else {
+                mime = pickMime();
+                audioCtx = new AudioContext();
+                const src = audioCtx.createMediaStreamSource(stream);
+                analyser = audioCtx.createAnalyser();
+                analyser.fftSize = 2048;
+                src.connect(analyser);
+                startRecorder();
+                levelTimer = window.setInterval(pollLevel, LEVEL_POLL_MS);
+            }
+        } catch {
+            fail("service-not-allowed");
         }
     };
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1403,6 +1403,8 @@ declare global {
         "voice:enabled"?: boolean;
         "voice:engine"?: string;
         "voice:groqApiKey"?: string;
+        "voice:whisperCliPath"?: string;
+        "voice:whisperModelPath"?: string;
         "notify:*"?: boolean;
         "notify:sounds:enabled"?: boolean;
         "notify:sounds:volume"?: number;

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -77,13 +77,18 @@
     // "notify:tooltones:scope":                 "all",  // "all" or "focused"
 
     // -- Voice input (speech-to-text) --
-    // "voice:enabled":     true,        // show the per-pane mic button (default true)
-    // "voice:engine":      "whisper",   // "whisper" (capture→server STT, default) or
-    //                                   // "webspeech" (browser API — does NOT work in
-    //                                   // packaged CEF builds; dev/Chromium only)
-    // "voice:groqApiKey":  "gsk_...",   // Groq key for the hosted Whisper backend.
-    //                                   // Read server-side only (never sent to the UI).
-    //                                   // Or set the AGENTMUX_GROQ_API_KEY env var.
+    // "voice:enabled":          true,       // show the per-pane mic button (default true)
+    // "voice:engine":           "groq",     // "groq" (hosted Whisper, default),
+    //                                       // "whisper-local" (offline whisper.cpp), or
+    //                                       // "webspeech" (browser API — does NOT work in
+    //                                       // packaged CEF builds; dev/Chromium only)
+    // -- groq engine: hosted, sends webm. Key read server-side only (never sent to UI).
+    // "voice:groqApiKey":       "gsk_...",  // or set AGENTMUX_GROQ_API_KEY
+    // -- whisper-local engine: offline, sends 16kHz WAV to a local whisper.cpp CLI.
+    //    Both paths user-provided (auto-download is a follow-up). Env overrides:
+    //    AGENTMUX_WHISPER_CLI / AGENTMUX_WHISPER_MODEL.
+    // "voice:whisperCliPath":   "C:/tools/whisper-cli.exe",
+    // "voice:whisperModelPath": "C:/models/ggml-base.en.bin",
 
     // -- Other --
     // "widget:icononly":           false,


### PR DESCRIPTION
## Summary

Adds an **offline** STT engine alongside the hosted Groq backend (#1623). **Purely additive and opt-in** — the default `groq`/webm path is untouched, so existing users have zero blast radius. Completes #1591 §4c.

## Server (`server/voice.rs`)
- `POST /api/v1/voice/transcribe` now **dispatches on the `voice:engine` setting** (`groq` default | `whisper-local`).
- **whisper-local**: writes the posted WAV to a temp file and runs a local **`whisper-cli` (whisper.cpp) subprocess** — deliberately *not* in-process `whisper-rs`, to avoid a bindgen/libclang/C++ build in the sidecar. CLI + model are user-provided (`voice:whisperCliPath` / `voice:whisperModelPath`, or `AGENTMUX_WHISPER_CLI` / `AGENTMUX_WHISPER_MODEL`); missing → 501. **Fully offline** — audio never leaves the machine.

## Frontend (`whisperVoiceEngine.ts`)
- For `whisper-local`, captures **16 kHz mono PCM** via Web Audio (`AudioContext({sampleRate:16000})` + `ScriptProcessor`) and POSTs **WAV** — whisper.cpp reads WAV natively, no ffmpeg, no server-side decoder. The webm/`MediaRecorder` path (Groq) is **unchanged**. Both modes share the same VAD + the ordered-POST chain.

## Settings
`voice:engine` / `voice:whisperCliPath` / `voice:whisperModelPath` added to `wconfig/types.rs` + `gotypes.d.ts` + the template.

## Cost / footprint
~0 MB to the build (subprocess; no new build deps). Users supply a `whisper-cli` binary + GGML model. **Bundled binary + on-demand model download is the PR-3 follow-up.**

## Test plan
- [x] `cargo check -p agentmux-srv` — clean.
- [x] `task build:frontend` — clean.
- [ ] Set `voice:engine: "whisper-local"` + `voice:whisperCliPath` + `voice:whisperModelPath`; click mic → speak → offline transcript appears.
- [ ] Confirm default (`groq`) behavior unchanged when `voice:engine` is unset.
- [ ] Missing CLI/model → 501 → "unavailable" toast.

⚠️ **Runtime-untested**: the local audio pipeline (WAV capture + whisper-cli) can't be exercised in CI — needs a live mic + a `whisper-cli`/model. It's opt-in and off by default, so the merged default path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)