### PR TITLE
fix(agent-pane): red !cmd styling, sh -c on Windows, MSYS path normalization

### DIFF
--- a/.changesets/1782229545-fix-agent-pane-red-input-styling-when-bang-cmd-sh-c-on-windo-bgyc.md
+++ b/.changesets/1782229545-fix-agent-pane-red-input-styling-when-bang-cmd-sh-c-on-windo-bgyc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): red input styling when bang-cmd; sh -c on Windows; MSYS path fix

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -150,6 +150,11 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     ).await;
 
                     if timeout_result.is_err() {
+                        // Kill the in-container process so it doesn't linger after
+                        // timeout. Mirrors the host branch's process-group SIGKILL.
+                        // signal_exec_process runs pkill -KILL -f <pattern> inside
+                        // the container; fire-and-forget (non-match is not an error).
+                        cm.signal_exec_process(&container_name, &cmd.command, true).await.ok();
                         return Err(format!("shellexec: timed out after {TIMEOUT_SECS}s"));
                     }
                     timeout_result.unwrap()?;

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -31,13 +31,21 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    // shellexec → run a shell command in the agent's working directory and return output.
+    // shellexec → run a shell command and return output.
     // Invoked by the `!cmd` prefix in the agent pane composer.
+    //
+    // Host agents:      sh -c <cmd> in the agent's working directory (all platforms;
+    //                   Git Bash provides sh on Windows).
+    // Container agents: docker exec <container> sh -c <cmd> via bollard.
+    //                   The host cmd:cwd is not valid inside the container — the
+    //                   command runs in the container's own working directory.
     let wstore_se = state.wstore.clone();
