### PR TITLE
fix(packaging): use APFS for intermediate DMG to avoid macOS 26 HFS+ decompressor regression

### DIFF
--- a/.changesets/1782077760-fix-packaging-use-apfs-for-intermediate-dmg-to-fix-err-conte-s5bb.md
+++ b/.changesets/1782077760-fix-packaging-use-apfs-for-intermediate-dmg-to-fix-err-conte-s5bb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(packaging): use APFS for intermediate DMG to fix ERR_CONTENT_LENGTH_MISMATCH on macOS 26 Tahoe

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -342,7 +342,16 @@ ln -s /Applications "$STAGE/Applications"
 # bundle as folders. Falls back to a plain DMG if Finder automation is
 # unavailable (headless / no TCC grant).
 RW="$(mktemp -u).dmg"
-hdiutil create -volname "$DMG_VOL" -srcfolder "$STAGE" -ov -format UDRW -fs HFS+ "$RW" >/dev/null
+# Use APFS (not HFS+) for the intermediate read-write volume. macOS 26 Tahoe
+# has a regression in HFS+ transparent file decompression (decmpfs, the `z`
+# attribute that hdiutil applies automatically to compressible files like JS/HTML
+# when building an HFS+ image). On the mounted HFS+ DMG, reading those files
+# fails with ENOTTY / Input/output error — the IPC server sets Content-Length
+# from file metadata but then can't stream the body, causing ERR_CONTENT_LENGTH_MISMATCH
+# in CEF. APFS images get the same `z` attribute but their decompressor is
+# unaffected on macOS 26, so switching here fixes the bug. APFS DMGs have been
+# mountable since macOS 10.14 and we target 11+, so this is safe.
+hdiutil create -volname "$DMG_VOL" -srcfolder "$STAGE" -ov -format UDRW -fs APFS "$RW" >/dev/null
 RWMNT="$(hdiutil attach "$RW" -nobrowse -noautoopen 2>/dev/null | sed -n 's/.*\(\/Volumes\/.*\)/\1/p' | tail -1)"
 if [ -n "$RWMNT" ]; then
     osascript >/dev/null 2>&1 <<OSA || echo "  ⚠ Finder layout skipped (automation unavailable) — DMG uses default view"


### PR DESCRIPTION
## Summary

- Switches the intermediate UDRW disk image from `-fs HFS+` to `-fs APFS` in `scripts/package-macos.sh`
- macOS 26 Tahoe has a regression in the HFS+ transparent file decompressor (the `decmpfs` layer, indicated by the `z` attribute on files). hdiutil applies this compression automatically to all compressible files (JS, HTML, CSS) when building an HFS+ image
- When such a DMG is mounted, reading those compressed files fails with I/O error after the kernel page cache is evicted
- The CEF IPC server (`ServeDir`) reads file sizes correctly from stat() metadata, sends the right `Content-Length` header, but then silently drops the connection when the actual `read()` fails — Chromium gets `ERR_CONTENT_LENGTH_MISMATCH (-354)` → "Failed to load agentmux frontend" on every window

## Root cause trace

```
agentmux-cef ipc.rs: ServeDir::new(&frontend_dir)
 → stat("/Volumes/AgentMux N/.../frontend/index.html") → 11447 bytes ✓
 → Content-Length: 11447 sent
 → tokio::fs::File::open() + read() → I/O error (HFS+ decmpfs broken on macOS 26)
 → connection closed with 0 bytes transferred
 → CEF: ERR_CONTENT_LENGTH_MISMATCH (-354)
```

## Fix

APFS images get the same `z` attribute from hdiutil but their decompressor works correctly on macOS 26. Switching the intermediate UDRW from HFS+ to APFS avoids the regression entirely. The final ULMO-compressed DMG is unaffected (that's a container-level format, not a filesystem format).

APFS DMGs have been mountable since macOS 10.14 (Mojave); we target 11.0+, so this is safe.

## Test plan

- [ ] Build fresh DMG with `task package:macos`
- [ ] Mount and verify `cat AgentMux.app/Contents/Resources/frontend/index.html` succeeds
- [ ] Launch from DMG — frontend should load without ERR_CONTENT_LENGTH_MISMATCH
- [ ] Verify Finder window shows drag-to-install layout (APFS-backed volume still works with the osascript layout script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)