### PR TITLE
fix(agent): show session digest summary in pane header

### DIFF
--- a/.changesets/1782077925-fix-agent-show-session-digest-summary-in-pane-header-fall-ba-06l0.md
+++ b/.changesets/1782077925-fix-agent-show-session-digest-summary-in-pane-header-fall-ba-06l0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): show session digest summary in pane header; fall back to term:activity

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -115,13 +115,20 @@ export class AgentViewModel implements ViewModel {
         this.viewText = (): HeaderElem[] => {
             const elems: HeaderElem[] = [];
 
+            // AI-generated conversation summary (session:digest_summary, written by
+            // useSessionDigest via the backend SessionDigest RPC). Takes priority
+            // over the raw OSC window-title because it's a complete description of
+            // the session rather than just the last active file/task.
+            const summary = this.blockAtom()?.meta?.["session:digest_summary"] as string | undefined;
             // Session-topic label from Claude Code OSC window-title extraction
             // (written by useBlockActivity via term:activity block metadata).
+            // Used as a fallback when no digest summary has been generated yet.
             const activity = this.blockAtom()?.meta?.["term:activity"] as string | undefined;
-            if (activity && activity.length > 0) {
+            const headerLabel = summary || activity;
+            if (headerLabel && headerLabel.length > 0) {
                 elems.push({
                     elemtype: "text",
-                    text: activity,
+                    text: headerLabel,
                     className: "term-activity",
                 });
             }


### PR DESCRIPTION
## Summary

`session:digest_summary` (AI-generated 10-word-or-fewer summary, stored in block meta by `useSessionDigest` via the backend `SessionDigest` RPC) was never being read by `AgentViewModel.viewText`, so it never appeared in the agent pane header.

- Show the digest summary as the header label when available
- Fall back to `term:activity` (Claude Code OSC window title) when no digest exists yet
- One-line change in `agent-model.ts` — no new signals, no new hooks; just reads an already-populated meta key

## Test plan

- [ ] Open an agent pane that has had at least one completed conversation — header should show the AI-generated summary (e.g. "Implementing auth middleware")
- [ ] Fresh agent pane with no digest yet but active Claude Code session — header falls back to `term:activity` OSC title
- [ ] Pane with neither → header shows nothing (same as before)
- [ ] `continued Xm ago` chip still appears alongside the label

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)