+    let container_manager = state.container_manager.clone();
     engine.register_handler(
         COMMAND_SHELL_EXEC,
         Box::new(move |data, _ctx| {
             let wstore = wstore_se.clone();
+            let cm_opt = container_manager.clone();
             Box::pin(async move {
                 let cmd: CommandShellExecData = serde_json::from_value(data)
                     .map_err(|e| format!("shellexec: {e}"))?;
@@ -47,10 +55,6 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 tracing::info!(block_id = %cmd.blockid, "ShellExec");
                 tracing::debug!(command = %cmd.command, "ShellExec command");
 
-                // Reject container agents: their filesystem lives inside the
-                // Docker container, so running sh on the host gives misleading
-                // results or mutates the wrong environment.  Routing through
-                // `docker exec` is tracked as a follow-up feature.
                 let block: crate::backend::obj::Block = wstore
                     .get(&cmd.blockid)
                     .map_err(|e| format!("shellexec: load block: {e}"))?
@@ -58,13 +62,123 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let agent_mode = crate::backend::obj::meta_get_string(
                     &block.meta, "agentMode", "host",
                 );
-                if agent_mode == "container" {
-                    return Err(
-                        "shellexec: container agents are not supported; \
-                         run the command from within the agent session instead".to_string()
-                    );
+
+                // 300s process timeout matches the frontend's RPC timeout so
+                // the client sees a clean error rather than a silent EC-TIME.
+                const TIMEOUT_SECS: u64 = 300;
+                // 1 MB cap per stream — bounds memory for runaway commands
+                // (`! yes`, `! dd if=/dev/zero`).
+                const MAX_OUTPUT: u64 = 1_000_000;
+
+                // Shared output formatter: if we accumulated more than MAX_OUTPUT
+                // bytes, the stream was truncated — append a notice.
+                fn format_output(bytes: Vec<u8>, cap: u64) -> String {
+                    if bytes.len() > cap as usize {
+                        let s = String::from_utf8_lossy(&bytes[..cap as usize]);
+                        format!("{s}…[output capped at {cap} bytes]")
+                    } else {
+                        String::from_utf8_lossy(&bytes).into_owned()
+                    }
                 }
 
+                // ── Container agents ─────────────────────────────────────────
+                if agent_mode == "container" {
+                    let cm = cm_opt.as_deref().ok_or_else(|| {
+                        "shellexec: Docker not available on this host; \
+                         cannot exec in container agent".to_string()
+                    })?;
+
+                    let agent_id = crate::backend::obj::meta_get_string(
+                        &block.meta, "agentId", "",
+                    );
+                    if agent_id.is_empty() {
+                        return Err("shellexec: container agent missing agentId in block meta".to_string());
+                    }
+                    let container_name =
+                        crate::backend::container::container_name_for_slug(&agent_id);
+
+                    let session = cm.exec(
+                        &container_name,
+                        &["sh".to_string(), "-c".to_string(), cmd.command.clone()],
+                        None, // container's own working directory (host path invalid inside)
+                        &[],  // no extra env vars for !cmd
+                    ).await.map_err(|e| format!("shellexec: container exec failed: {e}"))?;
+
+                    let exec_id = session.exec_id.clone();
+                    // No stdin needed for !cmd — drop to signal EOF immediately.
+                    drop(session.input);
+
+                    let mut stdout_buf: Vec<u8> = Vec::new();
+                    let mut stderr_buf: Vec<u8> = Vec::new();
+
+                    use futures_util::StreamExt as _;
+                    use bollard::container::LogOutput;
+
+                    let timeout_result = tokio::time::timeout(
+                        std::time::Duration::from_secs(TIMEOUT_SECS),
+                        async {
+                            let mut output = std::pin::pin!(session.output);
+                            while let Some(item) = output.next().await {
+                                match item {
+                                    Err(e) => return Err(format!(
+                                        "shellexec: container output read: {e}"
+                                    )),
+                                    Ok(log) => match log {
+                                        LogOutput::StdOut { message } => {
+                                            // Accumulate MAX_OUTPUT+1 bytes (the +1 sentinel lets
+                                            // format_output distinguish "exactly at cap" from
+                                            // "truncated", matching the host branch's take logic).
+                                            let cap = (MAX_OUTPUT + 1) as usize;
+                                            let take = cap
+                                                .saturating_sub(stdout_buf.len())
+                                                .min(message.len());
+                                            stdout_buf.extend_from_slice(&message[..take]);
+                                        }
+                                        LogOutput::StdErr { message } => {
+                                            let cap = (MAX_OUTPUT + 1) as usize;
+                                            let take = cap
+                                                .saturating_sub(stderr_buf.len())
+                                                .min(message.len());
+                                            stderr_buf.extend_from_slice(&message[..take]);
+                                        }
+                                        _ => {} // StdIn / Console frames not relevant here
+                                    }
+                                }
+                            }
+                            Ok(())
+                        }
+                    ).await;
+
+                    if timeout_result.is_err() {
+                        return Err(format!("shellexec: timed out after {TIMEOUT_SECS}s"));
+                    }
+                    timeout_result.unwrap()?;
+
+                    // The output stream closing does not carry the exit status —
+                    // retrieve it separately via inspect_exec.
+                    let exit_code = cm.inspect_exec(&exec_id).await
+                        .ok()
+                        .flatten()
+                        .unwrap_or(1) as i32;
+
+                    tracing::debug!(
+                        block_id = %cmd.blockid,
+                        container = %container_name,
+                        exit_code,
+                        "ShellExec container done",
+                    );
+
+                    let result = ShellExecResult {
+                        exit_code,
+                        stdout: format_output(stdout_buf, MAX_OUTPUT),
+                        stderr: format_output(stderr_buf, MAX_OUTPUT),
+                    };
+                    return Ok(Some(
+                        serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?
+                    ));
+                }
+
+                // ── Host agents ───────────────────────────────────────────────
                 let cwd: Option<std::path::PathBuf> = if cmd.working_dir.is_empty() {
                     None
                 } else {
@@ -96,16 +210,6 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         ))?;
                     Some(canonical)
                 };
-
-                // 300s process timeout matches the frontend's RPC timeout so
-                // the client sees a clean error rather than a silent EC-TIME.
-                const TIMEOUT_SECS: u64 = 300;
-                // 1 MB cap per stream — bounded during read via take() so a
-                // runaway command (`! yes`, `! dd if=/dev/zero`) cannot exhaust
-                // RAM before the timeout fires. The pipes are read concurrently
-                // to prevent deadlock when one buffer fills while the process is
-                // blocked writing to the other.
-                const MAX_OUTPUT: u64 = 1_000_000;
 
                 // Use sh -c on all platforms: agents run in a bash environment
                 // (Git Bash on Windows, sh on Unix) so Unix commands like ls/pwd/grep
@@ -197,7 +301,7 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 )
                 .await;
 
-                // On timeout: kill_on_drop kills the direct sh/cmd child, but
+                // On timeout: kill_on_drop kills the direct sh child, but
                 // compound commands (`! a | b`, `! foo &`) fork grandchildren
                 // in the same process group.  Kill the whole group so they don't
                 // linger.  (Unix only; on Windows the job-object approach is a
@@ -214,23 +318,10 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let status = timeout_result
                     .map_err(|_| format!("shellexec: timed out after {TIMEOUT_SECS}s"))??;
 
-                let format_output = |bytes: Vec<u8>| -> String {
-                    // bytes.len() > MAX_OUTPUT means we read the MAX_OUTPUT+1
-                    // sentinel — the stream was truncated.  Checking for equality
-                    // with MAX_OUTPUT (without +1) would be a false positive for
-                    // commands that emit exactly MAX_OUTPUT bytes.
-                    if bytes.len() > MAX_OUTPUT as usize {
-                        let s = String::from_utf8_lossy(&bytes[..MAX_OUTPUT as usize]);
-                        format!("{s}…[output capped at {MAX_OUTPUT} bytes]")
-                    } else {
-                        String::from_utf8_lossy(&bytes).into_owned()
-                    }
-                };
-
                 let result = ShellExecResult {
                     exit_code: status.code().unwrap_or(1),
-                    stdout: format_output(stdout_buf),
-                    stderr: format_output(stderr_buf),
+                    stdout: format_output(stdout_buf, MAX_OUTPUT),
+                    stderr: format_output(stderr_buf, MAX_OUTPUT),
                 };
                 Ok(Some(serde_json::to_value(result).map_err(|e| format!("shellexec: {e}"))?))
             })

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -152,9 +152,14 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     if timeout_result.is_err() {
                         // Kill the in-container process so it doesn't linger after
                         // timeout. Mirrors the host branch's process-group SIGKILL.
-                        // signal_exec_process runs pkill -KILL -f <pattern> inside
+                        // signal_exec_process runs `pkill -KILL -f <pattern>` inside
                         // the container; fire-and-forget (non-match is not an error).
-                        cm.signal_exec_process(&container_name, &cmd.command, true).await.ok();
+                        //
+                        // Pattern is "sh -c <command>" (the full cmdline we spawned),
+                        // not just cmd.command — a bare command like "python" or "sh"
+                        // would over-match the agent's own running processes.
+                        let kill_pattern = format!("sh -c {}", cmd.command);
+                        cm.signal_exec_process(&container_name, &kill_pattern, true).await.ok();
                         return Err(format!("shellexec: timed out after {TIMEOUT_SECS}s"));
                     }
                     timeout_result.unwrap()?;

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -8,7 +8,7 @@ use crate::backend::rpc_types::{
     COMMAND_SHELL_EXEC, COMMAND_SHELL_STOP,
     CommandShellExecData, ShellExecResult, CommandShellStopData,
 };
-use crate::backend::base::expand_home_dir_safe;
+use crate::backend::base::{expand_home_dir_safe, msys_to_windows_path};
 
 use super::AppState;
 
@@ -68,7 +68,12 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let cwd: Option<std::path::PathBuf> = if cmd.working_dir.is_empty() {
                     None
                 } else {
-                    let expanded = expand_home_dir_safe(&cmd.working_dir);
+                    // Convert MSYS/Git-Bash paths like /c/Users/... to C:\Users\...
+                    // before expansion. Without this, canonicalize() fails on Windows
+                    // with os error 267 (ERROR_DIRECTORY) — same fix applied to the
+                    // persistent shell node in d89c1458.
+                    let native = msys_to_windows_path(&cmd.working_dir);
+                    let expanded = expand_home_dir_safe(&native);
                     // Reject non-absolute paths to prevent relative traversal
                     // (e.g. "../etc") from resolving against the sidecar's cwd.
                     // expand_home_dir_safe turns "~" into an absolute home path;
@@ -102,11 +107,10 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // blocked writing to the other.
                 const MAX_OUTPUT: u64 = 1_000_000;
 
-                let mut proc = if cfg!(windows) {
-                    let mut c = tokio::process::Command::new("cmd");
-                    c.args(["/C", &cmd.command]);
-                    c
-                } else {
+                // Use sh -c on all platforms: agents run in a bash environment
+                // (Git Bash on Windows, sh on Unix) so Unix commands like ls/pwd/grep
+                // work consistently. cmd /C would exit 1 for any non-Windows command.
+                let mut proc = {
                     let mut c = tokio::process::Command::new("sh");
                     c.args(["-c", &cmd.command]);
                     c

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -227,6 +227,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // controlling the textarea.
     const [autocompletePrefix, setAutocompletePrefix] = createSignal<string | null>(null);
     const [autocompleteIndex, setAutocompleteIndex] = createSignal(0);
+    const [isBangCmd, setIsBangCmd] = createSignal(false);
 
     const completions = createMemo<SlashCommand[]>(() => {
         const p = autocompletePrefix();
@@ -280,6 +281,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (!textareaRef) return;
         textareaRef.value = `/${cmd.name} `;
         setAutocompletePrefix(null);
+        setIsBangCmd(false);
         textareaRef.focus();
         props.onTyping?.();
     };
@@ -293,6 +295,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (!textareaRef) return;
         textareaRef.value = text;
         textareaRef.setSelectionRange(text.length, text.length);
+        setIsBangCmd(text.startsWith("!"));
         updateAutocomplete();
         props.onTyping?.();
     };
@@ -311,6 +314,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // we measure only the synchronous handler cost.
         markStart("agent-keystroke");
         updateAutocomplete();
+        setIsBangCmd(textareaRef?.value.startsWith("!") ?? false);
         const cb = props.onTyping;
         if (!cb) {
             markEnd("agent-keystroke", "done");
@@ -406,6 +410,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             histDraft = "";
             textareaRef.value = "";
             setAutocompletePrefix(null);
+            setIsBangCmd(false);
             // Scroll the new user message into view. SolidJS flushes the
             // document signal synchronously before this point, so jumpToBottom
             // will include the just-added node in scrollHeight.
@@ -519,6 +524,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             if (textareaRef.value.trim().length > 0) {
                 e.preventDefault();
                 textareaRef.value = "";
+                setIsBangCmd(false);
                 // Clearing exits history navigation — park the cursor at the
                 // newest message so the next ArrowUp doesn't skip an entry.
                 // (The clear doesn't dispatch `input`, so handleInput's reset
@@ -551,7 +557,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 </Show>
                 <textarea
                     ref={textareaRef}
-                    class="agent-input"
+                    class={`agent-input${isBangCmd() ? " bang-command" : ""}`}
                     placeholder={placeholder()}
                     onKeyDown={handleKeyDown}
                     onInput={handleInput}

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -134,6 +134,16 @@
                     outline: none;
                     border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
                 }
+
+                &.bang-command {
+                    color: var(--error-color);
+                    border-color: var(--error-color);
+                    caret-color: var(--error-color);
+
+                    &:focus {
+                        border-color: var(--error-color);
+                    }
+                }
             }
 
 


### PR DESCRIPTION
## Summary

### Commit 1 — host agent fixes
- **Red input styling**: textarea text/border/caret turn `--error-color` (red) the moment input starts with `!`; `isBangCmd` signal tracks all write paths (keystrokes, history recall, autocomplete accept, send clear, Esc clear)
- **exit 1 on Unix commands**: backend hardcoded `cmd /C` on Windows — any `!ls`, `!pwd`, `!grep` exited with code 1. Switched to `sh -c` on all platforms (agents run in Git Bash; `sh` is always on PATH)
- **MSYS path canonicalize failure**: `cmd:cwd` POSIX paths like `/c/Users/…` passed to `expand_home_dir_safe` without `msys_to_windows_path` first → `canonicalize()` os error 267. Mirrors d89c1458 fix for persistent shell node

### Commit 2 — container agent support
- Container agents previously rejected `shellexec` with an error
- Now executes via bollard `docker exec` — same API as agent turns in `app_api.rs`/`subprocess.rs`
- Derives `container_name` from `agentId` meta key via `container_name_for_slug` (deterministic)
- Streams `LogOutput::StdOut`/`StdErr` frames with same 1 MB cap as host branch
- Exit code retrieved via `cm.inspect_exec(exec_id)` after stream EOF (stream close ≠ exit status in bollard)
- `None` working dir → container's own image default (host `cmd:cwd` path not valid inside)

### Platform matrix

| Agent type | Windows | macOS | Linux |
|------------|---------|-------|-------|
| host | `sh -c` (Git Bash) | `sh -c` | `sh -c` |
| container | `docker exec … sh -c` | `docker exec … sh -c` | `docker exec … sh -c` |

## Files changed

- `frontend/app/view/agent/components/AgentFooter.tsx` — `isBangCmd` signal + class binding
- `frontend/app/view/agent/styles/_pending-footer.scss` — `.bang-command` CSS rule
- `agentmux-srv/src/server/shell_handlers.rs` — container exec branch + `sh -c` + MSYS path fix

## Test plan

- [ ] Type `!` in agent composer — input text and border turn red; clears on send/Esc
- [ ] `!ls` in a **host** agent (e.g. Codex) — lists files, exits 0
- [ ] `!pwd` in a host agent — prints working directory, exits 0
- [ ] `!ls` in a **container** agent — lists container files, exits 0
- [ ] `!nonexistent-cmd` in a container agent — stderr surfaced, exit 1
- [ ] Container agent with Docker not running — shows "Docker not available" error
- [ ] `cargo check -p agentmux-srv` passes ✓ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)