### PR TITLE
feat(swarm): granular agent status from TurnPhase reducer

### DIFF
--- a/.changesets/1782231236-feat-swarm-granular-per-block-agent-status-from-turnphase-wo-js6c.md
+++ b/.changesets/1782231236-feat-swarm-granular-per-block-agent-status-from-turnphase-wo-js6c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): granular per-block agent status from TurnPhase (working/tools/stopping/error/offline)

--- a/frontend/app/store/agentActivity.ts
+++ b/frontend/app/store/agentActivity.ts
@@ -37,6 +37,16 @@ const [busyPanes, setBusyPanes] = createSignal<ReadonlySet<string>>(
 export const busyCount: Accessor<number> = () => busyPanes().size;
 export const anyBusy: Accessor<boolean> = () => busyPanes().size > 0;
 
+// Per-block phase accessor registry — plain Map (not reactive) because the
+// Swarm already rebuilds its row list when blocks are added/removed.
+// Reading the RETURNED accessor inside a reactive computation tracks changes.
+const phaseRegistry = new Map<string, Accessor<TurnPhase>>();
+
+/** Returns the live TurnPhase accessor for a registered block, or null. */
+export function getBlockTurnPhase(blockId: string): Accessor<TurnPhase> | null {
+    return phaseRegistry.get(blockId) ?? null;
+}
+
 /**
  * Register a pane's `turnPhase` accessor with the global tracker.
  *
@@ -52,6 +62,7 @@ export function registerActivity(
     blockId: string,
     turnPhase: Accessor<TurnPhase>,
 ): void {
+    phaseRegistry.set(blockId, turnPhase);
     createEffect(() => {
         const working = workingFromPhase(turnPhase());
         const cur = new Set(busyPanes());
@@ -67,6 +78,7 @@ export function registerActivity(
 }
 
 export function unregisterActivity(blockId: string): void {
+    phaseRegistry.delete(blockId);
     const cur = new Set(busyPanes());
     if (cur.delete(blockId)) setBusyPanes(cur);
 }

--- a/frontend/app/store/agentActivity.ts
+++ b/frontend/app/store/agentActivity.ts
@@ -37,14 +37,23 @@ const [busyPanes, setBusyPanes] = createSignal<ReadonlySet<string>>(
 export const busyCount: Accessor<number> = () => busyPanes().size;
 export const anyBusy: Accessor<boolean> = () => busyPanes().size > 0;
 
-// Per-block phase accessor registry — plain Map (not reactive) because the
-// Swarm already rebuilds its row list when blocks are added/removed.
-// Reading the RETURNED accessor inside a reactive computation tracks changes.
-const phaseRegistry = new Map<string, Accessor<TurnPhase>>();
+// Per-block phase accessor registry as a SolidJS signal so that reads
+// inside createMemo/createEffect track it. A createMemo with no tracked
+// dependencies never re-runs; using a plain Map would leave AgentRows
+// permanently stuck on the fallback if they mount before registerActivity
+// is called (the common case when the Swarm pane is already open).
+const [phaseRegistry, setPhaseRegistry] = createSignal<ReadonlyMap<string, Accessor<TurnPhase>>>(
+    new Map(),
+    { equals: false },
+);
 
-/** Returns the live TurnPhase accessor for a registered block, or null. */
+/**
+ * Returns the live TurnPhase accessor for a registered block, or null.
+ * Reading this inside a reactive computation tracks the registry signal,
+ * so the computation re-runs when the block later registers its phase.
+ */
 export function getBlockTurnPhase(blockId: string): Accessor<TurnPhase> | null {
-    return phaseRegistry.get(blockId) ?? null;
+    return phaseRegistry().get(blockId) ?? null;
 }
 
 /**
@@ -62,7 +71,7 @@ export function registerActivity(
     blockId: string,
     turnPhase: Accessor<TurnPhase>,
 ): void {
-    phaseRegistry.set(blockId, turnPhase);
+    setPhaseRegistry((prev) => new Map(prev).set(blockId, turnPhase));
     createEffect(() => {
         const working = workingFromPhase(turnPhase());
         const cur = new Set(busyPanes());
@@ -78,7 +87,7 @@ export function registerActivity(
 }
 
 export function unregisterActivity(blockId: string): void {
-    phaseRegistry.delete(blockId);
+    setPhaseRegistry((prev) => { const m = new Map(prev); m.delete(blockId); return m; });
     const cur = new Set(busyPanes());
     if (cur.delete(blockId)) setBusyPanes(cur);
 }

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -180,16 +180,28 @@
     border-radius: 50%;
     flex-shrink: 0;
 
-    &--running {
+    &--working {
         background: var(--warning-color, #f5a623);
         animation: swarm-pulse 1.5s ease-in-out infinite;
     }
-    &--done {
-        background: var(--success-color, #4caf50);
+    &--tools {
+        background: #7c6af5;
+        animation: swarm-pulse 1.2s ease-in-out infinite;
+    }
+    &--stopping {
+        background: var(--warning-color, #f5a623);
+        opacity: 0.7;
     }
     &--idle {
         background: var(--secondary-text-color);
-        opacity: 0.5;
+        opacity: 0.4;
+    }
+    &--error {
+        background: var(--error-color, #e05252);
+    }
+    &--disconnected {
+        background: var(--secondary-text-color);
+        opacity: 0.25;
     }
 }
 

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -8,6 +8,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { WOS, workspace, setActiveTab, atoms } from "@/app/store/global";
 import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
+import { getBlockTurnPhase } from "@/app/store/agentActivity";
 import "./swarm-view.scss";
 
 // Navigate to the pane for a given block ID, switching tabs if needed.
@@ -125,6 +126,24 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
     );
 }
 
+// ── Status derived from TurnPhase ────────────────────────────────────────
+
+type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected";
+
+function phaseToDisplayStatus(blockId: string, fallback: "running" | "idle"): AgentDisplayStatus {
+    const phaseAccessor = getBlockTurnPhase(blockId);
+    if (!phaseAccessor) return fallback === "running" ? "working" : "idle";
+    const phase = phaseAccessor();
+    switch (phase.kind) {
+        case "Submitting":    return "working";
+        case "Streaming":     return phase.toolsActive > 0 ? "tools" : "working";
+        case "Interrupting":  return "stopping";
+        case "Done":          return phase.outcome === "errored" ? "error" : "idle";
+        case "Disconnected":  return "disconnected";
+        default:              return "idle";
+    }
+}
+
 // ── Agent root row ───────────────────────────────────────────────────────
 
 function AgentRow({
@@ -134,6 +153,10 @@ function AgentRow({
     node: AgentTreeNode;
     focusedBlockId: () => string | null;
 }): JSX.Element {
+    const displayStatus = createMemo<AgentDisplayStatus>(() =>
+        phaseToDisplayStatus(node.blockId, node.agentStatus)
+    );
+
     return (
         <div class="swarm-agent-group">
             <div
@@ -147,7 +170,7 @@ function AgentRow({
             >
                 <span class="swarm-agent-icon">⬡</span>
                 <span class="swarm-agent-label">{node.agentName}</span>
-                <StatusChip status={node.agentStatus === "running" ? "running" : "idle"} />
+                <AgentStatusChip status={displayStatus()} />
             </div>
             <div class="swarm-children">
                 <Show when={node.activitySummary}>
@@ -182,19 +205,27 @@ function SubagentRow({ sub }: { sub: ActiveSubagent }): JSX.Element {
             title={sub.slug || sub.agent_id}
         >
             <span class="swarm-subagent-slug">{sub.slug || sub.agent_id.substring(0, 7)}</span>
-            <StatusChip status={sub.status === "active" ? "running" : "done"} />
+            <AgentStatusChip status={sub.status === "active" ? "working" : "idle"} />
         </div>
     );
 }
 
 // ── Status chip ──────────────────────────────────────────────────────────
 
-function StatusChip({ status }: { status: "running" | "idle" | "done" }): JSX.Element {
-    const label = status === "running" ? "running" : status === "done" ? "done" : "idle";
+const STATUS_LABEL: Record<AgentDisplayStatus, string> = {
+    working:      "working",
+    tools:        "tools",
+    stopping:     "stopping",
+    idle:         "idle",
+    error:        "error",
+    disconnected: "offline",
+};
+
+function AgentStatusChip({ status }: { status: AgentDisplayStatus }): JSX.Element {
     return (
         <span class={`swarm-status-chip swarm-status-chip--${status}`}>
             <span class={`swarm-status-dot swarm-status-dot--${status}`} />
-            {label}
+            {STATUS_LABEL[status]}
         </span>
     );
 }


### PR DESCRIPTION
## Summary

- Replaces the coarse `shellprocstatus` "running/idle" status chip with a live, per-block status driven by the `TurnPhase` reducer
- `agentActivity.ts` now maintains a `phaseRegistry` (`Map<blockId, Accessor<TurnPhase>>`) updated on `registerActivity` / `unregisterActivity`
- `AgentRow` reads the per-block accessor inside a `createMemo`, mapping all 6 `TurnPhase` variants to display states
- Falls back to coarse `shellprocstatus` when the pane's phase isn't registered (e.g. block not yet mounted)

## Status mapping

| TurnPhase | Display | Dot |
|-----------|---------|-----|
| `Submitting` | working | pulsing amber |
| `Streaming` (tools active) | tools | pulsing purple |
| `Streaming` (no tools) | working | pulsing amber |
| `Interrupting` | stopping | amber, no pulse |
| `Done` / errored | error | red |
| `Done` / completed/stopped/interrupted | idle | dim |
| `Disconnected` | offline | very dim |
| Not registered (fallback) | working / idle from shellprocstatus | — |

No backend changes — all state comes from the existing frontend reducer.

## Test plan

- [ ] Agent idle → chip shows "idle" with dim dot
- [ ] Send a message → chip flips to "working" (pulsing amber) while streaming
- [ ] Agent calls a tool → chip shows "tools" (pulsing purple)
- [ ] Press stop → chip shows "stopping" briefly
- [ ] Turn ends cleanly → chip returns to "idle"
- [ ] Agent errors → chip shows "error" (red dot)

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-naki} -->

🤖 Generated with [Claude Code](https://claude.ai/claude-code)