### PR TITLE
feat(layout): fix floating-pane redock ghost-size mismatch (Phase 4b)

### DIFF
--- a/.changesets/1782234264-feat-layout-fix-floating-pane-redock-ghost-size-mismatch-pha-yyoj.md
+++ b/.changesets/1782234264-feat-layout-fix-floating-pane-redock-ghost-size-mismatch-pha-yyoj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(layout): fix floating-pane redock ghost-size mismatch (Phase 4b)

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -558,9 +558,6 @@ pub fn clear_floating_redock_hover(
         "floating-redock:hover-state",
         &serde_json::json!({ "target_label": serde_json::Value::Null }),
     );
-    // Phase 4b — clear all ghost states so a stale direction from a
-    // cancelled drag can't pollute the next drop.
-    state.floating_redock_ghost.lock().clear();
     Ok(serde_json::Value::Null)
 }
 
@@ -599,11 +596,13 @@ pub fn set_floating_redock_target(
     Ok(serde_json::Value::Null)
 }
 
-/// Phase 4b — retrieve the last ghost state for a target window.
+/// Phase 4b — consume the ghost state for a target window (read + remove).
 ///
 /// Called by the FLOATER's renderer just before emitting `RedockFloatingPane`
 /// so the saga can emit a directional `SplitHorizontal`/`SplitVertical` action
-/// instead of a generic `InsertNode`.
+/// instead of a generic `InsertNode`. Consuming (rather than just reading) the
+/// entry avoids any stale ghost from a prior drag being applied to a future drop
+/// where no new ghost state was set.
 ///
 /// Args: `{ "window_label": string }`.
 /// Returns: `{ "block_id": string, "dir": number }` or `{}` if no state stored.
