### PR TITLE
feat(tab): larger close button, context-menu dismiss, close-confirm modal

### DIFF
--- a/.changesets/1781997998-feat-tab-larger-close-button-context-menu-dismiss-close-conf-yael.md
+++ b/.changesets/1781997998-feat-tab-larger-close-button-context-menu-dismiss-close-conf-yael.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tab): larger close button, context-menu dismiss, close-confirm modal

--- a/docs/specs/SPEC_TAB_UI_REFINEMENTS_2026_06_20.md
+++ b/docs/specs/SPEC_TAB_UI_REFINEMENTS_2026_06_20.md
@@ -1,0 +1,223 @@
+# SPEC: Tab UI Refinements
+
+**Date:** 2026-06-20  
+**Status:** Approved for implementation  
+**Scope:** `frontend/app/tab/`
+
+---
+
+## Overview
+
+Three targeted changes to the tab bar UI:
+
+1. **Larger close button (X)** — increase the SVG icon and hit target
+2. **Context-menu "Close" dismisses the menu only** — not the tab
+3. **Close-confirmation modal** — window-wide confirm before closing a tab, with a persistent "don't remind me" preference
+
+---
+
+## 1. Larger Close Button
+
+### Current state
+
+- **`frontend/app/tab/tab.tsx:294-307`** — SVG `width="14" height="14"`, `viewBox="0 0 16 16"`
+- **`frontend/app/tab/tab.scss:121-135`** — `.wave-button` container is 16×16px
+
+### Proposed change
+
+Increase the close icon to **16×16** and its container to **20×20px**, giving a larger click target without crowding the tab.
+
+#### `tab.tsx` (lines 294-296)
+```diff
+- width="14"
+- height="14"
++ width="16"
++ height="16"
+```
+`viewBox` stays `"0 0 16 16"` — no change needed, the icon path already fills a 16-unit grid.
+
+#### `tab.scss` (lines 121-135)
+```diff
+  .wave-button {
+    flex-shrink: 0;
+-   width: 16px;
+-   height: 16px;
++   width: 20px;
++   height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+```
+
+No other sizing changes. The tab's inner flex layout already centers the button; the 4px increase is absorbed by the tab-inner padding.
+
+---
+
+## 2. Context-Menu "Close" Dismisses the Menu Only
+
+### Current state
+
+**`frontend/app/tab/tab.tsx:32-104`** — `TabContextPanel` component.  
+The "✕ Close" button at lines 97-99 calls `props.onClose`, which closes the **tab** (deletes it from the workspace).
+
+### Proposed change
+
+"Close" in the context menu should **dismiss the popup** — not close the tab. Tab closing is now guarded by the confirmation modal (section 3) and is intentionally only reachable via the X button. The context menu "Close" becomes an escape hatch: "I right-clicked by mistake, dismiss this menu."
+
+#### `tab.tsx` — `TabContextPanel` (lines 97-99)
+```diff
+- <button class="tab-context-btn tab-context-btn-close" onClick={() => { props.onClose?.(); setShowPanel(false); }}>
+-     ✕ Close
+- </button>
++ <button class="tab-context-btn tab-context-btn-close" onClick={() => setShowPanel(false)}>
++     ✕ Close
++ </button>
+```
+
+> Note: exact signal/setter name for the panel's open state needs to be confirmed at implementation time — the Explore agent found the panel is dismissed via `setShowPanel` or equivalent in the `TabContextPanel` closure. The key invariant is: clicking "Close" in the menu calls only the panel-dismiss callback, with no `onClose` call.
+
+**Rename the button label** from "✕ Close" to "✕ Close menu" for clarity, so users understand it closes the popup, not the tab.
+
+---
+
+## 3. Close-Confirmation Modal
+
+### Behaviour
+
+When the user clicks the X button on a tab:
+
+1. **Check** `settingsAtom()["tab:skipcloseconfirm"]`.
+2. If `true` → skip modal, close tab immediately (existing `handleClose` flow).
+3. If falsy (default) → show a window-scoped `ConfirmModal`:
+   - **Title:** "Close tab?"
+   - **Body:** name of the tab being closed (e.g. "Close 'My tab'?")
+   - **Checkbox:** "Don't ask again" (unchecked by default)
+   - **Buttons:** Cancel | Close tab (destructive)
+4. **On confirm:**
+   - If checkbox is checked → `RpcApi.SetConfigCommand(TabRpcClient, { "tab:skipcloseconfirm": true } as any)` then close tab.
+   - If checkbox is unchecked → close tab immediately.
+5. **On cancel:** do nothing, tab stays open.
+
+### Settings schema addition
+
+**`schema/settings.json`** — add under the `tab:` block:
+
+```json
+"tab:skipcloseconfirm": {
+    "type": "boolean",
+    "default": false,
+    "description": "Skip the close-tab confirmation modal. Set automatically by the 'Don't ask again' checkbox."
+}
+```
+
+### Implementation
+
+#### A. `tabbar.tsx` — wrap `handleClose` in a modal gate
+
+The existing `handleClose` (lines 70-82) directly calls `WorkspaceService.CloseTab`. Introduce an intermediate function `requestClose(tabId)` that:
+
+1. Reads the skip-setting.
+2. If set: calls `handleClose(tabId)` directly.
+3. If not set: opens the confirmation modal.
+
+Pass `requestClose` as the `onClose` prop to each tab (currently the prop is `handleClose`).
+
+```typescript
+// tabbar.tsx — new signal for pending close
+const [pendingCloseTabId, setPendingCloseTabId] = createSignal<string | null>(null);
+
+function requestClose(tabId: string) {
+    const skip = settingsAtom()["tab:skipcloseconfirm"];
+    if (skip) {
+        handleClose(tabId);
+    } else {
+        setPendingCloseTabId(tabId);
+    }
+}
+```
+
+#### B. Modal JSX in `tabbar.tsx`
+
+Render a `ConfirmModal` driven by `pendingCloseTabId()`. The modal is window-scoped so it overlays the full window (not just a tab pane).
+
+```tsx
+<Show when={pendingCloseTabId() !== null}>
+    <TabCloseConfirmModal
+        tabId={pendingCloseTabId()!}
+        onConfirm={(skipFuture) => {
+            if (skipFuture) {
+                RpcApi.SetConfigCommand(TabRpcClient, { "tab:skipcloseconfirm": true } as any);
+            }
+            handleClose(pendingCloseTabId()!);
+            setPendingCloseTabId(null);
+        }}
+        onCancel={() => setPendingCloseTabId(null)}
+    />
+</Show>
+```
+
+#### C. `TabCloseConfirmModal` component
+
+New small component, can live in `tabbar.tsx` or a separate `tab-close-confirm-modal.tsx`.
+
+```tsx
+function TabCloseConfirmModal(props: {
+    tabId: string;
+    onConfirm: (skipFuture: boolean) => void;
+    onCancel: () => void;
+}) {
+    const [skipFuture, setSkipFuture] = createSignal(false);
+    const [tabData] = useWaveObjectValue<Tab>(makeORef("tab", props.tabId));
+    const tabName = () => tabData()?.name ?? "this tab";
+
+    return (
+        <Modal scope="window" onClose={props.onCancel}>
+            <ModalHeader title={`Close "${tabName()}"?`} />
+            <ModalBody>
+                <p>This tab and all its panes will be closed.</p>
+                <label style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "12px", cursor: "pointer" }}>
+                    <input
+                        type="checkbox"
+                        checked={skipFuture()}
+                        onChange={(e) => setSkipFuture(e.currentTarget.checked)}
+                    />
+                    Don't ask again
+                </label>
+            </ModalBody>
+            <ModalFooter>
+                <Button className="ghost grey" onClick={props.onCancel}>Cancel</Button>
+                <Button className="solid red" onClick={() => props.onConfirm(skipFuture())}>
+                    Close tab
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+}
+```
+
+#### D. `Modal` scope note
+
+The existing modal system (`frontend/app/element/modal.tsx`) supports `scope="window"`. This renders the modal via the window-level Portal, overlaying the full app content — correct for a destructive confirmation that blocks all tab interactions. The `inert` + scroll-lock machinery is already handled by the Modal component for this scope.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `frontend/app/tab/tab.tsx` | SVG size 14→16; context-menu "Close" → dismiss only |
+| `frontend/app/tab/tab.scss` | `.wave-button` container 16px→20px |
+| `frontend/app/tab/tabbar.tsx` | `requestClose` gate, `pendingCloseTabId` signal, `TabCloseConfirmModal` usage |
+| `schema/settings.json` | Add `tab:skipcloseconfirm` boolean key |
+
+Optional (if modal is extracted):
+| `frontend/app/tab/tab-close-confirm-modal.tsx` | New component |
+
+---
+
+## Edge Cases
+
+- **Last tab:** `handleClose` already guards against closing the last tab (`allTabs.length <= 1`). `requestClose` should apply the same guard before even showing the modal — no point confirming a close that won't happen.
+- **Keyboard close:** If there's a keyboard shortcut for closing a tab (Cmd/Ctrl+W equivalent), it should also route through `requestClose`.
+- **Multiple windows:** `tab:skipcloseconfirm` is a global setting (shared across all windows, written to `settings.json`). This is intentional — the user's preference should be consistent.
+- **Re-enabling the prompt:** Users can set `"tab:skipcloseconfirm": false` in `settings.json` to get the modal back. No UI needed for this edge case.

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -32,6 +32,7 @@ import { fireAndForget } from "@/util/util";
 import { createSignal } from "solid-js";
 import { modalsModel, openModal } from "./modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
