### PR TITLE
fix(agent-pane): busy bar freezes under reduced-motion; make bar opaque

### DIFF
--- a/.changesets/1782171756-fix-agent-pane-busy-bar-no-longer-freezes-under-reduced-moti-nm9r.md
+++ b/.changesets/1782171756-fix-agent-pane-busy-bar-no-longer-freezes-under-reduced-moti-nm9r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): busy bar no longer freezes under reduced-motion + opaque bar (no text bleed-through)

--- a/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
+++ b/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
@@ -1,0 +1,240 @@
+# Agent Busy Bar (Marching Ants) Refinement
+
+**Date:** 2026-06-22
+**Owner:** AgentC
+**Status:** Proposed (design)
+**Scope:** `frontend/app/view/agent/styles/_control-bar.scss`
+**Builds on:** [`SPEC_AGENT_BUSY_ANIMATION_2026_06_21.md`](./SPEC_AGENT_BUSY_ANIMATION_2026_06_21.md) and PR #1694
+(`feat(agent-pane): replace gradient sweep with marching-ants progress bar`)
+
+---
+
+## 1. Context
+
+PR #1694 replaced the aurora gradient sweep with a diagonal repeating-stripe
+("marching ants") busy indicator. The current implementation (top of
+`_control-bar.scss`):
+
+```scss
+.agent-pane-progress-bar {
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 3px;
+    z-index: var(--z-pane-overlay, 4);
+    pointer-events: none;
+    opacity: 0;
+    overflow: hidden;
+    transition: opacity 200ms ease;
+
+    &::before {
+        content: "";
+        position: absolute; top: 0; bottom: 0; left: -12px; right: -12px;
+        background: var(--accent-color);                       // < Chromium 111 fallback
+        background: repeating-linear-gradient(
+            -45deg,
+            var(--accent-color)                                       0px,
+            var(--accent-color)                                       4px,
+            color-mix(in srgb, var(--accent-color) 25%, transparent) 4px,
+            color-mix(in srgb, var(--accent-color) 25%, transparent) 8px
+        );
+        will-change: transform;
+    }
+
+    &--active { opacity: 1; &::before { animation: agent-ant-march 0.5s linear infinite; } }
+    &--active#{&}--stopping { opacity: 0.55; }
+}
+
+@keyframes agent-ant-march {
+    from { transform: translateX(0); }
+    to   { transform: translateX(11.314px); }   // one stripe period (8px * sqrt2)
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-pane-progress-bar--active::before { animation: none; }
+}
+```
+
+The bar is rendered in `agent-view.tsx:1008` as a `position:absolute; top:0`
+overlay (z-index 4) sitting above the agent content; `.agent-view` itself paints
+`background: var(--main-bg-color)` (`agent-view.scss:39`).
+
+Two defects, reported while running v0.48.1 on Windows 11.
+
+---
+
+## 2. Problem 1: bar is "stuck" (frozen) on Windows 11, animates on Windows 10
+
+### Root cause (confirmed, not hypothesized)
+
+The `@media (prefers-reduced-motion: reduce)` block sets `animation: none` and
+provides **no replacement motion**. When the OS reports reduced motion, the bar
+still shows at full opacity (`--active` sets `opacity: 1`) but the stripe pattern
+is frozen mid-phase. To the user that reads as a stuck/broken progress bar, not
+as an intentional "motion suppressed" state.
+
+CEF/Chromium maps `prefers-reduced-motion: reduce` to the Win32
+`SPI_GETCLIENTAREAANIMATION` system parameter, which is the
+**Settings > Accessibility > Visual effects > Animation effects** toggle.
+
+Verified on claudius (Windows 11) via `SystemParametersInfo(0x1042)`:
+
+```
+ClientAreaAnimation (animations ON) = False   => prefers-reduced-motion: REDUCE
+```
+
+So this box reports reduced motion and the bar freezes. A Windows 10 machine
+with Animation effects ON reports `no-preference`, so `agent-ant-march` plays.
+The behavior is therefore **per-machine OS setting**, not an OS-version code
+path: any Windows 11 (or 10) box with Animation effects off, or in a power mode
+that auto-disables animations, will freeze.
+
+This is a **regression introduced by #1694**: the prior aurora implementation
+gave reduced motion a visible static fallback (`transform: translateX(0)
+rotate(0deg); opacity: 0.7`). #1694 deleted that, leaving only `animation: none`.
+
+### Requirement
+
+Under reduced motion the bar must still clearly communicate "agent is working"
+without positional motion, and must not look frozen mid-pattern.
+
+### Proposed fix
+
+Replace the bare `animation: none` with a compositor-friendly, non-positional
+"breathe" (opacity only). Opacity pulsing carries no translational motion, is
+GPU-composited, and is an accepted pattern for an essential status indicator
+under `prefers-reduced-motion`. Also drop the frozen diagonal stripe in this
+mode in favor of a solid bar so there is no half-finished pattern.
+
+```scss
+@media (prefers-reduced-motion: reduce) {
+    .agent-pane-progress-bar--active::before {
+        // No translation under reduced motion. Show a solid bar (no frozen
+        // stripe phase) and breathe its opacity so "working" still reads.
+        animation: agent-ant-breathe 1.6s ease-in-out infinite;
+        background: var(--accent-color);
+    }
+}
+
+@keyframes agent-ant-breathe {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.45; }
+}
+```
+
+Notes:
+- The breathe animates the `::before` opacity, leaving the parent's
+  show/hide `opacity` transition (on `.agent-pane-progress-bar`) intact.
+- If product prefers **zero** animation under reduced motion (strict reading),
+  the fallback degrades to a static solid full-opacity bar
+  (`animation: none; background: var(--accent-color);`). Either is acceptable;
+  the breathe is recommended because a perfectly static line is easy to mistake
+  for "hung."
+
+### Secondary robustness (compositor)
+
+`will-change: transform` is declared permanently, promoting the layer for the
+bar's whole lifetime even at rest. This is not the cause of the freeze above,
+but to avoid a permanently-promoted idle layer (and any driver-specific
+tick-starvation on a promoted-but-static layer), scope `will-change` to the
+animating state only:
+
+```scss
+.agent-pane-progress-bar::before { /* no will-change here */ }
+.agent-pane-progress-bar--active::before { will-change: transform; }
+```
+
+---
+
+## 3. Problem 2: translucent stripe gaps let underlying text bleed through
+
+### Root cause
+
+The gap stripes use `color-mix(in srgb, var(--accent-color) 25%, transparent)`,
+i.e. 25% accent over 75% **transparent**, and the bar element has **no opaque
+background**. The bar sits at `top:0` (z-index 4) over the agent content. As the
+ants march across content that reaches the top edge (text, headers), that
+content shows through the translucent gaps. The clean stripe pattern is muddied
+and the effect is lost.
+
+### Requirement
+
+The bar must be fully opaque. Nothing behind the 3px strip should be visible
+through the gaps, in any theme.
+
+### Proposed fix
+
+Two layers of defense (apply both):
+
+1. **Opaque base on the bar element** so the 3px strip always covers the content
+   beneath it, matching the pane surface so the bar reads as chrome:
+
+   ```scss
+   .agent-pane-progress-bar {
+       background: var(--main-bg-color);   // same token .agent-view paints
+       // ...existing props...
+   }
+   ```
+
+2. **Opaque gap stripes** so the pattern itself never carries alpha. Mix the
+   faded stripe against the pane background instead of `transparent`:
+
+   ```scss
+   &::before {
+       background: var(--accent-color);    // pre-color-mix fallback (unchanged)
+       background: repeating-linear-gradient(
+           -45deg,
+           var(--accent-color)                                          0px,
+           var(--accent-color)                                          4px,
+           color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 4px,
+           color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 8px
+       );
+   }
+   ```
+
+   This keeps the same visual contrast (bright accent stripe vs. dim accent-tinted
+   stripe) but every stop is fully opaque, so the marching pattern stays crisp
+   over any content.
+
+`--main-bg-color` is the agent pane's own background, so the bar blends into the
+pane chrome and the ants ride on the surface rather than floating over glass.
+(If a more saturated bar is wanted, `--block-bg-solid-color` is an alternative
+opaque token; `--main-bg-color` is the match for the agent view.)
+
+---
+
+## 4. Out of scope
+
+- The 0.5s march speed, stripe width (4px/4px), -45deg angle, and 3px height are
+  unchanged; this spec only fixes the freeze and the transparency.
+- No change to the show/hide logic or the `--stopping` interrupt dim.
+- No JS changes; `agent-view.tsx` markup is untouched.
+
+---
+
+## 5. Verification
+
+1. **Reduced motion (the reported bug):** with claudius's Animation effects OFF
+   (current state, `SPI_GETCLIENTAREAANIMATION = false`), launch an agent turn
+   and confirm the bar breathes (or, in the strict variant, shows a solid bar)
+   instead of freezing. Toggle Animation effects ON and confirm the ants march.
+   In DevTools, `Rendering > Emulate CSS prefers-reduced-motion` reproduces both
+   states without changing OS settings.
+2. **Opacity / no bleed:** start a turn with content (a long header / wrapped
+   text) reaching the very top of the agent view. Confirm no text is visible
+   through the stripe gaps as the bar animates, in both a light and a dark theme.
+3. **Compositor:** DevTools `Layers` panel - confirm the bar's layer is promoted
+   only while `--active`, and `Performance` shows the animation on the compositor
+   thread (no main-thread paint per frame).
+4. **Regression:** confirm normal (animations-on) Windows and Linux still show
+   the marching ants exactly as in #1694.
+
+---
+
+## 6. Summary of edits (all in `_control-bar.scss`)
+
+| Change | Reason |
+|--------|--------|
+| Add `background: var(--main-bg-color)` to `.agent-pane-progress-bar` | Opaque base, no content bleed (Problem 2) |
+| Gap stops `…, transparent` -> `…, var(--main-bg-color)` | Opaque stripe pattern (Problem 2) |
+| Move `will-change: transform` onto `--active::before` only | Avoid permanent idle layer promotion (Problem 1 robustness) |
+| Replace reduced-motion `animation: none` with `agent-ant-breathe` (opacity) + solid background | Bar no longer freezes when OS reports reduced motion (Problem 1) |
+| Add `@keyframes agent-ant-breathe` | Non-positional reduced-motion fallback |

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -67,6 +67,11 @@
         opacity: 0;
         overflow: hidden;
         transition: opacity 200ms ease;
