### PR TITLE
fix(cef): harden two CEF-init log errors — cache_path under root + dynamic debug port

### DIFF
--- a/.changesets/1782003483-fix-cef-cache-path-and-dynamic-debug-port.md
+++ b/.changesets/1782003483-fix-cef-cache-path-and-dynamic-debug-port.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): root per-window browser contexts under root_cache_path (stop in-memory fallback) + pick a free remote-debugging port per instance (stop multi-instance bind() collision)

--- a/agentmux-cef/src/commands/mod.rs
+++ b/agentmux-cef/src/commands/mod.rs
@@ -25,7 +25,9 @@ use crate::state::AppState;
 /// Each browser window needs its own renderer process to get an isolated
 /// JavaScript context (own `document`, own module state, own SolidJS render tree).
 /// CEF assigns a separate renderer process when the RequestContext has a unique
-/// `cache_path`. We use `<data_dir>/browser-contexts/<label>/` for this.
+/// `cache_path`. We use `<root_cache_path>/browser-contexts/<label>/` — it MUST
+/// be a child of `Settings.root_cache_path` (the cef-cache dir) or CEF rejects it
+/// and falls back to in-memory storage. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
 pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Option<cef::RequestContext> {
     // Phase 1 diagnostic tracing (added 2026-05-02 freeze investigation, see
     // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md). The freeze
@@ -35,7 +37,12 @@ pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Op
     let t0 = std::time::Instant::now();
     tracing::info!(label = %label, "[cef-profile-init] entering create_isolated_request_context");
 
-    let data_dir = state.version_data_dir.lock().clone()
+    // Root the per-window context UNDER root_cache_path (the cef-cache dir) so
+    // CEF accepts it — it requires cache_path to be a descendant of
+    // root_cache_path, else it rejects it and falls back to in-memory storage
+    // (SPEC_CEF_LOG_ROBUSTNESS §1). Fall back to a temp dir only if
+    // root_cache_path isn't initialized yet (pre-boot edge).
+    let cache_root = state.cef_cache_dir.lock().clone()
         .unwrap_or_else(|| {
             std::env::temp_dir()
                 .join("agentmux-cef-contexts")
@@ -43,7 +50,7 @@ pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Op
                 .to_string()
         });
 
-    let ctx_path = std::path::PathBuf::from(&data_dir)
+    let ctx_path = std::path::PathBuf::from(&cache_root)
         .join("browser-contexts")
         .join(label);
     // Do NOT pre-create the directory — CEF's Chrome profile initializer

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -670,10 +670,33 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     }
     tracing::info!("CEF cache dir: {}", data_dir.display());
     let cache_dir = CefString::from(data_dir.to_str().unwrap_or(""));
+    // Expose root_cache_path so per-window RequestContexts root their cache_path
+    // UNDER it — CEF requires a descendant of root_cache_path, else it falls back
+    // to in-memory storage. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
+    *app_state.cef_cache_dir.lock() = Some(data_dir.to_string_lossy().to_string());
 
     // Configure CEF settings.
-    let debug_port: u16 = if is_dev { 9223 } else { 9222 };
+    // Pick a FREE remote-debugging port instead of a fixed one: AgentMux runs
+    // many instances in parallel (isolation I1–I6), so a hardcoded port collides
+    // (WSAEADDRINUSE / 0x2740) and the 2nd+ instance gets no DevTools server →
+    // the browser DOM API (`/agentmux/browser/*`) can't connect. Prefer the
+    // conventional port (9223 dev / 9222 release) for muscle memory; fall back to
+    // an OS-assigned free port. Store the ACTUAL port so `browser_api` targets
+    // it. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §2.
+    let preferred: u16 = if is_dev { 9223 } else { 9222 };
+    let debug_port: u16 = {
+        use std::net::TcpListener;
+        if TcpListener::bind(("127.0.0.1", preferred)).is_ok() {
+            preferred
+        } else {
+            TcpListener::bind(("127.0.0.1", 0))
+                .and_then(|l| l.local_addr())
+                .map(|a| a.port())
+                .unwrap_or(preferred)
+        }
+    };
     *app_state.debug_port.lock() = debug_port;
