### PR TITLE
fix(container-agent): force subprocess controller at block creation, guard resync

### DIFF
--- a/.changesets/1782238012-fix-container-agent-force-subprocess-controller-type-at-bloc-go6c.md
+++ b/.changesets/1782238012-fix-container-agent-force-subprocess-controller-type-at-bloc-go6c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(container-agent): force subprocess controller type at block creation; guard resync

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -353,6 +353,20 @@ pub fn resync_controller(
         return Ok(());
     }
 
+    // Container agents (agentMode == "container") require a subprocess controller for
+    // per-turn docker exec. Persistent is incompatible. Override any stale "persistent"
+    // value that may have been written before this invariant was enforced at creation time.
+    let agent_mode = super::obj::meta_get_string(block_meta, "agentMode", "");
+    let controller_type = if agent_mode == "container" && controller_type == BLOCK_CONTROLLER_PERSISTENT {
+        tracing::warn!(
+            block_id = %block_id,
+            "container agent has persistent controller in meta — overriding to subprocess"
+        );
+        BLOCK_CONTROLLER_SUBPROCESS.to_string()
+    } else {
+        controller_type
+    };
+
     tracing::info!(
         block_id = %block_id,
         controller_type = %controller_type,

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -1002,6 +1002,18 @@ impl SubprocessController {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::warn!(block_id = %block_id, error = %e, "container exec failed");
+                    // Surface the error in the agent pane so the user sees what went wrong.
+                    if let Some(ref b) = broker {
+                        let safe_msg = e.to_string().replace('"', "'");
+                        let error_frame = format!(
+                            r#"{{"type":"result","is_error":true,"subtype":"error_during_execution","error":{{"message":"[AgentMux] container exec failed: {safe_msg}"}}}}"#
+                        );
+                        super::shell::handle_append_block_file(
+                            b, &block_id, SUBPROCESS_OUTPUT_SUBJECT,
+                            format!("{error_frame}\n").as_bytes(),
+                            filestore.as_ref(), None,
+                        );
+                    }
                     // A failed exec must still run the SAME completion + queue
                     // drain as the normal-exit path below: publish a terminal
                     // status so the client sees the turn end (exit 1), mark the

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -1004,10 +1004,12 @@ impl SubprocessController {
                     tracing::warn!(block_id = %block_id, error = %e, "container exec failed");
                     // Surface the error in the agent pane so the user sees what went wrong.
                     if let Some(ref b) = broker {
-                        let safe_msg = e.to_string().replace('"', "'");
-                        let error_frame = format!(
-                            r#"{{"type":"result","is_error":true,"subtype":"error_during_execution","error":{{"message":"[AgentMux] container exec failed: {safe_msg}"}}}}"#
-                        );
+                        let error_frame = serde_json::json!({
+                            "type": "result",
+                            "is_error": true,
+                            "subtype": "error_during_execution",
+                            "error": {"message": format!("[AgentMux] container exec failed: {e}")}
+                        }).to_string();
                         super::shell::handle_append_block_file(
                             b, &block_id, SUBPROCESS_OUTPUT_SUBJECT,
                             format!("{error_frame}\n").as_bytes(),

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3286,8 +3286,23 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         let volumes: Vec<String> = serde_json::from_str(&volumes_json).unwrap_or_default();
 
                         // Ensure container is alive (pull image if needed — P1b).
-                        cm.ensure_running(&container_name, &container_image, &volumes, &[]).await
-                            .map_err(|e| format!("container ensure_running failed: {e}"))?;
+                        if let Err(e) = cm.ensure_running(&container_name, &container_image, &volumes, &[]).await {
+                            // Surface the error in the agent pane before returning, so the user
+                            // sees why the container failed (image not found, Docker down, etc.).
+                            let safe_msg = e.to_string().replace('"', "'");
+                            let error_frame = format!(
+                                r#"{{"type":"result","is_error":true,"subtype":"error_during_execution","error":{{"message":"[AgentMux] container ensure_running failed: {safe_msg}"}}}}"#
+                            );
+                            crate::backend::blockcontroller::shell::handle_append_block_file(
+                                &broker,
+                                &cmd.blockid,
+                                crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
+                                format!("{error_frame}\n").as_bytes(),
+                                None,
+                                None,
+                            );
+                            return Err(format!("container ensure_running failed: {e}"));
+                        }
 
                         tracing::info!(
                             block_id = %cmd.blockid,

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3289,10 +3289,12 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         if let Err(e) = cm.ensure_running(&container_name, &container_image, &volumes, &[]).await {
                             // Surface the error in the agent pane before returning, so the user
                             // sees why the container failed (image not found, Docker down, etc.).
-                            let safe_msg = e.to_string().replace('"', "'");
-                            let error_frame = format!(
-                                r#"{{"type":"result","is_error":true,"subtype":"error_during_execution","error":{{"message":"[AgentMux] container ensure_running failed: {safe_msg}"}}}}"#
-                            );
+                            let error_frame = serde_json::json!({
+                                "type": "result",
+                                "is_error": true,
+                                "subtype": "error_during_execution",
+                                "error": {"message": format!("[AgentMux] container ensure_running failed: {e}")}
+                            }).to_string();
                             crate::backend::blockcontroller::shell::handle_append_block_file(
                                 &broker,
                                 &cmd.blockid,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -244,6 +244,14 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // 6. Build metadata
                 let controller_type = provider.controller_type_str();
+                // Container agents use per-turn docker exec; the subprocess controller
+                // is required regardless of what the provider defaults to (claude returns
+                // "persistent", which causes AgentInput to skip the container exec path).
+                let controller_type = if agent.agent_type == "container" {
+                    "subprocess"
+                } else {
+                    controller_type
+                };
                 let is_persistent = controller_type == "persistent";
                 let mut cli_args: Vec<String> = if is_persistent {
                     provider.persistent_launch_args

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -182,7 +182,11 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Ensure the controller is registered (may be missing if block
                     // was created by the frontend without backend initialization)
                     if blockcontroller::get_controller(&existing.oid).is_none() {
-                        let controller_type = provider.controller_type_str();
+                        let controller_type = if agent.agent_type == "container" {
+                            "subprocess"
+                        } else {
+                            provider.controller_type_str()
+                        };
                         // Set essential metadata if missing
                         let mut meta_update = obj::MetaMapType::new();
                         meta_update.insert("controller".to_string(), json!(controller_type));


### PR DESCRIPTION
## Summary

- Container agents (agentMode == "container") require `SubprocessController` for per-turn docker exec. Claude's provider returns `"persistent"` as its default controller type, so new container agent blocks were created with `controller:"persistent"` in their meta.
- `AgentInput` matched the persistent branch, saw `agentMode=="container"`, and returned an RPC error that never reached the blockfile — the pane appeared blank with no feedback.
- **Root cause traced to**: `app_api.rs:246` — `controller_type = provider.controller_type_str()` with no override for container agents.

**Fix 1 — `app_api.rs`**: Override `controller_type` to `"subprocess"` when `agent.agent_type == "container"` before writing block meta. New container agent blocks will be created with the correct controller type.

**Fix 2 — `blockcontroller/mod.rs`**: In `resync_controller`, override stale `"persistent"` → `"subprocess"` when `agentMode == "container"`. Existing blocks created before this fix are self-correcting at the next `ControllerResync` without a DB patch.

## Test plan

- [ ] Open a container agent (e.g. Pconat with `container_image` set) — pane should load and start Claude inside Docker
- [ ] Send a message — docker exec fires, no "requires subprocess controller" RPC error
- [ ] Non-container (host) Claude agents continue to use persistent controller unchanged
- [ ] Existing container agent blocks with stale `controller:"persistent"` self-correct on `ControllerResync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)