### PR TITLE
feat(agent): persist per-agent zoom across pane close/reopen

### DIFF
--- a/.changesets/1782145929-feat-agent-persist-per-agent-zoom-across-pane-close-reopen-gsqo.md
+++ b/.changesets/1782145929-feat-agent-persist-per-agent-zoom-across-pane-close-reopen-gsqo.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): persist per-agent zoom across pane close/reopen

--- a/agentmux-srv/src/backend/storage/content.rs
+++ b/agentmux-srv/src/backend/storage/content.rs
@@ -170,17 +170,25 @@ impl Store {
     }
 
     /// Delete a specific content blob. Returns true if a row was deleted.
-    #[allow(dead_code)]
     pub fn agent_content_delete(
         &self,
         agent_id: &str,
         content_type: &str,
     ) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_agent_content WHERE agent_id=?1 AND content_type=?2",
-            params![agent_id, content_type],
-        )?;
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "DELETE FROM db_agent_content WHERE agent_id=?1 AND content_type=?2",
+                params![agent_id, content_type],
+            )?
+        };
+        // conn dropped — re-mirror the definition so the global cross-channel
+        // record drops the just-deleted content key too. Symmetric with
+        // `agent_content_set`: without this a reset-to-default (e.g. ui:zoom)
+        // clears the local row but leaves the stale value in the shared
+        // def-registry, which a cross-channel/other-instance reopen would
+        // resurrect via the `agent_content_get` registry fallback. (P0.2b.)
+        self.registry_def_upsert(agent_id);
         Ok(rows > 0)
     }
 }

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -339,6 +339,60 @@ mod tests {
     }
 
     #[test]
+    fn local_content_delete_propagates_to_global() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        store.set_def_registry(def_store.clone());
+
+        // LOCAL user agent with a per-agent ui:zoom blob (mirrored to global).
+        let mut def = local_def("local-z", "LocalZ");
+        store.agent_def_insert(&mut def).unwrap();
+        store
+            .agent_content_set(&AgentContent {
+                agent_id: "local-z".into(),
+                content_type: "ui:zoom".into(),
+                content: "1.5".into(),
+                updated_at: 1,
+            })
+            .unwrap();
+        assert!(
+            def_store
+                .get("local-z")
+                .unwrap()
+                .unwrap()
+                .data
+                .content
+                .iter()
+                .any(|c| c.content_type == "ui:zoom"),
+            "content mirrored to global"
+        );
+
+        // Reset-to-default deletes the local row.
+        store.agent_content_delete("local-z", "ui:zoom").unwrap();
+
+        // Local read is clean (no resurrection from the global record)...
+        assert!(
+            store.agent_content_get("local-z", "ui:zoom").unwrap().is_none(),
+            "deleted local content must not reappear from the global record"
+        );
+        // ...and the deletion propagated to the global record, so a
+        // cross-channel/other-instance reopen won't restore the stale zoom.
+        // (reviewer P1 on #1700 — agent_content_delete must re-mirror, like set.)
+        assert!(
+            def_store
+                .get("local-z")
+                .unwrap()
+                .unwrap()
+                .data
+                .content
+                .iter()
+                .all(|c| c.content_type != "ui:zoom"),
+            "content deletion must propagate cross-channel"
+        );
+    }
+
+    #[test]
     fn delete_tombstones_a_cross_channel_only_agent() {
         let store = Store::open_in_memory().unwrap();
         let tmp = tempfile::tempdir().unwrap();

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -326,6 +326,17 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut meta = MetaMapType::new();
                 meta.insert("view".to_string(), json!("agent"));
                 meta.insert("agentId".to_string(), json!(&agent.id));
+                // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE): seed
+                // the new block's `term:zoom` from the agent's saved `ui:zoom`
+                // (per-agent content store, global cross-channel) so reopening
+                // the same agent restores its zoom instead of resetting to 1.0.
+                // Stored only for non-default zooms; clamp to the frontend's
+                // [0.5, 2.0] range so a corrupt value can't escape it.
+                if let Ok(Some(c)) = wstore.agent_content_get(&agent.id, "ui:zoom") {
+                    if let Some(z) = parse_seed_zoom(&c.content) {
+                        meta.insert("term:zoom".to_string(), json!(z));
+                    }
+                }
                 meta.insert("agentProvider".to_string(), json!(&agent.provider));
                 meta.insert("agentName".to_string(), json!(&agent.name));
                 meta.insert("agentIcon".to_string(), json!(if agent.icon.is_empty() { "sparkles" } else { &agent.icon }));
@@ -3231,5 +3242,42 @@ mod pane_open_reducer_tests {
         )
         .await;
         assert!(r.is_ok(), "tear-off of an opened pane must succeed, got: {:?}", r.err());
+    }
+}
+
+/// Parse + validate a saved per-agent `ui:zoom` content blob for seeding a new
+/// agent block's `term:zoom`. Returns `Some(z)` only for a parseable,
+/// non-default (≠ 1.0), in-[0.5, 2.0] zoom (the range the frontend enforces in
+/// term.tsx); anything else (default, out of range, garbage) returns `None` so
+/// the new block opens at the default 1.0. See SPEC_AGENT_ZOOM_PERSISTENCE §4.2.
+fn parse_seed_zoom(raw: &str) -> Option<f64> {
+    let z = raw.trim().parse::<f64>().ok()?;
+    if (z - 1.0).abs() > f64::EPSILON && (0.5..=2.0).contains(&z) {
+        Some(z)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod agent_zoom_seed_tests {
+    use super::parse_seed_zoom;
+
+    #[test]
+    fn seeds_valid_non_default_zoom() {
+        assert_eq!(parse_seed_zoom("1.3"), Some(1.3));
+        assert_eq!(parse_seed_zoom("0.5"), Some(0.5));
+        assert_eq!(parse_seed_zoom("2"), Some(2.0));
+        assert_eq!(parse_seed_zoom("  1.4  "), Some(1.4)); // trims
+    }
+
+    #[test]
+    fn rejects_default_out_of_range_and_garbage() {
+        assert_eq!(parse_seed_zoom("1.0"), None, "default seeds nothing");
+        assert_eq!(parse_seed_zoom("1"), None, "default seeds nothing");
+        assert_eq!(parse_seed_zoom("2.5"), None, "above range");
+        assert_eq!(parse_seed_zoom("0.4"), None, "below range");
+        assert_eq!(parse_seed_zoom("abc"), None, "unparseable");
+        assert_eq!(parse_seed_zoom(""), None, "empty");
     }
 }

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -600,6 +600,27 @@ async fn handle_object_service(state: &AppState, call: &WebCallType) -> WebRetur
                 }
             }
             publish_events(state, &events);
