### PR TITLE
fix(auth): Use existing login primary for Claude; Login via terminal fallback

### DIFF
--- a/.changesets/1782229694-fix-auth-seed-from-global-primary-redact-tokens-in-login-pty-gqip.md
+++ b/.changesets/1782229694-fix-auth-seed-from-global-primary-redact-tokens-in-login-pty-gqip.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): seed-from-global primary; redact tokens in login PTY logs

--- a/.changesets/1782231138-feat-auth-seed-from-global-is-the-primary-pre-launch-cta-for-fvnp.md
+++ b/.changesets/1782231138-feat-auth-seed-from-global-is-the-primary-pre-launch-cta-for-fvnp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(auth): seed-from-global is the primary pre-launch CTA for Claude

--- a/.changesets/1782234871-ci-nightly-windows-artifact-build-portable-zip-setup-install-l0xu.md
+++ b/.changesets/1782234871-ci-nightly-windows-artifact-build-portable-zip-setup-install-l0xu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ci: nightly Windows artifact build — portable ZIP + setup installer (Phase B of #1718)

--- a/.changesets/1782237945-fix-auth-use-existing-login-primary-for-claude-in-failure-ba-ze7k.md
+++ b/.changesets/1782237945-fix-auth-use-existing-login-primary-for-claude-in-failure-ba-ze7k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): Use existing login primary for Claude in failure banner; add Login via terminal fallback (CREATE_NEW_CONSOLE)

--- a/.github/workflows/ci-nightly-artifacts.yml
+++ b/.github/workflows/ci-nightly-artifacts.yml
@@ -1,0 +1,86 @@
+name: CI — nightly artifacts (Windows)
+
+# Phase B of SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md (issue #1718):
+# Full build → package → upload runnable Windows artifacts (portable ZIP +
+# setup installer). Runs nightly so each morning there's a fresh downloadable
+# build from HEAD.
+#
+# Linux AppImage: deferred — the libcef.so BeginWindowDrag patch gate blocks
+#   packaging unless AGENTMUX_SKIP_CEF_PATCH_CHECK=1; the upstream cef-dll-sys
+#   cache lacks the patch. Tracked on #1718.
+# macOS DMG: deferred — package:macos hard-requires a Developer ID certificate
+#   (no unsigned path in scripts/package-macos.sh); needs secrets/keychain
+#   plumbing before it can run in CI. Tracked on #1718.
+#
+# Standard runners only (free on public repos for any workload; CI-1).
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # 06:00 UTC daily (ahead of Phase A at 07:00)
+  workflow_dispatch: {}
+
+jobs:
+  windows:
+    name: Windows portable + installer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Ninja: CEF's C wrapper (cef-dll-sys) needs CMake + Ninja; CMake ships
+      # with VS on this runner. go-task: scripts/package.sh delegates build
+      # steps to `task`. innosetup: package-installer.ps1 needs ISCC.
+      - name: Install build tools (Ninja, go-task, Inno Setup)
+        shell: pwsh
+        run: choco install ninja go-task innosetup -y
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Full build + assemble portable. Outputs:
+      #   artifacts/agentmux-<LABEL>-x64-portable/   ← unpacked tree
+      #   artifacts/agentmux-<LABEL>-x64-portable.zip
+      # RELEASE_CHANNEL=stable so the artifact opens the user's real data dir.
+      # STRIP_MAPS=1 removes ~28 MB of source maps (release build).
+      # rcedit is self-downloading (curl in scripts/inject-exe-icon.sh).
+      - name: Build portable (task package:release)
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/artifacts"
+          STRIP_MAPS=1 RELEASE_CHANNEL=stable bash scripts/package.sh "$GITHUB_WORKSPACE/artifacts"
+
+      # Inno Setup installer. package-installer.ps1 defaults to picking the
+      # newest portable on the Desktop; we discover it in artifacts/ instead.
+      # Output: artifacts/AgentMux-<ver>-x64-setup.exe
+      - name: Build installer (task package:installer)
+        shell: pwsh
+        run: |
+          $artifacts = Join-Path $env:GITHUB_WORKSPACE "artifacts"
+          $portableDir = Get-ChildItem $artifacts -Directory -Filter "agentmux-*-x64-portable" |
+                         Sort-Object LastWriteTime -Descending |
+                         Select-Object -First 1 -ExpandProperty FullName
+          if (-not $portableDir) { throw "portable dir not found in $artifacts" }
+          Write-Host "Portable: $portableDir"
+          & (Join-Path $env:GITHUB_WORKSPACE "scripts\package-installer.ps1") `
+            -PortableDir $portableDir `
+            -OutputDir $artifacts
+
+      - name: Upload portable ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-portable
+          path: ${{ github.workspace }}/artifacts/agentmux-*-x64-portable.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload installer EXE
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: ${{ github.workspace }}/artifacts/AgentMux-*-x64-setup.exe
+          if-no-files-found: error
+          retention-days: 7

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -674,6 +674,12 @@ async fn run_cli_login_pty(
         cmd.cwd(cwd);
     }
 
+    // §5.1: capture the isolated CLAUDE_CONFIG_DIR so the reaper can report
+    // whether `setup-token` wrote `.credentials.json` there on completion — that
+    // decides whether the agent is auto-authed via the dir (no env-persist needed)
+    // or we must persist the captured CLAUDE_CODE_OAUTH_TOKEN into the spawn env.
+    let cred_check_dir = auth_env.get("CLAUDE_CONFIG_DIR").cloned();
+
     let child = pair
         .slave
         .spawn_command(cmd)
