### PR TITLE
fix(linux): center the startup splash on Wayland via the XWayland backend

### DIFF
--- a/.changesets/1782035709-fix-linux-center-the-startup-splash-on-wayland-by-routing-it-zleg.md
+++ b/.changesets/1782035709-fix-linux-center-the-startup-splash-on-wayland-by-routing-it-zleg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux): center the startup splash on Wayland by routing it through the self-centering XWayland backend (Mutter drops uncentered toplevels top-left)

--- a/agentmux-launcher/src/splash_linux/mod.rs
+++ b/agentmux-launcher/src/splash_linux/mod.rs
@@ -8,9 +8,14 @@
 //! over a dark backdrop in that gap — the Linux analogue of `splash.rs` (Win32)
 //! and `splash_mac.rs` (Cocoa).
 //!
-//! The backend mirrors the host's ozone choice (`agentmux-cef/src/app.rs`): an
-//! X11 splash for X11 / XWayland sessions, a Wayland splash for native-Wayland
-//! sessions — so the splash always speaks the same display protocol as the host.
+//! The backend is chosen for **centering fidelity**, not to mirror the host's
+//! ozone choice: the X11 backend draws an `override_redirect` window it positions
+//! itself (centered on the primary monitor) and XWayland honors that, so it
+//! centers under both X11 and native-Wayland sessions. A native-Wayland
+//! `xdg_toplevel`, by contrast, cannot self-position — Mutter drops small
+//! toplevels at the top-left, not centered. XWayland is present in nearly every
+//! Wayland session, so we prefer the X11 backend whenever an X server is reachable
+//! and fall back to the Wayland backend only when there is no X display at all.
 //!
 //! Dismiss protocol is the macOS one: `spawn()` sets `AGENTMUX_SPLASH_READY_FILE`
 //! (the host inherits it and writes the file on first paint); the splash thread
@@ -53,25 +58,28 @@ enum Session {
     X11,
 }
 
