### PR TITLE
chore: release v0.47.4

### DIFF
--- a/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
+++ b/.changesets/1782063152-fix-editor-apply-css-zoom-property-instead-of-calc-font-size-6x35.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom

--- a/.changesets/1782077760-fix-packaging-use-apfs-for-intermediate-dmg-to-fix-err-conte-s5bb.md
+++ b/.changesets/1782077760-fix-packaging-use-apfs-for-intermediate-dmg-to-fix-err-conte-s5bb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(packaging): use APFS for intermediate DMG to fix ERR_CONTENT_LENGTH_MISMATCH on macOS 26 Tahoe

--- a/.changesets/1782077925-fix-agent-show-session-digest-summary-in-pane-header-fall-ba-06l0.md
+++ b/.changesets/1782077925-fix-agent-show-session-digest-summary-in-pane-header-fall-ba-06l0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): show session digest summary in pane header; fall back to term:activity

--- a/.changesets/1782078641-fix-sysinfo-robust-cpu-chart-zoh-gap-fill-debounced-resize-n-tua9.md
+++ b/.changesets/1782078641-fix-sysinfo-robust-cpu-chart-zoh-gap-fill-debounced-resize-n-tua9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): robust CPU chart — ZOH gap fill, debounced resize, no blank-on-reload

--- a/.changesets/1782078771-fix-swarm-show-agent-panes-in-swarm-view-jjf2.md
+++ b/.changesets/1782078771-fix-swarm-show-agent-panes-in-swarm-view-jjf2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): show agent panes in Swarm view

--- a/.changesets/1782078840-fix-ui-remove-stub-pane-minimize-button-that-did-nothing-no--thex.md
+++ b/.changesets/1782078840-fix-ui-remove-stub-pane-minimize-button-that-did-nothing-no--thex.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): remove stub pane minimize button that did nothing (no layout collapse on macOS/Linux)

--- a/.changesets/1782080390-fix-floating-pane-make-floaters-fully-independent-of-their-p-9l28.md
+++ b/.changesets/1782080390-fix-floating-pane-make-floaters-fully-independent-of-their-p-9l28.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): make floaters fully independent of their parent window and stop a failed tear-off from jamming all future tear-offs

--- a/.changesets/1782080753-feat-agent-haiku-powered-live-mini-summary-in-agent-pane-hea-dy46.md
+++ b/.changesets/1782080753-feat-agent-haiku-powered-live-mini-summary-in-agent-pane-hea-dy46.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): Haiku-powered live mini-summary in agent pane header

--- a/.changesets/1782081028-feat-agent-organic-aurora-busy-animation-on-agent-progress-b-313t.md
+++ b/.changesets/1782081028-feat-agent-organic-aurora-busy-animation-on-agent-progress-b-313t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): organic aurora busy animation on agent progress bar

--- a/.changesets/1782083832-feat-splash-show-user-host-version-footer-on-the-startup-spl-5gq4.md
+++ b/.changesets/1782083832-feat-splash-show-user-host-version-footer-on-the-startup-spl-5gq4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(splash): show user@host + version footer on the startup splash, and add a splash:disabled setting (all platforms)

--- a/.changesets/1782094216-fix-floating-pane-redock-no-longer-deletes-the-block-onnoded-u7cy.md
+++ b/.changesets/1782094216-fix-floating-pane-redock-no-longer-deletes-the-block-onnoded-u7cy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): tear-off and redock no longer delete the moved block (onNodeDelete guard) — fixes empty-slot redock and logo-only floater on tear-off (#1662)

--- a/.changesets/1782111701-fix-floating-pane-dark-floater-background-browser-window-cla-l4lo.md
+++ b/.changesets/1782111701-fix-floating-pane-dark-floater-background-browser-window-cla-l4lo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): dark floater background (browser + window class) so tear-off no longer flashes white

--- a/.changesets/1782114529-feat-splash-render-the-user-host-version-footer-on-macos-and-lct0.md
+++ b/.changesets/1782114529-feat-splash-render-the-user-host-version-footer-on-macos-and-lct0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(splash): render the user@host + version footer on macOS and Windows too (completes the cross-platform footer)

--- a/.changesets/1782118300-fix-layout-a-backend-block-move-no-longer-deletes-the-moved--m71j.md
+++ b/.changesets/1782118300-fix-layout-a-backend-block-move-no-longer-deletes-the-moved--m71j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): a backend block-MOVE no longer deletes the moved block (R1) — removes the block-move guard band-aid; tear-off/redock preserve the block at the root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.47.3"
+version = "0.47.4"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.47.3"
+version = "0.47.4"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,23 @@
 # AgentMux Version History
 
+## 0.47.4 — 2026-06-22
+
+- fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom
+- fix(packaging): use APFS for intermediate DMG to fix ERR_CONTENT_LENGTH_MISMATCH on macOS 26 Tahoe
+- fix(agent): show session digest summary in pane header; fall back to term:activity
+- fix(sysinfo): robust CPU chart — ZOH gap fill, debounced resize, no blank-on-reload
+- fix(swarm): show agent panes in Swarm view
+- fix(ui): remove stub pane minimize button that did nothing (no layout collapse on macOS/Linux)
+- fix(floating-pane): make floaters fully independent of their parent window and stop a failed tear-off from jamming all future tear-offs
+- feat(agent): Haiku-powered live mini-summary in agent pane header
+- feat(agent): organic aurora busy animation on agent progress bar
+- feat(splash): show user@host + version footer on the startup splash, and add a splash:disabled setting (all platforms)
+- fix(floating-pane): tear-off and redock no longer delete the moved block (onNodeDelete guard) — fixes empty-slot redock and logo-only floater on tear-off (#1662)
+- fix(floating-pane): dark floater background (browser + window class) so tear-off no longer flashes white
+- feat(splash): render the user@host + version footer on macOS and Windows too (completes the cross-platform footer)
+- fix(layout): a backend block-MOVE no longer deletes the moved block (R1) — removes the block-move guard band-aid; tear-off/redock preserve the block at the root
+
+
 ## 0.47.3 — 2026-06-21
 
 - fix(srv): seed the default 3-pane layout for new windows so 'Open another window' is not blank

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.47.3",
+  "version": "0.47.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.47.3",
+      "version": "0.47.4",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.47.3",
+  "version": "0.47.4",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release **v0.47.4** — consumes 14 pending changesets. Bump forced to **patch** via \`task release -- --as patch\` (two splash \`minor\` changesets ship under this patch, consistent with 0.47.3).

Highlights this cycle:
- **Floating-pane DnD lifecycle** (#1677): floater independence, tear-off un-jam, redock/tear-off block survival, darker floater
- **Layout move-vs-close R1** (#1685): a block move no longer deletes the moved block; removes the block-move guard band-aid
- **Sysinfo CPU chart** (#1667): ZOH gap fill, debounced resize, no blank-on-reload
- Plus editor zoom, swarm panes, agent header summary, splash footer, macOS DMG packaging fix

Full list in \`VERSION_HISTORY.md\`. Version invariant verified — all five locations at 0.47.4.

Known follow-ups (tracked #1681): 2nd-window tear-off with pool (R3), remaining floater flash (R2).

<!-- agentmux:agent_id=agentc -->