### PR TITLE
fix(editor): md preview width, first-open blank render, tab path tooltip

### DIFF
--- a/.changesets/1781984501-fix-editor-markdown-preview-width-first-open-blank-render-an-uiuf.md
+++ b/.changesets/1781984501-fix-editor-markdown-preview-width-first-open-blank-render-an-uiuf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): markdown preview width, first-open blank render, and tab path tooltip

--- a/docs/analysis/ANALYSIS_EDITOR_MD_BUGS_2026_06_20.md
+++ b/docs/analysis/ANALYSIS_EDITOR_MD_BUGS_2026_06_20.md
@@ -1,0 +1,184 @@
+# Editor — Markdown rendering bugs (analysis)
+
+**Date:** 2026-06-20  
+**Scope:** `view: "editor"` pane (`frontend/app/view/editor/`)  
+**Status:** Analysis only — no code changed.
+
+Three reported issues, in priority order (Bug 3 is the real defect; 1 and 2 are
+small polish).
+
+---
+
+## Bug 3 — Markdown loads blank on first open; toggling Source→Preview fixes it
+
+**Severity:** High (the headline bug). Every freshly-opened `.md` renders blank
+until the user clicks **✎ Source** then **👁 Preview**.
+
+### Where
+- Preview render: `editor-view.tsx:838-841`
+  ```tsx
+  <Show when={showRendered()}>
+    <div class="editor-md-preview">
+      <Markdown textAtom={() => liveDoc()} />
+    </div>
+  </Show>
+  ```
+- The preview binds to the **`liveDoc`** signal, which is seeded *imperatively*,
+  not derived from the model's content.
+- Seeding sites: `onMount` (`editor-view.tsx:414`), the tab-change
+  `createEffect` (`:470` and `:475`), and the CodeMirror update listener (`:398`,
+  and the `updateListener` that calls `setLiveDoc` on `docChanged`).
+
+### Root cause
+`liveDoc` is only ever set as a side effect of building/restoring CodeMirror or
+of a CM edit. There is **no reactive path from "file content finished loading" to
+"preview buffer updated."** On first open the timing loses the race:
+
+1. First render: `loadingAtom()` is `true`, so the body `<Show>`
+   (`editor-view.tsx:823-832`) renders `<EmptyEditor/>` — the
+   `<div ref={containerRef}>` (`:834`) is **not mounted yet**, so `containerRef`
+   is `undefined`.
+2. `onMount` (`:410-416`) runs with empty `contentAtom()` → `setLiveDoc("")`.
+3. RPC returns, content arrives, `loadingAtom()` flips `false`.
+4. The tab-change `createEffect` (`:447`) re-runs (it tracks `activeIdAtom` +
+   `loadingAtom`). **But it guards on `!containerRef` and returns early
+   (`:450`)** when the container isn't mounted. Because the effect was *created*
+   before the JSX `<Show>` and runs earlier in Solid's update order, on the
+   `loadingAtom` flip it can execute **before** the `<Show>` re-renders and
+   assigns `containerRef`. → early return → `liveDoc` never re-seeded with the
+   loaded content.
+5. `liveDoc` stays `""`. The preview (`showRendered()` is the default for `.md`)
+   renders empty.
+
+Clicking **Source** then **Preview** works because by then `containerRef` is
+mounted; the next `setupEditor`/restore path calls `setLiveDoc(content)` with the
+real text.
+
+The blank-preview symptom is fundamentally that **`liveDoc` is an imperative
+mirror of CodeMirror, but the preview consumes it before CodeMirror has been
+built with real content.**
+
+### Recommended fix
+Make the preview buffer reactive to loaded content, independent of
+container/CM timing. Add a dedicated effect that re-seeds `liveDoc` whenever the
+model's content (re)loads:
+
+```tsx
+// Sync the preview buffer when content finishes loading for the active tab,
+// regardless of whether CodeMirror has mounted yet. Fixes the first-open
+// blank-preview race. CM edits still drive liveDoc via the update listener;
+// contentAtom only changes on load/save, so this never clobbers live edits.
+createEffect(() => {
+    const c = model.contentAtom();
+    if (!model.loadingAtom()) setLiveDoc(c);
+});
+```
+
+Alternatives considered:
+- Gate the preview `<Show>` on `!loadingAtom()` — hides the blank but doesn't fix
+  the underlying missing reactivity (still blank if the effect races).
+- Have `<Markdown>` read `model.contentAtom()` directly in preview mode — loses
+  unsaved source edits when toggling to preview.
+
+The dedicated-effect fix is smallest and correct: contentAtom changes only on
+load/save (edits go through CM → updateListener → `setLiveDoc`), so re-seeding on
+content change is safe and deterministic.
+
+---
+
+## Bug 1 — Markdown preview has a fixed width; should conform to the window
+
+**Severity:** Low (cosmetic).
+
+### Where
+`editor-view.scss:585-589`:
+```scss
+.editor-md-preview {
+    .markdown {
+        max-width: 860px;   // ← fixed reading measure
+        margin: 0 auto;     // ← centers the narrow column
+        font-size: calc(var(--markdown-font-size, 14px) * var(--editor-zoom, 1));
+    }
+}
+```
+
+### Root cause
+The rendered markdown is intentionally constrained to an 860px centered reading
+column (`.editor-md-preview` container fills the pane via `position:absolute;
+inset:0` at `:572-574`, but its `.markdown` child is capped). The user wants it
+to fill the pane width instead.
+
+### Recommended fix
+Remove the cap (or make it opt-in). Drop `max-width: 860px` and `margin: 0 auto`
+so `.markdown` flows to the container width; keep the container's
+`padding` (`:583`) for breathing room. If a reading measure is still wanted as a
+default, gate it behind a setting or a wider `max-width: 100%`. The
+`.editor-md-preview` already scrolls (`overflow:auto`, `:576`) so width-fill is
+safe.
+
+Note: this `.markdown` rule is editor-scoped (`.editor-md-preview .markdown`), so
+changing it does **not** affect the shared `Markdown` component elsewhere
+(`frontend/app/element/markdown.tsx`).
+
+---
+
+## Bug 2 — In-editor file tab should show the full path on hover
+
+**Severity:** Low. **Target confirmed by user: the in-editor file tab strip**
+(`editor-tab-strip.tsx`), not the pane header.
+
+### Findings (corrected after deeper investigation)
+The tab **already sets a native `title`** with the full path
+(`editor-tab-strip.tsx:106`):
+```tsx
+title={props.tab.isPreview ? `${props.tab.filePath} (preview …)` : props.tab.filePath}
+```
+And the content is correct: `tab.filePath` is the **full absolute path** —
+`canonicalizePath` (`editor-pane-state-store.ts:221-234`) only normalizes
+slashes / drive-letter casing / trailing slash; it does not strip the path to a
+basename or `~`. So the *data* is right.
+
+**The real problem is the mechanism.** This app does not rely on the native
+`title` tooltip for hover affordances — native `title` has a ~1s OS delay and is
+inconsistent in the CEF/Chromium embedding. The codebase instead uses **custom
+instant tooltips**:
+- a pure-CSS `data-tip` pattern (`editor-view.scss:71-94`, used by the file-tree
+  toolbar), explicitly *"visible the same frame mouseenter fires"*;
+- a shared `Tooltip` component (`@/app/element/tooltip`, used by e.g.
+  `action-widgets.tsx`).
+
+So hovering an editor tab feels like "nothing shows" — the native `title` is
+there but slow/unreliable, and it isn't the affordance users see elsewhere.
+
+### Recommended fix
+Replace the native `title` on `.editor-tab` with the app's tooltip mechanism so
+the full path shows instantly and consistently. Two options:
+
+1. **Shared `Tooltip` component (preferred).** Wrap the tab (or its label) in
+   `<Tooltip>` from `@/app/element/tooltip`. It uses floating-ui positioning, so
+   a long absolute path is placed and constrained sensibly rather than clipping
+   at the window edge. Best for long paths.
+2. **Scoped `data-tip` CSS** (matches the file-tree pattern). Add
+   `data-tip={props.tab.filePath}` and an `.editor-tab[data-tip]:hover::after`
+   rule mirroring `editor-view.scss:74-94`. Lighter, but the file-tree rule uses
+   `white-space: nowrap`; a long absolute path would overflow, so this variant
+   needs `max-width` + wrapping (`white-space: normal; word-break: break-all`).
+
+Recommendation: option 1 (shared `Tooltip`) — consistent with the widget bar,
+handles long paths, instant. Keep the preview-tab suffix ("(preview — double-click
+to pin)") in the tooltip text. The native `title` can be dropped once the
+component tooltip is in place (avoid having both fire).
+
+---
+
+## Suggested sequencing
+
+1. **Bug 3** first — it's the actual defect and self-contained
+   (`editor-view.tsx`, one effect).
+2. **Bug 1** — one SCSS edit.
+3. **Bug 2** — swap the native `title` on `.editor-tab` for the shared
+   `Tooltip` component (`editor-tab-strip.tsx:106`). Data is already correct
+   (full absolute path); only the tooltip mechanism changes.
+
+All three are low-risk, frontend-only, no backend/schema involvement. Could ship
+as one small PR.

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -7,6 +7,7 @@
 // (tabs compress to min-width when crowded); chip lands in Phase 2.
 
 import { createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { Tooltip } from "@/app/element/tooltip";
 import type { EditorViewModel } from "./editor-model";
 import type { EditorTab } from "@/app/store/editor-pane-state-store";
 
@@ -94,37 +95,51 @@ function Tab(props: TabProps): JSX.Element {
         props.model.closeTab(props.tab.id);
     };
 
+    // Full path on hover. Uses the shared Tooltip (Portal-based) rather than a
+    // native `title` — the strip + tab both have `overflow:hidden`, which would
+    // clip a CSS tooltip, and native `title` is slow/inconsistent in CEF. The
+    // Tooltip's wrapper div carries the flex sizing (.editor-tab-tip); the tab
+    // keeps its own mousedown/click/dblclick handlers.
     return (
-        <div
-            class="editor-tab"
-            classList={{
-                "editor-tab--active": props.active,
-                "editor-tab--dirty": props.tab.dirty,
-                "editor-tab--preview": props.tab.isPreview,
-                "editor-tab--saveas": isSaveAsMode(),
-            }}
-            title={props.tab.isPreview ? `${props.tab.filePath} (preview — double-click to pin)` : props.tab.filePath}
-            onMouseDown={onMouseDown}
-            onClick={onClick}
-            onDblClick={onDblClick}
+        <Tooltip
+            placement="bottom"
+            divClassName="editor-tab-tip"
+            content={
+                props.tab.isPreview
+                    ? `${props.tab.filePath} (preview — double-click to pin)`
+                    : props.tab.filePath
+            }
         >
-            <Show when={isSaveAsMode()} fallback={<span class="editor-tab-label">{basename()}</span>}>
-                <SaveAsInput
-                    onConfirm={props.onSaveAsConfirm ?? (() => undefined)}
-                    onCancel={props.onSaveAsCancel ?? (() => undefined)}
-                />
-            </Show>
-            <button
-                class="editor-tab-close"
-                onClick={onCloseClick}
-                title={props.tab.dirty ? "Close (unsaved changes)" : "Close"}
-                aria-label="Close tab"
+            <div
+                class="editor-tab"
+                classList={{
+                    "editor-tab--active": props.active,
+                    "editor-tab--dirty": props.tab.dirty,
+                    "editor-tab--preview": props.tab.isPreview,
+                    "editor-tab--saveas": isSaveAsMode(),
+                }}
+                onMouseDown={onMouseDown}
+                onClick={onClick}
+                onDblClick={onDblClick}
             >
-                {/* The × always renders for dirty tabs (since closing prompts
-                    the user in a follow-up commit); hover-shown otherwise. */}
-                ×
-            </button>
-        </div>
+                <Show when={isSaveAsMode()} fallback={<span class="editor-tab-label">{basename()}</span>}>
+                    <SaveAsInput
+                        onConfirm={props.onSaveAsConfirm ?? (() => undefined)}
+                        onCancel={props.onSaveAsCancel ?? (() => undefined)}
+                    />
+                </Show>
+                <button
+                    class="editor-tab-close"
+                    onClick={onCloseClick}
+                    title={props.tab.dirty ? "Close (unsaved changes)" : "Close"}
+                    aria-label="Close tab"
+                >
+                    {/* The × always renders for dirty tabs (since closing prompts
+                        the user in a follow-up commit); hover-shown otherwise. */}
+                    ×
+                </button>
+            </div>
+        </Tooltip>
     );
 }
 

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -257,10 +257,20 @@
     overflow-x: hidden;
 }
 
