### PR TITLE
fix(ui): remove stub pane minimize button that did nothing on macOS/Linux

### DIFF
--- a/.changesets/1782078840-fix-ui-remove-stub-pane-minimize-button-that-did-nothing-no--thex.md
+++ b/.changesets/1782078840-fix-ui-remove-stub-pane-minimize-button-that-did-nothing-no--thex.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): remove stub pane minimize button that did nothing (no layout collapse on macOS/Linux)

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -280,12 +280,6 @@
                         padding: 0;
                     }
 
-                    .block-frame-minimize {
-                        justify-content: center;
-                        align-items: center;
-                        padding: 0;
-                    }
-
                     .block-frame-btn-separator {
                         width: 1px;
                         height: 14px;
@@ -295,16 +289,6 @@
                         margin: 0 3px;
                         flex-shrink: 0;
                     }
-                }
-            }
-
-            &.minimized {
-                .block-frame-default-inner > *:not(.block-frame-default-header) {
-                    display: none;
-                }
-
-                .block-frame-default-header {
-                    border-bottom: none;
                 }
             }
 

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -212,8 +212,6 @@ function EndIcons(props: {
     /** View key from `blockData.meta.view`, used to render a context-aware
      *  tooltip on the per-pane mic button (e.g. "Speak into this terminal"). */
     blockView?: string;
-    isMinimized: () => boolean;
-    toggleMinimize: () => void;
 }): JSX.Element {
     // createMemo so blockAtom reads inside endIconButtons() are tracked and
     // the button array re-evaluates when the agent loads/unloads.
@@ -258,15 +256,7 @@ function EndIcons(props: {
                     }
                 />
             </Show>
-            <IconButton
-                decl={{
-                    elemtype: "iconbutton",
-                    icon: "window-minimize",
-                    title: props.isMinimized() ? "Restore pane" : "Minimize pane",
-                    click: props.toggleMinimize,
-                }}
-                className="block-frame-minimize"
-            />
+
             <Show when={ephemeral()} fallback={
                 <Show when={floatingLabel()} fallback={
                     <OptMagnifyButton
@@ -290,7 +280,7 @@ function EndIcons(props: {
     );
 }
 
-function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error; isMinimized: () => boolean; toggleMinimize: () => void }): JSX.Element {
+function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error }): JSX.Element {
     const [blockData] = WOS.useWaveObjectValue<Block>(WOS.makeORef("block", props.nodeModel.blockId));
     const showBlockIds = getSettingsKeyAtom("blockheader:showblockids")();
     const preIconButton = util.useAtomValueSafe(props.viewModel?.preIconButton);
@@ -480,8 +470,6 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     nodeModel={props.nodeModel}
                     onContextMenu={onContextMenu}
                     blockView={blockData()?.meta?.view}
-                    isMinimized={props.isMinimized}
-                    toggleMinimize={props.toggleMinimize}
                 />
             </div>
         </div>
@@ -716,15 +704,6 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     const magnifiedBlockOpacity = () => magnifiedBlockOpacityAtom();
     let connBtnRef: { current: HTMLDivElement | null } = { current: null };
     const noHeader = util.useAtomValueSafe(props.viewModel?.noHeader);
-    const isMinimized = () => !!blockData()?.meta?.["layout:minimized"];
-    const toggleMinimize = () => {
-        const next = !isMinimized();
-        RpcApi.SetMetaCommand(TabRpcClient, {
-            oref: WOS.makeORef("block", nodeModel.blockId),
-            meta: { "layout:minimized": next || null },
-        }).catch(console.error);
-    };
-
     // Captured outer-frame ref for PaneSizeBadge. Live as long as the
     // frame is mounted; cleared on unmount via the callback ref.
     // SPEC_PANE_RESIZE_DIMENSION_OVERLAY_2026_05_26.md.
@@ -793,10 +772,10 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     }
     const previewElem = <div class="block-frame-preview">{viewIconElem}</div>;
     const headerElem = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} isMinimized={isMinimized} toggleMinimize={toggleMinimize} />
+        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} />
     );
     const headerElemNoView = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} isMinimized={isMinimized} toggleMinimize={toggleMinimize} />
+        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} />
     );
 
     // Body right-click handler
@@ -827,7 +806,6 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
                 "has-agent-color": !!blockAgentColor(),
                 ephemeral: isEphemeral(),
                 magnified: isMagnified(),
-                minimized: isMinimized(),
             })}
             data-blockid={nodeModel.blockId}
             onClick={props.blockModel?.onClick}


### PR DESCRIPTION
## Summary

- Removes the pane minimize button added in #1658
- The button called `SetMetaCommand` to set `"layout:minimized"` on the block, which applied a CSS class hiding the content area — but the tiling layout engine never reads this meta key, so the pane container keeps its full allocated size
- On macOS/Linux users saw the pane become an empty header-only rectangle that still occupied full space — indistinguishable from a no-op
- Removes: `isMinimized` signal, `toggleMinimize` callback, `EndIcons` props, `BlockFrame_Header` props, the `IconButton` render, `.minimized` SCSS rule, `.block-frame-minimize` SCSS rule

## Why not implement it properly?

Real pane collapse requires the tiling layout geometry engine (`layoutGeometry.ts`) to read block meta and constrain a pane's computed height to header-height, redistributing freed space to siblings. That's a larger feature tracked separately.

## Test plan

- [ ] Verify minimize button no longer appears in pane headers
- [ ] Verify close (×) and magnify buttons still render correctly
- [ ] Verify no TypeScript errors in blockframe.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)