### PR TITLE
chore: release v0.48.0

### DIFF
--- a/.changesets/1782083516-fix-macos-disable-macappcodesignclone-so-packaged-app-launch-zy8d.md
+++ b/.changesets/1782083516-fix-macos-disable-macappcodesignclone-so-packaged-app-launch-zy8d.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): disable MacAppCodeSignClone so packaged app launches from any volume

--- a/.changesets/1782094468-fix-lifecycle-level-triggered-quit-reconcile-decision-safety-lpa3.md
+++ b/.changesets/1782094468-fix-lifecycle-level-triggered-quit-reconcile-decision-safety-lpa3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lifecycle): level-triggered quit reconcile decision + safety-net tests

--- a/.changesets/1782114572-feat-toolchain-external-widgets-catalog-detection-health-che-2wya.md
+++ b/.changesets/1782114572-feat-toolchain-external-widgets-catalog-detection-health-che-2wya.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(toolchain): external widgets catalog, detection + health check

--- a/.changesets/1782117808-chore-rpc-api-remove-vestigial-command-label-comments-4ege.md
+++ b/.changesets/1782117808-chore-rpc-api-remove-vestigial-command-label-comments-4ege.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(rpc-api): remove vestigial command-label comments

--- a/.changesets/1782118309-chore-rust-strip-phase-migration-markers-and-trivial-field-d-dwu8.md
+++ b/.changesets/1782118309-chore-rust-strip-phase-migration-markers-and-trivial-field-d-dwu8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(rust): strip phase-migration markers and trivial field doc comments

--- a/.changesets/1782118350-chore-frontend-trim-verbose-jsdoc-blocks-section-dividers-an-c3rh.md
+++ b/.changesets/1782118350-chore-frontend-trim-verbose-jsdoc-blocks-section-dividers-an-c3rh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(frontend): trim verbose JSDoc blocks, section dividers, and ticket refs

--- a/.changesets/1782133923-fix-splash-center-the-macos-splash-footer-unified-nstextalig-w112.md
+++ b/.changesets/1782133923-fix-splash-center-the-macos-splash-footer-unified-nstextalig-w112.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(splash): center the macOS splash footer (unified NSTextAlignment value)

--- a/.changesets/1782134598-feat-toolchain-open-pane-button-for-running-external-widgets-b0bd.md
+++ b/.changesets/1782134598-feat-toolchain-open-pane-button-for-running-external-widgets-b0bd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(toolchain): Open Pane button for running external widgets

--- a/.changesets/1782134938-fix-layout-seed-new-window-default-blocks-through-the-reduce-bbiy.md
+++ b/.changesets/1782134938-fix-layout-seed-new-window-default-blocks-through-the-reduce-bbiy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): seed new-window default blocks through the reducer so secondary-window tear-off works (R3, #1681)

--- a/.changesets/1782135834-fix-dnd-redock-floating-panes-into-secondary-windows-r3-wind-7ft0.md
+++ b/.changesets/1782135834-fix-dnd-redock-floating-panes-into-secondary-windows-r3-wind-7ft0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dnd): redock floating panes into secondary windows (R3 window-label resolve, #1681)

--- a/.changesets/1782137046-fix-dnd-create-docked-agent-pane-blocks-through-the-reducer--mchi.md
+++ b/.changesets/1782137046-fix-dnd-create-docked-agent-pane-blocks-through-the-reducer--mchi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dnd): create docked agent/pane blocks through the reducer so freshly-opened panes can tear off/redock (#1681)

--- a/.changesets/1782137474-feat-macos-open-a-new-window-on-app-reopen-fix-not-respondin-s6i1.md
+++ b/.changesets/1782137474-feat-macos-open-a-new-window-on-app-reopen-fix-not-respondin-s6i1.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(macos): open a new window on app reopen (fix 'not responding' on Finder double-click)

--- a/.changesets/1782140096-fix-lifecycle-quit-instance-on-last-window-close-views-recyc-ukjn.md
+++ b/.changesets/1782140096-fix-lifecycle-quit-instance-on-last-window-close-views-recyc-ukjn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lifecycle): quit instance on last-window close (Views recycle-on-close) + clean Windows exit

--- a/.changesets/1782141143-fix-dnd-redock-into-the-first-window-when-it-is-served-by-a--2653.md
+++ b/.changesets/1782141143-fix-dnd-redock-into-the-first-window-when-it-is-served-by-a--2653.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dnd): redock into the first window when it is served by a promoted pool window (#1681)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.47.4"
+version = "0.48.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.47.4"
+version = "0.48.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,23 @@
 # AgentMux Version History
 
+## 0.48.0 — 2026-06-22
+
+- fix(macos): disable MacAppCodeSignClone so packaged app launches from any volume
+- fix(lifecycle): level-triggered quit reconcile decision + safety-net tests
+- feat(toolchain): external widgets catalog, detection + health check
+- chore(rpc-api): remove vestigial command-label comments
+- chore(rust): strip phase-migration markers and trivial field doc comments
+- chore(frontend): trim verbose JSDoc blocks, section dividers, and ticket refs
+- fix(splash): center the macOS splash footer (unified NSTextAlignment value)
+- feat(toolchain): Open Pane button for running external widgets
+- fix(layout): seed new-window default blocks through the reducer so secondary-window tear-off works (R3, #1681)
+- fix(dnd): redock floating panes into secondary windows (R3 window-label resolve, #1681)
+- fix(dnd): create docked agent/pane blocks through the reducer so freshly-opened panes can tear off/redock (#1681)
+- feat(macos): open a new window on app reopen (fix 'not responding' on Finder double-click)
+- fix(lifecycle): quit instance on last-window close (Views recycle-on-close) + clean Windows exit
+- fix(dnd): redock into the first window when it is served by a promoted pool window (#1681)
+
+
 ## 0.47.4 — 2026-06-22
 
 - fix(editor): apply CSS zoom property instead of calc font-size scaling for correct per-pane zoom

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.47.4",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.47.4",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.47.4",
+  "version": "0.48.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes 14 pending changesets (3 minor) and bumps **0.47.4 → 0.48.0**.

Highlights: lifecycle quit-on-last-window-close + clean Windows exit, a batch of floating-pane/DnD fixes (redock/tear-off across secondary + promoted-pool windows, reducer-routed block creation), external-widgets toolchain catalog + Open Pane, macOS open-window-on-reopen, and the macOS splash-footer centering fix.

All 5 version locations agree (release-consistency passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)