+    tracing::info!("CEF remote-debugging port: {} (preferred {})", debug_port, preferred);
 
     // Route CEF's internal Chromium logging into our log dir alongside the
     // tracing-subscriber file. Without this, init failures leave an empty

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -803,6 +803,13 @@ pub struct AppState {
     /// pane targets. See `docs/specs/SPEC_BROWSER_DOM_API.md` §6.
     pub debug_port: Mutex<u16>,
 
+    /// CEF `root_cache_path` (the version's `cef-cache` dir). Stored so
+    /// per-window RequestContexts (`create_isolated_request_context`) root their
+    /// `cache_path` UNDER it — CEF requires every context cache_path to be a
+    /// descendant of root_cache_path, else it rejects it and falls back to
+    /// in-memory storage. See SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
+    pub cef_cache_dir: Mutex<Option<String>>,
+
     // Phase B.1 removed `job_handle` (was Windows-only). Launcher
     // owns J0 wrapping srv now; host no longer needs its own job.
 
@@ -871,6 +878,7 @@ impl Default for AppState {
             browser_panes: crate::browser_panes::BrowserPaneManager::new(),
             browser_api: crate::browser_api::BrowserApiState::new(),
             debug_port: Mutex::new(0),
+            cef_cache_dir: Mutex::new(None),
             #[cfg(target_os = "windows")]
             window_hwnds: Mutex::new(HashMap::new()),
         }

--- a/docs/specs/SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md
+++ b/docs/specs/SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md
@@ -1,0 +1,170 @@
+# SPEC: Harden two CEF-init log errors (cache_path + debug-port bind)
+
+**Date:** 2026-06-20
+**Author:** AgentA
+**Status:** Draft — ready to implement
+**Found in:** the `0.46.6+gb80dc396` (Windows sandbox Phase 3, #1633) launch — `cef-debug.log` at startup
+**Scope:** `agentmux-cef` host CEF/Chromium configuration. Not sandbox-related (surfaced while verifying the sandbox build, but both predate it).
+
+---
+
+## 0. Summary
+
+The host's `cef-debug.log` logs two non-fatal errors at every launch. Both
+degrade gracefully today (CEF continues), but each silently loses a real
+capability:
+
+| # | Error | Who it hits | Lost capability |
+|---|-------|-------------|-----------------|
+| 1 | `cache_path … is not a child of the root_cache_path … Defaulting to in-memory storage` | **every** user (per extra/pool/browser window) | disk-backed browser state for non-main windows — cache/cookies/storage live only in RAM, lost on close |
+| 2 | `bind() returned an error: Only one usage of each socket address … (0x2740)` | **multi-instance** (AgentMux's core design) | the 2nd+ instance gets no DevTools remote-debugging server → the browser DOM API (`/agentmux/browser/*`, pane CSS queries) can't connect |
+
+Both are config-shape bugs, not logic bugs. Fixing them makes the host robust
+under its own design (multiple instances; per-window contexts).
+
+---
+
+## 1. Error 1 — `cache_path` is not a child of `root_cache_path`
+
+### 1.1 Evidence
+```
+ERROR:cef\libcef\browser\context.cc:161] The cache_path directory
+  (…\versions\0.46.6\data\browser-contexts\window-pool-<id>)
+  is not a child of the root_cache_path directory (…\versions\0.46.6\cef-cache)
+ERROR:cef\libcef\browser\context.cc:185] The cache_path is invalid.
+  Defaulting to in-memory storage.
+```
+
+### 1.2 Root cause
+- **`root_cache_path`** is set once in `agentmux-cef/src/lib.rs` (~l.672, l.715):
+  `cache_dir = data_dir` where that `data_dir` is the **CEF cache dir**
+  `…/versions/<ver>/cef-cache`.
+- **Per-window `cache_path`** is built in
+  `agentmux-cef/src/commands/mod.rs` `create_isolated_request_context()`
+  (~l.46-48) from `state.version_data_dir` →
+  `…/versions/<ver>/data/browser-contexts/<label>`.
+
+`cef-cache/` and `data/` are **siblings** under `…/versions/<ver>/`. CEF
+requires every `RequestContextSettings.cache_path` to be a **descendant** of
+the global `Settings.root_cache_path` (a hard Chromium invariant —
+`context.cc:161`). It isn't, so CEF rejects it and falls back to in-memory
+storage for that window's context.
+
+### 1.3 Impact
+Every isolated browser window (pool windows, tear-offs, browser panes) runs
+with an **in-memory** request context: no disk cache, session cookies, IndexedDB,
+or Local Storage persistence. Cosmetic-looking, but it means browser-pane state
+silently doesn't survive a window close, and the cache is rebuilt every open
+(slower, more memory).
+
+### 1.4 Fix
+Root the per-window browser-contexts **under** `root_cache_path` instead of the
+sibling `data` dir:
+
+```
+…/versions/<ver>/cef-cache/browser-contexts/<label>/      ← child of root ✓
+```
+
+Implementation:
+1. Expose the resolved `root_cache_path` (the `cef-cache` dir) to
+   `create_isolated_request_context` — either store it in `AppState` next to
+   `version_data_dir` (e.g. `cef_cache_dir: Mutex<Option<String>>`, set in the
+   same place `lib.rs` builds `cache_dir`), or add a `DataPaths` helper both
+   sites call. Single source of truth — do **not** recompute `cef-cache` in two
+   places.
+2. In `create_isolated_request_context`, build
+   `ctx_path = <cef_cache_dir>/browser-contexts/<label>`.
+3. Keep the existing "don't pre-create the dir" rule (CEF's Chrome profile
+   initializer fails on an existing-but-empty dir — `mod.rs:49`).
+4. `<label>` is already sanitized for path use upstream; keep that.
+
+### 1.5 Test / verify
+- Launch; grep `cef-debug.log` → **no** `context.cc:161/185` lines.
+- Open a browser pane, set a cookie / localStorage value, close + reopen the
+  window → value persists (was lost before).
+- The on-disk `cef-cache/browser-contexts/<label>/` dir exists after a window
+  opens.
+
+---
+
+## 2. Error 2 — `bind()` collision on the remote-debugging port
+
+### 2.1 Evidence
+```
+ERROR:net\socket\tcp_socket_win.cc:530] bind() returned an error:
+  Only one usage of each socket address (protocol/network address/port)
+  is normally permitted. (0x2740)
+```
+Observed with multiple AgentMux instances running (0.46.4 + 0.46.5-dev +
+0.46.6). On a single-instance machine the preferred port is free and this does
+not fire.
+
+### 2.2 Root cause
+`agentmux-cef/src/lib.rs:675`:
+```rust
+let debug_port: u16 = if is_dev { 9223 } else { 9222 };   // hardcoded
+…
+remote_debugging_port: debug_port as i32,                 // l.714
+```
+The remote-debugging server binds a **hardcoded** port (`9222` release / `9223`
+dev). A second instance of the same channel/profile binds the same port and
+fails (`WSAEADDRINUSE`, 0x2740). AgentMux is **designed** to run many instances
+in parallel (different versions, dev + portable, per-build channels — see the
+isolation invariants I1–I6), so a fixed port contradicts the model. (This is the
+same hardcoded port that made cross-instance CDP driving impossible during the
+provider-isolation verification.)
+
+### 2.3 Impact
+The instance whose bind failed has **no** CEF DevTools server. The browser DOM
+API (`browser_api/*`: `/agentmux/browser/*`, the pane CSS-selector lookups in
+`browser_api/resolver.rs` / `routes.rs`) connects to
+`ws://127.0.0.1:<debug_port>/devtools/page/<target>` — which doesn't exist for
+that instance → browser-pane introspection / DOM queries silently break for the
+2nd+ instance. `state.debug_port` still holds the (unbound) hardcoded value, so
+the failure is invisible until a DOM-API call times out.
+
+### 2.4 Fix
+Pick a **free** port instead of a fixed one, and record the *actual* port:
+
+1. Try the preferred port first (`9223` dev / `9222` release) for muscle-memory
+   convenience: bind-test `TcpListener::bind(("127.0.0.1", preferred))`. If it
+   binds, use `preferred`; drop the listener immediately so CEF can take it.
+2. If the preferred port is taken, fall back to an OS-assigned free port:
+   `TcpListener::bind(("127.0.0.1", 0))` → read `.local_addr().port()` → drop.
+3. Set `remote_debugging_port` to the chosen port **and** store it in
+   `app_state.debug_port` (already the value `browser_api` reads — so the DOM
+   API automatically targets the right port).
+4. Accept the small TOCTOU window between the bind-test and CEF's own bind
+   (another process could grab the port in that gap). Mitigate by doing the
+   probe immediately before constructing `Settings` and logging the chosen port;
+   if CEF still can't bind, the DOM API degrades exactly as today (no worse).
+
+Note: CEF/Chromium does **not** reliably auto-assign on `remote_debugging_port =
+0`, so we must choose the concrete port ourselves (hence the bind-probe).
+
+### 2.5 Test / verify
+- Launch **two** instances; grep both `cef-debug.log` → neither logs the
+  `tcp_socket_win.cc:530 bind()` error.
+- `state.debug_port` differs between the two instances; `GET
+  http://127.0.0.1:<port>/json` succeeds for **each** (DevTools server up).
+- A browser-pane DOM query (`/agentmux/browser/*`) works in the **second**
+  instance (was broken before).
+
+---
+
+## 3. Non-goals / notes
+
+- The `[getApi] called before window.api exists` console line is a benign
+  frontend startup-order log (window.api injects a tick later) — not in scope.
+- These are independent fixes; either can land alone. Bundle them in one PR
+  (both are `agentmux-cef` CEF-config robustness) with a `patch` changeset.
+- Neither changes the sandbox; they were merely surfaced by the Phase 3 launch.
+
+## 4. Change surface
+- `agentmux-cef/src/lib.rs` — §1.4 (resolve + expose `root_cache_path`),
+  §2.4 (free-port selection for `remote_debugging_port`, store in
+  `app_state.debug_port`).
+- `agentmux-cef/src/commands/mod.rs` — §1.4 (`create_isolated_request_context`
+  roots `browser-contexts` under the cef-cache dir).
+- `agentmux-cef/src/state.rs` — if option (a): add `cef_cache_dir` field beside
+  `version_data_dir` / `debug_port`.


### PR DESCRIPTION
Spec: `docs/specs/SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md`. Two non-fatal CEF-init log errors that degrade silently — surfaced while verifying the Phase 3 sandbox build (#1633); both predate it.

## 1. `cache_path` not a child of `root_cache_path` → in-memory storage (every user)
Per-window `RequestContext` cache paths were built from `version_data_dir` (`…/data/browser-contexts/<label>`) — a **sibling** of `root_cache_path` (`…/cef-cache`). CEF requires `cache_path` to be a descendant of `root_cache_path`, so it rejected it and fell back to **in-memory** storage (pool/tear-off/browser-pane windows lost disk cache/cookies/storage on close).
**Fix:** store `root_cache_path` in `AppState.cef_cache_dir`; root `browser-contexts/<label>` under it.

## 2. `bind()` collision on the hardcoded remote-debugging port (multi-instance)
`debug_port` was hardcoded `9222`/`9223`. A 2nd instance can't bind it (`WSAEADDRINUSE` 0x2740) → no DevTools server → the browser DOM API (`/agentmux/browser/*`) can't connect for that instance. AgentMux is designed to run many instances in parallel (isolation I1–I6).
**Fix:** bind-probe the preferred port, fall back to an OS-assigned free port, store the **actual** port in `AppState.debug_port` (which `browser_api` already reads).

## Verification (real build, other instances holding 9222)
- `CEF remote-debugging port: 52489 (preferred 9222)` — fell back to a free port; **0** `tcp_socket_win.cc:530 bind()` errors.
- **0** `context.cc:161/185` errors; contexts now under `cef-cache/browser-contexts/window-pool-*` (disk-backed), **none** under `data/`.

`cargo check -p agentmux-cef` clean.

<!-- agentmux:agent_id=smike -->