### PR TITLE
fix(auth): provider environment isolation — agents never touch the user's ~/.claude

### DIFF
--- a/.changesets/1781984071-fix-auth-provider-env-isolation-no-claude-pollution.md
+++ b/.changesets/1781984071-fix-auth-provider-env-isolation-no-claude-pollution.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): provider environment isolation — agents read/refresh credentials in the AgentMux dir, never the user's ~/.claude (provider-isolation auth half: migration reversal of #983 pointer-to-ambient + sweep + hardened seed target)

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -452,16 +452,34 @@ pub fn seed_provider_auth_from_global(
         }
     }
 
-    // ISOLATED destination — the same path `ensure_auth_dir` builds.
+    // ISOLATED destination (SPEC_PROVIDER_ISOLATION §4.5). Prefer the agent's
+    // RESOLVED config dir (passed as `config_dir` from its `cmd:env`), so a
+    // per-identity/bundle agent is seeded into the dir it actually reads — but
+    // ONLY when that dir is under the AgentMux home (`~/.agentmux`). A stale
+    // frozen dir pointing at the user's own `~/.claude` is REJECTED → fall back
+    // to the shared default, so the seed can NEVER write into the user's
+    // personal env (INV-R). Default agents resolve to the shared dir, which
+    // matches their post-migration binding.
     let home = state
         .user_home_dir
         .lock()
         .clone()
         .ok_or_else(|| "User home dir not initialized yet".to_string())?;
-    let dest_dir = std::path::PathBuf::from(home)
-        .join("shared")
-        .join("providers")
-        .join(provider);
+    let home_path = std::path::PathBuf::from(&home);
+    let shared_default = home_path.join("shared").join("providers").join(provider);
+    let requested = args
+        .get("config_dir")
+        .or_else(|| args.get("configDir"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(std::path::PathBuf::from);
+    let dest_dir = match requested {
+        // Accept the agent's resolved dir only if it's inside `~/.agentmux`
+        // (covers `shared/providers/*` and `shared/identities/*` bundle dirs).
+        Some(d) if d.starts_with(&home_path) => d,
+        // Anything else (incl. the user's `~/.claude`) → shared default.
+        _ => shared_default,
+    };
     std::fs::create_dir_all(&dest_dir)
         .map_err(|e| format!("Failed to create isolated auth dir: {e}"))?;
     let dest_cred = dest_dir.join(".credentials.json");

--- a/agentmux-srv/src/identity/migration.rs
+++ b/agentmux-srv/src/identity/migration.rs
@@ -37,7 +37,7 @@
 //! account upsert / bind / publish errors are logged and skipped, the
 //! srv keeps coming up.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -74,6 +74,9 @@ pub struct MigrationStats {
     pub providers_skipped_no_ambient: usize,
     /// Number of providers we successfully bound into the Default bundle.
     pub providers_seeded: usize,
+    /// Number of existing Default accounts repointed off the user's ambient
+    /// `~/.<provider>` dir to the AgentMux-owned dir (isolation sweep, §4.2).
+    pub providers_repointed: usize,
     /// Whether the Default bundle was created (vs. reused) this run.
     pub default_bundle_created: bool,
     /// Count of `db_agent_instances` rows whose `identity_id` was
@@ -215,23 +218,32 @@ pub fn run_default_bundle_migration(
             }
         }
 
-        // Probe the ambient creds so the seeded binding lands with an
-        // accurate status (valid / expired / needs_reauth) rather than
-        // the resolver having to discover it on the next spawn.
-        // `probe_oauth_status` reads `<dir>/.credentials.json` itself,
-        // so we pass the ambient_dir, not the creds_file.
-        let ambient_dir_str = ambient_dir.to_string_lossy().to_string();
-        let probed_status = probe_oauth_status(provider_id, &ambient_dir_str, now_ms)
+        // SPEC_PROVIDER_ISOLATION (INV-A/INV-R): the live auth dir must be
+        // AgentMux-owned, never the user's ambient `~/.<provider>`. Import the
+        // ambient credential into the AgentMux dir ONCE (read-only copy,
+        // sentinel-gated), then point the account at the AgentMux dir so the
+        // CLI reads + refreshes THERE — `~/.<provider>` is never written and
+        // never the live target. (Reverses the #983 pointer-to-ambient.)
+        let dest_dir = provider_auth_dir(&home, &provider_cfg.auth_dir_name);
+        let dest_str = dest_dir.to_string_lossy().to_string();
+        if let Err(e) = import_ambient_once(&creds_file, &dest_dir) {
+            tracing::warn!(
+                target: "identity",
+                provider_id,
+                error = %e,
+                "oauth-bundles migration: failed to import ambient creds into the AgentMux dir — skipping provider"
+            );
+            continue;
+        }
+
+        // Probe the AgentMux dir (the dir the agent will actually run in), so
+        // the seeded binding lands with an accurate status.
+        let probed_status = probe_oauth_status(provider_id, &dest_str, now_ms)
             .map(|s| s.as_str())
             .unwrap_or(oauth_status::UNKNOWN);
 
-        // Mirror `persist_oauth_binding_or_synthetic` (PR C):
-        // reuse the account_id if a binding already exists, mint a
-        // fresh uuid otherwise. (In practice we already filtered out
-        // covered providers above, so this is always the mint path —
-        // but the lookup costs nothing and keeps the shape identical
-        // to PR C, which makes the two paths interchangeable for any
-        // future refactor.)
+        // Mirror `persist_oauth_binding_or_synthetic` (PR C): reuse the
+        // account_id if a binding already exists, mint a fresh uuid otherwise.
         let account_id = wstore
             .bundle_identity_bindings(DEFAULT_BUNDLE_ID)
             .ok()
@@ -247,15 +259,8 @@ pub fn run_default_bundle_migration(
             provider: provider_id.to_string(),
             kind: "oauth".to_string(),
             display_name: String::new(),
-            secret_ref: SecretRef::OAuthConfigDir {
-                // Point at the ambient dir (`~/.claude/`, `~/.codex/`,
-                // `~/.openclaw/`) — NOT a per-bundle copy. Per spec §5
-                // the SecretRef is a pointer; we don't move tokens.
-                // The CLI keeps reading + refreshing in place, the
-                // resolver injects the dir at spawn time, end-to-end
-                // identical to a manually-configured bundle.
-                dir: ambient_dir_str.clone(),
-            },
+            // INV-A: AgentMux-owned dir, NOT the user's `~/.<provider>`.
+            secret_ref: SecretRef::OAuthConfigDir { dir: dest_str.clone() },
             context: serde_json::json!({}),
             status: probed_status.to_string(),
             created_at: now_ms,
@@ -287,9 +292,9 @@ pub fn run_default_bundle_migration(
             target: "identity",
             provider_id,
             account_id,
-            dir = %ambient_dir.display(),
+            dir = %dest_str,
             status = probed_status,
-            "oauth-bundles migration: bound ambient credentials into Default bundle"
+            "oauth-bundles migration: imported ambient credentials into the AgentMux dir + bound into Default bundle"
         );
 
         // Best-effort broker publish so any open UI refreshes. None in
@@ -318,6 +323,13 @@ pub fn run_default_bundle_migration(
             );
         }
     }
