### PR TITLE
feat(toolchain): Open Pane button for running external widgets

### DIFF
--- a/.changesets/1782134598-feat-toolchain-open-pane-button-for-running-external-widgets-b0bd.md
+++ b/.changesets/1782134598-feat-toolchain-open-pane-button-for-running-external-widgets-b0bd.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(toolchain): Open Pane button for running external widgets

--- a/frontend/app/modals/toolchain-modal.tsx
+++ b/frontend/app/modals/toolchain-modal.tsx
@@ -24,7 +24,7 @@ import { Modal } from "@/element/modal";
 import { openModal, type ModalCloseProps } from "@/app/store/modalmodel";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { getApi } from "@/store/global";
+import { getApi, createBlock } from "@/store/global";
 import { getPlatform } from "@/util/platformutil";
 import { CORE_TOOLS, cliCommandForPlatform, type Platform } from "@/app/view/agent/providers/toolchain-catalog";
 import { EXTERNAL_WIDGETS, widgetCliCommandForPlatform } from "@/app/view/agent/providers/widget-catalog";
@@ -55,6 +55,7 @@ interface WidgetRow {
     icon: string;
     description: string;
     defaultPort: number;
+    embedPath: string;
     healthCheckPath: string;
     docsUrl: string;
     installKind: "pip" | "npm" | "manual";
@@ -136,6 +137,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
         icon: w.icon,
         description: w.description,
         defaultPort: w.defaultPort,
+        embedPath: w.embedPath,
         healthCheckPath: w.healthCheckPath,
         docsUrl: w.docsUrl,
         installKind: w.install.kind,
@@ -417,6 +419,23 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
                                     <div class="toolchain-row-path toolchain-widget-desc">{row.description}</div>
                                 </div>
                                 <div class="toolchain-row-actions">
+                                    <Show when={row.running}>
+                                        <button
+                                            class="toolchain-btn"
+                                            onClick={() => {
+                                                void createBlock({
+                                                    meta: {
+                                                        view: "browser",
+                                                        url: `http://127.0.0.1:${row.defaultPort}${row.embedPath}`,
+                                                        "frame:title": row.label,
+                                                    },
+                                                });
+                                                props.close();
+                                            }}
+                                        >
+                                            Open Pane <i class="fa-solid fa-arrow-up-right-from-square" />
+                                        </button>
+                                    </Show>
                                     <Show when={row.docsUrl}>
                                         <button class="toolchain-link-btn" onClick={() => open(row.docsUrl)} title="Docs">
                                             <i class="fa-solid fa-book" />


### PR DESCRIPTION
## Summary
- Running widgets in the Toolchain modal now show an **Open Pane** button
- Clicking it opens the widget's local URL (`http://127.0.0.1:<port><embedPath>`) in a browser pane and closes the modal
- Button is only shown when the health check confirms the widget is live (Running pill visible)

## Changes
- `frontend/app/modals/toolchain-modal.tsx` — added `embedPath` to `WidgetRow` and its initialization; added "Open Pane" button in the widget row actions slot wired to `createBlock({ meta: { view: "browser", url, "frame:title" } })`

## Test plan
- [ ] Start ComfyUI locally on port 8188; open Toolchain modal — widget row should show Running pill + "Open Pane" button
- [ ] Click "Open Pane" — modal closes, browser pane opens at `http://127.0.0.1:8188/`
- [ ] Widget not running — confirm button does NOT appear (only Running pill triggers it)
- [ ] Check no regression on core tools / agent CLIs rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)