### PR TITLE
feat(splash): identity footer on macOS + Windows (completes cross-platform footer)

### DIFF
--- a/.changesets/1782114529-feat-splash-render-the-user-host-version-footer-on-macos-and-lct0.md
+++ b/.changesets/1782114529-feat-splash-render-the-user-host-version-footer-on-macos-and-lct0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(splash): render the user@host + version footer on macOS and Windows too (completes the cross-platform footer)

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -46,11 +46,27 @@ use windows_sys::Win32::UI::WindowsAndMessaging::*;
 // renderer. Provides `BRAIN_W` / `BRAIN_H` as `i32` consts.
 include!(concat!(env!("OUT_DIR"), "/brain_dims.rs"));
 
-// Splash window is the brain bitmap plus a 12px BG border on each side.
+// Splash window is the brain bitmap plus a 12px BG border on each side, with an
+// identity footer band added below (SPEC_SPLASH_USERINFO_AND_DISABLE_2026_06_21).
 const SPLASH_PADDING: i32 = 12;
+/// Brain-region square (brain + border). The card adds the footer band below.
 const SPLASH_SIZE: i32 = BRAIN_W + SPLASH_PADDING * 2;
 const BRAIN_X: i32 = SPLASH_PADDING;
 const BRAIN_Y: i32 = SPLASH_PADDING;
+
+// ── Footer (identity strip near the bottom) ─────────────────────────────────
+/// Muted footer text color (R, G, B) = #8A8A93.
+const FOOTER_COLOR: [u8; 3] = [0x8A, 0x8A, 0x93];
+const FOOTER_PAD_TOP: i32 = 12;
+const FOOTER_LINE_GAP: i32 = 3;
+const FOOTER_PAD_BOTTOM: i32 = 12;
+const FOOTER_H: i32 = FOOTER_PAD_TOP
+    + 2 * crate::splash_font::GLYPH_H as i32
+    + FOOTER_LINE_GAP
+    + FOOTER_PAD_BOTTOM;
+/// Full card: width = brain-region; height = brain-region + footer band.
+const SPLASH_W: i32 = SPLASH_SIZE;
+const SPLASH_H: i32 = SPLASH_SIZE + FOOTER_H;
 
 // Background color (B, G, R) — dark app background. Stored as
 // channels rather than a packed COLORREF because the compositor
