### PR TITLE
feat(voice): auto-download whisper model for the local engine

### DIFF
--- a/.changesets/1781984338-feat-voice-auto-download-whisper-model-for-the-local-engine-smo4.md
+++ b/.changesets/1781984338-feat-voice-auto-download-whisper-model-for-the-local-engine-smo4.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(voice): auto-download whisper model for the local engine

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -235,6 +235,10 @@ pub struct SettingsType {
     // AGENTMUX_WHISPER_CLI / AGENTMUX_WHISPER_MODEL.
     #[serde(rename = "voice:whisperCliPath", default, skip_serializing_if = "Option::is_none")]
     pub voice_whisper_cli_path: Option<String>,
+    // GGML model name to auto-download on first use (default "base.en"). The
+    // explicit-path override below skips the download.
+    #[serde(rename = "voice:whisperModel", default, skip_serializing_if = "Option::is_none")]
+    pub voice_whisper_model: Option<String>,
     #[serde(rename = "voice:whisperModelPath", default, skip_serializing_if = "Option::is_none")]
     pub voice_whisper_model_path: Option<String>,
 

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -219,11 +219,99 @@ async fn transcribe_groq(
 /// and run the CLI. Fully offline; nothing leaves the machine.
 ///
 /// Config (env-first):
-///   * binary — `AGENTMUX_WHISPER_CLI`  / settings `voice:whisperCliPath`
-///   * model  — `AGENTMUX_WHISPER_MODEL` / settings `voice:whisperModelPath`
+///   * binary — `AGENTMUX_WHISPER_CLI` / settings `voice:whisperCliPath`
+///              (user-provided; auto-bundling is a follow-up — per-platform
+///              binary fetch is fragile)
+///   * model  — auto-downloaded on first use (default `base.en`, configurable
+///              via `voice:whisperModel`); override with an explicit
+///              `voice:whisperModelPath` / `AGENTMUX_WHISPER_MODEL`.
 ///
-/// On-demand model/binary download is a follow-up (#1591); for now both paths
-/// are user-provided. Missing config → NotConfigured (501).
+/// Missing binary → NotConfigured (501).
+/// Default GGML model name when none is configured. base.en (~142 MB) is a good
+/// accuracy/size balance for English; configurable via `voice:whisperModel`.
+const DEFAULT_WHISPER_MODEL: &str = "base.en";
+/// Cap the one-time model download so a stuck transfer can't wedge a request.
+const MODEL_DOWNLOAD_TIMEOUT_SECS: u64 = 600;
+
+/// Resolve the GGML model path, downloading an auto-managed model on first use.
+///
+///   * Explicit `voice:whisperModelPath` / `AGENTMUX_WHISPER_MODEL` → used as-is
+///     (no download; error if missing).
+///   * Otherwise → `<config>/whisper-models/ggml-<name>.bin`, where `name` comes
+///     from `voice:whisperModel` (default `base.en`), fetched once from the
+///     whisper.cpp model repo. A global lock serializes concurrent first-uses.
+async fn ensure_local_model(
+    settings: &Option<serde_json::Value>,
+) -> Result<std::path::PathBuf, SttError> {
+    if let Some(p) = resolve_path(settings, "AGENTMUX_WHISPER_MODEL", "voice:whisperModelPath") {
+        let pb = std::path::PathBuf::from(&p);
+        return if pb.exists() {
+            Ok(pb)
+        } else {
+            Err(NotConfigured(format!("whisper model not found at {p}")))
+        };
+    }
+
+    let name = std::env::var("AGENTMUX_WHISPER_MODEL_NAME")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| settings_str(settings, "voice:whisperModel"))
+        .unwrap_or_else(|| DEFAULT_WHISPER_MODEL.to_string());
+    // Sanitize: model names are simple tokens — reject anything that could be a
+    // path or URL component (defends the format!-built path and URL below).
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_')) {
+        return Err(NotConfigured(format!("invalid voice:whisperModel name: {name}")));
+    }
+
+    let dir = crate::backend::base::get_wave_config_dir().join("whisper-models");
+    let path = dir.join(format!("ggml-{name}.bin"));
+    if path.exists() {
+        return Ok(path);
+    }
+
+    // Serialize concurrent first-use downloads of the same model.
+    static DL_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    let _guard = DL_LOCK.get_or_init(|| tokio::sync::Mutex::new(())).lock().await;
+    if path.exists() {
+        return Ok(path); // another request finished the download while we waited
+    }
+
+    std::fs::create_dir_all(&dir).map_err(|e| Upstream(format!("create models dir: {e}")))?;
+    let url =
+        format!("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{name}.bin");
+    tracing::info!(target: "voice", "downloading whisper model '{name}' from {url}");
+
+    let bytes = tokio::time::timeout(
+        std::time::Duration::from_secs(MODEL_DOWNLOAD_TIMEOUT_SECS),
+        async {
+            let resp = reqwest::Client::new()
+                .get(&url)
+                .send()
+                .await
+                .map_err(|e| Upstream(format!("model download request: {e}")))?;
+            if !resp.status().is_success() {
+                return Err(Upstream(format!(
+                    "model download {} for '{name}'",
+                    resp.status().as_u16()
+                )));
+            }
+            resp.bytes()
+                .await
+                .map_err(|e| Upstream(format!("model download body: {e}")))
+        },
+    )
+    .await
+    .map_err(|_| Upstream(format!("model download timed out after {MODEL_DOWNLOAD_TIMEOUT_SECS}s")))??;
+
+    // Write to a temp file then rename so a partial download never looks valid.
+    let tmp = dir.join(format!("ggml-{name}.bin.part"));
+    std::fs::write(&tmp, &bytes).map_err(|e| Upstream(format!("model write: {e}")))?;
+    std::fs::rename(&tmp, &path).map_err(|e| Upstream(format!("model finalize: {e}")))?;
+    tracing::info!(target: "voice", "whisper model '{name}' ready ({} bytes)", bytes.len());
+    Ok(path)
+}
+
 async fn transcribe_local_whisper(
     audio: Bytes,
     lang: Option<&str>,
@@ -238,20 +326,12 @@ async fn transcribe_local_whisper(
             )
         },
     )?;
