### PR TITLE
feat(editor): collapsible live markdown preview panel

### DIFF
--- a/.changesets/1782057645-feat-editor-collapsible-live-markdown-preview-panel-wttw.md
+++ b/.changesets/1782057645-feat-editor-collapsible-live-markdown-preview-panel-wttw.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): collapsible live markdown preview panel

--- a/docs/specs/SPEC_EDITOR_MD_PREVIEW_PANEL_2026_06_21.md
+++ b/docs/specs/SPEC_EDITOR_MD_PREVIEW_PANEL_2026_06_21.md
@@ -1,0 +1,277 @@
+# SPEC — Editor Markdown Live Preview Panel
+
+**Date:** 2026-06-21
+**Status:** Proposed
+
+---
+
+## Goal
+
+When editing a `.md` file in the editor pane, a collapsible live-preview panel
+appears in the bottom half of the editor body. The user can write in CodeMirror
+(top) and watch the rendered result update in real-time (bottom) — or collapse
+the panel to a slim strip when they don't need it.
+
+This replaces the existing **full-overlay toggle** (`showRendered()` /
+`editor-md-preview` / `editor-md-toggle` button / Mod-Shift-V) with a
+non-destructive split: the source is always visible; the preview slides in below
+it.
+
+---
+
+## What exists — reuse, don't reimplement
+
+| Existing piece | Where | How it's reused |
+|---|---|---|
+| `<Markdown textAtom={() => liveDoc()} />` | `editor-view.tsx:851` | Exact same call, same signal — drop into the new panel |
+| `liveDoc` signal | `editor-view.tsx:113` | Already seeded on tab switch + every keystroke |
+| `isMarkdown()` guard | `editor-view.tsx:114` | Show panel only when true |
+| `META_TREE_EXPANDED` / `persistMeta()` pattern | `editor-model.ts:39,803` | Add `META_PREVIEW_OPEN` + `META_PREVIEW_HEIGHT` with identical plumbing |
+| Tree resize-handle drag | `editor-view.tsx:430–447` | Copy `handleResizeMouseDown` verbatim, swap `setTreeWidth` → `setPreviewHeight` |
+| Chevron toggle button | `AgentComposerStrip.tsx:267–288` | Same `▾`/`▴` + `aria-expanded`/`aria-controls` contract |
+
+---
+
+## Layout
+
+```
+editor-main-column (flex-column)
+├── EditorTabStrip
+├── [error / loading / banner slots]
+└── editor-body-wrap (flex-column, height: 100%)
+    ├── editor-codemirror            flex: 1 1 auto; overflow: hidden
+    ├── editor-preview-divider       4px drag handle, .md only, when expanded
+    └── editor-preview-pane          flex: 0 0 <previewHeight>px; .md only
+        ├── editor-preview-header    28px strip: "Preview" label + chevron button
+        └── editor-preview-content   overflow-y: auto; <Markdown textAtom={...} />
+```
+
+When the panel is **collapsed**, `editor-preview-divider` is hidden and the pane
+height collapses to the header height only (28px). The `editor-codemirror` flex
+item fills the freed space automatically.
+
+---
+
+## State & persistence
+
+Two new block meta keys (same pattern as `editor:tree_expanded` /
+`editor:tree_width`):
+
+| Constant | Block meta key | Type | Default |
+|---|---|---|---|
+| `META_PREVIEW_OPEN` | `"editor:preview_open"` | boolean | `true` |
+| `META_PREVIEW_HEIGHT` | `"editor:preview_height"` | number (px) | `300` |
+
+In `EditorModel`:
+
+```ts
+const META_PREVIEW_OPEN   = "editor:preview_open";
+const META_PREVIEW_HEIGHT = "editor:preview_height";
+
+const PREVIEW_HEIGHT_MIN = 80;
+const PREVIEW_HEIGHT_MAX = 1200;
+const PREVIEW_HEIGHT_DEFAULT = 300;
+
+private _previewOpen   = createSignal<boolean>(true);
+private _previewHeight = createSignal<number>(PREVIEW_HEIGHT_DEFAULT);
+
+previewOpenAtom:   Accessor<boolean> = this._previewOpen[0];
+previewHeightAtom: Accessor<number>  = this._previewHeight[0];
+
+// Hydrate in the same block that reads META_TREE_EXPANDED:
+if (meta?.[META_PREVIEW_OPEN] === false) this._previewOpen[1](false);
+const h = meta?.[META_PREVIEW_HEIGHT];
+if (typeof h === "number") this._previewHeight[1](clamp(h, PREVIEW_HEIGHT_MIN, PREVIEW_HEIGHT_MAX));
+
+// Toggle:
+async togglePreview(): Promise<void> {
+    const next = !this._previewOpen[0]();
+    this._previewOpen[1](next);
+    await this.persistMeta({ [META_PREVIEW_OPEN]: next });
+}
+
+// Commit height (called on mouseup, like commitTreeWidth):
+async commitPreviewHeight(): Promise<void> {
+    await this.persistMeta({ [META_PREVIEW_HEIGHT]: this._previewHeight[0]() });
+}
+```
+
+---
+
+## View changes (`editor-view.tsx`)
+
+### Remove
+
+- `mdSourceTabs` signal and all `setMdSourceTabs` / `mdSourceTabs()` calls
+- `showRendered()` computed
+- `toggleMdMode()` function
+- The `<Show when={showRendered()}>…<div class="editor-md-preview">…</Show>` overlay
+- The `<Show when={isMarkdown()}>…<button class="editor-md-toggle">…</Show>` toggle button
+- The `Mod-Shift-V` keydown handler body (key stays, action changes — see below)
+
+### Add
+
+Resize handler (verbatim copy of `handleResizeMouseDown`, renaming tree→preview):
+
+```tsx
+const handlePreviewResizeMouseDown = (e: MouseEvent) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const startH = model.previewHeightAtom();
+    const onMove = (ev: MouseEvent) => {
+        const delta = startY - ev.clientY; // drag up → taller preview
+        model.setPreviewHeight(startH + delta);
+    };
+    const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        void model.commitPreviewHeight();
+    };
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+};
+```
+
+Mod-Shift-V now calls `model.togglePreview()` instead of `toggleMdMode()`.
+
+In the JSX, replace the old overlay + toggle button with:
+
+```tsx
+<div class="editor-body-wrap">
+    <div class="editor-codemirror" ref={setContainerRef} />
+
+    <Show when={isMarkdown()}>
+        <Show when={model.previewOpenAtom()}>
+            <div
+                class="editor-preview-divider"
+                onMouseDown={handlePreviewResizeMouseDown}
+                title="Drag to resize preview"
+            />
+        </Show>
+        <div
+            class="editor-preview-pane"
+            classList={{ "editor-preview-pane--collapsed": !model.previewOpenAtom() }}
+            style={model.previewOpenAtom()
+                ? { height: `${model.previewHeightAtom()}px` }
+                : undefined}
+            id="editor-preview-panel"
+        >
+            <div class="editor-preview-header">
+                <span class="editor-preview-header-label">Preview</span>
+                <button
+                    type="button"
+                    class="editor-preview-chevron"
+                    aria-expanded={model.previewOpenAtom()}
+                    aria-controls="editor-preview-panel"
+                    aria-label={model.previewOpenAtom() ? "Collapse preview" : "Expand preview (Ctrl+Shift+V)"}
+                    onClick={() => void model.togglePreview()}
+                >
+                    {model.previewOpenAtom() ? "▴" : "▾"}
+                </button>
+            </div>
+            <Show when={model.previewOpenAtom()}>
+                <div class="editor-preview-content">
+                    <Markdown textAtom={() => liveDoc()} />
+                </div>
+            </Show>
+        </div>
+    </Show>
+</div>
+```
+
+---
+
+## CSS additions (`editor-view.scss`)
+
+```scss
+// Preview pane
+.editor-body-wrap {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-height: 0;
+}
+
+.editor-codemirror { flex: 1 1 auto; min-height: 0; overflow: hidden; }
+
+.editor-preview-divider {
+    flex: 0 0 4px;
+    background: var(--border-color);
+    cursor: row-resize;
+    &:hover { background: var(--accent-color); }
+}
+
+.editor-preview-pane {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--border-color);
+    min-height: 28px; // header-only when collapsed
+
+    &--collapsed { height: 28px !important; }
+}
+
+.editor-preview-header {
+    flex: 0 0 28px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 8px;
+    background: var(--panel-bg-color);
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    user-select: none;
+}
+
+.editor-preview-header-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--main-text-color);
+    opacity: 0.7;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.editor-preview-chevron {
+    background: none;
+    border: none;
+    color: var(--main-text-color);
+    opacity: 0.7;
+    cursor: pointer;
+    padding: 2px 4px;
+    font-size: 10px;
+    &:hover { opacity: 1; }
+}
+
+.editor-preview-content {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 16px 20px;
+}
+```
+
+---
+
+## Shortcut reference (updated empty-editor hint)
+
+```ts
+{ keys: [MOD, "⇧", "V"], label: "Toggle .md preview" }  // unchanged label, new behaviour
+```
+
+The hint text is already correct; no change needed.
+
+---
+
+## Out of scope
+
+- Side-by-side split (preview right of editor) — can be a follow-on. The bottom
+  panel pattern ships faster and covers the primary use case (phones / narrow
+  laptops where side-by-side is cramped).
+- Per-file collapsed state — panel state is per-pane (block meta), not per-tab.
+  All tabs in the same editor pane share the same open/height preference.
+- Scratch buffer behaviour — the panel renders fine on scratch buffers; no special
+  case needed (unlike the old overlay which skipped `isScratch`).

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -39,11 +39,16 @@ import { FileTreeModel } from "./file-tree-model";
 const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
