### PR TITLE
fix(packaging): purge inactive pages before ULMO DMG compression

### DIFF
--- a/.changesets/1782144434-fix-packaging-purge-inactive-pages-before-ulmo-compression-t-d4eg.md
+++ b/.changesets/1782144434-fix-packaging-purge-inactive-pages-before-ulmo-compression-t-d4eg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(packaging): purge inactive pages before ULMO compression to prevent OOM kill

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -379,6 +379,9 @@ fi
 # ULMO (LZMA) compression — LZMA-class like Linux's SquashFS AppImage, vs the
 # default UDZO (zlib) which left the DMG ~50% larger. Requires macOS 10.15+ to
 # mount (we target 11+, so fine). On this build: UDZO 248MB -> ULMO 167MB.
+# Purge inactive pages first — LZMA peaks at 4-6GB RAM and gets OOM-killed if
+# the system is under memory pressure after the Rust compile phase.
+sudo purge 2>/dev/null || true
 hdiutil convert "$RW" -format ULMO -o "$DMG" >/dev/null
 rm -f "$RW"
 codesign --force --timestamp --sign "$CERT" "$DMG"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -381,7 +381,7 @@ fi
 # mount (we target 11+, so fine). On this build: UDZO 248MB -> ULMO 167MB.
 # Purge inactive pages first — LZMA peaks at 4-6GB RAM and gets OOM-killed if
 # the system is under memory pressure after the Rust compile phase.
-sudo purge 2>/dev/null || true
+sudo -n purge 2>/dev/null || true
 hdiutil convert "$RW" -format ULMO -o "$DMG" >/dev/null
 rm -f "$RW"
 codesign --force --timestamp --sign "$CERT" "$DMG"


### PR DESCRIPTION
LZMA (`hdiutil convert -format ULMO`) peaks at 4-6GB RAM. After a full Rust compile the system holds significant inactive pages and macOS OOM-kills the compression step (SIGKILL, exit 137), silently falling through to a corrupt/missing DMG.

`sudo purge` before the conversion releases inactive pages so LZMA has headroom. `|| true` means CI/sandboxed builds that can't run purge continue without error.

Confirmed: previous build OOM-killed at ULMO step → workaround of converting an already-built UDZO DMG to ULMO post-compile succeeded → this adds purge so the inline step works too.

<!-- agentmux:agent_id=masty -->