### PR TITLE
chore: release v0.47.1

### DIFF
--- a/.changesets/1781997497-fix-linux-restrict-pane-tear-off-to-header-whole-tile-drag-t-2uur.md
+++ b/.changesets/1781997497-fix-linux-restrict-pane-tear-off-to-header-whole-tile-drag-t-2uur.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux): restrict pane tear-off to header — whole-tile drag triggered tear-off anywhere

--- a/.changesets/1782005606-fix-sandbox-taskbar-and-exe-icon.md
+++ b/.changesets/1782005606-fix-sandbox-taskbar-and-exe-icon.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): restore the AgentMux icon on Windows sandbox builds (Chrome-icon regression from #1633). Load the window/taskbar icon from the host module (cdylib) via GetModuleHandleExW(FROM_ADDRESS) instead of the bootstrap.exe process exe, and stamp the AgentMux icon onto the bootstrap.exe host at package time with rcedit (fixes the Explorer / Task Manager / Alt-Tab exe-file icon).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.47.0"
+version = "0.47.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,11 @@
 # AgentMux Version History
 
+## 0.47.1 — 2026-06-21
+
+- fix(linux): restrict pane tear-off to header — whole-tile drag triggered tear-off anywhere
+- fix(cef): restore the AgentMux icon on Windows sandbox builds (Chrome-icon regression from #1633). Load the window/taskbar icon from the host module (cdylib) via GetModuleHandleExW(FROM_ADDRESS) instead of the bootstrap.exe process exe, and stamp the AgentMux icon onto the bootstrap.exe host at package time with rcedit (fixes the Explorer / Task Manager / Alt-Tab exe-file icon).
+
+
 ## 0.47.0 — 2026-06-20
 
 - feat(sound): ambient waiting tone when agent is blocked for user input

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.47.0",
+      "version": "0.47.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes the two queued `patch` changesets and bumps **0.47.0 → 0.47.1**:

- fix(linux): restrict pane tear-off to header only (#1635)
- fix(sandbox): taskbar and exe icon

All 5 version locations agree (release-consistency check passes). Changesets deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)