### PR TITLE
chore: release v0.47.0

### DIFF
--- a/.changesets/1781951352-feat-sound-ambient-waiting-tone-when-agent-is-blocked-for-us-mub0.md
+++ b/.changesets/1781951352-feat-sound-ambient-waiting-tone-when-agent-is-blocked-for-us-mub0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(sound): ambient waiting tone when agent is blocked for user input

--- a/.changesets/1781955118-feat-pool-pane-tear-off-pool-on-macos-linux-floating-pool-uu-ft4c.md
+++ b/.changesets/1781955118-feat-pool-pane-tear-off-pool-on-macos-linux-floating-pool-uu-ft4c.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pool): pane tear-off pool on macOS/Linux — floating-pool-{uuid} pre-warmed frameless windows

--- a/.changesets/1781956729-feat-pool-windows-pane-tear-off-pool-ws-popup-pre-warmed-flo-07i8.md
+++ b/.changesets/1781956729-feat-pool-windows-pane-tear-off-pool-ws-popup-pre-warmed-flo-07i8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pool): Windows pane tear-off pool — WS_POPUP pre-warmed floating-pool windows

--- a/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
+++ b/.changesets/1781972847-feat-tear-off-resize-mother-window-when-tearing-off-a-full-h-k5jw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tear-off): resize mother window when tearing off a full-height pane column

--- a/.changesets/1781972947-feat-muxbus-auto-register-agents-with-cloud-subscriber-at-sp-fnyo.md
+++ b/.changesets/1781972947-feat-muxbus-auto-register-agents-with-cloud-subscriber-at-sp-fnyo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxbus): auto-register agents with cloud subscriber at spawn/stop

--- a/.changesets/1781973703-feat-linux-session-aware-startup-splash-x11-wayland-backends-vtbt.md
+++ b/.changesets/1781973703-feat-linux-session-aware-startup-splash-x11-wayland-backends-vtbt.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(linux): session-aware startup splash (X11 + Wayland backends)

--- a/.changesets/1781975234-feat-trust-center-rename-memory-bundles-to-presets-presets-a-jrgq.md
+++ b/.changesets/1781975234-feat-trust-center-rename-memory-bundles-to-presets-presets-a-jrgq.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(trust-center): rename Memory bundles to Presets; presets are provider-agnostic

--- a/.changesets/1781976316-fix-mcp-prefer-agentmux-blockid-over-agentmux-agent-bus-id-f-5j8a.md
+++ b/.changesets/1781976316-fix-mcp-prefer-agentmux-blockid-over-agentmux-agent-bus-id-f-5j8a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(mcp): prefer AGENTMUX_BLOCKID over AGENTMUX_AGENT_BUS_ID for shell scope

--- a/.changesets/1781977194-fix-win32-suppress-console-windows-for-bashwrap-and-persiste-78b1.md
+++ b/.changesets/1781977194-fix-win32-suppress-console-windows-for-bashwrap-and-persiste-78b1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(win32): suppress console windows for bashwrap and persistent shell spawns

--- a/.changesets/1781979079-feat-voice-whisper-stt-engine-capture-audio-and-transcribe-v-licc.md
+++ b/.changesets/1781979079-feat-voice-whisper-stt-engine-capture-audio-and-transcribe-v-licc.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(voice): Whisper STT engine — capture audio and transcribe via Groq

--- a/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
+++ b/.changesets/1781981537-security-cef-enable-renderer-sandbox-on-macos-and-linux-1374-a8kx.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-security(cef): enable renderer sandbox on macOS and Linux (issue #1374)

--- a/.changesets/1781982267-feat-voice-offline-whisper-cpp-backend-whisper-local-engine-2qdr.md
+++ b/.changesets/1781982267-feat-voice-offline-whisper-cpp-backend-whisper-local-engine-2qdr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(voice): offline whisper.cpp backend (whisper-local engine)

--- a/.changesets/1781984071-fix-auth-provider-env-isolation-no-claude-pollution.md
+++ b/.changesets/1781984071-fix-auth-provider-env-isolation-no-claude-pollution.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): provider environment isolation — agents read/refresh credentials in the AgentMux dir, never the user's ~/.claude (provider-isolation auth half: migration reversal of #983 pointer-to-ambient + sweep + hardened seed target)

--- a/.changesets/1781984338-feat-voice-auto-download-whisper-model-for-the-local-engine-smo4.md
+++ b/.changesets/1781984338-feat-voice-auto-download-whisper-model-for-the-local-engine-smo4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(voice): auto-download whisper model for the local engine

--- a/.changesets/1781984501-fix-editor-markdown-preview-width-first-open-blank-render-an-uiuf.md
+++ b/.changesets/1781984501-fix-editor-markdown-preview-width-first-open-blank-render-an-uiuf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): markdown preview width, first-open blank render, and tab path tooltip

