### PR TITLE
feat(agent-pane): aggressive URL hyperlinking in all text node types

### DIFF
--- a/.changesets/1781995722-feat-agent-pane-aggressive-url-hyperlinking-linkify-it-detec-xddu.md
+++ b/.changesets/1781995722-feat-agent-pane-aggressive-url-hyperlinking-linkify-it-detec-xddu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): aggressive URL hyperlinking — linkify-it detects bare domains, localhost:PORT, and https:// links in all agent pane text nodes

--- a/docs/specs/SPEC_AGENT_PANE_HYPERLINKS_2026_06_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_HYPERLINKS_2026_06_20.md
@@ -301,7 +301,8 @@ match.url includes "://"    →  use as-is
 otherwise (bare domain)     →  "https://" + match.url
 ```
 
-`localhost:3000` → `https://localhost:3000`  
+`localhost:3000` → `http://localhost:3000` (loopback uses http)  
+`127.0.0.1:8080` → `http://127.0.0.1:8080` (loopback uses http)  
 `github.com/foo` → `https://github.com/foo`  
 `http://example.com` → `http://example.com` (unchanged)
 

--- a/docs/specs/SPEC_AGENT_PANE_HYPERLINKS_2026_06_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_HYPERLINKS_2026_06_20.md
@@ -1,0 +1,387 @@
+# SPEC: Aggressive Hyperlink Detection in Agent Pane
+
+**Date:** 2026-06-20  
+**Status:** Draft  
+**Scope:** Frontend only. Two implementation paths; ~100 lines total across 3–4 files.
+
+---
+
+## 1. Goal
+
+Any URL that appears in agent output — including those **without** an `http://` prefix
+(bare domains like `github.com/foo`, local dev servers like `localhost:3000`,
+IPs with ports like `127.0.0.1:8080`) — should be rendered as a clickable hyperlink
+that opens in the system browser via the existing `openLink()` / `openExternal` IPC.
+
+---
+
+## 2. Scope: All Text-Bearing Node Types
+
+| Node type | Rendered by | Text format | Linkify path |
+|-----------|-------------|-------------|--------------|
+| `MarkdownNode` (assistant output) | `MarkdownBlock` → `Markdown` | Markdown AST via rehype | rehype plugin (§4) |
+| `MarkdownNode` with `metadata.thinking: true` | Same as above | Same | Same rehype plugin |
+| `AgentMessageNode` | `AgentMessageBlock` | Plain `<pre>` text | `LinkifiedText` component (§5) |
+| `UserMessageNode` | `UserMessageBlock` | Plain `<pre>` text | `LinkifiedText` component (§5) |
+| `ShellNode` output lines | `PersistentShellBlock` (or equivalent) | Plain text per line | `LinkifiedText` component (§5) |
+
+Reasoning (thinking) blocks are `MarkdownNode` with `metadata.thinking = true` — they
+go through the exact same `Markdown` component as regular assistant content, so the
+rehype plugin covers them automatically.
+
+---
+
+## 3. Library: `linkify-it`
+
+**Choice:** `linkify-it` (not `linkifyjs`, not `autolinker`)
+
+**Rationale:**
+- 11.9M weekly npm downloads; actively maintained (v5.x)
+- Used internally by `markdown-it` (the most-deployed markdown renderer)
+- TypeScript: `@types/linkify-it` available on DefinitelyTyped
+- ~3–5 KB gzipped — smallest in class
+- Handles bare domains, `localhost:PORT`, `//`-relative URLs, Unicode TLDs
+- Correctly strips trailing punctuation (`.`, `,`, `)`, `?`, `!`) without configuration
+
+**Install:**
+```
+pnpm add linkify-it
+pnpm add -D @types/linkify-it
+```
+
+**Configuration:**
+```typescript
+import LinkifyIt from "linkify-it";
+
+const linkify = new LinkifyIt();
+// Match bare domains (github.com, localhost:3000, etc.)
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+```
+
+`fuzzyLink: true` enables matching without `http://`. `fuzzyEmail: false` avoids
+false positives on `name@host` patterns in shell output.
+
+---
+
+## 4. Path A — MarkdownNode (including thinking blocks)
+
+### 4.1 Where to insert
+
+`markdown.tsx` builds a unified processor. The rehype plugin array (lines 476–513)
+currently runs in this order:
+
+```
+rehypeRaw
+rehypeHighlight (conditional)
+rehypeAlignToClass
+rehypeSanitize(...)    ← our plugin goes HERE, just before this
+rehypeSlug
+```
+
+Insert **before** `rehypeSanitize` so the sanitizer can see and preserve our
+injected `<a href>` elements. (`defaultSchema` already allows `<a>` with `href`.)
+
+Insert **after** `rehypeHighlight` so we don't attempt to linkify inside
+already-tokenized code spans.
+
+### 4.2 New file: `frontend/app/element/rehype-linkify.ts`
+
+```typescript
+import type { Root, Element, Text } from "hast";
+import type { Plugin } from "unified";
+import { visit, SKIP } from "unist-util-visit";
+import LinkifyIt from "linkify-it";
+
+const linkify = new LinkifyIt();
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+
+// Ancestor tag names that mean "don't linkify inside here"
+const SKIP_TAGS = new Set(["a", "code", "pre", "script", "style"]);
+
+export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
+    visit(tree, "text", (node: Text, index, parent) => {
+        if (!parent || index == null) return;
+
+        // Skip nodes whose nearest-ancestor is a skipped tag
+        // (unist-util-visit provides the immediate parent; we need to walk up.
+        // A pragmatic shortcut: visit() with ancestors tracking.)
+        // Instead: check if any ancestor in the walk is a skip tag.
+        // We do this via the parent reference provided at call time.
+        const parentElement = parent as Element;
+        if (parentElement.type === "element" && SKIP_TAGS.has(parentElement.tagName)) {
+            return SKIP;
+        }
+
+        const matches = linkify.match(node.value);
+        if (!matches) return;
+
+        const newNodes: (Text | Element)[] = [];
+        let lastIndex = 0;
+
+        for (const match of matches) {
+            if (match.index > lastIndex) {
+                newNodes.push({ type: "text", value: node.value.slice(lastIndex, match.index) });
+            }
+            const href = match.url.startsWith("//")
+                ? "https:" + match.url
+                : match.url.includes("://")
+                ? match.url
+                : "https://" + match.url;
+
+            newNodes.push({
+                type: "element",
+                tagName: "a",
+                properties: { href },
+                children: [{ type: "text", value: match.text }],
+            } as Element);
+            lastIndex = match.lastIndex;
+        }
+
+        if (lastIndex < node.value.length) {
+            newNodes.push({ type: "text", value: node.value.slice(lastIndex) });
+        }
+
+        parent.children.splice(index, 1, ...newNodes);
+        return SKIP; // don't re-visit the inserted nodes
+    });
+};
+```
+
+> **Ancestor check note:** `visit()` from `unist-util-visit` provides only the
+> immediate parent. For deeper skip-tag detection (e.g. `<pre><code>text</code></pre>`),
+> use the `ancestors` variant: `visit(tree, "text", visitor, ancestors)` and check
+> `ancestors.some(a => a.type === "element" && SKIP_TAGS.has(a.tagName))`.
+> The `unist-util-visit-parents` package provides this. Use it instead of
+> `unist-util-visit` to get reliable code-block exclusion.
+
+### 4.3 Wire into `markdown.tsx`
+
+In the `rehypePlugins` array (around line 476), change:
+
+```typescript
+// Before:
+rehypeAlignToClass,
+() => rehypeSanitize({...}),
+
+// After:
+rehypeAlignToClass,
+rehypeLinkify,
+() => rehypeSanitize({...}),
+```
+
+Import at top:
+```typescript
+import { rehypeLinkify } from "./rehype-linkify";
+```
+
+### 4.4 Click handling — no change needed
+
+The `markdownComponents` registry in `markdown.tsx` (line 406) maps every `<a>`
+element to the existing `Link` component:
+
+```typescript
+a: (props: any) => <Link props={props} setFocusedHeading={setFocusedHeading} />,
+```
+
+`Link` already calls `openLink(href)` for all non-anchor hrefs. Our injected
+`<a href="https://...">` elements will automatically route through this handler.
+No additional click wiring needed.
+
+---
+
+## 5. Path B — Plain Text Nodes (`AgentMessageBlock`, `UserMessageBlock`, Shell)
+
+These render raw text in `<pre>` tags. No markdown pipeline is involved.
+
+### 5.1 New file: `frontend/app/element/linkified-text.tsx`
+
+```typescript
+import { createMemo, For } from "solid-js";
+import LinkifyIt from "linkify-it";
+import { openLink } from "@/app/store/global";
+
+const linkify = new LinkifyIt();
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+
+type Segment = { text: string; url?: string };
+
+function linkifySegments(text: string): Segment[] {
+    const matches = linkify.match(text);
+    if (!matches) return [{ text }];
+
+    const segments: Segment[] = [];
+    let lastIndex = 0;
+
+    for (const match of matches) {
+        if (match.index > lastIndex) {
+            segments.push({ text: text.slice(lastIndex, match.index) });
+        }
+        const href = match.url.startsWith("//")
+            ? "https:" + match.url
+            : match.url.includes("://")
+            ? match.url
+            : "https://" + match.url;
+        segments.push({ text: match.text, url: href });
+        lastIndex = match.lastIndex;
+    }
+
+    if (lastIndex < text.length) {
+        segments.push({ text: text.slice(lastIndex) });
+    }
+
+    return segments;
+}
+
+export const LinkifiedText = (props: { text: string }) => {
+    const segments = createMemo(() => linkifySegments(props.text));
+    return (
+        <For each={segments()}>
+            {(seg) =>
+                seg.url ? (
+                    <a
+                        href={seg.url}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            openLink(seg.url!);
+                        }}
+                    >
+                        {seg.text}
+                    </a>
+                ) : (
+                    <>{seg.text}</>
+                )
+            }
+        </For>
+    );
+};
+```
+
+### 5.2 `AgentMessageBlock.tsx`
+
+Replace the plain `<pre>` content:
+
+```typescript
+// Before:
+<pre class="agent-message-body">{props.node.message}</pre>
+
+// After:
+<pre class="agent-message-body">
+    <LinkifiedText text={props.node.message} />
+</pre>
+```
+
+### 5.3 `UserMessageBlock.tsx`
+
+Locate the user message `<pre>` element (around line 244) and wrap similarly:
+
+```typescript
+// Before:
+<pre>{props.node.message}</pre>
+
+// After:
+<pre><LinkifiedText text={props.node.message} /></pre>
+```
+
+### 5.4 Shell output
+
+If shell lines are rendered as raw text strings, wrap them with `<LinkifiedText>` in
+the same way. Investigate `PersistentShellBlock` or the relevant shell renderer to
+find the exact `<pre>` / text render site.
+
+---
+
+## 6. URL Normalization
+
+All injected `href` values follow this rule (applied in both `rehype-linkify.ts` and
+`linkified-text.tsx`):
+
+```
+match.url starts with "//"  →  "https:" + match.url
+match.url includes "://"    →  use as-is
+otherwise (bare domain)     →  "https://" + match.url
+```
+
+`localhost:3000` → `https://localhost:3000`  
+`github.com/foo` → `https://github.com/foo`  
+`http://example.com` → `http://example.com` (unchanged)
+
+---
+
+## 7. Security
+
+- `openLink()` delegates to `getApi().openExternal()` → Chromium / OS default handler.
+  The OS will refuse `javascript:` and `data:` URIs for browser launch.
+- As a defense-in-depth layer, filter before calling `openLink`:
+  ```typescript
+  const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;
+  const isSafe = (url: string) => SAFE_SCHEMES.test(url) || url.startsWith("//");
+  ```
+  Only call `openLink` when `isSafe(href)` is true.
+- `rehype-sanitize` (already in the markdown pipeline) strips `javascript:` hrefs from
+  any injected `<a>` elements that somehow slip through.
+- `linkify-it` with `fuzzyLink` will not match bare words without TLDs or ports.
+  False positive rate on typical LLM prose is very low.
+
+---
+
+## 8. Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Trailing `.` or `,` after URL | `linkify-it` strips correctly by default |
+| URL in parentheses: `(https://example.com)` | `linkify-it` strips trailing `)` |
+| Markdown explicit link `[text](url)` | Already an `<a>` in HAST before our plugin runs; `SKIP_TAGS` includes `a` → no double-linkification |
+| URL in fenced code block | HAST `<pre><code>` ancestry → skip via ancestor check |
+| URL in inline code `` `localhost:3000` `` | HAST `<code>` ancestry → skip |
+| `localhost` with no port | Not matched (no TLD, no port — not a URL) |
+| `localhost:3000` | Matched via `fuzzyLink` + port detection |
+| `127.0.0.1:8080` | Matched |
+| Bare IPv4 `192.168.1.1` (no port) | Not matched (avoids IP false positives) |
+| Path like `./src/foo.ts` | Not matched (no TLD/port) |
+| Email `user@example.com` | Not matched (`fuzzyEmail: false`) |
+| Same URL in streaming update | `createMemo` in `LinkifiedText` recomputes; rehype plugin re-runs on changed text — idempotent |
+
+---
+
+## 9. Styling
+
+Add to `_document-nodes.scss` (or the global link style):
+
+```scss
+// Linkified URLs in agent output
+.agent-markdown-block a,
+.agent-message-body a,
+.agent-user-message a {
+    color: var(--link-color, #60a5fa);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--link-color, #60a5fa) 40%, transparent);
+    cursor: pointer;
+
+    &:hover {
+        text-decoration-color: var(--link-color, #60a5fa);
+    }
+}
+```
+
+The `.thinking-block a` inherits from `.agent-markdown-block a` because thinking
+blocks are wrapped in `.agent-markdown-block.thinking-block`.
+
+---
+
+## 10. Implementation Steps
+
+1. `pnpm add linkify-it && pnpm add -D @types/linkify-it` (in `frontend/`)
+2. Create `frontend/app/element/rehype-linkify.ts` (§4.2) — use `unist-util-visit-parents` for ancestor checking
+3. Wire `rehypeLinkify` into `markdown.tsx` rehype plugin array (§4.3)
+4. Create `frontend/app/element/linkified-text.tsx` (§5.1)
+5. Update `AgentMessageBlock.tsx` (§5.2)
+6. Update `UserMessageBlock.tsx` (§5.3)
+7. Update shell output renderer (§5.4)
+8. Add link styles to `_document-nodes.scss` (§9)
+9. Test: paste `check out github.com/foo and localhost:3000` in user message → both clickable
+10. Test: URL inside code block → NOT linkified
+11. Test: thinking block with URL → linkified
+12. Test: existing `[text](url)` markdown links → unaffected
+13. Changeset: `patch "feat(agent-pane): aggressive URL hyperlinking in all text node types"`
+
+**Total diff estimate:** ~120 lines across 5 files + 1 new file + 1 new file.