-/// Mirror the host's ozone selection (`agentmux-cef/src/app.rs`): an explicit
-/// `AGENTMUX_OZONE_PLATFORM` wins; otherwise native Wayland when `WAYLAND_DISPLAY`
-/// is set; otherwise X11. Keeping this in lockstep guarantees splash and host
-/// never end up on different display protocols.
+/// Pick the splash backend by **centering ability**. The X11 backend self-centers
+/// (override-redirect, positioned on the RANDR primary) and XWayland honors that,
+/// so prefer it whenever an X server is actually reachable — including under a
+/// native-Wayland session, where the Wayland backend can't self-center and Mutter
+/// drops the splash top-left. Only with no usable X display do we fall back to the
+/// best-effort Wayland backend.
+///
+/// An explicit `AGENTMUX_OZONE_PLATFORM=x11|wayland` still pins a specific backend
+/// (escape hatch / for exercising the Wayland path itself); note that pinning
+/// `wayland` re-introduces the top-left placement Mutter gives uncentered toplevels.
 fn detect() -> Session {
-    if let Ok(forced) = std::env::var("AGENTMUX_OZONE_PLATFORM") {
-        match forced.as_str() {
-            "wayland" => return Session::Wayland,
-            "x11" => return Session::X11,
-            _ => {}
-        }
+    match std::env::var("AGENTMUX_OZONE_PLATFORM").ok().as_deref() {
+        Some("x11") => return Session::X11,
+        Some("wayland") => return Session::Wayland,
+        _ => {}
     }
-    let on_wayland = std::env::var("WAYLAND_DISPLAY")
-        .map(|s| !s.is_empty())
-        .unwrap_or(false);
-    if on_wayland {
-        Session::Wayland
-    } else {
+    // `DISPLAY` being set doesn't prove a server is live (stale env / no
+    // XWayland), so probe a real connection — a failed handshake is fast.
+    if x11::server_reachable() {
         Session::X11
+    } else {
+        Session::Wayland
     }
 }
 

--- a/agentmux-launcher/src/splash_linux/wayland.rs
+++ b/agentmux-launcher/src/splash_linux/wayland.rs
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wayland splash backend — a software-drawn (`wl_shm`) `xdg_toplevel` showing
-//! the pulsing brain, for native-Wayland sessions (the default since #1611).
+//! the pulsing brain. This is the **fallback** path, used only when no X server
+//! is reachable (`super::detect` prefers the self-centering X11/XWayland backend
+//! whenever XWayland is up — see that module's doc for why).
 //!
 //! Wayland deliberately denies clients window positioning and "always on top",
-//! and GNOME/Mutter does not implement `wlr-layer-shell`, so this is a
-//! best-effort splash: a borderless `xdg_toplevel` the compositor places (Mutter
-//! centers small toplevels) and which we dismiss the instant the host paints.
-//! No GPU/EGL — a shared-memory buffer we blit each frame. See
-//! docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md §3, §6.
+//! and GNOME/Mutter does not implement `wlr-layer-shell`, so this splash *cannot
+//! self-center*: it's a borderless `xdg_toplevel` the compositor places — Mutter
+//! drops small toplevels at the top-left, not centered — which we dismiss the
+//! instant the host paints. No GPU/EGL — a shared-memory buffer we blit each
+//! frame. See docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md §3, §6.
 
 use std::error::Error;
 use std::path::{Path, PathBuf};

--- a/agentmux-launcher/src/splash_linux/x11.rs
+++ b/agentmux-launcher/src/splash_linux/x11.rs
@@ -33,6 +33,15 @@ use super::{
     DISMISS_TIMEOUT, FRAME_MS, PADDING,
 };
 
+/// Cheap reachability probe for the backend selector (`super::detect`): can we
+/// actually open an X11 connection? `DISPLAY` being set doesn't guarantee a live
+/// server, so we test the real handshake (which fails fast when there's none).
+/// Only when this succeeds do we prefer the self-centering X11/XWayland splash
+/// over the native-Wayland fallback.
+pub(super) fn server_reachable() -> bool {
+    x11rb::connect(None).is_ok()
+}
+
 pub(super) fn run(ready_file: &Path) -> Result<(), Box<dyn Error>> {
     let (conn, screen_num) = x11rb::connect(None)?;
     let screen = conn.setup().roots[screen_num].clone();

--- a/docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md
+++ b/docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md
@@ -54,6 +54,8 @@ CEF 148 fixed the native-Wayland bug (verified: no `OnTrancheFlags Not implement
 
 The splash backend must therefore track the **same** session decision the host makes, so splash and host always speak the same display protocol.
 
+> **Correction (2026-06-21):** this "mirror the host's protocol" rule was superseded. It rested on the §3.2 assumption that Mutter centers small toplevels — which proved **false** (Mutter drops them top-left). Because the host/splash protocols need not match (dismiss is via the ready-file, not the wire protocol), the selector now picks the backend by **centering ability**: prefer the self-centering X11/XWayland backend whenever an X server is reachable (XWayland is up in nearly every Wayland session), falling back to the native-Wayland backend only when there is no X display. See `agentmux-launcher/src/splash_linux/mod.rs::detect`.
+
 ---
 
 ## 3. Research findings (Wayland/GNOME feasibility)
@@ -63,7 +65,7 @@ The splash backend must therefore track the **same** session decision the host m
 
 ### 3.2 Wayland forbids client-controlled positioning and stacking — by design
 Wayland intentionally does **not** expose absolute window position to clients, and there is **no client-side "always on top."** "Throughout the design of Wayland the approach has been for the client to make requests and the server to make the final decisions." A standalone `xdg_toplevel` therefore:
-- **Cannot self-center** — the compositor places it. (Mutter places small new toplevels roughly centered on the work area, which is acceptable for a splash.)
+- **Cannot self-center** — the compositor places it. (**Correction, 2026-06-21:** the original claim that "Mutter places small new toplevels roughly centered" is **false** — Mutter drops them at the **top-left**. This is exactly why the selector now prefers the self-centering XWayland backend; see the §2 correction note.)
 - **Cannot force itself above** the host window — best effort only.
 - **Cannot avoid the taskbar/overview** the way EWMH `_NET_WM_STATE_SKIP_TASKBAR` does on X11 (no equivalent without extension protocols).
 
@@ -128,7 +130,7 @@ New. Best-effort native-Wayland splash for the now-default path.
 - **Connection/thread:** dedicated thread; `Connection::connect_to_env()`, `registry_queue_init()`, bind `CompositorState` / `Shm` / `XdgShell`.
 - **Surface:** `XdgShell::create_window(surface, WindowDecorations::None, &qh)`; `set_title("AgentMux")`, `set_app_id("ai.agentmux.AgentMux")` — **same app_id as the host** so Mutter groups/associates them and is more likely to stack the splash with the app. Set a fixed `min`/`max` size = `SPLASH_SIZE` so the compositor gives us exactly that (a splash is non-resizable).
 - **Buffer/draw:** `SlotPool` → **ARGB8888** `wl_shm` buffer; blit the dark backdrop + alpha-modulated brain each `frame` callback (~16 ms); `damage` + `commit`. (Note: `wl_shm` ARGB is **pre-multiplied** straight-alpha per Wayland — match the backdrop opaque and the brain alpha-pulsed.)
-- **Placement / stacking — accepted limitations (§3.2):** we cannot center or force-on-top. We rely on Mutter's default centered placement for small toplevels and on dismissing *the instant* the host paints (so the two-window overlap window is sub-frame in practice). Document this as expected.
+- **Placement / stacking — accepted limitations (§3.2):** we cannot center or force-on-top. ~~We rely on Mutter's default centered placement for small toplevels~~ (**2026-06-21:** Mutter does **not** center — it drops the toplevel top-left, so this native-Wayland path is now a *fallback*; the splash is centered by preferring the XWayland backend, §2 correction note) and on dismissing *the instant* the host paints (so the two-window overlap window is sub-frame in practice). Document this as expected.
 - **Taskbar/overview:** the splash may flash briefly in the overview/alt-tab. Mitigations: minimal lifetime + matching `app_id`; if a suitable hint protocol is available at impl time (e.g. `xdg-toplevel-tag-v1`), set it, but do **not** depend on it.
 - **Dismiss:** identical file-poll + fade + teardown as X11.
 - **Crates:** `smithay-client-toolkit` (pulls `wayland-client`, `wayland-protocols`). Software-only; no GPU/EGL.


### PR DESCRIPTION
## Problem
On native-Wayland sessions the startup splash (the pulsing brain) appears in the **top-left** of the screen instead of centered.

## Root cause
Since #1611 the host defaults to native Wayland, and the splash *mirrored the host's ozone choice* — so it took the native-Wayland `xdg_toplevel` backend. Wayland forbids a client from positioning its own toplevel, and the spec's assumption that "Mutter centers small toplevels" is **false**: Mutter drops them at the top-left.

The X11 backend, by contrast, draws an **override-redirect** window it positions itself (centered on the RANDR primary), and XWayland honors that — it's the pre-#1611 behavior that always centered.

## Fix
Choose the splash backend by **centering ability**, not by mirroring the host (the two need not share a display protocol — dismiss is via the ready-file, not the wire). `detect()` now prefers the self-centering X11/XWayland backend whenever an X server is actually reachable (probed via a real connection, so a stale `DISPLAY` can't strand the splash), and falls back to the native-Wayland backend only when there is no X display. `AGENTMUX_OZONE_PLATFORM=x11|wayland` still pins a backend explicitly.

## Verification
Empirically confirmed on this GNOME/Mutter Wayland session: a standalone override-redirect window at the computed center lands at **exactly (585, 1162)** on the 1354×2509 primary — i.e. Mutter/XWayland honors override-redirect positioning. `cargo check -p agentmux-launcher` is clean.

## Files
- `splash_linux/mod.rs` — `detect()` now picks by centering ability + probes a live X server
- `splash_linux/x11.rs` — adds `server_reachable()` probe
- `splash_linux/wayland.rs` — doc: now the no-X-server fallback (can't self-center)
- spec `SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md` — corrected the false "Mutter centers" claims

<!-- agentmux:agent_id=smike -->