### PR TITLE
fix(floating-pane): full floater independence + unjam tear-off after a failed drag

### DIFF
--- a/.changesets/1782080390-fix-floating-pane-make-floaters-fully-independent-of-their-p-9l28.md
+++ b/.changesets/1782080390-fix-floating-pane-make-floaters-fully-independent-of-their-p-9l28.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): make floaters fully independent of their parent window and stop a failed tear-off from jamming all future tear-offs

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -260,43 +260,24 @@ unsafe extern "system" fn floater_cascade_wndproc(
     lparam: isize,
 ) -> isize {
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        CallWindowProcW, DefWindowProcW, PostMessageW, SetWindowPos, ShowWindow,
-        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE, SW_SHOWNOACTIVATE,
-        WM_ACTIVATE, WM_CLOSE, WM_DESTROY, WM_SIZE,
+        CallWindowProcW, DefWindowProcW, WM_DESTROY,
     };
-    const WA_INACTIVE: usize = 0;
-    const SIZE_MINIMIZED: usize = 1;
 
-    if msg == WM_ACTIVATE {
-        if (wparam & 0xFFFF) as usize != WA_INACTIVE {
-            // Main window activated — place every floater below it in z-order.
-            // This lets the user click the main window and have it visually
-            // appear in front of the floating pane (replaces the owned-window
-            // always-on-top invariant with a cooperative z-order contract).
-            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
-                SetWindowPos(
-                    fhwnd as *mut _,
-                    hwnd, // insertAfter=main → floater is placed below main
-                    0, 0, 0, 0,
-                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
-                );
-            }
-        }
-    } else if msg == WM_SIZE {
-        if wparam == SIZE_MINIMIZED {
-            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
-                ShowWindow(fhwnd as *mut _, SW_HIDE);
-            }
-        } else {
-            for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
-                ShowWindow(fhwnd as *mut _, SW_SHOWNOACTIVATE);
-            }
-        }
-    } else if msg == WM_DESTROY {
-        for fhwnd in crate::floating_pane::floater_hwnds_for_parent(hwnd as isize) {
-            PostMessageW(fhwnd as *mut _, WM_CLOSE, 0, 0);
-        }
-    }
+    // FLOATER INDEPENDENCE (supersedes the issue #1560 cascade): a floating
+    // pane is now a fully independent top-level window. Closing, minimizing,
+    // restoring, or activating a FullInstance window must NOT touch its
+    // floaters — the OS already z-orders unowned top-level windows on its own,
+    // and a floater torn from one window can be redocked into another, so no
+    // window "owns" a floater's lifecycle. The previous WM_ACTIVATE z-order /
+    // WM_SIZE hide-show / WM_DESTROY close-cascade handlers are removed.
+    //
+    // Two bugs they caused: (1) WM_DESTROY cascade-closed any floater whose
+    // parent matched OR was parent==0, so closing one window killed unrelated
+    // floaters; (2) that surprise close destroyed the block under an in-flight
+    // tear-off, which then jammed the drag session and broke tear-off entirely.
+    //
+    // The subclass itself is kept ONLY as a pure observer-passthrough that
+    // self-prunes FLOATER_CASCADE_ORIGINALS on WM_DESTROY (HWND-reuse safety).
 
     // Always pass through — we observe only, never short-circuit.
     let original = FLOATER_CASCADE_ORIGINALS

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -42,6 +42,31 @@ pub fn start_cross_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Resu
 
     tracing::info!(drag_id = %drag_id, drag_type = ?drag_type, source_window = %source_window, "[dnd:cef] start_cross_drag");
 
