### PR TITLE
fix(ui): pane tear-off renders as full window instead of floating pane (pool path)

### DIFF
--- a/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
+++ b/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): disable macOS renderer sandbox in dev — skip Seatbelt init and pass no_sandbox=1 when libcef_sandbox.dylib is absent (task dev flat layout)

--- a/.changesets/1782003217-fix-ui-pane-tear-off-renders-full-window-instead-of-floating-pk1z.md
+++ b/.changesets/1782003217-fix-ui-pane-tear-off-renders-full-window-instead-of-floating-pk1z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): pane tear-off renders full window instead of floating pane when using pool fast path

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -197,6 +197,43 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
         .map(|v| v.trim() == "1")
         .unwrap_or(false);
 
+    // macOS sandbox availability: the cef::sandbox::Sandbox type resolves
+    // libcef_sandbox.dylib via a path relative to current_exe() that is only
+    // valid when running as a Helper app inside a packaged .app bundle:
+    //   ../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib
+    // In `task dev` the renderer re-execs the flat binary in dist/cef-dev/, so
+    // the path lands three levels above the build tree — no dylib there.
+    // We check existence once and use it in two places:
+    //   1. Seatbelt init (subprocess only) — skip if not in bundle.
+    //   2. no_sandbox flag to CefInitialize — must also be 1 when not in bundle,
+    //      otherwise CEF tries to sandbox GPU/network/renderer processes and they
+    //      get killed by the OS before they can start.
+    #[cfg(all(target_os = "macos", feature = "sandbox"))]
+    let macos_sandbox_available = {
+        const LIBCEF_SANDBOX_REL: &str =
+            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join(LIBCEF_SANDBOX_REL)))
+            .map(|p| p.exists())
+            .unwrap_or(false)
+    };
+
+    // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
+    // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
+    //   1. cef_sandbox_initialize     ← here, before dlopen
+    //   2. LoadInHelper / _library    ← CEF framework loaded within the sandbox
+    //   3. CefExecuteProcess
+    // Subprocess mode is detected from raw argv (--type=…) because cef::Args
+    // cannot be parsed until after the framework is loaded. Browser process
+    // skips this entirely — the host process is unsandboxed by design.
+    // Non-macOS / sandbox-off: define macos_sandbox_available as a no-op
+    // placeholder so the no_sandbox computation below compiles on all targets.
+    // On those targets cfg!(all(target_os="macos",feature="sandbox")) is false,
+    // so the `&& !macos_sandbox_available` branch is never reached at runtime.
+    #[cfg(not(all(target_os = "macos", feature = "sandbox")))]
+    let macos_sandbox_available = true; // irrelevant — guarded by cfg!() in no_sandbox
+
     // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
     // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
     //   1. cef_sandbox_initialize     ← here, before dlopen
@@ -208,6 +245,7 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
     let _macos_sandbox = if std::env::args().any(|a| a.starts_with("--type="))
         && !force_no_sandbox
