### PR TITLE
fix(statusbar): wrap long tooltips instead of overflowing the balloon

### DIFF
--- a/.changesets/1782144490-fix-statusbar-wrap-long-data-tip-tooltips-instead-of-overflo-hwjh.md
+++ b/.changesets/1782144490-fix-statusbar-wrap-long-data-tip-tooltips-instead-of-overflo-hwjh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): wrap long data-tip tooltips instead of overflowing the balloon

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -163,8 +163,16 @@
             border: 1px solid var(--border-color);
             border-radius: 0;
             font-size: 11px;
-            white-space: nowrap;
+            // Size to content, but wrap (don't single-line overflow) once the
+            // tip exceeds max-width. `nowrap` + `max-width` contradicted: long
+            // tips (e.g. GFX's full GPU renderer string) spilled out of the
+            // balloon. `max-content` keeps short tips on one line; long ones
+            // wrap, and `overflow-wrap: anywhere` breaks unbreakable renderer
+            // strings instead of overflowing.
+            white-space: normal;
+            width: max-content;
             max-width: 320px;
+            overflow-wrap: anywhere;
             pointer-events: none;
             z-index: calc(var(--zindex-modal-wrapper) + 10);
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Problem
The GFX status-bar item's tooltip overflows its balloon: the text spills outside the bordered box.

## Root cause
The shared `[data-tip]` balloon rule (`StatusBar.scss`) set both:
```scss
white-space: nowrap;
max-width:   320px;
```
That's contradictory — `nowrap` forces a single line, so `max-width` can't constrain it. A long tip (the GFX item appends the full GPU renderer string, e.g. `… — ANGLE (NVIDIA GeForce RTX …) · terminal: WEBGL`) lays out wider than 320px on one line and overflows the balloon.

## Fix
Let the balloon wrap within its max-width:
```scss
white-space:   normal;
width:         max-content;   // short tips stay one line; long ones wrap at max-width
max-width:     320px;
overflow-wrap: anywhere;      // break unbreakable renderer strings instead of overflowing
```
One shared-rule change → fixes GFX, Backend, Host, Config, and every other status-bar tooltip. No markup changes, no regression for short tips (they stay single-line via `max-content`).

<!-- agentmux:agent_id=agentc -->