-.editor-tab {
+// Tooltip wrapper (shared Tooltip component) — carries the flex sizing the tab
+// used to own, so wrapping the tab for a hover tooltip doesn't change layout.
+.editor-tab-tip {
     flex: 1 1 140px;
     min-width: 80px;
     max-width: 200px;
+    display: flex;
+    align-items: stretch;
+}
+
+.editor-tab {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
     display: flex;
     align-items: center;
     gap: var(--space-1);
@@ -583,8 +593,9 @@
     padding: calc(16px * var(--editor-zoom, 1)) calc(24px * var(--editor-zoom, 1));
 
     .markdown {
-        max-width: 860px;
-        margin: 0 auto;
+        // Fill the pane width — was a fixed 860px centered reading column,
+        // which looked cramped in a wide editor. The container already
+        // supplies padding + scroll.
         font-size: calc(var(--markdown-font-size, 14px) * var(--editor-zoom, 1));
     }
 }

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -74,7 +74,14 @@ async function loadLanguage(lang: string): Promise<Extension | null> {
 
 export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>): JSX.Element {
     const model = props.model;
-    let containerRef: HTMLDivElement | undefined;
+    // Reactive ref: the markdown preview seeds `liveDoc` from the tab-change
+    // effect, which guards on the container being mounted. On first open the
+    // container mounts only AFTER content finishes loading (the body <Show>
+    // gates on !loadingAtom), so a plain `let` ref left the effect early-
+    // returning before the container existed → blank preview until a manual
+    // Source/Preview toggle. A signal makes the effect re-run when the
+    // container mounts, seeding the preview reliably.
+    const [containerRef, setContainerRef] = createSignal<HTMLDivElement>();
     let rootRef: HTMLDivElement | undefined;
     let cmView: EditorView | null = null;
 
@@ -318,7 +325,8 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
     // Build or rebuild CodeMirror when the active tab changes
     const setupEditor = async (content: string, language: string, readOnly: boolean) => {
-        if (!containerRef) return;
+        const container = containerRef();
+        if (!container) return;
 
         // Destroy previous instance
         if (cmView) {
@@ -393,7 +401,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 doc: content,
                 extensions,
             }),
-            parent: containerRef,
+            parent: container,
         });
         setLiveDoc(content); // seed preview from the freshly-built doc
     };
