### PR TITLE
fix(floating-pane): redock ghost target, maximize on macOS, dock-click focus

### DIFF
--- a/.changesets/1782056025-fix-macos-floating-pane-maximize-button-now-works-on-macos-l-ywtc.md
+++ b/.changesets/1782056025-fix-macos-floating-pane-maximize-button-now-works-on-macos-l-ywtc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): floating pane maximize button now works on macOS/Linux via CEF Views window.maximize()

--- a/.changesets/1782056025-fix-redock-floating-panes-are-never-valid-redock-targets-gho-4ckc.md
+++ b/.changesets/1782056025-fix-redock-floating-panes-are-never-valid-redock-targets-gho-4ckc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(redock): floating panes are never valid redock targets — ghost no longer appears on idle floaters

--- a/.changesets/1782056026-fix-macos-dock-icon-single-click-focuses-existing-window-ins-w3nq.md
+++ b/.changesets/1782056026-fix-macos-dock-icon-single-click-focuses-existing-window-ins-w3nq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): Dock icon single-click focuses existing window instead of opening a new one

--- a/agentmux-cef/src/commands/window/chrome.rs
+++ b/agentmux-cef/src/commands/window/chrome.rs
@@ -129,6 +129,13 @@ pub fn toggle_floating_maximize(
     };
     #[cfg(not(target_os = "windows"))]
     let current_rect: Option<crate::state::PaneRect> = None;
