### PR TITLE
fix(window): keep the status-bar window count accurate (close report + gap resync)

### DIFF
--- a/.changesets/1782167695-fix-window-accurate-status-bar-window-count-on-close-event-s-uny9.md
+++ b/.changesets/1782167695-fix-window-accurate-status-bar-window-count-on-close-event-s-uny9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): accurate status-bar window count on close + event-stream gaps

--- a/agentmux-cef/src/commands/window/lifecycle.rs
+++ b/agentmux-cef/src/commands/window/lifecycle.rs
@@ -38,6 +38,19 @@ use cef::{ImplBrowser, ImplBrowserHost};
 pub fn close_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
 
+    // Report the logical window-close to the launcher so the frontend's window
+    // count ("(N)" next to the version) decrements. `on_before_close` — the only
+    // other caller of `report_window_closed` — does NOT fire on a CEF Views
+    // recycle-on-close (the window hides, the browser is reused), so without
+    // this the count goes stale (Discussion #1680, sibling of #1676). The
+    // launcher pairs WindowClosed with WindowOpened and no-ops unknown/
+    // already-removed labels, so an extra report (if on_before_close DOES fire,
+    // e.g. a real destroy) is harmless. Skip browser-pane-* — same gate as
+    // on_before_close (client/mod.rs).
+    if !label.starts_with("browser-pane-") {
+        crate::launcher_ipc::report_window_closed(label.to_string());
+    }
+
     // Close via the registered browser's CefWindow (post_close_window →
     // CloseWindowTask → window.close()) when one exists — reliable for the CEF
     // *Views* main window, whose window_handle() is NULL on Win32 so the old