@@ -447,7 +455,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     createEffect(() => {
         const activeId = model.activeIdAtom(); // reactive: tab change
         const loading = model.loadingAtom(); // reactive: wait for content
-        if (!activeId || loading || !containerRef) return;
+        // containerRef() is reactive: when the body <Show> mounts the container
+        // after content loads, this effect re-runs and proceeds (fixes the
+        // first-open blank-preview race).
+        if (!activeId || loading || !containerRef()) return;
 
         untrack(() => {
             const path = model.filePathAtom();
@@ -831,7 +842,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                     fallback={<EmptyEditor />}
                 >
                     <div class="editor-body-wrap">
-                        <div class="editor-codemirror" ref={containerRef} />
+                        <div class="editor-codemirror" ref={setContainerRef} />
                         {/* Styled markdown preview, overlaid over CodeMirror for
                             .md tabs in rendered mode. CM stays mounted beneath so
                             toggling back keeps cursor/scroll/undo. */}


### PR DESCRIPTION
Three editor fixes. Analysis: `docs/analysis/ANALYSIS_EDITOR_MD_BUGS_2026_06_20.md`.

## 1. Markdown blank on first open (the real bug)
Opening an `.md` rendered blank until you clicked **✎ Source** then **👁 Preview**.

**Root cause:** the preview binds to the `liveDoc` signal, which was only seeded as a side effect of building/restoring CodeMirror. On first open the CM container (`<div ref=…>`) mounts only *after* content finishes loading (the body `<Show>` gates on `!loadingAtom()`), so the tab-change `createEffect` ran while `containerRef` was still undefined, hit its `!containerRef` guard, early-returned, and never seeded the preview. `containerRef` wasn't reactive, so nothing re-ran when it mounted.

**Fix:** make `containerRef` a signal (`createSignal`). The effect now tracks it and re-runs when the container mounts, seeding the preview reliably. The existing tab-switch restore path (cached CodeMirror state → `setLiveDoc`) is untouched, so unsaved-edit previews aren't clobbered.

## 2. Markdown preview fixed width → fills the pane
`.editor-md-preview .markdown` had `max-width: 860px; margin: 0 auto`, a narrow centered column. Removed so it flows to the pane width (the container already supplies padding + scroll). Editor-scoped — does not affect the shared `Markdown` component.

## 3. In-editor tab: full path on hover
The tab already set a native `title` with the full absolute path, but native `title` is slow/inconsistent in CEF, and a pure-CSS tooltip would be clipped (`.editor-tab-strip` and `.editor-tab` are `overflow:hidden`). Switched to the shared Portal-based `Tooltip`. A wrapper (`.editor-tab-tip`) carries the flex sizing the tab used to own, so layout is unchanged; the tab keeps its mousedown (middle-click close) / click / dblclick (pin preview) handlers.

## Verification
- `tsc` clean for all touched files (31 pre-existing unrelated errors remain, incl. `editor-model.ts:788`).
- `stylelint`: 13 violations before == 13 after — zero introduced (all pre-existing/grandfathered in `editor-view.scss`).
- Frontend-only, no backend/schema.

Bug 1 (first-open blank) is reasoned statically from the render/effect ordering; worth a quick manual confirm in a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)