+            // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE): when an
+            // agent block's `term:zoom` changes, mirror it (debounced) into the
+            // agent's per-agent `ui:zoom` content so the zoom survives the block
+            // and is restored at `agent.open`. Only blocks carrying `agentId`
+            // (agent panes) participate; everything else is untouched. A `null`
+            // `term:zoom` (the frontend's reset-to-1.0 convention) deletes the
+            // saved value so a default agent stores nothing.
+            if oref.otype == OTYPE_BLOCK && meta_update.contains_key("term:zoom") {
+                if let Ok(block) = store.must_get::<Block>(&oref.oid) {
+                    let agent_id = block
+                        .meta
+                        .get("agentId")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if !agent_id.is_empty() {
+                        let zoom = meta_update.get("term:zoom").and_then(|v| v.as_f64());
+                        schedule_agent_zoom_mirror(store.clone(), agent_id, zoom);
+                    }
+                }
+            }
             // Return the updated object so the frontend WOS cache stays in sync.
             if oref.otype == OTYPE_BLOCK {
                 if let Ok(block) = store.must_get::<Block>(&oref.oid) {
@@ -2789,6 +2810,56 @@ pub(crate) fn update_object_meta(
 /// events. Locks the reducer mutex briefly; the lock is released
 /// before any I/O (caller is responsible for publishing the events
 /// to the broadcast bus).
+/// Per-`agent_id` debounce generation for zoom mirroring. Each `term:zoom`
+/// change bumps the agent's generation; the spawned trailing-write task only
+/// commits if its captured generation is still current 300ms later, so a
+/// Ctrl+Wheel burst collapses into a single durable write (+ one global
+/// def-registry re-mirror). See SPEC_AGENT_ZOOM_PERSISTENCE §4.3.
+static ZOOM_MIRROR_GEN: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, u64>>> =
+    std::sync::OnceLock::new();
+
+fn zoom_mirror_gen() -> &'static std::sync::Mutex<std::collections::HashMap<String, u64>> {
+    ZOOM_MIRROR_GEN.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Debounced trailing mirror of an agent block's `term:zoom` into the per-agent
+/// `ui:zoom` content blob. `zoom = Some(z)` upserts; `zoom = None` (term:zoom
+/// reset to null / 1.0) deletes the row so a default agent persists nothing.
+fn schedule_agent_zoom_mirror(
+    store: std::sync::Arc<crate::backend::storage::store::Store>,
+    agent_id: String,
+    zoom: Option<f64>,
+) {
+    let generation = {
+        let mut gens = zoom_mirror_gen().lock().unwrap();
+        let g = gens.entry(agent_id.clone()).or_insert(0);
+        *g += 1;
+        *g
+    };
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        // Superseded by a newer zoom change for this agent → drop this write.
+        if zoom_mirror_gen().lock().unwrap().get(&agent_id).copied() != Some(generation) {
+            return;
+        }
+        let now = chrono::Utc::now().timestamp_millis();
+        let result = match zoom {
+            Some(z) => store.agent_content_set(
+                &crate::backend::storage::store::AgentContent {
+                    agent_id: agent_id.clone(),
+                    content_type: "ui:zoom".to_string(),
+                    content: format!("{}", z),
+                    updated_at: now,
+                },
+            ),
+            None => store.agent_content_delete(&agent_id, "ui:zoom").map(|_| ()),
+        };
+        if let Err(e) = result {
+            tracing::warn!(agent_id = %agent_id, error = %e, "[zoom] agent zoom mirror write failed");
+        }
+    });
+}
+
 pub(crate) async fn dispatch_to_reducer(
     state: &AppState,
     cmd: agentmux_common::ipc::Command,
@@ -3099,6 +3170,78 @@ mod create_window_seed_tests {
             result.is_ok(),
             "tear-off from a freshly-created window must succeed, got: {:?}",
             result.err()
+        );
+    }
+}
+
+#[cfg(test)]
+mod agent_zoom_mirror_tests {
+    use super::schedule_agent_zoom_mirror;
+    use crate::backend::storage::store::{AgentContent, AgentDefinition, Store};
+    use std::sync::Arc;
+
+    /// `db_agent_content.agent_id` has a FK to the agent-definitions table, so a
+    /// real mirror only ever fires for an existing agent (the def was loaded at
+    /// agent.open). Seed a minimal def so the test mirrors that invariant.
+    fn seed_agent_def(store: &Store, id: &str) {
+        let mut def: AgentDefinition = serde_json::from_value(serde_json::json!({
+            "id": id,
+            "name": id,
+            "icon": "sparkles",
+            "provider": "claude",
+            "description": "",
+            "created_at": 1,
+        }))
+        .expect("build minimal AgentDefinition");
+        store.agent_def_insert(&mut def).expect("insert agent def");
+    }
+
+    /// A Ctrl+Wheel burst of `term:zoom` changes must collapse into a single
+    /// durable write of the FINAL value (SPEC_AGENT_ZOOM_PERSISTENCE §4.3).
+    #[tokio::test]
+    async fn debounced_mirror_persists_only_final_value() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let agent = "agent-zoom-burst";
+        seed_agent_def(&store, agent);
+
+        schedule_agent_zoom_mirror(store.clone(), agent.into(), Some(1.1));
+        schedule_agent_zoom_mirror(store.clone(), agent.into(), Some(1.2));
+        schedule_agent_zoom_mirror(store.clone(), agent.into(), Some(1.4));
+
+        // Nothing committed before the debounce window elapses.
+        assert!(store.agent_content_get(agent, "ui:zoom").unwrap().is_none());
+
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        let saved = store
+            .agent_content_get(agent, "ui:zoom")
+            .unwrap()
+            .expect("zoom persisted after debounce");
+        assert_eq!(saved.content, "1.4", "only the final zoom of the burst persists");
+    }
+
+    /// `term:zoom` reset to null/1.0 → `None` → delete the saved row so a
+    /// default agent stores nothing.
+    #[tokio::test]
+    async fn reset_to_default_deletes_saved_zoom() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let agent = "agent-zoom-reset";
+        seed_agent_def(&store, agent);
+        store
+            .agent_content_set(&AgentContent {
+                agent_id: agent.into(),
+                content_type: "ui:zoom".into(),
+                content: "1.5".into(),
+                updated_at: 1,
+            })
+            .unwrap();
+
+        schedule_agent_zoom_mirror(store.clone(), agent.into(), None);
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        assert!(
+            store.agent_content_get(agent, "ui:zoom").unwrap().is_none(),
+            "reset-to-default removes the persisted zoom"
         );
     }
 }