+
+    // Isolation sweep (SPEC_PROVIDER_ISOLATION §4.2): repoint any pre-existing
+    // Default account still pointing at the user's ambient `~/.<provider>`
+    // (seeded by the old #983 pointer-to-ambient behaviour) to the
+    // AgentMux-owned dir, so existing agents stop reading/refreshing in the
+    // user's personal login. Idempotent + sentinel-gated.
+    sweep_default_accounts_off_ambient(wstore, broker, &home, now_ms, &mut stats);
 
     // Back-fill the empty / "blank" identity_id rows on
     // db_agent_instances → Default bundle id. Per spec §5 step 4.
@@ -365,6 +377,125 @@ pub fn run_default_bundle_migration(
         "oauth-bundles migration: complete"
     );
     stats
+}
+
+/// `<home>/.agentmux/shared/providers/<auth_dir_name>` — the AgentMux-owned
+/// live auth dir (SPEC_PROVIDER_ISOLATION INV-A). Rooted on the migration's
+/// resolved `home` (not a globally-resolved `DataPaths`) so tests using
+/// `home_dir_override` stay hermetic. Mirrors `DataPaths::provider_auth_dir`.
+fn provider_auth_dir(home: &Path, auth_dir_name: &str) -> PathBuf {
+    home.join(".agentmux")
+        .join("shared")
+        .join("providers")
+        .join(auth_dir_name)
+}
+
+/// Import the user's ambient credential into the AgentMux dir ONCE — a
+/// read-only **copy** of `~/.<provider>/.credentials.json` (never a move,
+/// never a write-back to the user's dir). Sentinel-gated
+/// (`<dest>/.agentmux-cred-seeded`) so a later logout in the AgentMux dir
+/// sticks and we never silently re-import. Returns `Ok(true)` when a copy
+/// happened this call. (SPEC_PROVIDER_ISOLATION INV-R.)
+fn import_ambient_once(ambient_creds: &Path, dest_dir: &Path) -> std::io::Result<bool> {
+    let sentinel = dest_dir.join(".agentmux-cred-seeded");
+    if sentinel.exists() {
+        return Ok(false);
+    }
+    std::fs::create_dir_all(dest_dir)?;
+    let mut copied = false;
+    if ambient_creds.exists() {
+        std::fs::copy(ambient_creds, dest_dir.join(".credentials.json"))?;
+        copied = true;
+    }
+    // Mark the AgentMux dir as "taken over" even if there was nothing to copy,
+    // so a later fresh login here isn't clobbered by a future ambient import.
+    std::fs::write(&sentinel, b"")?;
+    Ok(copied)
+}
+
+/// Repoint any Default-bundle account still pointing at the user's ambient
+/// `~/.<provider>` dir to the AgentMux-owned dir (SPEC_PROVIDER_ISOLATION
+/// INV-A / §4.2). Fixes installs seeded by the old #983 pointer-to-ambient
+/// behaviour so existing agents stop reading/refreshing in the user's personal
+/// login. Idempotent: accounts already pointing at the AgentMux dir (or a
+/// custom dir) are untouched; the credential is imported once (sentinel-gated).
+fn sweep_default_accounts_off_ambient(
+    wstore: &Arc<Store>,
+    broker: Option<&Arc<Broker>>,
+    home: &Path,
+    now_ms: i64,
+    stats: &mut MigrationStats,
+) {
+    let bindings = match wstore.bundle_identity_bindings(DEFAULT_BUNDLE_ID) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    for b in bindings {
+        let provider_cfg = match get_provider(&b.provider) {
+            Some(p) => p,
+            None => continue,
+        };
+        let ambient_dir = home.join(format!(".{}", provider_cfg.auth_dir_name));
+        let ambient_str = ambient_dir.to_string_lossy().to_string();
+        let dest_dir = provider_auth_dir(home, &provider_cfg.auth_dir_name);
+        let dest_str = dest_dir.to_string_lossy().to_string();
+
+        let mut acct = match wstore.identity_get(&b.account_id) {
+            Ok(Some(a)) => a,
+            _ => continue,
+        };
+        let points_at_ambient = matches!(
+            &acct.secret_ref,
+            SecretRef::OAuthConfigDir { dir } if *dir == ambient_str
+        );
+        if !points_at_ambient {
+            continue; // already AgentMux-owned (or a custom dir) — leave it
+        }
+
+        if let Err(e) = import_ambient_once(&ambient_dir.join(".credentials.json"), &dest_dir) {
+            tracing::warn!(
+                target: "identity",
+                provider = %b.provider,
+                error = %e,
+                "isolation sweep: import failed — leaving account pointed at ambient"
+            );
+            continue;
+        }
+        acct.secret_ref = SecretRef::OAuthConfigDir {
+            dir: dest_str.clone(),
+        };
+        acct.status = probe_oauth_status(&b.provider, &dest_str, now_ms)
+            .map(|s| s.as_str())
+            .unwrap_or(oauth_status::UNKNOWN)
+            .to_string();
+        acct.updated_at = now_ms;
+        if let Err(e) = wstore.identity_upsert(&acct) {
+            tracing::warn!(
+                target: "identity",
+                provider = %b.provider,
+                error = %e,
+                "isolation sweep: identity_upsert failed"
+            );
+            continue;
+        }
+        stats.providers_repointed += 1;
+        tracing::info!(
+            target: "identity",
+            provider = %b.provider,
+            from = %ambient_str,
+            to = %dest_str,
+            "isolation sweep: repointed Default account off the user's ambient dir to the AgentMux dir"
+        );
+        if let Some(br) = broker {
+            br.publish(WaveEvent {
+                event: format!("identitybundlebindings:changed:{DEFAULT_BUNDLE_ID}"),
+                scopes: vec![],
+                sender: String::new(),
+                persist: 0,
+                data: None,
+            });
+        }
+    }
 }
 
 /// Collect the set of providers that are bound in ANY identity bundle
