### PR TITLE
fix(container-agent): empty image fallback, skip empty meta, guard null blockId in swarm

### DIFF
--- a/.changesets/1782232002-fix-container-agent-empty-image-fallback-skip-empty-meta-gua-l8c6.md
+++ b/.changesets/1782232002-fix-container-agent-empty-image-fallback-skip-empty-meta-gua-l8c6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(container-agent): empty image fallback, skip empty meta, guard null blockId in swarm

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3272,9 +3272,10 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     if agent_mode == "container" {
                         let cm = container_manager.as_deref()
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
-                        let container_image = crate::backend::obj::meta_get_string(
-                            &block.meta, "agent:container_image", "ghcr.io/agentmuxai/agent-claude:latest",
-                        );
+                        let container_image = {
+                            let img = crate::backend::obj::meta_get_string(&block.meta, "agent:container_image", "");
+                            if img.is_empty() { "ghcr.io/agentmuxai/agent-claude:latest".to_string() } else { img }
+                        };
                         // Use agentId (UUID) — always valid as a Docker name; display names can have spaces.
                         let agent_id = crate::backend::obj::meta_get_string(
                             &block.meta, "agentId", "",

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -640,9 +640,10 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     if agent_mode == "container" {
                         let cm = container_manager.as_deref()
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
-                        let container_image = obj::meta_get_string(
-                            &block.meta, "agent:container_image", "ghcr.io/agentmuxai/agent-claude:latest",
-                        );
+                        let container_image = {
+                            let img = obj::meta_get_string(&block.meta, "agent:container_image", "");
+                            if img.is_empty() { "ghcr.io/agentmuxai/agent-claude:latest".to_string() } else { img }
+                        };
                         // Use agentId (UUID) — always valid as a Docker name; display names can have spaces.
                         let agent_id = obj::meta_get_string(&block.meta, "agentId", "");
                         let container_name = crate::backend::container::container_name_for_slug(&agent_id);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -551,7 +551,7 @@ export class AgentViewModel implements ViewModel {
                 agentName: instanceName,
                 agentIcon: agent.icon,
                 agentMode: overrides?.agentType ?? agent.agent_type ?? "host",
-                "agent:container_image": overrides?.containerImage ?? agent.container_image ?? "",
+                ...(overrides?.containerImage || agent.container_image ? { "agent:container_image": overrides?.containerImage || agent.container_image } : {}),
                 controller: isPersistent ? "persistent" : "subprocess",
                 cmd: cliBin,
                 "cmd:args": cliArgs,

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -26,7 +26,7 @@ export interface ActiveSubagent {
 }
 
 export interface AgentTreeNode {
-    blockId: string;
+    blockId: string | null;
     agentName: string;
     activitySummary: string | null;
     agentStatus: "running" | "idle";

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -142,7 +142,7 @@ function AgentRow({
                     [`swarm-agent-row--${node.agentStatus}`]: true,
                     "swarm-agent-row--active": focusedBlockId() === node.blockId,
                 }}
-                onClick={() => void focusBlock(node.blockId)}
+                onClick={() => node.blockId && void focusBlock(node.blockId)}
                 title={node.agentName}
             >
                 <span class="swarm-agent-icon">⬡</span>


### PR DESCRIPTION
## Summary

Three bugs causing container agents (e.g. Pconat) to silently fail to load:

- **`app_api.rs`**: `meta_get_string` returns `""` when `"agent:container_image"` is present-but-empty (the frontend always writes the key). Added empty-string guard to fall back to `ghcr.io/agentmuxai/agent-claude:latest` so agents with no explicit image still start. Root cause: `meta_get_string(meta, key, default)` returns the value, not the default, when the value is `""`.

- **`agent-model.ts`**: `launchAgentDefinition` always wrote `"agent:container_image": ""` to block meta when neither `overrides.containerImage` nor `agent.container_image` was set, defeating the backend default. Now skips the key if both are blank, so the backend default applies.

- **`swarm-view.tsx`**: `AgentRow` called `focusBlock(node.blockId)` even when `blockId` was `null` (agent never launched — not yet registered with muxbus). Click was a silent no-op that confused users into thinking the pane opened. Added `node.blockId &&` guard.

## Reproduction
Create a container agent without setting `container_image` → agent definition gets `container_image: ""` → open pane → first user message → `ensure_running("...", "", ...)` → Docker fails → pane shows nothing.

## Test plan
- [ ] Container agent with `container_image: ""` in definition: send first message → container starts with default image (not a Docker error)
- [ ] Container agent with explicit `container_image` set: still uses the explicit image
- [ ] New container agent opened via agent picker: `agent:container_image` key absent from block meta when image is blank
- [ ] Click unstarted agent in swarm view: click does nothing (no console error) rather than a broken focusBlock(null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)