### PR TITLE
fix(pool): keep pool-promoted new windows on-screen on HiDPI (DPI positioning)

### DIFF
--- a/.changesets/1782052109-fix-pool-clamp-re-assert-pool-promoted-new-window-placement--d5cm.md
+++ b/.changesets/1782052109-fix-pool-clamp-re-assert-pool-promoted-new-window-placement--d5cm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(pool): clamp + re-assert pool-promoted new window placement so it can't land off-screen on HiDPI

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -409,6 +409,32 @@ pub fn get_monitor_work_area(px: i32, py: i32) -> Option<(i32, i32, i32, i32)> {
     }
 }
 
+/// Like [`get_monitor_work_area`] but returns the work area in **physical**
+/// pixels (no DIP division). Win32 `SetWindowPos`/`GetWindowRect` operate in
+/// physical pixels, so clamping a physical-pixel window rect must use physical
+/// work-area bounds — using the DIP variant over-constrains placement on HiDPI
+/// (reagent P1 on PR #1652). Returns `(left, top, width, height)`.
+#[cfg(target_os = "windows")]
+pub fn get_monitor_work_area_physical(px: i32, py: i32) -> Option<(i32, i32, i32, i32)> {
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITOR_DEFAULTTOPRIMARY,
+    };
+    unsafe {
+        let point = windows_sys::Win32::Foundation::POINT { x: px, y: py };
+        let hmonitor = MonitorFromPoint(point, MONITOR_DEFAULTTOPRIMARY);
+        if hmonitor.is_null() {
+            return None;
+        }
+        let mut info: MONITORINFO = std::mem::zeroed();
+        info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+        if GetMonitorInfoW(hmonitor, &mut info) == 0 {
+            return None;
+        }
+        let rc = info.rcWork;
+        Some((rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top))
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub fn get_monitor_work_area(_px: i32, _py: i32) -> Option<(i32, i32, i32, i32)> {
     // TODO: Use NSScreen.main.visibleFrame for proper work area (minus Dock/menu bar).

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -876,13 +876,16 @@ pub fn promote_pool_window(
     // target rect to the DESTINATION monitor's work area so a HiDPI coordinate
     // miscalc can't strand the promoted window off-screen — the "blank new
     // window" bug where the window rendered but sat at the DPI-scaled
-    // POOL_OFFSCREEN. The anchor/origin picks the monitor.
-    let (pos_x, pos_y, win_w, win_h) = match crate::app::get_monitor_work_area(pos_x, pos_y) {
-        Some((wa_x, wa_y, wa_w, wa_h)) => {
-            clamp_rect_within(pos_x, pos_y, win_w, win_h, wa_x, wa_y, wa_w, wa_h)
-        }
-        None => (pos_x, pos_y, win_w, win_h),
-    };
+    // POOL_OFFSCREEN. The anchor/origin picks the monitor. Use the PHYSICAL work
+    // area: pos/size here and SetWindowPos below are physical pixels, so the DIP
+    // variant would over-constrain on HiDPI (reagent P1 #1652).
+    let (pos_x, pos_y, win_w, win_h) =
+        match crate::app::get_monitor_work_area_physical(pos_x, pos_y) {
+            Some((wa_x, wa_y, wa_w, wa_h)) => {
+                clamp_rect_within(pos_x, pos_y, win_w, win_h, wa_x, wa_y, wa_w, wa_h)
+            }
+            None => (pos_x, pos_y, win_w, win_h),
+        };
 
     // Take the window out of WS_EX_TOOLWINDOW so the promoted window
     // appears in the taskbar / Alt+Tab like any other AgentMux
@@ -939,7 +942,10 @@ pub fn promote_pool_window(
             // this class is caught in logs rather than only by users.
             let mut r: RECT = std::mem::zeroed();
             if GetWindowRect(raw_hwnd, &mut r) != 0 {
-                if let Some((wx, wy, ww, wh)) = crate::app::get_monitor_work_area(pos_x, pos_y) {
+                // Physical work area: GetWindowRect is physical px (reagent P2 #1652).
+                if let Some((wx, wy, ww, wh)) =
+                    crate::app::get_monitor_work_area_physical(pos_x, pos_y)
+                {
                     let onscreen =
                         r.right > wx && r.left < wx + ww && r.bottom > wy && r.top < wy + wh;
                     if !onscreen {

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -119,6 +119,65 @@ const POOL_HEIGHT: i32 = 800;
 /// of the title bar after promotion.
 const TITLE_BAR_OFFSET_PX: i32 = 16;
 
+/// Clamp a window rect so it lies fully within a monitor work area.
+///
+/// Shrinks `(w, h)` to fit the work area if larger, then shifts the origin so no
+/// edge falls outside. The result is guaranteed on-screen — the safety net that
+/// prevents a HiDPI coordinate miscalc from stranding a pool-promoted new window
+/// off-screen (the 2026-06-21 "blank new window" bug: a window parked at the
+/// DPI-scaled `POOL_OFFSCREEN`, e.g. `-25600 = -32000 × 0.8` at 125%). Pure — the
+/// work-area rect is passed in — so the placement logic is unit-tested without
+/// Win32. See docs/specs/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md.
+pub(crate) fn clamp_rect_within(
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    wa_x: i32,
+    wa_y: i32,
+    wa_w: i32,
+    wa_h: i32,
+) -> (i32, i32, i32, i32) {
+    let w = w.clamp(1, wa_w.max(1));
+    let h = h.clamp(1, wa_h.max(1));
+    // Pull the right/bottom edge inside first, then the left/top edge — order
+    // matters so an oversized-or-far rect ends up flush against the work area
+    // origin rather than hanging off the far edge.
+    let x = x.min(wa_x + wa_w - w).max(wa_x);
+    let y = y.min(wa_y + wa_h - h).max(wa_y);
+    (x, y, w, h)
+}
+
+#[cfg(test)]
+mod clamp_tests {
+    use super::clamp_rect_within;
+
+    #[test]
+    fn brings_offscreen_rect_onscreen() {
+        // The Window 3 case: scaled POOL_OFFSCREEN with a broken size.
+        let (x, y, w, h) = clamp_rect_within(-25600, -25600, 159, 27, 0, 0, 1920, 1040);
+        assert!(x >= 0 && y >= 0 && x + w <= 1920 && y + h <= 1040, "got {:?}", (x, y, w, h));
+    }
+
+    #[test]
+    fn shrinks_oversized_and_keeps_inside() {
+        let (x, y, w, h) = clamp_rect_within(1800, 1000, 1200, 800, 0, 0, 1920, 1040);
+        assert!(w <= 1920 && h <= 1040 && x >= 0 && y >= 0 && x + w <= 1920 && y + h <= 1040);
+    }
+
+    #[test]
+    fn leaves_valid_rect_unchanged() {
+        assert_eq!(clamp_rect_within(421, 246, 960, 640, 0, 0, 1920, 1040), (421, 246, 960, 640));
+    }
+
+    #[test]
+    fn respects_negative_monitor_origin() {
+        // Secondary monitor to the left of the primary (negative virtual coords).
+        let (x, _y, w, _h) = clamp_rect_within(-1900, 100, 960, 640, -1920, 0, 1920, 1080);
+        assert!(x >= -1920 && x + w <= 0, "rect must stay on the left monitor: {:?}", (x, w));
+    }
+}
+
 // Tab-anchor placement: PR #730 hardcoded FIRST_TAB_INSET_X /
 // TAB_STRIP_TOP_OFFSET_PX as best-effort window-chrome offsets.
 // Smoke on v0.33.704 showed they were inaccurate (new window's
@@ -813,6 +872,18 @@ pub fn promote_pool_window(
         ),
     };
 
+    // Safety net (PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21): clamp the
+    // target rect to the DESTINATION monitor's work area so a HiDPI coordinate
+    // miscalc can't strand the promoted window off-screen — the "blank new
+    // window" bug where the window rendered but sat at the DPI-scaled
+    // POOL_OFFSCREEN. The anchor/origin picks the monitor.
+    let (pos_x, pos_y, win_w, win_h) = match crate::app::get_monitor_work_area(pos_x, pos_y) {
+        Some((wa_x, wa_y, wa_w, wa_h)) => {
+            clamp_rect_within(pos_x, pos_y, win_w, win_h, wa_x, wa_y, wa_w, wa_h)
+        }
+        None => (pos_x, pos_y, win_w, win_h),
+    };
+
     // Take the window out of WS_EX_TOOLWINDOW so the promoted window
     // appears in the taskbar / Alt+Tab like any other AgentMux
     // instance. Must run BEFORE the position/show below; otherwise
@@ -850,6 +921,39 @@ pub fn promote_pool_window(
             );
         }
         let _ = ShowWindow(raw_hwnd, SW_SHOW);
+
+        // Re-assert the rect AFTER show. The pre-show SetWindowPos can be lost to
+        // the pool window's create/show sequence and per-monitor DPI-context
+        // settling, which intermittently leaves the window at the (scaled)
+        // POOL_OFFSCREEN — shown and rendered, but off the screen (the HiDPI
+        // "blank new window" bug). A second, idempotent move after show makes the
+        // placement deterministic. SWP_NOACTIVATE so we don't steal focus again;
+        // HWND_TOP keeps it frontmost (same as the pre-show move).
+        {
+            use windows_sys::Win32::Foundation::RECT;
+            use windows_sys::Win32::UI::WindowsAndMessaging::{GetWindowRect, SWP_NOACTIVATE};
+            let _ = SetWindowPos(
+                raw_hwnd, HWND_TOP, pos_x, pos_y, win_w, win_h, SWP_NOACTIVATE,
+            );
+            // Telemetry: flag any residual off-screen result so a regression of
+            // this class is caught in logs rather than only by users.
+            let mut r: RECT = std::mem::zeroed();
+            if GetWindowRect(raw_hwnd, &mut r) != 0 {
+                if let Some((wx, wy, ww, wh)) = crate::app::get_monitor_work_area(pos_x, pos_y) {
+                    let onscreen =
+                        r.right > wx && r.left < wx + ww && r.bottom > wy && r.top < wy + wh;
+                    if !onscreen {
+                        tracing::error!(
+                            target: "pool:new-window",
+                            label = %label,
+                            left = r.left,
+                            top = r.top,
+                            "[pool] promoted window still off-screen after post-show re-assert"
+                        );
+                    }
+                }
+            }
+        }
 
         // Pool windows skip the cascade-hook install in on_after_created
         // (gated on !label.starts_with("window-pool-")) because they are

--- a/docs/specs/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md
+++ b/docs/specs/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md
@@ -1,0 +1,162 @@
+# Implementation Plan: fix HiDPI mis-positioning of pool-promoted new windows
+
+**Date:** 2026-06-21
+**Area:** `agentmux-cef` — Windows new-window pool promotion
+**Bug:** "Open another window" can open a blank/invisible window on HiDPI displays.
+**Regression source:** `#1609` (`c004540c`) "feat(pool): Windows new-window pool"
+**Status:** Implemented — §3.2 (clamp) + §3.3 (post-show re-assert) + telemetry landed; `clamp_rect_within` unit-tested. §3.1 (size normalization) and §3.4 (explicit repaint) deferred as follow-ups (the clamp+re-assert already guarantees on-screen at the current 960×640 size).
+**Related:** `#1610`/`#1612`/`#1616` (recent pool work), `docs/retro/retro-blank-new-window-2026-06-21.md` (the layout-seed fix, orthogonal and already shipped).
+
+---
+
+## 1. Symptom & evidence
+
+On Windows at 125% scaling, clicking status-bar "+ Open another window" sometimes
+yields a window that renders its content but is never shown on-screen.
+
+Live CDP inspection of the running 0.47.1 build (4 opens), `window.screenX/Y` +
+`outerWidth/Height` + rendered block count:
+
+| Window | screen pos | size | blocks | on-screen |
+|--------|-----------|------|--------|-----------|
+| Starter (main) | (397,222) | 2150×1176 | 75 | ✅ |
+| Window 2 | (421,246) | 960×640 | 75 | ✅ |
+| Window 4 | (421,246) | 960×640 | 75 | ✅ |
+| **Window 3** | **(-25600,-25600)** | **159×27** | **75** | ❌ |
+| pool spare ×2 | (-26214,-26214)→(-32000) | 1200×800 | 0 | off-screen (correct) |
+
+The layout seed works (every window has 75 block-frames / the 3 panes). The defect
+is purely **window placement**: Window 3 rendered but stayed off-screen.
+
+Two numeric tells, both `× 0.8` (= `96/120`, i.e. ÷1.25 at 125% DPI):
+- `-25600 = -32000 × 0.8` → Window 3 is parked at the **DPI-scaled `POOL_OFFSCREEN`**;
+  it was never moved on-screen.
+- `960×640 = 1200×800 × 0.8` → even the "good" windows are the **POOL default size
+  virtualized**, not the intended `get_secondary_window_size` (70% of work area).
+
+So the coordinates that promotion feeds `SetWindowPos` are in an inconsistent DPI
+space, and nothing guarantees the result is on-screen.
+
+---
+
+## 2. Code flow (today)
+
+`open_new_window` (`commands/window/creation.rs:251`):
+```rust
+let (pos_x, pos_y) = get_offset_position();                 // GetWindowRect(cur)+30  (creation.rs:388)
+let (win_w, win_h) = get_secondary_window_size(pos_x,pos_y);// 70% of monitor work area (creation.rs:411)
+promote_pool_window_for_new_window(state, pos_x, pos_y, win_w, win_h)  // win_w/h DROPPED on Windows
+```
+
+`promote_pool_window_for_new_window` (Windows, `window_pool.rs:1057`):
+```rust
+promote_pool_window(state, "", pos_x, pos_y,
+    None, None,                 // width/height → POOL_WIDTH/HEIGHT defaults (1200×800)
+    Some(pos_x), Some(pos_y))   // tab_anchor → final pos = (pos_x, pos_y)
+```
+
+`promote_pool_window` (Windows, `window_pool.rs:547`):
+- size: `width=None` ⇒ `win_w = POOL_WIDTH (1200)`, `win_h = POOL_HEIGHT (800)` — no conversion.
+- pos: anchor branch ⇒ `(pos_x, pos_y)`.
+- `SetWindowPos(hwnd, HWND_TOP, pos_x, pos_y, 1200, 800, 0)` then `ShowWindow(SW_SHOW)` (`:831`,`:852`).
+
+Pool window was created at `POOL_OFFSCREEN (-32000,-32000)`, size 1200×800 (`window_pool.rs:113-116`).
+
+**Defects:**
+- **D1 — wrong/virtualized size:** intended `win_w/win_h` (70% work area) are discarded;
+  `POOL_WIDTH/HEIGHT` are used and then DPI-virtualized to 960×640. The `width.is_some()`
+  branch in `promote_pool_window` (`:774`) would *double*-convert already-physical inputs,
+  which is why #1609 passes `None` — trading a double-convert bug for a wrong-size bug.
+- **D2 — no on-screen guarantee:** if `SetWindowPos` doesn't take effect (races the pool
+  window's create/show, or DPI-context not yet established), the window is left at the
+  scaled `POOL_OFFSCREEN`. Nothing detects or corrects an off-screen result.
+- **D3 — DPI-context race:** the pool window's per-monitor DPI context can change as it
+  moves from the off-screen origin to the destination monitor; a single pre-show
+  `SetWindowPos` is applied before that settles.
+
+---
+
+## 3. Fix
+
+Goal: the promoted new window lands **on-screen, correctly sized, every time**, on any
+DPI. Strategy: compute the rect once in correct physical px for the destination monitor,
+**clamp to the work area** (the hard guarantee), and **re-assert after show** (kill the race).
+
+### 3.1 Thread the intended size through (fix D1)
+- `promote_pool_window_for_new_window` (Windows): stop dropping `width/height`. Pass them
+  to `promote_pool_window`, tagged as **already-physical** so no DPI multiply is applied.
+- In `promote_pool_window`, replace the `width.is_some() ? to_physical(w) : w` logic with a
+  single rule: **callers pass physical px; never multiply.** `get_secondary_window_size`
+  returns work-area-derived physical px; the tear-off caller already passes
+  `window.outerWidth/Height`-derived values — audit both and make the unit a documented
+  contract on the function signature (e.g. rename params `phys_w/phys_h` or add a doc
+  invariant). Remove the now-unneeded `to_physical` size path.
+
+### 3.2 Compute + clamp the destination rect (fix D2 — the safety net)
+Add a helper, `clamp_rect_to_work_area(x, y, w, h, anchor_x, anchor_y) -> (x,y,w,h)`:
+- Resolve the destination monitor via `MonitorFromPoint((anchor_x, anchor_y), NEAREST)`.
+- Read its `rcWork` (physical px, `GetMonitorInfoW`).
+- Shrink `w/h` to fit the work area if larger; then shift `x/y` so the full window is
+  inside `rcWork` (right/bottom edges clamped, then left/top, so a too-large or
+  out-of-bounds rect can never leave the window partially or fully off-screen).
+- Apply in `promote_pool_window` right before `SetWindowPos`. This alone removes the
+  user-visible symptom even if subtle DPI math remains.
+
+### 3.3 Re-assert geometry after show (fix D3)
+- Order: `ShowWindow(SW_SHOW)` → then `SetWindowPos` (move+size+`HWND_TOP`) → then a
+  second `SetWindowPos` with `SWP_NOZORDER|SWP_NOACTIVATE` on the **next UI tick**
+  (`post_task` to the UI thread) to re-assert the rect after the window's DPI context and
+  first paint have settled. Verify the final `GetWindowRect` intersects the work area; if
+  not, log `pool:new-window placement off-screen` at `error` for telemetry.
+
+### 3.4 Trigger a repaint on promotion (defensive)
+- After show, invalidate/repaint the CEF host view (`InvalidateRect` on the host HWND, or
+  `browser.host().was_resized()`) so the off-screen→on-screen surface is composited. Pool
+  windows are painted off-screen; ensure the move forces a fresh frame. (Low risk; guards
+  against a "shown but stale surface" variant.)
+
+### 3.5 Scope guard
+- Changes are **Windows-only**, confined to `agentmux-cef/src/commands/window_pool.rs`
+  (and a 1-line caller change in `promote_pool_window_for_new_window`). The tear-off path
+  shares `promote_pool_window`; the clamp + re-assert are safe for tear-off too (a torn-off
+  window should also never land off-screen), but verify the anchor-drag UX still feels right
+  (the clamp only moves a window that would otherwise be off-screen).
+
+---
+
+## 4. Files to change
+- `agentmux-cef/src/commands/window_pool.rs`
+  - `promote_pool_window` (Windows, ~547): size-unit contract (3.1), clamp (3.2), re-assert + repaint (3.3/3.4).
+  - `promote_pool_window_for_new_window` (Windows, ~1057): pass real `width/height` (3.1).
+  - new `clamp_rect_to_work_area` helper.
+- (maybe) `agentmux-cef/src/commands/window/motion.rs` if the re-assert reuses `set_window_full_rect`.
+
+## 5. Test plan
+**Automated**
+- Unit-test `clamp_rect_to_work_area`: rect bigger than work area, rect off the right/bottom,
+  rect at scaled `POOL_OFFSCREEN`, negative-coord secondary monitor → result fully inside the
+  given work area, size ≤ work area.
+
+**Manual / CDP (HiDPI, 125%)**
+- Open ≥6 windows via "+ Open another window" in quick succession. For each, assert via CDP
+  `window.screenX/Y` is on-screen (inside a monitor work area) and `outerWidth/Height` ≈ 70%
+  work area, and `blocks=75`. **Zero** windows at `~-25600` or sized `159×27`.
+- Repeat on a second monitor at a different scale (e.g. 100%) by moving the source window
+  there first — confirms destination-monitor DPI is used.
+- Tear-off a tab → the torn window still lands under the cursor (clamp didn't regress UX).
+
+## 6. Risks & rollback
+- **Risk:** clamp interferes with intentional multi-monitor negative coords. Mitigated by
+  clamping to the **destination** monitor's work area (chosen from the anchor point), not the
+  primary, and only adjusting when the rect would be off that monitor.
+- **Risk:** re-assert `post_task` introduces a visible reposition flicker. Mitigated by
+  doing the authoritative move pre-show and the re-assert as a same-rect idempotent confirm.
+- **Rollback:** the whole change is gated to the Windows promote path; reverting restores
+  current behavior. If the DPI math proves fragile under time pressure, fall back to
+  **disabling the Windows new-window pool** (route `open_new_window` to the cold path) —
+  correct, ~3s slower first window — as a stopgap.
+
+## 7. Verification gate (done = )
+- `cargo check -p agentmux-cef` clean; `clamp_rect_to_work_area` unit tests pass.
+- CDP sweep: 6/6 new windows on-screen, correctly sized, 75 blocks; none off-screen.
+- Retro/PR references this plan.


### PR DESCRIPTION
## Problem

On HiDPI (125%) Windows, status-bar **"Open another window"** can open a **blank/invisible** window. CDP inspection of the running build showed the promoted pool window **rendered its content** (3-pane layout, 75 block-frames) but was parked **off-screen**:

| Window | screen pos | size | blocks |
|--------|-----------|------|--------|
| Window 2 / 4 | (421,246) | 960×640 | 75 ✅ |
| **Window 3** | **(-25600,-25600)** | **159×27** | 75 ❌ off-screen |

`-25600 = -32000 × 0.8` — the window stayed at the **DPI-scaled `POOL_OFFSCREEN`**; the reposition that should move it on-screen intermittently didn't take. The layout-seed fix (#1650) is unaffected — this is pure **window placement**, from the Windows new-window pool (#1609) reusing the tear-off promote path, whose DPI/physical-pixel handling is unstable and has no on-screen guarantee.

## Fix (`agentmux-cef/src/commands/window_pool.rs`, Windows-only)

1. **`clamp_rect_within`** (pure, unit-tested): shrink-to-fit + shift so a rect is always fully inside a monitor work area.
2. **Clamp before `SetWindowPos`** to the *destination* monitor's work area — a HiDPI miscalc can no longer strand the window off-screen.
3. **Re-assert the rect after `ShowWindow`** (`SWP_NOACTIVATE`): the pre-show move can be lost to the create/show + per-monitor DPI-context settle; a second idempotent move makes placement deterministic. Logs `error` if still off-screen (telemetry).

Deferred follow-ups (noted in the plan): size normalization to 70%-work-area (currently 960×640, which is fine and now guaranteed on-screen) and an explicit repaint.

## Verification

- `cargo check -p agentmux-cef`: clean.
- `cargo test -p agentmux-cef clamp_tests`: **4/4 pass** (off-screen rect, oversized, valid-unchanged, negative-monitor-origin).
- Runtime HiDPI verification via a fresh portable + CDP position sweep to follow (will confirm 0 windows land off-screen across repeated opens).

Plan with full coordinate-flow analysis: `docs/specs/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)