--- a/.changesets/1781984600-chore-muxbus-set-vite-muxbus-client-id-from-deployed-cognito-stack-m1.md
+++ b/.changesets/1781984600-chore-muxbus-set-vite-muxbus-client-id-from-deployed-cognito-stack-m1.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-chore(M1): set VITE_MUXBUS_CLIENT_ID from deployed Cognito stack

--- a/.changesets/1781984693-feat-agent-context-compaction-transcript-marker-g7dw.md
+++ b/.changesets/1781984693-feat-agent-context-compaction-transcript-marker-g7dw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): context compaction transcript marker

--- a/.changesets/1781995700-fix-linux-splash-fade-out-rounded-corners-and-primary-monito-hr4p.md
+++ b/.changesets/1781995700-fix-linux-splash-fade-out-rounded-corners-and-primary-monito-hr4p.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux-splash): fade-out, rounded corners, and primary-monitor centering

--- a/.changesets/1781995722-feat-agent-pane-aggressive-url-hyperlinking-linkify-it-detec-xddu.md
+++ b/.changesets/1781995722-feat-agent-pane-aggressive-url-hyperlinking-linkify-it-detec-xddu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): aggressive URL hyperlinking — linkify-it detects bare domains, localhost:PORT, and https:// links in all agent pane text nodes

--- a/.changesets/1781996547534-security-cef-windows-sandbox-phase3-dll-wrapper-1374-w9kx.md
+++ b/.changesets/1781996547534-security-cef-windows-sandbox-phase3-dll-wrapper-1374-w9kx.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-security(cef): enable renderer sandbox on Windows via DLL wrapper pattern (issue #1374)

--- a/.changesets/1781997998-feat-tab-larger-close-button-context-menu-dismiss-close-conf-yael.md
+++ b/.changesets/1781997998-feat-tab-larger-close-button-context-menu-dismiss-close-conf-yael.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tab): larger close button, context-menu dismiss, close-confirm modal

--- a/.changesets/1782000000-fix-macos26-dual-dock-icon-lsuielement-launcher-vtbt.md
+++ b/.changesets/1782000000-fix-macos26-dual-dock-icon-lsuielement-launcher-vtbt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): add LSUIElement to launcher Info.plist to eliminate duplicate Dock icon on macOS 26 Tahoe

--- a/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
+++ b/.changesets/1782002647-fix-cef-disable-macos-renderer-sandbox-in-dev-skip-seatbelt--kj87.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): disable macOS renderer sandbox in dev — skip Seatbelt init and pass no_sandbox=1 when libcef_sandbox.dylib is absent (task dev flat layout)

--- a/.changesets/1782003217-fix-ui-pane-tear-off-renders-full-window-instead-of-floating-pk1z.md
+++ b/.changesets/1782003217-fix-ui-pane-tear-off-renders-full-window-instead-of-floating-pk1z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): pane tear-off renders full window instead of floating pane when using pool fast path

--- a/.changesets/1782003483-fix-cef-cache-path-and-dynamic-debug-port.md
+++ b/.changesets/1782003483-fix-cef-cache-path-and-dynamic-debug-port.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): root per-window browser contexts under root_cache_path (stop in-memory fallback) + pick a free remote-debugging port per instance (stop multi-instance bind() collision)

--- a/.changesets/1782003804-fix-cursor-restrict-hand-cursor-to-hyperlinks-only-arrow-on--guwr.md
+++ b/.changesets/1782003804-fix-cursor-restrict-hand-cursor-to-hyperlinks-only-arrow-on--guwr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cursor): restrict hand cursor to hyperlinks only — arrow on all UI controls

--- a/.changesets/1782003902-fix-exec-pin-claude-cli-to-2-1-185-annotate-detect-cli-as-in-o6lo.md
+++ b/.changesets/1782003902-fix-exec-pin-claude-cli-to-2-1-185-annotate-detect-cli-as-in-o6lo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(exec): pin Claude CLI to 2.1.185, annotate detect_cli as informational-only (INV-X)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.46.6"
+version = "0.47.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,36 @@
 # AgentMux Version History
 