@@ -520,19 +651,100 @@ mod tests {
         let claude_binding = &bindings[0];
         assert_eq!(claude_binding.provider, "claude");
 
-        // Account row exists with OAuthConfigDir pointing at the
-        // ambient dir.
+        // SPEC_PROVIDER_ISOLATION INV-A: the account points at the AgentMux
+        // dir, NOT the user's ambient `~/.claude` (T-A1).
         let account = store.identity_get(&claude_binding.account_id).unwrap().unwrap();
         assert_eq!(account.provider, "claude");
         assert_eq!(account.kind, "oauth");
         assert_eq!(account.status, oauth_status::VALID);
+        let agentmux_dir = tmp
+            .path()
+            .join(".agentmux")
+            .join("shared")
+            .join("providers")
+            .join("claude");
         match account.secret_ref {
             SecretRef::OAuthConfigDir { dir } => {
-                let expected = tmp.path().join(".claude").to_string_lossy().to_string();
-                assert_eq!(dir, expected);
+                assert_eq!(dir, agentmux_dir.to_string_lossy());
             }
             other => panic!("expected OAuthConfigDir, got {:?}", other),
         }
+
+        // INV-R: the credential was COPIED into the AgentMux dir (with the
+        // import sentinel), and the user's ambient `~/.claude` is untouched.
+        let dest_creds = agentmux_dir.join(".credentials.json");
+        assert!(dest_creds.exists(), "credential should be copied into the AgentMux dir");
+        assert!(
+            agentmux_dir.join(".agentmux-cred-seeded").exists(),
+            "import sentinel should be written"
+        );
+        let ambient_creds = tmp.path().join(".claude").join(".credentials.json");
+        assert!(ambient_creds.exists(), "ambient ~/.claude creds must remain (read-only import)");
+        assert_eq!(
+            std::fs::read(&ambient_creds).unwrap(),
+            std::fs::read(&dest_creds).unwrap(),
+            "copy must be byte-identical to the ambient source"
+        );
+    }
+
+    #[test]
+    fn sweep_repoints_existing_ambient_account_to_agentmux_dir() {
+        // Simulate the old #983 state: a Default 'claude' account pointing AT
+        // the user's ambient `~/.claude`. The migration's isolation sweep
+        // (§4.2) must repoint it to the AgentMux dir (copy once) without a
+        // manual re-login — the fix for already-bound agents (Nark/Poal).
+        let store = make_store();
+        let tmp = tempfile::tempdir().unwrap();
+        plant_ambient_claude_creds(tmp.path());
+        let ambient_dir = tmp.path().join(".claude");
+
+        // Pre-seed an old-style account + binding pointing AT the ambient dir.
+        let legacy = IdentityAccount {
+            id: "acct-legacy".to_string(),
+            name: "claude-oauth".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir {
+                dir: ambient_dir.to_string_lossy().to_string(),
+            },
+            context: serde_json::json!({}),
+            status: oauth_status::VALID.to_string(),
+            created_at: 1,
+            updated_at: 1,
+        };
+        store.identity_upsert(&legacy).unwrap();
+        ensure_default_bundle(&store, 1).unwrap();
+        store
+            .bundle_identity_bind(DEFAULT_BUNDLE_ID, "claude", "acct-legacy")
+            .unwrap();
+
+        let stats = run_default_bundle_migration(&store, None, Some(tmp.path().to_path_buf()));
+        // claude is already bound → the loop skips it; the sweep repoints it.
+        assert_eq!(stats.providers_seeded, 0);
+        assert_eq!(stats.providers_repointed, 1);
+
+        let updated = store.identity_get("acct-legacy").unwrap().unwrap();
+        let agentmux_dir = tmp
+            .path()
+            .join(".agentmux")
+            .join("shared")
+            .join("providers")
+            .join("claude");
+        match updated.secret_ref {
+            SecretRef::OAuthConfigDir { dir } => {
+                assert_eq!(dir, agentmux_dir.to_string_lossy());
+            }
+            other => panic!("expected OAuthConfigDir, got {:?}", other),
+        }
+        assert!(
+            agentmux_dir.join(".credentials.json").exists(),
+            "creds copied into the AgentMux dir on sweep"
+        );
+
+        // Idempotent: a second run finds it already AgentMux-owned → no repoint.
+        let s2 = run_default_bundle_migration(&store, None, Some(tmp.path().to_path_buf()));
+        assert_eq!(s2.providers_repointed, 0);
     }
 
     #[test]