--- a/docs/specs/SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md
+++ b/docs/specs/SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md
@@ -1,0 +1,221 @@
+# SPEC — Reducer single-source-of-truth (SSOT) consolidation
+
+- **Status:** Draft (audit + roadmap; spec-first, rides with code per no-doc-only-PR rule)
+- **Date:** 2026-06-22
+- **Author:** AgentA
+- **Origin:** the stale/desynced window-count bug (`SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md`)
+  turned out to be one instance of a systemic pattern — state reconstructed/duplicated outside a
+  single reducer authority. The user asked: *"check if there are other loose ends that should be in
+  the reducer."* This is the rigorous answer.
+- **Supersedes/absorbs:** extends `SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md` — that spec
+  predates the #1676 win_event fix, which introduced a NEW fourth quit authority this document must
+  now account for (finding L1).
+- **Evidence:** two grounded codebase audits (frontend desync surface; host/launcher SSOT). All
+  file:line citations below are from those audits against the live tree at repo root (NOT the
+  `.claude/worktrees/*` copies).
+
+---
+
+## 1. The principle (what "in the reducer" means)
+
+Four rules. A violation of any is a "loose end":
+
+- **P1 — Single owner.** Each piece of state has exactly ONE authoritative home (a reducer over
+  `HostState` on the host, or the launcher's event-sourced mirror). No second copy that can drift.
+- **P2 — Decide by re-running a pure function, not by edge-triggered ad-hoc checks.** Lifecycle
+  decisions (quit, drain, promote) are pure `fn(&HostState) -> Decision` re-run after EVERY
+  transition — not recomputed independently at each call site with subtly different logic.
+- **P3 — Read the authority; never reconstruct from a lossy stream.** Renderers (and the launcher
+  mirror) reflect authoritative state via reliable snapshots/reconciliation, not by replaying a
+  best-effort incremental event feed that silently drops.
+- **P4 — Type state; don't parse it back out of labels.** Identity/role lives in a typed enum
+  (`BrowserKind`), not reconstructed from `label.starts_with("window-pool-")` string prefixes — which
+  are provably wrong (a promoted pool window keeps its `window-pool-*` label but is no longer a pool
+  window).
+
+The just-merged #1676 lifecycle bug violated P2 (quit decision duplicated/edge-triggered) and P4
+(user-window-ness parsed from label prefixes). The window-count desync violates P3. The audit below
+shows these are not isolated.
+
+---
+
+## 2. The six-headed counter (the canonical evidence)
+
+The lifecycle spec flagged THREE "is this the last user window?" computations. There are **six**, over
+**three different data sources**, each with its own exclusion rule:
+
+| # | Site | Data source | Exclusion rule | Purpose |
+|---|------|-------------|----------------|---------|
+| 1 | `state.rs:1096` `host_counts_snapshot` | CEF `browsers` map | `browser-pane-*` ∪ `floating-pool-*` ∪ pool-set | launcher pool-mirror drift feed |
+| 2 | `state.rs:1178` `user_visibility_snapshot` | `browsers` map | `pool.{unpromoted,queue}` ∪ `pane_pool.{…}` ∪ `browser-pane-*` | on_before_close logging |
+| 3 | `reducer/quit.rs:116` `count_live_user_windows` | `browsers` map | `TopLevel{is_pool:false}` AND not `floating-pool-*` | "authoritative" quit count |
+| 4 | `wrr/win_event.rs:236` `count_visible_user_windows` | **Win32 `EnumWindows`** | `IsWindowVisible` + `Chrome_WidgetWin_` + `x > -20000` pixel heuristic | **the LIVE quit trigger (post-#1676)** |
+| 5 | `saga_dispatch.rs:355` `drain_pool_if_last` | launcher state | `user_count==0 \|\| (==1 && label_present)` | launcher DrainPoolIfLast |
+| 6 | `orphan_reconcile.rs:101` `live_user_count` | **launcher `shadow_window_meta`** | keys minus `browser-pane-*` | orphan reconcile drain |
+
+Three sources (CEF `browsers` map, Win32 enumeration, launcher shadow projection) and four distinct
+exclusion rules computing the *same predicate*. Sites 1 and 3 must hand-mirror each other's
+`floating-pool-*` exclusion via cross-referencing comments (`quit.rs:106` literally points at
+`state.rs:~1121`) — change one, silently desync the other. **This is the single most dangerous SSOT
+violation in the tree.**
+
+---
+
+## 3. Ranked findings
+
+Severity = likelihood × blast-radius of the bug it can cause. 🔴 active/likely bug source, 🟠 real
+drift risk, 🟡 latent debt.
+
+### Track 1 — Lifecycle reducer (the quit/drain/count/typing cluster)
+
+**L1 🔴 — The live quit decision bypasses the reducer entirely (post-#1676).**
+`wrr/win_event.rs::maybe_quit_on_last_user_window` (win_event.rs:284-322) is now the actual quit
+trigger; it calls `cef::quit_message_loop()` (win_event.rs:321) based on a Win32 `EnumWindows` +
+`OFFSCREEN_POOL_THRESHOLD_X=-20000` pixel heuristic (win_event.rs:236-279) and two `static AtomicBool`s
+(`HAD_VISIBLE_USER_WINDOW`, `QUIT_INITIATED`, win_event.rs:218-223). `QuitState` in the reducer
+(`reducer/mod.rs:113`) is **not consulted** for the decision. The `-20000` threshold is itself
+duplicated into `commands/window/lifecycle.rs` (win_event.rs:226-227). Two MORE live exit primitives
+still exist: `client/mod.rs:1186` (on_before_close Stage 2) and `orphan_reconcile.rs:335,406`.
+*This was the correct emergency fix for #1676 (the Views close HIDES rather than firing
+on_before_close, so the reducer never saw the transition) — but the right end-state is to feed that
+HIDE/DESTROY OS signal INTO the reducer as a transition, then let `reconcile_quit` decide, rather
+than fork a parallel coordinate-based authority.*
+→ Owner: `reducer::quit::reconcile_quit` over typed state; the OS hook becomes a transition source, not a decider.
+
+**L2 🔴 — `reconcile_quit`/`should_begin_drain`/`user_creation_in_flight` are built, tested, UNWIRED.**
+`reducer/quit.rs:131-167`, all `#[allow(dead_code)]` (quit.rs:73,130,143,160), zero production callers
+(grep-confirmed: only quit.rs + tests). The level-triggered reconciler the lifecycle spec is built
+around already exists and is dormant; the live paths still edge-trigger (L1). quit.rs:56-60 documents
+the intended wiring as "the explicit next step."
+→ Wire `reconcile_quit(state)` at the tail of the browser-deregister, promote-complete, pane-reap, and
+creation-abort reducer arms; surface a "should exit" signal in `DispatchOutput` consumed by the
+UI-thread exit primitive. **Prerequisite: L4** (`user_creation_in_flight` currently parses pending-
+creation labels because `PendingWindowCreation` has no `source` field — state.rs:104-108).
+
+**L3 🟠 — Six counts, three sources (§2).** Route sites 1, 2, 5 (and ideally 4) through the single
+`reducer::quit::count_live_user_windows` (quit.rs:116; `AppState` already delegates at state.rs:1007).
+Site 6 (`orphan_reconcile`) reads the lagging launcher shadow projection — a genuinely different
+source that disagrees during the promote race; fold its decision into `reconcile_quit`.
+
+**L4 🟠 — Pane-pool has no `BrowserKind` variant → label-prefix classification in the hot path.**
+`BrowserKind` (state.rs:242-249) is `TopLevel{is_pool}` | `Pane{block_id}` — no pane-pool variant. So
+`floating-pool-*` windows register as `TopLevel{is_pool:false}` (classifier at client/mod.rs:434-446
+only special-cases `window-pool-`), indistinguishable BY TYPE from real user windows — only the
+`floating-pool-` label prefix separates them. This is the literal cause of the #1676 reagent P0. And
+the **promoted-pool trap** (P4): `PopAndPromoteFrontPoolWindow` flips `is_pool=false` (pool.rs:104-106)
+but the label stays `window-pool-*` forever, so prefix-classifying a `window-pool-*` label as "pool"
+is wrong for promoted windows — documented at quit.rs:83-85, client/mod.rs:993-996,
+orphan_reconcile.rs:709-725, yet prefix logic persists at ~20 sites (enumerated in the audit; key
+hot-path ones: client/mod.rs:440/1101/1345, quit.rs:75-77/110, state.rs:1122-1124, saga_dispatch.rs:367,
+orphan_reconcile.rs:104/302-304, meta.rs:111, motion.rs:411/435, lifecycle.rs:478).
+→ Extend `BrowserKind` with a pane-pool variant (lifecycle spec §5.2/§10.3). Then L3's `floating-pool-`
+exclusions disappear (they become a typed match) and L2's `user_creation_in_flight` can read a typed
+`source`. **This is the keystone prerequisite for L2/L3.**
+
+**L7 🟡 — H.6 top-level creation runner built, fully dormant.** `HostState.top_level_creation`
+(mod.rs:123), all of `reducer/top_level.rs`, the `EnqueueTopLevelWindow`/`PostCreateWindow` machinery —
+implemented + tested, **never dispatched** (every create calls `ui_tasks::post_create_window` directly:
+drag.rs:506, floating_pane.rs:353, window/creation.rs:376, window_pool.rs:389/1401; mod.rs:116-121
+admits "DORMANT"). It is the designed owner of "user creation in flight" (`InFlightCreation.source:
+TopLevelSource`, state.rs:333) — exactly L2's prerequisite, typed instead of prefix-matched. Wire it
+WITH L2 or not at all (a half-wired runner is worse).
+
+**L8 🟡 — `orphan_reconcile` is a second drain authority over a third data source.** It recomputes
+`begin_drain` (orphan_reconcile.rs:145-147) and independently dispatches `BeginDrain`/`quit_message_loop`
+(orphan_reconcile.rs:335,346,406) off the launcher's `HostShouldQuit`, counting from `shadow_window_meta`.
+Its in-flight/`freshly_promoted` guards (orphan_reconcile.rs:122-147) are load-bearing and MUST be
+preserved when folding its drain branch into `reconcile_quit` (lifecycle spec §10.2). Note the B.9.3
+history: launcher-side `HostShouldQuit`/`DrainPoolIfLast` is documented ADVISORY — likely redundant
+once the host self-reconciles (do NOT re-propose launcher quit authority — it was tried + demoted).
+
+### Track 2 — HWND/role registry (the drag/redock cluster)
+
+**R5 🟠 — Redock target resolution reconstructs labels from prefixes + side channels.**
+`resolve_window_at_cursor` (motion.rs:272+) classifies each HWND under the cursor every drag-frame by
+`window-pool-` prefix + `backend_window_id` presence + an `is_main_frame` heuristic
+(motion.rs:410-430), with a special "unregistered pool label on the main frame → promoted, renderer is
+'main'" case (motion.rs:415-419) and `starts_with("floating-")` exclusion (motion.rs:435). The memory
+`reference_redock_onto_main_pool_mislabel.md` records this exact reconstruction silently failing
+(redock-onto-main no-op); `ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` names it recurring
+regression root cause #1.
+→ Owner: a reducer holding `label ↔ outer-HWND ↔ role` so the walk looks role up by HWND.
+
+**R6 🟠 — `window_hwnds` HWND cache is an uncoupled `Mutex<HashMap>` on `AppState`.**
+`AppState.window_hwnds: Mutex<HashMap<String,isize>>` (state.rs:822), authoritative for window
+resolution (consulted first, lifecycle.rs:260-281), populated by `capture_hwnd_for_label`
+(lifecycle.rs:462,492) with no transactional coupling to the `browsers` map or pool promotion. The
+fallback capture (lifecycle.rs:468-495) picks "first eligible visible HWND" with an off-screen skip
+gated on the `window-pool-` prefix (lifecycle.rs:478) — the class of bug behind PR #1165
+(`window_hwnds["main"]` bound to a warm-pool HWND → drag/close no-op, memory
+`reference_window_drag_pool_hwnd_bug.md`). Capture, promotion, and HWND-cache writes are three
+separate locks → a promoted window's HWND can cache under the wrong label.
+→ Owner: a reducer map mutated atomically with `RegisterBrowser`/`PromotePoolWindow` (the
+`pane_window_states` reducer, mod.rs:142, already proves the pattern). *Caveat: the cache's EXISTENCE
+is defensible (CEF Views hides the main HWND; `host.window_handle()` returns an inner WS_CHILD,
+lifecycle.rs:442-454). The violation is that it is authoritative AND uncoupled, not that it exists.*
+
+### Track 3 — Reliable launcher→renderer delivery
+
+**D-count 🔴 — the window-count desync.** Per-renderer reconstruction from a lossy versioned stream
+with a log-only gap handler and a dev-gated reconcile path. Fully specified in
+`SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md` §8-11 (the resync-on-gap fix). Owner: renderers
+reconcile against the authoritative `list_window_instances` on a detected gap.
+
+**D-srv 🟡 — latent twin.** `srv-events.ts` shares the same lossy `PerSourceTracker` + log-only gap
+handling but has ZERO production consumers today; it becomes a desync risk the moment an srv
+atom-router subscribes. Apply the same resync-on-gap then, paired with an srv `GetSnapshot`/`Resync`
+(unbuilt Phase D). Flagged to prevent a silent future regression.
+
+---
+
+## 4. What is FINE as-is (explicitly not loose ends)
+
+So the consolidation doesn't over-reach:
+- The drag reducer (`active_drag` in `HostState`, drag.rs), pane-lifecycle/pane-window-placement
+  reducers (`browser_panes`, `pane_window_states`), and the browser registry (`browsers` map, fully
+  migrated into `HostState`, H.2.e complete) — correctly reducer-owned.
+- The launcher pool/window **mirror** + `DriftDetected{Pool}/{Windows}` (launcher/reducer/pool.rs:15-61,
+  window.rs:68-265) — correctly event-sourced and host-authoritative; it's a DETECTOR, not a second
+  authority. The loose end is the bespoke `host_counts_snapshot` FEED (L3), not the mirror.
+- Agent-document / pane stores fed by the WPS broker ring — self-healing by design (the ring persists
+  and replays on subscribe, `useAgentStream.ts:226-289`). Fundamentally different from the monotonic
+  `PerSourceTracker` pipes; not a version-gap risk.
+
+---
+
+## 5. Sequencing (dependency-ordered)
+
+1. **D-count (Track 3)** — ship now; it fixes the reported user-visible bug and is low-risk (wires
+   existing pieces). Rides with the close-fix (already done).
+2. **L4 (typed pane-pool `BrowserKind`)** — the keystone; unblocks L2/L3 and removes ~20 prefix sites.
+3. **L3 (single counter)** — collapse the six counts onto `count_live_user_windows` once L4 makes the
+   exclusions typed.
+4. **L2 + L7 (wire `reconcile_quit` + H.6)** — make the quit/creation decision level-triggered and
+   reducer-owned; requires L4's typed `source`.
+5. **L1 (retire the win_event parallel authority)** — feed HIDE/DESTROY into the reducer as a
+   transition; delete the pixel-coordinate heuristic once `reconcile_quit` observes the transition.
+   Do this LAST (it's the live quit path — must not regress #1676).
+6. **L8 (fold orphan_reconcile drain into reconcile_quit, preserving guards).**
+7. **Track 2 (R5/R6)** — separable; tackle after Track 1 stabilizes. Would also kill the recurring
+   drag/redock HWND regressions.
+
+Each step is independently shippable and independently testable.
+
+## 6. Hard constraints (from the lifecycle spec §10 adversarial review — do NOT relitigate)
+- `reconcile_quit` must be a PURE decider (`fn(&mut HostState)`); it must NOT call `quit_message_loop()`
+  (UI-thread-only; off-thread = silent no-op = the v0.33.492 bug) and must NOT re-lock `host_state`
+  (non-reentrant; v0.33.498 deadlock). Exit primitive stays UI-thread; off-UI transitions use
+  `PostThreadMessage(WM_QUIT)`.
+- Launcher-side single quit authority was tried (B.9.3) and demoted — `HostShouldQuit` is ADVISORY.
+  "Single authority" means HOST-side. Don't re-propose launcher authority.
+- Preserve `orphan_reconcile`'s in-flight/freshly-promoted guards; the New-Window + last-close corner
+  must NOT quit.
+- Extend `BrowserKind`; do not invent a parallel `WindowRole` taxonomy.
+
+## 7. Testing (depends on the CI runner)
+These consolidations are exactly what the absent CI test runner
+(`SPEC_CI_TEST_RUNNER_2026_06_22.md`) must cover: the keystone is a **host-reducer integration test**
+asserting `reconcile_quit` over synthetic transition sequences (open → promote → close-last →
+new-window-mid-close → …) reaches the right `QuitState`. The end-to-end "tree exits" check stays a
+local smoke (CI can't drive live CEF). Land the reducer tests alongside each step above so the
+#1676-class regression cannot recur silently.

--- a/docs/specs/SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md
+++ b/docs/specs/SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md
@@ -1,0 +1,163 @@
+# SPEC — Stale window count "(N)" after closing a Views window
+
+- **Status:** Draft → implementing (Part 1 close-fix done + smoked; Part 2 delivery-resync designed)
+- **Date:** 2026-06-22
+- **Two causes:** Part 1 (§1-7) — a missing *emit* (the close was never reported). Part 2 (§8-11) —
+  a lossy *delivery* (the report was dropped on the wire and never reconciled). The user-visible
+  count is only correct once BOTH are fixed.
+- **Author:** AgentA
+- **Sibling of:** #1676 / `SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md` / Discussion #1680
+  (same root cause; this is the per-window *count* symptom, distinct from the last-window *quit*).
+- **Reproduced by:** user (this machine) + another agent (another machine) — open 2 windows, close
+  one → status bar next to the version still shows `(2)` though only 1 window remains.
+
+---
+
+## 1. Symptom
+
+With 2 windows open the status bar shows `(2)` (StatusBar.tsx renders `({windowCount()})` when
+`windowCount() > 1`). Close one window → 1 remains, but the bar **still shows `(2)`** — the count
+does not decrement.
+
+## 2. Root cause (same as #1676)
+
+The count flows:
+
+```
+StatusBar "(2)"  ←  windowCountAtom  ←  setWindowCountAtom(state.instances.length)   (launcher-event-reducer.ts:104)
+                     state.instances  ←  launcher WindowOpened / WindowClosed events
+                     WindowClosed     ←  launcher_ipc::report_window_closed(label)   (host)
+                     report_window_closed  ←  client::on_before_close (client/mod.rs:888)
+```
+
+The Views window close **HIDES/recycles** the window (warm pool) instead of destroying the browser,
+so **`on_before_close` never fires** (confirmed for #1676, and here: closing the window logged
+`Unregistered browser: floating-*` for its tear-offs but **no** `Unregistered browser: window-*`).
+Therefore `report_window_closed` never fires → the launcher never emits `WindowClosed` → the
+frontend's `state.instances` keeps the closed window → `windowCountAtom` is stale.
+
+`on_before_close` was the **only** caller of `report_window_closed`. The window ✕
+(`getApi().closeWindow()` → `close_window` RPC) does the close but does **not** report it — it relied
+on `on_before_close` to do so. On a Views recycle-on-close that link is dead.
+
+## 3. Fix
+
+Report the close from the path that *knows* the user closed the window — the `close_window` RPC
+(`commands/window/lifecycle.rs`) — instead of relying on the dead `on_before_close`:
+
+```rust
+pub fn close_window(state, args) -> Result<...> {
+    let label = args.get("label")...unwrap_or("main");
+    // The Views recycle-on-close path won't fire on_before_close, which is the
+    // only other caller of report_window_closed — so report the logical close
+    // here so the launcher emits WindowClosed and the frontend's window count
+    // ("(N)") decrements. Idempotent on the launcher (no-op on unknown/already-
+    // removed labels), so harmless if on_before_close DOES fire (real destroy).
+    // Skip browser-pane-* (same gate as on_before_close, client/mod.rs:887).
+    if !label.starts_with("browser-pane-") {
+        crate::launcher_ipc::report_window_closed(label.to_string());
+    }
+    ... existing close (post_close_window / WM_CLOSE fallback) ...
+}
+```
+
+- **Scope:** `close_window` only (the window ✕). `close_window_by_label` (tear-off merge + floater
+  close) targets windows with *real* HWNDs whose `WM_CLOSE` → `on_before_close` *does* fire, so they
+  already report; not changed here (revisit if a floater-count symptom shows up).
+- **Idempotency / double-report:** `report_window_closed` is paired with `WindowOpened` and the
+  launcher silently no-ops unknown/already-removed labels (codex P2 #577), so an extra report (if
+  `on_before_close` later fires on a genuine destroy) is harmless.
+
+## 4. Edge cases to verify in smoke
+
+1. **Decrement:** 2 windows → close 1 → `(2)` → `(1)` (the bug).
+2. **Recycle → reopen:** after the close, open another window → does `report_window_opened` re-fire
+   (pool promote / on_after_created) so the count goes back to `(2)`? (If recycle reuses the browser
+   WITHOUT re-emitting `WindowOpened`, the count could undercount on reopen — verify; if broken,
+   escalate to §6 alt.)
+3. **Last window:** close the final window → count → `(0/1)` AND the instance still quits cleanly
+   (the #1676 path — must not regress).
+4. **Tear-offs:** floaters open/close during the sequence don't skew the *window* count.
+
+## 5. Out of scope / non-goals
+- The quit-on-last-window behavior (#1676, merged) — must not regress; this only fixes the count.
+- Floater/tear-off counting semantics (floaters are sub-windows, not instances).
+
+## 6. Alternative considered (if §4.2 fails)
+Drive `windowCountAtom` from the **OS-visible window count** the win_event hook already computes for
+the quit gate (`count_visible_user_windows`) — report it to the frontend on every
+HIDE/SHOW/CREATE/DESTROY. Robust (reflects actual visible windows, no event-pairing/recycle issues)
+but a larger change (new host→frontend reporting path). Prefer the minimal §3 fix unless reopen
+undercounts.
+
+## 7. Verification
+Build a portable, reproduce (2 windows → close 1 → expect `(1)`), then exercise §4.2-4.4. The live
+repro instance from the bug report is a ready baseline.
+
+---
+
+# Part 2 — the deeper cause: lossy per-renderer event delivery (the "3 vs 4" desync)
+
+## 8. Second symptom + root cause
+
+Smoking the Part-1 fix surfaced a DISTINCT bug: with 3 windows open, one window showed `(3)`
+(correct) while two showed `(4)`. The host accounting was CORRECT — `report_window_opened: 4`,
+`report_window_closed: 1` → net 3 (Part 1's close-fix working). The DISPLAY disagreed **per-renderer**.
+
+Root cause: `windowCountAtom = state.instances.length` is reconstructed **independently in every
+renderer** from a VERSIONED but LOSSY launcher event stream (`window.__agentmux_launcher_event(json)`;
+host side `agentmux-cef/src/launcher_event_bridge.rs`). The frontend consumer
+(`frontend/util/event-buffer.ts`, `PerSourceTracker.deliver`) detects two conditions:
+- **gap (missed events):** `event-buffer.ts:243-247` → the default `onVersionGap` handler
+  (`event-buffer.ts:162-168`) **only `console.warn`s** ("version gap: expected X, got Y"), then
+  advances `lastVersion` and accepts the new event — **the skipped events are gone forever**.
+- **stale (out-of-order):** `event-buffer.ts:235-240` drops (fine — idempotent).
+
+There is **no production `onVersionGap` callback** — every live tracker (`launcher-events.ts:49-56`,
+`srv-events.ts:71-78`) uses the log-only default. So a dropped `WindowClosed` leaves that renderer's
+`knownEntries` (→ `state.instances` → `windowCountAtom`) permanently over-counting. The healing
+machinery EXISTS — `reconcileKnownEntriesFromSnapshot` (`launcher-event-reducer.ts:146` →
+`ReconcileFromSnapshot`, `launcher-event/reducer.ts:272-315`, wholesale add/remove) backed by the
+authoritative `list_window_instances` RPC — but its only caller (`InstancePanel.tsx:91-103`) is gated
+behind `!launcherEventsActive()`, i.e. **dev-mode only; it never runs in production**.
+
+So Part 1 fixes a missing-EMIT cause; Part 2 fixes a dropped-ON-THE-WIRE cause. Both are needed.
+
+## 9. Fix — resync-on-gap (reducer-authoritative reconciliation)
+
+The authoritative window-instance state lives in a reducer (the launcher's `state.windows`, exposed
+via `list_window_instances`). Renderers must RECONCILE against it when they detect they've fallen
+behind, instead of trusting a lossy incremental stream forever.
+
+1. Wire a real `onVersionGap` for the launcher `PerSourceTracker` (`frontend/util/launcher-events.ts:49-56`;
+   the hook exists at `event-buffer.ts:103`, fired at `:246`).
+2. In the callback: re-pull `getApi().listWindowInstances()` → `reconcileKnownEntriesFromSnapshot(snapshot)`
+   (`launcher-event-reducer.ts:146`). The `ReconcileFromSnapshot` arm already does the wholesale
+   add/remove that heals an over- or under-count.
+3. Bypass the dev-only gate (`InstancePanel.tsx:91`) for the gap-triggered reconcile — the whole
+   point is to reconcile AFTER events have been flowing.
+4. **Race guard (codex P1 #733):** snapshot `launcherEventVersion()` before the RPC; discard the
+   reconcile if a newer event landed while the RPC was in flight (don't clobber fresh state with a
+   stale snapshot). Reconcile only on a DETECTED gap, never unconditionally.
+
+This is the minimal robust fix — it wires existing pieces (`onVersionGap` hook + `ReconcileFromSnapshot`
++ `list_window_instances`), no new host reporting path.
+
+### 9.1 Alternative (rejected for now): versioned snapshot push
+Have the bridge push full authoritative instance snapshots (versioned) so a missed incremental
+self-heals on the next snapshot. More robust (no pull RPC, no race window) but a larger host-side
+change. Defer unless resync-on-gap proves insufficient (e.g. gaps frequent enough to cause an RPC
+storm).
+
+## 10. Latent twin
+`srv-events.ts` uses the SAME lossy `PerSourceTracker` with the same log-only gap handling, but
+currently has ZERO production consumers (`subscribeSrvEvent` unused). It becomes the same desync risk
+the moment an atom-router subscribes — apply the same resync-on-gap pattern then, paired with an srv
+`GetSnapshot`/`Resync` RPC (the unbuilt Phase D flow). Flagged so it isn't a silent future regression.
+
+## 11. Relationship to the broader audit
+Per-renderer reconstruction from a lossy stream is one instance of a wider single-source-of-truth
+gap. The full ranked audit (host quit decision bypassing the reducer, 6× window-count computations,
+pane-pool typing, the HWND/role registry, the unwired `reconcile_quit`/H.6 runner) is in
+`SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md`. This count fix is Track 3 (reliable delivery) of
+that document.

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -27,7 +27,8 @@
 
 import { createEffect } from "solid-js";
 
-import { launcherEvent, launcherEventVersion } from "@/util/launcher-events";
+import { launcherEvent, launcherEventVersion, launcherEventGapSeq } from "@/util/launcher-events";
+import { getApi } from "@/store/app-api";
 import {
     setOpenWindowEntriesAtom,
     setOpenWindowLabelsAtom,
@@ -149,6 +150,35 @@ export function reconcileKnownEntriesFromSnapshot(
     dispatch({ type: "ReconcileFromSnapshot", entries });
 }
 
+/**
+ * Re-pull the authoritative window-instance snapshot and reconcile after the
+ * launcher event stream drops one or more events (a detected version gap).
+ *
+ * The stream is best-effort per-renderer dispatch — a dropped `window_closed`
+ * leaves this renderer's `knownEntries` permanently over-counting (the window
+ * count "(N)" never decrements; the observed "3 vs 4" desync). `ReconcileFromSnapshot`
+ * heals it (wholesale add/remove vs the authoritative `list_window_instances`).
+ *
+ * Race guard (mirrors the codex P1 #733 concern that gated the InstancePanel
+ * reconcile to dev-only): capture the event version BEFORE the async RPC; if a
+ * newer typed event lands while the RPC is in flight, that event already
+ * advanced state past the snapshot — discard the reconcile rather than clobber
+ * fresh state with a stale snapshot. We reconcile ONLY on a detected gap, never
+ * unconditionally, so this never fights the normal event flow.
+ * See `docs/specs/SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md` §9.
+ */
+async function resyncFromAuthorityAfterGap(): Promise<void> {
+    const versionAtRequest = launcherEventVersion();
+    try {
+        const snapshot = await getApi().listWindowInstances();
+        if (!Array.isArray(snapshot)) return;
+        if (launcherEventVersion() !== versionAtRequest) return; // raced a newer event — skip
+        reconcileKnownEntriesFromSnapshot(snapshot);
+    } catch (e) {
+        console.error("[launcher-event] gap resync failed", e);
+    }
+}
+
 let started = false;
 
 /**
@@ -176,6 +206,17 @@ export function startLauncherEventReducer(): void {
             applyingRemote = false;
         }
     });
+
+    // Resync-on-gap: the launcher event stream is lossy, and a dropped event
+    // leaves this renderer's `instances` stale forever. When the tracker detects
+    // a version gap it bumps `launcherEventGapSeq`; reconcile against the
+    // authoritative snapshot. Seeded at 0 so the initial run is a no-op (only a
+    // real gap, seq > prev, triggers a resync).
+    createEffect((prevSeq: number) => {
+        const seq = launcherEventGapSeq();
+        if (seq > prevSeq) void resyncFromAuthorityAfterGap();
+        return seq;
+    }, 0);
 }
 
 // ── Test/diagnostics helpers ───────────────────────────────────────────

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -31,12 +31,25 @@ export type LauncherEvent = VersionedEvent;
 const [latestEvent, setLatestEvent] = createSignal<LauncherEvent | null>(null);
 const [eventVersion, setEventVersion] = createSignal<number>(0);
 const [seenAnyEvent, setSeenAnyEvent] = createSignal<boolean>(false);
+const [gapSeq, setGapSeq] = createSignal<number>(0);
 
 /** Latest typed event delivered by the launcher. Null until the first event. */
 export const launcherEvent = latestEvent;
 
 /** Monotonic version of the most recent event. 0 until the first event. */
 export const launcherEventVersion = eventVersion;
+
+/**
+ * Monotonic counter, bumped each time the launcher event stream detects a
+ * VERSION GAP (one or more events dropped on the wire). The per-renderer
+ * incremental `instances` state cannot self-heal from a dropped event — a
+ * missed `window_closed` leaves the window count permanently over-counting
+ * (the "3 vs 4" desync). The launcher-event reducer reacts to this signal by
+ * re-pulling the authoritative `list_window_instances` snapshot and
+ * reconciling. 0 until the first gap.
+ * See `docs/specs/SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md` §9.
+ */
+export const launcherEventGapSeq = gapSeq;
 
 /**
  * True once we've received at least one typed event. Kept as a
@@ -47,7 +60,17 @@ export const launcherEventVersion = eventVersion;
 export const launcherEventsActive = seenAnyEvent;
 
 const tracker = new PerSourceTracker<LauncherEvent>(
-    { source: "launcher" },
+    {
+        source: "launcher",
+        onVersionGap: (gap, prev, next) => {
+            // Keep the diagnostic warning (matches the default handler)…
+            console.warn(
+                `[launcher-events] version gap: expected ${prev + 1}, got ${next} (${gap} event${gap === 1 ? "" : "s"} possibly dropped); scheduling authoritative resync`,
+            );
+            // …and signal the reducer to reconcile against the authority.
+            setGapSeq((n) => n + 1);
+        },
+    },
     {
         setLatest: setLatestEvent,
         setVersion: setEventVersion,


### PR DESCRIPTION
## Summary
Fixes the status-bar window count `(N)` (next to the version) going stale/inconsistent — a sibling of the #1676 lifecycle bug (Discussion #1680), same root cause (CEF Views recycle-on-close), two distinct symptoms.

## Two causes
1. **Missing emit** — closing a Views window HIDES/recycles it, so `on_before_close` (the only caller of `report_window_closed`) never fires → the launcher never emits `WindowClosed` → the count stayed stale (`(2)` with 1 window). **Fix:** `close_window` reports `report_window_closed(label)` itself (idempotent; skips `browser-pane-*`).
2. **Lossy delivery** — each renderer reconstructs the window list from a versioned but best-effort launcher event stream; a dropped event left renderers permanently diverged (`3 vs 4` across windows). The gap detector (`event-buffer.ts`) only logged. **Fix:** a detected version gap bumps `launcherEventGapSeq`; the launcher-event reducer re-pulls the authoritative `list_window_instances` and reconciles (`ReconcileFromSnapshot`), with a version race-guard (the codex P1 #733 concern) so an in-flight event can't be clobbered by a stale snapshot.

## Verification (live, packaged build)
- 3 windows → close 1 → **all** windows converge to `(2)`.
- Minimize last window → **stays alive** (confirmed `IsIconic=True` while the tree is up) — no spurious quit.
- Close-all → clean teardown, no orphans.
- 66 vitest green (launcher-events + event-buffer + reducer); touched files type-clean.

## Specs
- `SPEC_WINDOW_COUNT_STALE_ON_VIEWS_CLOSE_2026_06_22.md` — both causes + fixes.
- `SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md` — the broader single-source-of-truth audit this fix is **Track 3** of (six window-count computations across three data sources, the post-#1676 win_event quit authority that bypasses the reducer, the unwired `reconcile_quit`/H.6 runner, pane-pool typing, the HWND/role registry). Roadmap for follow-ups; this PR ships only Track 3.

Sibling of #1676 · Discussion #1680

<!-- agentmux:agent_id=agenta -->