### PR TITLE
fix(agent-pane): marching ants freeze on macOS with Reduce Motion

### DIFF
--- a/.changesets/1782212989-fix-agent-pane-marching-ants-freeze-on-macos-with-reduce-mot-rzgm.md
+++ b/.changesets/1782212989-fix-agent-pane-marching-ants-freeze-on-macos-with-reduce-mot-rzgm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): marching ants freeze on macOS with Reduce Motion — add animation-iteration-count: infinite in reduced-motion block

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -140,9 +140,16 @@
         // glow/"aurora", and `animation: none` freezes the stripe = looks
         // stuck). CEF maps reduced-motion to the Windows "Animation effects"
         // toggle (SPI_GETCLIENTAREAANIMATION), so machines with it off land
-        // here. Override only the duration so the same keyframe runs slower.
+        // here. On macOS, "Reduce Motion" in System Settings → Accessibility
+        // → Display triggers this branch.
+        // IMPORTANT: also explicitly set animation-iteration-count: infinite.
+        // Chromium internally limits `infinite` animations to a single
+        // iteration when prefers-reduced-motion fires, so without this override
+        // the ants march once (~1.5s), then freeze — the bug reported on macOS
+        // with Reduce Motion on and on Windows with Animation effects off.
         .agent-pane-progress-bar--active::before {
             animation-duration: 1.5s;
+            animation-iteration-count: infinite;
         }
     }
 


### PR DESCRIPTION
## Root cause

`#1715` overrode `animation-duration: 1.5s` in the `@media (prefers-reduced-motion: reduce)` block but did not touch `animation-iteration-count`. Chromium internally limits `animation-iteration-count: infinite` animations to **a single run** when `prefers-reduced-motion: reduce` is active. The ants march once (~1.5s under the slowed duration) and then freeze — reported as "ants appear but stuck, not animating" on macOS.

Linux was fine because the test machines don't have Reduce Motion enabled. macOS users with "Reduce Motion" turned on in System Settings → Accessibility → Display hit this path every time.

## Fix

Add `animation-iteration-count: infinite` to the reduced-motion rule so it overrides Chromium's internal single-iteration clamp:

```scss
@media (prefers-reduced-motion: reduce) {
    .agent-pane-progress-bar--active::before {
        animation-duration: 1.5s;
        animation-iteration-count: infinite;  // ← new
    }
}
```

## Test plan

- [ ] macOS with "Reduce Motion" ON (System Settings → Accessibility → Display): ants march continuously, not just once
- [ ] macOS with "Reduce Motion" OFF: ants march at original 0.5s speed
- [ ] Windows with "Animation effects" OFF: ants march continuously at 1.5s
- [ ] Linux (no Reduce Motion): ants march normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)