### PR TITLE
feat(widgets): per-widget port override and widget.api HTTP proxy RPC

### DIFF
--- a/.changesets/1782135271-feat-widgets-per-widget-port-override-and-widget-api-http-pr-0jfw.md
+++ b/.changesets/1782135271-feat-widgets-per-widget-port-override-and-widget-api-http-pr-0jfw.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(widgets): per-widget port override and widget.api HTTP proxy RPC

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -542,6 +542,80 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    // widget.api — HTTP proxy to a widget's local server. Bypasses browser CORS
+    // restrictions: the frontend sends { port, path, method?, headers?, body? }
+    // and gets back { ok, status_code, body, error? }. Agents use this to call
+    // ComfyUI /prompt, Grafana /api/query, etc. without needing a CORS header.
+    // 30-second timeout accommodates generative tasks (image synthesis, etc.).
+    engine.register_handler(
+        "widget.api",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let port_raw = data.get("port").and_then(|v| v.as_u64()).unwrap_or(0);
+                if port_raw == 0 || port_raw > 65535 {
+                    return Ok(Some(serde_json::json!({
+                        "ok": false, "status_code": null, "body": null,
+                        "error": "invalid port"
+                    })));
+                }
+                let port = port_raw as u16;
+                let path = data.get("path").and_then(|v| v.as_str()).unwrap_or("/").to_string();
+                let method = data
+                    .get("method")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("GET")
+                    .to_uppercase();
+                let body_str = data.get("body").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let headers_obj = data.get("headers").and_then(|v| v.as_object()).cloned();
+
+                let url = format!("http://127.0.0.1:{}{}", port, path);
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                    .map_err(|e| e.to_string())?;
+
+                let mut req = match method.as_str() {
+                    "POST" => client.post(&url),
+                    "PUT" => client.put(&url),
+                    "DELETE" => client.delete(&url),
+                    "PATCH" => client.patch(&url),
+                    _ => client.get(&url),
+                };
+
+                if let Some(headers) = headers_obj {
+                    for (k, v) in &headers {
+                        if let Some(vs) = v.as_str() {
+                            if let (Ok(hn), Ok(hv)) = (
+                                reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+                                reqwest::header::HeaderValue::from_str(vs),
+                            ) {
+                                req = req.header(hn, hv);
+                            }
+                        }
+                    }
+                }
+
+                if let Some(body) = body_str {
+                    req = req
+                        .header(reqwest::header::CONTENT_TYPE, "application/json")
+                        .body(body);
+                }
+
+                match req.send().await {
+                    Ok(resp) => {
+                        let status = resp.status().as_u16();
+                        let body = resp.text().await.unwrap_or_default();
+                        Ok(Some(serde_json::json!({ "ok": true, "status_code": status, "body": body })))
+                    }
+                    Err(e) => Ok(Some(serde_json::json!({
+                        "ok": false, "status_code": null, "body": null,
+                        "error": e.to_string()
+                    }))),
+                }
+            })
+        }),
+    );
 }
 
 /// Re-export from shared crate for internal use.

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -581,6 +581,7 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let url = format!("http://127.0.0.1:{}{}", port, path);
                 let client = reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
+                    .redirect(reqwest::redirect::Policy::none())
                     .build()
                     .map_err(|e| e.to_string())?;
 

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -561,6 +561,15 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 let port = port_raw as u16;
                 let path = data.get("path").and_then(|v| v.as_str()).unwrap_or("/").to_string();
+                // Reject paths that could escape localhost: must start with '/',
+                // no '@' (user-info injection: 127.0.0.1@evil.com), no backslash,
+                // no protocol-relative '//' prefix.
+                if !path.starts_with('/') || path.contains('@') || path.contains('\\') || path.starts_with("//") {
+                    return Ok(Some(serde_json::json!({
+                        "ok": false, "status_code": null, "body": null,
+                        "error": "invalid path"
+                    })));
+                }
                 let method = data
                     .get("method")
                     .and_then(|v| v.as_str())

--- a/frontend/app/modals/toolchain-modal.scss
+++ b/frontend/app/modals/toolchain-modal.scss
@@ -126,6 +126,42 @@
     text-overflow: unset;
 }
 