+    // On macOS/Linux the floater is a CEF Views window. Delegate to the same
+    // maximize/restore task used by normal windows — CEF Views handles the
+    // toggle and restore geometry natively via window.maximize()/restore().
+    // This must run before the reducer dispatch so the visual change is
+    // immediate; the reducer still records the placement state for the UI.
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_maximize_window(state, &label);
 
     // 1. Pure reducer dispatch — flips Normal↔Maximized, stashes/returns rect.
     let out = state.host_dispatch(crate::reducer::HostCommand::ToggleFloatingMaximize {

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -403,6 +403,13 @@ pub fn resolve_window_at_cursor(
                                 None => None,
                             };
                             if let Some(label) = resolved_label {
+                                // Floating panes are never valid redock targets.
+                                // Continue the Z-order walk so the docked main
+                                // window behind the floater can still be found.
+                                if label.starts_with("floating-") {
+                                    hwnd = GetWindow(hwnd, GW_HWNDNEXT);
+                                    continue;
+                                }
                                 let wid = state.backend_window_id(label);
                                 return Ok(serde_json::json!({
                                     "label": label,

--- a/agentmux-cef/src/macos_menu.rs
+++ b/agentmux-cef/src/macos_menu.rs
@@ -125,13 +125,16 @@ static REOPEN_STATE: OnceLock<Arc<AppState>> = OnceLock::new();
 
 /// `applicationShouldHandleReopen:hasVisibleWindows:` — the NSApplicationDelegate
 /// method AppKit invokes when macOS re-activates the already-running app
-/// (Finder/Dock double-click, `open` without `-n`). We answer it by opening a
-/// new window — matching the Windows relaunch-forwards-`open_new_window`
-/// behavior — and returns **NO**: we've taken responsibility for this reopen, so
-/// AppKit must not *also* run its own default reopen handling on top of ours.
-/// (Per the AppKit contract, returning YES means "AppKit, perform your default
-/// reopen too" — which could raise/create an extra window, especially in the
-/// no-visible-windows case. NO = "handled; do nothing further.")
+/// (Dock single-click, Finder double-click, `open` without `-n`).
+///
+/// Behaviour follows the standard macOS convention:
+/// - `hasVisibleWindows = YES` (Dock click with a visible window): bring the
+///   main window to front rather than opening a new one.
+/// - `hasVisibleWindows = NO` (all windows hidden/minimised): open a new
+///   window (same action as the Windows relaunch forward).
+///
+/// Returns **NO**: we've handled the event; AppKit must not also run its own
+/// default reopen on top of ours.
 ///
 /// Why the delegate, not a raw `kAEReopenApplication` `NSAppleEventManager`
 /// handler (the previous attempt): Chromium re-registers its own AE handler
@@ -149,15 +152,24 @@ unsafe extern "C" fn should_handle_reopen(
     _has_visible_windows: u8,
 ) -> u8 {
     match REOPEN_STATE.get() {
-        // open_new_window is non-blocking: it enqueues + posts to the CEF UI
-        // thread, so invoking it from the AppKit main thread is safe.
-        Some(state) => match crate::commands::window::open_new_window(state) {
-            Ok(_) => tracing::info!("reopen-hook:fired — applicationShouldHandleReopen opened a new window"),
-            Err(e) => tracing::warn!(error = %e, "reopen-hook:fired — open_new_window failed"),
-        },
+        Some(state) => {
+            if _has_visible_windows != 0 {
+                // Visible window exists — focus it (standard Dock single-click).
+                // post_focus_window is non-blocking and safe to call from the
+                // AppKit main thread.
+                crate::ui_tasks::post_focus_window(state, "main");
+                tracing::info!("reopen-hook:fired — focused main window (hasVisibleWindows=YES)");
+            } else {
+                // No visible windows — open a new one.
+                match crate::commands::window::open_new_window(state) {
+                    Ok(_) => tracing::info!("reopen-hook:fired — opened new window (hasVisibleWindows=NO)"),
+                    Err(e) => tracing::warn!(error = %e, "reopen-hook:fired — open_new_window failed"),
+                }
+            }
+        }
         None => tracing::warn!("reopen-hook fired before REOPEN_STATE was set"),
     }
-    0 // NO — we opened the window; AppKit must not also run its default reopen
+    0 // NO — handled; AppKit must not also run its default reopen
 }
 
 /// Install the reopen handler by wiring `applicationShouldHandleReopen:` onto

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1164,6 +1164,10 @@ wrap_task! {
                 }
                 if label.as_str() == "main" {
                     main_match = true;
+                } else if label.starts_with("floating-") {
+                    // Floating panes are never valid redock targets — skip
+                    // them so a dragged pane hovering over a stacked floater
+                    // doesn't ghost the idle floater instead of main.
                 } else {
                     // Deterministic pick among overlapping non-main windows:
                     // lexicographically smallest label. (HashMap iteration


### PR DESCRIPTION
Fixes three issues documented in `docs/analysis/ANALYSIS_FLOATING_PANE_ISSUES_2026_06_21.md`.

## 1 — Redock ghost appears on idle floating pane instead of main window (P1, both platforms)

The cursor resolver (`ui_tasks.rs` macOS/Linux, `motion.rs` Windows) had no filter for `floating-*` window labels. When an idle floater was stacked over the main window, it would win the Z-order / bounding-rect check and receive the `floating-redock:hover-state` event — painting a ghost on the wrong window. Fix: skip any label starting with `"floating-"` in both resolvers; continue the walk so the main window behind it is found instead.

## 2 — Maximize button no-op on macOS/Linux (P2)

`toggle_floating_maximize` had the `SetWindowPos` resize block inside `#[cfg(target_os = "windows")]` only. On macOS/Linux the reducer dispatch ran (flipping `Normal ↔ Maximized` in state) but the window geometry never changed. Fix: add a `#[cfg(not(target_os = "windows"))]` branch calling `post_maximize_window(state, &label)` — the existing CEF Views `window.maximize()` / `window.restore()` task handles the toggle and native restore geometry.

## 3 — Dock icon click opens new window instead of focusing (P2, macOS)

`should_handle_reopen` in `macos_menu.rs` ignored the `hasVisibleWindows` flag and always called `open_new_window`. Standard macOS convention: Dock click with a visible window = bring it to front; only open a new window when no windows are visible. Fix: branch on `_has_visible_windows != 0` — focus via `post_focus_window("main")` when YES, `open_new_window` when NO. The launcher unix-socket forward path stays as `open_new_window` (that path is always an explicit second-process launch).

## Test plan

- [ ] Drag floating pane over main window with another idle floater partially overlapping — ghost appears on the main window, not the idle floater
- [ ] Floating pane maximize button expands window to fill monitor work area on macOS; clicking again restores
- [ ] Dock single-click with AgentMux running brings the main window to front (no new window opened)
- [ ] Dock click with all windows minimised opens a new window
- [ ] `cargo check -p agentmux-cef` clean

<!-- agentmux:agent_id=masty-06136 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)