### PR TITLE
fix: use stable role slug for AGENTMUX_AGENT_ID at spawn time

### DIFF
--- a/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
+++ b/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
@@ -1,3 +1,5 @@
 ---
 type: patch
----fix(spawner): use stable role slug for AGENTMUX_AGENT_ID so muxbus routing is stable across respawns and renames
+---
+
+fix(spawner): use stable role slug for AGENTMUX_AGENT_ID so muxbus routing is stable across respawns and renames

--- a/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
+++ b/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
@@ -1,0 +1,3 @@
+---
+type: patch
+---fix(spawner): use stable role slug for AGENTMUX_AGENT_ID so muxbus routing is stable across respawns and renames

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -252,10 +252,17 @@ pub fn build_mcp_config(
     agent_name: &str,
     agent_bus_id: &str,
 ) -> Option<String> {
-    // Auto-injected AgentMux MCP server entry
+    // Auto-injected AgentMux MCP server entry.
+    // Slugify agent_name → stable lowercase routing ID (matches the
+    // pane env var set by app_api.rs and the TS buildMcpConfig).
     let mut env_map = serde_json::Map::new();
     if !agent_name.is_empty() {
-        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(agent_name));
+        let slug: String = agent_name
+            .to_lowercase()
+            .chars()
+            .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+            .collect();
+        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(slug));
     }
     if !agent_bus_id.is_empty() {
         env_map.insert("AGENTMUX_AGENT_BUS_ID".to_string(), json!(agent_bus_id));
@@ -565,7 +572,7 @@ mod tests {
         let servers = &parsed["mcpServers"];
         assert!(servers["agentmux"].is_object());
         assert_eq!(servers["agentmux"]["command"], "agentmux-mcp");
-        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_ID"], "Aria");
+        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_ID"], "aria");
         assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_BUS_ID"], "bus-42");
     }
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -37,6 +37,7 @@ pub fn build_config_files(
     skills: &[AgentSkill],
     agent_name: &str,
     agent_id: &str,
+    agent_slug: &str,
 ) -> Vec<AgentConfigFile> {
     let mut files: Vec<AgentConfigFile> = Vec::new();
 
@@ -134,7 +135,7 @@ pub fn build_config_files(
     // should call build_mcp_config directly and push the result themselves,
     // or use the variant below.
     let mcp_content = content_map.get("mcp").map(|s| s.as_str());
-    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, "") {
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_slug, "") {
         files.push(AgentConfigFile {
             filename: ".mcp.json".to_string(),
             content: mcp_json,
@@ -156,6 +157,7 @@ pub fn build_config_files_with_bus(
     agent_id: &str,
     agent_bus_id: &str,
     working_directory: &str,
+    agent_slug: &str,
 ) -> Vec<AgentConfigFile> {
     let mut files: Vec<AgentConfigFile> = Vec::new();
 
@@ -226,7 +228,7 @@ pub fn build_config_files_with_bus(
 
     // MCP — use full bus_id variant
     let mcp_content = content_map.get("mcp").map(|s| s.as_str());
-    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, agent_bus_id) {
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_slug, agent_bus_id) {
         files.push(AgentConfigFile {
             filename: ".mcp.json".to_string(),
             content: mcp_json,
@@ -249,20 +251,16 @@ pub fn build_config_files_with_bus(
 /// Mirrors `buildMcpConfig()` in `frontend/app/view/agent/agent-model.ts`.
 pub fn build_mcp_config(
     user_mcp_content: Option<&str>,
-    agent_name: &str,
+    agent_slug: &str,
     agent_bus_id: &str,
 ) -> Option<String> {
     // Auto-injected AgentMux MCP server entry.
-    // Slugify agent_name → stable lowercase routing ID (matches the
-    // pane env var set by app_api.rs and the TS buildMcpConfig).
+    // agent_slug must be the pre-computed stable role slug (e.g. "korp"),
+    // NOT the display name — callers are responsible for passing the right
+    // value so renamed agents always advertise the same routing ID.
     let mut env_map = serde_json::Map::new();
-    if !agent_name.is_empty() {
-        let slug: String = agent_name
-            .to_lowercase()
-            .chars()
-            .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
-            .collect();
-        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(slug));
+    if !agent_slug.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(agent_slug));
     }
     if !agent_bus_id.is_empty() {
         env_map.insert("AGENTMUX_AGENT_BUS_ID".to_string(), json!(agent_bus_id));
@@ -567,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_build_mcp_config_no_user_content() {
-        let result = build_mcp_config(None, "Aria", "bus-42").unwrap();
+        let result = build_mcp_config(None, "aria", "bus-42").unwrap();
         let parsed: Value = serde_json::from_str(&result).unwrap();
         let servers = &parsed["mcpServers"];
         assert!(servers["agentmux"].is_object());
@@ -579,7 +577,7 @@ mod tests {
     #[test]
     fn test_build_mcp_config_merges_user_servers() {
         let user_mcp = r#"{"mcpServers": {"mytool": {"type": "stdio", "command": "mytool"}}}"#;
-        let result = build_mcp_config(Some(user_mcp), "Aria", "").unwrap();
+        let result = build_mcp_config(Some(user_mcp), "aria", "").unwrap();
         let parsed: Value = serde_json::from_str(&result).unwrap();
         let servers = &parsed["mcpServers"];
         assert!(servers["agentmux"].is_object());
@@ -588,7 +586,7 @@ mod tests {
 
     #[test]
     fn test_build_mcp_config_invalid_user_json_uses_auto_injected() {
-        let result = build_mcp_config(Some("not json {{"), "Aria", "").unwrap();
+        let result = build_mcp_config(Some("not json {{"), "aria", "").unwrap();
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert!(parsed["mcpServers"]["agentmux"].is_object());
     }
@@ -599,7 +597,7 @@ mod tests {
         content_map.insert("soul".to_string(), "You are {{AGENT}}.".to_string());
         content_map.insert("agentmd".to_string(), "## Instructions\nDo stuff.".to_string());
 
-        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1", "aria");
         let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
         assert!(claude_md.content.contains("You are Aria."));
         assert!(claude_md.content.contains("---"));
@@ -614,7 +612,7 @@ mod tests {
             make_skill("Test", "test", "Run tests", "Run: test suite"),
         ];
 
-        let files = build_config_files(&content_map, &skills, "Aria", "agent-1");
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria");
 
         // CLAUDE.md should have the skills index
         let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
@@ -641,7 +639,7 @@ mod tests {
             r#"{"PreToolUse":[{"matcher":"Read","hooks":[{"type":"command","command":"my-audit"}]}]}"#
                 .to_string(),
         );
-        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1", "aria");
         let settings = files
             .iter()
             .find(|f| f.filename == ".claude/settings.json")
@@ -668,7 +666,7 @@ mod tests {
     #[test]
     fn test_build_config_files_mcp_written() {
         let content_map = HashMap::new();
-        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1", "aria");
         let mcp = files.iter().find(|f| f.filename == ".mcp.json").unwrap();
         let parsed: Value = serde_json::from_str(&mcp.content).unwrap();
         assert!(parsed["mcpServers"]["agentmux"].is_object());

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -303,7 +303,10 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 // Agent identity
                 env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("{}/gh-{}", config_home, agent_slug)));
-                env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(&agent.name));
+                // Use stored slug (stable across renames) for muxbus routing;
+                // fall back to the computed slug derived from the display name.
+                let routing_id = if !agent.slug.is_empty() { &agent.slug } else { &agent_slug };
+                env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(routing_id));
                 // Exit delay only for subprocess
                 if !is_persistent {
                     env_vars.insert("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY".to_string(), json!("30000"));

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -395,7 +395,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 //    missing and overwrites whatever's there. Same-
                 //    name same-hour launches will share a workdir;
                 //    proper allocation is tracked as a follow-up.
-                write_agent_config_files(&wstore, &agent, &agent_slug, &work_dir)?;
+                write_agent_config_files(&wstore, &agent, routing_id, &work_dir)?;
 
                 // 9. Register controller (resync)
                 let block_for_resync = wstore.must_get::<Block>(&block_id)

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2348,6 +2348,7 @@ fn write_agent_config_files(
         &skills,
         &agent.name,
         &agent.id,
+        agent_slug,
     );
 
     // Expand ~ in work_dir

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -410,11 +410,11 @@ export class AgentViewModel implements ViewModel {
         // slug so renaming doesn't orphan ~/.agentmux/config/gh-<old>.
         envVars["GH_CONFIG_DIR"] = `${agentmuxHome()}/config/gh-${slug}`;
 
-        // AGENTMUX_AGENT_ID: the instance name (modal-supplied or
-        // definition-default). Shell integration scripts emit this
-        // as the terminal pane label, and agentmux-mcp routes
-        // inter-agent messages by it.
-        envVars["AGENTMUX_AGENT_ID"] = instanceName;
+        // AGENTMUX_AGENT_ID: stable role slug for muxbus routing.
+        // Keyed on by send_message/inject_terminal — must not change
+        // across respawns of the same definition. Display name is in
+        // AGENTMUX_AGENT_DISPLAY.
+        envVars["AGENTMUX_AGENT_ID"] = slug;
         // Stable definition slug — survives renames and re-launches.
         // Downstream code reads this when it needs the rename-stable
         // form (e.g. session-id lookup).
@@ -758,7 +758,8 @@ function buildConfigFiles(
     }
 
     // Build .mcp.json: auto-inject AgentMux MCP + merge user-provided config
-    const mcpConfig = buildMcpConfig(contentMap["mcp"], agent, instanceName);
+    const agentSlug = agent ? (agent.slug || agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")) : undefined;
+    const mcpConfig = buildMcpConfig(contentMap["mcp"], agent, instanceName, agentSlug);
     if (mcpConfig) {
         files.push({ path: ".mcp.json", content: mcpConfig });
     }
@@ -881,12 +882,13 @@ function buildMcpConfig(
     userMcpContent: string | undefined,
     agent?: AgentDefinition,
     instanceName?: string,
+    slug?: string,
 ): string | null {
     // Auto-inject AgentMux MCP server for inter-agent messaging.
-    // `AGENTMUX_AGENT_ID` must match the shell's / pane title's
-    // `AGENTMUX_AGENT_ID` (the resolved instance name), otherwise
-    // inter-agent routing targets the definition name while
-    // everything else advertises the instance name.
+    // `AGENTMUX_AGENT_ID` must be the stable role slug (matching the
+    // pane env var) so agentmux-mcp advertises the same routing ID
+    // whether the agent reads it from its environment or from
+    // the MCP tool source field.
     const agentMuxServer: Record<string, any> = {
         type: "stdio",
         command: "agentmux-mcp",
@@ -894,7 +896,7 @@ function buildMcpConfig(
         env: {} as Record<string, string>,
     };
     if (agent) {
-        agentMuxServer.env["AGENTMUX_AGENT_ID"] = instanceName || agent.name;
+        agentMuxServer.env["AGENTMUX_AGENT_ID"] = slug || instanceName || agent.name;
         if (agent.agent_bus_id) {
             agentMuxServer.env["AGENTMUX_AGENT_BUS_ID"] = agent.agent_bus_id;
         }


### PR DESCRIPTION
## Summary

- **Root cause:** `AGENTMUX_AGENT_ID` was set to the display/instance name (`"Korp"` or `"Korp-0620g"`) which changes across renames and respawns, breaking muxbus routing — `send_message` and `inject_terminal` key on this value
- **Fix:** Set `AGENTMUX_AGENT_ID` to the stable definition slug (`"korp"`) in all three spawn paths (TS env vars, TS `.mcp.json`, Rust pane env, Rust `.mcp.json`)
- `AGENTMUX_AGENT_DISPLAY` already carries the human-readable display name; no callers of that need to change

## Changed files

| File | Change |
|---|---|
| `frontend/app/view/agent/agent-model.ts` | `AGENTMUX_AGENT_ID = slug` (was `instanceName`); `buildMcpConfig` gains `slug?` param |
| `agentmux-srv/src/server/app_api.rs` | Pane env var prefers `agent.slug`, falls back to computed slug from `agent.name` |
| `agentmux-srv/src/backend/agent_config.rs` | `build_mcp_config` slugifies `agent_name` before writing `AGENTMUX_AGENT_ID` into `.mcp.json`; test updated |

## How muxbus routing works end-to-end after this fix

```
Spawn: AGENTMUX_AGENT_ID=korp
    ↓
agentmux-mcp reads AGENTMUX_AGENT_ID → registers as "korp" source for SendMessage
    ↓
Any peer: send_message({ to: "korp", ... })  ← stable across respawns
```

## Test plan

- [ ] Launch an agent (e.g. Korp) — verify pane env shows `AGENTMUX_AGENT_ID=korp`
- [ ] Verify `.mcp.json` in working dir has `AGENTMUX_AGENT_ID: "korp"` 
- [ ] `send_message({ to: "korp", message: "ping" })` from a peer agent routes correctly
- [ ] Rename the pane via SetName — verify `AGENTMUX_AGENT_ID` is unchanged (display only)
- [ ] Rust unit test `test_build_mcp_config_no_user_content` passes (`"aria"` assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)