@@ -740,7 +746,24 @@ async fn run_cli_login_pty(
                     // tell capture-miss from no-browser from a silent exit.
                     let t = line.trim_end();
                     if !t.trim().is_empty() {
-                        tracing::info!(target: "login_pty", "[login-pty] {}", t);
+                        // SECURITY: `claude setup-token` (§5.1) prints a live
+                        // CLAUDE_CODE_OAUTH_TOKEN (`sk-ant-oat…`) to stdout — never
+                        // write it to the host log. redact_secrets masks it while
+                        // preserving the surrounding shape so we can still read the
+                        // output format from the capture.
+                        tracing::info!(target: "login_pty", "[login-pty] {}", redact_secrets(t));
+                    }
+                    // §5.1 (SPEC_HOST_CLI_LOGIN_CAPTURE): a CLAUDE_CODE_OAUTH_TOKEN /
+                    // `sk-ant-oat…` line is the setup-token headless contract — the
+                    // login completed and the token arrived. Log the capture (redacted)
+                    // so we can confirm format + completion without leaking the secret.
+                    // (Parser/env-persist wiring lands once this confirms the format.)
+                    if t.contains("sk-ant-oat") || t.contains("CLAUDE_CODE_OAUTH_TOKEN") {
+                        tracing::info!(
+                            target: "login_pty",
+                            "[login-pty] setup-token output detected ({} chars; token redacted above)",
+                            t.len()
+                        );
                     }
                     // Still capture an OAuth URL for providers that DO print one
                     // (Codex/Gemini/OpenClaw); a no-op for Claude v2.1.x.
@@ -803,6 +826,18 @@ async fn run_cli_login_pty(
                         exit_code = ?status.exit_code(),
                         "run_cli_login_pty: child exited"
                     );
+                    // §5.1: report whether the login persisted isolated creds. If
+                    // this is `true` after a setup-token completion, the agent is
+                    // auto-authed via CLAUDE_CONFIG_DIR and no env-persist is needed.
+                    if let Some(dir) = &cred_check_dir {
+                        let cred = std::path::Path::new(dir).join(".credentials.json");
+                        tracing::info!(
+                            target: "login_pty",
+                            "[login-pty] post-login: {}/.credentials.json exists = {}",
+                            dir,
+                            cred.exists()
+                        );
+                    }
                     break;
                 }
                 Ok(None) => {
@@ -836,6 +871,37 @@ async fn run_cli_login_pty(
     });
 
     Ok(serde_json::json!({ "auth_url": auth_url }))
+}
+
+/// Mask secret tokens before a PTY line is logged. `claude setup-token` (§5.1)
+/// prints a live `CLAUDE_CODE_OAUTH_TOKEN` (`sk-ant-oat…`, a ~1-year credential)
+/// to stdout; the slice-1 line logging would otherwise write it verbatim to the
+/// host log. We keep `sk-ant-` + 4 chars (enough to recognize the output format)
+/// and mask the rest of the token run, so the capture stays useful without
+/// leaking the credential. ASCII-only token chars → all byte slices are on char
+/// boundaries.
+fn redact_secrets(line: &str) -> String {
+    const PREFIX: &str = "sk-ant-";
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(pos) = rest.find(PREFIX) {
+        out.push_str(&rest[..pos]);
+        let after = &rest[pos..];
+        // Token run = PREFIX followed by [A-Za-z0-9_-]*.
+        let tok_end = after
+            .char_indices()
+            .skip(PREFIX.len())
+            .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '-' || *c == '_'))
+            .map(|(idx, _)| idx)
+            .unwrap_or(after.len());
+        let token = &after[..tok_end];
+        let keep = token.len().min(PREFIX.len() + 4);
+        out.push_str(&token[..keep]);
+        out.push_str("…REDACTED");
+        rest = &after[tok_end..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// Extract an OAuth URL from a line of CLI output.
@@ -1213,6 +1279,42 @@ mod external_url_tests {
         assert!(!is_external_http_url("data:text/html,hi"));
         assert!(!is_external_http_url("blob:abc"));
         assert!(!is_external_http_url("vscode://file/x"));
+    }
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::redact_secrets;
+
+    #[test]
+    fn masks_oauth_token_keeps_prefix() {
+        let red = redact_secrets("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-AbCdEf123456789");
+        assert!(red.starts_with("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat0"));
+        assert!(red.contains("…REDACTED"));
+        assert!(!red.contains("AbCdEf123456789"));
+    }
+
+    #[test]
+    fn masks_bare_token_and_preserves_surroundings() {
+        let red = redact_secrets("  token: sk-ant-api03-SECRETSECRETSECRET done");
+        assert!(!red.contains("SECRETSECRETSECRET"));
+        assert!(red.contains("sk-ant-api0")); // prefix + 4 kept
+        assert!(red.contains("…REDACTED"));
+        assert!(red.contains(" done")); // trailing text preserved
+    }
+
+    #[test]
+    fn passes_through_non_secret_lines() {
+        let s = "Visit https://claude.ai/oauth?code=xyz to continue";
+        assert_eq!(redact_secrets(s), s);
+    }
+
+    #[test]
+    fn masks_multiple_occurrences() {
+        let red = redact_secrets("sk-ant-oat01-AAAA and sk-ant-oat01-BBBB");
+        assert!(!red.contains("AAAA"));
+        assert!(!red.contains("BBBB"));
+        assert_eq!(red.matches("…REDACTED").count(), 2);
     }
 }
 

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1014,6 +1014,79 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
     Ok(serde_json::Value::Null)
 }
 
