### PR TITLE
fix(ui): pass isMinimized/toggleMinimize as props to BlockFrame_Header

### DIFF
--- a/.changesets/1782076247-fix-ui-pass-isminimized-toggleminimize-as-props-to-blockfram-0m9a.md
+++ b/.changesets/1782076247-fix-ui-pass-isminimized-toggleminimize-as-props-to-blockfram-0m9a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): pass isMinimized/toggleMinimize as props to BlockFrame_Header

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -480,8 +480,8 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     nodeModel={props.nodeModel}
                     onContextMenu={onContextMenu}
                     blockView={blockData()?.meta?.view}
-                    isMinimized={isMinimized}
-                    toggleMinimize={toggleMinimize}
+                    isMinimized={props.isMinimized}
+                    toggleMinimize={props.toggleMinimize}
                 />
             </div>
         </div>

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -290,7 +290,7 @@ function EndIcons(props: {
     );
 }
 
-function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error }): JSX.Element {
+function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error; isMinimized: () => boolean; toggleMinimize: () => void }): JSX.Element {
     const [blockData] = WOS.useWaveObjectValue<Block>(WOS.makeORef("block", props.nodeModel.blockId));
     const showBlockIds = getSettingsKeyAtom("blockheader:showblockids")();
     const preIconButton = util.useAtomValueSafe(props.viewModel?.preIconButton);
@@ -793,10 +793,10 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     }
     const previewElem = <div class="block-frame-preview">{viewIconElem}</div>;
     const headerElem = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} />
+        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} isMinimized={isMinimized} toggleMinimize={toggleMinimize} />
     );
     const headerElemNoView = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} />
+        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} isMinimized={isMinimized} toggleMinimize={toggleMinimize} />
     );
 
     // Body right-click handler


### PR DESCRIPTION
## Summary

- PR #1658 added `isMinimized` and `toggleMinimize` in `BlockFrame_Default_Component` and referenced them inside `BlockFrame_Header`, but `BlockFrame_Header` is a separate function — they were out of scope
- Every pane render threw `ReferenceError: isMinimized is not defined` and showed "this pane crashed"
- Fix: add `isMinimized` and `toggleMinimize` to `BlockFrame_Header`'s props type and pass them from both `BlockFrame_Header` call sites in `BlockFrame_Default_Component`

## Test plan

- [ ] Panes render without crashing
- [ ] Minimize button in pane header works

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-masty} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)