+## 0.47.0 — 2026-06-20
+
+- feat(sound): ambient waiting tone when agent is blocked for user input
+- feat(pool): pane tear-off pool on macOS/Linux — floating-pool-{uuid} pre-warmed frameless windows
+- feat(pool): Windows pane tear-off pool — WS_POPUP pre-warmed floating-pool windows
+- feat(tear-off): resize mother window when tearing off a full-height pane column
+- feat(muxbus): auto-register agents with cloud subscriber at spawn/stop
+- feat(linux): session-aware startup splash (X11 + Wayland backends)
+- feat(trust-center): rename Memory bundles to Presets; presets are provider-agnostic
+- fix(mcp): prefer AGENTMUX_BLOCKID over AGENTMUX_AGENT_BUS_ID for shell scope
+- fix(win32): suppress console windows for bashwrap and persistent shell spawns
+- feat(voice): Whisper STT engine — capture audio and transcribe via Groq
+- security(cef): enable renderer sandbox on macOS and Linux (issue #1374)
+- feat(voice): offline whisper.cpp backend (whisper-local engine)
+- fix(auth): provider environment isolation — agents read/refresh credentials in the AgentMux dir, never the user's ~/.claude (provider-isolation auth half: migration reversal of #983 pointer-to-ambient + sweep + hardened seed target)
+- feat(voice): auto-download whisper model for the local engine
+- fix(editor): markdown preview width, first-open blank render, and tab path tooltip
+- chore(M1): set VITE_MUXBUS_CLIENT_ID from deployed Cognito stack
+- feat(agent): context compaction transcript marker
+- fix(linux-splash): fade-out, rounded corners, and primary-monitor centering
+- feat(agent-pane): aggressive URL hyperlinking — linkify-it detects bare domains, localhost:PORT, and https:// links in all agent pane text nodes
+- security(cef): enable renderer sandbox on Windows via DLL wrapper pattern (issue #1374)
+- feat(tab): larger close button, context-menu dismiss, close-confirm modal
+- fix(macos): add LSUIElement to launcher Info.plist to eliminate duplicate Dock icon on macOS 26 Tahoe
+- fix(cef): disable macOS renderer sandbox in dev — skip Seatbelt init and pass no_sandbox=1 when libcef_sandbox.dylib is absent (task dev flat layout)
+- fix(ui): pane tear-off renders full window instead of floating pane when using pool fast path
+- fix(cef): root per-window browser contexts under root_cache_path (stop in-memory fallback) + pick a free remote-debugging port per instance (stop multi-instance bind() collision)
+- fix(cursor): restrict hand cursor to hyperlinks only — arrow on all UI controls
+- fix(exec): pin Claude CLI to 2.1.185, annotate detect_cli as informational-only (INV-X)
+
+
 ## 0.46.6 — 2026-06-20
 
 - fix(win32): bind floater cascade to source window; fix z-order and multi-window regression

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.46.6",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.46.6",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.46.6",
+  "version": "0.47.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## v0.47.0

Consumes 27 pending changesets. Minor bump for the voice STT engine, CEF renderer sandbox, tear-off pool, and URL hyperlinking features.

## Changelog

- feat(sound): ambient waiting tone when agent is blocked for user input
- feat(pool): pane tear-off pool on macOS/Linux — pre-warmed frameless windows
- feat(pool): Windows pane tear-off pool — WS_POPUP pre-warmed floating windows
- feat(tear-off): resize mother window when tearing off a full-height pane column
- feat(muxbus): auto-register agents with cloud subscriber at spawn/stop
- feat(linux): session-aware startup splash (X11 + Wayland backends)
- feat(trust-center): rename Memory bundles to Presets
- fix(mcp): prefer AGENTMUX_BLOCKID over AGENTMUX_AGENT_BUS_ID for shell scope
- fix(win32): suppress console windows for bashwrap and persistent shell spawns
- feat(voice): Whisper STT engine — capture audio and transcribe via Groq
- security(cef): enable renderer sandbox on macOS and Linux (#1374)
- feat(voice): offline whisper.cpp backend (whisper-local engine)
- fix(auth): provider environment isolation — agents read/refresh credentials in the AgentMux dir
- feat(voice): auto-download whisper model for the local engine
- fix(editor): markdown preview width, first-open blank render, tab path tooltip
- feat(agent): context compaction transcript marker
- fix(linux-splash): fade-out, rounded corners, primary-monitor centering
- feat(agent-pane): aggressive URL hyperlinking — linkify-it, bare domains, localhost:PORT
- security(cef): enable renderer sandbox on Windows via DLL wrapper (#1374)
- feat(tab): larger close button, context-menu dismiss, close-confirm modal
- fix(macos): eliminate duplicate Dock icon on macOS 26 Tahoe (LSUIElement)
- fix(cef): disable macOS renderer sandbox in dev; fix cache path; fix remote-debugging port
- fix(ui): pane tear-off renders full window instead of floating pane
- fix(cursor): restrict hand cursor to hyperlinks only
- fix(exec): pin Claude CLI to 2.1.185

## Release checklist
- [ ] VERSION_HISTORY.md updated ✓
- [ ] package.json → 0.47.0 ✓
- [ ] Cargo.toml → 0.47.0 ✓
- [ ] All 27 changesets consumed ✓

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)