+        // Opaque base so the 3px strip fully covers the pane content beneath it.
+        // Without this the translucent stripe gaps reveal text reaching the top
+        // edge and the marching pattern is lost. Matches .agent-view's surface
+        // (--main-bg-color) so the bar reads as chrome.
+        background: var(--main-bg-color);
 
         &::before {
             content: "";
@@ -79,20 +84,24 @@
             // unsupported — browser ignores the declaration below and
             // keeps this one so the bar remains visible.
             background: var(--accent-color);
+            // Every stop is fully opaque (the faded stripe mixes against the
+            // pane background, NOT transparent) so the pattern stays crisp over
+            // any content in any theme.
             background: repeating-linear-gradient(
                 -45deg,
-                var(--accent-color)                                        0px,
-                var(--accent-color)                                        4px,
-                color-mix(in srgb, var(--accent-color) 25%, transparent)  4px,
-                color-mix(in srgb, var(--accent-color) 25%, transparent)  8px
+                var(--accent-color)                                              0px,
+                var(--accent-color)                                              4px,
+                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 4px,
+                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 8px
             );
-            will-change: transform;
         }
 
         &--active {
             opacity: 1;
 
             &::before {
+                // Promote the layer only while animating, not at idle rest.
+                will-change: transform;
                 animation: agent-ant-march 0.5s linear infinite;
             }
         }
