### PR TITLE
chore(ci): run the test workflows nightly, not per-PR

### DIFF
--- a/.changesets/1782209694-chore-ci-run-test-workflows-nightly-not-per-pr-qdtk.md
+++ b/.changesets/1782209694-chore-ci-run-test-workflows-nightly-not-per-pr-qdtk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(ci): run test workflows nightly, not per-PR

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,20 +1,16 @@
-name: CI — fast (PR/push)
+name: CI — cross-platform CEF-free crates (nightly)
 
-# Fast, CEF-free checks on every PR/push: the non-CEF Rust crates + the frontend
-# vitest suite. The FULL workspace (incl. agentmux-cef's ~10-20 min CEF build)
-# runs nightly — see ci-nightly.yml. Standard GitHub-hosted runners only (free on
-# public repos). See docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md (invariant CI-1:
-# never a larger/self-hosted runner — those are always billed).
+# NIGHTLY, NOT per-PR (repo policy, 2026-06-23): the CEF-free Rust crates (OS
+# matrix) + the frontend vitest suite. The FULL workspace incl. agentmux-cef's
+# ~10-20 min CEF build runs in ci-nightly.yml. Standard GitHub-hosted runners
+# only (free on public repos). See docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md
+# (invariant CI-1: never a larger/self-hosted runner — those are always billed).
+# Run manually anytime via the Actions tab (workflow_dispatch).
 
 on:
-  pull_request:
-  push:
-    branches: [main]
-
-# Cancel superseded runs on the same ref to save runner time.
-concurrency:
-  group: ci-fast-${{ github.ref }}
-  cancel-in-progress: true
+  schedule:
+    - cron: '0 8 * * *' # 08:00 UTC daily (an hour before the full CEF nightly)
+  workflow_dispatch: {}
 
 jobs:
   rust-fast:

--- a/docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md
+++ b/docs/specs/SPEC_CI_TEST_RUNNER_2026_06_22.md
@@ -47,8 +47,11 @@ slow part on a schedule, not on every push.
 
 ## 3. Design — two lanes
 
-### Lane A — PR/push fast lane (CEF-free) — `ci-fast.yml`
-- **Trigger:** `pull_request` + `push` (to `main`).
+### Lane A — cross-platform CEF-free crates (CEF-free) — `ci-fast.yml`
+- **Trigger:** **nightly** `schedule` (08:00 UTC, an hour before Lane B) + `workflow_dispatch`.
+  **Repo policy (2026-06-23): CI runs nightly, NOT per-PR** — the per-PR `pull_request`/`push`
+  triggers were removed (PRs aren't gated by CI on this repo; run on demand via the Actions tab).
+  ("fast" now denotes *scope* — CEF-free, ~5 min — not cadence.)
 - **Runner:** the rust job is an **OS matrix** — `windows-latest` is the REQUIRED gate (primary dev
   platform; green), `ubuntu-latest` + `macos-latest` run **non-blocking** (`continue-on-error`) for
   cross-platform visibility (see §6.4 items 5-6 — the suite has untested-platform failures). The


### PR DESCRIPTION
## Summary
Repo policy: CI runs **nightly, not per-PR**. Moves `ci-fast.yml` from `pull_request` + `push` to a nightly `schedule` (08:00 UTC — an hour before the full-CEF `ci-nightly` at 09:00) + `workflow_dispatch`.

- PRs are no longer gated by CI; run the checks **on demand** via the Actions tab ("Run workflow"), or wait for the nightly.
- "fast" now denotes *scope* (CEF-free crates + vitest, ~5 min), not cadence.
- Spec §3 Lane A updated to match.

Note: this PR may still trigger the *old* `pull_request` run once — GitHub evaluates `pull_request` triggers from the base branch; nightly-only takes effect after merge.

<!-- agentmux:agent_id=agenta -->