### PR TITLE
fix(#1681): secondary-window DnD — 2nd-window tear-off + redock into any window

### DIFF
--- a/.changesets/1782134938-fix-layout-seed-new-window-default-blocks-through-the-reduce-bbiy.md
+++ b/.changesets/1782134938-fix-layout-seed-new-window-default-blocks-through-the-reduce-bbiy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): seed new-window default blocks through the reducer so secondary-window tear-off works (R3, #1681)

--- a/.changesets/1782135834-fix-dnd-redock-floating-panes-into-secondary-windows-r3-wind-7ft0.md
+++ b/.changesets/1782135834-fix-dnd-redock-floating-panes-into-secondary-windows-r3-wind-7ft0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dnd): redock floating panes into secondary windows (R3 window-label resolve, #1681)

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -377,28 +377,38 @@ pub fn resolve_window_at_cursor(
                                 main_hwnd = %format!("{:#x}", main_hwnd),
                                 "cursor inside window"
                             );
-                            // Resolution precedence (P1). The HWND→label
-                            // reverse map can carry a STALE `window-pool-*`
-                            // label for a promoted main frame: a warm-pool
-                            // window moved on-screen to serve as the user's
-                            // main window keeps its pool label in
-                            // `window_hwnds` while "main" is left with no live
-                            // HWND (proven 2026-05-30 — redock onto main
-                            // resolved the pool label, so the target rendered no
-                            // ghost and the drop was rejected: no dock).
-                            // `find_main_window` is the cache-INDEPENDENT
-                            // authority on which HWND is the main frame, so when
-                            // the cached label is a lingering pool label AND
-                            // this HWND is the main frame, "main" wins. Real
-                            // labels (floating-* / additional windows / an
-                            // already-correct "main") are used verbatim, so
-                            // multi-window resolution is unchanged.
+                            // Resolution (R3 identity fix, #1681). The label
+                            // stored in `window_hwnds` is ALWAYS the same string
+                            // the target window's frontend carries as its
+                            // `?windowLabel=` (promote inserts the
+                            // `window-pool-*` label; the renderer's URL carries
+                            // the same one; cold "main" and "floating-*" match
+                            // likewise). The redock ghost only renders when the
+                            // host-emitted `target_label` === that frontend
+                            // `windowLabel`, so resolve MUST return the tracked
+                            // label VERBATIM.
+                            //
+                            // A prior heuristic rewrote a tracked `window-pool-*`
+                            // label to "main" whenever `find_main_window()`
+                            // pointed at this HWND. But `find_main_window()` only
+                            // returns the topmost non-floater window — with
+                            // several promoted windows open it routinely picks a
+                            // SECONDARY one, so that window got relabeled "main",
+                            // never matched its own `window-pool-*` frontend, and
+                            // rendered no ghost (and `backend_window_id("main")`
+                            // mis-targeted the redock). That is exactly the
+                            // "can only redock into the home window" bug. Promoted
+                            // pool windows are always inserted into `window_hwnds`
+                            // at promote, so a tracked label is authoritative and
+                            // `is_main_frame` must NOT override it.
                             let is_main_frame = main_hwnd != 0 && h_isize == main_hwnd;
                             let resolved_label: Option<&str> = match label_by_hwnd.get(&h_isize) {
-                                Some(l) if l.starts_with("window-pool-") && is_main_frame => {
-                                    Some("main")
-                                }
+                                // Tracked → return verbatim (matches the frontend).
                                 Some(l) => Some(l.as_str()),
+                                // Untracked but it IS the main frame: best-effort
+                                // "main" for the genuine cold-main-before-cache
+                                // case. (Promoted windows are always tracked, so
+                                // this can't mislabel a secondary.)
                                 None if is_main_frame => Some("main"),
                                 None => None,
                             };

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -156,6 +156,38 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
     swarm_meta.insert("view".to_string(), serde_json::json!("swarm"));
     let swarm_block = create_block(store, &tab.oid, swarm_meta)?;
 
+    write_default_three_pane_layout(
+        store,
+        tab_id,
+        &agent_block.oid,
+        &sysinfo_block.oid,
+        &swarm_block.oid,
+    )
+}
+
+/// Write the default 3-pane launch layout (`agent | [sysinfo / swarm]`) into
+/// `tab_id`'s `LayoutState`, wrapping three block IDs that the caller has
+/// ALREADY created.
+///
+/// Split out of `seed_default_layout` for the 2nd-window-tear-off desync fix
+/// (#1681). `seed_default_layout` creates its blocks store-only via
+/// `create_block`, which is correct for first-launch (`ensure_initial_data`
+/// runs before bootstrap loads SQLite into the in-memory reducer `srv_state`).
+/// But the post-bootstrap "open another window" path (`service.rs` CreateWindow)
+/// must create the blocks THROUGH THE REDUCER so they also land in `srv_state`;
+/// otherwise the new window's blocks live only in SQLite, the frontend renders
+/// them, and `TearOffBlock` rejects them as "block not found" (the reducer never
+/// saw them). Both callers share this one function for the tree shape so the
+/// layout can never drift between the two paths.
+pub(crate) fn write_default_three_pane_layout(
+    store: &Store,
+    tab_id: &str,
+    agent_block_id: &str,
+    sysinfo_block_id: &str,
+    swarm_block_id: &str,
+) -> Result<(), StoreError> {
+    let tab = store.must_get::<Tab>(tab_id)?;
+
     // Node IDs for each tree position. Leaves get their own node IDs distinct
     // from the block IDs they wrap.
     let agent_node_id = Uuid::new_v4().to_string();
@@ -177,7 +209,7 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
                 size: 5.0,
                 children: Vec::new(),
                 data: Some(LayoutNodeData {
-                    block_id: agent_block.oid.clone(),
+                    block_id: agent_block_id.to_string(),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -193,7 +225,7 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
                         size: 2.0,
                         children: Vec::new(),
                         data: Some(LayoutNodeData {
-                            block_id: sysinfo_block.oid.clone(),
+                            block_id: sysinfo_block_id.to_string(),
                             ..Default::default()
                         }),
                         ..Default::default()
@@ -204,7 +236,7 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
                         size: 8.0,
                         children: Vec::new(),
                         data: Some(LayoutNodeData {
-                            block_id: swarm_block.oid.clone(),
+                            block_id: swarm_block_id.to_string(),
                             ..Default::default()
                         }),
                         ..Default::default()
@@ -221,9 +253,9 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
     layout.rootnode = Some(rootnode);
     layout.focusednodeid = agent_node_id.clone();
     layout.leaforder = Some(vec![
-        LeafOrderEntry { nodeid: agent_node_id, blockid: agent_block.oid.clone() },
-        LeafOrderEntry { nodeid: sysinfo_node_id, blockid: sysinfo_block.oid.clone() },
-        LeafOrderEntry { nodeid: swarm_node_id, blockid: swarm_block.oid.clone() },
+        LeafOrderEntry { nodeid: agent_node_id, blockid: agent_block_id.to_string() },
+        LeafOrderEntry { nodeid: sysinfo_node_id, blockid: sysinfo_block_id.to_string() },
+        LeafOrderEntry { nodeid: swarm_node_id, blockid: swarm_block_id.to_string() },
     ]);
     layout.pendingbackendactions = None;
     store.update(&mut layout)?;

--- a/agentmux-srv/src/sagas/tear_off_block.rs
+++ b/agentmux-srv/src/sagas/tear_off_block.rs
@@ -50,11 +50,37 @@ pub async fn run(
     // don't allocate a workspace + tab and then have to compensate.
     {
         let s = state.srv_state.lock().await;
+        // R3 diagnostic (#1681): a tear-off that references a workspace/tab/block
+        // this srv never created points at a frontend↔backend desync (a window
+        // bootstrapped a workspace that was never persisted), NOT a simple
+        // structural mismatch. The pre-condition used to reject SILENTLY (no log
+        // line — only an http-perf 0.05ms blip), which is why the 2nd-window
+        // tear-off failure was so hard to attribute. Log the full state context
+        // at ERROR on every rejection so a single repro is conclusive: does the
+        // source workspace exist in srv at all?
+        let reject = |reason: &str, s: &crate::state::State| {
+            tracing::error!(
+                target: "dnd:svc",
+                reason = %reason,
+                block_id = %block_id,
+                source_tab_id = %source_tab_id,
+                source_workspace_id = %source_workspace_id,
+                source_ws_exists = s.workspaces.contains_key(&source_workspace_id),
+                source_tab_exists = s.tabs.contains_key(&source_tab_id),
+                block_exists = s.blocks.contains_key(&block_id),
+                known_workspaces = s.workspaces.len(),
+                known_tabs = s.tabs.len(),
+                known_blocks = s.blocks.len(),
+                "[dnd:svc] TearOffBlock REJECTED — possible frontend/backend workspace desync"
+            );
+        };
         match s.blocks.get(&block_id) {
             None => {
+                reject("block_not_found", &s);
                 return Err(format!("TearOffBlock: block not found: {}", block_id));
             }
             Some(block) if block.tab_id != source_tab_id => {
+                reject("block_in_other_tab", &s);
                 return Err(format!(
                     "TearOffBlock: block {} is in tab {}, not {}",
                     block_id, block.tab_id, source_tab_id
@@ -64,12 +90,14 @@ pub async fn run(
         }
         match s.tabs.get(&source_tab_id) {
             None => {
+                reject("source_tab_not_found", &s);
                 return Err(format!(
                     "TearOffBlock: source tab not found: {}",
                     source_tab_id
                 ));
             }
             Some(tab) if tab.workspace_id != source_workspace_id => {
+                reject("tab_in_other_workspace", &s);
                 return Err(format!(
                     "TearOffBlock: tab {} is in workspace {}, not {}",
                     source_tab_id, tab.workspace_id, source_workspace_id

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -838,24 +838,93 @@ async fn handle_window_service(state: &AppState, call: &WebCallType) -> WebRetur
                     // Non-fatal: a seed failure leaves an empty tab (the prior
                     // behaviour) rather than failing window creation.
                     // See docs/retro/retro-blank-new-window-2026-06-21.md.
+                    //
+                    // 2nd-window-tear-off desync fix (#1681): the seed blocks
+                    // MUST be created through the reducer (CreateBlock command),
+                    // NOT via the store-only `seed_default_layout`/`create_block`
+                    // path. This handler runs AFTER bootstrap, so anything
+                    // written straight to SQLite is invisible to the in-memory
+                    // reducer `srv_state` until the next restart. A new window
+                    // seeded store-only renders fine (frontend reads SQLite) but
+                    // its blocks are absent from `srv_state`, so a later
+                    // `TearOffBlock` from that window is rejected "block not
+                    // found" (ws/tab exist — they went through the reducer — but
+                    // the block did not). Dispatch CreateBlock per pane so the
+                    // blocks land in BOTH srv_state and (via the subscriber)
+                    // SQLite, then write the shared layout referencing them.
+                    let mut block_seed_events: Vec<agentmux_common::ipc::Event> = Vec::new();
                     if let Some(new_tab_id) = tab_events.iter().find_map(|e| match e {
                         agentmux_common::ipc::Event::TabCreated { tab_id, .. } => {
                             Some(tab_id.clone())
                         }
                         _ => None,
                     }) {
-                        if let Err(e) =
-                            crate::backend::wcore::seed_default_layout(store, &new_tab_id)
-                        {
-                            tracing::warn!(
-                                tab_id = %new_tab_id,
-                                error = %e,
-                                "CreateWindow: default layout seed failed — opening blank tab"
-                            );
+                        // Dispatch the three seed blocks through the reducer.
+                        let mut seeded_ids: Vec<String> = Vec::new();
+                        for view in ["agent", "sysinfo", "swarm"] {
+                            let evs = dispatch_to_reducer(
+                                state,
+                                agentmux_common::ipc::Command::CreateBlock {
+                                    tab_id: new_tab_id.clone(),
+                                    meta: serde_json::json!({ "view": view }),
+                                },
+                            )
+                            .await;
+                            if let Some(err_msg) = evs.iter().find_map(|e| match e {
+                                agentmux_common::ipc::Event::Error { message, .. } => {
+                                    Some(message.clone())
+                                }
+                                _ => None,
+                            }) {
+                                tracing::warn!(
+                                    tab_id = %new_tab_id,
+                                    view = %view,
+                                    error = %err_msg,
+                                    "CreateWindow: seed block create failed — opening blank tab"
+                                );
+                                break;
+                            }
+                            for ev in &evs {
+                                if let Err(e) =
+                                    crate::persist_subscriber::apply_event_to_wstore(ev, store)
+                                {
+                                    tracing::warn!(
+                                        tab_id = %new_tab_id,
+                                        error = %e,
+                                        "CreateWindow: seed block SQLite write failed"
+                                    );
+                                }
+                            }
+                            if let Some(block_id) = evs.iter().find_map(|e| match e {
+                                agentmux_common::ipc::Event::BlockCreated { block_id, .. } => {
+                                    Some(block_id.clone())
+                                }
+                                _ => None,
+                            }) {
+                                seeded_ids.push(block_id);
+                            }
+                            block_seed_events.extend(evs);
+                        }
+
+                        if seeded_ids.len() == 3 {
+                            if let Err(e) = crate::backend::wcore::write_default_three_pane_layout(
+                                store,
+                                &new_tab_id,
+                                &seeded_ids[0],
+                                &seeded_ids[1],
+                                &seeded_ids[2],
+                            ) {
+                                tracing::warn!(
+                                    tab_id = %new_tab_id,
+                                    error = %e,
+                                    "CreateWindow: default layout write failed — opening blank tab"
+                                );
+                            }
                         }
                     }
                     let mut combined = ws_events;
                     combined.extend(tab_events);
+                    combined.extend(block_seed_events);
                     (new_ws_id, combined)
                 } else {
                     // Existing workspace — verify it's in the reducer
@@ -2951,5 +3020,85 @@ mod agent_context_tests {
         wcore::ensure_initial_data(&store).unwrap();
         let err = resolve_agent_context(&store, "does-not-exist").unwrap_err();
         assert!(err.contains("block not found"), "unexpected error: {err}");
+    }
+}
+
+#[cfg(test)]
+mod create_window_seed_tests {
+    use super::handle_window_service;
+    use crate::backend::service::WebCallType;
+    use crate::server::tests::test_state;
+
+    fn create_window_call(workspace_id: &str) -> WebCallType {
+        WebCallType {
+            service: "window".to_string(),
+            method: "CreateWindow".to_string(),
+            uicontext: None,
+            // arg0 is ignored by the handler; arg1 is the (optional) workspace
+            // to reattach. Empty → fresh-workspace seed path.
+            args: vec![
+                serde_json::Value::Null,
+                serde_json::Value::String(workspace_id.to_string()),
+            ],
+        }
+    }
+
+    /// Regression for the 2nd-window-tear-off desync (#1681).
+    ///
+    /// "Open another window" used to seed its three default blocks straight
+    /// into SQLite (`seed_default_layout` → `create_block`), bypassing the
+    /// reducer. The handler runs after bootstrap, so those blocks never
+    /// reached the in-memory `srv_state`. The frontend rendered them (it reads
+    /// SQLite) but a subsequent `TearOffBlock` from that window was rejected
+    /// "block not found" — the workspace/tab existed (they went through the
+    /// reducer) but the block did not. This asserts the seed blocks now land in
+    /// `srv_state` AND that a tear-off from the new window succeeds end-to-end.
+    #[tokio::test]
+    async fn new_window_seed_blocks_are_in_reducer_state_and_tear_off_succeeds() {
+        let state = test_state();
+        let blocks_before = state.srv_state.lock().await.blocks.len();
+
+        let ret = handle_window_service(&state, &create_window_call("")).await;
+        assert!(ret.success, "CreateWindow failed: {:?}", ret.error);
+
+        let win = ret.data.expect("CreateWindow returns the Window");
+        let workspace_id = win
+            .get("workspaceid")
+            .and_then(|v| v.as_str())
+            .expect("window has a workspaceid")
+            .to_string();
+
+        // The fix: the three seed blocks are present in the in-memory reducer
+        // state, attached to the new window's tab.
+        let (tab_id, block_id) = {
+            let s = state.srv_state.lock().await;
+            assert_eq!(
+                s.blocks.len(),
+                blocks_before + 3,
+                "the 3 seed blocks must be tracked in srv_state, not only SQLite"
+            );
+            let ws = s
+                .workspaces
+                .get(&workspace_id)
+                .expect("new workspace is in the reducer");
+            let tab_id = ws.tab_ids.first().expect("new workspace has a tab").clone();
+            let tab = s.tabs.get(&tab_id).expect("new tab is in the reducer");
+            assert_eq!(
+                tab.block_ids.len(),
+                3,
+                "the new window's tab must hold its 3 seed blocks in the reducer"
+            );
+            (tab_id, tab.block_ids[0].clone())
+        };
+
+        // End-to-end: tearing a block off the freshly-created window no longer
+        // hits the "block not found" pre-condition.
+        let result =
+            crate::sagas::tear_off_block::run(&state, block_id, tab_id, workspace_id).await;
+        assert!(
+            result.is_ok(),
+            "tear-off from a freshly-created window must succeed, got: {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION
Two fixes for the long-running #1681 "secondary-window drag-and-drop is broken" theme. Both stem from the same root: **pool-promoted secondary windows had no stable identity downstream** — one in the reducer (blocks), one in window-label resolution (redock).

---

## Fix 1 — 2nd-window tear-off (`block not found`)

**Problem:** tearing a pane/tab off a secondary window silently failed. The TearOffBlock saga had been rejecting at **0.05ms with no log line**:
```
block_not_found  source_ws_exists:true  source_tab_exists:true
block_exists:false  known_workspaces:4  known_tabs:4  known_blocks:3
```
Workspace and tab exist in the reducer; the **block does not**, and `known_blocks` is pinned at the main window's bootstrap count.

**Root cause:** "Open another window" seeded its 3 default panes **straight into SQLite** (`seed_default_layout` → `create_block`), bypassing the reducer. `CreateWindow` runs *after* bootstrap, and `srv_state` (which TearOffBlock checks) is only hydrated from SQLite once at startup. So new-window blocks lived only in SQLite — rendered fine, invisible to the reducer.

**Fix:** `CreateWindow`'s fresh path now creates the 3 seed blocks **through the reducer** (`CreateBlock`) → both `srv_state` and SQLite. Split `seed_default_layout` into block-creation + shared `write_default_three_pane_layout`. Kept a loud ERROR diagnostic in the tear-off saga (a silent reject is how this hid). **Regression test** drives a real `CreateWindow` → asserts blocks in `srv_state` → tear-off succeeds end-to-end.

**Verified** by user on portable build: 2nd-window tear-off works.

## Fix 2 — redock into secondary windows (no landing ghost)

**Problem:** floating-pane redock ghosts only appeared on the home window; dragging a floater over a 2nd/3rd window showed no drop preview → couldn't dock there.

**Root cause:** `resolve_window_at_cursor` rewrote a tracked `window-pool-*` label to `"main"` whenever `find_main_window()` pointed at that HWND. But `find_main_window()` returns the topmost non-floater window — with several promoted windows open it picks a SECONDARY one, which then resolved to `"main"`. The ghost is gated on `target_label === windowLabel` (app-init.ts), and the secondary's frontend `windowLabel` is `window-pool-*`, so it never matched; `backend_window_id("main")` also mis-targeted the drop. Confirmed via the `redock-resolve` host diagnostic:
```
cursor inside window  hwnd=0x60a26  label=window-pool-99ff…  is_main_hwnd=true
```

**Fix:** the `window_hwnds` label is always the exact string the target window's renderer carries as `?windowLabel=`, so resolve now returns the tracked label **verbatim** (removed the pool→"main" rewrite for tracked HWNDs). Kept the `None if is_main_frame => "main"` fallback for genuine cold-main-before-cache. Robust even when `find_main_window` picks the wrong frame.

---

## Known same-root-cause follow-up

`agent.open` / `pane.open` (`app_api.rs:362, 926`) also create blocks store-only post-bootstrap, so tearing off a *freshly-opened* pane likely fails identically. Scoped out; tracked for a focused follow-up.

<!-- agentmux:agent_id=agentc -->