### PR TITLE
refactor(lifecycle): typed Floater BrowserKind — floaters excluded from quit gate by type

### DIFF
--- a/.changesets/1782171094-fix-lifecycle-typed-floater-browserkind-floaters-excluded-fr-g6fe.md
+++ b/.changesets/1782171094-fix-lifecycle-typed-floater-browserkind-floaters-excluded-fr-g6fe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(lifecycle): typed Floater BrowserKind; floaters excluded from quit gate by type

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -425,18 +425,29 @@ impl AgentMuxHandler {
         // `browser-pane-`). LABEL is the source of truth. See
         // docs/retro/smoke-test-0.33.586-and-pr5-plan-2026-05-02.md.
         //
-        // Classification:
-        //   - label `browser-pane-<uuid>-<seq>` → Pane { block_id: uuid }
-        //   - label `window-pool-*` + still in unpromoted_pool_labels →
-        //     TopLevel { is_pool: true }
+        // Classification (LABEL is the source of truth at registration; after
+        // this the typed `BrowserKind` is authoritative — don't re-parse labels):
+        //   - `browser-pane-<uuid>-<seq>`            → Pane { block_id: uuid }
+        //   - `floating-<uuid>` / `floating-pool-<uuid>` → Floater { is_pool }
+        //       (is_pool=true only while a pane-pool floater is still warm /
+        //        unpromoted; a direct floater registers visible → is_pool:false)
+        //   - `window-pool-*` still unpromoted        → TopLevel { is_pool: true }
         //   - everything else (main, window-*, promoted pool windows) →
         //     TopLevel { is_pool: false }
+        // Floaters get their own variant so the last-window quit gate excludes
+        // them BY TYPE (invariant FP-LIFE) instead of a `floating-pool-` string
+        // check that missed direct `floating-<uuid>` floaters. Check `floating-`
+        // BEFORE `window-pool-` (a `floating-pool-` label also starts `floating-`).
         let kind = if let Some(rest) = label.strip_prefix("browser-pane-") {
             let block_id = rest
                 .rfind('-')
                 .map(|i| rest[..i].to_string())
                 .unwrap_or_default();
             crate::state::BrowserKind::Pane { block_id }
+        } else if label.starts_with("floating-") {
+            let is_pool = label.starts_with("floating-pool-")
+                && self.state.is_unpromoted_pane_pool_label(&label);
+            crate::state::BrowserKind::Floater { is_pool }
         } else if label.starts_with("window-pool-")
             && self.state.is_unpromoted_pool_label(&label)
         {

--- a/agentmux-cef/src/reducer/pane_pool.rs
+++ b/agentmux-cef/src/reducer/pane_pool.rs
@@ -66,9 +66,12 @@ pub(super) fn handle_pop_and_promote_front_pane_pool_window(state: &mut HostStat
         None => return DispatchOutput::default(),
     };
     state.pane_pool.unpromoted.remove(&label);
-    // Mark the BrowserHandle as no longer a pool window.
+    // Mark the BrowserHandle as no longer a warm pane-pool floater. Pane-pool
+    // windows are `BrowserKind::Floater` (NOT TopLevel) — a promoted floater is
+    // still a Floater, just `is_pool: false`. It remains excluded from the
+    // last-window quit gate by type (invariant FP-LIFE).
     if let Some(handle) = state.browsers.get_mut(&label) {
-        if let BrowserKind::TopLevel { is_pool } = &mut handle.kind {
+        if let BrowserKind::Floater { is_pool } = &mut handle.kind {
             *is_pool = false;
         }
     }

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -78,13 +78,19 @@ fn is_background_pending_creation_label(label: &str) -> bool {
 }
 
 /// Whether a registered browser is a live, user-visible top-level window — one
-/// that keeps the instance alive. The authoritative signal is the per-browser
-/// `BrowserKind::is_pool` flag, flipped `false` atomically at promote time
-/// (`pool.rs`). We must NOT classify by label here: a PROMOTED pool window keeps
-/// its `window-pool-` label forever yet IS the user's real window — classifying
-/// by label would drop it and quit with a window open (reagent P1 #1676).
-/// Unpromoted pool windows are `is_pool: true`; panes are `BrowserKind::Pane`;
-/// both are correctly excluded by the `is_pool: false` match.
+/// that keeps the instance alive. Decided PURELY BY TYPE (`BrowserKind`), never
+/// by label-prefix string:
+/// - `TopLevel { is_pool: false }` → YES (the user's real windows, including a
+///   PROMOTED pool window which keeps its `window-pool-` label forever yet IS a
+///   real window — classifying by label would drop it and quit with a window
+///   open, reagent P1 #1676).
+/// - `TopLevel { is_pool: true }` (warm window pool) → no.
+/// - `Floater { .. }` (floating panes / tear-offs, `floating-`/`floating-pool-`)
+///   → no — floaters die with the last top-level window (invariant FP-LIFE;
+///   docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md §1.1).
+///   This replaced a `!label.starts_with("floating-pool-")` string check that
+///   missed direct `floating-<uuid>` floaters (SPEC_REDUCER_SSOT_CONSOLIDATION L4).
+/// - `Pane { .. }` (browser-pane children) → no.
 ///
 /// `pub(crate)` + re-exported from `reducer` so the live last-window quit gate
 /// (`AppState::count_live_user_windows`, used by `client::on_before_close`) shares
@@ -93,31 +99,15 @@ pub(crate) fn is_live_user_window(kind: &BrowserKind) -> bool {
     matches!(kind, BrowserKind::TopLevel { is_pool: false })
 }
 
-/// Whether a REGISTERED browser (label + kind) counts as a live, user-visible
-/// top-level window for the last-window quit gate.
-///
-/// `is_live_user_window` handles the per-browser `is_pool` flag (the window
-/// pool), but **pane-pool** windows (`floating-pool-*`) register as
-/// `TopLevel { is_pool: false }` — the `on_after_created` classification only
-/// special-cases `window-pool-`, and `PanePoolState` has no `is_pool` flag — so
-/// the flag alone would count the always-seeded warm pane-pool window
-/// (macOS/Linux `init_pane_pool`, `PANE_POOL_TARGET_SIZE = 1`) as a real user
-/// window, and the gate would never reach 0 (reagent P0 #1676). Exclude them by
-/// label, matching the canonical `compute_and_report_host_counts` exclusion
-/// (state.rs:~1121). A PROMOTED `window-pool-*` window (is_pool:false, still
-/// `window-pool-` labelled) correctly still counts.
-pub(crate) fn counts_as_live_user_window(label: &str, kind: &BrowserKind) -> bool {
-    is_live_user_window(kind) && !label.starts_with("floating-pool-")
-}
-
 /// Count of live, user-visible top-level windows — the windows that keep the
 /// instance alive. Live last-window quit gate via `AppState::count_live_user_windows`
 /// → `client::on_before_close` and `wrr::win_event::maybe_quit_on_last_user_window`.
+/// Excludes pool windows, floaters, and panes BY TYPE (`is_live_user_window`).
 pub(crate) fn count_live_user_windows(state: &HostState) -> usize {
     state
         .browsers
-        .iter()
-        .filter(|(label, h)| counts_as_live_user_window(label, &h.kind))
+        .values()
+        .filter(|h| is_live_user_window(&h.kind))
         .count()
 }
 

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -816,34 +816,32 @@ fn queued_background_does_not_start_after_drain_begins() {
 // `reconcile_quit` decision so a gate regression can't ship silently again.
 
 use super::quit::{
-    counts_as_live_user_window, is_live_user_window, reconcile_quit, should_begin_drain,
-    user_creation_in_flight,
+    is_live_user_window, reconcile_quit, should_begin_drain, user_creation_in_flight,
 };
 
-/// reagent P0 #1676: a pane-pool window (`floating-pool-*`) registers as
-/// `TopLevel{is_pool:false}` (classification only special-cases `window-pool-`),
-/// so the is_pool flag alone counts it as a user window. `counts_as_live_user_window`
-/// must exclude it by label so the always-seeded warm pane-pool window on
-/// macOS/Linux doesn't pin the last-window quit gate above 0.
+/// The last-window quit gate is decided PURELY BY TYPE (`is_live_user_window`),
+/// never by label-prefix string (SPEC_REDUCER_SSOT_CONSOLIDATION L4). Floaters
+/// (both `floating-<uuid>` and `floating-pool-<uuid>`) are `BrowserKind::Floater`
+/// and never keep the instance alive (invariant FP-LIFE) — this replaced a
+/// `!starts_with("floating-pool-")` string check that wrongly counted direct
+/// `floating-<uuid>` floaters (and the reagent P0 #1676 where warm pane-pool
+/// windows pinned the gate above 0 on macOS/Linux).
 #[test]
-fn counts_as_live_user_window_excludes_floating_pool() {
+fn is_live_user_window_counts_only_top_level_by_type() {
     use crate::state::BrowserKind;
-    let user = BrowserKind::TopLevel { is_pool: false };
-    // Real user windows count — main, and a promoted window-pool window that
-    // keeps its `window-pool-` label (is_pool flipped false on promote).
-    assert!(counts_as_live_user_window("main", &user));
-    assert!(counts_as_live_user_window("window-pool-abc", &user));
-    // Warm pane-pool window: is_pool:false but floating-pool- → must NOT count.
-    assert!(!counts_as_live_user_window("floating-pool-xyz", &user));
-    // Unpromoted window-pool (is_pool:true) and panes never count.
-    assert!(!counts_as_live_user_window(
-        "window-pool-abc",
-        &BrowserKind::TopLevel { is_pool: true }
-    ));
-    assert!(!counts_as_live_user_window(
-        "browser-pane-1",
-        &BrowserKind::Pane { block_id: "b1".into() }
-    ));
+    // Real user windows: main + a promoted window-pool window (keeps its
+    // `window-pool-` label, is_pool flipped false on promote) → both count.
+    assert!(is_live_user_window(&BrowserKind::TopLevel { is_pool: false }));
+    // Warm window pool → not a user window.
+    assert!(!is_live_user_window(&BrowserKind::TopLevel { is_pool: true }));
+    // Floaters NEVER count — warm pane-pool AND promoted/direct floaters alike,
+    // regardless of is_pool. Excluded by type, not by label.
+    assert!(!is_live_user_window(&BrowserKind::Floater { is_pool: true }));
+    assert!(!is_live_user_window(&BrowserKind::Floater { is_pool: false }));
+    // Browser-pane children never count.
+    assert!(!is_live_user_window(&BrowserKind::Pane {
+        block_id: "b1".into()
+    }));
 }
 
 /// Registered browsers are classified by the authoritative `is_pool` flag, NOT

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -240,9 +240,19 @@ impl std::fmt::Debug for BrowserHandle {
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum BrowserKind {
-    /// Top-level window. `is_pool=true` while the window is in the warm
-    /// pool; cleared on promote.
+    /// Top-level window (`main`, `window-*`, and the window pool). `is_pool=true`
+    /// while the window is in the warm window pool; cleared on promote. This is
+    /// the ONLY kind that keeps the instance alive — see `is_live_user_window`.
     TopLevel { is_pool: bool },
+    /// Floating pane / tear-off in its own frameless `WS_POPUP` window —
+    /// `floating-<uuid>` (created directly) or `floating-pool-<uuid>` (taken from
+    /// the pane pool). `is_pool=true` while warm in the pane pool; cleared on
+    /// promote (`pane_pool.rs`). Floaters do **not** keep the instance alive
+    /// (invariant FP-LIFE) — `is_live_user_window` counts only
+    /// `TopLevel { is_pool: false }`, so a Floater is excluded by type, not by a
+    /// label-prefix string. They ARE trusted top-level renderers, so
+    /// `list_top_level_browsers` includes them for host JS-event emission.
+    Floater { is_pool: bool },
     /// Browser pane child window. `block_id` correlates with the
     /// `HostState.browser_panes` entry.
     Pane { block_id: String },
@@ -980,17 +990,24 @@ impl AppState {
             .collect()
     }
 
-    /// Snapshot of TOP-LEVEL browsers only — excludes `BrowserKind::Pane`
-    /// child browsers whose main frame is loading untrusted remote
-    /// content. Callers emitting JS-injected host events must use this
-    /// (or `emit_event_to_window`) so a hostile page in one pane can't
-    /// observe events meant for the host frontend.
+    /// Snapshot of top-level + floater browsers — excludes only `BrowserKind::Pane`
+    /// child browsers whose main frame is loading untrusted remote content.
+    /// Floaters render the trusted frontend (`FloatingPaneWorkspace`), so they
+    /// ARE included (they need host JS events); only `Pane` children are excluded.
+    /// Callers emitting JS-injected host events must use this (or
+    /// `emit_event_to_window`) so a hostile page in one pane can't observe events
+    /// meant for the host frontend.
     pub fn list_top_level_browsers(&self) -> Vec<(String, Browser)> {
         self.host_state
             .lock()
             .browsers
             .iter()
-            .filter(|(_, h)| matches!(h.kind, BrowserKind::TopLevel { .. }))
+            .filter(|(_, h)| {
+                matches!(
+                    h.kind,
+                    BrowserKind::TopLevel { .. } | BrowserKind::Floater { .. }
+                )
+            })
             .map(|(k, h)| (k.clone(), h.browser.clone()))
             .collect()
     }
@@ -999,11 +1016,14 @@ impl AppState {
     /// last-window quit gate (`client::on_before_close` +
     /// `wrr::win_event::maybe_quit_on_last_user_window`). Delegates to
     /// `reducer::count_live_user_windows`, which counts registered
-    /// `BrowserKind::TopLevel { is_pool: false }` browsers EXCEPT `floating-pool-*`
-    /// (pane-pool windows register as is_pool:false but must be excluded — see
-    /// `reducer::counts_as_live_user_window`). Promoted `window-pool-*` windows
-    /// (is_pool:false, still `window-pool-` labelled) correctly count. Single
-    /// host_state lock. See SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md §5.1/§10.1.
+    /// `BrowserKind::TopLevel { is_pool: false }` browsers ONLY. Floaters are a
+    /// distinct `BrowserKind::Floater` and do NOT count (invariant FP-LIFE — they
+    /// die with the last top-level window); warm window-pool windows are
+    /// `is_pool: true` and don't count; promoted `window-pool-*` windows
+    /// (`is_pool: false`, still `window-pool-` labelled) correctly count. No
+    /// label-prefix strings — excluded purely by type. Single host_state lock.
+    /// See SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md §5.1/§10.1 +
+    /// SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md (L4).
     pub fn count_live_user_windows(&self) -> usize {
         // Delegate to the reducer's pure counter under one lock (deref-coerces
         // the guard to &HostState) — single counting implementation.
@@ -1144,6 +1164,15 @@ impl AppState {
     /// `client.rs::on_after_created` BrowserKind classification.
     pub fn is_unpromoted_pool_label(&self, label: &str) -> bool {
         self.host_state.lock().pool.unpromoted.contains(label)
+    }
+
+    /// Single-label check against the unpromoted PANE-pool set. Mirror of
+    /// `is_unpromoted_pool_label` for `floating-pool-*` windows — used by
+    /// `client.rs::on_after_created` to classify a warm pane-pool floater as
+    /// `Floater { is_pool: true }` (a promoted one, no longer in the set, is
+    /// `is_pool: false`).
+    pub fn is_unpromoted_pane_pool_label(&self, label: &str) -> bool {
+        self.host_state.lock().pane_pool.unpromoted.contains(label)
     }
 
     /// Number of pool windows currently in the renderer-ready queue

--- a/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
+++ b/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
@@ -38,6 +38,34 @@ Every regression in this area is an instance of one of these five themes:
 
 ---
 
+## 1.1 Lifecycle policy — **floaters do NOT keep the instance alive**
+
+**Invariant FP-LIFE: a floating pane dies with the last top-level window.** Closing the last
+`main`/`window-*` (real top-level) window quits the instance even if one or more floaters are still
+open — they are torn down with it. A floater is never the sole thing keeping the process tree alive.
+
+**Why.** A floater is part of the user's session, not an independent instance. The #1676 win_event
+last-window quit trigger (`count_visible_user_windows`) already excludes floaters by window-class, so
+at the OS-quit level this has always been the behavior; this invariant makes the *reducer count*
+agree — it previously, accidentally, counted direct `floating-<uuid>` floaters as instance-keeping
+windows but **not** `floating-pool-<uuid>` ones (same user-facing thing, opposite behavior, decided
+purely by which code path created the floater).
+
+**How it's enforced — by TYPE, not by label.** Floaters are their own `BrowserKind::Floater` variant
+(warm pane-pool = `is_pool: true`, promoted/visible = `is_pool: false`). The last-window gate
+`reducer::quit::is_live_user_window` counts only `TopLevel { is_pool: false }`, so **all** floaters
+are excluded *by type*, regardless of `floating-<uuid>` vs `floating-pool-<uuid>` labeling. This
+replaced a fragile `!label.starts_with("floating-pool-")` string check. See
+`SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md` (finding L4) and
+`SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md`.
+
+**If this ever changes** (e.g. "a *visible* floater should keep the instance alive"), it is a
+deliberate decision that MUST update BOTH the win_event quit trigger (`count_visible_user_windows`)
+AND the reducer count together — never just one, or they desync (which is the bug class this whole
+doc exists to prevent).
+
+---
+
 ## 2. Operation flows (frontend → host)
 
 ### 2.1 Tear-off (docked pane → floater)

--- a/docs/specs/SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md
+++ b/docs/specs/SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md
@@ -112,6 +112,25 @@ orphan_reconcile.rs:104/302-304, meta.rs:111, motion.rs:411/435, lifecycle.rs:47
 exclusions disappear (they become a typed match) and L2's `user_creation_in_flight` can read a typed
 `source`. **This is the keystone prerequisite for L2/L3.**
 
+**Chosen design (2026-06-22) — a typed `Floater` variant, not just pane-pool.** Investigation showed
+the gap is broader: there are TWO floater labelings (`floating-<uuid>` direct, `floating-pool-<uuid>`
+pane-pool), and the count gate only excluded `floating-pool-` — so direct floaters were *accidentally*
+counted as instance-keeping windows while pane-pool floaters were not (same user-facing thing,
+opposite behavior). The fix:
+- Add `BrowserKind::Floater { is_pool }` (warm pane-pool = `is_pool: true`; promoted/visible =
+  `is_pool: false`, flipped at the `pane_pool.rs` promote handler).
+- Classify BOTH `floating-` and `floating-pool-` into `Floater`.
+- `is_live_user_window` stays `matches!(kind, TopLevel { is_pool: false })` → **all** floaters are
+  excluded *by type*; the `!starts_with("floating-pool-")` string check is deleted, and
+  `counts_as_live_user_window` collapses back into `is_live_user_window` (no label needed).
+- **Policy CANONIZED:** floaters do NOT keep the instance alive (invariant **FP-LIFE**,
+  `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` §1.1), aligning the reducer
+  count with the win_event quit trigger that already excludes floaters by class. User-confirmed
+  2026-06-22.
+- Out of scope for this slice (separate concerns, left label-based for now): `host_counts_snapshot`
+  (must match the launcher mirror's report-driven count, NOT the keep-alive policy) and the
+  `pending_window_creations` prefix classifier (pre-registration — no `BrowserKind` exists yet).
+
 **L7 🟡 — H.6 top-level creation runner built, fully dormant.** `HostState.top_level_creation`
 (mod.rs:123), all of `reducer/top_level.rs`, the `EnqueueTopLevelWindow`/`PostCreateWindow` machinery —
 implemented + tested, **never dispatched** (every create calls `ui_tasks::post_create_window` directly:


### PR DESCRIPTION
## Summary
SSOT keystone (Track 1 / finding **L4** of `SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md`): give floaters a typed `BrowserKind::Floater` variant so the last-window quit gate excludes them **by type**, not by a fragile label-prefix string.

## The bug it fixes
Floaters had no `BrowserKind` variant — `floating-*` registered as `TopLevel { is_pool: false }`, and the count gate only excluded `floating-pool-`. So:
- `floating-<uuid>` (direct floater) → **counted** as an instance-keeping window
- `floating-pool-<uuid>` (pane-pool floater) → **excluded**

Same user-facing thing (a torn-off floating pane), opposite keep-alive behavior, decided purely by which code path created it.

## Change
- `BrowserKind::Floater { is_pool }` — both floater labelings classify into it; pane-pool promote flips `is_pool`.
- `is_live_user_window` = `matches!(kind, TopLevel { is_pool: false })` → floaters excluded **by type**; the `!starts_with("floating-pool-")` string and `counts_as_live_user_window` are removed.
- `list_top_level_browsers` now includes `Floater` (floaters are trusted renderers needing host JS events — the `matches!` site that would have silently broken floater event delivery).
- New `is_unpromoted_pane_pool_label` (mirror of `is_unpromoted_pool_label`).

## Policy — canonized
**Invariant FP-LIFE: floaters die with the last top-level window** — `ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` §1.1 (user-confirmed). Aligns the reducer count with the #1676 win_event quit trigger, which already excludes floaters by window-class. The doc records that changing this must touch BOTH the win_event trigger and the reducer count together.

## Scope / out of scope
- `host_counts_snapshot` (launcher-mirror feed) and the `pending_window_creations` prefix classifier are deliberately left label-based — separate concerns (noted in spec L4).
- L4 of the roadmap; L2 (wire `reconcile_quit`), L3 (collapse the six counts), L1 (retire the win_event parallel quit authority) are follow-ups.

## Verification
- 140 `agentmux-cef` lib tests green (incl. new `is_live_user_window_counts_only_top_level_by_type`); cargo check clean; all 8 `BrowserKind` match sites audited.
- Live smoke on a packaged build — tear-off/redock floaters, FP-LIFE behavior intact. (A pre-existing, unrelated browser-black-on-redock race surfaced during smoke — diagnosed via `[pane-trace]`, tracked separately on Discussion #1205; not this change.)

Track 1 / L4 of SPEC_REDUCER_SSOT_CONSOLIDATION · sibling of #1676 / #1701

<!-- agentmux:agent_id=agenta -->