### PR TITLE
fix(editor): use CSS zoom property for correct per-pane zoom scaling

### DIFF
--- a/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
+++ b/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom

--- a/frontend/app/store/zoom.darwin.ts
+++ b/frontend/app/store/zoom.darwin.ts
@@ -49,6 +49,8 @@ function getBaseFontSize(blockId: string): number {
     if (typeof metaFontSize === "number" && !isNaN(metaFontSize) && metaFontSize >= 4 && metaFontSize <= 64) {
         return metaFontSize;
     }
+    const bcm = getBlockComponentModel(blockId);
+    if (bcm?.viewModel?.viewType === "editor") return 13;
     return 15;
 }
 

--- a/frontend/app/store/zoom.linux.ts
+++ b/frontend/app/store/zoom.linux.ts
@@ -47,6 +47,8 @@ function getBaseFontSize(blockId: string): number {
     if (typeof metaFontSize === "number" && !isNaN(metaFontSize) && metaFontSize >= 4 && metaFontSize <= 64) {
         return metaFontSize;
     }
+    const bcm = getBlockComponentModel(blockId);
+    if (bcm?.viewModel?.viewType === "editor") return 13;
     return 15;
 }
 

--- a/frontend/app/store/zoom.win32.ts
+++ b/frontend/app/store/zoom.win32.ts
@@ -48,6 +48,8 @@ function getBaseFontSize(blockId: string): number {
     if (typeof metaFontSize === "number" && !isNaN(metaFontSize) && metaFontSize >= 4 && metaFontSize <= 64) {
         return metaFontSize;
     }
+    const bcm = getBlockComponentModel(blockId);
+    if (bcm?.viewModel?.viewType === "editor") return 13;
     return 15;
 }
 

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -54,9 +54,7 @@
     flex-direction: column;
     flex: 1;
     min-height: 0;
-    // Tree text follows the per-pane zoom factor (set on .editor-view as
-    // --editor-zoom by editor-view.tsx). Toolbar chrome below is NOT zoomed.
-    font-size: calc(12px * var(--editor-zoom, 1));
+    font-size: 12px;
     color: var(--main-text-color);
 }
 
@@ -243,8 +241,7 @@
 }
 
 // ── Tab strip (Phase 1B of SPEC_EDITOR_TABS_2026-05-26.md) ─────────────────
-// Chrome above CodeMirror — not zoomed by --editor-zoom. Tabs flex 80–140px;
-// overflow chip lands in Phase 2.
+// Tabs flex 80–140px; overflow chip lands in Phase 2.
 
 .editor-tab-strip {
     flex: 0 0 auto;
@@ -546,10 +543,7 @@
 
     .cm-scroller {
         font-family: var(--termfontfamily, "JetBrains Mono", monospace);
-        // CodeMirror text follows the per-pane zoom factor — same source
-        // (--editor-zoom on .editor-view) the file tree uses, so both
-        // resize together.
-        font-size: calc(13px * var(--editor-zoom, 1));
+        font-size: 13px;
     }
 
     // Tight gutter — no debugger/breakpoint margin to reserve, so the line
@@ -643,10 +637,10 @@
 .editor-preview-content {
     flex: 1 1 auto;
     overflow-y: auto;
-    padding: calc(16px * var(--editor-zoom, 1)) calc(24px * var(--editor-zoom, 1));
+    padding: 16px 24px;
 
     .markdown {
-        font-size: calc(var(--markdown-font-size, 14px) * var(--editor-zoom, 1));
+        font-size: var(--markdown-font-size, 14px);
     }
 }
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -409,7 +409,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         const startX = e.clientX;
         const startWidth = model.treeWidthAtom();
         const onMove = (ev: MouseEvent) => {
-            model.setTreeWidth(startWidth + (ev.clientX - startX));
+            // document mousemove coords are in viewport CSS pixels; divide by
+            // zoom so the delta maps correctly to local CSS pixels inside the
+            // zoomed .editor-view element.
+            model.setTreeWidth(startWidth + (ev.clientX - startX) / model.zoomAtom());
         };
         const onUp = () => {
             document.removeEventListener("mousemove", onMove);
@@ -430,7 +433,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         const startY = e.clientY;
         const startH = model.previewHeightAtom();
         const onMove = (ev: MouseEvent) => {
-            model.setPreviewHeight(startH + (startY - ev.clientY));
+            model.setPreviewHeight(startH + (startY - ev.clientY) / model.zoomAtom());
         };
         const onUp = () => {
             document.removeEventListener("mousemove", onMove);
@@ -696,7 +699,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             ref={(el) => { rootRef = el; }}
             class="editor-view"
             classList={{ "editor-view--tree-collapsed": !model.treeExpandedAtom() }}
-            style={{ "--editor-zoom": String(model.zoomAtom()) }}
+            style={{ zoom: model.zoomAtom() }}
         >
             <Show when={model.treeExpandedAtom()}>
                 <div

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -108,9 +108,9 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     // Ctrl+Wheel zoom — plugs into the universal zoom system (term:zoom on
     // block meta, same path used by terminal/agent/swarm). Capture phase so
     // we intercept before CodeMirror's bubble-phase wheel; preventDefault
-    // suppresses CEF's native Ctrl+Scroll page zoom. The view's CSS var
-    // `--editor-zoom` (bound below) drives both the CodeMirror font-size
-    // and the file-tree font-size, so both resize in lockstep.
+    // suppresses CEF's native Ctrl+Scroll page zoom. The resulting zoom
+    // factor is applied as a CSS `zoom` property on .editor-view (see below),
+    // scaling the entire subtree uniformly.
     onMount(() => {
         if (!rootRef) return;
         const handleCtrlWheel = (ev: WheelEvent) => {


### PR DESCRIPTION
## Problem

Editor zoom in/out barely changed the visible size. Two bugs compounding:

1. **Wrong zoom mechanism** — zoom was applied via `--editor-zoom` CSS variable with `calc(Xpx * var(--editor-zoom))` on individual `font-size` rules in `editor-view.scss`. Only text scaled; padding, borders, icons, scrollbars, and layout stayed at base size. Compare: agent/swarm panes use `style={{ zoom }}` on their root element, which scales the entire subtree uniformly.

2. **`stepZoom` used terminal base font size (15px) for editor** — `getBaseFontSize()` in `zoom.{win32,darwin,linux}.ts` always returned 15 (terminal default). The editor's CodeMirror renders at 13px, so the integer-snapping guard that prevents no-visible-change steps was computing against the wrong base, requiring extra keypresses before zoom moved perceptibly.

## Fix

- `editor-view.tsx`: replace `--editor-zoom` style with `zoom: model.zoomAtom()` on `.editor-view` root
- `editor-view.scss`: remove all `calc(* var(--editor-zoom, 1))` expressions; restore flat `font-size` / `padding` values
- Both resize handlers (tree column width + preview panel height) now divide their mouse delta by `model.zoomAtom()` — `document` mousemove events are in viewport CSS pixels, but stored dimensions are in local CSS pixels; without the correction the resize handle moves at the wrong speed when zoomed
- `zoom.{win32,darwin,linux}.ts`: `getBaseFontSize()` returns 13 for editor blocks instead of 15

## Result

`Ctrl++` / `Ctrl+-` / `Ctrl+Scroll` on an editor pane now scales text, padding, borders, icons, and the file tree together, matching the visual behaviour of the agent and swarm panes.

<!-- agentmux:agent_id=smike -->