### PR TITLE
fix(dnd): redock into the first window when it's a promoted pool window (#1681)

### DIFF
--- a/.changesets/1782141143-fix-dnd-redock-into-the-first-window-when-it-is-served-by-a--2653.md
+++ b/.changesets/1782141143-fix-dnd-redock-into-the-first-window-when-it-is-served-by-a--2653.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dnd): redock into the first window when it is served by a promoted pool window (#1681)

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -377,38 +377,54 @@ pub fn resolve_window_at_cursor(
                                 main_hwnd = %format!("{:#x}", main_hwnd),
                                 "cursor inside window"
                             );
-                            // Resolution (R3 identity fix, #1681). The label
-                            // stored in `window_hwnds` is ALWAYS the same string
-                            // the target window's frontend carries as its
-                            // `?windowLabel=` (promote inserts the
-                            // `window-pool-*` label; the renderer's URL carries
-                            // the same one; cold "main" and "floating-*" match
-                            // likewise). The redock ghost only renders when the
-                            // host-emitted `target_label` === that frontend
-                            // `windowLabel`, so resolve MUST return the tracked
-                            // label VERBATIM.
+                            // Resolution (R3 identity, #1681). The redock ghost
+                            // only renders when the host-emitted `target_label`
+                            // === the target window's frontend `windowLabel`, so
+                            // resolve must return the label the frontend actually
+                            // uses for this HWND.
                             //
-                            // A prior heuristic rewrote a tracked `window-pool-*`
-                            // label to "main" whenever `find_main_window()`
-                            // pointed at this HWND. But `find_main_window()` only
-                            // returns the topmost non-floater window — with
-                            // several promoted windows open it routinely picks a
-                            // SECONDARY one, so that window got relabeled "main",
-                            // never matched its own `window-pool-*` frontend, and
-                            // rendered no ghost (and `backend_window_id("main")`
-                            // mis-targeted the redock). That is exactly the
-                            // "can only redock into the home window" bug. Promoted
-                            // pool windows are always inserted into `window_hwnds`
-                            // at promote, so a tracked label is authoritative and
-                            // `is_main_frame` must NOT override it.
+                            // window_hwnds maps this HWND to a `window-pool-*`
+                            // label (inserted at promote). Two different windows
+                            // wear a pool label, and they need OPPOSITE answers:
+                            //
+                            //  - A genuine promoted SECONDARY keeps its pool label
+                            //    as its real `windowLabel` and registers it via
+                            //    register_backend_window → it HAS a
+                            //    `backend_window_id`. Return the pool label
+                            //    verbatim so it matches.
+                            //  - The PRIMARY window can be served by a promoted
+                            //    pool window whose renderer re-identifies as
+                            //    "main" (it registers "main", NOT the pool label,
+                            //    so the pool label has NO backend_window_id, and
+                            //    window_hwnds never gets a "main" entry —
+                            //    capture_hwnd_for_label can't claim the
+                            //    already-pool-mapped HWND). Map to "main" when this
+                            //    is the main frame so its ghost matches.
+                            //
+                            // Using the registration (authoritative) instead of
+                            // find_main_window alone is what makes BOTH the first
+                            // window and secondary windows work: a registered pool
+                            // label is never rewritten, so find_main_window picking
+                            // the wrong frame can't mislabel a real secondary.
                             let is_main_frame = main_hwnd != 0 && h_isize == main_hwnd;
                             let resolved_label: Option<&str> = match label_by_hwnd.get(&h_isize) {
-                                // Tracked → return verbatim (matches the frontend).
+                                Some(l) if l.starts_with("window-pool-") => {
+                                    if state.backend_window_id(l).is_some() {
+                                        // Registered → the frontend's real label.
+                                        Some(l.as_str())
+                                    } else if is_main_frame {
+                                        // Unregistered pool label on the main frame
+                                        // → primary served by a promoted pool
+                                        // window; its renderer is "main".
+                                        Some("main")
+                                    } else {
+                                        Some(l.as_str())
+                                    }
+                                }
+                                // Real label (e.g. "main", "floating-*") → verbatim.
                                 Some(l) => Some(l.as_str()),
                                 // Untracked but it IS the main frame: best-effort
-                                // "main" for the genuine cold-main-before-cache
-                                // case. (Promoted windows are always tracked, so
-                                // this can't mislabel a secondary.)
+                                // "main" for the genuine cold-main-before-cache case.
                                 None if is_main_frame => Some("main"),
                                 None => None,
                             };


### PR DESCRIPTION
Follow-up to the redock fix in #1690. That PR made `resolve_window_at_cursor` return the tracked `window_hwnds` label verbatim — which fixed redock into promoted **secondary** windows but **regressed the first window**: no landing ghost, so a floater wouldn't dock into the primary window.

## Root cause (from the `redock-resolve` + `capture_hwnd_for_label` host logs)

The primary window can be served by a **promoted pool window**. The host knows it everywhere as `window-pool-<id>` (browser registry + `window_hwnds`), but that window's renderer **re-identifies as `"main"`** — it calls `register_backend_window("main")`, not the pool label. So:

- `window_hwnds` maps the HWND only to the pool label; `"main"` never gets a `window_hwnds` entry (`capture_hwnd_for_label` can't claim the already-pool-mapped HWND → log: `no available HWND for label=main`).
- The redock ghost gates on `target_label === the renderer's windowLabel` (`"main"`), but resolve returned the pool label → never matched → no ghost.

## The distinguisher

A genuine promoted **secondary** keeps its pool label as its `windowLabel` and **registers** it (`backend_window_id` is `Some`). The **primary-served-by-pool** registers `"main"` instead, leaving its pool label **unregistered**. resolve now uses that authoritative signal:

```
pool label WITH a backend_window_id        -> verbatim   (genuine secondary)
pool label WITHOUT one, on the main frame  -> "main"      (primary via pool)
```

This fixes the first window **without re-breaking secondaries**, and is robust to `find_main_window` picking the wrong frame (a registered pool label is never rewritten).

## Verification
Building for manual confirmation: redock into the first window AND into secondary windows. (The earlier secondary-window fix from #1690 stays covered by the `Some(l) if registered` branch.)

<!-- agentmux:agent_id=agentc -->