### PR TITLE
chore(frontend): trim JSDoc bloat, section dividers, and PR/ticket refs

### DIFF
--- a/.changesets/1782118350-chore-frontend-trim-verbose-jsdoc-blocks-section-dividers-an-c3rh.md
+++ b/.changesets/1782118350-chore-frontend-trim-verbose-jsdoc-blocks-section-dividers-an-c3rh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(frontend): trim verbose JSDoc blocks, section dividers, and ticket refs

--- a/frontend/app/element/ModalLayer.tsx
+++ b/frontend/app/element/ModalLayer.tsx
@@ -2,49 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * ModalLayer — scope-parameterized modal host.
+ * ModalLayer — scope-parameterized modal host component.
  *
- * Single dispatcher used by both tab-scoped and pane-scoped modal
- * hosts. Same request union, same imperative API (`open` / `replace`
- * / `close` / `current`), same render-dispatch table — the only knob
- * is the `scope` prop, which selects:
- *  - which `<Modal>` scope is used (`scope="tab"` vs `scope="pane"`),
- *  - which scope-mount context Provider is set (TabModalScope vs
- *    PaneModalScope) so the inner `<Modal>` resolves its mount node
- *    via the same scope axis.
- *
- * Mount strategy (unchanged from the original TabModalLayer):
- *  1. A real DOM mount node (`.modal-layer-mount`) wraps `props.children`
- *     and hosts the portalled `<Modal>` as a sibling.
- *  2. The Scope.Provider exposes that mount node as an accessor so the
- *     descendant `<Modal>` can resolve its mount via `useContext`.
- *  3. The unified `<Modal>` owns backdrop, panel chrome, ESC, focus
- *     trap, scope-relative `inert` + scroll lock, and the pane-overlay
- *     clip — this layer only handles dispatch.
- *
- * Use:
- *  - `<ModalLayer scope="tab">{props.children}</ModalLayer>` wraps a
- *    tab's tile layout in `frontend/app/tab/tabcontent.tsx`.
- *  - `<ModalLayer scope="pane">{props.children}</ModalLayer>` wraps a
- *    pane's content in `frontend/app/view/agent/agent-view.tsx` (and
- *    any other pane that wants pane-scoped modals).
- *
- * Inner components call `useModalLayer()` (from `./modal-layer`) and
- * never care which scope they're inside — pane wins over tab via
- * normal context resolution when both layers wrap the call site.
- *
- * History: this file is the descendant of `TabModalLayer` (per
- * `docs/specs/launch-modal-rearchitecture-2026-05-01.md`,
- * `SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21.md` §3/§5/§7/§9/§11). Lifted
- * out of `tab/` and parameterized over scope for the launch-modal
- * pane-scope work (`SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md`).
- *
- * Dismissal: `closeOnBackdropClick={false}` keeps the no-backdrop-
- * dismiss behaviour — a backdrop click nudges the panel's
- * `[data-modal-dismiss]` Cancel/Close control instead of closing.
- * ESC routes through `safeClose`, which no-ops while a submit RPC
- * is in-flight so the user can't lose error feedback or trigger a
- * duplicate launch.
+ * Wraps children in a `.modal-layer-mount` container that hosts the portalled
+ * `<Modal>`. The `scope` prop selects which `<Modal>` scope and Scope.Provider
+ * are used; pane-scope layers override tab-scope ones via context resolution.
+ * ESC is blocked while a submit RPC is in-flight (`safeClose` guard).
  */
 
 import { createMemo, createSignal, Show, type Component, type JSX } from "solid-js";

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -2,23 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * ModalLayer types + context — generic modal-host dispatcher.
+ * ModalLayer types + context — scope-neutral modal-host dispatcher.
  *
- * Single, scope-neutral dispatcher used by both tab-scoped and pane-
- * scoped modal hosts. A `<ModalLayer scope="tab">` wraps every tab's
- * tile layout (see `frontend/app/tab/tabcontent.tsx`); a
- * `<ModalLayer scope="pane">` wraps an individual pane's content (see
- * `frontend/app/view/agent/agent-view.tsx`). Components inside any
- * such layer call `useModalLayer()` to open / replace / close modals
- * scoped to the nearest layer in the tree — pane wins over tab via
- * normal context resolution.
- *
- * Background: this primitive started as `TabModalLayer` (per
- * `docs/specs/launch-modal-rearchitecture-2026-05-01.md`); when the
- * launch modal needed to lock only its agent pane — not the whole
- * tab — the dispatcher was lifted out of `tab/` and parameterized
- * over scope (`SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md`). One
- * dispatch table, one hook, one set of request types — DRY.
+ * `useModalLayer()` resolves to the nearest `<ModalLayer>` in the tree;
+ * pane-scoped layers override tab-scoped ones via normal context resolution.
  */
 
 import { createContext, useContext, type Accessor } from "solid-js";