+const META_PREVIEW_OPEN = "editor:preview_open";
+const META_PREVIEW_HEIGHT = "editor:preview_height";
 const META_LEGACY_FILE = "file";
 const META_SCRATCH = "editor:scratch";
 const TREE_WIDTH_DEFAULT = 240;
 const TREE_WIDTH_MIN = 150;
 const TREE_WIDTH_MAX = 600;
+const PREVIEW_HEIGHT_DEFAULT = 300;
+const PREVIEW_HEIGHT_MIN = 80;
+const PREVIEW_HEIGHT_MAX = 1200;
 
 /** Hash a string with SHA-256 → hex. Used for the slice's contentHash field
  *  so the saga (Phase 1C) can decide whether a tab is dirty vs. disk. Cheap;
@@ -132,6 +137,12 @@ export class EditorViewModel implements ViewModel {
 
     private _treeWidth = createSignal<number>(TREE_WIDTH_DEFAULT);
     treeWidthAtom: Accessor<number> = this._treeWidth[0];
+
+    private _previewOpen = createSignal<boolean>(true);
+    previewOpenAtom: Accessor<boolean> = this._previewOpen[0];
+
+    private _previewHeight = createSignal<number>(PREVIEW_HEIGHT_DEFAULT);
+    previewHeightAtom: Accessor<number> = this._previewHeight[0];
 
     treeModel = new FileTreeModel();
 
@@ -281,6 +292,13 @@ export class EditorViewModel implements ViewModel {
         const persistedWidth = meta?.[META_TREE_WIDTH];
         if (typeof persistedWidth === "number") {
             this._treeWidth[1](clampTreeWidth(persistedWidth));
+        }
+        if (meta?.[META_PREVIEW_OPEN] === false) {
+            this._previewOpen[1](false);
+        }
+        const persistedPreviewH = meta?.[META_PREVIEW_HEIGHT];
+        if (typeof persistedPreviewH === "number") {
+            this._previewHeight[1](clampPreviewHeight(persistedPreviewH));
         }
 
         // Backwards-compat hydration: existing block meta uses `file` (the
@@ -817,6 +835,20 @@ export class EditorViewModel implements ViewModel {
         await this.persistMeta({ [META_TREE_WIDTH]: this._treeWidth[0]() });
     }
 
+    async togglePreview(): Promise<void> {
+        const next = !this._previewOpen[0]();
+        this._previewOpen[1](next);
+        await this.persistMeta({ [META_PREVIEW_OPEN]: next });
+    }
+
+    setPreviewHeight(height: number): void {
+        this._previewHeight[1](clampPreviewHeight(height));
+    }
+
+    async commitPreviewHeight(): Promise<void> {
+        await this.persistMeta({ [META_PREVIEW_HEIGHT]: this._previewHeight[0]() });
+    }
+
     private async persistMeta(meta: Record<string, unknown>): Promise<void> {
         try {
             await RpcApi.SetMetaCommand(TabRpcClient, {
@@ -846,6 +878,11 @@ export class EditorViewModel implements ViewModel {
 function clampTreeWidth(w: number): number {
     if (!Number.isFinite(w)) return TREE_WIDTH_DEFAULT;
     return Math.max(TREE_WIDTH_MIN, Math.min(TREE_WIDTH_MAX, Math.round(w)));
+}
+
+function clampPreviewHeight(h: number): number {
+    if (!Number.isFinite(h)) return PREVIEW_HEIGHT_DEFAULT;
+    return Math.max(PREVIEW_HEIGHT_MIN, Math.min(PREVIEW_HEIGHT_MAX, Math.round(h)));
 }
 
 /** Sniff content that's unsafe to hand to CodeMirror. Returns a human-readable

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -568,57 +568,85 @@
     }
 }
 
-// ── Markdown rendered/source view ────────────────────────────────────
-// Wraps the CodeMirror body so the styled <Markdown> preview can overlay
-// it for .md tabs (CM stays mounted underneath). See editor-view.tsx.
+// ── Markdown live preview panel ───────────────────────────────────────
+// Split layout: CodeMirror on top (flex: 1), drag handle, preview below.
 
 .editor-body-wrap {
-    position: relative;
-    flex: 1;
+    flex: 1 1 0;
     min-height: 0;
     display: flex;
+    flex-direction: column;
 }
 
-.editor-md-preview {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    overflow: auto;
-    // Opaque surface — --block-bg-color is rgba(0,0,0,0.5), which let the
-    // CodeMirror source bleed through (a dim ghost) behind the preview. Use
-    // the solid block surface so the source is fully hidden.
-    background: var(--block-bg-solid-color);
-    // Center the rendered doc with comfortable reading measure, scaled by
-    // the same per-pane zoom CodeMirror uses.
-    padding: calc(16px * var(--editor-zoom, 1)) calc(24px * var(--editor-zoom, 1));
+.editor-codemirror {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
 
-    .markdown {
-        // Fill the pane width — was a fixed 860px centered reading column,
-        // which looked cramped in a wide editor. The container already
-        // supplies padding + scroll.
-        font-size: calc(var(--markdown-font-size, 14px) * var(--editor-zoom, 1));
+.editor-preview-divider {
+    flex: 0 0 4px;
+    background: var(--border-color);
+    cursor: row-resize;
+
+    &:hover {
+        background: var(--accent-color);
     }
 }
 
-.editor-md-toggle {
-    position: absolute;
-    top: var(--space-2);
-    right: var(--space-3);
-    z-index: 2;
-    padding: 2px 8px;
-    font-size: 11px;
-    line-height: 18px;
-    color: var(--secondary-text-color, var(--main-text-color));
-    background: var(--secondary-bg-color, var(--block-bg-color));
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    cursor: default;
-    opacity: 0.75;
+.editor-preview-pane {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--border-color);
+    min-height: 28px;
+
+    &--collapsed {
+        height: 28px !important;
+    }
+}
+
+.editor-preview-header {
+    flex: 0 0 28px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 8px;
+    background: var(--panel-bg-color, var(--block-bg-color));
+    border-bottom: 1px solid var(--border-color);
     user-select: none;
+}
+
+.editor-preview-header-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--main-text-color);
+    opacity: 0.7;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.editor-preview-chevron {
+    background: none;
+    border: none;
+    color: var(--main-text-color);
+    opacity: 0.7;
+    cursor: pointer;
+    padding: 2px 4px;
+    font-size: 10px;
 
     &:hover {
         opacity: 1;
-        background: var(--hover-bg-color);
+    }
+}
+
+.editor-preview-content {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: calc(16px * var(--editor-zoom, 1)) calc(24px * var(--editor-zoom, 1));
+
+    .markdown {
+        font-size: calc(var(--markdown-font-size, 14px) * var(--editor-zoom, 1));
     }
 }
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -97,14 +97,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     ];
 
     // ── Markdown rendered/source view ────────────────────────────────────────
-    // Markdown files open in the styled <Markdown> renderer by default; a
-    // toolbar toggle (and Mod-Shift-V) flips the active tab to CodeMirror
-    // source to edit, and back. We track only the tabs the user flipped TO
-    // source (default = rendered), keyed by tab id so each tab remembers its
-    // own mode. CodeMirror stays mounted underneath the preview (markdown isn't
-    // LSP-backed, so this is cheap) — the preview is an overlay, which keeps
-    // cursor/scroll/undo intact across toggles and sidesteps CM build-timing.
-    const [mdSourceTabs, setMdSourceTabs] = createSignal<Set<string>>(new Set());
     // Live CodeMirror doc text for the active tab — the markdown preview binds
     // to this, NOT model.contentAtom(): that memo only recomputes on file
     // load / tab change (onContentChange deliberately doesn't bump it on
@@ -112,21 +104,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     // whenever CM is (re)built or restored, and update it on every doc change.
     const [liveDoc, setLiveDoc] = createSignal("");
     const isMarkdown = (): boolean => model.languageAtom() === "markdown";
-    const showRendered = (): boolean =>
-        isMarkdown() &&
-        // Never auto-render an untitled scratch buffer — it's for typing.
-        !model.activeTabAtom()?.isScratch &&
-        !mdSourceTabs().has(model.activeIdAtom() ?? "");
-    const toggleMdMode = () => {
-        const id = model.activeIdAtom();
-        if (!id || !isMarkdown()) return;
-        setMdSourceTabs((prev) => {
-            const next = new Set(prev);
-            if (next.has(id)) next.delete(id);
-            else next.add(id);
-            return next;
-        });
-    };
 
     // Ctrl+Wheel zoom — plugs into the universal zoom system (term:zoom on
     // block meta, same path used by terminal/agent/swarm). Capture phase so
@@ -163,18 +140,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             // there's nothing editable to search. See
             // docs/specs/SPEC_EDITOR_AND_APP_FIND_2026_06_17.md.
             if (!ev.shiftKey && (ev.key === "f" || ev.key === "F")) {
-                if (!cmView || showRendered()) return;
+                if (!cmView) return;
                 ev.preventDefault();
                 ev.stopPropagation();
                 openSearchPanel(cmView);
                 return;
             }
-            // Mod-Shift-V toggles markdown rendered/source for the active tab.
+            // Mod-Shift-V toggles the markdown preview panel.
             if (ev.shiftKey && (ev.key === "v" || ev.key === "V")) {
                 if (!isMarkdown()) return;
                 ev.preventDefault();
                 ev.stopPropagation();
-                toggleMdMode();
+                void model.togglePreview();
             }
         };
         rootRef.addEventListener("keydown", handleEditorKeys, { capture: true });
@@ -447,6 +424,27 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         document.addEventListener("mouseup", onUp);
     };
 
+    // Preview-panel resize — drag up = taller, drag down = shorter.
+    const handlePreviewResizeMouseDown = (e: MouseEvent) => {
+        e.preventDefault();
+        const startY = e.clientY;
+        const startH = model.previewHeightAtom();
+        const onMove = (ev: MouseEvent) => {
+            model.setPreviewHeight(startH + (startY - ev.clientY));
+        };
+        const onUp = () => {
+            document.removeEventListener("mousemove", onMove);
+            document.removeEventListener("mouseup", onUp);
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+            void model.commitPreviewHeight();
+        };
+        document.body.style.cursor = "row-resize";
+        document.body.style.userSelect = "none";
+        document.addEventListener("mousemove", onMove);
+        document.addEventListener("mouseup", onUp);
+    };
+
     // Rebuild CodeMirror on tab change. Tracks activeIdAtom (not just
     // filePathAtom) so we get a unique trigger per tab — multiple tabs
     // could share the same path in pathological cases, but each has its own
@@ -496,14 +494,6 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     const unsubSliceEvents = model.onSliceEvent((event) => {
         if (event.type === "TabClosed") {
             cmStates.delete(event.tabId);
-            // Drop any remembered rendered/source mode for the closed tab.
-            if (mdSourceTabs().has(event.tabId)) {
-                setMdSourceTabs((prev) => {
-                    const next = new Set(prev);
-                    next.delete(event.tabId);
-                    return next;
-                });
-            }
         }
     });
 
@@ -843,27 +833,47 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 >
                     <div class="editor-body-wrap">
                         <div class="editor-codemirror" ref={setContainerRef} />
-                        {/* Styled markdown preview, overlaid over CodeMirror for
-                            .md tabs in rendered mode. CM stays mounted beneath so
-                            toggling back keeps cursor/scroll/undo. */}
-                        <Show when={showRendered()}>
-                            <div class="editor-md-preview">
-                                <Markdown textAtom={() => liveDoc()} />
-                            </div>
-                        </Show>
-                        {/* Rendered/Source toggle — markdown tabs only. */}
                         <Show when={isMarkdown()}>
