### PR TITLE
chore(portable): tidy package layout — fix README data location, drop vestigial data/, marker into runtime/

### DIFF
--- a/.changesets/1782139565-docs-portable-correct-readme-data-location-agentmux-versions-ffw5.md
+++ b/.changesets/1782139565-docs-portable-correct-readme-data-location-agentmux-versions-ffw5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(portable): correct README data location (~/.agentmux/versions, not local data/ folder)

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -171,14 +171,16 @@ fn is_sensitive_env_key(key: &str) -> bool {
 /// rebuild). Released / installed / dev builds have no marker → returns
 /// `None` and the UI falls back to the plain version + git hash.
 ///
-/// The host runs from `<portable>/runtime/`, so the marker sits one
-/// level up; we also check the exe dir itself for layout robustness.
+/// The host runs from `<portable>/runtime/` and the marker is packaged INTO
+/// `runtime/`, so it sits right next to this exe (the `exe_dir` candidate). We
+/// also check one level up (the extract root) for robustness against older
+/// portables that wrote the marker at the root.
 fn read_build_label() -> Option<String> {
     let exe = std::env::current_exe().ok()?;
     let exe_dir = exe.parent()?;
     let candidates = [
-        exe_dir.parent().map(|p| p.join("agentmux-portable.marker")),
         Some(exe_dir.join("agentmux-portable.marker")),
+        exe_dir.parent().map(|p| p.join("agentmux-portable.marker")),
     ];
     for cand in candidates.into_iter().flatten() {
         if let Ok(contents) = std::fs::read_to_string(&cand) {

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -141,8 +141,9 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
             None => {
                 // No launcher env — derive from the host's own vantage.
                 // Mode detection works at this point even though the host
-                // exe lives inside `runtime/`, because portable detection
-                // uses the `agentmux-portable.marker` (not `runtime/`).
+                // exe lives inside `runtime/`: the `agentmux-portable.marker`
+                // is packaged INTO `runtime/`, so it sits next to this host
+                // exe (`is_portable_marker_present` checks the exe dir).
                 let mode = agentmux_common::RuntimeMode::current(host_exe_dir);
                 agentmux_common::DataPaths::resolve(current_version, &mode)?
             }

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -18,10 +18,12 @@
 //! # Detection priority
 //!
 //! 1. `AGENTMUX_RUNTIME_MODE` env override (testing, CI).
-//! 2. Marker-based portable detection: `<exe-dir>/agentmux-portable.marker`
-//!    exists (also looks two levels up for macOS .app bundles). Written
-//!    by `scripts/package-portable.sh` at packaging time (see the
-//!    `printf '...' > "$PORTABLE/agentmux-portable.marker"` line).
+//! 2. Marker-based portable detection: an `agentmux-portable.marker` file
+//!    written by `scripts/package-portable.sh`. Looked for next to the
+//!    detecting exe, one level down in `runtime/` (the packaging puts it
+//!    there to keep the extract root clean; the launcher is at the root and
+//!    the host/srv run from `runtime/`), and two levels up for macOS .app
+//!    bundles.
 //! 3. Path-based dev detection: exe is under a known dev-build dir
 //!    (`dist/cef-dev/`, `target/debug/`, `target/release/`).
 //! 4. `AGENTMUX_DEV_BRANCH` env override (CI override for dev mode).
@@ -347,7 +349,16 @@ fn fnv1a_64(bytes: &[u8]) -> u64 {
 /// Falls back to `false` (i.e., not portable) if the dir isn't readable
 /// — installed-mode default is the safer guess when unsure.
 fn is_portable_marker_present(exe_dir: &Path) -> bool {
+    // Next to the detecting binary. Covers the host/srv (which live in
+    // `runtime/`, so `exe_dir` IS `runtime/`) and legacy portables that wrote
+    // the marker at the extract root next to the launcher.
     if exe_dir.join("agentmux-portable.marker").is_file() {
+        return true;
+    }
+    // The launcher sits at the extract root with the marker one level down in
+    // `runtime/` (the packaging keeps the root clean: just agentmux.exe +
+    // README + runtime/). Check there so root-level detection still works.
+    if exe_dir.join("runtime").join("agentmux-portable.marker").is_file() {
         return true;
     }
     // On macOS the launcher exe is at <Bundle>.app/Contents/MacOS/<exe>;
@@ -687,16 +698,26 @@ mod tests {
         // No marker → not portable.
         assert!(!is_portable_marker_present(exe_dir));
 
-        // With marker → portable.
+        // With marker next to the exe → portable (host/srv in runtime/, or a
+        // legacy portable with the marker at the root).
         std::fs::write(exe_dir.join("agentmux-portable.marker"), b"").unwrap();
         assert!(is_portable_marker_present(exe_dir));
+        std::fs::remove_file(exe_dir.join("agentmux-portable.marker")).unwrap();
 
-        // Marker two levels up (macOS .app bundle case).
+        // Marker inside runtime/ → portable (the launcher sits at the root and
+        // the marker lives one level down in runtime/). An empty runtime/ with
+        // no marker must NOT count (covered by
+        // current_with_only_runtime_subdir_is_not_portable).
+        std::fs::create_dir_all(exe_dir.join("runtime")).unwrap();
+        assert!(!is_portable_marker_present(exe_dir));
+        std::fs::write(exe_dir.join("runtime").join("agentmux-portable.marker"), b"").unwrap();
+        assert!(is_portable_marker_present(exe_dir));
+        std::fs::remove_file(exe_dir.join("runtime").join("agentmux-portable.marker")).unwrap();
+
+        // Marker two levels up (macOS .app bundle case). All markers are
+        // already removed above, so the bundle exe dir starts clean.
         let nested = exe_dir.join("Contents/MacOS");
         std::fs::create_dir_all(&nested).unwrap();
-        // Removing top-level marker would still allow detection via the
-        // bundle-root walk-up.
-        std::fs::remove_file(exe_dir.join("agentmux-portable.marker")).unwrap();
         assert!(!is_portable_marker_present(&nested));
         std::fs::write(exe_dir.join("agentmux-portable.marker"), b"").unwrap();
         assert!(is_portable_marker_present(&nested));

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -115,14 +115,14 @@ Data:
   Your data is NOT stored in this folder. AgentMux keeps it in your user
   profile, scoped by version:
 
-    %USERPROFILE%\.agentmux\versions\$VERSION\
-    (e.g. C:\Users\<you>\.agentmux\versions\$VERSION\)
+    %USERPROFILE%\\.agentmux\\versions\\${VERSION}\\
+    (e.g. C:\\Users\\<you>\\.agentmux\\versions\\${VERSION}\\)
 
-      config\      settings.json, keybindings.json
-      data\db\     session history and block state
-      logs\        host and sidecar logs
-      cef-cache\   browser cache (safe to delete when the app is closed)
-      agents\      agent working directories
+      config\\      settings.json, keybindings.json
+      data\\db\\     session history and block state
+      logs\\        host and sidecar logs
+      cef-cache\\   browser cache (safe to delete when the app is closed)
+      agents\\      agent working directories
 
   This makes the portable folder disposable: move it, re-extract it, or delete
   it without losing anything. A portable copy and an installed copy of the same

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -21,6 +21,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # through package.sh).
 VERSION=$(node -p "require('./package.json').version")
 LABEL="${AGENTMUX_BUILD_LABEL:-$VERSION}"
+# CHANNEL matches the AGENTMUX_BUILD_CHANNEL_DEFAULT compiled into the binaries
+# (scripts/package.sh exports it; release CI uses "stable", task package uses a
+# local-… channel). Same fallback as package-macos.sh so the README data path
+# matches DataPaths::resolve exactly (~/.agentmux/channels/<channel>/…).
+CHANNEL="${AGENTMUX_BUILD_CHANNEL_DEFAULT:-stable}"
 OUTDIR="${1:-$HOME/Desktop}"
 PORTABLE="$OUTDIR/agentmux-$LABEL-x64-portable"
 ZIPPATH="$OUTDIR/agentmux-$LABEL-x64-portable.zip"
@@ -113,21 +118,24 @@ Requirements:
 
 Data:
   Your data is NOT stored in this folder. AgentMux keeps it in your user
-  profile, scoped by version:
+  profile, under a per-channel folder (this build's channel: ${CHANNEL}):
 
-    %USERPROFILE%\\.agentmux\\versions\\${VERSION}\\
-    (e.g. C:\\Users\\<you>\\.agentmux\\versions\\${VERSION}\\)
+    %USERPROFILE%\\.agentmux\\channels\\${CHANNEL}\\
+    (e.g. C:\\Users\\<you>\\.agentmux\\channels\\${CHANNEL}\\)
 
-      config\\      settings.json, keybindings.json
-      data\\db\\     session history and block state
-      logs\\        host and sidecar logs
-      cef-cache\\   browser cache (safe to delete when the app is closed)
-      agents\\      agent working directories
+  Per-version (a separate folder per AgentMux version):
+      versions\\${VERSION}\\data\\        session history and block state
+      versions\\${VERSION}\\logs\\        host and sidecar logs
+      versions\\${VERSION}\\cef-cache\\   browser cache (safe to delete when closed)
+
+  Channel-wide (shared across versions, so settings and agents survive upgrades):
+      config\\    settings.json, keybindings.json
+      agents\\    agent working directories
 
   This makes the portable folder disposable: move it, re-extract it, or delete
   it without losing anything. A portable copy and an installed copy of the same
   version share this data, and your agents and sign-in carry across versions.
-  To back up or transfer your data, copy the .agentmux folder above - NOT this
+  To back up or transfer your data, copy the channel folder above - NOT this
   portable folder.
 READMEEOF
 

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -78,20 +78,25 @@ fi
 # Clean previous
 rm -rf "$PORTABLE" "$ZIPPATH"
 
-# Create structure
+# Create structure. No `data/` dir: portable builds are stateless on disk —
+# user data lives in ~/.agentmux/versions/<version>/ (agentmux-common::
+# RuntimeMode). A bundled data/ folder was vestigial (nothing wrote to it) and
+# misled users into thinking their data lived next to the exe. See the README
+# below and PR #1693.
 mkdir -p "$PORTABLE/runtime/locales" "$PORTABLE/runtime/frontend" "$PORTABLE/runtime/tools/bin"
-mkdir -p "$PORTABLE/data"
 
 # Launcher in root
 cp target/release/agentmux-launcher.exe "$PORTABLE/agentmux.exe"
 
 # Portable marker — read by agentmux-common::RuntimeMode::current to
-# distinguish portable extracts from installed builds. Both ship a
-# `runtime/` subdir, so the dir alone is not a discriminator. The
-# file's contents are advisory; the detection only checks for its
-# presence next to the launcher exe. Mac .app-bundle layouts are
-# also supported (marker can sit at the bundle root).
-printf 'AgentMux portable build %s\n' "$LABEL" > "$PORTABLE/agentmux-portable.marker"
+# distinguish portable extracts from installed builds (both ship a
+# `runtime/` subdir, so the dir alone is not a discriminator) and by
+# agentmux-cef read_build_label to show the ephemeral build label in the UI.
+# Lives INSIDE runtime/ to keep the extract root clean (just agentmux.exe +
+# README + runtime/). The launcher (at the root) looks one level down in
+# runtime/, and the host/srv (which run FROM runtime/) find it next to
+# themselves. Mac .app-bundle layouts (marker at the bundle root) still work.
+printf 'AgentMux portable build %s\n' "$LABEL" > "$PORTABLE/runtime/agentmux-portable.marker"
 
 # README
 cat > "$PORTABLE/README.txt" <<READMEEOF
@@ -125,23 +130,6 @@ Data:
   To back up or transfer your data, copy the .agentmux folder above - NOT this
   portable folder.
 READMEEOF
-
-# data/ placeholder. NOTE: AgentMux does not actually write here — data lives
-# under ~/.agentmux/versions/<version>/ (see the README above and
-# agentmux-common::RuntimeMode). This README exists so anyone who opens the
-# leftover data/ folder is pointed at the real location instead of assuming
-# their data is here.
-cat > "$PORTABLE/data/README.txt" <<DATAEOF
-This folder is not used.
-
-AgentMux does NOT store your data here. Your sessions, settings, logs, and
-browser cache live in your user profile, scoped by version:
-
-  %USERPROFILE%\.agentmux\versions\$VERSION\
-
-Back up or transfer THAT folder - not this one. This empty data\ folder is a
-leftover from an older layout and can be safely ignored or deleted.
-DATAEOF
 
 # Runtime binaries — versioned filenames so WER dumps & Event Viewer show versions.
 # Phase 3 sandbox (#1374): bootstrap.exe presence means sandbox feature was ON.

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -107,21 +107,40 @@ Requirements:
   - No admin rights required
 
 Data:
-  All user data (sessions, settings, logs) is stored in the data/ folder
-  next to agentmux.exe. Back it up or move it along with this folder.
+  Your data is NOT stored in this folder. AgentMux keeps it in your user
+  profile, scoped by version:
+
+    %USERPROFILE%\.agentmux\versions\$VERSION\
+    (e.g. C:\Users\<you>\.agentmux\versions\$VERSION\)
+
+      config\      settings.json, keybindings.json
+      data\db\     session history and block state
+      logs\        host and sidecar logs
+      cef-cache\   browser cache (safe to delete when the app is closed)
+      agents\      agent working directories
+
+  This makes the portable folder disposable: move it, re-extract it, or delete
+  it without losing anything. A portable copy and an installed copy of the same
+  version share this data, and your agents and sign-in carry across versions.
+  To back up or transfer your data, copy the .agentmux folder above - NOT this
+  portable folder.
 READMEEOF
 
-# data/ placeholder so the folder is visible immediately after extraction
+# data/ placeholder. NOTE: AgentMux does not actually write here — data lives
+# under ~/.agentmux/versions/<version>/ (see the README above and
+# agentmux-common::RuntimeMode). This README exists so anyone who opens the
+# leftover data/ folder is pointed at the real location instead of assuming
+# their data is here.
 cat > "$PORTABLE/data/README.txt" <<DATAEOF
-AgentMux user data
+This folder is not used.
 
-This folder contains your sessions, settings, and logs.
-It is safe to back up. Do not delete it while AgentMux is running.
+AgentMux does NOT store your data here. Your sessions, settings, logs, and
+browser cache live in your user profile, scoped by version:
 
-  data/config/   — settings.json, keybindings.json
-  data/db/       — session history and block state
-  data/logs/     — host and sidecar log files
-  data/cef/      — browser cache (safe to delete when app is closed)
+  %USERPROFILE%\.agentmux\versions\$VERSION\
+
+Back up or transfer THAT folder - not this one. This empty data\ folder is a
+leftover from an older layout and can be safely ignored or deleted.
 DATAEOF
 
 # Runtime binaries — versioned filenames so WER dumps & Event Viewer show versions.


### PR DESCRIPTION
Tidies the portable package's extract layout. Three related changes; no app behavior change beyond packaging.

## 1. README data location was wrong
Both portable READMEs claimed user data lives in the local `data/` folder next to `agentmux.exe`. It doesn't: portable builds run in Portable mode, whose state lives in `~/.agentmux/versions/<version>/` (`RuntimeMode` maps `Installed | Portable -> "versions"`; *"portable binaries are stateless on disk"*). Top-level README now points there and lists the real subfolders; the `data/README.txt` is removed with the folder (below).

## 2. Dropped the vestigial `data/` folder
The bundled `data/` folder was empty-but-for-its-README and **nothing ever wrote to it** — the last artifact of the pre-`SPEC_DATA_DIR_UNIFICATION` "portable = local data" design. It actively misled users into backing up an empty dir. Removed from packaging.

## 3. Moved the marker into `runtime/`
`agentmux-portable.marker` now lives in `runtime/` so the extract root is just `agentmux.exe` + `README.txt` + `runtime/`. The marker still earns its keep (it carries the ephemeral build label the UI shows via `read_build_label`, and flags portable mode). `is_portable_marker_present` now also checks one level down in `runtime/` (the launcher sits at the root; host/srv run from `runtime/` and find it next to themselves). **Backward compatible** — a root-level marker is still accepted. Detection test + stale comments (`runtime_mode` module doc, `sidecar.rs`, `platform.rs`) updated.

## Note surfaced during this work
Portable vs Installed mode is otherwise a **no-op**: both resolve data to `~/.agentmux/versions/<v>/`, and the only other `Portable`-specific code sets a diagnostic-only log flag. The mode distinction is effectively vestigial; the marker's sole live purpose is the UI build label. Flagging in case we want to retire the split later (out of scope here).

<!-- agentmux:agent_id=agentc -->