### PR TITLE
fix(macos): per-version bundle id — ai.agentmux.<channel>.<version>

### DIFF
--- a/.changesets/1782034958-fix-macos-per-version-bundle-id-ai-agentmux-channel-version--xj85.md
+++ b/.changesets/1782034958-fix-macos-per-version-bundle-id-ai-agentmux-channel-version--xj85.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): per-version bundle id (ai.agentmux.<channel>.<version>) — double-click any build without open -n

--- a/docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md
+++ b/docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md
@@ -1,8 +1,9 @@
-# SPEC: macOS Launch Coherence — Channel-Scoped Bundle ID, Reopen Handler, Unix Window Forward
+# SPEC: macOS Launch Coherence — Per-Version Bundle ID, Reopen Handler, Unix Window Forward
 
 - **Date:** 2026-06-18
-- **Status:** Proposed → implementation in progress
-- **Owner decision:** bundle id follows the channel; the default/release channel `stable` is suffixed explicitly (`ai.agentmux.cef.stable`).
+- **Updated:** 2026-06-21
+- **Status:** Implemented
+- **Owner decision:** bundle id is `ai.agentmux.<channel>.<version>` — every release is a distinct macOS app.
 
 ---
 
@@ -19,7 +20,7 @@ While running 0.44.1 / 0.45.0 / 0.46.1 / 0.46.3 simultaneously on macOS:
 ## 2. Root causes
 
 ### A. One constant bundle identifier → LaunchServices collision
-`scripts/package-macos.sh:58` → `BUNDLE_ID="ai.agentmux.cef"`, constant across every version **and** channel (helpers at `:171`, main app at `:207`). macOS LaunchServices keys app identity on `CFBundleIdentifier`. With one id for all builds, double-clicking build B while build A runs makes LaunchServices **reactivate A** (send it the reopen Apple Event) instead of launching B.
+`scripts/package-macos.sh:58` → `BUNDLE_ID="ai.agentmux.cef"`, constant across every version **and** channel (helpers at `:171`, main app at `:207`). macOS LaunchServices keys app identity on `CFBundleIdentifier`. With one id for all builds, double-clicking build B while build A runs makes LaunchServices **reactivate A** (send it the reopen Apple Event) instead of launching B. (Later narrowed to channel-scoped; then fully resolved by adding version — see §4.)
 
 ### B. No reopen handler
 No `applicationShouldHandleReopen:` / `kAEReopenApplication` handler exists in `agentmux-cef` or `agentmux-launcher` (only `setActivationPolicy`, `agentmux-cef/src/main.rs:1419-1461`). So the reactivation from (A) has nothing to answer it → LaunchServices times out → **"not responding."** A normal double-click of the running app also produces no new window.