@@ -129,15 +145,15 @@ unsafe fn run_splash(dismiss_ev: HANDLE, class_name: String) {
 
     let sw = GetSystemMetrics(SM_CXSCREEN);
     let sh = GetSystemMetrics(SM_CYSCREEN);
-    let x = (sw - SPLASH_SIZE) / 2;
-    let y = (sh - SPLASH_SIZE) / 2;
+    let x = (sw - SPLASH_W) / 2;
+    let y = (sh - SPLASH_H) / 2;
 
     let hwnd = CreateWindowExW(
         WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
         class.as_ptr(),
         std::ptr::null(),     // no title
         WS_POPUP,
-        x, y, SPLASH_SIZE, SPLASH_SIZE,
+        x, y, SPLASH_W, SPLASH_H,
         std::ptr::null_mut(), // no parent
         std::ptr::null_mut(), // no menu
         hinst,
@@ -156,9 +172,9 @@ unsafe fn run_splash(dismiss_ev: HANDLE, class_name: String) {
     let mem_dc = CreateCompatibleDC(screen_dc);
     let mut bmi: BITMAPINFO = std::mem::zeroed();
     bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
-    bmi.bmiHeader.biWidth = SPLASH_SIZE;
+    bmi.bmiHeader.biWidth = SPLASH_W;
     // Negative height = top-down rows (matches our pixel layout).
-    bmi.bmiHeader.biHeight = -SPLASH_SIZE;
+    bmi.bmiHeader.biHeight = -SPLASH_H;
     bmi.bmiHeader.biPlanes = 1;
     bmi.bmiHeader.biBitCount = 32;
     bmi.bmiHeader.biCompression = BI_RGB as u32;
@@ -183,10 +199,15 @@ unsafe fn run_splash(dismiss_ev: HANDLE, class_name: String) {
 
     let dib_pixels = std::slice::from_raw_parts_mut(
         dib_pixels_raw as *mut u8,
-        (SPLASH_SIZE * SPLASH_SIZE * 4) as usize,
+        (SPLASH_W * SPLASH_H * 4) as usize,
     );
 
     ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+
+    // Footer identity, gathered once and clamped to the card width.
+    let info = crate::splash_info::SplashInfo::gather();
+    let max_chars = ((SPLASH_W - 24) / crate::splash_font::GLYPH_W as i32).max(8) as usize;
+    let footer = info.footer_lines(max_chars);
 
     let start = std::time::Instant::now();
 
@@ -207,7 +228,7 @@ unsafe fn run_splash(dismiss_ev: HANDLE, class_name: String) {
             (160.0 + pulse * 60.0) as u8
         };
 
-        composite(dib_pixels, brain_alpha);
+        composite(dib_pixels, brain_alpha, &footer);
         push_layered(hwnd, mem_dc, 255);
 
         std::thread::sleep(std::time::Duration::from_millis(16)); // ~60 fps
@@ -227,7 +248,7 @@ unsafe fn run_splash(dismiss_ev: HANDLE, class_name: String) {
 /// Brain bytes are pre-multiplied BGRA (alpha already baked into
 /// RGB by build.rs). Modulating by `brain_alpha / 255` keeps them
 /// pre-multiplied for `UpdateLayeredWindow`'s AC_SRC_ALPHA blend.
-fn composite(dib: &mut [u8], brain_alpha: u8) {
+fn composite(dib: &mut [u8], brain_alpha: u8, footer: &[String]) {
     // Fast path: fill with opaque BG. Loop unrolled by the compiler.
     for px in dib.chunks_exact_mut(4) {
         px[0] = BG_B;
@@ -241,7 +262,7 @@ fn composite(dib: &mut [u8], brain_alpha: u8) {
     // standard premultiplied OVER onto the BG.
     let ba = brain_alpha as u16;
     for y in 0..BRAIN_H {
-        let dib_row = ((BRAIN_Y + y) * SPLASH_SIZE * 4) as usize;
+        let dib_row = ((BRAIN_Y + y) * SPLASH_W * 4) as usize;
         let src_row = (y * BRAIN_W * 4) as usize;
         for x in 0..BRAIN_W {
             let di = dib_row + ((BRAIN_X + x) * 4) as usize;
@@ -269,12 +290,21 @@ fn composite(dib: &mut [u8], brain_alpha: u8) {
             // dib[di+3] left at 255 — window stays opaque.
         }
     }
+
+    // Footer: muted identity lines in the bottom band. window_alpha = 1.0 — the
+    // whole window fades uniformly via the layered-window constant alpha
+    // (fade_out / push_layered), so the footer needs no per-pixel fade.
+    let footer_top = SPLASH_H - FOOTER_H + FOOTER_PAD_TOP;
+    for (i, line) in footer.iter().enumerate() {
+        let y = footer_top + i as i32 * (crate::splash_font::GLYPH_H as i32 + FOOTER_LINE_GAP);
+        crate::splash_text::draw_text_centered(dib, SPLASH_W, SPLASH_H, y, line, FOOTER_COLOR, 1.0, true);
+    }
 }
 
 unsafe fn push_layered(hwnd: HWND, mem_dc: HDC, source_alpha: u8) {
     let mut sz = SIZE {
-        cx: SPLASH_SIZE,
-        cy: SPLASH_SIZE,
+        cx: SPLASH_W,
+        cy: SPLASH_H,
     };
     let mut src_pt = POINT { x: 0, y: 0 };
     let blend = BLENDFUNCTION {

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -38,8 +38,21 @@ static BRAIN_PNG: &[u8] = include_bytes!("../resources/brain.png");
 
 const BRAIN_PX: f64 = 150.0; // displayed brain size
 const PAD_PX: f64 = 35.0; // backdrop padding around the brain
-const SPLASH_PX: f64 = BRAIN_PX + PAD_PX * 2.0; // 220×220 dark card
+const SPLASH_PX: f64 = BRAIN_PX + PAD_PX * 2.0; // 220×220 brain-region square
 const CORNER_RADIUS: f64 = 16.0;
+
+// Footer (identity strip near the bottom) — native NSTextField labels showing
+// user@host / v<version> (+ dev label). SPEC_SPLASH_USERINFO_AND_DISABLE.
+const FOOTER_LINE_H: f64 = 18.0;
+const FOOTER_PAD: f64 = 10.0;
+const FOOTER_BAND_H: f64 = FOOTER_PAD * 2.0 + FOOTER_LINE_H * 2.0; // 56
+/// Full card: width = brain region; height = brain region + footer band.
+const SPLASH_W: f64 = SPLASH_PX;
+const SPLASH_H: f64 = SPLASH_PX + FOOTER_BAND_H;
+// Muted footer text color #8A8A93.
+const FOOTER_R: f64 = 0x8A as f64 / 255.0;
+const FOOTER_G: f64 = 0x8A as f64 / 255.0;
+const FOOTER_B: f64 = 0x93 as f64 / 255.0;
 
 // Backdrop color — matches the Win32 splash's BG (R=0x1A, G=0x1A, B=0x1F).
 const BG_R: f64 = 26.0 / 255.0;
@@ -137,6 +150,27 @@ unsafe fn send_void_i64(recv: id, s: SEL, a: i64) {
 unsafe fn send_void_f64(recv: id, s: SEL, a: f64) {
     let f: extern "C" fn(id, SEL, f64) = std::mem::transmute(objc_msgSend as *const ());
     f(recv, s, a)
+}
+#[inline]
+unsafe fn send_id_f64(recv: id, s: SEL, a: f64) -> id {
+    let f: extern "C" fn(id, SEL, f64) -> id = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+#[inline]
+unsafe fn send_void_rect(recv: id, s: SEL, a: CGRect) {
+    let f: extern "C" fn(id, SEL, CGRect) = std::mem::transmute(objc_msgSend as *const ());
+    f(recv, s, a)
+}
+/// `[NSString stringWithUTF8String:]` — copies, so the temporary CString is fine.
+unsafe fn nsstring(s: &str) -> id {
+    let cstr = std::ffi::CString::new(s).unwrap_or_default();
+    let f: extern "C" fn(id, SEL, *const c_char) -> id =
+        std::mem::transmute(objc_msgSend as *const ());
+    f(
+        class(b"NSString\0"),
+        sel(b"stringWithUTF8String:\0"),
+        cstr.as_ptr(),
+    )
 }
 
 /// A live splash window plus the path the host touches when it's ready.
@@ -271,13 +305,13 @@ unsafe fn build_window() -> (id, id) {
         let f: extern "C" fn(id, SEL) -> CGRect = std::mem::transmute(objc_msgSend as *const ());
         f(screen, sel(b"frame\0"))
     };
-    let x = screen_frame.origin.x + (screen_frame.size.width - SPLASH_PX) / 2.0;
-    let y = screen_frame.origin.y + (screen_frame.size.height - SPLASH_PX) / 2.0;
+    let x = screen_frame.origin.x + (screen_frame.size.width - SPLASH_W) / 2.0;
+    let y = screen_frame.origin.y + (screen_frame.size.height - SPLASH_H) / 2.0;
     let win_rect = CGRect {
         origin: CGPoint { x, y },
         size: CGSize {
-            width: SPLASH_PX,
-            height: SPLASH_PX,
+            width: SPLASH_W,
+            height: SPLASH_H,
         },
     };
 
@@ -308,8 +342,8 @@ unsafe fn build_window() -> (id, id) {
     let local = CGRect {
         origin: CGPoint { x: 0.0, y: 0.0 },
         size: CGSize {
-            width: SPLASH_PX,
-            height: SPLASH_PX,
+            width: SPLASH_W,
+            height: SPLASH_H,
         },
     };
     let backdrop = {
@@ -337,11 +371,12 @@ unsafe fn build_window() -> (id, id) {
     send_void_f64(layer, sel(b"setCornerRadius:\0"), CORNER_RADIUS);
     send_void_bool(layer, sel(b"setMasksToBounds:\0"), 1);
 
-    // Brain image view centered on the backdrop, proportional scaling.
+    // Brain image view in the upper (brain) region, above the footer band.
+    // macOS Y is bottom-up, so a larger y sits higher.
     let brain_rect = CGRect {
         origin: CGPoint {
             x: PAD_PX,
-            y: PAD_PX,
+            y: FOOTER_BAND_H + PAD_PX,
         },
         size: CGSize {
             width: BRAIN_PX,
@@ -362,6 +397,51 @@ unsafe fn build_window() -> (id, id) {
     send_void_f64(image_view, sel(b"setAlphaValue:\0"), 0.0); // fades in
 
     send_void_id(backdrop, sel(b"addSubview:\0"), image_view);
+
+    // Footer: native NSTextField labels in the bottom band (muted, centered).
+    // They fade with the window on dismiss (window alpha ramps) and do not
+    // pulse. macOS Y is bottom-up: line[0] (user@host) sits above line[1] (version).
+    {
+        let info = crate::splash_info::SplashInfo::gather();
+        let max_chars = ((SPLASH_W - 24.0) / 7.5) as usize; // ~7.5 px/char at 13px mono
+        let lines = info.footer_lines(max_chars.max(8));
+        let footer_color = {
+            let f: extern "C" fn(id, SEL, f64, f64, f64, f64) -> id =
+                std::mem::transmute(objc_msgSend as *const ());
+            f(
+                class(b"NSColor\0"),
+                sel(b"colorWithSRGBRed:green:blue:alpha:\0"),
+                FOOTER_R,
+                FOOTER_G,
+                FOOTER_B,
+                1.0,
+            )
+        };
+        let font = send_id_f64(class(b"NSFont\0"), sel(b"userFixedPitchFontOfSize:\0"), 13.0);
+        let n = lines.len();
+        for (i, line) in lines.iter().enumerate() {
+            let ly = FOOTER_PAD + (n - 1 - i) as f64 * FOOTER_LINE_H;
+            let rect = CGRect {
+                origin: CGPoint { x: 0.0, y: ly },
+                size: CGSize {
+                    width: SPLASH_W,
+                    height: FOOTER_LINE_H,
+                },
+            };
+            // labelWithString: → a non-editable, borderless, transparent label.
+            let label = send_id(
+                class(b"NSTextField\0"),
+                sel(b"labelWithString:\0"),
+                nsstring(line),
+            );
+            send_void_rect(label, sel(b"setFrame:\0"), rect);
+            send_void_id(label, sel(b"setTextColor:\0"), footer_color);
+            send_void_id(label, sel(b"setFont:\0"), font);
+            send_void_i64(label, sel(b"setAlignment:\0"), 2); // NSTextAlignmentCenter
+            send_void_id(backdrop, sel(b"addSubview:\0"), label);
+        }
+    }
+
     send_void_id(window, sel(b"setContentView:\0"), backdrop);
 
     // Bring the app + window up immediately.


### PR DESCRIPTION
Completes the cross-platform splash footer started in #1674 (Linux). macOS and Windows now show the same `user@host` / `v<version>` (+ dev label) footer near the bottom, consuming the shared `SplashInfo`.

## Changes
- **Windows** (`splash.rs`) — software DIB path: split the square `SPLASH_SIZE` into `SPLASH_W`×`SPLASH_H`, re-center the card, and draw the footer into the premultiplied DIB via the shared `splash_text` blitter. `window_alpha = 1.0` because the layered window fades uniformly (`fade_out`/`push_layered`), so the footer needs no per-pixel fade.
- **macOS** (`splash_mac.rs`) — native AppKit: grow the card by a footer band, keep the brain in the upper region (Y-up coords), and add two `NSTextField` labels via `labelWithString:` (borderless/transparent) in muted gray. They fade with the window on dismiss and don't pulse.

## Verification status ⚠️
- **Linux build green** (the new code is `cfg`-gated to its platform, so Linux is unaffected — confirmed).
- **macOS / Windows: NOT built here** — this dev box has no macOS/Windows/cross toolchain (no `apple-darwin`/`windows-gnu` target, no mingw; rusqlite's bundled C build blocks a cross `cargo check`). The code is type-matched to the **existing** FFI/GDI patterns in each file (same `objc_msgSend` transmute helpers; same DIB/`UpdateLayeredWindow` model), but it needs an **on-machine / CI build** to confirm it compiles and renders. Flagging explicitly rather than claiming verification I can't do.

The shared pieces (`SplashInfo`, the baked atlas, `splash_text`) are unchanged and already verified on Linux.

<!-- agentmux:agent_id=smike -->