### PR TITLE
perf(layout): reduce native-pane reflow settle window 32ms -> 4ms

### DIFF
--- a/.changesets/1782144871-perf-layout-reduce-native-pane-reflow-settle-window-from-32m-yn2c.md
+++ b/.changesets/1782144871-perf-layout-reduce-native-pane-reflow-settle-window-from-32m-yn2c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(layout): reduce native-pane reflow settle window from 32ms to 4ms

--- a/frontend/app/platform/pane-anim.ts
+++ b/frontend/app/platform/pane-anim.ts
@@ -20,10 +20,12 @@ import { createSignal } from "solid-js";
 
 // Short settle window after the layout applies the new rect synchronously —
 // covers rAF/scheduler slack so the per-frame sampling lands on the final rect.
-// Was 220ms when this tracked a CSS pane reflow animation; the animation was
-// removed and the placeholder rect is now final immediately, so 2 rAF frames
-// (≈32ms) is enough to let Solid's reactive flush + ResizeObserver tick settle.
-const REFLOW_WINDOW_MS = 32;
+// Was 220ms when this tracked a CSS pane reflow animation, then 32ms (≈2 rAF
+// frames) after the animation was removed and the placeholder rect became final
+// immediately. Tuned down further to 4ms for a snappier post-change settle. The
+// resample loop in browser-view.tsx is rAF-gated, so this floors at ~1 frame in
+// practice regardless of the exact sub-frame value.
+const REFLOW_WINDOW_MS = 4;
 
 // Wall-clock instant (performance.now() ms) until which the post-change settle
 // window is open. Stored in a signal so consumers can reactively start their


### PR DESCRIPTION
Reduces `REFLOW_WINDOW_MS` (`frontend/app/platform/pane-anim.ts`) from 32ms to 4ms, as requested.

## What it is
After a pane geometry change, `notifyPaneReflow()` opens a settle window during which `browser-view.tsx`'s `requestAnimationFrame` loop re-samples the placeholder rect and re-positions the native pane HWND every frame. `REFLOW_WINDOW_MS` is how long that loop keeps running after the change. The CSS reflow animation it once tracked was removed (the rect is final synchronously), so the window now only covers scheduler slack: 220ms → 32ms → **4ms**.

## Honest caveats (called out in the commit + code comment)
- The resample loop is **rAF-gated**, so 4ms floors at ~1 frame in practice; the real effect is a shorter post-change settle *tail*, not a higher repaint rate.
- This same constant governs the settle after **pane open/close/split**, not just window resize. The prior ~2-frame (32ms) margin was there to catch Solid's async reactive flush / ResizeObserver tick — so those paths deserve a smoke for panes landing on a stale rect. `~16ms` (one full frame) is the safer fallback if 4ms regresses anything.

<!-- agentmux:agent_id=agentc -->