@@ -48,27 +49,26 @@ Today the OS layer is a **constant** while the launcher layer is **per-(channel,
 
 ---
 
-## 4. Decision: bundle id follows the channel
+## 4. Decision: bundle id is `ai.agentmux.<channel>.<version>`
 
-`CFBundleIdentifier = ai.agentmux.cef.<channel>`, derived from the **same** channel the binary is compiled with — `AGENTMUX_BUILD_CHANNEL_DEFAULT` (compile-time `option_env!`, default `"stable"`, `data_paths.rs:55-57`; `"default"` is a synonym for `"stable"`, `:458`). `scripts/package.sh:151` already exports `$CHANNEL` into `AGENTMUX_BUILD_CHANNEL_DEFAULT` for the cargo build; `package-macos.sh` reads the same value for the Info.plist. **Single source of truth** → the OS identity and the runtime channel cannot drift apart.
+`CFBundleIdentifier = ai.agentmux.<channel>.<version>`. Channel is derived from `AGENTMUX_BUILD_CHANNEL_DEFAULT` (compile-time `option_env!`, default `"stable"`, `data_paths.rs:55-57`) — the same value compiled into the binary — so the OS identity and runtime channel cannot drift. Version comes from `package.json` (semver, e.g. `0.47.0`).
 
-- **Default/release channel `stable` → `ai.agentmux.cef.stable`** (explicit suffix — uniform scheme, no bare special-case).
-- `dev` → `ai.agentmux.cef.dev`.
-- local builds → `ai.agentmux.cef.local-<branch>-<hash>-<build-id>` (sanitized to the bundle-id charset: `[A-Za-z0-9-.]`).
-- Helpers inherit the suffix automatically via `${BUNDLE_ID}.helper[.type]` (`package-macos.sh:171`).
+- `stable` 0.47.0 → `ai.agentmux.stable.0.47.0`
+- `dev` → `ai.agentmux.dev.<version>`
+- local builds → `ai.agentmux.local-<branch>-<hash>-<build-id>.<version>` (channel sanitized to `[A-Za-z0-9.-]`)
+- Helpers inherit automatically via `${BUNDLE_ID}.helper[.type]`.
 
-### What this fixes / doesn't
-- **Cross-channel:** dev/local builds become **distinct macOS apps** → double-click-launchable side by side with a running stable, no `open -n`. Local builds already carry a per-build hash *in the channel*, so every local build is its own app for free.
-- **Same channel, different versions** (stable 0.45.0 vs 0.46.3): still share `ai.agentmux.cef.stable` **by design**. Running two stable *releases* at once stays an `open -n` operation — intentional (avoids per-release Dock-app sprawl, which is what created the data-dir explosion in the first place).
+### What this fixes
+Every build — including two stable *releases* — is a **distinct macOS app**. Double-clicking any version always launches it directly, no `open -n` required.
 
-### Migration consequence of `.stable`
-Existing stable installs report `ai.agentmux.cef` today. Switching to `ai.agentmux.cef.stable` is a **one-time app-identity change**: on the next stable update macOS treats it as a new app → previously-granted permissions (notifications, screen recording, accessibility), login items, and default-app associations reset **once**; LaunchServices may keep a duplicate registration until the stale one is pruned. Accepted by the owner in exchange for a uniform, drift-proof scheme.
+### Migration consequence
+Existing installs report `ai.agentmux.cef` or `ai.agentmux.cef.stable`. The new scheme is a one-time app-identity change per version: macOS treats each new id as a new app → previously-granted permissions (notifications, screen recording, accessibility), login items, and default-app associations reset once per identity. Accepted in exchange for collision-free side-by-side launches.
 
 ---
 
 ## 5. Fix plan (one branch / PR)
 
-1. **`scripts/package-macos.sh`** — derive `BUNDLE_ID="ai.agentmux.cef.${CHANNEL}"` from `${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}`, sanitized; app / helpers / entitlements inherit it. (Attach target = right process.)
+1. **`scripts/package-macos.sh`** — derive `BUNDLE_ID="ai.agentmux.${CHANNEL}.${VERSION}"` from `${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}` + `package.json` version, channel sanitized; app / helpers / entitlements inherit it. (Attach target = right process.)
 2. **Reopen handler (Rust/AppKit, `agentmux-cef`)** — on `applicationShouldHandleReopen:` / `kAEReopenApplication`, POST `open_new_window` to self. Fixes "not responding" **and** makes a plain double-click open a window. (Attach action.)
 3. **Unix forward (`agentmux-launcher/src/main.rs:585`)** — call `forward_open_new_window` before exiting, mirroring the Windows path, for the `open -n` / CLI route.
 
@@ -81,6 +81,6 @@ Existing stable installs report `ai.agentmux.cef` today. Switching to `ai.agentm
 
 ## 7. Status (verified on-device 2026-06-18)
 
-- **#1 channel-scoped bundle id — ✅ verified.** A `.stable` build launches alongside a running `ai.agentmux.cef` 0.45.0 with **no "not responding"**; LaunchServices registers it as a distinct app, and helpers inherit `…stable.helper.*`.
+- **#1 per-version bundle id — ✅ implemented (2026-06-21).** Format `ai.agentmux.<channel>.<version>` — every release is a distinct macOS app; double-click always works without `open -n`.
 - **#3 unix `open_new_window` forward — ✅ verified.** `open -n` of a second instance opens a new window in the running instance, and the second launcher forwards then exits.
 - **#2 reopen handler — ✅ fixed (follow-up, 2026-06-18).** The first attempt — a raw `NSAppleEventManager` `kAEReopenApplication` handler — was **inert**: CEF re-registers its own AE handler after ours, so it never fired. The working fix installs a dedicated **NSApplication delegate** implementing `applicationShouldHandleReopen:hasVisibleWindows:` (CEF sets no delegate of its own — confirmed by the `reopen-hook: installed dedicated reopen delegate (NSApp had none)` log) and opens a new window. Verified on-device: an `open`/reopen of the running build logs `reopen-hook:fired` and a second window appears (renderer count 2→3). A plain Finder/Dock double-click of the running app now opens a new window; `open -n` and the in-app **"+ Open another window"** remain alternatives.

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -55,18 +55,17 @@ CERT="${MACOS_SIGN_CERT:-$(security find-identity -v -p codesigning 2>/dev/null 
         | awk -F'"' '/Developer ID Application/ {print $2; exit}')}"
 [ -n "$CERT" ] || { echo "❌ No 'Developer ID Application' identity in the keychain (and MACOS_SIGN_CERT unset)." >&2; exit 1; }
 ENTITLEMENTS="$REPO_ROOT/build/entitlements.mac.plist"
-# Bundle id follows the build CHANNEL so LaunchServices' app identity matches the
-# runtime data-dir channel (~/.agentmux/channels/<channel>/…). The channel is the
-# SAME value compiled into the binaries via AGENTMUX_BUILD_CHANNEL_DEFAULT
-# (agentmux-common/src/data_paths.rs; default "stable"), so the OS identity and the
-# launcher's per-(channel,version) instance key can't drift apart. dev/local builds
-# thus become distinct macOS apps (double-click-launchable beside a running stable);
-# only two stable RELEASES still share an id (by design — avoids per-release sprawl).
-# Sanitize to the bundle-id charset [A-Za-z0-9.-].
+# Bundle id: ai.agentmux.<channel>.<version>
+# Channel matches AGENTMUX_BUILD_CHANNEL_DEFAULT compiled into the binaries
+# (agentmux-common/src/data_paths.rs; default "stable"), keeping OS identity and
+# runtime channel in sync. Version suffix makes every release a distinct macOS app,
+# so double-clicking any build works without needing `open -n`.
+# Sanitize channel to the bundle-id charset [A-Za-z0-9.-]; VERSION (semver) is
+# already clean.
 # See docs/specs/SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md.
 CHANNEL="${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}"
 CHANNEL_ID="$(printf '%s' "$CHANNEL" | tr -C 'A-Za-z0-9.-' '-' | tr '[:upper:]' '[:lower:]')"
-BUNDLE_ID="ai.agentmux.cef.${CHANNEL_ID}"
+BUNDLE_ID="ai.agentmux.${CHANNEL_ID}.${VERSION}"
 NOTARIZE="${NOTARIZE:-1}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-notarytool}"
 SRV="dist/bin/agentmux-srv-${VERSION}-darwin.${ARCH}"


### PR DESCRIPTION
## Summary

- Drops the redundant `cef` segment from the macOS bundle ID
- Appends the semver version so every release is a distinct macOS app: `ai.agentmux.stable.0.47.0`
- Double-clicking any build now works without `open -n`, even when another version is running
- Updates `SPEC_MACOS_LAUNCH_COHERENCE_2026_06_18.md` to reflect the final scheme

## Before / After

| | Before | After |
|--|--|--|
| stable 0.47.0 | `ai.agentmux.cef.stable` | `ai.agentmux.stable.0.47.0` |
| stable 0.46.3 | `ai.agentmux.cef.stable` | `ai.agentmux.stable.0.46.3` |
| dev | `ai.agentmux.cef.dev` | `ai.agentmux.dev.0.47.0` |

## Test plan

- [ ] Build DMG, double-click while previous version DMG is already running — should launch directly, no "not responding" dialog
- [ ] Bundle ID in built `.app/Contents/Info.plist` matches `ai.agentmux.stable.<version>`
- [ ] Helpers inherit correctly: `ai.agentmux.stable.<version>.helper`, `.helper.gpu`, `.helper.renderer`

<!-- agentmux:agent_id=masty-06136 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)