--- a/docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md
+++ b/docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md
@@ -1,0 +1,219 @@
+# REPORT: Why one agent authenticates and another doesn't — and why "Login Again" is a no-op
+
+**Date:** 2026-06-20
+**Author:** AgentA
+**Status:** Diagnosis complete; fix proposed (not yet implemented)
+**Related:** `SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md` (failure-mode A), `SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20` (#1604), cross-channel persistence work (#1383–#1393)
+
+---
+
+## 0. TL;DR
+
+Two Claude agents — **Nark** (just created, works) and **Poal** (created ~Jun 18, 401s) — are bound to the **same** "Default" identity, which in both their instance DBs resolves to a **valid** credential (`dir: C:\Users\area54\.claude`, `status: valid`). They diverge only because **an agent's `CLAUDE_CONFIG_DIR` is frozen into its launch env at first launch and never re-resolved**:
+
+- **Nark** froze pointing at the live global login (`~/.claude`).
+- **Poal** froze pointing at the isolated `~/.agentmux/shared/providers/claude/` dir — which is **expired/dead**.
+
+"Login Again" does nothing because it (a) scrapes Claude v2.1.x's self-driving login TUI for an OAuth URL it never prints, and (b) even on success would write to Poal's stale frozen dir, not the valid global. The fix is to **reuse the create-time "existing login" resolution** (Default bundle → global `~/.claude`) in the recovery path instead of the broken scrape — the DRY ask.
+
+---
+
+## 1. Scenario
+
+In the v0.46.6 window the user sees two Claude agents:
+
+- **Nark** — just created — authenticates and responds normally.
+- **Poal** — around since ~Jun 18 — fails to authenticate; clicking **Login Again** does nothing.
+
+Both are the *same* provider (`claude`) and, as shown below, the *same* identity. So "they share one login" is **false** — and "one login is just expired" is also too simple.
+
+---
+
+## 2. Q1 — How is one agent authed while another isn't?
+
+### 2.1 Both are bound to the same "Default" identity → a *valid* account
+
+From each agent's instance DB:
+
+| Fact | Nark (`.6` channel DB) | Poal (`dev/agenta-template-runtime-choice` DB) |
+|---|---|---|
+| `db_agents.identity_id` | `default` | `default` |
+| binding `default→claude` account | `1615e7ae-…` | `1a1778c9-…` |
+| account `secret_ref` | `{backend: o_auth_config_dir, dir: "C:\Users\area54\.claude"}` | `{backend: o_auth_config_dir, dir: "C:\Users\area54\.claude"}` |
+| account `status` | `valid` | `valid` |
+
+So per the identity system, **both resolve to your valid global `~/.claude` login.** On paper they are identical.
+
+### 2.2 The real divergence: the credential dir is *frozen at launch*
+
+An agent's `CLAUDE_CONFIG_DIR` is captured into its block meta (`cmd:env`) at first launch and reused verbatim on every turn and on "Login Again". It is **not** re-resolved from the identity binding afterward.
+
+From Poal's block meta (`db_block` in its instance DB):
+
+```
+"CLAUDE_CONFIG_DIR":"C:\\Users\\area54\\.agentmux\\shared\\providers\\claude"
+```
+
+- **Poal** (`working_directory = ~/.agentmux/agents/poal-0618g`, `started_at = 1781824185672` ≈ Jun 18) froze pointing at the **isolated shared dir** `~/.agentmux/shared/providers/claude/`.
+- **Nark** (created just now) froze pointing at the **valid global** `~/.claude` (the Default-bundle account dir).
+
+The **resolution logic changed** between Jun 18 and now: earlier launches resolved Claude's config dir to the isolated `shared/providers/claude` (via the frontend's `ensureAuthDir` → host `ensure_auth_dir`), while later launches resolve via the Default-bundle migration to the global `~/.claude`. Poal is frozen on the old answer; Nark on the new one.
+
+### 2.3 Why the frozen dir is dead
+
+On-disk state of `~/.agentmux/shared/providers/claude/.credentials.json` (Poal's frozen dir):
+
+- **As-found (before any test):** `expiresAt = 1781831066028` (≈ Jun 19, **past**), `refreshToken` **empty**, `accessToken` 29 chars. → expired, **cannot refresh** → 401 / needs-reauth.
+- The global `~/.claude/.credentials.json` (Nark's dir): `expiresAt = 1781978253240` (**future**), has `refreshToken` → **valid**.
+
+> **Test-artifact disclosure:** during verification a forced-401 was written into that same shared dir (`accessToken` = `sk-ant-oat01-FORCED-401-VERIFICATION-DO-NOT-USE`, future expiry, empty refresh). That dir is Poal's frozen dir, so the corruption *lands on* Poal — but the dir was **already dead before the test**, so it is not the cause of Poal's failure, only a coincident overwrite. Restorable from `~/.agentmux/shared/providers/claude/.credentials.verify-backup.json`.
+
+### 2.4 Answer
+
+Same user, same "Default" identity, but **each agent froze a different `CLAUDE_CONFIG_DIR` at launch**. Nark's points at the live global login; Poal's points at the isolated shared dir, which is expired with no refresh token. This is a **cross-instance / temporal binding-consistency gap**: the identity→dir binding moved forward (Default bundle → `~/.claude`) but already-launched agents kept their stale frozen env.
+
+---
+
+## 3. Q2 — Why does "Login Again" do nothing?
+
+Path: failure-row **Login Again** → `relogin()` (`useAgentControllerStatus.ts`) → `forceProviderLogin()` (`frontend/app/view/agent/flows/force-login.ts`) → `getApi().runCliLogin(cliPath, authLoginCommand, authEnv, requiresTty)` → host `run_cli_login_pty` (`agentmux-cef/src/commands/platform.rs`).
+
+Two compounding reasons it no-ops for Poal:
+
+1. **No URL to scrape.** `run_cli_login_pty` spawns `claude auth login` in a PTY and scans stdout for an OAuth URL. Claude Code **v2.1.183** runs a self-driving login TUI: it opens its own browser and **clipboard-copies the URL on `c`** — it never prints a scrapeable `https://…` line. So `extract_url` captures nothing → no browser opens, no auth box appears → "nothing happens." (Spec failure-mode A.)
+2. **Wrong write target even on success.** `forceProviderLogin` reuses Poal's frozen `authEnv` (`CLAUDE_CONFIG_DIR = …/shared/providers/claude`). Even if a login completed, the fresh token would land in the **dead shared dir**, not the valid global — so the fix wouldn't stick.
+
+---
+
+## 4. How agent auth actually resolves (reference)
+
+| Stage | Where | What happens |
+|---|---|---|
+| **Create-time seed** | `agentmux-srv/src/identity/migration.rs` `run_default_bundle_migration()` (~l.92), `ensure_default_bundle()` (~l.409) | On srv startup, probes global `~/.claude`; if usable, creates the **"Default"** bundle + a `claude` account whose `secret_ref` is `OAuthConfigDir { dir: ~/.claude }`, and binds it. New agents get `identity_id="default"`. |
+| **Bundle dir compute** | `agentmux-srv/src/server/identity_handlers.rs` `compute_and_ensure_bundle_dir()` (~l.950) | For an explicit bundle, overrides `CLAUDE_CONFIG_DIR` to the per-bundle dir. |
+| **Default auth dir** | `agentmux-cef/src/commands/platform.rs` `ensure_auth_dir()` (l.79) | Returns the shared default `~/.agentmux/shared/providers/<provider>/`. This is the **legacy** target older agents froze. |
+| **Spawn-time inject** | `agentmux-srv/src/identity/resolver.rs` `inject_identity_env()` (~l.369), `probe_oauth_status()` (~l.85) | Resolves the binding → sets `CLAUDE_CONFIG_DIR` to the account's dir; probes expiry. |
+| **Frozen launch env** | frontend `launch-flow.ts` SetMeta (~l.159), `buildAuthEnv()` in `useAgentControllerStatus.ts` (~l.95) | The resolved `CLAUDE_CONFIG_DIR` is written to block meta `cmd:env` **once** and reused thereafter (incl. by `relogin`). **This is where the staleness is frozen in.** |
+| **Re-auth** | `force-login.ts` `forceProviderLogin()` (~l.43) | Reuses the frozen `cmd:env` + the broken OAuth-URL scrape. No re-resolution, no reuse of the create-time seed. |
+| **Seed-from-global (new, #1613)** | `agentmux-cef/src/commands/providers.rs` `seed_provider_auth_from_global()`; frontend `flows/seed-global-login.ts`; 🌐 CTA | Copies a valid global `~/.claude` cred into the **hardcoded** shared dir. |
+
+On-disk layout:
+
+```
+~/.claude/.credentials.json                                   ← global login (VALID)
+~/.agentmux/shared/providers/claude/.credentials.json         ← shared default (Poal's frozen dir; DEAD)
+~/.agentmux/shared/identities/<bundle_id>/claude/.credentials.json  ← per-bundle (NONE present here)
+```
+
+---
+
+## 5. Bug exposed in the shipped seed-from-global (#1613)
+
+`seed_provider_auth_from_global()` hardcodes its destination to `~/.agentmux/shared/providers/claude/`. That **happens to match Poal** (so clicking 🌐 would fix Poal today), but it would **silently miss** any agent whose resolved dir is a bundle or the global path (e.g. Nark → `~/.claude`). The seed must target the **agent's resolved `CLAUDE_CONFIG_DIR`** (passed from the caller), not a constant.
+
+---
+
+## 6. Proposed fix — DRY the "existing login" into recovery
+
+**Principle:** the "login an agent gets when first created" *is* the Default bundle → global `~/.claude`. Recovery (Login Again / the auth-failure CTA) should **reuse that exact resolution** instead of the OAuth scrape.
+
+Concretely, one shared "use the existing global login" path serving **create**, **Login Again**, and **🌐**:
+
+1. **Re-resolve, don't reuse-frozen.** On auth failure, re-run the identity resolution for the agent (`inject_identity_env` / the Default-bundle account dir) and **refresh its `cmd:env` `CLAUDE_CONFIG_DIR`**, so a stale agent picks up the same live dir a fresh agent gets. Fixes the temporal-staleness root cause (§2.2).
+2. **Fix the seed target.** Make `seed_provider_auth_from_global` accept the agent's **resolved** dir (frontend passes `cmd:env.CLAUDE_CONFIG_DIR`) instead of the hardcoded shared dir (§5).
+3. **Wire recovery to seed first, scrape last.** For Claude (un-scrapeable TUI), the auth-failure recovery should try the seed-from-global into the resolved dir **before** falling back to the OAuth flow — making "Login Again" actually succeed without a second button.
+4. **(Optional, deeper)** Globalize the identity→dir binding so the same "Default" identity resolves consistently across instances/channels (ties into #1383–#1393). Without this, re-resolution still depends on the running instance's DB.
+
+Trade-off to decide: **re-point env** (1) vs **seed file** (2) vs **both**. Recommended: both — re-point so the agent uses the live dir, and seed so that dir is guaranteed populated with a valid cred.
+
+---
+
+## 7. Immediate remediation options (for the live Poal)
+
+- **Click 🌐 "Use existing login" on Poal's failure row.** Poal's frozen dir is the shared dir, which is exactly where the current seed writes — so this should copy the valid global login in and recover Poal on the next message. (If the 🌐 button doesn't render — Poal's process lives in a dev instance — seed from CLI instead.)
+- **CLI seed:** copy `~/.claude/.credentials.json` → `~/.agentmux/shared/providers/claude/.credentials.json` (overwrites the dead/forced-401 cred with the valid global).
+- **Restore the test artifact:** `~/.agentmux/shared/providers/claude/.credentials.verify-backup.json` holds the as-found (dead) cred if a literal restore is wanted — but seeding the valid global is the actual fix.
+
+---
+
+## 8. Evidence appendix (commands used)
+
+```
+# identity binding (per instance DB)
+sqlite3 <objects.db> "SELECT identity_id FROM db_agents WHERE name IN ('Nark','Poal');"
+sqlite3 <objects.db> "SELECT * FROM db_identity_bindings WHERE provider='claude';"
+sqlite3 <objects.db> "SELECT id,provider,status,secret_ref FROM db_identity_accounts WHERE provider='claude';"
+
+# Poal's frozen launch env
+sqlite3 <poal objects.db> "SELECT * FROM db_block;" | grep -o 'CLAUDE_CONFIG_DIR":"[^"]*'
+#  → C:\Users\area54\.agentmux\shared\providers\claude
+
+# credential validity (no token values printed)
+#  ~/.claude/.credentials.json                          expiresAt future=true,  hasRefresh=true   (VALID)
+#  ~/.agentmux/shared/providers/claude/.credentials.json expiresAt future=false, refreshToken=""  (DEAD)
+```
+
+DB locations:
+- Nark: `~/.agentmux/channels/local-main-b28b7a-6e60a938/versions/0.46.6/data/db/objects.db`
+- Poal: `~/.agentmux/dev/agenta-template-runtime-choice/69d7a34a544eaf3e/data/db/objects.db`
+
+---
+
+## 9. History / provenance — how auth drifted from "isolated" to "shared-global"
+
+> Context: AgentMux was originally designed so each provider kept its **own**
+> AgentMux-owned auth, **decoupled from the user's personal `~/.claude`**. This
+> section traces when that changed. Cross-checked against git; the canonical
+> write-up of the drift is `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`.
+
+### 9.1 The original design (isolated, decoupled from global)
+
+`docs/specs/provider-auth-isolation.md` — design dated **2026-03-21** (src-tauri
+era; first committed to this repo 2026-05-14 in #850):
+
+- Each provider had its own AgentMux-owned dir:
+  `~/.agentmux/instances/v{version}/auth/{provider}/` — **isolated from the
+  user's personal `~/.claude`**, shared across agents *of that version*.
+- **§4 invariant ("the prophecy"):** *"the auth check must validate the SAME dir
+  the agent uses … otherwise the check passes using personal `~/.claude/` but the
+  subprocess fails using the isolated empty dir."* It explicitly warned against
+  touching the global login.
+
+### 9.2 The drift (dated; commits verified in git)
+
+| Date | PR / commit | What it introduced |
+|------|-------------|--------------------|
+| 2026-03-21 | `provider-auth-isolation.md` | **Isolated** per-provider auth, decoupled from `~/.claude`; §4 invariant |
+| **2026-05-14** | **#850** `f836aae5` | First **global `~/.claude` fallback** — two-phase `CheckCliAuth` phase-1 reads the personal login (the §4 violation) |
+| **2026-05-22** | **#983** `136f49fa` | **"seed Default identity bundle from ambient `~/.claude` on startup"** (`agentmux-srv/src/identity/migration.rs`). *This is the mechanism that makes today's `identity=default` agents resolve to the global `~/.claude`.* |
+| 2026-05-24 | #1027 `87726ae5` | Channels re-rooted auth from version-shared → **per-channel** (multiplied the empty-dir hazard) |
+| 2026-06-05 | — (retro) | The "validate-spin" regression surfaces; retro written |
+| **2026-06-05** | **#1291** `d1ecdc3c` | **"provider auth in one shared, instance-independent dir"** — introduces `~/.agentmux/shared/providers/<provider>/` (the `.join("shared")` path) + `SPEC_PROVIDER_PINNED_AUTH` |
+| ~2026-06-13+ | #1391 / #1396 / #1399 / #1403 … | **Cross-channel GLOBAL**: agents + auth + transcript shared across all channels/versions |
+
+### 9.3 "Shared global auth" was actually two separate changes
+
+1. **Coupling to the global `~/.claude`** — crept in via **#850 (2026-05-14)** as a
+   check-fallback, then cemented by **#983 (2026-05-22)** when the Default identity
+   bundle was seeded from / pointed at ambient `~/.claude`. This is why Nark
+   (identity `default`) reads `~/.claude` today.
+2. **The single shared AgentMux dir** (`~/.agentmux/shared/providers/<provider>/`)
+   replacing per-instance isolation — **#1291 (2026-06-05)**, the post-retro
+   structural fix, later generalized to fully global by the cross-channel work
+   (#1383–#1403).
+
+### 9.4 Nuance — directive vs. drift
+
+The 2026-06-05 retro's own conclusion (lesson #3) was that auth **should** be a
+shared *provider* property, quoting the user directive: *"every provider's
+requirements is a pinned version, completely independent from the installed
+instances."* But that directive pointed at an **AgentMux-owned** shared dir
+(`~/.agentmux/providers/<provider>/`) — **not** the personal `~/.claude`. The
+coupling to the global `~/.claude` (#850 / #983) is a **separate** drift that
+predates and exceeds that directive; the retro explicitly labelled the earlier
+"seed isolated creds from global" patch (#1283) a **symptom treatment**, not the
+intended design.
+
+**Net:** designed isolated-from-global → later directed shared-per-provider
+(instance-independent) → but also quietly coupled to the global `~/.claude` along
+the way. That last coupling is what produces the Nark-vs-Poal split in §2.

--- a/docs/specs/SPEC_PROVIDER_ISOLATION_2026_06_20.md
+++ b/docs/specs/SPEC_PROVIDER_ISOLATION_2026_06_20.md
@@ -1,0 +1,160 @@
+# SPEC: Provider environment isolation — never touch the user's `~/.claude` or global CLI
+
+**Status:** Approved — implementing auth half
+**Author:** AgentA
+**Date:** 2026-06-20
+**Extends / hardens:** `SPEC_PROVIDER_PINNED_AUTH_2026_06_05.md` (#1291), `provider-auth-isolation.md` (2026-03-21)
+**Diagnosis:** `docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md`
+**Related:** `SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md` (the login mechanism), retro `retro-provider-auth-isolation-regression-2026-06-05.md`
+
+---
+
+## 0. Directive
+
+> *We designed AgentMux so each provider keeps its own auth. I do not want to
+> pollute a user's environment. Same applies to the executable.* — 2026-06-20
+
+AgentMux must be a **self-contained sandbox** for every provider. It may **read**
+the user's environment once, with consent, to import an existing login — but it
+must **never run from, refresh into, or otherwise mutate** the user's personal
+`~/.claude` (etc.) or the user's globally-installed CLI.
+
+## 1. Hard invariant
+
+For every provider `P` and every agent:
+
+- **INV-A (auth):** the agent's live credential dir (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, …) is an **AgentMux-owned** path under `~/.agentmux/…`. It is **never** the user's `~/.<P>` dir. Tokens are read and **refreshed in the AgentMux dir only**.
+- **INV-X (executable):** the agent runs an **AgentMux-installed, version-pinned** CLI under `~/.agentmux/…`. It **never** resolves or runs the user's PATH/global CLI.
+- **INV-R (read-only import):** the user's `~/.<P>` may be **read** exactly once, on explicit/opt-in import, and **copied** into the AgentMux dir. It is never written, never pointed-at as the live dir, never the run target.
+
+A reviewer seeing any code that sets a `*_CONFIG_DIR`/`*_HOME` to `~/.<P>`, or runs a CLI resolved via `where`/`which`, must reject it.
+
+## 2. Current violations (verified)
+
+| Axis | Violation | Where | Commit |
+|---|---|---|---|
+| Auth | Default identity bundle's account `secret_ref` = `OAuthConfigDir { dir: ~/.claude }` — a **live pointer** to the user's global dir; "the CLI keeps reading + refreshing in place" | `agentmux-srv/src/identity/migration.rs` `run_default_bundle_migration` (account creation ~l.244-258) | #983 |
+| Auth | Two-phase `CheckCliAuth` phase-1 falls back to global `~/.claude` | `agentmux-srv/.../cli_handlers.rs` | #850 |
+| Exec | `detect_cli` resolves the CLI via `where`/`which <provider>` → the user's global binary; launch falls back to it when nothing is installed isolated | `agentmux-cef/src/commands/providers.rs` `detect_cli` (l.141), `get_cli_path` (l.514) | — |
+| Exec | `pinned_version` for claude is `"latest"` — not actually pinned | `agentmux-cef/src/commands/providers.rs` (`CLAUDE_VERSION`) | — |
+
+The #1291 shared-dir model (`~/.agentmux/shared/providers/<provider>/`) is correct
+and partly in place (`ensure_auth_dir`), but the #983 bundle pointer **overrides**
+it for any agent bound to an identity (today: all of them, via `default`). See the
+diagnosis report §2 (Nark resolves to `~/.claude`; Poal froze on the shared dir).
+
+## 3. The model
+
+```
+~/.agentmux/
+  shared/
+    providers/<provider>/.credentials.json     ← DEFAULT live auth dir (AgentMux-owned)   [INV-A]
+    providers/<provider>/.agentmux-cred-seeded  ← bootstrap sentinel (import-once gate)    [INV-R]
+    identities/<bundle>/<provider>/…            ← explicit multi-account bundles (own dirs) [INV-A]
+  <cli-root>/cli/<provider>/node_modules/.bin/  ← pinned, AgentMux-installed CLI            [INV-X]
+
+~/.claude  (and ~/.codex, …)                    ← USER's — read-once on import only, never written
+```
+
+- **Single auth source of truth:** `DataPaths::provider_auth_dir(<auth_dir_name>)` → `~/.agentmux/shared/providers/<auth_dir_name>`. The Default bundle's account `dir` is **this**, never `~/.<provider>`.
+- **§4 restored:** `CheckCliAuth` validates *exactly* the dir the agent runs in (the AgentMux dir), never "isolated OR global".
+- **Per-identity bundles** keep their own AgentMux-owned dirs for deliberate multi-account.
+
+## 4. Fix — AUTH half (this PR)
+
+### 4.1 Default bundle points at the AgentMux dir + copies creds (the #983 reversal)
+In `run_default_bundle_migration`, when ambient creds exist:
+1. Compute `dest = DataPaths::provider_auth_dir(auth_dir_name)` (e.g. `~/.agentmux/shared/providers/claude`).
+2. **Copy** `~/.<auth_dir_name>/.credentials.json` → `dest/.credentials.json` (read-only import), gated by a `dest/.agentmux-cred-seeded` sentinel so a later logout in the AgentMux dir sticks and we don't re-import.
+3. Create the account with `secret_ref: OAuthConfigDir { dir: dest }` — **not** the ambient dir.
+
+Result: agents refresh in `dest`, never in `~/.claude`. (INV-A, INV-R.)
+
+### 4.2 Migration sweep — un-pollute existing installs
+Existing Default accounts created by #983 already point at `~/.<provider>`. A one-time sweep: for any `default` account whose `secret_ref.dir` is the user's ambient `~/.<provider>`, **repoint** it to `dest` (copying creds first if `dest` is empty). This fixes already-bound agents (Nark, Poal) without a manual re-login. Idempotent; sentinel-gated.
+
+### 4.3 Re-resolve, don't trust the frozen launch env
+An agent's `CLAUDE_CONFIG_DIR` is frozen into block-meta `cmd:env` at first launch and reused on every turn + on "Login Again" (report §2.2). After 4.1/4.2 the binding is correct but already-launched agents carry a stale frozen dir. On **re-auth** (and on spawn), re-resolve `CLAUDE_CONFIG_DIR` from the identity binding (`inject_identity_env`) and refresh `cmd:env`, so a stale agent picks up the AgentMux dir. (This is the DRY hinge: create and re-auth resolve the **same** way.)
+
+### 4.4 §4 check fix
+Confirm/keep `CheckCliAuth` validating only the agent's resolved AgentMux dir — drop any global `~/.claude` fallback (the #850 hazard). Add the cross-module invariant test: the dir `CheckCliAuth` validates == the `CLAUDE_CONFIG_DIR` the agent is spawned with.
+
+### 4.5 `seed_provider_auth_from_global` (#1613) → explicit opt-in import, targeted
+Reframe the 🌐 path as the *manual* form of 4.1's import (read `~/.claude` → copy into the agent's **resolved** dir). Two changes:
+- Target the agent's **resolved** `CLAUDE_CONFIG_DIR` (passed by the frontend), not the hardcoded `shared/providers/claude` (report §5).
+- It remains read-only w.r.t. global and is never the default recovery — primary recovery is a fresh login into the AgentMux dir (§5 below / login-capture spec).
+
+## 5. Fix — EXECUTABLE half (follow-up PR)
+
+- **Ensure-pinned-install on launch:** if the pinned CLI isn't installed under `~/.agentmux/.../cli/<provider>`, install it (existing `install_cli`); run **only** that path.
+- **Drop the global run fallback:** remove the `where/which <provider>` resolution as a *run* target (it may survive only as an "import an existing login" hint, never executed).
+- **Pin the version:** replace `CLAUDE_VERSION = "latest"` with a concrete pinned version per provider.
+
+(Out of scope for this PR; tracked here so the executable axis isn't lost.)
+
+## 6. Behaviour matrix (post-auth-half)
+
+| State | Result |
+|---|---|
+| Fresh install, user logged in globally | Import `~/.claude` → `shared/providers/claude` **once** → authed in the AgentMux dir; `~/.claude` untouched thereafter |
+| Existing agent pointed at `~/.claude` (Nark/Poal) | Sweep repoints to the AgentMux dir (copy-once) → next spawn/re-auth authed, isolated |
+| Logged out in the AgentMux dir (sentinel present) | stays logged out → user logs in **into the AgentMux dir**; logout sticks; global never re-imported silently |
+| No global login | not-authed → log in once **into the AgentMux dir** (setup-token / paste-code per login-capture spec) |
+| User refreshes/rotates their personal `~/.claude` | no effect on AgentMux; the two are decoupled after import |
+
+## 7. Change surface — auth half
+
+- `agentmux-srv/src/identity/migration.rs` — §4.1 (copy + point at AgentMux dir, sentinel) and §4.2 (sweep existing ambient-pointing accounts).
+- `agentmux-common/src/data_paths.rs` — reuse `provider_auth_dir`; add a credential-copy + sentinel helper if shared.
+- `agentmux-srv/src/identity/resolver.rs` / `server/cli_handlers.rs` — §4.3 re-resolve on re-auth; §4.4 §4 check (verify it's already free of the global fallback; add the invariant test).
+- `agentmux-cef/src/commands/providers.rs` (`seed_provider_auth_from_global`) + frontend `seed-global-login.ts` — §4.5 target the resolved dir; keep as opt-in import.
+
+## 8. Invariants / tests
+
+- **T-A1:** after migration with an ambient `~/.claude` present, the Default `claude` account `secret_ref.dir` is under `~/.agentmux/…` and **not** `~/.claude`; `~/.claude/.credentials.json` is byte-unchanged (read-only).
+- **T-A2:** sweep repoints a pre-existing account whose `dir == ~/.claude` to the AgentMux dir, copying creds, idempotently (sentinel).
+- **T-A3 (§4):** the dir `CheckCliAuth` validates == the agent's spawned `CLAUDE_CONFIG_DIR`.
+- **T-A4:** a token refresh by an agent writes under `~/.agentmux/…`, never `~/.claude` (observed: `~/.claude` mtime unchanged across a refresh).
+
+## 9. Open decisions
+
+- **Migration smoothness:** §4.2 auto-imports (read-only copy) so existing globally-authed users don't break. The clean long-term state is a fresh login into the AgentMux dir; the copy shares a `refreshToken` with global until then (rotation could stale one side — acceptable for a one-time bridge; documented).
+- The shared `refreshToken` caveat applies equally to the 🌐 import (§4.5).
+
+## 10. Implementation log
+
+- **2026-06-20 — auth half landed.**
+  - **§4.1 + §4.2 (`agentmux-srv/src/identity/migration.rs`):** the Default
+    bundle account now points at the AgentMux dir (`provider_auth_dir`), with the
+    ambient `~/.claude` cred **copied** in once (`import_ambient_once`,
+    sentinel-gated) — reversing the #983 pointer-to-ambient. A
+    `sweep_default_accounts_off_ambient` pass repoints pre-existing
+    ambient-pointing accounts (Nark/Poal). Tests `T-A1`
+    (`ambient_claude_creds_create_default_bundle_and_bind`, updated) and `T-A2`
+    (`sweep_repoints_existing_ambient_account_to_agentmux_dir`, new) green;
+    8/8 migration tests pass.
+  - **§4.3 — satisfied server-side (key finding).** `inject_identity_env_async`
+    runs at **every** agent turn spawn (`app_api.rs` AgentSend,
+    `agent_handlers.rs` AgentInput) and **overwrites** `CLAUDE_CONFIG_DIR` from
+    the binding (`resolver.rs:563` `env_vars.insert(...)`). So the migration
+    fix propagates to every turn automatically — a stale frozen `cmd:env`
+    (e.g. Nark's `~/.claude`) is overridden by the binding's AgentMux dir on the
+    next turn. No frontend re-resolve needed for turn traffic. **Residual:** the
+    `runCliLogin` re-login path (a cef host command) still writes to the frozen
+    `cmd:env`; that's the un-scrapeable v2.1.x login anyway, so the credential
+    **write target** is folded into `SPEC_HOST_CLI_LOGIN_CAPTURE` (setup-token /
+    paste-code must write to the resolved dir), not duplicated here.
+  - **§4.4 — verified already-correct (#1291).** `cli_handlers.rs` `CheckCliAuth`
+    validates the dir the agent runs in (`cmd.auth_env.CLAUDE_CONFIG_DIR`, global
+    only as an absent-fallback), and the one-time global→isolated import targets
+    that same resolved dir. No "check global / run isolated" split remains.
+  - **§4.5 done (`providers.rs` + `cef-api.ts` + `custom.d.ts` +
+    `seed-global-login.ts` + `useAgentControllerStatus.ts`):** the 🌐 seed now
+    targets the agent's **resolved** `CLAUDE_CONFIG_DIR` (passed from `cmd:env`),
+    **guarded** to paths under `~/.agentmux` — a stale `~/.claude` is rejected →
+    shared default. The seed can never write the user's personal env (INV-R),
+    and bundle agents seed into their own dir.
+  - **Net:** after this lands + next srv startup, no agent turn reads/writes the
+    user's `~/.claude`; existing agents auto-recover via the sweep + per-spawn
+    re-resolution; the 🌐 import is hardened. Executable axis (§5) remains a
+    follow-up.

--- a/frontend/app/view/agent/flows/seed-global-login.ts
+++ b/frontend/app/view/agent/flows/seed-global-login.ts
@@ -24,9 +24,17 @@
 import { getApi } from "@/app/store/global";
 import type { LogFn } from "../types";
 
-export async function seedGlobalLogin(providerId: string, log: LogFn): Promise<boolean> {
+export async function seedGlobalLogin(
+    providerId: string,
+    log: LogFn,
+    configDir?: string,
+): Promise<boolean> {
     log("auth", "Use existing login — copying your global Claude login into this agent…");
-    const res = await getApi().seedProviderAuthFromGlobal(providerId);
+    // `configDir` is the agent's resolved auth dir (from cmd:env). The host
+    // seeds into it only if it's under ~/.agentmux; a stale ~/.claude is
+    // rejected there and falls back to the shared dir — the seed never writes
+    // the user's own login (SPEC_PROVIDER_ISOLATION §4.5 / INV-R).
+    const res = await getApi().seedProviderAuthFromGlobal(providerId, configDir);
     if (res?.seeded) {
         log("auth", "copied your existing login — just send your message again");
         return true;

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -210,7 +210,16 @@ export function useAgentControllerStatus(
         }
         seedInFlight = true;
         try {
-            await seedGlobalLogin(prov.id, opts.log);
+            // Seed into the agent's RESOLVED auth dir (from cmd:env), not a
+            // guessed one; the host guards it to ~/.agentmux so the seed never
+            // writes the user's ~/.claude (SPEC_PROVIDER_ISOLATION §4.5).
+            const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
+            let configDir: string | undefined;
+            if (prov.authConfigDirEnvVar && envMeta && typeof envMeta === "object") {
+                const v = (envMeta as Record<string, unknown>)[prov.authConfigDirEnvVar];
+                if (typeof v === "string") configDir = v;
+            }
+            await seedGlobalLogin(prov.id, opts.log, configDir);
         } catch (err: any) {
             opts.log("auth", `use existing login failed: ${err?.message ?? String(err)}`, "error");
         } finally {

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -183,7 +183,7 @@ declare global {
         ensureAuthDir: (providerId: string) => Promise<string>;
         runCliLogin: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>, requiresTty?: boolean) => Promise<string | null>;
         cancelCliLogin: () => Promise<void>;
-        seedProviderAuthFromGlobal: (providerId: string) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
+        seedProviderAuthFromGlobal: (providerId: string, configDir?: string) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (
             dragType: "pane" | "tab",

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -609,10 +609,10 @@ export function buildCefApi(): AppApi {
         cancelCliLogin: async () => {
             await invokeCommand("cancel_cli_login");
         },
-        seedProviderAuthFromGlobal: async (providerId: string) => {
+        seedProviderAuthFromGlobal: async (providerId: string, configDir?: string) => {
             return await invokeCommand<{ seeded: boolean; status: string; expiresAt?: number | null }>(
                 "seed_provider_auth_from_global",
-                { providerId },
+                { providerId, configDir: configDir ?? null },
             );
         },
 


### PR DESCRIPTION
Spec: `docs/specs/SPEC_PROVIDER_ISOLATION_2026_06_20.md` · Diagnosis: `docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md`

## Problem
AgentMux was designed so each provider keeps its **own** auth, isolated from the user's environment. That drifted: the **#983** Default-bundle migration pointed each Default account's `secret_ref` **directly at `~/.claude`** ("the CLI keeps reading + refreshing in place"), so every agent bound to `default` **refreshes tokens inside the user's personal login**. Two agents on the same identity diverge purely by *when* they launched (one frozen on `~/.claude`, one on a stale isolated dir) — see the diagnosis report.

Directive: *"I do not want to pollute a user's environment. Same applies to the executable."*

## Auth half (this PR)
- **§4.1** — New agents: import ambient `~/.claude` into the AgentMux dir **once** (read-only copy, sentinel-gated) and point the Default account at the **AgentMux dir** — reverses the #983 pointer-to-ambient. Tokens refresh in `~/.agentmux/shared/providers/<provider>`, never `~/.claude`.
- **§4.2** — Sweep: repoint any pre-existing Default account still pointing at `~/.claude` to the AgentMux dir (copy once) on next srv startup, so existing agents un-pollute with no manual re-login.
- **§4.3** — *Verified satisfied server-side*: `inject_identity_env` **overwrites** `CLAUDE_CONFIG_DIR` from the binding at every spawn (`resolver.rs:563`), so the migration fix propagates with no frontend change.
- **§4.4** — *Verified already-correct (#1291)*: `CheckCliAuth` validates the dir the agent runs in.
- **§4.5** — The "Use existing login" 🌐 seed now targets the agent's **resolved** dir (from `cmd:env`), **guarded** to `~/.agentmux` — a stale `~/.claude` is rejected → shared default, so the seed can never write the user's env (INV-R).

## Out of scope (follow-up, specced)
Executable isolation (§5): install-pinned-only, drop the global `claude` run fallback, pin the version.

## Verification
- `cargo check` (srv + cef) clean
- **8/8 migration tests**, incl. new `T-A1` (account points at AgentMux dir; `~/.claude` byte-unchanged) and `T-A2` (sweep repoints + idempotent)
- `tsc --noEmit` clean for all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)