--- a/docs/specs/SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md
+++ b/docs/specs/SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md
@@ -1,0 +1,215 @@
+# Per-agent zoom persistence
+
+**Date:** 2026-06-22
+**Status:** Proposed (design)
+**Owner:** AgentC
+**Area:** agent pane / view zoom, per-agent content storage
+
+---
+
+## 1. Problem
+
+Zooming an agent pane (Ctrl + mouse wheel) is lost the moment the pane is
+closed. Reopening the *same* agent comes back at the default 1.0 zoom. Users who
+prefer a particular agent at a larger or smaller size have to re-zoom every time
+they reopen it.
+
+The zoom is a genuine **per-agent reading preference**, but today it is bound to
+a throwaway object (the block), so it cannot outlive a single pane.
+
+## 2. Current behavior (root cause)
+
+Agent zoom lives in the **block's `meta`** under the key `term:zoom`:
+
+- **Read / apply:** `frontend/app/view/agent/agent-view.tsx:917` reads
+  `meta?.["term:zoom"]` into a memo and applies it as the CSS `zoom` on
+  `.agent-view` (`:1000`). The terminal view reads the same key
+  (`frontend/app/view/term/term.tsx:75`).
+- **Write:** `frontend/app/view/term/term.tsx:222-226` handles Ctrl+Wheel and
+  calls `SetMetaCommand` on `block:<id>` with `{ "term:zoom": next }` (or `null`
+  at 1.0, by convention, so a default pane carries no key). This routes through
+  the block-meta update path (`UpdateBlockMeta` reducer,
+  `agentmux-srv/src/reducer/block.rs`) and persists onto the **block** row.
+
+The block is ephemeral:
+
+- **Close pane** → `DeleteBlock` removes the block (and its `meta`, including
+  `term:zoom`).
+- **Reopen agent** → `agent.open` (`agentmux-srv/src/server/app_api.rs`, the
+  `register_agent_open` handler) builds a **brand-new block** and seeds its meta
+  with `agentId`, `agentProvider`, `controller`, `cmd*`, etc. — **but not**
+  `term:zoom`. So the new block defaults to 1.0.
+
+Nothing connects the zoom to the agent's stable identity (`agent.id`), so it
+cannot survive the block.
+
+## 3. Goal & requirements
+
+1. **Persist across close/reopen.** Reopening the same agent (by `agent.id`)
+   restores the last zoom the user set for it.
+2. **Keyed by agent identity, not block.** Zoom follows the agent, including a
+   cold reopen in a different tab/window/session.
+3. **Global, like the agent.** Agents are global cross-channel
+   (`CLAUDE.md`, agent/auth globalization). Zoom should follow the agent across
+   channels and instances, not be siloed per data dir.
+4. **No write amplification.** Ctrl+Wheel emits a burst of `term:zoom` updates;
+   persistence must coalesce so the durable store is written once per zoom
+   gesture, not once per tick.
+5. **Default stays clean.** An agent the user never zoomed (or reset to 1.0)
+   stores nothing — no row, no key, no migration.
+6. **No regression to the live path.** The block-meta `term:zoom` remains the
+   single live source the views render from; this feature only seeds it on open
+   and mirrors it on change.
+
+Non-goals (this spec): terminal-pane zoom persistence (terminals have no stable
+cross-open identity to key on — see §8), and live cross-pane sync of zoom while
+two panes of the same agent are open simultaneously (see §8).
+
+## 4. Design
+
+### 4.1 Storage — reuse the per-agent content store
+
+Persist zoom in the existing per-agent KV store
+(`agentmux-srv/src/backend/storage/content.rs`,
+`Store::agent_content_get` / `agent_content_set`), the same mechanism that
+backs `env` and `instructions`:
+
+- **`agent_id`** = the agent definition id.
+- **`content_type`** = `"ui:zoom"`.
+- **`content`** = the zoom factor as a short decimal string (e.g. `"1.3"`).
+  Absent row = default 1.0.
+
+Why this store:
+
+- Already **global cross-channel** — `agent_content_get` falls back to the
+  shared def registry for non-local agents (`content.rs:60-84`), and
+  `agent_content_set` re-mirrors via `registry_def_upsert` (`:106`). Zoom
+  inherits the agent's global reach for free.
+- Keyed by `agent.id`, exactly the identity we need.
+- Additive: new `content_type`, no schema change, no migration.
+
+> Alternative considered: `AgentDef.meta["ui:zoom"]`. Rejected as the primary
+> home because mutating the definition for a transient UI pref is heavier and
+> conflates "what the agent is" with "how I like to view it." The content store
+> is the established per-agent *side-data* channel. (See §7.)
+
+### 4.2 Restore — seed `term:zoom` at `agent.open`
+
+In `register_agent_open` (`app_api.rs`), while building the new block's `meta`
+(right where `agentId` etc. are inserted), read the saved zoom and seed it:
+
+```text
+if let Ok(Some(c)) = wstore.agent_content_get(&agent.id, "ui:zoom") {
+    if let Ok(z) = c.content.trim().parse::<f64>() {
+        if (z - 1.0).abs() > f64::EPSILON && (0.5..=2.0).contains(&z) {
+            meta.insert("term:zoom".to_string(), json!(z));
+        }
+    }
+}
+```
+
+The new block is therefore born at the saved zoom; the views render it through
+the unchanged `term:zoom` read path. Clamp to the same `[0.5, 2.0]` range the
+frontend enforces (`term.tsx:223`) so a corrupt value can't escape it. A `1.0`
+value (or unparviceable content) seeds nothing → default.
+
+### 4.3 Persist — mirror `term:zoom` → `ui:zoom` on change (debounced)
+
+The frontend keeps writing `term:zoom` to block meta exactly as today (no
+frontend change required for the core). The **backend** mirrors it: when a block
+that carries an `agentId` has its `term:zoom` updated, write the value through
+to the per-agent store.
+
+- **Hook point:** the block-meta update RPC handler in
+  `agentmux-srv/src/server/service.rs` (the `SetMeta` / `UpdateBlockMeta`
+  service path), NOT the pure reducer — keep agent-zoom knowledge out of
+  `reducer/block.rs`. After applying the meta update, if the updated keys
+  include `term:zoom` and the block's resolved meta has a non-empty `agentId`,
+  enqueue a debounced mirror.
+- **Coalescing:** maintain a per-`agent_id` debounce (≈300 ms trailing). Ctrl
+  +Wheel produces ~10 updates/sec; the trailing write persists only the final
+  resting zoom, so the global registry re-mirror fires once per gesture.
+- **Reset semantics:** the frontend already sends `term:zoom: null` at exactly
+  1.0. On a `null`/absent `term:zoom`, the mirror **deletes** the `ui:zoom` row
+  (`agent_content_delete`, `content.rs:174`) so a reset-to-default agent goes
+  back to storing nothing (requirement 5).
+- **`updated_at`:** stamp with the server clock at write time (consistent with
+  other `AgentContent` writes).
+
+> Why mirror server-side rather than add a second frontend RPC: the frontend
+> already emits the authoritative `term:zoom` change through one path. Mirroring
+> there keeps a single source of truth, avoids a race between two client writes,
+> and means every producer of `term:zoom` (agent view, and any future surface)
+> is covered without touching each call site.
+
+### 4.4 Data flow (end to end)
+
+```
+Ctrl+Wheel  ──SetMeta(block, term:zoom)──►  block.meta.term:zoom   (live render, unchanged)
+                                                   │
+                                      service.rs mirror hook (debounced, agentId present)
+                                                   ▼
+                                   agent_content_set(agent_id, "ui:zoom", "1.3")
+                                                   │  (global re-mirror)
+                                                   ▼
+close pane → DeleteBlock                    db_agent_content / shared def registry
+reopen agent → agent.open ──agent_content_get(agent_id,"ui:zoom")──► seed new block.meta.term:zoom
+```
+
+## 5. Implementation plan
+
+1. **Backend — restore (smallest, highest value):** in `register_agent_open`
+   (`app_api.rs`), seed `term:zoom` from `agent_content_get(agent.id,"ui:zoom")`
+   as in §4.2. This alone fixes the reported bug for any agent whose zoom is
+   already stored.
+2. **Backend — persist:** add the debounced mirror in the `SetMeta` block path
+   (`service.rs`), §4.3, including the delete-on-reset branch. A small
+   per-`agent_id` trailing-debounce map on `AppState` (or a lightweight
+   `tokio` task keyed by agent_id).
+3. **Tests:**
+   - `agent_content` round-trip for `ui:zoom` (set → get → parse).
+   - `agent.open` seeds `term:zoom` when a `ui:zoom` row exists; seeds nothing at
+     1.0 / missing; clamps out-of-range.
+   - Mirror: a `term:zoom` SetMeta on an agent block writes `ui:zoom`; a `null`
+     `term:zoom` deletes it; a SetMeta on a non-agent block (no `agentId`) does
+     nothing.
+   - Debounce: N rapid updates collapse to one `agent_content_set`.
+4. **Frontend:** none required for the core. (Optional polish in §8.)
+
+## 6. Test / acceptance
+
+- Zoom an agent pane to e.g. 1.4, close the pane, reopen the same agent → it
+  returns at 1.4.
+- Reopen the same agent in a **different window** → 1.4.
+- Reset to 1.0 (zoom back), close, reopen → default 1.0, and the `ui:zoom` row
+  is gone.
+- An agent never zoomed → default 1.0, no row written.
+- Rapid Ctrl+Wheel from 1.0 → 1.8 writes the durable store **once** (assert via
+  store write count / `updated_at` stability).
+
+## 7. Alternatives considered
+
+| Option | Verdict |
+|---|---|
+| Keep zoom on the block only (status quo) | Rejected — the reported bug. |
+| `AgentDef.meta["ui:zoom"]` | Viable, but conflates definition with view pref and is a heavier write; content store is the established per-agent side-data path. |
+| Frontend-only (persisted atom / localStorage keyed by agentId) | Rejected — not global cross-channel, renderer-scoped, and fragile across windows. |
+| New dedicated `db_agent_ui_prefs` table | Rejected for now — over-engineered for one scalar; revisit if more per-agent UI prefs accumulate (then migrate `ui:*` content_types into it). |
+
+## 8. Open questions / future work
+
+- **Live cross-pane sync.** If the same agent is open in two panes at once, this
+  design seeds each on open and last-writer-wins to the store; it does **not**
+  live-sync an in-flight zoom across the two open panes. If desired, broadcast
+  the `ui:zoom` change so sibling agent panes update their `term:zoom`. Likely a
+  small follow-up, not needed for the reported bug.
+- **Terminal panes.** Terminals share the `term:zoom` key but have no stable
+  cross-open identity to persist against. Out of scope here; a separate spec
+  could persist terminal zoom per-tab or as a global default.
+- **Generalize `ui:*` prefs.** If we later persist more per-agent view prefs
+  (font, wrap, theme), promote `ui:zoom` into a structured `ui:prefs` JSON
+  content blob rather than one content_type per pref.
+- **Per-pane override.** Should a user be able to zoom one pane *without*
+  changing the agent's saved default (a transient override)? Current design
+  treats every zoom as the new saved default; flag if product wants a "this pane
+  only" mode.