-    let model = resolve_path(settings, "AGENTMUX_WHISPER_MODEL", "voice:whisperModelPath")
-        .ok_or_else(|| {
-            NotConfigured(
-                "local whisper not configured — set voice:whisperModelPath (path to a GGML model) \
-                 in settings.json or AGENTMUX_WHISPER_MODEL"
-                    .to_string(),
-            )
-        })?;
     if !std::path::Path::new(&cli).exists() {
         return Err(NotConfigured(format!("whisper-cli not found at {cli}")));
     }
-    if !std::path::Path::new(&model).exists() {
-        return Err(NotConfigured(format!("whisper model not found at {model}")));
-    }
+    // Resolve the model: an explicit path wins, otherwise an auto-managed model
+    // is downloaded once to the config dir (zero-config for the model file).
+    let model = ensure_local_model(settings).await?;
 
     // Write the WAV body to a unique temp file. Timestamp alone can collide
     // under concurrent requests (coarse Windows SystemTime granularity), so add

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -266,7 +266,10 @@ async fn ensure_local_model(
         return Ok(path);
     }
 
-    // Serialize concurrent first-use downloads of the same model.
+    // Single global lock: serializes ALL first-use model downloads (not
+    // per-model), so one model's download blocks any other model's first-use
+    // for up to the 600s cap. Acceptable — first-use downloads are rare and
+    // models are typically not switched mid-session.
     static DL_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     let _guard = DL_LOCK.get_or_init(|| tokio::sync::Mutex::new(())).lock().await;
     if path.exists() {

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -252,11 +252,7 @@ async fn ensure_local_model(
         };
     }
 
-    let name = std::env::var("AGENTMUX_WHISPER_MODEL_NAME")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .or_else(|| settings_str(settings, "voice:whisperModel"))
+    let name = settings_str(settings, "voice:whisperModel")
         .unwrap_or_else(|| DEFAULT_WHISPER_MODEL.to_string());
     // Sanitize: model names are simple tokens — reject anything that could be a
     // path or URL component (defends the format!-built path and URL below).

--- a/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
+++ b/docs/specs/SPEC_VOICE_STT_ENGINE_2026_06_20.md
@@ -75,11 +75,15 @@ extractor `service.rs` uses), `Json<Value>` response. Auth-gated like the other
   libclang / C++ build in the sidecar). The renderer sends **16 kHz mono WAV**
   for this engine (whisper-cli reads WAV natively, no ffmpeg), captured via
   Web-Audio PCM (`AudioContext({sampleRate:16000})` + `ScriptProcessor`). Both
