### PR TITLE
refactor(reactive): muxbus naming for PollerConfig fields + comments (ARCH-001)

### DIFF
--- a/.changesets/1782237814-refactor-reactive-rename-pollerconfig-fields-to-muxbus-arch--4cgx.md
+++ b/.changesets/1782237814-refactor-reactive-rename-pollerconfig-fields-to-muxbus-arch--4cgx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(reactive): rename PollerConfig fields to muxbus_* (ARCH-001; wire key unchanged)

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -583,7 +583,7 @@ impl Controller for ShellController {
                 .join("logs");
             c.env("AGENTMUX_LOG_DIR", log_dir.to_string_lossy().as_ref());
 
-            // Propagate local backend URL so agentbus-client prefers local PTY delivery.
+            // Propagate local backend URL so the muxbus client (agentbus-client package) prefers local PTY delivery.
             // Set by main.rs after binding; absent in test/mock contexts (graceful no-op).
             if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
                 c.env("AGENTMUX_LOCAL_URL", &local_url);

--- a/agentmux-srv/src/backend/reactive/poller.rs
+++ b/agentmux-srv/src/backend/reactive/poller.rs
@@ -38,7 +38,7 @@ impl Poller {
     #[allow(dead_code)]
     pub fn is_configured(&self) -> bool {
         let config = self.config.read().unwrap();
-        config.agentmux_url.is_some() && config.agentmux_token.is_some()
+        config.muxbus_url.is_some() && config.muxbus_token.is_some()
     }
 
     /// Check if the poller is running.
@@ -72,10 +72,10 @@ impl Poller {
     pub fn status(&self) -> PollerStatus {
         let config = self.config.read().unwrap();
         PollerStatus {
-            configured: config.agentmux_url.is_some() && config.agentmux_token.is_some(),
+            configured: config.muxbus_url.is_some() && config.muxbus_token.is_some(),
             running: self.is_running(),
-            url: config.agentmux_url.clone(),
-            has_token: config.agentmux_token.is_some(),
+            url: config.muxbus_url.clone(),
+            has_token: config.muxbus_token.is_some(),
             poll_count: *self.poll_count.lock().unwrap(),
             injections_count: *self.injections_count.lock().unwrap(),
             last_poll: *self.last_poll.lock().unwrap(),
@@ -85,8 +85,8 @@ impl Poller {
     /// Reconfigure the poller with new URL and token.
     pub fn reconfigure(&self, url: Option<String>, token: Option<String>) {
         let mut config = self.config.write().unwrap();
-        config.agentmux_url = url;
-        config.agentmux_token = token;
+        config.muxbus_url = url;
+        config.muxbus_token = token;
     }
 
     /// Record a successful poll.

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -36,7 +36,7 @@ pub struct AgentEntry {
     /// struct (serde default) so older on-disk entries still deserialize;
     /// a missing or empty value means a forward to this entry will be
     /// rejected by the peer's auth layer (graceful — falls back to cloud
-    /// agentbus).
+    /// muxbus).
     #[serde(default)]
     pub auth_key: String,
 }

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -494,8 +494,8 @@ fn test_poller_status_unconfigured() {
     let handler = get_global_handler();
     let poller = Poller::new(
         PollerConfig {
-            agentmux_url: None,
-            agentmux_token: None,
+            muxbus_url: None,
+            muxbus_token: None,
             poll_interval_secs: 30,
         },
         handler,
@@ -511,8 +511,8 @@ fn test_poller_status_configured() {
     let handler = get_global_handler();
     let poller = Poller::new(
         PollerConfig {
-            agentmux_url: Some("https://example.com".to_string()),
-            agentmux_token: Some("token123".to_string()),
+            muxbus_url: Some("https://example.com".to_string()),
+            muxbus_token: Some("token123".to_string()),
             poll_interval_secs: 30,
         },
         handler,
@@ -528,8 +528,8 @@ fn test_poller_record_poll() {
     let handler = get_global_handler();
     let poller = Poller::new(
         PollerConfig {
-            agentmux_url: Some("https://example.com".to_string()),
-            agentmux_token: Some("token123".to_string()),
+            muxbus_url: Some("https://example.com".to_string()),
+            muxbus_token: Some("token123".to_string()),
             poll_interval_secs: 30,
         },
         handler,
@@ -550,8 +550,8 @@ fn test_poller_reconfigure() {
     let handler = get_global_handler();
     let poller = Poller::new(
         PollerConfig {
-            agentmux_url: None,
-            agentmux_token: None,
+            muxbus_url: None,
+            muxbus_token: None,
             poll_interval_secs: 30,
         },
         handler,

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -70,10 +70,14 @@ pub struct AuditLogEntry {
 /// Poller configuration for AgentMux cloud service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PollerConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agentmux_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agentmux_token: Option<String>,
+    // ARCH-001: the Rust identifier is `muxbus_*`; the wire key stays
+    // `agentmux_url`/`agentmux_token` (the cloud poller protocol rename is a
+    // separate, coordinated phase) and `muxbus_*` is accepted as a forward-
+    // compat alias on input.
+    #[serde(rename = "agentmux_url", alias = "muxbus_url", default, skip_serializing_if = "Option::is_none")]
+    pub muxbus_url: Option<String>,
+    #[serde(rename = "agentmux_token", alias = "muxbus_token", default, skip_serializing_if = "Option::is_none")]
+    pub muxbus_token: Option<String>,
     #[serde(default)]
     pub poll_interval_secs: u64,
 }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -872,8 +872,8 @@ async fn main() {
     }));
     let poller = Arc::new(Poller::new(
         PollerConfig {
-            agentmux_url: None,
-            agentmux_token: None,
+            muxbus_url: None,
+            muxbus_token: None,
             poll_interval_secs: reactive::DEFAULT_POLL_INTERVAL_SECS,
         },
         reactive_handler,
@@ -936,8 +936,8 @@ async fn main() {
     let local_web_url = format!("http://{}", web_addr);
 
     // Make local backend URL available to child processes (PTY shells).
-    // agentbus-client reads AGENTMUX_LOCAL_URL and uses it for local PTY delivery
-    // instead of routing through the cloud agentbus.
+    // the muxbus client (agentbus-client package) reads AGENTMUX_LOCAL_URL for local PTY delivery
+    // instead of routing through the cloud muxbus relay.
     std::env::set_var("AGENTMUX_LOCAL_URL", &local_web_url);
 
     // LAN discovery via mDNS — opt-in to avoid Windows Firewall prompt.

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3686,8 +3686,8 @@ mod recent_sessions_tests {
         let reactive_handler = crate::backend::reactive::get_global_handler();
         let poller = Arc::new(crate::backend::reactive::Poller::new(
             crate::backend::reactive::PollerConfig {
-                agentmux_url: None,
-                agentmux_token: None,
+                muxbus_url: None,
+                muxbus_token: None,
                 poll_interval_secs: 30,
             },
             reactive_handler,
@@ -3976,8 +3976,8 @@ mod recent_sessions_tests {
         let reactive_handler = crate::backend::reactive::get_global_handler();
         let poller = Arc::new(crate::backend::reactive::Poller::new(
             crate::backend::reactive::PollerConfig {
-                agentmux_url: None,
-                agentmux_token: None,
+                muxbus_url: None,
+                muxbus_token: None,
                 poll_interval_secs: 30,
             },
             reactive_handler,

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -190,7 +190,7 @@ pub fn build_router(state: AppState) -> Router {
     // security audit (C1 + C2) showed that any local process — or a
     // web page driving 127.0.0.1 via the permissive CORS layer — could
     // drive `/agentmux/reactive/inject` and reconfigure the cloud
-    // agentbus poller. These routes are now merged into `authed_routes`
+    // muxbus poller. These routes are now merged into `authed_routes`
     // below and gated by `auth_middleware`.
     let reactive_routes = Router::new()
         .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -18,8 +18,8 @@ pub(crate) fn test_state() -> AppState {
     let reactive_handler = backend_reactive::get_global_handler();
     let poller = Arc::new(Poller::new(
         backend_reactive::PollerConfig {
-            agentmux_url: None,
-            agentmux_token: None,
+            muxbus_url: None,
+            muxbus_token: None,
             poll_interval_secs: 30,
         },
         reactive_handler,


### PR DESCRIPTION
ARCH-001 app-side cleanup (non-breaking).

- Rename Rust identifiers `agentmux_url`/`agentmux_token` → `muxbus_url`/`muxbus_token` on `PollerConfig`.
- **Wire unchanged**: `#[serde(rename = "agentmux_url", alias = "muxbus_url")]` keeps the cloud-poller protocol emitting/accepting `agentmux_url`, and accepts `muxbus_url` as a forward-compat input alias. Persisted/received configs keep working.
- Update bus-layer code comments → muxbus (keeping the real package name `agentbus-client`).
- `validate_agentmux_url()` left as-is.

The wire/endpoint/OSC-key rename (`agentmux_url` → `muxbus_url` on the protocol) is the deferred, coordinated phase. `cargo check` + reactive tests pass.

<!-- agentmux:agent_id=agentc -->