### PR TITLE
docs(contributing): replace stale Tauri/React/Jotai references with current stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Guidelines:
 
 ## Project Structure
 
-AgentMux is a **Tauri v2** desktop application with a **100% Rust backend**.
+AgentMux is a **four-process Rust desktop application** running a bundled Chromium (CEF) host.
 
 ```
 agentmux/
@@ -69,33 +69,24 @@ agentmux/
 
 ### Frontend (`frontend/`)
 
-Written in React 19 + TypeScript, bundled by Vite. Entry point is [`frontend/wave.ts`](./frontend/wave.ts), React root is [`frontend/app/app.tsx`](./frontend/app/app.tsx).
+Written in **SolidJS + TypeScript**, bundled by Vite. Entry point is [`frontend/app/app.tsx`](./frontend/app/app.tsx).
 
-When running `task dev`, the frontend loads via Vite with Hot Module Reloading — most styling and component changes reload automatically. For state-level changes (Jotai atoms, layout), force-reload with `Ctrl+Shift+R`.
+When running `task dev`, the frontend loads via Vite with Hot Module Reloading — most styling and component changes reload automatically. For state-level changes (reducer stack, layout), force-reload with `Ctrl+Shift+R`.
 
 Key subdirectories:
-- `frontend/app/view/` — 10 pane view types (agent, term, codeeditor, sysinfo, webview, etc.)
-- `frontend/app/block/` — Block/pane rendering and registry
-- `frontend/app/store/` — Jotai atom state management
-- `frontend/app/element/` — 40+ reusable UI components
-- `frontend/app/aipanel/` — AI panel chat interface
+- `frontend/app/view/` — pane view types (agent, terminal, webview, etc.)
+- `frontend/app/store/` — signals + 4-layer reducer stack state management
+- `frontend/app/element/` — reusable UI components
 
-Each view type implements the `ViewModel` interface and is registered in the block registry:
+### CEF Host (`agentmux-cef/`)
 
-```typescript
-// frontend/app/block/block.tsx
-BlockRegistry.set("myview", MyViewModel);
-```
+The native desktop layer — handles window management, system tray, browser pane lifecycle, and IPC between the frontend and backend. Bundles its own Chromium via CEF; no system WebView is used.
 
-### Tauri Shell (`src-tauri/`)
-
-The native desktop layer — handles window management, system tray, native menus, file dialogs, and spawning the backend sidecar. Uses Tauri IPC commands (defined in `src-tauri/src/commands/`) to communicate with the frontend.
-
-Changes here do not hot-reload — Tauri auto-rebuilds in `task dev` when Rust files change, but the process restarts.
+Changes here require rebuilding: `task build` followed by restarting `task dev`.
 
 ### Rust Backend (`agentmux-srv/`)
 
-The async backend server — auto-spawned by Tauri, never launched manually. Handles:
+The async backend server — auto-spawned by the launcher, never launched manually. Handles:
 
 - Block/pane lifecycle and controller execution
 - WebSocket server for real-time frontend communication (JSON-RPC 2.0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,10 @@ Changes here require `task build:backend` followed by restarting `task dev`.
 The portable entry-point process (~325 KB). It owns process and single-instance
 lifecycle so the host and backend can stay focused on the app:
 
-- **Single-instance enforcement** keyed on `(channel, version)` — a second launch
-  of the same instance forwards an "open new window" request to the running host
-  instead of starting a duplicate.
+- **Single-instance enforcement** keyed on `hash(data_dir + version)`
+  (`agentmux-launcher/src/hash.rs`, invariant I1) — a second launch of the same
+  instance forwards an "open new window" request to the running host instead of
+  starting a duplicate.
 - **Job Object (Windows)** — the launcher creates the job that owns the whole
   process tree (`KILL_ON_JOB_CLOSE`), so closing the app cleanly reaps the host
   and backend with no orphans.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Key subdirectories:
 
 The native desktop layer — handles window management, system tray, browser pane lifecycle, and IPC between the frontend and backend. Bundles its own Chromium via CEF; no system WebView is used.
 
-Changes here require rebuilding: `task build` followed by restarting `task dev`.
+Changes here require rebuilding: `task build:host` followed by restarting `task dev`.
 
 ### Rust Backend (`agentmux-srv/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,26 @@ The async backend server — auto-spawned by the launcher, never launched manual
 
 Changes here require `task build:backend` followed by restarting `task dev`.
 
+### Launcher (`agentmux-launcher/`)
+
+The portable entry-point process (~325 KB). It owns process and single-instance
+lifecycle so the host and backend can stay focused on the app:
+
+- **Single-instance enforcement** keyed on `(channel, version)` — a second launch
+  of the same instance forwards an "open new window" request to the running host
+  instead of starting a duplicate.
+- **Job Object (Windows)** — the launcher creates the job that owns the whole
+  process tree (`KILL_ON_JOB_CLOSE`), so closing the app cleanly reaps the host
+  and backend with no orphans.
+- **Named-pipe / socket IPC** and the **saga coordinator** for crash-safe startup
+  and shutdown.
+- **Splash** while the host warms up, then **spawns the host** from `runtime/`.
+- Owns the **`agentmux-srv` lifecycle** (spawns and supervises the backend).
+
+On Windows, `task dev` exercises the launcher exactly as a packaged build does
+(production-parallel layout). See the isolation invariants (I1–I6) in
+[`CLAUDE.md`](./CLAUDE.md) for the contract that keeps parallel instances safe.
+
 ### Communication Flow
 
 ```


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md described "AgentMux is a Tauri v2 desktop application" with "React 19 + Jotai" frontend — none of which is accurate.
- Rewrites the technical sections to match README/CLAUDE: four-process Rust + CEF + SolidJS.
- Removes the `src-tauri/` section (shell doesn't exist); adds a CEF Host section.
- All contribution process, CLA, and PR guideline sections are unchanged.

## Test plan
- [ ] Read through updated CONTRIBUTING.md — no Tauri/React/Jotai/Jotai references remain in the technical sections
- [ ] Directory tree matches actual repo structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agentc -->
