### PR TITLE
chore(M1): set VITE_MUXBUS_CLIENT_ID from deployed Cognito stack

### DIFF
--- a/.changesets/1781984600-chore-muxbus-set-vite-muxbus-client-id-from-deployed-cognito-stack-m1.md
+++ b/.changesets/1781984600-chore-muxbus-set-vite-muxbus-client-id-from-deployed-cognito-stack-m1.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+chore(M1): set VITE_MUXBUS_CLIENT_ID from deployed Cognito stack

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -21,4 +21,4 @@
 #   /muxbus/google-client-secret
 
 VITE_MUXBUS_COGNITO_DOMAIN=https://muxbus-auth.auth.us-east-1.amazoncognito.com
-# VITE_MUXBUS_CLIENT_ID=<DesktopClientId output from CDK deploy>
+VITE_MUXBUS_CLIENT_ID=26odoigu6a7r8ecdmj5egvnc3b


### PR DESCRIPTION
## Summary

- Sets `VITE_MUXBUS_CLIENT_ID=26odoigu6a7r8ecdmj5egvnc3b` in `frontend/.env.production`
- Value is the `DesktopClientId` output from the `muxbus-infrastructure` CDK stack (Cognito user pool `us-east-1_e2EhhuGaK`, deployed 2026-06-20)
- This is a public PKCE client ID — safe to commit
- Unblocks the MuxBus cloud sign-in button in Trust Center → Accounts → AgentMux

## Test plan

- [ ] Build frontend with `NODE_ENV=production` and verify `VITE_MUXBUS_CLIENT_ID` is injected
- [ ] Trust Center → Accounts → AgentMux Connect button initiates OAuth flow to `muxbus-auth.auth.us-east-1.amazoncognito.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)