--- a/frontend/app/element/linkified-text.tsx
+++ b/frontend/app/element/linkified-text.tsx
@@ -1,0 +1,74 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMemo, For, type JSX } from "solid-js";
+import LinkifyIt from "linkify-it";
+import { openLink } from "@/app/store/global";
+
+const linkify = new LinkifyIt();
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+
+const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;
+
+function isSafeHref(url: string): boolean {
+    return SAFE_SCHEMES.test(url) || url.startsWith("//");
+}
+
+function normalizeHref(url: string): string {
+    if (url.startsWith("//")) return "https:" + url;
+    if (url.includes("://")) return url;
+    return "https://" + url;
+}
+
+type Segment = { text: string; href?: string };
+
+function toSegments(text: string): Segment[] {
+    const matches = linkify.match(text);
+    if (!matches) return [{ text }];
+
+    const segments: Segment[] = [];
+    let lastIndex = 0;
+
+    for (const match of matches) {
+        if (match.index > lastIndex) {
+            segments.push({ text: text.slice(lastIndex, match.index) });
+        }
+        segments.push({ text: match.text, href: normalizeHref(match.url) });
+        lastIndex = match.lastIndex;
+    }
+
+    if (lastIndex < text.length) {
+        segments.push({ text: text.slice(lastIndex) });
+    }
+
+    return segments;
+}
+
+/**
+ * Renders plain text with detected URLs converted to clickable links.
+ * Safe to use inside <pre> — renders as inline text + <a> elements.
+ */
+export const LinkifiedText = (props: { text: string }): JSX.Element => {
+    const segments = createMemo(() => toSegments(props.text));
+    return (
+        <For each={segments()}>
+            {(seg) => {
+                if (seg.href && isSafeHref(seg.href)) {
+                    return (
+                        <a
+                            href={seg.href}
+                            class="linkified-url"
+                            onClick={(e) => {
+                                e.preventDefault();
+                                openLink(seg.href!);
+                            }}
+                        >
+                            {seg.text}
+                        </a>
+                    );
+                }
+                return <>{seg.text}</>;
+            }}
+        </For>
+    );
+};

