### PR TITLE
fix(swarm): show agent panes in Swarm view

### DIFF
--- a/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
+++ b/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom

--- a/.changesets/1782078771-fix-swarm-show-agent-panes-in-swarm-view-jjf2.md
+++ b/.changesets/1782078771-fix-swarm-show-agent-panes-in-swarm-view-jjf2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): show agent panes in Swarm view

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -184,6 +184,11 @@ impl Handler {
         self.agent_info.values().cloned().collect()
     }
 
+    /// List all block IDs that have a registered agent.
+    pub fn list_active_blocks(&self) -> Vec<String> {
+        self.block_to_agent.keys().cloned().collect()
+    }
+
     /// Inject a message into an agent's terminal.
     ///
     /// Sends `message\r` as a single payload (required for text display),
@@ -536,6 +541,10 @@ impl ReactiveHandler {
 
     pub fn list_agents(&self) -> Vec<AgentRegistration> {
         self.inner.lock().unwrap().list_agents()
+    }
+
+    pub fn list_active_blocks(&self) -> Vec<String> {
+        self.inner.lock().unwrap().list_active_blocks()
     }
 
     pub fn inject_message(&self, req: InjectionRequest) -> InjectionResponse {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -92,8 +92,14 @@ fn register_agent_tracked_blocks(engine: &Arc<WshRpcEngine>, state: &AppState) {
         Box::new(move |_data, _ctx| {
             let process_tracker = process_tracker.clone();
             Box::pin(async move {
+                let process_ids = process_tracker.list_all_blocks();
+                let reactive_ids = crate::backend::reactive::get_global_handler().list_active_blocks();
+                let mut seen = std::collections::HashSet::new();
+                let block_ids: Vec<String> = process_ids.into_iter().chain(reactive_ids)
+                    .filter(|id| seen.insert(id.clone()))
+                    .collect();
                 Ok(Some(serde_json::to_value(&AgentTrackedBlocksResult {
-                    block_ids: process_tracker.list_all_blocks(),
+                    block_ids,
                 }).unwrap()))
             })
         }),

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -186,7 +186,12 @@ export class SwarmViewModel implements ViewModel {
         const subagents = this.subagentsAtom();
         const statuses = this.agentStatusesAtom();
 
-        return blockIds.map((blockId) => {
+        // Include parent block IDs from subagents as fallback for agent panes
+        // that registered subagents before their own registration propagated.
+        const parentIds = subagents.map((s) => s.parent_block_id).filter(Boolean);
+        const allBlockIds = [...new Set([...blockIds, ...parentIds])];
+
+        return allBlockIds.map((blockId) => {
             const blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
             const block = blockAtom();
             const label =


### PR DESCRIPTION
## Summary

- **Root cause:** `AgentTrackedBlocksCommand` sourced block IDs only from `process_tracker`, which only registers blocks when an OS subprocess spawns via `ensure_tracker()`. Claude Code agent panes never spawn OS-level subprocesses, so they were never visible in Swarm.
- **Rust fix:** Added `list_active_blocks()` to `ReactiveHandler` (reads `block_to_agent` keys) and unioned those IDs with process tracker IDs in `AgentTrackedBlocksCommand`.
- **Frontend fix:** `buildTree()` in `swarm-model.ts` also includes unique `parent_block_id` values from active subagents as a safety net for race conditions where subagents spawn before their parent's registration propagates.

## Test plan

- [ ] Launch AgentMux and open Swarm pane
- [ ] Open one or more Agent panes — they should appear immediately in Swarm tree
- [ ] Verify agent status badge (running/idle) reflects actual agent activity
- [ ] Launch a deep-research / workflow that spawns subagents — parent + children should appear in tree
- [ ] Close an agent pane — confirm it disappears from Swarm on next refresh

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)