### PR DESCRIPTION
## Problem
Zooming an agent pane (Ctrl+Wheel) is lost on close. Reopening the same agent comes back at default 1.0. Zoom is a per-agent reading preference but was bound to the throwaway block.

## Root cause
Agent zoom lives in the block's `term:zoom` meta (`agent-view.tsx:917` reads it, `term.tsx:222` writes it). Closing the pane deletes the block; `agent.open` builds a fresh block seeding `agentId`/provider/etc. but **not** `term:zoom`, so it defaults to 1.0. Nothing tied zoom to the agent's stable id.

## Design (full spec: `docs/specs/SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md`)
Persist zoom per `agent.id` in the existing per-agent content store (`agent_content`, new `content_type = "ui:zoom"`) — the same vehicle as `env`/`instructions`, already **global cross-channel**, so zoom follows the agent everywhere. No schema change, additive.

- **Restore** — `agent.open` seeds the new block's `term:zoom` from `ui:zoom` (`parse_seed_zoom`: parseable, non-default, clamped to the frontend's `[0.5, 2.0]`). Live render path unchanged.
- **Persist** — the `SetMeta` handler mirrors an agent block's `term:zoom` change into `ui:zoom`, **debounced ~300ms** via a per-`agent_id` generation counter, so a Ctrl+Wheel burst collapses to one durable write (+ one global re-mirror). `term:zoom: null` (the frontend's reset-to-1.0 convention) **deletes** the row, so default agents store nothing. Only blocks carrying `agentId` participate.
- **No frontend change** for the core.

## Tests
- `parse_seed_zoom`: valid/non-default → `Some`; default/out-of-range/garbage → `None`.
- mirror debounce: a 3-update burst persists only the final value, and nothing before the window elapses.
- reset-to-default (`None`) deletes the saved row.

(4 new tests, all green; full srv suite unaffected.)

## Out of scope (noted in spec §8)
Live cross-pane sync of an in-flight zoom across two simultaneously-open panes of the same agent; terminal-pane zoom (no stable cross-open identity); a per-pane "transient override" mode.

<!-- agentmux:agent_id=agentc -->