### PR TITLE
fix(cef): restore the AgentMux icon on Windows sandbox builds (#1633 regression)

### DIFF
--- a/.changesets/1782005606-fix-sandbox-taskbar-and-exe-icon.md
+++ b/.changesets/1782005606-fix-sandbox-taskbar-and-exe-icon.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): restore the AgentMux icon on Windows sandbox builds (Chrome-icon regression from #1633). Load the window/taskbar icon from the host module (cdylib) via GetModuleHandleExW(FROM_ADDRESS) instead of the bootstrap.exe process exe, and stamp the AgentMux icon onto the bootstrap.exe host at package time with rcedit (fixes the Explorer / Task Manager / Alt-Tab exe-file icon).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -493,6 +493,10 @@ tasks:
                 } else {
                   Copy-Item target/release/agentmux-cef.exe dist/cef/agentmux-cef.exe -Force
                 }"
+            # Stamp the AgentMux icon onto the staged host exe — bootstrap.exe
+            # ships Chrome's icon under the Phase 3 sandbox; winres can't edit a
+            # built PE so rcedit rewrites the resource. Idempotent on the raw bin.
+            - cmd: bash scripts/inject-exe-icon.sh dist/cef/agentmux-cef.exe
             - echo "✓ Built host + launcher for Windows"
 
     build:host:darwin:

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -454,11 +454,27 @@ pub(super) unsafe fn skip_taskbar(hwnd: *mut std::ffi::c_void) {
 #[cfg(target_os = "windows")]
 pub(super) unsafe fn set_window_icon(hwnd: *mut std::ffi::c_void) {
     use windows_sys::Win32::UI::WindowsAndMessaging::*;
-    use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows_sys::Win32::System::LibraryLoader::{
+        GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    };
 
-    let hinstance = GetModuleHandleW(std::ptr::null());
-    if hinstance.is_null() {
-        tracing::warn!("set_window_icon: GetModuleHandleW returned null");
+    // Resolve the module that CONTAINS this code, NOT the process exe. Under the
+    // Phase 3 Windows sandbox (#1633) the host process is CEF's bootstrap.exe —
+    // which has no AgentMux icon resource — while the real host logic + the
+    // winres-embedded icon live in agentmux_cef.dll. The old
+    // `GetModuleHandleW(null)` returned bootstrap.exe → no resource ID 1 → the
+    // window/taskbar fell back to Chrome's icon. `FROM_ADDRESS` on a function in
+    // this module returns the DLL (sandbox build) or the exe (non-sandbox build)
+    // — whichever actually carries the embedded resource.
+    let mut hinstance: windows_sys::Win32::Foundation::HMODULE = std::ptr::null_mut();
+    let got = GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        set_window_icon as *const () as *const u16,
+        &mut hinstance,
+    );
+    if got == 0 || hinstance.is_null() {
+        tracing::warn!("set_window_icon: GetModuleHandleExW(FROM_ADDRESS) failed");
         return;
     }
 

--- a/scripts/inject-exe-icon.sh
+++ b/scripts/inject-exe-icon.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Set the AgentMux icon on a Windows host exe.
+#
+# Why: the Phase 3 Windows sandbox host (#1633) is CEF's bootstrap.exe (renamed
+# to the host exe), which ships Chrome's icon — so Explorer / Task Manager /
+# Alt-Tab show Chrome instead of AgentMux. (The running WINDOW icon is fixed
+# separately at runtime via set_window_icon → WM_SETICON; this fixes the EXE
+# FILE's own icon resource.) winres can't edit an already-built PE, so we rewrite
+# the icon resource with electron's `rcedit`. Idempotent — safe to run on the
+# non-sandbox raw bin too (it just re-sets the same icon).
+#
+# Usage: bash scripts/inject-exe-icon.sh <path-to-exe>
+set -euo pipefail
+
+EXE="${1:?usage: inject-exe-icon.sh <exe>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ICO="$REPO_ROOT/agentmux-cef/resources/win/agentmux.ico"
+
+[ -f "$EXE" ] || { echo "inject-exe-icon: exe not found: $EXE" >&2; exit 1; }
+[ -f "$ICO" ] || { echo "inject-exe-icon: icon not found: $ICO" >&2; exit 1; }
+
+# rcedit is a BUILD tool (not shipped) — cache it under the account-wide build
+# tools dir, pinned by sha256.
+RCEDIT_URL="https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe"
+RCEDIT_SHA="3e7801db1a5edbec91b49a24a094aad776cb4515488ea5a4ca2289c400eade2a"
+CACHE_DIR="${AGENTMUX_BUILD_TOOLS:-$HOME/.agentmux/build-tools}"
+RCEDIT="$CACHE_DIR/rcedit-x64.exe"
+mkdir -p "$CACHE_DIR"
+
+if [ ! -f "$RCEDIT" ] || [ "$(sha256sum "$RCEDIT" | cut -d' ' -f1)" != "$RCEDIT_SHA" ]; then
+    echo "  [icon] downloading rcedit (v2.0.0)…"
+    curl -fsSL "$RCEDIT_URL" -o "$RCEDIT"
+    got="$(sha256sum "$RCEDIT" | cut -d' ' -f1)"
+    if [ "$got" != "$RCEDIT_SHA" ]; then
+        echo "inject-exe-icon: rcedit sha256 mismatch (expected $RCEDIT_SHA got $got)" >&2
+        rm -f "$RCEDIT"
+        exit 1
+    fi
+fi
+
+# rcedit is a native Windows exe — feed it Windows paths.
+win() { cygpath -w "$1" 2>/dev/null || echo "$1"; }
+win_exe="$(win "$EXE")"
+win_ico="$(win "$ICO")"
+
+# rcedit can transiently fail with "Unable to commit changes" when a scanner
+# (Defender / Search indexer) still holds a handle on the just-copied exe — the
+# same handle race that bites CEF extraction. Retry, then degrade to a warning:
+# a missed exe-file icon stamp must NOT break packaging (the runtime WINDOW icon
+# is set independently at startup via set_window_icon → WM_SETICON).
+err="$(mktemp)"
+attempt=0
+max=6
+until "$RCEDIT" "$win_exe" --set-icon "$win_ico" 2>"$err"; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge "$max" ]; then
+        echo "  [icon] WARNING: rcedit failed after $max attempts on $(basename "$EXE") —" >&2
+        echo "         shipping without the stamped exe-file icon (runtime window icon unaffected):" >&2
+        sed 's/^/           /' "$err" >&2
+        rm -f "$err"
+        exit 0
+    fi
+    echo "  [icon] rcedit busy (attempt $attempt/$max) — retrying in 2s…" >&2
+    sleep 2
+done
+rm -f "$err"
+echo "  [icon] set AgentMux icon on $(basename "$EXE")"

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -138,6 +138,15 @@ else
     echo "         Build with the default 'sandbox' feature for a sandboxed Windows portable." >&2
     cp target/release/agentmux-cef.exe "$PORTABLE/runtime/agentmux-$VERSION.exe"
 fi
+
+# Stamp the AgentMux icon onto the staged host exe. Under the Phase 3 sandbox the
+# host is CEF's bootstrap.exe (ships Chrome's icon); winres can't edit an
+# already-built PE, so rewrite the icon resource here (idempotent on the raw-bin
+# path too). Fixes the Explorer / Task Manager / Alt-Tab exe-file icon — the
+# #1633 regression. The running WINDOW icon is fixed separately at runtime
+# (set_window_icon → WM_SETICON).
+bash "$REPO_ROOT/scripts/inject-exe-icon.sh" "$PORTABLE/runtime/agentmux-$VERSION.exe"
+
 cp dist/bin/agentmux-srv-$VERSION-windows.x64.exe "$PORTABLE/runtime/"
 
 # Streaming bash wrapper — invoked by Claude's Bash subprocess via the


### PR DESCRIPTION
The Phase 3 Windows sandbox (#1633) makes the host process CEF's **bootstrap.exe**, which ships Chrome's icon and carries none of the winres-embedded AgentMux resources (those went into the cdylib + the old raw bin). Two surfaces showed Chrome.

## 1. Running window / taskbar / Alt-Tab
`set_window_icon` used `GetModuleHandleW(null)` → the *process exe* (bootstrap.exe) → no resource ID 1 → "no icon found" → Chrome.
**Fix:** resolve the module that *contains the code* via `GetModuleHandleExW(FROM_ADDRESS)` — the cdylib (sandbox build) or the exe (non-sandbox), whichever carries the embedded icon.
**Verified:** host log now logs `Set window icon from embedded resource` (was "no icon found"). User confirmed visually.

## 2. Host exe-file icon (Explorer / Task Manager / Alt-Tab thumbnail)
winres can't edit an already-built PE, so we stamp the AgentMux icon onto the staged host exe at package time with electron's **rcedit** (pinned by sha256, cached under `~/.agentmux/build-tools`, idempotent on the raw bin). Wired into `package-portable.sh` **and** `build:host:windows`.
rcedit can transiently fail (`Unable to commit changes`) when Defender / the search indexer still holds a handle on the just-copied exe — the same race that bites CEF extraction — so the helper **retries, then degrades to a warning** (a cosmetic stamp must never break packaging; the runtime window icon is set independently).
**Verified:** the stamped exe icon hash (`530460D2…`) differs from the un-stamped Chrome bootstrap (`84303ABE…`).

## Installer
Already correct — `SetupIconFile=agentmux.ico`, `AppExe=agentmux.exe` (the *launcher*, which has the icon), shortcuts use `IconFilename: agentmux.ico`. The installed host exe inherits the stamp via the packaged portable. No change needed.

## Files
- `agentmux-cef/src/client/wndproc.rs` — Fix A (`GetModuleHandleExW(FROM_ADDRESS)`)
- `scripts/inject-exe-icon.sh` (new) — rcedit helper (pinned, cached, retry+degrade)
- `scripts/package-portable.sh`, `Taskfile.yml` — wire the stamp into both build paths

`cargo check -p agentmux-cef` clean; built + verified on a real portable.

<!-- agentmux:agent_id=smike -->