### PR TITLE
chore: release v0.47.2

### DIFF
--- a/.changesets/1782034958-fix-macos-per-version-bundle-id-ai-agentmux-channel-version--xj85.md
+++ b/.changesets/1782034958-fix-macos-per-version-bundle-id-ai-agentmux-channel-version--xj85.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): per-version bundle id (ai.agentmux.<channel>.<version>) — double-click any build without open -n

--- a/.changesets/1782035405-fix-srv-set-create-no-window-on-persistent-agent-task-runner-c4jg.md
+++ b/.changesets/1782035405-fix-srv-set-create-no-window-on-persistent-agent-task-runner-c4jg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): set CREATE_NO_WINDOW on persistent-agent, task-runner, and LSP spawns (stops Windows 11 opening a Terminal window per spawn)

--- a/.changesets/1782035709-fix-linux-center-the-startup-splash-on-wayland-by-routing-it-zleg.md
+++ b/.changesets/1782035709-fix-linux-center-the-startup-splash-on-wayland-by-routing-it-zleg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux): center the startup splash on Wayland by routing it through the self-centering XWayland backend (Mutter drops uncentered toplevels top-left)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.47.1"
+version = "0.47.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.47.2 — 2026-06-21
+
+- fix(macos): per-version bundle id (ai.agentmux.<channel>.<version>) — double-click any build without open -n
+- fix(srv): set CREATE_NO_WINDOW on persistent-agent, task-runner, and LSP spawns (stops Windows 11 opening a Terminal window per spawn)
+- fix(linux): center the startup splash on Wayland by routing it through the self-centering XWayland backend (Mutter drops uncentered toplevels top-left)
+
+
 ## 0.47.1 — 2026-06-21
 
 - fix(linux): restrict pane tear-off to header — whole-tile drag triggered tear-off anywhere

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.47.1",
+      "version": "0.47.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes the 3 queued `patch` changesets and bumps **0.47.1 → 0.47.2**:

- fix(linux): center the startup splash on Wayland via the XWayland backend (#1648)
- fix(srv): set CREATE_NO_WINDOW on persistent agent task-runner (#1647)
- fix(macos): per-version bundle id

All 5 version locations agree (release-consistency passes). Changesets deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)