-  the CLI binary and GGML model are **user-provided paths** in v1
-  (`voice:whisperCliPath` / `voice:whisperModelPath`, or `AGENTMUX_WHISPER_CLI`
-  / `AGENTMUX_WHISPER_MODEL`); missing config → 501. Bundled binary +
-  on-demand model download is the **PR-3** follow-up. Fully offline — audio
-  never leaves the machine. ~0 MB ship.
+  the CLI binary is user-provided (`voice:whisperCliPath` /
+  `AGENTMUX_WHISPER_CLI`); the **GGML model auto-downloads on first use**
+  (PR-3 — default `base.en`, configurable via `voice:whisperModel`, to
+  `<config>/whisper-models/`, serialized by a global lock with a 600s cap and
+  temp→rename so partial downloads never look valid). An explicit
+  `voice:whisperModelPath` overrides and skips the download. Missing binary →
+  501. **Bundled CLI binary** (so it's fully zero-config) remains a follow-up —
+  per-platform binary fetch is fragile. Fully offline — audio never leaves the
+  machine. ~0 MB ship.
 
 ### 3.2 Backend selection + key (server-side)
 Resolved once at request time from, in order:

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1404,6 +1404,7 @@ declare global {
         "voice:engine"?: string;
         "voice:groqApiKey"?: string;
         "voice:whisperCliPath"?: string;
+        "voice:whisperModel"?: string;
         "voice:whisperModelPath"?: string;
         "notify:*"?: boolean;
         "notify:sounds:enabled"?: boolean;

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -85,10 +85,12 @@
     // -- groq engine: hosted, sends webm. Key read server-side only (never sent to UI).
     // "voice:groqApiKey":       "gsk_...",  // or set AGENTMUX_GROQ_API_KEY
     // -- whisper-local engine: offline, sends 16kHz WAV to a local whisper.cpp CLI.
-    //    Both paths user-provided (auto-download is a follow-up). Env overrides:
-    //    AGENTMUX_WHISPER_CLI / AGENTMUX_WHISPER_MODEL.
+    //    Provide the whisper-cli binary path; the GGML model auto-downloads on
+    //    first use (default "base.en", ~142MB) to <config>/whisper-models/.
+    //    Env override for the binary: AGENTMUX_WHISPER_CLI.
     // "voice:whisperCliPath":   "C:/tools/whisper-cli.exe",
-    // "voice:whisperModelPath": "C:/models/ggml-base.en.bin",
+    // "voice:whisperModel":     "base.en",   // tiny.en | base.en | small.en | …
+    // "voice:whisperModelPath": "C:/models/ggml-base.en.bin",  // explicit override; skips auto-download
 
     // -- Other --
     // "widget:icononly":           false,


### PR DESCRIPTION
## Summary

Removes the model-file config burden for the `whisper-local` engine (#1625): the GGML model now **downloads on first use** instead of requiring `voice:whisperModelPath`. Completes most of #1591 §4c.

- **`ensure_local_model()`**: an explicit `voice:whisperModelPath` / `AGENTMUX_WHISPER_MODEL` still wins (no download); otherwise fetches `ggml-<name>.bin` (default **`base.en`** ~142 MB, configurable via `voice:whisperModel`) from the whisper.cpp model repo to `<config>/whisper-models/`.
- Robustness: a **global lock** serializes concurrent first-uses, a **600 s timeout** caps a stuck transfer, **temp→rename** so a partial download never looks valid, and the model name is **sanitized** (defends the `format!`-built path + URL).
- Settings: `voice:whisperModel` added (`wconfig/types.rs` + `gotypes.d.ts` + template).

## Still required for local
The **`whisper-cli` binary** is still user-provided (`voice:whisperCliPath`). Per-platform binary auto-bundling is genuinely fragile (release asset names/variants differ per OS), so it stays a follow-up. After this PR, local setup is: install whisper-cli → set `voice:engine: "whisper-local"` + `voice:whisperCliPath` → the model fetches itself.

## Scope / safety
Additive; the default `groq` path and the existing explicit-model-path override are untouched.

## Test plan
- [x] `cargo check -p agentmux-srv` — clean.
- [x] `task build:frontend` — clean.
- [ ] `voice:engine: "whisper-local"` + `voice:whisperCliPath`, no model path → first mic use downloads `ggml-base.en.bin` to `<config>/whisper-models/`, then transcribes; second use reuses the cached file.
- [ ] Explicit `voice:whisperModelPath` → no download.
- [ ] Bad `voice:whisperModel` (e.g. `../evil`) → rejected.

⚠️ Runtime-untested in CI (needs a live mic + whisper-cli + a real ~142 MB download); opt-in and off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)