+    // Self-heal a STALE drag session before starting a new one. The reducer
+    // enforces a singleton (StartDrag errors if one is already active), which
+    // is correct for a genuinely-concurrent drag — but if a prior drag's
+    // end/cancel never reached the host (the renderer threw mid-drop, or the
+    // dragged pane/window was destroyed under it), `active_drag` would stay
+    // Some forever and reject EVERY future tear-off ("drag session already
+    // active"). No legitimate drag is held for tens of seconds, so an active
+    // session older than STALE_MS is presumed dead: cancel it (EndDrag) so the
+    // new drag can proceed. Belt-and-suspenders behind the frontend's
+    // catch-path cancelCrossDrag — recovers even if the renderer never runs it.
+    const STALE_MS: u64 = 30_000;
+    if let Some(prev) = state.active_drag_snapshot() {
+        if now.saturating_sub(prev.started_at) > STALE_MS {
+            tracing::warn!(
+                stale_drag_id = %prev.drag_id,
+                age_ms = now.saturating_sub(prev.started_at),
+                "[dnd:cef] clearing stale drag session before new start_cross_drag"
+            );
+            state.host_dispatch(crate::reducer::HostCommand::EndDrag {
+                drag_id: prev.drag_id.clone(),
+                outcome: crate::reducer::DragOutcome::Cancelled,
+            });
+        }
+    }
+
     let session = DragSession {
         drag_id: drag_id.clone(),
         drag_type,

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -95,21 +95,10 @@ pub(crate) fn unregister_floater_by_hwnd(hwnd: isize) {
     }
 }
 