+/// Spawn the CLI login command in a NEW visible console window so the OS can
+/// open a browser (the piped/PTY paths used by `run_cli_login` are headless
+/// and block the browser from launching — confirmed for Claude v2.1.x).
+///
+/// Fire-and-forget: returns immediately; the frontend polls for credentials
+/// via `seed_provider_auth_from_global` and seeds them once they appear.
+pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let cli_path = args
+        .get("cli_path")
+        .or_else(|| args.get("cliPath"))
+        .and_then(|v| v.as_str())
+        .ok_or("open_login_terminal: missing cliPath")?;
+
+    let login_args: Vec<String> = args
+        .get("loginArgs")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let auth_env: std::collections::HashMap<String, String> = args
+        .get("authEnv")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Quote the CLI path if it contains spaces (cmd.exe /k token split).
+    let quoted_cli = if cli_path.contains(' ') {
+        format!("\"{}\"", cli_path.replace('"', ""))
+    } else {
+        cli_path.to_string()
+    };
+    let cmd_str = if login_args.is_empty() {
+        quoted_cli
+    } else {
+        format!("{} {}", quoted_cli, login_args.join(" "))
+    };
+
+    tracing::info!(cmd = %cmd_str, "open_login_terminal: spawning new console");
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_CONSOLE (0x10): the child gets its own visible console
+        // window, separate from the host's hidden console. This is what allows
+        // the Claude CLI to open the OS default browser for OAuth.
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        std::process::Command::new("cmd.exe")
+            .args(["/k", &cmd_str])
+            .envs(&auth_env)
+            .stdin(std::process::Stdio::null())
+            .creation_flags(CREATE_NEW_CONSOLE)
+            .spawn()
+            .map_err(|e| format!("open_login_terminal: spawn failed: {e}"))?;
+    }
+
+    #[cfg(not(windows))]
+    {
+        // macOS / Linux: xterm / open -a Terminal. Tracked follow-up.
+        let _ = (cmd_str, auth_env);
+        return Err("open_login_terminal: not yet implemented on this platform".to_string());
+    }
+
+    Ok(serde_json::json!({ "opened": true }))
+}
+
 /// Platform-specific best-effort kill of a child process by PID.
 #[cfg(windows)]
 fn kill_pid(pid: u32) -> std::io::Result<()> {

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -364,6 +364,7 @@ async fn route_command(
         }
         "run_cli_login" => commands::platform::run_cli_login(state.clone(), args).await,
         "cancel_cli_login" => commands::platform::cancel_cli_login(state),
+        "open_login_terminal" => commands::platform::open_login_terminal(args),
         "ensure_settings_file" => commands::platform::ensure_settings_file(state),
         "open_in_editor" => commands::platform::open_in_editor(args),
         "copy_file_to_dir" => commands::providers::copy_file_to_dir(args),

--- a/docs/retro/retro-claude-v2-1-auth-spawn-2026-06-23.md
+++ b/docs/retro/retro-claude-v2-1-auth-spawn-2026-06-23.md
@@ -1,0 +1,76 @@
+# Retro — Claude v2.1.x in-app login: the spawn can't open the browser (2026-06-23)
+
+## TL;DR
+We spent the session trying to make Claude's in-app login work by driving the CLI under
+our host PTY — first scraping the OAuth URL, then pivoting to `claude setup-token`
+(§5.1 of `SPEC_HOST_CLI_LOGIN_CAPTURE`). Two real capture attempts (agents "Marks", "Lazo")
+**both hung with no browser and no token output.** Web research settled it: Claude Code
+**v2.1.x** opens the OS default browser via a local OAuth callback — but **in any spawned /
+piped / tmux / headless context the flow hangs silently** (no browser). Our host→PTY spawn
+*is* such a context, so neither `auth login` nor `setup-token` can complete in-app.
+**Upstream's own recommendation (issue #7100) is exactly our seed-from-global path:** run
+`setup-token` once on a machine with a browser, then seed those credentials into the
+headless environment. **Decision: make seed-from-global the PRIMARY Claude auth path; stop
+trying to drive OAuth inside AgentMux's spawn.**
+
+## Timeline
+- §4 instrumentation + §5.5 seed-from-global shipped earlier (#1613).
+- This session: chased §5.1 — flipped Claude's `authLoginCommand` to `setup-token`,
+  instrumented `run_cli_login_pty` (token redaction in logs, token-line detection,
+  post-login `.credentials.json` check), built two capture portables.
+- Capture 1 ("Marks") + Capture 2 ("Lazo"): `run_cli_login: spawned (PTY)` →
+  `no auth URL captured within 15s`, **zero `[login-pty]` lines** (the TUI redraws with no
+  newlines → `read_line` blocks), **no browser opened**, no token.
+- User (correctly) pushed back on "it can't open a browser." Researched it.
+
+## What's actually true (evidence)
+- The OAuth flow **opens the default browser** to `console.anthropic.com`, runs a localhost
+  callback, exchanges the code for access+refresh tokens. ([authentication docs](https://code.claude.com/docs/en/authentication))
+- **But headless/piped/tmux/spawned contexts hang silently** — `/login` isn't available in
+  `-p` mode; the browser flow "hangs or errors" in containers. ([headless docs](https://code.claude.com/docs/en/headless),
+  [login-not-working](https://www.remoteopenclaw.com/blog/claude-code-login-not-working-fix))
+- Upstream's documented remedy = run `setup-token` on a browser machine, **seed the creds**
+  into the headless env. ([#7100](https://github.com/anthropics/claude-code/issues/7100))
+- "It worked before" = a *real terminal* (the user's global `setup-token`) gets the browser;
+  older CLI versions printed a scrapeable URL. The v2.1.x **spawned** case is the dead end.
+
+## Why we chased the wrong thing
+- `setup-token` looked like a clean "headless contract" (prints a token), so it read as the
+  fix. But it shares the **same browser front-end** — the token only prints *after* an OAuth
+  that can't start under our spawn. The headless contract is "run it where a browser works,"
+  not "we can run it for you."
+
+## Lessons
+1. **Don't assert mechanism without evidence.** "The spawn can't open a browser" was stated
+   too absolutely; the truth was nuanced (opens in real terminals, hangs when spawned). The
+   user's pushback → web research → correct, defensible model. Research *before* the strong
+   claim, not after.
+2. **The CLI's auth UX is not ours to drive.** Three approaches (URL-scrape, setup-token
+   capture, paste-code) all founder on the same rock: the v2.1.x login is a self-driving TUI
+   that won't open a browser when spawned. Stop fighting it.
+3. **Seed-from-global is the robust, upstream-blessed path** — and it works *now* (a valid
+   global login seeds the isolated dir, `refreshToken` keeps it alive). Make it primary, not
+   a 401 fallback.
+4. **Auth × lifecycle interaction (bonus orphan-leak):** a pending login PTY arms a 6-min
+   reap task that counts as "live work" and can **block the host's clean exit** — closing all
+   windows left a 9-proc orphan tree even though the #1676 quit-chain fired
+   (`0 visible — quitting message loop`). Recorded in the lifecycle consolidation notes; the
+   robust machine must cancel the login reap on quit.
+
+## Salvage (kept)
+- `redact_secrets()` + token-detection in `run_cli_login_pty` — a real security fix
+  (`setup-token` would otherwise log a live `CLAUDE_CODE_OAUTH_TOKEN`); keep it regardless.
+- The slice-1 PTY capture proved its worth: it's how we confirmed "no output, no browser."
+
+## Next (the robust machine)
+- Make **seed-from-global the primary** Claude auth path: on launch/create of a Claude agent
+  that lacks a valid isolated credential, if a valid global login exists, offer/auto a
+  one-click "Use my existing login" up-front (not only on the 401 row).
+- Keep `auth login`/`setup-token` only as the "no global login yet → go authenticate in a
+  real terminal, then seed" instruction.
+- Cancel the login PTY reap on host quit (close the orphan-leak vector).
+
+Sources: [authentication](https://code.claude.com/docs/en/authentication) ·
+[headless](https://code.claude.com/docs/en/headless) ·
+[#7100](https://github.com/anthropics/claude-code/issues/7100) ·
+[login-not-working](https://www.remoteopenclaw.com/blog/claude-code-login-not-working-fix)

--- a/docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md
+++ b/docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md
@@ -1,8 +1,37 @@
 # SPEC: Host-side CLI login capture is broken for Claude Code v2.1.183
 **Date:** 2026-06-20
 **Author:** AgentA
-**Status:** Draft — revised 2026-06-20 after upstream-docs research + code re-read
-**Related:** SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20 (frontend force-login, merged #1604)
+**Status:** Draft — revised 2026-06-20; **2026-06-23 capture outcome: §5.1 (`setup-token`) is a confirmed DEAD END under our spawn; §5.5 (seed-from-global) is now the PRIMARY path.**
+**Related:** SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20 (frontend force-login, merged #1604); retro `docs/retro/retro-claude-v2-1-auth-spawn-2026-06-23.md`
+
+---
+
+## 0. CAPTURE OUTCOME + DECISION (2026-06-23) — READ FIRST
+
+Two live captures (agents "Marks", "Lazo") on a `setup-token` build proved §5.1 **cannot work
+in-app**: `run_cli_login: spawned (PTY)` → `no auth URL captured within 15s`, **zero `[login-pty]`
+lines** (the v2.1.x login is a full-screen TUI that redraws with no newlines), and **no browser
+opened**. Web research confirms why: the OAuth flow opens the OS default browser via a localhost
+callback, but **in any spawned / piped / tmux / headless context it hangs silently** — and
+`setup-token` shares that same browser front-end (the token only prints *after* an OAuth that
+can't start under our spawn). Upstream's own remedy (issue #7100) is exactly seed-from-global:
+authenticate once where a browser works, then seed the creds into the headless env.
+
+**DECISION:**
+- §5.1 (`setup-token` capture), §5.2 (paste-code), and §5.6 (URL-scrape) are **abandoned for
+  Claude v2.1.x** — all founder on the un-spawnable TUI / no-browser problem.
+- **§5.5 (seed-from-global) is the PRIMARY auth path.** Make it a first-class, up-front flow
+  ("Use my existing login" offered on launch/create when a valid global login exists), not just a
+  401-row fallback. `auth login`/`setup-token` survive only as the "no global login yet → go
+  authenticate in a real terminal, then seed" instruction.
+- **Salvage kept:** `redact_secrets()` + token-line detection in `run_cli_login_pty` (security —
+  `setup-token` would otherwise log a live token). Also: a pending login PTY's 6-min reap can
+  block host clean-exit (auth × lifecycle orphan leak — see lifecycle consolidation notes); the
+  robust machine should cancel the reap on quit.
+
+Evidence: [authentication](https://code.claude.com/docs/en/authentication) ·
+[headless](https://code.claude.com/docs/en/headless) ·
+[#7100](https://github.com/anthropics/claude-code/issues/7100).
 
 ---
 

--- a/docs/specs/SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md
+++ b/docs/specs/SPEC_NIGHTLY_CROSS_PLATFORM_BUILDS_2026_06_23.md
@@ -1,6 +1,6 @@
 # SPEC — Nightly cross-platform CI builds
 
-- **Status:** Phase A implementing; Phase B deferred
+- **Status:** Phase A ✅ MERGED (all 3 platforms green); Phase B implementing (Windows only — macOS/Linux deferred, see §3)
 - **Date:** 2026-06-23
 - **Author:** AgentA
 - **Tracking:** GitHub issue **#1718**

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -748,6 +748,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         blockId: model.blockId,
         onRetry: retryLastTurn,
         onTrustCenter: () => openBundleManager(),
+        canSeed: () => provider()?.id === "claude",
         // context_exceeded recovery — drop the over-full session and return to
         // the picker for a clean relaunch (resuming would only re-fail).
         onNewSession: () => {
@@ -776,6 +777,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         onUseExistingLogin: () => {
             log("auth", "Use existing login — seeding from your global Claude login");
             void status.useGlobalLogin();
+        },
+        // Open a real console window (CREATE_NEW_CONSOLE) so the browser OAuth
+        // can launch. Polls for new credentials and seeds when they appear.
+        onLoginViaTerminal: () => {
+            log("auth", "Login via terminal — opening a console window for browser login");
+            void status.loginViaTerminal();
         },
     });
 

--- a/frontend/app/view/agent/auth/auth-flow-controller.ts
+++ b/frontend/app/view/agent/auth/auth-flow-controller.ts
@@ -431,6 +431,17 @@ export class AuthFlowController {
         this.dispatch({ type: "ConnectFailed", error: message });
     }
 
+    /** Seed-from-global accepted — the agent's isolated dir now holds the
+     *  user's valid global credential, so auth is satisfied WITHOUT in-app
+     *  OAuth (the dead end for Claude v2.1.x; SPEC_HOST_CLI_LOGIN_CAPTURE §0).
+     *  The seed RPC itself is fired by the view (PreLaunchAuthPanel via the
+     *  seed-global-login flow); this records the success in the state machine
+     *  so the reducer transitions to `ready` and the Launch button enables.
+     *  Single-phase — no session, no poll. */
+    markSeeded(bundleId: string): void {
+        this.dispatch({ type: "Seeded", bundleId });
+    }
+
     dispose(): void {
         // Fire-and-forget auth.cancel for any in-flight session so we
         // don't leave an orphan CLI subprocess on the backend. Reagent

--- a/frontend/app/view/agent/auth/auth-state.test.ts
+++ b/frontend/app/view/agent/auth/auth-state.test.ts
@@ -129,6 +129,58 @@ describe("auth-state reducer", () => {
         });
     });
 
+    describe("Seeded (seed-from-global → ready)", () => {
+        it("transitions unauthenticated → ready single-phase", () => {
+            const r = update(
+                seed({ kind: "unauthenticated", providerId: "claude", bundleId: "b1" }),
+                { type: "Seeded", bundleId: "b1" },
+            );
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.bundleId).toBe("b1");
+            expect(r.state.sessionId).toBe("");
+            expect(r.events[0]).toMatchObject({ type: "seeded", bundleId: "b1" });
+        });
+
+        it("empty bundleId falls back to the existing bundle (default identity)", () => {
+            const r = update(
+                seed({ kind: "expired", providerId: "claude", bundleId: "b2" }),
+                { type: "Seeded", bundleId: "" },
+            );
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.bundleId).toBe("b2");
+        });
+
+        it("clears a prior error when seeding from `failed`", () => {
+            const r = update(seed({ kind: "failed", error: "boom" }), {
+                type: "Seeded",
+                bundleId: "b3",
+            });
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.error).toBe("");
+        });
+
+        it("is dropped from non-connect-able kinds (never clobbers ready/waiting/saving)", () => {
+            for (const kind of [
+                "ready",
+                "waiting",
+                "saving",
+                "authenticated",
+                "idle",
+            ] as const) {
+                const r = update(seed({ kind, bundleId: "keep" }), {
+                    type: "Seeded",
+                    bundleId: "other",
+                });
+                expect(r.state.kind).toBe(kind);
+                expect(r.state.bundleId).toBe("keep");
+                expect(r.events[0]).toMatchObject({
+                    type: "post-close-command-dropped",
+                    commandType: "Seeded",
+                });
+            }
+        });
+    });
+
     describe("Polled", () => {
         it("`pending` is a no-op", () => {
             const seeded = seed({ kind: "waiting", sessionId: "s1" });

--- a/frontend/app/view/agent/auth/auth-state.ts
+++ b/frontend/app/view/agent/auth/auth-state.ts
@@ -182,6 +182,19 @@ export type AuthCommand =
      */
     | { type: "ApiKeyAccepted"; bundleId: string }
     /**
+     * Seed-from-global accepted (SPEC_HOST_CLI_LOGIN_CAPTURE §0 / §5.5):
+     * the user's valid GLOBAL Claude login was copied into the agent's
+     * isolated dir, so auth is satisfied WITHOUT in-app OAuth — which is a
+     * dead end for Claude v2.1.x (the spawned login can't open a browser).
+     * Single-phase, like `ApiKeyAccepted`: the credential file IS the
+     * persistence, so transition straight to `ready`. Honored only from
+     * connect-able kinds (`unauthenticated`/`expired`/`failed`); a stale
+     * dispatch from `ready`/`waiting`/etc. is dropped. `bundleId` may be ""
+     * for the default identity (the existing dir is seeded in place — no new
+     * bundle row created).
+     */
+    | { type: "Seeded"; bundleId: string }
+    /**
      * User confirmed the bundle name in the SaveBundle panel. View
      * fires `auth.savebundle` RPC on the emitted event. Transitions
      * to `saving`. Reagent-pinned: only honored from `authenticated`.
@@ -258,6 +271,7 @@ export type AuthEvent =
           accountName: string;
       }
     | { type: "api-key-accepted"; bundleId: string }
+    | { type: "seeded"; bundleId: string }
     | { type: "disposed" }
     | { type: "post-close-command-dropped"; commandType: string };
 
@@ -560,6 +574,39 @@ export function update(state: AuthState, command: AuthCommand): ReducerResult {
                     error: "",
                 },
                 events: [{ type: "api-key-accepted", bundleId: command.bundleId }],
+            };
+        }
+
+        case "Seeded": {
+            // Honored only from connect-able kinds, so a stale dispatch can't
+            // clobber a newer `ready`/`waiting`/`saving`/`idle`.
+            if (
+                state.kind !== "unauthenticated" &&
+                state.kind !== "expired" &&
+                state.kind !== "failed"
+            ) {
+                return {
+                    state,
+                    events: [
+                        { type: "post-close-command-dropped", commandType: "Seeded" },
+                    ],
+                };
+            }
+            // Single-phase (the seeded credential file IS the persistence) →
+            // straight to `ready`. bundleId may be "" for the default identity
+            // (no new bundle row — the existing isolated dir was seeded in place).
+            const bundleId = command.bundleId || state.bundleId;
+            return {
+                state: {
+                    ...state,
+                    kind: "ready",
+                    bundleId,
+                    sessionId: "",
+                    authUrl: "",
+                    deviceCode: null,
+                    error: "",
+                },
+                events: [{ type: "seeded", bundleId }],
             };
         }
 

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -43,7 +43,9 @@ import {
     type SelectionOutcome,
 } from "../auth";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { seedGlobalLogin } from "../flows/seed-global-login";
 import type { ProviderDefinition } from "../providers";
+import type { LogFn } from "../types";
 import "./PreLaunchAuthPanel.scss";
 
 export interface PreLaunchAuthPanelProps {
@@ -222,6 +224,39 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         void startConnect(controller, prov);
     };
 
+    // "Use my existing login" — the PRIMARY path for Claude v2.1.x, whose
+    // in-app OAuth can't open a browser when WE spawn it (a dead end —
+    // SPEC_HOST_CLI_LOGIN_CAPTURE §0). Copies the user's valid GLOBAL login
+    // into the agent's isolated dir, then marks the controller `ready` so
+    // Launch enables — no in-app browser, no OAuth.
+    const seedLog: LogFn = (_cat, msg) => console.log(`[auth-diag] seed: ${msg}`);
+    const handleUseExistingLogin = async (): Promise<void> => {
+        const prov = props.provider;
+        if (!prov) return;
+        // Resolve the agent's isolated auth dir so the seed lands where the
+        // agent reads it (host falls back to the shared dir if absent/invalid).
+        let configDir: string | undefined;
+        if (prov.authConfigDirEnvVar) {
+            try {
+                configDir = await getApi().ensureAuthDir(prov.id);
+            } catch (e) {
+                console.warn(
+                    `[auth-diag] seed ensureAuthDir failed: ${(e as Error)?.message ?? String(e)}`,
+                );
+            }
+        }
+        const ok = await seedGlobalLogin(prov.id, seedLog, configDir);
+        if (ok) {
+            controller.markSeeded(props.identityId());
+        } else {
+            controller.failConnect(
+                new Error(
+                    "No valid global Claude login to copy. Run `claude setup-token` in a real terminal (it opens a browser), complete it, then click “Use my existing login” again.",
+                ),
+            );
+        }
+    };
+
     // Auto-start OAuth once on mount when the parent set `autoStartAuth`
     // — the New Identity → launch round-trip (spec §2). By this point
     // the user has named + created the bundle, so the dropdown carries
@@ -274,6 +309,8 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                         bindingStatus={props.bindingStatus?.() ?? null}
                         hasBinding={props.hasMatchingBinding()}
                         onConnect={() => handleConnect()}
+                        canSeed={props.provider?.id === "claude"}
+                        onUseExistingLogin={() => void handleUseExistingLogin()}
                         disabled={props.disabled ?? false}
                     />
                 </Match>
@@ -325,6 +362,8 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                         bindingStatus={props.bindingStatus?.() ?? null}
                         hasBinding={props.hasMatchingBinding()}
                         onConnect={() => handleConnect()}
+                        canSeed={props.provider?.id === "claude"}
+                        onUseExistingLogin={() => void handleUseExistingLogin()}
                         disabled={props.disabled ?? false}
                     />
                 </Match>
@@ -458,6 +497,12 @@ const ConnectCta = (p: {
      *  Connect CTA wording the user already knows). */
     hasBinding: boolean;
     onConnect: () => void;
+    /** True for providers where seed-from-global is the path (Claude
+     *  v2.1.x — in-app OAuth can't open a browser under our spawn, so the
+     *  Connect CTA is a dead end). When true the panel leads with "Use my
+     *  existing login" instead of OAuth. SPEC_HOST_CLI_LOGIN_CAPTURE §0. */
+    canSeed: boolean;
+    onUseExistingLogin: () => void;
     disabled: boolean;
 }): JSX.Element => {
     const catalog = () =>
@@ -480,31 +525,56 @@ const ConnectCta = (p: {
                     ? `⚠ Your ${providerLabel()} credentials need reconnecting.`
                     : isExpired()
                         ? `⚠ Your ${providerLabel()} session is expired. Re-authenticate before launching.`
-                        : `⚠ ${providerLabel()} requires an OAuth login before launch.`}
+                        : `⚠ ${providerLabel()} requires a login before launch.`}
             </div>
-            <Button
-                onClick={() => p.onConnect()}
-                disabled={p.disabled}
-                className="pre-launch-auth-panel-connect green solid"
+            <Show
+                when={p.canSeed}
+                fallback={
+                    <>
+                        <Button
+                            onClick={() => p.onConnect()}
+                            disabled={p.disabled}
+                            className="pre-launch-auth-panel-connect green solid"
+                        >
+                            <span class="pre-launch-auth-panel-connect-icon" aria-hidden="true">
+                                {catalog()?.icon ?? "🔐"}
+                            </span>
+                            <span class="pre-launch-auth-panel-connect-label">
+                                {needsReconnect()
+                                    ? `Reconnect ${providerLabel()}`
+                                    : isExpired()
+                                        ? "Re-authenticate"
+                                        : `Connect to ${providerLabel()}`}
+                            </span>
+                        </Button>
+                        <div class="pre-launch-auth-panel-hint">
+                            {needsReconnect()
+                                ? `Re-runs OAuth into your existing Identity bundle. Launch stays available — your CLI will refresh on first call.`
+                                : `Opens browser → ${providerLabel()} login → returns to AgentMux.
+                                Tokens get saved into a new Identity bundle so the next
+                                agent doesn't have to re-authenticate.`}
+                        </div>
+                    </>
+                }
             >
-                <span class="pre-launch-auth-panel-connect-icon" aria-hidden="true">
-                    {catalog()?.icon ?? "🔐"}
-                </span>
-                <span class="pre-launch-auth-panel-connect-label">
-                    {needsReconnect()
-                        ? `Reconnect ${providerLabel()}`
-                        : isExpired()
-                            ? "Re-authenticate"
-                            : `Connect to ${providerLabel()}`}
-                </span>
-            </Button>
-            <div class="pre-launch-auth-panel-hint">
-                {needsReconnect()
-                    ? `Re-runs OAuth into your existing Identity bundle. Launch stays available — your CLI will refresh on first call.`
-                    : `Opens browser → ${providerLabel()} login → returns to AgentMux.
-                    Tokens get saved into a new Identity bundle so the next
-                    agent doesn't have to re-authenticate.`}
-            </div>
+                {/* Claude v2.1.x: in-app OAuth can't open a browser under our
+                    spawn (SPEC_HOST_CLI_LOGIN_CAPTURE §0), so seed the user's
+                    existing global login instead — the upstream-recommended
+                    method (issue #7100). PRIMARY path. */}
+                <Button
+                    onClick={() => p.onUseExistingLogin()}
+                    disabled={p.disabled}
+                    className="pre-launch-auth-panel-connect green solid"
+                >
+                    <span class="pre-launch-auth-panel-connect-icon" aria-hidden="true">🌐</span>
+                    <span class="pre-launch-auth-panel-connect-label">Use my existing login</span>
+                </Button>
+                <div class="pre-launch-auth-panel-hint">
+                    Copies your existing terminal login into this agent — no in-app
+                    browser needed. First time? Run <code>claude setup-token</code> in a
+                    terminal, finish it in the browser, then click this.
+                </div>
+            </Show>
         </div>
     );
 };

--- a/frontend/app/view/agent/failure/failure-accessory.test.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.test.ts
@@ -21,12 +21,13 @@ const mkView = (overrides: Partial<FailureViewState> = {}): FailureViewState => 
 });
 
 const mkActions = (): FailureActions & { _calls: Record<keyof FailureActions, number> } => {
-    const _calls = { retry: 0, loginAgain: 0, useExistingLogin: 0, trustCenter: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
+    const _calls = { retry: 0, loginAgain: 0, useExistingLogin: 0, loginViaTerminal: 0, trustCenter: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
     return {
         _calls,
         retry: vi.fn(() => void _calls.retry++),
         loginAgain: vi.fn(() => void _calls.loginAgain++),
         useExistingLogin: vi.fn(() => void _calls.useExistingLogin++),
+        loginViaTerminal: vi.fn(() => void _calls.loginViaTerminal++),
         trustCenter: vi.fn(() => void _calls.trustCenter++),
         newSession: vi.fn(() => void _calls.newSession++),
         toggleDetails: vi.fn(() => void _calls.toggleDetails++),
@@ -63,7 +64,7 @@ describe("failureToRow", () => {
         expect(on._calls.dismiss).toBe(1);
     });
 
-    it("auth → 🔐 sigil with Login Again (re-auth) + Trust Center actions", () => {
+    it("auth (non-Claude) → 🔐 sigil with Login Again primary + Use existing login secondary", () => {
         const on = mkActions();
         const row = failureToRow(mkFailure({ code: "auth", title: "Not authenticated" }), mkView(), on);
         expect(row.sigil).toBe("🔐");
@@ -74,7 +75,6 @@ describe("failureToRow", () => {
         login?.onClick();
         expect(on._calls.loginAgain).toBe(1);
 
-        // Seed-from-global recovery sits alongside Login Again (not primary).
         const useExisting = action(row, "Use existing login");
         expect(useExisting).toBeTruthy();
         expect(useExisting?.primary).toBeFalsy();
@@ -85,6 +85,26 @@ describe("failureToRow", () => {
         expect(trust).toBeTruthy();
         trust?.onClick();
         expect(on._calls.trustCenter).toBe(1);
+    });
+
+    it("auth (Claude / canSeed) → Use existing login is primary, Login via terminal is secondary", () => {
+        const on = mkActions();
+        const row = failureToRow(mkFailure({ code: "auth", title: "Not authenticated" }), mkView({ canSeed: true }), on);
+        expect(row.sigil).toBe("🔐");
+
+        const useExisting = action(row, "Use existing login");
+        expect(useExisting?.primary).toBe(true);
+        useExisting?.onClick();
+        expect(on._calls.useExistingLogin).toBe(1);
+
+        const terminal = action(row, "Login via terminal");
+        expect(terminal).toBeTruthy();
+        expect(terminal?.primary).toBeFalsy();
+        terminal?.onClick();
+        expect(on._calls.loginViaTerminal).toBe(1);
+
+        // "Login Again" (PTY path) must NOT appear for Claude — it hangs headlessly.
+        expect(action(row, "Login Again")).toBeUndefined();
     });
 
     it("usage_limit → Trust Center is the primary action", () => {

--- a/frontend/app/view/agent/failure/failure-accessory.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.ts
@@ -25,6 +25,8 @@ export interface FailureActions {
     loginAgain: () => void;
     /** Seed from the user's existing valid global Claude login (no fresh OAuth). */
     useExistingLogin: () => void;
+    /** Open a real terminal window so the browser OAuth can open, then poll for creds. */
+    loginViaTerminal: () => void;
     /** Open Trust Center → Accounts. */
     trustCenter: () => void;
     /** Start a fresh agent session — recovery for a context-window overflow,
@@ -44,6 +46,12 @@ export interface FailureViewState {
     autoRetryIn: number | null;
     /** True while a retry is in flight (disables the button). */
     retrying: boolean;
+    /**
+     * True when the provider supports seed-from-global recovery (Claude only).
+     * Promotes "Use existing login" to primary and adds "Login via terminal"
+     * as the fresh-OAuth path instead of the broken spawned-PTY path.
+     */
+    canSeed?: boolean;
 }
 
 /** Per-class sigil. */
@@ -99,11 +107,22 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
     const actions: PaneRowAction[] = [];
     switch (f.code) {
         case "auth":
-            actions.push(
-                { glyph: "🔑", label: "Login Again", title: "Re-authenticate this agent", primary: true, onClick: on.loginAgain },
-                { glyph: "🌐", label: "Use existing login", title: "Copy your existing valid global Claude login into this agent (no re-OAuth)", onClick: on.useExistingLogin },
-                trustCenter,
-            );
+            if (view.canSeed) {
+                // Claude provider: seed-from-global is the reliable path;
+                // "Login via terminal" opens a real console so the browser
+                // can launch (the spawned PTY path is headless and hangs).
+                actions.push(
+                    { glyph: "🌐", label: "Use existing login", title: "Copy your valid global Claude login into this agent (no re-OAuth)", primary: true, onClick: on.useExistingLogin },
+                    { glyph: "🖥", label: "Login via terminal", title: "Open a terminal window where the browser login can complete", onClick: on.loginViaTerminal },
+                    trustCenter,
+                );
+            } else {
+                actions.push(
+                    { glyph: "🔑", label: "Login Again", title: "Re-authenticate this agent", primary: true, onClick: on.loginAgain },
+                    { glyph: "🌐", label: "Use existing login", title: "Copy your existing valid global Claude login into this agent (no re-OAuth)", onClick: on.useExistingLogin },
+                    trustCenter,
+                );
+            }
             break;
         case "usage_limit":
             actions.push({ ...trustCenter, label: "Trust Center (switch / upgrade)", primary: true });

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -239,6 +239,7 @@ export function useAgentControllerStatus(
     // then poll for credentials seeding into the isolated dir.
     const loginViaTerminal = async () => {
         if (reloginInFlight) return;
+        loginCancelled = false;
         const prov = opts.provider();
         if (!prov) {
             opts.log("auth", "login via terminal: no active provider", "warn");

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -83,6 +83,14 @@ export interface UseAgentControllerStatus {
      * the running agent re-reads its credential per request.
      */
     useGlobalLogin: () => Promise<void>;
+    /**
+     * Open a real terminal window (CREATE_NEW_CONSOLE on Windows) running the
+     * provider's login command so the OS can open the browser — the piped/PTY
+     * paths that `runCliLogin` uses are headless and block the browser. After
+     * spawning, polls `seedGlobalLogin` every 5s for up to 5 minutes; seeds
+     * the isolated dir as soon as credentials appear.
+     */
+    loginViaTerminal: () => Promise<void>;
     cancelLogin: () => void;
 }
 
@@ -227,6 +235,60 @@ export function useAgentControllerStatus(
         }
     };
 
+    // Open a real visible terminal window so the browser OAuth flow works,
+    // then poll for credentials seeding into the isolated dir.
+    const loginViaTerminal = async () => {
+        if (reloginInFlight) return;
+        const prov = opts.provider();
+        if (!prov) {
+            opts.log("auth", "login via terminal: no active provider", "warn");
+            return;
+        }
+        const cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
+        if (!cliPath) {
+            opts.log("auth", "login via terminal: CLI not resolved — running launch flow instead", "warn");
+            void startLaunchFlow();
+            return;
+        }
+        const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
+        const authEnv: Record<string, string> = {};
+        if (envMeta && typeof envMeta === "object") {
+            for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
+                if (typeof v === "string") authEnv[k] = v;
+            }
+        }
+        const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
+
+        reloginInFlight = true;
+        setLoginWaiting(true);
+        try {
+            await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, authEnv);
+            opts.log("auth", "A terminal window opened — complete the login there, then come back.");
+
+            // Poll silently every 5s for up to 5 minutes; seed on first hit.
+            const POLL_MS = 5_000;
+            const TIMEOUT_MS = 5 * 60 * 1_000;
+            const deadline = performance.now() + TIMEOUT_MS;
+            const silentLog: typeof opts.log = () => {};
+            let seeded = false;
+            while (!seeded && performance.now() < deadline && !loginCancelled) {
+                await new Promise<void>((r) => setTimeout(r, POLL_MS));
+                if (loginCancelled) break;
+                seeded = await seedGlobalLogin(prov.id, silentLog, configDir);
+            }
+            if (seeded) {
+                opts.log("auth", "Login successful — your next message will use the new token.");
+            } else if (!loginCancelled) {
+                opts.log("auth", "No login detected after 5 minutes. Complete the login in the terminal, then click 'Use existing login'.", "warn");
+            }
+        } catch (err: any) {
+            opts.log("auth", `terminal login failed: ${err?.message ?? String(err)}`, "error");
+        } finally {
+            reloginInFlight = false;
+            setLoginWaiting(false);
+        }
+    };
+
     const cancelLogin = () => {
         loginCancelled = true;
         getApi().cancelCliLogin().catch(() => {});
@@ -258,6 +320,7 @@ export function useAgentControllerStatus(
         startLaunchFlow,
         relogin,
         useGlobalLogin,
+        loginViaTerminal,
         cancelLogin,
     };
 }

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -260,10 +260,18 @@ export function useAgentControllerStatus(
         }
         const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
 
+        // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
+        // login writes to the user's global ~/.claude instead of the isolated dir.
+        // seedGlobalLogin polls the global dir and copies on success — if we kept
+        // the isolated dir key the poll would look in global but the creds would
+        // land in isolated, and a terminal-fresh login would never be detected.
+        const terminalEnv: Record<string, string> = { ...authEnv };
+        if (prov.authConfigDirEnvVar) delete terminalEnv[prov.authConfigDirEnvVar];
+
         reloginInFlight = true;
         setLoginWaiting(true);
         try {
-            await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, authEnv);
+            await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, terminalEnv);
             opts.log("auth", "A terminal window opened — complete the login there, then come back.");
 
             // Poll silently every 5s for up to 5 minutes; seed on first hit.

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -35,10 +35,15 @@ export interface UseAgentFailureOptions {
     onLoginAgain: () => void;
     /** Seed this agent from the user's existing global Claude login (§5.5). */
     onUseExistingLogin: () => void;
+    /** Open a real terminal window for browser-based OAuth (Claude v2.1.x). */
+    onLoginViaTerminal: () => void;
     /** Open Trust Center → Accounts. */
     onTrustCenter: () => void;
     /** Start a fresh agent session (context-window overflow recovery). */
     onNewSession: () => void;
+    /** True when the provider supports seed-from-global (Claude). Promotes
+     *  "Use existing login" to primary in the auth failure banner. */
+    canSeed?: () => boolean;
 }
 
 export interface UseAgentFailureResult {
@@ -183,11 +188,12 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
         if (!f) return null;
         return failureToRow(
             f,
-            { expanded: expanded(), autoRetryIn: autoRetryIn(), retrying: retrying() },
+            { expanded: expanded(), autoRetryIn: autoRetryIn(), retrying: retrying(), canSeed: opts.canSeed?.() },
             {
                 retry: doRetry,
                 loginAgain: opts.onLoginAgain,
                 useExistingLogin: opts.onUseExistingLogin,
+                loginViaTerminal: opts.onLoginViaTerminal,
                 trustCenter: opts.onTrustCenter,
                 newSession: opts.onNewSession,
                 toggleDetails: () => setExpanded((v) => !v),

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -134,8 +134,15 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         styledOutputFormat: "claude-stream-json",
         authType: "oauth",
         authCheckCommand: ["auth", "status", "--json"],
-        authLoginCommand: ["auth", "login"],
-        // Run `claude auth login` under a PTY (run_cli_login's PTY branch).
+        // §5.1 (SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20): switched from
+        // ["auth","login"] — the un-scrapeable v2.1.x TUI (URL goes to clipboard,
+        // no stdout line) — to `setup-token`, the documented headless path that
+        // prints a long-lived CLAUDE_CODE_OAUTH_TOKEN to stdout after a one-time
+        // browser OAuth. The host runs it under a PTY and captures the printed
+        // token instead of scraping a URL. (Capture-build step: confirm the token
+        // output format via slice-1 `login_pty` logs before wiring the parser.)
+        authLoginCommand: ["setup-token"],
+        // Run under a PTY (run_cli_login's PTY branch).
         // Spawned with plain pipes from the GUI host, the CLI exits cleanly
         // ~5s after printing the OAuth URL — before the user can return from
         // the browser and paste the code — so the login always appeared stuck

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -134,15 +134,15 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         styledOutputFormat: "claude-stream-json",
         authType: "oauth",
         authCheckCommand: ["auth", "status", "--json"],
-        // §5.1 (SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20): switched from
-        // ["auth","login"] — the un-scrapeable v2.1.x TUI (URL goes to clipboard,
-        // no stdout line) — to `setup-token`, the documented headless path that
-        // prints a long-lived CLAUDE_CODE_OAUTH_TOKEN to stdout after a one-time
-        // browser OAuth. The host runs it under a PTY and captures the printed
-        // token instead of scraping a URL. (Capture-build step: confirm the token
-        // output format via slice-1 `login_pty` logs before wiring the parser.)
-        authLoginCommand: ["setup-token"],
-        // Run under a PTY (run_cli_login's PTY branch).
+        // NOTE (2026-06-23, SPEC_HOST_CLI_LOGIN_CAPTURE §0): in-app OAuth is a DEAD
+        // END for Claude v2.1.x — the login is a self-driving TUI that opens its own
+        // browser, and when WE spawn it (host→PTY, not a real terminal) the browser
+        // never opens (it hangs). `setup-token` shares the same browser front-end, so
+        // it can't help in-app either (confirmed via two live captures). The robust
+        // path is seed-from-global (§5.5): authenticate once in a real terminal, then
+        // seed. Kept as ["auth","login"] only for the legacy Connect CTA.
+        authLoginCommand: ["auth", "login"],
+        // Run `claude auth login` under a PTY (run_cli_login's PTY branch).
         // Spawned with plain pipes from the GUI host, the CLI exits cleanly
         // ~5s after printing the OAuth URL — before the user can return from
         // the browser and paste the code — so the login always appeared stuck

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -184,6 +184,7 @@ declare global {
         runCliLogin: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>, requiresTty?: boolean) => Promise<string | null>;
         cancelCliLogin: () => Promise<void>;
         seedProviderAuthFromGlobal: (providerId: string, configDir?: string) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
+        openLoginTerminal: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>) => Promise<{ opened: boolean }>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (
             dragType: "pane" | "tab",

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -615,6 +615,9 @@ export function buildCefApi(): AppApi {
                 { providerId, configDir: configDir ?? null },
             );
         },
+        openLoginTerminal: async (cliPath: string, loginArgs: string[], authEnv: Record<string, string>) => {
+            return await invokeCommand<{ opened: boolean }>("open_login_terminal", { cliPath, loginArgs, authEnv });
+        },
 
         listen: async (event: string, callback: (event: any) => void) => {
             const unlisten = await listenEvent(event, callback);


### PR DESCRIPTION
## Summary

- **"🌐 Use existing login"** is now the **primary** action for Claude auth failures in the in-agent failure banner — this is the reliable seed-from-global path (no browser spawn needed)
- **"🖥 Login via terminal"** replaces "Login Again" for Claude — opens a real `cmd.exe` window with `CREATE_NEW_CONSOLE` so the OS can launch the browser for OAuth, then polls for credentials every 5s for up to 5 minutes and auto-seeds when they appear
- **Non-Claude providers** keep "Login Again" as primary (PTY path may work for them)
- 14 tests green (2 new cases: `canSeed=false` legacy path, `canSeed=true` Claude path)

**Root cause confirmed in logs:** clicking "Login Again" called `run_cli_login_pty` → "no auth URL captured within 15s" → silent hang → user sees nothing happen. The PTY is headless; Claude v2.1.x needs a real console to open the browser.

Closes the "Login Again does nothing" UX regression for Claude agents.

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->