-                            <button
-                                class="editor-md-toggle"
-                                title={
-                                    showRendered()
-                                        ? "Edit source (Ctrl+Shift+V)"
-                                        : "Show rendered preview (Ctrl+Shift+V)"
+                            <Show when={model.previewOpenAtom()}>
+                                <div
+                                    class="editor-preview-divider"
+                                    onMouseDown={handlePreviewResizeMouseDown}
+                                    title="Drag to resize preview"
+                                />
+                            </Show>
+                            <div
+                                class="editor-preview-pane"
+                                classList={{ "editor-preview-pane--collapsed": !model.previewOpenAtom() }}
+                                style={
+                                    model.previewOpenAtom()
+                                        ? { height: `${model.previewHeightAtom()}px` }
+                                        : undefined
                                 }
-                                onClick={toggleMdMode}
+                                id="editor-preview-panel"
                             >
-                                {showRendered() ? "✎ Source" : "👁 Preview"}
-                            </button>
+                                <div class="editor-preview-header">
+                                    <span class="editor-preview-header-label">Preview</span>
+                                    <button
+                                        type="button"
+                                        class="editor-preview-chevron"
+                                        aria-expanded={model.previewOpenAtom()}
+                                        aria-controls="editor-preview-panel"
+                                        aria-label={
+                                            model.previewOpenAtom()
+                                                ? "Collapse preview"
+                                                : "Expand preview (Ctrl+Shift+V)"
+                                        }
+                                        onClick={() => void model.togglePreview()}
+                                    >
+                                        {model.previewOpenAtom() ? "▴" : "▾"}
+                                    </button>
+                                </div>
+                                <Show when={model.previewOpenAtom()}>
+                                    <div class="editor-preview-content">
+                                        <Markdown textAtom={() => liveDoc()} />
+                                    </div>
+                                </Show>
+                            </div>
                         </Show>
                     </div>
                 </Show>

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -849,7 +849,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                                         ? { height: `${model.previewHeightAtom()}px` }
                                         : undefined
                                 }
