### PR TITLE
chore(ci): nightly cross-platform compile-build (Phase A, #1718)

### DIFF
--- a/.changesets/1782210050-chore-ci-nightly-cross-platform-compile-build-phase-a-1718-cpuj.md
+++ b/.changesets/1782210050-chore-ci-nightly-cross-platform-compile-build-phase-a-1718-cpuj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(ci): nightly cross-platform compile-build (Phase A, #1718)

--- a/.github/workflows/ci-nightly-build.yml
+++ b/.github/workflows/ci-nightly-build.yml
@@ -1,0 +1,47 @@
+name: CI — nightly cross-platform build
+
+# Phase A of SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md (issue #1718):
+# compile the whole workspace (incl. agentmux-cef → the CEF build) on all three
+# shipping platforms, nightly, so a Linux/macOS BUILD break is caught instead of
+# shipping unnoticed. NOT packaging — that's Phase B (artifacts).
+#
+# Windows is the REQUIRED leg (primary platform); ubuntu + macOS are NON-BLOCKING
+# (continue-on-error) until greened — same staged approach as ci-fast. Standard
+# GitHub-hosted runners only (free on public repos for any workload; only LARGER
+# runners are billed — invariant CI-1). Run on demand via the Actions tab.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 07:00 UTC daily (ahead of the test nightlies at 08/09)
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: cargo build --release --workspace
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'windows-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      # cef-dll-sys builds CEF's C wrapper with CMake + Ninja.
+      - name: Install Ninja (Windows — CMake ships with VS)
+        if: matrix.os == 'windows-latest'
+        run: choco install ninja -y
+      - name: Install build deps (Linux — CEF + launcher Wayland/GTK)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake libwayland-dev libxkbcommon-dev libgtk-3-dev
+      - name: Install build deps (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install ninja cmake
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Compile every crate, incl. agentmux-cef (pays the CEF download + build).
+      # Surfaces cross-platform compile/link breaks; packaging is Phase B (#1718).
+      - name: cargo build --release --workspace
+        run: cargo build --release --workspace

--- a/docs/specs/SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md
+++ b/docs/specs/SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md
@@ -1,0 +1,66 @@
+# SPEC — Nightly cross-platform CI builds
+
+- **Status:** Phase A implementing; Phase B deferred
+- **Date:** 2026-06-23
+- **Author:** AgentA
+- **Tracking:** GitHub issue **#1718**
+- **Related:** `SPEC_CI_TEST_RUNNER_2026_06_22.md` (the nightly *test* runner — same billing model,
+  same non-blocking-until-green approach; this is its *build* sibling).
+- **Motivation:** AgentMux ships on Windows / macOS / Linux, but **nothing builds it cross-platform
+  in CI** — a Linux or macOS build break (a `#[cfg]` slip, a missing dep, a platform API change)
+  ships unnoticed until someone builds locally on that OS. This is the exact blind spot the test
+  runner just exposed for *tests* (smithay/Wayland, the `..`-path test); this catches it for *builds*.
+
+---
+
+## 1. Billing basis (the same hard rule as the test runner)
+
+Standard GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`) are **free on
+public repos for ANY workload — tests or builds**. Only *larger* runners are billed (CI-1 in the
+test-runner spec). So a nightly 3-platform build costs **$0** on standard runners — cost is not a
+constraint; wall-clock + disk are.
+
+## 2. Phase A — compile-build matrix (this PR) — `ci-nightly-build.yml`
+
+- **Trigger:** nightly `schedule` (07:00 UTC — ahead of the test nightlies at 08:00/09:00) +
+  `workflow_dispatch`.
+- **Matrix:** `windows-latest` (REQUIRED — primary platform), `ubuntu-latest` + `macos-latest`
+  (**non-blocking**, `continue-on-error`, until greened — same staged approach the tests used).
+- **Build:** `cargo build --release --workspace` — compiles every crate **including `agentmux-cef`**,
+  so it pays the CEF build (`cef-dll-sys`: ~200 MB download + CMake/Ninja C-wrapper) and surfaces any
+  cross-platform compile/link break. NOT packaging (that's Phase B) — just "does it build."
+- **Per-platform build deps:**
+  - Windows — CMake ships with VS; install **Ninja** (`choco install ninja`).
+  - Ubuntu — `ninja-build cmake libwayland-dev libxkbcommon-dev libgtk-3-dev` (CEF-linux + the
+    launcher's smithay/Wayland). Expect to extend this on the first run (CEF-linux link deps).
+  - macOS — `brew install ninja cmake`.
+- **Cache:** `Swatinem/rust-cache` (`~/.cargo` + `target/` + the CEF download).
+- **Wall-clock:** ~15-30 min/platform cold (CEF build); faster warm. Free regardless.
+
+## 3. Phase B — full artifacts (deferred — issue #1718)
+
+`task package` on each platform → produce + **upload portable artifacts** (Windows ZIP, macOS
+`.app`/`.dmg`, Linux AppImage) as nightly dogfood builds (`actions/upload-artifact`). Heavier:
+per-platform packaging tooling, artifact retention policy, and **macOS codesigning/notarization**
+(unsigned `.app`s gatekeeper-block). Land after Phase A's per-platform builds are green.
+
+## 4. Caveats / open questions (tracked on #1718)
+
+1. **Disk.** A standard runner has ~14 GB free SSD; the CEF download + build + `target/` may be
+   tight. If a leg ENOSPCs, options: free disk in-job (delete unused toolchains), or accept a
+   *larger* (billed) runner — a **maintainer cost decision, not a silent opt-in**. Verify on the
+   first nightly run.
+2. **Non-Windows greening.** ubuntu/macOS will likely fail the first run (untested platform builds,
+   like the tests). They're non-blocking; green them incrementally → flip each to required.
+3. **Cadence/stagger.** 07:00 UTC keeps it ahead of the two test nightlies; revisit if runner
+   contention shows up.
+4. **macOS codesigning** (Phase B only).
+
+## 5. Success criteria
+- Phase A: nightly Windows build is green (the primary build can't silently break); ubuntu/macOS
+  build *and report* (non-blocking) so cross-platform breaks are visible.
+- Eventually: all three green + required, and Phase B publishes nightly artifacts.
+
+## 6. Implementation note
+Ships as `.github/workflows/ci-nightly-build.yml` (Phase A) in a normal PR with this spec. Phase B is
+a follow-up PR tracked on #1718.


### PR DESCRIPTION
## Summary
**Phase A** of #1718 — nightly cross-platform **build** coverage. Adds `ci-nightly-build.yml`: `cargo build --release --workspace` (incl. `agentmux-cef` → the CEF build) on **Windows / macOS / Linux**, nightly + `workflow_dispatch`. Catches a Linux/macOS *build* break before it ships unnoticed — the build sibling of the portability gaps the test runner just surfaced.

- **Windows** = required leg (primary); **ubuntu + macOS** non-blocking (`continue-on-error`) until greened (expect first-run failures, like the tests).
- Per-platform build deps (Ninja/CMake; Linux Wayland/GTK; macOS brew).
- Standard runners only → **$0** on the public repo (any workload; only larger runners are billed).
- **Not** packaging — that's **Phase B** (full `task package` + uploaded artifacts), deferred on #1718.

Spec: `SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md`. Tracking: #1718. Sibling of `SPEC_CI_TEST_RUNNER`.

<!-- agentmux:agent_id=agenta -->