### PR TITLE
feat(linux-splash): fade-out, rounded corners, primary-monitor centering (P3)

### DIFF
--- a/.changesets/1781995700-fix-linux-splash-fade-out-rounded-corners-and-primary-monito-hr4p.md
+++ b/.changesets/1781995700-fix-linux-splash-fade-out-rounded-corners-and-primary-monito-hr4p.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux-splash): fade-out, rounded corners, and primary-monitor centering

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -104,7 +104,8 @@ libc = "0.2"
 # Session-aware Linux startup splash (SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20).
 # X11 backend: a software-drawn override-redirect splash window (pixmap blit,
 # no GPU). Pure-Rust RustConnection over libxcb; present on every X11 stack.
-x11rb = "0.13"
+# `randr` → primary-monitor centering.
+x11rb = { version = "0.13", features = ["randr"] }
 # Wayland backend: a software-drawn (wl_shm) xdg_toplevel splash for native-
 # Wayland sessions (the default since #1611). No GPU/EGL. wayland-client is used
 # via sctk's reexport so the protocol versions can't skew.

--- a/agentmux-launcher/src/splash_linux/mod.rs
+++ b/agentmux-launcher/src/splash_linux/mod.rs
@@ -22,7 +22,7 @@
 mod wayland;
 mod x11;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // ── Shared look (matches splash_mac.rs / splash.rs) ─────────────────────────
 /// Opaque dark backdrop RGB(26, 26, 31) = #1A1A1F.
@@ -39,6 +39,10 @@ const PULSE_MIN: f32 = 0.73;
 const PULSE_MAX: f32 = 1.0;
 /// Self-dismiss if the host never signals first paint (crash before frame).
 pub(crate) const DISMISS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Rounded-corner radius for the backdrop (px). Matches splash_mac.rs.
+pub(crate) const CORNER_RADIUS_PX: f32 = 16.0;
+/// Opacity fade-out duration on dismiss. Matches splash_mac.rs.
+pub(crate) const FADE_OUT: Duration = Duration::from_millis(160);
 
 /// Brain logo as straight (non-pre-multiplied) RGBA8, emitted by build.rs.
 pub(crate) static BRAIN_RGBA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/brain_rgba.bin"));
@@ -95,40 +99,80 @@ pub(crate) fn pulse_alpha(t: f32) -> f32 {
     PULSE_MIN + s * (PULSE_MAX - PULSE_MIN)
 }
 
