### PR TITLE
feat(layout): pane minimize — collapse to header bar

### DIFF
--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -280,6 +280,12 @@
                         padding: 0;
                     }
 
+                    .block-frame-minimize {
+                        justify-content: center;
+                        align-items: center;
+                        padding: 0;
+                    }
+
                     .block-frame-btn-separator {
                         width: 1px;
                         height: 14px;

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -170,6 +170,16 @@ function getViewIconElem(viewIconUnion: string | IconButtonDecl, blockData: Bloc
     }
 }
 
+function OptMinimizeButton(props: { minimized: boolean; toggleMinimize: () => void }): JSX.Element {
+    const decl = createMemo<IconButtonDecl>(() => ({
+        elemtype: "iconbutton",
+        icon: props.minimized ? "chevron-up" : "chevron-down",
+        title: props.minimized ? "Restore" : "Minimize",
+        click: props.toggleMinimize,
+    }));
+    return <IconButton decl={decl()} className="block-frame-minimize" />;
+}
+
 function OptMagnifyButton(props: { magnified: boolean; toggleMagnify: () => void; disabled: boolean }): JSX.Element {
     const magnifyDecl = createMemo<IconButtonDecl>(() => ({
         elemtype: "iconbutton",
@@ -217,7 +227,9 @@ function EndIcons(props: {
     // the button array re-evaluates when the agent loads/unloads.
     const endIconButtons = createMemo(() => util.useAtomValueSafe(props.viewModel?.endIconButtons));
     const magnified = () => props.nodeModel.isMagnified();
+    const minimized = () => props.nodeModel.isMinimized();
     const ephemeral = () => props.nodeModel.isEphemeral();
+    const numLeafs = () => props.nodeModel.numLeafs();
     const magnifyDisabled = () => false;
     // In a torn-off floating shell the window carries a `?windowLabel=floating-…`
     // URL param (set by the host when it opens the popup). When present, the
@@ -254,6 +266,13 @@ function EndIcons(props: {
                                 ? "Speak into this agent (Ctrl+Shift+V)"
                                 : undefined
                     }
+                />
+            </Show>
+
+            <Show when={!ephemeral() && !magnified() && numLeafs() > 1}>
+                <OptMinimizeButton
+                    minimized={minimized()}
+                    toggleMinimize={props.nodeModel.toggleMinimize}
                 />
             </Show>
 

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -1,6 +1,7 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+
 import { findNode, findParent } from "./layoutNode";
 import type { LayoutModel } from "./layoutModel";
 

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -1,0 +1,91 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { findNode, findParent } from "./layoutNode";
+import type { LayoutModel } from "./layoutModel";
+
+/** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
+export const HeaderHeightPx = 33;
+
+/**
+ * Toggle minimize for a given leaf node. Minimized panes collapse to their header
+ * bar, redistributing freed space to an adjacent sibling. Restoring returns the
+ * pane to its original size by reclaiming space from that same sibling.
+ */
+export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
+    const node = findNode(model.treeState.rootNode, nodeId);
+    if (!node) return;
+
+    const parentNode = findParent(model.treeState.rootNode, nodeId);
+    if (!parentNode?.children?.length) return;
+
+    const addlProps = model.getter(model.additionalProps);
+    const pixelToSizeRatio = addlProps[parentNode.id]?.pixelToSizeRatio;
+    if (!pixelToSizeRatio) return;
+
+    const siblings = parentNode.children;
+    const nodeIdx = siblings.findIndex((c) => c.id === nodeId);
+
+    // Pick the adjacent sibling that will absorb or yield space.
+    const sibling = siblings[nodeIdx + 1] ?? siblings[nodeIdx - 1];
+    if (!sibling) return;
+
+    // Add gap so the header isn't clipped by the tile-leaf's gap/2 inset padding on each side.
+    const gapSizePx = model.gapSizePx();
+    const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
+
+    if (node.minimizedSize === undefined) {
+        // --- Minimize ---
+        const freedUnits = node.size - headerSizeUnits;
+        if (freedUnits <= 0) return; // already tiny — no-op
+
+        node.minimizedSize = node.size;
+        node.size = headerSizeUnits;
+        sibling.size += freedUnits;
+    } else {
+        // --- Restore ---
+        const reclaimUnits = node.minimizedSize - headerSizeUnits;
+        const siblingAfterReclaim = sibling.size - reclaimUnits;
+        // Clamp: don't let sibling go below its own header height.
+        const minSiblingUnits = HeaderHeightPx * pixelToSizeRatio;
+        if (siblingAfterReclaim < minSiblingUnits) {
+            const available = sibling.size - minSiblingUnits;
+            node.size += available;
+            sibling.size = minSiblingUnits;
+        } else {
+            node.size = node.minimizedSize;
+            sibling.size = siblingAfterReclaim;
+        }
+        node.minimizedSize = undefined;
+    }
+
+    // Update the minimized-node-id set for reactive isMinimized checks.
+    model.minimizedNodeIds._set((prev) => {
+        const next = new Set(prev);
+        if (node.minimizedSize !== undefined) {
+            next.add(nodeId);
+        } else {
+            next.delete(nodeId);
+        }
+        return next;
+    });
+
+    model.updateTree();
+    model.localTreeStateAtom._set({ ...model.treeState });
+    model.persistToBackend();
+}
+
+/**
+ * Scan the loaded tree for nodes that carry a `minimizedSize` field and rebuild
+ * the in-memory `minimizedNodeIds` set. Called once during `initializeFromWaveObject`.
+ */
+export function rebuildMinimizedSet(model: LayoutModel) {
+    const ids = new Set<string>();
+    function walk(node: typeof model.treeState.rootNode) {
+        if (!node) return;
+        if (node.minimizedSize !== undefined) ids.add(node.id);
+        node.children?.forEach(walk);
+    }
+    walk(model.treeState.rootNode);
+    model.minimizedNodeIds._set(ids);
+}

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -90,6 +90,10 @@ import {
     validateMagnifiedNode as validateMagnifiedNodeImpl,
 } from "./layoutMagnify";
 import {
+    minimizeNodeToggle as minimizeNodeToggleImpl,
+    rebuildMinimizedSet as rebuildMinimizedSetImpl,
+} from "./layoutMinimize";
+import {
     initializeFromWaveObject as initializeFromWaveObjectImpl,
     onBackendUpdate as onBackendUpdateImpl,
     persistToBackend as persistToBackendImpl,
@@ -288,6 +292,12 @@ export class LayoutModel {
     magnifyMount: SignalAtom<HTMLElement | null>;
 
     /**
+     * Set of node IDs that are currently minimized (collapsed to header bar).
+     * Kept in sync with `node.minimizedSize` on each LayoutNode in the tree.
+     */
+    minimizedNodeIds: SignalAtom<Set<string>>;
+
+    /**
      * The size of the resize handles, in CSS pixels.
      * @internal
      */
@@ -450,6 +460,7 @@ export class LayoutModel {
             this.ephemeralNode = createSignalAtom<LayoutNode>(undefined);
             this.magnifiedNodeSizeAtom = getSettingsKeyAtom("window:magnifiedblocksize");
             this.magnifyMount = createSignalAtom<HTMLElement | null>(null);
+            this.minimizedNodeIds = createSignalAtom<Set<string>>(new Set());
 
             this.magnifiedNodeIdAtom = createMemo(() => {
                 const treeState = this.localTreeStateAtom();
@@ -758,6 +769,14 @@ export class LayoutModel {
 
     magnifyNodeToggle(nodeId: string, setState = true) {
         magnifyNodeToggleImpl(this, nodeId, setState);
+    }
+
+    minimizeNodeToggle(nodeId: string) {
+        minimizeNodeToggleImpl(this, nodeId);
+    }
+
+    rebuildMinimizedSet() {
+        rebuildMinimizedSetImpl(this);
     }
 
     async closeNode(nodeId: string) {

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -55,6 +55,10 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                     const treeState = model.localTreeStateAtom();
                     return treeState.magnifiedNodeId === nodeid;
                 }),
+                isMinimized: createMemo(() => {
+                    const minimizedIds = model.minimizedNodeIds();
+                    return minimizedIds.has(nodeid);
+                }),
                 isEphemeral: createMemo(() => {
                     const ephemeralNode = model.ephemeralNode();
                     return ephemeralNode?.id === nodeid;
@@ -67,6 +71,7 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                     fireAndForget(() => model.closeNode(nodeid));
                 },
                 toggleMagnify: () => model.magnifyNodeToggle(nodeid),
+                toggleMinimize: () => model.minimizeNodeToggle(nodeid),
                 focusNode: () => model.focusNode(nodeid),
                 dragHandleRef: { current: null as HTMLDivElement | null },
                 displayContainerRef: model.displayContainerRef,

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -4,6 +4,7 @@
 import { batch } from "solid-js";
 import { fireAndForget } from "@/util/util";
 import { findNodeByBlockId, newLayoutNode } from "./layoutNode";
+import { rebuildMinimizedSet } from "./layoutMinimize";
 import {
     LayoutTreeActionType,
     LayoutTreeClearTreeAction,
@@ -35,6 +36,7 @@ export function initializeFromWaveObject(model: LayoutModel) {
     model.treeState = initialState;
     model.magnifiedNodeId = initialState.magnifiedNodeId;
     model.setter(model.localTreeStateAtom, { ...initialState });
+    rebuildMinimizedSet(model);
 
     if (initialState.pendingBackendActions?.length) {
         fireAndForget(() => processPendingBackendActions(model));

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -98,8 +98,12 @@ export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps
     const beforeNodeSize = model.resizeContext.beforeNodeStartSize - clientDiff;
     const afterNodeSize = model.resizeContext.afterNodeStartSize + clientDiff;
 
-    // If either node will be too small after this resize, don't let it happen.
-    if (beforeNodeSize < minNodeSize || afterNodeSize < minNodeSize) {
+    // Minimized nodes can legitimately be smaller than MinNodeSizePx — skip the guard for them.
+    const beforeNode = findNode(model.treeState.rootNode, model.resizeContext.beforeNodeId);
+    const afterNode = findNode(model.treeState.rootNode, model.resizeContext.afterNodeId);
+    const beforeMinimized = beforeNode?.minimizedSize !== undefined;
+    const afterMinimized = afterNode?.minimizedSize !== undefined;
+    if ((!beforeMinimized && beforeNodeSize < minNodeSize) || (!afterMinimized && afterNodeSize < minNodeSize)) {
         return;
     }
 

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -188,6 +188,8 @@ export interface LayoutNode {
     children?: LayoutNode[];
     flexDirection: FlexDirection;
     size: number;
+    /** Original size before minimization. Presence indicates the node is minimized. */
+    minimizedSize?: number;
 }
 
 export type LayoutTreeStateSetter = (value: LayoutState) => void;
@@ -264,10 +266,12 @@ export interface NodeModel {
     isSplitterDragging: Accessor<boolean>;
     isFocused: Accessor<boolean>;
     isMagnified: Accessor<boolean>;
+    isMinimized: Accessor<boolean>;
     isEphemeral: Accessor<boolean>;
     ready: Accessor<boolean>;
     disablePointerEvents: Accessor<boolean>;
     toggleMagnify: () => void;
+    toggleMinimize: () => void;
     focusNode: () => void;
     onClose: () => void;
     // DOM refs in SolidJS are plain { current: T | null } objects


### PR DESCRIPTION
## Summary

- Adds a working **minimize button** (chevron-down/chevron-up) to every tiled pane header bar
- Clicking minimize collapses the pane to its 33 px header bar and gives the freed space to an adjacent sibling; clicking again restores the original size
- Minimized state persists across page reloads via the existing `rootNode` WaveObject (stored in `node.minimizedSize`)
- Button is only visible when `numLeafs > 1` (can't minimize the only pane) and hidden when the pane is magnified or ephemeral

## Architecture

New file `layoutMinimize.ts` handles all geometry:
- `minimizeNodeToggle(model, nodeId)`: reads parent's `pixelToSizeRatio` from `additionalProps`, sets `node.size = (33 + gap) * ratio`, saves original in `node.minimizedSize`, redistributes freed units to sibling. Restore reclaims the same amount, clamped so sibling can't go below its own header height.
- `rebuildMinimizedSet(model)`: scans the loaded tree for `minimizedSize !== undefined` to rebuild the reactive `minimizedNodeIds` Set on startup.

The layout geometry engine (`updateTreeHelper`) naturally clips content via `overflow: hidden` on `.tile-leaf` — no extra CSS needed to hide pane content.

`layoutResize.ts` now skips the `MinNodeSizePx` guard for minimized nodes so the resize handle beside a minimized pane doesn't block dragging.

## Test plan

- [ ] Open multiple panes; click chevron-down on one — it collapses to header bar, neighbor expands to fill
- [ ] Click chevron-up (same button) on the collapsed pane — it restores to original size
- [ ] Reload page — minimized pane stays minimized
- [ ] Drag the resize handle between a minimized pane and its neighbor — should move freely
- [ ] With only 1 pane open — minimize button should not appear
- [ ] Magnify a pane — minimize button should not appear
- [ ] Test on macOS, Linux, Windows (all three TileLayout variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)