### PR TITLE
fix(agent-pane): make the busy bar zoom-invariant

### DIFF
--- a/.changesets/1782176589-fix-agent-pane-keep-the-busy-bar-a-fixed-size-regardless-of--56wl.md
+++ b/.changesets/1782176589-fix-agent-pane-keep-the-busy-bar-a-fixed-size-regardless-of--56wl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): keep the busy bar a fixed size regardless of pane zoom

--- a/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
+++ b/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
@@ -201,6 +201,60 @@ opaque token; `--main-bg-color` is the match for the agent view.)
 
 ---
 
+## 3b. Problem 3: bar scales with pane zoom
+
+### Root cause
+
+`.agent-view` applies per-pane zoom as the CSS `zoom` property
+(`agent-view.tsx:1000`, `style={{ zoom: zoomFactor() }}`, range 0.5-2.0). The
+progress bar is a child of `.agent-view`, so `zoom` scales the whole bar: at 2x
+the 3px bar renders 6px tall with a doubled stripe period and march distance; at
+0.5x it shrinks. The busy indicator is chrome, not content, so it should read at
+a constant size no matter how the user has zoomed the pane.
+
+### Requirement
+
+The bar's height, stripe period, overshoot, and march distance render at a fixed
+screen size at any pane zoom. (Width still spans the pane, by design.)
+
+### Proposed fix
+
+Counter-scale every px dimension by the zoom. `zoom` re-multiplies all lengths in
+the subtree, so dividing first yields a fixed rendered size. Expose the factor as
+a custom property (custom properties are plain values, unaffected by `zoom`):
+
+```tsx
+// agent-view.tsx
+style={{ zoom: zoomFactor(), "--agent-pane-zoom": String(zoomFactor()) }}
+```
+
+```scss
+// _control-bar.scss — divide every px by var(--agent-pane-zoom, 1)
+.agent-pane-progress-bar { height: calc(3px / var(--agent-pane-zoom, 1)); }
+.agent-pane-progress-bar::before {
+    left:  calc(-12px / var(--agent-pane-zoom, 1));
+    right: calc(-12px / var(--agent-pane-zoom, 1));
+    background: repeating-linear-gradient(-45deg,
+        var(--accent-color) 0px,
+        var(--accent-color) calc(4px / var(--agent-pane-zoom, 1)),
+        color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) calc(4px / var(--agent-pane-zoom, 1)),
+        color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) calc(8px / var(--agent-pane-zoom, 1)));
+}
+@keyframes agent-ant-march {
+    from { transform: translateX(0); }
+    to   { transform: translateX(calc(11.314px / var(--agent-pane-zoom, 1))); }
+}
+```
+
+Notes:
+- `var(--agent-pane-zoom)` is set on `.agent-view` and inherits down to the bar
+  and its `::before` (custom properties inherit), so the keyframe resolves it per
+  element. Fallback `1` keeps current behavior if the var is ever absent.
+- Overshoot is scaled by the same factor so it stays larger than the (also
+  scaled) march distance, preserving edge coverage at every zoom.
+
+---
+
 ## 4. Out of scope
 
 - The 0.5s march speed, stripe width (4px/4px), -45deg angle, and 3px height are

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -997,7 +997,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         <div
             ref={rootRef}
             class="agent-view agent-view--presentation"
-            style={{ zoom: zoomFactor() }}
+            style={{ zoom: zoomFactor(), "--agent-pane-zoom": String(zoomFactor()) }}
             onContextMenu={handleContextMenu}
             tabIndex={-1}
         >

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -56,12 +56,19 @@
     // on all Linux GPU drivers and some Windows HW-accel paths.
     // The ::before overshoots left/right by 12px so the translated edge
     // never clips; parent overflow:hidden trims it.
