### PR TITLE
fix(cursor): restrict hand cursor to hyperlinks only — arrow on all UI controls

### DIFF
--- a/.changesets/1782003804-fix-cursor-restrict-hand-cursor-to-hyperlinks-only-arrow-on--guwr.md
+++ b/.changesets/1782003804-fix-cursor-restrict-hand-cursor-to-hyperlinks-only-arrow-on--guwr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cursor): restrict hand cursor to hyperlinks only — arrow on all UI controls

--- a/docs/analysis/ANALYSIS_CURSOR_POINTER_AUDIT_2026_06_20.md
+++ b/docs/analysis/ANALYSIS_CURSOR_POINTER_AUDIT_2026_06_20.md
@@ -1,0 +1,327 @@
+# ANALYSIS: Cursor hand (`cursor: pointer`) — full codebase audit
+
+**Date:** 2026-06-20  
+**Status:** Analysis complete — implementation pending  
+**Scope:** All `cursor: pointer` / Tailwind `cursor-pointer` occurrences in `frontend/`  
+**Trigger:** Hand cursor appearing on window controls, pane title-bars, hamburger menu, tab bars,
+status-bar items, floating-pane widgets, and menus — none of which are hyperlinks.
+
+**Related:** `docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md` (earlier analysis focused
+specifically on scrollbars; the token layer and utility classes it proposed were shipped and
+are now in production — this document supersedes it for the broader pointer-cursor policy.)
+
+---
+
+## 0. TL;DR
+
+**Rule:** `cursor: pointer` (the link hand) must appear ONLY on elements that navigate to an
+external URL or open a filesystem path outside the app. All buttons, menus, tabs, toggles,
+modals, panels, and other interactive UI controls must use the arrow (`cursor: default`).
+
+**Scale:** ~150 occurrences of `cursor: pointer` exist in the frontend. Approximately 2 are
+correct; the rest (≥148) are incorrect by this rule.
+
+**Root causes (3 lines control the majority):**
+1. `app/element/button.scss:11` — `cursor: pointer` on every `<button>` element globally.
+2. `app/theme.scss:308` — `--cursor-interactive: pointer`; components consume this token.
+3. Tailwind `cursor-pointer` utility applied directly in TSX class strings on non-link elements.
+
+**Minimum viable fix:** Change two values — `button.scss:11` and `theme.scss:308` — to
+`cursor: default`. Then add one new rule: `a[href] { cursor: pointer; }`. This flip
+automatically fixes every site that inherited from the button baseline or consumed the token,
+with no per-file churn, and leaves the rare correct cases needing no change (they already
+have `cursor: pointer` explicitly via other selectors).
+
+---
+
+## 1. The correct rule
+
+| Cursor | Value | Correct on |
+|---|---|---|
+| Hand / link | `pointer` | `<a href="…">` to external URL; filesystem-path opener elements; terminal URL hover (xterm) |
+| Arrow | `default` | Everything else — buttons, menus, tabs, toggles, modals, panels, status-bar items, window controls, hamburger, widgets, pane headers |
+
+The rationale is the W3C / OS HCI convention: the pointer cursor communicates "this is a
+hyperlink that navigates away." Using it on buttons teaches users the wrong affordance —
+every click target is NOT a link.
+
+---
+
+## 2. Correct occurrences (keep `cursor: pointer`)
+
+These are the only occurrences that satisfy the rule:
+
+| File | Line | Element | Why correct |
+|---|---|---|---|
+| `app/view/term/xterm.css` | 134–136 | `.xterm-cursor-pointer` | Applied by xterm.js when the terminal detects a hovered URL in output; this IS a hyperlink. |
+
+**Borderline (review before touching):**
+
+| File | Line | Element | Note |
+|---|---|---|---|
+| `app/view/browser/browser-view.scss` | 39 | Browser pane nav button | This is a `<button>` for browser back/forward — should be `default`. However the embedded Chromium web content sets its own cursor independently; the rule on the host container is mostly irrelevant. Change to `default` for consistency. |
+| `app/element/markdown.scss` | 244 | `.toc-item` | Table-of-contents anchor — in-page navigation. Not an external link; use `default`. |
+| `app/view/agent/styles/_document-nodes.scss` | 1161 | `.clickable` modifier on tool result rows | If these rows open filesystem paths or external URLs, `pointer` is correct. If they expand/collapse in-app content, change to `default`. Verify at call site. |
+
+---
+
+## 3. Root causes
+
+### 3.1 `app/element/button.scss:11` — global button baseline
+
+```scss
+// Current (incorrect):
+button, [type="button"], [type="submit"] {
+    cursor: pointer;   // ← propagates to ALL <button> in the app
+    …
+}
+```
+
+This single line is the cascade root. Every button — window controls, hamburger, tabs,
+modals, status-bar items, menus — inherits the hand cursor from here. Removing or changing
+this one declaration fixes the majority of incorrect sites automatically via cascade.
+
+### 3.2 `app/theme.scss:308` — `--cursor-interactive` token
+
+```scss
+// Current (incorrect for the new rule):
+--cursor-interactive: pointer;     // buttons, links, clickable rows
+```
+
+The June-15 analysis introduced this token and the utility class `.u-cursor-interactive`.
+Components consume it via `cursor: var(--cursor-interactive)`. Since the token value is
+`pointer`, all consumers show the hand. Changing this one value to `default` fixes all
+token-consuming sites simultaneously.
+
+### 3.3 Tailwind `cursor-pointer` in TSX files
+
+Several TSX files pass `cursor-pointer` in Tailwind class strings on non-link elements:
+
+- `app/element/emojibutton.tsx:35`
+- `app/element/quicktips.tsx:263,276,289,302,315,345`
+- `app/element/streamdown.tsx:222`
+- `app/suggestion/suggestion.tsx:315`
+- `app/view/launcher/launcher.tsx:236`
+- `app/window/action-widgets.tsx:121`
+
+These must be removed case-by-case (replacing with nothing, or explicitly `cursor-default`
+where the Tailwind reset is needed).
+
+---
+
+## 4. Full classified inventory
+
+### INCORRECT — should be `cursor: default` (148+ sites)
+
+**Global / element layer**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/element/button.scss` | 11 | All `<button>` elements (cascade root) |
+| `app/element/iconbutton.scss` | 3 | Icon buttons |
+| `app/element/toggle.scss` | 25, 64 | Toggle controls |
+| `app/element/flyoutmenu.scss` | 29 | Flyout menu items |
+| `app/element/expandablemenu.scss` | 18 | Expandable menu items |
+| `app/element/collapsiblemenu.scss` | 12 | Collapsible menu items |
+| `app/element/popover-menu.scss` | 22 | Popover menu items |
+| `app/element/modal.scss` | 180, 244 | Modal close/action buttons |
+| `app/element/markdown.scss` | 244 | `.toc-item` (in-page TOC) |
+| `app/element/emojipalette.scss` | 25 | Emoji picker cells |
+
+**Window / chrome layer**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/window/hamburger-menu.scss` | 21 | Hamburger (≡) button |
+| `app/window/action-widgets.scss` | 142 | Widget more-menu dropdown items |
+| `app/window/action-widgets.tsx` | 121 | Widget slot button (Tailwind) |
+| `app/tab/tab.scss` | 128, 285, 303 | Tab controls, close button, drag handle |
+| `app/block/block.scss` | 158, 588 | Pane block controls |
+| `app/block/titlebar.scss` | 45 | Pane title-bar button |
+
+**Status bar**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/statusbar/StatusBar.scss` | 80, 231, 319, 330, 376 | Status-bar section items |
+| `app/statusbar/_cpu-cores-popover.scss` | 17 | CPU cores popover item |
+| `app/statusbar/_instance-panel.scss` | 56, 94, 148, 186 | Instance panel items |
+| `app/statusbar/_token-usage.scss` | 18, 158 | Token usage items |
+
+**App-level**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/app.scss` | 206 | Flash-error notification panel |
+| `app/init/error-display.ts` | 318, 332 | Recovery button inline styles |
+| `app/errors/ErrorBanner.scss` | 63, 108 | Error banner dismiss button |
+| `app/components/confirm-dialog.scss` | 50 | Confirm dialog button |
+| `app/notification/memory-pressure-banner.scss` | 39 | Banner CTA (uses `var(--cursor-interactive)`) |
+
+**Modals**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/modals/command-palette.scss` | 87 | Command palette item |
+| `app/modals/bundle-manager-modal.scss` | 46, 103 | Bundle manager items |
+| `app/modals/toolchain-modal.scss` | 177, 196 | Toolchain modal items |
+| `app/modals/typeaheadmodal.scss` | 81 | Typeahead modal item |
+
+**Agent view**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/view/agent/styles/_action-bar.scss` | 29 | Action bar button |
+| `app/view/agent/styles/_activity-log.scss` | 41, 240 | Activity log items / buttons |
+| `app/view/agent/styles/_composer-strip.scss` | 25, 119, 151 | Composer strip buttons |
+| `app/view/agent/styles/_connection-status.scss` | 45, 113, 154 | Connection status indicators |
+| `app/view/agent/styles/_control-bar.scss` | 241, 299, 355 | Control bar buttons |
+| `app/view/agent/styles/_decision-panel.scss` | 48, 193, 268 | Decision panel items |
+| `app/view/agent/styles/_disconnected-banner.scss` | 54 | Reconnect button |
+| `app/view/agent/styles/_document-nodes.scss` | 80, 141, 353, 388, 663, 735, 953, 1022, 1276, 1444 | Collapsible sections, tool expand buttons, subagent-link, show-more button |
+| `app/view/agent/styles/_focused-overlay.scss` | 56, 101 | Overlay buttons |
+| `app/view/agent/styles/_header-controls.scss` | 82, 147, 151, 170 | Agent pane header buttons |
+| `app/view/agent/styles/_identity-panel.scss` | 106, 127 | Identity panel items |
+| `app/view/agent/styles/_launch-modal-body.scss` | 98, 165, 267, 293, 320 | Launch modal items |
+| `app/view/agent/styles/_pending-footer.scss` | 73 | Pending footer button |
+| `app/view/agent/styles/_picker.scss` | 67, 125, 155, 249, 374, 444, 467 | Picker rows |
+| `app/view/agent/styles/_recent-sessions.scss` | 84, 247 | Session list items |
+| `app/view/agent/styles/_retry-empty.scss` | 24, 54 | Retry / new session buttons |
+| `app/view/agent/styles/_search.scss` | 67 | Search result item |
+| `app/view/agent/styles/_session-digest.scss` | 43 | Session digest row |
+| `app/view/agent/styles/_setup-wizard.scss` | 260, 273, 335 | Setup wizard items |
+| `app/view/agent/styles/_shell-node.scss` | 71, 143, 223, 294, 332 | Shell summary collapsibles and activity controls |
+| `app/view/agent/styles/_slash.scss` | 41, 106, 175, 219 | Slash-command palette items |
+| `app/view/agent/styles/_tool-overlay-portal.scss` | 87 | Tool overlay button |
+| `app/view/agent/components/AgentIdentityModal.scss` | 32 | Modal button |
+| `app/view/agent/components/AgentNativeMemoryModal.scss` | 101, 146, 257 | Memory modal items |
+| `app/view/agent/components/AgentNewBundleModal.scss` | 106, 110 | Bundle modal items |
+| `app/view/agent/components/AgentPrereqModal.scss` | 70 | Prereq modal item |
+| `app/view/agent/components/AgentQuestionPanel.scss` | 85, 161, 196 | Question panel items |
+| `app/view/agent/components/PaneRow.scss` | 29, 78 | Pane rows (uses `var(--cursor-interactive)`) |
+| `app/view/agent/fork/ForkBar.scss` | 24 | Fork bar (uses `var(--cursor-interactive)`) |
+
+**Other views**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/view/accounts/accounts-gallery.scss` | 31, 151, 179 | Account gallery items |
+| `app/view/accounts/oauth-connect.scss` | 26 | OAuth connect button |
+| `app/view/brain/global-brain.scss` | 175, 195, 225, 263 | Brain panel items |
+| `app/view/browser/browser-view.scss` | 39 | Browser nav button (should be `default`) |
+| `app/view/bundle-summary.scss` | 41 | Bundle summary item |
+| `app/view/drone/drone-view.scss` | 98, 196, 265, 317 | Drone controls |
+| `app/view/editor/editor-view.scss` | 107, 139, 281, 343, 531, 615, 662, 696 | Editor buttons and file-tree rows (in-app navigation) |
+| `app/view/identity/identity-pane-view.scss` | 31, 49, 201, 224 | Identity pane items |
+| `app/view/identity/styles/_accounts.scss` | 51 | Account item |
+| `app/view/identity/styles/_detail.scss` | 95 | Detail item |
+| `app/view/identity/styles/_empty-states.scss` | 28 | Empty-state CTA |
+| `app/view/identity/styles/_form-overlay.scss` | 44 | Form overlay button |
+| `app/view/identity/styles/_header.scss` | 36, 58 | Identity pane header buttons |
+| `app/view/memory/memory-view.scss` | 32, 50, 190 | Memory view items |
+| `app/view/subagent/subagent-view.scss` | 156, 231 | Subagent view items |
+| `app/view/swarm/swarm-view.scss` | 84, 126, 211 | Swarm view items |
+| `app/view/warden/warden.scss` | 172 | Warden view item |
+
+**TSX files with Tailwind `cursor-pointer`**
+
+| File | Lines | Element |
+|---|---|---|
+| `app/element/emojibutton.tsx` | 35 | Emoji button |
+| `app/element/quicktips.tsx` | 263, 276, 289, 302, 315, 345 | Quick tips items |
+| `app/element/streamdown.tsx` | 222 | Stream down button |
+| `app/suggestion/suggestion.tsx` | 315 | Suggestion row |
+| `app/view/launcher/launcher.tsx` | 236 | Launcher grid item |
+| `app/window/action-widgets.tsx` | 121 | Widget slot button |
+
+---
+
+## 5. Recommended fix strategy
+
+### Step 1 — Token flip (highest leverage, zero per-file churn)
+
+Change `theme.scss:308`:
+```diff
+-    --cursor-interactive: pointer;
++    --cursor-interactive: default;
+```
+
+This fixes every site consuming `cursor: var(--cursor-interactive)` automatically:
+`PaneRow.scss:29,78`, `ForkBar.scss:24`, `notification/memory-pressure-banner.scss:39`,
+and any future consumer of the token.
+
+### Step 2 — Button baseline (second-highest leverage)
+
+Change `button.scss:11`:
+```diff
+-    cursor: pointer;
++    cursor: default;
+```
+
+This fixes the entire cascade — every `<button>` in the app reverts to the arrow
+without touching any call site.
+
+### Step 3 — Add the single correct global rule
+
+In `app.scss` (or a new `_links.scss` global partial), add:
+```scss
+// External links only — the ONLY place the hand cursor is correct.
+a[href] {
+    cursor: pointer;
+}
+```
+
+Optionally introduce `--cursor-link: pointer` as a distinct design token so future
+file-path openers can use `cursor: var(--cursor-link)` rather than a raw keyword:
+```scss
+--cursor-link: pointer;    // hyperlinks and external file-path openers only
+```
+
+### Step 4 — Remove remaining hardcoded `cursor: pointer` in SCSS
+
+After steps 1–2 flip the cascade, grep for surviving `cursor: pointer` in SCSS and
+remove them (they are now doubly-wrong: violating the rule AND overriding the fixed
+baseline). The list in §4 above enumerates all sites.
+
+### Step 5 — Fix TSX Tailwind usages
+
+For each `cursor-pointer` class in the TSX files listed in §4, remove it (or replace
+with `cursor-default` if the Tailwind reset needs to be explicit).
+
+### Step 6 — Add `init/error-display.ts` inline style fixes
+
+```diff
+-"padding:9px 18px;border-radius:7px;border:none;cursor:pointer;…"
++"padding:9px 18px;border-radius:7px;border:none;…"
+```
+
+---
+
+## 6. Implementation order
+
+| Priority | Step | Blast radius | Why |
+|---|---|---|---|
+| P0 | `theme.scss:308` token flip | Auto-fixes 3+ token-consumer sites | Zero per-file churn |
+| P0 | `button.scss:11` baseline flip | Auto-fixes majority of SCSS sites via cascade | Zero per-file churn |
+| P0 | Add `a[href] { cursor: pointer; }` | Enables the correct rule globally | 1 line |
+| P1 | Remove hardcoded `cursor: pointer` from SCSS | Clears remaining overrides | File-by-file |
+| P1 | Remove `cursor-pointer` Tailwind from TSX | Clears in-markup overrides | File-by-file |
+| P2 | Fix `error-display.ts` inline styles | Clears the two inline override sites | 2 lines |
+| P3 | Add CI grep gate | Prevents regression | `scripts/check-cursor.sh` |
+
+P0 is safe to ship in one small commit and immediately resolves the visible symptom on
+hamburger, menus, tabs, window controls, pane headers, and status bar. P1–P2 are cleanup
+that can follow file-by-file. P3 keeps it from drifting back.
+
+---
+
+## 7. What NOT to change
+
+- `app/view/term/xterm.css:134-136` — `.xterm-cursor-pointer` — **keep `pointer`**; this is
+  the only genuinely correct use.
+- Drag cursors (`cursor: grab / grabbing`) — not in scope; these are correct.
+- Resize cursors (`cursor: ew-resize`, `ns-resize`, etc.) — not in scope; correct.
+- Disabled cursors (`cursor: not-allowed`) — not in scope; correct.
+- Text-input cursors (`cursor: text`) — not in scope; correct.
+- `tailwindsetup.css:84` — the `.cursor-pointer` Tailwind utility definition itself is
+  fine; only its misuse on non-link elements is incorrect.

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -139,12 +139,19 @@ a.plain-link {
     cursor: var(--cursor-default);
 }
 
-// ─── Cursor utilities — interaction affordances ─────────────────────────────
-// Resolve to the `--cursor-*` design tokens (theme.scss). Use these on markup
-// that can't easily reach a component stylesheet; SCSS authors can also write
-// `cursor: var(--cursor-interactive)` directly. See
-// `docs/analysis/ANALYSIS_CURSOR_STYLING_2026_06_15.md`.
+// ─── Cursor layer ──────────────────────────────────────────────────────────
+// Rule: `cursor: pointer` (the link hand) appears ONLY on genuine hyperlinks
+// and filesystem-path openers. All buttons, menus, tabs, and controls use the
+// arrow. See `docs/analysis/ANALYSIS_CURSOR_POINTER_AUDIT_2026_06_20.md`.
+//
+// The single global pointer rule — all <a href> elements:
+a[href] {
+    cursor: var(--cursor-link);
+}
+//
+// Utility classes (resolve to `--cursor-*` design tokens):
 .u-cursor-interactive { cursor: var(--cursor-interactive); }
+.u-cursor-link        { cursor: var(--cursor-link); }
 .u-cursor-default     { cursor: var(--cursor-default); }
 .u-cursor-text        { cursor: var(--cursor-text); }
 .u-cursor-disabled    { cursor: var(--cursor-disabled); }
@@ -203,7 +210,7 @@ a {
         width: 280px;
         border: 1px solid transparent;
         max-height: 100px;
-        cursor: pointer;
+        cursor: default;
 
         .flash-error-scroll {
             overflow-y: auto;

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -155,7 +155,7 @@
                         direction: rtl;
                         text-align: left;
                         span {
-                            cursor: pointer;
+                            cursor: default;
 
                             &:hover {
                                 background: var(--highlight-bg-color);
@@ -585,7 +585,7 @@
         font-size: var(--text-xs);
         padding: 2px 8px;
         border-radius: var(--radius-sm);
-        cursor: pointer;
+        cursor: default;
 
         &:hover {
             color: var(--main-text-color);

--- a/frontend/app/block/titlebar.scss
+++ b/frontend/app/block/titlebar.scss
@@ -42,7 +42,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        cursor: pointer;
+        cursor: default;
         color: var(--main-text-color);
 
         &:hover {

--- a/frontend/app/components/confirm-dialog.scss
+++ b/frontend/app/components/confirm-dialog.scss
@@ -47,7 +47,7 @@
     padding: 5px 14px;
     border-radius: 4px;
     font-size: 12px;
-    cursor: pointer;
+    cursor: default;
     transition: background 80ms ease, opacity 80ms ease;
 
     &--cancel {

--- a/frontend/app/element/button.scss
+++ b/frontend/app/element/button.scss
@@ -8,7 +8,7 @@
     border: 1px solid transparent;
     outline: 1px solid transparent;
 
-    cursor: pointer;
+    cursor: default;
     display: flex;
     padding-top: var(--space-2);
     padding-bottom: var(--space-2);

--- a/frontend/app/element/collapsiblemenu.scss
+++ b/frontend/app/element/collapsiblemenu.scss
@@ -9,7 +9,7 @@
 }
 
 .collapsible-menu-item {
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     padding: 0;
 }

--- a/frontend/app/element/emojibutton.tsx
+++ b/frontend/app/element/emojibutton.tsx
@@ -32,7 +32,7 @@ export const EmojiButton = (props: {
             <button
                 onClick={props.onClick}
                 class={cn(
-                    "px-2 py-1 rounded border cursor-pointer transition-colors",
+                    "px-2 py-1 rounded border transition-colors",
                     props.isClicked
                         ? "bg-accent/20 border-accent text-accent"
                         : "bg-transparent border-border/50 text-foreground/70 hover:border-border",

--- a/frontend/app/element/emojipalette.scss
+++ b/frontend/app/element/emojipalette.scss
@@ -22,7 +22,7 @@
 .emoji-button {
     font-size: 24px;
     padding: 5px;
-    cursor: pointer;
+    cursor: default;
     background: none;
     border: none;
     transition: background-color 0.3s ease;

--- a/frontend/app/element/expandablemenu.scss
+++ b/frontend/app/element/expandablemenu.scss
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     padding: var(--space-2) var(--space-3); /* Left and right padding, we'll adjust this for the right side */
-    cursor: pointer;
+    cursor: default;
     box-sizing: border-box;
     border-radius: 0;
 

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -26,7 +26,7 @@
     display: flex;
     align-items: center;
     padding: var(--space-1) var(--space-1-5);
-    cursor: pointer;
+    cursor: default;
     color: var(--main-text-color);
     font-size: 12px;
     font-style: normal;

--- a/frontend/app/element/iconbutton.scss
+++ b/frontend/app/element/iconbutton.scss
@@ -1,6 +1,6 @@
 .wave-iconbutton {
     display: flex;
-    cursor: pointer;
+    cursor: default;
     opacity: 0.85;
     align-items: center;
     background: none;

--- a/frontend/app/element/markdown.scss
+++ b/frontend/app/element/markdown.scss
@@ -241,7 +241,7 @@
             }
 
             .toc-item {
-                cursor: pointer;
+                cursor: default;
                 --indent-factor: 1;
                 // The offset in the padding will ensure that when the text in the item wraps, it indents slightly.
                 // The indent factor is set in the React code and denotes the depth of the item in the TOC tree.

--- a/frontend/app/element/modal.scss
+++ b/frontend/app/element/modal.scss
@@ -177,7 +177,7 @@
     color: var(--secondary-text-color);
     font-size: var(--text-md);
     line-height: 1;
-    cursor: pointer;
+    cursor: default;
     transition: all var(--motion-fast);
 
     &:hover {
@@ -241,7 +241,7 @@
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     transition: background var(--motion-fast), border-color var(--motion-fast), color var(--motion-fast);
 
     &:hover:not(:disabled) {

--- a/frontend/app/element/popover-menu.scss
+++ b/frontend/app/element/popover-menu.scss
@@ -19,7 +19,7 @@
 }
 
 .popover-menu-section-header {
-    cursor: pointer;
+    cursor: default;
     color: var(--secondary-text-color, rgb(from var(--main-text-color) r g b / 0.65));
     font-size: 11px;
     text-transform: uppercase;

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -260,7 +260,7 @@ const QuickTips = (): JSX.Element => {
                     <span class="text-foreground">Need More Help?</span>
                 </div>
                 <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-brands fa-discord fa-fw" />
                         </IconBox>
@@ -273,7 +273,7 @@ const QuickTips = (): JSX.Element => {
                             Join Our Discord
                         </a>
                     </div>
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-sliders fa-fw" />
                         </IconBox>
@@ -286,7 +286,7 @@ const QuickTips = (): JSX.Element => {
                             Configuration Options
                         </a>
                     </div>
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-keyboard fa-fw" />
                         </IconBox>
@@ -299,7 +299,7 @@ const QuickTips = (): JSX.Element => {
                             All Keybindings
                         </a>
                     </div>
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-book fa-fw" />
                         </IconBox>
@@ -312,7 +312,7 @@ const QuickTips = (): JSX.Element => {
                             Full Documentation
                         </a>
                     </div>
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors">
                         <IconBox variant="secondary">
                             <i class="fa-solid fa-sharp fa-bug fa-fw" />
                         </IconBox>
@@ -342,7 +342,7 @@ const QuickTips = (): JSX.Element => {
                     <p>
                         To report bugs, request features, or flag issues with AI-generated content:
                     </p>
-                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors cursor-pointer mt-1">
+                    <div class="flex items-center gap-3 p-3 rounded-md bg-black/20 hover:bg-black/30 transition-colors mt-1">
                         <IconBox variant="secondary">
                             <i class="fa-brands fa-github fa-fw" />
                         </IconBox>

--- a/frontend/app/element/streamdown.tsx
+++ b/frontend/app/element/streamdown.tsx
@@ -219,7 +219,7 @@ function Collapsible(props: { title?: JSX.Element; children?: JSX.Element; defau
     return (
         <div class="my-3">
             <button
-                class="flex items-center gap-2 cursor-pointer bg-transparent border-0 p-0 font-medium text-secondary hover:text-primary"
+                class="flex items-center gap-2 bg-transparent border-0 p-0 font-medium text-secondary hover:text-primary"
                 onClick={() => setIsOpen(!isOpen())}
             >
                 <span class="text-[0.65rem] text-primary transition-transform duration-200 inline-block w-3">

--- a/frontend/app/element/toggle.scss
+++ b/frontend/app/element/toggle.scss
@@ -22,7 +22,7 @@
 
         .slider {
             position: absolute;
-            cursor: pointer;
+            cursor: default;
             content: "";
             top: 0;
             bottom: 0;
@@ -61,7 +61,7 @@
 
     label,
     .toggle-label {
-        cursor: pointer;
+        cursor: default;
         padding: 0 5px;
     }
 }

--- a/frontend/app/errors/ErrorBanner.scss
+++ b/frontend/app/errors/ErrorBanner.scss
@@ -60,7 +60,7 @@
     color: var(--secondary-text-color);
     font-size: 11px;
     text-decoration: underline dotted;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         color: var(--main-text-color);
@@ -105,7 +105,7 @@
     font-size: 16px;
     line-height: 1;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         color: var(--main-text-color);

--- a/frontend/app/init/error-display.ts
+++ b/frontend/app/init/error-display.ts
@@ -315,7 +315,7 @@ export function showStartupError(message: string): void {
     const restore = document.createElement("button");
     restore.textContent = "⟳ Restore";
     restore.style.cssText =
-        "padding:9px 18px;border-radius:7px;border:none;cursor:pointer;font-size:13px;font-weight:600;" +
+        "padding:9px 18px;border-radius:7px;border:none;font-size:13px;font-weight:600;" +
         "background:#4c8dff;color:#fff;";
     restore.onclick = () => {
         restore.disabled = true;
@@ -329,7 +329,7 @@ export function showStartupError(message: string): void {
     const details = document.createElement("details");
     const summary = document.createElement("summary");
     summary.textContent = "Technical details";
-    summary.style.cssText = "cursor:pointer;font-size:12px;color:rgba(255,255,255,0.55);";
+    summary.style.cssText = "font-size:12px;color:rgba(255,255,255,0.55);";
     details.appendChild(summary);
 
     const pre = document.createElement("pre");

--- a/frontend/app/modals/bundle-manager-modal.scss
+++ b/frontend/app/modals/bundle-manager-modal.scss
@@ -43,7 +43,7 @@
     color: var(--main-text-color);
     font-size: 13px;
     text-align: left;
-    cursor: pointer;
+    cursor: default;
 
     i {
         width: 16px;
@@ -100,7 +100,7 @@
     font-size: 12px;
     font-weight: 500;
     text-align: center;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         filter: brightness(1.08);

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -84,7 +84,7 @@
     align-items: center;
     gap: 10px;
     padding: 7px 14px;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
 
     &.selected {

--- a/frontend/app/modals/toolchain-modal.scss
+++ b/frontend/app/modals/toolchain-modal.scss
@@ -174,7 +174,7 @@
     border-radius: var(--radius-md, 6px);
     border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
     background: var(--button-bg, transparent);
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--panel-bg-alt, rgba(127, 127, 127, 0.12));
@@ -193,7 +193,7 @@
     border: none;
     background: transparent;
     color: var(--link-color, #58a6ff);
-    cursor: pointer;
+    cursor: default;
     border-radius: 4px;
 
     &:hover {

--- a/frontend/app/modals/typeaheadmodal.scss
+++ b/frontend/app/modals/typeaheadmodal.scss
@@ -78,7 +78,7 @@
 
         .suggestion-item {
             width: 100%;
-            cursor: pointer;
+            cursor: default;
             display: flex;
             padding: var(--space-1-5) var(--space-2);
             align-items: center;

--- a/frontend/app/notification/memory-pressure-banner.scss
+++ b/frontend/app/notification/memory-pressure-banner.scss
@@ -36,7 +36,7 @@
         background: transparent;
         border: none;
         color: var(--secondary-text-color);
-        cursor: var(--cursor-interactive);
+        cursor: var(--cursor-default);
         font-size: var(--text-md);
         line-height: 1;
         padding: 0 var(--space-1);

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -77,7 +77,7 @@
         border-radius: 0;
 
         &.clickable {
-            cursor: pointer;
+            cursor: default;
 
             &:hover {
                 background: var(--hover-bg-color);
@@ -228,7 +228,7 @@
         line-height: inherit;
 
         &.clickable {
-            cursor: pointer;
+            cursor: default;
             color: inherit;
 
             &:hover {
@@ -316,7 +316,7 @@
     .status-bar-toggle {
         display: inline-flex;
         align-items: center;
-        cursor: pointer;
+        cursor: default;
         user-select: none;
 
         input[type="checkbox"] {
@@ -327,7 +327,7 @@
             background: var(--border-color);
             border-radius: 0;
             position: relative;
-            cursor: pointer;
+            cursor: default;
             transition: background 120ms ease;
             margin: 0;
 
@@ -373,7 +373,7 @@
     color: #fff; /* stylelint-disable-line color-no-hex */
     border: none;
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     font-size: 11px;
     opacity: 0.85;
 

--- a/frontend/app/statusbar/_cpu-cores-popover.scss
+++ b/frontend/app/statusbar/_cpu-cores-popover.scss
@@ -14,7 +14,7 @@
     line-height: inherit;
     padding: 0 2px;
     margin: 0;
-    cursor: pointer;
+    cursor: default;
     border-radius: 0;
     transition: background 80ms ease;
 

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -53,7 +53,7 @@
     background: transparent;
     border: 1px solid transparent;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     padding: 2px 4px;
     border-radius: 0;
     font-size: 12px;
@@ -91,7 +91,7 @@
     color: var(--main-text-color);
     font-size: 12px;
     text-align: left;
-    cursor: pointer;
+    cursor: default;
     line-height: 1.3;
 
     &:hover:not(:disabled) {
@@ -145,7 +145,7 @@
     padding: var(--space-1) var(--space-2);
     border-radius: 0;
     font-size: 12px;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--hover-bg-color);
@@ -183,7 +183,7 @@
     flex: 1 1 auto;
     height: 4px;
     accent-color: var(--accent-color);
-    cursor: pointer;
+    cursor: default;
 }
 
 .instance-panel-opacity-value {

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -15,7 +15,7 @@
     color: inherit;
     font-family: inherit;
     font-size: inherit;
-    cursor: pointer;
+    cursor: default;
     white-space: nowrap;
     border-radius: 0;
     opacity: 0.7;
@@ -155,7 +155,7 @@
         font-size: 11px;
         padding: var(--space-0-5) var(--space-2);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         transition: background 80ms ease, border-color 80ms ease;
 
         &:hover:not(:disabled) {

--- a/frontend/app/suggestion/suggestion.tsx
+++ b/frontend/app/suggestion/suggestion.tsx
@@ -312,7 +312,7 @@ function SuggestionControlInner(props: SuggestionControlInnerProps): JSX.Element
                             {(suggestion, index) => (
                                 <div
                                     class={clsx(
-                                        "flex items-center gap-3 px-4 py-2 cursor-pointer",
+                                        "flex items-center gap-3 px-4 py-2",
                                         index() === selectedIndex() ? "bg-accentbg" : "hover:bg-hoverbg",
                                         "text-gray-100"
                                     )}

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -125,7 +125,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        cursor: pointer;
+        cursor: default;
         z-index: var(--zindex-tab-name);
         padding: 0;
         /* Tab close button must NOT pick up the general `.tab *`
@@ -282,7 +282,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     border-radius: 0;
     color: var(--secondary-text-color);
     font-size: 11px;
-    cursor: pointer;
+    cursor: default;
     white-space: nowrap;
 
     &:hover {
@@ -300,7 +300,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     width: 20px;
     height: 20px;
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -305,7 +305,8 @@
     // give the arrow, it gives the host's `text`/`pointer`. The `.u-cursor-*`
     // utilities + the `scripts/check-scrollbar-cursor.sh` grep gate keep this
     // honest. See `docs/retro/retro-scrollbar-cursor-regression-2026-06-17.md`.
-    --cursor-interactive: pointer;     // buttons, links, clickable rows
+    --cursor-interactive: default;     // interactive controls (buttons, menus, tabs) — arrow, not hand
+    --cursor-link:        pointer;     // hyperlinks and filesystem-path openers ONLY
     --cursor-default:     default;     // arrow — surfaces, scroll thumbs, chrome
     --cursor-text:        text;        // editable text
     --cursor-disabled:    not-allowed; // disabled controls

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -28,7 +28,7 @@
         border-radius: 0;
         color: inherit;
         font-family: inherit;
-        cursor: pointer;
+        cursor: default;
         transition: background 90ms ease, border-color 90ms ease;
 
         &:hover {
@@ -148,7 +148,7 @@
         background: transparent;
         border: none;
         color: var(--secondary-text-color);
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
         padding: 2px 4px;
 
@@ -176,7 +176,7 @@
         color: inherit;
         font-family: inherit;
         text-align: left;
-        cursor: pointer;
+        cursor: default;
         transition: background 90ms ease, border-color 90ms ease;
 
         &:hover {

--- a/frontend/app/view/accounts/oauth-connect.scss
+++ b/frontend/app/view/accounts/oauth-connect.scss
@@ -23,7 +23,6 @@
 
     .oauth-link {
         color: var(--accent-color);
-        cursor: default;
         text-decoration: none;
 
         &:hover {

--- a/frontend/app/view/accounts/oauth-connect.scss
+++ b/frontend/app/view/accounts/oauth-connect.scss
@@ -23,7 +23,7 @@
 
     .oauth-link {
         color: var(--accent-color);
-        cursor: pointer;
+        cursor: default;
         text-decoration: none;
 
         &:hover {

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -29,7 +29,7 @@
     background: var(--accent-color);
     border: none;
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
 
     &:hover:not(:disabled) {
         background: color-mix(in srgb, var(--accent-color) 85%, var(--main-text-color));

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
@@ -98,7 +98,7 @@
     color: var(--main-text-color);
     font-size: var(--text-sm);
     text-align: left;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--hover-bg-color);
@@ -143,7 +143,7 @@
     color: var(--accent-color);
     font-size: var(--text-sm);
     text-align: left;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--hover-bg-color);
@@ -254,7 +254,7 @@
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     transition: opacity 0.1s;
 
     &:hover:not(:disabled) {

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -103,9 +103,9 @@
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
-    cursor: pointer;
+    cursor: default;
     font-size: var(--text-sm);
     color: var(--main-text-color);
 
-    input { cursor: pointer; }
+    input { cursor: default; }
 }

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -67,7 +67,7 @@
     font-size: var(--text-sm);
     color: var(--accent-color);
     text-decoration: none;
-    cursor: pointer;
+    cursor: default;
     width: fit-content;
 
     &:hover {

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -67,7 +67,6 @@
     font-size: var(--text-sm);
     color: var(--accent-color);
     text-decoration: none;
-    cursor: default;
     width: fit-content;
 
     &:hover {

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -82,7 +82,7 @@
     padding: var(--space-1-5) var(--space-2);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-sm, 0);
-    cursor: pointer;
+    cursor: default;
     transition: background 80ms ease, border-color 80ms ease;
 
     &:hover {
@@ -158,7 +158,7 @@
     border-radius: var(--radius-sm, 0);
     background: transparent;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: var(--text-sm, 12px);
     transition: background 80ms ease, opacity 80ms ease;
 
@@ -193,7 +193,7 @@
     border: 1px solid var(--accent-color);
     border-radius: var(--radius-md, 0);
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: var(--text-sm, 12px);
 }
 

--- a/frontend/app/view/agent/components/PaneRow.scss
+++ b/frontend/app/view/agent/components/PaneRow.scss
@@ -26,7 +26,7 @@
     min-height: 24px;
     overflow: hidden;
     white-space: nowrap;
-    cursor: var(--cursor-interactive);
+    cursor: var(--cursor-default);
     user-select: none;
 }
 
@@ -75,7 +75,7 @@
     border: none;
     border-radius: var(--radius-sm, 0);
     color: var(--secondary-text-color);
-    cursor: var(--cursor-interactive);
+    cursor: var(--cursor-default);
     font-size: var(--text-sm);
     line-height: 1;
     transition: color 80ms ease, background 80ms ease;

--- a/frontend/app/view/agent/fork/ForkBar.scss
+++ b/frontend/app/view/agent/fork/ForkBar.scss
@@ -21,7 +21,7 @@
     border: 1px solid var(--border-color);
     border-radius: var(--radius-sm, 0);
     color: var(--secondary-text-color);
-    cursor: var(--cursor-interactive);
+    cursor: var(--cursor-default);
     font-size: var(--text-xs);
     transition: color 80ms ease, border-color 80ms ease, background 80ms ease;
 

--- a/frontend/app/view/agent/styles/_action-bar.scss
+++ b/frontend/app/view/agent/styles/_action-bar.scss
@@ -26,7 +26,7 @@
             background: transparent;
             border: 1px solid var(--border-color);
             border-radius: 0;
-            cursor: pointer;
+            cursor: default;
             white-space: nowrap;
             transition: background 0.1s, color 0.1s;
 

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -38,7 +38,7 @@
             color: var(--secondary-text-color);
             font: inherit;
             text-align: left;
-            cursor: pointer;
+            cursor: default;
             transition: background 80ms ease;
 
             &:hover {
@@ -237,7 +237,7 @@
         color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         opacity: 0;
         transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -22,7 +22,7 @@
     background: color-mix(in srgb, var(--main-bg-color) 96%, var(--main-text-color));
     border-top: 1px solid var(--border-color);
     border-bottom: 1px solid var(--border-color);
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     transition: background 0.08s;
 
@@ -116,7 +116,7 @@
     background: color-mix(in srgb, var(--accent-color) 12%, transparent);
     border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: color-mix(in srgb, var(--accent-color) 20%, transparent);
@@ -148,7 +148,7 @@
     font-size: 12px;
     line-height: 1;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     transition: color 0.08s;
 
     .agent-composer-strip:hover & {

--- a/frontend/app/view/agent/styles/_connection-status.scss
+++ b/frontend/app/view/agent/styles/_connection-status.scss
@@ -42,7 +42,7 @@
                 border-radius: 0;
                 color: var(--secondary-text-color);
                 font-size: 12px;
-                cursor: pointer;
+                cursor: default;
                 transition: all 0.15s;
 
                 &:hover {
@@ -110,7 +110,7 @@
                 color: var(--main-bg-color);
                 font-size: 11px;
                 font-weight: 500;
-                cursor: pointer;
+                cursor: default;
                 transition: opacity 0.15s;
 
                 &:hover {
@@ -151,7 +151,7 @@
                 color: var(--main-bg-color);
                 font-size: 12px;
                 font-weight: 500;
-                cursor: pointer;
+                cursor: default;
                 transition: opacity 0.15s;
                 display: flex;
                 align-items: center;

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -238,7 +238,7 @@
         font-family: inherit;
         font-size: 10px;
         font-weight: 500;
-        cursor: pointer;
+        cursor: default;
         transition: background 80ms ease, border-color 80ms ease;
 
         &:hover {
@@ -296,7 +296,7 @@
         align-items: center;
         gap: var(--space-1);
         padding: 3px var(--space-1-5);
-        cursor: pointer;
+        cursor: default;
         user-select: none;
         color: var(--secondary-text-color);
 
@@ -352,7 +352,7 @@
         padding: var(--space-0-5) var(--space-1);
         font-size: 11px;
         font-family: inherit;
-        cursor: pointer;
+        cursor: default;
         outline: none;
 
         &:hover {

--- a/frontend/app/view/agent/styles/_decision-panel.scss
+++ b/frontend/app/view/agent/styles/_decision-panel.scss
@@ -45,7 +45,7 @@
     color: var(--warning-color);
     font-family: inherit;
     font-size: 11px;
-    cursor: pointer;
+    cursor: default;
     text-align: left;
     transition: background 80ms ease, border-color 80ms ease;
     flex-shrink: 0;
@@ -190,7 +190,7 @@
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-1);
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     transition: background 80ms ease;
 
     &:hover {
@@ -265,7 +265,7 @@
     font-size: 12px;
     font-weight: 500;
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     border: 1px solid transparent;
     transition: background 80ms ease, border-color 80ms ease;
 

--- a/frontend/app/view/agent/styles/_disconnected-banner.scss
+++ b/frontend/app/view/agent/styles/_disconnected-banner.scss
@@ -51,7 +51,7 @@
     .agent-disconnected-banner-action {
         background: none;
         border: 1px solid color-mix(in srgb, var(--error-color) 50%, transparent);
-        cursor: pointer;
+        cursor: default;
         padding: var(--space-0-5) var(--space-1-5);
         color: var(--error-color);
         font-size: 11px;

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -77,7 +77,7 @@
                 color: var(--secondary-text-color);
                 font-size: 11px;
                 font-family: var(--fixed-font, monospace);
-                cursor: pointer;
+                cursor: default;
                 width: 100%;
                 text-align: left;
 
@@ -138,7 +138,7 @@
         border-left: 2px solid var(--border-color);
         border-radius: 0;
         background: transparent;
-        cursor: pointer;
+        cursor: default;
         transition: background 0.1s;
 
         &:hover {
@@ -350,7 +350,7 @@
             border: 1px solid var(--border-color);
             border-radius: 0;
             color: var(--accent-color);
-            cursor: pointer;
+            cursor: default;
             font-size: 13px;
             padding: 1px var(--space-1-5);
             line-height: 1;
@@ -385,7 +385,7 @@
             color: var(--main-bg-color);
             border: none;
             border-radius: 0;
-            cursor: pointer;
+            cursor: default;
             font-size: 11px;
 
             &:hover {
@@ -660,7 +660,7 @@
         border-left: 2px solid var(--border-color);
         border-radius: 0;
         background: transparent;
-        cursor: pointer;
+        cursor: default;
 
         &.incoming {
             border-left: 2px solid var(--accent-color);
@@ -732,7 +732,7 @@
         border: 1px solid var(--border-color);
         border-left: 2px solid var(--accent-color);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         transition: all 0.15s;
         user-select: none;
 
@@ -950,7 +950,7 @@
                 overflow: hidden;
                 min-width: 0;
                 user-select: none;
-                cursor: pointer;
+                cursor: default;
 
                 &:focus-visible {
                     // Visible focus ring for keyboard users — matches
@@ -1019,7 +1019,7 @@
                     line-height: 1;
                     padding: 2px 6px;
                     border-radius: 0;
-                    cursor: pointer;
+                    cursor: default;
                     opacity: 0.6;
 
                     &:hover {
@@ -1158,7 +1158,7 @@
             line-height: 1.4;
 
             &.clickable {
-                cursor: pointer;
+                cursor: default;
                 &:hover {
                     opacity: 1;
                 }
@@ -1273,7 +1273,7 @@
         border: 1px solid var(--border-color);
         border-radius: 0;
         background: var(--main-bg-color);
-        cursor: pointer;
+        cursor: default;
 
         &:hover {
             border-color: var(--accent-color);
@@ -1441,7 +1441,7 @@
         font-size: 11px;
         font-weight: 600;
         white-space: nowrap;
-        cursor: pointer;
+        cursor: default;
 
         &:hover {
             background: color-mix(in srgb, var(--error-color) 15%, transparent);

--- a/frontend/app/view/agent/styles/_focused-overlay.scss
+++ b/frontend/app/view/agent/styles/_focused-overlay.scss
@@ -53,7 +53,7 @@
     .agent-focused-panel-close {
         background: none;
         border: none;
-        cursor: pointer;
+        cursor: default;
         color: var(--secondary-text-color);
         font-size: 12px;
         padding: var(--space-0-5) var(--space-1);
@@ -98,7 +98,7 @@
         padding: var(--space-1) var(--space-3);
         border-radius: 0;
         font-size: 12px;
-        cursor: pointer;
+        cursor: default;
         border: 1px solid var(--border-color, rgba(255, 255, 255, 0.2));
         background: rgba(255, 255, 255, 0.05);
         color: var(--main-text-color);

--- a/frontend/app/view/agent/styles/_header-controls.scss
+++ b/frontend/app/view/agent/styles/_header-controls.scss
@@ -79,7 +79,7 @@
             background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
             color: var(--main-text-color);
             font-size: 11px;
-            cursor: pointer;
+            cursor: default;
             transition: all 0.15s;
 
             &:hover:not(:disabled) {
@@ -144,11 +144,11 @@
             display: flex;
             align-items: center;
             gap: var(--space-2);
-            cursor: pointer;
+            cursor: default;
             font-size: 12px;
 
             input[type="checkbox"] {
-                cursor: pointer;
+                cursor: default;
             }
 
             &:hover {
@@ -167,7 +167,7 @@
         border-radius: 0;
         color: var(--accent-color);
         font-size: 11px;
-        cursor: pointer;
+        cursor: default;
         z-index: 10;
 
         &:hover {

--- a/frontend/app/view/agent/styles/_identity-panel.scss
+++ b/frontend/app/view/agent/styles/_identity-panel.scss
@@ -103,7 +103,7 @@
     border-radius: 0;
     padding: var(--space-0-5) var(--space-1);
     max-width: 140px;
-    cursor: pointer;
+    cursor: default;
 
     &:focus {
         outline: 1px solid var(--accent-color);
@@ -124,7 +124,7 @@
     border-radius: 0;
     color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
     padding: var(--space-0-5) 5px;
-    cursor: pointer;
+    cursor: default;
     white-space: nowrap;
 
     &:hover:not(:disabled) {

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -95,7 +95,7 @@
     padding: var(--space-1-5) var(--space-2);
     border: 1px solid var(--border-color);
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     transition: background 0.08s, border-color 0.08s;
 
     &:has(input:checked) {
@@ -162,7 +162,7 @@
 }
 
 .agent-launch-modal-advanced-summary {
-    cursor: pointer;
+    cursor: default;
     font-size: 11px;
     font-weight: 500;
     color: var(--secondary-text-color);
@@ -264,7 +264,7 @@
     border-radius: 0;
     color: var(--main-text-color);
     font-size: var(--text-sm);
-    cursor: pointer;
+    cursor: default;
     transition: border-color 0.12s, color 0.12s, background 0.12s;
 
     &:hover:not(:disabled) {
@@ -290,7 +290,7 @@
     font-size: 12px;
     font-family: inherit;
     color: var(--accent-color);
-    cursor: pointer;
+    cursor: default;
 
     &:hover:not(:disabled) {
         text-decoration: underline;
@@ -317,7 +317,7 @@
     font-size: 16px;
     font-weight: 500;
     line-height: 1;
-    cursor: pointer;
+    cursor: default;
     transition: border-color 0.12s, color 0.12s, background 0.12s;
 
     &:hover:not(:disabled) {

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -70,7 +70,7 @@
             font-weight: 500;
             text-transform: none;
             letter-spacing: 0;
-            cursor: pointer;
+            cursor: default;
             transition: background 80ms ease;
             flex-shrink: 0;
             &:hover {

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -64,7 +64,7 @@
 
     .agent-picker-hidden-templates-header {
         all: unset;
-        cursor: pointer;
+        cursor: default;
         font-size: var(--text-sm, 0.875rem);
         font-weight: 600;
         color: color-mix(in srgb, var(--main-text-color) 60%, transparent);
@@ -122,7 +122,7 @@
 
     .agent-picker-hidden-template-unhide-btn {
         all: unset;
-        cursor: pointer;
+        cursor: default;
         padding: 4px 10px;
         border-radius: 0;
         font-size: var(--text-xs, 0.75rem);
@@ -152,7 +152,7 @@
         border: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         transition: all 0.15s;
         color: var(--main-text-color);
         text-align: left;
@@ -246,7 +246,7 @@
             background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
             border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
             border-radius: 0;
-            cursor: pointer;
+            cursor: default;
             opacity: 0;
             transition: opacity 0.12s ease-out, background 0.12s, color 0.12s, border-color 0.12s;
             pointer-events: none;
@@ -371,7 +371,7 @@
             border-radius: 0;
             color: var(--main-text-color);
             font-size: 11px;
-            cursor: pointer;
+            cursor: default;
             flex-shrink: 0;
 
             &:hover {
@@ -441,7 +441,7 @@
             color: var(--secondary-text-color);
             border-radius: 0;
             font-size: 12px;
-            cursor: pointer;
+            cursor: default;
             transition: all 0.1s;
 
             &:hover:not(.active) {
@@ -464,7 +464,7 @@
             background: transparent;
             color: var(--secondary-text-color);
             font-size: 14px;
-            cursor: pointer;
+            cursor: default;
             border-radius: 0;
 
             &:hover {

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -81,7 +81,7 @@
         border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
         background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         text-align: left;
         color: var(--main-text-color);
         font-family: inherit;
@@ -244,7 +244,7 @@
         font-family: inherit;
         border-radius: 0;
         border: 1px solid transparent;
-        cursor: pointer;
+        cursor: default;
         transition: background 0.12s, border-color 0.12s, opacity 0.12s;
         white-space: nowrap;
 

--- a/frontend/app/view/agent/styles/_retry-empty.scss
+++ b/frontend/app/view/agent/styles/_retry-empty.scss
@@ -21,7 +21,7 @@
         color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         &:hover { opacity: 0.85; }
         &:active { opacity: 0.7; }
         &--cancel {
@@ -51,7 +51,7 @@
         background: transparent;
         color: var(--accent-color);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
         transition: background 0.15s, color 0.15s;
 

--- a/frontend/app/view/agent/styles/_search.scss
+++ b/frontend/app/view/agent/styles/_search.scss
@@ -64,7 +64,7 @@
         background: none;
         border: 1px solid transparent;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         color: var(--secondary-text-color);
         font-size: 11px;
         line-height: 1;

--- a/frontend/app/view/agent/styles/_session-digest.scss
+++ b/frontend/app/view/agent/styles/_session-digest.scss
@@ -40,7 +40,7 @@
     .agent-session-digest-action {
         background: none;
         border: none;
-        cursor: pointer;
+        cursor: default;
         padding: var(--space-0-5) 5px;
         color: var(--secondary-text-color);
         opacity: 0.75;

--- a/frontend/app/view/agent/styles/_setup-wizard.scss
+++ b/frontend/app/view/agent/styles/_setup-wizard.scss
@@ -257,7 +257,7 @@
             border: 1px solid var(--border-color);
             border-radius: 0;
             padding: var(--space-3);
-            cursor: pointer;
+            cursor: default;
             transition: all 0.15s;
 
             &:hover {
@@ -270,7 +270,7 @@
             }
 
             input[type="radio"] {
-                cursor: pointer;
+                cursor: default;
             }
 
             .setup-wizard-provider-info {
@@ -332,7 +332,7 @@
             border-radius: 0;
             font-size: 12px;
             font-weight: 500;
-            cursor: pointer;
+            cursor: default;
             transition: all 0.15s;
             border: 1px solid var(--border-color);
             background: transparent;

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -68,7 +68,7 @@
     align-items: baseline;
     gap: var(--space-1);
     padding: var(--space-1) var(--space-2);
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     min-height: 24px;
 
@@ -140,7 +140,7 @@
     line-height: 1;
     padding: 2px 6px;
     border-radius: 3px;
-    cursor: pointer;
+    cursor: default;
     opacity: 0.55;
     transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
 
@@ -220,7 +220,7 @@
     align-items: baseline;
     gap: var(--space-1);
     padding: var(--space-1) var(--space-2);
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     min-height: 24px;
 
@@ -291,7 +291,7 @@
     line-height: 1;
     padding: 0 9px;
     border-radius: 6px;
-    cursor: pointer;
+    cursor: default;
     opacity: 0.75;
     transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 
@@ -329,7 +329,7 @@
     border: none;
     background: transparent;
     text-align: left;
-    cursor: pointer;
+    cursor: default;
     padding: var(--space-1) var(--space-2);
     font-size: 11px;
     color: var(--secondary-text-color);

--- a/frontend/app/view/agent/styles/_slash.scss
+++ b/frontend/app/view/agent/styles/_slash.scss
@@ -38,7 +38,7 @@
         align-items: baseline;
         gap: var(--space-2);
         padding: var(--space-1) 10px;
-        cursor: pointer;
+        cursor: default;
         line-height: 1.4;
         color: var(--main-text-color);
 
@@ -103,7 +103,7 @@
         align-items: baseline;
         gap: 10px;
         padding: var(--space-1) 10px;
-        cursor: pointer;
+        cursor: default;
         line-height: 1.4;
         color: var(--main-text-color);
 
@@ -172,7 +172,7 @@
         background: none;
         border: 1px solid transparent;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         color: var(--secondary-text-color);
         font-size: 16px;
         line-height: 1;
@@ -216,7 +216,7 @@
         align-items: baseline;
         gap: var(--space-2);
         padding: 3px 10px;
-        cursor: pointer;
+        cursor: default;
         line-height: 1.4;
         color: var(--main-text-color);
 

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -84,7 +84,7 @@
         background: transparent;
         color: var(--main-text-color);
         font-size: 11px;
-        cursor: pointer;
+        cursor: default;
 
         &:hover:not(.agent-tool-overlay-action--disabled) {
             background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -172,7 +172,7 @@
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
 }
 
 // ── Preview ──────────────────────────────────────────────────────────────────
@@ -192,7 +192,7 @@
     background: transparent;
     color: var(--secondary-text-color);
     font-size: var(--text-sm);
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         color: var(--main-text-color);
@@ -222,7 +222,7 @@
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     transition: opacity 0.1s;
 
     &:hover:not(:disabled) {
@@ -260,7 +260,7 @@
     border-radius: 0;
     background: transparent;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
 
     &:hover:not(:disabled) {
         background: var(--hover-bg-color);

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -36,7 +36,7 @@
     background: transparent;
     color: var(--main-text-color);
     font-size: 14px;
-    cursor: pointer;
+    cursor: default;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/app/view/bundle-summary.scss
+++ b/frontend/app/view/bundle-summary.scss
@@ -38,7 +38,7 @@
         color: var(--accent-text-color, #fff);
         border: none;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
 
         &:hover {

--- a/frontend/app/view/drone/drone-view.scss
+++ b/frontend/app/view/drone/drone-view.scss
@@ -95,7 +95,7 @@
     color: inherit;
     padding: 4px 12px;
     border-radius: 0;
-    cursor: pointer;
+    cursor: default;
     font-size: 12px;
     &:hover { background: color-mix(in srgb, var(--main-text-color) 8%, transparent); }
     &:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -193,7 +193,7 @@
     stroke-width: 14;
     fill: none;
     pointer-events: stroke;
-    cursor: pointer;
+    cursor: default;
 }
 
 .drone-edge-preview {
@@ -262,7 +262,7 @@
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     color: inherit;
-    cursor: pointer;
+    cursor: default;
     font-size: 15px;
     line-height: 1;
     &:hover {
@@ -314,7 +314,7 @@
     background: transparent;
     border: none;
     color: white;
-    cursor: pointer;
+    cursor: default;
     font-size: 14px;
     line-height: 1;
     padding: 0 4px;

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -104,7 +104,7 @@
     border-radius: 3px;
     background: transparent;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: 11px;
     transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
 
@@ -136,7 +136,7 @@
     align-items: center;
     gap: var(--space-1);
     padding: 2px var(--space-1);
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     white-space: nowrap;
     overflow: hidden;
@@ -278,7 +278,7 @@
     border-right: 1px solid var(--border-color);
     background: transparent;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     user-select: none;
     font-size: 11px;
     overflow: hidden;
@@ -340,7 +340,7 @@
     border-radius: 3px;
     background: transparent;
     color: inherit;
-    cursor: pointer;
+    cursor: default;
     font-size: 14px;
     line-height: 1;
     opacity: 0;
@@ -528,7 +528,7 @@
     border: 1px solid var(--border-color);
     border-radius: 3px;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: 12px;
 
     &:hover {
@@ -612,7 +612,7 @@
     background: var(--secondary-bg-color, var(--block-bg-color));
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    cursor: pointer;
+    cursor: default;
     opacity: 0.75;
     user-select: none;
 
@@ -659,7 +659,7 @@
     background: transparent;
     border: none;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: 16px;
     line-height: 1;
     padding: 0;
@@ -693,7 +693,7 @@
     border: 1px solid var(--border-color);
     border-radius: 3px;
     color: var(--main-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: 11px;
     text-decoration: none;
     font-family: var(--main-font-family, sans-serif);

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -693,7 +693,6 @@
     border: 1px solid var(--border-color);
     border-radius: 3px;
     color: var(--main-text-color);
-    cursor: default;
     font-size: 11px;
     text-decoration: none;
     font-family: var(--main-font-family, sans-serif);

--- a/frontend/app/view/identity/identity-pane-view.scss
+++ b/frontend/app/view/identity/identity-pane-view.scss
@@ -28,7 +28,7 @@
         color: var(--accent-text-color, #fff);
         border: none;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
 
         &:hover {
@@ -46,7 +46,7 @@
 
     .identity-pane-list-item {
         padding: 10px 12px;
-        cursor: pointer;
+        cursor: default;
         border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
 
         &:hover {
@@ -198,7 +198,7 @@
         color: var(--accent-color);
         border: 1px solid var(--accent-color);
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
 
         &:hover {
             background: var(--accent-color);
@@ -221,7 +221,7 @@
         border-radius: 0;
         background: transparent;
         color: var(--main-text-color);
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
 
         &:hover:not(:disabled) {

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -48,7 +48,7 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1-5) var(--space-2);
-    cursor: pointer;
+    cursor: default;
     border: 1px solid var(--border-color);
     border-radius: 0;
     background: color-mix(in srgb, var(--main-text-color) 3%, transparent);

--- a/frontend/app/view/identity/styles/_detail.scss
+++ b/frontend/app/view/identity/styles/_detail.scss
@@ -92,7 +92,7 @@
     font-size: 12px;
     border-radius: 0;
     border: 1px solid transparent;
-    cursor: pointer;
+    cursor: default;
     transition: opacity 0.1s;
 
     &:hover { opacity: 0.85; }

--- a/frontend/app/view/identity/styles/_empty-states.scss
+++ b/frontend/app/view/identity/styles/_empty-states.scss
@@ -25,7 +25,7 @@
     border: 1px solid var(--accent-color);
     background: transparent;
     color: var(--accent-color);
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--hover-bg-color);

--- a/frontend/app/view/identity/styles/_form-overlay.scss
+++ b/frontend/app/view/identity/styles/_form-overlay.scss
@@ -41,7 +41,7 @@
     background: transparent;
     border: none;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     font-size: 14px;
     padding: var(--space-0-5) var(--space-1-5);
     border-radius: 0;

--- a/frontend/app/view/identity/styles/_header.scss
+++ b/frontend/app/view/identity/styles/_header.scss
@@ -33,7 +33,7 @@
     border: none;
     background: transparent;
     color: var(--secondary-text-color);
-    cursor: pointer;
+    cursor: default;
     transition: background 0.1s, color 0.1s;
 
     &:hover {
@@ -55,7 +55,7 @@
     border: 1px solid var(--border-color);
     background: transparent;
     color: var(--accent-color);
-    cursor: pointer;
+    cursor: default;
 
     &:hover {
         background: var(--hover-bg-color);

--- a/frontend/app/view/launcher/launcher.tsx
+++ b/frontend/app/view/launcher/launcher.tsx
@@ -233,7 +233,7 @@ function LauncherView(props: ViewComponentProps<LauncherViewModel>): JSX.Element
                             onClick={() => model.handleWidgetSelect(widget)}
                             title={widget.description || widget.label}
                             class={clsx(
-                                "flex flex-col items-center justify-center cursor-pointer rounded-md p-2 text-center",
+                                "flex flex-col items-center justify-center rounded-md p-2 text-center",
                                 "transition-colors duration-150",
                                 index() === selectedIndex()
                                     ? "bg-white/20 text-white"

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -29,7 +29,7 @@
         color: var(--accent-text-color, #fff);
         border: none;
         border-radius: 0;
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
 
         &:hover {
@@ -47,7 +47,7 @@
 
     .memory-view-list-item {
         padding: 10px 12px;
-        cursor: pointer;
+        cursor: default;
         border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
 
         &:hover {
@@ -187,7 +187,7 @@
         border-radius: 0;
         background: transparent;
         color: var(--main-text-color);
-        cursor: pointer;
+        cursor: default;
         font-size: 13px;
 
         &:hover:not(:disabled) {

--- a/frontend/app/view/subagent/subagent-view.scss
+++ b/frontend/app/view/subagent/subagent-view.scss
@@ -153,7 +153,7 @@
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
-    cursor: pointer;
+    cursor: default;
     padding: var(--space-0-5) 0;
     font-size: 12px;
     user-select: none;
@@ -228,7 +228,7 @@
     background: var(--panel-bg-color);
     color: var(--main-text-color);
     font-size: 11px;
-    cursor: pointer;
+    cursor: default;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     z-index: 10;
 

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -81,7 +81,7 @@
     height: 36px;
     padding: 0 6px 0 10px;
     gap: 5px;
-    cursor: pointer;
+    cursor: default;
     border-radius: 4px;
     user-select: none;
 
@@ -123,7 +123,7 @@
     height: 30px;
     padding: 0 6px 0 30px;
     gap: 5px;
-    cursor: pointer;
+    cursor: default;
     border-radius: 4px;
     user-select: none;
 
@@ -208,7 +208,7 @@
     border: 1px solid var(--border-color);
     color: var(--secondary-text-color);
     background: transparent;
-    cursor: pointer;
+    cursor: default;
     flex-shrink: 0;
     font-family: inherit;
 

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -169,7 +169,7 @@
     border: 1px solid transparent;
     color: var(--main-text-color);
     opacity: 0.4;
-    cursor: pointer;
+    cursor: default;
     width: 20px;
     height: 20px;
     border-radius: 0;

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -139,7 +139,7 @@
         display: flex;
         align-items: center;
         padding: var(--space-1) var(--space-1-5);
-        cursor: pointer;
+        cursor: default;
         color: var(--main-text-color);
         font-size: 12px;
         line-height: normal;

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -118,7 +118,7 @@ const ActionWidget = (props: {
         <Tooltip
             content={props.widget.description || props.widget.label}
             placement="bottom"
-            divClassName="flex flex-row items-center gap-1 px-2 py-0.5 text-secondary hover:bg-hoverbg hover:text-white cursor-pointer rounded-sm h-full"
+            divClassName="flex flex-row items-center gap-1 px-2 py-0.5 text-secondary hover:bg-hoverbg hover:text-white rounded-sm h-full"
             divOnClick={() => handleWidgetSelect(props.widget)}
         >
             <div class="widget-icon text-sm">

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -18,7 +18,7 @@
     border: none;
     color: var(--accent-color);
     -webkit-app-region: no-drag;
-    cursor: pointer;
+    cursor: default;
     align-self: center;
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which

--- a/frontend/tailwindsetup.css
+++ b/frontend/tailwindsetup.css
@@ -81,7 +81,7 @@ svg [aria-label="tip"] g path {
 
 /* Monaco editor scrollbar styling */
 .monaco-editor .slider {
-    cursor: pointer;
+    cursor: default;
     background: rgba(255, 255, 255, 0.4);
     border-radius: 0;
     transition: background 0.2s ease;


### PR DESCRIPTION
## Summary

- **Rule enforced:** `cursor: pointer` (the hand) appears only on `<a href>` elements and xterm terminal link hover. Every button, menu, tab, hamburger, window control, status-bar item, widget, modal, and pane control now shows the arrow.
- **Scale:** 150+ incorrect `cursor: pointer` sites fixed across 80 SCSS/TSX/TS files.
- **Root-cause approach** — 3 token/baseline changes cascade-fix the majority, no per-file churn needed for inherited cases:
  - `theme.scss`: `--cursor-interactive` → `default`; new `--cursor-link: pointer` token
  - `button.scss`: `cursor: default` baseline for all `<button>` elements
  - `app.scss`: `a[href] { cursor: var(--cursor-link) }` global rule + `.u-cursor-link` utility class

## Test plan

- [ ] Hover over hamburger menu (≡) — should show arrow
- [ ] Hover over tab bar controls — should show arrow
- [ ] Hover over pane title-bar close/maximize buttons — should show arrow
- [ ] Hover over status bar items — should show arrow
- [ ] Hover over agent view buttons (control bar, composer, decision panel) — should show arrow
- [ ] Hover over any URL in terminal output — should still show hand (xterm)
- [ ] Hover over an `<a href>` rendered link in agent markdown output — should show hand
- [ ] Hover over widget slot buttons — should show arrow
- [ ] Drag handles / resize dividers — should still show grab/resize cursors (not changed)

See `docs/analysis/ANALYSIS_CURSOR_POINTER_AUDIT_2026_06_20.md` for the full classified inventory.

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-mazs} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)