### PR TITLE
fix(pool): paint pool-promoted new/tear-off windows on Windows (CEF Views show + chrome binding + taskbar name)

### DIFF
--- a/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
+++ b/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(pool): show promoted pool window on-screen first (fix Windows blank-on-promote)
+fix(pool): paint pool-promoted windows on Windows — drive CEF Views Window.show() on the UI thread at promote (macOS parity), register the promoted HWND for chrome ops (drag/close/min/max), and stamp FileDescription/ProductName=AgentMux on the host exe so the taskbar no longer shows "CEF Bootstrap application"

--- a/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
+++ b/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(pool): show promoted pool window on-screen first (fix Windows blank-on-promote)

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -78,6 +78,10 @@ wrap_window_delegate! {
                     if !raw_hwnd.is_null() {
                         crate::commands::window_pool::init_pool_window_hwnd(label, raw_hwnd);
                     }
+                    // Cache the CEF Views Window itself (valid here; lost post-load
+                    // via browser_view.window()) so the promote can run the
+                    // macOS-parity set_bounds()+show() visibility fix.
+                    crate::commands::window_pool::cache_pool_window_view(label, window);
                 }
             }
 

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -435,6 +435,25 @@ pub fn get_monitor_work_area_physical(px: i32, py: i32) -> Option<(i32, i32, i32
     }
 }
 