+    //
+    // Zoom invariance: .agent-view applies CSS `zoom` for per-pane zoom, which
+    // would otherwise scale this bar (a 3px bar becomes 6px at 2x). Every px
+    // dimension below is divided by --agent-pane-zoom (set alongside the zoom in
+    // agent-view.tsx). Because `zoom` re-multiplies all lengths in the subtree,
+    // dividing first renders the bar at a FIXED screen size at any pane zoom.
+    // Falls back to 1 (no scaling) if the var is absent.
     .agent-pane-progress-bar {
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 3px;
+        height: calc(3px / var(--agent-pane-zoom, 1));
         z-index: var(--z-pane-overlay, 4);
         pointer-events: none;
         opacity: 0;
@@ -78,8 +85,12 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            left: -12px;
-            right: -12px;
+            // Overshoot and stripe widths are divided by the pane zoom too, so
+            // the overshoot stays larger than the (also-scaled) march distance
+            // and the stripe period renders at a fixed screen size. See the
+            // zoom-invariance note above.
+            left: calc(-12px / var(--agent-pane-zoom, 1));
+            right: calc(-12px / var(--agent-pane-zoom, 1));
             // Solid fallback for Chromium < 111 where color-mix() is
             // unsupported — browser ignores the declaration below and
             // keeps this one so the bar remains visible.
@@ -90,9 +101,9 @@
             background: repeating-linear-gradient(
                 -45deg,
                 var(--accent-color)                                              0px,
-                var(--accent-color)                                              4px,
-                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 4px,
-                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) 8px
+                var(--accent-color)                                              calc(4px / var(--agent-pane-zoom, 1)),
+                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) calc(4px / var(--agent-pane-zoom, 1)),
+                color-mix(in srgb, var(--accent-color) 25%, var(--main-bg-color)) calc(8px / var(--agent-pane-zoom, 1))
             );
         }
 
@@ -114,9 +125,11 @@
     @keyframes agent-ant-march {
         // Shift by one stripe period (8px × √2 ≈ 11.314px) per cycle so the
         // repeating pattern loops seamlessly. translateX keeps the animation
-        // on the GPU compositor.
+        // on the GPU compositor. Divided by --agent-pane-zoom (resolved on
+        // ::before, which inherits it) so the march distance matches the
+        // zoom-scaled stripe period and renders fixed at any pane zoom.
         from { transform: translateX(0); }
-        to   { transform: translateX(11.314px); }
+        to   { transform: translateX(calc(11.314px / var(--agent-pane-zoom, 1))); }
     }
 
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Refines the marching-ants busy bar so it stays a **fixed size regardless of pane zoom**.

## Problem
The bar lives inside `.agent-view`, which applies per-pane zoom via the CSS `zoom` property (`agent-view.tsx`, range 0.5-2.0). As a child, the bar scaled with it: 6px tall with a doubled stripe period/march at 2x, shrunk at 0.5x. The busy indicator is chrome, not content, so it should read at a constant size.

## Fix
Expose the zoom factor as `--agent-pane-zoom` alongside the `zoom` on the root div, and divide every px dimension by it:
- bar `height`
- `::before` overshoot (`left`/`right`)
- stripe period (`repeating-linear-gradient` stops)
- march distance (`@keyframes agent-ant-march` translateX)

`zoom` re-multiplies all lengths in the subtree, so dividing first renders the bar at a fixed screen size at any pane zoom. Overshoot is scaled by the same factor so it stays larger than the (also-scaled) march distance and edge coverage holds. The custom property inherits to `::before` (so the keyframe resolves it per element); fallback `1` preserves current behavior if absent.

Width still spans the pane, by design.

## Scope
- `frontend/app/view/agent/agent-view.tsx` (expose the var)
- `frontend/app/view/agent/styles/_control-bar.scss` (counter-scale)
- Spec updated: `SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md` §3b
- Frontend build verified.

## Verify
Zoom an agent pane in/out (Ctrl+wheel) during a turn — the busy bar's thickness, stripe size, and march speed stay constant; only the pane content scales.

<!-- agentmux:agent_id=agentc -->