@@ -55,8 +42,7 @@ export interface LaunchAgentRequest {
     /** Initial form state for the launch modal — used by the
      *  "+ New" → create → replace-back flow to restore the user's
      *  in-progress edits (name, runtime, image, identity, memory)
-     *  across the new-bundle round-trip. Codex P2 on PR #910
-     *  rounds 6 + 7. */
+     *  across the new-bundle round-trip. */
     initialFormState?: Partial<LaunchFormStateWire>;
     /** When true, the launch modal fires its OAuth `startConnect()`
      *  exactly once on mount. Set by the OAuth-Connect → New Identity
@@ -131,9 +117,8 @@ export interface InstallAgentRequest {
      *    the launch modal as the natural next step.
      *  - `false` — "Close": flip install state but do not chain.
      *
-     * Callers MUST flip cached install state in both branches; codex
-     * caught a regression on PR #895 where the Close path skipped the
-     * flip and stranded users on a stale ribbon.
+     * Callers MUST flip cached install state in both branches — the Close
+     * path skipping the flip strands users on a stale ribbon.
      */
     onInstalled: (continueToLaunch: boolean) => void;
 }
@@ -173,8 +158,7 @@ export interface AgentPrereqRequest {
  *
  * The actual UpsertIdentityBundle RPC is owned by the layer so its
  * `submitting()` flag (which gates safeClose) tracks the in-flight
- * call — see reagent P1 on PR #911. Callers only supply the chain
- * callbacks for after-success / on-cancel.
+ * call. Callers only supply the chain callbacks for after-success / on-cancel.
  *
  * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
  */
@@ -197,7 +181,7 @@ export interface NewIdentityBundleRequest {
      *  `modalLayer.replace(launchRequest)` with the prior selection
      *  intact, OR `modalLayer.close()` to exit. The layer does NOT
      *  close after this fires — running both replace + close
-     *  synchronously nullified the replace, reagent P1 on PR #910. */
+     *  synchronously nullified the replace. */
     onCancel: () => void;
 }
 

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -66,9 +66,8 @@ export type AgentDocumentCommand =
      *
      * Why prepend (not full-replace): `useAgentStream` may dispatch
      * `StreamFlush` during the async snapshot read window. A full
-     * replace would wipe those live arrivals. Codex P1 on PR #877
-     * round 4. Existing nodes (live arrivals) win on id collision; the
-     * snapshot version is dropped.
+     * replace would wipe those live arrivals. Existing nodes (live
+     * arrivals) win on id collision; the snapshot version is dropped.
      *
      * `fromSnapshot: true` is a discriminator field per spec §4.5 — the
      * view layer reads it from the audit event (history-restored) to

--- a/frontend/app/store/agent-pane-model.ts
+++ b/frontend/app/store/agent-pane-model.ts
@@ -2,61 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentPaneModel — per-pane lifecycle handle with a `disposed` flag.
+ * AgentPaneModel — per-pane lifecycle handle that carries a `disposed` flag
+ * and dispatch helpers for both agent-pane stores.
  *
- * PR-4 of the cascade follow-up sequence (see
- * docs/retro/retro-agent-pane-cascade-replacechild-2026-05-23.md §"Action
- * items" → "PR-4", + docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md).
- *
- * ## What this adds
- *
- * Each agent pane gets a model object whose lifetime matches the pane
- * itself: created during `registerPane`, marked `disposed` at the very
- * START of `unregisterPane` (before either store deletes its slot), and
- * carried by props/opts into the hooks that need to dispatch.
- *
- * Hooks that previously had to remember "use `dispatchIfRegistered`
- * here because it's an async callsite that can race against unmount"
- * call `model.dispatchPane(cmd)` / `model.dispatchDoc(cmd)` instead. The
- * disposed-flag check inside the model is the structural safeguard —
- * new code is default-safe, no need for a reviewer to spot the soft
- * variant choice case-by-case.
- *
- * ## Pattern source
- *
- * `frontend/app/view/drone/drone-model.ts` (see `DroneViewModel.disposed`
- * + `DroneViewModel.dispatchIfAlive` at lines ~131 and 509–515): same
- * idempotency-flag rule applied to a single-store handle. PR-4
- * generalizes it across both agent-pane stores in one helper.
- *
- * ## Coexistence with module-level `dispatchIfRegistered`
- *
- * We picked **Option B-coexist**: the per-store `dispatchIfRegistered`
- * exports stay live. Reasons:
- *
- *   - Some dispatchers don't have a model handle (the cascade-detection
- *     log inside the stores themselves; tests; future code that doesn't
- *     thread the model in).
- *   - Migration can land incrementally — each hook that gains a
- *     `model` opt flips its own dispatches.
- *
- * The model is the PREFERRED path; new code defaults to it. The
- * cleanup PR that removes `dispatchIfRegistered` is downstream, gated
- * on every production call site migrating.
- *
- * ## Why this AND the per-store cascade detection
- *
- * The cascade-detection logging in agent-pane-state-store.ts (PR #878)
- * + the unified atomic registration (PR #999) close the cascade source.
- * The model-level disposed flag is a SECOND safety net: even if some
- * future code path manages to schedule a dispatch that lands AFTER the
- * cleanup runs (a stale setTimeout, an unhandled promise resolution, a
- * subscribe handler still in flight), the disposed check catches it
- * and turns it into a fire-and-forget no-op with one debug log line.
- *
- * The two safety nets compose: cascade detection identifies the trigger
- * setter when a dispatch lands mid-frame; the disposed flag stops a
- * post-cleanup dispatch from reaching the underlying store at all.
+ * Created during `registerPane`, marked `disposed` at the start of
+ * `unregisterPane` (before either store deletes its slot). Hooks pass
+ * `model.dispatchPane` / `model.dispatchDoc` so async call sites are
+ * default-safe against post-unmount races without having to remember the
+ * soft-dispatch variant per call site. The module-level `dispatchIfRegistered`
+ * exports remain live for call sites that lack a model handle.
  */
 
 import { trail } from "@/log/render-trail";

--- a/frontend/app/store/agent-pane-registration.ts
+++ b/frontend/app/store/agent-pane-registration.ts
@@ -2,78 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Unified per-pane registration — atomic across BOTH stores.
+ * Unified per-pane registration — atomic across BOTH stores (agent-document
+ * and agent-pane-state).
  *
- * PR-3 of the cascade follow-up sequence (see
- * docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md §6.2 + the
- * 2026-05-23 retro on the replaceChild cascade incident).
- *
- * ## The problem this closes
- *
- * Before this module existed, agent-view registered each pane with two
- * stores in sequence:
- *
- *     registerAgentDocPane(blockId, setter);                       // store A
- *     registerAgentPaneStatePane(blockId, agentId, projections);   // store B
- *
- * There was a brief synchronous window AFTER store A registered and
- * BEFORE store B registered — and an even worse asymmetry on cleanup
- * (the unregister calls happen in two distinct `onCleanup` callbacks
- * registered against the same owner). A `StreamFlush` dispatch (from
- * `useAgentStream`, hooked subscriptions, or anywhere else with a hot
- * dispatch loop) that landed in either window found the pane registered
- * in one store but not the other.
- *
- * That partial-registration window is precisely the cascade-mid-dispatch
- * failure mode PR #878 added detection for and PR #989 migrated three
- * dispatch sites away from throw-on-missing. PR-3 closes the window
- * structurally — by making registration / unregistration atomic across
- * both stores at the source.
- *
- * ## The contract
- *
- * At any observable point in time (from any dispatcher's POV), a blockId
- * is either FULLY registered in BOTH stores, or FULLY unregistered from
- * BOTH stores. There is no half-state.
- *
- * Practically: this module is the ONLY surface that production code uses
- * to register / unregister a pane. The per-store `registerPane` /
- * `unregisterPane` exports survive but are documented `@internal — tests
- * only`. The store-internal tests
- * (`agent-pane-state-store.test.ts`, `agent-document-store.test.ts`)
- * exercise each reducer in isolation and need direct register/unregister
- * access without bringing the sibling store along; they import the
- * per-store functions directly. Every production call site goes through
- * this helper.
- *
- * ## Option A/B choice
- *
- * - **Option A** (keep both per-store `registerPane` exported, mark
- *   `@internal`): lighter, enforcement is comment-only.
- * - **Option B** (per-store registration is private to the store + the
- *   unified helper; tests use the helper too): strictest.
- *
- * We picked **Option A** for a pragmatic reason: the per-store cascade
- * tests in `agent-pane-state-store.test.ts` (PR #878) drive
- * single-store cascade-disposal scenarios that require direct access to
- * `registerPane` / `unregisterPane` on a single store, with custom
- * projection setters that synchronously call `unregisterPane` to
- * simulate a reactive subscriber's mid-dispatch dispose. Forcing those
- * tests through the unified helper would require either bringing up the
- * full second-store slot (changing what the test is testing) or adding
- * a test-only escape hatch (which defeats Option B's enforcement
- * point). Marking the per-store exports `@internal — tests only` and
- * documenting that ALL production callers go through the unified helper
- * gives the same structural guarantee for the actual failure mode (the
- * half-registered window in agent-view's lifecycle) without the test
- * thrash.
- *
- * If the test surface ever migrates to a fake/mock projection layer
- * that doesn't need raw single-store access, the per-store exports can
- * be flipped to Option-B-strict (renamed `_register*` etc.) in a
- * follow-up. PR-4 of the cascade sequence introduces a model-level
- * `dispatchIfAlive` pattern that may make the per-store cascade tests
- * obsolete — at which point the Option B flip becomes cheap.
+ * Invariant: at any observable point a blockId is either FULLY registered in
+ * both stores or FULLY unregistered from both. This is the ONLY production
+ * surface for register/unregister; per-store exports are `@internal — tests only`.
  */
 
 import {
@@ -164,8 +98,7 @@ function notifyLifecycleListeners(): void {
  * `dispatchPane` / `dispatchDoc` surface that is default-safe against
  * post-unmount dispatch races — the model carries a `disposed` flag
  * flipped before `unregisterPane` runs the store deletes. See
- * `agent-pane-model.ts` for the rationale (PR-4 of the cascade
- * follow-up sequence).
+ * `agent-pane-model.ts` for the rationale.
  */
 export function registerPane(
     blockId: string,
@@ -222,7 +155,7 @@ export function registerPane(
  * LIFECYCLE_DISPATCH_LEAK analysis). The intermediate state seen by
  * any synchronously-running subscriber between the two `delete` calls
  * is "pane-state gone, document still there" — which the soft-dispatch
- * variants in PR #878 + #989 already handle correctly (they return [];
+ * variants in the soft-dispatch path already handle correctly (they return [];
  * they don't throw). Reversing the order would expose the
  * "document gone, pane-state still there" intermediate, in which a
  * pane-state subscriber that read the document store would see an
@@ -234,8 +167,8 @@ export function registerPane(
  * helper, not the callers.
  */
 export function unregisterPane(blockId: string): void {
-    // PR-4 — flip the model's `disposed` flag BEFORE either store
-    // unregisters. The contract: any synchronous cascade triggered by
+    // Flip the model's `disposed` flag BEFORE either store unregisters.
+    // The contract: any synchronous cascade triggered by
     // a future store-delete that fires setters (the current stores
     // don't, but a future projection might) observes `model.disposed
     // === true` and the model's dispatch helpers no-op. Closes the

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -50,16 +50,11 @@ export type InitPhase =
     | { kind: "InitReady"; at: number }
     | { kind: "InitFailed"; at: number; reason: string };
 
-// ─────────────────────────────────────────────────────────────────────────
 // TurnPhase discriminated union — single source of truth for the turn
 // lifecycle (since PR G).
 //
 // SPEC: docs/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_23.md §5.
-// This union replaces the scattered { turnActive, stopping, streaming.active }
-// booleans that PR A introduced as a dual-write, PR B migrated the view
-// off, and PR G removed entirely. Consumers project via `isWorking` /
-// `isDisconnected` / `state.turnPhase.kind`.
-// ─────────────────────────────────────────────────────────────────────────
+// Consumers project via `isWorking` / `isDisconnected` / `state.turnPhase.kind`.
 
 /** Why the turn entered Interrupting. */
 export type InterruptReason =
@@ -195,7 +190,6 @@ export interface AgentPaneState {
      */
     turnPhase: TurnPhase;
 
-    // ── Composer details panel ────────────────────────────────────────
     /**
      * Whether the composer details panel (the expandable section that
      * holds the activity log, session stats, permission/model/effort
@@ -357,7 +351,6 @@ export function isDisconnected(state: AgentPaneState): boolean {
 }
 
 export type AgentPaneCommand =
-    // ── Init lifecycle (gap 1) ─────────────────────────────────────
     /**
      * Caller signal: history fetch began. Idempotent — if the pane is
      * already in any terminal state (`InitReady` / `InitFailed`),
@@ -369,7 +362,6 @@ export type AgentPaneCommand =
     /** Caller signal: history fetch failed; reason surfaced for diagnostics. */
     | { type: "InitFailed"; at: number; reason: string }
 
-    // ── Stream lifecycle ───────────────────────────────────────────
     /** Hook signal: subscription is up. */
     | { type: "StreamSubscribe"; at: number }
     /** Hook signal: subscription torn down. */
@@ -386,7 +378,6 @@ export type AgentPaneCommand =
      */
     | { type: "StreamWatchdogTick"; nowMs: number }
 
-    // ── Turn lifecycle ─────────────────────────────────────────────
     /**
      * User pressed send — turn becomes active. Also clears stale
      * sessionStats from the previous turn.
@@ -418,15 +409,12 @@ export type AgentPaneCommand =
      */
     | { type: "TurnReset" }
 
-    // ── Tool ───────────────────────────────────────────────────────
     | { type: "ToolStart"; name: string }
     | { type: "ToolEnd" }
 
-    // ── Tokens (live deltas during a turn) ────────────────────────
     | { type: "TokensIn"; input: number; model?: string }
     | { type: "TokensOut"; output: number }
 
-    // ── Stop flow ──────────────────────────────────────────────────
     /** User pressed Esc / clicked Stop. */
     | { type: "RequestStop"; at: number }
     /** Stop RPC failed — bail on the stopping state. */
@@ -454,7 +442,6 @@ export type AgentPaneCommand =
      */
     | { type: "SubmitTimeoutElapsed"; at: number }
 
-    // ── Pending message queue (composer side) ─────────────────────
     | {
           type: "PendingMessageQueued";
           id: string;
@@ -482,7 +469,6 @@ export type AgentPaneCommand =
      */
     | { type: "PendingMessageExpired"; id: string }
 
-    // ── Composer details panel ────────────────────────────────────
     /**
      * User clicked the chevron or the strip body — toggle the details
      * panel. On flip-to-open, resets `composerUnreadCount` to 0.

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -2,42 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Type definitions for the browser-pane-state reducer.
+ * Type definitions for the browser-pane-state reducer (multi-tab shape).
  *
- * **Phase 1A — multi-tab scaffolding (slice #9 extension).**
- * See `specs/SPEC_BROWSER_PANE_TABS_2026-05-27.md` §"State management".
- *
- * The slice was originally per-pane single-URL — `url`, `title`,
- * `loading`, `error`, `canGoBack`, `canGoForward`, `faviconUrl` all
- * lived directly on `BrowserPaneState`. Phase 1A moves those into a
- * `BrowserTab` record and introduces a list of tabs per pane, modelled
- * on the slice #10 (editor-tabs) shape.
- *
- * Pane-level state retained:
- *   - `closed` — terminal flag from `dispose()`. Once true every command
- *     is a no-op. (Existing invariant; preserved verbatim.)
- *
- * Per-tab state (was pane-level pre-Phase-1A):
- *   - `url` / `title` / `faviconUrl` — display + identity
- *   - `loading` / `error` — page-load tracking
- *   - `canGoBack` / `canGoForward` — history navigability
- *   - `titleOverridden` / `faviconOverridden` — optimistic-header
- *     placeholder vs. real-CEF-value tracking flags (carried per-tab
- *     so each tab keeps its own placeholder/real-value distinction)
- *
- * New per-tab state (Phase 1A introductions):
- *   - `id` — uuid, stable across reorders
- *   - `isPreview` — VS Code-style preview slot; all tabs pinned in
- *     Phase 1 but the field is reserved for Phase 2 "middle-click
- *     opens preview" semantics
- *   - `backendCreated` — tracker; flips true once the BrowserView
- *     has been created backend-side. Set by the view via
- *     `TabBackendCreated`; defaults false so hydrated tabs are
- *     lazy-created on first activation.
- *
- * Backend-driven commands carry `source: "backend"` so the reducer
- * can suppress the `navigate` event emission and prevent the
- * OnAddressChange-becomes-Navigate echo loop documented in slice #10.
+ * Each pane holds an ordered list of `BrowserTab` records; pane-level state
+ * retains only `closed` (terminal flag — once true, all commands are no-ops).
+ * Backend-driven commands carry `source: "backend"` to suppress the
+ * navigate-event echo loop.
  */
 
 /** A single browsing context within a Browser pane. */
@@ -238,7 +208,6 @@ export interface HydratedBrowserTab {
 }
 
 export type BrowserPaneCommand =
-    // ─── Tab list management (new in Phase 1A) ─────────────────────
     /**
      * Append a new tab and (by default) activate it. `mode: "background"`
      * appends without activating — used for Phase 2 middle-click-link
@@ -272,7 +241,6 @@ export type BrowserPaneCommand =
           toIndex: number;
           source?: BrowserCommandSource;
       }
-    // ─── Per-tab backend-driven updates (new in Phase 1A) ──────────
     /** Backend reported a URL change (typically `OnAddressChange`). */
     | {
           type: "TabUrlChanged";
@@ -319,7 +287,6 @@ export type BrowserPaneCommand =
           activeTabId: string | null;
           source?: BrowserCommandSource;
       }
-    // ─── Existing commands (pre-Phase-1A) — now operate on active tab
     /**
      * The user (or the host's link-click forwarding) initiated a
      * navigation in the active tab. Sets loading=true, clears error.
@@ -383,7 +350,6 @@ export type BrowserPaneCommand =
     | { type: "Disposed" };
 
 export type BrowserPaneEvent =
-    // ─── Tab list events (new in Phase 1A) ────────────────────────
     | { type: "tab-opened"; tabId: string; url: string; atIndex: number }
     | { type: "tab-closed"; tabId: string; url: string }
     | { type: "tab-activated"; tabId: string }
@@ -418,7 +384,6 @@ export type BrowserPaneEvent =
           type: "hydrate-suppressed";
           reason: "duplicate-tab-ids" | "empty-tabs-with-active-id";
       }
-    // ─── Existing events (pre-Phase-1A) ───────────────────────────
     /** Active-tab navigate intent. Suppressed when the originating
      *  command carried `source: "backend"` (echo-loop guard). */
     | { type: "navigate"; url: string }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -92,11 +92,10 @@ import "./agent-view.scss";
  * an agentId exists. If the layer wrapped only the presentation
  * view, every first-launch / template-launch call site would resolve
  * `useModalLayer()` to the outer tab-scope layer and the modal would
- * inert the whole tab instead of just this pane (codex P1 on PR
- * #1034). Wrapping at the wrapper covers both the pre-launch picker
- * AND the post-launch presentation view, so the pane-scope lock
- * holds across the entire pane lifecycle.
- * SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md.
+ * inert the whole tab instead of just this pane. Wrapping at the
+ * wrapper covers both the pre-launch picker AND the post-launch
+ * presentation view, so the pane-scope lock holds across the entire
+ * pane lifecycle. SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md.
  */
 export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Element => {
     const block = model.blockAtom;
@@ -118,8 +117,6 @@ AgentViewWrapper.displayName = "AgentViewWrapper";
 
 // Launch flow lives in `flows/launch-flow.ts` — Step 2 of
 // specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
-
-// ── Presentation View ───────────────────────────────────────────────────────────
 
 const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agentId: string }): JSX.Element => {
     const block = model.blockAtom;
@@ -147,7 +144,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // list. A plain function-mutation (_hasAgentDef = () => ...) would
     // not create a tracking subscription — BlockFrame evaluates
     // endIconButtons once with the default () => false and the id-card
-    // button never appears (codex P1 on PR #1587).
+    // button never appears without a reactive signal atom.
     createEffect(() => {
         model._agentDefLoaded._set(currentAgent() != null);
     });
@@ -184,19 +181,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Register this pane with BOTH the document store and the pane-state
     // store SYNCHRONOUSLY in one atomic call, during component-body
-    // execution — before any hook's onMount can dispatch
-    // (codex P1 PR #681 round 1). The stores throw on dispatch to an
-    // unregistered slot to prevent silent reducer-command drops, so both
-    // slots must exist before useAgentStream / useHistoryPagination call
-    // their first dispatch from `onMount` handlers.
+    // execution — before any hook's onMount can dispatch. The stores throw
+    // on dispatch to an unregistered slot to prevent silent reducer-command
+    // drops, so both slots must exist before useAgentStream /
+    // useHistoryPagination call their first dispatch from `onMount` handlers.
     //
-    // PR-3 of the cascade follow-up sequence: registration is unified so
-    // a dispatcher can never observe the pane registered in one store
-    // but not the other. The half-registered window was the structural
-    // root of the cascade-mid-dispatch failure mode PR #878 detected and
-    // PR #989 migrated three call sites away from
-    // (docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md + the
-    // 2026-05-23 replaceChild retro). See agent-pane-registration.ts.
+    // Registration is unified so a dispatcher can never observe the pane
+    // registered in one store but not the other — the half-registered window
+    // was the structural root of a cascade-mid-dispatch failure mode. See
+    // agent-pane-registration.ts.
     //
     // `turnPhase` is the single-source-of-truth working/stopping signal
     // since PR G — the legacy `turnActive` / `stopping` /
@@ -204,9 +197,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // removed. The view binds the working animation to
     // `workingFromPhase(turnPhase)` and the "Stopping…" label to
     // `turnPhase.kind === "Interrupting"`.
-    // Capture the model returned by registerPane (PR-4 of the cascade
-    // follow-up) — passed into hooks/views so their dispatch callsites
-    // are default-safe against post-unmount races. The disposed flag on
+    // Capture the model returned by registerPane — passed into hooks/views
+    // so their dispatch callsites are default-safe against post-unmount races. The disposed flag on
     // the model flips synchronously inside `unregisterAgentPane` BEFORE
     // either store unregisters, so any deferred dispatcher landing in
     // the cleanup window observes disposed=true and silently drops.
@@ -314,8 +306,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // History pagination: dispatches HistoryLoaded into the agent-document-store
     // for the trailing 200 lines on mount + each user-triggered loadOlder.
     //
-    // Option E (PR #1007 backend, this PR frontend): pass the agent
-    // definition id so the snapshot fast-path reads from the
+    // Pass the agent definition id so the snapshot fast-path reads from the
     // agent-anchored zone (`agent:<defId>:current`) rather than the
     // per-block zone. `agentId` here is the AgentDefinition slug/UUID —
     // a non-empty string is guaranteed at this point by the `Show
@@ -324,11 +315,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // here on mount (before any async history work starts), so
     // useHistoryPagination can signal "history done" into the viewState
     // that lives inside AgentDocumentView. This drives the enter-animation
-    // gate on the streaming buffer. See PR #1212.
+    // gate on the streaming buffer.
     let historyReadyFn: (() => void) | undefined;
     const history = useHistoryPagination({
         blockId: model.blockId,
-        // PR-4 — see useAgentStream above; same rationale.
         model: paneModel,
         outputFormat,
         definitionId: agentId,
@@ -357,7 +347,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Auth + launch flow state and the onCleanup that kills the CLI
     // if the pane closes mid-login.
     // `getDocument` is read-only; for writes we MUST dispatch through
-    // agent-document-store so slot.state stays in sync (codex P1 PR #681).
+    // agent-document-store so slot.state stays in sync.
     const [getDocument] = agentAtoms().documentAtom;
 
     // Agent-pane state-persistence (RFC #857 + spec
@@ -367,12 +357,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     //     the lossy 200-line NDJSON replay;
     // (b) during the pane lifetime, write a snapshot every 30s if the
     //     document changed since the last save. Bounds crash-loss to ~30s.
-    // Serialize concurrent writes through a single promise chain
-    // (codex P2 on #877 round 5): the 30s interval and the on-close
-    // cleanup can both call writeSnapshotNow() with their own captured
-    // `nodes` snapshot, then race through an async line-count RPC and
-    // write. Without ordering, the older interval write can resolve
-    // LAST and overwrite the close-time snapshot, losing recent nodes.
+    // Serialize concurrent writes through a single promise chain: the 30s
+    // interval and the on-close cleanup can both call writeSnapshotNow()
+    // with their own captured `nodes` snapshot, then race through an async
+    // line-count RPC and write. Without ordering, the older interval write
+    // can resolve LAST and overwrite the close-time snapshot, losing recent nodes.
     let inFlightSnapshot: Promise<void> = Promise.resolve();
     const writeSnapshotNow = () => {
         // Don't let a cross-block continuation pane (one that mounted against a
@@ -475,8 +464,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // transitioning its status. Defer is HANDLED INSIDE THE PANEL
     // (it minimizes locally) — per
     // docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md §7,
-    // the parent must NOT filter pending. The actual
-    // `tool:decision` IPC + sidecar stdin write lands in PR-3.
+    // the parent must NOT filter pending.
     const pendingDecisions = (): import("./types").ToolNode[] => {
         const docs = getDocument();
         const out: import("./types").ToolNode[] = [];
@@ -512,11 +500,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 "user",
             );
         }
-        // Send the decision to the sidecar so it can record + audit
-        // it (PR-3a). Actual delivery to the agent CLI — rules
-        // persistence (path 1) or interactive subprocess stdin (path
-        // 2) — is deferred to PR-3b/PR-4 per
-        // SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
+        // Send the decision to the sidecar so it can record + audit it.
+        // Delivery routes: rules persistence (path 1) or interactive
+        // subprocess stdin (path 2) per SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
         void RpcApi.ToolDecisionCommand(TabRpcClient, {
             blockid: model.blockId,
             request_id: decision.request_id,
@@ -668,17 +654,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const pendingMessagesAtom = agentAtoms().pendingMessagesAtom;
     useAgentStream({
         blockId: model.blockId,
-        // PR-4 — pass the per-pane model so the hook's dispatch sites
-        // are default-safe against post-unmount races. Without the
-        // model, the hook had to import / remember the soft variant
-        // (`dispatchIfRegistered`) per call site; with the model the
-        // disposed-flag check is centralized.
+        // Pass the per-pane model so the hook's dispatch sites are
+        // default-safe against post-unmount races — the disposed-flag
+        // check is centralized in the model rather than per call site.
         model: paneModel,
         outputFormat: outputFormat(),
         documentAtom: agentAtoms().documentAtom,
-        // turnPhase is the SoT for "is a stop in flight" — replaces the
-        // legacy `stoppingAtom` dropped in PR G. useAgentStream needs
-        // it to detect user-initiated stops and append the
+        // turnPhase is the SoT for "is a stop in flight". useAgentStream
+        // needs it to detect user-initiated stops and append the
         // "⏹ Interrupted by user" row when session_end lands.
         turnPhaseAtom: agentAtoms().turnPhaseAtom,
         pendingMessagesAtom,
@@ -701,7 +684,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // See hooks/useAgentCommands.ts.
     const commands = useAgentCommands({
         blockId: model.blockId,
-        // PR-4 — see useAgentStream above; same rationale.
+        // Per-pane model keeps dispatch sites default-safe; see useAgentStream above.
         model: paneModel,
         block,
         provider,
@@ -862,7 +845,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
     };
 
-    // ── Startup sequence ────────────────────────────────────────────────────────
     // On first connect (no existing session), assemble a structured startup
     // payload from agent-definition + Identity data and send it as the opening turn.
     // See docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md
@@ -905,8 +887,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             log("warn", `startup sequence failed: ${err}`, "warn");
         }
     };
-
-    // ── Jump-to-node ───────────────────────────────────────────────────────────
 
     // Signal-based jump command. AgentDocumentView reacts via a
     // createEffect and scrolls inside its own container — no mutable
@@ -1116,8 +1096,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 tool calls are gated by the CLI awaiting user approval.
                 Sits above the queue so it can't be missed. The panel
                 renders nothing when no ToolNode is in pending_approval.
-                v1 PR-2 wires the UI; PR-3 adds the IPC + sidecar stdin
-                write so decisions actually reach the subprocess.
                 Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5. */}
             <AgentDecisionPanel
                 pending={pendingDecisions}

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -165,7 +165,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         // after PR G removed the legacy `turnActiveAtom` / `stoppingAtom`.
         initPhaseAtom: createSignal<InitPhase>({ kind: "InitPending" }),
         turnPhaseAtom: createSignal<TurnPhase>({ kind: "Idle" }),
-        // Composer details panel — reducer-owned (PR #1068).
+        // Composer details panel — reducer-owned.
         // SPEC_AGENT_COMPOSER_SLIM_STATUS_2026_05_26.md §5.4.
         detailsOpenAtom: createSignal<boolean>(false),
         composerUnreadCountAtom: createSignal<number>(0),


### PR DESCRIPTION
## Summary

Audit finding (comment-verbosity-audit-2026-06-22): ~310 lines of retrospective prose removed across 9 frontend TypeScript files, no logic changes.

- **P4 — JSDoc compression**: Collapsed 4 verbose module-level JSDoc blocks (74, 57, 45, and 38 lines) in `agent-pane-registration.ts`, `agent-pane-model.ts`, `ModalLayer.tsx`, and `browser-pane-state/types.ts`. Removed "the problem this closes" narratives, Option A/B design-decision comparisons, and migration history. Replaced with 1-sentence purpose + key invariants. Current-constraint sentences preserved.
- **P6 — Section dividers**: Removed unicode box-drawing section-divider lines (`// ── X ────────────`) from `agent-view.tsx` and `agent-pane-state/types.ts`. Also stripped the `// ─────────────────────` frame pair around the TurnPhase block comment. Blank lines between sections need no replacement — they were already there.
- **P7 — Ticket refs**: Stripped `(codex P1 PR #NNN)`, `(PR-N)`, and similar citation fragments from inline comments in `agent-view.tsx`, `modal-layer.ts`, `agent-pane-registration.ts`, `agent-document/types.ts`, and `state.ts`. Explanations kept; pure citation fragments dropped. Whole-line deletions applied only where the comment had no content beyond the reference.

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors in touched files (pre-existing errors in `BlockErrorBoundary.test.tsx`, `tab-presets.ts`, `ActivityDock.tsx` etc. are unrelated)
- [ ] Diff review: confirm no non-comment lines removed

<!-- agentmux:agent_id=smark-06122 -->