--- a/frontend/app/element/linkified-text.tsx
+++ b/frontend/app/element/linkified-text.tsx
@@ -2,27 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, For, type JSX } from "solid-js";
-import LinkifyIt from "linkify-it";
 import { openLink } from "@/app/store/global";
-
-const linkify = new LinkifyIt();
-linkify.set({ fuzzyLink: true, fuzzyEmail: false });
-
-const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;
-
-function isSafeHref(url: string): boolean {
-    return SAFE_SCHEMES.test(url) || url.startsWith("//");
-}
-
-// Local addresses use http://, not https://
-const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
-
-function normalizeHref(url: string): string {
-    if (url.startsWith("//")) return "https:" + url;
-    if (url.includes("://")) return url;
-    const scheme = LOCAL_HOST_RE.test(url.split("/")[0]) ? "http" : "https";
-    return `${scheme}://${url}`;
-}
+import { linkify, normalizeHref, isLikelyFilename, isSafeHref } from "./linkify-config";
 
 type Segment = { text: string; href?: string };
 
@@ -34,6 +15,17 @@ function toSegments(text: string): Segment[] {
     let lastIndex = 0;
 
     for (const match of matches) {
+        // Drop fuzzy matches that are actually source-code filenames
+        // (e.g. README.md, main.rs, setup.py treated as ccTLD URLs)
+        if (isLikelyFilename(match.schema, match.url)) {
+            if (match.index > lastIndex) {
+                segments.push({ text: text.slice(lastIndex, match.index) });
+            }
+            segments.push({ text: match.raw });
+            lastIndex = match.lastIndex;
+            continue;
+        }
+
         if (match.index > lastIndex) {
             segments.push({ text: text.slice(lastIndex, match.index) });
         }

--- a/frontend/app/element/linkified-text.tsx
+++ b/frontend/app/element/linkified-text.tsx
@@ -14,10 +14,14 @@ function isSafeHref(url: string): boolean {
     return SAFE_SCHEMES.test(url) || url.startsWith("//");
 }
 
+// Local addresses use http://, not https://
+const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
+
 function normalizeHref(url: string): string {
     if (url.startsWith("//")) return "https:" + url;
     if (url.includes("://")) return url;
-    return "https://" + url;
+    const scheme = LOCAL_HOST_RE.test(url.split("/")[0]) ? "http" : "https";
+    return `${scheme}://${url}`;
 }
 
 type Segment = { text: string; href?: string };

--- a/frontend/app/element/linkified-text.tsx
+++ b/frontend/app/element/linkified-text.tsx
@@ -29,7 +29,7 @@ function toSegments(text: string): Segment[] {
         if (match.index > lastIndex) {
             segments.push({ text: text.slice(lastIndex, match.index) });
         }
-        segments.push({ text: match.text, href: normalizeHref(match.url) });
+        segments.push({ text: match.text, href: normalizeHref(match.schema, match.url) });
         lastIndex = match.lastIndex;
     }
 

--- a/frontend/app/element/linkify-config.ts
+++ b/frontend/app/element/linkify-config.ts
@@ -11,8 +11,10 @@ export const linkify = new LinkifyIt();
 // fuzzyEmail off: avoids false positives on name@host patterns in shell output
 linkify.set({ fuzzyLink: true, fuzzyEmail: false });
 
-// Local addresses stay on http://, everything else is upgraded to https://
-const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
+// Local / private-network addresses stay on http://, everything else → https://
+// Covers: loopback, any-addr, IPv6 loopback, RFC 1918 class A/B/C
+const LOCAL_HOST_RE =
+    /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\]|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+)(:\d+)?$/i;
 
 /**
  * Normalize a linkify-it match to a final href.

--- a/frontend/app/element/linkify-config.ts
+++ b/frontend/app/element/linkify-config.ts
@@ -14,9 +14,12 @@ linkify.set({ fuzzyLink: true, fuzzyEmail: false });
 // Local addresses open with http://, not https://
 const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
 
+// Matches any RFC 3986 scheme prefix (http:, https:, mailto:, ftp:, ssh:, …)
+const HAS_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
 export function normalizeHref(url: string): string {
     if (url.startsWith("//")) return "https:" + url;
-    if (url.includes("://")) return url;
+    if (HAS_SCHEME_RE.test(url)) return url;
     const host = url.split("/")[0].split(":")[0];
     const scheme = LOCAL_HOST_RE.test(host) ? "http" : "https";
     return `${scheme}://${url}`;

--- a/frontend/app/element/linkify-config.ts
+++ b/frontend/app/element/linkify-config.ts
@@ -11,18 +11,32 @@ export const linkify = new LinkifyIt();
 // fuzzyEmail off: avoids false positives on name@host patterns in shell output
 linkify.set({ fuzzyLink: true, fuzzyEmail: false });
 
-// Local addresses open with http://, not https://
+// Local addresses stay on http://, everything else is upgraded to https://
 const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
 
-// Matches any RFC 3986 scheme prefix (http:, https:, mailto:, ftp:, ssh:, …)
-const HAS_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
-
-export function normalizeHref(url: string): string {
-    if (url.startsWith("//")) return "https:" + url;
-    if (HAS_SCHEME_RE.test(url)) return url;
-    const host = url.split("/")[0].split(":")[0];
-    const scheme = LOCAL_HOST_RE.test(host) ? "http" : "https";
-    return `${scheme}://${url}`;
+/**
+ * Normalize a linkify-it match to a final href.
+ *
+ * linkify-it always populates match.url with an absolute URL (it prepends
+ * "http://" to schemeless fuzzy matches), so the raw url is always usable.
+ * We only need to act when schema is empty (fuzzy match) and the user typed a
+ * bare public domain — in that case linkify-it already prepended "http://" but
+ * we want to serve "https://" for security. Local addresses keep "http://".
+ *
+ * Explicit-schema matches (http://, https://, mailto:, ssh:, …) are returned
+ * unchanged — the user or model typed a real URL and we respect it.
+ */
+export function normalizeHref(schema: string, url: string): string {
+    // Explicit schema typed by user/model — honour it as-is
+    if (schema) return url;
+    // Fuzzy match: linkify-it prepended "http://"; upgrade public hosts to https://
+    if (url.startsWith("http://")) {
+        const host = url.slice(7).split("/")[0].split(":")[0];
+        if (!LOCAL_HOST_RE.test(host)) {
+            return "https://" + url.slice(7);
+        }
+    }
+    return url;
 }
 
 // ccTLDs that double as common source-code file extensions.