+.toolchain-widget-port {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+}
+
+.toolchain-widget-port-label {
+    font-size: 0.72rem;
+    opacity: 0.5;
+    min-width: 26px;
+}
+
+.toolchain-widget-port-input {
+    width: 60px;
+    font-size: 0.78rem;
+    padding: 1px 5px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    text-align: right;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, rgba(88, 166, 255, 0.6));
+    }
+
+    // hide number spinners — the field is narrow, arrows would clutter it
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+    }
+    -moz-appearance: textfield;
+}
+
 .toolchain-row-cmd {
     display: flex;
     align-items: center;

--- a/frontend/app/modals/toolchain-modal.tsx
+++ b/frontend/app/modals/toolchain-modal.tsx
@@ -25,6 +25,25 @@ import { openModal, type ModalCloseProps } from "@/app/store/modalmodel";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getApi, createBlock } from "@/store/global";
+
+function loadWidgetPorts(): Record<string, number> {
+    try {
+        const raw = localStorage.getItem("agentmux:widget-ports");
+        return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    } catch {
+        return {};
+    }
+}
+
+function saveWidgetPort(widgetId: string, port: number | undefined): void {
+    const saved = loadWidgetPorts();
+    if (port === undefined) {
+        delete saved[widgetId];
+    } else {
+        saved[widgetId] = port;
+    }
+    localStorage.setItem("agentmux:widget-ports", JSON.stringify(saved));
+}
 import { getPlatform } from "@/util/platformutil";
 import { CORE_TOOLS, cliCommandForPlatform, type Platform } from "@/app/view/agent/providers/toolchain-catalog";
 import { EXTERNAL_WIDGETS, widgetCliCommandForPlatform } from "@/app/view/agent/providers/widget-catalog";
