### PR TITLE
fix(hamburger): Exit closes the current window, not main

### DIFF
--- a/.changesets/1782059166-fix-hamburger-exit-closes-the-current-window-not-main-58hu.md
+++ b/.changesets/1782059166-fix-hamburger-exit-closes-the-current-window-not-main-58hu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(hamburger): Exit closes the current window, not main

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -154,7 +154,7 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
             {
                 label: "Exit",
                 icon: "right-from-bracket",
-                onClick: () => fireAndForget(() => invokeCommand("close_window", {})),
+                onClick: () => getApi().closeWindow().catch(console.error),
             },
         ];
     });


### PR DESCRIPTION
## Summary

- `Exit` in the hamburger menu called `invokeCommand("close_window", {})` with no window label
- The Rust handler fell back to `"main"`, so clicking Exit in any non-main window closed the **main** window instead
- Fixed to use `getApi().closeWindow()`, which reads `windowLabel` from the page's URL search params — the same path used by the close button and Cmd+W

## Test plan

- [ ] Open a second window (hamburger → New Window)
- [ ] In the new window, hamburger → Exit — the **new** window should close, original stays open
- [ ] Confirm the original window is still alive and responsive

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-masty} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)