### PR TITLE
feat(agent): context compaction transcript marker

### DIFF
--- a/.changesets/1781984693-feat-agent-context-compaction-transcript-marker-g7dw.md
+++ b/.changesets/1781984693-feat-agent-context-compaction-transcript-marker-g7dw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): context compaction transcript marker

--- a/docs/specs/SPEC_CONTEXT_COMPACTION_NOTIFICATION_2026_06_20.md
+++ b/docs/specs/SPEC_CONTEXT_COMPACTION_NOTIFICATION_2026_06_20.md
@@ -1,0 +1,89 @@
+# SPEC: Context Compaction Notification
+
+**Date:** 2026-06-20
+**Issue:** #1553
+**Status:** Implementation
+
+---
+
+## Problem
+
+When Claude Code auto-compacts the conversation context, earlier history is
+summarized and the context window resets. The context bar already drops (handled
+by #1543), but there is a silent transcript discontinuity — no visible marker
+explains why the agent's apparent memory reset.
+
+## AgentMux /clear vs Compaction
+
+`/clear` in AgentMux is **frontend-only** (`commands/global/clear.ts`). It
+dispatches `UserClear` to the document store and empties the visible transcript.
+The Claude Code process and its conversation history are untouched. No token drop
+occurs. No marker is needed.
+
+Compaction — triggered by Claude's native `/compact` slash command or by
+auto-compact at ~95% context fill — is a real context reset. A marker IS needed.
+
+## Detection
+
+Claude Code emits a `{"type":"system","subtype":"compact_boundary",...}` event in
+stream-json mode, but the schema is undocumented and the event has been observed
+missing in some versions (GitHub #63015 regression). The heuristic is therefore
+the primary detection path, with the wire signal as an optional enhancement.
+
+**Heuristic (primary):** In the reducer's `TokensIn` arm, compare against the
+previous `lastContextTokens`:
+
+```
+prevTokens > 10_000 AND newTokens < prevTokens × 0.5
+```
+
+- Compaction drops 80–95% — well above the 50% threshold
+- Normal turn-to-turn growth is monotonically increasing — no false positives
+- AgentMux `/clear` does not touch tokens — no false positives
+- `prevTokens > 10_000` guards against noise at session start
+
+**Wire signal (future enhancement):** Handle `type:"system"` in
+`ClaudeTranslator` — if `subtype === "compact_boundary"`, emit a
+`context_compacted` StreamEvent directly. More precise but depends on
+undocumented/unstable schema.
+
+## Surface
+
+A transcript marker (divider + pill) rendered as a `ContextCompactedNode`:
+
+```
+─────────────── context compacted ───────────────
+        Earlier history summarized · 847k → 52k tokens
+```
+
+- Not a toast — the marker is most valuable when the user scrolls back to ask
+  "why did the agent forget X?"
+- Persisted in the agent document (visible on reload and in exports)
+- Token counts shown as rounded integers (e.g. `847k → 52k`)
+
+## Files
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/types.ts` | Add `ContextCompactedNode` interface; add to `DocumentNode` union |
+| `frontend/app/store/agent-pane-state/types.ts` | Add `context-compacted` to `AgentPaneEvent` |
+| `frontend/app/store/agent-pane-state/reducer.ts` | Detect drop in `TokensIn` arm; emit `context-compacted` event |
+| `frontend/app/view/agent/useAgentStream.ts` | Handle `context-compacted` event; append synthetic node |
+| `frontend/app/view/agent/virtualization/renderers.ts` | Register + size `context_compacted` node |
+| `frontend/app/view/agent/components/AgentDocumentView.tsx` | Render `ContextCompactedNode` |
+| `frontend/app/view/agent/styles/_document-nodes.scss` | Divider + pill styles |
+
+## Acceptance Criteria
+
+- [ ] After compaction (context drops ≥50% from >10k tokens), marker appears at the boundary
+- [ ] Marker shows pre- and post-compaction token counts in rounded form
+- [ ] Marker persists on reload
+- [ ] No marker appears for normal turn-to-turn context growth
+- [ ] No marker appears when AgentMux `/clear` is used
+- [ ] Context bar continues to drop/recover correctly (no regression from #1543)
+
+## Out of Scope
+
+- Wire signal (`compact_boundary`) handling — follow-up
+- `autoCompactEnabled` / `compactPrompt` settings UI
+- Toast in addition to transcript marker

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -478,6 +478,18 @@ export function update(
             const events: AgentPaneEvent[] = [
                 { type: "tokens-updated", input: command.input, output: null },
             ];
+            // Detect context compaction: token count drops ≥50% from a
+            // non-trivial baseline. Compaction typically drops 80–95%;
+            // normal turn-to-turn growth is monotonically increasing.
+            // AgentMux /clear is frontend-only and does not affect tokens.
+            const prev = state.lastContextTokens;
+            if (prev != null && prev > 10_000 && command.input < prev * 0.5) {
+                events.push({
+                    type: "context-compacted",
+                    tokensBefore: prev,
+                    tokensAfter: command.input,
+                });
+            }
             return { state: nextState, events };
         }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -550,6 +550,7 @@ export type AgentPaneEvent =
     | { type: "tool-started"; name: string }
     | { type: "tool-ended" }
     | { type: "tokens-updated"; input: number | null; output: number | null }
+    | { type: "context-compacted"; tokensBefore: number; tokensAfter: number }
     | { type: "stop-requested"; at: number }
     | { type: "stop-failed" }
     /**

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1448,3 +1448,42 @@
         }
     }
 }
+
+.agent-context-compacted {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    padding: 10px var(--space-2);
+    user-select: none;
+    position: relative;
+
+    &::before,
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        width: 25%;
+        height: 1px;
+        background: var(--border-color, rgba(255, 255, 255, 0.12));
+    }
+
+    &::before { left: 0; }
+    &::after  { right: 0; }
+
+    .agent-context-compacted-label {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.45));
+        padding: 2px 10px;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+        border-radius: 10px;
+    }
+
+    .agent-context-compacted-detail {
+        font-size: 11px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.3));
+    }
+}

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -52,7 +52,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode | ShellNode | AgentErrorNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode | ShellNode | AgentErrorNode | ContextCompactedNode;
 
 /**
  * Raw markdown text block
@@ -354,6 +354,15 @@ export interface AgentErrorNode {
     id: string;
     code: number;   // HTTP status code (e.g. 401, 429)
     message: string; // Full error text from the CLI result event
+}
+
+/** Transcript boundary marker inserted when Claude compacts its context. */
+export interface ContextCompactedNode {
+    type: "context_compacted";
+    id: string;
+    tokensBefore: number;
+    tokensAfter: number;
+    timestamp: number;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -16,7 +16,7 @@ import { batch, createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser, STARTUP_HEADING_RE } from "./stream-parser";
-import type { DocumentNode, SessionStats, ShellNode, ToolLogChunk, UserMessageNode } from "./types";
+import type { ContextCompactedNode, DocumentNode, SessionStats, ShellNode, ToolLogChunk, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
 import type { TurnPhase } from "@/app/store/agent-pane-state/types";
 import {
@@ -704,7 +704,26 @@ export function useAgentStream({
                             // "claude-opus-4-8") — used to seed the context-window
                             // meter per model (Opus/Sonnet 1M, Haiku 200K).
                             const modelId = inner.message?.model as string | undefined;
-                            model.dispatchPane({ type: "TokensIn", input: inputTok, model: modelId });
+                            const paneEvents = model.dispatchPane({ type: "TokensIn", input: inputTok, model: modelId });
+                            // Detect context compaction from the reducer's event output.
+                            // The reducer emits "context-compacted" when input tokens
+                            // drop ≥50% from a >10k baseline — the signature of compaction.
+                            for (const ev of paneEvents ?? []) {
+                                if (ev.type === "context-compacted") {
+                                    const compactNode: ContextCompactedNode = {
+                                        type: "context_compacted",
+                                        id: `context-compacted-${Date.now()}`,
+                                        tokensBefore: ev.tokensBefore,
+                                        tokensAfter: ev.tokensAfter,
+                                        timestamp: Date.now(),
+                                    };
+                                    if (!nodeIdSet.has(compactNode.id)) {
+                                        nodeIdSet.add(compactNode.id);
+                                        pendingNew.push(compactNode);
+                                        scheduleFlush();
+                                    }
+                                }
+                            }
                         }
                     } else if (inner?.type === "message_delta") {
                         const outputTok = inner.usage?.output_tokens as number | undefined;

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -272,6 +272,22 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     </Show>
                 </div>
             </Show>
+            <Show when={props.node() && props.node().type === "context_compacted"}>
+                {(() => {
+                    const n = props.node() as Extract<DocumentNode, { type: "context_compacted" }>;
+                    const fmt = (tok: number) => tok >= 1000 ? `${Math.round(tok / 1000)}k` : String(tok);
+                    return (
+                        <div class="agent-context-compacted">
+                            <div class="agent-context-compacted-label">
+                                context compacted
+                            </div>
+                            <div class="agent-context-compacted-detail">
+                                Earlier history summarized · {fmt(n.tokensBefore)} → {fmt(n.tokensAfter)} tokens
+                            </div>
+                        </div>
+                    );
+                })()}
+            </Show>
         </>
     );
 }

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -103,5 +103,9 @@ export function currentExpansion(
         case "agent_error":
             // Error nodes are fixed-height and never user-collapsible.
             return OPEN_DEFAULT;
+
+        case "context_compacted":
+            // Fixed-height divider — never collapsible.
+            return OPEN_DEFAULT;
     }
 }

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -16,6 +16,7 @@ import type { Component } from "solid-js";
 import type {
     AgentErrorNode,
     AgentMessageNode,
+    ContextCompactedNode,
     DocumentNode,
     DocumentState,
     MarkdownNode,
@@ -181,6 +182,7 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     subagent_link: false,
     shell: false,
     agent_error: false, // fixed-content inline error — not a streaming node
+    context_compacted: false,
 };
 
 // ── Registry factory ────────────────────────────────────────────────────────
@@ -196,6 +198,7 @@ export interface RendererComponents {
     /** agent_error nodes are rendered inline in DocumentRow — this slot is a
      *  registry placeholder so NodeRendererRegistry stays exhaustive. */
     AgentError: Component<{ node: AgentErrorNode; state: DocumentState }>;
+    ContextCompacted: Component<{ node: ContextCompactedNode; state: DocumentState }>;
 }
 
 /**
@@ -245,6 +248,11 @@ export function buildRendererRegistry(components: RendererComponents): NodeRende
             estimatedSize: (_node: AgentErrorNode) => 64,
             isStreamingCapable: STREAMING_CAPABLE.agent_error,
         },
+        context_compacted: {
+            component: components.ContextCompacted,
+            estimatedSize: (_node: ContextCompactedNode) => 48,
+            isStreamingCapable: STREAMING_CAPABLE.context_compacted,
+        },
     };
 }
 
@@ -262,7 +270,8 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "user_message": return estimateUserMessage(node, state);
         case "subagent_link": return estimateSubagentLink(node);
         case "shell": return estimateShell(node, state);
-        case "agent_error": return 64; // compact fixed-height error node
+        case "agent_error":       return 64;
+        case "context_compacted": return 48;
     }
 }
 
@@ -300,18 +309,20 @@ export function estimateNodeForState(
                     : estimateTextHeight(node.content);
             case "subagent_link": return SUBAGENT_LINK_PX;
             case "shell":         return SHELL_COLLAPSED_PX;
-            case "agent_error":   return 64;
+            case "agent_error":       return 64;
+            case "context_compacted": return 48;
         }
     }
     // expanded
     switch (node.type) {
-        case "tool":          return TOOL_EXPANDED_PX;
-        case "agent_message": return estimateTextHeight(node.message);
-        case "user_message":  return estimateUnwrappedTextHeight(node.message);
-        case "section":       return SECTION_PX;
-        case "markdown":      return estimateTextHeight(node.content);
-        case "subagent_link": return SUBAGENT_LINK_PX;
-        case "shell":         return SHELL_EXPANDED_PX;
-        case "agent_error":   return 64;
+        case "tool":              return TOOL_EXPANDED_PX;
+        case "agent_message":     return estimateTextHeight(node.message);
+        case "user_message":      return estimateUnwrappedTextHeight(node.message);
+        case "section":           return SECTION_PX;
+        case "markdown":          return estimateTextHeight(node.content);
+        case "subagent_link":     return SUBAGENT_LINK_PX;
+        case "shell":             return SHELL_EXPANDED_PX;
+        case "agent_error":       return 64;
+        case "context_compacted": return 48;
     }
 }


### PR DESCRIPTION
Closes #1553

## Summary

- Detects context compaction in the `TokensIn` reducer arm: when input tokens drop ≥50% from a >10k baseline (compaction typically drops 80–95%)
- Injects a `ContextCompactedNode` into the transcript at the boundary — a horizontal divider pill showing pre/post token counts
- Persists in the agent document (visible on reload, in exports)
- AgentMux `/clear` is frontend-only and does not affect tokens — no false positive

## Marker appearance

```
─────────────── context compacted ───────────────
    Earlier history summarized · 847k → 52k tokens
```

## Changes

- `types.ts` — `ContextCompactedNode` interface + added to `DocumentNode` union
- `agent-pane-state/types.ts` — `context-compacted` AgentPaneEvent
- `reducer.ts` — detection in `TokensIn` arm
- `useAgentStream.ts` — reads `dispatchPane` return value, injects node
- `renderers.ts` — registry entry sized at 48px
- `DocumentRow.tsx` — inline renderer (divider + pill + detail line)
- `_document-nodes.scss` — `.agent-context-compacted` styles

## Test plan

- [ ] Let a Claude agent session run until auto-compact fires — marker appears at the boundary
- [ ] Verify marker shows correct rounded token counts (e.g. `847k → 52k`)
- [ ] Reload the pane — marker persists
- [ ] Run `/clear` in the composer — no marker appears (UI-only, no token drop)
- [ ] Normal multi-turn session with growing context — no spurious marker
- [ ] Context bar continues to drop/recover correctly (no #1543 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)