-                                id="editor-preview-panel"
+                                id={`editor-preview-panel-${model.blockId}`}
                             >
                                 <div class="editor-preview-header">
                                     <span class="editor-preview-header-label">Preview</span>
@@ -857,7 +857,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                                         type="button"
                                         class="editor-preview-chevron"
                                         aria-expanded={model.previewOpenAtom()}
-                                        aria-controls="editor-preview-panel"
+                                        aria-controls={`editor-preview-panel-${model.blockId}`}
                                         aria-label={
                                             model.previewOpenAtom()
                                                 ? "Collapse preview"


### PR DESCRIPTION
## Summary

- Replaces the full-overlay rendered/source toggle with a persistent **bottom split panel** — CodeMirror always visible on top, rendered Markdown below
- Preview open state and panel height persist per editor pane via block meta (`editor:preview_open`, `editor:preview_height`)
- Drag-to-resize handle (same pattern as tree-width); Mod-Shift-V toggles the panel; chevron button in header strip follows `aria-expanded`/`aria-controls` contract
- Reuses existing `<Markdown textAtom={() => liveDoc()} />` call and `persistMeta()` plumbing — no new primitives

## Files changed

- `frontend/app/view/editor/editor-model.ts` — add `META_PREVIEW_OPEN`/`META_PREVIEW_HEIGHT` constants, signals, hydration, `togglePreview()` / `setPreviewHeight()` / `commitPreviewHeight()` methods
- `frontend/app/view/editor/editor-view.tsx` — remove `mdSourceTabs`/`showRendered`/`toggleMdMode` overlay system; add `handlePreviewResizeMouseDown`; replace overlay JSX with split panel
- `frontend/app/view/editor/editor-view.scss` — remove `.editor-md-preview` / `.editor-md-toggle`; update `.editor-body-wrap` to flex-column; add preview pane styles

## Test plan

- [ ] Open a `.md` file — preview panel appears below CodeMirror showing live render
- [ ] Type in editor — preview updates in real time
- [ ] Drag the resize handle up/down — panel height changes; reopen editor block → height restored
- [ ] Click chevron or Mod-Shift-V — panel collapses to 28px header strip; CodeMirror expands to fill; toggle back restores height
- [ ] Open a non-markdown file — no preview panel visible
- [ ] Ctrl+F in a `.md` file — search panel opens correctly
- [ ] Close and reopen a block — `previewOpen` and `previewHeight` restored from block meta

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)