### PR TITLE
fix(cef): disable macOS renderer sandbox in task dev (no_sandbox=1 when not in .app bundle)

### DIFF
--- a/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
+++ b/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): disable macOS renderer sandbox in dev — skip Seatbelt init and pass no_sandbox=1 when libcef_sandbox.dylib is absent (task dev flat layout)

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -197,6 +197,43 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
         .map(|v| v.trim() == "1")
         .unwrap_or(false);
 
+    // macOS sandbox availability: the cef::sandbox::Sandbox type resolves
+    // libcef_sandbox.dylib via a path relative to current_exe() that is only
+    // valid when running as a Helper app inside a packaged .app bundle:
+    //   ../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib
+    // In `task dev` the renderer re-execs the flat binary in dist/cef-dev/, so
+    // the path lands three levels above the build tree — no dylib there.
+    // We check existence once and use it in two places:
+    //   1. Seatbelt init (subprocess only) — skip if not in bundle.
+    //   2. no_sandbox flag to CefInitialize — must also be 1 when not in bundle,
+    //      otherwise CEF tries to sandbox GPU/network/renderer processes and they
+    //      get killed by the OS before they can start.
+    #[cfg(all(target_os = "macos", feature = "sandbox"))]
+    let macos_sandbox_available = {
+        const LIBCEF_SANDBOX_REL: &str =
+            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join(LIBCEF_SANDBOX_REL)))
+            .map(|p| p.exists())
+            .unwrap_or(false)
+    };
+
+    // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
+    // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
+    //   1. cef_sandbox_initialize     ← here, before dlopen
+    //   2. LoadInHelper / _library    ← CEF framework loaded within the sandbox
+    //   3. CefExecuteProcess
+    // Subprocess mode is detected from raw argv (--type=…) because cef::Args
+    // cannot be parsed until after the framework is loaded. Browser process
+    // skips this entirely — the host process is unsandboxed by design.
+    // Non-macOS / sandbox-off: define macos_sandbox_available as a no-op
+    // placeholder so the no_sandbox computation below compiles on all targets.
+    // On those targets cfg!(all(target_os="macos",feature="sandbox")) is false,
+    // so the `&& !macos_sandbox_available` branch is never reached at runtime.
+    #[cfg(not(all(target_os = "macos", feature = "sandbox")))]
+    let macos_sandbox_available = true; // irrelevant — guarded by cfg!() in no_sandbox
+
     // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
     // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
     //   1. cef_sandbox_initialize     ← here, before dlopen
@@ -208,6 +245,7 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
     let _macos_sandbox = if std::env::args().any(|a| a.starts_with("--type="))
         && !force_no_sandbox
