### PR TITLE
fix(test): un-skip AgentLaunchModal preset test — stale Memory→Preset label

### DIFF
--- a/.changesets/1782178546-fix-test-un-skip-agentlaunchmodal-preset-test-stale-memory-p-x16s.md
+++ b/.changesets/1782178546-fix-test-un-skip-agentlaunchmodal-preset-test-stale-memory-p-x16s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(test): un-skip AgentLaunchModal preset test (stale Memory->Preset label)

--- a/docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md
+++ b/docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md
@@ -127,10 +127,13 @@ is handled minimally + tracked; the follow-up is a "test-health" pass that remov
 3. **`tools/**` excluded from the frontend vitest** (`vitest.config.ts`). `tools/tests/lib/
    bench-stats.test.mjs` is standalone Node tooling, not a frontend jsdom test. *Follow-up: a
    separate tools-test job if those are worth gating.*
-4. **`AgentLaunchModal` "auth state on memory change" is `it.skip`'d — a REAL pre-existing failure**
-   (fails in isolation): a Memory selection change resets auth-ready state. This is a genuine
-   regression that shipped because there was no CI. *Follow-up (highest priority of the four):
-   triage product-bug-vs-stale-test and fix → un-skip.*
+4. **`AgentLaunchModal` "auth state on memory change" — ✅ RESOLVED (was a stale test, NOT a
+   regression).** It looked like an auth regression, but triage showed the test's selector had gone
+   stale on the **Memory bundle → Preset** rename (the select's `aria-label` is now `"Preset"`); the
+   `findByLabelText("Memory bundle")` failed before reaching the auth assertion. The §6.10
+   requirement holds — changing the preset does NOT reset auth. Fixed the selector + un-skipped; the
+   test passes. (Lesson: "real regression vs stale test" must be triaged, not assumed — here it was
+   the latter.)
 5. **Rust fast lane is an OS matrix; only Windows is REQUIRED.** AgentMux ships on
    Windows/macOS/Linux, so the rust fast lane runs all three — but only the `windows-latest` leg
    blocks PRs (the primary dev platform; green). `ubuntu-latest` + `macos-latest` run **non-blocking**

--- a/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
@@ -151,12 +151,11 @@ afterEach(() => {
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe("AgentLaunchModal — memory change must not reset auth state (§6.10)", () => {
-    // PRE-EXISTING FAILURE (not flaky — fails in isolation): a Memory selection
-    // change resets the auth-ready state. Surfaced when standing up the CI runner
-    // (it shipped because there was no CI). Skipped to unblock CI; this is a REAL
-    // regression to triage (product bug vs stale test), NOT to leave skipped.
-    // Tracked: SPEC_CI_TEST_RUNNER_2026_06_22.md §6.4.
-    it.skip("preserves auth-ready state across a Memory selection change", async () => {
+    // The §6.10 requirement holds — changing the preset does NOT reset auth
+    // (asserted below). This test had gone stale on the "Memory bundle" → "Preset"
+    // rename (the select's aria-label is now "Preset"); the stale selector read as
+    // an auth "regression" when CI first ran it. Selector fixed; logic unchanged.
+    it("preserves auth-ready state across a Memory selection change", async () => {
         const user = userEvent.setup();
         const onSubmit = vi.fn();
         const onCancel = vi.fn();
@@ -174,7 +173,7 @@ describe("AgentLaunchModal — memory change must not reset auth state (§6.10)"
         // BindingsLoaded.  The Identity selector renders once
         // identities are loaded.
         const identitySelect = await screen.findByLabelText("Identity bundle");
-        const memorySelect = await screen.findByLabelText("Memory bundle");
+        const memorySelect = await screen.findByLabelText("Preset");
 
         // Verify the auto-pick wired the bound identity. With Work
         // bundle bound to claude, the Connect panel must NOT mount.


### PR DESCRIPTION
## Summary
The CI runner (#1709) flagged `AgentLaunchModal` "memory change must not reset auth state (§6.10)" as a possible auth regression, and it was skipped to unblock CI. **Triage result: stale test, NOT a product bug.**

The `Memory bundle` `<select>` was renamed to **Preset** (the Memory→Preset rename), so the test's `findByLabelText("Memory bundle")` failed *before* reaching the auth assertion — which read as an "auth regression." The §6.10 requirement holds: changing the preset does **not** reset auth (the assertion passes once the selector is correct).

- Fixed the selector → `findByLabelText("Preset")` + un-skipped. Test passes (verified locally + via this PR's `ci-fast` vitest).
- Spec §6.4 item 4 marked resolved.

First of the six CI-surfaced test-debt items closed — and a reminder to *triage* "real regression vs stale test", not assume.

<!-- agentmux:agent_id=agenta -->