-/// Composite one frame into a 4-byte-per-pixel buffer: fill the dark backdrop,
-/// then alpha-blend the brain (centered) at `alpha` strength. Pixel byte order
-/// is given by `bgr`: `true` writes B,G,R,X (X11 depth-24 / Wayland ARGB on LE),
-/// `false` writes R,G,B,X. Shared by both backends.
-pub(crate) fn render_frame(buf: &mut [u8], w: i32, h: i32, alpha: f32, bgr: bool) {
-    let (c0, c2) = if bgr { (BG_B, BG_R) } else { (BG_R, BG_B) };
-    for px in buf.chunks_exact_mut(4) {
-        px[0] = c0;
-        px[1] = BG_G;
-        px[2] = c2;
-        px[3] = 0xFF;
+/// Global fade-out opacity in 0..=1. Returns 1.0 until `fade_start` is set, then
+/// ramps linearly to 0.0 over `FADE_OUT`. Shared by both backends.
+pub(crate) fn fade_alpha(fade_start: Option<Instant>, now: Instant) -> f32 {
+    match fade_start {
+        None => 1.0,
+        Some(s) => (1.0 - now.duration_since(s).as_secs_f32() / FADE_OUT.as_secs_f32())
+            .clamp(0.0, 1.0),
     }
+}
+
+/// Rounded-rect coverage (0..=1) at pixel (x, y) for a `w`×`h` rect with corner
+/// `radius` (0 = square), anti-aliased over a 1-px band on the corner arcs.
+fn corner_coverage(x: i32, y: i32, w: i32, h: i32, radius: f32) -> f32 {
+    if radius <= 0.0 {
+        return 1.0;
+    }
+    let (fx, fy) = (x as f32 + 0.5, y as f32 + 0.5);
+    // Clamp to the corner-arc center; in the straight edges/interior this yields
+    // dist 0 → full coverage. Only the four corner boxes produce a nonzero dist.
+    let cx = fx.clamp(radius, w as f32 - radius);
+    let cy = fy.clamp(radius, h as f32 - radius);
+    let dist = ((fx - cx).powi(2) + (fy - cy).powi(2)).sqrt();
+    if dist <= radius - 0.5 {
+        1.0
+    } else if dist >= radius + 0.5 {
+        0.0
+    } else {
+        radius + 0.5 - dist
+    }
+}
+
+/// Composite one frame, **pre-multiplied**, into a 4-byte-per-pixel buffer: the
+/// dark backdrop with the centered brain blended at `brain_alpha`, masked to a
+/// `radius`-rounded rect, all scaled by the global `window_alpha` (fade-out).
+/// Pre-multiplied output is what both X Render compositors and `wl_shm`
+/// ARGB8888 expect. `bgr` selects byte order: `true` → B,G,R,A (X11 ARGB /
+/// Wayland ARGB8888 on LE), `false` → R,G,B,A. Shared by both backends.
+///
+/// `radius=0` + `window_alpha=1` yields a fully-opaque square (the X11
+/// no-compositor fallback path).
+pub(crate) fn render_frame(
+    buf: &mut [u8],
+    w: i32,
+    h: i32,
+    brain_alpha: f32,
+    window_alpha: f32,
+    radius: f32,
+    bgr: bool,
+) {
     let ox = (w - BRAIN_W) / 2;
     let oy = (h - BRAIN_H) / 2;
-    for by in 0..BRAIN_H {
-        let dy = oy + by;
-        if dy < 0 || dy >= h {
-            continue;
-        }
-        for bx in 0..BRAIN_W {
-            let dx = ox + bx;
-            if dx < 0 || dx >= w {
-                continue;
+    for y in 0..h {
+        for x in 0..w {
+            // Backdrop, in RGB.
+            let mut rr = BG_R as f32;
+            let mut gg = BG_G as f32;
+            let mut bb = BG_B as f32;
+            // Brain over backdrop (straight alpha).
+            let (bx, by) = (x - ox, y - oy);
+            if bx >= 0 && bx < BRAIN_W && by >= 0 && by < BRAIN_H {
+                let si = ((by * BRAIN_W + bx) * 4) as usize;
+                let ba = (BRAIN_RGBA[si + 3] as f32 / 255.0) * brain_alpha;
+                rr = rr * (1.0 - ba) + BRAIN_RGBA[si] as f32 * ba;
+                gg = gg * (1.0 - ba) + BRAIN_RGBA[si + 1] as f32 * ba;
+                bb = bb * (1.0 - ba) + BRAIN_RGBA[si + 2] as f32 * ba;
             }
-            let si = ((by * BRAIN_W + bx) * 4) as usize;
-            let sr = BRAIN_RGBA[si] as f32;
-            let sg = BRAIN_RGBA[si + 1] as f32;
-            let sb = BRAIN_RGBA[si + 2] as f32;
-            let a = (BRAIN_RGBA[si + 3] as f32 / 255.0) * alpha;
-            let di = ((dy * w + dx) * 4) as usize;
-            let (b0, b2) = if bgr { (sb, sr) } else { (sr, sb) };
-            buf[di] = (buf[di] as f32 * (1.0 - a) + b0 * a) as u8;
-            buf[di + 1] = (buf[di + 1] as f32 * (1.0 - a) + sg * a) as u8;
-            buf[di + 2] = (buf[di + 2] as f32 * (1.0 - a) + b2 * a) as u8;
+            // Coverage (rounded corners) × global fade → pre-multiplied alpha.
+            let a = corner_coverage(x, y, w, h, radius) * window_alpha;
+            let di = ((y * w + x) * 4) as usize;
+            let (o0, o2) = if bgr { (bb, rr) } else { (rr, bb) };
+            buf[di] = (o0 * a) as u8;
+            buf[di + 1] = (gg * a) as u8;
+            buf[di + 2] = (o2 * a) as u8;
+            buf[di + 3] = (a * 255.0) as u8;
         }
     }
 }

--- a/agentmux-launcher/src/splash_linux/wayland.rs
+++ b/agentmux-launcher/src/splash_linux/wayland.rs
@@ -37,7 +37,10 @@ use smithay_client_toolkit::reexports::client::{
     Connection, QueueHandle,
 };
 
-use super::{min_hold, pulse_alpha, render_frame, BRAIN_H, BRAIN_W, DISMISS_TIMEOUT, PADDING};
+use super::{
+    fade_alpha, min_hold, pulse_alpha, render_frame, BRAIN_H, BRAIN_W, CORNER_RADIUS_PX,
+    DISMISS_TIMEOUT, PADDING,
+};
 
 pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
     let conn = Connection::connect_to_env()?;
@@ -73,6 +76,7 @@ pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
         start: Instant::now(),
         min_hold: min_hold(),
         ready_file: ready_file.to_path_buf(),
+        fade_start: None,
         exit: false,
     };
 
@@ -93,6 +97,7 @@ struct SplashState {
     start: Instant,
     min_hold: Duration,
     ready_file: PathBuf,
+    fade_start: Option<Instant>,
     exit: bool,
 }
 
@@ -106,7 +111,14 @@ impl SplashState {
     /// the dismiss condition is met. Driven by the compositor's frame callbacks
     /// (which also pace the ~60 fps pulse).
     fn draw(&mut self, qh: &QueueHandle<Self>) {
-        if self.should_dismiss() {
+        let now = Instant::now();
+        // Begin the fade-out the first time the dismiss condition holds; tear
+        // down once it completes.
+        if self.fade_start.is_none() && self.should_dismiss() {
+            self.fade_start = Some(now);
+        }
+        let window_alpha = fade_alpha(self.fade_start, now);
+        if self.fade_start.is_some() && window_alpha <= 0.0 {
             self.exit = true;
             return;
         }
@@ -124,9 +136,17 @@ impl SplashState {
             }
         };
 
-        let alpha = pulse_alpha(self.start.elapsed().as_secs_f32());
-        // wl_shm ARGB8888 is native-endian 0xAARRGGBB → bytes B,G,R,A on LE.
-        render_frame(canvas, w, h, alpha, /* bgr = */ true);
+        let brain_alpha = pulse_alpha(self.start.elapsed().as_secs_f32());
+        // wl_shm ARGB8888 is native-endian 0xAARRGGBB → pre-multiplied B,G,R,A on LE.
+        render_frame(
+            canvas,
+            w,
+            h,
+            brain_alpha,
+            window_alpha,
+            CORNER_RADIUS_PX,
+            /* bgr = */ true,
+        );
 
         let surface = self.window.wl_surface();
         surface.damage_buffer(0, 0, w, h);

--- a/agentmux-launcher/src/splash_linux/x11.rs
+++ b/agentmux-launcher/src/splash_linux/x11.rs
@@ -2,47 +2,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! X11 splash backend — a software-drawn, override-redirect window showing the
-//! pulsing brain over a dark backdrop, dismissed when the host writes the
-//! ready-file (or after the safety timeout). Used for X11 and XWayland sessions.
+//! pulsing brain over a dark backdrop, dismissed (with a fade-out) when the host
+//! writes the ready-file or after the safety timeout. For X11 / XWayland sessions.
 //!
-//! No GPU: we composite each frame into an off-screen pixmap (depth-24 BGRX) and
-//! `CopyArea` it to the window at ~60 fps. Window placement, `override_redirect`,
-//! and EWMH splash/above/skip-taskbar hints give a proper splash under any X11
-//! window manager and under XWayland.
+//! When a compositor is present we use a 32-bit **ARGB** visual so the backdrop
+//! can have rounded corners and the whole splash can fade out (per-pixel alpha,
+//! pre-multiplied). With no compositor there's no per-pixel alpha, so we fall
+//! back to an opaque depth-24 square that dismisses abruptly. Centering uses the
+//! RANDR primary monitor. No GPU — we composite each frame into an off-screen
+//! pixmap and `CopyArea` it to the window at ~60 fps.
+//!
+//! Spec: docs/specs/SPEC_LINUX_SPLASH_POLISH_2026_06_20.md
 
 use std::error::Error;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
 use x11rb::connection::Connection;
+use x11rb::protocol::randr::ConnectionExt as _;
 use x11rb::protocol::xproto::ConnectionExt as _;
 use x11rb::protocol::xproto::{
-    AtomEnum, CreateGCAux, CreateWindowAux, EventMask, ImageFormat, PropMode, Window, WindowClass,
+    AtomEnum, ColormapAlloc, CreateGCAux, CreateWindowAux, EventMask, ImageFormat, PropMode, Screen,
+    VisualClass, Window, WindowClass,
 };
 use x11rb::wrapper::ConnectionExt as _;
+use x11rb::NONE;
 
 use super::{
-    pulse_alpha, render_frame, BRAIN_H, BRAIN_W, DISMISS_TIMEOUT, FRAME_MS, PADDING,
+    fade_alpha, min_hold, pulse_alpha, render_frame, BRAIN_H, BRAIN_W, CORNER_RADIUS_PX,
+    DISMISS_TIMEOUT, FRAME_MS, PADDING,
 };
 
 pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
     let (conn, screen_num) = x11rb::connect(None)?;
-    let screen = &conn.setup().roots[screen_num];
+    let screen = conn.setup().roots[screen_num].clone();
     let root = screen.root;
-    let depth = screen.root_depth; // typically 24
-    let visual = screen.root_visual;
 
     let w = (BRAIN_W + PADDING * 2) as u16;
     let h = (BRAIN_H + PADDING * 2) as u16;
-    // Center on the X screen. (RANDR primary-monitor centering is P3 polish.)
-    let x = (((screen.width_in_pixels as i32) - w as i32) / 2).max(0) as i16;
-    let y = (((screen.height_in_pixels as i32) - h as i32) / 2).max(0) as i16;
+
+    // Per-pixel alpha (→ fade + rounded corners) needs a compositor + an ARGB
+    // visual. Otherwise fall back to an opaque depth-24 square.
+    let argb_visual = if has_compositor(&conn, screen_num).unwrap_or(false) {
+        find_argb_visual(&screen)
+    } else {
+        None
+    };
+
+    let (depth, visual, colormap) = match argb_visual {
+        Some(vid) => {
+            let cmap = conn.generate_id()?;
+            conn.create_colormap(ColormapAlloc::NONE, cmap, root, vid)?;
+            (32u8, vid, Some(cmap))
+        }
+        None => (screen.root_depth, screen.root_visual, None),
+    };
+    let radius = if colormap.is_some() { CORNER_RADIUS_PX } else { 0.0 };
+
+    // Center on the primary monitor (RANDR), falling back to the whole screen.
+    let (mx, my, mw, mh) = primary_monitor(&conn, root, &screen);
+    let x = (mx + (mw - w as i32) / 2).max(0) as i16;
+    let y = (my + (mh - h as i32) / 2).max(0) as i16;
 
     let win = conn.generate_id()?;
-    let win_aux = CreateWindowAux::new()
+    let mut win_aux = CreateWindowAux::new()
         .override_redirect(1)
-        .background_pixel(screen.black_pixel)
         .event_mask(EventMask::EXPOSURE);
+    win_aux = if let Some(cmap) = colormap {
+        // A window whose depth differs from its parent needs its own colormap
+        // and an explicit border_pixel (else BadMatch). 0 = transparent backdrop.
+        win_aux.colormap(cmap).border_pixel(0).background_pixel(0)
+    } else {
+        win_aux.background_pixel(screen.black_pixel)
+    };
     conn.create_window(
         depth,
         win,
@@ -68,24 +100,34 @@ pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
     conn.flush()?;
 
     let start = Instant::now();
-    let min_hold = super::min_hold();
-    // BGRX, 4 bytes/pixel (depth-24 pixmaps are 32 bpp on every modern server).
+    let hold = min_hold();
+    let mut fade_start: Option<Instant> = None;
+    // 4 bytes/pixel (depth-24 and depth-32 are both 32 bpp on modern servers).
     let mut buf = vec![0u8; w as usize * h as usize * 4];
 
     loop {
-        let elapsed = start.elapsed();
-        // Dismiss once the host has painted AND we've shown for the minimum hold,
-        // or unconditionally at the safety timeout (host crashed before paint).
-        if (ready_file.exists() && elapsed >= min_hold) || elapsed >= DISMISS_TIMEOUT {
+        let now = Instant::now();
+        let elapsed = now.duration_since(start);
+        let dismiss =
+            (ready_file.exists() && elapsed >= hold) || elapsed >= DISMISS_TIMEOUT;
+        if dismiss {
+            if colormap.is_none() {
+                break; // opaque depth-24: can't alpha-fade, dismiss now
+            }
+            if fade_start.is_none() {
+                fade_start = Some(now);
+            }
+        }
+        let window_alpha = fade_alpha(fade_start, now);
+        if fade_start.is_some() && window_alpha <= 0.0 {
             break;
         }
 
-        let alpha = pulse_alpha(start.elapsed().as_secs_f32());
-        render_frame(&mut buf, w as i32, h as i32, alpha, /* bgr = */ true);
+        let brain_alpha = pulse_alpha(elapsed.as_secs_f32());
+        render_frame(&mut buf, w as i32, h as i32, brain_alpha, window_alpha, radius, true);
 
         // PutImage in horizontal strips so no single request exceeds the server's
-        // max request size (a full ~312×312 BGRX frame is ~380 KB, over the
-        // 256 KB non-BIG-REQUESTS limit — strips keep us portable either way).
+        // max request size (~380 KB frame > the 256 KB non-BIG-REQUESTS limit).
         let row_bytes = w as usize * 4;
         let strip_rows = (200_000 / row_bytes).max(1) as u16;
         let mut row = 0u16;
@@ -110,22 +152,65 @@ pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
         conn.copy_area(pixmap, win, gc, 0, 0, 0, 0, w, h)?;
         conn.flush()?;
 
-        // Drain and ignore events so the connection's read buffer can't stall.
         while let Ok(Some(_)) = conn.poll_for_event() {}
-
         std::thread::sleep(Duration::from_millis(FRAME_MS));
     }
 
     let _ = conn.destroy_window(win);
     let _ = conn.free_pixmap(pixmap);
     let _ = conn.free_gc(gc);
+    if let Some(cmap) = colormap {
+        let _ = conn.free_colormap(cmap);
+    }
     let _ = conn.flush();
     Ok(())
 }
 
-/// Best-effort EWMH hints (harmless under `override_redirect`, helpful if a WM
-/// still considers them): mark the window as a splash, ask for above + no
-/// taskbar/pager entry.
+/// True if a compositing manager owns the `_NET_WM_CM_S<screen>` selection
+/// (GNOME/Mutter and XWayland under it always do) — i.e. per-pixel alpha works.
+fn has_compositor<C: Connection>(conn: &C, screen_num: usize) -> Result<bool, Box<dyn Error>> {
+    let name = format!("_NET_WM_CM_S{screen_num}");
+    let atom = conn.intern_atom(false, name.as_bytes())?.reply()?.atom;
+    let owner = conn.get_selection_owner(atom)?.reply()?.owner;
+    Ok(owner != NONE)
+}
+
+/// First 32-bit TrueColor visual on the screen, if any.
+fn find_argb_visual(screen: &Screen) -> Option<u32> {
+    screen
+        .allowed_depths
+        .iter()
+        .filter(|d| d.depth == 32)
+        .flat_map(|d| d.visuals.iter())
+        .find(|v| v.class == VisualClass::TRUE_COLOR)
+        .map(|v| v.visual_id)
+}
+
+/// RANDR primary-monitor geometry `(x, y, w, h)`, falling back to the whole X
+/// screen if RANDR/primary is unavailable.
+fn primary_monitor<C: Connection>(conn: &C, root: Window, screen: &Screen) -> (i32, i32, i32, i32) {
+    let fallback = (
+        0,
+        0,
+        screen.width_in_pixels as i32,
+        screen.height_in_pixels as i32,
+    );
+    let prim = match conn.randr_get_output_primary(root).ok().and_then(|c| c.reply().ok()) {
+        Some(p) if p.output != NONE => p.output,
+        _ => return fallback,
+    };
+    let info = match conn.randr_get_output_info(prim, 0).ok().and_then(|c| c.reply().ok()) {
+        Some(i) if i.crtc != NONE => i,
+        _ => return fallback,
+    };
+    match conn.randr_get_crtc_info(info.crtc, 0).ok().and_then(|c| c.reply().ok()) {
+        Some(c) => (c.x as i32, c.y as i32, c.width as i32, c.height as i32),
+        None => fallback,
+    }
+}
+
+/// Best-effort EWMH hints (harmless under `override_redirect`): mark as a splash,
+/// ask for above + no taskbar/pager entry.
 fn set_ewmh_hints<C: Connection>(conn: &C, win: Window) -> Result<(), Box<dyn Error>> {
     let atom = |name: &[u8]| -> Result<u32, Box<dyn Error>> {
         Ok(conn.intern_atom(false, name)?.reply()?.atom)

--- a/docs/specs/SPEC_LINUX_SPLASH_POLISH_2026_06_20.md
+++ b/docs/specs/SPEC_LINUX_SPLASH_POLISH_2026_06_20.md
@@ -1,0 +1,145 @@
+# SPEC: Linux splash polish (fade-out, multi-monitor centering, rounded corners)
+
+**Date:** 2026-06-20
+**Status:** Draft / in progress
+**Owner:** launcher / Linux platform
+**Builds on:** [`SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md`](./SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md) — this is its **Phase 3 (polish)**.
+
+---
+
+## 0. TL;DR
+
+The shipped Linux splash (PR #1618) is deliberately minimal: an **opaque, square** window that **vanishes abruptly** on dismiss, **centered on the whole X screen** (wrong on multi-monitor). This brings it to parity with the Windows/macOS splashes:
+
+1. **Fade-out** (~160 ms) on dismiss, on both backends — matching `splash.rs`/`splash_mac.rs`.
+2. **Rounded corners** (16 px) — matching macOS.
+3. **Primary-monitor centering** on X11 via RANDR (Wayland is compositor-placed, unchanged).
+
+The enabler on X11 is switching the splash window to a **32-bit ARGB visual** (per-pixel alpha) when a compositor is present — Wayland already has per-pixel alpha via `wl_shm` ARGB8888.
+
+---
+
+## 1. Goals / non-goals
+
+### Goals
+- Smooth ~160 ms opacity fade-out when the splash dismisses (host first-paint *or* safety timeout), then tear down.
+- 16 px rounded corners on the dark backdrop, both backends.
+- X11: center on the **primary** monitor (RANDR), not the union of all screens.
+- Graceful fallback: if X11 has **no compositor** (no per-pixel alpha), keep today's behavior (opaque, square, abrupt) rather than render garbage.
+
+### Non-goals
+- Wayland positioning/stacking changes — still compositor-controlled (protocol limitation; unchanged from the base spec).
+- Drop shadows / blur / fancy easing — straight linear opacity fade is enough.
+- Per-monitor DPI scaling of the brain (the asset is fixed-size; revisit only if HiDPI looks wrong).
+
+---
+
+## 2. Shared rendering changes
+
+`render_frame` currently writes an **opaque** BGRX frame (alpha byte = 0xFF, square). Polish needs **per-pixel alpha** with **rounded corners** and a **global fade multiplier**, and the output must be **pre-multiplied** (what both X Render compositors and `wl_shm` ARGB8888 expect).
+
+New signature (shared in `splash_linux/mod.rs`):
+
+```rust
+/// Composite one frame, pre-multiplied, into a 4-byte/pixel buffer.
+/// `brain_alpha` is the pulse (0..1); `window_alpha` is the global fade (0..1);
+/// `radius` rounds the backdrop corners (0 = square). `bgr` selects channel
+/// order (B,G,R,A on LE for both X11 ARGB and wl_shm ARGB8888).
+fn render_frame(buf, w, h, brain_alpha, window_alpha, radius, bgr)
+```
+
+Per pixel:
+1. `cov` = rounded-rect coverage at (x,y) — `1.0` inside, `0.0` outside, anti-aliased on the corner arcs (distance-to-corner-center vs `radius`, 1-px smoothstep).
+2. Composite brain over backdrop in straight RGB (as today).
+3. `a = cov * window_alpha` (backdrop is otherwise opaque); **pre-multiply**: each channel `*= a`; alpha byte `= a*255`.
+
+A square, fully-opaque frame (`radius=0`, `window_alpha=1`) reduces to today's output, so the **opaque-fallback path keeps using the existing fast opaque fill**.
+
+`pulse_alpha(t)` is unchanged (drives `brain_alpha`). A new helper computes `window_alpha` during the fade phase (see §5).
+
+---
+
+## 3. X11 backend (`splash_x11.rs`)
+
+### 3.1 ARGB visual + compositor gate
+- Detect a running compositor: an owner exists for the `_NET_WM_CM_S<screen>` selection (`GetSelectionOwner`). GNOME/Mutter (and XWayland under it) always have one.
+- If composited: find a **depth-32, TrueColor** visual on the screen; create a **colormap** for it; create the window at depth 32 with that visual + colormap. Required extra `CreateWindowAux`: `colormap`, `border_pixel` (0) — X requires both when the window depth differs from the parent. The pixmap + GC are created at depth 32. → per-pixel alpha works; fade + rounded corners enabled.
+- If **not** composited (or no depth-32 visual): keep the current **depth-24 opaque** path (`window_alpha` forced to 1, `radius` forced to 0, abrupt dismiss). Log which path was taken.
+
+### 3.2 Primary-monitor centering (RANDR)
+- Enable the `randr` feature on `x11rb`.
+- Query the **primary** output: `randr::get_output_primary(root)` → output; `get_crtc_info` of its CRTC → `(x, y, width, height)`. Center the splash within that rect.
+- Fallbacks: no primary set → first connected/enabled CRTC; RANDR unavailable → today's whole-screen centering.
+
+### 3.3 Loop
+Unchanged structure; the draw call now passes `window_alpha` (1.0 until fading) and `radius`, and the put-image strips already handle 32-bit depth.
+
+---
+
+## 4. Wayland backend (`splash_wayland.rs`)
+- `wl_shm` ARGB8888 already carries per-pixel alpha and is always composited, so **no visual gymnastics** — just pass `radius` and `window_alpha` to `render_frame`.
+- Set an **opaque region** only when not rounded/fading (optimization); with rounded corners + fade we leave the surface fully alpha-blended (correctness over the minor perf win for a ~1 s splash).
+- App-id grouping unchanged. No taskbar-hint protocol — GNOME honors none for a plain toplevel (documented limitation, base spec §3.2).
+
+---
+
+## 5. Fade-out (both backends)
+- Dismiss is now two-phase. When `should_dismiss()` first returns true, record `fade_start` and keep looping; compute `window_alpha = 1.0 - clamp01((now - fade_start)/FADE_OUT)` with `FADE_OUT = 160 ms`. When `window_alpha` reaches 0, tear down.
+- On the **opaque-fallback** X11 path (no compositor), skip the fade (can't alpha a depth-24 window) — dismiss immediately, as today.
+- The safety timeout (10 s) also fades out (host crashed before paint) rather than vanishing.
+
+Helper in `mod.rs`:
+```rust
+const FADE_OUT: Duration = Duration::from_millis(160);
+/// 1.0 while not fading; ramps to 0.0 over FADE_OUT once `fade_start` is set.
+fn fade_alpha(fade_start: Option<Instant>, now: Instant) -> f32 { … }
+```
+
+---
+
+## 6. Constants
+- `CORNER_RADIUS_PX = 16` (matches macOS).
+- `FADE_OUT = 160 ms` (matches macOS).
+- Backdrop, pulse, padding, `min_hold` — unchanged from the base spec.
+
+---
+
+## 7. Testing & acceptance
+
+X11 (composited GNOME / XWayland, via `AGENTMUX_OZONE_PLATFORM=x11`):
+- [ ] Rounded corners visible; backdrop alpha-blended (no black square box).
+- [ ] Centered on the **primary** monitor (verify on a multi-monitor setup, or at least correct on single).
+- [ ] Smooth ~160 ms fade-out on dismiss; no abrupt pop.
+
+X11 non-composited (e.g. plain `Xorg` + no compositor, or `picom` off):
+- [ ] Falls back cleanly to opaque square, abrupt dismiss — **no garbage/black-corner rendering**.
+
+Wayland (GNOME default):
+- [ ] Rounded corners + fade-out both render via `wl_shm`.
+- [ ] No protocol errors; buffer released on teardown.
+
+Both:
+- [ ] Host-crash-before-paint → fade-out at the 10 s timeout.
+- [ ] Windows/macOS splash unchanged.
+
+Validation will use the same `AGENTMUX_SPLASH_HOLD_MS` long-hold trick to inspect the fade/corners, and a fresh-channel cold start (`env -u AGENTMUX … AGENTMUX_CHANNEL=…`).
+
+---
+
+## 8. Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+| --- | --- | --- |
+| X11 ARGB window renders black/garbage with no compositor | Med | `_NET_WM_CM_S*` gate → opaque-24 fallback; never create ARGB without a compositor. |
+| No depth-32 TrueColor visual on some servers | Low | Fall back to opaque-24. |
+| RANDR absent / headless | Low | Fall back to whole-screen centering. |
+| Pre-multiplied-alpha mistakes (dark fringing on the brain/edges) | Med | Pre-multiply once at the end; eyeball vs macOS; unit-check a corner + center pixel. |
+| Rounded-corner AA cost per frame | Low | Compute coverage cheaply (only the corner boxes need the arc test; interior is a fast opaque fill). |
+
+---
+
+## 9. Files touched
+- `agentmux-launcher/src/splash_linux/mod.rs` — `render_frame` rework (per-pixel alpha, rounded mask, fade), `fade_alpha`, constants.
+- `agentmux-launcher/src/splash_linux/x11.rs` — ARGB visual + compositor gate, RANDR primary centering, two-phase dismiss/fade.
+- `agentmux-launcher/src/splash_linux/wayland.rs` — pass radius + window_alpha, two-phase dismiss/fade.
+- `agentmux-launcher/Cargo.toml` — `x11rb` `randr` feature.


### PR DESCRIPTION
## What
Phase-3 polish of the Linux startup splash (#1618), bringing it to parity with the Windows/macOS splashes.

- **Fade-out** (~160 ms opacity ramp) on dismiss — host first-paint *or* the 10 s safety timeout — instead of an abrupt pop. Two-phase dismiss in both backends.
- **16 px rounded corners** on the dark backdrop.
- **X11: primary-monitor centering** via RANDR (was centered on the whole X screen — wrong on multi-monitor).

Spec: `docs/specs/SPEC_LINUX_SPLASH_POLISH_2026_06_20.md`.

## How
`render_frame` now writes **pre-multiplied per-pixel alpha** with a rounded-rect coverage mask and a global fade multiplier (a square, opaque, fade=1 frame reduces to the old output — the no-compositor fallback).

- **X11:** switch to a **32-bit ARGB visual + colormap** when a compositor owns `_NET_WM_CM_S<screen>` → per-pixel alpha for fade + rounded corners. With **no compositor**, fall back to the opaque depth-24 square + abrupt dismiss (never renders garbage). RANDR `get_output_primary` → CRTC geometry for centering, with whole-screen fallback. Adds the `randr` x11rb feature.
- **Wayland:** `wl_shm` ARGB8888 already carries per-pixel alpha and is always composited, so it just passes the new `radius` + `window_alpha` args.

## Testing
Validated on the GNOME/Wayland VM (CEF 148), both backends, via cold-start with a long `AGENTMUX_SPLASH_HOLD_MS`:
- **X11 (ARGB path):** window creates with no protocol error (no BadMatch), cold-starts, **fade-out completes** → clean exit.
- **Wayland:** runs with no error, fade-out completes.

(Visual confirmation of the corners/fade appearance is cosmetic; the mechanics — ARGB window creation, RANDR query, two-phase fade — are validated.)

## Test plan
- [ ] X11 (composited): rounded corners + alpha-blended backdrop (no black box); centered on primary monitor; smooth fade-out.
- [ ] X11 (no compositor): opaque square, abrupt dismiss — no garbage.
- [ ] Wayland (GNOME): rounded corners + fade via wl_shm.
- [ ] Host crash before paint → fade-out at the 10 s timeout.
- [ ] Windows/macOS splash unchanged.