### PR TITLE
fix(linux): restrict pane tear-off to header only

### DIFF
--- a/.changesets/1781997497-fix-linux-restrict-pane-tear-off-to-header-whole-tile-drag-t-2uur.md
+++ b/.changesets/1781997497-fix-linux-restrict-pane-tear-off-to-header-whole-tile-drag-t-2uur.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux): restrict pane tear-off to header — whole-tile drag triggered tear-off anywhere

--- a/docs/retro/2026-06-20-linux-pane-tearoff-anywhere.md
+++ b/docs/retro/2026-06-20-linux-pane-tearoff-anywhere.md
@@ -1,0 +1,85 @@
+# Retro: Linux pane tear-off triggers from any click-drag, not just the header
+
+**Date:** 2026-06-20
+**Status:** Fix planned (see below)
+
+---
+
+## The problem
+
+On Linux, clicking and dragging anywhere on a pane body — terminal text, browser content, agent transcript — triggers a window tear-off. Tear-off must only activate when the drag originates on the pane's title bar / header strip. On macOS and Windows this works correctly.
+
+---
+
+## How it started
+
+### PR #180 — text selection fix (correct)
+
+`dd5268c7 fix: restrict pane drag to header — fix text selection (#180)`
+
+Added `dragHandle` to pragmatic-dnd's `draggable()` call, passing the header element ref. This correctly restricted drag to the header on all platforms, fixing text selection inside panes.
+
+### PR #182 — the regression
+
+`1d3679be fix: restore pane drag on Linux (WebKitGTK dragHandle incompatibility) (#182)`
+
+WebKitGTK does not support HTML5 DnD when `draggable="true"` is set on a child inside a `draggable="false"` parent. pragmatic-dnd's `dragHandle` option does exactly that: it sets `draggable="true"` on the handle and `draggable="false"` on the tile root. On Linux this silently broke pane drag entirely, so the fix reverted to `element: tileNodeRef, dragHandle: undefined` — the entire tile became the drag surface again. The platform-specific file `TileLayout.linux.tsx` was introduced here.
+
+At the time there was no tear-off feature, so the consequence was just "text selection still broken on Linux" — annoying but not destructive.
+
+### PR #188 — tear-off
+
+`ad10cbfc feat: cross-window drag tear-off, correct tear-off content, maximize drag region (#188)`
+
+Tear-off was wired to pragmatic-dnd's `onDragStart` inside the same tile registrations. Because the Linux tile registered on `tileNodeRef` (the full pane), any drag anywhere now fires tear-off.
+
+### PR #1610 — tear-off pool on macOS/Linux
+
+`ef08433c feat(pool): pane tear-off pool on macOS/Linux (#1610)`
+
+Made tear-off a polished user feature on Linux — which made the whole-tile drag regression immediately visible and annoying.
+
+---
+
+## Why the Windows fix didn't land on Linux
+
+PR #182's commit message correctly identified the WebKitGTK constraint and documented it. But it chose the wrong escape hatch: widening the drag target to the whole tile rather than avoiding the `draggable="false"` parent entirely.
+
+Windows discovered the same constraint later (WebView2 has the same `draggable="true"` child / `draggable="false"` parent limitation) and solved it differently in `TileLayout.win32.tsx`:
+
+> Instead of passing `dragHandle` to `draggable()` (which sets draggable="false" on the tile), register `draggable()` directly on the header element. Only the header gets `draggable="true"`; the tile root gets no draggable attribute at all, which defaults to non-draggable. No `draggable="false"` on any parent → no WebView2/WebKitGTK incompatibility.
+
+This pattern was never backported to the Linux file.
+
+---
+
+## Fix plan
+
+**File:** `frontend/layout/lib/TileLayout.linux.tsx`, lines 351–416.
+
+**Change:** Mirror the win32 pattern exactly:
+
+1. Replace `element: tileNodeRef, dragHandle: undefined` with registration on the live header element found via `tileNodeRef.querySelector('[data-role="block-header"]')`.
+2. Add the polling loop (`setInterval(register, 100)`) from win32 — the header is not in the DOM at tile mount time (block content loads async behind a SolidJS `<Show>` gate).
+3. Guard re-registration against active drags (same guard as win32: if `props.layoutModel.activeDrag()` is true, skip the re-register to avoid blowing away pragmatic-dnd's onDrop listener mid-drag).
+4. Keep `dragHandle: undefined` (or omit it) — we're registering on the header element itself, so there is no parent to suppress.
+5. Drop the `dragHandleRef` variable (line 360) — it's unused after this change.
+6. Update the top-of-file comment to explain the new approach.
+
+No changes needed outside `TileLayout.linux.tsx`. No Rust changes. No new dependencies.
+
+**Why this is safe on WebKitGTK:**
+- pragmatic-dnd sets `draggable="true"` on the registered `element` only.
+- When `element` is the header, the header gets `draggable="true"`.
+- `tileNodeRef` (the parent) gets no `draggable` attribute — defaults to `false` implicitly.
+- WebKitGTK's constraint is specifically about an *explicit* `draggable="false"` attribute on a parent. A parent with no attribute is fine.
+
+---
+
+## Lessons
+
+1. **"Can't use dragHandle" ≠ "use full-tile drag."** The correct escape hatch is to register on the target element directly, not to widen the drag surface. Both WebKitGTK and WebView2 have the same constraint; Windows found the right fix later and it should have been backported immediately.
+
+2. **Per-platform files create a backport debt.** The three `TileLayout.{linux,darwin,win32}.tsx` files diverge silently. When win32 fixes something that applies to Linux, there's no automated signal. A shared comment block or a cross-reference in the file headers would reduce drift.
+
+3. **"Annoying but not destructive" bugs compound.** The Linux whole-tile drag was accepted as a known regression after #182 because pane DnD worked at all. The tear-off feature in #188 silently promoted that regression into a destructive UX issue (users losing pane position on every accidental drag). Known regressions should be tracked as issues, not left as comments in source.

--- a/docs/specs/SPEC_LINUX_TEAROFF_HEADER_ONLY_2026-06-20.md
+++ b/docs/specs/SPEC_LINUX_TEAROFF_HEADER_ONLY_2026-06-20.md
@@ -1,0 +1,129 @@
+# Fix Spec: Linux pane tear-off restricted to header only
+
+**Date:** 2026-06-20
+**Retro:** `docs/retro/2026-06-20-linux-pane-tearoff-anywhere.md`
+**File:** `frontend/layout/lib/TileLayout.linux.tsx`
+
+---
+
+## Problem
+
+On Linux, any click-drag on a pane body (terminal text, browser content, agent transcript, etc.) triggers a pane tear-off. Tear-off must only activate when the drag starts on the pane's title bar / header strip. macOS and Windows are unaffected.
+
+---
+
+## Root cause
+
+`TileLayout.linux.tsx` registers pragmatic-dnd's `draggable()` on `tileNodeRef` — the full pane root element — making the entire pane surface a drag source. Any HTML5 dragstart from anywhere inside the pane fires `onDragStart`, which sets `currentDragPayload` and triggers tear-off on drop.
+
+**Why the whole tile is draggable:** PR #182 removed the `dragHandle` restriction because WebKitGTK does not support `draggable="true"` on a child inside an explicit `draggable="false"` parent. pragmatic-dnd's `dragHandle` option sets exactly that pairing, so drag broke entirely on Linux after PR #180 restricted it to the header. The fix in #182 widened the drag surface back to the whole tile and left a TODO.
+
+**Why it became destructive:** The original regression (whole-tile drag) predated the tear-off feature. PR #188 wired tear-off to the same `onDragStart` hook without a Linux-specific guard, so every incidental drag anywhere now tears the pane off.
+
+---
+
+## Correct fix
+
+Register `draggable()` directly on the header element instead of on the tile root.
+
+**Why this works around the WebKitGTK constraint:** The constraint is specifically about a `draggable="true"` child inside an *explicit* `draggable="false"` parent. pragmatic-dnd's `dragHandle` option creates that explicit `draggable="false"` attribute on the tile root — that's what WebKitGTK rejects. Registering directly on the header element puts `draggable="true"` only on the header; the tile root gets *no* `draggable` attribute (implicitly false). No explicit `draggable="false"` on any ancestor → no WebKitGTK issue.
+
+This is the same pattern Windows uses (`TileLayout.win32.tsx`, PR #1450 area) for the identical WebView2 constraint.
+
+---
+
+## Implementation
+
+### `frontend/layout/lib/TileLayout.linux.tsx`
+
+Replace the `onMount` drag registration block:
+
+**Before:**
+```ts
+const dragHandleRef = nodeModel.dragHandleRef;
+onMount(() => {
+    if (!tileNodeRef) return;
+    let cleanupFn: (() => void) | null = null;
+
+    const register = () => {
+        cleanupFn = draggable({
+            element: tileNodeRef,
+            dragHandle: undefined,
+            canDrag: () => !isEphemeral() && !isMagnified(),
+            // ... handlers
+        });
+        return true;
+    };
+
+    register();
+    onCleanup(() => cleanupFn?.());
+});
+```
+
+**After:**
+```ts
+onMount(() => {
+    if (!tileNodeRef) return;
+    let cleanupFn: (() => void) | null = null;
+    let registeredHandle: HTMLElement | null = null;
+
+    const findHandle = (): HTMLElement | null =>
+        tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
+
+    const register = () => {
+        const handle = findHandle();
+        if (handle === registeredHandle) return;
+        if (props.layoutModel.activeDrag()) return;   // never tear down mid-drag
+
+        cleanupFn?.();
+        cleanupFn = null;
+        registeredHandle = null;
+
+        if (!handle) return;
+
+        registeredHandle = handle;
+        cleanupFn = draggable({
+            element: handle,                          // header only, not tileNodeRef
+            canDrag: () => !isEphemeral() && !isMagnified(),
+            // ... same handlers
+        });
+    };
+
+    register();
+    const interval = setInterval(register, 100);     // poll for async header mount
+    onCleanup(() => {
+        clearInterval(interval);
+        cleanupFn?.();
+    });
+});
+```
+
+Key changes:
+- `element: tileNodeRef` → `element: handle` (header querySelector result)
+- Drop `dragHandle: undefined` (irrelevant when registering on header directly)
+- Drop unused `dragHandleRef` variable
+- Add `registeredHandle` guard (no-op if element unchanged)
+- Add `activeDrag()` guard (no teardown mid-drag)
+- Add `setInterval(register, 100)` polling + `clearInterval` in cleanup (header not in DOM at mount time)
+
+---
+
+## Test plan
+
+1. **Drag on pane body** — drag terminal text, browser content, agent transcript. No tear-off must occur. Text selection should work normally.
+2. **Drag on pane header** — drag the title bar of a pane. Tear-off must occur; the pane detaches into a floating window.
+3. **In-window rearrange** — drag a pane header to another quadrant inside the same window. Pane repositions; no floater created.
+4. **Cross-window drag** — drag a pane header to a different AgentMux window. Pane transfers to that window.
+5. **Magnified pane** — drag inside or on the header of a magnified pane. No drag/tear-off (magnified panes are locked).
+6. **Ephemeral pane** — drag inside or on the header of an ephemeral pane. No drag/tear-off.
+7. **After error recovery** — trigger an ErrorBoundary in a pane (bad block data), then drag the header of a recovered pane. Drag still works (polling re-registers on the replacement header element).
+
+---
+
+## No-change scope
+
+- `TileLayout.darwin.tsx` — unaffected (already registers on header element)
+- `TileLayout.win32.tsx` — unaffected (same pattern, source of this fix)
+- `CrossWindowDragMonitor.linux.tsx` — no change
+- Rust / CEF / backend — no change
+- CSS / SCSS — no change

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Linux-specific TileLayout.
-// dragHandle: undefined — whole-tile drag because WebKitGTK does not
-// support HTML5 DnD from draggable="true" child inside draggable="false" parent.
+//
+// WebKitGTK does not support HTML5 DnD from draggable="true" child inside an
+// explicit draggable="false" parent — pragmatic-dnd's dragHandle option sets
+// exactly that, so we cannot use it. The fix (same as win32) is to register
+// draggable() directly on the header element. Only the header gets
+// draggable="true"; the tile root receives no draggable attribute (implicitly
+// non-draggable). No explicit draggable="false" on any parent → no WebKitGTK
+// breakage, and drag is correctly restricted to the header.
 
 import { getApi, getSettingsKeyAtom } from "@/app/store/global";
 import { draggable, dropTargetForElements, monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
@@ -348,26 +354,39 @@ const DisplayNode = (props: DisplayNodeProps) => {
         }
     };
 
-    // Register pragmatic-dnd draggable on the tile node, using the header
-    // (dragHandleRef) as the drag handle. pragmatic-dnd wraps HTML5 DnD but
-    // fires onDragStart AFTER the browser commits the drag, so SolidJS
-    // reactive state updates here won't cause mid-event DOM mutations.
+    // Register pragmatic-dnd draggable on the live header element. Registering
+    // on the header (not the tile) means only the header gets draggable="true";
+    // the tile root stays attribute-free. This avoids the WebKitGTK constraint
+    // (see file header) while still restricting drag — and tear-off — to the
+    // header strip only.
     //
-    // The header ref may not be available at mount time (block content loads
-    // async behind a Show gate). Poll briefly until the ref is set, then
-    // register with the correct drag handle. Without a drag handle, the
-    // entire tile would be draggable — breaking text selection in panes.
-    const dragHandleRef = nodeModel.dragHandleRef;
+    // The header is not in the DOM at tile mount time (block content loads
+    // async behind a Show gate). Poll until it appears, then re-register if
+    // SolidJS ever swaps the element (ErrorBoundary Show-gate replacement).
+    // Never re-register while a drag is active — that would remove pragmatic-dnd's
+    // onDrop listener mid-drag and leave activeDrag stuck true ("widgets broken").
     onMount(() => {
         if (!tileNodeRef) return;
         let cleanupFn: (() => void) | null = null;
+        let registeredHandle: HTMLElement | null = null;
+
+        const findHandle = (): HTMLElement | null =>
+            tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
 
         const register = () => {
-            // WebKitGTK does not support HTML5 DnD from draggable="true" child
-            // inside draggable="false" parent — no dragHandle restriction.
+            const handle = findHandle();
+            if (handle === registeredHandle) return;
+            if (props.layoutModel.activeDrag()) return;
+
+            cleanupFn?.();
+            cleanupFn = null;
+            registeredHandle = null;
+
+            if (!handle) return;
+
+            registeredHandle = handle;
             cleanupFn = draggable({
-                element: tileNodeRef,
-                dragHandle: undefined,
+                element: handle,
                 canDrag: () => !isEphemeral() && !isMagnified(),
                 getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
                 onGenerateDragPreview: ({ nativeSetDragImage }) => {
@@ -406,13 +425,14 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     // Cleared in dropTargetForElements.onDrop instead.
                 },
             });
-            return true;
         };
 
-        // Register immediately — no dragHandle needed on Linux.
         register();
-
-        onCleanup(() => cleanupFn?.());
+        const interval = setInterval(register, 100);
+        onCleanup(() => {
+            clearInterval(interval);
+            cleanupFn?.();
+        });
     });
 
     const leafContent = () => (


### PR DESCRIPTION
## Summary

- On Linux, any click-drag anywhere on a pane body (terminal, browser, agent transcript) triggered a window tear-off. Should only fire when dragging the pane header.
- Root cause: `TileLayout.linux.tsx` registered `draggable()` on `tileNodeRef` (the full pane), so every drag anywhere fired `onDragStart` → tear-off. This dates to PR #182 which worked around a WebKitGTK constraint by widening the drag surface to the whole tile.
- Fix: register `draggable()` directly on the header element (`querySelector('[data-role="block-header"]')`). Only the header gets `draggable="true"`; the tile root gets no `draggable` attribute. No explicit `draggable="false"` on any parent → WebKitGTK is satisfied, drag/tear-off restricted to header. Same pattern as `TileLayout.win32.tsx`.
- Adds 100ms polling loop (matching win32) to handle async Show-gate header mount and ErrorBoundary element swaps.

## Test plan

- [ ] Drag on pane body (terminal text, browser, transcript) — no tear-off, text selection works
- [ ] Drag on pane header — tear-off fires, pane detaches into floating window
- [ ] In-window rearrange via header drag — pane repositions, no floater
- [ ] Cross-window header drag — pane transfers to target window
- [ ] Magnified/ephemeral pane header drag — no drag (canDrag returns false)
- [ ] ErrorBoundary recovery — drag still works after header element is swapped by Show gate

Retro: `docs/retro/2026-06-20-linux-pane-tearoff-anywhere.md`
Spec: `docs/specs/SPEC_LINUX_TEAROFF_HEADER_ONLY_2026-06-20.md`

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-opal} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)