### PR TITLE
chore: release v0.48.1

### DIFF
--- a/.changesets/1782135271-feat-widgets-per-widget-port-override-and-widget-api-http-pr-0jfw.md
+++ b/.changesets/1782135271-feat-widgets-per-widget-port-override-and-widget-api-http-pr-0jfw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(widgets): per-widget port override and widget.api HTTP proxy RPC

--- a/.changesets/1782139565-docs-portable-correct-readme-data-location-agentmux-versions-ffw5.md
+++ b/.changesets/1782139565-docs-portable-correct-readme-data-location-agentmux-versions-ffw5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(portable): correct README data location (~/.agentmux/versions, not local data/ folder)

--- a/.changesets/1782140264-feat-agent-pane-replace-gradient-sweep-with-marching-ants-pr-wj9z.md
+++ b/.changesets/1782140264-feat-agent-pane-replace-gradient-sweep-with-marching-ants-pr-wj9z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): replace gradient sweep with marching-ants progress bar

--- a/.changesets/1782144434-fix-packaging-purge-inactive-pages-before-ulmo-compression-t-d4eg.md
+++ b/.changesets/1782144434-fix-packaging-purge-inactive-pages-before-ulmo-compression-t-d4eg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(packaging): purge inactive pages before ULMO compression to prevent OOM kill

--- a/.changesets/1782144490-fix-statusbar-wrap-long-data-tip-tooltips-instead-of-overflo-hwjh.md
+++ b/.changesets/1782144490-fix-statusbar-wrap-long-data-tip-tooltips-instead-of-overflo-hwjh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): wrap long data-tip tooltips instead of overflowing the balloon

--- a/.changesets/1782144871-perf-layout-reduce-native-pane-reflow-settle-window-from-32m-yn2c.md
+++ b/.changesets/1782144871-perf-layout-reduce-native-pane-reflow-settle-window-from-32m-yn2c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-perf(layout): reduce native-pane reflow settle window from 32ms to 4ms

--- a/.changesets/1782145929-feat-agent-persist-per-agent-zoom-across-pane-close-reopen-gsqo.md
+++ b/.changesets/1782145929-feat-agent-persist-per-agent-zoom-across-pane-close-reopen-gsqo.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): persist per-agent zoom across pane close/reopen

--- a/.changesets/1782167695-fix-window-accurate-status-bar-window-count-on-close-event-s-uny9.md
+++ b/.changesets/1782167695-fix-window-accurate-status-bar-window-count-on-close-event-s-uny9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): accurate status-bar window count on close + event-stream gaps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,17 @@
 # AgentMux Version History
 
+## 0.48.1 — 2026-06-22
+
+- feat(widgets): per-widget port override and widget.api HTTP proxy RPC
+- docs(portable): correct README data location (~/.agentmux/versions, not local data/ folder)
+- feat(agent-pane): replace gradient sweep with marching-ants progress bar
+- fix(packaging): purge inactive pages before ULMO compression to prevent OOM kill
+- fix(statusbar): wrap long data-tip tooltips instead of overflowing the balloon
+- perf(layout): reduce native-pane reflow settle window from 32ms to 4ms
+- feat(agent): persist per-agent zoom across pane close/reopen
+- fix(window): accurate status-bar window count on close + event-stream gaps
+
+
 ## 0.48.0 — 2026-06-22
 
 - fix(macos): disable MacAppCodeSignClone so packaged app launches from any volume

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release **v0.48.1** (patch). Consumes all 8 pending changesets.

> Note: bump type **forced to patch** via \`task release -- --as patch\` per request. Two minor-level feats (per-widget port override, per-agent zoom persistence) ship under this patch.

## Changelog
- feat(widgets): per-widget port override and widget.api HTTP proxy RPC
- docs(portable): correct README data location (~/.agentmux/channels/<channel>/…)
- feat(agent-pane): replace gradient sweep with marching-ants progress bar
- fix(packaging): purge inactive pages before ULMO compression to prevent OOM kill
- fix(statusbar): wrap long data-tip tooltips instead of overflowing the balloon
- perf(layout): reduce native-pane reflow settle window from 32ms to 4ms
- feat(agent): persist per-agent zoom across pane close/reopen
- fix(window): accurate status-bar window count on close + event-stream gaps

## Version consistency (reagent gate)
All five locations agree at **0.48.1**: package.json, Cargo.toml [workspace.package], Cargo.lock (agentmux-cef), package-lock.json root, VERSION_HISTORY.md head.

<!-- agentmux:agent_id=agentc -->