-/// Floater HWNDs whose parent main window matches `parent_hwnd`, plus any
-/// floaters registered with parent=0 (unresolved source, legacy callers).
-/// Used by the cascade hook — parent=0 floaters are claimed by whichever
-/// window fires the hook first, preventing them from becoming permanent orphans.
-pub(crate) fn floater_hwnds_for_parent(parent_hwnd: isize) -> Vec<isize> {
-    ACTIVE_FLOATER_HWNDS
-        .lock()
-        .map(|m| {
-            m.values()
-                .filter(|(_, ph)| *ph == parent_hwnd || *ph == 0)
-                .map(|(fh, _)| *fh)
-                .collect()
-        })
-        .unwrap_or_default()
-}
+// `floater_hwnds_for_parent` removed: the window→floater cascade it fed was
+// deleted in favour of full floater independence (see the FLOATER INDEPENDENCE
+// note in `client/wndproc.rs::floater_cascade_wndproc`). The registry below is
+// retained for the diagnostic snapshot only.
 
 /// Snapshot for the `get_pane_debug_state` diagnostic command.
 pub(crate) fn floater_debug_snapshot() -> Vec<(String, isize)> {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1045,6 +1045,15 @@ impl AppState {
             .cloned()
     }
 
+    /// Snapshot the current active drag session regardless of drag_id.
+    /// Used by `start_cross_drag` to detect and self-heal a *stale* session
+    /// (a prior drag whose end/cancel never reached the host — e.g. the
+    /// renderer threw mid-drop, or a window/pane was destroyed under it),
+    /// which would otherwise reject every future tear-off forever.
+    pub fn active_drag_snapshot(&self) -> Option<DragSession> {
+        self.host_state.lock().active_drag.clone()
+    }
+
     // ── PR #5 H.4 — pool read helpers ───────────────────────────────────
     //
     // Replace the legacy `state.unpromoted_pool_labels: Mutex<HashSet>` /

--- a/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
@@ -132,8 +132,11 @@ async function handleCrossWindowDragEnd(
         dragType = "tab";
     }
 
+    // Hoisted so the catch can release the session even when startCrossDrag
+    // succeeded but a later step (TearOffBlock / drop) threw.
+    let dragId: string | null = null;
     try {
-        const dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
+        dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
         const targetWindow = await api.updateCrossDrag(dragId, cursorPoint.x, cursorPoint.y);
 
         if (targetWindow && targetWindow !== src) {
@@ -147,6 +150,9 @@ async function handleCrossWindowDragEnd(
         }
     } catch (e) {
         Logger.error("dnd:cross", "cross-window drag error", { error: String(e), dragType, dragPayloadForApi });
+        // CRITICAL: release the host drag session so a failed drop/tear-off
+        // can't jam every future tear-off with "drag session already active".
+        if (dragId) { try { await api.cancelCrossDrag(dragId); } catch {} }
     }
 }
 

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -132,8 +132,11 @@ async function handleCrossWindowDragEnd(
         dragType = "tab";
     }
 
+    // Hoisted so the catch can release the session even when startCrossDrag
+    // succeeded but a later step (TearOffBlock / drop) threw.
+    let dragId: string | null = null;
     try {
-        const dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
+        dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
         const targetWindow = await api.updateCrossDrag(dragId, cursorPoint.x, cursorPoint.y);
 
         if (targetWindow && targetWindow !== src) {
@@ -147,6 +150,9 @@ async function handleCrossWindowDragEnd(
         }
     } catch (e) {
         Logger.error("dnd:cross", "cross-window drag error", { error: String(e), dragType, dragPayloadForApi });
+        // CRITICAL: release the host drag session so a failed drop/tear-off
+        // can't jam every future tear-off with "drag session already active".
+        if (dragId) { try { await api.cancelCrossDrag(dragId); } catch {} }
     }
 }
 

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -200,8 +200,11 @@ async function handleCrossWindowDragEnd(
         dragType = "tab";
     }
 
+    // Hoisted so the catch can release the session even when startCrossDrag
+    // succeeded but a later step (TearOffBlock / drop) threw.
+    let dragId: string | null = null;
     try {
-        const dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
+        dragId = await api.startCrossDrag(dragType, src, workspace.oid, activeTabId, dragPayloadForApi);
         const targetWindow = await api.updateCrossDrag(dragId, cursorPoint.x, cursorPoint.y);
 
         if (targetWindow && targetWindow !== src) {
@@ -216,6 +219,12 @@ async function handleCrossWindowDragEnd(
         }
     } catch (e) {
         Logger.error("dnd:cross", "cross-window drag error", { error: String(e), dragType, dragPayloadForApi });
+        // CRITICAL: release the host drag session. If startCrossDrag set
+        // active_drag and a later step threw (e.g. TearOffBlock "block not
+        // found" when the source block was destroyed under the drag), the
+        // session would otherwise stay Some forever and reject EVERY future
+        // tear-off with "drag session already active" until restart.
+        if (dragId) { try { await api.cancelCrossDrag(dragId); } catch {} }
     }
 }
 


### PR DESCRIPTION
## Symptoms (reported on 0.47.3)

Tearing off panes/windows worked, then after closing a window/floater, **a second unrelated floating pane closed along with it**, and **tear-off stopped working entirely**.

## Root cause — two compounding state-management bugs (traced in the 0.47.3 host log)

**Bug 1 — window close cascaded into closing an independent floater.**
The issue #1560 cascade hook (`client/wndproc.rs::floater_cascade_wndproc`) posts `WM_CLOSE` to every floater in `floater_hwnds_for_parent(hwnd)` on a FullInstance `WM_DESTROY`. That set matched `parent == hwnd` **OR `parent == 0`**, so closing one window could destroy floaters it didn't own.

**Bug 2 — a failed tear-off permanently jammed all future tear-offs.**
When Bug 1 destroyed the block under an in-flight drag, `TearOffBlock` threw `block not found: …`. `CrossWindowDragMonitor`'s `catch` logged but **never released the host drag session**, so `active_drag` stayed `Some` forever and every later tear-off was rejected with `start_drag: drag session already active` until restart.

## Fix

**Floaters are now fully independent top-level windows.** Removed the `WM_ACTIVATE` z-order / `WM_SIZE` hide-show / `WM_DESTROY` close cascades — a window's lifecycle never touches floaters. The subclass is retained only as an observer-passthrough that self-prunes `FLOATER_CASCADE_ORIGINALS` on `WM_DESTROY` (HWND-reuse safety). `floater_hwnds_for_parent` deleted.

**Tear-off can no longer be jammed by a failed drag.** `CrossWindowDragMonitor` (`win32`/`linux`/`darwin`) now calls `cancelCrossDrag(dragId)` in its `catch`. Belt-and-suspenders: `start_cross_drag` self-heals a stale session (`active_drag` older than 30s) via a new `AppState::active_drag_snapshot()`.

## Verified on Windows

- ✅ Closing a window leaves its floaters open and independent
- ✅ Tear-off keeps working after closing windows/floaters (no permanent jam)

## Not in this PR

The floating-pane **redock empty-slot** (#1662) is a separate, deeper lifecycle race (the floater's `onNodeDelete` → `DeleteBlock` destroys the redocked block) and is tracked there.

<!-- agentmux:agent_id=agentc -->