@@ -63,6 +82,8 @@ interface WidgetRow {
     /** CLI detection */
     cliLoading: boolean;
     cliFound: boolean;
+    /** User-overridden port; falls back to defaultPort when undefined */
+    customPort?: number;
     /** Health check (only run after cliFound or for manual installs) */
     healthLoading: boolean;
     running: boolean;
@@ -131,6 +152,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
 
     const [rows, setRows] = createStore<ToolRow[]>([...coreRows, ...providerRows]);
 
+    const savedPorts = loadWidgetPorts();
     const widgetRows0: WidgetRow[] = EXTERNAL_WIDGETS.map((w) => ({
         id: w.id,
         label: w.label,
@@ -142,6 +164,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
         docsUrl: w.docsUrl,
         installKind: w.install.kind,
         installPkg: w.install.kind !== "manual" ? w.install.package : undefined,
+        customPort: savedPorts[w.id],
         cliLoading: true,
         cliFound: false,
         healthLoading: false,
@@ -151,6 +174,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
 
     const probeWidget = async (idx: number) => {
         const w = EXTERNAL_WIDGETS[idx];
+        const effectivePort = wrows[idx].customPort ?? w.defaultPort;
         const cliCmd = widgetCliCommandForPlatform(w, plat);
         // For manual-install tools without a CLI command, skip CLI check and go
         // straight to health so the Running pill still lights up when they're live.
@@ -178,7 +202,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
             const h = await RpcApi.WidgetHealthCommand(
                 TabRpcClient,
                 {
-                    port: w.defaultPort,
+                    port: effectivePort,
                     health_check_path: w.healthCheckPath,
                     health_check_body_contains: w.healthCheckBodyContains,
                 },
@@ -389,7 +413,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
                 <section class="toolchain-section">
                     <h3 class="toolchain-section-title">External Widgets</h3>
                     <For each={wrows}>
-                        {(row) => (
+                        {(row, i) => (
                             <div class="toolchain-row" classList={{ "toolchain-row--missing": !row.cliLoading && !row.cliFound && !row.running }}>
                                 <i class={`toolchain-row-icon fa-solid fa-${row.icon}`} aria-hidden="true" />
                                 <div class="toolchain-row-main">
@@ -417,6 +441,40 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
                                         </Show>
                                     </div>
                                     <div class="toolchain-row-path toolchain-widget-desc">{row.description}</div>
+                                    <div class="toolchain-widget-port">
+                                        <span class="toolchain-widget-port-label">Port</span>
+                                        <input
+                                            class="toolchain-widget-port-input"
+                                            type="number"
+                                            min="1"
+                                            max="65535"
+                                            value={row.customPort ?? row.defaultPort}
+                                            onBlur={(e) => {
+                                                const val = parseInt(e.currentTarget.value, 10);
+                                                if (isNaN(val) || val <= 0 || val > 65535) {
+                                                    e.currentTarget.value = String(row.customPort ?? row.defaultPort);
+                                                    return;
+                                                }
+                                                const newPort = val === row.defaultPort ? undefined : val;
+                                                setWrows(i(), { customPort: newPort, cliLoading: true, cliFound: false, healthLoading: false, running: false });
+                                                saveWidgetPort(row.id, newPort);
+                                                void probeWidget(i());
+                                            }}
+                                        />
+                                        <Show when={row.customPort !== undefined}>
+                                            <button
+                                                class="toolchain-link-btn"
+                                                onClick={() => {
+                                                    setWrows(i(), { customPort: undefined, cliLoading: true, cliFound: false, healthLoading: false, running: false });
+                                                    saveWidgetPort(row.id, undefined);
+                                                    void probeWidget(i());
+                                                }}
+                                                title="Reset to default port"
+                                            >
+                                                <i class="fa-solid fa-rotate-left" />
+                                            </button>
+                                        </Show>
+                                    </div>
                                 </div>
                                 <div class="toolchain-row-actions">
                                     <Show when={row.running}>
@@ -426,7 +484,7 @@ export const ToolchainModal = (props: ModalCloseProps): JSX.Element => {
                                                 void createBlock({
                                                     meta: {
                                                         view: "browser",
-                                                        url: `http://127.0.0.1:${row.defaultPort}${row.embedPath}`,
+                                                        url: `http://127.0.0.1:${row.customPort ?? row.defaultPort}${row.embedPath}`,
                                                         "frame:title": row.label,
                                                     },
                                                 });

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1301,6 +1301,26 @@ class RpcApiType {
         return client.rpcCall("widget.health", data, opts);
     }
 
+    // command "widget.api" [call] — HTTP proxy to a widget's local server.
+    // Bypasses browser CORS restrictions so agents (and the frontend) can call
+    // ComfyUI /prompt, Grafana /api/query, etc. without a CORS header.
+    // body must be a pre-serialised JSON string when calling JSON APIs.
+    // Returns { ok, status_code, body } — never throws on HTTP errors, only on
+    // transport failures (connection refused, timeout).
+    WidgetApiCommand(
+        client: RpcClient,
+        data: {
+            port: number;
+            path: string;
+            method?: string;
+            headers?: Record<string, string>;
+            body?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<{ ok: boolean; status_code: number | null; body: string | null; error?: string }> {
+        return client.rpcCall("widget.api", data, opts);
+    }
+
 
     CheckCliAuthCommand(client: RpcClient, data: CommandCheckCliAuthData, opts?: RpcOpts): Promise<CheckCliAuthResult> {
         return client.rpcCall("checkcliauth", data, opts);

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1305,8 +1305,8 @@ class RpcApiType {
     // Bypasses browser CORS restrictions so agents (and the frontend) can call
     // ComfyUI /prompt, Grafana /api/query, etc. without a CORS header.
     // body must be a pre-serialised JSON string when calling JSON APIs.
-    // Returns { ok, status_code, body } — never throws on HTTP errors, only on
-    // transport failures (connection refused, timeout).
+    // Never throws. HTTP errors → ok:false + status_code set.
+    // Transport failures (connection refused, timeout) → ok:false + error set.
     WidgetApiCommand(
         client: RpcClient,
         data: {

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1305,8 +1305,10 @@ class RpcApiType {
     // Bypasses browser CORS restrictions so agents (and the frontend) can call
     // ComfyUI /prompt, Grafana /api/query, etc. without a CORS header.
     // body must be a pre-serialised JSON string when calling JSON APIs.
-    // Never throws. HTTP errors → ok:false + status_code set.
-    // Transport failures (connection refused, timeout) → ok:false + error set.
+    // Never throws. ok:true means the HTTP exchange completed — check status_code
+    // for HTTP-level success/failure (4xx/5xx still return ok:true).
+    // ok:false means transport failure (connection refused, timeout) or invalid
+    // port/path — status_code is null and error is set.
     WidgetApiCommand(
         client: RpcClient,
         data: {


### PR DESCRIPTION
## Summary
- **Port override**: each widget row in the Toolchain modal now shows an editable port field; changing it re-probes immediately and persists to `localStorage` under `agentmux:widget-ports`. A reset button (↺) appears when the port differs from the default.
- **`widget.api` RPC**: new Rust handler proxies HTTP requests from the frontend/agents to a widget's local server, bypassing browser CORS. Supports GET/POST/PUT/DELETE/PATCH, arbitrary headers, and a JSON body. Returns `{ ok, status_code, body }` — never throws on HTTP-level errors, only transport failures.

## Changed files
- `agentmux-srv/src/server/cli_handlers.rs` — `widget.api` handler (30s timeout for generative tasks)
- `frontend/app/store/rpc-api.ts` — `WidgetApiCommand` binding
- `frontend/app/modals/toolchain-modal.tsx` — `customPort` on `WidgetRow`, localStorage load/save helpers, port input UI, effective-port usage in health probe and Open Pane URL
- `frontend/app/modals/toolchain-modal.scss` — `.toolchain-widget-port*` styles (spinner-free number input)

## Test plan
- [ ] Open Toolchain modal — widget rows show a port number field with default value
- [ ] Change ComfyUI port to 9000, tab away — pill resets to Checking… then updates; localStorage stores `{ "comfyui": 9000 }`
- [ ] Change back to 8188 — reset button (↺) disappears, localStorage entry removed
- [ ] Start ComfyUI on non-default port, set matching override — Running pill lights up, Open Pane opens correct URL
- [ ] Reload modal — custom port is restored from localStorage
- [ ] `widget.api` RPC: from agent, call `widget.api { port: 8188, path: "/system_stats", method: "GET" }` — returns `{ ok: true, status_code: 200, body: "..." }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)