### PR TITLE
fix(cef): disable Web Notifications to stop duplicate macOS permission toasts

### DIFF
--- a/.changesets/1782061686-fix-macos-suppress-duplicate-notification-permission-prompts-8hqt.md
+++ b/.changesets/1782061686-fix-macos-suppress-duplicate-notification-permission-prompts-8hqt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): suppress duplicate notification permission prompts on new-version install

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -807,6 +807,15 @@ wrap_app! {
                 cmd.append_switch(Some(&CefString::from("disable-sync")));
                 cmd.append_switch(Some(&CefString::from("disable-extensions")));
 
+                // Disable Chromium's Web Notifications API. We don't use
+                // `new Notification()` anywhere; CEF still registers both the
+                // main app and AgentMux Helper (Alerts) as OS notification
+                // sources and requests macOS permission for each at startup,
+                // showing two permission toasts on every new-version install.
+                // Suppressing the API at the command-line level prevents both
+                // registrations and eliminates the duplicate prompts.
+                cmd.append_switch(Some(&CefString::from("disable-notifications")));
+
                 // HTTP Basic / Digest auth — route the challenge to the
                 // embedder's `RequestHandler::on_auth_credentials` callback
                 // (which surfaces our `BrowserAuthModal` from PR #906)


### PR DESCRIPTION
## Summary

- On every new-version install, macOS shows **two** "Notifications may include alerts, sounds, and icon badges" permission toasts — one from AgentMux (banner-style) and one from AgentMux Helper (Alerts) (alert-style)
- This happens because CEF registers both processes as OS notification sources and requests permission for each at startup; PR #1646's per-version bundle IDs make every upgrade trigger a fresh permission request
- We don't use `new Notification()` anywhere in the frontend — the Web Notifications API is unused
- Fix: add `--disable-notifications` Chromium switch in `on_before_command_line_processing`, which prevents CEF from registering either notification channel and eliminates both permission toasts

## Test plan

- [ ] Build DMG and install fresh (or reset notification permissions: `tccutil reset Notifications ai.agentmux.stable.X.Y.Z`)
- [ ] Launch — no notification permission toasts appear
- [ ] Agent turn-complete sounds still play (sound service is separate from Web Notifications)

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-masty} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)