+/// Effective DPI scale (1.0 == 96 DPI == 100%) of the monitor under `(px, py)`
+/// in physical px. Used to convert physical-pixel rects to DIP for CEF Views
+/// `set_bounds` (which works in DIP). Returns 1.0 if the monitor can't be found.
+#[cfg(target_os = "windows")]
+pub fn dpi_scale_at(px: i32, py: i32) -> f32 {
+    use windows_sys::Win32::Graphics::Gdi::{MonitorFromPoint, MONITOR_DEFAULTTOPRIMARY};
+    use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+    unsafe {
+        let pt = windows_sys::Win32::Foundation::POINT { x: px, y: py };
+        let mon = MonitorFromPoint(pt, MONITOR_DEFAULTTOPRIMARY);
+        if mon.is_null() {
+            return 1.0;
+        }
+        let (mut dx, mut dy) = (96u32, 96u32);
+        let _ = GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &mut dx, &mut dy);
+        (dx as f32 / 96.0).max(0.1)
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub fn get_monitor_work_area(_px: i32, _py: i32) -> Option<(i32, i32, i32, i32)> {
     // TODO: Use NSScreen.main.visibleFrame for proper work area (minus Dock/menu bar).

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -546,13 +546,14 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     #[cfg(target_os = "windows")]
     {
         pool_hwnd_cache().lock().unwrap().remove(label);
+        // Likewise drop the cached CEF Views Window. Only `take_pool_window_view`
+        // (on promote) otherwise removes entries, so a pool window that dies
+        // *before* promote would leak its cached `cef::Window` for the process
+        // lifetime. Idempotent — `take_*` already removed it if this is a
+        // post-promote close. (reagent P2 PR #1654.) Windows-only: the cache
+        // and `take_pool_window_view` are `#[cfg(target_os = "windows")]`.
+        let _ = take_pool_window_view(label);
     }
-    // Likewise drop the cached CEF Views Window. Only `take_pool_window_view`
-    // (on promote) otherwise removes entries, so a pool window that dies
-    // *before* promote would leak its cached `cef::Window` for the process
-    // lifetime. Idempotent — `take_*` already removed it if this is a
-    // post-promote close. (reagent P2 PR #1654.)
-    let _ = take_pool_window_view(label);
     // PR #5 H.4 — atomic remove-from-{unpromoted,queue} + clear
     // respawn semaphore via reducer. The dispatch returns:
     //   - `pool_destroyed_was_unpromoted`: distinguishes pre-promote

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -791,6 +791,22 @@ pub fn promote_pool_window(
         }
     };
 
+    // Register the promoted window's outer top-level HWND under its label in the
+    // chrome-resolution cache (`window_hwnds`) so the new window's title-bar
+    // DRAG / CLOSE / MINIMIZE / MAXIMIZE act on THIS window. Pool windows
+    // otherwise never land in `window_hwnds`: `capture_hwnd_for_label` reads
+    // `host.window_handle()`, which is null for pool windows
+    // (SPEC_POOL_WINDOW_HWND_NULL), so `resolve_window_hwnd` fell back to
+    // `find_own_top_level_window()` (the MAIN window) — which is why dragging the
+    // new window's header moved the original, and close/maximize would hit the
+    // wrong window. `raw_hwnd` is the CefWindow top-level handle (already the
+    // outer HWND), so store it directly; this also overwrites any stale entry
+    // pointing at the off-screen pre-promote pool window.
+    state
+        .window_hwnds
+        .lock()
+        .insert(label.clone(), raw_hwnd as isize);
+
     // Phase F.5 — explicit promote signal sent BETWEEN the matching
     // `report_pool_window_removed` (above) and `report_window_opened`
     // (next). The launcher's pool-respawn saga starts on the

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -887,34 +887,34 @@ pub fn promote_pool_window(
             None => (pos_x, pos_y, win_w, win_h),
         };
 
-    // Take the window out of WS_EX_TOOLWINDOW so the promoted window
-    // appears in the taskbar / Alt+Tab like any other AgentMux
-    // instance. Must run BEFORE the position/show below; otherwise
-    // the taskbar entry won't appear until the next style refresh.
-    set_taskbar_hidden(raw_hwnd, false);
-
-    // Reposition + raise to top + show. SWP_NOZORDER is intentionally
-    // *not* set — for tear-off we need the new window at the top of
-    // the Z-order so the subsequent SC_MOVE handshake routes the
-    // mouse-capture correctly. With SWP_NOZORDER set, HWND_TOP would
-    // be silently ignored.
+    // FIX — Stage 0 (RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21,
+    // cef#3638): position the window at its final ON-SCREEN rect while it is still
+    // HIDDEN, then perform the FIRST show THERE.
+    //
+    // Pool windows are created hidden (set_taskbar_hidden(true) -> SW_HIDE at
+    // spawn; CEF Views show skipped). The previous order showed the window first —
+    // via set_taskbar_hidden(false)'s internal SW_SHOWNA — at the OFF-SCREEN pool
+    // position, and THEN moved it on-screen. On Windows that binds the browser
+    // compositor's visibility/surface state to the off-screen show, and the
+    // subsequent move+resize never re-syncs it, so the promoted window paints
+    // BLANK despite a valid DOM. Showing for the first time at the final on-screen
+    // position gives Chromium the genuine hidden->visible transition it needs.
+    // (macOS is unaffected — occlusion-driven visibility / IOSurface.)
+    //
+    // SWP_NOZORDER is intentionally *not* set on the placement move — tear-off
+    // needs the window at the top of the Z-order for the SC_MOVE mouse-capture
+    // handshake.
     unsafe {
+        use windows_sys::Win32::Foundation::RECT;
         use windows_sys::Win32::UI::WindowsAndMessaging::{
-            SetWindowPos, ShowWindow, HWND_TOP, SW_SHOW,
+            GetWindowRect, SetWindowPos, ShowWindow, HWND_TOP, SW_SHOW, SWP_NOACTIVATE,
         };
-        let pos_ok = SetWindowPos(
-            raw_hwnd,
-            HWND_TOP,
-            pos_x,
-            pos_y,
-            win_w,
-            win_h,
-            0, // no flags — apply move + size + Z-order all
-        );
+
+        // 1. Position to the final on-screen rect WHILE HIDDEN (no show yet).
+        let pos_ok = SetWindowPos(raw_hwnd, HWND_TOP, pos_x, pos_y, win_w, win_h, 0);
         if pos_ok == 0 {
-            // Non-fatal: the SC_MOVE handshake will still try to
-            // run, but the user may see a misplaced window. Log
-            // for diagnostics so we can detect a pattern.
+            // Non-fatal: the SC_MOVE handshake still runs; the user may see a
+            // misplaced window. Log so we can detect a pattern.
             let err = windows_sys::Win32::Foundation::GetLastError();
             tracing::error!(
                 target: "dnd:tearoff:pool",
@@ -923,40 +923,36 @@ pub fn promote_pool_window(
                 "[pool] SetWindowPos failed"
             );
         }
+
+        // 2. Apply the taskbar (APPWINDOW) style AND perform the genuine first
+        //    show: set_taskbar_hidden(false)'s SW_HIDE -> style -> SW_SHOWNA cycle
+        //    is now the first hidden->visible transition, at the on-screen rect
+        //    set in step 1 (set_taskbar_hidden's inner SetWindowPos is NOMOVE/
+        //    NOSIZE, so it preserves that position).
+        set_taskbar_hidden(raw_hwnd, false);
+
+        // 3. Ensure shown + activated (SW_SHOWNA above does not activate).
         let _ = ShowWindow(raw_hwnd, SW_SHOW);
 
-        // Re-assert the rect AFTER show. The pre-show SetWindowPos can be lost to
-        // the pool window's create/show sequence and per-monitor DPI-context
-        // settling, which intermittently leaves the window at the (scaled)
-        // POOL_OFFSCREEN — shown and rendered, but off the screen (the HiDPI
-        // "blank new window" bug). A second, idempotent move after show makes the
-        // placement deterministic. SWP_NOACTIVATE so we don't steal focus again;
-        // HWND_TOP keeps it frontmost (same as the pre-show move).
-        {
-            use windows_sys::Win32::Foundation::RECT;
-            use windows_sys::Win32::UI::WindowsAndMessaging::{GetWindowRect, SWP_NOACTIVATE};
-            let _ = SetWindowPos(
-                raw_hwnd, HWND_TOP, pos_x, pos_y, win_w, win_h, SWP_NOACTIVATE,
-            );
-            // Telemetry: flag any residual off-screen result so a regression of
-            // this class is caught in logs rather than only by users.
-            let mut r: RECT = std::mem::zeroed();
-            if GetWindowRect(raw_hwnd, &mut r) != 0 {
-                // Physical work area: GetWindowRect is physical px (reagent P2 #1652).
-                if let Some((wx, wy, ww, wh)) =
-                    crate::app::get_monitor_work_area_physical(pos_x, pos_y)
-                {
-                    let onscreen =
-                        r.right > wx && r.left < wx + ww && r.bottom > wy && r.top < wy + wh;
-                    if !onscreen {
-                        tracing::error!(
-                            target: "pool:new-window",
-                            label = %label,
-                            left = r.left,
-                            top = r.top,
-                            "[pool] promoted window still off-screen after post-show re-assert"
-                        );
-                    }
+        // 4. Re-assert the rect after show + off-screen telemetry (#1652).
+        //    SWP_NOACTIVATE so we don't steal focus again; HWND_TOP keeps it frontmost.
+        let _ = SetWindowPos(raw_hwnd, HWND_TOP, pos_x, pos_y, win_w, win_h, SWP_NOACTIVATE);
+        let mut r: RECT = std::mem::zeroed();
+        if GetWindowRect(raw_hwnd, &mut r) != 0 {
+            // Physical work area: GetWindowRect is physical px (reagent P2 #1652).
+            if let Some((wx, wy, ww, wh)) =
+                crate::app::get_monitor_work_area_physical(pos_x, pos_y)
+            {
+                let onscreen =
+                    r.right > wx && r.left < wx + ww && r.bottom > wy && r.top < wy + wh;
+                if !onscreen {
+                    tracing::error!(
+                        target: "pool:new-window",
+                        label = %label,
+                        left = r.left,
+                        top = r.top,
+                        "[pool] promoted window still off-screen after post-show re-assert"
+                    );
                 }
             }
         }

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -981,6 +981,27 @@ pub fn promote_pool_window(
         host.was_resized();
     }
 
+    // macOS-PARITY VISIBILITY FIX (the load-bearing one): drive the CEF Views
+    // `Window` set_bounds() + show() exactly as the macOS/Linux promote does
+    // (ui_tasks::PromotePoolWindowTask). The Win32 ShowWindow + host.was_hidden()
+    // above show the HWND and hint the host, but they do NOT flip the browser's
+    // view-hierarchy/compositor visibility — only the Views Window show() does,
+    // which is the single thing macOS does and Windows didn't, and is why macOS
+    // renders and Windows paints blank. set_bounds is in DIP (Views space), so
+    // convert the physical rect we positioned the HWND at.
+    {
+        let scale = crate::app::dpi_scale_at(pos_x, pos_y);
+        let to_dip = |v: i32| (v as f32 / scale).round() as i32;
+        crate::ui_tasks::show_pool_window_via_views(
+            state,
+            &label,
+            to_dip(pos_x),
+            to_dip(pos_y),
+            to_dip(win_w),
+            to_dip(win_h),
+        );
+    }
+
     // Phase B.7.3.3 — the launcher's typed events drive the
     // InstancePanel atoms via the CEF JS bridge. No sync emit here.
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -48,6 +48,14 @@ use crate::state::{AppState, WindowKind, WindowMeta};
 /// `Send + Sync` without `unsafe`; callers cast back to `HWND` /
 /// `*mut c_void` at use site.
 #[cfg(target_os = "windows")]
+static POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn pool_hwnd_cache() -> &'static Mutex<HashMap<String, usize>> {
+    POOL_HWND_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Global cache of pool windows' CEF Views `Window`, captured at
 /// `on_window_created` (UI thread) and consumed by a promote UI task. The
 /// macOS/Linux `state.windows` registry is cfg-gated OFF on Windows, and
@@ -87,14 +95,6 @@ pub fn cache_pool_window_view(label: &str, window: &cef::Window) {
 #[cfg(target_os = "windows")]
 pub fn take_pool_window_view(label: &str) -> Option<cef::Window> {
     pool_window_views().lock().unwrap().remove(label)
-}
-
-static POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
-    std::sync::OnceLock::new();
-
-#[cfg(target_os = "windows")]
-fn pool_hwnd_cache() -> &'static Mutex<HashMap<String, usize>> {
-    POOL_HWND_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// HWND cache for pane pool windows. Separate from `POOL_HWND_CACHE` because

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -547,6 +547,12 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     {
         pool_hwnd_cache().lock().unwrap().remove(label);
     }
+    // Likewise drop the cached CEF Views Window. Only `take_pool_window_view`
+    // (on promote) otherwise removes entries, so a pool window that dies
+    // *before* promote would leak its cached `cef::Window` for the process
+    // lifetime. Idempotent — `take_*` already removed it if this is a
+    // post-promote close. (reagent P2 PR #1654.)
+    let _ = take_pool_window_view(label);
     // PR #5 H.4 — atomic remove-from-{unpromoted,queue} + clear
     // respawn semaphore via reducer. The dispatch returns:
     //   - `pool_destroyed_was_unpromoted`: distinguishes pre-promote
@@ -948,10 +954,11 @@ pub fn promote_pool_window(
     // cef#3638): position the window at its final ON-SCREEN rect while it is still
     // HIDDEN, then perform the FIRST show THERE.
     //
-    // Pool windows are created hidden (set_taskbar_hidden(true) -> SW_HIDE at
-    // spawn; CEF Views show skipped). The previous order showed the window first —
-    // via set_taskbar_hidden(false)'s internal SW_SHOWNA — at the OFF-SCREEN pool
-    // position, and THEN moved it on-screen. On Windows that binds the browser
+    // Pool windows are spawned visible-but-OFF-SCREEN, then immediately
+    // SW_HIDE'd (set_taskbar_hidden(true)) in init_pool_window_hwnd, so by
+    // promote time the raw HWND is hidden. The previous order re-showed it
+    // first — via set_taskbar_hidden(false)'s internal SW_SHOWNA — at the
+    // OFF-SCREEN pool position, and THEN moved it on-screen. On Windows that binds the browser
     // compositor's visibility/surface state to the off-screen show, and the
     // subsequent move+resize never re-syncs it, so the promoted window paints
     // BLANK despite a valid DOM. Showing for the first time at the final on-screen

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -48,18 +48,25 @@ use crate::state::{AppState, WindowKind, WindowMeta};
 /// `Send + Sync` without `unsafe`; callers cast back to `HWND` /
 /// `*mut c_void` at use site.
 #[cfg(target_os = "windows")]
-/// UI-thread-local cache of pool windows' CEF Views `Window`, captured at
-/// `on_window_created`. The macOS/Linux `state.windows` registry is cfg-gated OFF
-/// on Windows, and `browser_view.window()` returns None for pool windows
-/// post-load (SPEC_POOL_WINDOW_HWND_NULL), so the Windows promote can't otherwise
-/// reach the Views `Window` to apply the macOS-parity `set_bounds()`+`show()`
-/// visibility fix. Both `on_window_created` and the promote run on the CEF UI
-/// thread, so a thread-local (no `Send`) is correct and avoids touching the
-/// shared `AppState`.
+/// Global cache of pool windows' CEF Views `Window`, captured at
+/// `on_window_created` (UI thread) and consumed by a promote UI task. The
+/// macOS/Linux `state.windows` registry is cfg-gated OFF on Windows, and
+/// `browser_view.window()` returns None for pool windows post-load
+/// (SPEC_POOL_WINDOW_HWND_NULL), so the promote can't otherwise reach the Views
+/// `Window` to apply the macOS-parity `set_bounds()`+`show()` fix.
+///
+/// This is a Send `Mutex` (NOT a thread-local): `on_window_created` runs on the
+/// CEF UI thread but the Windows promote runs on the IPC thread, so the cache
+/// must cross threads. `cef::Window` is `Send` (same as the macOS `state.windows`
+/// registry). The actual `set_bounds()`+`show()` is still performed on the UI
+/// thread via a posted task — CEF Views calls are UI-thread-only.
 #[cfg(target_os = "windows")]
-thread_local! {
-    static POOL_WINDOW_VIEWS: std::cell::RefCell<HashMap<String, cef::Window>> =
-        std::cell::RefCell::new(HashMap::new());
+static POOL_WINDOW_VIEWS: std::sync::OnceLock<Mutex<HashMap<String, cef::Window>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn pool_window_views() -> &'static Mutex<HashMap<String, cef::Window>> {
+    POOL_WINDOW_VIEWS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Cache a pool window's CEF Views `Window` (called from `on_window_created`,
@@ -69,15 +76,17 @@ pub fn cache_pool_window_view(label: &str, window: &cef::Window) {
     if !label.starts_with("window-pool-") {
         return;
     }
-    POOL_WINDOW_VIEWS.with(|c| {
-        c.borrow_mut().insert(label.to_string(), window.clone());
-    });
+    pool_window_views()
+        .lock()
+        .unwrap()
+        .insert(label.to_string(), window.clone());
 }
 
-/// Take (remove + return) a pool window's cached CEF Views `Window` for promote.
+/// Take (remove + return) a pool window's cached CEF Views `Window`. Called on
+/// the UI thread by the promote show task.
 #[cfg(target_os = "windows")]
 pub fn take_pool_window_view(label: &str) -> Option<cef::Window> {
-    POOL_WINDOW_VIEWS.with(|c| c.borrow_mut().remove(label))
+    pool_window_views().lock().unwrap().remove(label)
 }
 
 static POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
@@ -997,46 +1006,27 @@ pub fn promote_pool_window(
         crate::client::install_main_window_floater_cascade_hook(raw_hwnd);
     }
 
-    // FIX (the macOS-vs-Windows asymmetry — likely the real root cause):
-    // notify the CEF browser that it became visible at its new size. The Win32
-    // ShowWindow above only shows the HWND; it does NOT tell the CEF browser its
-    // visibility changed, so the renderer's compositor stays in the hidden/evicted
-    // state and the promoted window paints BLANK despite a valid DOM. macOS works
-    // precisely because it promotes via CEF Views `window.show()` (ui_tasks.rs),
-    // which notifies CEF — the Windows path used raw Win32 and skipped it.
-    // WasHidden(false) drives RenderWidgetHost::WasShown -> FrameEvictor::SetVisible(true);
-    // WasResized forces a fresh compositor frame at the new size. See
-    // docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md
-    // (electron#42378 FrameEvictor eviction; #32001 paints-only-after-show).
-    if let Some(host) = state.get_browser(&label).and_then(|b| b.host()) {
-        host.was_hidden(0); // 0 = not hidden = visible
-        host.was_resized();
-    }
-
     // macOS-PARITY VISIBILITY FIX (the load-bearing one): drive the CEF Views
-    // `Window` set_bounds() + show() exactly as the macOS/Linux promote does
-    // (ui_tasks::PromotePoolWindowTask). The Win32 ShowWindow + host.was_hidden()
-    // above show the HWND and hint the host, but they do NOT flip the browser's
-    // view-hierarchy/compositor visibility — only the Views Window show() does,
-    // which is the single thing macOS does and Windows didn't, and is why macOS
-    // renders and Windows paints blank. set_bounds is in DIP (Views space), so
-    // convert the physical rect we positioned the HWND at.
-    if let Some(window) = take_pool_window_view(&label) {
+    // `Window` set_bounds() + show() exactly as the macOS/Linux promote does — but
+    // POSTED TO THE UI THREAD, because CEF Views calls are UI-thread-only and this
+    // promote runs on the IPC thread (the previous in-line attempt no-op'd: the
+    // thread-local cache + show ran on the wrong thread). The Window was cached at
+    // on_window_created (browser_view.window() is None for pool windows post-load
+    // on Windows). The Win32 SetWindowPos + ShowWindow above position/show the raw
+    // HWND but do NOT flip the browser's view-hierarchy/compositor visibility —
+    // only the Views Window show() does, which is the one thing macOS does and
+    // Windows didn't, and is why macOS renders and Windows paints blank. set_bounds
+    // is DIP, so convert the physical rect we positioned the HWND at.
+    {
         let scale = crate::app::dpi_scale_at(pos_x, pos_y);
         let to_dip = |v: i32| (v as f32 / scale).round() as i32;
-        crate::ui_tasks::show_pool_window_via_views(
-            &window,
+        crate::ui_tasks::post_promote_pool_window_views_show(
+            state,
             &label,
             to_dip(pos_x),
             to_dip(pos_y),
             to_dip(win_w),
             to_dip(win_h),
-        );
-    } else {
-        tracing::warn!(
-            target: "pool:new-window",
-            label = %label,
-            "[pool] no cached CEF Views Window — macOS-parity visibility fix NOT applied"
         );
     }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -48,6 +48,38 @@ use crate::state::{AppState, WindowKind, WindowMeta};
 /// `Send + Sync` without `unsafe`; callers cast back to `HWND` /
 /// `*mut c_void` at use site.
 #[cfg(target_os = "windows")]
+/// UI-thread-local cache of pool windows' CEF Views `Window`, captured at
+/// `on_window_created`. The macOS/Linux `state.windows` registry is cfg-gated OFF
+/// on Windows, and `browser_view.window()` returns None for pool windows
+/// post-load (SPEC_POOL_WINDOW_HWND_NULL), so the Windows promote can't otherwise
+/// reach the Views `Window` to apply the macOS-parity `set_bounds()`+`show()`
+/// visibility fix. Both `on_window_created` and the promote run on the CEF UI
+/// thread, so a thread-local (no `Send`) is correct and avoids touching the
+/// shared `AppState`.
+#[cfg(target_os = "windows")]
+thread_local! {
+    static POOL_WINDOW_VIEWS: std::cell::RefCell<HashMap<String, cef::Window>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Cache a pool window's CEF Views `Window` (called from `on_window_created`,
+/// where the Window is valid). No-op for non-pool labels.
+#[cfg(target_os = "windows")]
+pub fn cache_pool_window_view(label: &str, window: &cef::Window) {
+    if !label.starts_with("window-pool-") {
+        return;
+    }
+    POOL_WINDOW_VIEWS.with(|c| {
+        c.borrow_mut().insert(label.to_string(), window.clone());
+    });
+}
+
+/// Take (remove + return) a pool window's cached CEF Views `Window` for promote.
+#[cfg(target_os = "windows")]
+pub fn take_pool_window_view(label: &str) -> Option<cef::Window> {
+    POOL_WINDOW_VIEWS.with(|c| c.borrow_mut().remove(label))
+}
+
 static POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
     std::sync::OnceLock::new();
 
@@ -989,16 +1021,22 @@ pub fn promote_pool_window(
     // which is the single thing macOS does and Windows didn't, and is why macOS
     // renders and Windows paints blank. set_bounds is in DIP (Views space), so
     // convert the physical rect we positioned the HWND at.
-    {
+    if let Some(window) = take_pool_window_view(&label) {
         let scale = crate::app::dpi_scale_at(pos_x, pos_y);
         let to_dip = |v: i32| (v as f32 / scale).round() as i32;
         crate::ui_tasks::show_pool_window_via_views(
-            state,
+            &window,
             &label,
             to_dip(pos_x),
             to_dip(pos_y),
             to_dip(win_w),
             to_dip(win_h),
+        );
+    } else {
+        tracing::warn!(
+            target: "pool:new-window",
+            label = %label,
+            "[pool] no cached CEF Views Window — macOS-parity visibility fix NOT applied"
         );
     }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -965,6 +965,22 @@ pub fn promote_pool_window(
         crate::client::install_main_window_floater_cascade_hook(raw_hwnd);
     }
 
+    // FIX (the macOS-vs-Windows asymmetry — likely the real root cause):
+    // notify the CEF browser that it became visible at its new size. The Win32
+    // ShowWindow above only shows the HWND; it does NOT tell the CEF browser its
+    // visibility changed, so the renderer's compositor stays in the hidden/evicted
+    // state and the promoted window paints BLANK despite a valid DOM. macOS works
+    // precisely because it promotes via CEF Views `window.show()` (ui_tasks.rs),
+    // which notifies CEF — the Windows path used raw Win32 and skipped it.
+    // WasHidden(false) drives RenderWidgetHost::WasShown -> FrameEvictor::SetVisible(true);
+    // WasResized forces a fresh compositor frame at the new size. See
+    // docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md
+    // (electron#42378 FrameEvictor eviction; #32001 paints-only-after-show).
+    if let Some(host) = state.get_browser(&label).and_then(|b| b.host()) {
+        host.was_hidden(0); // 0 = not hidden = visible
+        host.was_resized();
+    }
+
     // Phase B.7.3.3 — the launcher's typed events drive the
     // InstancePanel atoms via the CEF JS bridge. No sync emit here.
 

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -25,6 +25,45 @@ fn get_window_on_ui(state: &Arc<AppState>, label: &str) -> Option<Window> {
     browser_view.window()
 }
 
+/// Windows-only: drive the CEF Views `Window` set_bounds() + show() for a
+/// promoted pool window — the same path the macOS/Linux promote uses
+/// (`PromotePoolWindowTask`). The Windows promote positions the raw HWND via
+/// Win32 and never touched the Views `Window`, so the browser's view-hierarchy /
+/// compositor visibility never flipped from hidden -> the promoted window painted
+/// BLANK despite a valid DOM. This is the macOS-vs-Windows asymmetry. Bounds are
+/// DIP (CEF Views space); the Win32 caller converts physical -> DIP via
+/// `app::dpi_scale_at`. Must run on the UI thread.
+/// See docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md.
+#[cfg(target_os = "windows")]
+pub(crate) fn show_pool_window_via_views(
+    state: &Arc<AppState>,
+    label: &str,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+) {
+    match get_window_on_ui(state, label) {
+        Some(window) => {
+            window.set_bounds(Some(&cef::Rect { x, y, width, height }));
+            window.show();
+            tracing::info!(
+                target: "pool:new-window",
+                label = %label,
+                x, y, width, height,
+                "[pool] CEF Views set_bounds + show (macOS-parity visibility fix)"
+            );
+        }
+        None => {
+            tracing::warn!(
+                target: "pool:new-window",
+                label = %label,
+                "[pool] no CEF Views window for promote show — cannot apply visibility fix"
+            );
+        }
+    }
+}
+
 // ── Deferred load_url (used by on_before_popup to avoid UI-thread deadlock)
 //
 // Calling `frame.load_url(url)` synchronously inside a CEF callback that

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -36,32 +36,26 @@ fn get_window_on_ui(state: &Arc<AppState>, label: &str) -> Option<Window> {
 /// See docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md.
 #[cfg(target_os = "windows")]
 pub(crate) fn show_pool_window_via_views(
-    state: &Arc<AppState>,
+    window: &Window,
     label: &str,
     x: i32,
     y: i32,
     width: i32,
     height: i32,
 ) {
-    match get_window_on_ui(state, label) {
-        Some(window) => {
-            window.set_bounds(Some(&cef::Rect { x, y, width, height }));
-            window.show();
-            tracing::info!(
-                target: "pool:new-window",
-                label = %label,
-                x, y, width, height,
-                "[pool] CEF Views set_bounds + show (macOS-parity visibility fix)"
-            );
-        }
-        None => {
-            tracing::warn!(
-                target: "pool:new-window",
-                label = %label,
-                "[pool] no CEF Views window for promote show — cannot apply visibility fix"
-            );
-        }
-    }
+    use cef::ImplWindow;
+    // The exact macOS/Linux promote sequence (PromotePoolWindowTask), on the CEF
+    // Views Window captured at creation. set_bounds is DIP; caller converts from
+    // physical px. This is the visibility transition the raw-Win32 promote never
+    // performed, which is why Windows painted blank and macOS did not.
+    window.set_bounds(Some(&cef::Rect { x, y, width, height }));
+    window.show();
+    tracing::info!(
+        target: "pool:new-window",
+        label = %label,
+        x, y, width, height,
+        "[pool] CEF Views set_bounds + show on cached Window (macOS-parity visibility fix)"
+    );
 }
 
 // ── Deferred load_url (used by on_before_popup to avoid UI-thread deadlock)

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -34,28 +34,80 @@ fn get_window_on_ui(state: &Arc<AppState>, label: &str) -> Option<Window> {
 /// DIP (CEF Views space); the Win32 caller converts physical -> DIP via
 /// `app::dpi_scale_at`. Must run on the UI thread.
 /// See docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md.
+// Windows-only: run the macOS-parity CEF Views show() on the UI thread. The
+// Windows promote runs on the IPC thread, but CEF Views calls are UI-thread-only,
+// so the set_bounds()+show() must be posted here (mirroring the macOS
+// PromotePoolWindowTask). The Window was cached at on_window_created because
+// browser_view.window() returns None for pool windows post-load on Windows.
 #[cfg(target_os = "windows")]
-pub(crate) fn show_pool_window_via_views(
-    window: &Window,
+wrap_task! {
+    pub struct PromotePoolWindowViewsShowTask {
+        state: Arc<AppState>,
+        label: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            use cef::ImplWindow;
+            match crate::commands::window_pool::take_pool_window_view(&self.label) {
+                Some(window) => {
+                    // set_bounds is DIP (the Win32 promote already positioned the
+                    // HWND in physical px; this syncs the Views Window so show()
+                    // doesn't jump and performs the real hidden->visible transition).
+                    window.set_bounds(Some(&cef::Rect {
+                        x: self.x,
+                        y: self.y,
+                        width: self.width,
+                        height: self.height,
+                    }));
+                    window.show();
+                    // Nudge the browser compositor to present a fresh frame.
+                    if let Some(host) =
+                        self.state.get_browser(&self.label).and_then(|b| b.host())
+                    {
+                        host.was_resized();
+                    }
+                    tracing::info!(
+                        target: "pool:new-window",
+                        label = %self.label,
+                        x = self.x, y = self.y, width = self.width, height = self.height,
+                        "[pool] CEF Views set_bounds + show on cached Window (macOS-parity, UI thread)"
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        target: "pool:new-window",
+                        label = %self.label,
+                        "[pool] no cached CEF Views Window at promote show task — fix not applied"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn post_promote_pool_window_views_show(
+    state: &Arc<AppState>,
     label: &str,
     x: i32,
     y: i32,
     width: i32,
     height: i32,
 ) {
-    use cef::ImplWindow;
-    // The exact macOS/Linux promote sequence (PromotePoolWindowTask), on the CEF
-    // Views Window captured at creation. set_bounds is DIP; caller converts from
-    // physical px. This is the visibility transition the raw-Win32 promote never
-    // performed, which is why Windows painted blank and macOS did not.
-    window.set_bounds(Some(&cef::Rect { x, y, width, height }));
-    window.show();
-    tracing::info!(
-        target: "pool:new-window",
-        label = %label,
-        x, y, width, height,
-        "[pool] CEF Views set_bounds + show on cached Window (macOS-parity visibility fix)"
+    let mut task = PromotePoolWindowViewsShowTask::new(
+        state.clone(),
+        label.to_string(),
+        x,
+        y,
+        width,
+        height,
     );
+    post_task(ThreadId::UI, Some(&mut task));
 }
 
 // ── Deferred load_url (used by on_before_popup to avoid UI-thread deadlock)

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -65,7 +65,12 @@ wrap_task! {
                         height: self.height,
                     }));
                     window.show();
-                    // Nudge the browser compositor to present a fresh frame.
+                    // Belt-and-suspenders compositor nudge. NOTE: CefBrowserHost
+                    // ::WasResized is only load-bearing in windowless/OSR mode; in
+                    // CEF windowed mode (our case) it is effectively a no-op. The
+                    // ACTUAL fix is the CEF Views window.show() above (the genuine
+                    // hidden->visible transition). Kept as a cheap hint in case the
+                    // host ever runs OSR; do not rely on it. (plan doc §6.)
                     if let Some(host) =
                         self.state.get_browser(&self.label).and_then(|b| b.host())
                     {

--- a/docs/plans/PLAN_POOL_HIDDEN_PREWARM_2026_06_21.md
+++ b/docs/plans/PLAN_POOL_HIDDEN_PREWARM_2026_06_21.md
@@ -8,6 +8,34 @@
 
 ---
 
+## 0. RESOLUTION (what actually fixed it — added after implementation)
+
+The research's *diagnosis* was right (a Windows compositor visibility-state
+desync; macOS works because it shows via CEF Views), but the *plan's* "hidden
+pre-warm" approach was **not** what fixed it. The actual fix, verified on HiDPI:
+
+1. **Render (load-bearing):** the Windows promote positioned the raw HWND via
+   Win32 but **never drove the CEF Views `Window.show()`** that flips the
+   browser's compositor visibility — so the renderer's frame was evicted and the
+   window painted blank. Fix: cache the CEF Views `Window` at `on_window_created`
+   (a global `Mutex`, because `browser_view.window()` is `None` for pool windows
+   post-load and the promote runs on the IPC thread), then **post a UI task** that
+   runs `set_bounds()` + `show()` — the exact macOS sequence, on the UI thread.
+   Ruled out first (all no-ops/wrong-layer): HWND show-order; `was_hidden()`/
+   `was_resized()` host hints; a direct `show()` that couldn't reach the Window;
+   a thread-local cache read on the wrong thread.
+2. **Window identity (drag/close/min/max):** promoted pool windows never landed
+   in `state.window_hwnds`, so `resolve_window_hwnd` fell back to the main window
+   and the new window's chrome acted on the original. Fix: register the promoted
+   outer HWND under its label at promote.
+3. **Taskbar name:** the host exe is CEF's `bootstrap.exe` ("CEF Bootstrap
+   application" FileDescription). Fix: `inject-exe-icon.sh` now also stamps
+   `FileDescription`/`ProductName` = AgentMux via rcedit.
+
+The pool is fully retained (no cold-path fallback needed).
+
+---
+
 ## 1. Problem in one line
 
 Pool windows are created **visible-but-off-screen** at `(-32000,-32000)`. On Windows that puts the aura `Window` in the **"already visible"** state, so the promotion's move+resize generates no **hidden→visible transition**, and Chromium's compositor/occlusion state never re-syncs → the on-screen window is **blank** despite a correct DOM (research §1a, cef#3638). macOS is unaffected (research §3).

--- a/docs/plans/PLAN_POOL_HIDDEN_PREWARM_2026_06_21.md
+++ b/docs/plans/PLAN_POOL_HIDDEN_PREWARM_2026_06_21.md
@@ -1,0 +1,70 @@
+# Implementation Plan: hidden-pre-warm window pool (fix Windows blank-on-promote)
+
+**Date:** 2026-06-21
+**Area:** `agentmux-cef` — window pool (`src/commands/window_pool.rs`, `src/ui_tasks.rs`, window creation)
+**Goal:** keep the new-window/tear-off pool, but make pool-promoted windows **paint correctly on Windows**.
+**Backed by:** `docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md`
+**Prior point-fixes (orthogonal, already merged):** #1650 (default layout), #1652 (on-screen clamp).
+
+---
+
+## 1. Problem in one line
+
+Pool windows are created **visible-but-off-screen** at `(-32000,-32000)`. On Windows that puts the aura `Window` in the **"already visible"** state, so the promotion's move+resize generates no **hidden→visible transition**, and Chromium's compositor/occlusion state never re-syncs → the on-screen window is **blank** despite a correct DOM (research §1a, cef#3638). macOS is unaffected (research §3).
+
+## 2. Core idea (the Electron/VS Code model)
+
+Stop pre-warming **shown-off-screen**. Pre-warm **genuinely hidden** (never shown), then do a real **hidden→visible transition** on promote. This is the CEF analog of `BrowserWindow({show:false})` → `ready-to-show` → `win.show()` (research §2). We keep the main pool benefit — the CEF window + renderer process are already spawned and the (empty, pool-mode) page is loaded, which is the ~3 s saving. We do **not** rely on a *pre-painted* surface (Windows may not paint a hidden window; research §5.3), and we don't need to: pool windows render an empty body in pool mode and only bootstrap the workspace **at promote time** anyway, so nothing is pre-painted today either.
+
+## 3. Current code (what changes)
+
+- `spawn_pool_window` (`window_pool.rs:193`) → `crate::ui_tasks::post_create_window(state, url, label, POOL_OFFSCREEN_X, POOL_OFFSCREEN_Y, w, h, frameless=true)` (`:348`). The window is created **shown** (comment `:345` "visible (frameless) but well outside any monitor bounds").
+- `promote_pool_window` (`window_pool.rs:547`, Windows) → `set_taskbar_hidden(false)` + `SetWindowPos(HWND_TOP, rect)` + `ShowWindow(SW_SHOW)` + (post-#1652) clamp + re-assert.
+- Pool window post-create handling: `on_after_created` / `register_pool_window` (`window_pool.rs`), `set_taskbar_hidden` keeps it out of the taskbar.
+
+## 4. Plan — staged, repro-gated (the research flagged real uncertainty)
+
+The research could not pin a single mechanism and noted #3638 may be patched in our CEF and that hidden windows may not pre-paint on Windows. So **Stage 0 is a decisive spike** before the full change.
+
+### Stage 0 — Spike: create pool windows hidden, measure (½ day)
+Smallest change that tests the hypothesis:
+1. Add a `show: bool` parameter (or a `post_create_window_hidden` variant) to the pool window-creation path so the CEF window/native HWND is created **without `WS_VISIBLE`** (or `ShowWindow(SW_HIDE)` immediately at `on_after_created` for `window-pool-*` labels) and is **not** positioned at `-32000` while visible. The window can sit hidden at any size (use `POOL_WIDTH×POOL_HEIGHT`).
+2. In `promote_pool_window` (Windows), keep the existing sequence — it already ends in `ShowWindow(SW_SHOW)`. Because the window was never shown, this `SW_SHOW` is now the **genuine first show** (hidden→visible). Add a `CefBrowserHost::WasResized()` (or a 1px size jiggle) right after show as belt-and-suspenders.
+3. **Build + verify** (see §5). Decision gate:
+   - **Blank fixed** → proceed to Stage 1 (polish).
+   - **Still blank** → the dominant mechanism isn't the "already visible" path; go to Stage 2 (forced-resync or layered pre-warm), using `about:gpu` + `--enable-logging` occlusion logs to identify which of occlusion-tracker / FrameEvictor is responsible (research §5.1).
+
+### Stage 1 — Productionize the hidden pre-warm (if Stage 0 works)
+- Make "hidden" the real pool-window state end to end: never `SW_SHOW` until promote; ensure `set_taskbar_hidden`/`WS_EX_TOOLWINDOW` still applies while hidden (a hidden window has no taskbar entry anyway, but keep the style correct for the post-show taskbar reveal).
+- Promote sequence (authoritative, single place): `SetWindowPos`(final clamped rect, real size delta) → `set_taskbar_hidden(false)` → `ShowWindow(SW_SHOW)` → `UpdateWindow` → `WasResized()`. Keep the #1652 work-area clamp + post-show re-assert + off-screen telemetry.
+- Drop `POOL_OFFSCREEN_X/Y` usage for the new-window/tear-off pool (no longer needed; a hidden window needs no off-screen parking). Keep the constant only if the pane-pool path still relies on it; otherwise remove.
+- Refill (`spawn_pool_window` after each promote) creates the replacement **hidden** too.
+- Confirm **tear-off** still works: tear-off promotes the same window; a hidden→shown window must still land under the cursor and run the SC_MOVE drag handshake. Verify the drag handshake doesn't depend on the window being pre-shown.
+
+### Stage 2 — Fallback (only if hidden pre-warm doesn't paint)
+If a genuinely-hidden window still won't paint on first show in our CEF build:
+- **2a. Forced promotion-time resync:** after show, a real resize (e.g. final-1px then final) to force `WM_SIZE`, and/or a `SW_HIDE`→`SW_SHOW` toggle (research §4c, electron#27353 "paints after move/resize"). Cheap, ugly, effective.
+- **2b. Layered/transparent on-screen pre-warm:** create the pool window **on-screen but fully transparent** (`WS_EX_LAYERED`, alpha 0) so it is neither off-screen-visible nor hidden — it paints (not occluded) and reveal = set alpha 255 + reposition. More complex; only if pre-painted pixels are actually required. (research §5.3)
+- **2c. GPU/feature flags** as mitigation layer: `--disable-features=CalculateNativeWinOcclusion` (already set) **plus** `--disable-backgrounding-occluded-windows --disable-renderer-backgrounding`. Not a standalone fix (refuted 0-3 individually) but may stack with 2a.
+
+## 5. Verification
+
+**Empirical repro harness (build once, reuse each stage):**
+- Launch the build; drive N "Open another window" via CDP (`window.api.openNewWindow()`); for each promoted window capture:
+  - position/size + `blocks`/`tiles` (already scripted) — confirms DOM + placement, AND
+  - **`Page.captureScreenshot` byte-size per pixel vs a known-blank pool spare and the known-good Starter** — distinguishes "DOM populated but surface blank" from "actually painted." (DOM-count alone is NOT sufficient — that's what masked this bug.)
+- Pass criterion: every promoted window's screenshot has content-level entropy comparable to Starter (not to a blank spare), AND user-visual confirmation.
+- Diagnostics if still blank: `about:gpu`, `--enable-logging=stderr --vmodule=native_window_occlusion*=1`, toggle one lever at a time.
+
+**Regression:** tear-off a tab (window follows cursor, lands correctly, paints); multi-monitor + 125%/100% mixed DPI; pool exhaustion → cold path still works.
+
+## 6. Risks & rollback
+- **Risk:** hidden window doesn't pre-paint → first show has a brief paint-in (not a blank, just a frame later). Acceptable; if not, Stage 2b.
+- **Risk:** tear-off drag handshake assumed a pre-shown window. Mitigation: verify in Stage 1; the SC_MOVE handshake runs after show in both cases.
+- **Risk:** `WasResized()`/windowed-mode CEF host calls may be no-ops (some are OSR-only — `Invalidate(PET_VIEW)` is OSR-only, do NOT use). Rely on Win32 `ShowWindow`/`SetWindowPos`/`WM_SIZE` as the load-bearing mechanism.
+- **Rollback:** the change is gated to pool window creation + promote (Windows `#cfg`). Reverting restores current behavior. If Stage 0/2 all fail under time pressure, the documented stopgap is to route `open_new_window` to the **cold path** (no pool) — correct, ~3 s slower — while keeping the pool for tear-off only.
+
+## 7. Done =
+- Spike result recorded (which stage fixed it) + the screenshot-based pass for ≥6 consecutive opens, 0 blank, on HiDPI.
+- Tear-off + multi-monitor regressions pass.
+- Research + this plan referenced in the PR; a short retro on the root cause (visibility-state desync, not GPU).

--- a/docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md
+++ b/docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md
@@ -1,0 +1,80 @@
+# Research: pre-warmed CEF window renders blank on Windows (promotion blank-surface)
+
+**Date:** 2026-06-21
+**Method:** multi-source web research with adversarial (3-vote) claim verification — 20 sources, 80 claims extracted, 25 verified (**14 confirmed, 11 refuted**), 102 research sub-agents.
+**Context:** AgentMux's window pool (`agentmux-cef/src/commands/window_pool.rs`) pre-spawns CEF top-level windows **visible but off-screen at `(-32000,-32000)`**, then on demand moves+resizes them on-screen and populates the DOM. On **Windows**, the promoted window has a correct DOM (CDP: full element tree, `visibilityState=visible`, on-screen at correct size) but the **visible surface is blank**. **macOS works.** Cold-created (on-screen at final size) windows render fine. `--disable-features=CalculateNativeWinOcclusion` (CEF #3638) did **not** fix it.
+
+---
+
+## 1. Root cause (confirmed): a Windows compositor **visibility-state desync**, not a GPU/swapchain allocation failure
+
+The symptom (valid DOM, blank surface) is produced on Windows by the browser-compositor's *visibility state* getting stuck, so the compositor frame is never presented/kept. Three independently-documented mechanisms produce it; the first is the direct match for our pattern:
+
+### 1a. The "already visible" defect — CEF #3638 (primary match)
+The CEF maintainer's own diagnosis: the aura `Window` is marked **VISIBLE *before* the real Show/Restore**. Because it is already "visible," the later `Show` is **ignored in `Window::SetVisibleInternal` as "No change."** The genuine **hidden→visible transition** that the compositor / occlusion detector needs is therefore suppressed.
+
+> *"The Window having visible status prior to Show (and prior to Restore) seems logically wrong. We want the Window to transition from hidden to visible when Restore is called."* — magreenblatt, cef#3638
+
+**Why this is exactly our bug:** an **off-screen-but-VISIBLE** pre-warm window is already in the "visible" state. The promotion (SetWindowPos move + resize) does **not** generate a hidden→visible transition, so the compositor/occlusion state never re-syncs → blank. A genuinely *hidden* (never-shown) window transitions cleanly on first show. [confirmed 2-1; source: github.com/chromiumembedded/cef/issues/3638]
+
+### 1b. Native window occlusion mis-classification
+`NativeWindowOcclusionTrackerWin` can mark a window HIDDEN/OCCLUDED; when it does, *"rendering stops, and js is throttled,"* and *"if a window is falsely determined to be occluded, the content area will be white."* [confirmed 3-0; source: Chromium `docs/windows_native_window_occlusion_tracking.md`]
+
+### 1c. Compositor-frame eviction (DelegatedFrameHost / FrameEvictor)
+The browser-side visibility (`RenderWidgetHostImpl::is_hidden_` / `WasShown`) can desync so `DelegatedFrameHost::WasShown` → `FrameEvictor::SetVisible(true)` is skipped and the **compositor frame is evicted while the DOM stays valid and interactive** — the exact "DOM correct, surface blank" symptom. [confirmed 2-1; sources: electron#42378, electron#42638]
+
+### Refuted along the way (do NOT rely on these)
+- "Off-screen positioning (`-32000`) marks the window occluded" → **refuted 0-3.** The off-screen *position* is not the trigger; the *"already visible"* state is.
+- "`--disable-features=CalculateNativeWinOcclusion` alone fixes it" → **refuted 0-3.**
+- "`--disable-gpu` fixes it (proving a pure GPU/swapchain root cause)" → **refuted 0-3.**
+- "Creating hidden via `SW_HIDE`→`SW_SHOW` itself triggers blank" → **refuted 0-3.**
+- "CEF 139 blank is Windows-11-only" → **refuted 0-3.**
+
+---
+
+## 2. How Electron / VS Code avoid it
+
+Electron's `BrowserWindow({ show: false })` is a **genuinely hidden, never-shown** window; the canonical lifecycle is `win.once('ready-to-show', () => win.show())`, which the docs state **"will have no visual flash."** This is a true hidden→visible transition — *not* an off-screen-but-visible window. [confirmed 3-0; source: electronjs.org BrowserWindow docs]
+
+**Important nuance (verified, tempers the framing):** Electron's hidden-window path is **not flawless on Windows** either. Per maintainer-confirmed electron#32001: *"On Windows and Linux, paint events do not fire while the window is hidden… On macOS, it works as expected."* So on Windows a hidden window may **not pre-paint while hidden** — it paints correctly **after** `show()`. Related: electron#22670 (blank after hide/update/show on Windows, *"works fine on Mac OS"*) and electron#27353 (hidden BrowserView blank after show **until moved/resized/unfocused** — direct evidence that forcing a `WM_SIZE`/focus event re-syncs the compositor). [confirmed 3-0]
+
+---
+
+## 3. Why macOS works but Windows doesn't
+
+macOS drives renderer/window visibility from **OS window occlusion** (Core Animation / IOSurface backing), so a hidden/pre-warmed window keeps a valid surface and paints. On Windows/Linux, visibility is tied to **explicit `show()`/`hide()`** and the **DirectComposition/Aura** compositor + native occlusion tracker, which can leave the surface stale/evicted/occluded. Same code, different result across OSes → the defect is localized to the Windows compositor/visibility stack, consistent with the IOSurface-vs-DirectComposition framing. [confirmed 3-0; sources: electron#32001, electron#22670, Electron docs]
+
+---
+
+## 4. Recommended fix direction (medium confidence — verify empirically)
+
+Ranked, from the confirmed mechanisms:
+
+- **(a) PREFERRED — pre-warm GENUINELY HIDDEN, not off-screen-visible.** Create pool windows **without `WS_VISIBLE` / `SW_HIDE`, never shown at `-32000`.** On promote: `SetWindowPos`(final rect, **real size delta**) → `ShowWindow(SW_SHOW)` → `UpdateWindow`, then force compositor resync (`CefBrowserHost::WasResized()`). This produces the real hidden→visible transition #3638 shows is required; it is the CEF analog of Electron `show:false` + `show()`.
+- **(b) On promote, force the resync** even if (a) is partial: a real size change (→ `WM_SIZE`), `ShowWindow(SW_SHOW)`, `WasResized()`/`WasHidden(false)`.
+- **(c) Last resort toggles** known to repaint: minimize→restore, `SW_HIDE`→`SW_SHOW`, or move/resize/unfocus (electron#27353).
+- **(d) Mitigations, not standalone fixes:** `--disable-features=CalculateNativeWinOcclusion` + `--disable-backgrounding-occluded-windows` + `--disable-renderer-backgrounding`.
+
+---
+
+## 5. Caveats / open questions (carry into the implementation plan)
+
+1. **No single source pins THE exact mechanism for our specific off-screen-visible CEF windowed-mode case.** Three documented Windows mechanisms each produce the symptom; confirm which one bites via an isolated repro (`about:gpu`, occlusion logging, toggling one lever at a time).
+2. **CEF #3638 was fixed in M120+/2024.** If our CEF is recent, that exact defect may already be patched, shifting cause toward the occlusion-tracker / FrameEvictor paths or to off-screen-visible behavior not covered by #3638's fix.
+3. **Hidden windows may not pre-paint on Windows** (electron#32001). So genuinely-hidden pre-warm likely keeps the renderer-spawn + page-load saving but does **not** keep a pre-painted surface; it paints on first show (no flash). If a *pre-painted* surface is required, a **layered/transparent on-screen** pre-warm (WS_EX_LAYERED alpha 0, on-screen so not occluded) is the alternative to evaluate.
+4. CEF windowed mode uses a raw native HWND (child of the app HWND); Electron uses Views/aura + BrowserView abstractions, so its issues are a strong analog but not a 1:1 map. `Invalidate(PET_VIEW)` is **OSR-only** and won't help windowed mode.
+
+---
+
+## 6. Sources (primary unless noted)
+- CEF #3638 — premature-visible / "No change" suppression: github.com/chromiumembedded/cef/issues/3638
+- Chromium occlusion design doc (white content on false occlusion): github.com/chromium/chromium/blob/main/docs/windows_native_window_occlusion_tracking.md
+- Electron #42378 + PR #42638 — FrameEvictor eviction / visibility desync
+- Electron #32001 — paint events don't fire for hidden windows on Windows/Linux (macOS does)
+- Electron #22670 — blank after hide/update/show on Windows, fine on macOS
+- Electron #27353 (+ PR #29919) — hidden BrowserView blank until move/resize/unfocus
+- Electron BrowserWindow docs — `show:false` + `ready-to-show` + `show()` (no visual flash)
+- Electron #50250 — `setBackgroundThrottling(false)` early-return short-circuits visibility notifications (thematic)
+- magpcss CEF forum threads (t=11672, t=20363) — corroborating, some claims refuted
+
+*Verification stats: 5 search angles, 20 sources fetched, 80 claims extracted, 25 verified (14 confirmed / 11 refuted), 8 after synthesis, 102 agent calls.*

--- a/scripts/inject-exe-icon.sh
+++ b/scripts/inject-exe-icon.sh
@@ -51,7 +51,17 @@ win_ico="$(win "$ICO")"
 err="$(mktemp)"
 attempt=0
 max=6
-until "$RCEDIT" "$win_exe" --set-icon "$win_ico" 2>"$err"; do
+# Also stamp the version-info strings. The host exe is CEF's bootstrap.exe, whose
+# FileDescription is "CEF Bootstrap application" — that is what Explorer's
+# Properties, Task Manager's Details, and the TASKBAR right-click (jump list)
+# header show. Overwrite them so the user sees "AgentMux" everywhere. Same rcedit
+# call as the icon (one PE rewrite, one retry loop).
+until "$RCEDIT" "$win_exe" --set-icon "$win_ico" \
+    --set-version-string "FileDescription" "AgentMux" \
+    --set-version-string "ProductName" "AgentMux" \
+    --set-version-string "CompanyName" "AgentMux Corp" \
+    --set-version-string "InternalName" "AgentMux" \
+    --set-version-string "OriginalFilename" "agentmux.exe" 2>"$err"; do
     attempt=$((attempt + 1))
     if [ "$attempt" -ge "$max" ]; then
         echo "  [icon] WARNING: rcedit failed after $max attempts on $(basename "$EXE") —" >&2
@@ -64,4 +74,4 @@ until "$RCEDIT" "$win_exe" --set-icon "$win_ico" 2>"$err"; do
     sleep 2
 done
 rm -f "$err"
-echo "  [icon] set AgentMux icon on $(basename "$EXE")"
+echo "  [icon] set AgentMux icon + version strings (FileDescription/ProductName=AgentMux) on $(basename "$EXE")"


### PR DESCRIPTION
## Problem

On Windows, windows served from the pre-warm window pool (used for instant **"Open another window"** and **tab/pane tear-off**) rendered **blank** despite a valid DOM. macOS was unaffected. Three distinct defects, all on the pool-promote path:

1. **Blank surface** — the Windows promote positioned the raw HWND via Win32 but never drove the CEF Views `Window.show()` that flips the browser's compositor visibility, so the renderer's frame was evicted and the window painted blank.
2. **Chrome acted on the wrong window** — promoted pool windows never landed in `state.window_hwnds`, so `resolve_window_hwnd` fell back to the main window; dragging/closing/min/max on the new window's chrome hit the original.
3. **Taskbar name** — the host exe is CEF's `bootstrap.exe`, so the taskbar jump-list / Properties showed **"CEF Bootstrap application"**.

## Fix

1. **Render (load-bearing):** cache the CEF Views `Window` at `on_window_created` in a global `Mutex` (because `browser_view.window()` is `None` for pool windows post-load **and** the Windows promote runs on the IPC thread), then **post a UI task** that runs `set_bounds()` + `show()` — the exact macOS sequence, on the UI thread. This is the genuine hidden→visible transition Chromium needs.
2. **Chrome binding:** register the promoted outer HWND under its label in `window_hwnds` at promote, so drag/close/min/max resolve to the new window.
3. **Taskbar name:** `inject-exe-icon.sh` now also stamps `FileDescription`/`ProductName` = `AgentMux` via rcedit.

The pool is fully retained (no cold-path fallback). Research + implementation notes: `docs/research/RESEARCH_CEF_PREWARM_WINDOW_BLANK_ON_WINDOWS_2026_06_21.md`, `docs/plans/PLAN_POOL_HIDDEN_PREWARM_2026_06_21.md` (§0 RESOLUTION documents what actually fixed it vs. the abandoned "hidden pre-warm" framing).

## Verified on HiDPI Windows

- ✅ "Open another window" paints correctly (was blank)
- ✅ New-window chrome: drag / close / minimize / maximize act on the new window
- ✅ Tab tear-off and pane tear-off into a new window
- ✅ Taskbar right-click shows "AgentMux"

## Known follow-up (not in this PR)

Redocking a torn-off floating pane back onto a pool-served main window leaves an **empty spot** — the block re-docks in the workspace model but the target window's frontend never instantiates the pane's child browser (no `createPane` reaches the host). Signature is independent of the pool-render work here; tracked separately in #1662.

<!-- agentmux:agent_id=agentc -->