### PR TITLE
fix(agent-pane): keep marching ants under reduced-motion (gentler), drop the breathe

### DIFF
--- a/.changesets/1782178592-fix-agent-pane-keep-marching-ants-under-reduced-motion-slowe-tr48.md
+++ b/.changesets/1782178592-fix-agent-pane-keep-marching-ants-under-reduced-motion-slowe-tr48.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): keep marching ants under reduced-motion (slower) instead of an opacity breathe

--- a/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
+++ b/docs/specs/SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md
@@ -96,38 +96,37 @@ rotate(0deg); opacity: 0.7`). #1694 deleted that, leaving only `animation: none`
 Under reduced motion the bar must still clearly communicate "agent is working"
 without positional motion, and must not look frozen mid-pattern.
 
-### Proposed fix
+### Proposed fix (revised)
 
-Replace the bare `animation: none` with a compositor-friendly, non-positional
-"breathe" (opacity only). Opacity pulsing carries no translational motion, is
-GPU-composited, and is an accepted pattern for an essential status indicator
-under `prefers-reduced-motion`. Also drop the frozen diagonal stripe in this
-mode in favor of a solid bar so there is no half-finished pattern.
+> **Update (2026-06-22):** an earlier revision swapped the march for an opacity
+> "breathe" on a solid bar under reduced motion. On a reduced-motion machine
+> that reads as a soft glow / "aurora", not the marching ants the indicator is
+> supposed to show (and it is a different effect from what motion-enabled
+> machines see). Product intent is to **always show the ants**. The breathe is
+> dropped.
+
+Keep the marching ants under reduced motion - this is a small (3px), looping,
+**essential** "agent is working" indicator, not large or parallax motion. Rather
+than change the effect, simply **slow the march** so the motion is gentle when
+the OS requests reduced motion. Override only `animation-duration` so the same
+`agent-ant-march` keyframe runs slower; the striped gradient and translation are
+unchanged.
 
 ```scss
 @media (prefers-reduced-motion: reduce) {
     .agent-pane-progress-bar--active::before {
-        // No translation under reduced motion. Show a solid bar (no frozen
-        // stripe phase) and breathe its opacity so "working" still reads.
-        animation: agent-ant-breathe 1.6s ease-in-out infinite;
-        background: var(--accent-color);
+        animation-duration: 1.5s;   // gentler march; same keyframe
     }
-}
-
-@keyframes agent-ant-breathe {
-    0%, 100% { opacity: 1; }
-    50%      { opacity: 0.45; }
 }
 ```
 
 Notes:
-- The breathe animates the `::before` opacity, leaving the parent's
-  show/hide `opacity` transition (on `.agent-pane-progress-bar`) intact.
-- If product prefers **zero** animation under reduced motion (strict reading),
-  the fallback degrades to a static solid full-opacity bar
-  (`animation: none; background: var(--accent-color);`). Either is acceptable;
-  the breathe is recommended because a perfectly static line is easy to mistake
-  for "hung."
+- This keeps a single effect (marching ants) on every machine, so a
+  reduced-motion box no longer shows a different-looking bar. Motion-enabled
+  machines keep the 0.5s march; reduced-motion machines get a calmer 1.5s march.
+- `animation: none` (freeze) was rejected: it reads as a stuck bar (the original
+  Windows 11 report). The opacity breathe was rejected: it reads as a glow and
+  is a different effect from the ants.
 
 ### Secondary robustness (compositor)
 
@@ -290,5 +289,4 @@ Notes:
 | Add `background: var(--main-bg-color)` to `.agent-pane-progress-bar` | Opaque base, no content bleed (Problem 2) |
 | Gap stops `…, transparent` -> `…, var(--main-bg-color)` | Opaque stripe pattern (Problem 2) |
 | Move `will-change: transform` onto `--active::before` only | Avoid permanent idle layer promotion (Problem 1 robustness) |
-| Replace reduced-motion `animation: none` with `agent-ant-breathe` (opacity) + solid background | Bar no longer freezes when OS reports reduced motion (Problem 1) |
-| Add `@keyframes agent-ant-breathe` | Non-positional reduced-motion fallback |
+| Reduced-motion: keep `agent-ant-march`, override `animation-duration: 1.5s` (slower) | Bar no longer freezes (Problem 1) and shows the same ants effect everywhere, just gentler (no "aurora" glow) |

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -133,22 +133,17 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
-        // Don't translate. But `animation: none` alone leaves the diagonal
-        // stripe frozen mid-phase at full opacity, which reads as a stuck bar.
-        // (CEF maps reduced-motion to the Windows "Animation effects" toggle /
-        // SPI_GETCLIENTAREAANIMATION, so any machine with it off lands here.)
-        // Show a solid bar and breathe its opacity so "working" still reads,
-        // without positional motion.
+        // Keep the marching ants - this is a small (3px), looping, essential
+        // "agent is working" indicator, not large/parallax motion. Just slow
+        // the march so it's gentle when the OS asks for reduced motion, rather
+        // than swapping to a different effect (an opacity breathe reads as a
+        // glow/"aurora", and `animation: none` freezes the stripe = looks
+        // stuck). CEF maps reduced-motion to the Windows "Animation effects"
+        // toggle (SPI_GETCLIENTAREAANIMATION), so machines with it off land
+        // here. Override only the duration so the same keyframe runs slower.
         .agent-pane-progress-bar--active::before {
-            background: var(--accent-color);
-            will-change: opacity;
-            animation: agent-ant-breathe 1.6s ease-in-out infinite;
+            animation-duration: 1.5s;
         }
-    }
-
-    @keyframes agent-ant-breathe {
-        0%, 100% { opacity: 1; }
-        50%      { opacity: 0.45; }
     }
 
     // === Working Row ===


### PR DESCRIPTION
Follow-up to #1705. A user on Windows 11 with **Animation effects off** reported the busy bar "appears now as aurora."

## Cause
#1705's reduced-motion fallback swapped the marching ants for an opacity **breathe** on a solid bar. On a reduced-motion machine (Windows "Animation effects" off → CEF reports `prefers-reduced-motion: reduce`), that renders as a soft pulsing glow that reads as "aurora" — a **different effect** from the marching ants the indicator is meant to show, and not what motion-enabled machines see. (There is no actual aurora animation in the code; it was the breathe.)

## Fix
Keep a single effect everywhere. Under reduced motion, run the **same `agent-ant-march` keyframe but slower** (override only `animation-duration` to 1.5s). The busy bar is a small (3px) looping *essential* "working" indicator, so a gentle march is an acceptable reduced-motion treatment — and it no longer looks like a different effect or a stuck/frozen bar.

- Motion-enabled machines: 0.5s march (unchanged).
- Reduced-motion machines: 1.5s march (gentler), same ants.
- Removes `agent-ant-breathe`.

Frontend build verified. Spec updated (`SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md`).

Note: enabling Windows "Animation effects" also restores the full-speed 0.5s march.

<!-- agentmux:agent_id=agentc -->