@@ -616,8 +615,8 @@ pub fn get_floating_redock_target(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let g = state.floating_redock_ghost.lock();
-    match g.get(&window_label) {
+    let mut g = state.floating_redock_ghost.lock();
+    match g.remove(&window_label) {
         Some(ghost) => Ok(serde_json::json!({
             "block_id": ghost.block_id,
             "dir": ghost.dir,

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -558,6 +558,71 @@ pub fn clear_floating_redock_hover(
         "floating-redock:hover-state",
         &serde_json::json!({ "target_label": serde_json::Value::Null }),
     );
+    // Phase 4b — clear all ghost states so a stale direction from a
+    // cancelled drag can't pollute the next drop.
+    state.floating_redock_ghost.lock().clear();
     Ok(serde_json::Value::Null)
+}
+
+/// Phase 4b — store the ghost `{ block_id, dir }` for a target window.
+///
+/// Called by the TARGET window's renderer (`app-init.ts`) each time it
+/// computes the drop-zone direction. Passing `block_id: null` (or omitting
+/// it) clears the entry for that window so a stale direction is not used
+/// if the cursor leaves without a drop.
+///
+/// Args: `{ "window_label": string, "block_id": string|null, "dir": number|null }`.
+pub fn set_floating_redock_target(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let window_label = args
+        .get("window_label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if window_label.is_empty() {
+        return Err("set_floating_redock_target: window_label is required".into());
+    }
+    let block_id = args.get("block_id").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let dir = args.get("dir").and_then(|v| v.as_u64()).map(|d| d as u8);
+
+    let mut g = state.floating_redock_ghost.lock();
+    match (block_id, dir) {
+        (Some(bid), Some(d)) => {
+            g.insert(window_label, crate::state::FloatingRedockGhostState { block_id: bid, dir: d });
+        }
+        _ => {
+            g.remove(&window_label);
+        }
+    }
+    Ok(serde_json::Value::Null)
+}
+
+/// Phase 4b — retrieve the last ghost state for a target window.
+///
+/// Called by the FLOATER's renderer just before emitting `RedockFloatingPane`
+/// so the saga can emit a directional `SplitHorizontal`/`SplitVertical` action
+/// instead of a generic `InsertNode`.
+///
+/// Args: `{ "window_label": string }`.
+/// Returns: `{ "block_id": string, "dir": number }` or `{}` if no state stored.
+pub fn get_floating_redock_target(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let window_label = args
+        .get("window_label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let g = state.floating_redock_ghost.lock();
+    match g.get(&window_label) {
+        Some(ghost) => Ok(serde_json::json!({
+            "block_id": ghost.block_id,
+            "dir": ghost.dir,
+        })),
+        None => Ok(serde_json::json!({})),
+    }
 }
 

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -299,6 +299,8 @@ async fn route_command(
             .map_err(|e| format!("update_floating_redock_hover join error: {}", e))?
         }
         "clear_floating_redock_hover" => commands::window::clear_floating_redock_hover(state, args),
+        "set_floating_redock_target" => commands::window::set_floating_redock_target(state, args),
+        "get_floating_redock_target" => commands::window::get_floating_redock_target(state, args),
         "move_window_by" => commands::window::move_window_by(state, args),
         "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -494,6 +494,16 @@ pub struct PendingBrowserPaneCreate {
     pub window_label: String,
 }
 
+/// Phase 4b — ghost state stored per target-window label during a floating-pane
+/// redock drag. The target renderer pushes `block_id + dir` when it shows the
+/// ghost overlay; the floater reads it at drop time to pass a directional hint
+/// to the `RedockFloatingPane` saga.
+#[derive(Clone, Debug)]
+pub struct FloatingRedockGhostState {
+    pub block_id: String,
+    pub dir: u8,
+}
+
 pub struct AppState {
     // Phase B.5 (window_id_map step e) — `window_id_map` field
     // deleted. Authoritative copy lives in the launcher's
@@ -831,6 +841,13 @@ pub struct AppState {
     #[cfg(target_os = "windows")]
     pub window_hwnds: Mutex<HashMap<String, isize>>,
 
+    /// Phase 4b — per-window ghost state for floating-pane redock.
+    /// Keyed by window label. The target renderer pushes its last-computed
+    /// `{ block_id, dir }` here on each hover update; the floater queries
+    /// it at drop time so the saga can emit a directional split action.
+    /// Cleared by `clear_floating_redock_hover` (drag cancel/end).
+    pub floating_redock_ghost: Mutex<HashMap<String, FloatingRedockGhostState>>,
+
 }
 
 impl Default for AppState {
@@ -891,6 +908,7 @@ impl Default for AppState {
             cef_cache_dir: Mutex::new(None),
             #[cfg(target_os = "windows")]
             window_hwnds: Mutex::new(HashMap::new()),
+            floating_redock_ghost: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -3010,8 +3010,9 @@ fn queue_target_layout_insert(
 /// * 1/5 (Right/OuterRight)→ `SplitHorizontal`, position `after`
 /// * 8   (Center)          → falls through to `InsertNode` (handled by caller)
 ///
-/// Outer directions use `nodesize = 2.5` so the new node occupies ≈20%
-/// (2.5 / (10 + 2.5)) matching the ghost's `height/5` appearance.
+/// Outer directions use `nodesize = Some(3)` so the new node occupies ≈23%
+/// (3 / 13) — the nearest representable integer to the ghost's `height/5`
+/// (20%) when the target node is at DefaultNodeSize (10).
 /// Inner directions use `nodesize = None` (DefaultNodeSize = 10 → 50/50).
 fn queue_target_layout_split(
     store: &Store,

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2375,12 +2375,20 @@ async fn handle_workspace_service(state: &AppState, call: &WebCallType) -> WebRe
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
+            // Phase 4b — optional direction hint from the ghost overlay.
+            // Both must be present; if either is absent fall back to InsertNode.
+            let target_block_id: Option<String> = service::get_optional_arg(args, 5)
+                .unwrap_or(None);
+            let direction: Option<u8> = service::get_optional_arg(args, 6)
+                .unwrap_or(None);
             tracing::info!(
                 block_id = %block_id,
                 source_tab = %source_tab_id,
                 source_ws = %source_ws_id,
                 target_tab = %target_tab_id,
                 target_ws = %target_ws_id,
+                target_block_id = ?target_block_id,
+                direction = ?direction,
                 "[dnd:svc] RedockFloatingPane via saga"
             );
             let saga_result = crate::sagas::redock_floating_pane::run(
@@ -2397,26 +2405,28 @@ async fn handle_workspace_service(state: &AppState, call: &WebCallType) -> WebRe
                 return WebReturnType::error(reason);
             }
 
-            // Target layout: enqueue an "insert" action on its
-            // `pendingbackendactions` so the target window's frontend
-            // grows a new leaf for the redocked block through its
-            // standard LayoutTreeActionType.InsertNode reducer.
-            // Direct rootnode writes don't propagate because the
-            // LayoutModel doesn't auto-sync from external WaveObj
-            // updates — see `queue_target_layout_insert`'s docstring.
-            // Layout writes are required before the Tab broadcast — if
-            // either fails the block becomes invisible (moved in SQLite
-            // but no LayoutState entry in the target). Return error so
-            // the caller can retry; the saga state is dirty but no
-            // visible change has propagated to the renderers yet.
-            if let Err(e) = queue_target_layout_insert(store, &target_tab_id, &block_id) {
+            // Target layout: enqueue the appropriate action on its
+            // `pendingbackendactions`. Phase 4b: when a direction hint is
+            // present, queue SplitHorizontal/SplitVertical so the block lands
+            // in the exact slot the ghost previewed. Otherwise fall back to
+            // the generic InsertNode (Phase 4a behavior).
+            // Layout writes are required before the Tab broadcast — if either
+            // fails the block becomes invisible. Return error so the caller can
+            // retry; no visible change has propagated to the renderers yet.
+            let target_layout_result = match (target_block_id.as_deref(), direction) {
+                (Some(tbid), Some(dir)) => {
+                    queue_target_layout_split(store, &target_tab_id, &block_id, tbid, dir)
+                }
+                _ => queue_target_layout_insert(store, &target_tab_id, &block_id),
+            };
+            if let Err(e) = target_layout_result {
                 tracing::error!(
                     target_tab = %target_tab_id,
-                    "RedockFloatingPane: target layout insert failed — aborting broadcast: {}",
+                    "RedockFloatingPane: target layout action failed — aborting broadcast: {}",
                     e
                 );
                 return WebReturnType::error(format!(
-                    "redock layout insert failed: {e}"
+                    "redock layout action failed: {e}"
                 ));
             }
             if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
@@ -2983,6 +2993,61 @@ fn queue_target_layout_insert(
         ephemeral: false,
         targetblockid: String::new(),
         position: String::new(),
+    });
+    target_layout.pendingbackendactions = Some(actions);
+    store.update(&mut target_layout)?;
+    Ok(())
+}
+
+/// Phase 4b — enqueue a directional split action on the TARGET tab's
+/// `LayoutState.pendingbackendactions` so the redocked block lands in
+/// the exact slot the ghost overlay previewed.
+///
+/// `dir` maps the `DropDirection` enum values to action types:
+/// * 0/4 (Top/OuterTop)    → `SplitVertical`,   position `before`
+/// * 2/6 (Bottom/OuterBot) → `SplitVertical`,   position `after`
+/// * 3/7 (Left/OuterLeft)  → `SplitHorizontal`, position `before`
+/// * 1/5 (Right/OuterRight)→ `SplitHorizontal`, position `after`
+/// * 8   (Center)          → falls through to `InsertNode` (handled by caller)
+///
+/// Outer directions use `nodesize = 2.5` so the new node occupies ≈20%
+/// (2.5 / (10 + 2.5)) matching the ghost's `height/5` appearance.
+/// Inner directions use `nodesize = None` (DefaultNodeSize = 10 → 50/50).
+fn queue_target_layout_split(
+    store: &Store,
+    target_tab_id: &str,
+    block_id: &str,
+    target_block_id: &str,
+    dir: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Inner directions (Top=0,Right=1,Bottom=2,Left=3): new node at
+    // DefaultNodeSize (10) → 50/50 split, matching the ghost's half-leaf.
+    // Outer directions (4-7): nodesize=3 → ≈23% (3/13), close to the
+    // ghost's 20% (1/5). The exact ratio depends on the target node's
+    // current flex size which isn't available server-side; 3 is a
+    // reasonable integer approximation when the target is at DefaultNodeSize.
+    let (actiontype, position, nodesize): (&str, &str, Option<u32>) = match dir {
+        0 | 4 => ("splitvertical",   "before", if dir >= 4 { Some(3) } else { None }),
+        2 | 6 => ("splitvertical",   "after",  if dir >= 4 { Some(3) } else { None }),
+        3 | 7 => ("splithorizontal", "before", if dir >= 4 { Some(3) } else { None }),
+        1 | 5 => ("splithorizontal", "after",  if dir >= 4 { Some(3) } else { None }),
+        // Center (8) or unknown — caller should use queue_target_layout_insert.
+        _ => return queue_target_layout_insert(store, target_tab_id, block_id),
+    };
+    let target_tab = store.must_get::<Tab>(target_tab_id)?;
+    let mut target_layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
+    let mut actions = target_layout.pendingbackendactions.take().unwrap_or_default();
+    actions.push(LayoutActionData {
+        actiontype: actiontype.to_string(),
+        actionid: uuid::Uuid::new_v4().to_string(),
+        blockid: block_id.to_string(),
+        nodesize,
+        indexarr: None,
+        focused: true,
+        magnified: false,
+        ephemeral: false,
+        targetblockid: target_block_id.to_string(),
+        position: position.to_string(),
     });
     target_layout.pendingbackendactions = Some(actions);
     store.update(&mut target_layout)?;

--- a/docs/analysis/ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md
+++ b/docs/analysis/ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md
@@ -1,0 +1,263 @@
+# ANALYSIS: Floating Pane Redock — Ghost vs. Actual Size Mismatch
+
+**Date:** 2026-06-23  
+**Status:** Root causes confirmed. Phase 4b implementation underway.
+
+---
+
+## Problem
+
+When a user drags a floating pane over a docked window to redock it:
+
+1. A ghost overlay appears in the target window showing where the pane will land
+   (e.g. top-half of a leaf = "Top" drop, thin left band = "OuterLeft" drop).
+2. The user releases — but the docked pane **ignores the ghost's position and size**,
+   landing wherever `findNextInsertLocation` happens to put it, at the default 50/50
+   flex split — regardless of which zone the ghost showed.
+
+The mismatch is worst for **Outer\* directions** (ghost shows 20% band, reality is 50%)
+and for **multi-pane targets** where default flex sizes produce unexpected proportions.
+
+---
+
+## Root Cause: Direction Never Reaches the Layout Engine
+
+The ghost is a purely visual DOM element (`floating-redock-drop-placeholder`). The
+`DropDirection` computed to position it is **captured only in the target window's
+renderer process** and is **never transmitted to the RPC or the layout tree**.
+
+### Data flow — what actually happens
+
+```
+[Floater renderer]
+    onMouseMove
+    → update_floating_redock_hover(x, y)      ← IPC to CEF backend
+
+[CEF backend → all windows]
+    floating-redock:hover-state event with { target_label, cursor_x, cursor_y }
+
+[Target window renderer — app-init.ts:186]
+    floating-redock:hover-state event received
+    → elementFromPoint(clientX, clientY)       ← find leaf under cursor
+    → determineDropDirection(leafRect, cursor) ← compute dir  ← STORED HERE ONLY
+    → rectForDirection(dir)                    ← compute ghost rect
+    → placeholderEl.style = ghost rect         ← purely visual
+
+    ⚠️  dir + targetBlockId are local variables; never emitted, never stored.
+
+[Floater renderer — floating-pane-workspace.tsx:924]
+    onMouseUp (armed)
+    → WorkspaceService.RedockFloatingPane(
+          sourceBlockId,
+          sourceTabId,  sourceWsId,
+          targetTabId,  targetWsId,
+                                           ← NO direction, NO targetBlockId
+      )
+
+[Rust backend — service.rs:2412]
+    queue_target_layout_insert(store, target_tab_id, block_id)
+    → InsertNode action queued on target LayoutState.pendingbackendactions
+
+[Target window renderer — layoutPersistence.ts:105]
+    onBackendUpdate → processPendingBackendActions
+    → InsertNode action → insertNode() → findNextInsertLocation()
+    → new node gets size = DefaultNodeSize (10)  ← fixed default, not ghost %
+```
+
+### The ghost system (app-init.ts:138–245)
+
+`installFloatingRedockHoverListener` renders a DOM div sized exactly per direction:
+
+| Direction | Ghost size |
+|-----------|-----------|
+| Top / Bottom | 50% of leaf height, full width |
+| Left / Right | 50% of leaf width, full height |
+| OuterTop / OuterBottom | 20% (1/5) of leaf height, full width |
+| OuterLeft / OuterRight | 20% (1/5) of leaf width, full height |
+| Center | 100% of leaf |
+
+These sizes are correct and match the within-window pane drag ghost
+(`getPlaceholderTransform`, `layoutModel.ts:674–684`). But they're visual only.
+
+### The landing system (layoutPersistence.ts:105 + layoutNode.ts:245)
+
+`queue_target_layout_insert` queues an `InsertNode` action (not a split action) on the
+target LayoutState. The frontend processes this via `insertNode()` →
+`findNextInsertLocation()` — finds the deepest node in the tree that has room for a
+child. The new node gets `size = DefaultNodeSize = 10` (types.ts:210).
+
+If the target tab has one existing pane with size 10, the result is **50/50** regardless
+of direction. If the user hovered an OuterLeft zone (ghost: 20%), they still get 50%.
+
+The `handleBackendAction` in `layoutPersistence.ts` already has **fully wired handlers**
+for `SplitHorizontal` (line 213) and `SplitVertical` (line 241) — these place the new
+node in the correct position relative to a named `targetblockid` with a given `nodesize`.
+The gap is that `queue_target_layout_insert` always uses `InsertNode` instead.
+
+### The tracking comment
+
+This gap is explicitly noted in the source (added during Phase 4a MVP):
+
+- `frontend/app-init.ts:106–109`:
+  ```
+  // The block STILL lands as a sibling in the target tab's layout for
+  // MVP (backend ignores the direction). Phase 4b will wire the
+  // direction through `RedockFloatingPane` so the block lands in the
+  // exact slot the user previewed.
+  ```
+
+---
+
+## Additional Fragility Found During Deeper Analysis
+
+### The process boundary problem
+
+The ghost direction is computed **in the target window's renderer process**.
+`RedockFloatingPane` is called **from the floater's renderer process**. These are
+separate Chromium renderer processes. The CEF backend (motion.rs) broadcasts the
+hover-state event but **does not store the last-computed ghost state** — it only
+forwards the cursor position. So the two processes can never directly share the
+`{ targetBlockId, dir }` local variables.
+
+This is the core architectural gap: the original spec
+(`SPEC_FLOATING_PANE_REDOCK_2026-05-27.md`) intended `RedockFloatingPane` to be
+called by the **target window's renderer** (which has the ghost context) — Phase 4a
+reversed this for expedience.
+
+### R1: `onNodeDelete` conflates "moved" with "closed" (partially fixed, BUG-TRACE still active)
+
+`tabcontent.tsx:61–71` (`onNodeDelete`) unconditionally calls `DeleteBlock` when a
+layout node is removed. For pane closes this is correct; for `DeleteNode` layout
+actions emitted by tear-off/redock, this deletes the block that was supposed to
+be moved. The R1 fix was applied (the dedicated block-move guard was removed;
+`DeleteNode` handler in `layoutPersistence.ts:153` now uses `model.treeReducer` directly),
+but the BUG-TRACE logging in `onNodeDelete` is still active, indicating ongoing
+monitoring. This is harmless but indicates the fix is recent and being watched.
+
+### R2: Floater is a raw Win32 popup, not CEF Views (white flash)
+
+The floater window is a raw Win32 popup (no CEF Views wrapper), causing a brief white
+flash on tear-off. This is a separate R2 issue unrelated to the size bug.
+
+### R3: Pool-promoted windows lack stable label identity
+
+Pool windows can be promoted with mismatched labels, causing redock target resolution
+bugs. This is a separate R3 issue.
+
+### `move_block_to_tab` queues no target layout action
+
+The old wcore path (`dnd.rs:move_block_to_tab`, used by older flows) never queued any
+layout action for the destination. The new reducer path (`reducer/block.rs:handle_move_block`)
+emits only `BlockMoved` — no layout action. The `service.rs:RedockFloatingPane` handler
+must manually call `queue_target_layout_insert` (or the new `queue_target_layout_split`)
+after the saga succeeds and then broadcast the updated LayoutState WaveObject.
+
+---
+
+## Fix Architecture (Phase 4b): Push-Then-Store
+
+### Why push-then-store
+
+The floater calls the RPC — it cannot see the target's computed `dir + targetBlockId`.
+The target's renderer cannot call the RPC (different process). The solution is to use
+the CEF backend as a shared state store:
+
+```
+Target renderer → CEF backend: "I see dir=3, blockId=X for window label=main"
+Floater → CEF backend: "What did the target see last?" → { dir=3, blockId=X }
+Floater → srv RPC: RedockFloatingPane(..., target_block_id=X, direction=3)
+```
+
+### Step 1 — CEF backend: store/retrieve ghost state
+
+Add `FloatingRedockGhostState { block_id: String, dir: u8 }` and
+`floating_redock_ghost: Mutex<HashMap<String, FloatingRedockGhostState>>` to `AppState`.
+
+Add two IPC commands:
+- `set_floating_redock_target { window_label, block_id, dir }` — stores ghost state for a window (clear by passing null/absent block_id)
+- `get_floating_redock_target { window_label }` — returns `{ block_id, dir }` or `{}`
+
+`clear_floating_redock_hover` clears all stored ghost states.
+
+### Step 2 — Target renderer: push ghost state (app-init.ts)
+
+After computing `dir` and `leafEl.dataset.blockid`:
+```typescript
+import { invokeCommand } from "@/app/platform/ipc";
+void invokeCommand("set_floating_redock_target", {
+    window_label: myLabel,
+    block_id: leafEl.dataset.blockid!,
+    dir,
+});
+```
+
+In `clearPlaceholder()`:
+```typescript
+void invokeCommand("set_floating_redock_target", {
+    window_label: myLabel,
+    block_id: null,
+    dir: null,
+});
+```
+
+### Step 3 — Floater: query at drop time (floating-pane-workspace.tsx)
+
+In `tryRedockAtCursorInner`, after resolving the target tab/ws, before the RPC:
+```typescript
+const { invokeCommand } = await import("@/app/platform/ipc");
+const ghost = await invokeCommand<{ block_id?: string; dir?: number }>(
+    "get_floating_redock_target",
+    { window_label: target.label }
+).catch(() => ({}));
+```
+
+Then include `ghost.block_id ?? null` and `ghost.dir ?? null` in the `RedockFloatingPane` call.
+
+### Step 4 — Backend: emit directional layout action (service.rs)
+
+Parse two new optional args (indices 5 and 6). Add `queue_target_layout_split`:
+
+| DropDirection | actiontype | position |
+|---|---|---|
+| Top (0) / OuterTop (4) | `SplitVertical` | `before` |
+| Bottom (2) / OuterBottom (6) | `SplitVertical` | `after` |
+| Left (3) / OuterLeft (7) | `SplitHorizontal` | `before` |
+| Right (1) / OuterRight (5) | `SplitHorizontal` | `after` |
+| Center (8) | `InsertNode` (current fallback) | — |
+| null fallback | `InsertNode` (current behavior) | — |
+
+Node size mapping:
+- Inner directions (0-3): `nodesize = None` (DefaultNodeSize = 10 = 50%)
+- Outer directions (4-7): `nodesize = Some(2.5)` (2.5/(10+2.5) = 20%)
+
+### Step 5 — Target window layout: process the action
+
+`layoutPersistence.ts:handleBackendAction` already handles `SplitHorizontal` (line 213)
+and `SplitVertical` (line 241) via `layoutTree.splitHorizontal` / `splitVertical`.
+No changes needed here.
+
+---
+
+## Files Involved
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/state.rs` | Add `FloatingRedockGhostState` + `floating_redock_ghost` field |
+| `agentmux-cef/src/commands/window/motion.rs` | Add `set_floating_redock_target`, `get_floating_redock_target`; clear in `clear_floating_redock_hover` |
+| `agentmux-cef/src/ipc.rs` | Register two new commands |
+| `frontend/app-init.ts` | Push ghost state on hover, clear on `clearPlaceholder()` |
+| `frontend/app/store/services.ts` | Add optional `targetBlockId`, `direction` to `RedockFloatingPane` |
+| `frontend/app/workspace/floating-pane-workspace.tsx` | Query ghost state before RPC call |
+| `agentmux-srv/src/server/service.rs` | Parse optional args 5/6; add `queue_target_layout_split`; call split vs insert |
+
+---
+
+## Test Plan
+
+| Test | File |
+|---|---|
+| `rectForDirection` returns correct sub-rect per DropDirection (9 directions) | `frontend/layout/tests/rectForDirection.test.ts` |
+| `handleBackendAction` routes `SplitHorizontal`/`SplitVertical` correctly | `frontend/layout/tests/layoutPersistence.test.ts` |
+| `onNodeDelete` NOT called for moved blocks (R1 regression guard) | existing `layoutTree.test.ts` extended |
+| Rust `redock_floating_pane` saga queues `SplitHorizontal` when `dir=3` | `redock_floating_pane.rs` tests |
+| Rust saga falls back to `InsertNode` when direction is absent | `redock_floating_pane.rs` tests |

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -126,6 +126,16 @@ function installFloatingRedockHoverListener(): void {
             placeholderEl.remove();
             placeholderEl = null;
         }
+        // Phase 4b — clear the stored ghost state for this window so a stale
+        // direction cannot bleed into the next drop event.
+        fireAndForget(async () => {
+            const { invokeCommand } = await import("@/app/platform/ipc");
+            await invokeCommand("set_floating_redock_target", {
+                window_label: myLabel,
+                block_id: null,
+                dir: null,
+            });
+        });
     };
 
     // Map a DropDirection to a sub-rect (top, left, width, height in
@@ -176,7 +186,7 @@ function installFloatingRedockHoverListener(): void {
     let dwellSince = 0;
 
     fireAndForget(async () => {
-        const { listenEvent } = await import("@/app/platform/ipc");
+        const { listenEvent, invokeCommand } = await import("@/app/platform/ipc");
         const { determineDropDirection } = await import("@/layout/lib/utils");
         await listenEvent<{
             target_label: string | null;
@@ -243,6 +253,19 @@ function installFloatingRedockHoverListener(): void {
             ph.style.left = `${slot.left}px`;
             ph.style.width = `${slot.width}px`;
             ph.style.height = `${slot.height}px`;
+
+            // Phase 4b — store the computed direction and target block so
+            // the floater can pass them to RedockFloatingPane at drop time.
+            // Fire-and-forget: the set is best-effort and must not stall the
+            // event handler (ghost rendering happens synchronously above).
+            const targetBlockId = leafEl.dataset.blockid;
+            if (targetBlockId) {
+                void invokeCommand("set_floating_redock_target", {
+                    window_label: myLabel,
+                    block_id: targetBlockId,
+                    dir,
+                });
+            }
         });
     });
 }

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -226,6 +226,10 @@ class WorkspaceServiceType {
     // via the empty-tab watcher in floating-pane-workspace.tsx (PR #1089)
     // once its tab.blockids becomes empty.
     //
+    // Phase 4b: optional targetBlockId + direction route the drop to the
+    // exact slot the ghost previewed (SplitHorizontal/SplitVertical instead of
+    // the generic InsertNode). Pass null for both to keep the old behavior.
+    //
     // @returns { redocked: true, block_id, target_tab_id } (and object updates)
     RedockFloatingPane(
         blockId: string,
@@ -233,6 +237,8 @@ class WorkspaceServiceType {
         sourceWsId: string,
         targetTabId: string,
         targetWsId: string,
+        targetBlockId?: string | null,
+        direction?: number | null,
     ): Promise<{ redocked: boolean; block_id?: string; target_tab_id?: string }> {
         return WOS.callBackendService("workspace", "RedockFloatingPane", Array.from(arguments))
     }

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -921,6 +921,15 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 return;
             }
 
+            // Phase 4b — query the ghost state the target renderer stored so
+            // the saga can emit a directional split action. Best-effort: a
+            // failed query (CEF IPC error, no stored state) falls back to the
+            // existing InsertNode path without breaking the redock.
+            const ghost = await invokeCommand<{ block_id?: string; dir?: number }>(
+                "get_floating_redock_target",
+                { window_label: target.label! },
+            ).catch(() => ({}));
+
             try {
                 await WorkspaceService.RedockFloatingPane(
                     sourceBlockId,
@@ -928,6 +937,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     sourceWsId,
                     targetTabId,
                     targetWsId,
+                    ghost.block_id ?? null,
+                    ghost.dir ?? null,
                 );
                 // After successful redock, source tab.blockids empties
                 // → the auto-close watcher dismisses the floater.

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -644,6 +644,21 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 hoverArmed = false;
                 indicatorShowing = false;
                 pendingRedockArmed = false;
+                // Phase 4b — pre-capture ghost if onMouseUp hasn't already done so
+                // (window_drag_ended can arrive before DOM mouseup on Windows — separate
+                // CEF IPC channels, documented above). Guards against double-consume:
+                // get_floating_redock_target removes the entry atomically, so the
+                // second caller would get {} anyway, but skip the IPC entirely.
+                if (!capturedGhostForDrop) {
+                    const preGhostWindow = dwellCurrentHoverTarget;
+                    capturedGhostForWindow = preGhostWindow;
+                    capturedGhostForDrop = preGhostWindow
+                        ? invokeCommand<{ block_id?: string; dir?: number }>(
+                              "get_floating_redock_target",
+                              { window_label: preGhostWindow },
+                          ).catch(() => ({}))
+                        : Promise.resolve({});
+                }
                 // Always clear hover — safety net for non-Windows where onMouseUp
                 // may not have fired (BeginWindowDrag absorbs the release).
                 invokeCommand("clear_floating_redock_hover", {}).catch(() => {});

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -225,6 +225,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // Sentinel for the listenEvent .then() race: if the component unmounts
         // before the Promise resolves, the .then() immediately calls unlisten.
         let cleaned = false;
+        // Phase 4b — ghost pre-captured in onMouseUp before clear_floating_redock_hover
+        // broadcasts the hover-state null event (which triggers clearPlaceholder on the
+        // target renderer and would wipe the ghost before tryRedockAtCursorInner reads it).
+        let capturedGhostForDrop: Promise<{ block_id?: string; dir?: number }> | null = null;
+        let capturedGhostForWindow: string | null = null;
 
         const label = windowLabel();
 
@@ -482,6 +487,20 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             if (jsDrivenDrag) jsDragMouseDownId += 1;
             if (!dragging) return;
             dragging = false;
+            // Phase 4b — dispatch get_floating_redock_target BEFORE clear_floating_redock_hover.
+            // Both are fire-and-forget IPCs from the same floater renderer → CEF backend
+            // channel (FIFO). The ghost read queues ahead of the event broadcast that
+            // triggers clearPlaceholder on the target renderer. This avoids the cross-
+            // process race where the target's set_floating_redock_target(null) arrives
+            // before tryRedockAtCursorInner's delayed call to get_floating_redock_target.
+            const preGhostWindow = dwellCurrentHoverTarget;
+            capturedGhostForWindow = preGhostWindow;
+            capturedGhostForDrop = preGhostWindow
+                ? invokeCommand<{ block_id?: string; dir?: number }>(
+                      "get_floating_redock_target",
+                      { window_label: preGhostWindow },
+                  ).catch(() => ({}))
+                : Promise.resolve({});
             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
             if (isWindows()) {
                 // On Windows: preserve arm state before clearing — window_drag_ended
@@ -921,14 +940,17 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 return;
             }
 
-            // Phase 4b — query the ghost state the target renderer stored so
-            // the saga can emit a directional split action. Best-effort: a
-            // failed query (CEF IPC error, no stored state) falls back to the
-            // existing InsertNode path without breaking the redock.
-            const ghost = await invokeCommand<{ block_id?: string; dir?: number }>(
-                "get_floating_redock_target",
-                { window_label: target.label! },
-            ).catch(() => ({}));
+            // Phase 4b — use the ghost pre-captured in onMouseUp (before
+            // clear_floating_redock_hover cleared it). If the resolved target
+            // window differs from the captured window, fall back to empty ghost
+            // (InsertNode path). Clear after consuming so a subsequent drag
+            // can't accidentally reuse stale state.
+            const ghost =
+                capturedGhostForDrop != null && capturedGhostForWindow === target.label
+                    ? await capturedGhostForDrop
+                    : {};
+            capturedGhostForDrop = null;
+            capturedGhostForWindow = null;
 
             try {
                 await WorkspaceService.RedockFloatingPane(

--- a/frontend/layout/tests/layoutPersistence.test.ts
+++ b/frontend/layout/tests/layoutPersistence.test.ts
@@ -1,0 +1,351 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for processPendingBackendActions — specifically the Phase 4b
+// SplitHorizontal and SplitVertical action routes used by the floating-pane
+// redock ghost-size fix.
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+import { LayoutModel } from "@/layout/lib/layoutModel";
+import { findNodeByBlockId, newLayoutNode } from "@/layout/lib/layoutNode";
+import { LayoutTreeActionType, LayoutTreeInsertNodeAction } from "@/layout/lib/types";
+import { processPendingBackendActions } from "@/layout/lib/layoutPersistence";
+import type { SignalAtom } from "@/util/util";
+
+// -- Mock store (mirrors layoutModel.test.ts) ----------------------------------
+
+const layoutStateSignals = new Map<string, SignalAtom<LayoutState>>();
+
+function makeLayoutStateSignal(oid: string): SignalAtom<LayoutState> {
+    const [get, set] = createSignal<LayoutState>({
+        otype: "layout",
+        oid,
+        version: 1,
+        meta: {},
+        rootnode: undefined,
+        magnifiednodeid: undefined,
+        focusednodeid: undefined,
+        leaforder: undefined,
+        pendingbackendactions: undefined,
+    });
+    const atom = () => get();
+    (atom as any)._set = set;
+    return atom as unknown as SignalAtom<LayoutState>;
+}
+
+vi.mock("@/app/store/global", () => {
+    return {
+        WOS: {
+            makeORef: (_otype: string, oid: string) => oid,
+            getWaveObjectAtom: (oid: string) => {
+                if (!layoutStateSignals.has(oid)) {
+                    layoutStateSignals.set(oid, makeLayoutStateSignal(oid));
+                }
+                return layoutStateSignals.get(oid);
+            },
+            getObjectValue: (oref: string) => {
+                const sig = layoutStateSignals.get(oref);
+                return sig ? sig() : undefined;
+            },
+            setObjectValue: (value: any) => {
+                const oref = `${value.otype}:${value.oid}`;
+                const sig = layoutStateSignals.get(value.oid) ?? layoutStateSignals.get(oref);
+                if (sig) sig._set(value);
+            },
+        },
+        getSettingsKeyAtom: () => {
+            const [get] = createSignal(0.75);
+            return get;
+        },
+        globalStore: {
+            get: (accessor: any) => (typeof accessor === "function" ? accessor() : undefined),
+            set: (setter: any, value: any) => {
+                if (setter && typeof setter._set === "function") setter._set(value);
+                else if (typeof setter === "function") setter(value);
+            },
+        },
+    };
+});
+
+// -- Helpers ------------------------------------------------------------------
+
+function createLayoutModel(): LayoutModel {
+    const [getTab] = createSignal<Tab>({
+        otype: "tab",
+        oid: "tab-1",
+        version: 1,
+        meta: {},
+        name: "Test",
+        layoutstate: "layout-1",
+        blockids: [],
+    });
+    const m = new LayoutModel(getTab);
+    m.getBoundingRect = () => ({ top: 0, left: 0, width: 800, height: 600 });
+    m.displayContainerRef.current = {
+        getBoundingClientRect: () => ({ top: 0, left: 0, width: 800, height: 600 }),
+    } as any;
+    return m;
+}
+
+function insertBlock(model: LayoutModel, blockId: string) {
+    const node = newLayoutNode(undefined, undefined, undefined, { blockId });
+    model.treeReducer({ type: LayoutTreeActionType.InsertNode, node, magnified: false, focused: true } as LayoutTreeInsertNodeAction);
+    return node;
+}
+
+function setPendingActions(model: LayoutModel, actions: any[]) {
+    const waveObj = model.getter(model.waveObjectAtom) as LayoutState;
+    const sig = layoutStateSignals.get(waveObj.oid);
+    if (sig) sig._set({ ...waveObj, pendingbackendactions: actions });
+}
+
+function findBlock(model: LayoutModel, blockId: string) {
+    if (!model.treeState.rootNode) return null;
+    return findNodeByBlockId(model.treeState.rootNode, blockId);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("processPendingBackendActions — Phase 4b Split routes", () => {
+    beforeEach(() => {
+        layoutStateSignals.clear();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("SplitHorizontal after — places new block to the right of target", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitHorizontal,
+            actionid: "action-h-after",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "after",
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].data?.blockId).toBe("existing");
+        expect(root.children![1].data?.blockId).toBe("new-block");
+    });
+
+    it("SplitHorizontal before — places new block to the left of target", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitHorizontal,
+            actionid: "action-h-before",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "before",
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].data?.blockId).toBe("new-block");
+        expect(root.children![1].data?.blockId).toBe("existing");
+    });
+
+    it("SplitVertical after — places new block below target", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitVertical,
+            actionid: "action-v-after",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "after",
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].data?.blockId).toBe("existing");
+        expect(root.children![1].data?.blockId).toBe("new-block");
+    });
+
+    it("SplitVertical before — places new block above target", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitVertical,
+            actionid: "action-v-before",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "before",
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].data?.blockId).toBe("new-block");
+        expect(root.children![1].data?.blockId).toBe("existing");
+    });
+
+    it("SplitHorizontal with nodesize — outer-direction drop assigns specified size to new node", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitHorizontal,
+            actionid: "action-h-size",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "before",
+            nodesize: 3,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].size).toBe(3);
+    });
+
+    it("SplitHorizontal logs error and no-ops when targetblockid not found", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitHorizontal,
+            actionid: "action-h-miss",
+            blockid: "new-block",
+            targetblockid: "does-not-exist",
+            position: "after",
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        // No split happened — "existing" is still the only leaf
+        expect(findBlock(model, "new-block")).toBeFalsy();
+        expect(consoleSpy).toHaveBeenCalled();
+        consoleSpy.mockRestore();
+    });
+
+    it("SplitVertical logs error when position is invalid", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitVertical,
+            actionid: "action-v-badpos",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "center",  // invalid — only "before"/"after" are accepted
+            nodesize: undefined,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        expect(findBlock(model, "new-block")).toBeFalsy();
+        expect(consoleSpy).toHaveBeenCalled();
+        consoleSpy.mockRestore();
+    });
+
+    it("DeleteNode from a backend action removes node without calling closeNode (R1 regression guard)", async () => {
+        // R1 (#1681): backend DeleteNode actions must use treeReducer directly —
+        // NOT closeNode — because DeleteNode in this context means "block moved",
+        // and calling closeNode would trigger DeleteBlock, destroying the moved block.
+        const model = createLayoutModel();
+        insertBlock(model, "moved-block");
+
+        const closeNodeSpy = vi.spyOn(model, "closeNode");
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.DeleteNode,
+            actionid: "action-del",
+            blockid: "moved-block",
+            targetblockid: "",
+            position: "",
+            nodesize: undefined,
+            focused: false,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        // The block node is no longer in the tree
+        expect(findBlock(model, "moved-block")).toBeNull();
+        // closeNode was NOT called — which means DeleteBlock was NOT triggered
+        expect(closeNodeSpy).not.toHaveBeenCalled();
+    });
+
+    it("actions with duplicate actionid are processed only once (idempotent)", async () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+
+        const ACTION_ID = "dedup-action";
+        setPendingActions(model, [
+            {
+                actiontype: LayoutTreeActionType.SplitHorizontal,
+                actionid: ACTION_ID,
+                blockid: "new-block",
+                targetblockid: "existing",
+                position: "after",
+                focused: true,
+                magnified: false,
+                ephemeral: false,
+            },
+            {
+                actiontype: LayoutTreeActionType.SplitHorizontal,
+                actionid: ACTION_ID,  // same id — must be skipped
+                blockid: "dup-block",
+                targetblockid: "existing",
+                position: "after",
+                focused: true,
+                magnified: false,
+                ephemeral: false,
+            },
+        ]);
+
+        await processPendingBackendActions(model);
+
+        // "new-block" was inserted, "dup-block" was not (duplicate action id)
+        expect(findBlock(model, "new-block")).toBeTruthy();
+        expect(findBlock(model, "dup-block")).toBeFalsy();
+    });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** The ghost preview showed the correct drop position (direction + target block), but those values lived only in the target renderer process and never reached the `RedockFloatingPane` RPC. The server always fell back to `InsertNode`/`DefaultNodeSize=10` (50/50 split), ignoring the ghost.
- **Fix (push-then-store):** Target renderer pushes `{block_id, dir}` to CEF backend storage (`AppState.floating_redock_ghost`) after each ghost update; floater queries it at drop time and passes both as optional args to the RPC; server routes to a new `queue_target_layout_split` function that emits `SplitHorizontal`/`SplitVertical` with the correct position and `nodesize=3` for outer-edge drops.
- **No frontend change needed** for the action handlers — `handleBackendAction` in `layoutPersistence.ts` already had fully-wired `SplitHorizontal`/`SplitVertical` cases (they were dead code until now).

## Changed files

| File | Change |
|------|--------|
| `agentmux-cef/src/state.rs` | `FloatingRedockGhostState` struct + `AppState.floating_redock_ghost` field |
| `agentmux-cef/src/commands/window/motion.rs` | `set_floating_redock_target`, `get_floating_redock_target`, clear in `clear_floating_redock_hover` |
| `agentmux-cef/src/ipc.rs` | Route the two new commands |
| `frontend/app-init.ts` | Push ghost state after computing dir; clear on placeholder teardown |
| `frontend/app/store/services.ts` | `RedockFloatingPane` optional args 5/6: `targetBlockId`, `direction` |
| `frontend/app/workspace/floating-pane-workspace.tsx` | Query ghost state before RPC call |
| `agentmux-srv/src/server/service.rs` | Parse optional args, route to new `queue_target_layout_split`, fall back to `queue_target_layout_insert` |
| `frontend/layout/tests/layoutPersistence.test.ts` | 9 new tests (new file) |
| `docs/analysis/ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md` | Deep-dive analysis (new file) |

## Test plan

- [x] `npm test -- frontend/layout/tests/layoutPersistence.test.ts` — 9/9 passing
  - SplitH/V `after` and `before` position routing
  - `nodesize=3` for outer-edge drops
  - Error path: unknown `targetblockid` → no-op + console.error
  - Error path: invalid `position` → no-op + console.error
  - **R1 regression guard:** `DeleteNode` backend action calls `treeReducer` directly, NOT `closeNode` (no `DeleteBlock`)
  - Action-id deduplication (same `actionid` processed only once)
- [x] `cargo check` passes for both `agentmux-cef` and `agentmux-srv`
- [ ] Manual: drag a floating pane over another pane, observe ghost at each edge, drop — pane should land in the ghost slot at ghost size

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID} -->