@@ -111,9 +120,22 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
+        // Don't translate. But `animation: none` alone leaves the diagonal
+        // stripe frozen mid-phase at full opacity, which reads as a stuck bar.
+        // (CEF maps reduced-motion to the Windows "Animation effects" toggle /
+        // SPI_GETCLIENTAREAANIMATION, so any machine with it off lands here.)
+        // Show a solid bar and breathe its opacity so "working" still reads,
+        // without positional motion.
         .agent-pane-progress-bar--active::before {
-            animation: none;
+            background: var(--accent-color);
+            will-change: opacity;
+            animation: agent-ant-breathe 1.6s ease-in-out infinite;
         }
+    }
+
+    @keyframes agent-ant-breathe {
+        0%, 100% { opacity: 1; }
+        50%      { opacity: 0.45; }
     }
 
     // === Working Row ===


### PR DESCRIPTION
Refines the #1694 marching-ants busy indicator. Two defects seen running v0.48.1 on Windows 11.

## 1. "Stuck" bar under reduced-motion (the Win11 report)
`@media (prefers-reduced-motion: reduce)` set `animation: none` with no replacement, so the diagonal stripe froze mid-phase at full opacity and read as a hung bar.

CEF maps `prefers-reduced-motion: reduce` to the Windows **Animation effects** toggle (`SPI_GETCLIENTAREAANIMATION`). Verified **OFF** on the affected Win11 box, so it lands in that branch; a Win10 box with animations on plays normally. This is **per-machine OS setting**, not a Win10-vs-Win11 code path — and it **regressed #1694**, which deleted the prior aurora bar's static reduced-motion fallback.

**Fix:** replace the bare `animation: none` with a non-positional opacity `agent-ant-breathe` on a solid bar, so "working" still reads without motion. Scope `will-change` to the active state only (no permanent idle layer).

## 2. Text bleeds through the stripe gaps
Gap stops used `color-mix(..., transparent)` and the bar had no opaque background, so content reaching the top edge showed through as the ants marched.

**Fix:** opaque base `background: var(--main-bg-color)` (the pane's own surface), and mix the faded stripe against `--main-bg-color` instead of `transparent` so every stop is opaque and the pattern stays crisp in any theme.

## Scope
- One file: `frontend/app/view/agent/styles/_control-bar.scss`. No JS/markup changes.
- Spec: `docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md`
- Frontend build verified (SCSS compiles).

## Verify
- DevTools ▸ Rendering ▸ **Emulate `prefers-reduced-motion`** → bar breathes instead of freezing; disable → ants march.
- Start a turn with text reaching the top edge → no bleed-through, light + dark themes.

<!-- agentmux:agent_id=agentc -->