### PR TITLE
chore(ci): move input-handler guardrails to nightly (not per-PR)

### DIFF
--- a/.changesets/1782210673-chore-ci-move-input-handler-guardrails-to-nightly-not-per-pr-rcoq.md
+++ b/.changesets/1782210673-chore-ci-move-input-handler-guardrails-to-nightly-not-per-pr-rcoq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(ci): move input-handler guardrails to nightly (not per-PR)

--- a/.github/workflows/input-handler-layout-reads.yml
+++ b/.github/workflows/input-handler-layout-reads.yml
@@ -3,26 +3,19 @@ name: Input-handler layout-read guardrail
 # Enforces SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md
 # rule #3: "Never read layout after touching style on the keystroke path."
 #
-# Catches the 22 ms-per-keystroke reflow regression at PR time rather
-# than chasing it in a Chrome trace later (see
-# docs/analysis/agent-typing-lag-trace-2026-04-12.md for prior incident).
+# Catches the 22 ms-per-keystroke reflow regression (see
+# docs/analysis/agent-typing-lag-trace-2026-04-12.md for the prior incident).
 #
-# Path-filtered — only runs when an in-scope file is modified.
+# Repo policy (2026-06-23): CI runs NIGHTLY, not per-PR — so this runs on a
+# nightly schedule + manual dispatch instead of on pull_request (reagent still
+# reviews PRs). The path filter is dropped — the lint is fast and runs whole-tree
+# nightly. Trade-off: an in-scope regression is now caught the next morning, not
+# at PR time.
 
 on:
-  pull_request:
-    paths:
-      - 'frontend/app/view/term/**'
-      - 'frontend/app/view/agent/components/AgentFooter.tsx'
-      - 'tools/lint/check-input-handler-layout-reads.sh'
-      - '.github/workflows/input-handler-layout-reads.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/app/view/term/**'
-      - 'frontend/app/view/agent/components/AgentFooter.tsx'
-      - 'tools/lint/check-input-handler-layout-reads.sh'
+  schedule:
+    - cron: '0 10 * * *' # nightly
+  workflow_dispatch: {}
 
 jobs:
   check:

--- a/.github/workflows/input-handler-sync-ipc.yml
+++ b/.github/workflows/input-handler-sync-ipc.yml
@@ -8,26 +8,16 @@ name: Input-handler sync-IPC guardrail
 # but must never BLOCK on it before paint. See
 # docs/analysis/ANALYSIS_KEYDOWN_IPC_AUDIT_2026_05_29.md for the audit baseline.
 #
-# Path-filtered — only runs when an in-scope file is modified.
+# Repo policy (2026-06-23): CI runs NIGHTLY, not per-PR — so this runs on a
+# nightly schedule + manual dispatch instead of on pull_request (reagent still
+# reviews PRs). The path filter is dropped — the lint is fast and runs whole-tree
+# nightly. Trade-off: an in-scope sync-IPC regression is now caught the next
+# morning, not at PR time.
 
 on:
-  pull_request:
-    paths:
-      - 'frontend/app/store/keymodel.ts'
-      - 'frontend/app/view/term/termViewModel.ts'
-      - 'frontend/app/view/launcher/launcher.tsx'
-      - 'frontend/app/view/agent/components/AgentFooter.tsx'
-      - 'tools/lint/check-input-handler-sync-ipc.sh'
-      - '.github/workflows/input-handler-sync-ipc.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/app/store/keymodel.ts'
-      - 'frontend/app/view/term/termViewModel.ts'
-      - 'frontend/app/view/launcher/launcher.tsx'
-      - 'frontend/app/view/agent/components/AgentFooter.tsx'
-      - 'tools/lint/check-input-handler-sync-ipc.sh'
+  schedule:
+    - cron: '0 10 * * *' # nightly
+  workflow_dispatch: {}
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
Repo policy (2026-06-23): **CI runs nightly, not per-PR.** The two **input-handler guardrails** (layout-read + sync-IPC) were the workflows still triggering on PRs (path-filtered to input-handler files). Both move to a nightly `schedule` (10:00 UTC) + `workflow_dispatch`; `pull_request`/`push` triggers + path filters dropped (the lints are fast — run whole-tree nightly). reagent still reviews PRs.

**Trade-off:** an in-scope input-handler regression (reflow / sync-IPC) is now caught the next morning, not at PR time.

## Not changed (with reasons)
- **`container-image.yml`** — tag-triggered (`push: tags: ['v*']`), not PR. Already not a PR run.
- **`release-consistency.yml`** — fires only on **release PRs** (`VERSION_HISTORY.md` path), and CLAUDE.md documents it as "the deterministic CI gate that can't be reviewed past." It doesn't churn regular PRs, and moving it weakens release safety (reagent + `scripts/release.sh` would be the only PR-time checks). **Left as-is pending a call** — say the word to move it too (I'd update CLAUDE.md accordingly).

Completes the "CI nightly, not per-PR" sweep alongside #1717 (ci-fast) and #1719 (nightly builds).

<!-- agentmux:agent_id=agenta -->