@@ -42,8 +56,9 @@ const FILENAME_STEMS = new Set([
 export function isLikelyFilename(schema: string, url: string): boolean {
     // Matches with an explicit protocol are real URLs
     if (schema) return false;
-    // Strip path/port to get the bare host (e.g. "main.rs" from "main.rs/foo")
-    const host = url.split("/")[0].split(":")[0];
+    // linkify-it prepends http:// to fuzzy matches — strip it to get the host
+    const schemeless = url.startsWith("http://") ? url.slice(7) : url;
+    const host = schemeless.split("/")[0].split(":")[0];
     const dotIdx = host.lastIndexOf(".");
     if (dotIdx === -1) return false;
     const ext = host.slice(dotIdx + 1).toLowerCase();
@@ -59,8 +74,8 @@ export function isLikelyFilename(schema: string, url: string): boolean {
     return FILENAME_STEMS.has(label.toLowerCase());
 }
 
-export const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;
-
+// Allow-list of schemes safe to pass to openExternal. No :// requirement —
+// mailto: and ssh: are valid without it.
 export function isSafeHref(url: string): boolean {
-    return SAFE_SCHEMES.test(url) || url.startsWith("//");
+    return /^(https?|ftp|mailto|ssh|file):/i.test(url) || url.startsWith("//");
 }

--- a/frontend/app/element/linkify-config.ts
+++ b/frontend/app/element/linkify-config.ts
@@ -22,24 +22,38 @@ export function normalizeHref(url: string): string {
     return `${scheme}://${url}`;
 }
 
-// ccTLDs that are also ubiquitous source-code file extensions. fuzzyLink
-// would turn `README.md`, `main.rs`, `setup.py`, `build.sh` into bogus
-// external links (https://README.md etc.). We reject any fuzzy match whose
-// entire "hostname" is a single bare word + one of these extensions.
+// ccTLDs that double as common source-code file extensions.
 const FILE_EXT_TLDS = new Set(["md", "rs", "py", "sh", "pl", "ml"]);
 
+// Generic filename stem words. Combined with FILE_EXT_TLDS, these let us
+// reject `main.rs` / `README.md` / `setup.py` while keeping real single-label
+// domains like `docs.rs`, `pkg.sh`, `rustup.rs`.
+const FILENAME_STEMS = new Set([
+    "main", "build", "setup", "index", "mod", "lib", "test", "spec", "app",
+    "utils", "types", "constants", "config", "package", "requirements",
+    "cargo", "dockerfile", "vagrantfile", "makefile", "gemfile", "pipfile",
+    "procfile", "gruntfile", "gulpfile", "webpack", "rollup", "vite",
+    "init", "run", "start", "install", "update", "deploy", "release",
+]);
+
 export function isLikelyFilename(schema: string, url: string): boolean {
-    // Matches with an explicit protocol are never filenames
+    // Matches with an explicit protocol are real URLs
     if (schema) return false;
-    // Strip path/port to get the bare host (e.g. "README.md" from "README.md/foo")
+    // Strip path/port to get the bare host (e.g. "main.rs" from "main.rs/foo")
     const host = url.split("/")[0].split(":")[0];
     const dotIdx = host.lastIndexOf(".");
     if (dotIdx === -1) return false;
     const ext = host.slice(dotIdx + 1).toLowerCase();
-    // Only filter single-label hosts (one dot total): "README.md" yes,
-    // "example.io" or "api.github.md" both have more dots and are real URLs.
+    // Only FILE_EXT_TLDS trigger this check — .com/.io/.dev etc. are fine
+    if (!FILE_EXT_TLDS.has(ext)) return false;
+    // Only single-label hosts (one dot): "docs.rs" yes, "api.docs.rs" no
     const dotsInHost = (host.match(/\./g) ?? []).length;
-    return dotsInHost === 1 && FILE_EXT_TLDS.has(ext);
+    if (dotsInHost !== 1) return false;
+    const label = host.slice(0, dotIdx);
+    // All-uppercase label → always a filename (README, CHANGELOG, LICENSE)
+    if (label === label.toUpperCase() && label.length > 1) return true;
+    // Known generic filename stems (main, build, setup, …)
+    return FILENAME_STEMS.has(label.toLowerCase());
 }
 
 export const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;

--- a/frontend/app/element/linkify-config.ts
+++ b/frontend/app/element/linkify-config.ts
@@ -1,0 +1,49 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared linkify-it instance and helpers used by both rehype-linkify.ts
+// (markdown pipeline) and linkified-text.tsx (plain-text nodes).
+
+import LinkifyIt from "linkify-it";
+
+export const linkify = new LinkifyIt();
+// fuzzyLink: bare domains (github.com, localhost:3000) detected without http://
+// fuzzyEmail off: avoids false positives on name@host patterns in shell output
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+
+// Local addresses open with http://, not https://
+const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
+
+export function normalizeHref(url: string): string {
+    if (url.startsWith("//")) return "https:" + url;
+    if (url.includes("://")) return url;
+    const host = url.split("/")[0].split(":")[0];
+    const scheme = LOCAL_HOST_RE.test(host) ? "http" : "https";
+    return `${scheme}://${url}`;
+}
+
+// ccTLDs that are also ubiquitous source-code file extensions. fuzzyLink
+// would turn `README.md`, `main.rs`, `setup.py`, `build.sh` into bogus
+// external links (https://README.md etc.). We reject any fuzzy match whose
+// entire "hostname" is a single bare word + one of these extensions.
+const FILE_EXT_TLDS = new Set(["md", "rs", "py", "sh", "pl", "ml"]);
+
+export function isLikelyFilename(schema: string, url: string): boolean {
+    // Matches with an explicit protocol are never filenames
+    if (schema) return false;
+    // Strip path/port to get the bare host (e.g. "README.md" from "README.md/foo")
+    const host = url.split("/")[0].split(":")[0];
+    const dotIdx = host.lastIndexOf(".");
+    if (dotIdx === -1) return false;
+    const ext = host.slice(dotIdx + 1).toLowerCase();
+    // Only filter single-label hosts (one dot total): "README.md" yes,
+    // "example.io" or "api.github.md" both have more dots and are real URLs.
+    const dotsInHost = (host.match(/\./g) ?? []).length;
+    return dotsInHost === 1 && FILE_EXT_TLDS.has(ext);
+}
+
+export const SAFE_SCHEMES = /^(https?|ftp|mailto|ssh|file):\/\//i;
+
+export function isSafeHref(url: string): boolean {
+    return SAFE_SCHEMES.test(url) || url.startsWith("//");
+}

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -32,6 +32,7 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { openLink } from "../store/global";
+import { rehypeLinkify } from "./rehype-linkify";
 import { IconButton } from "./iconbutton";
 import "./markdown.scss";
 
@@ -478,6 +479,7 @@ const Markdown = (props: MarkdownProps) => {
                   rehypeRaw,
                   ...((props.highlight ?? true) ? [rehypeHighlight] : []),
                   rehypeAlignToClass,
+                  rehypeLinkify,
                   () =>
                       rehypeSanitize({
                           ...defaultSchema,

--- a/frontend/app/element/rehype-linkify.ts
+++ b/frontend/app/element/rehype-linkify.ts
@@ -4,25 +4,10 @@
 import type { Root, Element, Text, ElementContent } from "hast";
 import type { Plugin } from "unified";
 import { visitParents, SKIP } from "unist-util-visit-parents";
-import LinkifyIt from "linkify-it";
-
-const linkify = new LinkifyIt();
-// fuzzyLink matches bare domains (github.com, localhost:3000) without http://
-// fuzzyEmail off to avoid false positives on name@host patterns in shell output
-linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+import { linkify, normalizeHref, isLikelyFilename } from "./linkify-config";
 
 // Don't linkify text inside these elements — already an anchor, or code/pre
 const SKIP_ANCESTORS = new Set(["a", "code", "pre", "script", "style"]);
-
-// Local addresses use http://, not https://
-const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
-
-function normalizeHref(url: string): string {
-    if (url.startsWith("//")) return "https:" + url;
-    if (url.includes("://")) return url;
-    const scheme = LOCAL_HOST_RE.test(url.split("/")[0]) ? "http" : "https";
-    return `${scheme}://${url}`;
-}
 
 export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
     visitParents(tree, "text", (node: Text, ancestors) => {
@@ -40,6 +25,17 @@ export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
         let lastIndex = 0;
 
         for (const match of matches) {
+            // Drop fuzzy matches that are actually source-code filenames
+            // (e.g. README.md, main.rs, setup.py treated as ccTLD URLs)
+            if (isLikelyFilename(match.schema, match.url)) {
+                if (match.index > lastIndex) {
+                    newNodes.push({ type: "text", value: node.value.slice(lastIndex, match.index) });
+                }
+                newNodes.push({ type: "text", value: match.raw });
+                lastIndex = match.lastIndex;
+                continue;
+            }
+
             if (match.index > lastIndex) {
                 newNodes.push({ type: "text", value: node.value.slice(lastIndex, match.index) });
             }
@@ -55,6 +51,9 @@ export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
         if (lastIndex < node.value.length) {
             newNodes.push({ type: "text", value: node.value.slice(lastIndex) });
         }
+
+        // If nothing was actually linkified, bail out without mutating the tree
+        if (newNodes.length === 1 && newNodes[0].type === "text") return;
 
         const parent = ancestors[ancestors.length - 1] as Element;
         const index = parent.children.indexOf(node as ElementContent);

--- a/frontend/app/element/rehype-linkify.ts
+++ b/frontend/app/element/rehype-linkify.ts
@@ -14,10 +14,14 @@ linkify.set({ fuzzyLink: true, fuzzyEmail: false });
 // Don't linkify text inside these elements — already an anchor, or code/pre
 const SKIP_ANCESTORS = new Set(["a", "code", "pre", "script", "style"]);
 
+// Local addresses use http://, not https://
+const LOCAL_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|\[::1\])(:\d+)?$/i;
+
 function normalizeHref(url: string): string {
     if (url.startsWith("//")) return "https:" + url;
     if (url.includes("://")) return url;
-    return "https://" + url;
+    const scheme = LOCAL_HOST_RE.test(url.split("/")[0]) ? "http" : "https";
+    return `${scheme}://${url}`;
 }
 
 export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {

--- a/frontend/app/element/rehype-linkify.ts
+++ b/frontend/app/element/rehype-linkify.ts
@@ -1,0 +1,61 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Root, Element, Text, ElementContent } from "hast";
+import type { Plugin } from "unified";
+import { visitParents, SKIP } from "unist-util-visit-parents";
+import LinkifyIt from "linkify-it";
+
+const linkify = new LinkifyIt();
+// fuzzyLink matches bare domains (github.com, localhost:3000) without http://
+// fuzzyEmail off to avoid false positives on name@host patterns in shell output
+linkify.set({ fuzzyLink: true, fuzzyEmail: false });
+
+// Don't linkify text inside these elements — already an anchor, or code/pre
+const SKIP_ANCESTORS = new Set(["a", "code", "pre", "script", "style"]);
+
+function normalizeHref(url: string): string {
+    if (url.startsWith("//")) return "https:" + url;
+    if (url.includes("://")) return url;
+    return "https://" + url;
+}
+
+export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
+    visitParents(tree, "text", (node: Text, ancestors) => {
+        // Walk ancestor chain — skip if we're inside a, code, pre, etc.
+        for (const ancestor of ancestors) {
+            if (ancestor.type === "element" && SKIP_ANCESTORS.has((ancestor as Element).tagName)) {
+                return SKIP;
+            }
+        }
+
+        const matches = linkify.match(node.value);
+        if (!matches) return;
+
+        const newNodes: ElementContent[] = [];
+        let lastIndex = 0;
+
+        for (const match of matches) {
+            if (match.index > lastIndex) {
+                newNodes.push({ type: "text", value: node.value.slice(lastIndex, match.index) });
+            }
+            newNodes.push({
+                type: "element",
+                tagName: "a",
+                properties: { href: normalizeHref(match.url) },
+                children: [{ type: "text", value: match.text }],
+            });
+            lastIndex = match.lastIndex;
+        }
+
+        if (lastIndex < node.value.length) {
+            newNodes.push({ type: "text", value: node.value.slice(lastIndex) });
+        }
+
+        const parent = ancestors[ancestors.length - 1] as Element;
+        const index = parent.children.indexOf(node as ElementContent);
+        parent.children.splice(index, 1, ...newNodes);
+        // Jump past our inserted nodes so they aren't re-visited
+        return [SKIP, index + newNodes.length];
+    });
+};

--- a/frontend/app/element/rehype-linkify.ts
+++ b/frontend/app/element/rehype-linkify.ts
@@ -42,7 +42,7 @@ export const rehypeLinkify: Plugin<[], Root> = () => (tree) => {
             newNodes.push({
                 type: "element",
                 tagName: "a",
-                properties: { href: normalizeHref(match.url) },
+                properties: { href: normalizeHref(match.schema, match.url) },
                 children: [{ type: "text", value: match.text }],
             });
             lastIndex = match.lastIndex;

--- a/frontend/app/view/agent/components/AgentMessageBlock.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.tsx
@@ -8,6 +8,7 @@
 import clsx from "clsx";
 import { Show, type JSX } from "solid-js";
 import type { AgentMessageNode } from "../types";
+import { LinkifiedText } from "@/app/element/linkified-text";
 
 interface AgentMessageBlockProps {
     node: AgentMessageNode;
@@ -44,7 +45,9 @@ export const AgentMessageBlock = (props: AgentMessageBlockProps): JSX.Element =>
                         <span class="agent-message-to">To: {props.node.to}</span>
                         <span class="agent-message-method">Method: {props.node.method}</span>
                     </div>
-                    <pre class="agent-message-body">{props.node.message}</pre>
+                    <pre class="agent-message-body">
+                        <LinkifiedText text={props.node.message} />
+                    </pre>
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -15,6 +15,7 @@ import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import { LinkifiedText } from "@/app/element/linkified-text";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import type { ShellNode, ToolLogChunk } from "../types";
@@ -158,7 +159,7 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
                         <For each={visibleChunks()}>
                             {(chunk) => (
                                 <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
-                                    {capChars(chunk.content)}
+                                    <LinkifiedText text={capChars(chunk.content)} />
                                 </pre>
                             )}
                         </For>

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -46,6 +46,7 @@
 import clsx from "clsx";
 import { Show, createSignal, onCleanup, type JSX } from "solid-js";
 import type { UserMessageNode } from "../types";
+import { LinkifiedText } from "@/app/element/linkified-text";
 import {
     findScrollContainerRect,
     maxOverlayHeight,
@@ -241,7 +242,7 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                             {props.pinned ? "✕" : "📌"}
                         </button>
                     </Show>
-                    <pre>{props.node.message}</pre>
+                    <pre><LinkifiedText text={props.node.message} /></pre>
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -723,6 +723,22 @@
         }
     }
 
+    // Linkified URLs in plain-text and markdown blocks
+    .agent-message-body,
+    .agent-user-message-content pre,
+    .agent-tool-log-line {
+        a.linkified-url {
+            color: var(--link-color, #60a5fa);
+            text-decoration: underline;
+            text-decoration-color: color-mix(in srgb, var(--link-color, #60a5fa) 40%, transparent);
+            cursor: pointer;
+
+            &:hover {
+                text-decoration-color: var(--link-color, #60a5fa);
+            }
+        }
+    }
+
     // === Subagent Link ===
     .agent-subagent-link {
         display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "debug": "^4.4.3",
         "htl": "^0.3.1",
         "html-to-image": "^1.11.13",
+        "linkify-it": "^5.0.1",
         "mermaid": "^11.12.2",
         "overlayscrollbars": "^2.13.0",
         "parse-srcset": "^1.0.2",
@@ -63,6 +64,7 @@
         "tailwind-merge": "^3.4.0",
         "throttle-debounce": "^5.0.2",
         "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.2",
         "vite-plugin-solid": "^2.11.10",
         "ws": "^8.19.0"
       },
@@ -75,6 +77,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/css-tree": "^2",
         "@types/debug": "^4",
+        "@types/linkify-it": "^5.0.0",
         "@types/node": "^22.13.17",
         "@types/sprintf-js": "^1",
         "@types/throttle-debounce": "^5",
@@ -166,7 +169,7 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
@@ -272,6 +275,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -899,6 +903,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -947,6 +952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1044,7 +1050,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,7 +1066,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,7 +1082,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,7 +1098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1112,7 +1114,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1129,7 +1130,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1146,7 +1146,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,7 +1162,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1180,7 +1178,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1197,7 +1194,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,7 +1210,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,7 +1226,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,7 +1242,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1265,7 +1258,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1282,7 +1274,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1299,7 +1290,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,7 +1306,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1333,7 +1322,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,7 +1338,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1367,7 +1354,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,7 +1370,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1401,7 +1386,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1418,7 +1402,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1435,7 +1418,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1452,7 +1434,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1469,7 +1450,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,6 +1677,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1914,7 +1905,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1954,7 +1944,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1975,7 +1964,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1996,7 +1984,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,7 +2004,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,7 +2024,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,7 +2044,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2080,7 +2064,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,7 +2084,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2122,7 +2104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,7 +2124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2164,7 +2144,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,7 +2164,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2206,7 +2184,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2286,7 +2263,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2300,7 +2276,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2314,7 +2289,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2328,7 +2302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2342,7 +2315,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,7 +2328,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,7 +2341,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,7 +2354,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,7 +2367,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,7 +2380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,7 +2393,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2440,7 +2406,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2454,7 +2419,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,7 +2432,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2482,7 +2445,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,7 +2458,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2510,7 +2471,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,7 +2484,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,7 +2497,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,7 +2510,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,7 +2523,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,7 +2536,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2594,7 +2549,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2608,7 +2562,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2622,7 +2575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3008,6 +2960,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3445,6 +3398,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3463,8 +3417,9 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -3483,7 +3438,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
@@ -3899,6 +3854,13 @@
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3918,8 +3880,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4013,6 +3976,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4465,6 +4429,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4556,7 +4521,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4761,6 +4726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4774,6 +4740,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4941,6 +4914,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4966,7 +4940,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5158,7 +5132,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -5185,6 +5159,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5594,6 +5569,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5804,7 +5780,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5930,7 +5906,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5997,6 +5973,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6295,7 +6272,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6412,7 +6388,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6458,7 +6433,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7141,7 +7116,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7186,7 +7161,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7303,7 +7278,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7323,7 +7298,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7514,7 +7489,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7683,6 +7658,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7750,7 +7726,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7783,7 +7759,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7804,7 +7779,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7825,7 +7799,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7846,7 +7819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7867,7 +7839,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7888,7 +7859,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7909,7 +7879,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7930,7 +7899,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7951,7 +7919,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7972,7 +7939,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7993,7 +7959,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8013,6 +7978,25 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -8058,6 +8042,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8599,6 +8595,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9235,7 +9232,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9268,7 +9266,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9325,7 +9323,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9375,7 +9372,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9677,7 +9673,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9723,7 +9718,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9739,6 +9733,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9822,6 +9817,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9853,6 +9849,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9993,6 +9990,19 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -10004,7 +10014,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10018,7 +10028,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -10333,7 +10343,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10399,8 +10409,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10501,8 +10511,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10548,6 +10559,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10670,6 +10682,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10695,6 +10708,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10878,7 +10912,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -10960,6 +10994,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11396,7 +11431,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11421,6 +11457,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11512,7 +11574,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11741,7 +11802,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11761,7 +11822,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11791,6 +11851,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11823,6 +11884,12 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -11843,7 +11910,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11864,6 +11931,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -12074,8 +12142,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12241,7 +12309,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12258,7 +12325,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12275,7 +12341,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12292,7 +12357,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12309,7 +12373,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12326,7 +12389,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12343,7 +12405,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12360,7 +12421,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12377,7 +12437,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12394,7 +12453,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12411,7 +12469,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12428,7 +12485,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12445,7 +12501,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12462,7 +12517,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12479,7 +12533,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12496,7 +12549,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12513,7 +12565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12530,7 +12581,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12547,7 +12597,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12564,7 +12613,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12581,7 +12629,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12598,7 +12645,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12615,7 +12661,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12632,7 +12677,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12649,7 +12693,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12666,7 +12709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12680,7 +12722,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12722,7 +12763,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12758,6 +12798,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/css-tree": "^2",
     "@types/debug": "^4",
+    "@types/linkify-it": "^5.0.0",
     "@types/node": "^22.13.17",
     "@types/sprintf-js": "^1",
     "@types/throttle-debounce": "^5",
@@ -97,6 +98,7 @@
     "debug": "^4.4.3",
     "htl": "^0.3.1",
     "html-to-image": "^1.11.13",
+    "linkify-it": "^5.0.1",
     "mermaid": "^11.12.2",
     "overlayscrollbars": "^2.13.0",
     "parse-srcset": "^1.0.2",
@@ -116,6 +118,7 @@
     "tailwind-merge": "^3.4.0",
     "throttle-debounce": "^5.0.2",
     "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
     "vite-plugin-solid": "^2.11.10",
     "ws": "^8.19.0"
   },


### PR DESCRIPTION
## Summary

- Adds `linkify-it` (4KB, 11.9M weekly downloads — the same engine markdown-it uses) for URL detection
- Bare domains (`github.com/foo`), `localhost:3000`, IPs with ports, and `https://` links all become clickable in every text-bearing pane region
- Opens in system browser via existing `openExternal` IPC

## Changes

**New files:**
- `frontend/app/element/rehype-linkify.ts` — rehype plugin that walks HAST text nodes (skipping `<a>`, `<code>`, `<pre>` ancestors) and injects `<a href>` for every detected URL; inserted before `rehype-sanitize` in the unified pipeline so all markdown + thinking blocks get linkification automatically
- `frontend/app/element/linkified-text.tsx` — `<LinkifiedText>` SolidJS component for plain-text nodes: splits on `linkify-it` matches, renders interleaved text + `<a>` elements wired to `openLink()`

**Edited files:**
- `markdown.tsx` — adds `rehypeLinkify` to the rehype plugin array (covers MarkdownNode + reasoning/thinking blocks)
- `AgentMessageBlock.tsx` — wraps `<pre>` content with `<LinkifiedText>`
- `UserMessageBlock.tsx` — wraps `<pre>` content with `<LinkifiedText>`
- `PersistentShellBlock.tsx` — wraps shell output lines with `<LinkifiedText>`
- `_document-nodes.scss` — link styles for `.linkified-url` inside plain-text containers

## Edge cases handled
- Code blocks / inline code: ancestor check skips them
- Existing `[text](url)` markdown links: already `<a>` in HAST before plugin runs — not double-processed
- Trailing `.`, `,`, `)`: `linkify-it` strips these correctly by default
- `javascript:`/`data:` URIs: blocked by `isSafeHref()` guard in `LinkifiedText` + `rehype-sanitize` strips them from markdown
- Bare `localhost` (no port): not matched — avoids false positives

## Test plan
- [ ] Paste `check github.com/foo and localhost:3000` in user message → both clickable
- [ ] Paste `visit https://example.com today.` → link detected, trailing `.` not included
- [ ] Inline code `` `localhost:3000` `` in markdown → NOT linkified
- [ ] Fenced code block with URL → NOT linkified
- [ ] Existing `[text](url)` markdown link → unchanged, still works
- [ ] Thinking block with a URL → linkified
- [ ] Shell output with a URL (e.g. `vite dev server running at http://localhost:5173`) → clickable

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)