+import { triggerTabCloseRequest } from "@/app/tab/tab-close-request";
 
 // Debug logging function - writes to file
 const DEBUG_LOG_PATH = "C:/Systems/agentmux-debug.log";
@@ -155,21 +156,12 @@ function getStaticTabBlockCount(): number {
 
 function simpleCloseStaticTab() {
     debugLog("simpleCloseStaticTab called");
-    const ws = atoms.workspace();
-    const tabId = atoms.activeTabId();
-    // Guard: don't close the only tab. Mirrors the same check in the
-    // tabbar close button (`tabbar.tsx:63`). Without this gate, the
-    // backend rejects the CloseTab as "last tab" but
-    // `deleteLayoutModelForTab` still runs unconditionally, leaving
-    // client/server diverged. (reagent P1 round 2 PR #633.)
-    const allTabs = (ws.tabids ?? []).concat(ws.pinnedtabids ?? []);
-    if (allTabs.length <= 1) {
-        return;
-    }
-    WorkspaceService.CloseTab(ws.oid, tabId).catch((e) => {
-        console.error("[closeTab] failed:", e);
-    });
-    deleteLayoutModelForTab(tabId);
+    // Route through TabBar's requestClose so the close-confirmation modal
+    // (and the tab:skipcloseconfirm setting) is honoured on keyboard close
+    // the same way it is on the X-button path. The last-tab guard and the
+    // WorkspaceService.CloseTab + deleteLayoutModelForTab calls all live
+    // inside handleClose, which requestClose delegates to. (reagent P2 #1636.)
+    triggerTabCloseRequest();
 }
 
 function uxCloseBlock(blockId: string) {

--- a/frontend/app/tab/tab-close-request.ts
+++ b/frontend/app/tab/tab-close-request.ts
@@ -1,0 +1,20 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Thin bridge so keymodel.ts can trigger the tab-close confirmation flow
+// without importing from tabbar.tsx (which would create a circular dep via
+// the store imports). TabBar registers its requestClose handler on mount;
+// callers (keyboard shortcuts, etc.) call triggerTabCloseRequest().
+
+let _handler: (() => void) | null = null;
+
+export function registerTabCloseRequestHandler(fn: () => void): () => void {
+    _handler = fn;
+    return () => {
+        if (_handler === fn) _handler = null;
+    };
+}
+
+export function triggerTabCloseRequest(): void {
+    _handler?.();
+}

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -120,8 +120,8 @@
 
     .wave-button {
         flex-shrink: 0;
-        width: 16px;
-        height: 16px;
+        width: 20px;
+        height: 20px;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -35,7 +35,6 @@ interface TabContextPanelProps {
     onColorSelect: (hex: string | null) => void;
     onRename: () => void;
     onClose: (e?: MouseEvent) => void;
-    onCloseTab: () => void;
 }
 
 const TabContextPanel = (props: TabContextPanelProps): JSX.Element => {
@@ -315,7 +314,6 @@ function Tab(props: TabProps): JSX.Element {
                     onColorSelect={handleColorSelect}
                     onRename={() => handleRenameTab()}
                     onClose={() => setShowColorPicker(false)}
-                    onCloseTab={() => props.onClose(null)}
                 />
             </Show>
         </>

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -94,8 +94,8 @@ const TabContextPanel = (props: TabContextPanelProps): JSX.Element => {
                     <button class="tab-context-btn" onClick={() => { props.onRename(); props.onClose(); }}>
                         ✏️ Rename
                     </button>
-                    <button class="tab-context-btn tab-context-btn-close" onClick={() => { props.onCloseTab(); props.onClose(); }}>
-                        ✕ Close
+                    <button class="tab-context-btn tab-context-btn-close" onClick={() => props.onClose()}>
+                        ✕ Close menu
                     </button>
                 </div>
             </div>
@@ -292,8 +292,8 @@ function Tab(props: TabProps): JSX.Element {
                             from microsoft/vscode-codicons (close.svg) —
                             the same glyph VS Code uses for tab-close. */}
                         <svg
-                            width="14"
-                            height="14"
+                            width="16"
+                            height="16"
                             viewBox="0 0 16 16"
                             fill="currentColor"
                             xmlns="http://www.w3.org/2000/svg"

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -15,8 +15,7 @@ import { ObjectService, WorkspaceService } from "../store/services";
 import { RpcApi } from "@/store/rpc-api";
 import { TabRpcClient } from "@/store/rpc-util";
 import { makeORef, getObjectValue } from "../store/wos";
-import { Modal, ModalHeader, ModalBody, ModalFooter } from "@/element/modal";
-import { Button } from "@/element/button";
+import { ConfirmModal } from "@/element/modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
 import { deleteLayoutModelForTab } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
@@ -61,24 +60,25 @@ function TabCloseConfirmModal(props: {
     const tabName = () => getObjectValue<Tab>(makeORef("tab", props.tabId))?.name ?? "this tab";
 
     return (
-        <Modal scope="window" open={true} onClose={props.onCancel} size="sm">
-            <ModalHeader title={`Close "${tabName()}"?`} />
-            <ModalBody>
-                <p style={{ margin: "0 0 12px 0" }}>This tab and all its panes will be closed.</p>
-                <label style={{ display: "flex", "align-items": "center", gap: "8px", cursor: "pointer", "font-size": "13px" }}>
-                    <input
-                        type="checkbox"
-                        checked={skipFuture()}
-                        onChange={(e) => setSkipFuture(e.currentTarget.checked)}
-                    />
-                    Don't ask again
-                </label>
-            </ModalBody>
-            <ModalFooter>
-                <Button className="ghost grey" onClick={props.onCancel}>Cancel</Button>
-                <Button className="solid red" onClick={() => props.onConfirm(skipFuture())}>Close tab</Button>
-            </ModalFooter>
-        </Modal>
+        <ConfirmModal
+            open={true}
+            scope="window"
+            title={`Close "${tabName()}"?`}
+            description="This tab and all its panes will be closed."
+            confirmLabel="Close tab"
+            destructive={true}
+            onConfirm={() => props.onConfirm(skipFuture())}
+            onCancel={props.onCancel}
+        >
+            <label style={{ display: "flex", "align-items": "center", gap: "8px", cursor: "pointer", "font-size": "13px" }}>
+                <input
+                    type="checkbox"
+                    checked={skipFuture()}
+                    onChange={(e) => setSkipFuture(e.currentTarget.checked)}
+                />
+                Don't ask again
+            </label>
+        </ConfirmModal>
     );
 }
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -2,16 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atoms, getApi, setActiveTab } from "@/store/global";
+import { settingsAtom } from "@/store/config-signals";
 import { fireAndForget } from "@/util/util";
 import { isMacOS } from "@/util/platformutil";
 import { HamburgerMenu } from "@/app/window/hamburger-menu";
 import { getTabGrabOffset } from "./tab-grab-offset";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { For, onCleanup, onMount, Show } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import { ObjectService, WorkspaceService } from "../store/services";
+import { RpcApi } from "@/store/rpc-api";
+import { TabRpcClient } from "@/store/rpc-util";
 import { makeORef, getObjectValue } from "../store/wos";
+import { Modal, ModalHeader, ModalBody, ModalFooter } from "@/element/modal";
+import { Button } from "@/element/button";
 import { deleteLayoutModelForTab } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
 import {
@@ -46,6 +51,36 @@ interface TabBarProps {
 // Spec: SPEC_TAB_TEAROFF_POSITION_AND_PAINT_2026-05-07.md §4.2.
 const TEAR_PAST_PX = 5;
 
+function TabCloseConfirmModal(props: {
+    tabId: string;
+    onConfirm: (skipFuture: boolean) => void;
+    onCancel: () => void;
+}): JSX.Element {
+    const [skipFuture, setSkipFuture] = createSignal(false);
+    const tabName = () => getObjectValue<Tab>(makeORef("tab", props.tabId))?.name ?? "this tab";
+
+    return (
+        <Modal scope="window" open={true} onClose={props.onCancel} size="sm">
+            <ModalHeader title={`Close "${tabName()}"?`} />
+            <ModalBody>
+                <p style={{ margin: "0 0 12px 0" }}>This tab and all its panes will be closed.</p>
+                <label style={{ display: "flex", "align-items": "center", gap: "8px", cursor: "pointer", "font-size": "13px" }}>
+                    <input
+                        type="checkbox"
+                        checked={skipFuture()}
+                        onChange={(e) => setSkipFuture(e.currentTarget.checked)}
+                    />
+                    Don't ask again
+                </label>
+            </ModalBody>
+            <ModalFooter>
+                <Button className="ghost grey" onClick={props.onCancel}>Cancel</Button>
+                <Button className="solid red" onClick={() => props.onConfirm(skipFuture())}>Close tab</Button>
+            </ModalFooter>
+        </Modal>
+    );
+}
+
 function TabBar(props: TabBarProps): JSX.Element {
     const activeTabId = atoms.activeTabId;
     let tabBarScrollRef!: HTMLDivElement;
@@ -79,6 +114,17 @@ function TabBar(props: TabBarProps): JSX.Element {
             await WorkspaceService.CloseTab(props.workspace.oid, tabId);
             deleteLayoutModelForTab(tabId);
         });
+    };
+
+    const [pendingCloseTabId, setPendingCloseTabId] = createSignal<string | null>(null);
+
+    const requestClose = (tabId: string) => {
+        if (tabIds().length <= 1) return;
+        if ((settingsAtom() as any)["tab:skipcloseconfirm"]) {
+            handleClose(tabId);
+        } else {
+            setPendingCloseTabId(tabId);
+        }
     };
 
     const { dragProps } = useWindowDrag();
@@ -643,7 +689,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 tabIndex={i()}
                                 tabIds={tabIds()}
                                 onSelect={() => handleSelect(tabId)}
-                                onClose={() => handleClose(tabId)}
+                                onClose={() => requestClose(tabId)}
                             />
                         </>
                     )}
@@ -657,6 +703,20 @@ function TabBar(props: TabBarProps): JSX.Element {
                     of the scroll container looked draggable but wasn't. */}
                 <div class="tab-bar-fill" data-drag-region="true" />
             </div>
+            <Show when={pendingCloseTabId() !== null}>
+                <TabCloseConfirmModal
+                    tabId={pendingCloseTabId()!}
+                    onConfirm={(skipFuture) => {
+                        const tabId = pendingCloseTabId()!;
+                        setPendingCloseTabId(null);
+                        if (skipFuture) {
+                            fireAndForget(() => RpcApi.SetConfigCommand(TabRpcClient, { "tab:skipcloseconfirm": true } as any));
+                        }
+                        handleClose(tabId);
+                    }}
+                    onCancel={() => setPendingCloseTabId(null)}
+                />
+            </Show>
         </div>
     );
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -17,6 +17,7 @@ import { TabRpcClient } from "@/store/rpc-util";
 import { makeORef, getObjectValue } from "../store/wos";
 import { Modal, ModalHeader, ModalBody, ModalFooter } from "@/element/modal";
 import { Button } from "@/element/button";
+import { registerTabCloseRequestHandler } from "./tab-close-request";
 import { deleteLayoutModelForTab } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
 import {
@@ -126,6 +127,11 @@ function TabBar(props: TabBarProps): JSX.Element {
             setPendingCloseTabId(tabId);
         }
     };
+
+    onMount(() => {
+        const unregister = registerTabCloseRequestHandler(() => requestClose(activeTabId()));
+        onCleanup(unregister);
+    });
 
     const { dragProps } = useWindowDrag();
 

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -83,6 +83,9 @@
         "tab:preset": {
           "type": "string"
         },
+        "tab:skipcloseconfirm": {
+          "type": "boolean"
+        },
         "widget:*": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

Three targeted tab UI refinements:

- **Larger X button** — SVG icon 14→16 px, hit-target container 16→20 px. Bigger and easier to click without crowding the tab label.
- **Context-menu "Close" → dismiss only** — renamed to "Close menu". Previously it deleted the tab; now it just closes the right-click panel. Tab deletion is intentional-only via the X button.
- **Close-confirmation modal** — clicking X shows a window-wide `<Modal scope="window">` with the tab name, a "Don't ask again" checkbox, and Cancel / Close tab (destructive) buttons. Checking "Don't ask again" writes `tab:skipcloseconfirm: true` via `SetConfigCommand`, bypassing the modal on future closes. New `tab:skipcloseconfirm` boolean key added to `schema/settings.json`.

## Files changed

| File | Change |
|------|--------|
| `frontend/app/tab/tab.tsx` | SVG 14→16 px; context-menu "Close" → dismiss-only |
| `frontend/app/tab/tab.scss` | `.wave-button` container 16→20 px |
| `frontend/app/tab/tabbar.tsx` | `requestClose` gate, `pendingCloseTabId` signal, `TabCloseConfirmModal` component |
| `schema/settings.json` | Add `tab:skipcloseconfirm` boolean |
| `docs/specs/SPEC_TAB_UI_REFINEMENTS_2026_06_20.md` | Spec |

## Test plan

- [ ] X button is visibly larger and easier to click
- [ ] Right-click a tab → "Close menu" closes only the popup, tab stays open
- [ ] Click X → modal appears with correct tab name
- [ ] Cancel → modal closes, tab stays open
- [ ] Confirm → tab closes
- [ ] Check "Don't ask again" + confirm → tab closes; subsequent X clicks close immediately with no modal
- [ ] Reset by setting `"tab:skipcloseconfirm": false` in settings.json → modal reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)