### PR TITLE
chore: release v0.47.3

### DIFF
--- a/.changesets/1782037055-fix-srv-seed-the-default-3-pane-layout-for-new-windows-so-op-51bk.md
+++ b/.changesets/1782037055-fix-srv-seed-the-default-3-pane-layout-for-new-windows-so-op-51bk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): seed the default 3-pane layout for new windows so 'Open another window' is not blank

--- a/.changesets/1782037473-fix-macos-add-icon-to-agentmux-helper-alerts-notification-pe-1rmo.md
+++ b/.changesets/1782037473-fix-macos-add-icon-to-agentmux-helper-alerts-notification-pe-1rmo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): add icon to AgentMux Helper (Alerts) — notification permission prompt no longer shows blank icon

--- a/.changesets/1782052109-fix-pool-clamp-re-assert-pool-promoted-new-window-placement--d5cm.md
+++ b/.changesets/1782052109-fix-pool-clamp-re-assert-pool-promoted-new-window-placement--d5cm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pool): clamp + re-assert pool-promoted new window placement so it can't land off-screen on HiDPI

--- a/.changesets/1782056025-fix-macos-floating-pane-maximize-button-now-works-on-macos-l-ywtc.md
+++ b/.changesets/1782056025-fix-macos-floating-pane-maximize-button-now-works-on-macos-l-ywtc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): floating pane maximize button now works on macOS/Linux via CEF Views window.maximize()

--- a/.changesets/1782056025-fix-redock-floating-panes-are-never-valid-redock-targets-gho-4ckc.md
+++ b/.changesets/1782056025-fix-redock-floating-panes-are-never-valid-redock-targets-gho-4ckc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(redock): floating panes are never valid redock targets — ghost no longer appears on idle floaters

--- a/.changesets/1782056026-fix-macos-dock-icon-single-click-focuses-existing-window-ins-w3nq.md
+++ b/.changesets/1782056026-fix-macos-dock-icon-single-click-focuses-existing-window-ins-w3nq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): Dock icon single-click focuses existing window instead of opening a new one

--- a/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
+++ b/.changesets/1782057571-fix-pool-show-promoted-pool-window-on-screen-first-fix-windo-vpts.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pool): paint pool-promoted windows on Windows — drive CEF Views Window.show() on the UI thread at promote (macOS parity), register the promoted HWND for chrome ops (drag/close/min/max), and stamp FileDescription/ProductName=AgentMux on the host exe so the taskbar no longer shows "CEF Bootstrap application"

--- a/.changesets/1782057645-feat-editor-collapsible-live-markdown-preview-panel-wttw.md
+++ b/.changesets/1782057645-feat-editor-collapsible-live-markdown-preview-panel-wttw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): collapsible live markdown preview panel

--- a/.changesets/1782059166-fix-hamburger-exit-closes-the-current-window-not-main-58hu.md
+++ b/.changesets/1782059166-fix-hamburger-exit-closes-the-current-window-not-main-58hu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(hamburger): Exit closes the current window, not main

--- a/.changesets/1782059538-chore-docs-remove-tauri-era-spec-files-ywj2.md
+++ b/.changesets/1782059538-chore-docs-remove-tauri-era-spec-files-ywj2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(docs): remove Tauri-era spec files

--- a/.changesets/1782060159-feat-ui-pane-minimize-button-with-separator-collapse-failed--js7m.md
+++ b/.changesets/1782060159-feat-ui-pane-minimize-button-with-separator-collapse-failed--js7m.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ui): pane minimize button with separator; collapse failed tool calls immediately

--- a/.changesets/1782061686-fix-macos-suppress-duplicate-notification-permission-prompts-8hqt.md
+++ b/.changesets/1782061686-fix-macos-suppress-duplicate-notification-permission-prompts-8hqt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): suppress duplicate notification permission prompts on new-version install

--- a/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
+++ b/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom

--- a/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
+++ b/.changesets/1782063247-fix-stable-agent-slug-for-muxbus-routing-via-agentmux-id-env-var.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(spawner): use stable role slug for AGENTMUX_AGENT_ID so muxbus routing is stable across respawns and renames

--- a/.changesets/1782076247-fix-ui-pass-isminimized-toggleminimize-as-props-to-blockfram-0m9a.md
+++ b/.changesets/1782076247-fix-ui-pass-isminimized-toggleminimize-as-props-to-blockfram-0m9a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): pass isMinimized/toggleMinimize as props to BlockFrame_Header

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.47.2"
+version = "0.47.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,24 @@
 # AgentMux Version History
 
+## 0.47.3 — 2026-06-21
+
+- fix(srv): seed the default 3-pane layout for new windows so 'Open another window' is not blank
+- fix(macos): add icon to AgentMux Helper (Alerts) — notification permission prompt no longer shows blank icon
+- fix(pool): clamp + re-assert pool-promoted new window placement so it can't land off-screen on HiDPI
+- fix(macos): floating pane maximize button now works on macOS/Linux via CEF Views window.maximize()
+- fix(redock): floating panes are never valid redock targets — ghost no longer appears on idle floaters
+- fix(macos): Dock icon single-click focuses existing window instead of opening a new one
+- fix(pool): paint pool-promoted windows on Windows — drive CEF Views Window.show() on the UI thread at promote (macOS parity), register the promoted HWND for chrome ops (drag/close/min/max), and stamp FileDescription/ProductName=AgentMux on the host exe so the taskbar no longer shows "CEF Bootstrap application"
+- feat(editor): collapsible live markdown preview panel
+- fix(hamburger): Exit closes the current window, not main
+- chore(docs): remove Tauri-era spec files
+- feat(ui): pane minimize button with separator; collapse failed tool calls immediately
+- fix(macos): suppress duplicate notification permission prompts on new-version install
+- fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom
+- fix(spawner): use stable role slug for AGENTMUX_AGENT_ID so muxbus routing is stable across respawns and renames
+- fix(ui): pass isMinimized/toggleMinimize as props to BlockFrame_Header
+
+
 ## 0.47.2 — 2026-06-21
 
 - fix(macos): per-version bundle id (ai.agentmux.<channel>.<version>) — double-click any build without open -n

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.47.2",
+      "version": "0.47.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release **v0.47.3** — consumes 15 pending changesets.

Bump type **forced to patch** via `task release -- --as patch` (one `feat`-level changeset ships under this patch per the deliberate override).

Headline (this cycle): pool-promoted new/tear-off windows now paint on Windows + chrome binding + taskbar name (#1654). Full list in `VERSION_HISTORY.md`.

Version invariant verified — all five locations at 0.47.3 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md top section).

<!-- agentmux:agent_id=agentc -->