### PR TITLE
fix(srv): set CREATE_NO_WINDOW on agent/LSP spawns — stop Windows 11 Terminal-window leak

### DIFF
--- a/.changesets/1782035405-fix-srv-set-create-no-window-on-persistent-agent-task-runner-c4jg.md
+++ b/.changesets/1782035405-fix-srv-set-create-no-window-on-persistent-agent-task-runner-c4jg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): set CREATE_NO_WINDOW on persistent-agent, task-runner, and LSP spawns (stops Windows 11 opening a Terminal window per spawn)

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -123,6 +123,15 @@ pub(crate) async fn run_agent_with_bin(
     if let Some(n) = task.max_turns {
         cmd.arg("--max-turns").arg(n.to_string());
     }
+    // On Windows: suppress console-window allocation. Spawned from the windowless
+    // srv without CREATE_NO_WINDOW, this one-shot task-agent CLI opens a Windows
+    // Terminal window per run (Win11 default-terminal handler). stdio is piped, so
+    // no console is needed. See docs/retro/retro-windows-terminal-window-leak-2026-06-21.md.
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
     let mut child = cmd
         .arg(&task.prompt)
         .current_dir(&working_dir)

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -563,6 +563,20 @@ impl PersistentSubprocessController {
 
         core::apply_working_dir(&mut cmd, &self.block_id, &config.working_dir, &config.env_vars);
 
+        // On Windows: suppress console-window allocation. The srv runs without a
+        // console of its own, so spawning the agent CLI without CREATE_NO_WINDOW
+        // makes Windows allocate a fresh console — which Windows 11's default-
+        // terminal handler renders as a NEW Windows Terminal window. One leaks per
+        // agent start / resume / respawn; a flapping or restart-heavy session
+        // accumulates dozens. stdio is piped here, so the console is never needed.
+        // See docs/retro/retro-windows-terminal-window-leak-2026-06-21.md.
+        // Matches acp.rs / subprocess.rs; sibling of shell.rs's PTY path.
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());

--- a/agentmux-srv/src/backend/lsp/supervisor.rs
+++ b/agentmux-srv/src/backend/lsp/supervisor.rs
@@ -131,6 +131,17 @@ impl LspSupervisor {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
 
+        // On Windows: suppress console-window allocation. Spawned from the
+        // windowless srv without CREATE_NO_WINDOW, each LSP server (ts-language-
+        // server, pyright, gopls, rust-analyzer) opens a Windows Terminal window
+        // (Win11 default-terminal handler). stdio is piped, so no console is
+        // needed. See docs/retro/retro-windows-terminal-window-leak-2026-06-21.md.
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         let mut child = cmd
             .spawn()
             .map_err(|e| LspError::SpawnFailed(e.to_string()))?;

--- a/docs/retro/retro-windows-terminal-window-leak-2026-06-21.md
+++ b/docs/retro/retro-windows-terminal-window-leak-2026-06-21.md
@@ -1,0 +1,178 @@
+# Retro: AgentMux leaks a Windows Terminal window per agent spawn (Win11)
+
+**Date:** 2026-06-21
+**Severity:** High (UX + resource leak; contributed to a wedged, unrecoverable session)
+**Area:** `agentmux-srv` process spawning (Windows)
+**Fix branch:** `agentc/fix-win-console-window-leak`
+**Status:** Root-caused, fixed, verified
+
+---
+
+## 1. What the user saw
+
+> "We got into a strange state with AgentMux. There are a bunch of open terminals
+> ... when opening .47 from the desktop, it just says 'CEF' in the taskbar and
+> doesn't load anything. I think things regarding lifecycle got corrupted."
+
+Three symptoms, one underlying degraded state:
+1. **~2 dozen (actually 53) terminal windows** open on the desktop.
+2. A **v0.47.0** portable window stuck showing **"CEF"** in the taskbar, blank.
+3. General "lifecycle corruption" — two instances running, orphaned processes.
+
+---
+
+## 2. Inventory (evidence)
+
+### 2.1 Two instances + orphaned processes
+
+`Get-CimInstance Win32_Process` (parent-linked) showed **two** full instances live
+at once:
+
+| Instance | Launcher | Host | Srv | Notes |
+|----------|----------|------|-----|-------|
+| 0.46.6 | `agentmux.exe` 508972 | 212332 (+8 render kids) | 321524 | **+3 orphans** 202972/401192/412208 and conhost 225472 whose parent **PID 556136 was dead** |
+| 0.47.0 | `agentmux.exe` 153864 | 178204 (+10 render kids) | 375764 | window "Window 3 - tab1 - AgentMux" |
+
+The dead-parent orphans (556136) are the literal "lifecycle corruption": a host
+that died without reaping its children, leaving zombies behind.
+
+### 2.2 The "terminals" are Windows Terminal windows
+
+A `user32!EnumWindows` sweep filtering console/terminal window classes returned **54
+visible windows**:
+
+```
+VISIBLE CONSOLE/TERMINAL WINDOWS: 54
+  53 × PID 407772  WindowsTerminal  class=CASCADIA_HOSTING_WINDOW_CLASS  title="Terminal"
+   1 × PID 313696  pwsh             class=ConsoleWindowClass             (this admin session)
+```
+
+**53 of them belong to a single `WindowsTerminal.exe` (PID 407772)**, whose parent
+is `svchost.exe` — i.e. the Windows 11 **DefTerm** (default-terminal) handler.
+Started `06/20 09:56`, it had been accumulating "Terminal" windows for ~24h.
+
+### 2.3 The "CEF" window
+
+`.47` host log (`channels/local-main-b28b7a-86f99d43/.../agentmux-host-v0.47.0.log`)
+showed the stuck window healthy up to:
+
+```
+[frontend] [initApp] pool mode — deferring init until pool:promote or pool:new-window
+```
+
+i.e. a **pre-warmed window-pool window that never received its promote event** — so
+it stays blank with the default CEF title. Memory was tight at the time
+(`load_pct 84`, `avail_phys 9.8 GB`) with two instances + orphans competing. This is
+a *consequence* of the degraded state, not the root cause (§6).
+
+---
+
+## 3. Root cause
+
+### 3.1 The Windows 11 mechanism
+
+`agentmux-srv` runs **without a console of its own**. On Windows, when such a process
+launches a **console** child *without* the `CREATE_NO_WINDOW` (`0x0800_0000`) creation
+flag, the OS allocates a fresh console and hands it to the user's **default terminal
+application**. On Windows 11 that is **Windows Terminal**, so each such spawn becomes a
+**new Windows Terminal window**. ConPTY/`portable-pty` spawns (terminal panes,
+`shell.rs`) are headless and exempt — the leak is only from plain `Command` spawns.
+
+### 3.2 The gap: agent spawn paths omit the flag
+
+A full audit of `Command` spawn sites in `agentmux-srv` shows the flag is applied in
+most places but **missing in three** — including the highest-frequency one:
+
+| Spawn site | Spawns | `CREATE_NO_WINDOW`? |
+|---|---|---|
+| `blockcontroller/acp.rs` | ACP agent CLI | ✅ set |
+| `blockcontroller/subprocess.rs` | subprocess agent CLI | ✅ set |
+| `blockcontroller/shell.rs` | terminal pane (ConPTY) | ✅ set (+ headless PTY) |
+| `backend/shell_node.rs`, `tool_store.rs`, `server/cli_handlers.rs` | helpers/probes | ✅ set |
+| **`blockcontroller/persistent.rs`** | **persistent agent CLI (the main agent type)** | ❌ **missing** |
+| **`agents/runner.rs`** | one-shot `claude --print` task/drone agents | ❌ **missing** |
+| **`backend/lsp/supervisor.rs`** | LSP servers (ts-language-server, pyright, gopls, rust-analyzer) | ❌ **missing** |
+
+`persistent.rs` is the dominant leak: it spawns the agent CLI (`claude.cmd`) for
+**every persistent agent**, and **once per start / resume / respawn**. The
+`core.rs:34` doc comment even names `CREATE_NO_WINDOW` ("must come after the env
+setup") — the intent was known, but the flag was never actually applied on this path.
+
+### 3.3 Why it ran away to 53
+
+The per-spawn leak is multiplied by lifecycle churn:
+- **Health-watchdog flapping.** As documented on 2026-06-18 (Naki), a busy-resuming
+  agent is mislabeled `Healthy→Stalled→Dead` and **respawned** — each respawn is a new
+  leaked window.
+- **Two instances** running for ~24h, each restarting agents.
+- **Orphaned hosts** that died without cleanup.
+
+One leaked window per spawn × many spawns × a day = 53.
+
+---
+
+## 4. The fix
+
+Add the Windows-only flag to the three spawn builders, after `apply_working_dir`
+(per the `core.rs:34` ordering note), copying the existing `acp.rs`/`subprocess.rs`
+idiom. All three use `tokio::process::Command`, whose `creation_flags` is inherent
+(no import), and all three already pipe stdio — so the console was never needed.
+
+```rust
+#[cfg(windows)]
+{
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+```
+
+Files changed:
+- `agentmux-srv/src/backend/blockcontroller/persistent.rs`
+- `agentmux-srv/src/agents/runner.rs`
+- `agentmux-srv/src/backend/lsp/supervisor.rs`
+
+---
+
+## 5. Verification (evidence)
+
+**Cleanup performed during diagnosis (proves the source of the windows):**
+- Killed both instances (launchers first, so the Job Objects reaped children) →
+  `agentmux procs: 0`.
+- Killed `WindowsTerminal.exe` 407772 → visible console/terminal windows dropped
+  **54 → 1** (only this admin pwsh remained). Confirms all 53 were the leak, and that
+  no live agent owned them (they were already detached).
+
+**Build / test (the fix):**
+- `cargo check -p agentmux-srv`: **clean** (exit 0, 27s; 67 warnings, all pre-existing dead-code — none from the change).
+- `cargo test -p agentmux-srv --bins`: **1221 passed, 0 failed, 2 ignored** (compiles + green).
+
+**Behavioural expectation:** with the flag set, a persistent-agent start/resume spawns
+the CLI with stdio piped and **no console allocation**, so DefTerm never opens a
+Windows Terminal window. ConPTY terminal panes are unaffected (already headless).
+
+---
+
+## 6. Follow-ups (separate from this fix)
+
+1. **Health-watchdog false "Dead" on resume** (2026-06-18 retro). It mislabels a
+   busy-resuming agent as dead and forces respawns — which, pre-fix, each leaked a
+   window. Distinguish "process alive, no first token yet" from "hung/dead".
+2. **Window-pool promotion wedging** (the "CEF" blank window). The pool window never
+   got its `pool:promote`. Investigate whether promotion can stall under memory
+   pressure / many windows, and add a fallback so a forwarded `open_new_window`
+   always yields a usable window or a clear error rather than a blank "CEF" frame.
+3. **Orphan reaping.** A host that dies should not leave child render processes +
+   conhosts behind (PID 556136 case). Verify the Job Object kill-on-close path covers
+   abnormal host exit, not just launcher-initiated shutdown.
+
+---
+
+## 7. Timeline
+
+- **2026-06-20 09:56** — `WindowsTerminal.exe` 407772 started by DefTerm; window
+  accumulation begins.
+- **2026-06-21 ~09:2x–09:34** — user opens v0.47.0; pool window wedges ("CEF"); two
+  instances + orphans; 53 terminal windows visible.
+- **2026-06-21** — diagnosis: inventory → EnumWindows → spawn audit; killed instances
+  + WindowsTerminal (54→1 windows); root-caused to missing `CREATE_NO_WINDOW` in
+  `persistent.rs`/`runner.rs`/`supervisor.rs`; fix applied + verified; PR opened.


### PR DESCRIPTION
## Problem

On Windows 11, AgentMux leaks a **Windows Terminal window per agent spawn**. A user hit a degraded session with **53 stray "Terminal" windows** (plus a wedged window-pool "CEF" window and two live instances).

**Mechanism:** `agentmux-srv` runs with no console of its own. When it launches a **console** child *without* `CREATE_NO_WINDOW`, Windows allocates a fresh console and hands it to the default-terminal handler (DefTerm) → **Windows Terminal opens a new window**. ConPTY panes (`shell.rs`) are headless and exempt; the leak is from plain `Command` spawns.

**The gap:** the flag is set in `acp.rs`/`subprocess.rs`/`shell.rs`/helpers, but **missing in three paths**, including the dominant one:

| Spawn path | Frequency | Before |
|---|---|---|
| `blockcontroller/persistent.rs` | **every persistent agent, per start/resume/respawn** | ❌ missing |
| `agents/runner.rs` | one-shot `claude --print` task/drone agents | ❌ missing |
| `backend/lsp/supervisor.rs` | LSP servers (ts-language-server, pyright, gopls, rust-analyzer) | ❌ missing |

`core.rs:34` even names `CREATE_NO_WINDOW` in a comment — the intent was known, but it was never applied on these paths. Health-watchdog respawn flapping + a multi-instance day multiplied the per-spawn leak to 53.

## Fix

Add, after `apply_working_dir` (per the `core.rs:34` ordering note), matching the existing `acp.rs`/`subprocess.rs` idiom:

```rust
#[cfg(windows)]
{
    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
    cmd.creation_flags(CREATE_NO_WINDOW);
}
```

stdio is already piped in all three, so the console was never needed.

## Evidence / verification

- Killing `WindowsTerminal.exe` (the DefTerm host owning all 53) dropped visible console/terminal windows **54 → 1** — confirming all 53 were the leak and none had a live owner.
- `EnumWindows` sweep: 53 × `WindowsTerminal` (`CASCADIA_HOSTING_WINDOW_CLASS`, parent `svchost.exe`/DefTerm) + 1 admin pwsh.
- `cargo check -p agentmux-srv`: clean.
- `cargo test -p agentmux-srv`: **1221 passed, 0 failed, 2 ignored**.

Full retro with the inventory, window enumeration, and spawn audit: `docs/retro/retro-windows-terminal-window-leak-2026-06-21.md`.

## Follow-ups (out of scope, noted in retro)
- Health-watchdog false "Dead" on slow resume (forces leak-y respawns).
- Window-pool promotion wedging (the blank "CEF" window).
- Orphan reaping when a host dies abnormally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)