+        && macos_sandbox_available
     {
         let raw = cef::args::Args::new();
         let mut s = cef::sandbox::Sandbox::new();
@@ -694,7 +732,10 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     // (kernel namespace isolation), and Windows (bootstrap.exe DLL wrapper,
     // Phase 3) when built with `--features sandbox` (the default).
     // Escape hatch: AGENTMUX_UNSAFE_NOSANDBOX=1 disables on all platforms.
-    let no_sandbox: i32 = if cfg!(not(feature = "sandbox")) || force_no_sandbox {
+    let no_sandbox: i32 = if cfg!(not(feature = "sandbox"))
+        || force_no_sandbox
+        || cfg!(all(target_os = "macos", feature = "sandbox")) && !macos_sandbox_available
+    {
         1
     } else {
         0

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -197,36 +197,38 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
         .map(|v| v.trim() == "1")
         .unwrap_or(false);
 
-    // macOS sandbox availability: the cef::sandbox::Sandbox type resolves
-    // libcef_sandbox.dylib via a path relative to current_exe() that is only
-    // valid when running as a Helper app inside a packaged .app bundle:
-    //   ../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib
-    // In `task dev` the renderer re-execs the flat binary in dist/cef-dev/, so
-    // the path lands three levels above the build tree — no dylib there.
-    // We check existence once and use it in two places:
-    //   1. Seatbelt init (subprocess only) — skip if not in bundle.
-    //   2. no_sandbox flag to CefInitialize — must also be 1 when not in bundle,
-    //      otherwise CEF tries to sandbox GPU/network/renderer processes and they
-    //      get killed by the OS before they can start.
+    // macOS sandbox availability: probe for libcef_sandbox.dylib to detect
+    // whether we are running inside a packaged .app bundle. Two uses:
+    //   1. Seatbelt init (subprocess only) — skip if dylib not reachable.
+    //   2. no_sandbox flag to CefInitialize — must be 1 when not in bundle,
+    //      otherwise CEF kills GPU/network/renderer with a sandbox error.
+    //
+    // The path is relative to current_exe().parent() and differs by role
+    // because the Host and Helper processes live at different depths:
+    //
+    //   Host   — Contents/MacOS/AgentMux
+    //            → ../Frameworks/Chromium Embedded Framework.framework/…
+    //
+    //   Helper — Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/AgentMux Helper
+    //            → ../../../Chromium Embedded Framework.framework/…
+    //
+    // In task dev neither path exists (flat dist/cef-dev/ tree), so the probe
+    // returns false for both roles → sandbox skipped, no crash.
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
     let macos_sandbox_available = {
-        const LIBCEF_SANDBOX_REL: &str =
-            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
+        let is_subprocess = std::env::args().any(|a| a.starts_with("--type="));
+        let rel: &str = if is_subprocess {
+            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+        } else {
+            "../Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+        };
         std::env::current_exe()
             .ok()
-            .and_then(|p| p.parent().map(|d| d.join(LIBCEF_SANDBOX_REL)))
+            .and_then(|p| p.parent().map(|d| d.join(rel)))
             .map(|p| p.exists())
             .unwrap_or(false)
     };
 
-    // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
-    // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
-    //   1. cef_sandbox_initialize     ← here, before dlopen
-    //   2. LoadInHelper / _library    ← CEF framework loaded within the sandbox
-    //   3. CefExecuteProcess
-    // Subprocess mode is detected from raw argv (--type=…) because cef::Args
-    // cannot be parsed until after the framework is loaded. Browser process
-    // skips this entirely — the host process is unsandboxed by design.
     // Non-macOS / sandbox-off: define macos_sandbox_available as a no-op
     // placeholder so the no_sandbox computation below compiles on all targets.
     // On those targets cfg!(all(target_os="macos",feature="sandbox")) is false,


### PR DESCRIPTION
## Summary

- **Probes `libcef_sandbox.dylib` existence** once at startup (`macos_sandbox_available`) to detect whether we're running inside a packaged `.app` bundle or in `task dev`'s flat `dist/cef-dev/` layout
- **Skips `Seatbelt` init** in renderer subprocesses when the dylib isn't present (avoids panic at `cef::sandbox::Sandbox::new()` → `canonicalize()` → ENOENT)
- **Passes `no_sandbox=1` to `CefInitialize`** when not in bundle — without this, CEF attempts to sandbox GPU/network/renderer processes which get killed by the OS (`exit_code=5` crash loop)
- Packaged `.app` builds are **fully unaffected** — dylib present → Seatbelt active as before (Phases 1+2 behavior unchanged)

## Root cause

In `task dev`, renderer subprocesses re-exec the flat `agentmux-cef` binary from `dist/cef-dev/`. The `cef` crate's `Sandbox::new()` resolves `libcef_sandbox.dylib` via `../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib` — a relative path designed for the Helper app (`Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/` → 3 hops up = `Contents/Frameworks/`). In dev, 3 hops above `dist/cef-dev/` is empty space → ENOENT panic on every renderer spawn.

## Test plan

- [x] `task dev` on macOS: window opens, no crash loop (`GPU process exited unexpectedly` gone)
- [x] `cargo check -p agentmux-cef` on macOS — compiles clean
- [ ] Packaged `.app`: renderer sandbox still active (libcef_sandbox.dylib present → `macos_sandbox_available=true` → full Seatbelt)
- [ ] `AGENTMUX_UNSAFE_NOSANDBOX=1` still disables sandbox as before

<!-- agentmux:agent_id=masty-06136 -->