+        && macos_sandbox_available
     {
         let raw = cef::args::Args::new();
         let mut s = cef::sandbox::Sandbox::new();
@@ -694,7 +732,10 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     // (kernel namespace isolation), and Windows (bootstrap.exe DLL wrapper,
     // Phase 3) when built with `--features sandbox` (the default).
     // Escape hatch: AGENTMUX_UNSAFE_NOSANDBOX=1 disables on all platforms.
-    let no_sandbox: i32 = if cfg!(not(feature = "sandbox")) || force_no_sandbox {
+    let no_sandbox: i32 = if cfg!(not(feature = "sandbox"))
+        || force_no_sandbox
+        || cfg!(all(target_os = "macos", feature = "sandbox")) && !macos_sandbox_available
+    {
         1
     } else {
         0

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -197,36 +197,38 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
         .map(|v| v.trim() == "1")
         .unwrap_or(false);
 
-    // macOS sandbox availability: the cef::sandbox::Sandbox type resolves
-    // libcef_sandbox.dylib via a path relative to current_exe() that is only
-    // valid when running as a Helper app inside a packaged .app bundle:
-    //   ../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib
-    // In `task dev` the renderer re-execs the flat binary in dist/cef-dev/, so
-    // the path lands three levels above the build tree — no dylib there.
-    // We check existence once and use it in two places:
-    //   1. Seatbelt init (subprocess only) — skip if not in bundle.
-    //   2. no_sandbox flag to CefInitialize — must also be 1 when not in bundle,
-    //      otherwise CEF tries to sandbox GPU/network/renderer processes and they
-    //      get killed by the OS before they can start.
+    // macOS sandbox availability: probe for libcef_sandbox.dylib to detect
+    // whether we are running inside a packaged .app bundle. Two uses:
+    //   1. Seatbelt init (subprocess only) — skip if dylib not reachable.
+    //   2. no_sandbox flag to CefInitialize — must be 1 when not in bundle,
+    //      otherwise CEF kills GPU/network/renderer with a sandbox error.
+    //
+    // The path is relative to current_exe().parent() and differs by role
+    // because the Host and Helper processes live at different depths:
+    //
+    //   Host   — Contents/MacOS/AgentMux
+    //            → ../Frameworks/Chromium Embedded Framework.framework/…
+    //
+    //   Helper — Contents/Frameworks/AgentMux Helper.app/Contents/MacOS/AgentMux Helper
+    //            → ../../../Chromium Embedded Framework.framework/…
+    //
+    // In task dev neither path exists (flat dist/cef-dev/ tree), so the probe
+    // returns false for both roles → sandbox skipped, no crash.
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
     let macos_sandbox_available = {
-        const LIBCEF_SANDBOX_REL: &str =
-            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
+        let is_subprocess = std::env::args().any(|a| a.starts_with("--type="));
+        let rel: &str = if is_subprocess {
+            "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+        } else {
+            "../Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+        };
         std::env::current_exe()
             .ok()
-            .and_then(|p| p.parent().map(|d| d.join(LIBCEF_SANDBOX_REL)))
+            .and_then(|p| p.parent().map(|d| d.join(rel)))
             .map(|p| p.exists())
             .unwrap_or(false)
     };
 
-    // macOS: initialize Seatbelt sandbox context BEFORE the CEF framework is
-    // loaded. This is the order required by CEF (cefsimple/process_helper_mac.cc):
-    //   1. cef_sandbox_initialize     ← here, before dlopen
-    //   2. LoadInHelper / _library    ← CEF framework loaded within the sandbox
-    //   3. CefExecuteProcess
-    // Subprocess mode is detected from raw argv (--type=…) because cef::Args
-    // cannot be parsed until after the framework is loaded. Browser process
-    // skips this entirely — the host process is unsandboxed by design.
     // Non-macOS / sandbox-off: define macos_sandbox_available as a no-op
     // placeholder so the no_sandbox computation below compiles on all targets.
     // On those targets cfg!(all(target_os="macos",feature="sandbox")) is false,

--- a/docs/retro/retro-pane-tearoff-full-window-regression-2026-06-20.md
+++ b/docs/retro/retro-pane-tearoff-full-window-regression-2026-06-20.md
@@ -1,0 +1,134 @@
+# Retro: Pane Tear-Off Produces Full Window With Tabs
+
+**Date**: 2026-06-20  
+**Severity**: P1 regression — core floating-pane UX broken  
+**Introduced by**: PR #1610 — Pane tear-off pool (macOS/Linux), merged ~2026-06-19  
+**Fixed in**: `frontend/app/app.tsx` — move `IS_FLOATING_PANE` evaluation from module load to component mount  
+**Reported by**: User (manual testing immediately after pool work)
+
+---
+
+## Symptom
+
+After PR #1610 landed, dragging a pane out of the main window (pane tear-off) produced a **full AgentMux window** — tab bar, widget bar, status bar — instead of the expected **chromeless floating pane** (just the pane content, no chrome). The floating-pane UX was completely broken on the fast (pool) path on macOS and Linux.
+
+---
+
+## Root Cause
+
+### Background
+
+Floating-pane mode is rendered via a branch in `AppInner` (app.tsx):
+
+```tsx
+<Show when={IS_FLOATING_PANE} fallback={<Workspace />}>
+    <FloatingPaneWorkspace />
+</Show>
+```
+
+`IS_FLOATING_PANE` was a **module-level IIFE constant**:
+
+```typescript
+const IS_FLOATING_PANE: boolean = (() => {
+    try {
+        return new URLSearchParams(window.location.search).has("floatingPaneId");
+    } catch {
+        return false;
+    }
+})();
+```
+
+The comment above it read: *"the URL never changes in-flight for an AgentMux renderer"*.
+
+### Before PR #1610 (cold path)
+
+`open_floating_pane_window` created a **new** CEF window with `?floatingPaneId=...` already in the URL from the start. Module load → IIFE fires → URL already has `floatingPaneId` → `IS_FLOATING_PANE = true`. Correct.
+
+### After PR #1610 (pane pool path)
+
+PR #1610 introduced a pre-warmed pane pool window for fast tear-off. The pool window is spawned with `?pane-pool=1` in the URL — **no `floatingPaneId`** at spawn time, since the pane being torn off isn't known yet.
+
+The bootstrap sequence for a pool window is:
+
+```
+bootstrap → initApp → isPanePoolMode() → awaitPanePoolPromote()
+    → [waits for pool:pane-promote event]
+    → replaceState: adds floatingPaneId + workspaceId, removes pane-pool=1
+    → initHostNewWindow() → initWaveWrap() → initWave() → render(App, elem)
+```
+
+The problem: `app.tsx` is imported at **program start** (it's a static `import` in `app-init.ts`). When `app.tsx` is first parsed, the IIFE fires immediately — the URL still has `?pane-pool=1`, not `?floatingPaneId`. So `IS_FLOATING_PANE = false`.
+
+By the time `render(App, elem)` is called (after `awaitPanePoolPromote` updated the URL), `IS_FLOATING_PANE` is already frozen as `false`. The App renders `<Workspace>` — full chrome — forever, no matter what the URL now says.
+
+### Why the assumption was valid before
+
+The comment was correct for all pre-pool paths: new CEF windows have their final URL from the host at creation time and never navigate. The module-level IIFE was a reasonable micro-optimization.
+
+PR #1610 violated the assumption by making the URL mutable (via `replaceState`) as part of the pool promote handshake. The IIFE fires at module parse time, which is always before any async pool coordination.
+
+---
+
+## Fix
+
+Remove the module-level IIFE. Move the URL check inside `AppInner`, which is a SolidJS component function called at render time — after `awaitPanePoolPromote()` has updated the URL and after `render(App, elem)` is called.
+
+**`frontend/app/app.tsx`**:
+
+```typescript
+// BEFORE (module level, fires at parse time):
+const IS_FLOATING_PANE: boolean = (() => {
+    try {
+        return new URLSearchParams(window.location.search).has("floatingPaneId");
+    } catch {
+        return false;
+    }
+})();
+
+const AppInner = () => {
+    ...
+```
+
+```typescript
+// AFTER (inside component, fires at render time):
+const AppInner = () => {
+    // Evaluated at component-mount time so the pane pool fast path works:
+    // awaitPanePoolPromote() calls replaceState() to inject floatingPaneId
+    // into the URL BEFORE initHostNewWindow() calls render(App) — but a
+    // module-level IIFE fires before any of that and always sees ?pane-pool=1.
+    const IS_FLOATING_PANE = new URLSearchParams(window.location.search).has("floatingPaneId");
+    ...
+```
+
+This is safe because SolidJS component functions run once at mount, not on every render cycle — the URL is read exactly once per window lifetime, as before.
+
+---
+
+## Timeline
+
+| Step | What happened |
+|------|---------------|
+| Pre-PR #1610 | Cold `open_floating_pane_window` creates window with `?floatingPaneId=` in URL from the start. IIFE fires at module load with the final URL. Works. |
+| PR #1610 merges | Pane pool added. Pool windows start with `?pane-pool=1`. `awaitPanePoolPromote` updates URL via `replaceState` before `render()`. But IIFE already fired with wrong URL. |
+| User tests | Every pane tear-off produces a full window instead of a floating pane. |
+| Root cause found | Module-level IIFE vs. runtime URL mutation — the pool path mutates the URL between module parse and `render()`. |
+| Fix | Move IIFE evaluation inside `AppInner` component body. |
+
+---
+
+## Contributing Factors
+
+1. **Stale assumption in code comment**: "the URL never changes in-flight" was true for all pre-pool paths and reasonable as an optimization, but became a liability when PR #1610 introduced URL mutation via `replaceState` during the pool promote handshake.
+
+2. **Implicit coupling across layers**: `pool.ts:awaitPanePoolPromote()` has a comment saying *"FloatingPaneWorkspace renders because floatingPaneId is in the URL — same code path as the cold-start"*. This comment was right about the intent but wrong about the mechanics — it didn't account for the module-level IIFE.
+
+3. **No integration test for pool promote path**: The floating-pane render branch (`IS_FLOATING_PANE`) had no automated test that exercised the pool promote flow end-to-end. A test that verified `<FloatingPaneWorkspace>` renders after a `pool:pane-promote` event (with the URL mutation) would have caught this immediately.
+
+---
+
+## Lessons
+
+- **Module-level IIFEs that read browser state (URL, DOM) are fragile** when async init sequences mutate that state. Prefer lazy evaluation at component mount time, or use a reactive signal that can be updated.
+- **URL mutation via `replaceState` is not free**: callers need to audit what module-level code has already captured a snapshot of the URL.
+- **Comments about invariants should list their assumptions explicitly**: "the URL never changes" is an invariant — any PR that introduces URL mutation in the bootstrap path should verify no module-level snapshot of the URL exists.
+- **Pool promote paths need end-to-end render tests**: the pool fast path and cold path have subtly different initialization orders. Both should be covered by a test that asserts the correct component (`<FloatingPaneWorkspace>` vs `<Workspace>`) is rendered.

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -369,24 +369,15 @@ const FlashError = () => {
     );
 };
 
-// Detect floating-pane mode once at module load — the URL never changes
-// in-flight for an AgentMux renderer (each render process is opened with
-// its own URL and stays on it). Reading the search params once avoids
-// re-parsing on every render.
-//
-// When `?floatingPaneId=` is present the host opened this window via
-// `open_floating_pane_window` (SPEC_FLOATING_PANE_TEAROFF), and we
-// render `<FloatingPaneWorkspace>` instead of the standard
-// `<Workspace>` — same backend, no tab bar / widgets / status bar.
-const IS_FLOATING_PANE: boolean = (() => {
-    try {
-        return new URLSearchParams(window.location.search).has("floatingPaneId");
-    } catch {
-        return false;
-    }
-})();
-
 const AppInner = () => {
+    // Evaluated at component-mount time (not module-load time) so the pane
+    // pool fast path works: awaitPanePoolPromote() calls replaceState() to
+    // inject floatingPaneId into the URL BEFORE initHostNewWindow() calls
+    // render(App) — but a module-level IIFE fires before any of that, so it
+    // would always see the original ?pane-pool=1 URL and return false.
+    // Cold path (open_floating_pane_window) opens the window with floatingPaneId
+    // in the URL from the start, so both paths are correct here.
+    const IS_FLOATING_PANE = new URLSearchParams(window.location.search).has("floatingPaneId");
     const prefersReducedMotion = atoms.prefersReducedMotionAtom;
     const client = atoms.client;
     const windowData = atoms.waveWindow;


### PR DESCRIPTION
## Summary

- **Bug**: After PR #1610 (pane tear-off pool), tearing off a pane produced a full AgentMux window (tab bar, widget bar, status bar) instead of a chromeless floating pane.
- **Root cause**: `IS_FLOATING_PANE` in `app.tsx` was a module-level IIFE evaluated at JS parse time — before `awaitPanePoolPromote()` could call `replaceState()` to inject `floatingPaneId` into the URL. The IIFE always saw `?pane-pool=1` (no `floatingPaneId`) and froze `IS_FLOATING_PANE=false`.
- **Fix**: Move the URL check inside `AppInner` so it evaluates at component-mount time, after the pool promote handshake has updated the URL. Cold path (non-pool) is unaffected — the URL already has `floatingPaneId` from the start in that case.

## What changed

- `frontend/app/app.tsx`: remove module-level `IS_FLOATING_PANE` IIFE; read `window.location.search` at the top of `AppInner` instead.
- `docs/retro/retro-pane-tearoff-full-window-regression-2026-06-20.md`: full retrospective.

## Test plan

- [ ] Tear off a pane (drag a pane out of the main window) — should produce a chromeless floating window with just the pane content, no tab bar or widget bar
- [ ] Tear off a tab — should still produce a full window with tabs (unaffected path)
- [ ] Cold-path floating pane (first tear-off before pool is ready) — should also render `FloatingPaneWorkspace`
- [ ] Normal windows — should render `<Workspace>` (no `floatingPaneId` in URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)